### PR TITLE
Atomically pin local tool workspace execution

### DIFF
--- a/.github/workflows/task-19637-platform-evidence.yml
+++ b/.github/workflows/task-19637-platform-evidence.yml
@@ -1,0 +1,56 @@
+name: TASK-19637 pinned workspace platform evidence
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  platform-evidence:
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'task-19637-platform-evidence'
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2022, macos-15-intel]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out the exact tested commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install -e ".[dev]"
+
+      - name: Run bounded pinned-workspace evidence
+        run: >-
+          python -m pytest
+          Tests/Tools/test_workspace_root_pin.py::test_root_replacement_before_pin_is_refused_by_identity
+          Tests/Tools/test_workspace_root_pin.py::test_root_replacement_after_pin_never_redirects_relative_io
+          Tests/Tools/test_workspace_root_pin.py::test_root_replacement_after_pin_never_redirects_relative_write
+          Tests/Tools/test_workspace_tool_executor.py::test_executor_uses_fixed_private_launch_and_admits_before_stdin
+          Tests/Tools/test_workspace_tool_executor.py::test_timeout_terminates_the_tree_and_returns_no_in_process_result
+          Tests/Tools/test_workspace_tool_executor.py::test_crash_and_bounded_stderr_return_only_fixed_metadata
+          Tests/Tools/test_workspace_tool_executor.py::test_platform_evidence_representative_one_shot_operations
+          Tests/Tools/test_workspace_tool_executor.py::test_pinned_git_supports_linked_worktree_without_granting_metadata_fs_access
+          Tests/Agents/test_local_tool_provider.py::test_each_local_workspace_tool_routes_once_through_injected_executor
+          Tests/Agents/test_virtual_cli_provider.py::test_provider_constructs_and_injects_real_executor_by_default
+          --junitxml="$RUNNER_TEMP/task-19637-platform-junit.xml"
+          -q --tb=short
+
+      - name: Upload JUnit evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: task-19637-platform-evidence-${{ matrix.os }}
+          path: ${{ runner.temp }}/task-19637-platform-junit.xml
+          if-no-files-found: error

--- a/.github/workflows/task-19637-platform-evidence.yml
+++ b/.github/workflows/task-19637-platform-evidence.yml
@@ -41,6 +41,7 @@ jobs:
           Tests/Tools/test_workspace_tool_executor.py::test_timeout_terminates_the_tree_and_returns_no_in_process_result
           Tests/Tools/test_workspace_tool_executor.py::test_crash_and_bounded_stderr_return_only_fixed_metadata
           Tests/Tools/test_workspace_tool_executor.py::test_platform_evidence_representative_one_shot_operations
+          Tests/Tools/test_workspace_tool_executor.py::test_platform_evidence_outer_executor_git_ignores_workspace_path
           Tests/Tools/test_workspace_tool_executor.py::test_pinned_git_supports_linked_worktree_without_granting_metadata_fs_access
           Tests/Agents/test_local_tool_provider.py::test_each_local_workspace_tool_routes_once_through_injected_executor
           Tests/Agents/test_virtual_cli_provider.py::test_provider_constructs_and_injects_real_executor_by_default

--- a/.github/workflows/task-19637-platform-evidence.yml
+++ b/.github/workflows/task-19637-platform-evidence.yml
@@ -44,7 +44,7 @@ jobs:
           Tests/Tools/test_workspace_tool_executor.py::test_pinned_git_supports_linked_worktree_without_granting_metadata_fs_access
           Tests/Agents/test_local_tool_provider.py::test_each_local_workspace_tool_routes_once_through_injected_executor
           Tests/Agents/test_virtual_cli_provider.py::test_provider_constructs_and_injects_real_executor_by_default
-          --junitxml="$RUNNER_TEMP/task-19637-platform-junit.xml"
+          --junitxml="${{ runner.temp }}/task-19637-platform-junit.xml"
           -q --tb=short
 
       - name: Upload JUnit evidence

--- a/.github/workflows/task-19637-platform-evidence.yml
+++ b/.github/workflows/task-19637-platform-evidence.yml
@@ -2,7 +2,7 @@ name: TASK-19637 pinned workspace platform evidence
 
 on:
   pull_request:
-    types: [labeled]
+    types: [labeled, synchronize]
   workflow_dispatch:
 
 permissions:
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   platform-evidence:
-    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'task-19637-platform-evidence'
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'task-19637-platform-evidence')
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/Docs/superpowers/plans/2026-08-28-task-19637-atomic-local-tool-workspace-execution.md
+++ b/Docs/superpowers/plans/2026-08-28-task-19637-atomic-local-tool-workspace-execution.md
@@ -1,0 +1,659 @@
+# TASK-19637 Atomic Local-Tool Workspace Execution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bind every structured local filesystem, patch, read-only Git, and equivalent Virtual CLI call to the exact run-admitted workspace identity with a one-shot, fail-closed worker.
+
+**Architecture:** The provider captures a canonical directory identity and validates model arguments before launching a fixed Python helper. The parent admits that helper to the repository's existing process-tree containment owner, sends one bounded JSON request on stdin, and the helper pins the root before dispatching one relative filesystem or Git operation. Local Tool, Virtual CLI, and external MCP use the same executor; legacy sync cores remain only as non-production compatibility adapters.
+
+**Tech Stack:** Python 3.11+, `subprocess`, POSIX directory descriptors/`fchdir`, Windows directory handles and `SetCurrentDirectoryW`, existing `ExecutorProcessTree`, pytest, GitHub Actions.
+
+**Spec:** `Docs/superpowers/specs/2026-08-28-task-19637-atomic-local-tool-workspace-execution-design.md`
+
+## Global Constraints
+
+- ADR required: yes.
+- ADR path: `backlog/decisions/101-one-shot-pinned-workspace-tool-execution.md`.
+- One helper process is created per operation and always exits; no daemon, pool, retained workspace process, or cross-call mutable worker state.
+- Requests use bounded stdin; workspace locators, file content, patches, and model arguments never appear in argv, environment, or generic diagnostics.
+- New executor/worker diagnostics use fixed metadata only: no root, relative path, request or response payload, exception text, traceback, or child stderr is emitted to production logs.
+- The helper accepts only `fs_list`, `fs_read`, `fs_write`, `fs_edit`, `fs_patch`, `fs_glob`, `fs_grep`, `stat_path`, `git_status`, `git_diff`, `git_log`, `git_blame`, and `git_branches`.
+- `shell=False`; no shell text, arbitrary Python, caller-selected module, caller-selected executable, or unsafe `preexec_fn` is accepted.
+- The helper is admitted to a retained POSIX process group or Windows kill-on-close Job Object before it receives workspace authority.
+- POSIX retains a verified root descriptor and performs I/O through relative names; Windows retains a verified root handle and helper-only current directory.
+- Git receives no `-C <workspace>`, launches no new POSIX session inside the helper, and remains in the helper's process tree.
+- Existing permission identities, sensitive-path rules, result text, in-root symlink behavior, escaping-symlink name-only glob behavior, configured roots, selected bindings, and linked worktrees remain compatible when no root drift occurs.
+- Root retargeting is in scope; a general OS sandbox, raw CLI confinement, mutating Git, transactional multi-file patching, and every descendant-content race are not.
+- Exact protocol ceilings: 16 MiB request, 15 MiB individual string, 16 KiB path, `PATCH_MAX_BYTES` patch, `GIT_MAX_OUTPUT_BYTES + 64 KiB` response, 8 KiB diagnostic stderr, and 300-second outer helper timeout. Existing smaller caps still win.
+- Development verification is targeted. Do not run the full suite without explicit user approval.
+
+## File Map
+
+- Create `tldw_chatbook/Utils/filesystem_identity.py`: shared canonical directory/ancestor identity capture and reparse detection.
+- Modify `tldw_chatbook/Agents/project_instruction_resolver.py`: consume shared identity helpers without changing public behavior.
+- Create `tldw_chatbook/Tools/workspace_tool_protocol.py`: closed operations and strict bounded request/response serialization.
+- Create `tldw_chatbook/Tools/workspace_root_pin.py`: POSIX and Windows root-pin context managers.
+- Create `tldw_chatbook/Tools/workspace_tool_executor.py`: parent one-shot launch, containment, protocol, timeout, redaction, cleanup.
+- Create `tldw_chatbook/Tools/workspace_tool_worker.py`: fixed module entry; one request, one operation, one terminal response.
+- Create `tldw_chatbook/Tools/workspace_tool_dispatch.py`: normalized relative-operation dispatch inside the pinned helper.
+- Modify `tldw_chatbook/Tools/local_tool_impls.py` and `patch_tool_impls.py`: extract relative operation bodies while retaining public sync adapters.
+- Modify `tldw_chatbook/Tools/git_tool_impls.py`: explicit cwd, absolute Git executable, inherited helper containment, no `-C`.
+- Modify `tldw_chatbook/Agents/local_tool_provider.py`, `Tools/virtual_cli_impls.py`, and `Agents/virtual_cli_provider.py`: route every production frontend through the executor.
+- Modify `Docs/security/production-diagnostic-inventory.json` only after reviewing any branch-added diagnostic rows with the repository scanner.
+- Test `Tests/Architecture/test_diagnostic_path_privacy.py` and `Tests/Architecture/test_persistent_diagnostic_inventory.py`: enforce the latest `origin/dev` diagnostic privacy and inventory contracts.
+- Use `scripts/check_persistent_diagnostic_inventory.py`: review statement-level drift before regenerating the committed inventory.
+- Add focused protocol, pinning, race, operation, provider, platform, and performance tests.
+
+---
+
+### Task 0: Synchronize and record the untouched baseline
+
+**Files:** Verify only.
+
+- [ ] **Step 1: Fetch and rebase**
+
+```bash
+git fetch origin dev
+git rebase origin/dev
+git status --short --branch
+```
+
+Expected: clean worktree. If upstream changed a File Map path, inspect the semantic delta and revise this plan before code.
+
+- [ ] **Step 2: Establish focused behavior baseline**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Tools/test_local_tool_impls.py Tests/Tools/test_local_tool_impls_properties.py \
+  Tests/Tools/test_patch_tool_impls.py Tests/Tools/test_git_tool_impls.py \
+  Tests/Tools/test_git_tool_sensitive_paths.py Tests/Tools/test_virtual_cli_impls.py \
+  Tests/Agents/test_local_tool_provider.py Tests/Agents/test_virtual_cli_provider.py \
+  Tests/Agents/test_project_instruction_runtime.py Tests/STT/test_executor_process_tree.py \
+  -q --tb=short
+```
+
+Expected: PASS. Record exact count and warnings.
+
+- [ ] **Step 3: Record touched-file lint baseline**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  tldw_chatbook/Agents/project_instruction_resolver.py \
+  tldw_chatbook/Agents/local_tool_provider.py tldw_chatbook/Agents/virtual_cli_provider.py \
+  tldw_chatbook/Tools/local_tool_impls.py tldw_chatbook/Tools/patch_tool_impls.py \
+  tldw_chatbook/Tools/git_tool_impls.py tldw_chatbook/Tools/virtual_cli_impls.py
+```
+
+Expected: PASS or a recorded exact pre-existing failure set that the branch must not enlarge.
+
+### Task 1: Share directory identity and lock the protocol contract
+
+**Files:**
+
+- Create: `tldw_chatbook/Utils/filesystem_identity.py`
+- Create: `tldw_chatbook/Tools/workspace_tool_protocol.py`
+- Create: `Tests/Utils/test_filesystem_identity.py`
+- Create: `Tests/Tools/test_workspace_tool_protocol.py`
+- Modify: `tldw_chatbook/Agents/project_instruction_resolver.py:105-116,409-435,717-761`
+- Test: `Tests/Agents/test_project_instruction_resolver.py`
+- Test: `Tests/Agents/test_project_instruction_runtime.py`
+
+**Interfaces:**
+
+- `DirectoryIdentity(device: int, inode: int, mode: int, reparse: bool)`.
+- `DirectoryChain(canonical_root: Path, identities: tuple[DirectoryIdentity, ...])`, root first.
+- `capture_directory_chain(root: Path) -> DirectoryChain`.
+- `WorkspaceToolRequest.from_bytes(raw: bytes)`, `.to_bytes()`, and equivalent `WorkspaceToolResponse` methods.
+- `WorkspaceOperation` and `WorkspaceIntent` literal aliases consumed by all later tasks.
+
+- [ ] **Step 1: Write RED identity tests**
+
+Cover canonical alias capture, root-first ancestors, symlink/reparse rejection at the canonical locator, missing Windows attributes, and stable equality:
+
+```python
+def test_capture_directory_chain_canonicalizes_stable_alias(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(root, target_is_directory=True)
+    chain = capture_directory_chain(alias)
+    assert chain.canonical_root == root.resolve()
+    assert chain.identities[0] == directory_identity_from_stat(os.stat(root))
+```
+
+- [ ] **Step 2: Verify identity tests fail**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Utils/test_filesystem_identity.py -q --tb=short
+```
+
+Expected: FAIL because the module does not exist.
+
+- [ ] **Step 3: Implement shared identity values and adopt them in the resolver**
+
+```python
+@dataclass(frozen=True, slots=True)
+class DirectoryIdentity:
+    device: int
+    inode: int
+    mode: int
+    reparse: bool
+
+@dataclass(frozen=True, slots=True)
+class DirectoryChain:
+    canonical_root: Path = field(repr=False)
+    identities: tuple[DirectoryIdentity, ...] = field(repr=False)
+```
+
+Preserve `BindingRootIdentity` as the resolver-facing type, built from this helper. On Windows, absent `st_file_attributes` fails closed.
+
+- [ ] **Step 4: Write RED protocol tests**
+
+Cover exact keys, version, every operation/intent, identity encoding, duplicate JSON keys, non-finite values, NUL, wrong types, unknown keys, each ceiling, wrong operation ID, malformed frames, and redacted repr/errors.
+
+```python
+def test_duplicate_json_keys_fail_before_request_construction() -> None:
+    with pytest.raises(WorkspaceProtocolError, match="duplicate key"):
+        WorkspaceToolRequest.from_bytes(b'{"version":1,"version":1}')
+```
+
+- [ ] **Step 5: Verify protocol tests fail**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Tools/test_workspace_tool_protocol.py -q --tb=short
+```
+
+Expected: FAIL because the protocol module does not exist.
+
+- [ ] **Step 6: Implement strict JSON framing**
+
+Use `object_pairs_hook` for duplicate rejection, `parse_constant` rejection, `allow_nan=False`, exact type checks where bool/int ambiguity matters, and UTF-8 byte counts. Add no serialization dependency.
+
+- [ ] **Step 7: Verify and commit**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Utils/test_filesystem_identity.py Tests/Tools/test_workspace_tool_protocol.py \
+  Tests/Agents/test_project_instruction_resolver.py Tests/Agents/test_project_instruction_runtime.py \
+  -q --tb=short
+git add tldw_chatbook/Utils/filesystem_identity.py tldw_chatbook/Tools/workspace_tool_protocol.py \
+  tldw_chatbook/Agents/project_instruction_resolver.py Tests/Utils/test_filesystem_identity.py \
+  Tests/Tools/test_workspace_tool_protocol.py
+git commit -m "feat(security): define workspace execution protocol"
+```
+
+Expected: PASS, then one focused commit.
+
+### Task 2: Deliver one contained, pinned `stat_path` operation
+
+**Files:**
+
+- Create: `tldw_chatbook/Tools/workspace_root_pin.py`
+- Create: `tldw_chatbook/Tools/workspace_tool_executor.py`
+- Create: `tldw_chatbook/Tools/workspace_tool_worker.py`
+- Create: `tldw_chatbook/Tools/workspace_tool_dispatch.py`
+- Create: `Tests/Tools/test_workspace_root_pin.py`
+- Create: `Tests/Tools/test_workspace_tool_executor.py`
+- Modify: `tldw_chatbook/Tools/local_tool_impls.py`
+- Test: `Tests/Architecture/test_diagnostic_path_privacy.py`
+- Reference: `tldw_chatbook/STT/executor_process_tree.py`
+
+**Interfaces:**
+
+- `PinnedWorkspaceRoot` context with `canonical_locator`, `identity`, POSIX `root_fd`, and `relative_path(value: str) -> Path`.
+- `WorkspaceToolExecutor(workspace_root: Path).execute(operation, arguments, *, intent) -> str`.
+- `execute_pinned_operation(request, root) -> str`; initially `stat_path` succeeds and other closed operations return `unsupported_operation`.
+
+- [ ] **Step 1: Write deterministic RED root-race tests**
+
+Use a dedicated child process and `multiprocessing.Event`, never sleeps. Before pin, replace A with B and expect identity mismatch. After pin, attempt replacement and read `sentinel.txt` relative to the retained pin; expect A or documented Windows sharing refusal, never B.
+
+```python
+def _post_pin_child(locator: str, chain: DirectoryChain, ready, resume, output) -> None:
+    with pin_workspace_root(Path(locator), chain) as pinned:
+        ready.set()
+        if not resume.wait(5):
+            raise RuntimeError("test barrier timed out")
+        output.put(pinned.relative_path("sentinel.txt").read_text(encoding="utf-8"))
+```
+
+- [ ] **Step 2: Verify root-pin tests fail**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Tools/test_workspace_root_pin.py -q --tb=short
+```
+
+Expected: FAIL because the module does not exist.
+
+- [ ] **Step 3: Implement POSIX and Windows pins**
+
+POSIX opens no-follow/directory/close-on-exec, compares `fstat`, calls `fchdir`, verifies `.`, and retains the descriptor. Windows opens without following reparse points, compares volume/file identity, calls helper-only `SetCurrentDirectoryW`, verifies `.`, and retains the handle. Unsupported capability raises `WorkspaceRootPinError`; no fallback.
+
+- [ ] **Step 4: Write RED executor lifecycle/privacy tests**
+
+Cover fixed argv, `shell=False`, allowlisted environment, stdin-only request, containment before request write, one terminal frame, timeout, crash, malformed/oversized response, bounded stderr, cleanup-unproven refusal, and no in-process fallback. Assert marker root/content/exception/stderr strings are absent from argv, env, and production logs, and that only fixed operation/status metadata may be logged.
+
+- [ ] **Step 5: Verify executor tests fail**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Tools/test_workspace_tool_executor.py -q --tb=short
+```
+
+Expected: FAIL because executor/worker modules do not exist.
+
+- [ ] **Step 6: Implement the executor and fixed worker**
+
+Launch only:
+
+```python
+argv = [sys.executable, "-I", "-m", "tldw_chatbook.Tools.workspace_tool_worker"]
+process = subprocess.Popen(
+    argv,
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    env=workspace_worker_environment(),
+    shell=False,
+    start_new_session=(os.name == "posix"),
+)
+```
+
+Wrap Popen with the minimal `is_alive/join/terminate/kill` adapter expected by `ExecutorProcessTree`; do not copy Job Object code. Admit before writing stdin. Helper parses one request, pins once, dispatches once, emits one terminal response, and exits.
+
+- [ ] **Step 7: Extract relative `stat_path`, verify, and commit**
+
+The worker's private stat body accepts only an already validated relative `Path` and never resolves it to an absolute pathname before I/O. Keep public `stat_path(path, workspace_root=...)` unchanged.
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Tools/test_workspace_root_pin.py Tests/Tools/test_workspace_tool_executor.py \
+  Tests/Tools/test_local_tool_impls.py::test_stat_path_returns_only_allowlisted_workspace_metadata \
+  Tests/STT/test_executor_process_tree.py Tests/Architecture/test_diagnostic_path_privacy.py \
+  -q --tb=short
+git add tldw_chatbook/Tools/workspace_root_pin.py tldw_chatbook/Tools/workspace_tool_executor.py \
+  tldw_chatbook/Tools/workspace_tool_worker.py tldw_chatbook/Tools/workspace_tool_dispatch.py \
+  tldw_chatbook/Tools/local_tool_impls.py Tests/Tools/test_workspace_root_pin.py \
+  Tests/Tools/test_workspace_tool_executor.py
+git commit -m "feat(security): run pinned workspace stat operations"
+```
+
+Expected: PASS, then one vertical-slice commit.
+
+### Task 3: Move every read-only filesystem operation behind the pin
+
+**Files:**
+
+- Modify: `tldw_chatbook/Tools/workspace_tool_dispatch.py`
+- Modify: `tldw_chatbook/Tools/local_tool_impls.py:196-329,405-513`
+- Modify: `Tests/Tools/test_workspace_tool_executor.py`
+- Modify: `Tests/Tools/test_local_tool_impls.py`
+- Modify: `Tests/Tools/test_local_tool_impls_properties.py`
+- Test: `Tests/Tools/test_local_tool_sensitive_paths.py`
+
+**Interfaces:** Pinned handlers for `fs_list`, `fs_read`, `fs_glob`, and `fs_grep`; parent normalization converts admitted targets to relative strings and computes bounded relative sensitive exclusions.
+
+- [ ] **Step 1: Write RED parameterized A/B tests**
+
+For each operation, create A/B roots with distinct sentinels, replace before pin, and assert output is A/refusal and never B. Add in-root symlink, escaping read/grep symlink, and name-only glob cases.
+
+```python
+READ_CASES = (
+    ("fs_list", {"path": "."}, "A_ONLY"),
+    ("fs_read", {"path": "sentinel.txt", "offset": 1, "limit": None}, "A_ONLY"),
+    ("fs_glob", {"pattern": "**/*.txt", "max_results": 100}, "sentinel.txt"),
+    ("fs_grep", {"pattern": "A_ONLY", "mode": "content", "max_results": 100}, "A_ONLY"),
+)
+```
+
+- [ ] **Step 2: Verify RED failures**
+
+Run the new parameterized nodes. Expected: stable `unsupported_operation` failures, not timeouts.
+
+- [ ] **Step 3: Extract relative operation bodies**
+
+Parent uses current confinement/sensitive validation while A is admitted. Worker uses normalized relative paths only. Enumeration receives bounded root-relative sensitive exclusions, preserves scan/work caps and ordering, and never calls `.resolve()` then opens that absolute result.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Tools/test_workspace_tool_executor.py Tests/Tools/test_local_tool_impls.py \
+  Tests/Tools/test_local_tool_impls_properties.py Tests/Tools/test_local_tool_sensitive_paths.py \
+  -q --tb=short
+git add tldw_chatbook/Tools/workspace_tool_dispatch.py tldw_chatbook/Tools/local_tool_impls.py \
+  Tests/Tools/test_workspace_tool_executor.py Tests/Tools/test_local_tool_impls.py \
+  Tests/Tools/test_local_tool_impls_properties.py
+git commit -m "feat(security): pin local filesystem reads"
+```
+
+Expected: PASS, including current ordering, truncation, binary refusal, line numbering, and symlink behavior.
+
+### Task 4: Move filesystem mutations and patch behind one pin
+
+**Files:**
+
+- Modify: `tldw_chatbook/Tools/workspace_tool_dispatch.py`
+- Modify: `tldw_chatbook/Tools/local_tool_impls.py:332-402`
+- Modify: `tldw_chatbook/Tools/patch_tool_impls.py:381-449`
+- Modify: `Tests/Tools/test_workspace_tool_executor.py`
+- Modify: `Tests/Tools/test_local_tool_impls.py`
+- Modify: `Tests/Tools/test_patch_tool_impls.py`
+- Test: `Tests/Tools/test_local_tool_sensitive_paths.py`
+
+**Interfaces:**
+
+- Pinned handlers for `fs_write`, `fs_edit`, and `fs_patch`.
+- `patch_validated_files(plans: tuple[PatchFile, ...], *, root: PinnedWorkspaceRoot, dry_run: bool = False) -> str`.
+
+- [ ] **Step 1: Write RED A/B mutation tests**
+
+For write, edit, and a two-file patch, pause before pin, replace A with B, resume, and assert every B file plus an external sentinel remain byte-exact. For post-pin, attempt replacement and assert changes land only in A or refuse. Assert one patch request emits one `admitted` frame and retains one root identity across both files.
+
+```python
+MUTATION_CASES = (
+    ("fs_write", {"path": "note.txt", "content": "changed"}),
+    ("fs_edit", {"path": "note.txt", "old_string": "before", "new_string": "after", "replace_all": False}),
+)
+```
+
+- [ ] **Step 2: Verify RED mutation failures**
+
+Run the exact new nodes. Expected: `unsupported_operation`; byte-exact B assertions pass.
+
+- [ ] **Step 3: Extract relative mutation/patch bodies**
+
+Encode before opening, preserve newline and partial multi-file semantics, and use relative I/O only. Parent parses and validates all patch targets before spawn. Worker reparses bounded patch text and rejects any target set differing from the normalized request target list.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Tools/test_workspace_tool_executor.py Tests/Tools/test_local_tool_impls.py \
+  Tests/Tools/test_patch_tool_impls.py Tests/Tools/test_local_tool_sensitive_paths.py \
+  -q --tb=short
+git add tldw_chatbook/Tools/workspace_tool_dispatch.py tldw_chatbook/Tools/local_tool_impls.py \
+  tldw_chatbook/Tools/patch_tool_impls.py Tests/Tools/test_workspace_tool_executor.py \
+  Tests/Tools/test_local_tool_impls.py Tests/Tools/test_patch_tool_impls.py
+git commit -m "feat(security): pin local filesystem mutations"
+```
+
+Expected: PASS, then one mutation commit.
+
+### Task 5: Run read-only Git inside the helper's containment owner
+
+**Files:**
+
+- Modify: `tldw_chatbook/Tools/git_tool_impls.py:132-317,436-602,602-1035`
+- Modify: `tldw_chatbook/Tools/workspace_tool_dispatch.py`
+- Modify: `Tests/Tools/test_git_tool_impls.py`
+- Modify: `Tests/Tools/test_git_tool_sensitive_paths.py`
+- Modify: `Tests/Tools/test_workspace_tool_executor.py`
+- Test: `Tests/Chunking/test_sync_script.py::test_validated_source_accepts_linked_git_worktree`
+
+**Interfaces:**
+
+Extend `run_git` to the exact signature `run_git(argv: list[str], *, cwd:
+Path | None = None, executable: Path | None = None, own_process_group: bool =
+True, timeout: float = GIT_TIMEOUT_SECONDS, max_output_bytes: int =
+GIT_MAX_OUTPUT_BYTES) -> GitCommandResult`.
+
+Worker dispatch supplies relative repository cwd, absolute `shutil.which("git")`, and `own_process_group=False`. Direct compatibility adapters may use absolute cwd and `own_process_group=True`.
+
+- [ ] **Step 1: Write RED argv/tree/race tests**
+
+Assert all five operations omit `-C`, Popen argv zero is absolute, worker Git uses relative cwd and `start_new_session=False`, outer helper owns timeout cleanup, and A/B replacement never returns B status/diff/log/blame/branch content.
+
+```python
+def test_worker_git_uses_relative_cwd_without_new_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(subprocess, "Popen", recording_popen(seen))
+    run_git(["git", "status"], cwd=Path("repo"), executable=Path("/usr/bin/git"), own_process_group=False)
+    assert seen["argv"][0] == "/usr/bin/git"
+    assert "-C" not in seen["argv"]
+    assert seen["cwd"] == Path("repo")
+    assert seen["start_new_session"] is False
+```
+
+- [ ] **Step 2: Verify RED Git failures**
+
+Run exact new nodes. Expected: current `run_git` rejects new kwargs or records `-C`/new session.
+
+- [ ] **Step 3: Implement cwd-based launch and pinned dispatch**
+
+Logical argv still begins `git` for validation/result compatibility; Popen receives `[str(executable), *argv[1:]]`. Remove `-C` from discovery and operations. Preserve subcommands, machine-safe flags, sensitive pathspecs, output caps, and timeouts. When `own_process_group=False`, direct kill does not signal a new group; outer retained tree proves descendant cleanup.
+
+- [ ] **Step 4: Prove linked-worktree compatibility**
+
+Create a real linked worktree whose `.git` file points outside its working root. Run helper Git operations successfully while a normal local filesystem read of that external administrative path remains unauthorized.
+
+- [ ] **Step 5: Verify and commit**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Tools/test_git_tool_impls.py Tests/Tools/test_git_tool_sensitive_paths.py \
+  Tests/Tools/test_workspace_tool_executor.py \
+  Tests/Chunking/test_sync_script.py::test_validated_source_accepts_linked_git_worktree \
+  -q --tb=short
+git add tldw_chatbook/Tools/git_tool_impls.py tldw_chatbook/Tools/workspace_tool_dispatch.py \
+  Tests/Tools/test_git_tool_impls.py Tests/Tools/test_git_tool_sensitive_paths.py \
+  Tests/Tools/test_workspace_tool_executor.py
+git commit -m "feat(security): pin read-only Git execution"
+```
+
+Expected: PASS, then one Git commit.
+
+### Task 6: Route every production frontend through the executor
+
+**Files:**
+
+- Modify: `tldw_chatbook/Agents/local_tool_provider.py:228-327,748-806,1126-1425`
+- Modify: `tldw_chatbook/Tools/virtual_cli_impls.py:175-230`
+- Modify: `tldw_chatbook/Agents/virtual_cli_provider.py:95-127,273-327`
+- Modify: `Tests/Agents/test_local_tool_provider.py`
+- Modify: `Tests/Agents/test_virtual_cli_provider.py`
+- Modify: `Tests/Tools/test_virtual_cli_impls.py`
+- Modify: `Tests/Agents/test_local_tools_integration.py`
+- Test: `Tests/Chat/test_console_agent_project_instructions.py`
+- Test: `Tests/Chat/test_console_agent_bridge_local.py`
+- Test: `Tests/MCP/test_control_plane_permissions.py`
+- Test: `Tests/MCP/test_local_server_tools.py`
+
+**Interfaces:**
+
+- Add keyword `workspace_executor: WorkspaceToolExecutor | None = None` to
+  `LocalToolProvider.__init__`; it constructs the real executor when omitted,
+  while tests may inject a recording fake.
+- Add required keyword `workspace_executor: WorkspaceToolExecutor` to
+  `_default_specs`; it binds only path-authority handlers to `.execute`.
+- `VirtualCliRegistry(workspace_root, *, workspace_executor=None)` retains direct cores only for explicitly unleased compatibility tests.
+- Add keyword `workspace_executor: WorkspaceToolExecutor | None = None` to
+  `VirtualCliProvider.__init__`; it constructs/injects a real executor by
+  default.
+
+- [ ] **Step 1: Write RED no-bypass tests**
+
+Inject a recording executor; assert each Local Tool and Virtual CLI path command creates exactly one operation/intent/args call. Monkeypatch every direct local/Git core to raise if reached. Assert web/todo/Watchlists do not launch helpers. Construct external MCP local tools and prove `fs_read` reaches the executor.
+
+- [ ] **Step 2: Verify provider tests fail**
+
+Expected: direct handlers and Virtual CLI registry reach the fail-fast monkeypatches.
+
+- [ ] **Step 3: Wire exact intent and refusal mapping**
+
+| Operations | Intent |
+| --- | --- |
+| `fs_write`, `fs_edit`, `fs_patch` | `write` |
+| every other workspace/Git operation | `read` |
+
+Keep root guard, authority scope, permission verdict, and kill switch before executor admission. Root mismatch maps to `LOCAL_ROOT_CHANGED_REFUSAL`; containment/protocol/platform inability maps to `LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL`; domain failures retain bounded current text.
+
+- [ ] **Step 4: Prove schemas/permissions unchanged**
+
+Assert catalog order, every schema, risk tags, definition hashes, approval copy, `allow_write=False`, path-target preflight, and Virtual CLI independent permission identities match baseline.
+
+- [ ] **Step 5: Verify and commit**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Agents/test_local_tool_provider.py Tests/Agents/test_virtual_cli_provider.py \
+  Tests/Agents/test_local_tools_integration.py Tests/Tools/test_virtual_cli_impls.py \
+  Tests/Chat/test_console_agent_project_instructions.py Tests/Chat/test_console_agent_bridge_local.py \
+  Tests/MCP/test_control_plane_permissions.py Tests/MCP/test_local_server_tools.py \
+  -q --tb=short
+git add tldw_chatbook/Agents/local_tool_provider.py tldw_chatbook/Agents/virtual_cli_provider.py \
+  tldw_chatbook/Tools/virtual_cli_impls.py Tests/Agents/test_local_tool_provider.py \
+  Tests/Agents/test_virtual_cli_provider.py Tests/Agents/test_local_tools_integration.py \
+  Tests/Tools/test_virtual_cli_impls.py
+git commit -m "feat(security): lease all local workspace frontends"
+```
+
+Expected: PASS, then one routing commit.
+
+### Task 7: Add bounded platform and performance evidence
+
+**Files:**
+
+- Create: `.github/workflows/task-19637-platform-evidence.yml`
+- Create: `Tests/CI/test_task19637_platform_evidence.py`
+- Create: `Tests/Performance/run_workspace_tool_executor_profile.py`
+- Create: `Tests/Performance/test_workspace_tool_executor_profile.py`
+- Modify: `Tests/Tools/test_workspace_root_pin.py`
+- Modify: `Tests/Tools/test_workspace_tool_executor.py`
+
+**Interfaces:**
+
+- Workflow label `task-19637-platform-evidence`; `ubuntu-24.04`, `windows-2022`, `macos-15-intel`; Python 3.12; exact PR head; read-only permissions; 30-minute timeout.
+- Profile CLI: `python Tests/Performance/run_workspace_tool_executor_profile.py --samples 30 --output <path>`.
+- JSON keys: `schema_version`, `head_commit`, `platform`, `python`, `samples`, and `operations`; operation metrics contain `direct_ms`, `one_shot_ms`, and `startup_overhead_ms`, each with `median` and nearest-rank `p95`.
+
+- [ ] **Step 1: Write RED workflow contract tests**
+
+Assert only labeled-PR/manual triggers, exact matrix/head checkout, no secrets/write permissions, bounded test nodes, JUnit upload, and failure propagation.
+
+- [ ] **Step 2: Add three-OS workflow**
+
+Run root-pin races, executor lifecycle/privacy, one representative read/write/patch/Git, linked-worktree, and provider-routing test. Do not run the full suite or install unrelated extras.
+
+- [ ] **Step 3: Write RED profile tests and implement runner**
+
+Test nearest-rank p95, JSON finiteness, exact operations (`stat`, `read`, `write`, `list`, `git_status`, `git_diff`), content-free metadata, and fake clock/sample injection. Add no timing threshold.
+
+- [ ] **Step 4: Run profile and evidence tests**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Tests/Performance/run_workspace_tool_executor_profile.py \
+  --samples 30 --output /tmp/task-19637-workspace-tool-profile.json
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Performance/test_workspace_tool_executor_profile.py \
+  Tests/CI/test_task19637_platform_evidence.py -q --tb=short
+```
+
+Expected: finite median/p95 for all operations and PASS. Record profile hash and summary; do not commit host-specific output.
+
+- [ ] **Step 5: Run full targeted feature shard**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Utils/test_filesystem_identity.py Tests/Tools/test_workspace_tool_protocol.py \
+  Tests/Tools/test_workspace_root_pin.py Tests/Tools/test_workspace_tool_executor.py \
+  Tests/Tools/test_local_tool_impls.py Tests/Tools/test_local_tool_impls_properties.py \
+  Tests/Tools/test_local_tool_sensitive_paths.py Tests/Tools/test_patch_tool_impls.py \
+  Tests/Tools/test_git_tool_impls.py Tests/Tools/test_git_tool_sensitive_paths.py \
+  Tests/Tools/test_virtual_cli_impls.py Tests/Agents/test_local_tool_provider.py \
+  Tests/Agents/test_virtual_cli_provider.py Tests/Agents/test_local_tools_integration.py \
+  Tests/Agents/test_project_instruction_resolver.py Tests/Agents/test_project_instruction_runtime.py \
+  Tests/STT/test_executor_process_tree.py Tests/CI/test_task19637_platform_evidence.py \
+  Tests/Performance/test_workspace_tool_executor_profile.py -q --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit evidence infrastructure**
+
+```bash
+git add .github/workflows/task-19637-platform-evidence.yml \
+  Tests/CI/test_task19637_platform_evidence.py \
+  Tests/Performance/run_workspace_tool_executor_profile.py \
+  Tests/Performance/test_workspace_tool_executor_profile.py \
+  Tests/Tools/test_workspace_root_pin.py Tests/Tools/test_workspace_tool_executor.py
+git commit -m "test(security): prove pinned workspace execution"
+```
+
+### Task 8: Final review, documentation, and merge readiness
+
+**Files:**
+
+- Modify: `backlog/decisions/101-one-shot-pinned-workspace-tool-execution.md`
+- Modify: `backlog/tasks/task-19637 - Atomically-pin-local-tool-workspace-execution.md`
+- Modify: `Docs/security/production-diagnostic-inventory.json` only when reviewed branch-added diagnostics require it.
+- Modify: `backlog/docs/lessons-testing-evidence.md` only for a real reusable incident.
+
+- [ ] **Step 1: Run branch static gates**
+
+```bash
+git diff --check origin/dev...HEAD
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  tldw_chatbook/Utils/filesystem_identity.py tldw_chatbook/Tools/workspace_tool_protocol.py \
+  tldw_chatbook/Tools/workspace_root_pin.py tldw_chatbook/Tools/workspace_tool_executor.py \
+  tldw_chatbook/Tools/workspace_tool_worker.py tldw_chatbook/Tools/workspace_tool_dispatch.py \
+  tldw_chatbook/Tools/local_tool_impls.py tldw_chatbook/Tools/patch_tool_impls.py \
+  tldw_chatbook/Tools/git_tool_impls.py tldw_chatbook/Tools/virtual_cli_impls.py \
+  tldw_chatbook/Agents/local_tool_provider.py tldw_chatbook/Agents/virtual_cli_provider.py \
+  tldw_chatbook/Agents/project_instruction_resolver.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m compileall -q \
+  tldw_chatbook/Utils/filesystem_identity.py tldw_chatbook/Tools/workspace_tool_protocol.py \
+  tldw_chatbook/Tools/workspace_root_pin.py tldw_chatbook/Tools/workspace_tool_executor.py \
+  tldw_chatbook/Tools/workspace_tool_worker.py tldw_chatbook/Tools/workspace_tool_dispatch.py
+```
+
+Expected: PASS or no branch-added lint delta against Task 0.
+
+- [ ] **Step 2: Review diagnostic privacy and inventory drift**
+
+```bash
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/Architecture/test_diagnostic_path_privacy.py \
+  Tests/Architecture/test_persistent_diagnostic_inventory.py -q --tb=short
+PYTHONPATH=. /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python \
+  scripts/check_persistent_diagnostic_inventory.py --diff
+```
+
+Expected: privacy tests pass. If the inventory reports branch-added rows, inspect the statement-level report and confirm every new diagnostic contains fixed metadata only. Then, and only then, run `python scripts/check_persistent_diagnostic_inventory.py --write`, inspect the JSON diff, rerun both architecture tests and `--diff`, and include the inventory in the relevant implementation commit. Never regenerate merely to silence drift.
+
+- [ ] **Step 3: Review boundary tripwires**
+
+```bash
+rg -n 'git.*-C|start_new_session=True|preexec_fn|shell=True' \
+  tldw_chatbook/Tools/workspace_* tldw_chatbook/Tools/git_tool_impls.py
+rg -n 'LocalToolProvider\(|VirtualCliProvider\(|VirtualCliRegistry\(' tldw_chatbook
+git diff --stat origin/dev...HEAD
+git diff origin/dev...HEAD
+```
+
+Expected: only the fixed helper owns a new POSIX session; Git does not. All production frontends are leased, raw CLI is unchanged, no pool exists, and no workspace locator enters argv/env/logs.
+
+- [ ] **Step 4: Request full-suite approval**
+
+Ask the user whether to run the repository-wide suite. If approved, run the documented full command and record exact output. If not, final evidence is the targeted shard plus three-OS workflow.
+
+- [ ] **Step 5: Rebase and repeat affected verification**
+
+Fetch/rebase `origin/dev`. Rerun all targeted tests if affected files changed; otherwise rerun protocol, races, provider routing, Git, static, and diff checks. Recheck ADR-101 against `origin/dev` and open PR file lists; renumber all references if collision appears.
+
+- [ ] **Step 6: Complete task and ADR**
+
+Set ADR-101 to `Accepted`; check all six acceptance criteria; add concise Implementation Notes with approach, files, trade-offs, exact targeted/cross-platform/performance evidence, full-suite decision, and ADR; set task status `Done`. Add a lesson only when a concrete incident generalizes.
+
+- [ ] **Step 7: Commit closeout docs and prove clean tree**
+
+```bash
+git add backlog/decisions/101-one-shot-pinned-workspace-tool-execution.md \
+  "backlog/tasks/task-19637 - Atomically-pin-local-tool-workspace-execution.md" \
+  Docs/security/production-diagnostic-inventory.json
+git commit -m "docs(security): close pinned workspace execution task"
+git status --short --branch
+git log --oneline --decorate origin/dev..HEAD
+git diff --check origin/dev...HEAD
+```
+
+Expected: intentional TASK-19637 commits only, no modified/untracked files, no whitespace errors.

--- a/Docs/superpowers/specs/2026-08-28-task-19637-atomic-local-tool-workspace-execution-design.md
+++ b/Docs/superpowers/specs/2026-08-28-task-19637-atomic-local-tool-workspace-execution-design.md
@@ -1,0 +1,463 @@
+# Atomic Local-Tool Workspace Execution Design
+
+**Date:** 2026-08-28
+**Status:** Review requested
+**Related task:** TASK-19637
+**Prerequisite for:** TASK-19504
+**ADR required:** yes
+**ADR path:** `backlog/decisions/101-one-shot-pinned-workspace-tool-execution.md`
+**Reason:** This establishes a cross-platform helper-process security boundary
+and defines its authority, lifecycle, failure, compatibility, and performance
+contracts.
+
+## 1. Summary
+
+Workspace-confined local file and Git tools currently validate a `Path` and then
+use that pathname later. A concurrent rename or replacement can retarget the
+operation after the check. Call-time binding identity checks reduce the window
+but cannot close it.
+
+Each affected operation will instead run in a fresh, one-shot worker. The parent
+revalidates the run-admitted workspace authority and admits the worker to a
+retained process group or Job Object. The worker independently opens and verifies
+the exact root, pins it for the operation, executes one closed operation, emits a
+bounded result, and exits. No helper remains running between calls.
+
+This is a root-identity execution lease, not a general OS sandbox. It protects
+the exact failure TASK-19637 records while preserving existing permission,
+sensitive-path, in-root symlink, linked-worktree, and result behavior when no
+drift occurs.
+
+## 2. Current gap
+
+The affected path is:
+
+```text
+provider root guard
+  -> resolve_workspace_path(...).resolve()
+  -> ordinary Path or git -C pathname use
+```
+
+`LocalToolProvider.invoke()` runs `root_guard` before dispatch and may hold an
+`authority_scope`, but the handlers captured by `_default_specs()` still receive
+an ordinary `Path`. `local_tool_impls.py` and `git_tool_impls.py` resolve that
+path again and reopen it later. The same cores are called directly by
+`VirtualCliRegistry`, so fixing only `LocalToolProvider` would leave a bypass.
+
+The race is externally reproducible:
+
+1. admit root identity A at locator L;
+2. finish the current pathname confinement check;
+3. rename A away and place attacker-controlled root B at L;
+4. allow the existing implementation to reopen L;
+5. observe a read from or write into B.
+
+On POSIX, a directory descriptor continues to refer to A after its name moves.
+On Windows, a helper can set its own process current directory after identity
+verification; Windows documents that current directory as locked against
+movement, deletion, and rename while the process executes. Neither mechanism is
+safe to establish by changing the multithreaded Chatbook process's current
+directory or by running arbitrary Python in `preexec_fn`.
+
+## 3. Goals and non-goals
+
+### 3.1 Goals
+
+1. Bind each affected call to the exact run-admitted root identity across root
+   rename, replacement, symlink, junction, and reparse substitution attempts.
+2. Prevent mutating local tools from writing into a replacement root.
+3. Prevent read-only local and Git tools from returning replacement-root data.
+4. Work or fail closed on macOS, Linux, and Windows without `preexec_fn`.
+5. Preserve ordinary tool schemas, permission behavior, result text, sensitive
+   path rules, in-root symlink behavior, and linked Git worktrees.
+6. Keep helper requests, file contents, patches, and absolute roots out of argv,
+   environment, generic diagnostics, and process listings.
+7. Prove bounded cleanup for the helper and every Git descendant.
+8. Measure the cost of one-shot startup before closeout.
+
+### 3.2 Non-goals
+
+- A general filesystem sandbox against privileged or arbitrary hostile code.
+- Raw CLI or persistent terminal confinement.
+- Mutating Git commands.
+- A persistent helper pool or daemon.
+- Changing permission-store, approval, or Change Review semantics.
+- Redesigning sensitive-path policy.
+- Eliminating every possible concurrent mutation of arbitrary descendants. The
+  task owns retargeting of the admitted root; existing descendant validation and
+  in-root symlink behavior remain in force.
+- Making a multi-file patch transactionally atomic. It remains one root-pinned
+  operation with the existing partial-failure contract.
+- Consolidating every process-tree controller already present in the repository.
+
+## 4. Scope
+
+The pinned executor covers every production frontend that reaches the local path
+cores:
+
+- `fs_list`, `fs_read`, `fs_write`, `fs_edit`, `fs_patch`, `fs_glob`, and
+  `fs_grep`;
+- `stat_path`, currently exposed through Virtual CLI;
+- `git_status`, `git_diff`, `git_log`, `git_blame`, and `git_branches`;
+- Virtual CLI `ls`, `cat`, `grep`, `find`, `stat`, and read-only Git commands;
+- external MCP serving when it composes the same Local Tool provider.
+
+The separate built-in scratch/multi-root file tools remain under their existing
+ADR-028 and ADR-069 authority. TASK-19504 deliberately preserves that family
+while changing the Local Tool provider's root selection. Raw CLI remains under
+ADR-094 and is explicitly not workspace-confined.
+
+## 5. Authority and linearization
+
+### 5.1 Immutable admitted authority
+
+Provider construction receives an immutable authority snapshot containing:
+
+- workspace ID;
+- stable binding ID or configured-root authority kind;
+- canonical-locator fingerprint;
+- access mode;
+- canonical root locator, derived under the existing ancestor-identity checks
+  and kept private;
+- canonical root identity and available ancestor identities; and
+- authority generation or equivalent invalidation token when the owning
+  registry supplies one.
+
+TASK-19504 will expand this snapshot to selected and run-admitted bindings. This
+task supports both that future form and today's configured-workspace root without
+making a registry lookup an authorization source inside the helper.
+
+### 5.2 Admission sequence
+
+One operation is admitted in this order:
+
+1. Resolve the exact provider owner and permission verdict as today.
+2. Re-read and compare binding membership, locator fingerprint, access mode, and
+   filesystem identity through the provider's root guard.
+3. For a mutation, require current `rw` authority.
+4. Normalize the already-validated operation into an immutable bounded request.
+5. Spawn the fixed helper in a root-ineligible protocol-wait state and admit its
+   process tree.
+6. Send the request over the private stdin channel.
+7. The helper opens and verifies the root, pins it, and publishes a content-free
+   `admitted` frame.
+8. The helper performs the operation and publishes exactly one terminal frame.
+
+Successful root pinning is the filesystem execution linearization point. A root
+or registry change before it refuses the operation. A registry downgrade after
+it does not retarget or asynchronously cancel the in-flight call; it blocks all
+later calls. This is the only enforceable meaning of an immediate downgrade that
+does not introduce unsafe mid-write cancellation.
+
+## 6. One-shot worker protocol
+
+### 6.1 Launch
+
+The parent launches the helper with an absolute `sys.executable` and a fixed
+module entry point. `shell=False` is mandatory. Argv contains only fixed
+code-owned switches; it contains no root, file path, patch, file content, model
+argument, or executable selected by the caller. A workspace originally selected
+through a symlink alias is canonicalized during run admission; the worker gets
+that admitted canonical locator and identity, not an alias it would resolve
+again at operation time.
+
+The environment starts from a small Python/runtime allowlist. Provider API keys,
+tokens, proxy credentials, tracing state, Python injection variables, and
+unrelated ambient values are absent. The helper has `stdin`, `stdout`, and
+`stderr` pipes and no interactive input.
+
+The existing spawned-worker containment pattern in
+`STT/executor_process_tree.py` is reused rather than adding a third Windows Job
+Object implementation. The helper starts in a fixed protocol-wait path that
+cannot read a workspace request or spawn descendants before containment is
+acknowledged:
+
+- POSIX: the fixed helper enters or is launched into a new session/process group
+  using a safe subprocess/spawn facility, never `preexec_fn`;
+- Windows: the parent obtains the fixed helper PID and the helper waits until the
+  parent assigns it to a kill-on-close Job Object;
+- only after the parent acknowledges containment does the helper read and admit
+  the workspace request.
+
+The integration may extract those generic primitives to a shared module only if
+needed to avoid a domain-layer import. That extraction must preserve the STT API
+and tests and must not redesign the separate asynchronous Notes Git controller.
+
+### 6.2 Request
+
+The request is a versioned JSON object with a hard byte cap and exact keys:
+
+- protocol version;
+- opaque operation ID;
+- closed operation name;
+- read or write intent;
+- private canonical root locator captured at run admission;
+- expected root and available ancestor identities;
+- normalized, bounded operation arguments; and
+- effective timeout and output ceilings.
+
+Unknown keys, unknown versions, duplicate JSON keys, non-finite numbers, wrong
+types, NUL, oversized strings/collections, or unsupported operations fail before
+root access. File content and patch text are permitted only for their exact
+mutating operations and receive explicit request-size ceilings.
+
+The worker never accepts shell text, Python source, module names, arbitrary argv,
+environment overrides, or caller-selected executable paths.
+
+### 6.3 Response
+
+Stdout carries framed protocol messages only:
+
+- one optional content-free `admitted` frame; and
+- exactly one terminal success or failure frame.
+
+The terminal frame includes the operation ID, stable outcome code, bounded
+result/error text, elapsed time, and truncation/cleanup flags. Absolute root text
+is redacted before serialization. Stderr is bounded and reserved for
+content-free helper diagnostics; it is never copied directly into model output.
+
+Missing, malformed, duplicate-terminal, oversized, wrong-ID, or post-terminal
+frames are protocol failures. A protocol failure never triggers an in-process
+fallback.
+
+## 7. Platform root pinning
+
+### 7.1 POSIX
+
+The helper receives the admitted canonical locator rather than re-resolving any
+user-visible alias. It then:
+
+1. opens the lexical root with directory, close-on-exec, and no-follow-final
+   flags supported by the platform;
+2. `fstat`s the descriptor and compares its directory identity with the admitted
+   identity;
+3. rejects an unsafe or mismatched descriptor;
+4. calls `fchdir(root_fd)` inside the already-single-threaded helper;
+5. verifies `stat(".")` against the same descriptor identity; and
+6. keeps `root_fd` open until the terminal result is committed.
+
+Filesystem operations receive normalized workspace-relative paths and use
+descriptor-relative standard-library primitives where supported. They never
+reconstruct `root_locator / relative_path` after pinning. Enumeration starts
+from the descriptor (`scandir`/`listdir`, `glob`/`fwalk` equivalents as
+appropriate) and retains the current result caps and filtering.
+
+The parent-side validation still resolves current in-root symlinks and converts
+an admitted exact target to a stable root-relative target. The helper is not a
+license to accept `..`, absolute operation paths, or a target that parent policy
+did not admit.
+
+### 7.2 Windows
+
+The helper receives the admitted canonical locator rather than re-resolving any
+user-visible alias. It uses the existing identity representation where
+sufficient and a small native wrapper where Python metadata cannot prove the
+contract. It:
+
+1. opens the root as a directory without following a reparse point;
+2. rejects a symlink, junction, or other reparse point at that canonical
+   locator;
+3. compares volume/file identity with the admitted identity;
+4. calls `SetCurrentDirectoryW` only inside the helper;
+5. opens and verifies `.` against the expected identity; and
+6. retains both the current-directory state and verification handle until the
+   operation is terminal.
+
+Windows documents the process current directory as locked against movement,
+deletion, and rename. If native identity, reparse attributes, current-directory
+locking, or post-set verification cannot be proven, the operation fails closed.
+
+Operation paths remain relative to the pinned helper current directory. The
+multithreaded Chatbook process never calls `SetCurrentDirectory`.
+
+## 8. Filesystem operation behavior
+
+The implementation separates policy normalization from root-relative execution:
+
+```text
+model args
+  -> existing schema and sensitive-path validation
+  -> immutable WorkspaceToolRequest
+  -> pinned worker
+  -> root-relative operation core
+  -> existing bounded result text
+```
+
+The existing public sync functions may remain as compatibility/test adapters,
+but production Local Tool and Virtual CLI invocation must use the pinned
+executor. No frontend may silently call the old pathname implementation after a
+lease failure.
+
+`fs_patch` parses and validates every target before helper admission, then sends
+one request. The worker retains one root pin across the whole patch. Existing
+patch ordering, failure, newline, and partial-write behavior remains unchanged.
+
+Enumeration retains current distinctions:
+
+- list and glob may report an escaping symlink's name where current policy
+  allows name-only disclosure;
+- grep and reads do not return content resolved outside the admitted root;
+- sensitive entries remain filtered before content access; and
+- result ordering and truncation caps remain unchanged.
+
+## 9. Git behavior
+
+The helper resolves Git through the existing sanitized environment and uses an
+absolute executable path. Git receives fixed allowlisted subcommands and
+validated arguments exactly as today, except:
+
+- the workspace locator is never passed through `git -C`;
+- Git inherits the helper's pinned current directory;
+- repository discovery and model-supplied path scopes are workspace-relative;
+- the Git child does not use `start_new_session=True` or otherwise leave the
+  helper's admitted process group/Job Object; and
+- parent cancellation/timeout owns the entire helper/Git tree.
+
+The current Git runner's internal output and command timeouts remain useful, but
+they cannot create a second process-group owner. One layer has authoritative
+tree cleanup and terminal reporting.
+
+Linked worktrees remain supported. A worktree-local `.git` file may reference
+Git administrative metadata outside the workspace root; this is Git's existing
+repository metadata contract, not general filesystem authority. The allowlisted
+read-only Git commands, sanitized environment, sensitive-path pathspecs, and
+repository-root-within-workspace checks remain unchanged.
+
+## 10. Failure and lifecycle
+
+Terminal outcomes distinguish:
+
+- authority changed before spawn;
+- process containment unavailable;
+- helper spawn or admission failure;
+- root identity mismatch;
+- unsafe root link/reparse metadata;
+- unsupported platform capability;
+- invalid operation request;
+- tool-domain failure;
+- timeout or cancellation;
+- malformed/oversized helper response; and
+- cleanup unproven.
+
+Model-facing text is stable, bounded, and recovery-oriented without absolute
+paths. Generic logs contain operation kind, stable reason code, platform, timing,
+and cleanup state only.
+
+Timeout and cancellation first request ordinary helper termination where safe,
+then force-terminate the retained process group/Job Object and wait boundedly for
+settlement. Closing a Windows kill-on-close Job handle is part of the fail-safe
+cleanup path. A helper cannot be reported complete while a Git descendant is
+still unaccounted for.
+
+No error path executes the operation in Chatbook's process. No error path retries
+against a newly resolved root.
+
+## 11. Compatibility
+
+The following remain stable when no drift occurs:
+
+- model-facing schemas and tool names;
+- permission identities, Ask/Allow/Off behavior, and approval copy;
+- `LocalToolError`-style result text;
+- file read numbering, size caps, binary refusal, edit/patch semantics, and
+  enumeration ordering;
+- sensitive-path and `.git` metadata write refusal;
+- read-only Git output and linked-worktree support;
+- configured-root external MCP behavior; and
+- selected-binding behavior introduced by TASK-19504.
+
+Persistent approvals may change only if a schema or definition hash must change;
+the implementation should avoid such churn because the execution boundary is
+internal.
+
+## 12. Verification
+
+### 12.1 Deterministic root-race tests
+
+Test-only barriers pause the helper at two points: immediately before root pin
+and after successful pin but before operation use.
+
+For each relevant platform and operation class:
+
+1. create authorized root A and replacement root B with distinguishable
+   sentinels;
+2. capture A's admitted identity;
+3. pause at the chosen barrier;
+4. rename, replace, symlink, junction, or reparse-substitute the locator where
+   the platform permits;
+5. resume; and
+6. assert the operation uses A or refuses safely, never B.
+
+Mutating cases prove B and every external sentinel remain byte-exact. Read cases
+prove no B content appears. Windows tests accept a documented sharing-violation
+refusal when the pinned current directory prevents the attempted rename.
+
+### 12.2 Operation and compatibility tests
+
+- Every structured local path tool routes through the executor.
+- Every Virtual CLI filesystem/Git command routes through the executor.
+- `fs_patch` keeps one pin across all targets.
+- `rw`/`ro`, root guard, kill switch, approvals, and result redaction remain
+  unchanged.
+- In-root file symlink, escaping symlink name-only glob behavior, sensitive-path
+  filtering, and linked Git worktree coverage remain green.
+- Git never receives `-C <workspace-locator>` and never starts a new contained
+  session inside the helper.
+
+### 12.3 Lifecycle and protocol tests
+
+- worker waits for process-containment acknowledgement;
+- invalid/oversized requests fail before root access;
+- wrong identity, unsafe reparse metadata, malformed response, timeout,
+  cancellation, crash, and forced kill fail closed;
+- POSIX grandchildren die with the retained process group;
+- Windows grandchildren die with the Job Object;
+- descriptors, handles, pipes, and temporary resources close on every terminal
+  path; and
+- no request body, result body, absolute root, patch, or file content reaches
+  argv, environment, or generic logs.
+
+### 12.4 Performance evidence
+
+Record cold and warm median/p95 wall time for representative `stat`, small read,
+small write, directory list, Git status, and Git diff operations against the
+current direct implementation. Record helper startup separately from operation
+time. The task does not introduce a flaky CI timing threshold; evidence must be
+published in implementation notes, and a severe regression must be optimized or
+explicitly brought back for design review rather than hidden by pooling.
+
+### 12.5 Test scope
+
+Development uses focused suites for the execution protocol, local cores, Local
+Tool provider, Virtual CLI, Git, project-instruction authority, and platform
+containment. Per repository policy, a full test sweep is run only with explicit
+user approval before final merge.
+
+## 13. Delivery and migration
+
+1. Land this design and ADR before implementation.
+2. Add the one-shot protocol and platform root pin adapters behind focused red
+   race tests.
+3. Add root-relative filesystem/Git execution without changing public behavior.
+4. Route Local Tool and Virtual CLI production calls through the executor.
+5. Run compatibility, lifecycle, privacy, and performance evidence.
+6. Complete TASK-19637 and merge it before starting TASK-19504's new root
+   selection behavior.
+
+There is no database, config, or user-data migration. A platform that cannot
+prove the required boundary reports local path tools unavailable for that call;
+it never falls back to the old pathname-only execution.
+
+## 14. Open implementation constraints
+
+These are constraints to resolve in the implementation plan, not product choices
+left open by the design:
+
+- choose the smallest shared import surface for the existing worker process-tree
+  primitives without duplicating Windows Job Object code;
+- define exact request/output byte caps from current tool and run budgets;
+- keep direct sync core APIs only where tests or non-production compatibility
+  require them, while proving every production frontend is leased; and
+- re-check ADR-101 against `origin/dev` and open PRs immediately before merge,
+  renumbering the file, header, README row, task, spec, and plan references if a
+  collision appears.

--- a/Tests/Agents/test_fleet_runtime.py
+++ b/Tests/Agents/test_fleet_runtime.py
@@ -79,6 +79,13 @@ from Tests.Agents.conftest import (
     pin_max_live_subagents,
     pin_turn_scoped_children,
 )
+
+
+class _NoopWorkspaceExecutor:
+    def execute(self, operation: str, arguments: dict, *, intent: str) -> str:
+        raise AssertionError(f"unexpected workspace operation: {operation}")
+
+
 _JOIN_TIMEOUT = 5.0
 
 
@@ -159,7 +166,11 @@ def _todo_provider(workspace, store: SessionTodoStore) -> LocalToolProvider:
     """Build one real provider whose four task handlers close over ``store``."""
     todo_specs = [
         spec
-        for spec in _default_specs(workspace, todo_store=store)
+        for spec in _default_specs(
+            workspace,
+            workspace_executor=_NoopWorkspaceExecutor(),
+            todo_store=store,
+        )
         if spec.name in {"todo_create", "todo_update", "todo_get", "todo_list"}
     ]
     return LocalToolProvider(

--- a/Tests/Agents/test_local_tool_provider.py
+++ b/Tests/Agents/test_local_tool_provider.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import shutil
 import subprocess
 from io import BytesIO
@@ -328,6 +329,37 @@ def test_local_executor_domain_failure_text_is_redacted_and_bounded(tmp_path):
     assert str(private_root) not in result.error
     assert result.error.startswith("bounded domain failure: marker ")
     assert len(result.error) == 300
+
+
+def test_local_provider_refuses_root_replaced_after_second_guard(tmp_path):
+    locator = tmp_path / "workspace"
+    locator.mkdir()
+    (locator / "sentinel.txt").write_bytes(b"A_ONLY")
+    retained = tmp_path / "retained-a"
+    calls = 0
+
+    def replace_after_second_guard() -> bool:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            os.replace(locator, retained)
+            locator.mkdir()
+            (locator / "sentinel.txt").write_bytes(b"B_BYTE_EXACT\x00\xff")
+        return True
+
+    provider = make_provider(
+        root=locator,
+        state=ALLOW,
+        root_guard=replace_after_second_guard,
+        use_default_executor=True,
+    )
+
+    result = provider.invoke("local:fs_read", {"path": "sentinel.txt"})
+
+    assert calls == 2
+    assert not result.ok and result.outcome == "blocked"
+    assert result.error == LOCAL_ROOT_CHANGED_REFUSAL
+    assert (locator / "sentinel.txt").read_bytes() == b"B_BYTE_EXACT\x00\xff"
 
 
 def test_catalog_lists_default_specs_with_local_ids(tmp_path):
@@ -933,7 +965,11 @@ def test_git_handlers_smoke_against_tmp_repo(git_workspace):
 def test_git_diff_handler_refuses_commit_range_injection(git_workspace):
     p = make_provider(root=git_workspace)
     r = p.invoke("local:git_diff", {"commit_range": "HEAD; rm -rf ."})
-    assert not r.ok and r.error == "workspace operation failed"
+    assert not r.ok
+    assert r.error == (
+        "invalid commit_range 'HEAD; rm -rf .': must be a ref/range matching "
+        "[A-Za-z0-9._/~^-] and not start with '-'"
+    )
 
 
 def test_invoke_happy_path(tmp_path):

--- a/Tests/Agents/test_local_tool_provider.py
+++ b/Tests/Agents/test_local_tool_provider.py
@@ -2,17 +2,20 @@ import json
 import logging
 import shutil
 import subprocess
+from io import BytesIO
 from collections import UserDict
 from pathlib import Path
 
 import pytest
 from jsonschema import Draft202012Validator
 
+import tldw_chatbook.Agents.local_tool_provider as local_tool_provider
 from tldw_chatbook.Agents.local_tool_provider import (
     LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL,
     LOCAL_DENY_REFUSAL,
     LOCAL_GATE_ERROR_REFUSAL,
     LOCAL_KILL_SWITCH_REFUSAL,
+    LOCAL_ROOT_CHANGED_REFUSAL,
     LOCAL_TIMEOUT_REFUSAL,
     LocalToolProvider,
 )
@@ -25,8 +28,19 @@ from tldw_chatbook.Agents.session_todo_store import (
     SessionTodoStore,
 )
 from tldw_chatbook.MCP.permission_store import EffectiveToolState
-from tldw_chatbook.Tools import web_tool_impls
+from tldw_chatbook.Tools import (
+    git_tool_impls,
+    local_tool_impls,
+    patch_tool_impls,
+    web_tool_impls,
+)
 from tldw_chatbook.Tools.watchlists_tool_service import WatchlistsToolService
+from tldw_chatbook.Tools.workspace_tool_executor import (
+    WorkspaceToolExecutionError,
+    WorkspaceToolExecutor,
+)
+from tldw_chatbook.Tools.workspace_tool_protocol import WorkspaceToolResponse
+from tldw_chatbook.Tools.workspace_tool_worker import run_workspace_worker
 
 ALLOW = EffectiveToolState(state="allow", origin="tool_override")
 ASK = EffectiveToolState(state="ask", origin="global_default")
@@ -35,6 +49,51 @@ DENY = EffectiveToolState(state="deny", origin="tool_override")
 #: PR2a Task 5: per-turn stamps are keyed by RUN. Every test here drives a
 #: single run, so it stamps and dispatches under this one id.
 RUN = "run-1"
+
+
+class RecordingWorkspaceExecutor:
+    """Record the public executor contract without launching a helper."""
+
+    def __init__(
+        self,
+        result: str = "leased-result",
+        error: str | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        self.result = result
+        self.error = error
+        self.error_message = error_message
+        self.calls: list[tuple[str, dict, str]] = []
+
+    def execute(self, operation: str, arguments: dict, *, intent: str) -> str:
+        self.calls.append((operation, dict(arguments), intent))
+        if self.error is not None:
+            raise WorkspaceToolExecutionError(self.error, self.error_message)
+        return self.result
+
+
+class InProcessWorkspaceExecutor:
+    """Run the real validated worker dispatch without subprocess containment.
+
+    Production routing is covered with fail-fast recording fakes above. Legacy
+    behavior tests use this explicit test-only seam because isolated helpers
+    cannot import an editable checkout from this linked worktree.
+    """
+
+    def __init__(self, workspace_root: Path) -> None:
+        self._executor = WorkspaceToolExecutor(workspace_root)
+
+    def execute(self, operation: str, arguments: dict, *, intent: str) -> str:
+        request = self._executor._build_request(operation, arguments, intent=intent)
+        stdout = BytesIO()
+        run_workspace_worker(BytesIO(request.to_bytes()), stdout, BytesIO())
+        frames = stdout.getvalue().splitlines()
+        response = WorkspaceToolResponse.from_bytes(
+            frames[-1], expected_operation_id=request.operation_id
+        )
+        if response.outcome != "success":
+            raise WorkspaceToolExecutionError(response.code, response.error)
+        return response.result or ""
 
 
 @pytest.fixture(autouse=True)
@@ -64,14 +123,211 @@ def _reset_web_tool_state():
 
 
 def make_provider(state=ALLOW, kill=False, **kwargs):
+    use_default_executor = kwargs.pop("use_default_executor", False)
     kwargs.setdefault("resolve_state", lambda hub: state)
     kwargs.setdefault("kill_switch", lambda: kill)
-    return LocalToolProvider(
-        workspace_root=Path(kwargs.pop("root", ".")).resolve()
+    root = (
+        Path(kwargs.pop("root", ".")).resolve()
         if "root" in kwargs
-        else Path("."),
+        else Path(".")
+    )
+    if not use_default_executor:
+        kwargs.setdefault("workspace_executor", InProcessWorkspaceExecutor(root))
+    return LocalToolProvider(
+        workspace_root=root,
         **kwargs,
     )
+
+
+_LOCAL_WORKSPACE_EXECUTOR_CASES = (
+    ("fs_list", {"path": "docs"}, "read"),
+    ("fs_read", {"path": "a.txt", "offset": 2, "limit": 4}, "read"),
+    ("fs_write", {"path": "a.txt", "content": "new"}, "write"),
+    (
+        "fs_edit",
+        {
+            "path": "a.txt",
+            "old_string": "old",
+            "new_string": "new",
+            "replace_all": True,
+        },
+        "write",
+    ),
+    ("fs_patch", {"diff": "bounded patch", "dry_run": True}, "write"),
+    ("fs_glob", {"pattern": "**/*.py", "max_results": 7}, "read"),
+    (
+        "fs_grep",
+        {"pattern": "needle", "mode": "files", "max_results": 8},
+        "read",
+    ),
+    ("git_status", {"path": "src"}, "read"),
+    (
+        "git_diff",
+        {
+            "staged": True,
+            "commit_range": "HEAD~1..HEAD",
+            "path": "a.py",
+            "stat": True,
+        },
+        "read",
+    ),
+    ("git_log", {"count": 7, "path": "src"}, "read"),
+    (
+        "git_blame",
+        {"path": "a.py", "start_line": 2, "end_line": 5},
+        "read",
+    ),
+    ("git_branches", {}, "read"),
+)
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments", "intent"),
+    _LOCAL_WORKSPACE_EXECUTOR_CASES,
+)
+def test_each_local_workspace_tool_routes_once_through_injected_executor(
+    tmp_path, monkeypatch, tool_name, arguments, intent
+):
+    """Deleting one leased handler must expose the corresponding direct core."""
+
+    def direct_core_reached(*_args, **_kwargs):
+        pytest.fail("production local tools must not call direct workspace cores")
+
+    for module, names in (
+        (
+            local_tool_impls,
+            (
+                "list_directory",
+                "read_file",
+                "write_file",
+                "edit_file",
+                "glob_files",
+                "grep_files",
+            ),
+        ),
+        (patch_tool_impls, ("patch_files",)),
+        (
+            git_tool_impls,
+            ("git_status", "git_diff", "git_log", "git_blame", "git_branches"),
+        ),
+    ):
+        for name in names:
+            monkeypatch.setattr(module, name, direct_core_reached)
+
+    executor = RecordingWorkspaceExecutor()
+    provider = make_provider(root=tmp_path, workspace_executor=executor)
+
+    result = provider.invoke(f"local:{tool_name}", arguments)
+
+    assert result.ok and result.content == "leased-result"
+    assert executor.calls == [(tool_name, arguments, intent)]
+
+
+def test_local_provider_constructs_and_uses_real_executor_when_omitted(
+    tmp_path, monkeypatch
+):
+    constructed: list[Path] = []
+
+    class RecordingFactory(RecordingWorkspaceExecutor):
+        def __init__(self, workspace_root: Path) -> None:
+            constructed.append(workspace_root)
+            super().__init__()
+
+    monkeypatch.setattr(
+        local_tool_provider,
+        "WorkspaceToolExecutor",
+        RecordingFactory,
+        raising=False,
+    )
+
+    result = make_provider(root=tmp_path, use_default_executor=True).invoke(
+        "local:fs_list", {"path": "."}
+    )
+
+    assert result.ok and result.content == "leased-result"
+    assert constructed == [tmp_path.resolve()]
+
+
+def test_web_todo_and_watchlists_handlers_never_launch_workspace_executor(
+    tmp_path, monkeypatch
+):
+    for name in ("web_fetch", "web_search", "web_crawl"):
+        monkeypatch.setattr(web_tool_impls, name, lambda *_args, **_kwargs: "web")
+    executor = RecordingWorkspaceExecutor()
+    store = SessionTodoStore()
+    watchlists = RecordingWatchlistsService()
+    provider = make_provider(
+        root=tmp_path,
+        workspace_executor=executor,
+        todo_store=store,
+        watchlists_service=watchlists,
+    )
+
+    results = [
+        provider.invoke("local:web_fetch", {"url": "https://example.test"}),
+        provider.invoke("local:web_search", {"query": "topic"}),
+        provider.invoke("local:web_crawl", {"url": "https://example.test"}),
+        provider.invoke("local:todo_create", {"content": "task"}),
+        provider.invoke("local:todo_update", {
+            "id": "1",
+            "expected_version": 1,
+            "status": "completed",
+        }),
+        provider.invoke("local:todo_get", {"id": "1"}),
+        provider.invoke("local:todo_list", {}),
+        provider.invoke("local:watchlists_search_items", {"query": "topic"}),
+        provider.invoke(
+            "local:watchlists_get_item",
+            {"item_id": "local:watchlist_item:1"},
+        ),
+    ]
+
+    assert all(result.ok for result in results)
+    assert executor.calls == []
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    (
+        ("root_pin_failed", LOCAL_ROOT_CHANGED_REFUSAL),
+        ("containment_unavailable", LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL),
+        ("protocol_failure", LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL),
+        ("spawn_failed", LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL),
+    ),
+)
+def test_local_executor_boundary_failures_map_to_pinned_refusals(
+    tmp_path, code, expected
+):
+    executor = RecordingWorkspaceExecutor(error=code)
+
+    result = make_provider(
+        root=tmp_path,
+        workspace_executor=executor,
+    ).invoke("local:fs_list", {"path": "."})
+
+    assert not result.ok and result.outcome == "blocked"
+    assert result.error == expected
+    assert executor.calls == [("fs_list", {"path": "."}, "read")]
+
+
+def test_local_executor_domain_failure_text_is_redacted_and_bounded(tmp_path):
+    private_root = tmp_path / "private-root"
+    private_root.mkdir()
+    executor = RecordingWorkspaceExecutor(
+        error="tool_failure",
+        error_message=f"bounded domain failure: {private_root}/marker " + ("x" * 400),
+    )
+
+    result = make_provider(
+        root=private_root,
+        result_redaction_root=private_root,
+        workspace_executor=executor,
+    ).invoke("local:fs_list", {"path": "."})
+
+    assert not result.ok and result.outcome is None
+    assert str(private_root) not in result.error
+    assert result.error.startswith("bounded domain failure: marker ")
+    assert len(result.error) == 300
 
 
 def test_catalog_lists_default_specs_with_local_ids(tmp_path):
@@ -677,7 +933,7 @@ def test_git_handlers_smoke_against_tmp_repo(git_workspace):
 def test_git_diff_handler_refuses_commit_range_injection(git_workspace):
     p = make_provider(root=git_workspace)
     r = p.invoke("local:git_diff", {"commit_range": "HEAD; rm -rf ."})
-    assert not r.ok and "invalid commit_range" in r.error
+    assert not r.ok and r.error == "workspace operation failed"
 
 
 def test_invoke_happy_path(tmp_path):
@@ -767,7 +1023,7 @@ def test_stamp_scope_isolates_nested_run(tmp_path):
 
 def test_execution_error_becomes_result_string(tmp_path):
     r = make_provider(root=tmp_path).invoke("local:fs_list", {"path": "../escape"})
-    assert not r.ok and "outside the workspace root" in r.error
+    assert not r.ok and r.error == "workspace operation failed (invalid_request)"
 
 
 def test_authority_scope_failure_uses_authority_refusal_not_root_drift(tmp_path):
@@ -801,7 +1057,7 @@ def test_private_root_locator_is_redacted_from_local_tool_errors(tmp_path):
 
     assert not result.ok
     assert str(scratch) not in result.error
-    assert "workspace root (.)" in result.error
+    assert result.error == "workspace operation failed (invalid_request)"
 
 
 def test_private_root_locator_is_redacted_before_error_length_cap(tmp_path):

--- a/Tests/Agents/test_local_tools_integration.py
+++ b/Tests/Agents/test_local_tools_integration.py
@@ -18,10 +18,13 @@ review_tool_calls=hook, review_state_scope=provider.stamp_scope).
 
 import dataclasses
 import json
+from io import BytesIO
 from types import SimpleNamespace
 
 import pytest
 
+import tldw_chatbook.Agents.local_tool_provider as local_tool_provider
+import tldw_chatbook.MCP.local_server_tools as local_server_tools
 from tldw_chatbook.Agents.agent_models import (
     DIRECT_DISCLOSE_THRESHOLD,
     RUN_DONE,
@@ -50,6 +53,39 @@ from tldw_chatbook.MCP.permission_store import (
     EffectiveToolState,
     resolve_effective_state,
 )
+from tldw_chatbook.Tools.workspace_tool_executor import (
+    WorkspaceToolExecutionError,
+    WorkspaceToolExecutor,
+)
+from tldw_chatbook.Tools.workspace_tool_protocol import WorkspaceToolResponse
+from tldw_chatbook.Tools.workspace_tool_worker import run_workspace_worker
+
+
+class InProcessWorkspaceExecutor:
+    """Test-only real worker dispatch for linked checkouts not importable under -I."""
+
+    def __init__(self, workspace_root):
+        self._executor = WorkspaceToolExecutor(workspace_root)
+
+    def execute(self, operation, arguments, *, intent):
+        request = self._executor._build_request(operation, arguments, intent=intent)
+        stdout = BytesIO()
+        run_workspace_worker(BytesIO(request.to_bytes()), stdout, BytesIO())
+        response = WorkspaceToolResponse.from_bytes(
+            stdout.getvalue().splitlines()[-1],
+            expected_operation_id=request.operation_id,
+        )
+        if response.outcome != "success":
+            raise WorkspaceToolExecutionError(response.code, response.error)
+        return response.result or ""
+
+
+def _test_default_specs(workspace, **kwargs):
+    return _default_specs(
+        workspace,
+        workspace_executor=InProcessWorkspaceExecutor(workspace),
+        **kwargs,
+    )
 
 
 def fence(name, args):
@@ -97,6 +133,56 @@ def workspace(tmp_path):
     return root
 
 
+def test_external_mcp_fs_read_uses_the_pinned_workspace_executor(
+    workspace, monkeypatch
+):
+    calls: list[tuple[str, dict, str]] = []
+
+    class RecordingWorkspaceExecutor:
+        def __init__(self, workspace_root):
+            assert workspace_root == workspace.resolve()
+
+        def execute(self, operation, arguments, *, intent):
+            calls.append((operation, dict(arguments), intent))
+            return "leased external read"
+
+    class PermissionStore:
+        def load(self):
+            return {}
+
+        def get_kill_switch(self):
+            return False
+
+    monkeypatch.setattr(
+        local_tool_provider,
+        "WorkspaceToolExecutor",
+        RecordingWorkspaceExecutor,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        local_server_tools,
+        "resolve_effective_state",
+        lambda _payload, _hub: EffectiveToolState(
+            state="allow",
+            origin="tool_override",
+        ),
+    )
+    provider = local_server_tools.build_server_local_provider(
+        workspace,
+        PermissionStore(),
+    )
+    registration = next(
+        item
+        for item in local_server_tools._local_agent_tool_registrations(provider)
+        if item.name == "fs_read"
+    )
+
+    result = registration.handler({"path": "notes.txt"})
+
+    assert result.ok and result.content == "leased external read"
+    assert calls == [("fs_read", {"path": "notes.txt"}, "read")]
+
+
 def make_service(
     db,
     workspace,
@@ -123,7 +209,7 @@ def make_service(
     base = (
         list(specs)
         if specs is not None
-        else _default_specs(
+        else _test_default_specs(
             workspace,
             todo_store=todo_store,
             watchlists_service=watchlists_service,
@@ -281,7 +367,7 @@ def fs_only_specs(workspace):
     """The original 6 fs_* specs (fs_patch and later tools deliberately
     excluded): 6 local + 2 builtin = 8 entries, comfortably under the
     direct-disclosure threshold."""
-    return [s for s in _default_specs(workspace) if s.name in FS_TOOL_NAMES]
+    return [s for s in _test_default_specs(workspace) if s.name in FS_TOOL_NAMES]
 
 
 def _padding_specs(count: int):
@@ -300,7 +386,7 @@ def _padding_specs(count: int):
 
 
 def production_registry(workspace, extra_specs=(), specs=None):
-    base = list(specs) if specs is not None else _default_specs(workspace)
+    base = list(specs) if specs is not None else _test_default_specs(workspace)
     registry = ToolCatalogRegistry()
     registry.register_provider(BuiltinToolProvider())
     registry.register_provider(
@@ -503,7 +589,7 @@ def test_find_load_path_executes_web_fetch_after_approve_once(db, workspace):
 
     specs = [
         dataclasses.replace(s, handler=fake_fetch) if s.name == "web_fetch" else s
-        for s in _default_specs(workspace)
+        for s in _test_default_specs(workspace)
     ]
     approval_calls = []
     service, chat = make_service(
@@ -594,7 +680,7 @@ def test_todo_create_mutates_session_store_after_approve_once(db, workspace):
     pinned by test_allow_state_executes_without_approval_round_trip."""
     todo_store = SessionTodoStore()
     assert "todo_write" not in {
-        spec.name for spec in _default_specs(workspace, todo_store=todo_store)
+        spec.name for spec in _test_default_specs(workspace, todo_store=todo_store)
     }
     create_args = {
         "content": "Write the report",
@@ -805,7 +891,7 @@ def test_find_load_path_executes_git_log_after_approve_once(db, workspace):
 
     specs = [
         dataclasses.replace(s, handler=fake_log) if s.name == "git_log" else s
-        for s in _default_specs(workspace)
+        for s in _test_default_specs(workspace)
     ]
     approval_calls = []
     service, chat = make_service(

--- a/Tests/Agents/test_virtual_cli_provider.py
+++ b/Tests/Agents/test_virtual_cli_provider.py
@@ -1,3 +1,5 @@
+import os
+from io import BytesIO
 from pathlib import Path
 
 import pytest
@@ -21,7 +23,12 @@ from tldw_chatbook.Agents.virtual_cli_provider import (
 )
 from tldw_chatbook.MCP.permission_store import EffectiveToolState, definition_hash
 from tldw_chatbook.Tools.virtual_cli_impls import VIRTUAL_CLI_COMMANDS
-from tldw_chatbook.Tools.workspace_tool_executor import WorkspaceToolExecutionError
+from tldw_chatbook.Tools.workspace_tool_executor import (
+    WorkspaceToolExecutionError,
+    WorkspaceToolExecutor,
+)
+from tldw_chatbook.Tools.workspace_tool_protocol import WorkspaceToolResponse
+from tldw_chatbook.Tools.workspace_tool_worker import run_workspace_worker
 
 ALLOW = EffectiveToolState(state="allow", origin="tool_override")
 ASK = EffectiveToolState(state="ask", origin="global_default")
@@ -45,6 +52,23 @@ class RecordingWorkspaceExecutor:
         if self.error is not None:
             raise WorkspaceToolExecutionError(self.error, self.error_message)
         return self.result
+
+
+class InProcessWorkspaceExecutor:
+    def __init__(self, workspace_root: Path) -> None:
+        self._executor = WorkspaceToolExecutor(workspace_root)
+
+    def execute(self, operation: str, arguments: dict, *, intent: str) -> str:
+        request = self._executor._build_request(operation, arguments, intent=intent)
+        stdout = BytesIO()
+        run_workspace_worker(BytesIO(request.to_bytes()), stdout, BytesIO())
+        response = WorkspaceToolResponse.from_bytes(
+            stdout.getvalue().splitlines()[-1],
+            expected_operation_id=request.operation_id,
+        )
+        if response.outcome != "success":
+            raise WorkspaceToolExecutionError(response.code, response.error)
+        return response.result or ""
 
 
 def make_provider(tmp_path: Path, state=ASK, **kwargs) -> VirtualCliProvider:
@@ -170,6 +194,54 @@ def test_virtual_cli_root_guard_refuses_as_root_drift_before_executor(tmp_path):
     assert not result.ok and result.outcome == "blocked"
     assert result.error == LOCAL_ROOT_CHANGED_REFUSAL
     assert executor.calls == []
+
+
+def test_virtual_cli_refuses_root_replaced_after_second_guard(tmp_path):
+    locator = tmp_path / "workspace"
+    locator.mkdir()
+    (locator / "sentinel.txt").write_bytes(b"A_ONLY")
+    retained = tmp_path / "retained-a"
+    calls = 0
+
+    def replace_after_second_guard() -> bool:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            os.replace(locator, retained)
+            locator.mkdir()
+            (locator / "sentinel.txt").write_bytes(b"B_BYTE_EXACT\x00\xff")
+        return True
+
+    provider = make_provider(
+        locator,
+        state=ALLOW,
+        root_guard=replace_after_second_guard,
+        use_default_executor=True,
+    )
+
+    result = provider.invoke(
+        "virtual_cli", {"command": "cat", "argv": ["sentinel.txt"]}
+    )
+
+    assert calls == 2
+    assert not result.ok and result.outcome == "blocked"
+    assert result.error == LOCAL_ROOT_CHANGED_REFUSAL
+    assert (locator / "sentinel.txt").read_bytes() == b"B_BYTE_EXACT\x00\xff"
+
+
+def test_virtual_cli_preserves_bounded_domain_failure_text(tmp_path):
+    provider = make_provider(
+        tmp_path,
+        state=ALLOW,
+        workspace_executor=InProcessWorkspaceExecutor(tmp_path),
+    )
+
+    result = provider.invoke(
+        "virtual_cli", {"command": "cat", "argv": ["missing.txt"]}
+    )
+
+    assert not result.ok and result.outcome is None
+    assert result.error == "file not found: missing.txt"
 
 
 def test_tool_call_id_context_is_nested_and_restored():

--- a/Tests/Agents/test_virtual_cli_provider.py
+++ b/Tests/Agents/test_virtual_cli_provider.py
@@ -3,7 +3,12 @@ from pathlib import Path
 import pytest
 from loguru import logger
 
+import tldw_chatbook.Agents.virtual_cli_provider as virtual_cli_provider
 from tldw_chatbook.Agents.agent_models import ToolCall
+from tldw_chatbook.Agents.local_tool_provider import (
+    LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL,
+    LOCAL_ROOT_CHANGED_REFUSAL,
+)
 from tldw_chatbook.Agents.run_context import (
     current_tool_call_id,
     use_run_id,
@@ -16,16 +21,39 @@ from tldw_chatbook.Agents.virtual_cli_provider import (
 )
 from tldw_chatbook.MCP.permission_store import EffectiveToolState, definition_hash
 from tldw_chatbook.Tools.virtual_cli_impls import VIRTUAL_CLI_COMMANDS
+from tldw_chatbook.Tools.workspace_tool_executor import WorkspaceToolExecutionError
 
 ALLOW = EffectiveToolState(state="allow", origin="tool_override")
 ASK = EffectiveToolState(state="ask", origin="global_default")
 DENY = EffectiveToolState(state="deny", origin="tool_override")
 
 
+class RecordingWorkspaceExecutor:
+    def __init__(
+        self,
+        result: str = "1\thello",
+        error: str | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        self.result = result
+        self.error = error
+        self.error_message = error_message
+        self.calls: list[tuple[str, dict, str]] = []
+
+    def execute(self, operation: str, arguments: dict, *, intent: str) -> str:
+        self.calls.append((operation, dict(arguments), intent))
+        if self.error is not None:
+            raise WorkspaceToolExecutionError(self.error, self.error_message)
+        return self.result
+
+
 def make_provider(tmp_path: Path, state=ASK, **kwargs) -> VirtualCliProvider:
+    use_default_executor = kwargs.pop("use_default_executor", False)
     kwargs.setdefault("resolve_state", lambda _hub: state)
     kwargs.setdefault("local_tools_enabled", lambda: True)
     kwargs.setdefault("kill_switch", lambda: False)
+    if not use_default_executor:
+        kwargs.setdefault("workspace_executor", RecordingWorkspaceExecutor())
     return VirtualCliProvider(workspace_root=tmp_path, **kwargs)
 
 
@@ -45,6 +73,103 @@ def test_provider_exposes_one_structured_model_tool(tmp_path):
     assert schema.parameters["properties"]["argv"]["type"] == "array"
     assert "shell" not in schema.parameters["properties"]
     assert "command_line" not in schema.parameters["properties"]
+
+
+def test_provider_constructs_and_injects_real_executor_by_default(
+    tmp_path, monkeypatch
+):
+    constructed: list[Path] = []
+
+    class RecordingFactory(RecordingWorkspaceExecutor):
+        def __init__(self, workspace_root: Path) -> None:
+            constructed.append(workspace_root)
+            super().__init__(result="leased-result")
+
+    monkeypatch.setattr(
+        virtual_cli_provider,
+        "WorkspaceToolExecutor",
+        RecordingFactory,
+        raising=False,
+    )
+
+    result = make_provider(tmp_path, state=ALLOW, use_default_executor=True).invoke(
+        "virtual_cli",
+        {"command": "ls", "argv": ["."]},
+    )
+
+    assert result.ok and result.content == "leased-result"
+    assert constructed == [tmp_path]
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    (
+        ("root_pin_failed", LOCAL_ROOT_CHANGED_REFUSAL),
+        ("containment_unavailable", LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL),
+        ("protocol_failure", LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL),
+        ("spawn_failed", LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL),
+    ),
+)
+def test_virtual_cli_executor_boundary_failures_map_to_pinned_refusals(
+    tmp_path, code, expected
+):
+    executor = RecordingWorkspaceExecutor(error=code)
+    provider = make_provider(
+        tmp_path,
+        state=ALLOW,
+        workspace_executor=executor,
+    )
+
+    result = provider.invoke(
+        "virtual_cli",
+        {"command": "ls", "argv": ["."]},
+    )
+
+    assert not result.ok and result.outcome == "blocked"
+    assert result.error == expected
+    assert executor.calls == [("fs_list", {"path": "."}, "read")]
+
+
+def test_virtual_cli_domain_failure_text_is_redacted_and_bounded(tmp_path):
+    executor = RecordingWorkspaceExecutor(
+        error="invalid_request",
+        error_message=f"bounded domain failure: {tmp_path}/marker " + ("x" * 400),
+    )
+    provider = make_provider(
+        tmp_path,
+        state=ALLOW,
+        workspace_executor=executor,
+        result_redaction_root=tmp_path,
+    )
+
+    result = provider.invoke(
+        "virtual_cli",
+        {"command": "ls", "argv": ["."]},
+    )
+
+    assert not result.ok and result.outcome is None
+    assert str(tmp_path) not in result.error
+    assert result.error.startswith("bounded domain failure: marker ")
+    assert len(result.error) == 300
+
+
+def test_virtual_cli_root_guard_refuses_as_root_drift_before_executor(tmp_path):
+    executor = RecordingWorkspaceExecutor()
+    provider = make_provider(
+        tmp_path,
+        state=ALLOW,
+        workspace_executor=executor,
+        root_guard=lambda: False,
+    )
+
+    result = provider.invoke(
+        "virtual_cli",
+        {"command": "ls", "argv": ["."]},
+    )
+
+    assert not result.ok and result.outcome == "blocked"
+    assert result.error == LOCAL_ROOT_CHANGED_REFUSAL
+    assert executor.calls == []
 
 
 def test_tool_call_id_context_is_nested_and_restored():

--- a/Tests/CI/test_task19637_platform_evidence.py
+++ b/Tests/CI/test_task19637_platform_evidence.py
@@ -9,6 +9,7 @@ import yaml
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPOSITORY_ROOT / ".github/workflows/task-19637-platform-evidence.yml"
+JUNIT_PATH = "${{ runner.temp }}/task-19637-platform-junit.xml"
 
 EXPECTED_NODES = (
     "Tests/Tools/test_workspace_root_pin.py::test_root_replacement_before_pin_is_refused_by_identity",
@@ -98,7 +99,8 @@ def test_workflow_runs_each_bounded_named_node_once_and_emits_junit() -> None:
     for node in EXPECTED_NODES:
         assert command.split().count(node) == 1
     assert command.count("Tests/") == len(EXPECTED_NODES)
-    assert '--junitxml="$RUNNER_TEMP/task-19637-platform-junit.xml"' in command
+    assert f'--junitxml="{JUNIT_PATH}"' in command
+    assert "$RUNNER_TEMP" not in command
     assert "--tb=short" in command
     assert "continue-on-error" not in run_step
     assert "if" not in run_step
@@ -119,8 +121,9 @@ def test_workflow_uploads_junit_on_failure_without_masking_test_failure() -> Non
         "uses": "actions/upload-artifact@v4",
         "with": {
             "name": "task-19637-platform-evidence-${{ matrix.os }}",
-            "path": "${{ runner.temp }}/task-19637-platform-junit.xml",
+            "path": JUNIT_PATH,
             "if-no-files-found": "error",
         },
     }
+    assert f'--junitxml="{upload["with"]["path"]}"' in run_step["run"]
     assert "if" not in run_step

--- a/Tests/CI/test_task19637_platform_evidence.py
+++ b/Tests/CI/test_task19637_platform_evidence.py
@@ -19,6 +19,7 @@ EXPECTED_NODES = (
     "Tests/Tools/test_workspace_tool_executor.py::test_timeout_terminates_the_tree_and_returns_no_in_process_result",
     "Tests/Tools/test_workspace_tool_executor.py::test_crash_and_bounded_stderr_return_only_fixed_metadata",
     "Tests/Tools/test_workspace_tool_executor.py::test_platform_evidence_representative_one_shot_operations",
+    "Tests/Tools/test_workspace_tool_executor.py::test_platform_evidence_outer_executor_git_ignores_workspace_path",
     "Tests/Tools/test_workspace_tool_executor.py::test_pinned_git_supports_linked_worktree_without_granting_metadata_fs_access",
     "Tests/Agents/test_local_tool_provider.py::test_each_local_workspace_tool_routes_once_through_injected_executor",
     "Tests/Agents/test_virtual_cli_provider.py::test_provider_constructs_and_injects_real_executor_by_default",

--- a/Tests/CI/test_task19637_platform_evidence.py
+++ b/Tests/CI/test_task19637_platform_evidence.py
@@ -46,11 +46,11 @@ def _step(name: str) -> dict[str, object]:
     return matches[0]
 
 
-def test_workflow_has_only_labeled_pr_and_manual_triggers_with_read_only_permissions() -> None:
+def test_workflow_retests_labeled_pr_updates_with_read_only_permissions() -> None:
     workflow = _workflow()
 
     assert workflow["on"] == {
-        "pull_request": {"types": ["labeled"]},
+        "pull_request": {"types": ["labeled", "synchronize"]},
         "workflow_dispatch": "",
     }
     assert workflow["permissions"] == {"contents": "read"}
@@ -69,7 +69,8 @@ def test_workflow_pins_exact_matrix_python_head_and_job_bound() -> None:
 
     assert job["if"] == (
         "github.event_name == 'workflow_dispatch' || "
-        "github.event.label.name == 'task-19637-platform-evidence'"
+        "contains(github.event.pull_request.labels.*.name, "
+        "'task-19637-platform-evidence')"
     )
     assert job["timeout-minutes"] == "30"
     assert job["strategy"] == {

--- a/Tests/CI/test_task19637_platform_evidence.py
+++ b/Tests/CI/test_task19637_platform_evidence.py
@@ -1,0 +1,126 @@
+"""Contract tests for TASK-19637's bounded cross-platform evidence workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github/workflows/task-19637-platform-evidence.yml"
+
+EXPECTED_NODES = (
+    "Tests/Tools/test_workspace_root_pin.py::test_root_replacement_before_pin_is_refused_by_identity",
+    "Tests/Tools/test_workspace_root_pin.py::test_root_replacement_after_pin_never_redirects_relative_io",
+    "Tests/Tools/test_workspace_root_pin.py::test_root_replacement_after_pin_never_redirects_relative_write",
+    "Tests/Tools/test_workspace_tool_executor.py::test_executor_uses_fixed_private_launch_and_admits_before_stdin",
+    "Tests/Tools/test_workspace_tool_executor.py::test_timeout_terminates_the_tree_and_returns_no_in_process_result",
+    "Tests/Tools/test_workspace_tool_executor.py::test_crash_and_bounded_stderr_return_only_fixed_metadata",
+    "Tests/Tools/test_workspace_tool_executor.py::test_platform_evidence_representative_one_shot_operations",
+    "Tests/Tools/test_workspace_tool_executor.py::test_pinned_git_supports_linked_worktree_without_granting_metadata_fs_access",
+    "Tests/Agents/test_local_tool_provider.py::test_each_local_workspace_tool_routes_once_through_injected_executor",
+    "Tests/Agents/test_virtual_cli_provider.py::test_provider_constructs_and_injects_real_executor_by_default",
+)
+
+
+def _workflow() -> dict[str, object]:
+    return yaml.load(WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _steps() -> list[dict[str, object]]:
+    workflow = _workflow()
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    job = jobs["platform-evidence"]
+    assert isinstance(job, dict)
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    return steps
+
+
+def _step(name: str) -> dict[str, object]:
+    matches = [step for step in _steps() if step.get("name") == name]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def test_workflow_has_only_labeled_pr_and_manual_triggers_with_read_only_permissions() -> None:
+    workflow = _workflow()
+
+    assert workflow["on"] == {
+        "pull_request": {"types": ["labeled"]},
+        "workflow_dispatch": "",
+    }
+    assert workflow["permissions"] == {"contents": "read"}
+    serialized = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "secrets." not in serialized
+    assert ": write" not in serialized
+
+
+def test_workflow_pins_exact_matrix_python_head_and_job_bound() -> None:
+    workflow = _workflow()
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    assert set(jobs) == {"platform-evidence"}
+    job = jobs["platform-evidence"]
+    assert isinstance(job, dict)
+
+    assert job["if"] == (
+        "github.event_name == 'workflow_dispatch' || "
+        "github.event.label.name == 'task-19637-platform-evidence'"
+    )
+    assert job["timeout-minutes"] == "30"
+    assert job["strategy"] == {
+        "fail-fast": "false",
+        "matrix": {
+            "os": ["ubuntu-24.04", "windows-2022", "macos-15-intel"]
+        },
+    }
+    assert job["runs-on"] == "${{ matrix.os }}"
+
+    checkout = _step("Check out the exact tested commit")
+    assert checkout["uses"] == "actions/checkout@v4"
+    assert checkout["with"] == {
+        "ref": "${{ github.event.pull_request.head.sha || github.sha }}"
+    }
+    setup = _step("Set up Python 3.12")
+    assert setup["uses"] == "actions/setup-python@v5"
+    assert setup["with"] == {"python-version": "3.12"}
+
+
+def test_workflow_runs_each_bounded_named_node_once_and_emits_junit() -> None:
+    run_step = _step("Run bounded pinned-workspace evidence")
+    command = run_step["run"]
+    assert isinstance(command, str)
+
+    assert "python -m pytest" in command
+    for node in EXPECTED_NODES:
+        assert command.split().count(node) == 1
+    assert command.count("Tests/") == len(EXPECTED_NODES)
+    assert '--junitxml="$RUNNER_TEMP/task-19637-platform-junit.xml"' in command
+    assert "--tb=short" in command
+    assert "continue-on-error" not in run_step
+    assert "if" not in run_step
+
+
+def test_workflow_uploads_junit_on_failure_without_masking_test_failure() -> None:
+    serialized = WORKFLOW_PATH.read_text(encoding="utf-8")
+    install = _step("Install test dependencies")
+    run_step = _step("Run bounded pinned-workspace evidence")
+    upload = _step("Upload JUnit evidence")
+
+    assert install["run"] == 'python -m pip install -e ".[dev]"'
+    assert "continue-on-error" not in serialized
+    assert "|| true" not in serialized
+    assert upload == {
+        "name": "Upload JUnit evidence",
+        "if": "always()",
+        "uses": "actions/upload-artifact@v4",
+        "with": {
+            "name": "task-19637-platform-evidence-${{ matrix.os }}",
+            "path": "${{ runner.temp }}/task-19637-platform-junit.xml",
+            "if-no-files-found": "error",
+        },
+    }
+    assert "if" not in run_step

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -9,6 +9,7 @@ import os
 import threading
 import time
 from dataclasses import replace
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -116,12 +117,37 @@ from tldw_chatbook.Agents.tool_catalog import (
 from tldw_chatbook.Agents.local_tool_provider import LocalToolProvider, _default_specs
 from tldw_chatbook.Agents.project_instruction_resolver import ProjectInstructionResolver
 from tldw_chatbook.MCP.permission_store import EffectiveToolState
+from tldw_chatbook.Tools.workspace_tool_executor import (
+    WorkspaceToolExecutionError,
+    WorkspaceToolExecutor,
+)
+from tldw_chatbook.Tools.workspace_tool_protocol import WorkspaceToolResponse
+from tldw_chatbook.Tools.workspace_tool_worker import run_workspace_worker
 from tldw_chatbook.Persona_Buddy.console_adapter import PersonaBuddyConsoleAdapter
 from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
 from tldw_chatbook.Skills_Interop.skill_trust_models import SkillTrustBlockedError
 from tldw_chatbook.Workspaces.change_turn_tracker import TurnChangeRecord
 
 from Tests.Agents.test_agent_service import SUBAGENT_PROMPT_PREFIX
+
+
+class _InProcessWorkspaceExecutor:
+    """Exercise the real worker contract without an isolated child import."""
+
+    def __init__(self, workspace_root: Path) -> None:
+        self._executor = WorkspaceToolExecutor(workspace_root)
+
+    def execute(self, operation: str, arguments: dict, *, intent: str) -> str:
+        request = self._executor._build_request(operation, arguments, intent=intent)
+        stdout = BytesIO()
+        run_workspace_worker(BytesIO(request.to_bytes()), stdout, BytesIO())
+        response = WorkspaceToolResponse.from_bytes(
+            stdout.getvalue().splitlines()[-1],
+            expected_operation_id=request.operation_id,
+        )
+        if response.outcome != "success":
+            raise WorkspaceToolExecutionError(response.code, response.error)
+        return response.result or ""
 
 
 @pytest.fixture(autouse=True)
@@ -551,7 +577,11 @@ def test_nested_project_instructions_defer_whole_batch_before_review_and_executi
     local = LocalToolProvider(
         workspace_root=root,
         specs=[
-            spec for spec in _default_specs(root) if spec.name in {"fs_read", "fs_list"}
+            spec
+            for spec in _default_specs(
+                root, workspace_executor=_InProcessWorkspaceExecutor(root)
+            )
+            if spec.name in {"fs_read", "fs_list"}
         ],
         resolve_state=lambda _tool: EffectiveToolState(
             state="allow", origin="global_default"
@@ -616,7 +646,13 @@ def test_fenced_nested_delivery_counts_exact_transformed_payload_before_mark(
     )
     local = LocalToolProvider(
         workspace_root=root,
-        specs=[spec for spec in _default_specs(root) if spec.name == "fs_read"],
+        specs=[
+            spec
+            for spec in _default_specs(
+                root, workspace_executor=_InProcessWorkspaceExecutor(root)
+            )
+            if spec.name == "fs_read"
+        ],
         resolve_state=lambda _tool: EffectiveToolState(
             state="allow", origin="global_default"
         ),
@@ -727,7 +763,13 @@ def test_nested_resolution_rejects_backdated_root_replacement_after_consent(tmp_
     )
     local = LocalToolProvider(
         workspace_root=root,
-        specs=[spec for spec in _default_specs(root) if spec.name == "fs_read"],
+        specs=[
+            spec
+            for spec in _default_specs(
+                root, workspace_executor=_InProcessWorkspaceExecutor(root)
+            )
+            if spec.name == "fs_read"
+        ],
         resolve_state=lambda _tool: EffectiveToolState(
             state="allow", origin="global_default"
         ),
@@ -805,7 +847,13 @@ def test_parent_and_child_share_activation_but_each_receive_nested_revision(
     )
     local = LocalToolProvider(
         workspace_root=root,
-        specs=[spec for spec in _default_specs(root) if spec.name == "fs_read"],
+        specs=[
+            spec
+            for spec in _default_specs(
+                root, workspace_executor=_InProcessWorkspaceExecutor(root)
+            )
+            if spec.name == "fs_read"
+        ],
         resolve_state=lambda _tool: EffectiveToolState(
             state="allow", origin="global_default"
         ),

--- a/Tests/Chat/test_console_agent_bridge_local.py
+++ b/Tests/Chat/test_console_agent_bridge_local.py
@@ -44,6 +44,7 @@ from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
 from Tests.Agents.test_agent_service import FleetChat
 from tldw_chatbook.MCP.permission_store import EffectiveToolState
+from tldw_chatbook.Tools.workspace_tool_executor import WorkspaceToolExecutor
 
 
 def test_run_registry_includes_local_tools(tmp_path):
@@ -283,7 +284,10 @@ def test_skill_run_child_still_approval_gated(tmp_path):
     workspace.mkdir()
     specs = [
         dataclasses.replace(s, handler=fake_fetch)
-        for s in _default_specs(workspace)
+        for s in _default_specs(
+            workspace,
+            workspace_executor=WorkspaceToolExecutor(workspace),
+        )
         if s.name == "web_fetch"
     ]
     provider = LocalToolProvider(

--- a/Tests/Chat/test_console_project_instruction_persistence_boundary.py
+++ b/Tests/Chat/test_console_project_instruction_persistence_boundary.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import time
+from io import BytesIO
+from pathlib import Path
 
 from loguru import logger
 
@@ -24,12 +26,37 @@ from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Chat.console_provider_gateway import ProviderToolCalls
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 from tldw_chatbook.MCP.permission_store import EffectiveToolState
+from tldw_chatbook.Tools.workspace_tool_executor import (
+    WorkspaceToolExecutionError,
+    WorkspaceToolExecutor,
+)
+from tldw_chatbook.Tools.workspace_tool_protocol import WorkspaceToolResponse
+from tldw_chatbook.Tools.workspace_tool_worker import run_workspace_worker
 
 
 SENTINEL = "CHATBOOK_AGENTS_SENTINEL_7d1e9c"
 EXPLICIT_READ = "EXPLICIT_AGENTS_READ_RETAINS_CONTENT"
 MODEL_QUOTATION = "MODEL_QUOTATION_RETAINS_CONTENT"
 CALLBACK_SENTINEL = "CALLBACK_FAILURE_SECRET_/private/project/AGENTS.md"
+
+
+class _InProcessWorkspaceExecutor:
+    """Exercise the real worker contract without an isolated child import."""
+
+    def __init__(self, workspace_root: Path) -> None:
+        self._executor = WorkspaceToolExecutor(workspace_root)
+
+    def execute(self, operation: str, arguments: dict, *, intent: str) -> str:
+        request = self._executor._build_request(operation, arguments, intent=intent)
+        stdout = BytesIO()
+        run_workspace_worker(BytesIO(request.to_bytes()), stdout, BytesIO())
+        response = WorkspaceToolResponse.from_bytes(
+            stdout.getvalue().splitlines()[-1],
+            expected_operation_id=request.operation_id,
+        )
+        if response.outcome != "success":
+            raise WorkspaceToolExecutionError(response.code, response.error)
+        return response.result or ""
 
 
 class _Resolution:
@@ -95,7 +122,13 @@ def test_automatic_nested_body_is_absent_from_every_durable_and_diagnostic_surfa
     )
     local = LocalToolProvider(
         workspace_root=root,
-        specs=[spec for spec in _default_specs(root) if spec.name == "fs_read"],
+        specs=[
+            spec
+            for spec in _default_specs(
+                root, workspace_executor=_InProcessWorkspaceExecutor(root)
+            )
+            if spec.name == "fs_read"
+        ],
         resolve_state=lambda _tool: EffectiveToolState(
             state="allow", origin="global_default"
         ),
@@ -178,7 +211,13 @@ def test_activation_callback_failure_is_content_free_and_does_not_block_provider
     )
     local = LocalToolProvider(
         workspace_root=root,
-        specs=[spec for spec in _default_specs(root) if spec.name == "fs_read"],
+        specs=[
+            spec
+            for spec in _default_specs(
+                root, workspace_executor=_InProcessWorkspaceExecutor(root)
+            )
+            if spec.name == "fs_read"
+        ],
         resolve_state=lambda _tool: EffectiveToolState(
             state="allow", origin="global_default"
         ),

--- a/Tests/MCP/test_local_server_tools.py
+++ b/Tests/MCP/test_local_server_tools.py
@@ -16,6 +16,7 @@ import time
 import pytest
 from loguru import logger
 
+import tldw_chatbook.Agents.local_tool_provider as local_tool_provider
 from tldw_chatbook.Agents.agent_models import ToolResult
 from tldw_chatbook.Agents.local_tool_provider import (
     LOCAL_DENY_REFUSAL,
@@ -40,6 +41,28 @@ from tldw_chatbook.runtime_policy.types import RuntimeSourceState
 
 BUILTIN_TOOL_NAMES = [descriptor["name"] for descriptor in _describe_local_tools()]
 TASK_TOOL_NAMES = {"todo_create", "todo_update", "todo_get", "todo_list"}
+
+
+class RecordingWorkspaceExecutor:
+    """Protocol-shaped executor fake for MCP admission/effect tests."""
+
+    def __init__(self, result="hello world\n"):
+        self.result = result
+        self.calls = []
+
+    def execute(self, operation, arguments, *, intent):
+        self.calls.append((operation, dict(arguments), intent))
+        return self.result
+
+
+def _provider_with_recording_executor(monkeypatch, workspace, store):
+    executor = RecordingWorkspaceExecutor()
+    monkeypatch.setattr(
+        local_tool_provider,
+        "WorkspaceToolExecutor",
+        lambda workspace_root: executor,
+    )
+    return build_server_local_provider(workspace, store), executor
 
 
 def _pin_runtime_source(monkeypatch, source):
@@ -100,11 +123,14 @@ def _grant(store, provider, name):
     )
 
 
-def test_granted_tool_executes(workspace, store):
-    provider = build_server_local_provider(workspace, store)
+def test_granted_tool_executes(monkeypatch, workspace, store):
+    provider, executor = _provider_with_recording_executor(
+        monkeypatch, workspace, store
+    )
     _grant(store, provider, "fs_read")
     r = provider.invoke("local:fs_read", {"path": "hello.txt"})
     assert r.ok and "hello world" in r.content
+    assert executor.calls == [("fs_read", {"path": "hello.txt"}, "read")]
 
 
 def test_default_ask_fails_closed_with_external_refusal(workspace, store):
@@ -188,16 +214,19 @@ def test_deny_state_refuses(workspace, store):
     assert not r.ok and r.error == LOCAL_DENY_REFUSAL
 
 
-def test_resolve_state_reads_store_fresh_per_call(workspace, store):
+def test_resolve_state_reads_store_fresh_per_call(monkeypatch, workspace, store):
     # Operator changes take effect immediately: grant -> executes, revoke
     # -> fails closed, all against the same composed provider.
-    provider = build_server_local_provider(workspace, store)
+    provider, executor = _provider_with_recording_executor(
+        monkeypatch, workspace, store
+    )
     _grant(store, provider, "fs_read")
     assert provider.invoke("local:fs_read", {"path": "hello.txt"}).ok
     hub = provider.hub_tool_for("fs_read")
     store.set_tool_state(hub.server_key, hub.name, None)  # operator revokes
     r = provider.invoke("local:fs_read", {"path": "hello.txt"})
     assert not r.ok and r.error == EXTERNAL_NO_CALLBACK_REFUSAL
+    assert executor.calls == [("fs_read", {"path": "hello.txt"}, "read")]
 
 
 def test_session_task_tools_absent_from_external_catalog(workspace, store):
@@ -495,8 +524,10 @@ def _registrations(provider):
     return {r.name: r for r in _local_agent_tool_registrations(provider)}
 
 
-def test_granted_tool_registration_handler_executes(workspace, store):
-    provider = build_server_local_provider(workspace, store)
+def test_granted_tool_registration_handler_executes(monkeypatch, workspace, store):
+    provider, executor = _provider_with_recording_executor(
+        monkeypatch, workspace, store
+    )
     _grant(store, provider, "fs_read")
     regs = _registrations(provider)
     assert "fs_read" in regs
@@ -507,6 +538,7 @@ def test_granted_tool_registration_handler_executes(workspace, store):
     result = reg.handler({"path": "hello.txt"})
     assert isinstance(result, ToolResult)
     assert result.ok and "hello world" in result.content
+    assert executor.calls == [("fs_read", {"path": "hello.txt"}, "read")]
 
 
 def test_ask_state_handler_returns_tool_result(workspace, store):

--- a/Tests/Performance/run_workspace_tool_executor_profile.py
+++ b/Tests/Performance/run_workspace_tool_executor_profile.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import ntpath
 import os
 import platform as platform_module
 import shutil
 import site
 import statistics
 import subprocess
+import sys
 import tempfile
 import time
 import venv
@@ -20,6 +22,7 @@ from typing import Any, Literal
 
 OPERATIONS = ("stat", "read", "write", "list", "git_status", "git_diff")
 _ISOLATED_RUNTIME_MARKER = "TLDW_TASK19637_PROFILE_RUNTIME"
+_CHILD_FAILURE_DIAGNOSTIC = "isolated profile child failed"
 _MODE = Literal["direct", "one_shot"]
 _Clock = Callable[[], float]
 _SampleRunner = Callable[[Path, str, _MODE, int], None]
@@ -249,42 +252,73 @@ def _isolated_runtime_python(runtime_root: Path) -> Path:
     return runtime_python
 
 
+def _isolated_environment(
+    runtime_root: Path,
+    *,
+    platform_name: str | None = None,
+    source_environment: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Build the minimal child environment around one temporary profile."""
+    source = os.environ if source_environment is None else source_environment
+    platform_name = os.name if platform_name is None else platform_name
+    home = runtime_root / "home"
+    config = runtime_root / "config"
+    data = runtime_root / "data"
+    home.mkdir()
+    config.mkdir()
+    data.mkdir()
+    home_text = str(home)
+    environment = {
+        "PATH": source.get("PATH", os.defpath),
+        "HOME": home_text,
+        "XDG_CONFIG_HOME": str(config),
+        "XDG_DATA_HOME": str(data),
+        "TLDW_CONFIG_PATH": str(config / "config.toml"),
+        _ISOLATED_RUNTIME_MARKER: "1",
+    }
+    if platform_name == "nt":
+        home_drive, home_path = ntpath.splitdrive(home_text)
+        environment.update(
+            {
+                "USERPROFILE": home_text,
+                "HOMEDRIVE": home_drive,
+                "HOMEPATH": home_path,
+            }
+        )
+    for name in ("LANG", "LC_ALL", "SYSTEMROOT", "WINDIR", "TEMP", "TMP"):
+        if value := source.get(name):
+            environment[name] = value
+    return environment
+
+
 def _run_isolated(args: argparse.Namespace) -> int:
     """Run the profiler under an isolated profile before application import."""
     with tempfile.TemporaryDirectory(prefix="tldw-workspace-profile-runtime-") as raw:
         runtime_root = Path(raw)
         runtime_python = _isolated_runtime_python(runtime_root)
-        home = runtime_root / "home"
-        config = runtime_root / "config"
-        data = runtime_root / "data"
-        home.mkdir()
-        config.mkdir()
-        data.mkdir()
-        environment = {
-            "PATH": os.environ.get("PATH", os.defpath),
-            "HOME": str(home),
-            "XDG_CONFIG_HOME": str(config),
-            "XDG_DATA_HOME": str(data),
-            "TLDW_CONFIG_PATH": str(config / "config.toml"),
-            _ISOLATED_RUNTIME_MARKER: "1",
-        }
-        for name in ("LANG", "LC_ALL", "SYSTEMROOT", "WINDIR", "TEMP", "TMP"):
-            if value := os.environ.get(name):
-                environment[name] = value
-        completed = subprocess.run(
-            [
-                str(runtime_python),
-                "-I",
-                str(Path(__file__).resolve()),
-                "--samples",
-                str(args.samples),
-                "--output",
-                str(args.output.resolve()),
-            ],
-            cwd=Path(__file__).resolve().parents[2],
-            env=environment,
-            timeout=1800,
-        )
+        environment = _isolated_environment(runtime_root)
+        try:
+            completed = subprocess.run(
+                [
+                    str(runtime_python),
+                    "-I",
+                    str(Path(__file__).resolve()),
+                    "--samples",
+                    str(args.samples),
+                    "--output",
+                    str(args.output.resolve()),
+                ],
+                cwd=Path(__file__).resolve().parents[2],
+                env=environment,
+                timeout=1800,
+                capture_output=True,
+                text=True,
+            )
+        except (OSError, subprocess.SubprocessError):
+            print(_CHILD_FAILURE_DIAGNOSTIC, file=sys.stderr)
+            return 1
+        if completed.returncode != 0:
+            print(_CHILD_FAILURE_DIAGNOSTIC, file=sys.stderr)
         return completed.returncode
 
 

--- a/Tests/Performance/run_workspace_tool_executor_profile.py
+++ b/Tests/Performance/run_workspace_tool_executor_profile.py
@@ -1,0 +1,308 @@
+"""Profile direct workspace operations against the one-shot pinned executor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import platform as platform_module
+import shutil
+import site
+import statistics
+import subprocess
+import tempfile
+import time
+import venv
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, Literal
+
+OPERATIONS = ("stat", "read", "write", "list", "git_status", "git_diff")
+_ISOLATED_RUNTIME_MARKER = "TLDW_TASK19637_PROFILE_RUNTIME"
+_MODE = Literal["direct", "one_shot"]
+_Clock = Callable[[], float]
+_SampleRunner = Callable[[Path, str, _MODE, int], None]
+
+
+def nearest_rank_p95(values: Sequence[float]) -> float:
+    """Return the one-based nearest-rank 95th percentile."""
+    if not values:
+        raise ValueError("at least one value is required")
+    ordered = sorted(float(value) for value in values)
+    rank = math.ceil(0.95 * len(ordered))
+    return ordered[rank - 1]
+
+
+def _summary(values: Sequence[float]) -> dict[str, float]:
+    """Summarize finite milliseconds without imposing a performance gate."""
+    if not values or not all(math.isfinite(value) for value in values):
+        raise ValueError("profile timings must be finite")
+    return {
+        "median": round(float(statistics.median(values)), 6),
+        "p95": round(float(nearest_rank_p95(values)), 6),
+    }
+
+
+def _default_metadata() -> dict[str, str]:
+    repository = Path(__file__).resolve().parents[2]
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return {
+        "head_commit": completed.stdout.strip(),
+        "platform": platform_module.platform(),
+        "python": platform_module.python_version(),
+    }
+
+
+def build_profile(
+    workspace: Path,
+    *,
+    samples: int,
+    clock: _Clock = time.perf_counter,
+    sample_runner: _SampleRunner | None = None,
+    metadata: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Measure paired direct/one-shot calls and return content-free summaries."""
+    if not isinstance(samples, int) or isinstance(samples, bool) or samples <= 0:
+        raise ValueError("samples must be a positive integer")
+    runner = sample_runner or _run_sample
+    identity = dict(metadata or _default_metadata())
+    if set(identity) != {"head_commit", "platform", "python"}:
+        raise ValueError("profile metadata has unexpected keys")
+
+    operations: dict[str, dict[str, dict[str, float]]] = {}
+    for operation in OPERATIONS:
+        direct_values: list[float] = []
+        one_shot_values: list[float] = []
+        overhead_values: list[float] = []
+        for sample_index in range(samples):
+            direct_started = clock()
+            runner(workspace, operation, "direct", sample_index)
+            direct_ms = (clock() - direct_started) * 1000.0
+
+            one_shot_started = clock()
+            runner(workspace, operation, "one_shot", sample_index)
+            one_shot_ms = (clock() - one_shot_started) * 1000.0
+
+            if not math.isfinite(direct_ms) or not math.isfinite(one_shot_ms):
+                raise ValueError("profile timings must be finite")
+            direct_values.append(direct_ms)
+            one_shot_values.append(one_shot_ms)
+            overhead_values.append(one_shot_ms - direct_ms)
+        operations[operation] = {
+            "direct_ms": _summary(direct_values),
+            "one_shot_ms": _summary(one_shot_values),
+            "startup_overhead_ms": _summary(overhead_values),
+        }
+
+    return {
+        "schema_version": 1,
+        "head_commit": identity["head_commit"],
+        "platform": identity["platform"],
+        "python": identity["python"],
+        "samples": samples,
+        "operations": operations,
+    }
+
+
+def write_profile(report: Mapping[str, Any], output: Path) -> None:
+    """Write strict finite JSON to the requested evidence path."""
+    encoded = json.dumps(report, indent=2, sort_keys=False, allow_nan=False) + "\n"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(encoded, encoding="utf-8")
+
+
+def _run_git(workspace: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=workspace,
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+
+def _prepare_workspace(workspace: Path) -> None:
+    workspace.mkdir()
+    (workspace / "small.txt").write_text("small profile payload\n", encoding="utf-8")
+    (workspace / "profile-write.txt").write_text("initial\n", encoding="utf-8")
+    (workspace / "tracked.txt").write_text("base\n", encoding="utf-8")
+    (workspace / "listing-entry.txt").write_text("listed\n", encoding="utf-8")
+    _run_git(workspace, "init")
+    _run_git(workspace, "config", "user.email", "profile@example.invalid")
+    _run_git(workspace, "config", "user.name", "Profile Runner")
+    _run_git(workspace, "config", "commit.gpgsign", "false")
+    _run_git(workspace, "add", ".")
+    _run_git(workspace, "commit", "-m", "profile baseline")
+    (workspace / "tracked.txt").write_text("base\nprofile diff\n", encoding="utf-8")
+
+
+def _run_sample(
+    workspace: Path,
+    operation: str,
+    mode: _MODE,
+    sample_index: int,
+) -> None:
+    if mode == "direct":
+        _run_direct(workspace, operation, sample_index)
+        return
+    _run_one_shot(workspace, operation, sample_index)
+
+
+def _run_direct(workspace: Path, operation: str, sample_index: int) -> None:
+    from tldw_chatbook.Tools.git_tool_impls import git_diff, git_status
+    from tldw_chatbook.Tools.local_tool_impls import (
+        list_directory,
+        read_file,
+        stat_path,
+        write_file,
+    )
+
+    if operation == "stat":
+        stat_path("small.txt", workspace_root=workspace)
+    elif operation == "read":
+        read_file("small.txt", workspace_root=workspace)
+    elif operation == "write":
+        write_file(
+            "profile-write.txt",
+            f"direct sample {sample_index}\n",
+            workspace_root=workspace,
+        )
+    elif operation == "list":
+        list_directory(".", workspace_root=workspace)
+    elif operation == "git_status":
+        git_status(workspace)
+    elif operation == "git_diff":
+        git_diff(workspace)
+    else:
+        raise ValueError("unknown profile operation")
+
+
+def _run_one_shot(workspace: Path, operation: str, sample_index: int) -> None:
+    from tldw_chatbook.Tools.workspace_tool_executor import WorkspaceToolExecutor
+
+    executor = WorkspaceToolExecutor(workspace)
+    if operation == "stat":
+        executor.execute("stat_path", {"path": "small.txt"}, intent="read")
+    elif operation == "read":
+        executor.execute("fs_read", {"path": "small.txt"}, intent="read")
+    elif operation == "write":
+        executor.execute(
+            "fs_write",
+            {
+                "path": "profile-write.txt",
+                "content": f"one-shot sample {sample_index}\n",
+            },
+            intent="write",
+        )
+    elif operation == "list":
+        executor.execute("fs_list", {"path": "."}, intent="read")
+    elif operation == "git_status":
+        executor.execute("git_status", {}, intent="read")
+    elif operation == "git_diff":
+        executor.execute("git_diff", {}, intent="read")
+    else:
+        raise ValueError("unknown profile operation")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--samples", type=int, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser
+
+
+def _isolated_runtime_python(runtime_root: Path) -> Path:
+    """Create a temporary interpreter whose ``-I`` imports this checkout."""
+    environment_root = runtime_root / "venv"
+    venv.EnvBuilder(with_pip=False, symlinks=os.name != "nt").create(environment_root)
+    scripts = environment_root / ("Scripts" if os.name == "nt" else "bin")
+    runtime_python = scripts / ("python.exe" if os.name == "nt" else "python")
+    site_query = subprocess.run(
+        [
+            str(runtime_python),
+            "-I",
+            "-c",
+            "import site; print(site.getsitepackages()[0])",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    isolated_site_packages = Path(site_query.stdout.strip())
+    repository = Path(__file__).resolve().parents[2]
+    dependency_paths = [
+        Path(value).resolve() for value in site.getsitepackages() if Path(value).is_dir()
+    ]
+    (isolated_site_packages / "task19637-profile.pth").write_text(
+        "\n".join(str(path) for path in (repository, *dependency_paths)) + "\n",
+        encoding="utf-8",
+    )
+    return runtime_python
+
+
+def _run_isolated(args: argparse.Namespace) -> int:
+    """Run the profiler under an isolated profile before application import."""
+    with tempfile.TemporaryDirectory(prefix="tldw-workspace-profile-runtime-") as raw:
+        runtime_root = Path(raw)
+        runtime_python = _isolated_runtime_python(runtime_root)
+        home = runtime_root / "home"
+        config = runtime_root / "config"
+        data = runtime_root / "data"
+        home.mkdir()
+        config.mkdir()
+        data.mkdir()
+        environment = {
+            "PATH": os.environ.get("PATH", os.defpath),
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(config),
+            "XDG_DATA_HOME": str(data),
+            "TLDW_CONFIG_PATH": str(config / "config.toml"),
+            _ISOLATED_RUNTIME_MARKER: "1",
+        }
+        for name in ("LANG", "LC_ALL", "SYSTEMROOT", "WINDIR", "TEMP", "TMP"):
+            if value := os.environ.get(name):
+                environment[name] = value
+        completed = subprocess.run(
+            [
+                str(runtime_python),
+                "-I",
+                str(Path(__file__).resolve()),
+                "--samples",
+                str(args.samples),
+                "--output",
+                str(args.output.resolve()),
+            ],
+            cwd=Path(__file__).resolve().parents[2],
+            env=environment,
+            timeout=1800,
+        )
+        return completed.returncode
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.samples <= 0:
+        _parser().error("--samples must be a positive integer")
+    if shutil.which("git") is None:
+        raise RuntimeError("git is required for this profile")
+    if os.environ.get(_ISOLATED_RUNTIME_MARKER) != "1":
+        return _run_isolated(args)
+    with tempfile.TemporaryDirectory(prefix="tldw-workspace-tool-profile-") as raw:
+        workspace = Path(raw) / "workspace"
+        _prepare_workspace(workspace)
+        report = build_profile(workspace, samples=args.samples)
+    write_profile(report, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tests/Performance/run_workspace_tool_executor_profile.py
+++ b/Tests/Performance/run_workspace_tool_executor_profile.py
@@ -264,9 +264,11 @@ def _isolated_environment(
     home = runtime_root / "home"
     config = runtime_root / "config"
     data = runtime_root / "data"
+    temp = runtime_root / "temp"
     home.mkdir()
     config.mkdir()
     data.mkdir()
+    temp.mkdir()
     home_text = str(home)
     environment = {
         "PATH": source.get("PATH", os.defpath),
@@ -274,6 +276,8 @@ def _isolated_environment(
         "XDG_CONFIG_HOME": str(config),
         "XDG_DATA_HOME": str(data),
         "TLDW_CONFIG_PATH": str(config / "config.toml"),
+        "TEMP": str(temp),
+        "TMP": str(temp),
         _ISOLATED_RUNTIME_MARKER: "1",
     }
     if platform_name == "nt":
@@ -285,7 +289,7 @@ def _isolated_environment(
                 "HOMEPATH": home_path,
             }
         )
-    for name in ("LANG", "LC_ALL", "SYSTEMROOT", "WINDIR", "TEMP", "TMP"):
+    for name in ("LANG", "LC_ALL", "SYSTEMROOT", "WINDIR"):
         if value := source.get(name):
             environment[name] = value
     return environment
@@ -293,11 +297,11 @@ def _isolated_environment(
 
 def _run_isolated(args: argparse.Namespace) -> int:
     """Run the profiler under an isolated profile before application import."""
-    with tempfile.TemporaryDirectory(prefix="tldw-workspace-profile-runtime-") as raw:
-        runtime_root = Path(raw)
-        runtime_python = _isolated_runtime_python(runtime_root)
-        environment = _isolated_environment(runtime_root)
-        try:
+    try:
+        with tempfile.TemporaryDirectory(prefix="tldw-workspace-profile-runtime-") as raw:
+            runtime_root = Path(raw)
+            runtime_python = _isolated_runtime_python(runtime_root)
+            environment = _isolated_environment(runtime_root)
             completed = subprocess.run(
                 [
                     str(runtime_python),
@@ -314,12 +318,12 @@ def _run_isolated(args: argparse.Namespace) -> int:
                 capture_output=True,
                 text=True,
             )
-        except (OSError, subprocess.SubprocessError):
-            print(_CHILD_FAILURE_DIAGNOSTIC, file=sys.stderr)
-            return 1
-        if completed.returncode != 0:
-            print(_CHILD_FAILURE_DIAGNOSTIC, file=sys.stderr)
-        return completed.returncode
+    except (OSError, subprocess.SubprocessError):
+        print(_CHILD_FAILURE_DIAGNOSTIC, file=sys.stderr)
+        return 1
+    if completed.returncode != 0:
+        print(_CHILD_FAILURE_DIAGNOSTIC, file=sys.stderr)
+    return completed.returncode
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/Tests/Performance/run_workspace_tool_executor_profile.py
+++ b/Tests/Performance/run_workspace_tool_executor_profile.py
@@ -215,11 +215,59 @@ def _run_one_shot(workspace: Path, operation: str, sample_index: int) -> None:
         raise ValueError("unknown profile operation")
 
 
-def _parser() -> argparse.ArgumentParser:
+def _parser(*, validate: bool) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--samples", type=int, required=True)
-    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--samples",
+        type=_positive_sample_count if validate else str,
+        required=True,
+    )
+    parser.add_argument(
+        "--output",
+        type=_validated_output_path if validate else _absolute_output_path,
+        required=True,
+    )
     return parser
+
+
+def _positive_sample_count(value: str) -> int:
+    """Return a shared-validator-approved positive CLI sample count."""
+    from tldw_chatbook.Utils.input_validation import validate_number_range
+
+    try:
+        samples = int(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(
+            "--samples must be a positive integer"
+        ) from None
+    try:
+        valid = validate_number_range(samples, min_val=1)
+    except (OverflowError, ValueError):
+        valid = False
+    if not valid:
+        raise argparse.ArgumentTypeError("--samples must be a positive integer")
+    return samples
+
+
+def _validated_output_path(value: str) -> Path:
+    """Return the central validator's canonical CLI output path."""
+    from tldw_chatbook.Utils.path_validation import validate_path
+
+    absolute = _absolute_output_path(value)
+    try:
+        return validate_path(
+            absolute,
+            absolute.parent,
+            redact_paths=True,
+            allow_hidden=True,
+        )
+    except ValueError:
+        raise argparse.ArgumentTypeError("--output path is invalid") from None
+
+
+def _absolute_output_path(value: str) -> Path:
+    """Anchor a CLI output path to the caller without application imports."""
+    return Path(value).resolve()
 
 
 def _isolated_runtime_python(runtime_root: Path) -> Path:
@@ -310,7 +358,7 @@ def _run_isolated(args: argparse.Namespace) -> int:
                     "--samples",
                     str(args.samples),
                     "--output",
-                    str(args.output.resolve()),
+                    str(args.output),
                 ],
                 cwd=Path(__file__).resolve().parents[2],
                 env=environment,
@@ -327,12 +375,11 @@ def _run_isolated(args: argparse.Namespace) -> int:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    args = _parser().parse_args(argv)
-    if args.samples <= 0:
-        _parser().error("--samples must be a positive integer")
+    isolated = os.environ.get(_ISOLATED_RUNTIME_MARKER) == "1"
+    args = _parser(validate=isolated).parse_args(argv)
     if shutil.which("git") is None:
         raise RuntimeError("git is required for this profile")
-    if os.environ.get(_ISOLATED_RUNTIME_MARKER) != "1":
+    if not isolated:
         return _run_isolated(args)
     with tempfile.TemporaryDirectory(prefix="tldw-workspace-tool-profile-") as raw:
         workspace = Path(raw) / "workspace"

--- a/Tests/Performance/test_workspace_tool_executor_profile.py
+++ b/Tests/Performance/test_workspace_tool_executor_profile.py
@@ -1,0 +1,122 @@
+"""Deterministic contracts for the one-shot workspace executor profiler."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+from Tests.Performance import run_workspace_tool_executor_profile as profile
+
+
+def test_nearest_rank_p95_uses_one_based_ceiling() -> None:
+    assert profile.nearest_rank_p95(list(range(1, 31))) == 29
+    assert profile.nearest_rank_p95([7.0]) == 7.0
+
+
+def test_profile_uses_exact_operations_and_fake_clock_sample_injection(
+    tmp_path: Path,
+) -> None:
+    calls: list[tuple[str, str, int]] = []
+    ticks = iter(float(value) / 1000.0 for value in range(0, 240, 2))
+
+    def fake_sample(
+        _workspace: Path, operation: str, mode: str, sample_index: int
+    ) -> None:
+        calls.append((operation, mode, sample_index))
+
+    report = profile.build_profile(
+        tmp_path,
+        samples=2,
+        clock=lambda: next(ticks),
+        sample_runner=fake_sample,
+        metadata={
+            "head_commit": "a" * 40,
+            "platform": "test-platform",
+            "python": "3.12.test",
+        },
+    )
+
+    assert tuple(report["operations"]) == (
+        "stat",
+        "read",
+        "write",
+        "list",
+        "git_status",
+        "git_diff",
+    )
+    assert calls == [
+        (operation, mode, sample_index)
+        for operation in profile.OPERATIONS
+        for sample_index in range(2)
+        for mode in ("direct", "one_shot")
+    ]
+    for metrics in report["operations"].values():
+        assert metrics == {
+            "direct_ms": {"median": 2.0, "p95": 2.0},
+            "one_shot_ms": {"median": 2.0, "p95": 2.0},
+            "startup_overhead_ms": {"median": 0.0, "p95": 0.0},
+        }
+
+
+def test_profile_json_is_finite_content_free_metadata_without_timing_gate(
+    tmp_path: Path,
+) -> None:
+    private_marker = "private-root-and-content-marker"
+
+    def fake_sample(
+        _workspace: Path, _operation: str, _mode: str, _sample_index: int
+    ) -> None:
+        return None
+
+    ticks = iter(float(value) for value in range(1000))
+    report = profile.build_profile(
+        tmp_path / private_marker,
+        samples=1,
+        clock=lambda: next(ticks),
+        sample_runner=fake_sample,
+        metadata={
+            "head_commit": "b" * 40,
+            "platform": "bounded-platform",
+            "python": "3.12.0",
+        },
+    )
+    output = tmp_path / "profile.json"
+    profile.write_profile(report, output)
+    raw = output.read_text(encoding="utf-8")
+    decoded = json.loads(raw, parse_constant=lambda value: (_ for _ in ()).throw(ValueError(value)))
+
+    assert set(decoded) == {
+        "schema_version",
+        "head_commit",
+        "platform",
+        "python",
+        "samples",
+        "operations",
+    }
+    assert private_marker not in raw
+    assert "path" not in decoded
+    assert "content" not in decoded
+    assert "threshold" not in decoded
+    assert "passed" not in decoded
+    assert "qualification" not in decoded
+    for metrics in decoded["operations"].values():
+        assert set(metrics) == {"direct_ms", "one_shot_ms", "startup_overhead_ms"}
+        for summary in metrics.values():
+            assert set(summary) == {"median", "p95"}
+            assert all(math.isfinite(value) for value in summary.values())
+
+
+def test_invalid_sample_count_is_refused() -> None:
+    for value in (0, -1, True):
+        try:
+            profile.build_profile(
+                Path("."),
+                samples=value,
+                sample_runner=lambda *_args: None,
+            )
+        except ValueError as error:
+            assert str(error) == "samples must be a positive integer"
+        else:
+            raise AssertionError(f"accepted invalid sample count: {value!r}")
+

--- a/Tests/Performance/test_workspace_tool_executor_profile.py
+++ b/Tests/Performance/test_workspace_tool_executor_profile.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import json
 import math
+import ntpath
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 from Tests.Performance import run_workspace_tool_executor_profile as profile
@@ -120,3 +124,104 @@ def test_invalid_sample_count_is_refused() -> None:
         else:
             raise AssertionError(f"accepted invalid sample count: {value!r}")
 
+
+def test_windows_isolated_environment_uses_only_temporary_home(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A Windows child must never fall back to the developer profile."""
+    builder = getattr(profile, "_isolated_environment", None)
+    assert builder is not None, "profile runner has no isolated environment builder"
+    source_environment = {
+        "PATH": "isolated-path",
+        "LANG": "C.UTF-8",
+        "SYSTEMROOT": r"C:\Windows",
+        "WINDIR": r"C:\Windows",
+        "TEMP": r"C:\Temp",
+        "TMP": r"C:\Temp",
+        "HOME": "/real/developer/home",
+        "USERPROFILE": r"C:\Users\real-developer",
+        "API_SECRET": "must-not-cross-profile-boundary",
+    }
+
+    environment = builder(
+        tmp_path,
+        platform_name="nt",
+        source_environment=source_environment,
+    )
+    isolated_home = str(tmp_path / "home")
+
+    assert environment["HOME"] == isolated_home
+    assert environment["USERPROFILE"] == isolated_home
+    assert environment["HOMEDRIVE"] + environment["HOMEPATH"] == isolated_home
+    assert set(environment) == {
+        "PATH",
+        "LANG",
+        "SYSTEMROOT",
+        "WINDIR",
+        "TEMP",
+        "TMP",
+        "HOME",
+        "USERPROFILE",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "TLDW_CONFIG_PATH",
+        profile._ISOLATED_RUNTIME_MARKER,
+    }
+    assert "real-developer" not in repr(environment)
+    assert "must-not-cross-profile-boundary" not in repr(environment)
+    assert (tmp_path / "home").is_dir()
+    assert (tmp_path / "config").is_dir()
+    assert (tmp_path / "data").is_dir()
+
+    with monkeypatch.context() as clean_environment:
+        for name in tuple(os.environ):
+            clean_environment.delenv(name, raising=False)
+        for name, value in environment.items():
+            clean_environment.setenv(name, value)
+        assert ntpath.expanduser("~") == isolated_home
+
+
+def test_cli_suppresses_isolated_child_paths_and_secrets_on_failure(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Captured child diagnostics must not become public profile evidence."""
+    private_marker = str(tmp_path / "private-runtime-profile")
+    secret_marker = "synthetic-profile-secret-19637"
+
+    monkeypatch.delenv(profile._ISOLATED_RUNTIME_MARKER, raising=False)
+    monkeypatch.setattr(profile.shutil, "which", lambda _name: "git")
+    monkeypatch.setattr(
+        profile,
+        "_isolated_runtime_python",
+        lambda runtime_root: runtime_root / "python",
+    )
+
+    def failed_child(command, **kwargs):
+        if not kwargs.get("capture_output"):
+            print(f"child stdout leaked {private_marker}")
+            print(f"child stderr leaked {secret_marker}", file=sys.stderr)
+        return subprocess.CompletedProcess(
+            command,
+            23,
+            stdout=f"child stdout leaked {private_marker}",
+            stderr=f"child stderr leaked {secret_marker}",
+        )
+
+    monkeypatch.setattr(profile.subprocess, "run", failed_child)
+    output = tmp_path / "profile.json"
+
+    return_code = profile.main(["--samples", "1", "--output", str(output)])
+    captured = capsys.readouterr()
+    serialized = output.read_text(encoding="utf-8") if output.exists() else ""
+
+    assert return_code == 23
+    assert captured.out == ""
+    assert captured.err == "isolated profile child failed\n"
+    for public_evidence in (captured.out, captured.err, serialized):
+        assert private_marker not in public_evidence
+        assert secret_marker not in public_evidence

--- a/Tests/Performance/test_workspace_tool_executor_profile.py
+++ b/Tests/Performance/test_workspace_tool_executor_profile.py
@@ -8,6 +8,7 @@ import ntpath
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 from Tests.Performance import run_workspace_tool_executor_profile as profile
@@ -154,6 +155,8 @@ def test_windows_isolated_environment_uses_only_temporary_home(
     assert environment["HOME"] == isolated_home
     assert environment["USERPROFILE"] == isolated_home
     assert environment["HOMEDRIVE"] + environment["HOMEPATH"] == isolated_home
+    assert environment["TEMP"] == str(tmp_path / "temp")
+    assert environment["TMP"] == str(tmp_path / "temp")
     assert set(environment) == {
         "PATH",
         "LANG",
@@ -224,4 +227,98 @@ def test_cli_suppresses_isolated_child_paths_and_secrets_on_failure(
     assert captured.err == "isolated profile child failed\n"
     for public_evidence in (captured.out, captured.err, serialized):
         assert private_marker not in public_evidence
+        assert secret_marker not in public_evidence
+
+
+def test_child_temp_workspace_stays_inside_disposable_runtime(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Host TEMP/TMP must not outlive the isolated runtime boundary."""
+    hostile_temp = tmp_path / "real-developer-profile" / "Temp"
+    hostile_tmp = tmp_path / "host-secret-tmp"
+    hostile_temp.mkdir(parents=True)
+    hostile_tmp.mkdir()
+    runtime_roots: list[Path] = []
+    child_paths: list[Path] = []
+
+    monkeypatch.delenv(profile._ISOLATED_RUNTIME_MARKER, raising=False)
+    monkeypatch.setenv("TEMP", str(hostile_temp))
+    monkeypatch.setenv("TMP", str(hostile_tmp))
+    monkeypatch.setattr(profile.shutil, "which", lambda _name: "git")
+
+    def fake_bootstrap(runtime_root: Path) -> Path:
+        runtime_roots.append(runtime_root)
+        return runtime_root / "python"
+
+    def successful_child(command, **kwargs):
+        environment = kwargs["env"]
+        child_temp = Path(
+            tempfile.mkdtemp(prefix="child-profile-", dir=environment["TEMP"])
+        )
+        child_workspace = child_temp / "workspace"
+        child_workspace.mkdir()
+        child_paths.extend((child_temp, child_workspace))
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(profile, "_isolated_runtime_python", fake_bootstrap)
+    monkeypatch.setattr(profile.subprocess, "run", successful_child)
+
+    result = profile.main(
+        ["--samples", "1", "--output", str(tmp_path / "profile.json")]
+    )
+
+    assert result == 0
+    assert len(runtime_roots) == 1
+    runtime_root = runtime_roots[0]
+    assert child_paths
+    assert all(runtime_root in path.parents for path in child_paths)
+    assert not runtime_root.exists()
+    assert all(not path.exists() for path in child_paths)
+    assert list(hostile_temp.iterdir()) == []
+    assert list(hostile_tmp.iterdir()) == []
+
+
+def test_bootstrap_failure_emits_only_fixed_content_free_diagnostic(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """A bootstrap exception must not expose its command or captured output."""
+    private_marker = str(tmp_path / "private-bootstrap-runtime")
+    checkout_marker = "/private/checkout/task-19637"
+    secret_marker = "synthetic-bootstrap-secret-19637"
+
+    monkeypatch.delenv(profile._ISOLATED_RUNTIME_MARKER, raising=False)
+    monkeypatch.setattr(profile.shutil, "which", lambda _name: "git")
+
+    def failed_bootstrap(runtime_root: Path) -> Path:
+        raise subprocess.CalledProcessError(
+            17,
+            [str(runtime_root / private_marker), checkout_marker],
+            output=f"bootstrap stdout {private_marker}",
+            stderr=f"bootstrap stderr {secret_marker}",
+        )
+
+    monkeypatch.setattr(profile, "_isolated_runtime_python", failed_bootstrap)
+    output = tmp_path / "profile.json"
+    escaped_error: BaseException | None = None
+    return_code: int | None = None
+
+    try:
+        return_code = profile.main(["--samples", "1", "--output", str(output)])
+    except BaseException as error:  # noqa: BLE001 - regression guards CLI boundary
+        escaped_error = error
+    captured = capsys.readouterr()
+    serialized = output.read_text(encoding="utf-8") if output.exists() else ""
+
+    assert escaped_error is None, (
+        f"bootstrap exception escaped as {type(escaped_error).__name__}"
+    )
+    assert return_code == 1
+    assert captured.out == ""
+    assert captured.err == "isolated profile child failed\n"
+    for public_evidence in (captured.out, captured.err, serialized):
+        assert private_marker not in public_evidence
+        assert checkout_marker not in public_evidence
         assert secret_marker not in public_evidence

--- a/Tests/Performance/test_workspace_tool_executor_profile.py
+++ b/Tests/Performance/test_workspace_tool_executor_profile.py
@@ -11,6 +11,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from Tests.Performance import run_workspace_tool_executor_profile as profile
 
 
@@ -124,6 +126,75 @@ def test_invalid_sample_count_is_refused() -> None:
             assert str(error) == "samples must be a positive integer"
         else:
             raise AssertionError(f"accepted invalid sample count: {value!r}")
+
+
+def test_cli_parser_refuses_nonpositive_samples_at_input_boundary(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(SystemExit):
+        profile._parser(validate=True).parse_args(
+            ["--samples", "0", "--output", str(tmp_path / "profile.json")]
+        )
+
+
+def test_cli_parser_refuses_oversized_samples_at_input_boundary(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(SystemExit):
+        profile._parser(validate=True).parse_args(
+            ["--samples", "9" * 4000, "--output", str(tmp_path / "profile.json")]
+        )
+
+
+def test_cli_parser_returns_normalized_output_path(tmp_path: Path) -> None:
+    requested = tmp_path / "nested" / ".." / "profile.json"
+
+    args = profile._parser(validate=True).parse_args(
+        ["--samples", "1", "--output", str(requested)]
+    )
+
+    assert args.samples == 1
+    assert args.output == requested.resolve()
+
+
+def test_outer_cli_parse_does_not_import_application_modules() -> None:
+    repository = Path(__file__).resolve().parents[2]
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "from Tests.Performance import run_workspace_tool_executor_profile as p; "
+                "before=set(sys.modules); "
+                "p._parser(validate=False).parse_args(['--samples','1','--output','x']); "
+                "print(sorted(name for name in set(sys.modules)-before "
+                "if name.startswith('tldw_chatbook')))"
+            ),
+        ],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert probe.stdout.strip() == "[]"
+
+
+def test_outer_cli_anchors_relative_output_to_caller_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    caller = tmp_path / "caller"
+    caller.mkdir()
+    monkeypatch.chdir(caller)
+
+    args = profile._parser(validate=False).parse_args(
+        ["--samples", "1", "--output", "profile.json"]
+    )
+
+    assert args.output == caller / "profile.json"
 
 
 def test_windows_isolated_environment_uses_only_temporary_home(

--- a/Tests/Skills/test_web_research_skill.py
+++ b/Tests/Skills/test_web_research_skill.py
@@ -19,6 +19,11 @@ SKILL_DIR = (
 SKILL_PATH = SKILL_DIR / "SKILL.md"
 
 
+class _NoopWorkspaceExecutor:
+    def execute(self, operation: str, arguments: dict, *, intent: str) -> str:
+        raise AssertionError(f"unexpected workspace operation: {operation}")
+
+
 def _compat_service(store_dir: Path) -> LocalSkillsService:
     return LocalSkillsService(
         store_dir=store_dir,
@@ -54,7 +59,12 @@ async def test_web_research_allowed_tools_are_registered_local_tools(tmp_path):
 
     imported = await service.import_skill(name="web-research", content=content)
 
-    registered_names = {spec.name for spec in _default_specs(tmp_path)}
+    registered_names = {
+        spec.name
+        for spec in _default_specs(
+            tmp_path, workspace_executor=_NoopWorkspaceExecutor()
+        )
+    }
     assert {"web_search", "web_fetch"} <= registered_names
     for tool_name in imported["allowed_tools"]:
         assert tool_name in registered_names

--- a/Tests/Tools/test_git_tool_impls.py
+++ b/Tests/Tools/test_git_tool_impls.py
@@ -8,6 +8,7 @@ module is skipped when git is unavailable (re-plan §2.5).
 
 from __future__ import annotations
 
+import io
 import shutil
 import subprocess
 from pathlib import Path
@@ -73,9 +74,11 @@ def test_run_git_rejects_global_option_smuggling() -> None:
     # --version must be used alone
     with pytest.raises(LocalToolError):
         run_git(["git", "--version", "status"])
-    # -C requires a following path argument
+    # Cwd is a dedicated runner parameter; -C is never accepted in argv.
     with pytest.raises(LocalToolError):
         run_git(["git", "-C"])
+    with pytest.raises(LocalToolError, match="not allowlisted"):
+        run_git(["git", "-C", "/tmp", "status"])
 
 
 def test_run_git_timeout() -> None:
@@ -111,6 +114,92 @@ def test_run_git_env_sanitized(monkeypatch: pytest.MonkeyPatch) -> None:
     assert env["GIT_PAGER"] == "cat"
     assert "HOME" not in env
     assert "PATH" in env
+
+
+def test_worker_git_uses_absolute_executable_relative_cwd_without_new_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Worker Git stays in the outer helper's retained process tree."""
+    seen: dict[str, object] = {}
+
+    class RecordingProcess:
+        pid = 1234
+        returncode = 0
+        stdout = io.BytesIO(b"git version test\n")
+        stderr = io.BytesIO()
+
+        def wait(self, timeout: float | None = None) -> int:
+            del timeout
+            return self.returncode
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+    def recording_popen(argv: list[str], **kwargs: object) -> RecordingProcess:
+        seen["argv"] = argv
+        seen.update(kwargs)
+        return RecordingProcess()
+
+    monkeypatch.setattr(git_tool_impls.subprocess, "Popen", recording_popen)
+    monkeypatch.setattr(git_tool_impls.shutil, "which", lambda _name: "/usr/bin/git")
+
+    result = run_git(
+        ["git", "--version"],
+        cwd=Path("repo"),
+        executable=Path("/usr/bin/git"),
+        own_process_group=False,
+    )
+
+    assert result.argv == ["git", "--version"]
+    assert seen["argv"] == ["/usr/bin/git", "--version"]
+    assert "-C" not in seen["argv"]
+    assert seen["cwd"] == Path("repo")
+    assert seen["start_new_session"] is False
+
+
+def test_worker_git_timeout_kills_only_direct_child(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The outer helper remains the sole descendant-cleanup owner."""
+    events: list[str] = []
+
+    class RecordingProcess:
+        pid = 1234
+        returncode: int | None = None
+        stdout = io.BytesIO()
+        stderr = io.BytesIO()
+
+        def wait(self, timeout: float | None = None) -> int:
+            del timeout
+            self.returncode = -9
+            return self.returncode
+
+        def kill(self) -> None:
+            events.append("direct-kill")
+            self.returncode = -9
+
+    monkeypatch.setattr(
+        git_tool_impls.subprocess,
+        "Popen",
+        lambda _argv, **_kwargs: RecordingProcess(),
+    )
+    monkeypatch.setattr(git_tool_impls.shutil, "which", lambda _name: "/usr/bin/git")
+    monkeypatch.setattr(
+        git_tool_impls.os,
+        "killpg",
+        lambda *_args: events.append("process-group-kill"),
+    )
+
+    with pytest.raises(LocalToolError, match="timed out"):
+        run_git(
+            ["git", "status"],
+            cwd=Path("repo"),
+            executable=Path("/usr/bin/git"),
+            own_process_group=False,
+            timeout=0.0,
+        )
+
+    assert events == ["direct-kill"]
 
 
 def test_prepare_repository_finds_root(tmp_git_repo: Path) -> None:
@@ -193,6 +282,39 @@ def test_git_branches(tmp_git_repo: Path) -> None:
     # The current branch carries the marker.
     assert "* feature-x" in out
     assert f"* {main}" not in out
+
+
+def test_read_only_git_operations_use_cwd_without_dash_c(
+    tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every compatibility operation launches Git from its repository cwd."""
+    _commit_file(tmp_git_repo, "multi.txt", "line1\n", "add multi")
+    captured: list[tuple[list[str], dict[str, object]]] = []
+    real_run_git = git_tool_impls.run_git
+
+    def spy(argv: list[str], **kwargs: object) -> GitCommandResult:
+        captured.append((list(argv), dict(kwargs)))
+        return real_run_git(argv, **kwargs)
+
+    monkeypatch.setattr(git_tool_impls, "run_git", spy)
+
+    git_status(tmp_git_repo)
+    git_diff(tmp_git_repo)
+    git_log(tmp_git_repo)
+    git_blame(tmp_git_repo, "multi.txt")
+    git_branches(tmp_git_repo)
+
+    operation_calls = [
+        (argv, kwargs)
+        for argv, kwargs in captured
+        if any(command in argv for command in ("status", "diff", "log", "blame", "branch"))
+    ]
+    assert len(operation_calls) == 5
+    for argv, kwargs in operation_calls:
+        assert argv[0] == "git"
+        assert "-C" not in argv
+        assert Path(kwargs["cwd"]).is_absolute()
+        assert kwargs["own_process_group"] is True
 
 
 # --- git_log ------------------------------------------------------------

--- a/Tests/Tools/test_local_tool_impls.py
+++ b/Tests/Tools/test_local_tool_impls.py
@@ -14,6 +14,36 @@ from tldw_chatbook.Tools.local_tool_impls import (
     resolve_workspace_path,
     write_file,
 )
+from tldw_chatbook.Utils.sensitive_paths import SensitiveExclusion
+
+
+@pytest.mark.parametrize(
+    ("relative", "exclusion", "is_directory", "expected"),
+    (
+        (".", SensitiveExclusion("file", "."), True, True),
+        (".", SensitiveExclusion("subtree", "."), True, True),
+        ("child.txt", SensitiveExclusion("direct_children", "."), False, True),
+        ("nested/child.txt", SensitiveExclusion("direct_children", "."), False, False),
+        ("secret/child.txt", SensitiveExclusion("direct_children", "secret"), False, True),
+        ("secret/nested.txt", SensitiveExclusion("file", "secret/nested.txt"), False, True),
+        ("secret/nested/child.txt", SensitiveExclusion("file", "secret/nested.txt"), False, False),
+        ("secret/nested/child.txt", SensitiveExclusion("subtree", "secret"), False, True),
+        ("nested/credentials", SensitiveExclusion("name", "credentials"), False, True),
+        ("credentials", SensitiveExclusion("name", "credentials"), True, False),
+    ),
+)
+def test_relative_sensitive_exclusion_matcher_covers_root_and_each_kind(
+    relative: str,
+    exclusion: SensitiveExclusion,
+    is_directory: bool,
+    expected: bool,
+) -> None:
+    assert (
+        local_tool_impls._is_relative_sensitive_path(
+            Path(relative), (exclusion,), is_directory=is_directory
+        )
+        is expected
+    )
 
 
 def test_resolve_workspace_path_confines(tmp_path):

--- a/Tests/Tools/test_local_tool_impls.py
+++ b/Tests/Tools/test_local_tool_impls.py
@@ -321,6 +321,31 @@ def test_fs_write_unencodable_content_preserves_file(tmp_path):
     assert (ws / "f.txt").read_text() == "keep me"
 
 
+def test_relative_mutation_bodies_use_the_supplied_io_root_and_preserve_bytes(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "f.txt").write_bytes(b"before\r\n")
+
+    edit_result = local_tool_impls._edit_relative_file(
+        Path("f.txt"),
+        "before",
+        "after",
+        workspace=ws,
+        display_path="f.txt",
+    )
+    write_result = local_tool_impls._write_relative_file(
+        Path("new.txt"),
+        "created\n",
+        workspace=ws,
+        display_path="new.txt",
+    )
+
+    assert edit_result == "made 1 replacement in f.txt"
+    assert write_result == "wrote 8 characters to new.txt"
+    assert (ws / "f.txt").read_bytes() == b"after\r\n"
+    assert (ws / "new.txt").read_bytes() == b"created\n"
+
+
 def test_fs_glob_matches_and_sorts_by_mtime(tmp_path):
     ws = tmp_path / "ws"; ws.mkdir()
     import os, time

--- a/Tests/Tools/test_local_tool_impls.py
+++ b/Tests/Tools/test_local_tool_impls.py
@@ -148,6 +148,23 @@ def test_fs_read_missing_file(tmp_path):
         read_file("nope.txt", workspace_root=ws)
 
 
+def test_fs_read_keeps_in_root_symlinks_and_refuses_escaping_symlinks(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    inside = ws / "inside.txt"
+    inside.write_text("inside\n", encoding="utf-8")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside\n", encoding="utf-8")
+    import os
+
+    os.symlink(inside, ws / "inside-link.txt")
+    os.symlink(outside, ws / "outside-link.txt")
+
+    assert "1\tinside" in read_file("inside-link.txt", workspace_root=ws)
+    with pytest.raises(LocalToolError, match="outside the workspace root"):
+        read_file("outside-link.txt", workspace_root=ws)
+
+
 def test_fs_read_empty_file_returns_notice(tmp_path):
     ws = tmp_path / "ws"; ws.mkdir()
     (ws / "empty.txt").write_text("")

--- a/Tests/Tools/test_local_tool_sensitive_paths.py
+++ b/Tests/Tools/test_local_tool_sensitive_paths.py
@@ -457,14 +457,27 @@ def test_both_file_tool_families_refuse_the_same_denylisted_paths(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-#: Helpers in ``git_tool_impls`` that resolve their path argument through
-#: ``resolve_workspace_path`` themselves, so a git tool calling one of them
-#: IS on the choke point -- just one hop away. Enumerated (rather than
-#: chasing the call graph) so that adding a FOURTH indirect resolver is a
-#: deliberate edit here, with the same "does it call the choke point?"
-#: question asked of it directly below.
-_INDIRECT_CHOKE_POINT_RESOLVERS = frozenset(
-    {"prepare_repository", "_prepare_for_path", "_repo_relative_path"}
+#: Reviewed Git resolver chain. Each key is trusted by its callers only when
+#: the AST scan proves it directly calls every value. ``_resolve_git_path``
+#: must preserve both live-context enforcement and the pinned helper's
+#: admitted-exclusion enforcement; the three public-tool delegates must keep
+#: routing through that resolver. Adding another trusted hop is deliberately
+#: an explicit security-test change, not an automatic call-graph exemption.
+_CHOKE_POINT_DELEGATES = {
+    "_resolve_git_path": frozenset(
+        {"resolve_workspace_path", "_relative_target_is_safe"}
+    ),
+    "prepare_repository": frozenset({"_resolve_git_path"}),
+    "_prepare_for_path": frozenset({"_resolve_git_path"}),
+    "_repo_relative_path": frozenset({"_resolve_git_path"}),
+}
+
+#: These helpers take ``workspace_root`` only to transform already-admitted
+#: values or render an already-resolved cwd. They are not filesystem entry
+#: points. Keep this list exact: a new exemption requires a named review here
+#: and in the assertion below; private naming alone never grants an exemption.
+_NON_ENTRY_WORKSPACE_HELPERS = frozenset(
+    {"_denylist_pathspecs", "_repo_relative_exclusions", "_git_cwd"}
 )
 
 
@@ -478,13 +491,13 @@ def test_every_workspace_rooted_function_uses_the_choke_point():
     resolves its own path (``Path(workspace_root) / arg``) would reintroduce
     exactly the hole this task closed, so it fails here instead.
 
-    ``git_tool_impls`` is covered too (fix round): its four repo-scoped
-    tools reach the choke point INDIRECTLY, through the three helpers in
-    ``_INDIRECT_CHOKE_POINT_RESOLVERS`` -- each of which is itself required
-    below to call ``resolve_workspace_path`` directly, so the indirection is
-    verified rather than assumed. Covering only two of the family's three
-    modules is what let this test tick AC5 while a new git tool would have
-    got zero tripwire coverage.
+    ``git_tool_impls`` is covered too (fix round): its repo-scoped tools reach
+    the choke point through the reviewed delegate chain. The scan verifies
+    every hop: the tool delegates call ``_resolve_git_path``, and that resolver
+    directly retains both live ``resolve_workspace_path`` enforcement and the
+    pinned helper's admitted-exclusion enforcement. Covering only two of the
+    family's three modules is what let this test tick AC5 while a new git tool
+    would have got zero tripwire coverage.
 
     NOTE what this tripwire does NOT claim: reaching the choke point proves
     a tool's PATH ARGUMENT is denylist-checked, not that its OUTPUT is
@@ -529,8 +542,13 @@ def test_every_workspace_rooted_function_uses_the_choke_point():
         f"{sorted(discovered)}; if a module was renamed or retired, say so here"
     )
 
+    assert _NON_ENTRY_WORKSPACE_HELPERS == frozenset(
+        {"_denylist_pathspecs", "_repo_relative_exclusions", "_git_cwd"}
+    ), "adding a workspace-rooted non-entry helper requires explicit security review"
+
     offenders: list[str] = []
-    verified_resolvers: set[str] = set()
+    verified_delegates: set[str] = set()
+    visited_non_entry_helpers: set[str] = set()
     for module in modules:
         tree = ast.parse(Path(module.__file__).read_text())
         for node in tree.body:
@@ -547,36 +565,56 @@ def test_every_workspace_rooted_function_uses_the_choke_point():
                 for sub in ast.walk(node)
                 if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name)
             }
-            accepted = {"resolve_workspace_path"}
-            if node.name not in _INDIRECT_CHOKE_POINT_RESOLVERS:
-                # A resolver itself must reach the choke point DIRECTLY;
-                # only its callers may go through it.
-                accepted |= _INDIRECT_CHOKE_POINT_RESOLVERS
-            if not (calls & accepted):
+
+            if node.name in _NON_ENTRY_WORKSPACE_HELPERS:
+                visited_non_entry_helpers.add(node.name)
+                continue
+
+            required_calls = _CHOKE_POINT_DELEGATES.get(node.name)
+            if required_calls is not None:
+                missing_calls = required_calls - calls
+                if missing_calls:
+                    offenders.append(
+                        f"{module.__name__}.{node.name} "
+                        f"(missing {sorted(missing_calls)})"
+                    )
+                else:
+                    verified_delegates.add(node.name)
+                continue
+
+            accepted = {"resolve_workspace_path", *_CHOKE_POINT_DELEGATES}
+            if not calls & accepted:
                 offenders.append(f"{module.__name__}.{node.name}")
-            if node.name in _INDIRECT_CHOKE_POINT_RESOLVERS:
-                verified_resolvers.add(node.name)
 
     assert not offenders, (
         "these workspace-rooted functions never reach resolve_workspace_path "
-        "(directly or via one of "
-        f"{sorted(_INDIRECT_CHOKE_POINT_RESOLVERS)}), so they bypass the "
+        "(directly or via the fully verified delegate chain "
+        f"{sorted(_CHOKE_POINT_DELEGATES)}), so they bypass the "
         f"sensitive-path denylist: {offenders}"
     )
 
-    # Every accepted resolver must itself have been VISITED and verified above.
+    # Every accepted delegate must itself have been VISITED and verified above.
     # Without this, the accept-set is a hole rather than a delegation: the loop
     # only inspects functions that take a parameter literally named
-    # ``workspace_root``, so a resolver spelling it differently is added to the
+    # ``workspace_root``, so a delegate spelling it differently is added to the
     # accept-set, never checked itself, and silently launders its callers past
     # the choke point (demonstrated in review with a `root`-named resolver).
-    unverified = set(_INDIRECT_CHOKE_POINT_RESOLVERS) - verified_resolvers
+    unverified = set(_CHOKE_POINT_DELEGATES) - verified_delegates
     assert not unverified, (
-        "these names are trusted in _INDIRECT_CHOKE_POINT_RESOLVERS but were "
+        "these names are trusted in _CHOKE_POINT_DELEGATES but were "
         "never themselves inspected by the scan above -- they are an unchecked "
-        "hole, not a verified delegation. A resolver must live in one of the "
+        "hole, not a verified delegation. A delegate must live in one of the "
         "scanned modules and take a `workspace_root` parameter so that its own "
-        f"call to the choke point is proven: {sorted(unverified)}"
+        f"required enforcement calls are proven: {sorted(unverified)}"
+    )
+
+    unvisited_non_entry_helpers = (
+        set(_NON_ENTRY_WORKSPACE_HELPERS) - visited_non_entry_helpers
+    )
+    assert not unvisited_non_entry_helpers, (
+        "these names are exempted as pure already-admitted transforms/renderers "
+        "but were not found by the workspace-root scan; remove stale exemptions "
+        f"rather than silently widening the hole: {sorted(unvisited_non_entry_helpers)}"
     )
 
 

--- a/Tests/Tools/test_local_tool_sensitive_paths.py
+++ b/Tests/Tools/test_local_tool_sensitive_paths.py
@@ -481,6 +481,9 @@ _NON_ENTRY_WORKSPACE_HELPERS = frozenset(
         "tldw_chatbook.Tools.git_tool_impls._denylist_pathspecs",
         "tldw_chatbook.Tools.git_tool_impls._repo_relative_exclusions",
         "tldw_chatbook.Tools.git_tool_impls._git_cwd",
+        # Filters inherited executable-search directories against an already
+        # admitted canonical root; it never resolves a tool-supplied target.
+        "tldw_chatbook.Tools.workspace_tool_executor.workspace_worker_environment",
     }
 )
 
@@ -551,6 +554,7 @@ def test_every_workspace_rooted_function_uses_the_choke_point():
             "tldw_chatbook.Tools.git_tool_impls._denylist_pathspecs",
             "tldw_chatbook.Tools.git_tool_impls._repo_relative_exclusions",
             "tldw_chatbook.Tools.git_tool_impls._git_cwd",
+            "tldw_chatbook.Tools.workspace_tool_executor.workspace_worker_environment",
         }
     ), "adding a workspace-rooted non-entry helper requires explicit security review"
 

--- a/Tests/Tools/test_local_tool_sensitive_paths.py
+++ b/Tests/Tools/test_local_tool_sensitive_paths.py
@@ -477,7 +477,11 @@ _CHOKE_POINT_DELEGATES = {
 #: points. Keep this list exact: a new exemption requires a named review here
 #: and in the assertion below; private naming alone never grants an exemption.
 _NON_ENTRY_WORKSPACE_HELPERS = frozenset(
-    {"_denylist_pathspecs", "_repo_relative_exclusions", "_git_cwd"}
+    {
+        "tldw_chatbook.Tools.git_tool_impls._denylist_pathspecs",
+        "tldw_chatbook.Tools.git_tool_impls._repo_relative_exclusions",
+        "tldw_chatbook.Tools.git_tool_impls._git_cwd",
+    }
 )
 
 
@@ -543,12 +547,16 @@ def test_every_workspace_rooted_function_uses_the_choke_point():
     )
 
     assert _NON_ENTRY_WORKSPACE_HELPERS == frozenset(
-        {"_denylist_pathspecs", "_repo_relative_exclusions", "_git_cwd"}
+        {
+            "tldw_chatbook.Tools.git_tool_impls._denylist_pathspecs",
+            "tldw_chatbook.Tools.git_tool_impls._repo_relative_exclusions",
+            "tldw_chatbook.Tools.git_tool_impls._git_cwd",
+        }
     ), "adding a workspace-rooted non-entry helper requires explicit security review"
 
     offenders: list[str] = []
     verified_delegates: set[str] = set()
-    visited_non_entry_helpers: set[str] = set()
+    visited_non_entry_helpers: dict[str, int] = {}
     for module in modules:
         tree = ast.parse(Path(module.__file__).read_text())
         for node in tree.body:
@@ -565,9 +573,12 @@ def test_every_workspace_rooted_function_uses_the_choke_point():
                 for sub in ast.walk(node)
                 if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name)
             }
+            qualified_name = f"{module.__name__}.{node.name}"
 
-            if node.name in _NON_ENTRY_WORKSPACE_HELPERS:
-                visited_non_entry_helpers.add(node.name)
+            if qualified_name in _NON_ENTRY_WORKSPACE_HELPERS:
+                visited_non_entry_helpers[qualified_name] = (
+                    visited_non_entry_helpers.get(qualified_name, 0) + 1
+                )
                 continue
 
             required_calls = _CHOKE_POINT_DELEGATES.get(node.name)
@@ -608,14 +619,59 @@ def test_every_workspace_rooted_function_uses_the_choke_point():
         f"required enforcement calls are proven: {sorted(unverified)}"
     )
 
-    unvisited_non_entry_helpers = (
-        set(_NON_ENTRY_WORKSPACE_HELPERS) - visited_non_entry_helpers
+    invalid_non_entry_helpers = {
+        name: visited_non_entry_helpers.get(name, 0)
+        for name in _NON_ENTRY_WORKSPACE_HELPERS
+        if visited_non_entry_helpers.get(name, 0) != 1
+    }
+    assert not invalid_non_entry_helpers, (
+        "each module-qualified pure transform/renderer exemption must match exactly "
+        "one workspace-rooted function; remove stale or duplicate exemptions rather "
+        f"than widening the hole: {invalid_non_entry_helpers}"
     )
-    assert not unvisited_non_entry_helpers, (
-        "these names are exempted as pure already-admitted transforms/renderers "
-        "but were not found by the workspace-root scan; remove stale exemptions "
-        f"rather than silently widening the hole: {sorted(unvisited_non_entry_helpers)}"
+
+
+def test_git_pure_helper_exemption_does_not_apply_to_same_name_in_other_module(
+    tmp_path,
+    monkeypatch,
+):
+    """A duplicate private name outside Git remains a checked entry point."""
+    import importlib
+    from types import SimpleNamespace
+
+    import tldw_chatbook.Tools as tools_pkg
+
+    fixture = tmp_path / "duplicate_workspace_helper.py"
+    fixture.write_text(
+        "def _git_cwd(workspace_root):\n"
+        "    return workspace_root / 'unchecked-target'\n",
+        encoding="utf-8",
     )
+    fixture_module_name = "tldw_chatbook.Tools.duplicate_workspace_helper"
+    fixture_module = SimpleNamespace(
+        __name__=fixture_module_name,
+        __file__=str(fixture),
+    )
+    tools_dir = Path(tools_pkg.__file__).parent
+    original_glob = Path.glob
+    original_import_module = importlib.import_module
+
+    def glob_with_fixture(path, pattern):
+        discovered = list(original_glob(path, pattern))
+        if path == tools_dir and pattern == "*.py":
+            discovered.append(fixture)
+        return iter(discovered)
+
+    def import_with_fixture(name):
+        if name == fixture_module_name:
+            return fixture_module
+        return original_import_module(name)
+
+    monkeypatch.setattr(Path, "glob", glob_with_fixture)
+    monkeypatch.setattr(importlib, "import_module", import_with_fixture)
+
+    with pytest.raises(AssertionError, match=r"duplicate_workspace_helper\._git_cwd"):
+        test_every_workspace_rooted_function_uses_the_choke_point()
 
 
 def test_fs_family_never_creates_directories_on_the_agents_behalf():

--- a/Tests/Tools/test_patch_tool_impls.py
+++ b/Tests/Tools/test_patch_tool_impls.py
@@ -10,8 +10,11 @@ from tldw_chatbook.Tools.patch_tool_impls import (
     PATCH_MAX_FILES,
     PATCH_MAX_HUNKS,
     parse_patch_targets,
+    patch_validated_files,
     patch_files,
 )
+from tldw_chatbook.Tools.workspace_root_pin import pin_workspace_root
+from tldw_chatbook.Utils.filesystem_identity import capture_directory_chain
 
 MODIFY_DIFF = """\
 --- a/notes.txt
@@ -65,6 +68,19 @@ def test_dry_run_writes_nothing(tmp_path):
     result = patch_files(CREATE_DIFF, workspace_root=ws, dry_run=True)
     assert "would patch new.txt" in result
     assert not (ws / "new.txt").exists()
+
+
+def test_patch_validated_files_uses_one_pin_and_preserves_dry_run(tmp_path):
+    ws = _ws(tmp_path)
+    (ws / "notes.txt").write_bytes(b"alpha\r\nbeta\r\ngamma\r\n")
+    plans = parse_patch_targets(MODIFY_DIFF)
+    chain = capture_directory_chain(ws)
+
+    with pin_workspace_root(chain.canonical_root, chain) as root:
+        result = patch_validated_files(plans, root=root, dry_run=True)
+
+    assert result == "would patch notes.txt"
+    assert (ws / "notes.txt").read_bytes() == b"alpha\r\nbeta\r\ngamma\r\n"
 
 
 def test_parse_patch_targets_reuses_bounded_parser_and_normalizes_paths():

--- a/Tests/Tools/test_virtual_cli_impls.py
+++ b/Tests/Tools/test_virtual_cli_impls.py
@@ -4,6 +4,19 @@ import pytest
 
 from tldw_chatbook.Tools import virtual_cli_impls
 from tldw_chatbook.Tools.local_tool_impls import LocalToolError
+from tldw_chatbook.Tools.workspace_tool_executor import WorkspaceToolExecutionError
+
+
+class RecordingWorkspaceExecutor:
+    def __init__(self, error: str | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[str, dict, str]] = []
+
+    def execute(self, operation: str, arguments: dict, *, intent: str) -> str:
+        self.calls.append((operation, dict(arguments), intent))
+        if self.error is not None:
+            raise WorkspaceToolExecutionError(self.error)
+        return operation
 
 
 def _registry(tmp_path: Path):
@@ -28,6 +41,106 @@ def test_virtual_cli_command_set_is_fixed_and_read_only():
 
 
 @pytest.mark.parametrize(
+    ("command", "argv", "operation", "arguments"),
+    (
+        ("ls", ["docs"], "fs_list", {"path": "docs"}),
+        (
+            "cat",
+            ["a.txt", "--offset", "2", "--limit", "4"],
+            "fs_read",
+            {"path": "a.txt", "offset": 2, "limit": 4},
+        ),
+        (
+            "grep",
+            ["needle", "--mode", "files"],
+            "fs_grep",
+            {"pattern": "needle", "mode": "files"},
+        ),
+        ("find", ["**/*.py"], "fs_glob", {"pattern": "**/*.py"}),
+        ("stat", ["a.txt"], "stat_path", {"path": "a.txt"}),
+        ("git_status", ["src"], "git_status", {"path": "src"}),
+        (
+            "git_diff",
+            ["--staged", "--range", "HEAD~1..HEAD", "--path", "a.py", "--stat"],
+            "git_diff",
+            {
+                "staged": True,
+                "commit_range": "HEAD~1..HEAD",
+                "path": "a.py",
+                "stat": True,
+            },
+        ),
+        (
+            "git_log",
+            ["--count", "7", "--path", "src"],
+            "git_log",
+            {"count": 7, "path": "src"},
+        ),
+        (
+            "git_blame",
+            ["a.py", "--start", "2", "--end", "5"],
+            "git_blame",
+            {"path": "a.py", "start_line": 2, "end_line": 5},
+        ),
+        ("git_branches", [], "git_branches", {}),
+    ),
+)
+def test_leased_virtual_cli_routes_every_command_once_through_executor(
+    tmp_path, monkeypatch, command, argv, operation, arguments
+):
+    """Replacing any leased branch with its direct core must trip this test."""
+
+    def direct_core_reached(*_args, **_kwargs):
+        pytest.fail("production Virtual CLI must not call direct workspace cores")
+
+    for name in (
+        "list_directory",
+        "read_file",
+        "grep_files",
+        "glob_files",
+        "stat_path",
+        "git_status",
+        "git_diff",
+        "git_log",
+        "git_blame",
+        "git_branches",
+    ):
+        monkeypatch.setattr(virtual_cli_impls, name, direct_core_reached)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    executor = RecordingWorkspaceExecutor()
+    registry = virtual_cli_impls.VirtualCliRegistry(
+        workspace,
+        workspace_executor=executor,
+    )
+
+    assert registry.execute(command, argv) == operation
+    assert executor.calls == [(operation, arguments, "read")]
+
+
+def test_leased_cat_limit_zero_calls_executor_once_and_returns_empty_page(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "note.txt").write_text("first\nsecond\n", encoding="utf-8")
+    unleased = virtual_cli_impls.VirtualCliRegistry(workspace)
+    expected = unleased.execute("cat", ["note.txt", "--limit", "0"])
+    executor = RecordingWorkspaceExecutor()
+    executor.execute = lambda operation, arguments, *, intent: (
+        executor.calls.append((operation, dict(arguments), intent)) or expected
+    )
+    registry = virtual_cli_impls.VirtualCliRegistry(
+        workspace,
+        workspace_executor=executor,
+    )
+
+    assert registry.execute("cat", ["note.txt", "--limit", "0"]) == ""
+    assert executor.calls == [
+        ("fs_read", {"path": "note.txt", "offset": 1, "limit": 0}, "read")
+    ]
+
+
+@pytest.mark.parametrize(
     ("command", "argv", "expected"),
     (
         ("ls", ["docs"], ("list_directory", "docs")),
@@ -46,7 +159,7 @@ def test_virtual_cli_command_set_is_fixed_and_read_only():
         ("git_branches", [], ("git_branches",)),
     ),
 )
-def test_virtual_cli_dispatches_each_command_directly(
+def test_explicitly_unleased_virtual_cli_dispatches_each_command_directly(
     tmp_path, monkeypatch, command, argv, expected
 ):
     registry, _workspace = _registry(tmp_path)

--- a/Tests/Tools/test_workspace_root_pin.py
+++ b/Tests/Tools/test_workspace_root_pin.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import multiprocessing
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.Tools.workspace_root_pin import (
+    WorkspaceRootPinError,
+    pin_workspace_root,
+)
+from tldw_chatbook.Utils.filesystem_identity import DirectoryChain, capture_directory_chain
+
+
+def _pre_pin_child(locator: str, chain: DirectoryChain, output: Any) -> None:
+    try:
+        with pin_workspace_root(Path(locator), chain):
+            output.put(("pinned", ""))
+    except WorkspaceRootPinError as error:
+        output.put(("refused", str(error)))
+
+
+def _post_pin_child(
+    locator: str,
+    chain: DirectoryChain,
+    ready: Any,
+    resume: Any,
+    output: Any,
+) -> None:
+    try:
+        with pin_workspace_root(Path(locator), chain) as pinned:
+            ready.set()
+            if not resume.wait(5):
+                raise RuntimeError("test barrier timed out")
+            output.put(
+                (
+                    "read",
+                    pinned.relative_path("sentinel.txt").read_text(encoding="utf-8"),
+                )
+            )
+    except BaseException as error:
+        output.put(("error", type(error).__name__))
+
+
+def _spawn_context() -> multiprocessing.context.BaseContext:
+    return multiprocessing.get_context("spawn")
+
+
+def _join_child(process: Any) -> None:
+    process.join(10)
+    if process.is_alive():
+        process.kill()
+        process.join(5)
+        pytest.fail("root-pin child did not exit")
+    assert process.exitcode == 0
+
+
+def test_root_replacement_before_pin_is_refused_by_identity(tmp_path: Path) -> None:
+    locator = tmp_path / "workspace"
+    locator.mkdir()
+    (locator / "sentinel.txt").write_text("A", encoding="utf-8")
+    chain = capture_directory_chain(locator)
+
+    retained_a = tmp_path / "retained-a"
+    locator.rename(retained_a)
+    locator.mkdir()
+    (locator / "sentinel.txt").write_text("B", encoding="utf-8")
+
+    context = _spawn_context()
+    output = context.Queue()
+    process = context.Process(
+        target=_pre_pin_child,
+        args=(str(locator), chain, output),
+    )
+    process.start()
+    _join_child(process)
+
+    assert output.get(timeout=2) == ("refused", "workspace root identity mismatch")
+
+
+def test_root_replacement_after_pin_never_redirects_relative_io(tmp_path: Path) -> None:
+    locator = tmp_path / "workspace"
+    locator.mkdir()
+    (locator / "sentinel.txt").write_text("A", encoding="utf-8")
+    replacement_b = tmp_path / "replacement-b"
+    replacement_b.mkdir()
+    (replacement_b / "sentinel.txt").write_text("B", encoding="utf-8")
+    chain = capture_directory_chain(locator)
+
+    context = _spawn_context()
+    ready = context.Event()
+    resume = context.Event()
+    output = context.Queue()
+    process = context.Process(
+        target=_post_pin_child,
+        args=(str(locator), chain, ready, resume, output),
+    )
+    process.start()
+    assert ready.wait(5), "root-pin child did not reach the barrier"
+
+    retained_a = tmp_path / "retained-a"
+    replacement_refused = False
+    try:
+        os.replace(locator, retained_a)
+        os.replace(replacement_b, locator)
+    except OSError:
+        replacement_refused = True
+        if retained_a.exists() and not locator.exists():
+            os.replace(retained_a, locator)
+    finally:
+        resume.set()
+
+    _join_child(process)
+    outcome = output.get(timeout=2)
+    assert outcome == ("read", "A")
+    if os.name == "nt":
+        assert replacement_refused, "Windows should lock the retained current directory"
+
+
+def test_relative_path_rejects_absolute_and_parent_paths(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    chain = capture_directory_chain(root)
+
+    with pin_workspace_root(root, chain) as pinned:
+        with pytest.raises(WorkspaceRootPinError, match="relative path"):
+            pinned.relative_path(str(tmp_path / "outside.txt"))
+        with pytest.raises(WorkspaceRootPinError, match="relative path"):
+            pinned.relative_path("../outside.txt")

--- a/Tests/Tools/test_workspace_root_pin.py
+++ b/Tests/Tools/test_workspace_root_pin.py
@@ -53,6 +53,26 @@ def _post_pin_child(
         output.put(("error", type(error).__name__))
 
 
+def _post_pin_write_child(
+    locator: str,
+    chain: DirectoryChain,
+    ready: Any,
+    resume: Any,
+    output: Any,
+) -> None:
+    try:
+        with pin_workspace_root(Path(locator), chain) as pinned:
+            ready.set()
+            if not resume.wait(5):
+                raise RuntimeError("test barrier timed out")
+            pinned.relative_path("written.txt").write_text(
+                "A_WRITE", encoding="utf-8"
+            )
+            output.put(("written", "A_WRITE"))
+    except BaseException as error:
+        output.put(("error", type(error).__name__))
+
+
 def _spawn_context() -> multiprocessing.context.BaseContext:
     return multiprocessing.get_context("spawn")
 
@@ -128,6 +148,54 @@ def test_root_replacement_after_pin_never_redirects_relative_io(tmp_path: Path) 
     _join_child(process)
     outcome = output.get(timeout=2)
     assert outcome == ("read", "A")
+    if os.name == "nt":
+        assert replacement_refused, "Windows should lock the retained current directory"
+
+
+def test_root_replacement_after_pin_never_redirects_relative_write(
+    tmp_path: Path,
+) -> None:
+    locator = tmp_path / "workspace"
+    locator.mkdir()
+    replacement_b = tmp_path / "replacement-b"
+    replacement_b.mkdir()
+    chain = capture_directory_chain(locator)
+
+    context = _spawn_context()
+    ready = context.Event()
+    resume = context.Event()
+    output = context.Queue()
+    process = context.Process(
+        target=_post_pin_write_child,
+        args=(str(locator), chain, ready, resume, output),
+    )
+    process.start()
+    assert ready.wait(5), "root-pin child did not reach the write barrier"
+
+    retained_a = tmp_path / "retained-a"
+    replacement_refused = False
+    try:
+        os.replace(locator, retained_a)
+        os.replace(replacement_b, locator)
+    except OSError:
+        replacement_refused = True
+        if retained_a.exists() and not locator.exists():
+            os.replace(retained_a, locator)
+    finally:
+        resume.set()
+
+    _join_child(process)
+    assert output.get(timeout=2) == ("written", "A_WRITE")
+    written_in_a = (
+        (retained_a / "written.txt")
+        if retained_a.exists()
+        else (locator / "written.txt")
+    )
+    assert written_in_a.read_text(encoding="utf-8") == "A_WRITE"
+    if replacement_b.exists():
+        assert not (replacement_b / "written.txt").exists()
+    else:
+        assert not (locator / "written.txt").exists()
     if os.name == "nt":
         assert replacement_refused, "Windows should lock the retained current directory"
 

--- a/Tests/Tools/test_workspace_root_pin.py
+++ b/Tests/Tools/test_workspace_root_pin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import multiprocessing
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 import pytest
@@ -14,8 +14,17 @@ from tldw_chatbook.Tools.workspace_root_pin import (
 from tldw_chatbook.Utils.filesystem_identity import DirectoryChain, capture_directory_chain
 
 
-def _pre_pin_child(locator: str, chain: DirectoryChain, output: Any) -> None:
+def _pre_pin_child(
+    locator: str,
+    chain: DirectoryChain,
+    ready: Any,
+    resume: Any,
+    output: Any,
+) -> None:
     try:
+        ready.set()
+        if not resume.wait(5):
+            raise RuntimeError("test barrier timed out")
         with pin_workspace_root(Path(locator), chain):
             output.put(("pinned", ""))
     except WorkspaceRootPinError as error:
@@ -63,18 +72,22 @@ def test_root_replacement_before_pin_is_refused_by_identity(tmp_path: Path) -> N
     (locator / "sentinel.txt").write_text("A", encoding="utf-8")
     chain = capture_directory_chain(locator)
 
+    context = _spawn_context()
+    ready = context.Event()
+    resume = context.Event()
+    output = context.Queue()
+    process = context.Process(
+        target=_pre_pin_child,
+        args=(str(locator), chain, ready, resume, output),
+    )
+    process.start()
+    assert ready.wait(5), "root-pin child did not reach the pre-pin barrier"
+
     retained_a = tmp_path / "retained-a"
     locator.rename(retained_a)
     locator.mkdir()
     (locator / "sentinel.txt").write_text("B", encoding="utf-8")
-
-    context = _spawn_context()
-    output = context.Queue()
-    process = context.Process(
-        target=_pre_pin_child,
-        args=(str(locator), chain, output),
-    )
-    process.start()
+    resume.set()
     _join_child(process)
 
     assert output.get(timeout=2) == ("refused", "workspace root identity mismatch")
@@ -129,3 +142,27 @@ def test_relative_path_rejects_absolute_and_parent_paths(tmp_path: Path) -> None
             pinned.relative_path(str(tmp_path / "outside.txt"))
         with pytest.raises(WorkspaceRootPinError, match="relative path"):
             pinned.relative_path("../outside.txt")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(r"\outside.txt", id="rooted-current-drive"),
+        pytest.param("C:outside.txt", id="drive-relative"),
+        pytest.param(r"C:\outside.txt", id="drive-rooted"),
+        pytest.param(r"\\server\share\outside.txt", id="unc"),
+    ],
+)
+def test_relative_path_rejects_windows_drive_root_and_anchor_on_every_platform(
+    tmp_path: Path,
+    value: str,
+) -> None:
+    windows_path = PureWindowsPath(value)
+    assert windows_path.drive or windows_path.root or windows_path.anchor
+    root = tmp_path / "workspace"
+    root.mkdir()
+    chain = capture_directory_chain(root)
+
+    with pin_workspace_root(root, chain) as pinned:
+        with pytest.raises(WorkspaceRootPinError, match="relative path"):
+            pinned.relative_path(value)

--- a/Tests/Tools/test_workspace_root_pin.py
+++ b/Tests/Tools/test_workspace_root_pin.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 
+import tldw_chatbook.Tools.workspace_root_pin as workspace_root_pin
 from tldw_chatbook.Tools.workspace_root_pin import (
     WorkspaceRootPinError,
     pin_workspace_root,
@@ -210,6 +211,43 @@ def test_relative_path_rejects_absolute_and_parent_paths(tmp_path: Path) -> None
             pinned.relative_path(str(tmp_path / "outside.txt"))
         with pytest.raises(WorkspaceRootPinError, match="relative path"):
             pinned.relative_path("../outside.txt")
+
+
+def test_root_locator_uses_central_path_validator_before_pin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+    chain = capture_directory_chain(root)
+    calls: list[tuple[Path, Path, bool, bool]] = []
+    validated = [root.resolve()]
+
+    def validate(
+        user_path: Path,
+        base_directory: Path,
+        *,
+        redact_paths: bool,
+        allow_hidden: bool,
+    ) -> Path:
+        calls.append(
+            (Path(user_path), Path(base_directory), redact_paths, allow_hidden)
+        )
+        return validated[0]
+
+    monkeypatch.setattr(workspace_root_pin, "validate_path", validate, raising=False)
+
+    with pin_workspace_root(root, chain) as pinned:
+        assert pinned.canonical_locator == root.resolve()
+
+    validated[0] = other.resolve()
+    with pytest.raises(WorkspaceRootPinError, match="invalid admitted"):
+        with pin_workspace_root(root, chain):
+            pass
+
+    assert calls == [(root, root, True, True), (root, root, True, True)]
 
 
 @pytest.mark.parametrize(

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import io
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.Tools.workspace_tool_executor import (
+    DIAGNOSTIC_STDERR_MAX_BYTES,
+    WorkspaceToolExecutionError,
+    WorkspaceToolExecutor,
+    workspace_worker_environment,
+)
+from tldw_chatbook.Tools.workspace_tool_protocol import (
+    MAX_RESPONSE_BYTES,
+    WorkspaceToolRequest,
+    WorkspaceToolResponse,
+)
+from tldw_chatbook.Tools.workspace_tool_worker import run_workspace_worker
+from tldw_chatbook.Utils.filesystem_identity import capture_directory_chain
+
+
+_OPERATION_ID = "fixed-operation-id"
+
+
+class _RecordingInput(io.BytesIO):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__()
+        self._events = events
+        self.was_closed = False
+
+    def write(self, value: bytes) -> int:
+        self._events.append("stdin-write")
+        return super().write(value)
+
+    def close(self) -> None:
+        self.was_closed = True
+        self._events.append("stdin-close")
+
+
+class _FakePopen:
+    def __init__(
+        self,
+        response: bytes,
+        stderr: bytes,
+        events: list[str],
+        *,
+        returncode: int = 0,
+        timeout: bool = False,
+    ) -> None:
+        self.pid = 7321
+        self.stdin = _RecordingInput(events)
+        self.stdout = io.BytesIO(response)
+        self.stderr = io.BytesIO(stderr)
+        self.returncode: int | None = None
+        self._final_returncode = returncode
+        self._timeout = timeout
+        self._events = events
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        self._events.append("wait")
+        if self._timeout:
+            raise subprocess.TimeoutExpired("fixed-worker", timeout)
+        self.returncode = self._final_returncode
+        return self._final_returncode
+
+    def terminate(self) -> None:
+        self._events.append("terminate")
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self._events.append("kill")
+        self.returncode = -9
+
+
+class _FakeTree:
+    cleanup_proven = True
+    instances: list[_FakeTree] = []
+
+    def __init__(self, process: Any, admission: Any, identity: Any) -> None:
+        self.process = process
+        self.admission = admission
+        self.identity = identity
+        self.events = process._process._events
+        type(self).instances.append(self)
+
+    def admit(self) -> None:
+        self.events.append("admit")
+
+    def close(self) -> bool:
+        self.events.append("close-tree")
+        return type(self).cleanup_proven
+
+    def terminate_tree(self, **_kwargs: Any) -> bool:
+        self.events.append("terminate-tree")
+        self.process._process.returncode = -9
+        return type(self).cleanup_proven
+
+
+def _response(
+    *,
+    outcome: str = "success",
+    code: str = "ok",
+    result: str | None = "RESULT",
+    error: str | None = None,
+) -> bytes:
+    admitted = WorkspaceToolResponse(
+        operation_id=_OPERATION_ID,
+        outcome="admitted",
+        code="root_pinned",
+        result=None,
+        error=None,
+        elapsed_ms=0,
+        truncated=False,
+        cleanup_proven=True,
+    ).to_bytes()
+    terminal = WorkspaceToolResponse(
+        operation_id=_OPERATION_ID,
+        outcome=outcome,  # type: ignore[arg-type]
+        code=code,
+        result=result,
+        error=error,
+        elapsed_ms=1,
+        truncated=False,
+        cleanup_proven=True,
+    ).to_bytes()
+    return admitted + b"\n" + terminal + b"\n"
+
+
+def _install_fake_launch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    response: bytes | None = None,
+    stderr: bytes = b"",
+    returncode: int = 0,
+    timeout: bool = False,
+) -> tuple[WorkspaceToolExecutor, dict[str, Any], list[str], _FakePopen]:
+    root = tmp_path / "private-root-marker"
+    root.mkdir()
+    (root / "private-path-marker.txt").write_text("payload", encoding="utf-8")
+    events: list[str] = []
+    process = _FakePopen(
+        response if response is not None else _response(),
+        stderr,
+        events,
+        returncode=returncode,
+        timeout=timeout,
+    )
+    captured: dict[str, Any] = {}
+
+    def fake_popen(argv: list[str], **kwargs: Any) -> _FakePopen:
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        return process
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_tool_executor.subprocess.Popen", fake_popen
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_tool_executor.ExecutorProcessTree", _FakeTree
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_tool_executor.uuid.uuid4",
+        lambda: SimpleNamespace(hex=_OPERATION_ID),
+    )
+    _FakeTree.cleanup_proven = True
+    _FakeTree.instances.clear()
+    return WorkspaceToolExecutor(root), captured, events, process
+
+
+def test_executor_uses_fixed_private_launch_and_admits_before_stdin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("PRIVATE_ENV_MARKER", "private-environment-value")
+    executor, captured, events, process = _install_fake_launch(monkeypatch, tmp_path)
+
+    with caplog.at_level(logging.DEBUG):
+        result = executor.execute(
+            "stat_path",
+            {"path": "private-path-marker.txt"},
+            intent="read",
+        )
+
+    assert result == "RESULT"
+    assert captured["argv"] == [
+        sys.executable,
+        "-I",
+        "-m",
+        "tldw_chatbook.Tools.workspace_tool_worker",
+    ]
+    kwargs = captured["kwargs"]
+    assert kwargs["shell"] is False
+    assert kwargs["stdin"] is subprocess.PIPE
+    assert kwargs["stdout"] is subprocess.PIPE
+    assert kwargs["stderr"] is subprocess.PIPE
+    assert kwargs["start_new_session"] is (sys.platform != "win32")
+    assert "PRIVATE_ENV_MARKER" not in kwargs["env"]
+    assert "private-root-marker" not in repr(captured)
+    assert "private-path-marker" not in repr(captured)
+    assert events.index("admit") < events.index("stdin-write")
+    request = WorkspaceToolRequest.from_bytes(process.stdin.getvalue())
+    assert request.arguments == {"path": "private-path-marker.txt"}
+    assert process.stdin.was_closed
+    diagnostic_text = caplog.text
+    assert "private-root-marker" not in diagnostic_text
+    assert "private-path-marker" not in diagnostic_text
+    assert "private-environment-value" not in diagnostic_text
+
+
+def test_worker_environment_is_a_small_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "private-key-marker")
+    monkeypatch.setenv("HTTP_PROXY", "private-proxy-marker")
+    monkeypatch.setenv("PYTHONPATH", "private-python-marker")
+
+    environment = workspace_worker_environment()
+
+    assert set(environment) <= {
+        "PATH",
+        "LANG",
+        "LC_ALL",
+        "SYSTEMROOT",
+        "WINDIR",
+        "TEMP",
+        "TMP",
+    }
+    assert "private" not in repr(environment)
+
+
+def test_spawn_exception_details_are_not_retained_in_the_public_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    root = tmp_path / "private-root-marker"
+    root.mkdir()
+
+    def refuse_spawn(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("private-exception-marker")
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_tool_executor.subprocess.Popen", refuse_spawn
+    )
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(WorkspaceToolExecutionError) as caught:
+            WorkspaceToolExecutor(root).execute(
+                "stat_path", {"path": "."}, intent="read"
+            )
+
+    assert caught.value.code == "spawn_failed"
+    assert caught.value.__cause__ is None
+    assert "private-exception-marker" not in repr(caught.value)
+    assert "private-exception-marker" not in caplog.text
+
+
+def test_worker_pins_and_dispatches_one_real_stat_request(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    (root / "note.txt").write_text("hello", encoding="utf-8")
+    chain = capture_directory_chain(root)
+    request = WorkspaceToolRequest(
+        operation_id="worker-stat",
+        operation="stat_path",
+        intent="read",
+        root_locator=chain.canonical_root,
+        root_identity=chain.identities[0],
+        ancestor_identities=chain.identities,
+        arguments={"path": "note.txt"},
+        timeout_seconds=300,
+        output_max_bytes=MAX_RESPONSE_BYTES,
+    )
+    stdout = io.BytesIO()
+
+    exit_code = run_workspace_worker(io.BytesIO(request.to_bytes()), stdout, io.BytesIO())
+
+    frames = [WorkspaceToolResponse.from_bytes(line) for line in stdout.getvalue().splitlines()]
+    assert exit_code == 0
+    assert [frame.outcome for frame in frames] == ["admitted", "success"]
+    assert frames[1].code == "ok"
+    assert frames[1].result is not None
+    assert "path: note.txt" in frames[1].result
+    assert "size: 5" in frames[1].result
+
+
+@pytest.mark.parametrize(
+    ("response", "code"),
+    [
+        pytest.param(b"not-json\n", "protocol_failure", id="malformed"),
+        pytest.param(b"x" * (MAX_RESPONSE_BYTES + 1), "protocol_failure", id="oversized"),
+        pytest.param(
+            _response() + _response().splitlines()[-1] + b"\n",
+            "protocol_failure",
+            id="duplicate-terminal",
+        ),
+    ],
+)
+def test_malformed_oversized_or_duplicate_worker_output_is_refused(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    response: bytes,
+    code: str,
+) -> None:
+    executor, _captured, _events, _process = _install_fake_launch(
+        monkeypatch,
+        tmp_path,
+        response=response,
+    )
+
+    with pytest.raises(WorkspaceToolExecutionError) as caught:
+        executor.execute("stat_path", {"path": "private-path-marker.txt"}, intent="read")
+
+    assert caught.value.code == code
+
+
+def test_timeout_terminates_the_tree_and_returns_no_in_process_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor, _captured, events, _process = _install_fake_launch(
+        monkeypatch,
+        tmp_path,
+        timeout=True,
+    )
+
+    with pytest.raises(WorkspaceToolExecutionError) as caught:
+        executor.execute("stat_path", {"path": "private-path-marker.txt"}, intent="read")
+
+    assert caught.value.code == "worker_timed_out"
+    assert "terminate-tree" in events
+
+
+def test_crash_and_bounded_stderr_return_only_fixed_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    stderr_marker = b"private-stderr-marker"
+    executor, _captured, _events, _process = _install_fake_launch(
+        monkeypatch,
+        tmp_path,
+        response=b"",
+        stderr=stderr_marker * (DIAGNOSTIC_STDERR_MAX_BYTES + 10),
+        returncode=23,
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(WorkspaceToolExecutionError) as caught:
+            executor.execute(
+                "stat_path", {"path": "private-path-marker.txt"}, intent="read"
+            )
+
+    assert caught.value.code == "worker_crashed"
+    assert "private-stderr-marker" not in str(caught.value)
+    assert "private-stderr-marker" not in caplog.text
+
+
+def test_unproven_cleanup_refuses_an_otherwise_successful_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor, _captured, _events, _process = _install_fake_launch(monkeypatch, tmp_path)
+    _FakeTree.cleanup_proven = False
+
+    with pytest.raises(WorkspaceToolExecutionError) as caught:
+        executor.execute("stat_path", {"path": "private-path-marker.txt"}, intent="read")
+
+    assert caught.value.code == "cleanup_unproven"
+
+
+def test_unsupported_closed_operation_is_a_stable_worker_refusal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor, _captured, _events, _process = _install_fake_launch(
+        monkeypatch,
+        tmp_path,
+        response=_response(
+            outcome="failure",
+            code="unsupported_operation",
+            result=None,
+            error="workspace operation is not implemented",
+        ),
+    )
+
+    with pytest.raises(WorkspaceToolExecutionError) as caught:
+        executor.execute("fs_list", {"path": "."}, intent="read")
+
+    assert caught.value.code == "unsupported_operation"

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -1154,7 +1154,8 @@ def test_direct_worker_unsupported_operations_do_not_require_read_exclusions(
     assert caught.value.code == "unsupported_operation"
 
 
-def test_direct_worker_rejects_a_bypassed_unsafe_glob_pattern() -> None:
+@pytest.mark.parametrize("pattern", ("../outside/*.txt", "safe\x00name/*.txt"))
+def test_direct_worker_rejects_a_bypassed_unsafe_glob_pattern(pattern: str) -> None:
     chain = capture_directory_chain(Path.cwd())
     request = WorkspaceToolRequest(
         operation_id="unsafe-direct-glob",
@@ -1163,7 +1164,7 @@ def test_direct_worker_rejects_a_bypassed_unsafe_glob_pattern() -> None:
         root_locator=chain.canonical_root,
         root_identity=chain.identities[0],
         ancestor_identities=chain.identities,
-        arguments={"pattern": "../outside/*.txt", "sensitive_exclusions": []},
+        arguments={"pattern": pattern, "sensitive_exclusions": []},
         timeout_seconds=30,
         output_max_bytes=MAX_RESPONSE_BYTES,
     )
@@ -1172,6 +1173,157 @@ def test_direct_worker_rejects_a_bypassed_unsafe_glob_pattern() -> None:
         execute_pinned_operation(request, SimpleNamespace())
 
     assert caught.value.code == "invalid_request"
+
+
+def _run_worker_request(request: WorkspaceToolRequest) -> WorkspaceToolResponse:
+    """Run a hand-built pinned request and return its sole terminal frame."""
+    stdout = io.BytesIO()
+    exit_code = run_workspace_worker(io.BytesIO(request.to_bytes()), stdout, io.BytesIO())
+    frames = [
+        WorkspaceToolResponse.from_bytes(line) for line in stdout.getvalue().splitlines()
+    ]
+    assert exit_code == (0 if frames[-1].outcome == "success" else 2), frames
+    return frames[-1]
+
+
+def test_pinned_worker_applies_exclusions_to_both_lexical_and_resolved_aliases(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "public.txt").write_text("PUBLIC", encoding="utf-8")
+    os.symlink(workspace / "public.txt", workspace / "credentials")
+    chain = capture_directory_chain(workspace)
+    request = WorkspaceToolRequest(
+        operation_id="lexical-alias",
+        operation="fs_read",
+        intent="read",
+        root_locator=chain.canonical_root,
+        root_identity=chain.identities[0],
+        ancestor_identities=chain.identities,
+        arguments={
+            "path": "credentials",
+            "offset": 1,
+            "sensitive_exclusions": [{"kind": "name", "value": "credentials"}],
+        },
+        timeout_seconds=30,
+        output_max_bytes=MAX_RESPONSE_BYTES,
+    )
+
+    denied = _run_worker_request(request)
+    assert denied.outcome == "failure"
+    assert "PUBLIC" not in (denied.error or "")
+
+    os.unlink(workspace / "credentials")
+    os.symlink(workspace / "public.txt", workspace / "safe-alias")
+    allowed = WorkspaceToolRequest(
+        operation_id="safe-alias",
+        operation="fs_read",
+        intent="read",
+        root_locator=chain.canonical_root,
+        root_identity=chain.identities[0],
+        ancestor_identities=chain.identities,
+        arguments={
+            "path": "safe-alias",
+            "offset": 1,
+            "sensitive_exclusions": [{"kind": "name", "value": "credentials"}],
+        },
+        timeout_seconds=30,
+        output_max_bytes=MAX_RESPONSE_BYTES,
+    )
+    accepted = _run_worker_request(allowed)
+    assert accepted.outcome == "success"
+    assert accepted.result is not None and "PUBLIC" in accepted.result
+
+
+@pytest.mark.parametrize(
+    ("operation", "arguments", "expected"),
+    (
+        ("fs_read", {"path": "protected/child.txt", "offset": 1}, "failure"),
+        ("fs_glob", {"pattern": "**/*", "max_results": 100}, "success"),
+        (
+            "fs_grep",
+            {"pattern": "DIRECT_SECRET", "mode": "content", "max_results": 100},
+            "success",
+        ),
+    ),
+)
+def test_pinned_worker_honors_direct_children_exclusions(
+    tmp_path: Path, operation: str, arguments: dict[str, Any], expected: str
+) -> None:
+    workspace = tmp_path / "workspace"
+    protected = workspace / "protected"
+    protected.mkdir(parents=True)
+    (protected / "child.txt").write_text("DIRECT_SECRET", encoding="utf-8")
+    chain = capture_directory_chain(workspace)
+    request = WorkspaceToolRequest(
+        operation_id=f"direct-children-{operation}",
+        operation=operation,  # type: ignore[arg-type]
+        intent="read",
+        root_locator=chain.canonical_root,
+        root_identity=chain.identities[0],
+        ancestor_identities=chain.identities,
+        arguments={
+            **arguments,
+            "sensitive_exclusions": [
+                {"kind": "direct_children", "value": "protected"}
+            ],
+            **(
+                {"content_exclusions": [{"kind": "direct_children", "value": "protected"}]}
+                if operation == "fs_grep"
+                else {}
+            ),
+        },
+        timeout_seconds=30,
+        output_max_bytes=MAX_RESPONSE_BYTES,
+    )
+
+    response = _run_worker_request(request)
+    assert response.outcome == expected
+    assert response.result != "protected/child.txt:1:DIRECT_SECRET"
+    assert "child.txt" not in (response.result or "")
+
+
+@pytest.mark.parametrize(
+    ("operation", "arguments", "target_kind"),
+    (
+        ("fs_read", {"path": "link", "offset": 1}, "escaping"),
+        ("fs_read", {"path": "link", "offset": 1}, "sensitive"),
+        ("fs_glob", {"pattern": "**/*", "max_results": 100}, "escaping"),
+        (
+            "fs_grep",
+            {"pattern": "RETARGET_SECRET", "mode": "content", "max_results": 100},
+            "sensitive",
+        ),
+    ),
+)
+def test_pinned_worker_refuses_stably_retargeted_symlinks_before_operation(
+    tmp_path: Path, operation: str, arguments: dict[str, Any], target_kind: str
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "public.txt").write_text("PUBLIC", encoding="utf-8")
+    (workspace / "credentials").write_text("RETARGET_SECRET", encoding="utf-8")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("RETARGET_SECRET", encoding="utf-8")
+    link = workspace / "link"
+    os.symlink(workspace / "public.txt", link)
+    request = WorkspaceToolExecutor(workspace)._build_request(
+        operation, arguments, intent="read"
+    )
+    os.unlink(link)
+    os.symlink(outside if target_kind == "escaping" else workspace / "credentials", link)
+
+    response = _run_worker_request(request)
+    if operation == "fs_read":
+        assert response.outcome == "failure"
+    else:
+        assert response.outcome == "success"
+    assert "link" not in (response.result or "")
+    if operation == "fs_grep":
+        assert response.result == "(no matches for 'RETARGET_SECRET')"
+    else:
+        assert "RETARGET_SECRET" not in (response.result or "")
 
 
 @pytest.mark.parametrize(("operation", "arguments", "expected"), READ_CASES)

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -1774,6 +1774,69 @@ def test_pinned_git_supports_linked_worktree_without_granting_metadata_fs_access
     assert caught.value.code == "invalid_request"
 
 
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is not available")
+def test_platform_evidence_representative_one_shot_operations(
+    tmp_path: Path,
+) -> None:
+    """Exercise one real pinned request for read, write, patch, and Git."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _git(workspace, "init")
+    _git(workspace, "config", "user.email", "test@example.invalid")
+    _git(workspace, "config", "user.name", "Test User")
+    _git(workspace, "config", "commit.gpgsign", "false")
+    (workspace / "note.txt").write_text("read marker\n", encoding="utf-8")
+    (workspace / "patch.txt").write_text("before\n", encoding="utf-8")
+    _git(workspace, "add", ".")
+    _git(workspace, "commit", "-m", "platform evidence baseline")
+    executor = WorkspaceToolExecutor(workspace)
+
+    read = _run_worker_request(
+        executor._build_request(
+            "fs_read", {"path": "note.txt", "offset": 1}, intent="read"
+        )
+    )
+    assert read.outcome == "success"
+    assert "read marker" in (read.result or "")
+
+    write = _run_worker_request(
+        executor._build_request(
+            "fs_write",
+            {"path": "written.txt", "content": "write marker\n"},
+            intent="write",
+        )
+    )
+    assert write.outcome == "success"
+    assert (workspace / "written.txt").read_text(encoding="utf-8") == "write marker\n"
+
+    patch_text = """\
+--- a/patch.txt
++++ b/patch.txt
+@@ -1 +1 @@
+-before
++after
+"""
+    patch = _run_worker_request(
+        executor._build_request(
+            "fs_patch", {"diff": patch_text, "dry_run": False}, intent="write"
+        )
+    )
+    assert patch.outcome == "success"
+    assert (workspace / "patch.txt").read_text(encoding="utf-8") == "after\n"
+
+    status = _run_worker_request(
+        executor._build_request("git_status", {}, intent="read")
+    )
+    assert status.outcome == "success"
+    assert "written.txt" in (status.result or "")
+
+    diff = _run_worker_request(
+        executor._build_request("git_diff", {}, intent="read")
+    )
+    assert diff.outcome == "success"
+    assert "+after" in (diff.result or "")
+
+
 @pytest.mark.parametrize(("operation", "arguments"), MUTATION_CASES)
 def test_pre_pin_mutations_refuse_a_replaced_root_without_touching_b_or_external_bytes(
     tmp_path: Path,

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -790,6 +790,64 @@ def test_cancellation_identity_survives_cleanup_exception_and_closes_pipes(
     assert process.stderr.closed
 
 
+def test_cleanup_supervisor_join_cancellation_preserves_identity_after_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    cancellation = KeyboardInterrupt("private-supervisor-join-marker")
+    executor, _captured, events, process = _install_fake_launch(monkeypatch, tmp_path)
+    original_join = threading.Thread.join
+    join_interrupted = threading.Event()
+    finished = threading.Event()
+    results: list[str] = []
+    outcome: list[BaseException] = []
+
+    def interrupt_completed_cleanup_join(
+        thread: threading.Thread,
+        timeout: float | None = None,
+    ) -> None:
+        original_join(thread, timeout)
+        if thread.name == "workspace-worker-cleanup" and not join_interrupted.is_set():
+            join_interrupted.set()
+            raise cancellation
+
+    def execute() -> None:
+        try:
+            results.append(
+                executor.execute(
+                    "stat_path",
+                    {"path": "private-path-marker.txt"},
+                    intent="read",
+                )
+            )
+        except BaseException as error:
+            outcome.append(error)
+        finally:
+            finished.set()
+
+    monkeypatch.setattr(threading.Thread, "join", interrupt_completed_cleanup_join)
+    with caplog.at_level(logging.DEBUG):
+        caller = threading.Thread(target=execute, name="workspace-executor-test-caller")
+        caller.start()
+        assert finished.wait(1), "supervisor join cancellation did not return boundedly"
+        caller.join(1)
+
+    assert not caller.is_alive()
+    assert join_interrupted.is_set()
+    assert results == []
+    assert len(outcome) == 1
+    assert outcome[0] is cancellation
+    assert "terminate-tree" in events
+    assert process.stdin.was_closed
+    assert process.stdout.closed
+    assert process.stderr.closed
+    assert "private-supervisor-join-marker" not in caplog.text
+    assert "private-root-marker" not in caplog.text
+    assert "private-path-marker" not in caplog.text
+    assert "RESULT" not in caplog.text
+
+
 @pytest.mark.parametrize(
     ("start_error", "expected_code"),
     [

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+import multiprocessing
 import os
 import site
 import subprocess
@@ -22,6 +23,14 @@ from tldw_chatbook.Tools.workspace_tool_executor import (
     WorkspaceToolExecutor,
     workspace_worker_environment,
 )
+from tldw_chatbook.Tools.workspace_root_pin import (
+    WorkspaceRootPinError,
+    pin_workspace_root,
+)
+from tldw_chatbook.Tools.workspace_tool_dispatch import (
+    WorkspaceToolDispatchError,
+    execute_pinned_operation,
+)
 from tldw_chatbook.Tools.workspace_tool_protocol import (
     MAX_RESPONSE_BYTES,
     WorkspaceToolRequest,
@@ -32,6 +41,54 @@ from tldw_chatbook.Utils.filesystem_identity import capture_directory_chain
 
 
 _OPERATION_ID = "fixed-operation-id"
+
+
+READ_CASES = (
+    ("fs_list", {"path": "."}, "A_ONLY"),
+    ("fs_read", {"path": "sentinel.txt", "offset": 1}, "A_ONLY"),
+    ("fs_glob", {"pattern": "**/*.txt", "max_results": 100}, "sentinel.txt"),
+    (
+        "fs_grep",
+        {"pattern": "A_ONLY", "mode": "content", "max_results": 100},
+        "A_ONLY",
+    ),
+)
+
+
+def _post_pin_read_operation_child(
+    locator: str,
+    chain: Any,
+    operation: str,
+    arguments: dict[str, Any],
+    ready: Any,
+    resume: Any,
+    output: Any,
+) -> None:
+    """Execute one read only after the parent attempts a root replacement."""
+    try:
+        with pin_workspace_root(Path(locator), chain) as root:
+            ready.set()
+            if not resume.wait(5):
+                raise RuntimeError("test barrier timed out")
+            request = WorkspaceToolRequest(
+                operation_id="post-pin-read",
+                operation=operation,  # type: ignore[arg-type]
+                intent="read",
+                root_locator=chain.canonical_root,
+                root_identity=chain.identities[0],
+                ancestor_identities=chain.identities,
+                arguments=arguments,
+                timeout_seconds=300,
+                output_max_bytes=MAX_RESPONSE_BYTES,
+            )
+            try:
+                output.put(("result", execute_pinned_operation(request, root)))
+            except WorkspaceToolDispatchError as error:
+                output.put(("refused", error.code))
+    except WorkspaceRootPinError:
+        output.put(("refused", "root_pin_failed"))
+    except BaseException as error:
+        output.put(("error", type(error).__name__))
 
 
 class _RecordingInput(io.BytesIO):
@@ -1036,3 +1093,134 @@ def test_unsupported_closed_operation_is_a_stable_worker_refusal(
         executor.execute("fs_list", {"path": "."}, intent="read")
 
     assert caught.value.code == "unsupported_operation"
+
+
+@pytest.mark.parametrize(("operation", "arguments", "expected"), READ_CASES)
+def test_pre_pin_read_operations_refuse_a_replaced_root(
+    tmp_path: Path,
+    operation: str,
+    arguments: dict[str, Any],
+    expected: str,
+) -> None:
+    """Every read rejects a replacement before it can observe B's contents."""
+    locator = tmp_path / "workspace"
+    locator.mkdir()
+    (locator / "sentinel.txt").write_text("A_ONLY", encoding="utf-8")
+    chain = capture_directory_chain(locator)
+    replacement = tmp_path / "replacement-b"
+    replacement.mkdir()
+    (replacement / "sentinel.txt").write_text("B_ONLY", encoding="utf-8")
+    retained = tmp_path / "retained-a"
+    os.replace(locator, retained)
+    os.replace(replacement, locator)
+    request = WorkspaceToolRequest(
+        operation_id="pre-pin-read",
+        operation=operation,  # type: ignore[arg-type]
+        intent="read",
+        root_locator=chain.canonical_root,
+        root_identity=chain.identities[0],
+        ancestor_identities=chain.identities,
+        arguments=arguments,
+        timeout_seconds=300,
+        output_max_bytes=MAX_RESPONSE_BYTES,
+    )
+    stdout = io.BytesIO()
+
+    exit_code = run_workspace_worker(
+        io.BytesIO(request.to_bytes()), stdout, io.BytesIO()
+    )
+
+    frames = [
+        WorkspaceToolResponse.from_bytes(line) for line in stdout.getvalue().splitlines()
+    ]
+    assert exit_code == 2
+    assert [frame.outcome for frame in frames] == ["failure"]
+    assert frames[0].code == "root_pin_failed"
+    assert expected not in (frames[0].error or "")
+    assert "B_ONLY" not in (frames[0].error or "")
+
+
+def test_pinned_read_refuses_a_sensitive_relative_name(tmp_path: Path) -> None:
+    """Pinned reads apply the bounded exclusion names before opening a file."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "credentials").write_text("SECRET", encoding="utf-8")
+    chain = capture_directory_chain(workspace)
+    request = WorkspaceToolRequest(
+        operation_id="sensitive-read",
+        operation="fs_read",
+        intent="read",
+        root_locator=chain.canonical_root,
+        root_identity=chain.identities[0],
+        ancestor_identities=chain.identities,
+        arguments={"path": "credentials", "offset": 1},
+        timeout_seconds=300,
+        output_max_bytes=MAX_RESPONSE_BYTES,
+    )
+
+    with pin_workspace_root(workspace, chain) as root:
+        with pytest.raises(WorkspaceToolDispatchError) as caught:
+            execute_pinned_operation(request, root)
+
+    assert caught.value.code == "invalid_request"
+    assert "SECRET" not in str(caught.value)
+
+
+@pytest.mark.parametrize(("operation", "arguments", "expected"), READ_CASES)
+def test_post_pin_read_operations_never_redirect_to_replaced_root(
+    tmp_path: Path,
+    operation: str,
+    arguments: dict[str, Any],
+    expected: str,
+) -> None:
+    """Pinned read bodies return A or refuse, never the replacement's B data."""
+    locator = tmp_path / "workspace"
+    locator.mkdir()
+    replacement = tmp_path / "replacement-b"
+    replacement.mkdir()
+    if operation == "fs_list":
+        (locator / "A_ONLY").write_text("a", encoding="utf-8")
+        (replacement / "B_ONLY").write_text("b", encoding="utf-8")
+    elif operation == "fs_glob":
+        (locator / "sentinel.txt").write_text("A_ONLY", encoding="utf-8")
+        (replacement / "B_ONLY.txt").write_text("B_ONLY", encoding="utf-8")
+    else:
+        (locator / "sentinel.txt").write_text("A_ONLY", encoding="utf-8")
+        (replacement / "sentinel.txt").write_text("B_ONLY", encoding="utf-8")
+    chain = capture_directory_chain(locator)
+
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    resume = context.Event()
+    output = context.Queue()
+    process = context.Process(
+        target=_post_pin_read_operation_child,
+        args=(str(locator), chain, operation, arguments, ready, resume, output),
+    )
+    process.start()
+    assert ready.wait(5), "read worker did not pin its root"
+
+    retained = tmp_path / "retained-a"
+    replacement_refused = False
+    try:
+        os.replace(locator, retained)
+        os.replace(replacement, locator)
+    except OSError:
+        replacement_refused = True
+        if retained.exists() and not locator.exists():
+            os.replace(retained, locator)
+    finally:
+        resume.set()
+    process.join(10)
+    if process.is_alive():
+        process.kill()
+        process.join(5)
+        pytest.fail("post-pin read worker did not exit")
+    assert process.exitcode == 0
+
+    outcome, value = output.get(timeout=2)
+    assert outcome == "result"
+    assert "B_ONLY" not in value
+    assert expected in value
+    if os.name == "nt":
+        assert replacement_refused, "Windows should lock the retained current directory"

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -791,6 +791,91 @@ def test_cancellation_identity_survives_cleanup_exception_and_closes_pipes(
 
 
 @pytest.mark.parametrize(
+    ("start_error", "expected_code"),
+    [
+        pytest.param(
+            RuntimeError("private-supervisor-start-marker"),
+            "worker_failure",
+            id="ordinary-start-failure",
+        ),
+        pytest.param(
+            KeyboardInterrupt("private-supervisor-cancellation-marker"),
+            None,
+            id="cancellation-start-failure",
+        ),
+    ],
+)
+def test_cleanup_supervisor_start_failure_precedes_authority_and_falls_back(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    start_error: BaseException,
+    expected_code: str | None,
+) -> None:
+    executor, _captured, events, process = _install_fake_launch(monkeypatch, tmp_path)
+    original_start = threading.Thread.start
+
+    def fail_cleanup_supervisor(thread: threading.Thread) -> None:
+        if thread.name == "workspace-worker-cleanup":
+            raise start_error
+        original_start(thread)
+
+    monkeypatch.setattr(threading.Thread, "start", fail_cleanup_supervisor)
+
+    with pytest.raises(BaseException) as caught:
+        executor.execute("stat_path", {"path": "private-path-marker.txt"}, intent="read")
+
+    if expected_code is None:
+        assert caught.value is start_error
+    else:
+        assert isinstance(caught.value, WorkspaceToolExecutionError)
+        assert caught.value.code == expected_code
+        assert "private-supervisor-start-marker" not in repr(caught.value)
+    assert "stdin-write" not in events
+    assert "terminate-tree" in events
+    assert process.stdin.was_closed
+    assert process.stdout.closed
+    assert process.stderr.closed
+
+
+@pytest.mark.parametrize("cancel_during_wait", [False, True])
+def test_pipe_closer_start_failure_is_bounded_and_preserves_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cancel_during_wait: bool,
+) -> None:
+    cancellation = KeyboardInterrupt("private-inflight-cancellation-marker")
+    executor, _captured, events, process = _install_fake_launch(
+        monkeypatch,
+        tmp_path,
+        wait_error=cancellation if cancel_during_wait else None,
+    )
+    original_start = threading.Thread.start
+
+    def fail_first_pipe_closer(thread: threading.Thread) -> None:
+        if thread.name == "workspace-worker-pipe-close-0":
+            raise RuntimeError("private-pipe-close-start-marker")
+        original_start(thread)
+
+    monkeypatch.setattr(threading.Thread, "start", fail_first_pipe_closer)
+    started_at = time.monotonic()
+
+    with pytest.raises(BaseException) as caught:
+        executor.execute("stat_path", {"path": "private-path-marker.txt"}, intent="read")
+
+    assert time.monotonic() - started_at < 1
+    if cancel_during_wait:
+        assert caught.value is cancellation
+    else:
+        assert isinstance(caught.value, WorkspaceToolExecutionError)
+        assert caught.value.code == "cleanup_unproven"
+        assert "private-pipe-close-start-marker" not in repr(caught.value)
+    assert events.index("admit") < events.index("stdin-write")
+    assert "terminate-tree" in events
+    assert process.stdout.closed
+    assert process.stderr.closed
+
+
+@pytest.mark.parametrize(
     ("lifecycle_error", "expected_code", "propagates"),
     [
         pytest.param(

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -19,6 +19,8 @@ from typing import Any
 import pytest
 
 import tldw_chatbook.Tools.git_tool_impls as git_tool_impls
+import tldw_chatbook.Tools.workspace_tool_worker as workspace_tool_worker
+from tldw_chatbook.Tools.local_tool_impls import LocalToolError
 from tldw_chatbook.Tools.workspace_tool_executor import (
     DIAGNOSTIC_STDERR_MAX_BYTES,
     WorkspaceToolExecutionError,
@@ -710,7 +712,7 @@ except WorkspaceToolExecutionError as error:
     payload = json.loads(completed.stdout.splitlines()[-1])
     assert payload == {
         "code": "tool_failure",
-        "message": "workspace operation failed",
+        "message": "old_string not found in note.txt",
         "cause": True,
     }
 
@@ -1340,6 +1342,74 @@ def _run_worker_request(request: WorkspaceToolRequest) -> WorkspaceToolResponse:
     ]
     assert exit_code == (0 if frames[-1].outcome == "success" else 2), frames
     return frames[-1]
+
+
+def test_executor_build_request_refuses_replaced_admitted_root(tmp_path: Path) -> None:
+    locator = tmp_path / "workspace"
+    locator.mkdir()
+    (locator / "sentinel.txt").write_bytes(b"A_ONLY")
+    executor = WorkspaceToolExecutor(locator)
+    retained = tmp_path / "retained-a"
+    os.replace(locator, retained)
+    locator.mkdir()
+    (locator / "sentinel.txt").write_bytes(b"B_BYTE_EXACT\x00\xff")
+
+    with pytest.raises(WorkspaceToolExecutionError) as caught:
+        executor._build_request("fs_read", {"path": "sentinel.txt"}, intent="read")
+
+    assert caught.value.code == "root_pin_failed"
+    assert (locator / "sentinel.txt").read_bytes() == b"B_BYTE_EXACT\x00\xff"
+
+
+def test_worker_preserves_only_sanitized_bounded_local_tool_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "private-workspace"
+    workspace.mkdir()
+    request = WorkspaceToolExecutor(workspace)._build_request(
+        "fs_list", {"path": "."}, intent="read"
+    )
+    marker = f"{workspace}/private\ncontrol\x1b" + ("x" * 400)
+
+    def raise_domain_error(*_args: Any, **_kwargs: Any) -> str:
+        raise LocalToolError(marker)
+
+    monkeypatch.setattr(
+        workspace_tool_worker, "execute_pinned_operation", raise_domain_error
+    )
+
+    response = _run_worker_request(request)
+
+    assert response.code == "tool_failure"
+    assert response.error is not None
+    assert str(workspace) not in response.error
+    assert "\n" not in response.error and "\x1b" not in response.error
+    assert response.error.startswith("privatecontrol")
+    assert len(response.error) == 300
+
+
+def test_worker_does_not_surface_arbitrary_value_error_text(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    request = WorkspaceToolExecutor(workspace)._build_request(
+        "fs_list", {"path": "."}, intent="read"
+    )
+
+    def raise_unexpected_value_error(*_args: Any, **_kwargs: Any) -> str:
+        raise ValueError("PRIVATE_UNVALIDATED_REQUEST_DERIVED_TEXT")
+
+    monkeypatch.setattr(
+        workspace_tool_worker,
+        "execute_pinned_operation",
+        raise_unexpected_value_error,
+    )
+
+    response = _run_worker_request(request)
+
+    assert response.code == "tool_failure"
+    assert response.error == "workspace operation failed"
 
 
 def test_pinned_worker_applies_exclusions_to_both_lexical_and_resolved_aliases(

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -1120,6 +1120,60 @@ def test_unsupported_closed_operation_is_a_stable_worker_refusal(
     assert caught.value.code == "unsupported_operation"
 
 
+@pytest.mark.parametrize(
+    ("operation", "intent", "arguments"),
+    (
+        ("fs_write", "write", {"path": "x", "content": "x"}),
+        ("fs_edit", "write", {"path": "x", "old_string": "x", "new_string": "y"}),
+        ("fs_patch", "write", {"diff": "--- a/x\n+++ b/x\n"}),
+        ("git_status", "read", {}),
+        ("git_diff", "read", {}),
+        ("git_log", "read", {}),
+        ("git_blame", "read", {"path": "x"}),
+        ("git_branches", "read", {}),
+    ),
+)
+def test_direct_worker_unsupported_operations_do_not_require_read_exclusions(
+    operation: str, intent: str, arguments: dict[str, Any]
+) -> None:
+    request = WorkspaceToolRequest(
+        operation_id="unsupported-direct",
+        operation=operation,  # type: ignore[arg-type]
+        intent=intent,  # type: ignore[arg-type]
+        root_locator=Path("/private/workspace"),
+        root_identity=capture_directory_chain(Path.cwd()).identities[0],
+        ancestor_identities=capture_directory_chain(Path.cwd()).identities,
+        arguments=arguments,
+        timeout_seconds=30,
+        output_max_bytes=MAX_RESPONSE_BYTES,
+    )
+
+    with pytest.raises(WorkspaceToolDispatchError) as caught:
+        execute_pinned_operation(request, SimpleNamespace())
+
+    assert caught.value.code == "unsupported_operation"
+
+
+def test_direct_worker_rejects_a_bypassed_unsafe_glob_pattern() -> None:
+    chain = capture_directory_chain(Path.cwd())
+    request = WorkspaceToolRequest(
+        operation_id="unsafe-direct-glob",
+        operation="fs_glob",
+        intent="read",
+        root_locator=chain.canonical_root,
+        root_identity=chain.identities[0],
+        ancestor_identities=chain.identities,
+        arguments={"pattern": "../outside/*.txt", "sensitive_exclusions": []},
+        timeout_seconds=30,
+        output_max_bytes=MAX_RESPONSE_BYTES,
+    )
+
+    with pytest.raises(WorkspaceToolDispatchError) as caught:
+        execute_pinned_operation(request, SimpleNamespace())
+
+    assert caught.value.code == "invalid_request"
+
+
 @pytest.mark.parametrize(("operation", "arguments", "expected"), READ_CASES)
 def test_pre_pin_read_operations_refuse_a_replaced_root(
     tmp_path: Path,
@@ -1267,6 +1321,25 @@ def test_parent_serializes_runtime_sensitive_exclusions_for_every_read_operation
 
     exclusions = request.arguments["sensitive_exclusions"]
     assert {"kind": "file", "value": "runtime-config.toml"} in exclusions
+
+
+def test_parent_read_exclusions_do_not_recursively_enumerate_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sensitive exclusion preparation is bounded by policy inputs, not tree size."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "ordinary.txt").write_text("ordinary", encoding="utf-8")
+
+    def _unexpected_rglob(self: Path, pattern: str) -> Any:
+        raise AssertionError("parent exclusion preparation must not walk the workspace")
+
+    monkeypatch.setattr(Path, "rglob", _unexpected_rglob)
+    request = WorkspaceToolExecutor(workspace)._build_request(
+        "fs_list", {"path": "."}, intent="read"
+    )
+
+    assert request.arguments["sensitive_exclusions"]
 
 
 def test_parent_refuses_runtime_config_read_before_worker_spawn(

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -588,6 +588,11 @@ print(json.dumps({"worker_source": str(worker_source), "result": result}))
     ("response", "code"),
     [
         pytest.param(b"not-json\n", "protocol_failure", id="malformed"),
+        pytest.param(
+            b'{"error":"private-unvalidated-worker-error"}\n',
+            "protocol_failure",
+            id="unvalidated-error",
+        ),
         pytest.param(b"x" * (MAX_RESPONSE_BYTES + 1), "protocol_failure", id="oversized"),
         pytest.param(
             _response() + _response().splitlines()[-1] + b"\n",
@@ -612,6 +617,8 @@ def test_malformed_oversized_or_duplicate_worker_output_is_refused(
         executor.execute("stat_path", {"path": "private-path-marker.txt"}, intent="read")
 
     assert caught.value.code == code
+    assert "private-path-marker.txt" not in str(caught.value)
+    assert "private-unvalidated-worker-error" not in str(caught.value)
 
 
 @pytest.mark.parametrize(
@@ -684,7 +691,11 @@ try:
         intent="write",
     )
 except WorkspaceToolExecutionError as error:
-    print(json.dumps({"code": error.code, "cause": error.__cause__ is None}))
+    print(json.dumps({
+        "code": error.code,
+        "message": str(error),
+        "cause": error.__cause__ is None,
+    }))
 """
 
     completed = subprocess.run(
@@ -697,7 +708,11 @@ except WorkspaceToolExecutionError as error:
 
     assert completed.returncode == 0, completed.stderr
     payload = json.loads(completed.stdout.splitlines()[-1])
-    assert payload == {"code": "tool_failure", "cause": True}
+    assert payload == {
+        "code": "tool_failure",
+        "message": "workspace operation failed",
+        "cause": True,
+    }
 
 
 def test_real_executor_surfaces_a_patch_target_mismatch_refusal(
@@ -730,7 +745,11 @@ try:
         intent="write",
     )
 except WorkspaceToolExecutionError as error:
-    print(json.dumps({"code": error.code, "cause": error.__cause__ is None}))
+    print(json.dumps({
+        "code": error.code,
+        "message": str(error),
+        "cause": error.__cause__ is None,
+    }))
 '''
 
     completed = subprocess.run(
@@ -743,7 +762,11 @@ except WorkspaceToolExecutionError as error:
 
     assert completed.returncode == 0, completed.stderr
     payload = json.loads(completed.stdout.splitlines()[-1])
-    assert payload == {"code": "invalid_request", "cause": True}
+    assert payload == {
+        "code": "invalid_request",
+        "message": "workspace patch targets changed after admission",
+        "cause": True,
+    }
     assert note.read_bytes() == b"before\n"
 
 

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import io
+import json
 import logging
+import os
+import site
 import subprocess
 import sys
+import threading
+import venv
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -52,6 +57,7 @@ class _FakePopen:
         *,
         returncode: int = 0,
         timeout: bool = False,
+        wait_error: BaseException | None = None,
     ) -> None:
         self.pid = 7321
         self.stdin = _RecordingInput(events)
@@ -60,6 +66,7 @@ class _FakePopen:
         self.returncode: int | None = None
         self._final_returncode = returncode
         self._timeout = timeout
+        self._wait_error = wait_error
         self._events = events
 
     def poll(self) -> int | None:
@@ -67,6 +74,8 @@ class _FakePopen:
 
     def wait(self, timeout: float | None = None) -> int:
         self._events.append("wait")
+        if self._wait_error is not None:
+            raise self._wait_error
         if self._timeout:
             raise subprocess.TimeoutExpired("fixed-worker", timeout)
         self.returncode = self._final_returncode
@@ -101,7 +110,8 @@ class _FakeTree:
 
     def terminate_tree(self, **_kwargs: Any) -> bool:
         self.events.append("terminate-tree")
-        self.process._process.returncode = -9
+        if self.process._process.returncode is None:
+            self.process._process.returncode = -9
         return type(self).cleanup_proven
 
 
@@ -111,16 +121,21 @@ def _response(
     code: str = "ok",
     result: str | None = "RESULT",
     error: str | None = None,
+    admitted_overrides: dict[str, Any] | None = None,
 ) -> bytes:
+    admitted_values: dict[str, Any] = {
+        "operation_id": _OPERATION_ID,
+        "outcome": "admitted",
+        "code": "root_pinned",
+        "result": None,
+        "error": None,
+        "elapsed_ms": 0,
+        "truncated": False,
+        "cleanup_proven": True,
+    }
+    admitted_values.update(admitted_overrides or {})
     admitted = WorkspaceToolResponse(
-        operation_id=_OPERATION_ID,
-        outcome="admitted",
-        code="root_pinned",
-        result=None,
-        error=None,
-        elapsed_ms=0,
-        truncated=False,
-        cleanup_proven=True,
+        **admitted_values,
     ).to_bytes()
     terminal = WorkspaceToolResponse(
         operation_id=_OPERATION_ID,
@@ -143,6 +158,7 @@ def _install_fake_launch(
     stderr: bytes = b"",
     returncode: int = 0,
     timeout: bool = False,
+    wait_error: BaseException | None = None,
 ) -> tuple[WorkspaceToolExecutor, dict[str, Any], list[str], _FakePopen]:
     root = tmp_path / "private-root-marker"
     root.mkdir()
@@ -154,6 +170,7 @@ def _install_fake_launch(
         events,
         returncode=returncode,
         timeout=timeout,
+        wait_error=wait_error,
     )
     captured: dict[str, Any] = {}
 
@@ -292,6 +309,110 @@ def test_worker_pins_and_dispatches_one_real_stat_request(tmp_path: Path) -> Non
     assert "size: 5" in frames[1].result
 
 
+@pytest.mark.parametrize("path", [r"\outside.txt", "C:outside.txt"])
+def test_worker_dispatch_refuses_cross_platform_rooted_stat_paths(
+    tmp_path: Path,
+    path: str,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    chain = capture_directory_chain(root)
+    request = WorkspaceToolRequest(
+        operation_id="worker-rooted-stat",
+        operation="stat_path",
+        intent="read",
+        root_locator=chain.canonical_root,
+        root_identity=chain.identities[0],
+        ancestor_identities=chain.identities,
+        arguments={"path": path},
+        timeout_seconds=300,
+        output_max_bytes=MAX_RESPONSE_BYTES,
+    )
+    stdout = io.BytesIO()
+
+    exit_code = run_workspace_worker(io.BytesIO(request.to_bytes()), stdout, io.BytesIO())
+
+    frames = [WorkspaceToolResponse.from_bytes(line) for line in stdout.getvalue().splitlines()]
+    assert exit_code == 2
+    assert [frame.outcome for frame in frames] == ["admitted", "failure"]
+    assert frames[1].code == "invalid_request"
+    assert path not in (frames[1].error or "")
+
+
+def test_real_isolated_subprocess_executes_this_worktree_vertical_slice(
+    tmp_path: Path,
+) -> None:
+    repository_root = Path(__file__).resolve().parents[2]
+    environment_root = tmp_path / "isolated-runtime"
+    # Symlinking preserves the signed macOS interpreter; copying it can make the
+    # temporary launcher abort before Python starts. Windows ignores this flag.
+    venv.EnvBuilder(with_pip=False, symlinks=True).create(environment_root)
+    runtime_python = environment_root / ("Scripts" if os.name == "nt" else "bin") / (
+        "python.exe" if os.name == "nt" else "python"
+    )
+    site_query = subprocess.run(
+        [
+            str(runtime_python),
+            "-I",
+            "-c",
+            "import site; print(site.getsitepackages()[0])",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    isolated_site_packages = Path(site_query.stdout.strip())
+    dependency_paths = [
+        Path(value).resolve()
+        for value in site.getsitepackages()
+        if Path(value).is_dir()
+    ]
+    (isolated_site_packages / "task2-worktree.pth").write_text(
+        "\n".join(str(path) for path in (repository_root, *dependency_paths)) + "\n",
+        encoding="utf-8",
+    )
+
+    workspace = tmp_path / "real-workspace"
+    workspace.mkdir()
+    (workspace / "note.txt").write_text("hello", encoding="utf-8")
+    harness = """
+import json
+import sys
+from pathlib import Path
+from tldw_chatbook.Tools import workspace_tool_worker
+from tldw_chatbook.Tools.workspace_tool_executor import WorkspaceToolExecutor
+
+expected_root = Path(sys.argv[1]).resolve()
+worker_source = Path(workspace_tool_worker.__file__).resolve()
+if not worker_source.is_relative_to(expected_root):
+    raise RuntimeError("wrong checkout imported")
+result = WorkspaceToolExecutor(Path(sys.argv[2])).execute(
+    "stat_path", {"path": "note.txt"}, intent="read"
+)
+print(json.dumps({"worker_source": str(worker_source), "result": result}))
+"""
+    completed = subprocess.run(
+        [
+            str(runtime_python),
+            "-I",
+            "-c",
+            harness,
+            str(repository_root),
+            str(workspace),
+        ],
+        env={"PATH": os.defpath, "LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout.splitlines()[-1])
+    assert Path(payload["worker_source"]).is_relative_to(repository_root)
+    assert "path: note.txt" in payload["result"]
+    assert "size: 5" in payload["result"]
+
+
 @pytest.mark.parametrize(
     ("response", "code"),
     [
@@ -322,6 +443,54 @@ def test_malformed_oversized_or_duplicate_worker_output_is_refused(
     assert caught.value.code == code
 
 
+@pytest.mark.parametrize(
+    "admitted_overrides",
+    [
+        pytest.param({"operation_id": "wrong-operation-id"}, id="wrong-operation-id"),
+        pytest.param({"outcome": "success"}, id="wrong-outcome"),
+        pytest.param({"code": "not_pinned"}, id="wrong-code"),
+        pytest.param({"result": "private-result"}, id="result-present"),
+        pytest.param({"error": "private-error"}, id="error-present"),
+        pytest.param({"truncated": True}, id="truncated"),
+        pytest.param({"cleanup_proven": False}, id="cleanup-unproven"),
+        pytest.param({"elapsed_ms": 2}, id="elapsed-after-terminal"),
+    ],
+)
+def test_admitted_frame_requires_exact_content_free_root_pinned_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    admitted_overrides: dict[str, Any],
+) -> None:
+    executor, _captured, _events, _process = _install_fake_launch(
+        monkeypatch,
+        tmp_path,
+        response=_response(admitted_overrides=admitted_overrides),
+    )
+
+    with pytest.raises(WorkspaceToolExecutionError) as caught:
+        executor.execute("stat_path", {"path": "private-path-marker.txt"}, intent="read")
+
+    assert caught.value.code == "protocol_failure"
+
+
+def test_nonzero_worker_exit_rejects_a_valid_success_frame(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor, _captured, _events, _process = _install_fake_launch(
+        monkeypatch,
+        tmp_path,
+        response=_response(),
+        returncode=23,
+    )
+
+    with pytest.raises(WorkspaceToolExecutionError) as caught:
+        executor.execute("stat_path", {"path": "private-path-marker.txt"}, intent="read")
+
+    assert caught.value.code == "worker_crashed"
+    assert caught.value.__cause__ is None
+
+
 def test_timeout_terminates_the_tree_and_returns_no_in_process_result(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -337,6 +506,139 @@ def test_timeout_terminates_the_tree_and_returns_no_in_process_result(
 
     assert caught.value.code == "worker_timed_out"
     assert "terminate-tree" in events
+
+
+class _BlockingInput(_RecordingInput):
+    def __init__(
+        self,
+        events: list[str],
+        write_started: threading.Event,
+        release_write: threading.Event,
+    ) -> None:
+        super().__init__(events)
+        self._write_started = write_started
+        self._release_write = release_write
+
+    def write(self, value: bytes) -> int:
+        self._events.append("stdin-write")
+        self._write_started.set()
+        if not self._release_write.wait(5):
+            raise RuntimeError("test write barrier timed out")
+        raise BrokenPipeError("simulated worker stopped consuming stdin")
+
+
+def test_outer_deadline_covers_a_stalled_stdin_write_and_proves_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "private-root-marker"
+    root.mkdir()
+    (root / "private-path-marker.txt").write_text("payload", encoding="utf-8")
+    events: list[str] = []
+    write_started = threading.Event()
+    wait_started = threading.Event()
+    release_write = threading.Event()
+    process = _FakePopen(b"", b"", events)
+    process.stdin = _BlockingInput(events, write_started, release_write)
+
+    def wait_for_deadline(timeout: float | None = None) -> int:
+        events.append("wait")
+        wait_started.set()
+        raise subprocess.TimeoutExpired("fixed-worker", timeout)
+
+    process.wait = wait_for_deadline  # type: ignore[method-assign]
+
+    def fake_popen(_argv: list[str], **_kwargs: Any) -> _FakePopen:
+        return process
+
+    class ReleasingTree(_FakeTree):
+        def terminate_tree(self, **kwargs: Any) -> bool:
+            events.append("terminate-tree")
+            events.append(f"cleanup-budget:{kwargs}")
+            release_write.set()
+            self.process._process.returncode = -9
+            return True
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_tool_executor.subprocess.Popen", fake_popen
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_tool_executor.ExecutorProcessTree", ReleasingTree
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_tool_executor.WORKSPACE_HELPER_TIMEOUT_SECONDS",
+        1,
+    )
+    outcome: list[BaseException] = []
+
+    def execute() -> None:
+        try:
+            WorkspaceToolExecutor(root).execute(
+                "stat_path", {"path": "private-path-marker.txt"}, intent="read"
+            )
+        except BaseException as error:
+            outcome.append(error)
+
+    caller = threading.Thread(target=execute)
+    caller.start()
+    try:
+        assert write_started.wait(2), "executor never attempted the bounded stdin write"
+        assert wait_started.wait(2), "blocking stdin write prevented the outer deadline"
+    finally:
+        release_write.set()
+        caller.join(5)
+
+    assert not caller.is_alive()
+    assert len(outcome) == 1
+    assert isinstance(outcome[0], WorkspaceToolExecutionError)
+    assert outcome[0].code == "worker_timed_out"  # type: ignore[union-attr]
+    assert "terminate-tree" in events
+
+
+@pytest.mark.parametrize(
+    ("lifecycle_error", "expected_code", "propagates"),
+    [
+        pytest.param(
+            RuntimeError("private-runtime-marker"),
+            "worker_failure",
+            False,
+            id="unexpected-exception",
+        ),
+        pytest.param(
+            KeyboardInterrupt("private-cancellation-marker"),
+            None,
+            True,
+            id="cancellation-base-exception",
+        ),
+    ],
+)
+def test_post_spawn_lifecycle_exceptions_always_cleanup_and_close_pipes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    lifecycle_error: BaseException,
+    expected_code: str | None,
+    propagates: bool,
+) -> None:
+    executor, _captured, events, process = _install_fake_launch(
+        monkeypatch,
+        tmp_path,
+        wait_error=lifecycle_error,
+    )
+
+    with pytest.raises(BaseException) as caught:
+        executor.execute("stat_path", {"path": "private-path-marker.txt"}, intent="read")
+
+    if propagates:
+        assert caught.value is lifecycle_error
+    else:
+        assert isinstance(caught.value, WorkspaceToolExecutionError)
+        assert caught.value.code == expected_code
+        assert caught.value.__cause__ is None
+        assert "private-runtime-marker" not in repr(caught.value)
+    assert "terminate-tree" in events
+    assert process.stdin.was_closed
+    assert process.stdout.closed
+    assert process.stderr.closed
 
 
 def test_crash_and_bounded_stderr_return_only_fixed_metadata(

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -468,11 +468,11 @@ def test_worker_dispatch_refuses_cross_platform_rooted_stat_paths(
     assert path not in (frames[1].error or "")
 
 
-def test_real_isolated_subprocess_executes_this_worktree_vertical_slice(
-    tmp_path: Path,
-) -> None:
+@pytest.fixture(scope="module")
+def isolated_runtime_python(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Create one isolated interpreter that imports this worktree under ``-I``."""
     repository_root = Path(__file__).resolve().parents[2]
-    environment_root = tmp_path / "isolated-runtime"
+    environment_root = tmp_path_factory.mktemp("isolated-runtime") / "venv"
     # Symlinking preserves the signed macOS interpreter; copying it can make the
     # temporary launcher abort before Python starts. Windows ignores this flag.
     venv.EnvBuilder(with_pip=False, symlinks=True).create(environment_root)
@@ -506,6 +506,13 @@ def test_real_isolated_subprocess_executes_this_worktree_vertical_slice(
         "\n".join(str(path) for path in (repository_root, *dependency_paths)) + "\n",
         encoding="utf-8",
     )
+    return runtime_python
+
+
+def test_real_isolated_subprocess_executes_this_worktree_vertical_slice(
+    tmp_path: Path, isolated_runtime_python: Path
+) -> None:
+    repository_root = Path(__file__).resolve().parents[2]
 
     workspace = tmp_path / "real-workspace"
     workspace.mkdir()
@@ -528,7 +535,7 @@ print(json.dumps({"worker_source": str(worker_source), "result": result}))
 """
     completed = subprocess.run(
         [
-            str(runtime_python),
+            str(isolated_runtime_python),
             "-I",
             "-c",
             harness,
@@ -624,6 +631,91 @@ def test_nonzero_worker_exit_rejects_a_valid_success_frame(
 
     assert caught.value.code == "worker_crashed"
     assert caught.value.__cause__ is None
+
+
+def test_real_executor_surfaces_an_ordinary_edit_failure_frame(
+    tmp_path: Path, isolated_runtime_python: Path
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "note.txt").write_text("before", encoding="utf-8")
+    harness = """
+import json
+import sys
+from pathlib import Path
+from tldw_chatbook.Tools.workspace_tool_executor import (
+    WorkspaceToolExecutionError,
+    WorkspaceToolExecutor,
+)
+
+try:
+    WorkspaceToolExecutor(Path(sys.argv[1])).execute(
+        "fs_edit",
+        {"path": "note.txt", "old_string": "missing", "new_string": "after"},
+        intent="write",
+    )
+except WorkspaceToolExecutionError as error:
+    print(json.dumps({"code": error.code, "cause": error.__cause__ is None}))
+"""
+
+    completed = subprocess.run(
+        [str(isolated_runtime_python), "-I", "-c", harness, str(workspace)],
+        env={"PATH": os.defpath, "LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout.splitlines()[-1])
+    assert payload == {"code": "tool_failure", "cause": True}
+
+
+def test_real_executor_surfaces_a_patch_target_mismatch_refusal(
+    tmp_path: Path, isolated_runtime_python: Path
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    note = workspace / "note.txt"
+    note.write_bytes(b"before\n")
+
+    harness = '''
+import json
+import sys
+from pathlib import Path
+from tldw_chatbook.Tools.workspace_tool_executor import (
+    WorkspaceToolExecutionError,
+    WorkspaceToolExecutor,
+)
+
+class TargetMismatchExecutor(WorkspaceToolExecutor):
+    def _build_request(self, operation, arguments, *, intent):
+        request = super()._build_request(operation, arguments, intent=intent)
+        request.arguments["targets"] = ["different.txt"]
+        return request
+
+try:
+    TargetMismatchExecutor(Path(sys.argv[1])).execute(
+        "fs_patch",
+        {"diff": "--- a/note.txt\\n+++ b/note.txt\\n@@ -1 +1 @@\\n-before\\n+after\\n"},
+        intent="write",
+    )
+except WorkspaceToolExecutionError as error:
+    print(json.dumps({"code": error.code, "cause": error.__cause__ is None}))
+'''
+
+    completed = subprocess.run(
+        [str(isolated_runtime_python), "-I", "-c", harness, str(workspace)],
+        env={"PATH": os.defpath, "LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout.splitlines()[-1])
+    assert payload == {"code": "invalid_request", "cause": True}
+    assert note.read_bytes() == b"before\n"
 
 
 def test_timeout_terminates_the_tree_and_returns_no_in_process_result(
@@ -1728,6 +1820,60 @@ def test_worker_rejects_patch_target_set_mismatch_before_writing(tmp_path: Path)
     assert response.code == "invalid_request"
     assert (workspace / "note.txt").read_bytes() == b"before\n"
     assert (workspace / "other.txt").read_bytes() == b"first\n"
+
+
+@pytest.mark.parametrize("operation", ("fs_write", "fs_edit", "fs_patch"))
+@pytest.mark.parametrize("retarget", ("external", "sensitive"))
+def test_worker_refuses_mutation_target_retargeted_after_parent_admission(
+    tmp_path: Path,
+    operation: str,
+    retarget: str,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    public = workspace / "public.txt"
+    public_bytes = b"before\n"
+    public.write_bytes(public_bytes)
+    sensitive = workspace / "credentials"
+    sensitive_bytes = b"before\nsensitive-byte-exact\x00\xff"
+    sensitive.write_bytes(sensitive_bytes)
+    external = tmp_path / "external-sentinel.bin"
+    external_bytes = b"before\nexternal-byte-exact\x00\xff"
+    external.write_bytes(external_bytes)
+    alias = workspace / "alias.txt"
+    os.symlink(public, alias)
+
+    if operation == "fs_write":
+        arguments = {"path": "alias.txt", "content": "changed"}
+    elif operation == "fs_edit":
+        arguments = {
+            "path": "alias.txt",
+            "old_string": "before",
+            "new_string": "after",
+        }
+    else:
+        arguments = {
+            "diff": """\
+--- a/alias.txt
++++ b/alias.txt
+@@ -1 +1 @@
+-before
++after
+"""
+        }
+    request = WorkspaceToolExecutor(workspace)._build_request(
+        operation, arguments, intent="write"
+    )
+    alias.unlink()
+    os.symlink(external if retarget == "external" else sensitive, alias)
+
+    response = _run_worker_request(request)
+
+    assert response.outcome == "failure"
+    assert response.code == "invalid_request"
+    assert public.read_bytes() == public_bytes
+    assert external.read_bytes() == external_bytes
+    assert sensitive.read_bytes() == sensitive_bytes
 
 
 def test_parent_validates_every_patch_target_before_worker_spawn(

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -8,6 +8,7 @@ import site
 import subprocess
 import sys
 import threading
+import time
 import venv
 from pathlib import Path
 from types import SimpleNamespace
@@ -350,17 +351,23 @@ def test_real_isolated_subprocess_executes_this_worktree_vertical_slice(
     runtime_python = environment_root / ("Scripts" if os.name == "nt" else "bin") / (
         "python.exe" if os.name == "nt" else "python"
     )
-    site_query = subprocess.run(
-        [
-            str(runtime_python),
-            "-I",
-            "-c",
-            "import site; print(site.getsitepackages()[0])",
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        site_query = subprocess.run(
+            [
+                str(runtime_python),
+                "-I",
+                "-c",
+                "import site; print(site.getsitepackages()[0])",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail("isolated runtime site query timed out", pytrace=False)
+    except subprocess.CalledProcessError:
+        pytest.fail("isolated runtime site query failed", pytrace=False)
     isolated_site_packages = Path(site_query.stdout.strip())
     dependency_paths = [
         Path(value).resolve()
@@ -593,6 +600,194 @@ def test_outer_deadline_covers_a_stalled_stdin_write_and_proves_cleanup(
     assert isinstance(outcome[0], WorkspaceToolExecutionError)
     assert outcome[0].code == "worker_timed_out"  # type: ignore[union-attr]
     assert "terminate-tree" in events
+
+
+class _BlockingCloseInput(_RecordingInput):
+    def __init__(
+        self,
+        events: list[str],
+        close_started: threading.Event,
+        close_finished: threading.Event,
+        release_close: threading.Event,
+    ) -> None:
+        super().__init__(events)
+        self._close_started = close_started
+        self._close_finished = close_finished
+        self._release_close = release_close
+
+    def close(self) -> None:
+        self._events.append("stdin-close-started")
+        self._close_started.set()
+        if not self._release_close.wait(5):
+            raise RuntimeError("test close barrier timed out")
+        super().close()
+        self._close_finished.set()
+
+
+def test_outer_deadline_bounds_multiphase_tree_settlement_and_pipe_close(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "private-root-marker"
+    root.mkdir()
+    (root / "private-path-marker.txt").write_text("payload", encoding="utf-8")
+    events: list[str] = []
+    operation_wait_started = threading.Event()
+    cleanup_started = threading.Event()
+    close_started = threading.Event()
+    close_finished = threading.Event()
+    release_blockers = threading.Event()
+    finished = threading.Event()
+    process = _FakePopen(b"", b"", events)
+    process.stdin = _BlockingCloseInput(
+        events,
+        close_started,
+        close_finished,
+        release_blockers,
+    )
+
+    def wait_for_real_budget(timeout: float | None = None) -> int:
+        events.append("wait")
+        operation_wait_started.set()
+        assert timeout is not None
+        if not release_blockers.wait(timeout):
+            raise subprocess.TimeoutExpired("fixed-worker", timeout)
+        process.returncode = -9
+        return -9
+
+    process.wait = wait_for_real_budget  # type: ignore[method-assign]
+
+    def fake_popen(_argv: list[str], **_kwargs: Any) -> _FakePopen:
+        return process
+
+    class BlockingTree(_FakeTree):
+        def terminate_tree(self, **_kwargs: Any) -> bool:
+            events.append("terminate-tree-started")
+            cleanup_started.set()
+            if not release_blockers.wait(5):
+                raise RuntimeError("test cleanup barrier timed out")
+            self.process._process.returncode = -9
+            return True
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_tool_executor.subprocess.Popen", fake_popen
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_tool_executor.ExecutorProcessTree", BlockingTree
+    )
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_tool_executor.WORKSPACE_HELPER_TIMEOUT_SECONDS",
+        1,
+    )
+    outcome: list[BaseException] = []
+    started_at = time.monotonic()
+
+    def execute() -> None:
+        try:
+            WorkspaceToolExecutor(root).execute(
+                "stat_path", {"path": "private-path-marker.txt"}, intent="read"
+            )
+        except BaseException as error:
+            outcome.append(error)
+        finally:
+            finished.set()
+
+    caller = threading.Thread(target=execute)
+    caller.start()
+    try:
+        assert operation_wait_started.wait(1), "operation wait did not start"
+        assert close_started.wait(1), "writer did not reach the blocking pipe close"
+        assert cleanup_started.wait(2), "tree settlement did not start"
+        assert finished.wait(1.4), "caller exceeded the one-second outer deadline"
+        elapsed = time.monotonic() - started_at
+        assert elapsed >= 0.75
+        assert elapsed < 1.4
+    finally:
+        release_blockers.set()
+        caller.join(5)
+        assert close_finished.wait(1), "pipe close did not finish after release"
+
+    assert not caller.is_alive()
+    assert len(outcome) == 1
+    assert isinstance(outcome[0], WorkspaceToolExecutionError)
+    assert outcome[0].code == "cleanup_unproven"  # type: ignore[union-attr]
+    assert events.count("stdin-close-started") >= 2
+    assert process.stdin.was_closed
+
+
+def test_pre_tree_terminate_timeout_falls_back_to_kill_and_bounded_wait(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "private-root-marker"
+    root.mkdir()
+    events: list[str] = []
+    process = _FakePopen(b"", b"", events)
+
+    def wait_for_cleanup(timeout: float | None = None) -> int:
+        events.append("cleanup-wait")
+        if process.returncode is None:
+            raise subprocess.TimeoutExpired("fixed-worker", timeout)
+        return process.returncode
+
+    def terminate_without_exit() -> None:
+        events.append("terminate")
+
+    process.wait = wait_for_cleanup  # type: ignore[method-assign]
+    process.terminate = terminate_without_exit  # type: ignore[method-assign]
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_tool_executor.subprocess.Popen",
+        lambda _argv, **_kwargs: process,
+    )
+
+    def fail_tree_construction(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("private-tree-construction-marker")
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_tool_executor.ExecutorProcessTree",
+        fail_tree_construction,
+    )
+
+    with pytest.raises(WorkspaceToolExecutionError) as caught:
+        WorkspaceToolExecutor(root).execute("stat_path", {"path": "."}, intent="read")
+
+    assert caught.value.code == "worker_failure"
+    assert events.index("terminate") < events.index("kill")
+    assert events.count("cleanup-wait") == 2
+    assert process.stdout.closed
+    assert process.stderr.closed
+
+
+def test_cancellation_identity_survives_cleanup_exception_and_closes_pipes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cancellation = KeyboardInterrupt("private-cancellation-marker")
+    executor, _captured, events, process = _install_fake_launch(
+        monkeypatch,
+        tmp_path,
+        wait_error=cancellation,
+    )
+
+    class RaisingCleanupTree(_FakeTree):
+        def terminate_tree(self, **_kwargs: Any) -> bool:
+            events.append("terminate-tree")
+            raise RuntimeError("private-cleanup-marker")
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_tool_executor.ExecutorProcessTree",
+        RaisingCleanupTree,
+    )
+
+    with pytest.raises(BaseException) as caught:
+        executor.execute("stat_path", {"path": "private-path-marker.txt"}, intent="read")
+
+    assert caught.value is cancellation
+    assert "terminate-tree" in events
+    assert process.stdin.was_closed
+    assert process.stdout.closed
+    assert process.stderr.closed
 
 
 @pytest.mark.parametrize(

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -44,12 +44,12 @@ _OPERATION_ID = "fixed-operation-id"
 
 
 READ_CASES = (
-    ("fs_list", {"path": "."}, "A_ONLY"),
-    ("fs_read", {"path": "sentinel.txt", "offset": 1}, "A_ONLY"),
-    ("fs_glob", {"pattern": "**/*.txt", "max_results": 100}, "sentinel.txt"),
+    ("fs_list", {"path": ".", "sensitive_exclusions": []}, "A_ONLY"),
+    ("fs_read", {"path": "sentinel.txt", "offset": 1, "sensitive_exclusions": []}, "A_ONLY"),
+    ("fs_glob", {"pattern": "**/*.txt", "max_results": 100, "sensitive_exclusions": []}, "sentinel.txt"),
     (
         "fs_grep",
-        {"pattern": "A_ONLY", "mode": "content", "max_results": 100},
+        {"pattern": "A_ONLY", "mode": "content", "max_results": 100, "sensitive_exclusions": [], "content_exclusions": []},
         "A_ONLY",
     ),
 )
@@ -85,6 +85,31 @@ def _post_pin_read_operation_child(
                 output.put(("result", execute_pinned_operation(request, root)))
             except WorkspaceToolDispatchError as error:
                 output.put(("refused", error.code))
+    except WorkspaceRootPinError:
+        output.put(("refused", "root_pin_failed"))
+    except BaseException as error:
+        output.put(("error", type(error).__name__))
+
+
+def _post_pin_request_child(
+    locator: str,
+    chain: Any,
+    request_bytes: bytes,
+    ready: Any,
+    resume: Any,
+    output: Any,
+) -> None:
+    """Dispatch a parent-built request after its pinned root is replaced."""
+    try:
+        request = WorkspaceToolRequest.from_bytes(request_bytes)
+        with pin_workspace_root(Path(locator), chain) as root:
+            ready.set()
+            if not resume.wait(5):
+                raise RuntimeError("test barrier timed out")
+            os.environ.pop("TLDW_CONFIG_PATH", None)
+            output.put(("result", execute_pinned_operation(request, root)))
+    except WorkspaceToolDispatchError as error:
+        output.put(("refused", error.code))
     except WorkspaceRootPinError:
         output.put(("refused", "root_pin_failed"))
     except BaseException as error:
@@ -1141,26 +1166,14 @@ def test_pre_pin_read_operations_refuse_a_replaced_root(
 
 
 def test_pinned_read_refuses_a_sensitive_relative_name(tmp_path: Path) -> None:
-    """Pinned reads apply the bounded exclusion names before opening a file."""
+    """Pinned reads reject a sensitive name while the parent still has policy."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / "credentials").write_text("SECRET", encoding="utf-8")
-    chain = capture_directory_chain(workspace)
-    request = WorkspaceToolRequest(
-        operation_id="sensitive-read",
-        operation="fs_read",
-        intent="read",
-        root_locator=chain.canonical_root,
-        root_identity=chain.identities[0],
-        ancestor_identities=chain.identities,
-        arguments={"path": "credentials", "offset": 1},
-        timeout_seconds=300,
-        output_max_bytes=MAX_RESPONSE_BYTES,
-    )
-
-    with pin_workspace_root(workspace, chain) as root:
-        with pytest.raises(WorkspaceToolDispatchError) as caught:
-            execute_pinned_operation(request, root)
+    with pytest.raises(WorkspaceToolExecutionError) as caught:
+        WorkspaceToolExecutor(workspace)._build_request(
+            "fs_read", {"path": "credentials", "offset": 1}, intent="read"
+        )
 
     assert caught.value.code == "invalid_request"
     assert "SECRET" not in str(caught.value)
@@ -1224,3 +1237,164 @@ def test_post_pin_read_operations_never_redirect_to_replaced_root(
     assert expected in value
     if os.name == "nt":
         assert replacement_refused, "Windows should lock the retained current directory"
+
+
+@pytest.mark.parametrize(
+    ("operation", "arguments"),
+    (
+        ("fs_list", {"path": "."}),
+        ("fs_glob", {"pattern": "**/*", "max_results": 100}),
+        ("fs_grep", {"pattern": "needle", "mode": "content", "max_results": 100}),
+    ),
+)
+def test_parent_serializes_runtime_sensitive_exclusions_for_every_read_operation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    arguments: dict[str, Any],
+) -> None:
+    """The parent captures runtime exclusions before the worker environment is stripped."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "note.txt").write_text("needle\n", encoding="utf-8")
+    runtime_config = workspace / "runtime-config.toml"
+    runtime_config.write_text("needle = 'SECRET'\n", encoding="utf-8")
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(runtime_config))
+
+    request = WorkspaceToolExecutor(workspace)._build_request(
+        operation, arguments, intent="read"
+    )
+
+    exclusions = request.arguments["sensitive_exclusions"]
+    assert {"kind": "file", "value": "runtime-config.toml"} in exclusions
+
+
+def test_parent_refuses_runtime_config_read_before_worker_spawn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A runtime config override is adjudicated while the parent still has it."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    runtime_config = workspace / "runtime-config.toml"
+    runtime_config.write_text("SECRET", encoding="utf-8")
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(runtime_config))
+
+    with pytest.raises(WorkspaceToolExecutionError) as caught:
+        WorkspaceToolExecutor(workspace)._build_request(
+            "fs_read", {"path": "runtime-config.toml", "offset": 1}, intent="read"
+        )
+
+    assert caught.value.code == "invalid_request"
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    ("../outside/*.txt", "/outside/*.txt", r"\outside\*.txt", r"C:\outside\*.txt"),
+)
+def test_parent_refuses_parent_and_cross_platform_rooted_glob_patterns(
+    tmp_path: Path, pattern: str
+) -> None:
+    """Pinned glob admission never grants a pattern a route outside the root."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    with pytest.raises(WorkspaceToolExecutionError) as caught:
+        WorkspaceToolExecutor(workspace)._build_request(
+            "fs_glob", {"pattern": pattern, "max_results": 100}, intent="read"
+        )
+
+    assert caught.value.code == "invalid_request"
+
+
+@pytest.mark.parametrize(
+    ("operation", "arguments"),
+    (
+        ("fs_list", {"path": "."}),
+        ("fs_read", {"path": "safe-link", "offset": 1}),
+        ("fs_glob", {"pattern": "**/*", "max_results": 100}),
+        ("fs_grep", {"pattern": "ALIAS_SECRET", "mode": "content", "max_results": 100}),
+    ),
+)
+def test_pinned_operations_do_not_disclose_in_root_sensitive_symlink_aliases(
+    tmp_path: Path,
+    operation: str,
+    arguments: dict[str, Any],
+) -> None:
+    """Parent-derived aliases hide sensitive in-root targets from every read."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "credentials").write_text("ALIAS_SECRET", encoding="utf-8")
+    os.symlink(workspace / "credentials", workspace / "safe-link")
+    executor = WorkspaceToolExecutor(workspace)
+
+    if operation == "fs_read":
+        with pytest.raises(WorkspaceToolExecutionError) as caught:
+            executor._build_request(operation, arguments, intent="read")
+        assert caught.value.code == "invalid_request"
+        return
+
+    request = executor._build_request(operation, arguments, intent="read")
+    stdout = io.BytesIO()
+    exit_code = run_workspace_worker(
+        io.BytesIO(request.to_bytes()), stdout, io.BytesIO()
+    )
+    frames = [
+        WorkspaceToolResponse.from_bytes(line) for line in stdout.getvalue().splitlines()
+    ]
+
+    assert exit_code == 0
+    assert frames[-1].result is not None
+    assert "safe-link" not in frames[-1].result
+
+
+def test_parent_exclusions_survive_root_replacement_and_worker_env_stripping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A parent-built location exclusion remains effective after the root rename."""
+    locator = tmp_path / "workspace"
+    locator.mkdir()
+    runtime_config = locator / "runtime-config.toml"
+    runtime_config.write_text("A_CONFIG_SECRET", encoding="utf-8")
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(runtime_config))
+    request = WorkspaceToolExecutor(locator)._build_request(
+        "fs_grep",
+        {"pattern": "CONFIG_SECRET", "mode": "content", "max_results": 100},
+        intent="read",
+    )
+    chain = capture_directory_chain(locator)
+    replacement = tmp_path / "replacement-b"
+    replacement.mkdir()
+    (replacement / "runtime-config.toml").write_text("B_CONFIG_SECRET", encoding="utf-8")
+
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    resume = context.Event()
+    output = context.Queue()
+    process = context.Process(
+        target=_post_pin_request_child,
+        args=(str(locator), chain, request.to_bytes(), ready, resume, output),
+    )
+    process.start()
+    assert ready.wait(5), "read worker did not pin its root"
+
+    retained = tmp_path / "retained-a"
+    try:
+        os.replace(locator, retained)
+        os.replace(replacement, locator)
+    except OSError as error:
+        if os.name == "nt":
+            pytest.skip(f"Windows current-directory sharing refused root replacement: {error}")
+        pytest.fail(f"POSIX root replacement unexpectedly failed: {error}")
+    finally:
+        resume.set()
+    process.join(10)
+    if process.is_alive():
+        process.kill()
+        process.join(5)
+        pytest.fail("post-pin read worker did not exit")
+    assert process.exitcode == 0
+
+    outcome, value = output.get(timeout=2)
+    assert outcome == "result"
+    assert "A_CONFIG_SECRET" not in value
+    assert "B_CONFIG_SECRET" not in value

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -5,6 +5,7 @@ import json
 import logging
 import multiprocessing
 import os
+import shutil
 import site
 import subprocess
 import sys
@@ -65,6 +66,14 @@ MUTATION_CASES = (
             "replace_all": False,
         },
     ),
+)
+
+GIT_RACE_CASES = (
+    ("git_status", {}, "A_STATUS.txt", "B_STATUS.txt"),
+    ("git_diff", {}, "A_DIFF", "B_DIFF"),
+    ("git_log", {"count": 20}, "A_LOG", "B_LOG"),
+    ("git_blame", {"path": "blame.txt"}, "A_BLAME", "B_BLAME"),
+    ("git_branches", {}, "A_BRANCH", "B_BRANCH"),
 )
 
 TWO_FILE_PATCH = """\
@@ -160,6 +169,25 @@ def _pre_pin_request_child(
         output.put((exit_code, stdout.getvalue()))
     except BaseException as error:
         output.put(("error", type(error).__name__))
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def _init_git_race_repository(repo: Path, marker: str) -> None:
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "commit.gpgsign", "false")
+    (repo / "tracked.txt").write_text("base\n", encoding="utf-8")
+    (repo / "blame.txt").write_text(f"{marker}_BLAME\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", f"{marker}_LOG")
+    _git(repo, "branch", f"{marker}_BRANCH")
+    (repo / "tracked.txt").write_text(f"base\n{marker}_DIFF\n", encoding="utf-8")
+    (repo / f"{marker}_STATUS.txt").write_text(marker, encoding="utf-8")
 
 
 class _RecordingInput(io.BytesIO):
@@ -1258,37 +1286,6 @@ def test_unsupported_closed_operation_is_a_stable_worker_refusal(
     assert caught.value.code == "unsupported_operation"
 
 
-@pytest.mark.parametrize(
-    ("operation", "intent", "arguments"),
-    (
-        ("git_status", "read", {}),
-        ("git_diff", "read", {}),
-        ("git_log", "read", {}),
-        ("git_blame", "read", {"path": "x"}),
-        ("git_branches", "read", {}),
-    ),
-)
-def test_direct_worker_unsupported_operations_do_not_require_read_exclusions(
-    operation: str, intent: str, arguments: dict[str, Any]
-) -> None:
-    request = WorkspaceToolRequest(
-        operation_id="unsupported-direct",
-        operation=operation,  # type: ignore[arg-type]
-        intent=intent,  # type: ignore[arg-type]
-        root_locator=Path("/private/workspace"),
-        root_identity=capture_directory_chain(Path.cwd()).identities[0],
-        ancestor_identities=capture_directory_chain(Path.cwd()).identities,
-        arguments=arguments,
-        timeout_seconds=30,
-        output_max_bytes=MAX_RESPONSE_BYTES,
-    )
-
-    with pytest.raises(WorkspaceToolDispatchError) as caught:
-        execute_pinned_operation(request, SimpleNamespace())
-
-    assert caught.value.code == "unsupported_operation"
-
-
 @pytest.mark.parametrize("pattern", ("../outside/*.txt", "safe\x00name/*.txt"))
 def test_direct_worker_rejects_a_bypassed_unsafe_glob_pattern(pattern: str) -> None:
     chain = capture_directory_chain(Path.cwd())
@@ -1578,6 +1575,109 @@ def test_post_pin_read_operations_never_redirect_to_replaced_root(
     assert expected in value
     if os.name == "nt":
         assert replacement_refused, "Windows should lock the retained current directory"
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is not available")
+@pytest.mark.parametrize(
+    ("operation", "arguments", "expected_a", "forbidden_b"), GIT_RACE_CASES
+)
+def test_post_pin_git_operations_never_redirect_to_replaced_root(
+    tmp_path: Path,
+    operation: str,
+    arguments: dict[str, Any],
+    expected_a: str,
+    forbidden_b: str,
+) -> None:
+    """All read-only Git operations stay bound to retained repository A."""
+    locator = tmp_path / "workspace"
+    replacement = tmp_path / "replacement-b"
+    _init_git_race_repository(locator, "A")
+    _init_git_race_repository(replacement, "B")
+    request = WorkspaceToolExecutor(locator)._build_request(
+        operation, arguments, intent="read"
+    )
+    chain = capture_directory_chain(locator)
+
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    resume = context.Event()
+    output = context.Queue()
+    process = context.Process(
+        target=_post_pin_request_child,
+        args=(str(locator), chain, request.to_bytes(), ready, resume, output),
+    )
+    process.start()
+    assert ready.wait(5), "Git worker did not pin its root"
+
+    retained = tmp_path / "retained-a"
+    replacement_refused = False
+    try:
+        os.replace(locator, retained)
+        os.replace(replacement, locator)
+    except OSError:
+        replacement_refused = True
+        if retained.exists() and not locator.exists():
+            os.replace(retained, locator)
+    finally:
+        resume.set()
+    process.join(15)
+    if process.is_alive():
+        process.kill()
+        process.join(5)
+        pytest.fail("post-pin Git worker did not exit")
+    assert process.exitcode == 0
+
+    outcome, value = output.get(timeout=2)
+    assert outcome == "result"
+    assert expected_a in value
+    assert forbidden_b not in value
+    if os.name == "nt":
+        assert replacement_refused, "Windows should lock the retained current directory"
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is not available")
+def test_pinned_git_supports_linked_worktree_without_granting_metadata_fs_access(
+    tmp_path: Path,
+) -> None:
+    """Git may follow a linked-worktree pointer that ordinary fs tools cannot."""
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    _git(primary, "init")
+    _git(primary, "config", "user.email", "test@example.invalid")
+    _git(primary, "config", "user.name", "Test User")
+    _git(primary, "config", "commit.gpgsign", "false")
+    (primary / "tracked.txt").write_text("base\n", encoding="utf-8")
+    _git(primary, "add", ".")
+    _git(primary, "commit", "-m", "linked initial")
+    worktree = tmp_path / "workspace"
+    _git(primary, "worktree", "add", "-b", "linked-branch", str(worktree))
+
+    git_pointer = (worktree / ".git").read_text(encoding="utf-8").strip()
+    assert git_pointer.startswith("gitdir: ")
+    admin = Path(git_pointer.removeprefix("gitdir: ")).resolve()
+    assert worktree.resolve() not in admin.parents
+
+    (worktree / "tracked.txt").write_text("base\nlinked diff\n", encoding="utf-8")
+    cases = (
+        ("git_status", {}, "tracked.txt"),
+        ("git_diff", {}, "linked diff"),
+        ("git_log", {"count": 20}, "linked initial"),
+        ("git_blame", {"path": "tracked.txt"}, "base"),
+        ("git_branches", {}, "linked-branch"),
+    )
+    executor = WorkspaceToolExecutor(worktree)
+    for operation, arguments, expected in cases:
+        response = _run_worker_request(
+            executor._build_request(operation, arguments, intent="read")
+        )
+        assert response.outcome == "success", (operation, response.code)
+        assert expected in (response.result or ""), operation
+
+    with pytest.raises(WorkspaceToolExecutionError) as caught:
+        executor._build_request(
+            "fs_read", {"path": str(admin / "HEAD"), "offset": 1}, intent="read"
+        )
+    assert caught.value.code == "invalid_request"
 
 
 @pytest.mark.parametrize(("operation", "arguments"), MUTATION_CASES)

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -395,23 +395,89 @@ def test_executor_uses_fixed_private_launch_and_admits_before_stdin(
     assert "private-environment-value" not in diagnostic_text
 
 
-def test_worker_environment_is_a_small_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_worker_environment_is_a_small_allowlist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "private-key-marker")
     monkeypatch.setenv("HTTP_PROXY", "private-proxy-marker")
     monkeypatch.setenv("PYTHONPATH", "private-python-marker")
+    monkeypatch.setenv("PATH", str(Path(sys.executable).parent))
 
-    environment = workspace_worker_environment()
+    environment = workspace_worker_environment(tmp_path / "workspace")
 
     assert set(environment) <= {
         "PATH",
         "LANG",
         "LC_ALL",
+        "NoDefaultCurrentDirectoryInExePath",
         "SYSTEMROOT",
         "WINDIR",
         "TEMP",
         "TMP",
     }
-    assert "private" not in repr(environment)
+    assert environment["NoDefaultCurrentDirectoryInExePath"] == "1"
+    for marker in ("private-key-marker", "private-proxy-marker", "private-python-marker"):
+        assert marker not in repr(environment)
+
+
+def test_worker_environment_excludes_workspace_and_relative_path_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    safe_bin = tmp_path / "safe-bin"
+    safe_bin.mkdir()
+    monkeypatch.setenv(
+        "PATH",
+        os.pathsep.join((".", str(workspace), str(safe_bin), "")),
+    )
+
+    environment = workspace_worker_environment(workspace)
+
+    assert environment["PATH"].split(os.pathsep) == [str(safe_bin.resolve())]
+
+
+def test_executor_validates_workspace_root_before_identity_capture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supplied = tmp_path / "supplied"
+    supplied.mkdir()
+    validated = tmp_path / "validated"
+    validated.mkdir()
+    calls: list[tuple[Path, Path]] = []
+
+    def _validate(value: Path, base: Path, **_kwargs: Any) -> Path:
+        calls.append((Path(value), Path(base)))
+        return validated
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Tools.workspace_tool_executor.validate_path",
+        _validate,
+        raising=False,
+    )
+
+    executor = WorkspaceToolExecutor(supplied)
+
+    assert calls == [(supplied, supplied)]
+    assert executor._workspace_root == validated
+    assert executor._authority_chain.canonical_root == validated.resolve()
+
+
+def test_executor_preserves_relative_workspace_root_from_caller_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    executor = WorkspaceToolExecutor(Path("workspace"))
+
+    assert executor._workspace_root == workspace.resolve()
+    assert executor._authority_chain.canonical_root == workspace.resolve()
 
 
 def test_spawn_exception_details_are_not_retained_in_the_public_failure(
@@ -1835,6 +1901,42 @@ def test_platform_evidence_representative_one_shot_operations(
     )
     assert diff.outcome == "success"
     assert "+after" in (diff.result or "")
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is not available")
+def test_platform_evidence_outer_executor_git_ignores_workspace_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_runtime_python: Path,
+) -> None:
+    """Run Git through the real child while ignoring a workspace executable."""
+    real_git = Path(shutil.which("git") or "").resolve()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _git(workspace, "init")
+    _git(workspace, "config", "user.email", "test@example.invalid")
+    _git(workspace, "config", "user.name", "Test User")
+    _git(workspace, "config", "commit.gpgsign", "false")
+    tracked = workspace / "tracked.txt"
+    tracked.write_text("base\n", encoding="utf-8")
+    _git(workspace, "add", ".")
+    _git(workspace, "commit", "-m", "outer executor baseline")
+    tracked.write_text("base\nchanged\n", encoding="utf-8")
+
+    hostile_git = workspace / ("git.exe" if os.name == "nt" else "git")
+    hostile_git.write_bytes(b"not a real executable")
+    hostile_git.chmod(0o755)
+    monkeypatch.setenv(
+        "PATH",
+        os.pathsep.join((str(workspace), str(real_git.parent))),
+    )
+    monkeypatch.setattr(sys, "executable", str(isolated_runtime_python))
+
+    result = WorkspaceToolExecutor(workspace).execute(
+        "git_status", {}, intent="read"
+    )
+
+    assert "tracked.txt" in result
 
 
 @pytest.mark.parametrize(("operation", "arguments"), MUTATION_CASES)

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -54,6 +54,32 @@ READ_CASES = (
     ),
 )
 
+MUTATION_CASES = (
+    ("fs_write", {"path": "note.txt", "content": "changed"}),
+    (
+        "fs_edit",
+        {
+            "path": "note.txt",
+            "old_string": "before",
+            "new_string": "after",
+            "replace_all": False,
+        },
+    ),
+)
+
+TWO_FILE_PATCH = """\
+--- a/note.txt
++++ b/note.txt
+@@ -1 +1 @@
+-before
++after
+--- a/other.txt
++++ b/other.txt
+@@ -1 +1 @@
+-first
++second
+"""
+
 
 def _post_pin_read_operation_child(
     locator: str,
@@ -112,6 +138,26 @@ def _post_pin_request_child(
         output.put(("refused", error.code))
     except WorkspaceRootPinError:
         output.put(("refused", "root_pin_failed"))
+    except BaseException as error:
+        output.put(("error", type(error).__name__))
+
+
+def _pre_pin_request_child(
+    request_bytes: bytes,
+    ready: Any,
+    resume: Any,
+    output: Any,
+) -> None:
+    """Pause a real worker request immediately before root pinning begins."""
+    try:
+        ready.set()
+        if not resume.wait(5):
+            raise RuntimeError("test barrier timed out")
+        stdout = io.BytesIO()
+        exit_code = run_workspace_worker(
+            io.BytesIO(request_bytes), stdout, io.BytesIO()
+        )
+        output.put((exit_code, stdout.getvalue()))
     except BaseException as error:
         output.put(("error", type(error).__name__))
 
@@ -1123,9 +1169,6 @@ def test_unsupported_closed_operation_is_a_stable_worker_refusal(
 @pytest.mark.parametrize(
     ("operation", "intent", "arguments"),
     (
-        ("fs_write", "write", {"path": "x", "content": "x"}),
-        ("fs_edit", "write", {"path": "x", "old_string": "x", "new_string": "y"}),
-        ("fs_patch", "write", {"diff": "--- a/x\n+++ b/x\n"}),
         ("git_status", "read", {}),
         ("git_diff", "read", {}),
         ("git_log", "read", {}),
@@ -1443,6 +1486,275 @@ def test_post_pin_read_operations_never_redirect_to_replaced_root(
     assert expected in value
     if os.name == "nt":
         assert replacement_refused, "Windows should lock the retained current directory"
+
+
+@pytest.mark.parametrize(("operation", "arguments"), MUTATION_CASES)
+def test_pre_pin_mutations_refuse_a_replaced_root_without_touching_b_or_external_bytes(
+    tmp_path: Path,
+    operation: str,
+    arguments: dict[str, Any],
+) -> None:
+    """A mutation admitted for A must not follow its locator to replacement B."""
+    locator = tmp_path / "workspace"
+    locator.mkdir()
+    (locator / "note.txt").write_bytes(b"before")
+    request = WorkspaceToolExecutor(locator)._build_request(
+        operation, arguments, intent="write"
+    )
+    replacement = tmp_path / "replacement-b"
+    replacement.mkdir()
+    b_note = b"B-note-byte-exact\r\n"
+    (replacement / "note.txt").write_bytes(b_note)
+    external = tmp_path / "external-sentinel.bin"
+    external_bytes = b"external-byte-exact\x00\xff"
+    external.write_bytes(external_bytes)
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    resume = context.Event()
+    output = context.Queue()
+    process = context.Process(
+        target=_pre_pin_request_child,
+        args=(request.to_bytes(), ready, resume, output),
+    )
+    process.start()
+    assert ready.wait(5), "mutation worker did not reach the pre-pin barrier"
+    retained = tmp_path / "retained-a"
+    try:
+        os.replace(locator, retained)
+        os.replace(replacement, locator)
+    finally:
+        resume.set()
+    process.join(10)
+    if process.is_alive():
+        process.kill()
+        process.join(5)
+        pytest.fail("pre-pin mutation worker did not exit")
+    assert process.exitcode == 0
+    exit_code, raw_frames = output.get(timeout=2)
+
+    frames = [
+        WorkspaceToolResponse.from_bytes(line) for line in raw_frames.splitlines()
+    ]
+    assert exit_code == 2
+    assert [frame.outcome for frame in frames] == ["failure"]
+    assert frames[0].code == "root_pin_failed"
+    assert (locator / "note.txt").read_bytes() == b_note
+    assert external.read_bytes() == external_bytes
+
+
+def test_pre_pin_two_file_patch_refuses_without_touching_any_b_or_external_bytes(
+    tmp_path: Path,
+) -> None:
+    locator = tmp_path / "workspace"
+    locator.mkdir()
+    (locator / "note.txt").write_bytes(b"before\n")
+    (locator / "other.txt").write_bytes(b"first\n")
+    request = WorkspaceToolExecutor(locator)._build_request(
+        "fs_patch", {"diff": TWO_FILE_PATCH}, intent="write"
+    )
+    replacement = tmp_path / "replacement-b"
+    replacement.mkdir()
+    b_note = b"B-note-byte-exact\r\n"
+    b_other = b"B-other-byte-exact\x00\xff"
+    (replacement / "note.txt").write_bytes(b_note)
+    (replacement / "other.txt").write_bytes(b_other)
+    external = tmp_path / "external-sentinel.bin"
+    external_bytes = b"external-byte-exact\x00\xff"
+    external.write_bytes(external_bytes)
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    resume = context.Event()
+    output = context.Queue()
+    process = context.Process(
+        target=_pre_pin_request_child,
+        args=(request.to_bytes(), ready, resume, output),
+    )
+    process.start()
+    assert ready.wait(5), "patch worker did not reach the pre-pin barrier"
+    retained = tmp_path / "retained-a"
+    try:
+        os.replace(locator, retained)
+        os.replace(replacement, locator)
+    finally:
+        resume.set()
+    process.join(10)
+    if process.is_alive():
+        process.kill()
+        process.join(5)
+        pytest.fail("pre-pin patch worker did not exit")
+    assert process.exitcode == 0
+    exit_code, raw_frames = output.get(timeout=2)
+
+    frames = [
+        WorkspaceToolResponse.from_bytes(line) for line in raw_frames.splitlines()
+    ]
+    assert exit_code == 2
+    assert [frame.outcome for frame in frames] == ["failure"]
+    assert frames[0].code == "root_pin_failed"
+    assert (locator / "note.txt").read_bytes() == b_note
+    assert (locator / "other.txt").read_bytes() == b_other
+    assert external.read_bytes() == external_bytes
+
+
+@pytest.mark.parametrize(
+    ("operation", "arguments", "expected_a"),
+    (
+        ("fs_write", {"path": "note.txt", "content": "changed"}, b"changed"),
+        (
+            "fs_edit",
+            {
+                "path": "note.txt",
+                "old_string": "before",
+                "new_string": "after",
+                "replace_all": False,
+            },
+            b"after",
+        ),
+        ("fs_patch", {"diff": TWO_FILE_PATCH}, b"after\n"),
+    ),
+)
+def test_post_pin_mutations_never_redirect_to_replaced_root(
+    tmp_path: Path,
+    operation: str,
+    arguments: dict[str, Any],
+    expected_a: bytes,
+) -> None:
+    """Post-pin mutations land only in retained A, or root replacement is refused."""
+    locator = tmp_path / "workspace"
+    locator.mkdir()
+    (locator / "note.txt").write_bytes(b"before\n" if operation == "fs_patch" else b"before")
+    if operation == "fs_patch":
+        (locator / "other.txt").write_bytes(b"first\n")
+    request = WorkspaceToolExecutor(locator)._build_request(
+        operation, arguments, intent="write"
+    )
+    chain = capture_directory_chain(locator)
+    replacement = tmp_path / "replacement-b"
+    replacement.mkdir()
+    b_note = b"B-note-byte-exact\r\n"
+    b_other = b"B-other-byte-exact\x00\xff"
+    (replacement / "note.txt").write_bytes(b_note)
+    if operation == "fs_patch":
+        (replacement / "other.txt").write_bytes(b_other)
+    external = tmp_path / "external-sentinel.bin"
+    external_bytes = b"external-byte-exact\x00\xff"
+    external.write_bytes(external_bytes)
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    resume = context.Event()
+    output = context.Queue()
+    process = context.Process(
+        target=_post_pin_request_child,
+        args=(str(locator), chain, request.to_bytes(), ready, resume, output),
+    )
+    process.start()
+    assert ready.wait(5), "mutation worker did not pin its root"
+
+    retained = tmp_path / "retained-a"
+    replacement_refused = False
+    try:
+        os.replace(locator, retained)
+        os.replace(replacement, locator)
+    except OSError:
+        replacement_refused = True
+        if retained.exists() and not locator.exists():
+            os.replace(retained, locator)
+    finally:
+        resume.set()
+    process.join(10)
+    if process.is_alive():
+        process.kill()
+        process.join(5)
+        pytest.fail("post-pin mutation worker did not exit")
+    assert process.exitcode == 0
+
+    outcome, value = output.get(timeout=2)
+    assert outcome == "result", value
+    a_root = locator if replacement_refused else retained
+    assert (a_root / "note.txt").read_bytes() == expected_a
+    if operation == "fs_patch":
+        assert (a_root / "other.txt").read_bytes() == b"second\n"
+    if replacement_refused:
+        assert not locator.samefile(replacement)
+    else:
+        assert (locator / "note.txt").read_bytes() == b_note
+        if operation == "fs_patch":
+            assert (locator / "other.txt").read_bytes() == b_other
+    assert external.read_bytes() == external_bytes
+
+
+def test_two_file_patch_uses_one_admitted_frame_and_one_requested_root_identity(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "note.txt").write_bytes(b"before\n")
+    (workspace / "other.txt").write_bytes(b"first\n")
+    chain = capture_directory_chain(workspace)
+    request = WorkspaceToolExecutor(workspace)._build_request(
+        "fs_patch", {"diff": TWO_FILE_PATCH}, intent="write"
+    )
+    stdout = io.BytesIO()
+
+    exit_code = run_workspace_worker(
+        io.BytesIO(request.to_bytes()), stdout, io.BytesIO()
+    )
+
+    frames = [
+        WorkspaceToolResponse.from_bytes(line) for line in stdout.getvalue().splitlines()
+    ]
+    assert exit_code == 0
+    assert [frame.outcome for frame in frames] == ["admitted", "success"]
+    assert sum(frame.outcome == "admitted" for frame in frames) == 1
+    assert request.root_identity == chain.identities[0]
+    assert request.arguments["targets"] == ["note.txt", "other.txt"]
+    assert (workspace / "note.txt").read_bytes() == b"after\n"
+    assert (workspace / "other.txt").read_bytes() == b"second\n"
+
+
+def test_worker_rejects_patch_target_set_mismatch_before_writing(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "note.txt").write_bytes(b"before\n")
+    (workspace / "other.txt").write_bytes(b"first\n")
+    request = WorkspaceToolExecutor(workspace)._build_request(
+        "fs_patch", {"diff": TWO_FILE_PATCH}, intent="write"
+    )
+    request.arguments["targets"] = ["note.txt", "different.txt"]
+
+    response = _run_worker_request(request)
+
+    assert response.outcome == "failure"
+    assert response.code == "invalid_request"
+    assert (workspace / "note.txt").read_bytes() == b"before\n"
+    assert (workspace / "other.txt").read_bytes() == b"first\n"
+
+
+def test_parent_validates_every_patch_target_before_worker_spawn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "note.txt").write_bytes(b"before\n")
+    runtime_config = workspace / "runtime-config.toml"
+    runtime_config.write_bytes(b"SECRET\n")
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(runtime_config))
+    diff = TWO_FILE_PATCH.replace("other.txt", "runtime-config.toml").replace(
+        "first", "SECRET"
+    ).replace("second", "CHANGED")
+
+    def unexpected_spawn(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("invalid patch targets must be refused before spawn")
+
+    monkeypatch.setattr(subprocess, "Popen", unexpected_spawn)
+    with pytest.raises(WorkspaceToolExecutionError) as caught:
+        WorkspaceToolExecutor(workspace).execute(
+            "fs_patch", {"diff": diff}, intent="write"
+        )
+
+    assert caught.value.code == "invalid_request"
+    assert (workspace / "note.txt").read_bytes() == b"before\n"
+    assert runtime_config.read_bytes() == b"SECRET\n"
 
 
 @pytest.mark.parametrize(

--- a/Tests/Tools/test_workspace_tool_executor.py
+++ b/Tests/Tools/test_workspace_tool_executor.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import pytest
 
+import tldw_chatbook.Tools.git_tool_impls as git_tool_impls
 from tldw_chatbook.Tools.workspace_tool_executor import (
     DIAGNOSTIC_STDERR_MAX_BYTES,
     WorkspaceToolExecutionError,
@@ -2031,6 +2032,135 @@ def test_parent_serializes_runtime_sensitive_exclusions_for_every_read_operation
 
     exclusions = request.arguments["sensitive_exclusions"]
     assert {"kind": "file", "value": "runtime-config.toml"} in exclusions
+
+
+@pytest.mark.parametrize(
+    ("operation", "arguments"),
+    (
+        ("git_status", {}),
+        ("git_diff", {}),
+        ("git_log", {}),
+        ("git_blame", {"path": "src/note.txt"}),
+        ("git_branches", {}),
+    ),
+)
+def test_parent_serializes_runtime_sensitive_exclusions_for_every_git_operation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    arguments: dict[str, Any],
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source = workspace / "src"
+    source.mkdir()
+    (source / "note.txt").write_text("ordinary\n", encoding="utf-8")
+    config = workspace / "config"
+    config.mkdir()
+    runtime_config = config / "runtime-config.toml"
+    runtime_config.write_text("api_key = 'SECRET'\n", encoding="utf-8")
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(runtime_config))
+
+    request = WorkspaceToolExecutor(workspace)._build_request(
+        operation, arguments, intent="read"
+    )
+
+    assert {"kind": "file", "value": "config/runtime-config.toml"} in request.arguments[
+        "sensitive_exclusions"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("operation", "arguments"),
+    (
+        ("git_status", {"path": "config/runtime-config.toml"}),
+        ("git_diff", {"path": "config/runtime-config.toml"}),
+        ("git_log", {"path": "config/runtime-config.toml"}),
+        ("git_blame", {"path": "config/runtime-config.toml"}),
+    ),
+)
+def test_parent_refuses_runtime_sensitive_git_path_before_worker_spawn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    arguments: dict[str, Any],
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = workspace / "config"
+    config.mkdir()
+    runtime_config = config / "runtime-config.toml"
+    runtime_config.write_text("api_key = 'SECRET'\n", encoding="utf-8")
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(runtime_config))
+
+    with pytest.raises(WorkspaceToolExecutionError) as caught:
+        WorkspaceToolExecutor(workspace)._build_request(
+            operation, arguments, intent="read"
+        )
+
+    assert caught.value.code == "invalid_request"
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is not available")
+def test_pinned_worker_preserves_runtime_git_exclusions_after_environment_scrubbing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pinned status/diff consume parent policy after runtime env is removed."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    repository = workspace / "repo"
+    repository.mkdir()
+    _git(repository, "init")
+    _git(repository, "config", "user.email", "test@example.invalid")
+    _git(repository, "config", "user.name", "Test User")
+    _git(repository, "config", "commit.gpgsign", "false")
+    config = repository / "config"
+    config.mkdir()
+    runtime_config = config / "runtime-config.toml"
+    runtime_config.write_text("api_key = 'OLD_SECRET'\n", encoding="utf-8")
+    ordinary = repository / "ordinary.txt"
+    ordinary.write_text("ordinary v1\n", encoding="utf-8")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "initial")
+    runtime_config.write_text("api_key = 'NEW_SECRET'\n", encoding="utf-8")
+    ordinary.write_text("ordinary v1\nordinary v2\n", encoding="utf-8")
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(runtime_config))
+
+    executor = WorkspaceToolExecutor(workspace)
+    status_request = executor._build_request(
+        "git_status", {"path": "repo"}, intent="read"
+    )
+    diff_request = executor._build_request(
+        "git_diff", {"path": "repo"}, intent="read"
+    )
+    monkeypatch.delenv("TLDW_CONFIG_PATH")
+
+    def _unexpected_worker_policy_resolution() -> None:
+        raise AssertionError("worker must consume the parent-admitted exclusions")
+
+    monkeypatch.setattr(
+        git_tool_impls,
+        "resolve_sensitive_context",
+        _unexpected_worker_policy_resolution,
+    )
+
+    status_response = _run_worker_request(status_request)
+    diff_response = _run_worker_request(diff_request)
+
+    assert status_response.outcome == "success"
+    assert diff_response.outcome == "success"
+    assert status_response.result is not None
+    assert diff_response.result is not None
+    status = status_response.result
+    diff = diff_response.result
+
+    assert "runtime-config.toml" not in status
+    assert "runtime-config.toml" not in diff
+    assert "OLD_SECRET" not in diff
+    assert "NEW_SECRET" not in diff
+    assert "ordinary.txt" in status
+    assert "ordinary.txt" in diff
+    assert "ordinary v2" in diff
 
 
 def test_parent_read_exclusions_do_not_recursively_enumerate_workspace(

--- a/Tests/Tools/test_workspace_tool_protocol.py
+++ b/Tests/Tools/test_workspace_tool_protocol.py
@@ -214,7 +214,13 @@ def test_request_rejects_write_content_for_read_only_operation() -> None:
 
 @pytest.mark.parametrize(
     "pattern",
-    ("../outside/*.txt", "/outside/*.txt", r"C:\\outside\\*.txt", r"\\\\host\\share\\*.txt"),
+    (
+        "../outside/*.txt",
+        "/outside/*.txt",
+        r"C:\\outside\\*.txt",
+        r"\\\\host\\share\\*.txt",
+        "safe\x00name/*.txt",
+    ),
 )
 def test_protocol_rejects_unsafe_glob_patterns_before_worker_dispatch(
     pattern: str,

--- a/Tests/Tools/test_workspace_tool_protocol.py
+++ b/Tests/Tools/test_workspace_tool_protocol.py
@@ -15,6 +15,7 @@ from tldw_chatbook.Tools.workspace_tool_protocol import (
     WorkspaceToolRequest,
     WorkspaceToolResponse,
 )
+from tldw_chatbook.Tools.git_tool_impls import GIT_MAX_OUTPUT_BYTES
 from tldw_chatbook.Tools.patch_tool_impls import PATCH_MAX_BYTES
 from tldw_chatbook.Utils.filesystem_identity import DirectoryIdentity
 
@@ -390,3 +391,21 @@ def test_response_enforces_frame_ceiling_and_redacts_repr_and_errors() -> None:
             b" " * (MAX_RESPONSE_BYTES + 1), expected_operation_id="operation-1"
         )
     assert secret_root not in str(exc_info.value)
+
+
+def test_response_ceiling_accepts_worst_case_escaped_git_output() -> None:
+    response = WorkspaceToolResponse(
+        operation_id="operation-1",
+        outcome="success",
+        code="ok",
+        result="\x01" * GIT_MAX_OUTPUT_BYTES,
+        error=None,
+        elapsed_ms=1,
+        truncated=True,
+        cleanup_proven=True,
+    )
+
+    raw = response.to_bytes()
+
+    assert len(raw) <= MAX_RESPONSE_BYTES
+    assert WorkspaceToolResponse.from_bytes(raw) == response

--- a/Tests/Tools/test_workspace_tool_protocol.py
+++ b/Tests/Tools/test_workspace_tool_protocol.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Tools.workspace_tool_protocol import (
+    MAX_PATH_BYTES,
+    MAX_REQUEST_BYTES,
+    MAX_RESPONSE_BYTES,
+    MAX_STRING_BYTES,
+    PROTOCOL_VERSION,
+    WorkspaceProtocolError,
+    WorkspaceToolRequest,
+    WorkspaceToolResponse,
+)
+from tldw_chatbook.Utils.filesystem_identity import DirectoryIdentity
+
+
+def _request(**changes: object) -> WorkspaceToolRequest:
+    values: dict[str, object] = {
+        "operation_id": "operation-1",
+        "operation": "stat_path",
+        "intent": "read",
+        "root_locator": Path("/private/workspace"),
+        "root_identity": DirectoryIdentity(1, 2, 0o040755, False),
+        "ancestor_identities": (DirectoryIdentity(1, 3, 0o040755, False),),
+        "arguments": {"path": "src/app.py"},
+        "timeout_seconds": 30,
+        "output_max_bytes": 1024,
+    }
+    values.update(changes)
+    return WorkspaceToolRequest(**values)  # type: ignore[arg-type]
+
+
+def _payload(request: WorkspaceToolRequest) -> dict[str, object]:
+    return json.loads(request.to_bytes())
+
+
+def test_request_round_trip_uses_the_closed_exact_schema() -> None:
+    request = _request()
+
+    raw = request.to_bytes()
+    payload = json.loads(raw)
+
+    assert set(payload) == {
+        "version",
+        "operation_id",
+        "operation",
+        "intent",
+        "root_locator",
+        "root_identity",
+        "ancestor_identities",
+        "arguments",
+        "timeout_seconds",
+        "output_max_bytes",
+    }
+    assert payload["version"] == PROTOCOL_VERSION
+    assert WorkspaceToolRequest.from_bytes(raw) == request
+
+
+@pytest.mark.parametrize(
+    ("operation", "intent"),
+    [
+        ("fs_list", "read"),
+        ("fs_read", "read"),
+        ("fs_write", "write"),
+        ("fs_edit", "write"),
+        ("fs_patch", "write"),
+        ("fs_glob", "read"),
+        ("fs_grep", "read"),
+        ("stat_path", "read"),
+        ("git_status", "read"),
+        ("git_diff", "read"),
+        ("git_log", "read"),
+        ("git_blame", "read"),
+        ("git_branches", "read"),
+    ],
+)
+def test_request_accepts_each_closed_operation_and_intent(
+    operation: str, intent: str
+) -> None:
+    request = _request(operation=operation, intent=intent)
+
+    assert WorkspaceToolRequest.from_bytes(request.to_bytes()) == request
+
+
+def test_request_encodes_directory_identities_without_paths() -> None:
+    payload = _payload(_request())
+
+    assert payload["root_identity"] == {
+        "device": 1,
+        "inode": 2,
+        "mode": 0o040755,
+        "reparse": False,
+    }
+    assert payload["ancestor_identities"] == [
+        {"device": 1, "inode": 3, "mode": 0o040755, "reparse": False}
+    ]
+
+
+def test_duplicate_json_keys_fail_before_request_construction() -> None:
+    with pytest.raises(WorkspaceProtocolError, match="duplicate key"):
+        WorkspaceToolRequest.from_bytes(b'{"version":1,"version":1}')
+
+
+@pytest.mark.parametrize("raw", [b'{"version":NaN}', b'{"version":Infinity}'])
+def test_non_finite_json_values_are_rejected(raw: bytes) -> None:
+    with pytest.raises(WorkspaceProtocolError, match="non-finite"):
+        WorkspaceToolRequest.from_bytes(raw)
+
+
+@pytest.mark.parametrize("field", ["operation_id", "root_locator"])
+def test_request_rejects_nul_in_private_strings(field: str) -> None:
+    payload = _payload(_request())
+    payload[field] = "unsafe\u0000value"
+
+    with pytest.raises(WorkspaceProtocolError, match="NUL"):
+        WorkspaceToolRequest.from_bytes(json.dumps(payload).encode())
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("version", True),
+        ("operation_id", 1),
+        ("operation", "shell"),
+        ("intent", "execute"),
+        ("root_locator", False),
+        ("root_identity", []),
+        ("ancestor_identities", {}),
+        ("arguments", []),
+        ("timeout_seconds", 1.5),
+        ("output_max_bytes", True),
+    ],
+)
+def test_request_rejects_wrong_types_and_closed_values(field: str, value: object) -> None:
+    payload = _payload(_request())
+    payload[field] = value
+
+    with pytest.raises(WorkspaceProtocolError):
+        WorkspaceToolRequest.from_bytes(json.dumps(payload).encode())
+
+
+def test_request_rejects_unknown_or_missing_keys() -> None:
+    payload = _payload(_request())
+    payload["unknown"] = "value"
+
+    with pytest.raises(WorkspaceProtocolError, match="keys"):
+        WorkspaceToolRequest.from_bytes(json.dumps(payload).encode())
+
+    payload.pop("unknown")
+    payload.pop("intent")
+    with pytest.raises(WorkspaceProtocolError, match="keys"):
+        WorkspaceToolRequest.from_bytes(json.dumps(payload).encode())
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("operation_id", "a" * (MAX_STRING_BYTES + 1)),
+        ("root_locator", "/" + "a" * MAX_PATH_BYTES),
+        ("arguments", {"path": "a" * (MAX_PATH_BYTES + 1)}),
+    ],
+)
+def test_request_enforces_string_and_path_ceilings(field: str, value: object) -> None:
+    payload = _payload(_request())
+    payload[field] = value
+
+    with pytest.raises(WorkspaceProtocolError, match="exceeds"):
+        WorkspaceToolRequest.from_bytes(json.dumps(payload).encode())
+
+
+def test_request_enforces_frame_ceiling_before_json_parse() -> None:
+    with pytest.raises(WorkspaceProtocolError, match="request frame exceeds"):
+        WorkspaceToolRequest.from_bytes(b" " * (MAX_REQUEST_BYTES + 1))
+
+
+def test_response_round_trip_requires_matching_operation_id() -> None:
+    response = WorkspaceToolResponse(
+        operation_id="operation-1",
+        outcome="success",
+        code="ok",
+        result="private result",
+        error=None,
+        elapsed_ms=12,
+        truncated=False,
+        cleanup_proven=True,
+    )
+
+    assert WorkspaceToolResponse.from_bytes(
+        response.to_bytes(), expected_operation_id="operation-1"
+    ) == response
+    with pytest.raises(WorkspaceProtocolError, match="operation ID"):
+        WorkspaceToolResponse.from_bytes(
+            response.to_bytes(), expected_operation_id="different"
+        )
+
+
+@pytest.mark.parametrize("raw", [b"", b"[]", b"{", b'{"version": 1}'])
+def test_response_rejects_malformed_frames(raw: bytes) -> None:
+    with pytest.raises(WorkspaceProtocolError):
+        WorkspaceToolResponse.from_bytes(raw, expected_operation_id="operation-1")
+
+
+def test_response_enforces_frame_ceiling_and_redacts_repr_and_errors() -> None:
+    secret_root = "/private/secret-workspace"
+    response = WorkspaceToolResponse(
+        operation_id="operation-1",
+        outcome="failure",
+        code="root_mismatch",
+        result=None,
+        error=f"request failed for {secret_root}",
+        elapsed_ms=1,
+        truncated=False,
+        cleanup_proven=True,
+    )
+
+    assert secret_root not in repr(response)
+    with pytest.raises(WorkspaceProtocolError) as exc_info:
+        WorkspaceToolResponse.from_bytes(
+            b" " * (MAX_RESPONSE_BYTES + 1), expected_operation_id="operation-1"
+        )
+    assert secret_root not in str(exc_info.value)

--- a/Tests/Tools/test_workspace_tool_protocol.py
+++ b/Tests/Tools/test_workspace_tool_protocol.py
@@ -235,6 +235,50 @@ def test_request_rejects_write_content_for_read_only_operation() -> None:
         WorkspaceToolRequest.from_bytes(json.dumps(payload).encode())
 
 
+def test_fs_read_limit_accepts_zero_without_loosening_other_positive_fields() -> None:
+    request = _request(
+        operation="fs_read",
+        intent="read",
+        arguments={"path": "read.txt", "limit": 0, "sensitive_exclusions": []},
+    )
+
+    assert WorkspaceToolRequest.from_bytes(request.to_bytes()) == request
+
+    other = _request(
+        operation="fs_glob",
+        intent="read",
+        arguments={"pattern": "**/*.py", "max_results": 0, "sensitive_exclusions": []},
+    )
+    with pytest.raises(WorkspaceProtocolError, match="positive int"):
+        other.to_bytes()
+
+
+@pytest.mark.parametrize("limit", [-1, True])
+def test_fs_read_limit_rejects_negative_and_bool(limit: object) -> None:
+    request = _request(
+        operation="fs_read",
+        intent="read",
+        arguments={"path": "read.txt", "limit": limit, "sensitive_exclusions": []},
+    )
+
+    with pytest.raises(WorkspaceProtocolError, match="non-negative int"):
+        request.to_bytes()
+
+
+def test_fs_read_limit_rejects_oversized_json_integer() -> None:
+    payload = _payload(
+        _request(
+            operation="fs_read",
+            intent="read",
+            arguments={"path": "read.txt", "limit": 1, "sensitive_exclusions": []},
+        )
+    )
+    raw = json.dumps(payload).encode().replace(b'"limit": 1', b'"limit": ' + b"9" * 5_000)
+
+    with pytest.raises(WorkspaceProtocolError, match="malformed"):
+        WorkspaceToolRequest.from_bytes(raw)
+
+
 @pytest.mark.parametrize(
     "pattern",
     (

--- a/Tests/Tools/test_workspace_tool_protocol.py
+++ b/Tests/Tools/test_workspace_tool_protocol.py
@@ -15,6 +15,7 @@ from tldw_chatbook.Tools.workspace_tool_protocol import (
     WorkspaceToolRequest,
     WorkspaceToolResponse,
 )
+from tldw_chatbook.Tools.patch_tool_impls import PATCH_MAX_BYTES
 from tldw_chatbook.Utils.filesystem_identity import DirectoryIdentity
 
 
@@ -36,6 +37,28 @@ def _request(**changes: object) -> WorkspaceToolRequest:
 
 def _payload(request: WorkspaceToolRequest) -> dict[str, object]:
     return json.loads(request.to_bytes())
+
+
+def _arguments_for(operation: str) -> dict[str, object]:
+    return {
+        "fs_list": {"path": "."},
+        "fs_read": {"path": "read.txt"},
+        "fs_write": {"path": "write.txt", "content": "contents"},
+        "fs_edit": {
+            "path": "edit.txt",
+            "old_string": "before",
+            "new_string": "after",
+        },
+        "fs_patch": {"diff": "--- a/file\n+++ b/file\n"},
+        "fs_glob": {"pattern": "**/*.py"},
+        "fs_grep": {"pattern": "needle"},
+        "stat_path": {"path": "file.txt"},
+        "git_status": {},
+        "git_diff": {},
+        "git_log": {},
+        "git_blame": {"path": "file.txt"},
+        "git_branches": {},
+    }[operation]
 
 
 def test_request_round_trip_uses_the_closed_exact_schema() -> None:
@@ -81,7 +104,9 @@ def test_request_round_trip_uses_the_closed_exact_schema() -> None:
 def test_request_accepts_each_closed_operation_and_intent(
     operation: str, intent: str
 ) -> None:
-    request = _request(operation=operation, intent=intent)
+    request = _request(
+        operation=operation, intent=intent, arguments=_arguments_for(operation)
+    )
 
     assert WorkspaceToolRequest.from_bytes(request.to_bytes()) == request
 
@@ -175,6 +200,51 @@ def test_request_enforces_string_and_path_ceilings(field: str, value: object) ->
 def test_request_enforces_frame_ceiling_before_json_parse() -> None:
     with pytest.raises(WorkspaceProtocolError, match="request frame exceeds"):
         WorkspaceToolRequest.from_bytes(b" " * (MAX_REQUEST_BYTES + 1))
+
+
+def test_request_rejects_write_content_for_read_only_operation() -> None:
+    payload = _payload(_request())
+    payload["operation"] = "fs_read"
+    payload["intent"] = "read"
+    payload["arguments"] = {"path": "read.txt", "content": "private text"}
+
+    with pytest.raises(WorkspaceProtocolError, match="arguments"):
+        WorkspaceToolRequest.from_bytes(json.dumps(payload).encode())
+
+
+def test_patch_diff_uses_the_utf8_patch_byte_ceiling() -> None:
+    payload = _payload(
+        _request(
+            operation="fs_patch",
+            intent="write",
+            arguments=_arguments_for("fs_patch"),
+        )
+    )
+    payload["arguments"] = {"diff": "é" * (PATCH_MAX_BYTES // 2)}
+
+    assert WorkspaceToolRequest.from_bytes(json.dumps(payload).encode())
+
+    payload["arguments"] = {"diff": "é" * ((PATCH_MAX_BYTES // 2) + 1)}
+    with pytest.raises(WorkspaceProtocolError, match="exceeds"):
+        WorkspaceToolRequest.from_bytes(json.dumps(payload).encode())
+
+
+def test_protocol_errors_do_not_echo_model_controlled_argument_keys() -> None:
+    secret_key = "/private/secret-root"
+    payload = _payload(_request())
+    payload["arguments"] = {secret_key: "contains\u0000nul"}
+
+    with pytest.raises(WorkspaceProtocolError) as exc_info:
+        WorkspaceToolRequest.from_bytes(json.dumps(payload).encode())
+
+    assert secret_key not in str(exc_info.value)
+
+
+def test_huge_json_integer_is_normalized_to_protocol_error() -> None:
+    raw = b'{"version":' + (b"9" * 5_000) + b"}"
+
+    with pytest.raises(WorkspaceProtocolError, match="malformed"):
+        WorkspaceToolRequest.from_bytes(raw)
 
 
 def test_response_round_trip_requires_matching_operation_id() -> None:

--- a/Tests/Tools/test_workspace_tool_protocol.py
+++ b/Tests/Tools/test_workspace_tool_protocol.py
@@ -212,6 +212,24 @@ def test_request_rejects_write_content_for_read_only_operation() -> None:
         WorkspaceToolRequest.from_bytes(json.dumps(payload).encode())
 
 
+@pytest.mark.parametrize(
+    "pattern",
+    ("../outside/*.txt", "/outside/*.txt", r"C:\\outside\\*.txt", r"\\\\host\\share\\*.txt"),
+)
+def test_protocol_rejects_unsafe_glob_patterns_before_worker_dispatch(
+    pattern: str,
+) -> None:
+    payload = _payload(
+        _request(
+            operation="fs_glob", intent="read", arguments=_arguments_for("fs_glob")
+        )
+    )
+    payload["arguments"] = {"pattern": pattern, "sensitive_exclusions": []}
+
+    with pytest.raises(WorkspaceProtocolError, match="glob pattern"):
+        WorkspaceToolRequest.from_bytes(json.dumps(payload).encode())
+
+
 def test_patch_diff_uses_the_utf8_patch_byte_ceiling() -> None:
     payload = _payload(
         _request(

--- a/Tests/Tools/test_workspace_tool_protocol.py
+++ b/Tests/Tools/test_workspace_tool_protocol.py
@@ -43,13 +43,21 @@ def _arguments_for(operation: str) -> dict[str, object]:
     return {
         "fs_list": {"path": ".", "sensitive_exclusions": []},
         "fs_read": {"path": "read.txt", "sensitive_exclusions": []},
-        "fs_write": {"path": "write.txt", "content": "contents"},
+        "fs_write": {
+            "path": "write.txt",
+            "content": "contents",
+            "sensitive_exclusions": [],
+        },
         "fs_edit": {
             "path": "edit.txt",
             "old_string": "before",
             "new_string": "after",
+            "sensitive_exclusions": [],
         },
-        "fs_patch": {"diff": "--- a/file\n+++ b/file\n"},
+        "fs_patch": {
+            "diff": "--- a/file\n+++ b/file\n",
+            "sensitive_exclusions": [],
+        },
         "fs_glob": {"pattern": "**/*.py", "sensitive_exclusions": []},
         "fs_grep": {"pattern": "needle", "sensitive_exclusions": [], "content_exclusions": []},
         "stat_path": {"path": "file.txt"},
@@ -244,11 +252,17 @@ def test_patch_diff_uses_the_utf8_patch_byte_ceiling() -> None:
             arguments=_arguments_for("fs_patch"),
         )
     )
-    payload["arguments"] = {"diff": "é" * (PATCH_MAX_BYTES // 2)}
+    payload["arguments"] = {
+        "diff": "é" * (PATCH_MAX_BYTES // 2),
+        "sensitive_exclusions": [],
+    }
 
     assert WorkspaceToolRequest.from_bytes(json.dumps(payload).encode())
 
-    payload["arguments"] = {"diff": "é" * ((PATCH_MAX_BYTES // 2) + 1)}
+    payload["arguments"] = {
+        "diff": "é" * ((PATCH_MAX_BYTES // 2) + 1),
+        "sensitive_exclusions": [],
+    }
     with pytest.raises(WorkspaceProtocolError, match="exceeds"):
         WorkspaceToolRequest.from_bytes(json.dumps(payload).encode())
 

--- a/Tests/Tools/test_workspace_tool_protocol.py
+++ b/Tests/Tools/test_workspace_tool_protocol.py
@@ -41,8 +41,8 @@ def _payload(request: WorkspaceToolRequest) -> dict[str, object]:
 
 def _arguments_for(operation: str) -> dict[str, object]:
     return {
-        "fs_list": {"path": "."},
-        "fs_read": {"path": "read.txt"},
+        "fs_list": {"path": ".", "sensitive_exclusions": []},
+        "fs_read": {"path": "read.txt", "sensitive_exclusions": []},
         "fs_write": {"path": "write.txt", "content": "contents"},
         "fs_edit": {
             "path": "edit.txt",
@@ -50,8 +50,8 @@ def _arguments_for(operation: str) -> dict[str, object]:
             "new_string": "after",
         },
         "fs_patch": {"diff": "--- a/file\n+++ b/file\n"},
-        "fs_glob": {"pattern": "**/*.py"},
-        "fs_grep": {"pattern": "needle"},
+        "fs_glob": {"pattern": "**/*.py", "sensitive_exclusions": []},
+        "fs_grep": {"pattern": "needle", "sensitive_exclusions": [], "content_exclusions": []},
         "stat_path": {"path": "file.txt"},
         "git_status": {},
         "git_diff": {},

--- a/Tests/Tools/test_workspace_tool_protocol.py
+++ b/Tests/Tools/test_workspace_tool_protocol.py
@@ -61,11 +61,11 @@ def _arguments_for(operation: str) -> dict[str, object]:
         "fs_glob": {"pattern": "**/*.py", "sensitive_exclusions": []},
         "fs_grep": {"pattern": "needle", "sensitive_exclusions": [], "content_exclusions": []},
         "stat_path": {"path": "file.txt"},
-        "git_status": {},
-        "git_diff": {},
-        "git_log": {},
-        "git_blame": {"path": "file.txt"},
-        "git_branches": {},
+        "git_status": {"sensitive_exclusions": []},
+        "git_diff": {"sensitive_exclusions": []},
+        "git_log": {"sensitive_exclusions": []},
+        "git_blame": {"path": "file.txt", "sensitive_exclusions": []},
+        "git_branches": {"sensitive_exclusions": []},
     }[operation]
 
 
@@ -117,6 +117,21 @@ def test_request_accepts_each_closed_operation_and_intent(
     )
 
     assert WorkspaceToolRequest.from_bytes(request.to_bytes()) == request
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ("git_status", "git_diff", "git_log", "git_blame", "git_branches"),
+)
+def test_git_requests_require_parent_admitted_sensitive_exclusions(
+    operation: str,
+) -> None:
+    arguments = _arguments_for(operation)
+    arguments.pop("sensitive_exclusions")
+    request = _request(operation=operation, intent="read", arguments=arguments)
+
+    with pytest.raises(WorkspaceProtocolError, match="arguments"):
+        request.to_bytes()
 
 
 def test_request_encodes_directory_identities_without_paths() -> None:

--- a/Tests/UI/test_settings_tools_section.py
+++ b/Tests/UI/test_settings_tools_section.py
@@ -5,12 +5,14 @@ returned {}, its executor had no callers, its save raised KeyError: 'None',
 and it had no tests.
 """
 
-import pytest
-
 from tldw_chatbook.Agents.tool_catalog import (
     BuiltinToolProvider,
-    gateable_builtin_tools,
 )
+
+
+class _NoopWorkspaceExecutor:
+    def execute(self, operation: str, arguments: dict, *, intent: str) -> str:
+        raise AssertionError(f"unexpected workspace operation: {operation}")
 
 
 def test_saving_a_gate_key_round_trips_to_the_provider(tmp_path, monkeypatch):
@@ -137,7 +139,9 @@ def test_web_deep_search_gate_key_round_trips_to_config(tmp_path, monkeypatch):
             {"tools": {"web_deep_search_enabled": True}}
         )
         config_module.load_settings(force_reload=True)
-        specs = _default_specs(tmp_path)
+        specs = _default_specs(
+            tmp_path, workspace_executor=_NoopWorkspaceExecutor()
+        )
         assert "web_deep_search" in {s.name for s in specs}
     finally:
         config_module._SETTINGS_CACHE = None

--- a/Tests/Utils/test_filesystem_identity.py
+++ b/Tests/Utils/test_filesystem_identity.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Utils import filesystem_identity as identity_module
+from tldw_chatbook.Utils.filesystem_identity import (
+    DirectoryIdentity,
+    DirectoryIdentityError,
+    capture_directory_chain,
+    directory_identity_from_stat,
+)
+
+
+def test_capture_directory_chain_canonicalizes_stable_alias(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(root, target_is_directory=True)
+
+    chain = capture_directory_chain(alias)
+
+    assert chain.canonical_root == root.resolve()
+    assert chain.identities[0] == directory_identity_from_stat(os.stat(root))
+
+
+def test_capture_directory_chain_records_root_first_ancestors(tmp_path: Path) -> None:
+    root = tmp_path / "one" / "two"
+    root.mkdir(parents=True)
+
+    chain = capture_directory_chain(root)
+
+    expected_paths = (root.resolve(), *root.resolve().parents)
+    assert chain.identities == tuple(
+        directory_identity_from_stat(os.lstat(path)) for path in expected_paths
+    )
+
+
+def test_capture_directory_chain_rejects_symlink_at_canonical_locator(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    canonical = root.resolve()
+    real_lstat = identity_module.os.lstat
+
+    monkeypatch.setattr(
+        identity_module.Path,
+        "resolve",
+        lambda self, strict=True: canonical,
+    )
+
+    def symlinked_locator(path: Path | str):
+        value = real_lstat(path)
+        if Path(path) == canonical:
+            return SimpleNamespace(
+                st_dev=value.st_dev,
+                st_ino=value.st_ino,
+                st_mode=stat.S_IFLNK,
+            )
+        return value
+
+    monkeypatch.setattr(identity_module.os, "lstat", symlinked_locator)
+
+    with pytest.raises(DirectoryIdentityError, match="unsafe directory"):
+        capture_directory_chain(root)
+
+
+def test_directory_identity_rejects_missing_windows_file_attributes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(identity_module, "_WINDOWS", True)
+    monkeypatch.setattr(identity_module, "_REPARSE_POINT", 0x400)
+    metadata = SimpleNamespace(st_dev=1, st_ino=2, st_mode=stat.S_IFDIR)
+
+    with pytest.raises(DirectoryIdentityError, match="file attributes"):
+        directory_identity_from_stat(metadata)
+
+
+def test_directory_identity_equality_is_stable() -> None:
+    left = DirectoryIdentity(device=1, inode=2, mode=stat.S_IFDIR, reparse=False)
+    right = DirectoryIdentity(device=1, inode=2, mode=stat.S_IFDIR, reparse=False)
+
+    assert left == right
+    assert hash(left) == hash(right)

--- a/backlog/decisions/101-one-shot-pinned-workspace-tool-execution.md
+++ b/backlog/decisions/101-one-shot-pinned-workspace-tool-execution.md
@@ -1,0 +1,134 @@
+# ADR-101: Use one-shot pinned workers for local workspace tool execution
+
+Status: Proposed
+Date: 2026-08-28
+Related Task: [TASK-19637](../tasks/task-19637%20-%20Atomically-pin-local-tool-workspace-execution.md)
+Design: [Atomic local-tool workspace execution](../../Docs/superpowers/specs/2026-08-28-task-19637-atomic-local-tool-workspace-execution-design.md)
+Supersedes: N/A
+
+## Decision
+
+Chatbook will execute workspace-confined local filesystem, patch, read-only Git,
+and equivalent Virtual CLI operations inside a fresh one-shot worker. The worker
+pins the exact run-admitted workspace directory before performing one operation,
+returns a bounded structured result, and exits. No worker remains alive between
+tool calls.
+
+The application validates the workspace binding, access mode, locator
+fingerprint, and captured filesystem identity immediately before starting the
+worker. Process-containment admission and successful root pinning form the
+operation's linearization boundary. A registry change made after that boundary
+does not retarget the admitted call; it applies to every later call.
+
+The worker receives its bounded request over standard input rather than argv or
+environment. It accepts a closed operation enum and cannot execute arbitrary
+Python, shell, or caller-supplied executables. The request uses the canonical
+root locator and identity captured at run admission, so a stable user-selected
+symlink alias remains compatible without becoming the later execution lookup.
+Absolute root locators, file content, patches, and model arguments are never
+placed in process listings or generic diagnostics.
+
+On POSIX, the worker opens the root without following the final component,
+compares the descriptor identity with the admitted identity, changes directory
+through the descriptor, and performs path work relative to that pinned
+descriptor. Git inherits the pinned current directory and does not receive
+`git -C <workspace-path>`.
+
+On Windows, the worker rejects a symlink/junction/reparse point at the admitted
+canonical locator, validates the directory identity, sets and re-verifies its
+own current directory, and retains that directory for the operation. Windows
+locks a process current directory against movement, deletion, and rename. The
+operation fails closed when the required identity or reparse metadata is
+unavailable.
+
+The worker and any Git descendant remain inside one retained POSIX process group
+or Windows kill-on-close Job Object. The implementation reuses the repository's
+existing worker-containment primitives. A Git child launched by the worker must
+not create a new POSIX session or otherwise escape that containment.
+
+This decision covers replacement of the authorized workspace root between
+confinement checking and use. It does not claim to create a general OS sandbox,
+contain raw CLI commands, or solve every possible concurrent mutation of an
+arbitrary descendant. Existing in-root symlink behavior, sensitive-path rules,
+linked-Git-worktree behavior, permission checks, and output contracts remain
+compatible when the admitted root does not drift.
+
+## Context
+
+The local `fs_*`, patch, and read-only `git_*` cores currently accept a `Path`
+workspace root. They resolve a model path, verify lexical/resolved containment,
+and later reopen ordinary pathnames. The local provider adds call-time root
+identity checks, but an external rename or replacement between that check and
+the actual open can redirect the operation.
+
+TASK-19504 will replace Console's hidden CWD/config-root fallback with exact
+run-admitted workspace bindings. Shipping that stronger selection contract while
+retaining a pathname check/use race would overstate its security boundary.
+TASK-19637 therefore precedes TASK-19504.
+
+A retained helper daemon was considered and rejected. It would reduce startup
+cost but add idle processes, cross-call mutable state, recovery, invalidation,
+and shutdown ownership. Per-call workers keep authority and failure scoped to
+one operation while still providing the fresh single-threaded context required
+for descriptor-relative `chdir` and Windows process-current-directory pinning.
+
+The read-only Virtual CLI dispatches directly to the same local filesystem and
+Git cores. It is part of this boundary even though it has independent permission
+state; otherwise it would become an alternate unpinned execution path.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Repeat identity checks immediately before and after pathname operations | A check before use still leaves a race, while a check after use detects a violation only after data was read or written. |
+| Keep one helper alive per active workspace authority | Adds idle processes, cross-call state, invalidation, crash recovery, and shutdown complexity before performance evidence shows it is necessary. |
+| Run POSIX descriptor operations in process and use a helper only on Windows/Git | Reduces some process startup but splits one security boundary across divergent invocation paths and leaves more ways for providers or Virtual CLI to bypass it. |
+| Change the multithreaded app process current directory on Windows | Windows current directory is process-wide, so this could redirect unrelated threads and libraries. |
+| Reject every symlink beneath an admitted root | Broadens this root-race fix into a behavioral change and breaks existing compatible in-root symlink semantics. |
+| Require a full OS sandbox | A portable sandbox is a distinct project. This task binds operations to one admitted root; it does not execute arbitrary code or claim hostile-code containment. |
+
+## Consequences
+
+### Benefits
+
+- Root rename, replacement, symlink, junction, and reparse substitution cannot
+  redirect an admitted local filesystem or Git operation.
+- The same execution boundary covers structured local tools and Virtual CLI.
+- No unsafe `preexec_fn` runs from Chatbook's multithreaded process.
+- Every helper has one authority, one request, one result, and bounded cleanup.
+- Root locators and tool payloads stay out of process argv and generic logs.
+
+### Costs and accepted risks
+
+- Every local path operation pays one Python worker startup. The implementation
+  must record cold and warm median/p95 overhead before closeout.
+- Filesystem implementations require a root-relative execution seam rather than
+  reopening absolute paths produced by `Path.resolve()`.
+- Windows needs native identity/reparse and Job Object evidence. Unsupported
+  capabilities refuse calls rather than falling back to pathname-only checks.
+- A call admitted before an access downgrade may finish. The downgrade blocks
+  subsequent admission; it does not promise unsafe asynchronous cancellation of
+  an operation already inside the pinned boundary.
+- This boundary prevents root retargeting but is not a general defense against
+  malicious code, raw shell access, privileged mount manipulation, or every
+  possible race within descendant content.
+
+### Binding tripwires
+
+- Pooling or retaining workers across calls requires a new ADR or an amendment
+  with lifecycle, invalidation, and performance evidence.
+- Adding mutating Git, shell, caller-selected executables, or arbitrary Python to
+  the worker requires a separate security decision.
+- Any fallback that executes after failed identity/reparse admission violates
+  this ADR.
+- New local path frontends must route through the pinned executor rather than
+  call the path cores directly.
+
+## Links
+
+- [TASK-19637](../tasks/task-19637%20-%20Atomically-pin-local-tool-workspace-execution.md)
+- [Approved design after review](../../Docs/superpowers/specs/2026-08-28-task-19637-atomic-local-tool-workspace-execution-design.md)
+- [ADR-069](069-console-project-instruction-local-state-and-preflight.md)
+- [ADR-094](094-raw-and-virtual-cli-execution-boundaries.md)
+- [Microsoft SetCurrentDirectory](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setcurrentdirectory)
+- [Microsoft process inheritance](https://learn.microsoft.com/en-us/windows/win32/procthread/inheritance)

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -89,6 +89,7 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-096](096-console-safe-capture-retention.md) | Accepted | Bound default Safe exchange capture to the first system row, latest user row, and newest eight rows; compact readable legacy Safe blobs transactionally while leaving Full semantics unchanged. |
 | [ADR-098](098-visible-bounded-console-prompt-queue.md) | Accepted | Keep a visible, bounded, process-local prompt queue per Console session with FIFO turns, explicit pause/recovery, and immutable owning-session execution context. |
 | [ADR-100](100-console-active-path-before-first-cursor.md) | Accepted | Represent a deliberately empty Console active path with a local before-message pointer, reconstruct its original prompt on restart, and preserve legacy unset fallback. |
+| [ADR-101](101-one-shot-pinned-workspace-tool-execution.md) | Proposed | Execute local workspace filesystem, patch, read-only Git, and equivalent Virtual CLI operations in one-shot workers pinned to the run-admitted root identity. |
 
 ## Historical Decision Material
 

--- a/backlog/tasks/task-19637 - Atomically-pin-local-tool-workspace-execution.md
+++ b/backlog/tasks/task-19637 - Atomically-pin-local-tool-workspace-execution.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-19637
 title: Atomically pin local-tool workspace execution
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-08-20 20:05'
-updated_date: '2026-08-21'
+updated_date: '2026-08-28'
 labels:
   - security
   - console

--- a/backlog/tasks/task-19637 - Atomically-pin-local-tool-workspace-execution.md
+++ b/backlog/tasks/task-19637 - Atomically-pin-local-tool-workspace-execution.md
@@ -48,3 +48,33 @@ Its governing decision is
 `backlog/decisions/069-console-project-instruction-local-state-and-preflight.md`.
 The old ambiguous `TASK-16320` dependency was removed during the TASK-19637
 renumber; this task must not depend on the unrelated duplicate TASK-16320.
+
+## Implementation Plan
+
+ADR required: yes
+
+ADR path: `backlog/decisions/101-one-shot-pinned-workspace-tool-execution.md`
+
+Reason: This task establishes a cross-platform helper-process security boundary
+for local filesystem and Git execution, including authority, lifecycle, failure,
+privacy, compatibility, and performance contracts.
+
+Detailed plan:
+`Docs/superpowers/plans/2026-08-28-task-19637-atomic-local-tool-workspace-execution.md`
+
+1. Share fail-closed canonical directory identity capture and define a strict,
+   bounded one-operation stdin/stdout protocol.
+2. Deliver one end-to-end contained worker with platform root pinning and a
+   deterministic `stat_path` root-replacement regression.
+3. Move read-only filesystem operations behind the retained root identity while
+   preserving sensitive-path, symlink, ordering, and truncation behavior.
+4. Move file writes, edits, and multi-file patch application behind one retained
+   root identity.
+5. Run all read-only Git operations from a relative pinned working directory,
+   with no `git -C` and no inner process-group escape.
+6. Route Local Tool, Virtual CLI, and external MCP production frontends through
+   the same one-shot executor without changing schemas or permissions.
+7. Publish deterministic Linux/macOS/Windows race/lifecycle evidence and
+   direct-versus-worker median/p95 measurements.
+8. Rebase, self-review, run approved verification, accept ADR-101, document the
+   evidence, and close the task only after every acceptance criterion is proven.

--- a/tldw_chatbook/Agents/local_tool_provider.py
+++ b/tldw_chatbook/Agents/local_tool_provider.py
@@ -30,6 +30,10 @@ from loguru import logger
 from tldw_chatbook.MCP.hub_tool_catalog import HubTool
 from tldw_chatbook.MCP.local_runtime_delegate import PERMISSION_STATE_UNRESOLVED_CLAUSE
 from tldw_chatbook.MCP.permission_store import EffectiveToolState
+from tldw_chatbook.Tools.workspace_tool_executor import (
+    WorkspaceToolExecutionError,
+    WorkspaceToolExecutor,
+)
 
 from ..config import coerce_bool_setting, get_cli_setting
 from .agent_models import ToolCatalogEntry, ToolResult, ToolSchema
@@ -225,6 +229,20 @@ def _fit_result(text: str) -> str:
     return raw[:_MAX_RESULT_BYTES].decode("utf-8", errors="ignore") + "\n… [truncated]"
 
 
+def _workspace_execution_error_result(
+    error: WorkspaceToolExecutionError,
+    *,
+    redaction_root: Path | None,
+) -> ToolResult:
+    """Translate one validated executor failure without a direct-core fallback."""
+    if error.code == "root_pin_failed":
+        return ToolResult.blocked(LOCAL_ROOT_CHANGED_REFUSAL)
+    if error.code not in {"invalid_request", "tool_failure"}:
+        return ToolResult.blocked(LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL)
+    text = redact_root_locator(str(error), redaction_root)
+    return ToolResult(ok=False, error=text[:_MAX_ERROR_CHARS])
+
+
 class LocalToolProvider:
     """Exposes LocalToolSpecs behind the ToolProvider protocol, gated per call.
 
@@ -270,6 +288,8 @@ class LocalToolProvider:
             locator must be replaced with relative text before results reach
             model history or run logs. Console private scratch passes its
             root; ordinary and explicitly bound Workspace providers omit it.
+        workspace_executor: One-shot pinned workspace executor. When omitted,
+            the provider constructs the production executor for ``workspace_root``.
     """
 
     def __init__(
@@ -292,13 +312,20 @@ class LocalToolProvider:
         root_guard: Callable[[], bool] | None = None,
         authority_scope: Callable[[], ContextManager[Path]] | None = None,
         result_redaction_root: Path | None = None,
+        workspace_executor: WorkspaceToolExecutor | None = None,
     ) -> None:
         self._root = workspace_root
+        selected_executor = (
+            WorkspaceToolExecutor(workspace_root)
+            if workspace_executor is None
+            else workspace_executor
+        )
         selected_specs = (
             specs
             if specs is not None
             else _default_specs(
                 workspace_root,
+                workspace_executor=selected_executor,
                 todo_store=todo_store,
                 on_todo_change=on_todo_change,
                 watchlists_service=watchlists_service,
@@ -766,6 +793,11 @@ class LocalToolProvider:
                             )
                         ),
                     )
+                except WorkspaceToolExecutionError as exc:
+                    return _workspace_execution_error_result(
+                        exc,
+                        redaction_root=self._result_redaction_root,
+                    )
                 except Exception as exc:  # noqa: BLE001 — protocol boundary
                     error = redact_root_locator(
                         str(exc) or repr(exc),
@@ -1126,29 +1158,12 @@ def _make_todo_list_handler(store: SessionTodoStore) -> Callable[[dict], str]:
 def _default_specs(
     workspace_root: Path,
     *,
+    workspace_executor: WorkspaceToolExecutor,
     todo_store: SessionTodoStore | None = None,
     on_todo_change: TodoChangeCallback | None = None,
     watchlists_service: WatchlistsToolService | None = None,
 ) -> list[LocalToolSpec]:
-    from tldw_chatbook.Tools.git_tool_impls import (
-        GIT_LOG_DEFAULT_COUNT,
-        git_blame,
-        git_branches,
-        git_diff,
-        git_log,
-        git_status,
-    )
-    from tldw_chatbook.Tools.local_tool_impls import (
-        MAX_GLOB_RESULTS,
-        MAX_GREP_RESULTS,
-        edit_file,
-        glob_files,
-        grep_files,
-        list_directory,
-        read_file,
-        write_file,
-    )
-    from tldw_chatbook.Tools.patch_tool_impls import patch_files
+    from tldw_chatbook.Tools.git_tool_impls import GIT_LOG_DEFAULT_COUNT
     from tldw_chatbook.Tools.watchlists_tool_service import WatchlistsToolService
     from tldw_chatbook.Tools.web_tool_impls import (
         CRAWL_DEFAULT_MAX_DEPTH,
@@ -1187,8 +1202,8 @@ def _default_specs(
                 },
                 "required": ["path"],
             },
-            handler=lambda args: list_directory(
-                args["path"], workspace_root=workspace_root
+            handler=lambda args: workspace_executor.execute(
+                "fs_list", args, intent="read"
             ),
             tags=(),
         ),
@@ -1214,11 +1229,8 @@ def _default_specs(
                 },
                 "required": ["path"],
             },
-            handler=lambda args: read_file(
-                args["path"],
-                workspace_root=workspace_root,
-                offset=args.get("offset", 1),
-                limit=args.get("limit"),
+            handler=lambda args: workspace_executor.execute(
+                "fs_read", args, intent="read"
             ),
             tags=(),
         ),
@@ -1239,8 +1251,8 @@ def _default_specs(
                 },
                 "required": ["path", "content"],
             },
-            handler=lambda args: write_file(
-                args["path"], args["content"], workspace_root=workspace_root
+            handler=lambda args: workspace_executor.execute(
+                "fs_write", args, intent="write"
             ),
             tags=("mutates",),
         ),
@@ -1270,12 +1282,8 @@ def _default_specs(
                 },
                 "required": ["path", "old_string", "new_string"],
             },
-            handler=lambda args: edit_file(
-                args["path"],
-                args["old_string"],
-                args["new_string"],
-                workspace_root=workspace_root,
-                replace_all=args.get("replace_all", False),
+            handler=lambda args: workspace_executor.execute(
+                "fs_edit", args, intent="write"
             ),
             tags=("mutates",),
         ),
@@ -1308,10 +1316,8 @@ def _default_specs(
                 },
                 "required": ["diff"],
             },
-            handler=lambda args: patch_files(
-                args["diff"],
-                workspace_root=workspace_root,
-                dry_run=args.get("dry_run", False),
+            handler=lambda args: workspace_executor.execute(
+                "fs_patch", args, intent="write"
             ),
             tags=("mutates",),
         ),
@@ -1333,10 +1339,8 @@ def _default_specs(
                 },
                 "required": ["pattern"],
             },
-            handler=lambda args: glob_files(
-                args["pattern"],
-                workspace_root=workspace_root,
-                max_results=args.get("max_results", MAX_GLOB_RESULTS),
+            handler=lambda args: workspace_executor.execute(
+                "fs_glob", args, intent="read"
             ),
             tags=(),
         ),
@@ -1364,11 +1368,8 @@ def _default_specs(
                 },
                 "required": ["pattern"],
             },
-            handler=lambda args: grep_files(
-                args["pattern"],
-                workspace_root=workspace_root,
-                mode=args.get("mode", "content"),
-                max_results=args.get("max_results", MAX_GREP_RESULTS),
+            handler=lambda args: workspace_executor.execute(
+                "fs_grep", args, intent="read"
             ),
             tags=(),
         ),
@@ -1392,7 +1393,9 @@ def _default_specs(
                     },
                 },
             },
-            handler=lambda args: git_status(workspace_root, path=args.get("path", ".")),
+            handler=lambda args: workspace_executor.execute(
+                "git_status", args, intent="read"
+            ),
             tags=(),
         ),
         LocalToolSpec(
@@ -1429,12 +1432,8 @@ def _default_specs(
                     },
                 },
             },
-            handler=lambda args: git_diff(
-                workspace_root,
-                staged=args.get("staged", False),
-                commit_range=args.get("commit_range"),
-                path=args.get("path"),
-                stat=args.get("stat", False),
+            handler=lambda args: workspace_executor.execute(
+                "git_diff", args, intent="read"
             ),
             tags=(),
         ),
@@ -1459,10 +1458,8 @@ def _default_specs(
                     },
                 },
             },
-            handler=lambda args: git_log(
-                workspace_root,
-                count=args.get("count", GIT_LOG_DEFAULT_COUNT),
-                path=args.get("path"),
+            handler=lambda args: workspace_executor.execute(
+                "git_log", args, intent="read"
             ),
             tags=(),
         ),
@@ -1492,11 +1489,8 @@ def _default_specs(
                 },
                 "required": ["path"],
             },
-            handler=lambda args: git_blame(
-                workspace_root,
-                args["path"],
-                start_line=args.get("start_line"),
-                end_line=args.get("end_line"),
+            handler=lambda args: workspace_executor.execute(
+                "git_blame", args, intent="read"
             ),
             tags=(),
         ),
@@ -1511,7 +1505,9 @@ def _default_specs(
                 "type": "object",
                 "properties": {},
             },
-            handler=lambda args: git_branches(workspace_root),
+            handler=lambda args: workspace_executor.execute(
+                "git_branches", args, intent="read"
+            ),
             tags=(),
         ),
         LocalToolSpec(

--- a/tldw_chatbook/Agents/project_instruction_resolver.py
+++ b/tldw_chatbook/Agents/project_instruction_resolver.py
@@ -10,6 +10,11 @@ from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Literal
 
+from tldw_chatbook.Utils.filesystem_identity import (
+    DirectoryIdentityError,
+    directory_identity_from_stat,
+)
+
 InstructionKind = Literal["override", "standard"]
 InstructionOutcomeCode = Literal[
     "omitted_byte_budget",
@@ -732,26 +737,18 @@ def _capture_ancestor_identities(
     identities: list[tuple[int, int, int]] = []
     for ancestor in (root, *root.parents):
         value = os.lstat(ancestor)
-        identity = _directory_identity(value)
+        try:
+            identity = directory_identity_from_stat(value)
+        except DirectoryIdentityError as error:
+            raise _UnsafeMetadata from error
         if (
             not stat.S_ISDIR(value.st_mode)
             or stat.S_ISLNK(value.st_mode)
             or _is_reparse(value)
         ):
             raise _UnsafeMetadata
-        identities.append(identity)
+        identities.append((identity.device, identity.inode, identity.mode))
     return tuple(identities)
-
-
-def _directory_identity(value: object) -> tuple[int, int, int]:
-    try:
-        return (
-            int(getattr(value, "st_dev")),
-            int(getattr(value, "st_ino")),
-            int(getattr(value, "st_mode")),
-        )
-    except (AttributeError, TypeError, ValueError) as error:
-        raise _UnsafeMetadata from error
 
 
 def _is_reparse(value: object) -> bool:

--- a/tldw_chatbook/Agents/virtual_cli_provider.py
+++ b/tldw_chatbook/Agents/virtual_cli_provider.py
@@ -19,12 +19,18 @@ from tldw_chatbook.Tools.virtual_cli_impls import (
     VirtualCliRegistry,
     parse_request,
 )
+from tldw_chatbook.Tools.workspace_tool_executor import (
+    WorkspaceToolExecutionError,
+    WorkspaceToolExecutor,
+)
 
 from .agent_models import ToolCall, ToolCatalogEntry, ToolResult, ToolSchema
 from .local_tool_provider import (
+    LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL,
     LOCAL_DENY_REFUSAL,
     LOCAL_GATE_ERROR_REFUSAL,
     LOCAL_KILL_SWITCH_REFUSAL,
+    LOCAL_ROOT_CHANGED_REFUSAL,
     LOCAL_TIMEOUT_REFUSAL,
 )
 from .mcp_tool_provider import MCPPendingCall
@@ -104,8 +110,17 @@ class VirtualCliProvider:
         root_guard: Callable[[], bool] | None = None,
         authority_scope: Callable[[], ContextManager[Path]] | None = None,
         result_redaction_root: Path | None = None,
+        workspace_executor: WorkspaceToolExecutor | None = None,
     ) -> None:
-        self._registry = VirtualCliRegistry(workspace_root)
+        selected_executor = (
+            WorkspaceToolExecutor(workspace_root)
+            if workspace_executor is None
+            else workspace_executor
+        )
+        self._registry = VirtualCliRegistry(
+            workspace_root,
+            workspace_executor=selected_executor,
+        )
         self._resolve_state = resolve_state or (
             lambda _hub: EffectiveToolState(state="ask", origin="global_default")
         )
@@ -275,7 +290,10 @@ class VirtualCliProvider:
         except VirtualCliArgumentError as exc:
             return ToolResult(ok=False, error=f"invalid virtual_cli request: {exc}")
         hub = self.hub_tool_for(command)
-        if not self._root_is_valid() or not self._local_tools_are_enabled():
+        if not self._root_is_valid():
+            self._record(hub, "denied")
+            return ToolResult.blocked(LOCAL_ROOT_CHANGED_REFUSAL)
+        if not self._local_tools_are_enabled():
             self._record(hub, "denied")
             return ToolResult.blocked(LOCAL_KILL_SWITCH_REFUSAL)
         if self._kill_switch_engaged():
@@ -301,16 +319,21 @@ class VirtualCliProvider:
             return ToolResult.blocked(refusal)
 
         def execute() -> ToolResult:
-            if (
-                not self._root_is_valid()
-                or not self._local_tools_are_enabled()
-                or self._kill_switch_engaged()
-            ):
+            if not self._root_is_valid():
+                return ToolResult.blocked(LOCAL_ROOT_CHANGED_REFUSAL)
+            if not self._local_tools_are_enabled() or self._kill_switch_engaged():
                 return ToolResult.blocked(LOCAL_KILL_SWITCH_REFUSAL)
             try:
                 content = self._registry.execute(command, argv)
                 content = redact_root_locator(content, self._result_redaction_root)
                 return ToolResult(ok=True, content=_sanitize_result(content))
+            except WorkspaceToolExecutionError as exc:
+                if exc.code == "root_pin_failed":
+                    return ToolResult.blocked(LOCAL_ROOT_CHANGED_REFUSAL)
+                if exc.code not in {"invalid_request", "tool_failure"}:
+                    return ToolResult.blocked(LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL)
+                error = redact_root_locator(str(exc), self._result_redaction_root)
+                return ToolResult(ok=False, error=error[:_MAX_ERROR_CHARS])
             except Exception as exc:  # noqa: BLE001 - provider boundary
                 error = redact_root_locator(
                     str(exc) or repr(exc), self._result_redaction_root
@@ -322,9 +345,7 @@ class VirtualCliProvider:
             with scope:
                 return execute()
         except Exception:
-            return ToolResult.blocked(
-                "Private scratch space is unavailable; the tool was not run."
-            )
+            return ToolResult.blocked(LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL)
 
     def _ask_verdict(self, hub: HubTool, command: str, args: dict) -> str:
         stamp = self._pop_stamp(current_run_id(), command)

--- a/tldw_chatbook/Tools/git_tool_impls.py
+++ b/tldw_chatbook/Tools/git_tool_impls.py
@@ -161,11 +161,6 @@ def _extract_subcommand_and_validate_globals(argv: list[str]) -> str | None:
             if len(argv) != 2:
                 raise LocalToolError("git global option --version must be used alone")
             return value
-        if value == "-C":
-            if index + 1 >= len(argv):
-                raise LocalToolError("git global option -C requires a workspace path")
-            index += 2
-            continue
         if value == "--no-pager":
             index += 1
             continue
@@ -202,15 +197,19 @@ def _read_bounded_stream(stream, max_output_bytes: int) -> tuple[bytes, bool]:
 def run_git(
     argv: list[str],
     *,
+    cwd: Path | None = None,
+    executable: Path | None = None,
+    own_process_group: bool = True,
     timeout: float = GIT_TIMEOUT_SECONDS,
     max_output_bytes: int = GIT_MAX_OUTPUT_BYTES,
 ) -> GitCommandResult:
     """Run an allowlisted git command with bounded output and a timeout.
 
-    Fixed argv only: ``argv[0]`` must be ``git``, the only permitted global
-    options are ``-C <path>`` and ``--no-pager`` (``--version`` must stand
-    alone), and the subcommand must be in ``_ALLOWED_GIT_SUBCOMMANDS``. The
-    environment is sanitized (PATH + git safety vars only) and stdin is
+    Fixed argv only: ``argv[0]`` must be logical ``git``, the only permitted
+    global option is ``--no-pager`` (``--version`` must stand alone), and the
+    subcommand must be in ``_ALLOWED_GIT_SUBCOMMANDS``. The absolute executable
+    replaces logical argv zero only at launch. The environment is sanitized
+    (PATH + git safety vars only) and stdin is
     DEVNULL. Output per stream is capped at ``max_output_bytes`` — the
     process is killed when the cap is exceeded (never fully buffered) and a
     truncation marker is appended. Timeout kills the process and raises.
@@ -227,22 +226,27 @@ def run_git(
         LocalToolError: argv validation failure, git unavailable, or timeout.
     """
     _validate_argv(argv)
-    if shutil.which("git") is None:
+    resolved_executable = executable or (
+        Path(found) if (found := shutil.which("git")) is not None else None
+    )
+    if resolved_executable is None:
         raise LocalToolError("git is not available on this system")
+    resolved_executable = resolved_executable.resolve()
     if not isinstance(max_output_bytes, int) or isinstance(max_output_bytes, bool) or max_output_bytes <= 0:
         max_output_bytes = GIT_MAX_OUTPUT_BYTES
 
     process = subprocess.Popen(
-        list(argv),
+        [str(resolved_executable), *argv[1:]],
         stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        cwd=cwd,
         env=_git_environment(),
         # Own process group so the timeout/cap kills can reap grandchildren
         # too (a bare process.kill() leaves e.g. a textconv child alive —
         # and a live grandchild holding the pipe write end would stall the
         # truncation fast-path until the full timeout).
-        start_new_session=os.name == "posix",
+        start_new_session=own_process_group and os.name == "posix",
     )
 
     results: dict[str, tuple[bytes, bool]] = {}
@@ -261,7 +265,7 @@ def run_git(
     while len(results) < 2:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            _kill_process(process)
+            _kill_process(process, own_process_group=own_process_group)
             with contextlib.suppress(Exception):
                 process.wait()
             raise LocalToolError(f"git command timed out after {timeout} seconds: {list(argv)}")
@@ -273,7 +277,7 @@ def run_git(
         if data[1]:
             # Cap exceeded: kill now (the reference behaviour) instead of
             # letting the process keep producing output we will discard.
-            _kill_process(process)
+            _kill_process(process, own_process_group=own_process_group)
 
     with contextlib.suppress(Exception):
         process.wait(timeout=REPOSITORY_DISCOVERY_TIMEOUT_SECONDS)
@@ -296,9 +300,11 @@ def run_git(
     )
 
 
-def _kill_process(process: subprocess.Popen) -> None:
+def _kill_process(
+    process: subprocess.Popen, *, own_process_group: bool = True
+) -> None:
     """Kill the whole process group on POSIX; fall back to the direct child."""
-    if os.name == "posix":
+    if own_process_group and os.name == "posix":
         # process was started with start_new_session=True, so its pid is
         # the group id: SIGKILL the group to reap grandchildren as well.
         with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
@@ -438,6 +444,8 @@ def prepare_repository(
     path: str = ".",
     *,
     context: SensitivePathContext | None = None,
+    executable: Path | None = None,
+    own_process_group: bool = True,
 ) -> Path:
     """Resolve the git repo root for ``path``, confined to ``workspace_root``.
 
@@ -464,12 +472,15 @@ def prepare_repository(
     Returns:
         The resolved repository root path.
     """
-    if shutil.which("git") is None:
+    if executable is None and shutil.which("git") is None:
         raise LocalToolError("git is not available on this system")
     workspace_root = Path(workspace_root).resolve()
     target = resolve_workspace_path(path, workspace_root, context=context)
     result = run_git(
-        ["git", "-C", str(target), "rev-parse", "--show-toplevel"],
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=_git_cwd(workspace_root, target, own_process_group=own_process_group),
+        executable=executable,
+        own_process_group=own_process_group,
         timeout=REPOSITORY_DISCOVERY_TIMEOUT_SECONDS,
     )
     if result.returncode != 0:
@@ -525,8 +536,20 @@ def _stderr_gist(result: GitCommandResult) -> str:
     return f"exit code {result.returncode}"
 
 
-def _run_git_checked(argv: list[str], *, subcommand: str) -> GitCommandResult:
-    result = run_git(argv)
+def _run_git_checked(
+    argv: list[str],
+    *,
+    subcommand: str,
+    cwd: Path,
+    executable: Path | None,
+    own_process_group: bool,
+) -> GitCommandResult:
+    result = run_git(
+        argv,
+        cwd=cwd,
+        executable=executable,
+        own_process_group=own_process_group,
+    )
     # A truncated result means the output cap fired and WE killed git
     # (SIGKILL -> returncode -9): that is not a git failure. Deliver the
     # bounded partial output (run_git already appended the truncation
@@ -534,6 +557,19 @@ def _run_git_checked(argv: list[str], *, subcommand: str) -> GitCommandResult:
     if result.returncode != 0 and not result.truncated:
         raise LocalToolError(f"git {subcommand} failed: {_stderr_gist(result)}")
     return result
+
+
+def _git_cwd(
+    workspace_root: Path,
+    target: Path,
+    *,
+    own_process_group: bool,
+) -> Path:
+    """Return absolute compatibility cwd or helper-root-relative cwd."""
+    if own_process_group:
+        return target
+    relative = target.relative_to(workspace_root)
+    return relative if relative.parts else Path(".")
 
 
 def _repo_relative_path(
@@ -569,6 +605,8 @@ def _prepare_for_path(
     path: str | None,
     *,
     context: SensitivePathContext | None = None,
+    executable: Path | None = None,
+    own_process_group: bool = True,
 ) -> Path:
     """Repo discovery that tolerates ``path`` being a file (uses its parent).
 
@@ -584,11 +622,23 @@ def _prepare_for_path(
             resolve its own — pays the ~11 config-accessor cost once.
     """
     if path is None:
-        return prepare_repository(workspace_root, ".", context=context)
+        return prepare_repository(
+            workspace_root,
+            ".",
+            context=context,
+            executable=executable,
+            own_process_group=own_process_group,
+        )
     resolved = resolve_workspace_path(path, Path(workspace_root).resolve(), context=context)
     discovery = resolved if resolved.is_dir() else resolved.parent
     relative = os.path.relpath(discovery, Path(workspace_root).resolve())
-    return prepare_repository(workspace_root, relative, context=context)
+    return prepare_repository(
+        workspace_root,
+        relative,
+        context=context,
+        executable=executable,
+        own_process_group=own_process_group,
+    )
 
 
 def _sanitize_author_name(value: str) -> str:
@@ -599,7 +649,13 @@ def _nul_records(stdout: str) -> list[str]:
     return [record for record in stdout.split("\0") if record]
 
 
-def git_status(workspace_root: Path, path: str = ".") -> str:
+def git_status(
+    workspace_root: Path,
+    path: str = ".",
+    *,
+    executable: Path | None = None,
+    own_process_group: bool = True,
+) -> str:
     """Branch header + staged/unstaged/untracked/conflicted entries as text.
 
     Sync adaptation of the reference's ``_execute_status`` (:570): porcelain
@@ -628,14 +684,19 @@ def git_status(workspace_root: Path, path: str = ".") -> str:
         ``"(working tree clean)"`` when there are none, and a truncation
         note appended if the repository has more entries than the cap.
     """
+    workspace_root = Path(workspace_root).resolve()
     context = resolve_sensitive_context()
-    repo_root = _prepare_for_path(workspace_root, path, context=context)
+    repo_root = _prepare_for_path(
+        workspace_root,
+        path,
+        context=context,
+        executable=executable,
+        own_process_group=own_process_group,
+    )
     result = _run_git_checked(
         [
             "git",
             "--no-pager",
-            "-C",
-            str(repo_root),
             "status",
             "--porcelain=v2",
             "-z",
@@ -645,6 +706,11 @@ def git_status(workspace_root: Path, path: str = ".") -> str:
             *_denylist_pathspecs(repo_root, context=context),
         ],
         subcommand="status",
+        cwd=_git_cwd(
+            workspace_root, repo_root, own_process_group=own_process_group
+        ),
+        executable=executable,
+        own_process_group=own_process_group,
     )
     branch, entries, truncated = _parse_status_porcelain_v2(
         result.stdout, limit=GIT_STATUS_MAX_ENTRIES
@@ -763,22 +829,37 @@ def _format_status_entry(entry: dict[str, object]) -> str:
     return f"{category}: {entry['xy']} {entry['path']}"
 
 
-def git_branches(workspace_root: Path) -> str:
+def git_branches(
+    workspace_root: Path,
+    *,
+    executable: Path | None = None,
+    own_process_group: bool = True,
+) -> str:
     """Verbose branch list with the current branch marked by ``*``.
 
     Sync adaptation of the reference's ``_execute_branches`` (:621).
     """
-    repo_root = prepare_repository(workspace_root, ".", context=resolve_sensitive_context())
+    workspace_root = Path(workspace_root).resolve()
+    repo_root = prepare_repository(
+        workspace_root,
+        ".",
+        context=resolve_sensitive_context(),
+        executable=executable,
+        own_process_group=own_process_group,
+    )
     result = _run_git_checked(
         [
             "git",
             "--no-pager",
-            "-C",
-            str(repo_root),
             "branch",
             "--format=%(HEAD)%00%(refname:short)%00%(upstream:short)%00%(objectname)",
         ],
         subcommand="branch",
+        cwd=_git_cwd(
+            workspace_root, repo_root, own_process_group=own_process_group
+        ),
+        executable=executable,
+        own_process_group=own_process_group,
     )
     lines: list[str] = []
     for record in result.stdout.splitlines():
@@ -805,6 +886,8 @@ def git_log(
     *,
     count: int = GIT_LOG_DEFAULT_COUNT,
     path: str | None = None,
+    executable: Path | None = None,
+    own_process_group: bool = True,
 ) -> str:
     """Bounded commit log, newest first; ``count`` is clamped to 1..100.
 
@@ -835,13 +918,18 @@ def git_log(
         first, or ``"(no commits)"`` when there are none.
     """
     count = min(max(int(count), 1), GIT_LOG_MAX_COUNT)
+    workspace_root = Path(workspace_root).resolve()
     context = resolve_sensitive_context()
-    repo_root = _prepare_for_path(workspace_root, path, context=context)
+    repo_root = _prepare_for_path(
+        workspace_root,
+        path,
+        context=context,
+        executable=executable,
+        own_process_group=own_process_group,
+    )
     argv = [
         "git",
         "--no-pager",
-        "-C",
-        str(repo_root),
         "log",
         "--format=%H%x1f%h%x1f%an%x1f%aI%x1f%s%x1e",
         "-n",
@@ -856,7 +944,15 @@ def git_log(
                 ),
             ]
         )
-    result = _run_git_checked(argv, subcommand="log")
+    result = _run_git_checked(
+        argv,
+        subcommand="log",
+        cwd=_git_cwd(
+            workspace_root, repo_root, own_process_group=own_process_group
+        ),
+        executable=executable,
+        own_process_group=own_process_group,
+    )
     lines: list[str] = []
     for record in result.stdout.split("\x1e"):
         fields = record.strip("\n").split("\x1f", 4)
@@ -876,6 +972,8 @@ def git_diff(
     commit_range: str | None = None,
     path: str | None = None,
     stat: bool = False,
+    executable: Path | None = None,
+    own_process_group: bool = True,
 ) -> str:
     """Unified diff of the worktree (default) or the index (``staged=True``).
 
@@ -931,13 +1029,18 @@ def git_diff(
                 f"invalid commit_range {commit_range!r}: "
                 "must be a ref/range matching [A-Za-z0-9._/~^-] and not start with '-'"
             )
+    workspace_root = Path(workspace_root).resolve()
     context = resolve_sensitive_context()
-    repo_root = _prepare_for_path(workspace_root, path, context=context)
+    repo_root = _prepare_for_path(
+        workspace_root,
+        path,
+        context=context,
+        executable=executable,
+        own_process_group=own_process_group,
+    )
     argv = [
         "git",
         "--no-pager",
-        "-C",
-        str(repo_root),
         "diff",
         "--no-ext-diff",
         "--no-textconv",
@@ -965,7 +1068,15 @@ def git_diff(
     # is applied to the whole tree, which is exactly the no-`path` case.
     pathspecs.extend(_denylist_pathspecs(repo_root, context=context))
     argv.extend(["--", *pathspecs])
-    result = _run_git_checked(argv, subcommand="diff")
+    result = _run_git_checked(
+        argv,
+        subcommand="diff",
+        cwd=_git_cwd(
+            workspace_root, repo_root, own_process_group=own_process_group
+        ),
+        executable=executable,
+        own_process_group=own_process_group,
+    )
     return result.stdout if result.stdout.strip() else "(no changes)"
 
 
@@ -975,6 +1086,8 @@ def git_blame(
     *,
     start_line: int | None = None,
     end_line: int | None = None,
+    executable: Path | None = None,
+    own_process_group: bool = True,
 ) -> str:
     """Per-line blame for ``path``; optional 1-based inclusive line range.
 
@@ -983,11 +1096,18 @@ def git_blame(
     neither bound is given) and the range is capped at
     ``GIT_BLAME_MAX_LINES`` lines.
     """
+    workspace_root = Path(workspace_root).resolve()
     context = resolve_sensitive_context()
     resolved = resolve_workspace_path(path, Path(workspace_root).resolve(), context=context)
     if not resolved.is_file():
         raise LocalToolError(f"file not found: {path}")
-    repo_root = _prepare_for_path(workspace_root, path, context=context)
+    repo_root = _prepare_for_path(
+        workspace_root,
+        path,
+        context=context,
+        executable=executable,
+        own_process_group=own_process_group,
+    )
     try:
         repo_relative = resolved.relative_to(repo_root).as_posix()
     except ValueError:
@@ -998,8 +1118,6 @@ def git_blame(
     argv = [
         "git",
         "--no-pager",
-        "-C",
-        str(repo_root),
         "blame",
         "--line-porcelain",
         "--no-textconv",
@@ -1023,7 +1141,15 @@ def git_blame(
     # it, and `resolved.is_file()` means it must genuinely exist.
     argv.extend(["--", repo_relative])
 
-    result = _run_git_checked(argv, subcommand="blame")
+    result = _run_git_checked(
+        argv,
+        subcommand="blame",
+        cwd=_git_cwd(
+            workspace_root, repo_root, own_process_group=own_process_group
+        ),
+        executable=executable,
+        own_process_group=own_process_group,
+    )
     lines = [f"{ln}: {author}: {text}" for ln, author, text in _parse_blame(result.stdout)]
     return "\n".join(lines) if lines else "(no blame output)"
 

--- a/tldw_chatbook/Tools/git_tool_impls.py
+++ b/tldw_chatbook/Tools/git_tool_impls.py
@@ -79,10 +79,15 @@ import subprocess
 import threading
 import time
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
-from tldw_chatbook.Tools.local_tool_impls import LocalToolError, resolve_workspace_path
+from tldw_chatbook.Tools.local_tool_impls import (
+    LocalToolError,
+    _relative_target_is_safe,
+    resolve_workspace_path,
+)
 from tldw_chatbook.Utils.sensitive_paths import (
+    SensitiveExclusion,
     SensitivePathContext,
     is_sensitive_path,
     resolve_sensitive_context,
@@ -356,7 +361,11 @@ def _literal_pathspec(relative_posix: str) -> str:
 
 
 def _denylist_pathspecs(
-    repo_root: Path, context: SensitivePathContext | None = None
+    repo_root: Path,
+    context: SensitivePathContext | None = None,
+    *,
+    workspace_root: Path | None = None,
+    sensitive_exclusions: tuple[SensitiveExclusion, ...] | None = None,
 ) -> tuple[str, ...]:
     """Render the sensitive-path denylist as git exclude pathspecs.
 
@@ -366,11 +375,12 @@ def _denylist_pathspecs(
     workspace -- never reached ``Utils/sensitive_paths.py`` at all.
 
     Excluding by PATHSPEC rather than filtering git's output is the
-    deliberate choice: git stays the authority on what matches, the
-    exclusions are recomputed from the live denylist on every call (so a
-    ``TLDW_CONFIG_PATH`` switch or a relocated database is observed
-    immediately), and no unified-diff or porcelain text is ever parsed to
-    decide what to withhold -- a half-parsed diff is worse than none.
+    deliberate choice: git stays the authority on what matches, and no
+    unified-diff or porcelain text is ever parsed to decide what to
+    withhold -- a half-parsed diff is worse than none. Direct callers
+    recompute the live denylist on each call. The pinned helper instead
+    consumes the bounded snapshot admitted by its parent before the helper
+    environment is scrubbed.
 
     Each :class:`~tldw_chatbook.Utils.sensitive_paths.SensitiveExclusion`
     kind maps to the pathspec form that expresses exactly that rule and
@@ -402,9 +412,8 @@ def _denylist_pathspecs(
 
     Args:
         repo_root: The already-resolved repository root; every pathspec
-            is rendered relative to it, which is what ``-C <repo_root>``
-            makes correct (git resolves pathspecs against the process's
-            working directory).
+            is rendered relative to it; git resolves pathspecs against the
+            process's working directory.
         context: Optional pre-resolved ``SensitivePathContext``, so one
             tool call resolves the denylist once.
 
@@ -419,8 +428,17 @@ def _denylist_pathspecs(
             or the denylist produced an exclusion kind this renderer does
             not know how to express.
     """
+    if sensitive_exclusions is None:
+        exclusions = sensitive_exclusions_under(repo_root, context=context)
+    else:
+        if workspace_root is None:
+            raise LocalToolError("workspace root is required for admitted exclusions")
+        exclusions = _repo_relative_exclusions(
+            Path(workspace_root).resolve(), repo_root, sensitive_exclusions
+        )
+
     specs: list[str] = []
-    for kind, value in sensitive_exclusions_under(repo_root, context=context):
+    for kind, value in exclusions:
         if kind in {"subtree", "file"}:
             if not value:
                 raise LocalToolError(
@@ -439,11 +457,47 @@ def _denylist_pathspecs(
     return tuple(specs)
 
 
+def _repo_relative_exclusions(
+    workspace_root: Path,
+    repo_root: Path,
+    exclusions: tuple[SensitiveExclusion, ...],
+) -> tuple[SensitiveExclusion, ...]:
+    """Translate parent-admitted workspace exclusions to repository-relative."""
+    repo_parts = tuple(
+        part.casefold()
+        for part in repo_root.relative_to(workspace_root).parts
+    )
+    translated: list[SensitiveExclusion] = []
+    for exclusion in exclusions:
+        if exclusion.kind == "name":
+            translated.append(exclusion)
+            continue
+        value_parts = PurePosixPath(exclusion.value).parts if exclusion.value else ()
+        folded_value = tuple(part.casefold() for part in value_parts)
+        if folded_value[: len(repo_parts)] == repo_parts:
+            relative_parts = value_parts[len(repo_parts) :]
+            translated.append(
+                SensitiveExclusion(
+                    exclusion.kind,
+                    PurePosixPath(*relative_parts).as_posix() if relative_parts else "",
+                )
+            )
+            continue
+        if repo_parts[: len(folded_value)] != folded_value:
+            continue
+        if exclusion.kind in {"subtree", "file"}:
+            translated.append(SensitiveExclusion(exclusion.kind, ""))
+        elif exclusion.kind == "direct_children" and len(repo_parts) == len(folded_value):
+            translated.append(SensitiveExclusion("direct_children", ""))
+    return tuple(translated)
+
+
 def prepare_repository(
     workspace_root: Path,
     path: str = ".",
     *,
     context: SensitivePathContext | None = None,
+    sensitive_exclusions: tuple[SensitiveExclusion, ...] | None = None,
     executable: Path | None = None,
     own_process_group: bool = True,
 ) -> Path:
@@ -475,7 +529,12 @@ def prepare_repository(
     if executable is None and shutil.which("git") is None:
         raise LocalToolError("git is not available on this system")
     workspace_root = Path(workspace_root).resolve()
-    target = resolve_workspace_path(path, workspace_root, context=context)
+    target = _resolve_git_path(
+        path,
+        workspace_root,
+        context=context,
+        sensitive_exclusions=sensitive_exclusions,
+    )
     result = run_git(
         ["git", "rev-parse", "--show-toplevel"],
         cwd=_git_cwd(workspace_root, target, own_process_group=own_process_group),
@@ -509,7 +568,17 @@ def prepare_repository(
     # denylist-checked -- this is here so that stays true if either
     # relationship is ever relaxed: excluding denied paths from a
     # repository that is ITSELF denied would leave nothing honest to show.
-    if is_sensitive_path(repo_root, context=context):
+    if sensitive_exclusions is None:
+        repo_is_sensitive = is_sensitive_path(repo_root, context=context)
+    else:
+        repo_relative = repo_root.relative_to(workspace_root)
+        repo_is_sensitive = not _relative_target_is_safe(
+            repo_relative,
+            workspace_root,
+            sensitive_exclusions,
+            is_directory=True,
+        )
+    if repo_is_sensitive:
         raise LocalToolError(
             f"repository root ({repo_root}) is a protected path; refusing"
         )
@@ -572,12 +641,45 @@ def _git_cwd(
     return relative if relative.parts else Path(".")
 
 
+def _resolve_git_path(
+    path: str,
+    workspace_root: Path,
+    *,
+    context: SensitivePathContext | None,
+    sensitive_exclusions: tuple[SensitiveExclusion, ...] | None,
+) -> Path:
+    """Resolve a Git path using either live or parent-admitted exclusions."""
+    workspace_root = Path(workspace_root).resolve()
+    if sensitive_exclusions is None:
+        return resolve_workspace_path(path, workspace_root, context=context)
+    candidate = Path(path)
+    try:
+        if candidate.is_absolute():
+            relative = candidate.resolve().relative_to(workspace_root)
+        else:
+            relative = candidate
+        target = workspace_root / relative
+        if not _relative_target_is_safe(
+            relative,
+            workspace_root,
+            sensitive_exclusions,
+            is_directory=target.is_dir(),
+        ):
+            raise LocalToolError(f"path '{path}' is outside the workspace or protected")
+        return target.resolve()
+    except (OSError, ValueError):
+        raise LocalToolError(
+            f"path '{path}' is outside the workspace or protected"
+        ) from None
+
+
 def _repo_relative_path(
     workspace_root: Path,
     repo_root: Path,
     path: str,
     *,
     context: SensitivePathContext | None = None,
+    sensitive_exclusions: tuple[SensitiveExclusion, ...] | None = None,
 ) -> str:
     """Resolve ``path`` confined to the workspace, rendered repo-relative.
 
@@ -590,7 +692,12 @@ def _repo_relative_path(
             already resolved one for the same tool call does not pay for
             it again here.
     """
-    resolved = resolve_workspace_path(path, Path(workspace_root).resolve(), context=context)
+    resolved = _resolve_git_path(
+        path,
+        Path(workspace_root).resolve(),
+        context=context,
+        sensitive_exclusions=sensitive_exclusions,
+    )
     try:
         relative = resolved.relative_to(repo_root)
     except ValueError:
@@ -605,6 +712,7 @@ def _prepare_for_path(
     path: str | None,
     *,
     context: SensitivePathContext | None = None,
+    sensitive_exclusions: tuple[SensitiveExclusion, ...] | None = None,
     executable: Path | None = None,
     own_process_group: bool = True,
 ) -> Path:
@@ -626,16 +734,23 @@ def _prepare_for_path(
             workspace_root,
             ".",
             context=context,
+            sensitive_exclusions=sensitive_exclusions,
             executable=executable,
             own_process_group=own_process_group,
         )
-    resolved = resolve_workspace_path(path, Path(workspace_root).resolve(), context=context)
+    resolved = _resolve_git_path(
+        path,
+        Path(workspace_root).resolve(),
+        context=context,
+        sensitive_exclusions=sensitive_exclusions,
+    )
     discovery = resolved if resolved.is_dir() else resolved.parent
     relative = os.path.relpath(discovery, Path(workspace_root).resolve())
     return prepare_repository(
         workspace_root,
         relative,
         context=context,
+        sensitive_exclusions=sensitive_exclusions,
         executable=executable,
         own_process_group=own_process_group,
     )
@@ -653,6 +768,7 @@ def git_status(
     workspace_root: Path,
     path: str = ".",
     *,
+    sensitive_exclusions: tuple[SensitiveExclusion, ...] | None = None,
     executable: Path | None = None,
     own_process_group: bool = True,
 ) -> str:
@@ -685,11 +801,12 @@ def git_status(
         note appended if the repository has more entries than the cap.
     """
     workspace_root = Path(workspace_root).resolve()
-    context = resolve_sensitive_context()
+    context = None if sensitive_exclusions is not None else resolve_sensitive_context()
     repo_root = _prepare_for_path(
         workspace_root,
         path,
         context=context,
+        sensitive_exclusions=sensitive_exclusions,
         executable=executable,
         own_process_group=own_process_group,
     )
@@ -703,7 +820,12 @@ def git_status(
             "--branch",
             "--untracked-files=all",
             "--",
-            *_denylist_pathspecs(repo_root, context=context),
+            *_denylist_pathspecs(
+                repo_root,
+                context=context,
+                workspace_root=workspace_root,
+                sensitive_exclusions=sensitive_exclusions,
+            ),
         ],
         subcommand="status",
         cwd=_git_cwd(
@@ -832,6 +954,7 @@ def _format_status_entry(entry: dict[str, object]) -> str:
 def git_branches(
     workspace_root: Path,
     *,
+    sensitive_exclusions: tuple[SensitiveExclusion, ...] | None = None,
     executable: Path | None = None,
     own_process_group: bool = True,
 ) -> str:
@@ -840,10 +963,12 @@ def git_branches(
     Sync adaptation of the reference's ``_execute_branches`` (:621).
     """
     workspace_root = Path(workspace_root).resolve()
+    context = None if sensitive_exclusions is not None else resolve_sensitive_context()
     repo_root = prepare_repository(
         workspace_root,
         ".",
-        context=resolve_sensitive_context(),
+        context=context,
+        sensitive_exclusions=sensitive_exclusions,
         executable=executable,
         own_process_group=own_process_group,
     )
@@ -886,6 +1011,7 @@ def git_log(
     *,
     count: int = GIT_LOG_DEFAULT_COUNT,
     path: str | None = None,
+    sensitive_exclusions: tuple[SensitiveExclusion, ...] | None = None,
     executable: Path | None = None,
     own_process_group: bool = True,
 ) -> str:
@@ -919,11 +1045,12 @@ def git_log(
     """
     count = min(max(int(count), 1), GIT_LOG_MAX_COUNT)
     workspace_root = Path(workspace_root).resolve()
-    context = resolve_sensitive_context()
+    context = None if sensitive_exclusions is not None else resolve_sensitive_context()
     repo_root = _prepare_for_path(
         workspace_root,
         path,
         context=context,
+        sensitive_exclusions=sensitive_exclusions,
         executable=executable,
         own_process_group=own_process_group,
     )
@@ -940,7 +1067,13 @@ def git_log(
             [
                 "--",
                 _literal_pathspec(
-                    _repo_relative_path(workspace_root, repo_root, path, context=context)
+                    _repo_relative_path(
+                        workspace_root,
+                        repo_root,
+                        path,
+                        context=context,
+                        sensitive_exclusions=sensitive_exclusions,
+                    )
                 ),
             ]
         )
@@ -972,6 +1105,7 @@ def git_diff(
     commit_range: str | None = None,
     path: str | None = None,
     stat: bool = False,
+    sensitive_exclusions: tuple[SensitiveExclusion, ...] | None = None,
     executable: Path | None = None,
     own_process_group: bool = True,
 ) -> str:
@@ -1030,11 +1164,12 @@ def git_diff(
                 "must be a ref/range matching [A-Za-z0-9._/~^-] and not start with '-'"
             )
     workspace_root = Path(workspace_root).resolve()
-    context = resolve_sensitive_context()
+    context = None if sensitive_exclusions is not None else resolve_sensitive_context()
     repo_root = _prepare_for_path(
         workspace_root,
         path,
         context=context,
+        sensitive_exclusions=sensitive_exclusions,
         executable=executable,
         own_process_group=own_process_group,
     )
@@ -1060,13 +1195,26 @@ def git_diff(
     if path is not None:
         pathspecs.append(
             _literal_pathspec(
-                _repo_relative_path(workspace_root, repo_root, path, context=context)
+                _repo_relative_path(
+                    workspace_root,
+                    repo_root,
+                    path,
+                    context=context,
+                    sensitive_exclusions=sensitive_exclusions,
+                )
             )
         )
     # Exclusions come LAST and are never empty (the name rule always
     # applies), so `--` is always present: an exclude-only pathspec list
     # is applied to the whole tree, which is exactly the no-`path` case.
-    pathspecs.extend(_denylist_pathspecs(repo_root, context=context))
+    pathspecs.extend(
+        _denylist_pathspecs(
+            repo_root,
+            context=context,
+            workspace_root=workspace_root,
+            sensitive_exclusions=sensitive_exclusions,
+        )
+    )
     argv.extend(["--", *pathspecs])
     result = _run_git_checked(
         argv,
@@ -1086,6 +1234,7 @@ def git_blame(
     *,
     start_line: int | None = None,
     end_line: int | None = None,
+    sensitive_exclusions: tuple[SensitiveExclusion, ...] | None = None,
     executable: Path | None = None,
     own_process_group: bool = True,
 ) -> str:
@@ -1097,14 +1246,20 @@ def git_blame(
     ``GIT_BLAME_MAX_LINES`` lines.
     """
     workspace_root = Path(workspace_root).resolve()
-    context = resolve_sensitive_context()
-    resolved = resolve_workspace_path(path, Path(workspace_root).resolve(), context=context)
+    context = None if sensitive_exclusions is not None else resolve_sensitive_context()
+    resolved = _resolve_git_path(
+        path,
+        Path(workspace_root).resolve(),
+        context=context,
+        sensitive_exclusions=sensitive_exclusions,
+    )
     if not resolved.is_file():
         raise LocalToolError(f"file not found: {path}")
     repo_root = _prepare_for_path(
         workspace_root,
         path,
         context=context,
+        sensitive_exclusions=sensitive_exclusions,
         executable=executable,
         own_process_group=own_process_group,
     )

--- a/tldw_chatbook/Tools/local_tool_impls.py
+++ b/tldw_chatbook/Tools/local_tool_impls.py
@@ -252,11 +252,12 @@ def _list_relative_directory(
     max_entries: int,
     sensitive_exclusions: tuple[SensitiveExclusion, ...],
     display_path: str | None = None,
-    validate_target: bool = True,
 ) -> str:
     """List a pinned-root-relative directory without opening an absolute path."""
     target = workspace / relative
-    if (validate_target and not _relative_path_stays_in_workspace(relative, workspace)) or not target.is_dir():
+    if not _relative_target_is_safe(
+        relative, workspace, sensitive_exclusions, is_directory=True
+    ) or not target.is_dir():
         raise LocalToolError(f"not a directory: {display_path or relative}")
     scanned: list[Path] = []
     scan_capped = False
@@ -266,10 +267,9 @@ def _list_relative_directory(
             break
         # Skipped entries still count against the scan cap: the cap bounds
         # the WORK done, and a denied entry was still scanned.
-        if _is_relative_sensitive_path(
-            _workspace_relative_path(entry, workspace),
-            sensitive_exclusions,
-            is_directory=entry.is_dir(),
+        entry_relative = _workspace_relative_path(entry, workspace)
+        if not _relative_target_is_safe(
+            entry_relative, workspace, sensitive_exclusions, is_directory=entry.is_dir()
         ):
             continue
         scanned.append(entry)
@@ -308,6 +308,7 @@ def read_file(
         workspace=Path(workspace_root).resolve(),
         offset=offset,
         limit=limit,
+        sensitive_exclusions=sensitive_exclusions_under(Path(workspace_root).resolve()),
         display_path=path,
     )
 
@@ -318,12 +319,14 @@ def _read_relative_file(
     workspace: Path,
     offset: int,
     limit: int | None,
+    sensitive_exclusions: tuple[SensitiveExclusion, ...],
     display_path: str | None = None,
-    validate_target: bool = True,
 ) -> str:
     """Read a pinned-root-relative text file without reopening its resolved path."""
     target = workspace / relative
-    if (validate_target and not _relative_path_stays_in_workspace(relative, workspace)) or not target.is_file():
+    if not _relative_target_is_safe(
+        relative, workspace, sensitive_exclusions, is_directory=False
+    ) or not target.is_file():
         raise LocalToolError(f"file not found: {display_path or relative}")
     with open(target, "rb") as fh:
         sniff = fh.read(8192)
@@ -504,6 +507,7 @@ def _glob_relative_files(
     workspace: Path,
     max_results: int,
     sensitive_exclusions: tuple[SensitiveExclusion, ...],
+    validate_targets: bool = False,
 ) -> str:
     """Glob from the pinned working directory using only relative I/O paths."""
     heap: list[tuple[float, Path]] = []  # min-heap of (mtime, normpath)
@@ -516,12 +520,17 @@ def _glob_relative_files(
             if not norm.is_relative_to(workspace):
                 continue
             rendered = norm.relative_to(workspace)
-            # Name-only glob output intentionally preserves the established
-            # escaping-link behavior: it never reads link target contents.
-            if _is_relative_sensitive_path(
+            if validate_targets:
+                # The pinned worker validates a live link target immediately
+                # before disclosure, but keeps ``rendered`` for all I/O/output.
+                if not _relative_target_is_safe(
+                    rendered, workspace, sensitive_exclusions, is_directory=False
+                ):
+                    continue
+            elif _is_relative_sensitive_path(
                 rendered, sensitive_exclusions, is_directory=False
             ):
-                continue  # never disclose a protected path, even by name
+                continue
             mtime = p.stat().st_mtime
         except OSError:
             continue  # racy/unreadable entry — skip it, not the whole search
@@ -590,7 +599,6 @@ def _grep_relative_files(
     mode: str,
     max_results: int,
     sensitive_exclusions: tuple[SensitiveExclusion, ...],
-    validate_symlink_targets: bool = True,
 ) -> str:
     """Grep pinned-root-relative files while refusing escaping symlink content."""
     import re
@@ -612,11 +620,9 @@ def _grep_relative_files(
         try:
             if not p.is_file() or p.stat().st_size > _MAX_GREP_FILE_BYTES:
                 continue
-            if validate_symlink_targets and not p.resolve().is_relative_to(workspace.resolve()):
-                continue  # symlink escaping the root — never read outside content
             relative = _workspace_relative_path(p, workspace)
-            if _is_relative_sensitive_path(
-                relative, sensitive_exclusions, is_directory=False
+            if not _relative_target_is_safe(
+                relative, workspace, sensitive_exclusions, is_directory=False
             ):
                 continue  # protected path — skipped BEFORE it is read
         except OSError:
@@ -643,10 +649,22 @@ def _grep_relative_files(
     return "\n".join(shown) if shown else f"(no matches for {pattern!r})"
 
 
-def _relative_path_stays_in_workspace(relative: Path, workspace: Path) -> bool:
-    """Check a relative target's resolved location without using it for I/O."""
+def _relative_target_is_safe(
+    relative: Path,
+    workspace: Path,
+    exclusions: tuple[SensitiveExclusion, ...],
+    *,
+    is_directory: bool,
+) -> bool:
+    """Validate a resolved target, then leave I/O on its original relative path."""
     try:
-        return (workspace / relative).resolve().is_relative_to(workspace.resolve())
+        resolved_workspace = workspace.resolve()
+        resolved = (workspace / relative).resolve()
+        if not resolved.is_relative_to(resolved_workspace):
+            return False
+        return not _is_relative_sensitive_path(
+            resolved.relative_to(resolved_workspace), exclusions, is_directory=is_directory
+        )
     except OSError:
         return False
 

--- a/tldw_chatbook/Tools/local_tool_impls.py
+++ b/tldw_chatbook/Tools/local_tool_impls.py
@@ -656,8 +656,12 @@ def _relative_target_is_safe(
     *,
     is_directory: bool,
 ) -> bool:
-    """Validate a resolved target, then leave I/O on its original relative path."""
+    """Require both lexical and resolved targets to be admissible for I/O."""
     try:
+        if _is_relative_sensitive_path(
+            relative, exclusions, is_directory=is_directory
+        ):
+            return False
         resolved_workspace = workspace.resolve()
         resolved = (workspace / relative).resolve()
         if not resolved.is_relative_to(resolved_workspace):

--- a/tldw_chatbook/Tools/local_tool_impls.py
+++ b/tldw_chatbook/Tools/local_tool_impls.py
@@ -401,9 +401,28 @@ def write_file(path: str, content: str, *, workspace_root: Path) -> str:
     The parent directory must already exist (deliberate divergence from
     claude-code's Write, to catch model path typos early — spec §2).
     """
-    root = resolve_workspace_path(path, workspace_root, intent="write")
-    if not root.parent.is_dir():
-        raise LocalToolError(f"parent directory does not exist for: {path}")
+    workspace = Path(workspace_root).resolve()
+    root = resolve_workspace_path(path, workspace, intent="write")
+    return _write_relative_file(
+        root.relative_to(workspace),
+        content,
+        workspace=workspace,
+        display_path=path,
+    )
+
+
+def _write_relative_file(
+    relative: Path,
+    content: str,
+    *,
+    workspace: Path,
+    display_path: str | None = None,
+) -> str:
+    """Write one already-admitted path relative to an I/O root."""
+    target = workspace / relative
+    shown = display_path or str(relative)
+    if not target.parent.is_dir():
+        raise LocalToolError(f"parent directory does not exist for: {shown}")
     try:
         data = content.encode("utf-8")
     except UnicodeEncodeError as exc:
@@ -412,8 +431,8 @@ def write_file(path: str, content: str, *, workspace_root: Path) -> str:
         ) from exc
     # encode BEFORE opening for write — a failed encode must never
     # truncate an existing file
-    root.write_bytes(data)
-    return f"wrote {len(content)} characters to {path}"
+    target.write_bytes(data)
+    return f"wrote {len(content)} characters to {shown}"
 
 
 def edit_file(
@@ -434,26 +453,49 @@ def edit_file(
     unencodable ``new_string`` (e.g. a lone surrogate from tool-call JSON)
     fails without truncating the file.
     """
+    workspace = Path(workspace_root).resolve()
+    root = resolve_workspace_path(path, workspace, intent="write")
+    return _edit_relative_file(
+        root.relative_to(workspace),
+        old_string,
+        new_string,
+        workspace=workspace,
+        replace_all=replace_all,
+        display_path=path,
+    )
+
+
+def _edit_relative_file(
+    relative: Path,
+    old_string: str,
+    new_string: str,
+    *,
+    workspace: Path,
+    replace_all: bool = False,
+    display_path: str | None = None,
+) -> str:
+    """Edit one already-admitted path relative to an I/O root."""
+    shown = display_path or str(relative)
     if not old_string:
         raise LocalToolError("old_string must not be empty")
     if old_string == new_string:
         raise LocalToolError("old_string and new_string are identical")
-    root = resolve_workspace_path(path, workspace_root, intent="write")
-    if not root.is_file():
-        raise LocalToolError(f"file not found: {path}")
+    target = workspace / relative
+    if not target.is_file():
+        raise LocalToolError(f"file not found: {shown}")
     try:
-        with open(root, encoding="utf-8", newline="") as fh:
+        with open(target, encoding="utf-8", newline="") as fh:
             content = fh.read()
     except UnicodeDecodeError as exc:
         raise LocalToolError(
-            f"'{path}' is not valid UTF-8; fs_edit only edits text files"
+            f"'{shown}' is not valid UTF-8; fs_edit only edits text files"
         ) from exc
     count = content.count(old_string)
     if count == 0:
-        raise LocalToolError(f"old_string not found in {path}")
+        raise LocalToolError(f"old_string not found in {shown}")
     if count > 1 and not replace_all:
         raise LocalToolError(
-            f"old_string appears {count} times in {path}; "
+            f"old_string appears {count} times in {shown}; "
             "provide more context to make it unique, or set replace_all=true"
         )
     updated = content.replace(old_string, new_string)
@@ -463,9 +505,9 @@ def edit_file(
         raise LocalToolError(
             f"new_string is not UTF-8 encodable (lone surrogate?): {exc}"
         ) from exc
-    root.write_bytes(data)
+    target.write_bytes(data)
     n = count if replace_all else 1
-    return f"made {n} replacement{'s' if n != 1 else ''} in {path}"
+    return f"made {n} replacement{'s' if n != 1 else ''} in {shown}"
 
 
 def glob_files(

--- a/tldw_chatbook/Tools/local_tool_impls.py
+++ b/tldw_chatbook/Tools/local_tool_impls.py
@@ -252,10 +252,11 @@ def _list_relative_directory(
     max_entries: int,
     sensitive_exclusions: tuple[SensitiveExclusion, ...],
     display_path: str | None = None,
+    validate_target: bool = True,
 ) -> str:
     """List a pinned-root-relative directory without opening an absolute path."""
     target = workspace / relative
-    if not _relative_path_stays_in_workspace(relative, workspace) or not target.is_dir():
+    if (validate_target and not _relative_path_stays_in_workspace(relative, workspace)) or not target.is_dir():
         raise LocalToolError(f"not a directory: {display_path or relative}")
     scanned: list[Path] = []
     scan_capped = False
@@ -318,10 +319,11 @@ def _read_relative_file(
     offset: int,
     limit: int | None,
     display_path: str | None = None,
+    validate_target: bool = True,
 ) -> str:
     """Read a pinned-root-relative text file without reopening its resolved path."""
     target = workspace / relative
-    if not _relative_path_stays_in_workspace(relative, workspace) or not target.is_file():
+    if (validate_target and not _relative_path_stays_in_workspace(relative, workspace)) or not target.is_file():
         raise LocalToolError(f"file not found: {display_path or relative}")
     with open(target, "rb") as fh:
         sniff = fh.read(8192)
@@ -588,6 +590,7 @@ def _grep_relative_files(
     mode: str,
     max_results: int,
     sensitive_exclusions: tuple[SensitiveExclusion, ...],
+    validate_symlink_targets: bool = True,
 ) -> str:
     """Grep pinned-root-relative files while refusing escaping symlink content."""
     import re
@@ -600,7 +603,6 @@ def _grep_relative_files(
         raise LocalToolError(f"unknown mode: {mode}")
     if max_results < 1:
         raise LocalToolError("max_results must be >= 1")
-    resolved_workspace = workspace.resolve()
     # Memory-bounded: only the first max_results output lines are kept; the
     # rest are counted, not stored. Per-entry fs errors (races, permissions)
     # skip the entry rather than failing the whole search.
@@ -610,7 +612,7 @@ def _grep_relative_files(
         try:
             if not p.is_file() or p.stat().st_size > _MAX_GREP_FILE_BYTES:
                 continue
-            if not p.resolve().is_relative_to(resolved_workspace):
+            if validate_symlink_targets and not p.resolve().is_relative_to(workspace.resolve()):
                 continue  # symlink escaping the root — never read outside content
             relative = _workspace_relative_path(p, workspace)
             if _is_relative_sensitive_path(

--- a/tldw_chatbook/Tools/local_tool_impls.py
+++ b/tldw_chatbook/Tools/local_tool_impls.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 
 import os
 import heapq
+import stat as stat_module
 from pathlib import Path
 from typing import Literal
 
@@ -310,17 +311,29 @@ def stat_path(path: str, *, workspace_root: Path) -> str:
     """
     root = Path(workspace_root).resolve()
     resolved = resolve_workspace_path(path, root, intent="read")
-    info = resolved.stat()
+    relative = resolved.relative_to(root)
+    return _format_stat_result(relative, resolved.stat())
+
+
+def _stat_relative_path(relative: Path) -> str:
+    """Inspect one already-validated path relative to the pinned worker root."""
+    if relative.is_absolute() or ".." in relative.parts:
+        raise LocalToolError("stat path must be workspace-relative")
+    return _format_stat_result(relative, relative.stat())
+
+
+def _format_stat_result(relative: Path, info: os.stat_result) -> str:
+    """Format the stable allowlisted stat fields for one relative path."""
     kind = (
         "directory"
-        if resolved.is_dir()
+        if stat_module.S_ISDIR(info.st_mode)
         else "file"
-        if resolved.is_file()
+        if stat_module.S_ISREG(info.st_mode)
         else "other"
     )
     return "\n".join(
         (
-            f"path: {resolved.relative_to(root)}",
+            f"path: {relative}",
             f"type: {kind}",
             f"size: {info.st_size}",
             f"modified_ns: {info.st_mtime_ns}",

--- a/tldw_chatbook/Tools/local_tool_impls.py
+++ b/tldw_chatbook/Tools/local_tool_impls.py
@@ -58,9 +58,11 @@ from tldw_chatbook.Utils.path_validation import validate_path
 from tldw_chatbook.Utils.sensitive_paths import (
     is_git_metadata_write,
     SensitivePathContext,
+    SensitiveExclusion,
     is_sensitive_path,
     refuses_new_directory_chain,
     resolve_sensitive_context,
+    sensitive_exclusions_under,
 )
 
 MAX_LIST_ENTRIES = 200
@@ -232,17 +234,42 @@ def list_directory(
     root = resolve_workspace_path(
         path, workspace_root, intent="list", context=sensitive_ctx
     )
-    if not root.is_dir():
-        raise LocalToolError(f"not a directory: {path}")
+    return _list_relative_directory(
+        root.relative_to(Path(workspace_root).resolve()),
+        workspace=Path(workspace_root).resolve(),
+        max_entries=max_entries,
+        sensitive_exclusions=sensitive_exclusions_under(
+            Path(workspace_root).resolve(), sensitive_ctx
+        ),
+        display_path=path,
+    )
+
+
+def _list_relative_directory(
+    relative: Path,
+    *,
+    workspace: Path,
+    max_entries: int,
+    sensitive_exclusions: tuple[SensitiveExclusion, ...],
+    display_path: str | None = None,
+) -> str:
+    """List a pinned-root-relative directory without opening an absolute path."""
+    target = workspace / relative
+    if not _relative_path_stays_in_workspace(relative, workspace) or not target.is_dir():
+        raise LocalToolError(f"not a directory: {display_path or relative}")
     scanned: list[Path] = []
     scan_capped = False
-    for index, entry in enumerate(root.iterdir()):
+    for index, entry in enumerate(target.iterdir()):
         if index >= MAX_SCAN_ENTRIES:
             scan_capped = True
             break
         # Skipped entries still count against the scan cap: the cap bounds
         # the WORK done, and a denied entry was still scanned.
-        if is_sensitive_path(entry, context=sensitive_ctx):
+        if _is_relative_sensitive_path(
+            _workspace_relative_path(entry, workspace),
+            sensitive_exclusions,
+            is_directory=entry.is_dir(),
+        ):
             continue
         scanned.append(entry)
     entries = sorted(scanned, key=lambda p: (p.is_file(), p.name.lower()))
@@ -275,13 +302,34 @@ def read_file(
     binary sniff; other non-UTF-8 text reads with U+FFFD replacement.
     """
     root = resolve_workspace_path(path, workspace_root, intent="read")
-    if not root.is_file():
-        raise LocalToolError(f"file not found: {path}")
-    with open(root, "rb") as fh:
+    return _read_relative_file(
+        root.relative_to(Path(workspace_root).resolve()),
+        workspace=Path(workspace_root).resolve(),
+        offset=offset,
+        limit=limit,
+        display_path=path,
+    )
+
+
+def _read_relative_file(
+    relative: Path,
+    *,
+    workspace: Path,
+    offset: int,
+    limit: int | None,
+    display_path: str | None = None,
+) -> str:
+    """Read a pinned-root-relative text file without reopening its resolved path."""
+    target = workspace / relative
+    if not _relative_path_stays_in_workspace(relative, workspace) or not target.is_file():
+        raise LocalToolError(f"file not found: {display_path or relative}")
+    with open(target, "rb") as fh:
         sniff = fh.read(8192)
     if b"\x00" in sniff:
-        raise LocalToolError(f"'{path}' appears to be binary; fs_read only reads text files")
-    text = root.read_text(encoding="utf-8", errors="replace")
+        raise LocalToolError(
+            f"'{display_path or relative}' appears to be binary; fs_read only reads text files"
+        )
+    text = target.read_text(encoding="utf-8", errors="replace")
     lines = text.splitlines()
     if not lines:
         return "(empty file)"
@@ -440,27 +488,48 @@ def glob_files(
     root = resolve_workspace_path(
         ".", workspace_root, intent="list", context=sensitive_ctx
     )
+    return _glob_relative_files(
+        pattern,
+        workspace=Path(workspace_root).resolve(),
+        max_results=max_results,
+        sensitive_exclusions=sensitive_exclusions_under(root, sensitive_ctx),
+    )
+
+
+def _glob_relative_files(
+    pattern: str,
+    *,
+    workspace: Path,
+    max_results: int,
+    sensitive_exclusions: tuple[SensitiveExclusion, ...],
+) -> str:
+    """Glob from the pinned working directory using only relative I/O paths."""
     heap: list[tuple[float, Path]] = []  # min-heap of (mtime, normpath)
     total = 0
-    for p in root.glob(pattern):
+    for p in workspace.glob(pattern):
         try:
             if not p.is_file():
                 continue
             norm = Path(os.path.normpath(p))
-            if not norm.is_relative_to(root):
+            if not norm.is_relative_to(workspace):
                 continue
-            if is_sensitive_path(norm, context=sensitive_ctx):
+            rendered = norm.relative_to(workspace)
+            # Name-only glob output intentionally preserves the established
+            # escaping-link behavior: it never reads link target contents.
+            if _is_relative_sensitive_path(
+                rendered, sensitive_exclusions, is_directory=False
+            ):
                 continue  # never disclose a protected path, even by name
             mtime = p.stat().st_mtime
         except OSError:
             continue  # racy/unreadable entry — skip it, not the whole search
         total += 1
         if len(heap) < max_results:
-            heapq.heappush(heap, (mtime, norm))
+            heapq.heappush(heap, (mtime, rendered))
         elif mtime > heap[0][0]:
-            heapq.heapreplace(heap, (mtime, norm))
+            heapq.heapreplace(heap, (mtime, rendered))
     best = sorted(heap, key=lambda t: t[0], reverse=True)
-    lines = [str(norm.relative_to(root)) for _, norm in best]
+    lines = [str(relative) for _, relative in best]
     if total > max_results:
         lines.append(f"… ({total - max_results} more, truncated)")
     return "\n".join(lines) if lines else f"(no files matching {pattern!r})"
@@ -492,10 +561,10 @@ def grep_files(
     import re
 
     try:
-        rx = re.compile(pattern)
+        re.compile(pattern)
     except re.error as exc:
         raise LocalToolError(f"invalid regex: {exc}") from exc
-    if mode not in ("content", "files", "count"):
+    if mode not in {"content", "files", "count"}:
         raise LocalToolError(f"unknown mode: {mode}")
     if max_results < 1:
         raise LocalToolError("max_results must be >= 1")
@@ -503,18 +572,50 @@ def grep_files(
     root = resolve_workspace_path(
         ".", workspace_root, intent="list", context=sensitive_ctx
     )
+    return _grep_relative_files(
+        pattern,
+        workspace=Path(workspace_root).resolve(),
+        mode=mode,
+        max_results=max_results,
+        sensitive_exclusions=sensitive_exclusions_under(root, sensitive_ctx),
+    )
+
+
+def _grep_relative_files(
+    pattern: str,
+    *,
+    workspace: Path,
+    mode: str,
+    max_results: int,
+    sensitive_exclusions: tuple[SensitiveExclusion, ...],
+) -> str:
+    """Grep pinned-root-relative files while refusing escaping symlink content."""
+    import re
+
+    try:
+        rx = re.compile(pattern)
+    except re.error as exc:
+        raise LocalToolError(f"invalid regex: {exc}") from exc
+    if mode not in ("content", "files", "count"):
+        raise LocalToolError(f"unknown mode: {mode}")
+    if max_results < 1:
+        raise LocalToolError("max_results must be >= 1")
+    resolved_workspace = workspace.resolve()
     # Memory-bounded: only the first max_results output lines are kept; the
     # rest are counted, not stored. Per-entry fs errors (races, permissions)
     # skip the entry rather than failing the whole search.
     shown: list[str] = []
     total = 0
-    for p in root.rglob("*"):
+    for p in workspace.rglob("*"):
         try:
             if not p.is_file() or p.stat().st_size > _MAX_GREP_FILE_BYTES:
                 continue
-            if not p.resolve().is_relative_to(root):
+            if not p.resolve().is_relative_to(resolved_workspace):
                 continue  # symlink escaping the root — never read outside content
-            if is_sensitive_path(p, context=sensitive_ctx):
+            relative = _workspace_relative_path(p, workspace)
+            if _is_relative_sensitive_path(
+                relative, sensitive_exclusions, is_directory=False
+            ):
                 continue  # protected path — skipped BEFORE it is read
         except OSError:
             continue  # racy/unreadable entry — skip it, not the whole search
@@ -522,7 +623,7 @@ def grep_files(
             text = p.read_text(encoding="utf-8")
         except (UnicodeDecodeError, OSError):
             continue  # binary/unreadable — skip
-        rel = str(p.relative_to(root))
+        rel = str(relative)
         hits = [f"{i}:{line}" for i, line in enumerate(text.splitlines(), 1) if rx.search(line)]
         if not hits:
             continue
@@ -538,3 +639,40 @@ def grep_files(
     if total > max_results:
         shown.append(f"… ({total - max_results} more, truncated)")
     return "\n".join(shown) if shown else f"(no matches for {pattern!r})"
+
+
+def _relative_path_stays_in_workspace(relative: Path, workspace: Path) -> bool:
+    """Check a relative target's resolved location without using it for I/O."""
+    try:
+        return (workspace / relative).resolve().is_relative_to(workspace.resolve())
+    except OSError:
+        return False
+
+
+def _workspace_relative_path(path: Path, workspace: Path) -> Path:
+    """Return a lexical candidate name relative to a workspace I/O base."""
+    return path.relative_to(workspace)
+
+
+def _is_relative_sensitive_path(
+    relative: Path,
+    exclusions: tuple[SensitiveExclusion, ...],
+    *,
+    is_directory: bool,
+) -> bool:
+    """Apply parent-derived sensitive exclusions to one relative candidate."""
+    parts = tuple(part.casefold() for part in relative.parts)
+    for kind, value in exclusions:
+        value_parts = tuple(part.casefold() for part in Path(value).parts)
+        if kind == "subtree" and parts[: len(value_parts)] == value_parts:
+            return True
+        if kind == "file" and parts == value_parts:
+            return True
+        if kind == "direct_children" and (
+            not is_directory
+            and parts[:-1] == value_parts
+        ):
+            return True
+        if kind == "name" and not is_directory and relative.name.casefold() == value:
+            return True
+    return False

--- a/tldw_chatbook/Tools/patch_tool_impls.py
+++ b/tldw_chatbook/Tools/patch_tool_impls.py
@@ -47,6 +47,10 @@ from pathlib import Path
 from typing import Literal
 
 from tldw_chatbook.Tools.local_tool_impls import LocalToolError, resolve_workspace_path
+from tldw_chatbook.Tools.workspace_root_pin import (
+    PinnedWorkspaceRoot,
+    WorkspaceRootPinError,
+)
 from tldw_chatbook.Utils.sensitive_paths import resolve_sensitive_context
 
 PATCH_MAX_BYTES = 256 * 1024
@@ -413,40 +417,15 @@ def patch_files(diff_text: str, *, workspace_root: Path, dry_run: bool = False) 
         rel_path = patch_file.new_path
         assert rel_path is not None  # guaranteed by parse_unified_diff
         try:
-            root = resolve_workspace_path(
+            target = resolve_workspace_path(
                 rel_path, workspace_root, intent="write", context=sensitive_ctx
             )
-            if patch_file.action == "modify":
-                if not root.is_file():
-                    raise LocalToolError(f"file not found: {rel_path}")
-                try:
-                    with open(root, encoding="utf-8", newline="") as fh:
-                        original = fh.read()
-                except UnicodeDecodeError as exc:
-                    raise LocalToolError(
-                        f"'{rel_path}' is not valid UTF-8; fs_patch only patches text files"
-                    ) from exc
-            else:  # create
-                if root.exists():
-                    raise LocalToolError(f"file already exists: {rel_path}")
-                if not root.parent.is_dir():
-                    raise LocalToolError(
-                        f"parent directory does not exist for: {rel_path}"
-                    )
-                original = ""
-
-            updated = apply_patch_to_text(original, patch_file)
-            # Encode BEFORE writing — a failed encode must never truncate an
-            # existing file. dry_run still validates encodability.
-            try:
-                data = updated.encode("utf-8")
-            except UnicodeEncodeError as exc:
-                raise LocalToolError(
-                    f"patched content for '{rel_path}' is not UTF-8 encodable "
-                    f"(lone surrogate?): {exc}"
-                ) from exc
-            if not dry_run:
-                root.write_bytes(data)
+            _patch_relative_file(
+                patch_file,
+                target.relative_to(Path(workspace_root).resolve()),
+                workspace=Path(workspace_root).resolve(),
+                dry_run=dry_run,
+            )
         except FilesystemPatchError as exc:
             raise LocalToolError(
                 f"fs_patch failed [{exc.reason_code}]: {rel_path}"
@@ -455,3 +434,73 @@ def patch_files(diff_text: str, *, workspace_root: Path, dry_run: bool = False) 
             f"{'would patch' if dry_run else 'patched'} {rel_path}"
         )
     return "\n".join(summaries)
+
+
+def patch_validated_files(
+    plans: tuple[PatchFile, ...],
+    *,
+    root: PinnedWorkspaceRoot,
+    dry_run: bool = False,
+) -> str:
+    """Apply parent-admitted plans through one retained workspace root pin."""
+    summaries: list[str] = []
+    for patch_file in plans:
+        rel_path = patch_file.new_path
+        if rel_path is None:
+            raise LocalToolError("fs_patch failed [invalid_patch_path]")
+        try:
+            relative = root.relative_path(rel_path)
+            _patch_relative_file(
+                patch_file,
+                relative,
+                workspace=Path("."),
+                dry_run=dry_run,
+            )
+        except WorkspaceRootPinError as exc:
+            raise LocalToolError("fs_patch failed [invalid_patch_path]") from exc
+        except FilesystemPatchError as exc:
+            raise LocalToolError(
+                f"fs_patch failed [{exc.reason_code}]: {rel_path}"
+            ) from exc
+        summaries.append(f"{'would patch' if dry_run else 'patched'} {rel_path}")
+    return "\n".join(summaries)
+
+
+def _patch_relative_file(
+    patch_file: PatchFile,
+    relative: Path,
+    *,
+    workspace: Path,
+    dry_run: bool,
+) -> None:
+    """Apply one parsed patch plan using only root-relative I/O."""
+    rel_path = patch_file.new_path
+    assert rel_path is not None
+    target = workspace / relative
+    if patch_file.action == "modify":
+        if not target.is_file():
+            raise LocalToolError(f"file not found: {rel_path}")
+        try:
+            with open(target, encoding="utf-8", newline="") as fh:
+                original = fh.read()
+        except UnicodeDecodeError as exc:
+            raise LocalToolError(
+                f"'{rel_path}' is not valid UTF-8; fs_patch only patches text files"
+            ) from exc
+    else:
+        if target.exists():
+            raise LocalToolError(f"file already exists: {rel_path}")
+        if not target.parent.is_dir():
+            raise LocalToolError(f"parent directory does not exist for: {rel_path}")
+        original = ""
+
+    updated = apply_patch_to_text(original, patch_file)
+    try:
+        data = updated.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise LocalToolError(
+            f"patched content for '{rel_path}' is not UTF-8 encodable "
+            f"(lone surrogate?): {exc}"
+        ) from exc
+    if not dry_run:
+        target.write_bytes(data)

--- a/tldw_chatbook/Tools/virtual_cli_impls.py
+++ b/tldw_chatbook/Tools/virtual_cli_impls.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Sequence, cast
+from typing import Any, Literal, Sequence, cast
 
 from .git_tool_impls import git_blame, git_branches, git_diff, git_log, git_status
 from .local_tool_impls import (
@@ -15,6 +15,7 @@ from .local_tool_impls import (
     read_file,
     stat_path,
 )
+from .workspace_tool_executor import WorkspaceToolExecutor
 
 VIRTUAL_CLI_COMMANDS = (
     "ls",
@@ -173,10 +174,16 @@ def parse_request(command: str, argv: Sequence[str]) -> tuple[VirtualCliRequest,
 
 
 class VirtualCliRegistry:
-    """Parse fixed argv forms and dispatch directly to policy-checked cores."""
+    """Parse fixed argv forms and dispatch through a pinned executor by default."""
 
-    def __init__(self, workspace_root: Path) -> None:
+    def __init__(
+        self,
+        workspace_root: Path,
+        *,
+        workspace_executor: WorkspaceToolExecutor | None = None,
+    ) -> None:
         self._root = Path(workspace_root).resolve()
+        self._workspace_executor = workspace_executor
 
     @property
     def workspace_root(self) -> Path:
@@ -184,6 +191,13 @@ class VirtualCliRegistry:
 
     def execute(self, command: str, argv: Sequence[str]) -> str:
         request, args = parse_request(command, argv)
+        if self._workspace_executor is not None:
+            operation, arguments = _leased_operation(request.command, args)
+            return self._workspace_executor.execute(
+                operation,
+                arguments,
+                intent="read",
+            )
 
         if request.command == "ls":
             return list_directory(args.path, workspace_root=self._root)
@@ -220,3 +234,45 @@ class VirtualCliRegistry:
                 end_line=args.end,
             )
         return git_branches(self._root)
+
+
+def _leased_operation(
+    command: VirtualCliCommand,
+    args: argparse.Namespace,
+) -> tuple[str, dict[str, Any]]:
+    """Project one parsed virtual command onto the closed executor protocol."""
+    if command == "ls":
+        return "fs_list", {"path": args.path}
+    if command == "cat":
+        arguments = {"path": args.path, "offset": args.offset}
+        if args.limit is not None:
+            arguments["limit"] = args.limit
+        return "fs_read", arguments
+    if command == "grep":
+        return "fs_grep", {"pattern": args.pattern, "mode": args.mode}
+    if command == "find":
+        return "fs_glob", {"pattern": args.pattern}
+    if command == "stat":
+        return "stat_path", {"path": args.path}
+    if command == "git_status":
+        return "git_status", {"path": args.path}
+    if command == "git_diff":
+        arguments = {"staged": args.staged, "stat": args.stat}
+        if args.commit_range is not None:
+            arguments["commit_range"] = args.commit_range
+        if args.path is not None:
+            arguments["path"] = args.path
+        return "git_diff", arguments
+    if command == "git_log":
+        arguments = {"count": args.count}
+        if args.path is not None:
+            arguments["path"] = args.path
+        return "git_log", arguments
+    if command == "git_blame":
+        arguments = {"path": args.path}
+        if args.start is not None:
+            arguments["start_line"] = args.start
+        if args.end is not None:
+            arguments["end_line"] = args.end
+        return "git_blame", arguments
+    return "git_branches", {}

--- a/tldw_chatbook/Tools/workspace_root_pin.py
+++ b/tldw_chatbook/Tools/workspace_root_pin.py
@@ -15,6 +15,7 @@ from tldw_chatbook.Utils.filesystem_identity import (
     DirectoryIdentityError,
     directory_identity_from_stat,
 )
+from tldw_chatbook.Utils.path_validation import validate_path
 
 
 class WorkspaceRootPinError(RuntimeError):
@@ -101,6 +102,15 @@ def pin_workspace_root(
 ) -> Iterator[PinnedWorkspaceRoot]:
     """Open, identity-check, chdir to, and retain one admitted root."""
     locator = Path(canonical_locator)
+    try:
+        locator = validate_path(
+            locator,
+            locator,
+            redact_paths=True,
+            allow_hidden=True,
+        )
+    except ValueError as error:
+        raise WorkspaceRootPinError("invalid admitted workspace root") from error
     if (
         type(chain) is not DirectoryChain
         or not chain.identities

--- a/tldw_chatbook/Tools/workspace_root_pin.py
+++ b/tldw_chatbook/Tools/workspace_root_pin.py
@@ -6,7 +6,7 @@ import ctypes
 import os
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Iterator
 
 from tldw_chatbook.Utils.filesystem_identity import (
@@ -37,6 +37,11 @@ class PinnedWorkspaceRoot:
         """Return one lexical path relative to the retained helper root."""
         if type(value) is not str or not value or "\x00" in value:
             raise WorkspaceRootPinError("workspace operation requires a relative path")
+        for lexical in (PurePosixPath(value), PureWindowsPath(value)):
+            if lexical.drive or lexical.root or lexical.anchor:
+                raise WorkspaceRootPinError(
+                    "workspace operation requires a relative path"
+                )
         relative = Path(value)
         if relative.is_absolute() or ".." in relative.parts:
             raise WorkspaceRootPinError("workspace operation requires a relative path")

--- a/tldw_chatbook/Tools/workspace_root_pin.py
+++ b/tldw_chatbook/Tools/workspace_root_pin.py
@@ -1,0 +1,315 @@
+"""Pin one admitted workspace root inside a single-threaded helper process."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator
+
+from tldw_chatbook.Utils.filesystem_identity import (
+    DirectoryChain,
+    DirectoryIdentity,
+    DirectoryIdentityError,
+    directory_identity_from_stat,
+)
+
+
+class WorkspaceRootPinError(RuntimeError):
+    """Raised when an admitted root cannot be retained and verified safely."""
+
+
+@dataclass(slots=True)
+class PinnedWorkspaceRoot:
+    """A verified helper-local current directory retained by an open handle."""
+
+    canonical_locator: Path = field(repr=False)
+    identity: DirectoryIdentity
+    root_fd: int | None = field(default=None, repr=False)
+    _previous_fd: int | None = field(default=None, repr=False)
+    _windows_handle: int | None = field(default=None, repr=False)
+    _previous_directory: str | None = field(default=None, repr=False)
+    _closed: bool = field(default=False, repr=False)
+
+    def relative_path(self, value: str) -> Path:
+        """Return one lexical path relative to the retained helper root."""
+        if type(value) is not str or not value or "\x00" in value:
+            raise WorkspaceRootPinError("workspace operation requires a relative path")
+        relative = Path(value)
+        if relative.is_absolute() or ".." in relative.parts:
+            raise WorkspaceRootPinError("workspace operation requires a relative path")
+        return relative
+
+    def close(self) -> None:
+        """Restore the prior helper directory and release retained handles."""
+        if self._closed:
+            return
+        self._closed = True
+        if os.name == "posix":
+            self._close_posix()
+        elif os.name == "nt":
+            self._close_windows()
+
+    def _close_posix(self) -> None:
+        restore_error = False
+        try:
+            if self._previous_fd is not None:
+                os.fchdir(self._previous_fd)
+        except OSError:
+            restore_error = True
+        finally:
+            for descriptor in (self.root_fd, self._previous_fd):
+                if descriptor is not None:
+                    try:
+                        os.close(descriptor)
+                    except OSError:
+                        restore_error = True
+            self.root_fd = None
+            self._previous_fd = None
+        if restore_error:
+            raise WorkspaceRootPinError("workspace root pin cleanup failed")
+
+    def _close_windows(self) -> None:
+        restore_error = False
+        try:
+            if self._previous_directory is not None:
+                _windows_set_current_directory(self._previous_directory)
+        except WorkspaceRootPinError:
+            restore_error = True
+        finally:
+            if self._windows_handle is not None:
+                try:
+                    _windows_close_handle(self._windows_handle)
+                except WorkspaceRootPinError:
+                    restore_error = True
+            self._windows_handle = None
+        if restore_error:
+            raise WorkspaceRootPinError("workspace root pin cleanup failed")
+
+
+@contextmanager
+def pin_workspace_root(
+    canonical_locator: Path,
+    chain: DirectoryChain,
+) -> Iterator[PinnedWorkspaceRoot]:
+    """Open, identity-check, chdir to, and retain one admitted root."""
+    locator = Path(canonical_locator)
+    if (
+        type(chain) is not DirectoryChain
+        or not chain.identities
+        or not locator.is_absolute()
+        or locator != chain.canonical_root
+    ):
+        raise WorkspaceRootPinError("invalid admitted workspace root")
+
+    if os.name == "posix":
+        pinned = _pin_posix(locator, chain.identities[0])
+    elif os.name == "nt":
+        pinned = _pin_windows(locator, chain.identities[0])
+    else:
+        raise WorkspaceRootPinError("workspace root pinning is unsupported")
+
+    try:
+        yield pinned
+    finally:
+        pinned.close()
+
+
+def _pin_posix(locator: Path, expected: DirectoryIdentity) -> PinnedWorkspaceRoot:
+    required = ("O_DIRECTORY", "O_NOFOLLOW", "O_CLOEXEC")
+    if not hasattr(os, "fchdir") or any(not hasattr(os, name) for name in required):
+        raise WorkspaceRootPinError("workspace root pinning is unsupported")
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
+    root_fd: int | None = None
+    previous_fd: int | None = None
+    try:
+        previous_fd = os.open(".", flags)
+        root_fd = os.open(locator, flags)
+        if _posix_identity(root_fd) != expected:
+            raise WorkspaceRootPinError("workspace root identity mismatch")
+        os.fchdir(root_fd)
+        if directory_identity_from_stat(os.stat(".", follow_symlinks=False)) != expected:
+            raise WorkspaceRootPinError("workspace root identity mismatch")
+        return PinnedWorkspaceRoot(
+            canonical_locator=locator,
+            identity=expected,
+            root_fd=root_fd,
+            _previous_fd=previous_fd,
+        )
+    except WorkspaceRootPinError:
+        _restore_and_close_posix(previous_fd, root_fd)
+        raise
+    except (DirectoryIdentityError, OSError, ValueError) as error:
+        _restore_and_close_posix(previous_fd, root_fd)
+        raise WorkspaceRootPinError("workspace root pinning failed") from error
+
+
+def _posix_identity(descriptor: int) -> DirectoryIdentity:
+    try:
+        return directory_identity_from_stat(os.fstat(descriptor))
+    except (DirectoryIdentityError, OSError) as error:
+        raise WorkspaceRootPinError("workspace root metadata unavailable") from error
+
+
+def _restore_and_close_posix(previous_fd: int | None, root_fd: int | None) -> None:
+    if previous_fd is not None:
+        try:
+            os.fchdir(previous_fd)
+        except OSError:
+            pass
+    for descriptor in (root_fd, previous_fd):
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def _pin_windows(locator: Path, expected: DirectoryIdentity) -> PinnedWorkspaceRoot:
+    if expected.reparse:
+        raise WorkspaceRootPinError("unsafe workspace root metadata")
+    handle: int | None = None
+    previous_directory: str | None = None
+    try:
+        previous_directory = os.getcwd()
+        handle, identity, reparse = _windows_open_directory(locator)
+        if reparse:
+            raise WorkspaceRootPinError("unsafe workspace root metadata")
+        if (identity.device, identity.inode) != (expected.device, expected.inode):
+            raise WorkspaceRootPinError("workspace root identity mismatch")
+        _windows_set_current_directory(str(locator))
+        verification, verified_identity, verified_reparse = _windows_open_directory(Path("."))
+        try:
+            if verified_reparse or (
+                verified_identity.device,
+                verified_identity.inode,
+            ) != (expected.device, expected.inode):
+                raise WorkspaceRootPinError("workspace root identity mismatch")
+        finally:
+            _windows_close_handle(verification)
+        return PinnedWorkspaceRoot(
+            canonical_locator=locator,
+            identity=expected,
+            _windows_handle=handle,
+            _previous_directory=previous_directory,
+        )
+    except WorkspaceRootPinError:
+        if previous_directory is not None:
+            try:
+                _windows_set_current_directory(previous_directory)
+            except WorkspaceRootPinError:
+                pass
+        if handle is not None:
+            try:
+                _windows_close_handle(handle)
+            except WorkspaceRootPinError:
+                pass
+        raise
+    except (OSError, ValueError) as error:
+        if handle is not None:
+            try:
+                _windows_close_handle(handle)
+            except WorkspaceRootPinError:
+                pass
+        raise WorkspaceRootPinError("workspace root pinning failed") from error
+
+
+def _windows_open_directory(path: Path) -> tuple[int, DirectoryIdentity, bool]:
+    if os.name != "nt":
+        raise WorkspaceRootPinError("Windows root pinning is unavailable")
+    from ctypes import wintypes
+
+    class ByHandleFileInformation(ctypes.Structure):
+        _fields_ = [
+            ("dwFileAttributes", wintypes.DWORD),
+            ("ftCreationTime", wintypes.FILETIME),
+            ("ftLastAccessTime", wintypes.FILETIME),
+            ("ftLastWriteTime", wintypes.FILETIME),
+            ("dwVolumeSerialNumber", wintypes.DWORD),
+            ("nFileSizeHigh", wintypes.DWORD),
+            ("nFileSizeLow", wintypes.DWORD),
+            ("nNumberOfLinks", wintypes.DWORD),
+            ("nFileIndexHigh", wintypes.DWORD),
+            ("nFileIndexLow", wintypes.DWORD),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    kernel32.CreateFileW.restype = wintypes.HANDLE
+    kernel32.GetFileInformationByHandle.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(ByHandleFileInformation),
+    ]
+    kernel32.GetFileInformationByHandle.restype = wintypes.BOOL
+
+    file_read_attributes = 0x0080
+    share_all = 0x00000001 | 0x00000002 | 0x00000004
+    open_existing = 3
+    backup_semantics = 0x02000000
+    open_reparse_point = 0x00200000
+    raw_handle = kernel32.CreateFileW(
+        str(path),
+        file_read_attributes,
+        share_all,
+        None,
+        open_existing,
+        backup_semantics | open_reparse_point,
+        None,
+    )
+    invalid_handle = ctypes.c_void_p(-1).value
+    handle = int(ctypes.cast(raw_handle, ctypes.c_void_p).value or 0)
+    if not handle or handle == invalid_handle:
+        raise WorkspaceRootPinError("workspace root open failed")
+    information = ByHandleFileInformation()
+    if not kernel32.GetFileInformationByHandle(handle, ctypes.byref(information)):
+        _windows_close_handle(handle)
+        raise WorkspaceRootPinError("workspace root metadata unavailable")
+    inode = (int(information.nFileIndexHigh) << 32) | int(information.nFileIndexLow)
+    reparse = bool(int(information.dwFileAttributes) & 0x00000400)
+    return (
+        handle,
+        DirectoryIdentity(
+            device=int(information.dwVolumeSerialNumber),
+            inode=inode,
+            mode=0,
+            reparse=reparse,
+        ),
+        reparse,
+    )
+
+
+def _windows_set_current_directory(path: str) -> None:
+    if os.name != "nt":
+        raise WorkspaceRootPinError("Windows root pinning is unavailable")
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.SetCurrentDirectoryW.argtypes = [wintypes.LPCWSTR]
+    kernel32.SetCurrentDirectoryW.restype = wintypes.BOOL
+    if not kernel32.SetCurrentDirectoryW(path):
+        raise WorkspaceRootPinError("workspace root current-directory pin failed")
+
+
+def _windows_close_handle(handle: int) -> None:
+    if os.name != "nt":
+        raise WorkspaceRootPinError("Windows root pinning is unavailable")
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    if not kernel32.CloseHandle(handle):
+        raise WorkspaceRootPinError("workspace root handle cleanup failed")
+
+
+__all__ = ["PinnedWorkspaceRoot", "WorkspaceRootPinError", "pin_workspace_root"]

--- a/tldw_chatbook/Tools/workspace_tool_dispatch.py
+++ b/tldw_chatbook/Tools/workspace_tool_dispatch.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from tldw_chatbook.Tools.local_tool_impls import _stat_relative_path
-from tldw_chatbook.Tools.workspace_root_pin import PinnedWorkspaceRoot
+from tldw_chatbook.Tools.workspace_root_pin import (
+    PinnedWorkspaceRoot,
+    WorkspaceRootPinError,
+)
 from tldw_chatbook.Tools.workspace_tool_protocol import WorkspaceToolRequest
 
 
@@ -25,7 +28,13 @@ def execute_pinned_operation(
             "unsupported_operation",
             "workspace operation is not implemented",
         )
-    relative = root.relative_path(request.arguments["path"])
+    try:
+        relative = root.relative_path(request.arguments["path"])
+    except WorkspaceRootPinError:
+        raise WorkspaceToolDispatchError(
+            "invalid_request",
+            "workspace operation path is invalid",
+        ) from None
     return _stat_relative_path(relative)
 
 

--- a/tldw_chatbook/Tools/workspace_tool_dispatch.py
+++ b/tldw_chatbook/Tools/workspace_tool_dispatch.py
@@ -10,9 +10,16 @@ from tldw_chatbook.Tools.local_tool_impls import (
     MAX_LIST_ENTRIES,
     _glob_relative_files,
     _grep_relative_files,
+    _edit_relative_file,
     _list_relative_directory,
     _read_relative_file,
     _stat_relative_path,
+    _write_relative_file,
+)
+from tldw_chatbook.Tools.patch_tool_impls import (
+    FilesystemPatchError,
+    parse_patch_targets,
+    patch_validated_files,
 )
 from tldw_chatbook.Tools.workspace_root_pin import (
     PinnedWorkspaceRoot,
@@ -41,6 +48,24 @@ def execute_pinned_operation(
     """Execute one supported request relative to ``root`` or refuse it."""
     if request.operation == "stat_path":
         return _stat_relative_path(_request_relative_path(request, root))
+    if request.operation == "fs_write":
+        return _write_relative_file(
+            _request_relative_path(request, root),
+            request.arguments["content"],
+            workspace=Path("."),
+            display_path=request.arguments["path"],
+        )
+    if request.operation == "fs_edit":
+        return _edit_relative_file(
+            _request_relative_path(request, root),
+            request.arguments["old_string"],
+            request.arguments["new_string"],
+            workspace=Path("."),
+            replace_all=request.arguments.get("replace_all", False),
+            display_path=request.arguments["path"],
+        )
+    if request.operation == "fs_patch":
+        return _patch_request(request, root)
     if request.operation not in {"fs_list", "fs_read", "fs_glob", "fs_grep"}:
         raise WorkspaceToolDispatchError(
             "unsupported_operation", "workspace operation is not implemented"
@@ -105,6 +130,34 @@ def _request_exclusions(
     return tuple(
         SensitiveExclusion(item["kind"], item["value"])
         for item in request.arguments[field]
+    )
+
+
+def _patch_request(request: WorkspaceToolRequest, root: PinnedWorkspaceRoot) -> str:
+    """Reparse a bounded patch and require its exact parent-admitted targets."""
+    try:
+        plans = parse_patch_targets(request.arguments["diff"])
+        parsed_targets = tuple(
+            root.relative_path(plan.new_path).as_posix()
+            for plan in plans
+            if plan.new_path is not None
+        )
+        requested_targets = tuple(
+            root.relative_path(target).as_posix()
+            for target in request.arguments.get("targets", ())
+        )
+    except (FilesystemPatchError, WorkspaceRootPinError, TypeError):
+        raise WorkspaceToolDispatchError(
+            "invalid_request", "workspace patch request is invalid"
+        ) from None
+    if len(parsed_targets) != len(plans) or parsed_targets != requested_targets:
+        raise WorkspaceToolDispatchError(
+            "invalid_request", "workspace patch targets changed after admission"
+        )
+    return patch_validated_files(
+        plans,
+        root=root,
+        dry_run=request.arguments.get("dry_run", False),
     )
 
 

--- a/tldw_chatbook/Tools/workspace_tool_dispatch.py
+++ b/tldw_chatbook/Tools/workspace_tool_dispatch.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
+from tldw_chatbook.Tools.git_tool_impls import (
+    git_blame,
+    git_branches,
+    git_diff,
+    git_log,
+    git_status,
+)
 from tldw_chatbook.Tools.local_tool_impls import (
     MAX_GLOB_RESULTS,
     MAX_GREP_RESULTS,
@@ -67,6 +75,14 @@ def execute_pinned_operation(
         )
     if request.operation == "fs_patch":
         return _patch_request(request, root)
+    if request.operation in {
+        "git_status",
+        "git_diff",
+        "git_log",
+        "git_blame",
+        "git_branches",
+    }:
+        return _git_request(request)
     if request.operation not in {"fs_list", "fs_read", "fs_glob", "fs_grep"}:
         raise WorkspaceToolDispatchError(
             "unsupported_operation", "workspace operation is not implemented"
@@ -109,6 +125,48 @@ def execute_pinned_operation(
             max_results=request.arguments.get("max_results", MAX_GREP_RESULTS),
             sensitive_exclusions=_request_exclusions(request, "content_exclusions"),
         )
+
+
+def _git_request(request: WorkspaceToolRequest) -> str:
+    """Run one closed read-only Git operation beneath the retained root."""
+    discovered = shutil.which("git")
+    if discovered is None:
+        raise WorkspaceToolDispatchError(
+            "tool_failure", "git is not available on this system"
+        )
+    executable = Path(discovered).resolve()
+    execution = {
+        "executable": executable,
+        "own_process_group": False,
+    }
+    arguments = request.arguments
+    if request.operation == "git_status":
+        return git_status(Path("."), arguments.get("path", "."), **execution)
+    if request.operation == "git_diff":
+        return git_diff(
+            Path("."),
+            staged=arguments.get("staged", False),
+            commit_range=arguments.get("commit_range"),
+            path=arguments.get("path"),
+            stat=arguments.get("stat", False),
+            **execution,
+        )
+    if request.operation == "git_log":
+        return git_log(
+            Path("."),
+            count=arguments.get("count", 20),
+            path=arguments.get("path"),
+            **execution,
+        )
+    if request.operation == "git_blame":
+        return git_blame(
+            Path("."),
+            arguments["path"],
+            start_line=arguments.get("start_line"),
+            end_line=arguments.get("end_line"),
+            **execution,
+        )
+    return git_branches(Path("."), **execution)
 
 
 def _request_relative_path(

--- a/tldw_chatbook/Tools/workspace_tool_dispatch.py
+++ b/tldw_chatbook/Tools/workspace_tool_dispatch.py
@@ -18,7 +18,11 @@ from tldw_chatbook.Tools.workspace_root_pin import (
     PinnedWorkspaceRoot,
     WorkspaceRootPinError,
 )
-from tldw_chatbook.Tools.workspace_tool_protocol import WorkspaceToolRequest
+from tldw_chatbook.Tools.workspace_tool_protocol import (
+    WorkspaceProtocolError,
+    WorkspaceToolRequest,
+    validate_glob_pattern,
+)
 from tldw_chatbook.Utils.sensitive_paths import SensitiveExclusion
 
 
@@ -37,7 +41,10 @@ def execute_pinned_operation(
     """Execute one supported request relative to ``root`` or refuse it."""
     if request.operation == "stat_path":
         return _stat_relative_path(_request_relative_path(request, root))
-
+    if request.operation not in {"fs_list", "fs_read", "fs_glob", "fs_grep"}:
+        raise WorkspaceToolDispatchError(
+            "unsupported_operation", "workspace operation is not implemented"
+        )
     exclusions = _request_exclusions(request, "sensitive_exclusions")
     if request.operation == "fs_list":
         return _list_relative_directory(
@@ -45,7 +52,6 @@ def execute_pinned_operation(
             workspace=Path("."),
             max_entries=MAX_LIST_ENTRIES,
             sensitive_exclusions=exclusions,
-            validate_target=False,
         )
     if request.operation == "fs_read":
         return _read_relative_file(
@@ -53,14 +59,21 @@ def execute_pinned_operation(
             workspace=Path("."),
             offset=request.arguments.get("offset", 1),
             limit=request.arguments.get("limit"),
-            validate_target=False,
+            sensitive_exclusions=exclusions,
         )
     if request.operation == "fs_glob":
+        try:
+            pattern = validate_glob_pattern(request.arguments["pattern"])
+        except WorkspaceProtocolError:
+            raise WorkspaceToolDispatchError(
+                "invalid_request", "workspace glob pattern is invalid"
+            ) from None
         return _glob_relative_files(
-            request.arguments["pattern"],
+            pattern,
             workspace=Path("."),
             max_results=request.arguments.get("max_results", MAX_GLOB_RESULTS),
             sensitive_exclusions=exclusions,
+            validate_targets=True,
         )
     if request.operation == "fs_grep":
         return _grep_relative_files(
@@ -69,12 +82,7 @@ def execute_pinned_operation(
             mode=request.arguments.get("mode", "content"),
             max_results=request.arguments.get("max_results", MAX_GREP_RESULTS),
             sensitive_exclusions=_request_exclusions(request, "content_exclusions"),
-            validate_symlink_targets=False,
         )
-    raise WorkspaceToolDispatchError(
-        "unsupported_operation",
-        "workspace operation is not implemented",
-    )
 
 
 def _request_relative_path(

--- a/tldw_chatbook/Tools/workspace_tool_dispatch.py
+++ b/tldw_chatbook/Tools/workspace_tool_dispatch.py
@@ -1,0 +1,32 @@
+"""Dispatch closed workspace operations against one retained root pin."""
+
+from __future__ import annotations
+
+from tldw_chatbook.Tools.local_tool_impls import _stat_relative_path
+from tldw_chatbook.Tools.workspace_root_pin import PinnedWorkspaceRoot
+from tldw_chatbook.Tools.workspace_tool_protocol import WorkspaceToolRequest
+
+
+class WorkspaceToolDispatchError(RuntimeError):
+    """A fixed-code refusal from the pinned worker dispatcher."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def execute_pinned_operation(
+    request: WorkspaceToolRequest,
+    root: PinnedWorkspaceRoot,
+) -> str:
+    """Execute one supported request relative to ``root`` or refuse it."""
+    if request.operation != "stat_path":
+        raise WorkspaceToolDispatchError(
+            "unsupported_operation",
+            "workspace operation is not implemented",
+        )
+    relative = root.relative_path(request.arguments["path"])
+    return _stat_relative_path(relative)
+
+
+__all__ = ["WorkspaceToolDispatchError", "execute_pinned_operation"]

--- a/tldw_chatbook/Tools/workspace_tool_dispatch.py
+++ b/tldw_chatbook/Tools/workspace_tool_dispatch.py
@@ -10,7 +10,6 @@ from tldw_chatbook.Tools.local_tool_impls import (
     MAX_LIST_ENTRIES,
     _glob_relative_files,
     _grep_relative_files,
-    _is_relative_sensitive_path,
     _list_relative_directory,
     _read_relative_file,
     _stat_relative_path,
@@ -20,10 +19,7 @@ from tldw_chatbook.Tools.workspace_root_pin import (
     WorkspaceRootPinError,
 )
 from tldw_chatbook.Tools.workspace_tool_protocol import WorkspaceToolRequest
-from tldw_chatbook.Utils.sensitive_paths import (
-    SensitiveExclusion,
-    sensitive_exclusions_under,
-)
+from tldw_chatbook.Utils.sensitive_paths import SensitiveExclusion
 
 
 class WorkspaceToolDispatchError(RuntimeError):
@@ -42,20 +38,22 @@ def execute_pinned_operation(
     if request.operation == "stat_path":
         return _stat_relative_path(_request_relative_path(request, root))
 
-    exclusions = sensitive_exclusions_under(Path("."))
+    exclusions = _request_exclusions(request, "sensitive_exclusions")
     if request.operation == "fs_list":
         return _list_relative_directory(
-            _read_relative_path(request, root, exclusions),
+            _request_relative_path(request, root),
             workspace=Path("."),
             max_entries=MAX_LIST_ENTRIES,
             sensitive_exclusions=exclusions,
+            validate_target=False,
         )
     if request.operation == "fs_read":
         return _read_relative_file(
-            _read_relative_path(request, root, exclusions),
+            _request_relative_path(request, root),
             workspace=Path("."),
             offset=request.arguments.get("offset", 1),
             limit=request.arguments.get("limit"),
+            validate_target=False,
         )
     if request.operation == "fs_glob":
         return _glob_relative_files(
@@ -70,7 +68,8 @@ def execute_pinned_operation(
             workspace=Path("."),
             mode=request.arguments.get("mode", "content"),
             max_results=request.arguments.get("max_results", MAX_GREP_RESULTS),
-            sensitive_exclusions=exclusions,
+            sensitive_exclusions=_request_exclusions(request, "content_exclusions"),
+            validate_symlink_targets=False,
         )
     raise WorkspaceToolDispatchError(
         "unsupported_operation",
@@ -91,19 +90,14 @@ def _request_relative_path(
         ) from None
 
 
-def _read_relative_path(
-    request: WorkspaceToolRequest,
-    root: PinnedWorkspaceRoot,
-    exclusions: tuple[SensitiveExclusion, ...],
-) -> Path:
-    """Return an admitted relative read path without exposing protected names."""
-    relative = _request_relative_path(request, root)
-    if _is_relative_sensitive_path(relative, exclusions, is_directory=relative.is_dir()):
-        raise WorkspaceToolDispatchError(
-            "invalid_request",
-            "workspace operation path is invalid",
-        )
-    return relative
+def _request_exclusions(
+    request: WorkspaceToolRequest, field: str
+) -> tuple[SensitiveExclusion, ...]:
+    """Decode the parent's fixed bounded exclusions without filesystem discovery."""
+    return tuple(
+        SensitiveExclusion(item["kind"], item["value"])
+        for item in request.arguments[field]
+    )
 
 
 __all__ = ["WorkspaceToolDispatchError", "execute_pinned_operation"]

--- a/tldw_chatbook/Tools/workspace_tool_dispatch.py
+++ b/tldw_chatbook/Tools/workspace_tool_dispatch.py
@@ -135,9 +135,11 @@ def _git_request(request: WorkspaceToolRequest) -> str:
             "tool_failure", "git is not available on this system"
         )
     executable = Path(discovered).resolve()
+    exclusions = _request_exclusions(request, "sensitive_exclusions")
     execution = {
         "executable": executable,
         "own_process_group": False,
+        "sensitive_exclusions": exclusions,
     }
     arguments = request.arguments
     if request.operation == "git_status":

--- a/tldw_chatbook/Tools/workspace_tool_dispatch.py
+++ b/tldw_chatbook/Tools/workspace_tool_dispatch.py
@@ -13,6 +13,7 @@ from tldw_chatbook.Tools.local_tool_impls import (
     _edit_relative_file,
     _list_relative_directory,
     _read_relative_file,
+    _relative_target_is_safe,
     _stat_relative_path,
     _write_relative_file,
 )
@@ -50,14 +51,14 @@ def execute_pinned_operation(
         return _stat_relative_path(_request_relative_path(request, root))
     if request.operation == "fs_write":
         return _write_relative_file(
-            _request_relative_path(request, root),
+            _request_mutation_path(request, root),
             request.arguments["content"],
             workspace=Path("."),
             display_path=request.arguments["path"],
         )
     if request.operation == "fs_edit":
         return _edit_relative_file(
-            _request_relative_path(request, root),
+            _request_mutation_path(request, root),
             request.arguments["old_string"],
             request.arguments["new_string"],
             workspace=Path("."),
@@ -133,15 +134,33 @@ def _request_exclusions(
     )
 
 
+def _request_mutation_path(
+    request: WorkspaceToolRequest, root: PinnedWorkspaceRoot
+) -> Path:
+    """Validate a mutation target's live lexical and resolved location."""
+    relative = _request_relative_path(request, root)
+    if not _relative_target_is_safe(
+        relative,
+        Path("."),
+        _request_exclusions(request, "sensitive_exclusions"),
+        is_directory=False,
+    ):
+        raise WorkspaceToolDispatchError(
+            "invalid_request", "workspace mutation target is invalid"
+        )
+    return relative
+
+
 def _patch_request(request: WorkspaceToolRequest, root: PinnedWorkspaceRoot) -> str:
     """Reparse a bounded patch and require its exact parent-admitted targets."""
     try:
         plans = parse_patch_targets(request.arguments["diff"])
-        parsed_targets = tuple(
-            root.relative_path(plan.new_path).as_posix()
+        parsed_paths = tuple(
+            root.relative_path(plan.new_path)
             for plan in plans
             if plan.new_path is not None
         )
+        parsed_targets = tuple(path.as_posix() for path in parsed_paths)
         requested_targets = tuple(
             root.relative_path(target).as_posix()
             for target in request.arguments.get("targets", ())
@@ -153,6 +172,16 @@ def _patch_request(request: WorkspaceToolRequest, root: PinnedWorkspaceRoot) -> 
     if len(parsed_targets) != len(plans) or parsed_targets != requested_targets:
         raise WorkspaceToolDispatchError(
             "invalid_request", "workspace patch targets changed after admission"
+        )
+    exclusions = _request_exclusions(request, "sensitive_exclusions")
+    if not all(
+        _relative_target_is_safe(
+            relative, Path("."), exclusions, is_directory=False
+        )
+        for relative in parsed_paths
+    ):
+        raise WorkspaceToolDispatchError(
+            "invalid_request", "workspace patch target is invalid"
         )
     return patch_validated_files(
         plans,

--- a/tldw_chatbook/Tools/workspace_tool_dispatch.py
+++ b/tldw_chatbook/Tools/workspace_tool_dispatch.py
@@ -2,12 +2,28 @@
 
 from __future__ import annotations
 
-from tldw_chatbook.Tools.local_tool_impls import _stat_relative_path
+from pathlib import Path
+
+from tldw_chatbook.Tools.local_tool_impls import (
+    MAX_GLOB_RESULTS,
+    MAX_GREP_RESULTS,
+    MAX_LIST_ENTRIES,
+    _glob_relative_files,
+    _grep_relative_files,
+    _is_relative_sensitive_path,
+    _list_relative_directory,
+    _read_relative_file,
+    _stat_relative_path,
+)
 from tldw_chatbook.Tools.workspace_root_pin import (
     PinnedWorkspaceRoot,
     WorkspaceRootPinError,
 )
 from tldw_chatbook.Tools.workspace_tool_protocol import WorkspaceToolRequest
+from tldw_chatbook.Utils.sensitive_paths import (
+    SensitiveExclusion,
+    sensitive_exclusions_under,
+)
 
 
 class WorkspaceToolDispatchError(RuntimeError):
@@ -23,19 +39,71 @@ def execute_pinned_operation(
     root: PinnedWorkspaceRoot,
 ) -> str:
     """Execute one supported request relative to ``root`` or refuse it."""
-    if request.operation != "stat_path":
-        raise WorkspaceToolDispatchError(
-            "unsupported_operation",
-            "workspace operation is not implemented",
+    if request.operation == "stat_path":
+        return _stat_relative_path(_request_relative_path(request, root))
+
+    exclusions = sensitive_exclusions_under(Path("."))
+    if request.operation == "fs_list":
+        return _list_relative_directory(
+            _read_relative_path(request, root, exclusions),
+            workspace=Path("."),
+            max_entries=MAX_LIST_ENTRIES,
+            sensitive_exclusions=exclusions,
         )
+    if request.operation == "fs_read":
+        return _read_relative_file(
+            _read_relative_path(request, root, exclusions),
+            workspace=Path("."),
+            offset=request.arguments.get("offset", 1),
+            limit=request.arguments.get("limit"),
+        )
+    if request.operation == "fs_glob":
+        return _glob_relative_files(
+            request.arguments["pattern"],
+            workspace=Path("."),
+            max_results=request.arguments.get("max_results", MAX_GLOB_RESULTS),
+            sensitive_exclusions=exclusions,
+        )
+    if request.operation == "fs_grep":
+        return _grep_relative_files(
+            request.arguments["pattern"],
+            workspace=Path("."),
+            mode=request.arguments.get("mode", "content"),
+            max_results=request.arguments.get("max_results", MAX_GREP_RESULTS),
+            sensitive_exclusions=exclusions,
+        )
+    raise WorkspaceToolDispatchError(
+        "unsupported_operation",
+        "workspace operation is not implemented",
+    )
+
+
+def _request_relative_path(
+    request: WorkspaceToolRequest, root: PinnedWorkspaceRoot
+) -> Path:
+    """Return one request path validated as lexical root-relative text."""
     try:
-        relative = root.relative_path(request.arguments["path"])
+        return root.relative_path(request.arguments["path"])
     except WorkspaceRootPinError:
         raise WorkspaceToolDispatchError(
             "invalid_request",
             "workspace operation path is invalid",
         ) from None
-    return _stat_relative_path(relative)
+
+
+def _read_relative_path(
+    request: WorkspaceToolRequest,
+    root: PinnedWorkspaceRoot,
+    exclusions: tuple[SensitiveExclusion, ...],
+) -> Path:
+    """Return an admitted relative read path without exposing protected names."""
+    relative = _request_relative_path(request, root)
+    if _is_relative_sensitive_path(relative, exclusions, is_directory=relative.is_dir()):
+        raise WorkspaceToolDispatchError(
+            "invalid_request",
+            "workspace operation path is invalid",
+        )
+    return relative
 
 
 __all__ = ["WorkspaceToolDispatchError", "execute_pinned_operation"]

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -144,8 +144,9 @@ class WorkspaceToolExecutor:
                 request.to_bytes(),
                 writer_errors,
             )
+            operation_deadline = _operation_phase_deadline(deadline)
             try:
-                process.wait(timeout=_operation_wait_budget(deadline))
+                process.wait(timeout=_remaining_seconds(operation_deadline))
             except subprocess.TimeoutExpired:
                 cleanup_attempted = True
                 cleanup = _settle_process(tree, process, deadline)
@@ -155,7 +156,7 @@ class WorkspaceToolExecutor:
                 raise WorkspaceToolExecutionError("worker_timed_out") from None
 
             if not _join_threads_until(
-                deadline,
+                operation_deadline,
                 writer_thread,
                 stdout_thread,
                 stderr_thread,
@@ -210,9 +211,10 @@ class WorkspaceToolExecutor:
             _settle_process(tree, process, deadline)
             raise
         finally:
-            _close_process_pipes(process)
+            _close_process_pipes_until(process, deadline)
             _join_threads_until(deadline, writer_thread, stdout_thread, stderr_thread)
             writer_errors.clear()
+            stdout_capture.clear()
             stderr_capture.clear()
 
     def _build_request(
@@ -304,10 +306,10 @@ def _join_threads_until(
     return all(thread is None or not thread.is_alive() for thread in threads)
 
 
-def _operation_wait_budget(deadline: float) -> float:
+def _operation_phase_deadline(deadline: float) -> float:
     remaining = _remaining_seconds(deadline)
     reserve = min(_CLEANUP_RESERVE_SECONDS, remaining / 5.0)
-    return max(0.0, remaining - reserve)
+    return deadline - reserve
 
 
 def _remaining_seconds(deadline: float) -> float:
@@ -361,36 +363,90 @@ def _settle_process(
 ) -> bool:
     if process is None:
         return True
+    outcome: list[bool] = []
+
+    def settle() -> None:
+        try:
+            outcome.append(_settle_process_blocking(tree, process, deadline))
+        except BaseException:
+            outcome.append(False)
+
+    thread = threading.Thread(target=settle, name="workspace-worker-cleanup", daemon=True)
+    thread.start()
+    thread.join(_remaining_seconds(deadline))
+    return bool(outcome and outcome[0])
+
+
+def _settle_process_blocking(
+    tree: ExecutorProcessTree | None,
+    process: subprocess.Popen[bytes],
+    deadline: float,
+) -> bool:
     remaining = _remaining_seconds(deadline)
     term_timeout = remaining / 2.0
     kill_timeout = remaining - term_timeout
+    if tree is not None:
+        # ExecutorProcessTree may use each phase timeout in two sequential waits
+        # (leader/job and group). Quarter budgets keep both phases inside the
+        # remaining outer window; the supervising thread is the final guard.
+        term_timeout = remaining / 4.0
+        kill_timeout = remaining / 4.0
+        return tree.terminate_tree(
+            term_timeout=term_timeout,
+            kill_timeout=kill_timeout,
+        )
+    if process.poll() is not None:
+        return True
     try:
-        if tree is not None:
-            return tree.terminate_tree(
-                term_timeout=term_timeout,
-                kill_timeout=kill_timeout,
-            )
-        if process.poll() is not None:
-            return True
         process.terminate()
-        process.wait(timeout=term_timeout)
-        if process.poll() is None:
-            process.kill()
-            process.wait(timeout=kill_timeout)
-        return process.poll() is not None
+    except OSError:
+        pass
+    try:
+        process.wait(timeout=min(term_timeout, _remaining_seconds(deadline)))
     except (OSError, subprocess.TimeoutExpired):
-        return False
+        pass
+    if process.poll() is None:
+        try:
+            process.kill()
+        except OSError:
+            pass
+        try:
+            process.wait(timeout=min(kill_timeout, _remaining_seconds(deadline)))
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    return process.poll() is not None
 
 
-def _close_process_pipes(process: subprocess.Popen[bytes] | None) -> None:
+def _close_process_pipes_until(
+    process: subprocess.Popen[bytes] | None,
+    deadline: float,
+) -> None:
     if process is None:
         return
-    for stream in (process.stdin, process.stdout, process.stderr):
+
+    def close(stream: BinaryIO) -> None:
+        try:
+            stream.close()
+        except BaseException:
+            pass
+
+    threads: list[threading.Thread] = []
+    for index, stream in enumerate((process.stdin, process.stdout, process.stderr)):
         if stream is not None:
-            try:
-                stream.close()
-            except Exception:
-                pass
+            thread = threading.Thread(
+                target=close,
+                args=(stream,),
+                name=f"workspace-worker-pipe-close-{index}",
+                daemon=True,
+            )
+            thread.start()
+            threads.append(thread)
+    for thread in threads:
+        try:
+            thread.join(_remaining_seconds(deadline))
+        except RuntimeError:
+            # A thread that could not start cannot have entered stream.close().
+            continue
 
 
 __all__ = [

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -107,7 +107,20 @@ class WorkspaceToolExecutor:
         *,
         intent: str,
     ) -> str:
-        """Validate, execute once, prove cleanup, and return bounded text."""
+        """Validate, execute once, prove cleanup, and return bounded text.
+
+        Args:
+            operation: Closed workspace protocol operation name.
+            arguments: Operation-specific arguments to validate and serialize.
+            intent: Required access intent for the requested operation.
+
+        Returns:
+            Bounded text returned by the successful one-shot worker.
+
+        Raises:
+            WorkspaceToolExecutionError: If admission, validation, execution,
+                protocol handling, containment, or cleanup fails.
+        """
         request = self._build_request(operation, arguments, intent=intent)
         deadline = time.monotonic() + request.timeout_seconds
         process: subprocess.Popen[bytes] | None = None

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -30,6 +30,7 @@ from tldw_chatbook.Utils.filesystem_identity import (
     DirectoryIdentityError,
     capture_directory_chain,
 )
+from tldw_chatbook.Utils.path_validation import validate_path
 from tldw_chatbook.Utils.sensitive_paths import (
     SensitiveExclusion, resolve_sensitive_context, sensitive_exclusions_under,
 )
@@ -78,9 +79,34 @@ class _PopenProcessAdapter:
         self._process.kill()
 
 
-def workspace_worker_environment() -> dict[str, str]:
-    """Return the fixed runtime allowlist inherited by the isolated helper."""
-    environment = {"PATH": os.defpath}
+def workspace_worker_environment(workspace_root: Path) -> dict[str, str]:
+    """Return the fixed runtime allowlist inherited by the isolated helper.
+
+    Args:
+        workspace_root: Admitted root whose contents must not supply executables.
+
+    Returns:
+        A small environment with only absolute, external PATH entries and the
+        minimum platform variables needed by the child runtime.
+    """
+    root = workspace_root.resolve()
+    path_entries: list[str] = []
+    seen: set[str] = set()
+    for raw_entry in os.environ.get("PATH", os.defpath).split(os.pathsep):
+        entry = Path(raw_entry)
+        if not raw_entry or not entry.is_absolute():
+            continue
+        resolved = entry.resolve()
+        if resolved == root or root in resolved.parents:
+            continue
+        key = os.path.normcase(str(resolved))
+        if key not in seen:
+            seen.add(key)
+            path_entries.append(str(resolved))
+    environment = {
+        "PATH": os.pathsep.join(path_entries),
+        "NoDefaultCurrentDirectoryInExePath": "1",
+    }
     if os.name == "posix":
         environment.update({"LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"})
     else:
@@ -95,7 +121,16 @@ class WorkspaceToolExecutor:
     """Launch one contained helper for one workspace operation."""
 
     def __init__(self, workspace_root: Path) -> None:
-        self._workspace_root = Path(workspace_root)
+        candidate = Path(os.path.abspath(workspace_root))
+        try:
+            self._workspace_root = validate_path(
+                candidate,
+                candidate,
+                redact_paths=True,
+                allow_hidden=True,
+            )
+        except ValueError:
+            raise WorkspaceToolExecutionError("invalid_request") from None
         self._authority_chain: DirectoryChain = capture_directory_chain(
             self._workspace_root
         )
@@ -140,7 +175,7 @@ class WorkspaceToolExecutor:
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                env=workspace_worker_environment(),
+                env=workspace_worker_environment(self._workspace_root),
                 shell=False,
                 start_new_session=(os.name == "posix"),
             )

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -1,0 +1,305 @@
+"""Parent-side one-shot executor for pinned workspace tool requests."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import threading
+import uuid
+from pathlib import Path
+from typing import Any, BinaryIO
+
+from tldw_chatbook.STT.executor_process_tree import (
+    ExecutorProcessTree,
+    ProcessContainmentError,
+    WorkerContainmentIdentity,
+)
+from tldw_chatbook.Tools.local_tool_impls import resolve_workspace_path
+from tldw_chatbook.Tools.workspace_tool_protocol import (
+    MAX_RESPONSE_BYTES,
+    WorkspaceProtocolError,
+    WorkspaceToolRequest,
+    WorkspaceToolResponse,
+)
+from tldw_chatbook.Utils.filesystem_identity import (
+    DirectoryIdentityError,
+    capture_directory_chain,
+)
+
+WORKSPACE_HELPER_TIMEOUT_SECONDS = 300
+DIAGNOSTIC_STDERR_MAX_BYTES = 8 * 1024
+_FIXED_WORKER_MODULE = "tldw_chatbook.Tools.workspace_tool_worker"
+_SAFE_CODE = re.compile(r"[a-z][a-z0-9_]{0,63}\Z")
+
+
+class WorkspaceToolExecutionError(RuntimeError):
+    """A stable, content-free one-shot workspace execution refusal."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(f"workspace operation failed ({code})")
+
+
+class _PopenProcessAdapter:
+    """Expose only the process lifecycle expected by ExecutorProcessTree."""
+
+    def __init__(self, process: subprocess.Popen[bytes]) -> None:
+        self._process = process
+        self.pid = process.pid
+
+    def is_alive(self) -> bool:
+        return self._process.poll() is None
+
+    def join(self, timeout: float | None = None) -> None:
+        try:
+            self._process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            pass
+
+    def terminate(self) -> None:
+        self._process.terminate()
+
+    def kill(self) -> None:
+        self._process.kill()
+
+
+def workspace_worker_environment() -> dict[str, str]:
+    """Return the fixed runtime allowlist inherited by the isolated helper."""
+    environment = {"PATH": os.defpath}
+    if os.name == "posix":
+        environment.update({"LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"})
+    else:
+        for key in ("SYSTEMROOT", "WINDIR"):
+            value = os.environ.get(key)
+            if value:
+                environment[key] = value
+    return environment
+
+
+class WorkspaceToolExecutor:
+    """Launch one contained helper for one workspace operation."""
+
+    def __init__(self, workspace_root: Path) -> None:
+        self._workspace_root = Path(workspace_root)
+
+    def execute(
+        self,
+        operation: str,
+        arguments: dict[str, Any],
+        *,
+        intent: str,
+    ) -> str:
+        """Validate, execute once, prove cleanup, and return bounded text."""
+        request = self._build_request(operation, arguments, intent=intent)
+        process: subprocess.Popen[bytes] | None = None
+        tree: ExecutorProcessTree | None = None
+        stdout_capture: list[bytes] = []
+        stderr_capture: list[bytes] = []
+        stdout_thread: threading.Thread | None = None
+        stderr_thread: threading.Thread | None = None
+        try:
+            argv = [sys.executable, "-I", "-m", _FIXED_WORKER_MODULE]
+            process = subprocess.Popen(
+                argv,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=workspace_worker_environment(),
+                shell=False,
+                start_new_session=(os.name == "posix"),
+            )
+            adapter = _PopenProcessAdapter(process)
+            identity = WorkerContainmentIdentity(
+                pid=process.pid,
+                process_group_id=process.pid if os.name == "posix" else None,
+            )
+            admission = threading.Event()
+            tree = ExecutorProcessTree(adapter, admission, identity)
+            tree.admit()
+
+            if process.stdout is None or process.stderr is None or process.stdin is None:
+                raise WorkspaceToolExecutionError("spawn_failed")
+            stdout_thread = _start_bounded_reader(
+                process.stdout,
+                MAX_RESPONSE_BYTES,
+                stdout_capture,
+                name="workspace-worker-stdout",
+            )
+            stderr_thread = _start_bounded_reader(
+                process.stderr,
+                DIAGNOSTIC_STDERR_MAX_BYTES,
+                stderr_capture,
+                name="workspace-worker-stderr",
+            )
+            process.stdin.write(request.to_bytes())
+            process.stdin.close()
+            try:
+                process.wait(timeout=request.timeout_seconds)
+            except subprocess.TimeoutExpired:
+                cleanup = tree.terminate_tree()
+                _join_readers(stdout_thread, stderr_thread)
+                if not cleanup:
+                    raise WorkspaceToolExecutionError("cleanup_unproven") from None
+                raise WorkspaceToolExecutionError("worker_timed_out") from None
+
+            _join_readers(stdout_thread, stderr_thread)
+            cleanup = tree.close()
+            if not cleanup:
+                raise WorkspaceToolExecutionError("cleanup_unproven")
+            if process.returncode != 0 and not stdout_capture:
+                raise WorkspaceToolExecutionError("worker_crashed")
+            response = _parse_worker_output(
+                b"".join(stdout_capture),
+                expected_operation_id=request.operation_id,
+            )
+            if not response.cleanup_proven:
+                raise WorkspaceToolExecutionError("cleanup_unproven")
+            if response.outcome == "failure":
+                raise WorkspaceToolExecutionError(response.code)
+            if response.result is None:
+                raise WorkspaceToolExecutionError("protocol_failure")
+            return response.result
+        except WorkspaceToolExecutionError:
+            if tree is not None and process is not None and process.poll() is None:
+                cleanup = _terminate_tree(tree)
+                if not cleanup:
+                    raise WorkspaceToolExecutionError("cleanup_unproven") from None
+            raise
+        except ProcessContainmentError:
+            cleanup = _terminate_tree(tree) if tree is not None else _stop_process(process)
+            if not cleanup:
+                raise WorkspaceToolExecutionError("cleanup_unproven") from None
+            raise WorkspaceToolExecutionError("containment_unavailable") from None
+        except (OSError, ValueError):
+            cleanup = _terminate_tree(tree) if tree is not None else _stop_process(process)
+            if not cleanup:
+                raise WorkspaceToolExecutionError("cleanup_unproven") from None
+            raise WorkspaceToolExecutionError("spawn_failed") from None
+        finally:
+            del stderr_capture
+
+    def _build_request(
+        self,
+        operation: str,
+        arguments: dict[str, Any],
+        *,
+        intent: str,
+    ) -> WorkspaceToolRequest:
+        try:
+            chain = capture_directory_chain(self._workspace_root)
+            normalized = dict(arguments)
+            if operation == "stat_path" and type(arguments) is dict:
+                raw_path = arguments.get("path")
+                if type(raw_path) is str:
+                    target = resolve_workspace_path(
+                        raw_path,
+                        chain.canonical_root,
+                        intent="read",
+                    )
+                    normalized["path"] = str(target.relative_to(chain.canonical_root))
+            request = WorkspaceToolRequest(
+                operation_id=uuid.uuid4().hex,
+                operation=operation,  # type: ignore[arg-type]
+                intent=intent,  # type: ignore[arg-type]
+                root_locator=chain.canonical_root,
+                root_identity=chain.identities[0],
+                ancestor_identities=chain.identities,
+                arguments=normalized,
+                timeout_seconds=WORKSPACE_HELPER_TIMEOUT_SECONDS,
+                output_max_bytes=MAX_RESPONSE_BYTES,
+            )
+            return WorkspaceToolRequest.from_bytes(request.to_bytes())
+        except (DirectoryIdentityError, WorkspaceProtocolError, OSError, ValueError):
+            raise WorkspaceToolExecutionError("invalid_request") from None
+
+
+def _start_bounded_reader(
+    stream: BinaryIO,
+    limit: int,
+    capture: list[bytes],
+    *,
+    name: str,
+) -> threading.Thread:
+    def read() -> None:
+        retained = 0
+        while True:
+            chunk = stream.read(64 * 1024)
+            if not chunk:
+                break
+            if retained <= limit:
+                piece = chunk[: limit + 1 - retained]
+                capture.append(piece)
+                retained += len(piece)
+
+    thread = threading.Thread(target=read, name=name, daemon=True)
+    thread.start()
+    return thread
+
+
+def _join_readers(*threads: threading.Thread | None) -> None:
+    for thread in threads:
+        if thread is not None:
+            thread.join(2.0)
+
+
+def _parse_worker_output(
+    raw: bytes,
+    *,
+    expected_operation_id: str,
+) -> WorkspaceToolResponse:
+    if len(raw) > MAX_RESPONSE_BYTES:
+        raise WorkspaceToolExecutionError("protocol_failure")
+    lines = raw.splitlines()
+    if not lines or len(lines) > 2:
+        raise WorkspaceToolExecutionError("protocol_failure")
+    try:
+        frames = [
+            WorkspaceToolResponse.from_bytes(
+                line,
+                expected_operation_id=expected_operation_id,
+            )
+            for line in lines
+        ]
+    except WorkspaceProtocolError:
+        raise WorkspaceToolExecutionError("protocol_failure") from None
+    terminal = frames[-1]
+    if len(frames) == 2 and frames[0].outcome != "admitted":
+        raise WorkspaceToolExecutionError("protocol_failure")
+    if terminal.outcome not in {"success", "failure"}:
+        raise WorkspaceToolExecutionError("protocol_failure")
+    if not _SAFE_CODE.fullmatch(terminal.code):
+        raise WorkspaceToolExecutionError("protocol_failure")
+    return terminal
+
+
+def _terminate_tree(tree: ExecutorProcessTree | None) -> bool:
+    if tree is None:
+        return True
+    try:
+        return tree.terminate_tree()
+    except Exception:
+        return False
+
+
+def _stop_process(process: subprocess.Popen[bytes] | None) -> bool:
+    if process is None or process.poll() is not None:
+        return True
+    try:
+        process.terminate()
+        process.wait(timeout=2.0)
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=2.0)
+        return process.poll() is not None
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+__all__ = [
+    "DIAGNOSTIC_STDERR_MAX_BYTES",
+    "WorkspaceToolExecutionError",
+    "WorkspaceToolExecutor",
+    "workspace_worker_environment",
+]

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -39,6 +39,9 @@ _FIXED_WORKER_MODULE = "tldw_chatbook.Tools.workspace_tool_worker"
 _SAFE_CODE = re.compile(r"[a-z][a-z0-9_]{0,63}\Z")
 _CLEANUP_RESERVE_SECONDS = 4.0
 _READ_OPERATIONS = frozenset({"fs_list", "fs_read", "fs_glob", "fs_grep"})
+_GIT_OPERATIONS = frozenset(
+    {"git_status", "git_diff", "git_log", "git_blame", "git_branches"}
+)
 
 
 class WorkspaceToolExecutionError(RuntimeError):
@@ -307,6 +310,23 @@ class WorkspaceToolExecutor:
                         intent="read",
                     )
                     normalized["path"] = str(target.relative_to(chain.canonical_root))
+            if operation in _GIT_OPERATIONS and type(arguments) is dict:
+                context = resolve_sensitive_context()
+                root = resolve_workspace_path(
+                    ".", chain.canonical_root, intent="list", context=context
+                )
+                exclusions, _ = _parent_read_exclusions(root, context)
+                normalized["sensitive_exclusions"] = _serialize_exclusions(
+                    exclusions
+                )
+                raw_path = arguments.get("path")
+                if raw_path is not None:
+                    if type(raw_path) is not str:
+                        raise ValueError("invalid git path")
+                    target = resolve_workspace_path(
+                        raw_path, root, intent="read", context=context
+                    )
+                    normalized["path"] = target.relative_to(root).as_posix() or "."
             if operation in _READ_OPERATIONS and type(arguments) is dict:
                 context = resolve_sensitive_context()
                 root = resolve_workspace_path(

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -185,18 +185,23 @@ class WorkspaceToolExecutor:
             )
             if not cleanup:
                 raise WorkspaceToolExecutionError("cleanup_unproven")
-            if process.returncode != 0:
-                raise WorkspaceToolExecutionError("worker_crashed")
             if writer_errors:
                 raise WorkspaceToolExecutionError("worker_crashed")
-            response = _parse_worker_output(
-                b"".join(stdout_capture),
-                expected_operation_id=request.operation_id,
-            )
+            try:
+                response = _parse_worker_output(
+                    b"".join(stdout_capture),
+                    expected_operation_id=request.operation_id,
+                )
+            except WorkspaceToolExecutionError:
+                if process.returncode != 0:
+                    raise WorkspaceToolExecutionError("worker_crashed") from None
+                raise
             if not response.cleanup_proven:
                 raise WorkspaceToolExecutionError("cleanup_unproven")
             if response.outcome == "failure":
                 raise WorkspaceToolExecutionError(response.code)
+            if process.returncode != 0:
+                raise WorkspaceToolExecutionError("worker_crashed")
             if response.result is None:
                 raise WorkspaceToolExecutionError("protocol_failure")
             return response.result
@@ -341,6 +346,12 @@ class WorkspaceToolExecutor:
                     context=context,
                 )
                 normalized["path"] = _normalize_relative_path(raw_path)
+                exclusions, _ = _parent_read_exclusions(
+                    chain.canonical_root, context
+                )
+                normalized["sensitive_exclusions"] = _serialize_exclusions(
+                    exclusions
+                )
             if operation == "fs_patch" and type(arguments) is dict:
                 raw_diff = arguments.get("diff")
                 if type(raw_diff) is not str:
@@ -359,6 +370,12 @@ class WorkspaceToolExecutor:
                     )
                     targets.append(_normalize_relative_path(rel_path))
                 normalized["targets"] = targets
+                exclusions, _ = _parent_read_exclusions(
+                    chain.canonical_root, context
+                )
+                normalized["sensitive_exclusions"] = _serialize_exclusions(
+                    exclusions
+                )
             request = WorkspaceToolRequest(
                 operation_id=uuid.uuid4().hex,
                 operation=operation,  # type: ignore[arg-type]

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -45,11 +45,13 @@ _GIT_OPERATIONS = frozenset(
 
 
 class WorkspaceToolExecutionError(RuntimeError):
-    """A stable, content-free one-shot workspace execution refusal."""
+    """A stable code plus optional protocol-validated worker failure text."""
 
-    def __init__(self, code: str) -> None:
+    def __init__(self, code: str, message: str | None = None) -> None:
         self.code = code
-        super().__init__(f"workspace operation failed ({code})")
+        super().__init__(
+            message if message is not None else f"workspace operation failed ({code})"
+        )
 
 
 class _PopenProcessAdapter:
@@ -202,7 +204,7 @@ class WorkspaceToolExecutor:
             if not response.cleanup_proven:
                 raise WorkspaceToolExecutionError("cleanup_unproven")
             if response.outcome == "failure":
-                raise WorkspaceToolExecutionError(response.code)
+                raise WorkspaceToolExecutionError(response.code, response.error)
             if process.returncode != 0:
                 raise WorkspaceToolExecutionError("worker_crashed")
             if response.result is None:

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -9,7 +9,7 @@ import sys
 import threading
 import time
 import uuid
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, BinaryIO
 
 from tldw_chatbook.STT.executor_process_tree import (
@@ -28,12 +28,19 @@ from tldw_chatbook.Utils.filesystem_identity import (
     DirectoryIdentityError,
     capture_directory_chain,
 )
+from tldw_chatbook.Utils.sensitive_paths import (
+    SensitiveExclusion,
+    is_sensitive_path,
+    resolve_sensitive_context,
+    sensitive_exclusions_under,
+)
 
 WORKSPACE_HELPER_TIMEOUT_SECONDS = 300
 DIAGNOSTIC_STDERR_MAX_BYTES = 8 * 1024
 _FIXED_WORKER_MODULE = "tldw_chatbook.Tools.workspace_tool_worker"
 _SAFE_CODE = re.compile(r"[a-z][a-z0-9_]{0,63}\Z")
 _CLEANUP_RESERVE_SECONDS = 4.0
+_READ_OPERATIONS = frozenset({"fs_list", "fs_read", "fs_glob", "fs_grep"})
 
 
 class WorkspaceToolExecutionError(RuntimeError):
@@ -297,6 +304,33 @@ class WorkspaceToolExecutor:
                         intent="read",
                     )
                     normalized["path"] = str(target.relative_to(chain.canonical_root))
+            if operation in _READ_OPERATIONS and type(arguments) is dict:
+                context = resolve_sensitive_context()
+                root = resolve_workspace_path(
+                    ".", chain.canonical_root, intent="list", context=context
+                )
+                exclusions, content_exclusions = _parent_read_exclusions(root, context)
+                normalized["sensitive_exclusions"] = _serialize_exclusions(exclusions)
+                if operation == "fs_grep":
+                    normalized["content_exclusions"] = _serialize_exclusions(
+                        content_exclusions
+                    )
+                if operation in {"fs_list", "fs_read"}:
+                    raw_path = arguments.get("path")
+                    if type(raw_path) is not str:
+                        raise ValueError("invalid read path")
+                    target = resolve_workspace_path(
+                        raw_path,
+                        root,
+                        intent="list" if operation == "fs_list" else "read",
+                        context=context,
+                    )
+                    normalized["path"] = str(target.relative_to(root))
+                if operation == "fs_glob":
+                    raw_pattern = arguments.get("pattern")
+                    if type(raw_pattern) is not str:
+                        raise ValueError("invalid glob pattern")
+                    normalized["pattern"] = _normalize_glob_pattern(raw_pattern)
             request = WorkspaceToolRequest(
                 operation_id=uuid.uuid4().hex,
                 operation=operation,  # type: ignore[arg-type]
@@ -311,6 +345,50 @@ class WorkspaceToolExecutor:
             return WorkspaceToolRequest.from_bytes(request.to_bytes())
         except (DirectoryIdentityError, WorkspaceProtocolError, OSError, ValueError):
             raise WorkspaceToolExecutionError("invalid_request") from None
+
+
+def _normalize_glob_pattern(pattern: str) -> str:
+    """Reject lexical glob routes that could traverse outside a pinned root."""
+    windows = PureWindowsPath(pattern)
+    if (
+        Path(pattern).is_absolute()
+        or windows.is_absolute()
+        or windows.root
+        or windows.drive
+        or any(part == ".." for part in pattern.replace("\\", "/").split("/"))
+    ):
+        raise ValueError("invalid glob pattern")
+    return pattern
+
+
+def _parent_read_exclusions(
+    root: Path, context: Any
+) -> tuple[tuple[SensitiveExclusion, ...], tuple[SensitiveExclusion, ...]]:
+    """Capture sensitive and unsafe symlink aliases before worker launch."""
+    exclusions = list(sensitive_exclusions_under(root, context))
+    content_exclusions = list(exclusions)
+    for candidate in root.rglob("*"):
+        try:
+            if not candidate.is_symlink():
+                continue
+            relative = candidate.relative_to(root)
+            resolved = candidate.resolve()
+            if resolved.is_relative_to(root) and is_sensitive_path(candidate, context=context):
+                exclusion = SensitiveExclusion(
+                    "subtree" if candidate.is_dir() else "file", relative.as_posix()
+                )
+                exclusions.append(exclusion)
+                content_exclusions.append(exclusion)
+            elif not resolved.is_relative_to(root) and candidate.is_file():
+                content_exclusions.append(SensitiveExclusion("file", relative.as_posix()))
+        except OSError:
+            continue
+    return tuple(dict.fromkeys(exclusions)), tuple(dict.fromkeys(content_exclusions))
+
+
+def _serialize_exclusions(exclusions: tuple[SensitiveExclusion, ...]) -> list[dict[str, str]]:
+    """Serialize bounded parent exclusions into the closed worker request."""
+    return [{"kind": exclusion.kind, "value": exclusion.value} for exclusion in exclusions]
 
 
 def _start_bounded_reader(

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -7,6 +7,7 @@ import re
 import subprocess
 import sys
 import threading
+import time
 import uuid
 from pathlib import Path
 from typing import Any, BinaryIO
@@ -32,6 +33,7 @@ WORKSPACE_HELPER_TIMEOUT_SECONDS = 300
 DIAGNOSTIC_STDERR_MAX_BYTES = 8 * 1024
 _FIXED_WORKER_MODULE = "tldw_chatbook.Tools.workspace_tool_worker"
 _SAFE_CODE = re.compile(r"[a-z][a-z0-9_]{0,63}\Z")
+_CLEANUP_RESERVE_SECONDS = 4.0
 
 
 class WorkspaceToolExecutionError(RuntimeError):
@@ -93,12 +95,16 @@ class WorkspaceToolExecutor:
     ) -> str:
         """Validate, execute once, prove cleanup, and return bounded text."""
         request = self._build_request(operation, arguments, intent=intent)
+        deadline = time.monotonic() + request.timeout_seconds
         process: subprocess.Popen[bytes] | None = None
         tree: ExecutorProcessTree | None = None
         stdout_capture: list[bytes] = []
         stderr_capture: list[bytes] = []
+        writer_errors: list[BaseException] = []
+        writer_thread: threading.Thread | None = None
         stdout_thread: threading.Thread | None = None
         stderr_thread: threading.Thread | None = None
+        cleanup_attempted = False
         try:
             argv = [sys.executable, "-I", "-m", _FIXED_WORKER_MODULE]
             process = subprocess.Popen(
@@ -133,22 +139,35 @@ class WorkspaceToolExecutor:
                 stderr_capture,
                 name="workspace-worker-stderr",
             )
-            process.stdin.write(request.to_bytes())
-            process.stdin.close()
+            writer_thread = _start_request_writer(
+                process.stdin,
+                request.to_bytes(),
+                writer_errors,
+            )
             try:
-                process.wait(timeout=request.timeout_seconds)
+                process.wait(timeout=_operation_wait_budget(deadline))
             except subprocess.TimeoutExpired:
-                cleanup = tree.terminate_tree()
-                _join_readers(stdout_thread, stderr_thread)
+                cleanup_attempted = True
+                cleanup = _settle_process(tree, process, deadline)
+                _join_threads_until(deadline, writer_thread, stdout_thread, stderr_thread)
                 if not cleanup:
                     raise WorkspaceToolExecutionError("cleanup_unproven") from None
                 raise WorkspaceToolExecutionError("worker_timed_out") from None
 
-            _join_readers(stdout_thread, stderr_thread)
-            cleanup = tree.close()
+            if not _join_threads_until(
+                deadline,
+                writer_thread,
+                stdout_thread,
+                stderr_thread,
+            ):
+                raise WorkspaceToolExecutionError("worker_timed_out")
+            cleanup_attempted = True
+            cleanup = _settle_process(tree, process, deadline)
             if not cleanup:
                 raise WorkspaceToolExecutionError("cleanup_unproven")
-            if process.returncode != 0 and not stdout_capture:
+            if process.returncode != 0:
+                raise WorkspaceToolExecutionError("worker_crashed")
+            if writer_errors:
                 raise WorkspaceToolExecutionError("worker_crashed")
             response = _parse_worker_output(
                 b"".join(stdout_capture),
@@ -162,23 +181,39 @@ class WorkspaceToolExecutor:
                 raise WorkspaceToolExecutionError("protocol_failure")
             return response.result
         except WorkspaceToolExecutionError:
-            if tree is not None and process is not None and process.poll() is None:
-                cleanup = _terminate_tree(tree)
+            if process is not None and not cleanup_attempted:
+                cleanup_attempted = True
+                cleanup = _settle_process(tree, process, deadline)
                 if not cleanup:
                     raise WorkspaceToolExecutionError("cleanup_unproven") from None
             raise
         except ProcessContainmentError:
-            cleanup = _terminate_tree(tree) if tree is not None else _stop_process(process)
+            cleanup_attempted = True
+            cleanup = _settle_process(tree, process, deadline)
             if not cleanup:
                 raise WorkspaceToolExecutionError("cleanup_unproven") from None
             raise WorkspaceToolExecutionError("containment_unavailable") from None
         except (OSError, ValueError):
-            cleanup = _terminate_tree(tree) if tree is not None else _stop_process(process)
+            cleanup_attempted = True
+            cleanup = _settle_process(tree, process, deadline)
             if not cleanup:
                 raise WorkspaceToolExecutionError("cleanup_unproven") from None
             raise WorkspaceToolExecutionError("spawn_failed") from None
+        except Exception:
+            cleanup_attempted = True
+            cleanup = _settle_process(tree, process, deadline)
+            if not cleanup:
+                raise WorkspaceToolExecutionError("cleanup_unproven") from None
+            raise WorkspaceToolExecutionError("worker_failure") from None
+        except BaseException:
+            cleanup_attempted = True
+            _settle_process(tree, process, deadline)
+            raise
         finally:
-            del stderr_capture
+            _close_process_pipes(process)
+            _join_threads_until(deadline, writer_thread, stdout_thread, stderr_thread)
+            writer_errors.clear()
+            stderr_capture.clear()
 
     def _build_request(
         self,
@@ -238,10 +273,45 @@ def _start_bounded_reader(
     return thread
 
 
-def _join_readers(*threads: threading.Thread | None) -> None:
+def _start_request_writer(
+    stream: BinaryIO,
+    request: bytes,
+    errors: list[BaseException],
+) -> threading.Thread:
+    def write() -> None:
+        try:
+            stream.write(request)
+        except BaseException as error:
+            errors.append(error)
+        finally:
+            try:
+                stream.close()
+            except BaseException as error:
+                errors.append(error)
+
+    thread = threading.Thread(target=write, name="workspace-worker-stdin", daemon=True)
+    thread.start()
+    return thread
+
+
+def _join_threads_until(
+    deadline: float,
+    *threads: threading.Thread | None,
+) -> bool:
     for thread in threads:
         if thread is not None:
-            thread.join(2.0)
+            thread.join(_remaining_seconds(deadline))
+    return all(thread is None or not thread.is_alive() for thread in threads)
+
+
+def _operation_wait_budget(deadline: float) -> float:
+    remaining = _remaining_seconds(deadline)
+    reserve = min(_CLEANUP_RESERVE_SECONDS, remaining / 5.0)
+    return max(0.0, remaining - reserve)
+
+
+def _remaining_seconds(deadline: float) -> float:
+    return max(0.0, deadline - time.monotonic())
 
 
 def _parse_worker_output(
@@ -265,8 +335,18 @@ def _parse_worker_output(
     except WorkspaceProtocolError:
         raise WorkspaceToolExecutionError("protocol_failure") from None
     terminal = frames[-1]
-    if len(frames) == 2 and frames[0].outcome != "admitted":
-        raise WorkspaceToolExecutionError("protocol_failure")
+    if len(frames) == 2:
+        admitted = frames[0]
+        if (
+            admitted.outcome != "admitted"
+            or admitted.code != "root_pinned"
+            or admitted.result is not None
+            or admitted.error is not None
+            or admitted.truncated
+            or not admitted.cleanup_proven
+            or admitted.elapsed_ms > terminal.elapsed_ms
+        ):
+            raise WorkspaceToolExecutionError("protocol_failure")
     if terminal.outcome not in {"success", "failure"}:
         raise WorkspaceToolExecutionError("protocol_failure")
     if not _SAFE_CODE.fullmatch(terminal.code):
@@ -274,27 +354,43 @@ def _parse_worker_output(
     return terminal
 
 
-def _terminate_tree(tree: ExecutorProcessTree | None) -> bool:
-    if tree is None:
+def _settle_process(
+    tree: ExecutorProcessTree | None,
+    process: subprocess.Popen[bytes] | None,
+    deadline: float,
+) -> bool:
+    if process is None:
         return True
+    remaining = _remaining_seconds(deadline)
+    term_timeout = remaining / 2.0
+    kill_timeout = remaining - term_timeout
     try:
-        return tree.terminate_tree()
-    except Exception:
-        return False
-
-
-def _stop_process(process: subprocess.Popen[bytes] | None) -> bool:
-    if process is None or process.poll() is not None:
-        return True
-    try:
+        if tree is not None:
+            return tree.terminate_tree(
+                term_timeout=term_timeout,
+                kill_timeout=kill_timeout,
+            )
+        if process.poll() is not None:
+            return True
         process.terminate()
-        process.wait(timeout=2.0)
+        process.wait(timeout=term_timeout)
         if process.poll() is None:
             process.kill()
-            process.wait(timeout=2.0)
+            process.wait(timeout=kill_timeout)
         return process.poll() is not None
     except (OSError, subprocess.TimeoutExpired):
         return False
+
+
+def _close_process_pipes(process: subprocess.Popen[bytes] | None) -> None:
+    if process is None:
+        return
+    for stream in (process.stdin, process.stdout, process.stderr):
+        if stream is not None:
+            try:
+                stream.close()
+            except Exception:
+                pass
 
 
 __all__ = [

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -9,7 +9,7 @@ import sys
 import threading
 import time
 import uuid
-from pathlib import Path, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, BinaryIO
 
 from tldw_chatbook.STT.executor_process_tree import (
@@ -316,13 +316,13 @@ class WorkspaceToolExecutor:
                     raw_path = arguments.get("path")
                     if type(raw_path) is not str:
                         raise ValueError("invalid read path")
-                    target = resolve_workspace_path(
+                    resolve_workspace_path(
                         raw_path,
                         root,
                         intent="list" if operation == "fs_list" else "read",
                         context=context,
                     )
-                    normalized["path"] = str(target.relative_to(root))
+                    normalized["path"] = _normalize_relative_path(raw_path)
                 if operation == "fs_glob":
                     raw_pattern = arguments.get("pattern")
                     if type(raw_pattern) is not str:
@@ -356,6 +356,17 @@ def _normalize_glob_pattern(pattern: str) -> str:
     ):
         raise ValueError("invalid glob pattern")
     return pattern
+
+
+def _normalize_relative_path(path: str) -> str:
+    """Retain a lexical relative target after parent-side policy admission."""
+    for lexical in (PurePosixPath(path), PureWindowsPath(path)):
+        if lexical.drive or lexical.root or lexical.anchor:
+            raise ValueError("invalid workspace path")
+    relative = Path(path)
+    if relative.is_absolute() or ".." in relative.parts or "\x00" in path:
+        raise ValueError("invalid workspace path")
+    return relative.as_posix()
 
 
 def _parent_read_exclusions(

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -104,6 +104,7 @@ class WorkspaceToolExecutor:
         writer_thread: threading.Thread | None = None
         stdout_thread: threading.Thread | None = None
         stderr_thread: threading.Thread | None = None
+        cleanup_supervisor: _CleanupSupervisor | None = None
         cleanup_attempted = False
         try:
             argv = [sys.executable, "-I", "-m", _FIXED_WORKER_MODULE]
@@ -127,6 +128,9 @@ class WorkspaceToolExecutor:
 
             if process.stdout is None or process.stderr is None or process.stdin is None:
                 raise WorkspaceToolExecutionError("spawn_failed")
+            candidate_supervisor = _CleanupSupervisor(tree, process, deadline)
+            candidate_supervisor.start()
+            cleanup_supervisor = candidate_supervisor
             stdout_thread = _start_bounded_reader(
                 process.stdout,
                 MAX_RESPONSE_BYTES,
@@ -149,7 +153,12 @@ class WorkspaceToolExecutor:
                 process.wait(timeout=_remaining_seconds(operation_deadline))
             except subprocess.TimeoutExpired:
                 cleanup_attempted = True
-                cleanup = _settle_process(tree, process, deadline)
+                cleanup = _settle_after_spawn(
+                    cleanup_supervisor,
+                    tree,
+                    process,
+                    deadline,
+                )
                 _join_threads_until(deadline, writer_thread, stdout_thread, stderr_thread)
                 if not cleanup:
                     raise WorkspaceToolExecutionError("cleanup_unproven") from None
@@ -163,7 +172,12 @@ class WorkspaceToolExecutor:
             ):
                 raise WorkspaceToolExecutionError("worker_timed_out")
             cleanup_attempted = True
-            cleanup = _settle_process(tree, process, deadline)
+            cleanup = _settle_after_spawn(
+                cleanup_supervisor,
+                tree,
+                process,
+                deadline,
+            )
             if not cleanup:
                 raise WorkspaceToolExecutionError("cleanup_unproven")
             if process.returncode != 0:
@@ -184,38 +198,85 @@ class WorkspaceToolExecutor:
         except WorkspaceToolExecutionError:
             if process is not None and not cleanup_attempted:
                 cleanup_attempted = True
-                cleanup = _settle_process(tree, process, deadline)
+                cleanup = _settle_after_spawn(
+                    cleanup_supervisor,
+                    tree,
+                    process,
+                    deadline,
+                )
                 if not cleanup:
                     raise WorkspaceToolExecutionError("cleanup_unproven") from None
             raise
         except ProcessContainmentError:
             cleanup_attempted = True
-            cleanup = _settle_process(tree, process, deadline)
+            cleanup = _settle_after_spawn(
+                cleanup_supervisor,
+                tree,
+                process,
+                deadline,
+            )
             if not cleanup:
                 raise WorkspaceToolExecutionError("cleanup_unproven") from None
             raise WorkspaceToolExecutionError("containment_unavailable") from None
         except (OSError, ValueError):
             cleanup_attempted = True
-            cleanup = _settle_process(tree, process, deadline)
+            cleanup = _settle_after_spawn(
+                cleanup_supervisor,
+                tree,
+                process,
+                deadline,
+            )
             if not cleanup:
                 raise WorkspaceToolExecutionError("cleanup_unproven") from None
             raise WorkspaceToolExecutionError("spawn_failed") from None
         except Exception:
             cleanup_attempted = True
-            cleanup = _settle_process(tree, process, deadline)
+            cleanup = _settle_after_spawn(
+                cleanup_supervisor,
+                tree,
+                process,
+                deadline,
+            )
             if not cleanup:
                 raise WorkspaceToolExecutionError("cleanup_unproven") from None
             raise WorkspaceToolExecutionError("worker_failure") from None
         except BaseException:
             cleanup_attempted = True
-            _settle_process(tree, process, deadline)
+            _settle_after_spawn(
+                cleanup_supervisor,
+                tree,
+                process,
+                deadline,
+            )
             raise
         finally:
-            _close_process_pipes_until(process, deadline)
-            _join_threads_until(deadline, writer_thread, stdout_thread, stderr_thread)
+            active_error = sys.exception()
+            pipes_closed, cleanup_cancellation = _close_process_pipes_until(
+                process,
+                deadline,
+            )
+            threads_joined = False
+            try:
+                threads_joined = _join_threads_until(
+                    deadline,
+                    writer_thread,
+                    stdout_thread,
+                    stderr_thread,
+                )
+            except BaseException as error:
+                if cleanup_cancellation is None and not isinstance(error, Exception):
+                    cleanup_cancellation = error
             writer_errors.clear()
             stdout_capture.clear()
             stderr_capture.clear()
+            active_cancellation = (
+                active_error is not None and not isinstance(active_error, Exception)
+            )
+            if not active_cancellation:
+                if cleanup_cancellation is not None:
+                    raise cleanup_cancellation
+                if not pipes_closed or not threads_joined:
+                    raise WorkspaceToolExecutionError("cleanup_unproven") from None
 
     def _build_request(
         self,
@@ -356,25 +417,96 @@ def _parse_worker_output(
     return terminal
 
 
-def _settle_process(
+class _CleanupSupervisor:
+    """Pre-started deadline guard for every post-authority settlement path."""
+
+    def __init__(
+        self,
+        tree: ExecutorProcessTree,
+        process: subprocess.Popen[bytes],
+        deadline: float,
+    ) -> None:
+        self._tree = tree
+        self._process = process
+        self._deadline = deadline
+        self._requested = threading.Event()
+        self._outcome: list[bool] = []
+        self._thread = threading.Thread(
+            target=self._run,
+            name="workspace-worker-cleanup",
+            daemon=True,
+        )
+
+    def start(self) -> None:
+        """Establish the supervisor before any request bytes are written."""
+        self._thread.start()
+
+    def settle(self) -> bool:
+        """Request settlement and wait only through the caller's deadline."""
+        self._requested.set()
+        try:
+            self._thread.join(_remaining_seconds(self._deadline))
+        except BaseException:
+            return False
+        return bool(self._outcome and self._outcome[0])
+
+    def _run(self) -> None:
+        self._requested.wait()
+        try:
+            self._outcome.append(
+                _settle_process_blocking(
+                    self._tree,
+                    self._process,
+                    self._deadline,
+                )
+            )
+        except BaseException:
+            self._outcome.append(False)
+
+
+def _settle_after_spawn(
+    supervisor: _CleanupSupervisor | None,
     tree: ExecutorProcessTree | None,
     process: subprocess.Popen[bytes] | None,
     deadline: float,
 ) -> bool:
     if process is None:
         return True
-    outcome: list[bool] = []
+    if supervisor is not None:
+        return supervisor.settle()
+    return _settle_without_supervisor(tree, process)
 
-    def settle() -> None:
+
+def _settle_without_supervisor(
+    tree: ExecutorProcessTree | None,
+    process: subprocess.Popen[bytes],
+) -> bool:
+    """Attempt immediate nonblocking containment when supervision could not start."""
+    if tree is not None:
         try:
-            outcome.append(_settle_process_blocking(tree, process, deadline))
+            return tree.terminate_tree(term_timeout=0.0, kill_timeout=0.0)
         except BaseException:
-            outcome.append(False)
-
-    thread = threading.Thread(target=settle, name="workspace-worker-cleanup", daemon=True)
-    thread.start()
-    thread.join(_remaining_seconds(deadline))
-    return bool(outcome and outcome[0])
+            return False
+    if process.poll() is not None:
+        return True
+    try:
+        process.terminate()
+    except BaseException:
+        pass
+    try:
+        process.wait(timeout=0.0)
+    except BaseException:
+        pass
+    if process.poll() is None:
+        try:
+            process.kill()
+        except BaseException:
+            pass
+        try:
+            process.wait(timeout=0.0)
+        except BaseException:
+            pass
+    return process.poll() is not None
 
 
 def _settle_process_blocking(
@@ -420,9 +552,9 @@ def _settle_process_blocking(
 def _close_process_pipes_until(
     process: subprocess.Popen[bytes] | None,
     deadline: float,
-) -> None:
+) -> tuple[bool, BaseException | None]:
     if process is None:
-        return
+        return True, None
 
     def close(stream: BinaryIO) -> None:
         try:
@@ -431,22 +563,33 @@ def _close_process_pipes_until(
             pass
 
     threads: list[threading.Thread] = []
+    cleanup_proven = True
+    cancellation: BaseException | None = None
     for index, stream in enumerate((process.stdin, process.stdout, process.stderr)):
         if stream is not None:
-            thread = threading.Thread(
-                target=close,
-                args=(stream,),
-                name=f"workspace-worker-pipe-close-{index}",
-                daemon=True,
-            )
-            thread.start()
-            threads.append(thread)
+            try:
+                thread = threading.Thread(
+                    target=close,
+                    args=(stream,),
+                    name=f"workspace-worker-pipe-close-{index}",
+                    daemon=True,
+                )
+                thread.start()
+                threads.append(thread)
+            except BaseException as error:
+                cleanup_proven = False
+                if cancellation is None and not isinstance(error, Exception):
+                    cancellation = error
     for thread in threads:
         try:
             thread.join(_remaining_seconds(deadline))
-        except RuntimeError:
-            # A thread that could not start cannot have entered stream.close().
-            continue
+            if thread.is_alive():
+                cleanup_proven = False
+        except BaseException as error:
+            cleanup_proven = False
+            if cancellation is None and not isinstance(error, Exception):
+                cancellation = error
+    return cleanup_proven, cancellation
 
 
 __all__ = [

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -29,10 +29,7 @@ from tldw_chatbook.Utils.filesystem_identity import (
     capture_directory_chain,
 )
 from tldw_chatbook.Utils.sensitive_paths import (
-    SensitiveExclusion,
-    is_sensitive_path,
-    resolve_sensitive_context,
-    sensitive_exclusions_under,
+    SensitiveExclusion, resolve_sensitive_context, sensitive_exclusions_under,
 )
 
 WORKSPACE_HELPER_TIMEOUT_SECONDS = 300
@@ -367,22 +364,6 @@ def _parent_read_exclusions(
     """Capture sensitive and unsafe symlink aliases before worker launch."""
     exclusions = list(sensitive_exclusions_under(root, context))
     content_exclusions = list(exclusions)
-    for candidate in root.rglob("*"):
-        try:
-            if not candidate.is_symlink():
-                continue
-            relative = candidate.relative_to(root)
-            resolved = candidate.resolve()
-            if resolved.is_relative_to(root) and is_sensitive_path(candidate, context=context):
-                exclusion = SensitiveExclusion(
-                    "subtree" if candidate.is_dir() else "file", relative.as_posix()
-                )
-                exclusions.append(exclusion)
-                content_exclusions.append(exclusion)
-            elif not resolved.is_relative_to(root) and candidate.is_file():
-                content_exclusions.append(SensitiveExclusion("file", relative.as_posix()))
-        except OSError:
-            continue
     return tuple(dict.fromkeys(exclusions)), tuple(dict.fromkeys(content_exclusions))
 
 

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -26,6 +26,7 @@ from tldw_chatbook.Tools.workspace_tool_protocol import (
     WorkspaceToolResponse,
 )
 from tldw_chatbook.Utils.filesystem_identity import (
+    DirectoryChain,
     DirectoryIdentityError,
     capture_directory_chain,
 )
@@ -95,6 +96,9 @@ class WorkspaceToolExecutor:
 
     def __init__(self, workspace_root: Path) -> None:
         self._workspace_root = Path(workspace_root)
+        self._authority_chain: DirectoryChain = capture_directory_chain(
+            self._workspace_root
+        )
 
     def execute(
         self,
@@ -301,7 +305,14 @@ class WorkspaceToolExecutor:
         intent: str,
     ) -> WorkspaceToolRequest:
         try:
-            chain = capture_directory_chain(self._workspace_root)
+            current_chain = capture_directory_chain(self._workspace_root)
+            if current_chain != self._authority_chain:
+                raise WorkspaceToolExecutionError("root_pin_failed")
+            chain = self._authority_chain
+        except (DirectoryIdentityError, OSError, ValueError):
+            raise WorkspaceToolExecutionError("root_pin_failed") from None
+
+        try:
             normalized = dict(arguments)
             if operation == "stat_path" and type(arguments) is dict:
                 raw_path = arguments.get("path")
@@ -410,6 +421,8 @@ class WorkspaceToolExecutor:
                 output_max_bytes=MAX_RESPONSE_BYTES,
             )
             return WorkspaceToolRequest.from_bytes(request.to_bytes())
+        except WorkspaceToolExecutionError:
+            raise
         except (DirectoryIdentityError, WorkspaceProtocolError, OSError, ValueError):
             raise WorkspaceToolExecutionError("invalid_request") from None
 

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -446,7 +446,7 @@ class _CleanupSupervisor:
         self._requested.set()
         try:
             self._thread.join(_remaining_seconds(self._deadline))
-        except BaseException:
+        except Exception:
             return False
         return bool(self._outcome and self._outcome[0])
 

--- a/tldw_chatbook/Tools/workspace_tool_executor.py
+++ b/tldw_chatbook/Tools/workspace_tool_executor.py
@@ -18,6 +18,7 @@ from tldw_chatbook.STT.executor_process_tree import (
     WorkerContainmentIdentity,
 )
 from tldw_chatbook.Tools.local_tool_impls import resolve_workspace_path
+from tldw_chatbook.Tools.patch_tool_impls import parse_patch_targets
 from tldw_chatbook.Tools.workspace_tool_protocol import (
     MAX_RESPONSE_BYTES,
     WorkspaceProtocolError,
@@ -328,6 +329,36 @@ class WorkspaceToolExecutor:
                     if type(raw_pattern) is not str:
                         raise ValueError("invalid glob pattern")
                     normalized["pattern"] = _normalize_glob_pattern(raw_pattern)
+            if operation in {"fs_write", "fs_edit"} and type(arguments) is dict:
+                raw_path = arguments.get("path")
+                if type(raw_path) is not str:
+                    raise ValueError("invalid mutation path")
+                context = resolve_sensitive_context()
+                resolve_workspace_path(
+                    raw_path,
+                    chain.canonical_root,
+                    intent="write",
+                    context=context,
+                )
+                normalized["path"] = _normalize_relative_path(raw_path)
+            if operation == "fs_patch" and type(arguments) is dict:
+                raw_diff = arguments.get("diff")
+                if type(raw_diff) is not str:
+                    raise ValueError("invalid patch")
+                context = resolve_sensitive_context()
+                targets: list[str] = []
+                for patch_file in parse_patch_targets(raw_diff):
+                    rel_path = patch_file.new_path
+                    if rel_path is None:
+                        raise ValueError("invalid patch target")
+                    resolve_workspace_path(
+                        rel_path,
+                        chain.canonical_root,
+                        intent="write",
+                        context=context,
+                    )
+                    targets.append(_normalize_relative_path(rel_path))
+                normalized["targets"] = targets
             request = WorkspaceToolRequest(
                 operation_id=uuid.uuid4().hex,
                 operation=operation,  # type: ignore[arg-type]

--- a/tldw_chatbook/Tools/workspace_tool_protocol.py
+++ b/tldw_chatbook/Tools/workspace_tool_protocol.py
@@ -1,0 +1,399 @@
+"""Strict, bounded stdin/stdout protocol for one-shot workspace workers."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from tldw_chatbook.Tools.git_tool_impls import GIT_MAX_OUTPUT_BYTES
+from tldw_chatbook.Tools.patch_tool_impls import PATCH_MAX_BYTES
+from tldw_chatbook.Utils.filesystem_identity import DirectoryIdentity
+
+PROTOCOL_VERSION = 1
+MAX_REQUEST_BYTES = 16 * 1024 * 1024
+MAX_RESPONSE_BYTES = GIT_MAX_OUTPUT_BYTES + 64 * 1024
+MAX_STRING_BYTES = 15 * 1024 * 1024
+MAX_PATH_BYTES = 16 * 1024
+MAX_COLLECTION_ITEMS = 1_024
+MAX_JSON_DEPTH = 16
+
+WorkspaceOperation = Literal[
+    "fs_list",
+    "fs_read",
+    "fs_write",
+    "fs_edit",
+    "fs_patch",
+    "fs_glob",
+    "fs_grep",
+    "stat_path",
+    "git_status",
+    "git_diff",
+    "git_log",
+    "git_blame",
+    "git_branches",
+]
+WorkspaceIntent = Literal["read", "write"]
+WorkspaceResponseOutcome = Literal["admitted", "success", "failure"]
+
+_OPERATIONS = frozenset(
+    {
+        "fs_list",
+        "fs_read",
+        "fs_write",
+        "fs_edit",
+        "fs_patch",
+        "fs_glob",
+        "fs_grep",
+        "stat_path",
+        "git_status",
+        "git_diff",
+        "git_log",
+        "git_blame",
+        "git_branches",
+    }
+)
+_INTENTS = frozenset({"read", "write"})
+_OUTCOMES = frozenset({"admitted", "success", "failure"})
+_REQUEST_KEYS = frozenset(
+    {
+        "version",
+        "operation_id",
+        "operation",
+        "intent",
+        "root_locator",
+        "root_identity",
+        "ancestor_identities",
+        "arguments",
+        "timeout_seconds",
+        "output_max_bytes",
+    }
+)
+_RESPONSE_KEYS = frozenset(
+    {
+        "version",
+        "operation_id",
+        "outcome",
+        "code",
+        "result",
+        "error",
+        "elapsed_ms",
+        "truncated",
+        "cleanup_proven",
+    }
+)
+
+
+class WorkspaceProtocolError(ValueError):
+    """Raised for an invalid frame without reflecting private frame content."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceToolRequest:
+    """One immutable operation admitted to a pinned workspace worker."""
+
+    operation_id: str
+    operation: WorkspaceOperation
+    intent: WorkspaceIntent
+    root_locator: Path = field(repr=False)
+    root_identity: DirectoryIdentity
+    ancestor_identities: tuple[DirectoryIdentity, ...]
+    arguments: dict[str, Any] = field(repr=False)
+    timeout_seconds: int
+    output_max_bytes: int
+
+    @classmethod
+    def from_bytes(cls, raw: bytes) -> WorkspaceToolRequest:
+        """Parse one strict bounded request frame."""
+        payload = _load_object(raw, cap=MAX_REQUEST_BYTES, frame_name="request")
+        _require_exact_keys(payload, _REQUEST_KEYS)
+        _require_version(payload)
+        operation_id = _require_string(payload["operation_id"], "operation_id")
+        operation = _require_closed_string(payload["operation"], _OPERATIONS, "operation")
+        intent = _require_closed_string(payload["intent"], _INTENTS, "intent")
+        root_locator = _require_path(payload["root_locator"], "root_locator")
+        root_identity = _identity_from_payload(payload["root_identity"])
+        ancestors_value = payload["ancestor_identities"]
+        if type(ancestors_value) is not list or not ancestors_value:
+            raise WorkspaceProtocolError("ancestor_identities must be a non-empty array")
+        if len(ancestors_value) > MAX_COLLECTION_ITEMS:
+            raise WorkspaceProtocolError("ancestor_identities exceeds collection ceiling")
+        ancestors = tuple(_identity_from_payload(value) for value in ancestors_value)
+        arguments = _require_arguments(payload["arguments"])
+        timeout_seconds = _require_positive_int(payload["timeout_seconds"], "timeout_seconds")
+        output_max_bytes = _require_positive_int(
+            payload["output_max_bytes"], "output_max_bytes"
+        )
+        return cls(
+            operation_id=operation_id,
+            operation=operation,  # type: ignore[arg-type]
+            intent=intent,  # type: ignore[arg-type]
+            root_locator=Path(root_locator),
+            root_identity=root_identity,
+            ancestor_identities=ancestors,
+            arguments=arguments,
+            timeout_seconds=timeout_seconds,
+            output_max_bytes=output_max_bytes,
+        )
+
+    def to_bytes(self) -> bytes:
+        """Serialize a request only after applying the same admission checks."""
+        payload = {
+            "version": PROTOCOL_VERSION,
+            "operation_id": self.operation_id,
+            "operation": self.operation,
+            "intent": self.intent,
+            "root_locator": str(self.root_locator),
+            "root_identity": _identity_to_payload(self.root_identity),
+            "ancestor_identities": [
+                _identity_to_payload(identity) for identity in self.ancestor_identities
+            ],
+            "arguments": self.arguments,
+            "timeout_seconds": self.timeout_seconds,
+            "output_max_bytes": self.output_max_bytes,
+        }
+        validated = type(self).from_bytes(_encode_object(payload))
+        return _encode_object(
+            {
+                "version": PROTOCOL_VERSION,
+                "operation_id": validated.operation_id,
+                "operation": validated.operation,
+                "intent": validated.intent,
+                "root_locator": str(validated.root_locator),
+                "root_identity": _identity_to_payload(validated.root_identity),
+                "ancestor_identities": [
+                    _identity_to_payload(identity)
+                    for identity in validated.ancestor_identities
+                ],
+                "arguments": validated.arguments,
+                "timeout_seconds": validated.timeout_seconds,
+                "output_max_bytes": validated.output_max_bytes,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceToolResponse:
+    """One content-redacted worker status or terminal result frame."""
+
+    operation_id: str
+    outcome: WorkspaceResponseOutcome
+    code: str
+    result: str | None = field(repr=False)
+    error: str | None = field(repr=False)
+    elapsed_ms: int
+    truncated: bool
+    cleanup_proven: bool
+
+    @classmethod
+    def from_bytes(
+        cls, raw: bytes, *, expected_operation_id: str | None = None
+    ) -> WorkspaceToolResponse:
+        """Parse one strict bounded response frame."""
+        payload = _load_object(raw, cap=MAX_RESPONSE_BYTES, frame_name="response")
+        _require_exact_keys(payload, _RESPONSE_KEYS)
+        _require_version(payload)
+        operation_id = _require_string(payload["operation_id"], "operation_id")
+        if expected_operation_id is not None and operation_id != expected_operation_id:
+            raise WorkspaceProtocolError("response operation ID mismatch")
+        outcome = _require_closed_string(payload["outcome"], _OUTCOMES, "outcome")
+        code = _require_string(payload["code"], "code")
+        result = _require_optional_string(payload["result"], "result")
+        error = _require_optional_string(payload["error"], "error")
+        elapsed_ms = _require_nonnegative_int(payload["elapsed_ms"], "elapsed_ms")
+        if type(payload["truncated"]) is not bool:
+            raise WorkspaceProtocolError("truncated must be a bool")
+        if type(payload["cleanup_proven"]) is not bool:
+            raise WorkspaceProtocolError("cleanup_proven must be a bool")
+        if outcome == "success" and error is not None:
+            raise WorkspaceProtocolError("successful response cannot contain error")
+        if outcome == "failure" and result is not None:
+            raise WorkspaceProtocolError("failed response cannot contain result")
+        return cls(
+            operation_id=operation_id,
+            outcome=outcome,  # type: ignore[arg-type]
+            code=code,
+            result=result,
+            error=error,
+            elapsed_ms=elapsed_ms,
+            truncated=payload["truncated"],
+            cleanup_proven=payload["cleanup_proven"],
+        )
+
+    def to_bytes(self) -> bytes:
+        """Serialize a response only after applying the same frame contract."""
+        payload = {
+            "version": PROTOCOL_VERSION,
+            "operation_id": self.operation_id,
+            "outcome": self.outcome,
+            "code": self.code,
+            "result": self.result,
+            "error": self.error,
+            "elapsed_ms": self.elapsed_ms,
+            "truncated": self.truncated,
+            "cleanup_proven": self.cleanup_proven,
+        }
+        type(self).from_bytes(_encode_object(payload))
+        return _encode_object(payload)
+
+
+def _load_object(raw: bytes, *, cap: int, frame_name: str) -> dict[str, Any]:
+    if type(raw) is not bytes:
+        raise WorkspaceProtocolError(f"{frame_name} frame must be bytes")
+    if len(raw) > cap:
+        raise WorkspaceProtocolError(f"{frame_name} frame exceeds byte ceiling")
+    try:
+        decoded = raw.decode("utf-8", errors="strict")
+        value = json.loads(
+            decoded,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_non_finite,
+        )
+    except UnicodeDecodeError as error:
+        raise WorkspaceProtocolError(f"{frame_name} frame is not UTF-8") from error
+    except json.JSONDecodeError as error:
+        raise WorkspaceProtocolError(f"{frame_name} frame is malformed") from error
+    if type(value) is not dict:
+        raise WorkspaceProtocolError(f"{frame_name} frame must be an object")
+    return value
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise WorkspaceProtocolError("duplicate key in protocol frame")
+        value[key] = item
+    return value
+
+
+def _reject_non_finite(value: str) -> None:
+    raise WorkspaceProtocolError("non-finite JSON value")
+
+
+def _require_exact_keys(value: Mapping[str, Any], expected: frozenset[str]) -> None:
+    if set(value) != expected:
+        raise WorkspaceProtocolError("protocol frame has invalid keys")
+
+
+def _require_version(payload: Mapping[str, Any]) -> None:
+    if type(payload["version"]) is not int or payload["version"] != PROTOCOL_VERSION:
+        raise WorkspaceProtocolError("unsupported protocol version")
+
+
+def _require_string(value: Any, field_name: str, *, cap: int = MAX_STRING_BYTES) -> str:
+    if type(value) is not str:
+        raise WorkspaceProtocolError(f"{field_name} must be a string")
+    if "\x00" in value:
+        raise WorkspaceProtocolError(f"{field_name} contains NUL")
+    try:
+        byte_count = len(value.encode("utf-8", errors="strict"))
+    except UnicodeEncodeError as error:
+        raise WorkspaceProtocolError(f"{field_name} is not UTF-8 encodable") from error
+    if byte_count > cap:
+        raise WorkspaceProtocolError(f"{field_name} exceeds byte ceiling")
+    return value
+
+
+def _require_optional_string(value: Any, field_name: str) -> str | None:
+    if value is None:
+        return None
+    return _require_string(value, field_name)
+
+
+def _require_closed_string(value: Any, choices: frozenset[str], field_name: str) -> str:
+    text = _require_string(value, field_name)
+    if text not in choices:
+        raise WorkspaceProtocolError(f"unsupported {field_name}")
+    return text
+
+
+def _require_path(value: Any, field_name: str) -> str:
+    return _require_string(value, field_name, cap=MAX_PATH_BYTES)
+
+
+def _require_positive_int(value: Any, field_name: str) -> int:
+    if type(value) is not int or value <= 0:
+        raise WorkspaceProtocolError(f"{field_name} must be a positive int")
+    return value
+
+
+def _require_nonnegative_int(value: Any, field_name: str) -> int:
+    if type(value) is not int or value < 0:
+        raise WorkspaceProtocolError(f"{field_name} must be a non-negative int")
+    return value
+
+
+def _identity_to_payload(identity: DirectoryIdentity) -> dict[str, int | bool]:
+    return {
+        "device": identity.device,
+        "inode": identity.inode,
+        "mode": identity.mode,
+        "reparse": identity.reparse,
+    }
+
+
+def _identity_from_payload(value: Any) -> DirectoryIdentity:
+    if type(value) is not dict or set(value) != {
+        "device",
+        "inode",
+        "mode",
+        "reparse",
+    }:
+        raise WorkspaceProtocolError("invalid directory identity")
+    device = _require_nonnegative_int(value["device"], "identity.device")
+    inode = _require_nonnegative_int(value["inode"], "identity.inode")
+    mode = _require_nonnegative_int(value["mode"], "identity.mode")
+    if type(value["reparse"]) is not bool:
+        raise WorkspaceProtocolError("identity.reparse must be a bool")
+    return DirectoryIdentity(device=device, inode=inode, mode=mode, reparse=value["reparse"])
+
+
+def _require_arguments(value: Any) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise WorkspaceProtocolError("arguments must be an object")
+    _validate_json_value(value, field_name="arguments", depth=0)
+    return value
+
+
+def _validate_json_value(value: Any, *, field_name: str, depth: int) -> None:
+    if depth > MAX_JSON_DEPTH:
+        raise WorkspaceProtocolError("arguments exceed nesting ceiling")
+    if value is None or type(value) is bool or type(value) is int:
+        return
+    if type(value) is float:
+        raise WorkspaceProtocolError("arguments cannot contain float values")
+    if type(value) is str:
+        cap = PATCH_MAX_BYTES if field_name.endswith("patch") else MAX_STRING_BYTES
+        if field_name == "path" or field_name.endswith("_path"):
+            cap = MAX_PATH_BYTES
+        _require_string(value, field_name, cap=cap)
+        return
+    if type(value) is list:
+        if len(value) > MAX_COLLECTION_ITEMS:
+            raise WorkspaceProtocolError("arguments exceed collection ceiling")
+        for item in value:
+            _validate_json_value(item, field_name=field_name, depth=depth + 1)
+        return
+    if type(value) is dict:
+        if len(value) > MAX_COLLECTION_ITEMS:
+            raise WorkspaceProtocolError("arguments exceed collection ceiling")
+        for key, item in value.items():
+            key = _require_string(key, "argument key", cap=MAX_PATH_BYTES)
+            _validate_json_value(item, field_name=key, depth=depth + 1)
+        return
+    raise WorkspaceProtocolError("arguments contain unsupported value")
+
+
+def _encode_object(value: Mapping[str, Any]) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8", errors="strict")
+    except (TypeError, ValueError, UnicodeEncodeError) as error:
+        raise WorkspaceProtocolError("protocol frame cannot be serialized") from error

--- a/tldw_chatbook/Tools/workspace_tool_protocol.py
+++ b/tldw_chatbook/Tools/workspace_tool_protocol.py
@@ -92,7 +92,7 @@ _ARGUMENT_SCHEMAS: dict[str, tuple[frozenset[str], dict[str, str]]] = {
     ),
     "fs_read": (
         frozenset({"path", "sensitive_exclusions"}),
-        {"path": "path", "offset": "positive_int", "limit": "positive_int", "sensitive_exclusions": "sensitive_exclusions"},
+        {"path": "path", "offset": "positive_int", "limit": "nonnegative_int", "sensitive_exclusions": "sensitive_exclusions"},
     ),
     "fs_write": (
         frozenset({"path", "content", "sensitive_exclusions"}),
@@ -477,6 +477,9 @@ def _require_argument_value(value: Any, *, kind: str) -> None:
         return
     if kind == "positive_int":
         _require_positive_int(value, "argument")
+        return
+    if kind == "nonnegative_int":
+        _require_nonnegative_int(value, "argument")
         return
     if kind == "grep_mode":
         mode = _require_string(value, "grep mode")

--- a/tldw_chatbook/Tools/workspace_tool_protocol.py
+++ b/tldw_chatbook/Tools/workspace_tool_protocol.py
@@ -86,10 +86,13 @@ _RESPONSE_KEYS = frozenset(
 )
 
 _ARGUMENT_SCHEMAS: dict[str, tuple[frozenset[str], dict[str, str]]] = {
-    "fs_list": (frozenset({"path"}), {"path": "path"}),
+    "fs_list": (
+        frozenset({"path", "sensitive_exclusions"}),
+        {"path": "path", "sensitive_exclusions": "sensitive_exclusions"},
+    ),
     "fs_read": (
-        frozenset({"path"}),
-        {"path": "path", "offset": "positive_int", "limit": "positive_int"},
+        frozenset({"path", "sensitive_exclusions"}),
+        {"path": "path", "offset": "positive_int", "limit": "positive_int", "sensitive_exclusions": "sensitive_exclusions"},
     ),
     "fs_write": (
         frozenset({"path", "content"}),
@@ -106,12 +109,12 @@ _ARGUMENT_SCHEMAS: dict[str, tuple[frozenset[str], dict[str, str]]] = {
     ),
     "fs_patch": (frozenset({"diff"}), {"diff": "patch", "dry_run": "bool"}),
     "fs_glob": (
-        frozenset({"pattern"}),
-        {"pattern": "text", "max_results": "positive_int"},
+        frozenset({"pattern", "sensitive_exclusions"}),
+        {"pattern": "text", "max_results": "positive_int", "sensitive_exclusions": "sensitive_exclusions"},
     ),
     "fs_grep": (
-        frozenset({"pattern"}),
-        {"pattern": "text", "mode": "grep_mode", "max_results": "positive_int"},
+        frozenset({"pattern", "sensitive_exclusions", "content_exclusions"}),
+        {"pattern": "text", "mode": "grep_mode", "max_results": "positive_int", "sensitive_exclusions": "sensitive_exclusions", "content_exclusions": "sensitive_exclusions"},
     ),
     "stat_path": (frozenset({"path"}), {"path": "path"}),
     "git_status": (frozenset(), {"path": "path"}),
@@ -433,6 +436,21 @@ def _require_argument_value(value: Any, *, kind: str) -> None:
         mode = _require_string(value, "grep mode")
         if mode not in {"content", "files", "count"}:
             raise WorkspaceProtocolError("invalid grep mode")
+        return
+    if kind == "sensitive_exclusions":
+        if type(value) is not list or len(value) > MAX_COLLECTION_ITEMS:
+            raise WorkspaceProtocolError("invalid sensitive exclusions")
+        for exclusion in value:
+            if type(exclusion) is not dict or set(exclusion) != {"kind", "value"}:
+                raise WorkspaceProtocolError("invalid sensitive exclusions")
+            kind_value = _require_closed_string(
+                exclusion["kind"],
+                frozenset({"subtree", "file", "direct_children", "name"}),
+                "sensitive exclusion kind",
+            )
+            text = _require_path(exclusion["value"], "sensitive exclusion value")
+            if "\x00" in text or (kind_value == "name" and ("/" in text or "\\" in text)):
+                raise WorkspaceProtocolError("invalid sensitive exclusions")
         return
     raise WorkspaceProtocolError("invalid argument schema")
 

--- a/tldw_chatbook/Tools/workspace_tool_protocol.py
+++ b/tldw_chatbook/Tools/workspace_tool_protocol.py
@@ -16,7 +16,10 @@ from tldw_chatbook.Utils.filesystem_identity import DirectoryIdentity
 
 PROTOCOL_VERSION = 1
 MAX_REQUEST_BYTES = 16 * 1024 * 1024
-MAX_RESPONSE_BYTES = GIT_MAX_OUTPUT_BYTES + 64 * 1024
+# JSON may encode one control byte as six ASCII bytes (``\u00xx``). Keep the
+# frame bounded while guaranteeing that any result accepted by Git's raw byte
+# ceiling plus fixed protocol metadata can cross the response boundary.
+MAX_RESPONSE_BYTES = (GIT_MAX_OUTPUT_BYTES * 6) + (64 * 1024)
 MAX_STRING_BYTES = 15 * 1024 * 1024
 MAX_PATH_BYTES = 16 * 1024
 MAX_COLLECTION_ITEMS = 1_024

--- a/tldw_chatbook/Tools/workspace_tool_protocol.py
+++ b/tldw_chatbook/Tools/workspace_tool_protocol.py
@@ -130,17 +130,41 @@ _ARGUMENT_SCHEMAS: dict[str, tuple[frozenset[str], dict[str, str]]] = {
         {"pattern": "text", "mode": "grep_mode", "max_results": "positive_int", "sensitive_exclusions": "sensitive_exclusions", "content_exclusions": "sensitive_exclusions"},
     ),
     "stat_path": (frozenset({"path"}), {"path": "path"}),
-    "git_status": (frozenset(), {"path": "path"}),
+    "git_status": (
+        frozenset({"sensitive_exclusions"}),
+        {"path": "path", "sensitive_exclusions": "sensitive_exclusions"},
+    ),
     "git_diff": (
-        frozenset(),
-        {"staged": "bool", "commit_range": "text", "path": "path", "stat": "bool"},
+        frozenset({"sensitive_exclusions"}),
+        {
+            "staged": "bool",
+            "commit_range": "text",
+            "path": "path",
+            "stat": "bool",
+            "sensitive_exclusions": "sensitive_exclusions",
+        },
     ),
-    "git_log": (frozenset(), {"count": "positive_int", "path": "path"}),
+    "git_log": (
+        frozenset({"sensitive_exclusions"}),
+        {
+            "count": "positive_int",
+            "path": "path",
+            "sensitive_exclusions": "sensitive_exclusions",
+        },
+    ),
     "git_blame": (
-        frozenset({"path"}),
-        {"path": "path", "start_line": "positive_int", "end_line": "positive_int"},
+        frozenset({"path", "sensitive_exclusions"}),
+        {
+            "path": "path",
+            "start_line": "positive_int",
+            "end_line": "positive_int",
+            "sensitive_exclusions": "sensitive_exclusions",
+        },
     ),
-    "git_branches": (frozenset(), {}),
+    "git_branches": (
+        frozenset({"sensitive_exclusions"}),
+        {"sensitive_exclusions": "sensitive_exclusions"},
+    ),
 }
 _EXPECTED_INTENTS = {
     operation: ("write" if operation in {"fs_write", "fs_edit", "fs_patch"} else "read")

--- a/tldw_chatbook/Tools/workspace_tool_protocol.py
+++ b/tldw_chatbook/Tools/workspace_tool_protocol.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from tldw_chatbook.Tools.git_tool_impls import GIT_MAX_OUTPUT_BYTES
-from tldw_chatbook.Tools.patch_tool_impls import PATCH_MAX_BYTES
+from tldw_chatbook.Tools.patch_tool_impls import PATCH_MAX_BYTES, PATCH_MAX_FILES
 from tldw_chatbook.Utils.filesystem_identity import DirectoryIdentity
 
 PROTOCOL_VERSION = 1
@@ -107,7 +107,10 @@ _ARGUMENT_SCHEMAS: dict[str, tuple[frozenset[str], dict[str, str]]] = {
             "replace_all": "bool",
         },
     ),
-    "fs_patch": (frozenset({"diff"}), {"diff": "patch", "dry_run": "bool"}),
+    "fs_patch": (
+        frozenset({"diff"}),
+        {"diff": "patch", "dry_run": "bool", "targets": "patch_targets"},
+    ),
     "fs_glob": (
         frozenset({"pattern", "sensitive_exclusions"}),
         {"pattern": "glob_pattern", "max_results": "positive_int", "sensitive_exclusions": "sensitive_exclusions"},
@@ -427,6 +430,12 @@ def _require_argument_value(value: Any, *, kind: str) -> None:
         return
     if kind == "patch":
         _require_string(value, "patch diff", cap=PATCH_MAX_BYTES)
+        return
+    if kind == "patch_targets":
+        if type(value) is not list or not value or len(value) > PATCH_MAX_FILES:
+            raise WorkspaceProtocolError("invalid patch targets")
+        for target in value:
+            _require_path(target, "patch target")
         return
     if kind == "bool":
         if type(value) is not bool:

--- a/tldw_chatbook/Tools/workspace_tool_protocol.py
+++ b/tldw_chatbook/Tools/workspace_tool_protocol.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
 from tldw_chatbook.Tools.git_tool_impls import GIT_MAX_OUTPUT_BYTES
 from tldw_chatbook.Tools.patch_tool_impls import PATCH_MAX_BYTES, PATCH_MAX_FILES
 from tldw_chatbook.Utils.filesystem_identity import DirectoryIdentity
@@ -172,6 +174,53 @@ _EXPECTED_INTENTS = {
 }
 
 
+class _DirectoryIdentityFrame(BaseModel):
+    """Strict typed directory identity at the JSON message boundary."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    device: int
+    inode: int
+    mode: int
+    reparse: bool
+
+
+class _RequestFrame(BaseModel):
+    """Strict typed request decoded before domain construction."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    version: int
+    operation_id: str
+    operation: WorkspaceOperation
+    intent: WorkspaceIntent
+    root_locator: str
+    root_identity: _DirectoryIdentityFrame
+    ancestor_identities: list[_DirectoryIdentityFrame] = Field(
+        min_length=1,
+        max_length=MAX_COLLECTION_ITEMS,
+    )
+    arguments: dict[str, Any]
+    timeout_seconds: int
+    output_max_bytes: int
+
+
+class _ResponseFrame(BaseModel):
+    """Strict typed response decoded before domain construction."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    version: int
+    operation_id: str
+    outcome: WorkspaceResponseOutcome
+    code: str
+    result: str | None
+    error: str | None
+    elapsed_ms: int
+    truncated: bool
+    cleanup_proven: bool
+
+
 class WorkspaceProtocolError(ValueError):
     """Raised for an invalid frame without reflecting private frame content."""
 
@@ -195,24 +244,26 @@ class WorkspaceToolRequest:
         """Parse one strict bounded request frame."""
         payload = _load_object(raw, cap=MAX_REQUEST_BYTES, frame_name="request")
         _require_exact_keys(payload, _REQUEST_KEYS)
-        _require_version(payload)
-        operation_id = _require_string(payload["operation_id"], "operation_id")
-        operation = _require_closed_string(payload["operation"], _OPERATIONS, "operation")
-        intent = _require_closed_string(payload["intent"], _INTENTS, "intent")
-        root_locator = _require_path(payload["root_locator"], "root_locator")
-        root_identity = _identity_from_payload(payload["root_identity"])
-        ancestors_value = payload["ancestor_identities"]
-        if type(ancestors_value) is not list or not ancestors_value:
+        frame = _validate_request_frame(payload)
+        _require_version(frame.version)
+        operation_id = _require_string(frame.operation_id, "operation_id")
+        operation = _require_closed_string(frame.operation, _OPERATIONS, "operation")
+        intent = _require_closed_string(frame.intent, _INTENTS, "intent")
+        root_locator = _require_path(frame.root_locator, "root_locator")
+        root_identity = _identity_from_frame(frame.root_identity)
+        if not frame.ancestor_identities:
             raise WorkspaceProtocolError("ancestor_identities must be a non-empty array")
-        if len(ancestors_value) > MAX_COLLECTION_ITEMS:
+        if len(frame.ancestor_identities) > MAX_COLLECTION_ITEMS:
             raise WorkspaceProtocolError("ancestor_identities exceeds collection ceiling")
-        ancestors = tuple(_identity_from_payload(value) for value in ancestors_value)
+        ancestors = tuple(
+            _identity_from_frame(value) for value in frame.ancestor_identities
+        )
         if intent != _EXPECTED_INTENTS[operation]:
             raise WorkspaceProtocolError("operation intent mismatch")
-        arguments = _require_arguments(payload["arguments"], operation=operation)
-        timeout_seconds = _require_positive_int(payload["timeout_seconds"], "timeout_seconds")
+        arguments = _require_arguments(frame.arguments, operation=operation)
+        timeout_seconds = _require_positive_int(frame.timeout_seconds, "timeout_seconds")
         output_max_bytes = _require_positive_int(
-            payload["output_max_bytes"], "output_max_bytes"
+            frame.output_max_bytes, "output_max_bytes"
         )
         return cls(
             operation_id=operation_id,
@@ -282,19 +333,16 @@ class WorkspaceToolResponse:
         """Parse one strict bounded response frame."""
         payload = _load_object(raw, cap=MAX_RESPONSE_BYTES, frame_name="response")
         _require_exact_keys(payload, _RESPONSE_KEYS)
-        _require_version(payload)
-        operation_id = _require_string(payload["operation_id"], "operation_id")
+        frame = _validate_response_frame(payload)
+        _require_version(frame.version)
+        operation_id = _require_string(frame.operation_id, "operation_id")
         if expected_operation_id is not None and operation_id != expected_operation_id:
             raise WorkspaceProtocolError("response operation ID mismatch")
-        outcome = _require_closed_string(payload["outcome"], _OUTCOMES, "outcome")
-        code = _require_string(payload["code"], "code")
-        result = _require_optional_string(payload["result"], "result")
-        error = _require_optional_string(payload["error"], "error")
-        elapsed_ms = _require_nonnegative_int(payload["elapsed_ms"], "elapsed_ms")
-        if type(payload["truncated"]) is not bool:
-            raise WorkspaceProtocolError("truncated must be a bool")
-        if type(payload["cleanup_proven"]) is not bool:
-            raise WorkspaceProtocolError("cleanup_proven must be a bool")
+        outcome = _require_closed_string(frame.outcome, _OUTCOMES, "outcome")
+        code = _require_string(frame.code, "code")
+        result = _require_optional_string(frame.result, "result")
+        error = _require_optional_string(frame.error, "error")
+        elapsed_ms = _require_nonnegative_int(frame.elapsed_ms, "elapsed_ms")
         if outcome == "success" and error is not None:
             raise WorkspaceProtocolError("successful response cannot contain error")
         if outcome == "failure" and result is not None:
@@ -306,8 +354,8 @@ class WorkspaceToolResponse:
             result=result,
             error=error,
             elapsed_ms=elapsed_ms,
-            truncated=payload["truncated"],
-            cleanup_proven=payload["cleanup_proven"],
+            truncated=frame.truncated,
+            cleanup_proven=frame.cleanup_proven,
         )
 
     def to_bytes(self) -> bytes:
@@ -368,8 +416,22 @@ def _require_exact_keys(value: Mapping[str, Any], expected: frozenset[str]) -> N
         raise WorkspaceProtocolError("protocol frame has invalid keys")
 
 
-def _require_version(payload: Mapping[str, Any]) -> None:
-    if type(payload["version"]) is not int or payload["version"] != PROTOCOL_VERSION:
+def _validate_request_frame(payload: Mapping[str, Any]) -> _RequestFrame:
+    try:
+        return _RequestFrame.model_validate(payload)
+    except ValidationError:
+        raise WorkspaceProtocolError("request frame validation failed") from None
+
+
+def _validate_response_frame(payload: Mapping[str, Any]) -> _ResponseFrame:
+    try:
+        return _ResponseFrame.model_validate(payload)
+    except ValidationError:
+        raise WorkspaceProtocolError("response frame validation failed") from None
+
+
+def _require_version(value: int) -> None:
+    if value != PROTOCOL_VERSION:
         raise WorkspaceProtocolError("unsupported protocol version")
 
 
@@ -425,20 +487,13 @@ def _identity_to_payload(identity: DirectoryIdentity) -> dict[str, int | bool]:
     }
 
 
-def _identity_from_payload(value: Any) -> DirectoryIdentity:
-    if type(value) is not dict or set(value) != {
-        "device",
-        "inode",
-        "mode",
-        "reparse",
-    }:
-        raise WorkspaceProtocolError("invalid directory identity")
-    device = _require_nonnegative_int(value["device"], "identity.device")
-    inode = _require_nonnegative_int(value["inode"], "identity.inode")
-    mode = _require_nonnegative_int(value["mode"], "identity.mode")
-    if type(value["reparse"]) is not bool:
-        raise WorkspaceProtocolError("identity.reparse must be a bool")
-    return DirectoryIdentity(device=device, inode=inode, mode=mode, reparse=value["reparse"])
+def _identity_from_frame(value: _DirectoryIdentityFrame) -> DirectoryIdentity:
+    return DirectoryIdentity(
+        device=_require_nonnegative_int(value.device, "identity.device"),
+        inode=_require_nonnegative_int(value.inode, "identity.inode"),
+        mode=_require_nonnegative_int(value.mode, "identity.mode"),
+        reparse=value.reparse,
+    )
 
 
 def _require_arguments(value: Any, *, operation: str) -> dict[str, Any]:

--- a/tldw_chatbook/Tools/workspace_tool_protocol.py
+++ b/tldw_chatbook/Tools/workspace_tool_protocol.py
@@ -460,6 +460,10 @@ def _require_argument_value(value: Any, *, kind: str) -> None:
 
 def validate_glob_pattern(value: Any) -> str:
     """Validate a platform-neutral, root-relative glob grammar."""
+    if type(value) is not str:
+        raise WorkspaceProtocolError("glob pattern must be a string")
+    if "\x00" in value:
+        raise WorkspaceProtocolError("invalid glob pattern")
     pattern = _require_string(value, "glob pattern")
     windows = Path(pattern.replace("\\", "/"))
     if (

--- a/tldw_chatbook/Tools/workspace_tool_protocol.py
+++ b/tldw_chatbook/Tools/workspace_tool_protocol.py
@@ -85,6 +85,52 @@ _RESPONSE_KEYS = frozenset(
     }
 )
 
+_ARGUMENT_SCHEMAS: dict[str, tuple[frozenset[str], dict[str, str]]] = {
+    "fs_list": (frozenset({"path"}), {"path": "path"}),
+    "fs_read": (
+        frozenset({"path"}),
+        {"path": "path", "offset": "positive_int", "limit": "positive_int"},
+    ),
+    "fs_write": (
+        frozenset({"path", "content"}),
+        {"path": "path", "content": "text"},
+    ),
+    "fs_edit": (
+        frozenset({"path", "old_string", "new_string"}),
+        {
+            "path": "path",
+            "old_string": "text",
+            "new_string": "text",
+            "replace_all": "bool",
+        },
+    ),
+    "fs_patch": (frozenset({"diff"}), {"diff": "patch", "dry_run": "bool"}),
+    "fs_glob": (
+        frozenset({"pattern"}),
+        {"pattern": "text", "max_results": "positive_int"},
+    ),
+    "fs_grep": (
+        frozenset({"pattern"}),
+        {"pattern": "text", "mode": "grep_mode", "max_results": "positive_int"},
+    ),
+    "stat_path": (frozenset({"path"}), {"path": "path"}),
+    "git_status": (frozenset(), {"path": "path"}),
+    "git_diff": (
+        frozenset(),
+        {"staged": "bool", "commit_range": "text", "path": "path", "stat": "bool"},
+    ),
+    "git_log": (frozenset(), {"count": "positive_int", "path": "path"}),
+    "git_blame": (
+        frozenset({"path"}),
+        {"path": "path", "start_line": "positive_int", "end_line": "positive_int"},
+    ),
+    "git_branches": (frozenset(), {}),
+}
+_EXPECTED_INTENTS = {
+    operation: ("write" if operation in {"fs_write", "fs_edit", "fs_patch"} else "read")
+    for operation in _OPERATIONS
+}
+
 
 class WorkspaceProtocolError(ValueError):
     """Raised for an invalid frame without reflecting private frame content."""
@@ -121,7 +167,9 @@ class WorkspaceToolRequest:
         if len(ancestors_value) > MAX_COLLECTION_ITEMS:
             raise WorkspaceProtocolError("ancestor_identities exceeds collection ceiling")
         ancestors = tuple(_identity_from_payload(value) for value in ancestors_value)
-        arguments = _require_arguments(payload["arguments"])
+        if intent != _EXPECTED_INTENTS[operation]:
+            raise WorkspaceProtocolError("operation intent mismatch")
+        arguments = _require_arguments(payload["arguments"], operation=operation)
         timeout_seconds = _require_positive_int(payload["timeout_seconds"], "timeout_seconds")
         output_max_bytes = _require_positive_int(
             payload["output_max_bytes"], "output_max_bytes"
@@ -251,9 +299,11 @@ def _load_object(raw: bytes, *, cap: int, frame_name: str) -> dict[str, Any]:
             object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_non_finite,
         )
+    except WorkspaceProtocolError:
+        raise
     except UnicodeDecodeError as error:
         raise WorkspaceProtocolError(f"{frame_name} frame is not UTF-8") from error
-    except json.JSONDecodeError as error:
+    except (json.JSONDecodeError, ValueError) as error:
         raise WorkspaceProtocolError(f"{frame_name} frame is malformed") from error
     if type(value) is not dict:
         raise WorkspaceProtocolError(f"{frame_name} frame must be an object")
@@ -351,40 +401,40 @@ def _identity_from_payload(value: Any) -> DirectoryIdentity:
     return DirectoryIdentity(device=device, inode=inode, mode=mode, reparse=value["reparse"])
 
 
-def _require_arguments(value: Any) -> dict[str, Any]:
+def _require_arguments(value: Any, *, operation: str) -> dict[str, Any]:
     if type(value) is not dict:
         raise WorkspaceProtocolError("arguments must be an object")
-    _validate_json_value(value, field_name="arguments", depth=0)
+    required, accepted = _ARGUMENT_SCHEMAS[operation]
+    if not required.issubset(value) or not set(value).issubset(accepted):
+        raise WorkspaceProtocolError("invalid operation arguments")
+    for key, argument in value.items():
+        _require_argument_value(argument, kind=accepted[key])
     return value
 
 
-def _validate_json_value(value: Any, *, field_name: str, depth: int) -> None:
-    if depth > MAX_JSON_DEPTH:
-        raise WorkspaceProtocolError("arguments exceed nesting ceiling")
-    if value is None or type(value) is bool or type(value) is int:
+def _require_argument_value(value: Any, *, kind: str) -> None:
+    if kind == "path":
+        _require_string(value, "argument path", cap=MAX_PATH_BYTES)
         return
-    if type(value) is float:
-        raise WorkspaceProtocolError("arguments cannot contain float values")
-    if type(value) is str:
-        cap = PATCH_MAX_BYTES if field_name.endswith("patch") else MAX_STRING_BYTES
-        if field_name == "path" or field_name.endswith("_path"):
-            cap = MAX_PATH_BYTES
-        _require_string(value, field_name, cap=cap)
+    if kind == "text":
+        _require_string(value, "argument text")
         return
-    if type(value) is list:
-        if len(value) > MAX_COLLECTION_ITEMS:
-            raise WorkspaceProtocolError("arguments exceed collection ceiling")
-        for item in value:
-            _validate_json_value(item, field_name=field_name, depth=depth + 1)
+    if kind == "patch":
+        _require_string(value, "patch diff", cap=PATCH_MAX_BYTES)
         return
-    if type(value) is dict:
-        if len(value) > MAX_COLLECTION_ITEMS:
-            raise WorkspaceProtocolError("arguments exceed collection ceiling")
-        for key, item in value.items():
-            key = _require_string(key, "argument key", cap=MAX_PATH_BYTES)
-            _validate_json_value(item, field_name=key, depth=depth + 1)
+    if kind == "bool":
+        if type(value) is not bool:
+            raise WorkspaceProtocolError("argument must be a bool")
         return
-    raise WorkspaceProtocolError("arguments contain unsupported value")
+    if kind == "positive_int":
+        _require_positive_int(value, "argument")
+        return
+    if kind == "grep_mode":
+        mode = _require_string(value, "grep mode")
+        if mode not in {"content", "files", "count"}:
+            raise WorkspaceProtocolError("invalid grep mode")
+        return
+    raise WorkspaceProtocolError("invalid argument schema")
 
 
 def _encode_object(value: Mapping[str, Any]) -> bytes:

--- a/tldw_chatbook/Tools/workspace_tool_protocol.py
+++ b/tldw_chatbook/Tools/workspace_tool_protocol.py
@@ -110,7 +110,7 @@ _ARGUMENT_SCHEMAS: dict[str, tuple[frozenset[str], dict[str, str]]] = {
     "fs_patch": (frozenset({"diff"}), {"diff": "patch", "dry_run": "bool"}),
     "fs_glob": (
         frozenset({"pattern", "sensitive_exclusions"}),
-        {"pattern": "text", "max_results": "positive_int", "sensitive_exclusions": "sensitive_exclusions"},
+        {"pattern": "glob_pattern", "max_results": "positive_int", "sensitive_exclusions": "sensitive_exclusions"},
     ),
     "fs_grep": (
         frozenset({"pattern", "sensitive_exclusions", "content_exclusions"}),
@@ -422,6 +422,9 @@ def _require_argument_value(value: Any, *, kind: str) -> None:
     if kind == "text":
         _require_string(value, "argument text")
         return
+    if kind == "glob_pattern":
+        validate_glob_pattern(value)
+        return
     if kind == "patch":
         _require_string(value, "patch diff", cap=PATCH_MAX_BYTES)
         return
@@ -453,6 +456,20 @@ def _require_argument_value(value: Any, *, kind: str) -> None:
                 raise WorkspaceProtocolError("invalid sensitive exclusions")
         return
     raise WorkspaceProtocolError("invalid argument schema")
+
+
+def validate_glob_pattern(value: Any) -> str:
+    """Validate a platform-neutral, root-relative glob grammar."""
+    pattern = _require_string(value, "glob pattern")
+    windows = Path(pattern.replace("\\", "/"))
+    if (
+        pattern.startswith(("/", "\\"))
+        or ":" in pattern.split("/")[0]
+        or any(part == ".." for part in pattern.replace("\\", "/").split("/"))
+        or windows.is_absolute()
+    ):
+        raise WorkspaceProtocolError("invalid glob pattern")
+    return pattern
 
 
 def _encode_object(value: Mapping[str, Any]) -> bytes:

--- a/tldw_chatbook/Tools/workspace_tool_protocol.py
+++ b/tldw_chatbook/Tools/workspace_tool_protocol.py
@@ -95,21 +95,31 @@ _ARGUMENT_SCHEMAS: dict[str, tuple[frozenset[str], dict[str, str]]] = {
         {"path": "path", "offset": "positive_int", "limit": "positive_int", "sensitive_exclusions": "sensitive_exclusions"},
     ),
     "fs_write": (
-        frozenset({"path", "content"}),
-        {"path": "path", "content": "text"},
+        frozenset({"path", "content", "sensitive_exclusions"}),
+        {
+            "path": "path",
+            "content": "text",
+            "sensitive_exclusions": "sensitive_exclusions",
+        },
     ),
     "fs_edit": (
-        frozenset({"path", "old_string", "new_string"}),
+        frozenset({"path", "old_string", "new_string", "sensitive_exclusions"}),
         {
             "path": "path",
             "old_string": "text",
             "new_string": "text",
             "replace_all": "bool",
+            "sensitive_exclusions": "sensitive_exclusions",
         },
     ),
     "fs_patch": (
-        frozenset({"diff"}),
-        {"diff": "patch", "dry_run": "bool", "targets": "patch_targets"},
+        frozenset({"diff", "sensitive_exclusions"}),
+        {
+            "diff": "patch",
+            "dry_run": "bool",
+            "targets": "patch_targets",
+            "sensitive_exclusions": "sensitive_exclusions",
+        },
     ),
     "fs_glob": (
         frozenset({"pattern", "sensitive_exclusions"}),

--- a/tldw_chatbook/Tools/workspace_tool_worker.py
+++ b/tldw_chatbook/Tools/workspace_tool_worker.py
@@ -1,0 +1,132 @@
+"""Fixed one-shot stdin/stdout worker for pinned workspace operations."""
+
+from __future__ import annotations
+
+import sys
+import time
+from typing import BinaryIO
+
+from tldw_chatbook.Tools.workspace_root_pin import (
+    WorkspaceRootPinError,
+    pin_workspace_root,
+)
+from tldw_chatbook.Tools.workspace_tool_dispatch import (
+    WorkspaceToolDispatchError,
+    execute_pinned_operation,
+)
+from tldw_chatbook.Tools.workspace_tool_protocol import (
+    MAX_REQUEST_BYTES,
+    WorkspaceProtocolError,
+    WorkspaceToolRequest,
+    WorkspaceToolResponse,
+)
+from tldw_chatbook.Utils.filesystem_identity import DirectoryChain
+
+
+def run_workspace_worker(
+    stdin: BinaryIO,
+    stdout: BinaryIO,
+    stderr: BinaryIO,
+) -> int:
+    """Read, pin, dispatch, respond once, and return a process exit code."""
+    del stderr  # Reserved for fixed diagnostics; no request-derived text is written.
+    started = time.monotonic()
+    raw = stdin.read(MAX_REQUEST_BYTES + 1)
+    if len(raw) > MAX_REQUEST_BYTES:
+        _emit(stdout, _failure("unknown", "invalid_request", started))
+        return 2
+    try:
+        request = WorkspaceToolRequest.from_bytes(raw)
+    except WorkspaceProtocolError:
+        _emit(stdout, _failure("unknown", "invalid_request", started))
+        return 2
+
+    chain = DirectoryChain(
+        canonical_root=request.root_locator,
+        identities=(request.root_identity, *request.ancestor_identities[1:]),
+    )
+    try:
+        with pin_workspace_root(request.root_locator, chain) as root:
+            _emit(
+                stdout,
+                WorkspaceToolResponse(
+                    operation_id=request.operation_id,
+                    outcome="admitted",
+                    code="root_pinned",
+                    result=None,
+                    error=None,
+                    elapsed_ms=_elapsed_ms(started),
+                    truncated=False,
+                    cleanup_proven=True,
+                ),
+            )
+            result = execute_pinned_operation(request, root)
+        _emit(
+            stdout,
+            WorkspaceToolResponse(
+                operation_id=request.operation_id,
+                outcome="success",
+                code="ok",
+                result=result,
+                error=None,
+                elapsed_ms=_elapsed_ms(started),
+                truncated=False,
+                cleanup_proven=True,
+            ),
+        )
+        return 0
+    except WorkspaceToolDispatchError as error:
+        _emit(
+            stdout,
+            _failure(request.operation_id, error.code, started, message=str(error)),
+        )
+        return 2
+    except WorkspaceRootPinError:
+        _emit(stdout, _failure(request.operation_id, "root_pin_failed", started))
+        return 2
+    except (OSError, ValueError):
+        _emit(stdout, _failure(request.operation_id, "tool_failure", started))
+        return 2
+    except BaseException:
+        _emit(stdout, _failure(request.operation_id, "worker_failure", started))
+        return 2
+
+
+def _failure(
+    operation_id: str,
+    code: str,
+    started: float,
+    *,
+    message: str = "workspace operation failed",
+) -> WorkspaceToolResponse:
+    return WorkspaceToolResponse(
+        operation_id=operation_id,
+        outcome="failure",
+        code=code,
+        result=None,
+        error=message,
+        elapsed_ms=_elapsed_ms(started),
+        truncated=False,
+        cleanup_proven=True,
+    )
+
+
+def _elapsed_ms(started: float) -> int:
+    return max(0, int((time.monotonic() - started) * 1_000))
+
+
+def _emit(stdout: BinaryIO, response: WorkspaceToolResponse) -> None:
+    stdout.write(response.to_bytes() + b"\n")
+    stdout.flush()
+
+
+def main() -> int:
+    """Run one isolated protocol exchange on standard streams."""
+    return run_workspace_worker(sys.stdin.buffer, sys.stdout.buffer, sys.stderr.buffer)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["main", "run_workspace_worker"]

--- a/tldw_chatbook/Tools/workspace_tool_worker.py
+++ b/tldw_chatbook/Tools/workspace_tool_worker.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import sys
 import time
+import unicodedata
 from typing import BinaryIO
 
+from tldw_chatbook.Tools.local_tool_impls import LocalToolError
 from tldw_chatbook.Tools.workspace_root_pin import (
     WorkspaceRootPinError,
     pin_workspace_root,
@@ -21,6 +23,8 @@ from tldw_chatbook.Tools.workspace_tool_protocol import (
     WorkspaceToolResponse,
 )
 from tldw_chatbook.Utils.filesystem_identity import DirectoryChain
+
+_MAX_DOMAIN_ERROR_CHARS = 300
 
 
 def run_workspace_worker(
@@ -84,6 +88,17 @@ def run_workspace_worker(
     except WorkspaceRootPinError:
         _emit(stdout, _failure(request.operation_id, "root_pin_failed", started))
         return 2
+    except LocalToolError as error:
+        _emit(
+            stdout,
+            _failure(
+                request.operation_id,
+                "tool_failure",
+                started,
+                message=_sanitized_domain_error(error, request.root_locator),
+            ),
+        )
+        return 2
     except (OSError, ValueError):
         _emit(stdout, _failure(request.operation_id, "tool_failure", started))
         return 2
@@ -109,6 +124,21 @@ def _failure(
         truncated=False,
         cleanup_proven=True,
     )
+
+
+def _sanitized_domain_error(error: LocalToolError, root_locator: object) -> str:
+    """Return bounded model-actionable text from one audited domain type."""
+    message = str(error)
+    root_text = str(root_locator)
+    for separator in ("/", "\\"):
+        message = message.replace(root_text + separator, "")
+    message = message.replace(root_text, ".")
+    message = "".join(
+        character
+        for character in message
+        if unicodedata.category(character) != "Cc"
+    )
+    return message[:_MAX_DOMAIN_ERROR_CHARS] or "workspace operation failed"
 
 
 def _elapsed_ms(started: float) -> int:

--- a/tldw_chatbook/Utils/filesystem_identity.py
+++ b/tldw_chatbook/Utils/filesystem_identity.py
@@ -1,0 +1,82 @@
+"""Fail-closed canonical directory identity capture shared by workspace code."""
+
+from __future__ import annotations
+
+import os
+import stat
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_WINDOWS = os.name == "nt"
+_REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", None)
+
+
+class DirectoryIdentityError(ValueError):
+    """Raised when a directory identity cannot be established safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class DirectoryIdentity:
+    """Stable metadata needed to recognize one directory."""
+
+    device: int
+    inode: int
+    mode: int
+    reparse: bool
+
+
+@dataclass(frozen=True, slots=True)
+class DirectoryChain:
+    """Canonical root and its root-first directory ancestor identities."""
+
+    canonical_root: Path = field(repr=False)
+    identities: tuple[DirectoryIdentity, ...] = field(repr=False)
+
+
+def directory_identity_from_stat(value: object) -> DirectoryIdentity:
+    """Build one directory identity, refusing incomplete platform metadata."""
+    try:
+        device = int(getattr(value, "st_dev"))
+        inode = int(getattr(value, "st_ino"))
+        mode = int(getattr(value, "st_mode"))
+    except (AttributeError, TypeError, ValueError) as error:
+        raise DirectoryIdentityError("directory metadata unavailable") from error
+
+    reparse = _reparse_from_stat(value)
+    return DirectoryIdentity(device=device, inode=inode, mode=mode, reparse=reparse)
+
+
+def capture_directory_chain(root: Path) -> DirectoryChain:
+    """Resolve ``root`` once and capture its root-first safe ancestor chain."""
+    try:
+        canonical_root = root.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError) as error:
+        raise DirectoryIdentityError("canonical directory unavailable") from error
+
+    identities: list[DirectoryIdentity] = []
+    for ancestor in (canonical_root, *canonical_root.parents):
+        try:
+            metadata = os.lstat(ancestor)
+        except OSError as error:
+            raise DirectoryIdentityError("directory metadata unavailable") from error
+        identity = directory_identity_from_stat(metadata)
+        if (
+            not stat.S_ISDIR(identity.mode)
+            or stat.S_ISLNK(identity.mode)
+            or identity.reparse
+        ):
+            raise DirectoryIdentityError("unsafe directory metadata")
+        identities.append(identity)
+    return DirectoryChain(canonical_root=canonical_root, identities=tuple(identities))
+
+
+def _reparse_from_stat(value: object) -> bool:
+    if not _WINDOWS:
+        return False
+    try:
+        attributes = getattr(value, "st_file_attributes")
+        if attributes is None or _REPARSE_POINT is None:
+            raise TypeError
+        return bool(int(attributes) & int(_REPARSE_POINT))
+    except (AttributeError, TypeError, ValueError) as error:
+        raise DirectoryIdentityError("directory file attributes unavailable") from error


### PR DESCRIPTION
## Summary
- add a closed one-operation workspace execution protocol and one-shot pinned worker
- route filesystem, patch, read-only Git, Local Tool, and Virtual CLI execution through pinned authority snapshots
- preserve process-tree cleanup, privacy, compatibility, and provider schemas with fail-closed lifecycle behavior

## Verification
- targeted feature shard: 762 passed, 3 skipped
- post-rebase affected subset: 430 passed
- production diagnostic inventory: 164 passed
- Ruff/compile/diff and boundary audits passed, except unchanged legacy Ruff findings documented from dev
- actual Ubuntu, Windows, and macOS workflow evidence will be attached before closeout

## Tracking
- TASK-19637
- ADR-101 remains Proposed until three-platform evidence succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TASK-19637 by closing the race where local workspace tools validated a path and used it later, letting a concurrent rename or replacement retarget the operation. Every local filesystem, patch, read-only Git, Virtual CLI, and MCP tool call now runs in a fresh one-shot worker that pins the admitted workspace root before dispatching and exits after one operation.

- The parent captures the canonical directory identity, revalidates the run-admitted workspace authority, and admits the worker to the existing process-tree containment before sending the request.
- The worker pins the root with an open handle and re-checks identity, so a changed root fails closed with a refusal instead of retargeting.
- The new bounded stdin/stdout protocol is versioned with caps on request, response, path, and string sizes.
- Process-tree cleanup, sensitive-path exclusions, worker environment, and tool provider schemas are preserved.
- Adds a platform evidence workflow for Ubuntu, Windows, and macOS, plus deterministic performance profiling of one-shot versus direct execution.

**Migration**
- Git's `-C` global option is no longer accepted; cwd is now a dedicated runner parameter.
- ADR-101 remains Proposed until the evidence workflow passes on all three platforms.

<sup>Written for commit 25a99f92ebba9c758dc2fbd76482f03e6bdba44c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

