### PR TITLE
fix: group mutation-triggered loader refreshes

### DIFF
--- a/Docs/superpowers/plans/2026-08-28-mutation-loader-group-dispatch.md
+++ b/Docs/superpowers/plans/2026-08-28-mutation-loader-group-dispatch.md
@@ -1,0 +1,307 @@
+# Mutation Loader Group Dispatch Implementation Plan
+
+> **For Codex:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to execute this plan task-by-task, and `superpowers:test-driven-development` for every production change.
+
+**Goal:** Make all eleven audited schedule, notification, and artifact mutation refreshes participate in the same exclusive worker groups as user refreshes so stale overlapping loads cannot repaint the UI.
+
+**Architecture:** Add one synchronous screen-local dispatch helper per affected loader and route every production scheduling call through it. Keep mutation work in its current worker group; the follow-up helper schedules the raw loader in the existing loader group. Extend the TASK-19559 AST inventory to ban inline awaits of the three raw loaders and to pin all eleven mutation owners to their expected helper.
+
+**Tech Stack:** Python 3.11+, Textual 8.x workers, `asyncio`, `pytest`, `unittest.mock`, Python `ast`, Ruff.
+
+**ADR required:** no
+
+**ADR path:** N/A
+
+**Reason:** This enforces TASK-19559's existing worker-group policy without changing an architectural boundary, storage contract, service API, dependency, or long-lived UX structure.
+
+---
+
+### Task 1: Make the architecture guard describe the full contract
+
+**Files:**
+
+- Modify: `Tests/Architecture/test_worker_exclusive_group_inventory.py`
+- Reference: `tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py`
+- Reference: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+
+**Step 1: Add a failing inline-loader detector test**
+
+Add a path-scoped inventory for these raw loaders:
+
+```python
+INLINE_LOADER_TARGETS = {
+    Path("tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py"): {
+        "load_tasks"
+    },
+    Path("tldw_chatbook/UI/Screens/watchlists_collections_screen.py"): {
+        "_load_notifications",
+        "_load_briefings",
+    },
+}
+```
+
+Implement a small AST helper that reports `await self.<target>(...)` with line
+and qualified owner. Add synthetic tests proving an awaited target is flagged,
+a helper dispatch is clean, and unrelated awaited loaders are ignored. Add the
+production sweep assertion.
+
+**Step 2: Run the guard and confirm the expected red state**
+
+Run:
+
+```bash
+pytest -q Tests/Architecture/test_worker_exclusive_group_inventory.py
+```
+
+Expected: FAIL, enumerating six `load_tasks`, two `_load_notifications`, and
+three `_load_briefings` inline awaits in the production files.
+
+**Step 3: Pin all eleven mutation owners to their helper**
+
+Add an explicit owner-to-helper inventory for:
+
+- schedule delete, save, run-now, enabled-state, bulk-delete, bulk-toggle;
+- notification mark-read and dismiss;
+- briefing generation, script cast, and audio synthesis.
+
+Use AST ownership rather than line numbers. Assert each owner calls its expected
+`self._request_*_refresh` helper exactly once. Add a synthetic mutation test
+showing removal or routing to a different helper fails.
+
+The production assertion remains red until the helpers and call sites land.
+
+**Step 4: Commit the red guard**
+
+```bash
+git add Tests/Architecture/test_worker_exclusive_group_inventory.py
+git commit -m "test: guard mutation loader dispatch groups"
+```
+
+---
+
+### Task 2: Route every schedules refresh through one loader-group seam
+
+**Files:**
+
+- Modify: `Tests/UI/test_schedules_workbench.py`
+- Modify: `tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py`
+
+**Step 1: Write the failing mounted concurrency regression**
+
+Extend the recording scheduling service with controllable `list_tasks()`
+responses. Mount the real `SchedulesWorkbench`, complete a delete mutation so
+its refresh starts, dispatch a user refresh while that load is blocked, release
+responses in stale-first order, and assert:
+
+- `delete_reminder()` was called;
+- the table and `_tasks` contain only the newest service snapshot;
+- the older load cannot repaint after the newer one.
+
+The test should use worker/task completion signals rather than a fixed sleep.
+
+**Step 2: Run the focused test and verify it fails for the inline await**
+
+```bash
+pytest -q Tests/UI/test_schedules_workbench.py -k "mutation_refresh or delete_refresh"
+```
+
+Expected: FAIL because the mutation's inline `load_tasks()` is outside
+`schedules-load-tasks` and can publish stale rows.
+
+**Step 3: Add `_request_tasks_refresh()`**
+
+Implement a synchronous helper that performs:
+
+```python
+self.run_worker(
+    self.load_tasks,
+    exclusive=True,
+    group="schedules-load-tasks",
+)
+```
+
+Route mount, sync event, conflict resolution, and other existing direct
+`load_tasks` scheduling through the helper so it is the sole production seam.
+Replace the six mutation-worker inline awaits with helper calls. Preserve all
+existing mutation service calls, marked-row clearing, notifications, and error
+handling.
+
+**Step 4: Run schedule and architecture tests**
+
+```bash
+pytest -q Tests/UI/test_schedules_workbench.py Tests/Architecture/test_worker_exclusive_group_inventory.py
+```
+
+Expected: schedule tests PASS; the architecture production sweep remains red
+only for Watchlists until Task 3.
+
+**Step 5: Commit the schedules slice**
+
+```bash
+git add tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py Tests/UI/test_schedules_workbench.py
+git commit -m "fix: group schedules mutation refreshes"
+```
+
+---
+
+### Task 3: Route notification and artifact refreshes through their loader groups
+
+**Files:**
+
+- Modify: `Tests/UI/test_watchlists_destination_shell.py`
+- Modify: `Tests/Watchlists/test_watchlists_artifacts_pane.py`
+- Modify: `tldw_chatbook/UI/Screens/watchlists_collections_screen.py`
+
+**Step 1: Write the failing notification race**
+
+Use the mounted `WatchlistsContextHarness` and a gate-controlled notifications
+controller. Trigger mark-read (or dismiss), allow its mutation refresh to enter
+`load_rows`, trigger the pane's user refresh, and release the two snapshots out
+of order. Assert the mutation call completed and only the newest notifications
+snapshot is present in both screen and pane state.
+
+Run:
+
+```bash
+pytest -q Tests/UI/test_watchlists_destination_shell.py -k "notification and mutation_refresh"
+```
+
+Expected: FAIL against the inline `_load_notifications()` mutation path.
+
+**Step 2: Write the failing artifacts race**
+
+Use the existing real Artifacts harness and database seam. Gate two
+`_load_briefings()` acquisitions, complete a generation reconciliation refresh,
+then dispatch the manual Artifacts refresh and release stale-first. Assert the
+generated row remains recorded and only the newest briefing projection reaches
+screen and pane state.
+
+Also add focused assertions that generation forwards
+`select_briefing_id=generated_id`, while cast and audio preserve their existing
+`is_attached` gates.
+
+Run:
+
+```bash
+pytest -q Tests/Watchlists/test_watchlists_artifacts_pane.py -k "mutation_refresh or briefing_refresh_dispatch"
+```
+
+Expected: FAIL against the three inline `_load_briefings()` paths.
+
+**Step 3: Add the two Watchlists dispatch helpers**
+
+Implement:
+
+- `_request_notifications_refresh()` using `exclusive=True` and
+  `group="wc_notifications"`;
+- `_request_briefings_refresh(*, select_briefing_id=None)` using
+  `exclusive=True` and `group="wl-briefings-load"`.
+
+Route active-section loading, explicit refresh events, briefing/script
+selection reloads, and all other existing direct schedules of these raw
+loaders through the helpers. Replace notification mark-read/dismiss inline
+awaits and artifact generation/cast/audio inline awaits with helper calls.
+
+Keep attachment policy at the existing call sites: generation always requests
+its refresh; cast and audio do so only when attached. Do not add a helper-level
+attachment check.
+
+**Step 4: Run Watchlists and architecture tests**
+
+```bash
+pytest -q \
+  Tests/UI/test_watchlists_destination_shell.py \
+  Tests/Watchlists/test_watchlists_artifacts_pane.py \
+  Tests/Architecture/test_worker_exclusive_group_inventory.py
+```
+
+Expected: PASS. The AST sweep finds zero raw inline awaits and all eleven
+mutation owners call the correct helper.
+
+**Step 5: Commit the Watchlists slice**
+
+```bash
+git add \
+  tldw_chatbook/UI/Screens/watchlists_collections_screen.py \
+  Tests/UI/test_watchlists_destination_shell.py \
+  Tests/Watchlists/test_watchlists_artifacts_pane.py
+git commit -m "fix: group watchlists mutation refreshes"
+```
+
+---
+
+### Task 4: Verify, document, and prepare review
+
+**Files:**
+
+- Modify: `backlog/tasks/task-19870 - Mutation-workers-refresh-inline-instead-of-dispatching-into-the-loader-group.md`
+- Modify if a general lesson emerged: `backlog/docs/lessons-testing-evidence.md`
+
+**Step 1: Run the complete targeted regression gate**
+
+```bash
+pytest -q \
+  Tests/Architecture/test_worker_exclusive_group_inventory.py \
+  Tests/UI/test_schedules_workbench.py \
+  Tests/UI/test_watchlists_destination_shell.py \
+  Tests/Watchlists/test_watchlists_artifacts_pane.py
+```
+
+Do not run the full repository suite unless separately requested.
+
+**Step 2: Run static checks on every modified Python file**
+
+```bash
+ruff check \
+  tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py \
+  tldw_chatbook/UI/Screens/watchlists_collections_screen.py \
+  Tests/Architecture/test_worker_exclusive_group_inventory.py \
+  Tests/UI/test_schedules_workbench.py \
+  Tests/UI/test_watchlists_destination_shell.py \
+  Tests/Watchlists/test_watchlists_artifacts_pane.py
+
+ruff format --check \
+  tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py \
+  tldw_chatbook/UI/Screens/watchlists_collections_screen.py \
+  Tests/Architecture/test_worker_exclusive_group_inventory.py \
+  Tests/UI/test_schedules_workbench.py \
+  Tests/UI/test_watchlists_destination_shell.py \
+  Tests/Watchlists/test_watchlists_artifacts_pane.py
+
+git diff --check
+git diff --check origin/dev...HEAD
+```
+
+**Step 3: Mutation-check the structural guard**
+
+Temporarily restore one production helper call to its raw inline await, run the
+architecture test and confirm it fails at the correct owner, then restore the
+working tree and rerun the guard green. Do not commit the temporary mutation.
+
+**Step 4: Complete backlog hygiene**
+
+Check all acceptance criteria, add concise implementation notes including the
+ADR decision and targeted verification evidence, and set TASK-19870 to Done
+only after all gates pass. Add a lessons entry only if this work produces a
+new, generalizable incident beyond the lesson already documented by TASK-19559.
+
+**Step 5: Review the diff and commit closeout**
+
+```bash
+git diff --stat origin/dev...HEAD
+git diff origin/dev...HEAD -- \
+  tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py \
+  tldw_chatbook/UI/Screens/watchlists_collections_screen.py \
+  Tests/Architecture/test_worker_exclusive_group_inventory.py \
+  Tests/UI/test_schedules_workbench.py \
+  Tests/UI/test_watchlists_destination_shell.py \
+  Tests/Watchlists/test_watchlists_artifacts_pane.py
+
+git add \
+  'backlog/tasks/task-19870 - Mutation-workers-refresh-inline-instead-of-dispatching-into-the-loader-group.md'
+git commit -m "docs: complete TASK-19870"
+```
+
+After the implementation diff passes review, push the branch and open the PR
+with the focused evidence and explicit note that no full-suite run was
+requested.

--- a/Docs/superpowers/specs/2026-08-28-mutation-loader-group-dispatch-design.md
+++ b/Docs/superpowers/specs/2026-08-28-mutation-loader-group-dispatch-design.md
@@ -81,10 +81,11 @@ for scheduling its affected loader:
 
 User actions, lifecycle-triggered refreshes, and mutation completions call the
 same helper. No caller awaits the raw loader. When a newer request is
-dispatched, Textual cancels the older worker in that group before the newer
-worker publishes its rows. Mutation workers remain in their existing mutation
-groups; scheduling the follow-up refresh does not move or serialize the write
-itself.
+dispatched, Textual cancels the older worker in that group so its coroutine
+cannot publish stale rows. Thread-side reads already submitted by a loader may
+still finish, but the canceled coroutine does not commit their result to the
+UI. Mutation workers remain in their existing mutation groups; scheduling the
+follow-up refresh does not move or serialize the write itself.
 
 The helpers remain screen-local rather than introducing a generic abstraction.
 There are only three loaders, their arguments differ, and the worker group
@@ -101,9 +102,12 @@ For each affected mutation:
 5. the exclusive loader group decides which overlapping refresh is current;
 6. only the surviving loader publishes list state.
 
-The artifact helpers retain the current attachment guard before requesting a
-refresh. Briefing generation passes its newly generated identity so the
-surviving reload can preserve the intended selection.
+Artifact call sites retain their current attachment behavior. Briefing
+generation requests its reconciliation refresh unconditionally, including
+refusal and failure paths. Cast and audio request theirs only while the screen
+is attached. The helper itself adds no attachment policy. Briefing generation
+passes its newly generated identity so the surviving reload can preserve the
+intended selection.
 
 ## Error and Cancellation Behavior
 
@@ -144,6 +148,12 @@ Representative mounted Textual tests cover each loader group:
 - artifacts: complete generate, cast, or synthesize while a manual artifact
   refresh overlaps; assert only the newest briefing projection is committed
   and the mutation result is retained.
+
+Lightweight dispatch tests cover all eleven affected mutation paths and assert
+that each requests the expected helper, including the generated-briefing
+selection argument and the existing cast/audio attachment gates. These tests
+catch a refresh being removed or routed through the wrong helper; the mounted
+race tests separately prove the helper's exclusivity behavior.
 
 The architecture test is mutation-checked by restoring one inline await and
 proving the guard fails. Targeted test modules, modified-file Ruff lint and

--- a/Docs/superpowers/specs/2026-08-28-mutation-loader-group-dispatch-design.md
+++ b/Docs/superpowers/specs/2026-08-28-mutation-loader-group-dispatch-design.md
@@ -1,0 +1,165 @@
+# Mutation Loader Group Dispatch Design
+
+Date: 2026-08-28
+Status: Approved
+ADR required: no
+ADR path: N/A
+Reason: this enforces the worker-group contract established by TASK-19559 and
+does not change storage, ownership, service, security, dependency, or long-lived
+application boundaries.
+Backlog:
+[TASK-19870](../../../backlog/tasks/task-19870%20-%20Mutation-workers-refresh-inline-instead-of-dispatching-into-the-loader-group.md)
+
+## Summary
+
+Route mutation-triggered list refreshes through the same exclusive Textual
+worker groups as user-triggered refreshes. Add one screen-local dispatch seam
+for each affected loader, replace every direct and mutation call site with that
+seam, and structurally forbid inline awaits of those loaders in production.
+
+The expanded audit covers eleven mutation paths: six schedule mutations, two
+notification mutations, and briefing generation, script casting, and audio
+synthesis. Other mutation-triggered loaders in the two screens already use a
+grouped dispatch or a grouped `@work` method and need no change.
+
+## Verified Problem
+
+TASK-19559 gave each standalone loader a distinct exclusive worker group, but
+some mutation workers still call the underlying async loader inline. An inline
+call is invisible to Textual's `WorkerManager`, so it is not cancelled when a
+new refresh enters the loader group. The inline and grouped calls may then both
+write the same screen-owned list, allowing an older result to repaint after a
+newer result.
+
+Current `origin/dev` contains:
+
+- six `await self.load_tasks()` calls inside schedule delete, save, run-now,
+  enabled-state, bulk-delete, and bulk-toggle workers, outside
+  `schedules-load-tasks`;
+- two `await self._load_notifications()` calls inside mark-read and dismiss
+  workers, outside `wc_notifications`;
+- three `await self._load_briefings()` calls in the `finally` blocks of
+  briefing generation, script casting, and audio synthesis, outside
+  `wl-briefings-load`.
+
+The remaining mutation refreshes audited in these screens are already safe:
+they call `run_worker(..., group=<loader group>)`, call a grouped `@work`
+method, or execute a narrower loader inside an outer worker already scheduled
+into that loader's group.
+
+## Goals
+
+- Give mutation and user refreshes one scheduling seam per affected list.
+- Preserve latest-request-wins behavior through the existing exclusive groups.
+- Prevent overlapping refreshes from interleaving writes to one list.
+- Preserve mutation success/failure handling and loader error presentation.
+- Make a future inline await of an affected loader fail an architecture test.
+- Cover schedules, notifications, and artifacts with production-shaped
+  concurrency regressions.
+
+## Non-Goals
+
+- Changing mutation ordering, service APIs, persistence, or business rules.
+- Converting every screen loader to a decorator or introducing a generic
+  application-wide loader coordinator.
+- Adding generation counters in parallel with Textual's worker cancellation.
+- Refactoring mutation workers that already dispatch through the correct group.
+- Broad changes to all worker groups or the TASK-19559 inventory.
+
+## Dispatch Contract
+
+Each screen owns a small synchronous helper that is the only production seam
+for scheduling its affected loader:
+
+- `SchedulesWorkbench._request_tasks_refresh()` schedules `load_tasks` with
+  `exclusive=True` in `schedules-load-tasks`;
+- `WatchlistsCollectionsScreen._request_notifications_refresh()` schedules
+  `_load_notifications()` with `exclusive=True` in `wc_notifications`;
+- `WatchlistsCollectionsScreen._request_briefings_refresh(...)` schedules
+  `_load_briefings(...)` with `exclusive=True` in `wl-briefings-load` and
+  forwards the optional briefing-selection identity.
+
+User actions, lifecycle-triggered refreshes, and mutation completions call the
+same helper. No caller awaits the raw loader. When a newer request is
+dispatched, Textual cancels the older worker in that group before the newer
+worker publishes its rows. Mutation workers remain in their existing mutation
+groups; scheduling the follow-up refresh does not move or serialize the write
+itself.
+
+The helpers remain screen-local rather than introducing a generic abstraction.
+There are only three loaders, their arguments differ, and the worker group
+names are domain contracts that should remain visible beside the loader.
+
+## Mutation Flow
+
+For each affected mutation:
+
+1. the existing mutation worker performs its service or database write;
+2. existing notification and error handling runs unchanged;
+3. the worker requests a refresh through the screen's dispatch helper;
+4. the mutation worker completes without awaiting list acquisition or repaint;
+5. the exclusive loader group decides which overlapping refresh is current;
+6. only the surviving loader publishes list state.
+
+The artifact helpers retain the current attachment guard before requesting a
+refresh. Briefing generation passes its newly generated identity so the
+surviving reload can preserve the intended selection.
+
+## Error and Cancellation Behavior
+
+Loaders keep their current error handling and empty/error-state presentation.
+Mutation workers keep their current write errors and success toasts. The change
+only transfers ownership of the refresh coroutine to Textual.
+
+Cancellation of an older loader is expected control flow. It must not be
+reported as a mutation failure or user-facing error. A mutation failure that
+currently refreshes the list continues to request that refresh so the screen
+reconciles with authoritative state.
+
+## Structural Guard
+
+Extend `Tests/Architecture/test_worker_exclusive_group_inventory.py` with a
+targeted AST rule for the three affected production loader methods. In their
+own screen modules, any `await self.load_tasks(...)`,
+`await self._load_notifications(...)`, or
+`await self._load_briefings(...)` is a violation. Calls inside tests are not
+restricted.
+
+This deliberately avoids whole-program call-graph inference. The exact risky
+loaders and modules are explicit, reviewable inventory, while future mutation
+paths in those modules are covered automatically.
+
+## Verification
+
+Use test-driven development. Before production changes, add regressions that
+are red against the inline-await implementation.
+
+Representative mounted Textual tests cover each loader group:
+
+- schedules: overlap a mutation-completion refresh and user refresh with
+  controllable service results; release them out of order and assert the newest
+  task rows are rendered and the mutation occurred;
+- notifications: perform mark-read or dismiss while a user refresh overlaps;
+  assert the newest notification rows and the completed mutation;
+- artifacts: complete generate, cast, or synthesize while a manual artifact
+  refresh overlaps; assert only the newest briefing projection is committed
+  and the mutation result is retained.
+
+The architecture test is mutation-checked by restoring one inline await and
+proving the guard fails. Targeted test modules, modified-file Ruff lint and
+format checks, and `git diff --check` form the implementation gate. A full test
+suite is not required unless separately requested.
+
+## Rejected Alternatives
+
+Decorating the raw loaders as `@work` methods was rejected because it changes
+their call type, makes nested-worker waiting implicit, and expands the change
+well beyond the defect.
+
+Generation tokens were rejected because they duplicate the latest-request-wins
+semantics already provided by exclusive Textual worker groups and introduce
+new mutable state with no additional user value.
+
+Duplicating `run_worker(...)` at every call site was rejected because it leaves
+group names and options free to drift again; one dispatch helper per loader is
+the smallest durable seam.

--- a/Tests/Architecture/test_worker_exclusive_group_inventory.py
+++ b/Tests/Architecture/test_worker_exclusive_group_inventory.py
@@ -230,6 +230,27 @@ def _self_call_name(node: ast.Call) -> str | None:
     return func.attr
 
 
+def _forbidden_inline_loader_awaits(
+    tree: ast.Module, forbidden_loaders: set[str] | frozenset[str]
+) -> list[tuple[int, str]]:
+    """Return each forbidden self-loader call below an await expression once."""
+    violations: list[tuple[int, str]] = []
+    seen_calls: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Await):
+            continue
+        for descendant in ast.walk(node.value):
+            if not isinstance(descendant, ast.Call):
+                continue
+            loader = _self_call_name(descendant)
+            call_identity = id(descendant)
+            if loader not in forbidden_loaders or call_identity in seen_calls:
+                continue
+            seen_calls.add(call_identity)
+            violations.append((descendant.lineno, loader))
+    return violations
+
+
 def _mutation_refresh_violations_in_tree(
     tree: ast.Module,
     *,
@@ -247,16 +268,14 @@ def _mutation_refresh_violations_in_tree(
     issues: dict[str, list[str]] = {}
     helper_counts = dict.fromkeys(owner_helpers, 0)
 
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Await) and isinstance(node.value, ast.Call):
-            loader = _self_call_name(node.value)
-            if loader in forbidden_loaders:
-                owner = owners.get(node.lineno, "<module>")
-                issues.setdefault(owner, []).append(
-                    f"await self.{loader}(...) is forbidden; dispatch through "
-                    "the loader-group refresh helper"
-                )
+    for lineno, loader in _forbidden_inline_loader_awaits(tree, forbidden_loaders):
+        owner = owners.get(lineno, "<module>")
+        issues.setdefault(owner, []).append(
+            f"await self.{loader}(...) is forbidden; dispatch through "
+            "the loader-group refresh helper"
+        )
 
+    for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         owner = owners.get(node.lineno, "<module>")
@@ -730,6 +749,32 @@ def test_awaited_mutation_loader_is_flagged() -> None:
     )
 
 
+def test_wrapped_awaited_mutation_loaders_are_flagged_once_each() -> None:
+    """Shield and gather wrappers cannot hide raw loader awaits."""
+    tree = ast.parse(
+        "import asyncio\n"
+        "class ScratchScreen:\n"
+        "    async def _mutate(self):\n"
+        "        await asyncio.shield(self.load_tasks())\n"
+        "        await asyncio.gather(self.load_tasks())\n"
+        "        await asyncio.shield(await self.load_tasks())\n"
+    )
+
+    violations = _mutation_refresh_violations_in_tree(
+        tree,
+        forbidden_loaders={"load_tasks"},
+        owner_helpers={},
+    )
+
+    assert set(violations) == {"ScratchScreen._mutate"}
+    assert (
+        violations["ScratchScreen._mutate"].count(
+            "await self.load_tasks(...) is forbidden"
+        )
+        == 3
+    )
+
+
 def test_helper_dispatch_and_unrelated_loader_are_clean() -> None:
     """The required helper is enough; unrelated awaited loaders stay out of scope."""
     tree = ast.parse(
@@ -763,3 +808,24 @@ def test_missing_or_wrong_refresh_helper_is_flagged() -> None:
             "expected exactly one self._request_tasks_refresh(...) call; found 0"
             in (violations["ScratchScreen._mutate"])
         )
+
+
+def test_duplicate_refresh_helper_is_flagged() -> None:
+    """Two helper dispatches violate the inventory's exact-one contract."""
+    tree = ast.parse(
+        "class ScratchScreen:\n"
+        "    def _mutate(self):\n"
+        "        self._request_tasks_refresh()\n"
+        "        self._request_tasks_refresh()\n"
+    )
+
+    violations = _mutation_refresh_violations_in_tree(
+        tree,
+        forbidden_loaders={"load_tasks"},
+        owner_helpers={"ScratchScreen._mutate": "_request_tasks_refresh"},
+    )
+
+    assert (
+        "expected exactly one self._request_tasks_refresh(...) call; found 2"
+        in violations["ScratchScreen._mutate"]
+    )

--- a/Tests/Architecture/test_worker_exclusive_group_inventory.py
+++ b/Tests/Architecture/test_worker_exclusive_group_inventory.py
@@ -58,6 +58,12 @@ loaders, and the Settings advanced-config backup load).
 ``test_multiline_ungrouped_exclusive_is_flagged`` pins the multi-line form the
 naive grep is blind to, and ``test_ungrouped_exclusive_decorator_is_flagged``
 pins the decorator form.
+
+TASK-19870 extends the same ownership rule to mutation-triggered refreshes in
+Schedules and Watchlists. Awaiting a raw loader inside a mutation worker
+bypasses the loader's exclusive group, so the two affected modules are scanned
+for ``await self.<raw loader>(...)`` and the eleven known mutation owners are
+pinned to exactly one call to their group-dispatch helper.
 """
 
 from __future__ import annotations
@@ -117,6 +123,47 @@ DEFAULT_GROUP_ALLOWLIST: dict[str, str] = {
     ),
 }
 
+SCHEDULES_WORKBENCH_PATH = "tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py"
+WATCHLISTS_COLLECTIONS_PATH = (
+    "tldw_chatbook/UI/Screens/watchlists_collections_screen.py"
+)
+
+#: TASK-19870: raw loaders whose direct await bypasses the exclusive loader
+#: group in each affected production module. This is deliberately path scoped:
+#: identically named methods elsewhere have not been audited into this contract.
+FORBIDDEN_MUTATION_LOADERS_BY_PATH: dict[str, frozenset[str]] = {
+    SCHEDULES_WORKBENCH_PATH: frozenset({"load_tasks"}),
+    WATCHLISTS_COLLECTIONS_PATH: frozenset({"_load_notifications", "_load_briefings"}),
+}
+
+#: Every audited mutation owner must dispatch exactly once through the named
+#: helper. Qualified owners survive edits above the site; nested worker bodies
+#: remain distinct from their enclosing handlers without relying on line pins.
+MUTATION_REFRESH_HELPER_INVENTORY: dict[str, str] = {
+    f"{SCHEDULES_WORKBENCH_PATH}::SchedulesWorkbench."
+    "_on_delete_task_requested._delete_and_refresh": "_request_tasks_refresh",
+    f"{SCHEDULES_WORKBENCH_PATH}::SchedulesWorkbench."
+    "_on_reminder_form_result._save_and_refresh": "_request_tasks_refresh",
+    f"{SCHEDULES_WORKBENCH_PATH}::SchedulesWorkbench."
+    "_run_reminder_now._run_and_refresh": "_request_tasks_refresh",
+    f"{SCHEDULES_WORKBENCH_PATH}::SchedulesWorkbench."
+    "_set_reminder_enabled._update_and_refresh": "_request_tasks_refresh",
+    f"{SCHEDULES_WORKBENCH_PATH}::SchedulesWorkbench."
+    "_on_bulk_delete_confirmed._bulk_delete": "_request_tasks_refresh",
+    f"{SCHEDULES_WORKBENCH_PATH}::SchedulesWorkbench."
+    "_bulk_toggle_marked._bulk_toggle": "_request_tasks_refresh",
+    f"{WATCHLISTS_COLLECTIONS_PATH}::WatchlistsCollectionsScreen."
+    "_mark_notification_read": "_request_notifications_refresh",
+    f"{WATCHLISTS_COLLECTIONS_PATH}::WatchlistsCollectionsScreen."
+    "_dismiss_notification": "_request_notifications_refresh",
+    f"{WATCHLISTS_COLLECTIONS_PATH}::WatchlistsCollectionsScreen."
+    "_generate_briefing": "_request_briefings_refresh",
+    f"{WATCHLISTS_COLLECTIONS_PATH}::WatchlistsCollectionsScreen."
+    "_cast_script": "_request_briefings_refresh",
+    f"{WATCHLISTS_COLLECTIONS_PATH}::WatchlistsCollectionsScreen."
+    "_synthesize_audio": "_request_briefings_refresh",
+}
+
 
 def _call_name(node: ast.Call) -> str | None:
     """Return the bare callee name for ``f()``, ``a.f()`` and ``f[T]()``."""
@@ -171,6 +218,82 @@ def _owner_index(tree: ast.Module) -> dict[int, str]:
 
     _Visitor().visit(tree)
     return owners
+
+
+def _self_call_name(node: ast.Call) -> str | None:
+    """Return the method name only for a direct ``self.method(...)`` call."""
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return None
+    if not isinstance(func.value, ast.Name) or func.value.id != "self":
+        return None
+    return func.attr
+
+
+def _mutation_refresh_violations_in_tree(
+    tree: ast.Module,
+    *,
+    forbidden_loaders: set[str] | frozenset[str],
+    owner_helpers: dict[str, str],
+) -> dict[str, str]:
+    """Return refresh-contract failures keyed by qualified function owner.
+
+    A row aggregates both halves of the contract so a current inline refresh
+    reports one mutation owner, not one raw-await row plus a second missing-
+    helper row. The caller supplies the path-specific raw-loader set and the
+    owner inventory, keeping this helper path-free for synthetic AST tests.
+    """
+    owners = _owner_index(tree)
+    issues: dict[str, list[str]] = {}
+    helper_counts = dict.fromkeys(owner_helpers, 0)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Await) and isinstance(node.value, ast.Call):
+            loader = _self_call_name(node.value)
+            if loader in forbidden_loaders:
+                owner = owners.get(node.lineno, "<module>")
+                issues.setdefault(owner, []).append(
+                    f"await self.{loader}(...) is forbidden; dispatch through "
+                    "the loader-group refresh helper"
+                )
+
+        if not isinstance(node, ast.Call):
+            continue
+        owner = owners.get(node.lineno, "<module>")
+        expected_helper = owner_helpers.get(owner)
+        if expected_helper is not None and _self_call_name(node) == expected_helper:
+            helper_counts[owner] += 1
+
+    for owner, expected_helper in owner_helpers.items():
+        count = helper_counts[owner]
+        if count != 1:
+            issues.setdefault(owner, []).append(
+                f"expected exactly one self.{expected_helper}(...) call; found {count}"
+            )
+
+    return {owner: "; ".join(issues[owner]) for owner in sorted(issues)}
+
+
+def _mutation_refresh_contract_violations() -> list[str]:
+    """Scan only the two TASK-19870 production modules."""
+    by_path: dict[str, dict[str, str]] = {
+        relative: {} for relative in FORBIDDEN_MUTATION_LOADERS_BY_PATH
+    }
+    for site, helper in MUTATION_REFRESH_HELPER_INVENTORY.items():
+        relative, owner = site.split("::", maxsplit=1)
+        by_path[relative][owner] = helper
+
+    violations: list[str] = []
+    for relative, forbidden_loaders in FORBIDDEN_MUTATION_LOADERS_BY_PATH.items():
+        path = PACKAGE_ROOT.parent / relative
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for owner, detail in _mutation_refresh_violations_in_tree(
+            tree,
+            forbidden_loaders=forbidden_loaders,
+            owner_helpers=by_path[relative],
+        ).items():
+            violations.append(f"{relative}::{owner}: {detail}")
+    return violations
 
 
 def _violations_in_tree(tree: ast.Module) -> list[tuple[int, str, str]]:
@@ -296,6 +419,16 @@ def test_no_ungrouped_exclusive_workers() -> None:
         "being done, or -- if default-group mutual exclusion really is what "
         "the site wants -- add it to DEFAULT_GROUP_ALLOWLIST with the reason:\n"
         + "\n".join(violations)
+    )
+
+
+def test_mutation_refreshes_dispatch_through_loader_group() -> None:
+    """Mutation workers dispatch refreshes through their loader-group helper."""
+    violations = _mutation_refresh_contract_violations()
+    assert not violations, (
+        "mutation-triggered refreshes must not await raw loaders outside their "
+        "exclusive loader group. Replace each raw await with exactly one call "
+        "to the inventoried dispatch helper:\n" + "\n".join(violations)
     )
 
 
@@ -575,3 +708,58 @@ def test_scan_is_a_single_cached_pass() -> None:
     # Deliberately no `cache_clear()`: forcing a rebuild here would spend the
     # very seconds this change exists to save.
     assert _scan_package.cache_info().misses <= 1, _scan_package.cache_info()
+
+
+def test_awaited_mutation_loader_is_flagged() -> None:
+    """An awaited raw loader bypasses the helper's exclusive worker group."""
+    tree = ast.parse(
+        "class ScratchScreen:\n"
+        "    async def _mutate(self):\n"
+        "        await self.load_tasks()\n"
+    )
+
+    violations = _mutation_refresh_violations_in_tree(
+        tree,
+        forbidden_loaders={"load_tasks"},
+        owner_helpers={},
+    )
+
+    assert set(violations) == {"ScratchScreen._mutate"}
+    assert (
+        "await self.load_tasks(...) is forbidden" in violations["ScratchScreen._mutate"]
+    )
+
+
+def test_helper_dispatch_and_unrelated_loader_are_clean() -> None:
+    """The required helper is enough; unrelated awaited loaders stay out of scope."""
+    tree = ast.parse(
+        "class ScratchScreen:\n"
+        "    async def _mutate(self):\n"
+        "        self._request_tasks_refresh()\n"
+        "        await self.load_people()\n"
+    )
+
+    assert not _mutation_refresh_violations_in_tree(
+        tree,
+        forbidden_loaders={"load_tasks"},
+        owner_helpers={"ScratchScreen._mutate": "_request_tasks_refresh"},
+    )
+
+
+def test_missing_or_wrong_refresh_helper_is_flagged() -> None:
+    """Every inventoried mutation owner calls its one named helper exactly once."""
+    for body in ("pass", "self._request_notifications_refresh()"):
+        tree = ast.parse(
+            f"class ScratchScreen:\n    def _mutate(self):\n        {body}\n"
+        )
+
+        violations = _mutation_refresh_violations_in_tree(
+            tree,
+            forbidden_loaders={"load_tasks"},
+            owner_helpers={"ScratchScreen._mutate": "_request_tasks_refresh"},
+        )
+
+        assert (
+            "expected exactly one self._request_tasks_refresh(...) call; found 0"
+            in (violations["ScratchScreen._mutate"])
+        )

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -1,11 +1,11 @@
 """Tests for the SchedulesWorkbench shell."""
 
+import asyncio
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from textual.app import App
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
@@ -690,6 +690,67 @@ class WorkbenchTestAppWithRecordingService(ConsolidatedCSSApp):
         self.scheduling_service = RecordingMockSchedulingService()
 
 
+class ControlledRefreshSchedulingService(_MockSchedulingServiceMixin):
+    """Return controlled snapshots for a delete/user-refresh overlap."""
+
+    def __init__(self) -> None:
+        self.deleted_ids: list[str] = []
+        self.delete_completed = asyncio.Event()
+        self.mutation_refresh_started = asyncio.Event()
+        self.user_refresh_started = asyncio.Event()
+        self.release_mutation_refresh = asyncio.Event()
+        self.release_user_refresh = asyncio.Event()
+        self._list_calls = 0
+        timestamp = datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+        self.initial_task = ReminderTask(
+            id="task-to-delete",
+            title="Delete me",
+            schedule_kind=ScheduleKind.ONE_TIME,
+            run_at=timestamp,
+            next_run_at=timestamp,
+        )
+        self.stale_task = ReminderTask(
+            id="stale-task",
+            title="Stale mutation snapshot",
+            schedule_kind=ScheduleKind.ONE_TIME,
+            run_at=timestamp,
+            next_run_at=timestamp,
+        )
+        self.newest_task = ReminderTask(
+            id="newest-task",
+            title="Newest user snapshot",
+            schedule_kind=ScheduleKind.ONE_TIME,
+            run_at=timestamp,
+            next_run_at=timestamp,
+        )
+
+    async def list_tasks(self):
+        self._list_calls += 1
+        if self._list_calls == 1:
+            return [self.initial_task]
+        if self._list_calls == 2:
+            self.mutation_refresh_started.set()
+            await self.release_mutation_refresh.wait()
+            return [self.stale_task]
+        if self._list_calls == 3:
+            self.user_refresh_started.set()
+            await self.release_user_refresh.wait()
+            return [self.newest_task]
+        raise AssertionError(f"Unexpected list_tasks call {self._list_calls}")
+
+    async def delete_reminder(self, task_id: str) -> None:
+        self.deleted_ids.append(task_id)
+        self.delete_completed.set()
+
+
+class WorkbenchTestAppWithControlledRefresh(ConsolidatedCSSApp):
+    """Test app with event-controlled task snapshots."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.scheduling_service = ControlledRefreshSchedulingService()
+
+
 @pytest.mark.asyncio
 async def test_delete_confirmation_runs_delete_requested_flow():
     """Confirming the delete dialog triggers the full DeleteTaskRequested flow."""
@@ -733,6 +794,46 @@ async def test_workbench_deletes_task_and_notifies_on_success():
         assert pilot.app.scheduling_service.deleted_ids == ["task-1"]
         table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
         assert table.row_count == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_mutation_refresh_cannot_repaint_after_newer_user_refresh():
+    """A delete reconciliation cannot overwrite a newer grouped refresh."""
+    app = WorkbenchTestAppWithControlledRefresh()
+    async with app.run_test() as pilot:
+        workbench = SchedulesWorkbench(app_instance=pilot.app)
+        await pilot.app.push_screen(workbench)
+        await pilot.app.workers.wait_for_complete()
+
+        service = app.scheduling_service
+        workbench.post_message(DeleteTaskRequested(workbench._tasks[0]))
+        await service.delete_completed.wait()
+        await service.mutation_refresh_started.wait()
+
+        # Resolving a conflict is a user action whose production handler
+        # requests a grouped task-list refresh.
+        workbench._on_conflict_resolved(
+            ConflictsTab.ConflictResolved("conflict-1", "local")
+        )
+        await service.user_refresh_started.wait()
+        user_worker = next(
+            worker
+            for worker in pilot.app.workers
+            if worker.node is workbench and worker.group == "schedules-load-tasks"
+        )
+
+        service.release_user_refresh.set()
+        await pilot.app.workers.wait_for_complete([user_worker])
+        assert [task.id for task in workbench._tasks] == ["newest-task"]
+
+        service.release_mutation_refresh.set()
+        await pilot.app.workers.wait_for_complete()
+
+        assert service.deleted_ids == ["task-to-delete"]
+        assert [task.id for task in workbench._tasks] == ["newest-task"]
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        assert table.row_count == 1
+        assert "Newest user snapshot" in str(table.get_row_at(0)[0])
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -724,7 +724,15 @@ class ControlledRefreshSchedulingService(_MockSchedulingServiceMixin):
             next_run_at=timestamp,
         )
 
-    async def list_tasks(self):
+    async def list_tasks(self) -> list[ReminderTask]:
+        """Return the next controlled task snapshot.
+
+        Returns:
+            list[ReminderTask]: Snapshot for the current load step.
+
+        Raises:
+            AssertionError: If the workbench performs an unexpected extra load.
+        """
         self._list_calls += 1
         if self._list_calls == 1:
             return [self.initial_task]
@@ -739,6 +747,11 @@ class ControlledRefreshSchedulingService(_MockSchedulingServiceMixin):
         raise AssertionError(f"Unexpected list_tasks call {self._list_calls}")
 
     async def delete_reminder(self, task_id: str) -> None:
+        """Record completion of the controlled delete.
+
+        Args:
+            task_id: Identifier of the deleted reminder.
+        """
         self.deleted_ids.append(task_id)
         self.delete_completed.set()
 

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -806,28 +806,29 @@ async def test_delete_mutation_refresh_cannot_repaint_after_newer_user_refresh()
         await pilot.app.workers.wait_for_complete()
 
         service = app.scheduling_service
-        workbench.post_message(DeleteTaskRequested(workbench._tasks[0]))
-        await service.delete_completed.wait()
-        await service.mutation_refresh_started.wait()
+        async with asyncio.timeout(2):
+            workbench.post_message(DeleteTaskRequested(workbench._tasks[0]))
+            await service.delete_completed.wait()
+            await service.mutation_refresh_started.wait()
 
-        # Resolving a conflict is a user action whose production handler
-        # requests a grouped task-list refresh.
-        workbench._on_conflict_resolved(
-            ConflictsTab.ConflictResolved("conflict-1", "local")
-        )
-        await service.user_refresh_started.wait()
-        user_worker = next(
-            worker
-            for worker in pilot.app.workers
-            if worker.node is workbench and worker.group == "schedules-load-tasks"
-        )
+            # Resolving a conflict is a user action whose production handler
+            # requests a grouped task-list refresh.
+            workbench._on_conflict_resolved(
+                ConflictsTab.ConflictResolved("conflict-1", "local")
+            )
+            await service.user_refresh_started.wait()
+            user_worker = next(
+                worker
+                for worker in pilot.app.workers
+                if worker.node is workbench and worker.group == "schedules-load-tasks"
+            )
 
-        service.release_user_refresh.set()
-        await pilot.app.workers.wait_for_complete([user_worker])
-        assert [task.id for task in workbench._tasks] == ["newest-task"]
+            service.release_user_refresh.set()
+            await pilot.app.workers.wait_for_complete([user_worker])
+            assert [task.id for task in workbench._tasks] == ["newest-task"]
 
-        service.release_mutation_refresh.set()
-        await pilot.app.workers.wait_for_complete()
+            service.release_mutation_refresh.set()
+            await pilot.app.workers.wait_for_complete()
 
         assert service.deleted_ids == ["task-to-delete"]
         assert [task.id for task in workbench._tasks] == ["newest-task"]

--- a/Tests/UI/test_watchlists_destination_shell.py
+++ b/Tests/UI/test_watchlists_destination_shell.py
@@ -746,6 +746,93 @@ async def test_watchlists_notifications_context_loads_and_updates_local_inbox():
 
 
 @pytest.mark.asyncio
+async def test_notification_mutation_refresh_cannot_overwrite_newer_pane_refresh():
+    """A mutation reconciliation and user refresh share latest-request-wins."""
+    app = _build_test_app()
+    screen = WatchlistsCollectionsScreen(app)
+    original = {
+        "id": 7,
+        "title": "Research complete",
+        "message": "The synthesis is ready.",
+        "category": "research",
+        "severity": "info",
+        "is_read": False,
+    }
+    stale_after_mutation = {**original, "title": "Stale mutation snapshot"}
+    newest = {**original, "title": "Newest pane snapshot", "is_read": True}
+    screen._notifications_controller.load_rows = AsyncMock(return_value=[original])
+    screen._notifications_controller.mark_read = AsyncMock(return_value=True)
+    screen.apply_navigation_context({"section": "notifications"})
+    host = WatchlistsContextHarness(screen)
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        async with asyncio.timeout(5):
+            while True:
+                pane = screen.query_one(
+                    "#watchlists-notifications-pane", NotificationsPane
+                )
+                if pane.notifications == [original]:
+                    break
+                await pilot.pause()
+
+        mutation_load_started = asyncio.Event()
+        pane_load_started = asyncio.Event()
+        release_mutation_load = asyncio.Event()
+        release_pane_load = asyncio.Event()
+        load_number = 0
+
+        async def controlled_load_rows():
+            nonlocal load_number
+            load_number += 1
+            if load_number == 1:
+                mutation_load_started.set()
+                await release_mutation_load.wait()
+                return [stale_after_mutation]
+            if load_number == 2:
+                pane_load_started.set()
+                await release_pane_load.wait()
+                return [newest]
+            raise AssertionError(f"unexpected notification load {load_number}")
+
+        screen._notifications_controller.load_rows = AsyncMock(
+            side_effect=controlled_load_rows
+        )
+        pane.select_notification_by_id("7")
+        await pilot.pause()
+        pane = screen.query_one("#watchlists-notifications-pane", NotificationsPane)
+        pane.query_one("#notifications-mark-read-button", Button).press()
+
+        async with asyncio.timeout(5):
+            await mutation_load_started.wait()
+
+        pane = screen.query_one("#watchlists-notifications-pane", NotificationsPane)
+        pane.query_one("#notifications-refresh-button", Button).press()
+        async with asyncio.timeout(5):
+            await pane_load_started.wait()
+
+        release_pane_load.set()
+        async with asyncio.timeout(5):
+            while screen._loaded_notifications != [newest]:
+                await pilot.pause()
+
+        release_mutation_load.set()
+        async with asyncio.timeout(5):
+            while any(
+                not worker.is_finished
+                for worker in app.workers
+                if screen in worker.node.ancestors_with_self
+            ):
+                await pilot.pause()
+
+        pane = screen.query_one("#watchlists-notifications-pane", NotificationsPane)
+        screen._notifications_controller.mark_read.assert_awaited_once_with(
+            7, is_read=True
+        )
+        assert screen._loaded_notifications == [newest]
+        assert pane.notifications == [newest]
+
+
+@pytest.mark.asyncio
 async def test_switching_to_notifications_does_not_report_recompose_as_load_error():
     app = _build_test_app()
     screen = WatchlistsCollectionsScreen(app)

--- a/Tests/Watchlists/test_watchlists_artifacts_pane.py
+++ b/Tests/Watchlists/test_watchlists_artifacts_pane.py
@@ -527,6 +527,136 @@ async def test_generate_records_a_complete_briefing_and_renders_its_body(monkeyp
         assert "evil.test/steal" in _painted(screen, detail.region)
 
 
+@pytest.mark.asyncio
+async def test_generation_refresh_cannot_overwrite_newer_artifacts_refresh(monkeypatch):
+    """Generation reconciliation and manual refresh share one load group."""
+    app = _build_test_app()
+    watchlist_id = _seed_watchlist(app)
+    db = app.watchlist_bundle_service.db
+    chat = _FakeChat()
+    _use_fake_chat(monkeypatch, chat)
+    real_generate = screen_module.generate_briefing
+    generation_written = asyncio.Event()
+    release_generation = asyncio.Event()
+
+    async def held_generate(*args, **kwargs):
+        row = await real_generate(*args, **kwargs)
+        generation_written.set()
+        await release_generation.wait()
+        return row
+
+    monkeypatch.setattr(screen_module, "generate_briefing", held_generate)
+
+    async with _open_artifacts(app, watchlist_id) as (screen, pilot, host):
+        real_list_briefings = db.list_briefings
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        pane.query_one("#artifacts-generate-button", Button).press()
+        async with asyncio.timeout(10):
+            await generation_written.wait()
+
+        newest_snapshot = real_list_briefings(watchlist_id)
+        assert len(newest_snapshot) == 1
+        assert newest_snapshot[0]["status"] == "complete"
+        stale_snapshot: list[dict] = []
+        load_started = [threading.Event(), threading.Event()]
+        release_load = [threading.Event(), threading.Event()]
+        load_lock = threading.Lock()
+        load_number = 0
+
+        def controlled_list_briefings(watchlist_id_arg):
+            nonlocal load_number
+            with load_lock:
+                current = load_number
+                load_number += 1
+            if current >= 2:
+                raise AssertionError(f"unexpected briefing load {current + 1}")
+            load_started[current].set()
+            if not release_load[current].wait(timeout=5):
+                raise AssertionError(f"briefing load {current + 1} was never released")
+            return stale_snapshot if current == 0 else newest_snapshot
+
+        db.list_briefings = controlled_list_briefings
+        release_generation.set()
+        async with asyncio.timeout(5):
+            while not load_started[0].is_set():
+                await pilot.pause()
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        pane.query_one("#artifacts-refresh-button", Button).press()
+        async with asyncio.timeout(5):
+            while not load_started[1].is_set():
+                await pilot.pause()
+
+        release_load[1].set()
+        async with asyncio.timeout(5):
+            while screen._loaded_briefings != newest_snapshot:
+                await pilot.pause()
+
+        release_load[0].set()
+        async with asyncio.timeout(5):
+            await host.workers.wait_for_complete()
+
+        pane = screen.query_one("#watchlists-artifacts-pane", ArtifactsPane)
+        recorded = real_list_briefings(watchlist_id)
+        assert len(chat.calls) == 1
+        assert [row["id"] for row in recorded] == [newest_snapshot[0]["id"]]
+        assert screen._loaded_briefings == newest_snapshot
+        assert pane.briefings == newest_snapshot
+
+
+@pytest.mark.asyncio
+async def test_generation_refresh_selects_the_generated_briefing(monkeypatch):
+    app = _build_test_app()
+    screen = WatchlistsCollectionsScreen(app)
+    screen._sweep_and_guard = Mock(return_value=([], []))
+    screen._request_briefings_refresh = Mock()
+    monkeypatch.setattr(
+        screen_module,
+        "generate_briefing",
+        AsyncMock(return_value={"id": 41, "status": "complete"}),
+    )
+
+    await screen._generate_briefing(Mock(), 7, None)
+
+    screen._request_briefings_refresh.assert_called_once_with(select_briefing_id=41)
+
+
+@pytest.mark.asyncio
+async def test_detached_cast_does_not_request_artifacts_refresh(monkeypatch):
+    app = _build_test_app()
+    screen = WatchlistsCollectionsScreen(app)
+    screen._sweep_and_guard_cast = Mock(return_value=([], []))
+    screen._request_briefings_refresh = Mock()
+    monkeypatch.setattr(
+        screen_module,
+        "generate_script",
+        AsyncMock(return_value={"id": 51, "status": "complete"}),
+    )
+
+    await screen._cast_script(Mock(), 41, None)
+
+    assert not screen.is_attached
+    screen._request_briefings_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_detached_audio_does_not_request_artifacts_refresh(monkeypatch):
+    app = _build_test_app()
+    screen = WatchlistsCollectionsScreen(app)
+    screen._sweep_and_guard_audio = Mock(return_value=([], []))
+    screen._request_briefings_refresh = Mock()
+    monkeypatch.setattr(
+        screen_module,
+        "generate_script_audio",
+        AsyncMock(return_value={"id": 61, "status": "complete"}),
+    )
+
+    await screen._synthesize_audio(Mock(), 51, Mock(), Mock())
+
+    assert not screen.is_attached
+    screen._request_briefings_refresh.assert_not_called()
+
+
 # --- 3. A stuck `generating` row is recovered, and says so -----------------
 
 

--- a/backlog/tasks/task-19870 - Mutation-workers-refresh-inline-instead-of-dispatching-into-the-loader-group.md
+++ b/backlog/tasks/task-19870 - Mutation-workers-refresh-inline-instead-of-dispatching-into-the-loader-group.md
@@ -21,13 +21,15 @@ priority: low
 Source: surfaced by **TASK-19559**'s reviewer while verifying that task's
 worker-group census.
 
-**Precondition, stated up front: this does not reproduce on `dev` today.** The
-worker groups it names — `schedules-load-tasks` and `wc_notifications` — are
-introduced by TASK-19559, which is still in flight (its first review returned
-do-not-ship). At `3605bd52d` every schedules worker is `exclusive=True` with no
-group at all, which is the larger defect TASK-19559 exists to fix. This task is
-the follow-up that becomes live the moment that one lands, and it is filed now
-so the observation is not lost between a fix round and a merge.
+**Historical filing context (2026-08-22):** this defect did not yet reproduce
+on `dev` when the task was filed because the named worker groups —
+`schedules-load-tasks` and `wc_notifications` — were being introduced by
+TASK-19559, whose first review had returned do-not-ship. At `3605bd52d` every
+schedules worker was `exclusive=True` with no group at all, the larger defect
+TASK-19559 existed to fix. This follow-up was recorded before that merge so the
+review observation would not be lost. TASK-19559 has since merged and is Done,
+so its dependency and implementation precondition were satisfied before this
+task began.
 
 The shape: once a loader has its own worker group, a mutation worker that wants
 the list refreshed afterwards should dispatch the refresh **into that group**,
@@ -102,9 +104,22 @@ targeted test modules. The exact Python 3.11.13 gate collected 291 tests: 285
 passed, three failures reproduced unchanged on `origin/dev` (the unrelated
 Console wiring inventory violation and two Watchlists shell behaviors), and
 three localhost feed-server tests were sandbox-blocked but passed 3/3 outside
-the sandbox. A fresh task-owned seven-node gate passed 7/7. Mutation checks
-proved both the structural guard and schedules race went red after restoring
-one raw inline await, then the restored guard/race passed 2/2.
+the sandbox. A fresh task-owned gate passed 7/7 under Python 3.11.13 with the
+following exact node inventory:
+
+```bash
+python -m pytest \
+  Tests/Architecture/test_worker_exclusive_group_inventory.py::test_mutation_refreshes_dispatch_through_loader_group \
+  Tests/UI/test_schedules_workbench.py::test_delete_mutation_refresh_cannot_repaint_after_newer_user_refresh \
+  Tests/UI/test_watchlists_destination_shell.py::test_notification_mutation_refresh_cannot_overwrite_newer_pane_refresh \
+  Tests/Watchlists/test_watchlists_artifacts_pane.py::test_generation_refresh_cannot_overwrite_newer_artifacts_refresh \
+  Tests/Watchlists/test_watchlists_artifacts_pane.py::test_generation_refresh_selects_the_generated_briefing \
+  Tests/Watchlists/test_watchlists_artifacts_pane.py::test_detached_cast_does_not_request_artifacts_refresh \
+  Tests/Watchlists/test_watchlists_artifacts_pane.py::test_detached_audio_does_not_request_artifacts_refresh
+```
+
+Mutation checks proved both the structural guard and schedules race went red
+after restoring one raw inline await, then the restored guard/race passed 2/2.
 
 Ruff lint passed all six modified Python files. Ruff format passed five files;
 `Tests/Watchlists/test_watchlists_artifacts_pane.py` retains the same unrelated
@@ -123,6 +138,7 @@ boundaries.
 
 ## Notes
 
-Do not start this before TASK-19559 merges — the group names this task refers
-to do not exist until then, and the pre-19559 code has a bigger problem (no
-groups at all) that this fix would sit on top of incoherently.
+Dependency satisfied: TASK-19559 is Done and merged, and its loader groups are
+present. Historically, this task was intentionally held until that merge
+because the pre-19559 code had the larger problem of no groups at all; applying
+this follow-up before then would have sat on top of that defect incoherently.

--- a/backlog/tasks/task-19870 - Mutation-workers-refresh-inline-instead-of-dispatching-into-the-loader-group.md
+++ b/backlog/tasks/task-19870 - Mutation-workers-refresh-inline-instead-of-dispatching-into-the-loader-group.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-19870
 title: Mutation workers refresh inline instead of dispatching into the loader group
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-22'
-updated_date: '2026-08-29 04:13'
+updated_date: '2026-08-29 05:46'
 labels:
   - workers
   - concurrency
@@ -61,16 +61,16 @@ a redundant or briefly out-of-order repaint rather than a lost write.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A refresh triggered by a mutation worker is subject to the same worker
+- [x] #1 A refresh triggered by a mutation worker is subject to the same worker
       group as a refresh triggered directly by the user
-- [ ] #2 Two refreshes that overlap — one from a mutation, one from a user action —
+- [x] #2 Two refreshes that overlap — one from a mutation, one from a user action —
       cannot interleave their writes to the same list
-- [ ] #3 A test drives a mutation and a concurrent user refresh and asserts the
+- [x] #3 A test drives a mutation and a concurrent user refresh and asserts the
       resulting list contents, and is mutation-checked (restoring the inline
       `await` makes it red)
-- [ ] #4 The schedules workbench, watchlists notification handlers, and watchlists
+- [x] #4 The schedules workbench, watchlists notification handlers, and watchlists
       briefing generation/cast/audio handlers are covered
-- [ ] #5 TASK-19559's worker-group guard is extended to notice an inline loader
+- [x] #5 TASK-19559's worker-group guard is extended to notice an inline loader
       call inside a worker body, or the reason it cannot is recorded
 <!-- AC:END -->
 
@@ -86,6 +86,40 @@ ADR required: no
 ADR path: N/A
 Reason: the task enforces TASK-19559's existing worker-group contract without changing an architectural boundary.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added screen-local refresh helpers for schedules, notifications, and artifacts,
+then routed all eleven audited mutation completions and the corresponding user
+refreshes through their existing exclusive loader groups. Extended the worker
+inventory with a path-scoped AST guard and mounted overlap regressions for all
+three surfaces; generation-selection and detached cast/audio behavior remain
+covered by focused dispatch tests.
+
+Modified production and test files are the two affected screens plus the four
+targeted test modules. The exact Python 3.11.13 gate collected 291 tests: 285
+passed, three failures reproduced unchanged on `origin/dev` (the unrelated
+Console wiring inventory violation and two Watchlists shell behaviors), and
+three localhost feed-server tests were sandbox-blocked but passed 3/3 outside
+the sandbox. A fresh task-owned seven-node gate passed 7/7. Mutation checks
+proved both the structural guard and schedules race went red after restoring
+one raw inline await, then the restored guard/race passed 2/2.
+
+Ruff lint passed all six modified Python files. Ruff format passed five files;
+`Tests/Watchlists/test_watchlists_artifacts_pane.py` retains the same unrelated
+whole-file drift as `origin/dev`, while the task-added lines 530–659 pass a
+range-scoped format check. Both working-tree and branch `git diff --check`
+commands passed. Review of `git diff origin/dev...HEAD` found no task-owned
+correctness issue. No full-suite run was requested, and no new general lesson
+or documentation change was warranted.
+
+ADR required: no
+ADR path: N/A
+Reason: this implements TASK-19559's existing worker-group contract without
+changing storage, ownership, service, security, dependency, or long-lived UX
+boundaries.
+<!-- SECTION:NOTES:END -->
 
 ## Notes
 

--- a/backlog/tasks/task-19870 - Mutation-workers-refresh-inline-instead-of-dispatching-into-the-loader-group.md
+++ b/backlog/tasks/task-19870 - Mutation-workers-refresh-inline-instead-of-dispatching-into-the-loader-group.md
@@ -4,7 +4,7 @@ title: Mutation workers refresh inline instead of dispatching into the loader gr
 status: In Progress
 assignee: []
 created_date: '2026-08-22'
-updated_date: '2026-08-29 04:01'
+updated_date: '2026-08-29 04:13'
 labels:
   - workers
   - concurrency
@@ -74,11 +74,18 @@ a redundant or briefly out-of-order repaint rather than a lost write.
       call inside a worker body, or the reason it cannot is recorded
 <!-- AC:END -->
 
-## Design
+## Implementation Plan
 
-[Mutation Loader Group Dispatch Design](../../Docs/superpowers/specs/2026-08-28-mutation-loader-group-dispatch-design.md)
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a path-scoped AST guard that rejects inline awaits of the three affected loaders and pins all eleven mutation owners to their dispatch helper.
+2. Write a mounted schedules overlap regression, then add one schedules refresh helper and route all direct and mutation refreshes through schedules-load-tasks.
+3. Write mounted notification and artifact overlap regressions, then add the Watchlists notification and briefing refresh helpers and route all relevant call sites through their existing loader groups.
+4. Run the targeted UI and architecture gate, Ruff lint/format, mutation-check the guard, complete task documentation, and review the diff before PR creation.
 
-
+ADR required: no
+ADR path: N/A
+Reason: the task enforces TASK-19559's existing worker-group contract without changing an architectural boundary.
+<!-- SECTION:PLAN:END -->
 
 ## Notes
 

--- a/backlog/tasks/task-19870 - Mutation-workers-refresh-inline-instead-of-dispatching-into-the-loader-group.md
+++ b/backlog/tasks/task-19870 - Mutation-workers-refresh-inline-instead-of-dispatching-into-the-loader-group.md
@@ -1,22 +1,23 @@
 ---
 id: TASK-19870
-title: >-
-  Mutation workers refresh inline instead of dispatching into the loader group
-status: To Do
+title: Mutation workers refresh inline instead of dispatching into the loader group
+status: In Progress
 assignee: []
 created_date: '2026-08-22'
+updated_date: '2026-08-29 04:01'
 labels:
   - workers
   - concurrency
   - scheduling
   - watchlists
-priority: low
 dependencies:
   - TASK-19559
+priority: low
 ---
 
 ## Description
 
+<!-- SECTION:DESCRIPTION:BEGIN -->
 Source: surfaced by **TASK-19559**'s reviewer while verifying that task's
 worker-group census.
 
@@ -39,6 +40,13 @@ the loader inline, inside their own worker:
   while the standalone refresh calls dispatch into `schedules-load-tasks`
 - the watchlists notification mark-read and dismiss handlers do the same
   outside `wc_notifications`
+- the watchlists briefing generate, cast, and audio-synthesis workers likewise
+  await `_load_briefings()` outside `wl-briefings-load`
+
+An implementation-time audit of every mutation-triggered loader in both
+screens found these eleven affected paths. Other mutation refreshes already
+dispatch into their loader group directly or call a loader decorated with the
+correct group and therefore remain out of scope.
 
 The consequence is that an inline refresh is invisible to the group that is
 supposed to serialize refreshes. A mutation-triggered refresh and a
@@ -49,20 +57,28 @@ found in the Study pane (blocker R2), reached by a different route.
 
 Low severity: both paths render from the same query, so the visible outcome is
 a redundant or briefly out-of-order repaint rather than a lost write.
+<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
-
-- [ ] A refresh triggered by a mutation worker is subject to the same worker
+<!-- AC:BEGIN -->
+- [ ] #1 A refresh triggered by a mutation worker is subject to the same worker
       group as a refresh triggered directly by the user
-- [ ] Two refreshes that overlap — one from a mutation, one from a user action —
+- [ ] #2 Two refreshes that overlap — one from a mutation, one from a user action —
       cannot interleave their writes to the same list
-- [ ] A test drives a mutation and a concurrent user refresh and asserts the
+- [ ] #3 A test drives a mutation and a concurrent user refresh and asserts the
       resulting list contents, and is mutation-checked (restoring the inline
       `await` makes it red)
-- [ ] The schedules workbench and the watchlists notification handlers are both
-      covered
-- [ ] TASK-19559's worker-group guard is extended to notice an inline loader
+- [ ] #4 The schedules workbench, watchlists notification handlers, and watchlists
+      briefing generation/cast/audio handlers are covered
+- [ ] #5 TASK-19559's worker-group guard is extended to notice an inline loader
       call inside a worker body, or the reason it cannot is recorded
+<!-- AC:END -->
+
+## Design
+
+[Mutation Loader Group Dispatch Design](../../Docs/superpowers/specs/2026-08-28-mutation-loader-group-dispatch-design.md)
+
+
 
 ## Notes
 

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -18,7 +18,11 @@ from textual.widgets import Button, DataTable, Input, Static, TabbedContent, Tab
 
 from ...Navigation.base_app_screen import BaseAppScreen
 from ...Navigation.screen_state_store import RuntimeIdentity
-from ...Workbench.workbench_state import RecoveryState, WorkbenchHeaderState, WorkbenchStatus
+from ...Workbench.workbench_state import (
+    RecoveryState,
+    WorkbenchHeaderState,
+    WorkbenchStatus,
+)
 from ...Workbench.workbench_widgets import DestinationHeader, RecoveryCallout
 from ....runtime_policy.bootstrap import set_authoritative_runtime_source
 from ....Scheduling.events import (
@@ -182,7 +186,9 @@ class SchedulesWorkbench(BaseAppScreen):
                                 placeholder="Filter: title, type, or status…",
                                 id="scheduling-queue-filter",
                             )
-                            yield DataTable(id="scheduling-task-table", cursor_type="row")
+                            yield DataTable(
+                                id="scheduling-task-table", cursor_type="row"
+                            )
                             yield Static("", id="scheduling-pane-notice")
                         with Vertical(id="scheduling-detail-pane"):
                             yield TaskDetail(id="scheduling-task-detail")
@@ -218,11 +224,7 @@ class SchedulesWorkbench(BaseAppScreen):
         self._next_run_refresh_timer = self.set_interval(
             NEXT_RUN_REFRESH_SECONDS, self._refresh_next_run_rendering
         )
-        self.run_worker(
-            self.load_tasks,
-            exclusive=True,
-            group="schedules-load-tasks",
-        )  # type: ignore[arg-type]
+        self._request_tasks_refresh()
 
     def _refresh_next_run_rendering(self) -> None:
         """Re-render the queue so relative next-run text stays honest.
@@ -267,6 +269,14 @@ class SchedulesWorkbench(BaseAppScreen):
             "schedules-workbench-compact",
         )
 
+    def _request_tasks_refresh(self) -> None:
+        """Schedule the task loader through its exclusive worker group."""
+        self.run_worker(
+            self.load_tasks,
+            exclusive=True,
+            group="schedules-load-tasks",
+        )  # type: ignore[arg-type]
+
     async def load_tasks(self) -> None:
         """Fetch reminders from the scheduling service and populate the table."""
         service = self._scheduling_service
@@ -297,9 +307,7 @@ class SchedulesWorkbench(BaseAppScreen):
         # Marks must always refer to rows that still exist (task-23107
         # review F1): a task deleted or filtered out of existence must not
         # linger as an invisible mark a bulk verb would act on.
-        self._marked_ids.intersection_update(
-            {task.id for task in self._tasks}
-        )
+        self._marked_ids.intersection_update({task.id for task in self._tasks})
         self._render_table()
         await self._refresh_console_context()
 
@@ -334,10 +342,7 @@ class SchedulesWorkbench(BaseAppScreen):
             # task-18937: filtering for "missed" finds late-dispatch rows too,
             # not just handler-failure ones -- both are honest matches for a
             # user asking "what went wrong while I wasn't looking".
-            or (
-                _was_missed_while_away(task)
-                and "missed" in text
-            )
+            or (_was_missed_while_away(task) and "missed" in text)
         ]
         rows: list[tuple[str, str, Text, str]] = [
             (
@@ -378,9 +383,7 @@ class SchedulesWorkbench(BaseAppScreen):
             self.query_one("#scheduling-task-inspector", TaskInspector).set_task(None)
             if self._tasks and self._filter_text.strip():
                 # Everything filtered out: say so instead of "select a task".
-                self.query_one(
-                    "#scheduling-task-detail-empty-state", Static
-                ).update(
+                self.query_one("#scheduling-task-detail-empty-state", Static).update(
                     f"No tasks match '{self._filter_text.strip()}'. "
                     "Clear the filter to see the queue."
                 )
@@ -570,7 +573,7 @@ class SchedulesWorkbench(BaseAppScreen):
                     f"Deleted '{event.task.title}'.",
                     severity="information",
                 )
-            await self.load_tasks()
+            self._request_tasks_refresh()
 
         self.run_worker(
             _delete_and_refresh,
@@ -669,7 +672,7 @@ class SchedulesWorkbench(BaseAppScreen):
                     "Failed to save the scheduled task. Check the form values and try again.",
                     severity="error",
                 )
-            await self.load_tasks()
+            self._request_tasks_refresh()
 
         self.run_worker(
             _save_and_refresh,
@@ -760,7 +763,7 @@ class SchedulesWorkbench(BaseAppScreen):
                     f"Failed to run '{task.title}'.",
                     severity="error",
                 )
-            await self.load_tasks()
+            self._request_tasks_refresh()
 
         self.run_worker(
             _run_and_refresh,
@@ -791,7 +794,7 @@ class SchedulesWorkbench(BaseAppScreen):
                     f"Failed to update '{task.title}'.",
                     severity="error",
                 )
-            await self.load_tasks()
+            self._request_tasks_refresh()
 
         self.run_worker(
             _update_and_refresh,
@@ -907,9 +910,7 @@ class SchedulesWorkbench(BaseAppScreen):
             hidden = sum(
                 1 for task_id in self._marked_ids if task_id not in visible_ids
             )
-            hidden_note = (
-                f" ({hidden} hidden by the filter)" if hidden else ""
-            )
+            hidden_note = f" ({hidden} hidden by the filter)" if hidden else ""
             parts.append(
                 f"{marked_count} marked{hidden_note} — space toggles all "
                 "· d deletes all · esc clears"
@@ -945,7 +946,7 @@ class SchedulesWorkbench(BaseAppScreen):
             app_config=self.app_instance.app_config,
         )
         self._refresh_owner_select()
-        self.run_worker(self.load_tasks, exclusive=True, group="schedules-load-tasks")
+        self._request_tasks_refresh()
         self._refresh_conflicts_tab()
 
     @on(Button.Pressed, "#scheduling-clear-error")
@@ -977,7 +978,7 @@ class SchedulesWorkbench(BaseAppScreen):
             message = "Sync finished — nothing to pull or push."
         self.app_instance.notify(message, severity="information")
         self._refresh_owner_select()
-        self.run_worker(self.load_tasks, exclusive=True, group="schedules-load-tasks")
+        self._request_tasks_refresh()
         self._refresh_conflicts_tab()
 
     @on(SyncFailed)
@@ -985,12 +986,12 @@ class SchedulesWorkbench(BaseAppScreen):
         self._sync_running = False
         self.app_instance.notify(f"Sync failed: {event.error}", severity="error")
         self._refresh_owner_select()
-        self.run_worker(self.load_tasks, exclusive=True, group="schedules-load-tasks")
+        self._request_tasks_refresh()
         self._refresh_conflicts_tab()
 
     @on(ConflictsTab.ConflictResolved)
     def _on_conflict_resolved(self, event: ConflictsTab.ConflictResolved) -> None:
-        self.run_worker(self.load_tasks, exclusive=True, group="schedules-load-tasks")
+        self._request_tasks_refresh()
         self._refresh_conflicts_tab()
 
     def _refresh_conflicts_tab(self) -> None:
@@ -1005,9 +1006,7 @@ class SchedulesWorkbench(BaseAppScreen):
         # Surface the conflict count on the tab label itself (UX-063).
         try:
             pane = self.query_one("#scheduling-conflicts-tab", TabPane)
-            pane.label = (
-                f"Conflicts ({len(conflicts)})" if conflicts else "Conflicts"
-            )
+            pane.label = f"Conflicts ({len(conflicts)})" if conflicts else "Conflicts"
         except Exception:  # noqa: BLE001 - pane not mounted
             pass
 
@@ -1078,11 +1077,12 @@ class SchedulesWorkbench(BaseAppScreen):
             count = len(marked) - errors
             self.app_instance.notify(
                 f"Deleted {count} marked task{'s' if count != 1 else ''}"
-                + (f" ({errors} failed)" if errors else "") + ".",
+                + (f" ({errors} failed)" if errors else "")
+                + ".",
                 severity="information" if not errors else "warning",
             )
             self._marked_ids.clear()
-            await self.load_tasks()
+            self._request_tasks_refresh()
 
         self.run_worker(
             _bulk_delete,
@@ -1220,11 +1220,12 @@ class SchedulesWorkbench(BaseAppScreen):
             count = len(marked) - errors
             self.app_instance.notify(
                 f"Toggled {count} marked task{'s' if count != 1 else ''}"
-                + (f" ({errors} failed)" if errors else "") + ".",
+                + (f" ({errors} failed)" if errors else "")
+                + ".",
                 severity="information" if not errors else "warning",
             )
             self._marked_ids.clear()
-            await self.load_tasks()
+            self._request_tasks_refresh()
 
         self.run_worker(
             _bulk_toggle,
@@ -1272,7 +1273,9 @@ class SchedulesWorkbench(BaseAppScreen):
             outcome = await service.sync_now(owner_id)
             if outcome is not None and getattr(outcome, "status", None) == "error":
                 self.post_message(
-                    SyncFailed(owner_id, getattr(outcome, "error", None) or "sync error")
+                    SyncFailed(
+                        owner_id, getattr(outcome, "error", None) or "sync error"
+                    )
                 )
                 return
             conflicts = service.db.get_conflicts(owner_id, primitive="reminder_task")

--- a/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
+++ b/tldw_chatbook/UI/Screens/watchlists_collections_screen.py
@@ -4723,9 +4723,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # (and offer Generate against the new one) -- the split-brain
             # shape, on a surface that spends the user's provider quota.
             self._selected_briefing = None
-            self.run_worker(
-                self._load_briefings(), exclusive=True, group="wl-briefings-load"
-            )
+            self._request_briefings_refresh()
 
     def _sync_tree_navigation_authority(self) -> None:
         """Push contextual selection availability into the mounted rail."""
@@ -5346,18 +5344,12 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         elif self.active_section == "sources":
             self.run_worker(self._load_sources(), exclusive=True, group="wc_sources")
         elif self.active_section == "notifications":
-            self.run_worker(
-                self._load_notifications(),
-                exclusive=True,
-                group="wc_notifications",
-            )
+            self._request_notifications_refresh()
         elif self.active_section == "artifacts":
             # Own group (TASK-1362): `exclusive=True` without one cancels
             # every other worker in the default group, which here would
             # include an in-flight briefing generation.
-            self.run_worker(
-                self._load_briefings(), exclusive=True, group="wl-briefings-load"
-            )
+            self._request_briefings_refresh()
 
     def _open_sources_create_form(self) -> None:
         if not self.is_mounted:
@@ -7602,6 +7594,14 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
                 "Failed to update the local notifications pane."
             )
 
+    def _request_notifications_refresh(self) -> None:
+        """Schedule the inbox loader through its latest-request-wins group."""
+        self.run_worker(
+            self._load_notifications(),
+            exclusive=True,
+            group="wc_notifications",
+        )
+
     @on(NotificationSelected)
     def handle_notification_selected(self, event: NotificationSelected) -> None:
         event.stop()
@@ -7620,11 +7620,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self, event: RefreshNotificationsRequested
     ) -> None:
         event.stop()
-        self.run_worker(
-            self._load_notifications(),
-            exclusive=True,
-            group="wc_notifications",
-        )
+        self._request_notifications_refresh()
 
     @on(MarkNotificationReadRequested)
     def handle_mark_notification_read_requested(
@@ -7642,7 +7638,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             notification_id, is_read=True
         )
         if updated:
-            await self._load_notifications()
+            self._request_notifications_refresh()
 
     @on(DismissNotificationRequested)
     def handle_dismiss_notification_requested(
@@ -7660,7 +7656,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             notification_id, is_dismissed=True
         )
         if dismissed:
-            await self._load_notifications()
+            self._request_notifications_refresh()
 
     # --- Artifacts: the briefings a watchlist has produced -----------------
     #
@@ -8227,6 +8223,16 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             self._watchlist_has_audio_episodes = has_audio_episodes
         self._apply_briefing_state_to_pane()
 
+    def _request_briefings_refresh(
+        self, *, select_briefing_id: int | None = None
+    ) -> None:
+        """Schedule the Artifacts loader through its latest-request-wins group."""
+        self.run_worker(
+            self._load_briefings(select_briefing_id=select_briefing_id),
+            exclusive=True,
+            group="wl-briefings-load",
+        )
+
     def _apply_briefing_state_to_pane(self) -> None:
         """Push every screen-held briefing value into the mounted pane.
 
@@ -8421,9 +8427,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         # selection at all). The screen-side mirrors above still have to be
         # cleared here -- they are what `handle_citation_activated` and a
         # later rebuild read.
-        self.run_worker(
-            self._load_briefings(), exclusive=True, group="wl-briefings-load"
-        )
+        self._request_briefings_refresh()
 
     @on(ScriptSelected)
     def handle_script_selected(self, event: ScriptSelected) -> None:
@@ -8461,9 +8465,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             pane = None
         if pane is not None:
             pane.script_audio = None
-        self.run_worker(
-            self._load_briefings(), exclusive=True, group="wl-briefings-load"
-        )
+        self._request_briefings_refresh()
 
     @on(CitationActivated)
     def handle_citation_activated(self, event: CitationActivated) -> None:
@@ -8533,9 +8535,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
         self, event: RefreshBriefingsRequested
     ) -> None:
         event.stop()
-        self.run_worker(
-            self._load_briefings(), exclusive=True, group="wl-briefings-load"
-        )
+        self._request_briefings_refresh()
 
     # --- Exporting a briefing as markdown (spec #2 phase 3, Task 1) --------
 
@@ -10014,7 +10014,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # Repaint on every path: a refusal has just changed a row's
             # status, and the failure path may leave a `generating` row this
             # attempt inserted before it broke.
-            await self._load_briefings(select_briefing_id=generated_id)
+            self._request_briefings_refresh(select_briefing_id=generated_id)
 
     # --- Cast a script from the selected briefing (spec #2 phase 2a, ------
     # Task 5). Sibling of the Generate chain immediately above: own
@@ -10361,7 +10361,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # Repaint on every path: a refusal may have just failed a
             # zombie row, and a completed cast has a new script to show.
             if self.is_attached:
-                await self._load_briefings()
+                self._request_briefings_refresh()
 
     # --- Artifacts: synthesizing and playing a script's audio (spec #2 --
     # phase 2b, Task 7) --------------------------------------------------
@@ -10630,7 +10630,7 @@ class WatchlistsCollectionsScreen(BaseAppScreen):
             # zombie row, and a completed (or failed) attempt has a new
             # audio row to show.
             if self.is_attached:
-                await self._load_briefings()
+                self._request_briefings_refresh()
 
     @on(PlayAudioRequested)
     def handle_play_audio_requested(self, event: PlayAudioRequested) -> None:


### PR DESCRIPTION
## Summary
- Route schedules, Watchlists notifications, and artifact mutation refreshes through their shared exclusive loader groups.
- Cover all eleven mutation paths and prevent stale older loads from repainting after newer refreshes.
- Add structural inventory guards plus mounted overlap regressions for schedules, notifications, and artifacts.

## Verification
- 7/7 task-owned regression nodes passed on the current head.
- Focused schedules suite: 40 passed.
- Ruff lint passed all six modified Python files.
- Ruff format passed five files; the artifacts test retains identical whole-file drift from origin/dev, while task-added lines are formatted.
- git diff --check and git diff --check origin/dev...HEAD passed.
- Independent final whole-branch review: APPROVED, no actionable findings.

## Baseline/environment notes
- The broader focused gate has three failures reproduced unchanged on origin/dev and three localhost feed-server failures caused by sandbox networking; those feed tests pass outside the sandbox.

## Governance
- Completes TASK-19870.
- ADR required: no; this enforces the existing TASK-19559 worker-group contract without changing architecture boundaries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mutation-triggered refreshes for schedules, watchlist notifications, and artifacts now dispatch through their exclusive loader groups instead of awaiting raw loaders inline, so older refreshes can no longer repaint the UI after newer ones. All eleven affected mutation paths use screen-local dispatch helpers, and an AST inventory guard rejects any future inline awaits of those loaders.

<sup>Written for commit 352a499b7095968f878467187ad1d90af77501e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

