### PR TITLE
feat: consolidate video generation and Console provider settings

### DIFF
--- a/Docs/User_Guide/library/file-notes.md
+++ b/Docs/User_Guide/library/file-notes.md
@@ -1,12 +1,13 @@
-# File Notes — plain files on disk, edited in place
+# Folder Files — plain notes on disk, edited in place
 
 ## What this screen is for
 
-File Notes edits ordinary files that live in a folder you choose on disk —
+Folder Files edits ordinary files that live in a folder you choose on disk —
 what you see in the editor is exactly what's in the file, and saves write
 straight back to it. It is a separate system from [Database notes](notes.md):
 nothing here is stored in the Library database, there are no templates or
-autosync, and no "Use in Console" handoff. This is also the key difference
+database mirror, and no "Use in Console" handoff. This is also the key
+difference
 from Library Notes lasting sync: lasting sync keeps a reviewed relationship
 between a managed Library folder and a local folder, while Folder files mode
 edits that folder directly with nothing mirrored anywhere. Reach for it
@@ -21,14 +22,24 @@ commit to its existing upstream, without leaving the app.
 Open [Library](../library.md) (**Ctrl+3**), pick **Notes** in the rail's
 Browse section, then use the source strip at the top of the canvas: it reads
 **Library notes** | **Folder files**. Click **Folder files** — while the
-workspace loads you'll briefly see "Opening File Notes…". At 120 columns
-and wider, the rail stays
-beside the workspace unless you press **Collapse** in its **Navigation**
-heading; use the slim **Nav** handle to expand it again. On compact
-terminals, Library shows the File Notes canvas as the single visible stage so
+workspace loads you'll briefly see "Opening File Notes…". At wide sizes,
+Library navigation and the Folder Files tree have separate slim collapse
+grips. Each pane remembers its own choice; collapsing the tree does not also
+collapse Library navigation or the Database Notes list. On compact
+terminals, Library shows the Folder Files canvas as the single visible stage so
 its controls remain on-screen; **Escape** or **Library notes** returns to the
 Library notes view. Either switch first saves any unsaved edits on the side
 you're leaving.
+
+The first editable file opened during a wide Notes work session closes Library
+navigation automatically once to make room. That temporary close does not
+change your saved pane choice. Reopen Library navigation with its grip and it
+stays open for the rest of the work session. Opening another file, switching
+between Edit and Manage, autosaving, resolving a conflict, or resizing does
+not close it again. The automatic close resets only when you close or clear
+the open Folder Files file, switch between Folder Files and Database Notes,
+change the linked folder, clear the selected Database note, or leave Notes.
+Using compact **Back to navigator** does not reset it.
 
 ## Layout tour
 
@@ -39,22 +50,20 @@ you're leaving.
   status becomes "Linked — \<folder\>" (or "Checking — …" / "Offline — …"
   when the folder can't be verified) and the button relabels to **Change…**.
   **Details** opens the read-only "File Notes folder details" dialog.
-- **Navigator** (left) — a "Search file contents…" input, the **Files** tree
-  of everything under the linked folder, a **Search results** tree that
-  appears only while a query is active, and the **Session Git (N)** button —
-  N counts the files changed in this session. Large folders and direct-path
+- **Folder navigator** (left) — a **New** action, a "File contents…" search
+  input, the **Files** tree of everything under the linked folder, and a
+  **Search results** tree that appears only while a query is active. Its grip
+  collapses or restores this tree independently of Library navigation and the
+  Database Notes list. Large folders and direct-path
   search fallbacks show 100 rows at a time; activate **Load more** to append
   the next 100 without rebuilding the entire tree.
-- **Editor pane** (right) — a breadcrumb ("No file selected" until you open
-  one; "Recently deleted: \<path\>" right after a delete), a save-status
-  label (Idle / Dirty / Saving / Saved / Conflict / Error, sometimes with a
-  detail after a dash), a path input labeled **Target path · New / Move / Save
-  copy** with placeholder "relative/path.md", two toolbars (the primary
-  actions plus the disclosed secondary actions), the text editor itself,
-  and an action-status line where results like "Deleted. Restore remains
-  available." appear.
-- **Session Git panel** — pressing **Session Git (N)** swaps the whole
-  workspace for the staging, commit, and guarded-push panel described below;
+- **File work area** (right) — a breadcrumb ("No file selected" until you
+  open one; "Recently deleted: \<path\>" right after a delete), an
+  Idle / Dirty / Saving / Saved / Conflict / Error status, and **Edit** /
+  **Manage** modes. Edit gives the file body nearly all available space;
+  Manage groups path details, file actions, Session Git, and Danger.
+- **Session Git panel** — **Manage** → **Review session changes (N)** opens
+  the staging, commit, and guarded-push panel described below;
   from the row list, **Esc** or **Back to navigator** returns to the files.
   During commit or push, **Esc** follows the phase-specific safe action in the
   keyboard table below.
@@ -68,30 +77,41 @@ you're leaving.
 | **Choose folder…** / **Change…** | Opens the "Choose File Notes Folder" picker; the choice is saved to `[file_notes] root` in config.toml |
 | **Details** | Opens "File Notes folder details" — a read-only status report; **Close** or **Esc** dismisses it |
 
-### Editor toolbar
+### Edit and Manage
 
-The persistently labeled path input ("relative/path.md") is the target for
-**New**, **Move**, and **Save copy** or **Export exact copy**: type where you
-want the file to go, then press the relevant button.
+**Edit** is the ordinary writing view. It keeps the file body prominent and
+shows only safe actions that become relevant to the current state, such as
+Restore, Compare, Resolve conflict, Reload from disk, or Save Copy. Saving is
+automatic; there is no ordinary Save button.
 
-The normal primary order is **New**, **Move**, **Delete**, then **More file
-actions**. **Delete** remains separated from **New**; compact actions use
-full-width rows and the editor pane scrolls to keep each focused action
-reachable. **More file actions** reveals the currently applicable secondary
-Protect/Unprotect, Reload, and Refresh actions.
+**Manage** keeps less-frequent controls in clearly named sections:
+
+- **File details & path** shows the exact linked path and save details.
+- **File actions** contains Move, Reload, Save copy, and **More file actions**;
+  the latter reveals Protect/Unprotect and Refresh when available.
+- **Session Git** contains **Review session changes (N)**.
+- **Danger** contains Delete, separated from routine file work.
+
+**New**, **Move**, and **Save copy** are named path tasks rather than one
+always-visible path field. Start the task, enter its labeled target such as
+`ideas/today.md`, and choose its named action: **Create**, **Move**, or **Save
+Copy**. Only one path task can be open at a time; starting another replaces it
+after any pending save or conflict is handled. **Cancel** or **Escape** closes
+the path task and returns focus to the action that opened it. **Restore** is
+contextual and restores the recently deleted path without asking for a target.
 
 | Control | What it does |
 |---|---|
-| **New** | Creates an empty file at the typed path and opens it — there is no file picker for creating content |
-| **Move** | Moves the open file to the typed path |
+| **New** | Opens a **New file path** task; **Create** makes an empty file at that absent relative path and opens it — there is no file picker for creating content |
+| **Move** | Opens a **Move file to** task; its **Move** action moves the open file to that relative path |
 | **Delete** | Two-press: first activation shows "Activate Delete again to confirm.", second deletes ("Deleted. Restore remains available.") |
 | **Restore** | Brings back the most recently deleted file |
 | **Protect** / **Unprotect** | Toggles protection on the open file ("Protected." / "Unprotected."); every save to a protected file first stores a checkpoint of its previous contents in the local recovery database |
 | **Reload** / **Reload from disk** / **Discard draft and reload** | Re-reads the open file from disk. **Reload from disk** becomes immediately visible in Conflict; in Error, the destructive label is shown. The first activation opens a confirmation with **Cancel** focused; only **Discard draft and load disk** replaces the editor contents |
 | **Compare** | Appears only for a Conflict and opens a read-only Base / Draft / Disk comparison without resolving the conflict or changing the editor |
 | **Resolve conflict** | Appears only for a Conflict and discloses the three bounded choices described below; none overwrites the changed disk file |
-| **Save copy** | Writes the complete editor draft to the typed path; enabled while the save status is Dirty, Conflict, or Error |
-| **Export exact copy** | Replaces **Save copy** for a large read-only file and streams the complete current disk bytes, not the visible excerpt, to an absent typed path |
+| **Save copy** | Opens a **Save copy as** task; **Save Copy** writes the complete editor draft to that absent path. It is available as an ordinary Manage action and as a safe recovery action when relevant |
+| **Export exact copy** | Replaces **Save copy** for a large read-only file and opens a named path task that streams the complete current disk bytes, not the visible excerpt, to an absent path |
 | **Refresh** | Re-scans the folder and rebuilds the **Files** tree |
 
 Saving is automatic: edit and the status walks Dirty → Saving → Saved. If the
@@ -104,14 +124,20 @@ report that diff output was omitted or elided. A deleted or unreadable Disk side
 is named explicitly. Closing Compare returns to the conflict without resolving
 it or changing any side.
 
+Folder Files does not use **Ctrl+S** and does not assign a replacement. Keep
+typing and autosave writes the file. When the file body has keyboard focus,
+only its boundary becomes more prominent; its background and size do not
+change. Compact inputs such as a named target path keep their usual filled
+focus treatment.
+
 **Resolve conflict** keeps **Compare** available and opens three explicit safe
 choices:
 
 - **Keep editing** closes the resolution choices and returns focus to
   **Resolve conflict**. The Base, Draft, Disk, and Conflict state are unchanged.
-- **Save draft as new note** uses the same persistently labeled target-path
-  input. It writes the exact draft only when that destination does not already
-  exist, then opens the new note after the write succeeds.
+- **Save draft as new note** opens the named **Save copy as** task. It writes
+  the exact draft only when that destination does not already exist, then
+  opens the new note after the write succeeds.
 - **Discard draft and load disk** opens the same Cancel-first, freshness-checked
   confirmation described below. It is the only resolution choice that can
   replace the editor draft.
@@ -122,14 +148,19 @@ exists, File Notes leaves both that file and the conflict draft unchanged.
 **Reload from disk** (Conflict) or **Discard draft and reload** (Error) first
 reads the current disk
 version and asks for confirmation. **Cancel** or **Escape** preserves the exact
-draft and conflict. The target path and **Save copy** stay available while the
-confirmation is open, so saving a copy remains a safe exit and dismisses the
+draft and conflict. **Save Copy** stays available while the confirmation is
+open, so opening its named path task remains a safe exit and dismisses the
 reload decision without changing the original file. Confirming rechecks the
 root, file, editing session, and disk version before it replaces the draft. If
 any of those changed, reload stops with recovery guidance and leaves the draft
 untouched.
 
 ### Session Git — stage and commit session edits, then push the exact commit
+
+Open **Manage** and choose **Review session changes (N)**. Consequential Git
+states such as checking, pushing, or needing attention also remain visible in
+the work header, so you do not have to leave Edit merely to learn that work is
+still running.
 
 The panel is headed "Prepare session for commit" with the scope line
 "Session paths only · stages complete file state" and the keyboard guide
@@ -225,8 +256,8 @@ outside Chatbook, or later note edits.
 You may use **Cancel check** before the network push process starts. Once the
 panel says "Pushing 1 reviewed commit…", cancellation is unavailable;
 **Back to Files — push continues** lets you keep editing while the owned
-operation settles. Reopening **Session Git** reattaches to that same operation
-or result without starting another request; the navigator button reports
+operation settles. Reopening **Manage** → **Review session changes** reattaches
+to that same operation or result without starting another request; the header reports
 **Push checking**, **Pushing**, or **Push needs attention** as appropriate.
 
 | Push result | Meaning and next step |
@@ -265,10 +296,11 @@ not available.
 1. **Link a notes folder.** Open **Folder files** (source strip), press
    **Choose folder…**, pick the folder in "Choose File Notes Folder". The
    status becomes "Linked — \<folder\>" and the **Files** tree fills in.
-2. **Create a file.** Type its location — e.g. `ideas/today.md` — into the
-   "relative/path.md" input and press **New**. The file is created on disk
-   and opened; start typing and it saves automatically.
-3. **Find text across files.** Type a query into "Search file contents…" —
+2. **Create a file.** Press **New** above the Folder files tree, enter a path
+   such as `ideas/today.md` in the **New file path** task, and choose
+   **Create**. The file is created on disk and opened; start typing and it
+   saves automatically.
+3. **Find text across files.** Type a query into "File contents…" —
    a **Search results** tree appears under the **Files** tree; pick a result
    to open that file. Activate **Load more** when a direct-path result set has
    another 100 rows. Clear the query and the tree disappears.
@@ -276,8 +308,8 @@ not available.
    Disk. Press **Resolve conflict**, then either keep editing, save the exact
    draft to an absent new-note path, or enter the Cancel-first discard
    confirmation. No choice overwrites the changed disk file.
-5. **Stage and commit this session's edits, then push the exact commit.** Press
-   **Session Git (N)**,
+5. **Stage and commit this session's edits, then push the exact commit.** Open
+   **Manage** and choose **Review session changes (N)**,
    trust the repository if asked, press **Stage all (N)**, then
    **Commit staged (N)**. Fill in **Subject**, press **Review commit**,
    confirm the exact message and "unrelated changes untouched" scope, then
@@ -294,12 +326,16 @@ not available.
 
 | Key | Action |
 |---|---|
+| Esc (named path task) | Cancel New, Move, or Save copy and return to the action that opened it |
 | Up / Down (Session Git panel) | Select a row |
 | Tab (Session Git panel) | Move into the selected row's actions |
 | Enter (Session Git panel) | Run the highlighted action |
 | Esc (reload confirmation) | Cancel reload, preserve the draft and conflict, and return focus to the action that opened the confirmation |
 | Esc (Session Git panel) | Step back safely: row list → Files; commit form → cancel; commit review → edit message; candidate/remote check → cancel; push review → Back; active push/uncertain recovery check → Files while it continues; push result → session |
 | Esc (dialogs) | Close "File Notes folder details" or **Endpoint Details**; cancel the repository-trust or destination-authorization dialog |
+
+Folder Files does not register **Ctrl+S** and does not replace it with another
+save shortcut. File edits save automatically.
 
 ## Related settings & docs
 

--- a/Docs/User_Guide/library/notes.md
+++ b/Docs/User_Guide/library/notes.md
@@ -19,6 +19,11 @@ under the rail's "Create" section.
 
 ## Layout tour
 
+Database Notes uses three side-by-side roles when there is room: Library
+navigation, the Notes list, and the note you are working on. The Library
+navigation and Notes list each have their own slim collapse grip. Collapsing
+one does not collapse the other, and each grip remembers its own choice.
+
 Wide Database Notes keeps Library navigation beside the list while you scan:
 
 ```text
@@ -32,9 +37,19 @@ Wide Database Notes keeps Library navigation beside the list while you scan:
 +----------------------+-----------------------------------------------+
 ```
 
-Opening a database note—or switching to Files—turns the workbench into one
-focused task. The Library rail stays mounted but yields its width, and one
-stable cue names the return destination:
+The first time you open an editable note during a wide Notes work session,
+Library navigation closes automatically once to give the note more room. This
+temporary close does not change your saved pane choice. Use the visible grip
+to reopen Library navigation; after you do, it stays open for the rest of that
+work session. Opening another note, switching between Edit, Preview, and Info,
+saving, resolving a conflict, or resizing the terminal does not close it
+again. The automatic close becomes available again only after you clear the
+selected Database note, switch between Database Notes and Folder Files,
+change the linked Folder Files root, leave Notes, or close the open Folder
+Files file. Folder Files' compact **Back to navigator** action is not a reset.
+
+When Library navigation is closed, one stable cue names the return
+destination:
 
 ```text
 +-----------------------------------------------------------------------+
@@ -60,9 +75,13 @@ editor's own Back control returns to its list.
   This page covers the Library notes side; see below for Folder files.
 - **Notes list** — the default view: a "Notes (N)" header, the
   "Filter notes… (Enter)" field, a toolbar (sort / Add from files… /
-  Export… / Select), and one row per note showing its title and age.
-- **Editor** — opens when you click a note: title, body, keywords, a meta
-  line with the autosave status, and an action row. On wide terminals the
+  Export… / Select), and one row per note showing its title and age. Its own
+  grip collapses or restores the list without changing the Folder Files tree
+  choice.
+- **Note work area** — opens when you click a note. **Edit** shows the title
+  and body, **Preview** renders the Markdown, and **Info** holds keywords,
+  dates, version details, copy/export actions, and Delete. Save status and
+  frequent actions remain in the header. On wide terminals the
   top `‹ Library / Notes` cue returns to the exact prior list row, scope, and
   scroll positions; on compact terminals use `‹ Back to list`.
 - **New note view** — opens from the rail's "New note": a "Blank note"
@@ -102,25 +121,36 @@ through the lasting-sync runtime.
 With no notes at all, the list reads "No notes yet. Create one to see it
 here."
 
-### Editor
+### Edit, Preview, and Info
 
 | Control | What it does |
 |---|---|
 | "‹ Back to list" | Returns to the list (your text is already saved — see autosave below). |
-| Title, body, keywords | The note's fields; keywords are comma-separated. |
-| Meta line | Created/Modified/version plus the autosave status: "N words · saved", "saving…", "changed elsewhere", or "save failed". |
-| "Save" | Saves immediately, without waiting for autosave. |
-| "Preview" / "Edit" | Toggles the body between editing and rendered Markdown. |
-| "Use in Console" | Hands the note to the Console as staged context, with the suggested prompt "Use this note as context and help me work with it." |
-| "Export .md" / "Export .txt" | Saves the note to a file you pick; success shows "Note exported successfully to \<name\>". |
-| "Copy" | Copies the note to the clipboard as Markdown — "Note copied to clipboard as markdown!" |
-| "Delete" | Asks inline first: "Delete this note? Undo will be available in the Notes list." Confirm with "Delete" or back out with "Cancel". A successful delete returns to the list with a named "✓ deleted · …" receipt offering **Undo** and **Dismiss**. |
+| **Edit** | Shows the editable title and body. This is the default view when you open a note. |
+| **Preview** | Shows the body as rendered Markdown without replacing your draft. |
+| **Info** | Shows Properties (including comma-separated keywords and note dates/version), Reuse & Export, and Danger sections. |
+| Status line | Shows the word count and autosave state: "N words · saved", "saving…", "changed elsewhere", or "save failed". Created/Modified/version details are under Info → Properties. |
+| **Save** | Saves immediately, without waiting for autosave. It remains visible beside the mode controls. |
+| **Use in Console** | Hands the note to the Console as staged context, with the suggested prompt "Use this note as context and help me work with it." It remains visible beside **Save**. |
+| **Copy** (Info) | Copies the note to the clipboard as Markdown — "Note copied to clipboard as markdown!" |
+| **Export Markdown** / **Export text** (Info) | Saves the note to a file you pick; success shows "Note exported successfully to \<name\>". |
+| **Delete** (Info → Danger) | Asks inline first: "Delete this note? Undo will be available in the Notes list." Confirm with "Delete" or back out with "Cancel". A successful delete returns to the list with a named "✓ deleted · …" receipt offering **Undo** and **Dismiss**. |
 
 **Autosave** runs about two seconds after you stop typing; the meta line
 flips to "saving…" and back to "saved". If the same note was changed
 somewhere else while you were editing, a banner appears: "This note
 changed elsewhere — Overwrite saves your text; Reload discards it." —
 pick **Overwrite** or **Reload**.
+
+Notes does not use **Ctrl+S**, and there is no replacement Notes save
+shortcut. Use the visible **Save** button when you want an immediate Database
+save; normal Tab navigation and **F6** can reach it. Autosave continues to
+handle ordinary typing.
+
+When the note body has keyboard focus, only its boundary becomes more
+prominent. The body background and editor size stay unchanged, so focusing
+the editor does not flash or fill the writing surface. Small fields such as
+Title and Keywords still use their usual filled focus treatment.
 
 The wide `‹ Library / Notes` cue and Escape use the same guarded return as
 the compact Back control. A dirty save, sync, conflict, reload confirmation,
@@ -279,7 +309,7 @@ automatic-sync setting.
    send or rewrite.
 
 ### Export a note as Markdown
-1. Open the note and click **Export .md**.
+1. Open the note, choose **Info**, and click **Export Markdown**.
 2. Choose a destination in the "Export Note as Markdown" dialog — the
    toast confirms "Note exported successfully to \<name\>".
 
@@ -295,8 +325,10 @@ automatic-sync setting.
 |---|---|
 | Enter (in "Filter notes… (Enter)") | Apply the filter |
 
-That is the only screen-specific key — everything else here is
-click-driven. Global navigation keys live in the [guide index](../index.md).
+That is the only screen-specific key. In particular, Notes does not register
+**Ctrl+S** and does not replace it with another save shortcut. Use the visible
+Database **Save** button for an immediate save; Folder Files saves
+automatically. Global navigation keys live in the [guide index](../index.md).
 
 ## Related settings & docs
 
@@ -391,13 +423,6 @@ the branch was unreachable by any exit path. Restored: the check now
 treats that literal seed as blank too, and the fix is proven at every exit
 seam (Back, Escape, rail switch, screen leave), not just the two this
 paragraph's prose already covered).*
-*Verified against fix/settings-appearance-crash @ 57ad075de — 2026-08-10
-(task-4023 AC#5: the Notes footer speaks the shared per-key grammar —
-"ctrl+n new note | / find note | esc focus rail" on the list, "ctrl+s
-save note | esc back to notes" in the editor (with shorter labels at
-compact widths); locked operations advertise no dead
-keys.)*
-
 *Verified on codex/notes-delete-undo-receipt — 2026-08-11 (TASK-15100:
 confirmed Database Note deletion now leaves a named inline Undo/Dismiss
 receipt; Undo restores the exact soft-deleted row and Notes rail count through

--- a/Docs/superpowers/plans/2026-08-26-library-notes-work-first-ux.md
+++ b/Docs/superpowers/plans/2026-08-26-library-notes-work-first-ux.md
@@ -1,0 +1,662 @@
+# Library Notes Work-First UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Database Notes and Folder Files one calmer, work-first Notes experience with a collapsible Folder Files tree, more room for note bodies, boundary-only editor focus, and clearer progressive disclosure without losing any existing capability, authority, recovery, or state.
+
+**Architecture:** Keep `LibraryScreen` as the single runtime preference and Notes-session coordinator, use `LibraryAdaptiveReaderShell` as the only Library/local-navigator/work geometry and focus-evacuation owner for both Notes authorities, and keep `LibraryFileNotesWorkspace` as the disk-authority/service owner while it supplies retained navigator and work regions to that shell. A small pure reducer owns only the transient `inactive | active | manually_cancelled` work-first lifecycle. Requested preferences, transient work-first requests, and responsive effective layout remain separate.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, TOML configuration, existing `ds-*` TCSS tokens and generated CSS bundle, pytest/pytest-asyncio with real Textual `run_test()` pilots.
+
+---
+
+## Governing records and scope gates
+
+- Backlog task: `TASK-22513`
+- Approved design: `Docs/superpowers/specs/2026-08-26-library-notes-ux-improvements-design.md`
+- Existing architecture: `backlog/decisions/086-library-adaptive-reader-shell.md` and `backlog/decisions/076-library-lifecycle-progressive-disclosure.md`
+- ADR required: no
+- ADR path: N/A
+- Reason: this implements the already-approved adaptive-reader and progressive-disclosure boundaries; it adds no storage, service, ownership, security, dependency, or cross-module contract decision.
+
+Before editing, inspect `git status --short` and the diff for every file in the task. This checkout contains unrelated user/concurrent changes. Never reset or overwrite them; stage only the exact task files after reviewing their complete diff.
+
+The implementation must preserve this capability ledger:
+
+- Database Notes: Edit, Preview, Info, filter/clear/sort, folders and placements, `#library-notes-new`, `#library-notes-add-from-files`, `#library-notes-manage-sync-folders`, `#library-notes-import-receipt`, whole-source `#library-notes-export`, selection and `#library-notes-export-selected`, undo, visible `#library-note-save`, primary `#library-note-use-in-console`, metadata/keywords/copy/export/delete in Info, conflict/recovery, and no invented bulk delete. Tests must continue to exercise the incumbent `LibraryScreen` handlers and their current guards/disabled reasons, not merely assert labels.
+- Folder Files: autosave, `#file-notes-choose-root`, root details, tree/search, New, Move, Save Copy, Restore, Compare, Resolve, Reload, Protect, Refresh, Delete, session Git, large-file guard/export, conflict/reload recovery, and the retained exact-path authority. Tests must keep the existing service calls, transition/overwrite guards, disabled reasons, and focus return paths pinned. It gains Edit and Manage, not Markdown Preview or an ordinary Save button.
+- Notes loses only the Notes-specific `Ctrl+S` binding and its Notes footer/F1 hints. The separately gated Skill-editor `Ctrl+S` remains.
+
+Run only the targeted commands listed below. Do not run the full suite unless the user separately opts in.
+
+## Task 1: Add the pure Notes work-session reducer
+
+**Files:**
+
+- Create: `tldw_chatbook/UI/Library_Modules/library_notes_work_session.py`
+- Create: `Tests/UI/test_library_notes_work_session.py`
+
+- [ ] **Step 1: Write the reducer contract as failing tests.**
+
+  Cover these named transitions in a parameterized matrix:
+
+  - `editable_item_opened` activates only from `inactive` at width `>= 120` after a Database note is loaded or a Folder file is successfully opened.
+  - `manual_library_expand` changes `active` to `manually_cancelled`; it is otherwise idempotent.
+  - selection/item changes, Edit/Preview/Info/Manage changes, save, conflict, recovery, resize, and Folder `back_to_navigator` preserve `active` and `manually_cancelled`.
+  - `database_identity_cleared`, `folder_identity_cleared`, `authority_changed`, `folder_root_changed`, and `left_notes` reset to `inactive`.
+  - another item open in the same session never rearms `manually_cancelled`.
+
+  Keep event names explicit; do not encode reset semantics as a generic Boolean.
+
+- [ ] **Step 2: Run the focused test and confirm RED.**
+
+  Run: `python -m pytest Tests/UI/test_library_notes_work_session.py -q`
+
+  Expected: collection/import failure because the reducer module does not exist.
+
+- [ ] **Step 3: Implement the smallest pure reducer with this public seam.**
+
+  ```python
+  class NotesWorkSessionPhase(StrEnum):
+      INACTIVE = "inactive"
+      ACTIVE = "active"
+      MANUALLY_CANCELLED = "manually_cancelled"
+
+  class NotesWorkSessionEvent(StrEnum):
+      # Use the explicit event names from Step 1.
+      ...
+
+  def reduce_notes_work_session(
+      phase: NotesWorkSessionPhase,
+      event: NotesWorkSessionEvent,
+      *,
+      reader_width: int | None = None,
+  ) -> NotesWorkSessionPhase:
+      ...
+  ```
+
+  `phase is ACTIVE` is the only force-closed signal consumed by `LibraryScreen`; no second Boolean is stored. The reducer must not import Textual, query widgets, read configuration, or write preferences.
+
+- [ ] **Step 4: Run the reducer tests and confirm GREEN.**
+
+  Run: `python -m pytest Tests/UI/test_library_notes_work_session.py -q`
+
+- [ ] **Step 5: Commit the reducer only.**
+
+  ```bash
+  git add tldw_chatbook/UI/Library_Modules/library_notes_work_session.py Tests/UI/test_library_notes_work_session.py
+  git commit -m "feat(library): add Notes work-session reducer"
+  ```
+
+## Task 2: Normalize and stage independent Folder-tree preferences
+
+**Files:**
+
+- Modify: `tldw_chatbook/config.py`
+- Modify: `tldw_chatbook/UI/Screens/settings_appearance_defaults.py`
+- Modify: `tldw_chatbook/UI/Screens/settings_screen.py`
+- Modify: `Tests/test_config_library_defaults.py`
+- Modify: `Tests/UI/test_settings_appearance_defaults.py`
+- Modify: `Tests/UI/test_settings_configuration_hub.py`
+
+- [ ] **Step 1: Add failing normalization tests.**
+
+  Extend `Tests/test_config_library_defaults.py` to prove:
+
+  - `[library.notes_reader].items_open/items_width` and `files_tree_open/files_tree_width` normalize independently.
+  - Folder-tree defaults are open and `ITEMS_TARGET_WIDTH`.
+  - `TLDW_LIBRARY_NOTES_READER_FILES_TREE_OPEN` and `TLDW_LIBRARY_NOTES_READER_FILES_TREE_WIDTH` override TOML per key.
+  - malformed Folder-tree values fall back without rewriting or borrowing Database `items_*` values.
+
+- [ ] **Step 2: Add failing Settings model and UI tests.**
+
+  Extend the Appearance tests for `library_notes_files_tree_open` and `library_notes_files_tree_width`: load, strict validation, default reset, deep-merge save, widget sync, field search, dirty tracking, and labels `Folder Files tree pane` / `Folder Files tree width`.
+
+- [ ] **Step 3: Run the focused configuration/Settings batch and confirm RED.**
+
+  Run:
+
+  ```bash
+  python -m pytest Tests/test_config_library_defaults.py Tests/UI/test_settings_appearance_defaults.py Tests/UI/test_settings_configuration_hub.py -q
+  ```
+
+  Expected: new assertions fail because the keys and Settings controls do not exist.
+
+- [ ] **Step 4: Implement normalization and Settings ownership.**
+
+  In `config.py`, extend only `library.notes_reader` with the two Folder-tree keys and environment overrides. In `SettingsAppearanceDefaults`, add the two typed fields and include them in load, validation, reset, and save-section construction. In `settings_screen.py`, render the two explicit Notes Folder-tree controls beside Notes Items; do not add Folder Files as a fake destination to `LIBRARY_READER_DESTINATIONS`, because both preference pairs intentionally share one `[library.notes_reader]` section.
+
+  Settings remains the only width mutation owner. Runtime grips may later write only open/closed state.
+
+- [ ] **Step 5: Re-run the focused batch and confirm GREEN.**
+
+  Run the Step 3 command again.
+
+- [ ] **Step 6: Commit only the configuration and Settings slice.**
+
+  ```bash
+  git add tldw_chatbook/config.py tldw_chatbook/UI/Screens/settings_appearance_defaults.py tldw_chatbook/UI/Screens/settings_screen.py Tests/test_config_library_defaults.py Tests/UI/test_settings_appearance_defaults.py Tests/UI/test_settings_configuration_hub.py
+  git commit -m "feat(settings): add Folder Files tree preferences"
+  ```
+
+## Task 3: Make shared-shell focus restoration manual and authority-neutral
+
+**Files:**
+
+- Modify: `tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py`
+- Modify: `Tests/UI/test_library_adaptive_reader_shell.py`
+- Verify unchanged consumer contracts: `Tests/UI/test_library_conversation_reader.py`
+- Verify unchanged consumer contracts: `Tests/UI/test_library_media_reader_shell.py`
+
+- [ ] **Step 1: Add failing focus-memory tests.**
+
+  Extend the existing `_ProbeApp` with two focusable controls per optional pane. Assert:
+
+  - collapsing a focused pane records the last valid focused descendant and evacuates focus to that pane's five-column grip;
+  - manual reopen restores the recorded control;
+  - if that control is removed or disabled, manual reopen chooses the first valid focus target in the pane;
+  - a responsive-only reopen never steals focus from work;
+  - retained child identities and the fixed five-column grip geometry do not change.
+
+- [ ] **Step 2: Run the shell tests and confirm RED.**
+
+  Run: `python -m pytest Tests/UI/test_library_adaptive_reader_shell.py -q`
+
+- [ ] **Step 3: Extend `sync_layout` with this explicit manual-restore signal.**
+
+  ```python
+  def sync_layout(
+      self,
+      layout: AdaptiveReaderEffectiveLayout,
+      *,
+      manual_reopen: PaneName | None = None,
+  ) -> None:
+      ...
+  ```
+
+  Retain one last-focused descendant per optional pane in `_last_focused_descendant: dict[PaneName, Widget | None]`. Record it before hiding. Preserve the existing focus-to-grip evacuation. Only `manual_reopen="library"` or `manual_reopen="items"` may restore focus. Normal mount, resize, hysteresis, and priority resolution omit the argument and therefore cannot steal focus.
+
+  Keep the shell authority-neutral: it knows only `library`, `items`, and `work`, never Database Notes or Folder Files.
+
+- [ ] **Step 4: Re-run the shell and unchanged-consumer tests and confirm GREEN.**
+
+  Run:
+
+  ```bash
+  python -m pytest Tests/UI/test_library_adaptive_reader_shell.py Tests/UI/test_library_conversation_reader.py Tests/UI/test_library_media_reader_shell.py -q
+  ```
+
+- [ ] **Step 5: Commit the shell slice.**
+
+  ```bash
+  git add tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py Tests/UI/test_library_adaptive_reader_shell.py
+  git commit -m "feat(library): restore adaptive pane focus on manual reopen"
+  ```
+
+## Task 4: Put Folder Files in the shared adaptive shell
+
+**Files:**
+
+- Modify: `tldw_chatbook/Widgets/Library/library_file_notes_workspace.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `tldw_chatbook/css/components/_agentic_terminal.tcss`
+- Modify: `tldw_chatbook/css/tldw_cli_modular.tcss`
+- Modify: `Tests/UI/test_library_file_notes_workspace.py`
+- Modify: `Tests/UI/test_library_file_notes_git.py`
+- Modify: `Tests/UI/test_library_notes_reader.py`
+
+- [ ] **Step 1: Add failing authority-scaffold, structural, and retention tests.**
+
+  Add these exact tests:
+
+  - `Tests/UI/test_library_notes_reader.py::test_folder_files_reader_authority_scaffold_is_distinct`
+  - `Tests/UI/test_library_file_notes_workspace.py::test_folder_files_builds_shared_adaptive_reader_roles`
+  - `Tests/UI/test_library_file_notes_workspace.py::test_folder_files_shared_shell_retains_state_across_breakpoints`
+  - `Tests/UI/test_library_file_notes_workspace.py::test_notes_authority_round_trip_retains_both_workspaces`
+  - `Tests/UI/test_library_file_notes_workspace.py::test_folder_files_routes_rail_descendants_to_visible_authority`
+  - `Tests/UI/test_library_file_notes_workspace.py::test_folder_files_low_height_rail_scrolls_to_last_action`
+
+  Add production-shell pilots proving that Folder Files has exactly one `LibraryAdaptiveReaderShell` with this mapping:
+
+  - `library`: the existing Library rail;
+  - `items`: the retained Folder tree/search navigator;
+  - `work`: the retained incumbent Folder authority/editor/action/recovery surface; Task 6 later reorganizes this same retained region into Edit/Manage without changing the Task 4 shell contract.
+
+  Assert `LibraryScreen` has separate Database and Folder requested/effective projections before Files mode handles a grip: `_library_notes_reader_preferences/_layout` and `_library_file_notes_reader_preferences/_layout`. Assert that both grips remain five columns, the Folder items grip is independently operable as `notes_file_items`, and the old `LibraryFileNotesWorkspace._narrow` display toggles no longer own navigator/editor geometry.
+
+  Across manual collapse/reopen and widths 160, `120 → 119 → 160 restored`, 100, 80, 79, and 60, retain editor identity, text, cursor/selection, undo, tree expansion/selection, search results, Git widget/operation state, recovery state, scroll, and autosave. Add a Database → Folder → Database → Folder round trip that preserves each authority's independent selection, draft, cursor/undo/scroll, navigator state, and Folder Git/recovery state. Reducer reset behavior is integrated and asserted in Task 5, after the workspace notification seam exists.
+
+- [ ] **Step 2: Run the structural tests and confirm RED.**
+
+  Run:
+
+  ```bash
+  python -m pytest Tests/UI/test_library_adaptive_reader_shell.py Tests/UI/test_library_notes_reader.py Tests/UI/test_library_file_notes_workspace.py Tests/UI/test_library_file_notes_git.py -q
+  ```
+
+- [ ] **Step 3: Add the Folder reader projection and authority mapping, then run its focused tests GREEN.**
+
+  Add `LibraryReaderDestination = Literal["media", "conversations", "notes", "notes_files"]` and centralize the mapping with one immutable target record (name it `_LibraryReaderPersistenceTarget`) containing `section`, `config_key`, `authority`, and `preferences_attribute`. The `notes_files/items` entry must be exactly:
+
+  ```python
+  _LibraryReaderPersistenceTarget(
+      section="library.notes_reader",
+      config_key="files_tree_open",
+      authority="notes_file_items",
+      preferences_attribute="_library_file_notes_reader_preferences",
+  )
+  ```
+
+  Create the Folder preference/layout projection plus distinct generation, durable-value, and lock entries before any Files grip can fire. Share only Library-pane preference fields. At this checkpoint, run:
+
+  ```bash
+  python -m pytest Tests/UI/test_library_notes_reader.py::test_folder_files_reader_authority_scaffold_is_distinct -q
+  ```
+
+  It must pass before changing Folder DOM structure.
+
+- [ ] **Step 4: Split Folder presentation into retained navigator and work regions, then run retention tests GREEN.**
+
+  Keep `LibraryFileNotesWorkspace` mounted as the disk session/service/timer/event owner. Refactor its composition so the Library rail, its navigator region, and its work region are descendants of one `LibraryAdaptiveReaderShell`; reuse the current tree, editor, Git, recovery, and action widget instances rather than recreating them during mode or layout changes. Use this narrow workspace seam:
+
+  ```python
+  def configure_reader_shell(
+      self,
+      *,
+      library_pane: Widget,
+      layout: AdaptiveReaderEffectiveLayout,
+  ) -> None:
+      ...
+
+  def sync_reader_layout(
+      self,
+      layout: AdaptiveReaderEffectiveLayout,
+      *,
+      manual_reopen: PaneName | None = None,
+  ) -> None:
+      ...
+  ```
+
+  `configure_reader_shell` is called while the retained workspace is detached/before compose; mounted changes use `sync_reader_layout`. Run:
+
+  ```bash
+  python -m pytest Tests/UI/test_library_file_notes_workspace.py::test_folder_files_builds_shared_adaptive_reader_roles -q
+  ```
+
+  Make it green before deleting legacy geometry.
+
+- [ ] **Step 5: Remove the competing Folder geometry owner, then run breakpoint tests GREEN.**
+
+  Move the existing `<80` Folder behavior into adaptive-layout `items` priority. Remove the workspace's competing `_narrow` width/display mutations only after the shared-shell tests pass. Prove the `120 → 119 → 160` restoration and the existing 80/79/60 behavior. Do not change root binding, filesystem validation, autosave, transition admission, or session-Git services. Run:
+
+  ```bash
+  python -m pytest Tests/UI/test_library_file_notes_workspace.py::test_folder_files_shared_shell_retains_state_across_breakpoints -q
+  ```
+
+- [ ] **Step 6: Route Folder shell resize/toggle messages through `LibraryScreen`, then run authority round trips GREEN.**
+
+  Files mode should use the same shared-shell message path as Database Notes. Manual Folder tree toggles identify the distinct `notes_file_items` authority. Automatic `<80`, focus-priority, and responsive resolutions update only effective layout and never write configuration. Run:
+
+  ```bash
+  python -m pytest Tests/UI/test_library_file_notes_workspace.py::test_notes_authority_round_trip_retains_both_workspaces -q
+  ```
+
+- [ ] **Step 7: Re-run the complete structural batch and confirm GREEN.**
+
+  Run the Step 2 command again.
+
+- [ ] **Step 8: Commit the shell migration.**
+
+  ```bash
+  git add tldw_chatbook/Widgets/Library/library_file_notes_workspace.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/css/components/_agentic_terminal.tcss tldw_chatbook/css/tldw_cli_modular.tcss Tests/UI/test_library_file_notes_workspace.py Tests/UI/test_library_file_notes_git.py Tests/UI/test_library_notes_reader.py
+  git commit -m "refactor(library): share adaptive shell with Folder Files"
+  ```
+
+## Task 5: Wire independent persistence and work-first behavior
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `tldw_chatbook/Widgets/Library/library_file_notes_workspace.py`
+- Modify: `Tests/UI/test_library_notes_reader.py`
+- Modify: `Tests/UI/test_library_file_notes_workspace.py`
+- Modify: `Tests/UI/test_library_shell.py`
+
+- [ ] **Step 1: Add failing persistence-authority tests.**
+
+  Prove `notes_items` writes `[library.notes_reader].items_open` and `notes_file_items` writes `[library.notes_reader].files_tree_open`. Cover optimistic mirror, success, write failure rollback, readback/configuration failure copy, and opposite-order generation races. Assert neither authority can roll back or overwrite the other, and neither grip writes width.
+
+- [ ] **Step 2: Add failing work-session integration pilots.**
+
+  Add these exact tests:
+
+  - `Tests/UI/test_library_notes_reader.py::test_database_notes_work_session_activates_once_and_resets_exactly`
+  - `Tests/UI/test_library_file_notes_workspace.py::test_folder_files_emits_only_admitted_work_session_events`
+  - `Tests/UI/test_library_file_notes_workspace.py::test_folder_notes_work_session_activates_once_and_resets_exactly`
+  - `Tests/UI/test_library_file_notes_workspace.py::test_notes_authority_round_trip_resets_only_transient_work_session`
+
+  For Database Notes and Folder Files, assert:
+
+  - entering Notes setup/list/root selection does not auto-collapse;
+  - successfully opening editable work at width `>=120` closes only the effective Library request once;
+  - when the saved Library request is already open, manual expansion cancels work-first with zero configuration writes;
+  - when the saved Library request is closed, manual expansion cancels work-first and produces exactly one `library_open=true` write;
+  - switching item or Edit/Preview/Info/Manage, saving, conflict, recovery, and resize do not rearm it;
+  - Database selected/loaded identity clear, Folder opened-file identity explicit clear, source/root change, and leaving Notes reset it;
+  - Folder `Back to navigator` at narrow width retains the opened file and does not reset;
+  - automatic work-first and responsive changes produce zero configuration writes.
+
+- [ ] **Step 3: Run the focused integration tests and confirm RED.**
+
+  Run:
+
+  ```bash
+  python -m pytest Tests/UI/test_library_notes_work_session.py Tests/UI/test_library_notes_reader.py Tests/UI/test_library_file_notes_workspace.py Tests/UI/test_library_shell.py -q
+  ```
+
+- [ ] **Step 4: Complete persistence behavior on the authority scaffold from Task 4.**
+
+  Use Task 4's `_LibraryReaderPersistenceTarget` mapping for optimistic mirror, serialized write, authoritative readback, rollback, and generation reconciliation. On Settings refresh, reload both projections. A Folder grip writes only `files_tree_open`; a Database grip writes only `items_open`; neither writes width. Manual reopen passes `manual_reopen` to the shell; responsive reopen does not.
+
+- [ ] **Step 5: Integrate the pure reducer at named lifecycle boundaries.**
+
+  Add these workspace-to-screen messages in `library_file_notes_workspace.py`:
+
+  ```python
+  class FileNotesEditableOpened(Message):
+      def __init__(self, identity: str) -> None: ...
+
+  class FileNotesIdentityCleared(Message):
+      pass
+
+  class FileNotesRootChanged(Message):
+      def __init__(self, root: Path) -> None: ...
+  ```
+
+  Emit `FileNotesEditableOpened` only after the current open request successfully applies its document; failed, cancelled, and stale opens emit nothing. Emit `FileNotesIdentityCleared` only when the opened-file identity is explicitly closed/cleared; narrow `Back to navigator` emits nothing. Emit `FileNotesRootChanged` only after an admitted root transition becomes the current binding; rejected/stale root changes emit nothing. `LibraryScreen` handles these messages and dispatches the corresponding reducer events.
+
+  Dispatch Database events only after successful load and at its exact identity-clear boundaries. Derive work-first layout from the reducer without mutating requested preferences. A manual Library grip expansion during `active` transitions the reducer to `manually_cancelled`: saved-open requests perform no write; saved-closed requests perform exactly one open write.
+
+  Run the message and lifecycle checkpoints directly:
+
+  ```bash
+  python -m pytest Tests/UI/test_library_file_notes_workspace.py::test_folder_files_emits_only_admitted_work_session_events Tests/UI/test_library_notes_reader.py::test_database_notes_work_session_activates_once_and_resets_exactly Tests/UI/test_library_file_notes_workspace.py::test_folder_notes_work_session_activates_once_and_resets_exactly Tests/UI/test_library_file_notes_workspace.py::test_notes_authority_round_trip_resets_only_transient_work_session -q
+  ```
+
+- [ ] **Step 6: Re-run the integration batch and confirm GREEN.**
+
+  Run the Step 3 command again.
+
+- [ ] **Step 7: Commit the runtime policy slice.**
+
+  ```bash
+  git add tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/Widgets/Library/library_file_notes_workspace.py Tests/UI/test_library_notes_reader.py Tests/UI/test_library_file_notes_workspace.py Tests/UI/test_library_shell.py
+  git commit -m "feat(library): apply work-first Notes sessions"
+  ```
+
+## Task 6: Reorganize Notes controls, modes, and status hierarchy
+
+**Files:**
+
+- Modify: `tldw_chatbook/Widgets/Library/library_notes_canvas.py`
+- Modify: `tldw_chatbook/Widgets/Library/library_file_notes_workspace.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `Tests/UI/test_library_notes_reader.py`
+- Modify: `Tests/UI/test_library_file_notes_workspace.py`
+- Modify: `Tests/UI/test_library_file_notes_git.py`
+- Modify: `Tests/UI/test_library_honesty_accessibility.py`
+
+- [ ] **Step 1: Write failing capability-inventory and mode tests.**
+
+  Add these exact tests:
+
+  - `Tests/UI/test_library_notes_reader.py::test_database_notes_capability_inventory_and_modes`
+  - `Tests/UI/test_library_file_notes_workspace.py::test_folder_files_capability_inventory_and_modes`
+  - `Tests/UI/test_library_file_notes_workspace.py::test_folder_files_primary_safe_recovery_actions_bypass_manage`
+  - `Tests/UI/test_library_file_notes_workspace.py::test_folder_files_edit_manage_retains_editor_git_and_recovery`
+
+  Add an explicit assertion for every selector/handler in the governing ledger, including current guard and disabled-reason behavior. Prove Database modes are exactly Edit/Preview/Info and Folder modes are exactly Edit/Manage. Assert `#library-note-use-in-console` remains a primary Database task action, Folder has no Markdown Preview and no ordinary Save control, Database has no bulk delete, and visible Database Save remains keyboard reachable through ordinary focus/F6 navigation.
+
+- [ ] **Step 2: Add failing Folder named-path-task tests.**
+
+  Add `Tests/UI/test_library_file_notes_workspace.py::test_folder_files_path_tasks_are_exclusive_execute_and_restore_focus`.
+
+  Model only `none | new | move | save_copy`. Assert opening another task respects the existing guard, Cancel/guarded Esc closes it and returns focus to its opener, and Save Copy remains immediately reachable in conflict/reload recovery. The target-path input should not consume editor height until one of those tasks is active.
+
+  Pin this workspace API:
+
+  ```python
+  FileNotesPathTask = Literal["none", "new", "move", "save_copy"]
+
+  async def _open_path_task(
+      self,
+      task: FileNotesPathTask,
+      *,
+      opener_id: str,
+  ) -> bool:
+      ...
+
+  def _close_path_task(self, *, restore_focus: bool = True) -> None:
+      ...
+
+  async def _submit_path_task(self) -> bool:
+      ...
+  ```
+
+  Use stable selectors `#file-notes-path-task`, existing `#file-notes-path`, `#file-notes-path-submit`, and `#file-notes-path-cancel`. Existing `#file-notes-new`, `#file-notes-move`, Manage's `#file-notes-save-copy`, and contextual recovery's new `#file-notes-recovery-save-copy` open the named task after `flush_pending_work()`/the incumbent transition guard admits replacement. Both Save Copy controls call `_open_path_task("save_copy", opener_id=event.button.id)` so cancellation returns focus to the actual opener. Submit maps exactly as follows:
+
+  - `new` → the validation and `service.create_file` path currently in `_new_file`;
+  - `move` → the validation and `service.move_file` path currently in `_move_file`;
+  - `save_copy` → `_save_editor_copy`, preserving exact-file export and no-clobber draft-copy behavior.
+
+  Extract service execution from the current button handlers rather than synthesizing a second implementation. Cancel and guarded Esc call `_close_path_task(restore_focus=True)`; successful submit closes the task through the same focus-safe seam.
+
+- [ ] **Step 3: Add failing header/status matrix tests.**
+
+  Add `Tests/UI/test_library_notes_reader.py::test_notes_header_status_channels_follow_approved_precedence` and parameterize both Database and Folder projections.
+
+  Test the two independent status channels and precedence:
+
+  - content/recovery: conflict → unavailable/read-only blocker → save failure → saving → dirty → saved/clean;
+  - authority/Git: always name Database authority or Folder root; then failure/uncertain → running → changes; omit ordinary clean Git success.
+
+  Git must never replace a content conflict, failed save, or safe next action. At wide size, headers use no more than two logical rows. At constrained size, consequential content/recovery copy remains complete; exact authority/path and secondary Git detail remain available in Info/Manage.
+
+  Drive both headers through named pure projections rather than concatenating status in async handlers:
+
+  ```python
+  @dataclass(frozen=True)
+  class NotesStatusChannels:
+      content_recovery: str
+      authority_git: str
+      safe_next_action: str | None = None
+
+  def resolve_database_note_status_channels(...) -> NotesStatusChannels:
+      ...
+
+  def resolve_file_note_status_channels(...) -> NotesStatusChannels:
+      ...
+  ```
+
+- [ ] **Step 4: Run the focused mode/action/status tests and confirm RED.**
+
+  Run:
+
+  ```bash
+  python -m pytest Tests/UI/test_library_notes_reader.py Tests/UI/test_library_file_notes_workspace.py Tests/UI/test_library_file_notes_git.py Tests/UI/test_library_honesty_accessibility.py -q
+  ```
+
+- [ ] **Step 5: Reorganize Database Notes without deleting handlers, then run Database capability nodes GREEN.**
+
+  Keep visible Save and Use in Console in the primary task group. Move metadata, copy/export, destructive, and maintenance details into Info while preserving their current events, guards, disabled reasons, and recovery focus. Keep all navigator workflows in their approved locations and retain widget/session identity across Edit/Preview/Info. Run:
+
+  ```bash
+  python -m pytest Tests/UI/test_library_notes_reader.py::test_database_notes_capability_inventory_and_modes -q
+  ```
+
+- [ ] **Step 6: Add Folder Edit/Manage progressive disclosure, then run identity/capability nodes GREEN.**
+
+  Keep editor, contextual recovery, and consequential status in Edit. Keep Choose folder and root details in the browse/setup header. Keep Restore contextual to a deleted-file selection. Keep Compare and Resolve in contextual conflict recovery, with `#file-notes-recovery-save-copy` immediately reachable there and `#file-notes-save-copy` in Manage; both route through the same named task/service seam. Put exact-path details, Move/Save Copy/Reload/Protect/Refresh, Session Git, and Danger/Delete into stable Manage groups. Keep New in the tree header. Safe recovery must not require entering Manage. Toggle display only; do not remount the editor, Git panel, or active recovery widgets.
+
+  Run:
+
+  ```bash
+  python -m pytest Tests/UI/test_library_file_notes_workspace.py::test_folder_files_capability_inventory_and_modes Tests/UI/test_library_file_notes_workspace.py::test_folder_files_primary_safe_recovery_actions_bypass_manage Tests/UI/test_library_file_notes_workspace.py::test_folder_files_edit_manage_retains_editor_git_and_recovery -q
+  ```
+
+- [ ] **Step 7: Implement named path tasks, then run path/recovery nodes GREEN.**
+
+  Reuse existing validation, save-copy non-overwrite, reload, deletion, and transition guards. Replace the always-visible target-path row with the one active task presentation through `_open_path_task`, `_submit_path_task`, and `_close_path_task`. Run:
+
+  ```bash
+  python -m pytest Tests/UI/test_library_file_notes_workspace.py::test_folder_files_path_tasks_are_exclusive_execute_and_restore_focus -q
+  ```
+
+- [ ] **Step 8: Implement the deterministic status projections, then run the full status matrix GREEN.**
+
+  Have async state changes update inputs only; render each header through the named pure resolver so partial updates cannot reorder precedence. Always include authority/root in `authority_git`, omit ordinary clean Git success, and keep recovery callouts in the form “what happened / draft impact / safest next action.” Run:
+
+  ```bash
+  python -m pytest Tests/UI/test_library_notes_reader.py::test_notes_header_status_channels_follow_approved_precedence -q
+  ```
+
+- [ ] **Step 9: Re-run the focused batch and confirm GREEN.**
+
+  Run the Step 4 command again.
+
+- [ ] **Step 10: Commit the information-architecture slice.**
+
+  ```bash
+  git add tldw_chatbook/Widgets/Library/library_notes_canvas.py tldw_chatbook/Widgets/Library/library_file_notes_workspace.py tldw_chatbook/UI/Screens/library_screen.py Tests/UI/test_library_notes_reader.py Tests/UI/test_library_file_notes_workspace.py Tests/UI/test_library_file_notes_git.py Tests/UI/test_library_honesty_accessibility.py
+  git commit -m "feat(library): simplify Notes work surfaces"
+  ```
+
+## Task 7: Apply boundary-only note-body focus and remove Notes Ctrl+S
+
+**Files:**
+
+- Modify: `tldw_chatbook/css/components/_forms.tcss`
+- Regenerate: `tldw_chatbook/css/tldw_cli_modular.tcss`
+- Regenerate if changed by the builder: `tldw_chatbook/css/.css-build-manifest.json`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `Tests/UI/test_focus_accessibility.py`
+- Modify: `Tests/UI/test_library_honesty_accessibility.py`
+- Modify: `Tests/UI/test_library_file_notes_workspace.py`
+- Modify: `Tests/UI/test_library_shell.py` only to migrate stale Notes-specific `Ctrl+S` behavior/footer assertions to the visible Save and no-shortcut contract; preserve unrelated dirty hunks.
+- Modify: `Tests/UI/test_css_staleness_manifest.py` only if a builder-contract test is required; do not change it merely to bless stale output.
+
+- [ ] **Step 1: Add failing focus-style tests.**
+
+  Under the real generated bundle and every shipped theme, measure `#library-note-body` and `#file-notes-editor` before and after focus. Assert identical computed background, unchanged region geometry, a `heavy` outline using an existing semantic `ds-*` focus token, and boundary contrast of at least 3:1 against adjacent surfaces. Also assert a compact Input and an unrelated TextArea retain the current focused-fill behavior.
+
+- [ ] **Step 2: Add failing shortcut/honesty tests.**
+
+  Assert Notes no longer registers, advertises in the footer, or lists in F1 any `Ctrl+S` Save action. Assert the Skill editor still does. Assert Database Save is visible/focusable and Folder Files still has no manual Save.
+
+- [ ] **Step 3: Run the focused accessibility tests and confirm RED.**
+
+  Run:
+
+  ```bash
+  python -m pytest Tests/UI/test_focus_accessibility.py Tests/UI/test_library_honesty_accessibility.py Tests/UI/test_library_file_notes_workspace.py -q
+  ```
+
+- [ ] **Step 4: Add exact-ID TCSS exceptions and remove only the Notes binding/hints.**
+
+  Scope focus exceptions exactly to `#library-note-body:focus` and `#file-notes-editor:focus`. Preserve resting background and geometry, add the heavy semantic outline, and do not change title/path/search fields or global TextArea rules. Remove only `library_notes_save` from `LibraryScreen.BINDINGS` and the Notes editor shortcut tuples/help projection; keep the visible Save handler and the separately gated Skill binding.
+
+- [ ] **Step 5: Regenerate CSS from source.**
+
+  Run: `python tldw_chatbook/css/build_css.py`
+
+  Never edit `tldw_chatbook/css/tldw_cli_modular.tcss` by hand. Review the generated diff and confirm it contains the exact-ID rules once.
+
+- [ ] **Step 6: Re-run accessibility and CSS integrity tests.**
+
+  Run:
+
+  ```bash
+  python -m pytest Tests/UI/test_focus_accessibility.py Tests/UI/test_library_honesty_accessibility.py Tests/UI/test_library_file_notes_workspace.py Tests/UI/test_widget_css_consolidation.py Tests/UI/test_css_staleness_manifest.py -q
+  ```
+
+- [ ] **Step 7: Commit the focus and shortcut slice.**
+
+  ```bash
+  git add tldw_chatbook/css/components/_forms.tcss tldw_chatbook/css/tldw_cli_modular.tcss tldw_chatbook/css/.css-build-manifest.json tldw_chatbook/UI/Screens/library_screen.py Tests/UI/test_focus_accessibility.py Tests/UI/test_library_honesty_accessibility.py Tests/UI/test_library_file_notes_workspace.py Tests/UI/test_library_shell.py Tests/UI/test_css_staleness_manifest.py
+  git commit -m "fix(library): quiet Notes editor focus"
+  ```
+
+  If the manifest path or a listed test file is unchanged, omit it from `git add` rather than forcing it into the commit.
+
+## Task 8: Document, verify live behavior, and close TASK-22513
+
+**Files:**
+
+- Modify: `Docs/User_Guide/library/notes.md`
+- Modify: `Docs/User_Guide/library/file-notes.md`
+- Modify: `backlog/tasks/task-22513 - Polish-Library-Notes-work-first-editors-and-Folder-Files-shell.md`
+- Modify only if an actual generalizable incident occurred: `backlog/docs/lessons-testing-evidence.md` or `backlog/docs/lessons-live-verification.md`
+- Modify for the shared-index incident encountered during Task 7: `backlog/docs/lessons-backlog-hygiene.md`
+
+- [ ] **Step 1: Update both user guides.**
+
+  Document Database Edit/Preview/Info, Folder Edit/Manage, both independent collapsible local navigators, once-per-work-session collapse/manual override/reset behavior, autosave versus visible Database Save, boundary-only body focus, named Folder path tasks, recovery/Git locations, and the removal of Notes `Ctrl+S` without implying a replacement shortcut.
+
+- [ ] **Step 2: Run the complete targeted automated verification.**
+
+  ```bash
+  python -m pytest Tests/UI/test_library_notes_work_session.py Tests/Library/test_library_adaptive_reader_state.py Tests/test_config_library_defaults.py Tests/UI/test_settings_appearance_defaults.py Tests/UI/test_settings_configuration_hub.py Tests/UI/test_library_adaptive_reader_shell.py Tests/UI/test_library_conversation_reader.py Tests/UI/test_library_media_reader_shell.py Tests/UI/test_library_notes_reader.py Tests/UI/test_library_file_notes_workspace.py Tests/UI/test_library_file_notes_git.py Tests/UI/test_library_shell.py Tests/UI/test_library_honesty_accessibility.py Tests/UI/test_focus_accessibility.py Tests/UI/test_widget_css_consolidation.py Tests/UI/test_css_staleness_manifest.py -q
+  ```
+
+  Expected: all targeted tests pass. If an unrelated failure appears, reproduce the exact node on the unchanged base before classifying it as pre-existing; do not substitute a different command as evidence.
+
+- [ ] **Step 3: Perform an isolated-profile live Textual walkthrough.**
+
+  Read `backlog/docs/lessons-live-verification.md` immediately before the run. Create a scratch root and set absolute `HOME`, `USERPROFILE`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_CACHE_HOME`, `TLDW_CONFIG_PATH`, `TMPDIR`, and `[paths].data_dir` before Python imports. Verify the effective paths are scratch paths, seed synthetic Database Notes and a temporary Folder Files root, and use no real user profile or real notes folder.
+
+  Walk both authorities at 160x40, then `120x35 → 119x35 → 160x40 restored`, plus 100x30, 80x24, 79x24, and 60x20. Verify:
+
+  - initial/list/setup states do not collapse unexpectedly;
+  - first editable open at wide size collapses Library once, both grips remain usable, manual reopen wins, and each declared reset starts a new session;
+  - Folder tree and Database list preferences remain independent across restart;
+  - resize/hysteresis and Folder narrow Back do not persist or reset state;
+  - Database → Folder → Database → Folder preserves both selections, drafts, cursor/undo/scroll, navigator state, and Folder Git/recovery state while the work-session reducer alone resets;
+  - editor text, cursor, undo, tree/search, Git, recovery, autosave, and focus survive collapse/mode/resize;
+  - headers remain bounded and consequential status/recovery actions remain complete;
+  - only the two note bodies use boundary-only focus and there is no layout shift;
+  - every capability in the ledger is reachable, Folder has no Preview/Save, Database has no bulk delete, and Notes has no `Ctrl+S` hint/binding.
+
+  Record the exact commands, terminal sizes, scratch paths (never secrets), and observed results in the Backlog Implementation Notes.
+
+- [ ] **Step 4: Perform final static checks.**
+
+  Run:
+
+  ```bash
+  git diff --check
+  python -m compileall -q tldw_chatbook/UI/Library_Modules/library_notes_work_session.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py tldw_chatbook/Widgets/Library/library_notes_canvas.py tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+  python -m ruff check tldw_chatbook/config.py tldw_chatbook/UI/Library_Modules/library_notes_work_session.py tldw_chatbook/UI/Screens/settings_appearance_defaults.py tldw_chatbook/UI/Screens/settings_screen.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py tldw_chatbook/Widgets/Library/library_notes_canvas.py tldw_chatbook/Widgets/Library/library_file_notes_workspace.py Tests/test_config_library_defaults.py Tests/UI/test_settings_appearance_defaults.py Tests/UI/test_settings_configuration_hub.py Tests/UI/test_library_notes_work_session.py Tests/UI/test_library_adaptive_reader_shell.py Tests/UI/test_library_notes_reader.py Tests/UI/test_library_file_notes_workspace.py Tests/UI/test_library_file_notes_git.py Tests/UI/test_library_shell.py Tests/UI/test_library_honesty_accessibility.py Tests/UI/test_focus_accessibility.py Tests/UI/test_css_staleness_manifest.py
+  python -m ruff format --check tldw_chatbook/config.py tldw_chatbook/UI/Library_Modules/library_notes_work_session.py tldw_chatbook/UI/Screens/settings_appearance_defaults.py tldw_chatbook/UI/Screens/settings_screen.py tldw_chatbook/UI/Screens/library_screen.py tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py tldw_chatbook/Widgets/Library/library_notes_canvas.py tldw_chatbook/Widgets/Library/library_file_notes_workspace.py Tests/test_config_library_defaults.py Tests/UI/test_settings_appearance_defaults.py Tests/UI/test_settings_configuration_hub.py Tests/UI/test_library_notes_work_session.py Tests/UI/test_library_adaptive_reader_shell.py Tests/UI/test_library_notes_reader.py Tests/UI/test_library_file_notes_workspace.py Tests/UI/test_library_file_notes_git.py Tests/UI/test_library_shell.py Tests/UI/test_library_honesty_accessibility.py Tests/UI/test_focus_accessibility.py Tests/UI/test_css_staleness_manifest.py
+  ```
+
+  Inspect `git status --short` and every task-file diff. Confirm unrelated dirty files remain untouched and no generated CSS source/bundle mismatch remains.
+
+- [ ] **Step 5: Complete Backlog hygiene.**
+
+  In the task file:
+
+  - check all acceptance criteria only after their evidence exists;
+  - add concise Implementation Notes with approach, trade-offs, exact files, test commands/results, live walkthrough evidence, and `ADR required: no` / `ADR path: N/A`;
+  - add a lesson only if implementation exposed a real, generalizable incident;
+  - set status to Done with `backlog task edit 22513 -s Done` only after every Definition-of-Done item is satisfied.
+
+- [ ] **Step 6: Commit documentation and task closure.**
+
+  ```bash
+  git add Docs/User_Guide/library/notes.md Docs/User_Guide/library/file-notes.md 'backlog/tasks/task-22513 - Polish-Library-Notes-work-first-editors-and-Folder-Files-shell.md'
+  git commit -m "docs(library): document work-first Notes UX"
+  ```
+
+## Final review gate
+
+Before claiming completion, use `superpowers:requesting-code-review`, address findings through `superpowers:receiving-code-review`, and then use `superpowers:verification-before-completion`. The final report must distinguish targeted automated evidence, isolated live evidence, and any unrun full-suite evidence; never imply the full suite passed unless the user separately authorized and it actually ran.

--- a/Docs/superpowers/plans/2026-08-27-console-turns-survive-navigation.md
+++ b/Docs/superpowers/plans/2026-08-27-console-turns-survive-navigation.md
@@ -1,0 +1,875 @@
+# Console Turns Survive Screen Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task with the review checkpoints below.
+
+**Goal:** Make every accepted Console turn and human-decision wait continue safely while the user navigates to another app screen, with exact cancellation boundaries and durable, privacy-preserving attention on hidden terminal outcomes.
+
+**Architecture:** Extend the existing app-owned `ConsoleRuntime` into the lifetime owner for accepted-turn tasks while leaving `ConsoleChatController` and `ConsoleChatStore` as the sole execution and transcript authorities. A disposable `ChatScreen` captures immutable send-time inputs, transfers custody before clearing the composer, and later reattaches by reconciling the live store. Existing decision registries become view-independent, ChaChaNotes writes terminal rows and exact local receipt marks atomically, and the shell derives a boolean Console-attention projection from pending decisions plus durable unseen receipts.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, asyncio, frozen dataclasses, SQLite/FTS5 through the existing ChaChaNotes transaction layer, pytest/pytest-asyncio, existing Loguru and Textual test harnesses. No new dependency and no schema migration.
+
+---
+
+## Planning references and constraints
+
+- **Backlog task:** `backlog/tasks/task-22514 - Console-turns-survive-screen-navigation.md`
+- **Approved design:** `Docs/superpowers/specs/2026-08-27-console-turns-survive-navigation-design.md`
+- **ADR required:** yes
+- **ADR path:** `backlog/decisions/094-console-turn-lifetime-and-navigation-boundary.md`
+- **Reason:** This changes the long-lived task-ownership, cancellation, decision-clock, and attention-persistence boundaries shared by the app, runtime, controller, screen, and shell navigation.
+- **Applicable lessons:** `backlog/docs/lessons-testing-evidence.md`, `backlog/docs/lessons-live-verification.md`, and `backlog/docs/lessons-backlog-hygiene.md`.
+- Preserve the fresh-screen invariant: never cache or hide `ChatScreen`.
+- Do not grow `chat_screen.py`; new non-visual behavior belongs in `UI/Console_Modules/` or `Chat/`, as enforced by `Tests/Architecture/test_screen_size_ratchet.py`.
+- Preserve existing dirty user work. Before Task 1, record `git status --short` and classify every pre-dirty overlapping path. The `git add ...` examples below assume a task-clean path; use `git add -p` for every pre-dirty/shared path, then inspect both `git diff --cached --name-only` and the full `git diff --cached` before each commit so unrelated hunks never enter this feature.
+- Before Task 1's first code edit, record `git rev-parse HEAD` in TASK-22514 as the implementation base. Every task commit must contain only this feature's paths, so the final `<recorded-task-base>..HEAD` Python manifest is safe to use for lint/format verification.
+- Run targeted tests throughout. Ask the user before any full-suite run.
+
+## Acceptance mapping
+
+| Task AC | Plan coverage |
+| --- | --- |
+| AC 1: ordinary and agent turns survive real navigation | Tasks 1–4 and 9 |
+| AC 2: all three human-decision types notify and wait detached | Task 5 |
+| AC 3: exact Stop/session-close/quit scopes | Task 8 |
+| AC 4: reattach reconciliation has no duplicate/missing content | Tasks 3 and 9 |
+| AC 5: deterministic, live-provider, restart, privacy, and narrow-layout evidence | Tasks 6–10 |
+| AC 6: User Guide is current | Task 10 |
+| AC 7: one notice plus durable exact unseen receipt | Tasks 6 and 7 |
+| AC 8: frozen context/attachments without payload or privacy expansion | Tasks 1, 2, 4, and 9 |
+
+## Task 1: Characterize the old ownership boundary and add the custody value objects
+
+**Files:**
+
+- Modify: `tldw_chatbook/Chat/console_runtime.py`
+- Modify: `tldw_chatbook/Chat/console_turn_context.py`
+- Modify: `Tests/Chat/test_console_runtime_lifetime.py`
+- Modify: `Tests/UI/test_console_runtime_ownership.py`
+
+### Steps
+
+- [ ] Add failing runtime-level tests for the desired custody contract: synchronous admission registers a sensitive request before scheduling, returns a stable turn ID, retrieves task failures, and releases custody at terminal cleanup. Leave the prompt-queue launcher change for Task 2 so this task can end green.
+
+  Run:
+
+  ```bash
+  pytest -q Tests/Chat/test_console_runtime_lifetime.py Tests/UI/test_console_runtime_ownership.py -k "custody or runtime_owned"
+  ```
+
+  Expected: new assertions fail because `ConsoleRuntime` has no custody registry or admission API.
+
+- [ ] Add a frozen, slots-based `ConsoleTurnCustodyRequest` next to the existing immutable turn-context types. Reuse `ConsoleTurnConfigurationSnapshot`; do not introduce a second provider/settings model.
+
+  The request should carry only the data needed after detachment:
+
+  ```python
+  @dataclass(frozen=True, slots=True)
+  class ConsoleTurnCustodyRequest:
+      turn_id: str
+      session_id: str
+      draft: str = field(repr=False)
+      configuration: ConsoleTurnConfigurationSnapshot = field(repr=False)
+      attachment_ids: tuple[str, ...] = ()
+      staged_evidence_launch: ConsoleLiveWorkLaunch | None = field(
+          default=None,
+          repr=False,
+      )
+  ```
+
+  Keep accepted attachment objects in a runtime-only record if controller APIs require them; do not deep-copy bytes or put names/content into `repr`.
+
+- [ ] Add a minimal private custody record and registry to `ConsoleRuntime`. The registry owns task lifetime only: stable turn ID, owning session ID, task handle, and sensitive request references marked `repr=False`. It must not mirror run state, queue state, or terminal state already owned by the controller/store.
+
+- [ ] Add a synchronous runtime admission method with registration-before-scheduling semantics:
+
+  ```python
+  def accept_turn(self, request: ConsoleTurnCustodyRequest) -> str:
+      self._raise_if_disposed_or_session_fenced(request.session_id)
+      record = self._register_custody(request)
+      try:
+          record.task = asyncio.create_task(self._run_custodied_turn(record))
+      except BaseException:
+          self._release_custody(record.turn_id)
+          raise
+      record.task.add_done_callback(self._finish_custodied_turn)
+      return record.turn_id
+  ```
+
+  The done callback must retrieve `task.result()` so exceptions cannot become “Task exception was never retrieved,” run terminal cleanup once, and release request/context/attachment references.
+
+- [ ] Add tests with deterministic scheduling barriers that assert:
+
+  - custody exists before the coroutine is allowed to start;
+  - task creation failure removes custody and leaves the caller in control of draft recovery;
+  - request and custody `repr` omit prompt, attachment, RAG, credential, and tool data;
+  - terminal cleanup removes the record and permits weak-reference collection of sensitive owned objects;
+  - `ConsoleRuntime` does not duplicate controller run-state fields.
+
+- [ ] Run the focused tests:
+
+  ```bash
+  pytest -q Tests/Chat/test_console_runtime_lifetime.py Tests/UI/test_console_runtime_ownership.py
+  ```
+
+  Expected: PASS.
+
+- [ ] Commit only this task's files:
+
+  ```bash
+  git add tldw_chatbook/Chat/console_runtime.py tldw_chatbook/Chat/console_turn_context.py Tests/Chat/test_console_runtime_lifetime.py Tests/UI/test_console_runtime_ownership.py
+  git diff --cached --name-only
+  git commit -m "feat: add Console turn runtime custody"
+  ```
+
+## Task 2: Transfer prompt custody before clearing the composer
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Console_Modules/prompt_queue.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/wiring.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/session.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/retrieval.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/message.py`
+- Modify: `tldw_chatbook/Widgets/Console/console_composer_bar.py`
+- Modify: `tldw_chatbook/Chat/console_runtime.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `tldw_chatbook/Chat/console_chat_store.py`
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py`
+- Modify: `tldw_chatbook/Chat/console_fleet_wake.py`
+- Modify: `tldw_chatbook/Chat/console_prompt_queue.py`
+- Modify: `tldw_chatbook/Chat/console_prompt_queue_coordinator.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `Tests/Chat/test_console_agent_bridge.py`
+- Modify: `Tests/Chat/test_console_fleet_wake.py`
+- Modify: `Tests/Chat/test_console_prompt_queue.py`
+- Modify: `Tests/Chat/test_console_prompt_queue_coordinator.py`
+- Modify: `Tests/Chat/test_console_run_state_per_session.py`
+- Modify: `Tests/UI/test_console_prompt_queue.py`
+- Modify: `Tests/UI/test_console_composer_improvement_transaction.py`
+- Modify: `Tests/UI/test_console_send_draft_snapshot.py`
+- Modify: `Tests/UI/test_chat_screen_worker_groups.py`
+- Modify: `Tests/UI/test_console_composer_undo.py`
+- Modify: `Tests/UI/test_console_fleet_wake_ui_freshness.py`
+- Modify: `Tests/UI/test_console_native_chat_flow.py`
+- Modify: `Tests/UI/test_console_parallel_runs.py`
+- Modify: `Tests/UI/test_console_regenerate_feedback.py`
+- Modify: `Tests/UI/test_console_skill_commands.py`
+- Modify: `Tests/Chat/test_console_turn_execution_context.py`
+
+### Steps
+
+- [ ] Write failing prompt-queue tests for the handoff transaction:
+
+  - immutable configuration and exact staged-evidence launch are captured for the selected session;
+  - runtime custody succeeds before the composer revision is cleared;
+  - a synchronous admission refusal leaves the composer and staged attachments untouched;
+  - a failure after custody but before durable acceptance creates a recovery keyed by turn ID with the exact draft and attachment references, without replacing an older recovery for that session;
+  - a failure after durable acceptance becomes transcript/run output and never restores unsent text;
+  - queued follow-up prompts retain their own immutable input snapshot rather than inheriting the first turn's configuration or consulting a later view.
+
+  Run:
+
+  ```bash
+  pytest -q Tests/UI/test_console_prompt_queue.py Tests/UI/test_console_send_draft_snapshot.py -k "custody or composer or revision or staged"
+  ```
+
+  Expected: FAIL because `_stage_normal_chain` currently returns after launching a screen worker and `_submit_console_native_draft` owns recovery on the screen.
+
+- [ ] Replace the keyboard path's destructive pre-launch `stash_draft_for_send()` with a two-step composer transaction: `capture_draft_for_send()` takes a non-destructive revision-pinned snapshot, and `commit_captured_draft(stash)` clears only that accepted revision after runtime custody succeeds while preserving any newer typing. Clicking Send and pressing Enter must use the same transaction. A synchronous refusal performs no restore because nothing was cleared.
+
+- [ ] Change `ConsolePromptQueueUIController`'s launch seam to return a synchronous custody result instead of a Textual worker. Remove screen-owned in-flight stash ownership after the composer transaction above becomes authoritative; only the runtime's turn-keyed recovery owns a post-custody/pre-acceptance draft.
+
+- [ ] In `wiring.py`, replace:
+
+  ```python
+  screen.run_worker(screen._submit_console_native_draft(...))
+  ```
+
+  with a small binding that synchronously captures:
+
+  - `ConsoleTurnConfigurationSnapshot` from `_build_console_turn_execution_context(session_id)`;
+  - the exact `ConsoleLiveWorkLaunch` from `_snapshot_console_staged_evidence()`;
+  - the exact staged attachment IDs expected for the handoff;
+  - the prompt-history/follow-intent values required by the current dispatch contract;
+  - the runtime's stable turn ID and session ID.
+
+  Then call the runtime admission method. The binding may read the mounted screen during this synchronous capture only; the resulting request and runtime task must not retain the screen or bound screen methods.
+
+- [ ] Add one store operation that atomically transfers the exact expected pending-attachment sequence to a stable turn ID and returns the original `PendingAttachment` objects without copying bytes. `ConsoleRuntime.accept_turn(...)` performs that transfer, registers custody, and schedules on the same owner loop. If validation, registration, or task creation refuses custody, roll the exact objects back in their original order without overwriting attachments staged after the snapshot. After custody, only the custody record/controller owns those references; the controller must no longer re-read `store.pending_attachments()` for that turn.
+
+- [ ] Add an in-memory, content-redacted `ConsoleTurnRecoveryEntry` registry to `ConsoleRuntime`, keyed by turn ID and secondarily indexed by session. If a custody task fails before the controller reports durable acceptance, move its exact draft and transferred attachment references into a new recovery entry; never overwrite or collapse an older entry for the same session. Expose ordered, exact restore/discard actions to the fresh-screen prompt-queue/composer projection. Restore re-stages only that entry's attachments and only into a live matching session; discard releases references. These entries are navigation-lifetime recovery only and must not create a second restart scanner or replace durable dispatch recovery.
+
+- [ ] Define queue ownership explicitly as **one runtime-owned chain task plus one immutable request per queued entry**. Extend `QueuedPrompt`/the registry so queue admission captures a repr-redacted `ConsoleTurnCustodyRequest`-equivalent snapshot for that entry (attachments and staged evidence remain prohibited by the existing staged-rider gate). Change `ConsolePromptQueueCoordinator._submit_queued` and `ConsoleChatController._submit_queued_entry` to consume the claimed entry's own snapshot. Do not pass the initial request's configuration through `run_prompt_chain`, and do not resolve queued configuration from a mounted screen when the chain drains headlessly.
+
+- [ ] Route the existing main-agent and fleet-wake submission entry points in `ConsoleAgentBridge`/`ConsoleFleetWakeCoordinator` through the same runtime custody API with their already app-owned, screen-free inputs. Preserve their wake ledger and controller origins; do not create a second agent task or duplicate bridge run state. Tests must prove ordinary, main-agent, and wake turns all appear in the runtime custody registry before scheduling and release their records independently.
+
+- [ ] Move the domain body currently in `ChatScreen._submit_console_native_draft` behind `ConsoleRuntime._run_custodied_turn`. Keep controller calls authoritative and pass the frozen configuration and frozen staged-evidence launch explicitly into `run_prompt_chain`/`submit_draft`.
+
+- [ ] Extend the existing controller signatures narrowly, for example:
+
+  ```python
+  await controller.run_prompt_chain(
+      session_id=session_id,
+      initial_turn=lambda: controller.submit_draft(
+          request.draft,
+          session_id=session_id,
+          configuration=request.configuration,
+          accepted_attachments=record.attachments,
+          staged_evidence_launch=request.staged_evidence_launch,
+      ),
+  )
+  ```
+
+  Do not re-resolve a mounted view's `_turn_context_provider` after custody. Each later queue claim supplies its own snapshot through the coordinator contract above. Preserve the controller's queue, cap, durable preparation, dispatch recovery, and terminalization logic.
+
+- [ ] Use `_capture_frozen_console_staged_rag(draft, context, launch)` and `_release_frozen_console_staged_rag(launch, result)` with the exact admitted launch. Refactor those operations into app-owned callables/services or values that the runtime can invoke without retaining `ChatScreen`; do not query newer staged UI state.
+
+- [ ] Remove the obsolete screen-owned submit coroutine after its logic has moved. Migrate every direct caller or test seam found by `rg -n "_submit_console_native_draft" Tests tldw_chatbook`: behavior tests should admit through the runtime and await the specific custody task via a narrow runtime test seam, skill-command spies should patch runtime admission, worker-group assertions should no longer classify ordinary sends as screen workers, and explanatory comments should name the runtime handoff. End with no executable production reference to the removed method. Ensure the screen-size ratchet does not increase.
+
+- [ ] Add negative architecture assertions that the accepted-turn path contains neither `screen.run_worker` nor a bound `ChatScreen._submit_console_native_draft` callback.
+
+- [ ] Run the focused tests:
+
+  ```bash
+  pytest -q Tests/Chat/test_console_agent_bridge.py Tests/Chat/test_console_fleet_wake.py Tests/Chat/test_console_prompt_queue.py Tests/Chat/test_console_prompt_queue_coordinator.py Tests/UI/test_console_prompt_queue.py Tests/UI/test_console_composer_improvement_transaction.py Tests/UI/test_console_send_draft_snapshot.py Tests/UI/test_chat_screen_worker_groups.py Tests/UI/test_console_composer_undo.py Tests/UI/test_console_fleet_wake_ui_freshness.py Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_parallel_runs.py Tests/UI/test_console_regenerate_feedback.py Tests/UI/test_console_skill_commands.py Tests/Chat/test_console_run_state_per_session.py Tests/Chat/test_console_turn_execution_context.py Tests/Architecture/test_screen_size_ratchet.py
+  ```
+
+  Expected: PASS.
+
+- [ ] Commit only this task's files after inspecting the staged list:
+
+  ```bash
+  git add tldw_chatbook/UI/Console_Modules/prompt_queue.py tldw_chatbook/UI/Console_Modules/wiring.py tldw_chatbook/UI/Console_Modules/session.py tldw_chatbook/UI/Console_Modules/retrieval.py tldw_chatbook/UI/Console_Modules/message.py tldw_chatbook/Widgets/Console/console_composer_bar.py tldw_chatbook/Chat/console_runtime.py tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_chat_store.py tldw_chatbook/Chat/console_agent_bridge.py tldw_chatbook/Chat/console_fleet_wake.py tldw_chatbook/Chat/console_prompt_queue.py tldw_chatbook/Chat/console_prompt_queue_coordinator.py tldw_chatbook/UI/Screens/chat_screen.py Tests/Chat/test_console_agent_bridge.py Tests/Chat/test_console_fleet_wake.py Tests/Chat/test_console_prompt_queue.py Tests/Chat/test_console_prompt_queue_coordinator.py Tests/Chat/test_console_run_state_per_session.py Tests/UI/test_console_prompt_queue.py Tests/UI/test_console_composer_improvement_transaction.py Tests/UI/test_console_send_draft_snapshot.py Tests/UI/test_chat_screen_worker_groups.py Tests/UI/test_console_composer_undo.py Tests/UI/test_console_fleet_wake_ui_freshness.py Tests/UI/test_console_native_chat_flow.py Tests/UI/test_console_parallel_runs.py Tests/UI/test_console_regenerate_feedback.py Tests/UI/test_console_skill_commands.py Tests/Chat/test_console_turn_execution_context.py
+  git diff --cached --name-only
+  git commit -m "refactor: hand Console sends to app runtime"
+  ```
+
+## Task 3: Remove surviving screen dependencies, then make navigation a pure detach
+
+**Files:**
+
+- Modify: `tldw_chatbook/Chat/console_runtime.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `tldw_chatbook/Chat/console_turn_context.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/wiring.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/session.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/retrieval.py`
+- Modify: `Tests/Chat/test_console_runtime_lifetime.py`
+- Modify: `Tests/Chat/test_console_viewless_hooks.py`
+- Modify: `Tests/UI/test_console_runtime_ownership.py`
+- Modify: `Tests/UI/test_console_store_continuity.py`
+- Modify: `Tests/UI/test_console_sync_outlives_screen.py`
+- Modify: `Tests/UI/test_screen_navigation.py`
+
+### Steps
+
+- [ ] Replace the old-policy assertions in `test_console_runtime_lifetime.py` with failing tests that navigation:
+
+  - clears only view hooks;
+  - does not set the controller visit-cancel event;
+  - does not tombstone prompt queues or cancel ordinary submit/stream tasks;
+  - does not deny or resolve pending decisions;
+  - leaves the same runtime/controller/store instances alive.
+
+- [ ] Add a failing real-navigation test that starts a barrier-controlled stream, invokes the production navigation handler to Library or Settings, lets the stream complete with no Console mounted, returns through production navigation, and observes the terminal row exactly once.
+
+  Run:
+
+  ```bash
+  pytest -q Tests/Chat/test_console_runtime_lifetime.py Tests/UI/test_console_runtime_ownership.py Tests/UI/test_console_store_continuity.py Tests/UI/test_screen_navigation.py -k "navigation or detach or reattach"
+  ```
+
+  Expected: FAIL because runtime `leave_console()` still calls controller `leave_console()` and the screen still asks for fleet-loss confirmation.
+
+- [ ] Before enabling pure detach, enumerate every `CONSOLE_VIEW_HOOK_SLOTS` entry in a failing owner test and move every post-custody domain dependency to either the immutable request or an app-owned service. This includes dictionary/world-info application, frozen RAG capture/release, Library policy, identity/history, project/workspace authority, settings/tool policy, and accepted attachments. After this step, the only detachable hooks are repaint/focus/card projections; a custody task must retain no `ChatScreen`, widget, or bound screen method.
+
+- [ ] Narrow `CONSOLE_VIEW_HOOK_SLOTS` to those disposable projection callbacks and add an architecture assertion that detaching all hooks during preparation, provider readiness, or streaming leaves the runtime request sufficient to continue. This ordering is mandatory: do not remove navigation cancellation while any accepted-turn domain operation still depends on a view hook.
+
+- [ ] Split attachment identity from app-disposal generation:
+
+  - `attach_view(view)` increments and returns a monotonic attachment generation;
+  - the screen stores that token;
+  - `detach_view(view, generation)` clears hooks only when both claimant and generation match;
+  - a late outgoing unmount cannot detach a freshly attached successor.
+
+- [ ] Make navigation call pure detach. Remove ordinary cancellation, queue tombstoning, decision denial, and teardown-notice behavior from `ConsoleRuntime.leave_console()` / `ConsoleChatController.leave_console()`; retain permanent cancellation only under explicit Stop, session close, and app disposal.
+
+- [ ] Move the runtime detach to the beginning of `ChatScreen.on_unmount` and guarantee it with `try/finally`. View-owned cleanup (microphone/audio, timers, modals, animations, local workers) may still run, but a cleanup failure must not leave runtime hooks bound.
+
+- [ ] Remove the Console navigate-away confirmation by making `ChatScreen.confirm_navigation()` return immediately or removing the Console-specific delegate. Preserve confirmation for actual destructive actions such as session close and app quit.
+
+- [ ] On attach, run one full store-driven reconciliation, re-derive the active session's pending decision projection, and then restart ordinary view-only refresh timers. Never replay per-token deltas accumulated while detached. Receipt-aware acknowledgement is wired in Task 7 after Task 6 introduces the durable receipt field; Task 3 only establishes the successful-render reconciliation boundary it will use.
+
+- [ ] Add failure-injection tests for unmount cleanup, stale outgoing detach, sync/render failure, and notification failure. Assert the runtime/store remain intact and the old screen can be garbage-collected.
+
+- [ ] Run the focused tests:
+
+  ```bash
+  pytest -q Tests/Chat/test_console_runtime_lifetime.py Tests/Chat/test_console_viewless_hooks.py Tests/UI/test_console_runtime_ownership.py Tests/UI/test_console_store_continuity.py Tests/UI/test_console_sync_outlives_screen.py Tests/UI/test_screen_navigation.py
+  ```
+
+  Expected: PASS.
+
+- [ ] Commit:
+
+  ```bash
+  git add tldw_chatbook/Chat/console_runtime.py tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_turn_context.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/UI/Console_Modules/wiring.py tldw_chatbook/UI/Console_Modules/session.py tldw_chatbook/UI/Console_Modules/retrieval.py Tests/Chat/test_console_runtime_lifetime.py Tests/Chat/test_console_viewless_hooks.py Tests/UI/test_console_runtime_ownership.py Tests/UI/test_console_store_continuity.py Tests/UI/test_console_sync_outlives_screen.py Tests/UI/test_screen_navigation.py
+  git diff --cached --name-only
+  git commit -m "fix: detach Console views without cancelling turns"
+  ```
+
+## Task 4: Harden frozen-input, privacy, and viewless-owner coverage
+
+**Files:**
+
+- Modify: `tldw_chatbook/Chat/console_runtime.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `tldw_chatbook/Chat/console_turn_context.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/wiring.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/session.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/retrieval.py`
+- Modify: `Tests/Chat/test_console_viewless_hooks.py`
+- Modify: `Tests/Chat/test_console_turn_execution_context.py`
+- Modify: `Tests/UI/test_console_sync_outlives_screen.py`
+- Modify: `Tests/UI/test_console_runtime_ownership.py`
+
+### Steps
+
+- [ ] Audit the Task 3 hook inventory with failing owner tests that classify every former/current hook as one of:
+
+  1. frozen into `ConsoleTurnCustodyRequest` before acceptance;
+  2. app-owned domain service safe while viewless; or
+  3. disposable UI projection callback cleared at detach.
+
+  Assert that no task reachable from runtime custody retains a `ChatScreen`, widget, DOM query, screen timer, cost timer, or `run_worker` callback.
+
+- [ ] Close any residual gaps in the frozen screen-derived inputs established in Task 3:
+
+  - provider/model/session settings and provider payload controls;
+  - scratch snapshot and selected workspace roots;
+  - selected dictionary and world-info application results;
+  - staged RAG launch plus source/top-k defaults;
+  - Library/direct-tool policy and tool configuration;
+  - global display identity and prompt-history values;
+  - accepted attachment identities/objects and their session ownership.
+
+  Prefer extending `ConsoleTurnConfigurationSnapshot` only when the value is configuration. Keep large/transient accepted objects in the private custody record with `repr=False`.
+
+- [ ] Verify `_console_chat_dictionary_applier`, `_console_world_info_applier`, frozen RAG capture/release, and Library policy resolution now execute through narrow app-owned helpers wherever post-handoff asynchronous work is required. Close any remaining screen reach-back; helpers may use app services and captured IDs/configuration, but never `ChatScreen` or widgets.
+
+- [ ] Assert `CONSOLE_VIEW_HOOK_SLOTS` contains only repaint/focus/card hooks and all are explicitly detached. Remove any residual old “viewless ordinary hooks are inert/fail closed” branch for domain work, because an accepted turn already holds everything it needs.
+
+- [ ] Add tests that mutate UI settings, staged RAG, workspace selection, identity, and attachments after handoff and verify the running turn uses the original frozen values. Also verify a later turn uses the new values.
+
+- [ ] Add provider-payload regression assertions: runtime bookkeeping and attention IDs never appear in the outbound provider request, and accepted attachments follow the exact pre-feature vision/non-vision filtering policy.
+
+- [ ] Run:
+
+  ```bash
+  pytest -q Tests/Chat/test_console_viewless_hooks.py Tests/Chat/test_console_turn_execution_context.py Tests/UI/test_console_sync_outlives_screen.py Tests/UI/test_console_runtime_ownership.py
+  ```
+
+  Expected: PASS.
+
+- [ ] Commit:
+
+  ```bash
+  git add tldw_chatbook/Chat/console_runtime.py tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_turn_context.py tldw_chatbook/UI/Console_Modules/wiring.py tldw_chatbook/UI/Console_Modules/session.py tldw_chatbook/UI/Console_Modules/retrieval.py Tests/Chat/test_console_viewless_hooks.py Tests/Chat/test_console_turn_execution_context.py Tests/UI/test_console_sync_outlives_screen.py Tests/UI/test_console_runtime_ownership.py
+  git diff --cached --name-only
+  git commit -m "refactor: freeze Console turn inputs at handoff"
+  ```
+
+## Task 5: Retain every human-decision round while Console is detached
+
+**Files:**
+
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `tldw_chatbook/Chat/console_runtime.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/wiring.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/skill.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `tldw_chatbook/Widgets/Chat_Widgets/chat_task_cards.py`
+- Modify: `Tests/UI/test_console_headless_approval.py`
+- Modify: `Tests/UI/test_console_mcp_approval.py`
+- Modify: `Tests/UI/test_console_skill_install_confirm.py`
+- Modify: `Tests/UI/test_skill_install_concurrent_confirms.py`
+- Modify: `Tests/Chat/test_console_skill_script_confirm.py`
+- Modify: `Tests/Chat/test_skill_script_concurrent_confirms.py`
+
+### Steps
+
+- [ ] Add failing parameterized tests for MCP/tool approval, skill-install confirmation, and skill-script confirmation. For each decision type prove:
+
+  - the stable round/request ID remains registered after detach;
+  - no default allow/deny result is produced by navigation;
+  - one sanitized app notice is emitted per stable ID while hidden;
+  - a fresh Console view re-derives and mounts the correct active-session head card;
+  - two rounds of the same type and mixed decision types retain FIFO order without overwriting each other;
+  - explicit response, Stop, session close, and app disposal each resolve only their documented scope.
+
+- [ ] Replace visit-cancel-based decision waiting with a small active-time clock stored on the existing round record:
+
+  ```python
+  remaining_active_seconds: float | None
+  active_since: float | None
+  ```
+
+  Under the existing round lock, time begins only after the active session's head card reports a successful mount. Detach, session switch, card unmount/replacement, head resolution, and card-render failure subtract elapsed monotonic time and pause before changing projection state. A configured timeout of zero remains unbounded. Do not retain a wall-clock deadline that advances while no answerable control exists.
+
+- [ ] Use an injected monotonic clock and explicit events/barriers in tests; do not use timing sleeps. Verify detach just before expiry preserves the remaining duration; switching sessions pauses the outgoing round and resumes only a successfully mounted incoming head; resolving one FIFO head does not start the next until its mount succeeds; and a mount/render failure consumes zero decision-active time.
+
+- [ ] Reuse the controller's existing MCP, skill-install, and skill-script registries and FIFO maps. Add one derived `pending_decision_projection(session_id)` that selects the ordered answerable card; do not build a parallel decision state machine in the runtime.
+
+- [ ] Have runtime attachment changes, Console session switches, head-card transitions, and `ChatTaskCards.sync_state`/unmount report through one narrow controller method such as `set_answerable_decision(session_id, decision_id | None)`. Pass a non-`None` decision ID only after the exact MCP/install/script card is successfully populated and mounted; clear it before unmount/replacement and in render-failure cleanup. Exactly that mounted head accrues time; detached, background-session, non-head, and failed-render rounds remain paused. The runtime may track “notice already sent” by stable decision ID, but must clear that memory when the round resolves.
+
+- [ ] Ensure a round that is not answerable—because Console is detached or another session/card is active—produces the same one-time app-wide notice with only safe type/session labels and a return-to-Console instruction. Never include arguments, scripts, paths, exception bodies, credentials, or raw approval payloads.
+
+- [ ] Run:
+
+  ```bash
+  pytest -q Tests/UI/test_console_headless_approval.py Tests/UI/test_console_mcp_approval.py Tests/UI/test_console_skill_install_confirm.py Tests/UI/test_skill_install_concurrent_confirms.py Tests/Chat/test_console_skill_script_confirm.py Tests/Chat/test_skill_script_concurrent_confirms.py
+  ```
+
+  Expected: PASS.
+
+- [ ] Commit:
+
+  ```bash
+  git add tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_runtime.py tldw_chatbook/UI/Console_Modules/wiring.py tldw_chatbook/UI/Console_Modules/skill.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/Widgets/Chat_Widgets/chat_task_cards.py Tests/UI/test_console_headless_approval.py Tests/UI/test_console_mcp_approval.py Tests/UI/test_console_skill_install_confirm.py Tests/UI/test_skill_install_concurrent_confirms.py Tests/Chat/test_console_skill_script_confirm.py Tests/Chat/test_skill_script_concurrent_confirms.py
+  git diff --cached --name-only
+  git commit -m "feat: keep Console decisions alive while detached"
+  ```
+
+## Task 6: Persist exact terminal receipts in the transcript transaction
+
+**Files:**
+
+- Modify: `tldw_chatbook/Chat/message_metadata.py`
+- Modify: `tldw_chatbook/Chat/conversation_local_marks_service.py`
+- Modify: `tldw_chatbook/Chat/chat_persistence_service.py`
+- Modify: `tldw_chatbook/Chat/console_chat_store.py`
+- Modify: `tldw_chatbook/Chat/console_dispatch_checkpoint.py`
+- Modify: `tldw_chatbook/Chat/console_dispatch_repository.py`
+- Modify: `tldw_chatbook/Chat/console_conversation_hydration.py`
+- Modify: `tldw_chatbook/Video_Generation/video_metadata.py`
+- Modify: `Tests/Chat/test_conversation_local_marks_service.py`
+- Modify: `Tests/Chat/test_chat_persistence_service.py`
+- Modify: `Tests/Chat/test_console_durable_turn_acceptance.py`
+- Modify: `Tests/Chat/test_console_dispatch_recovery.py`
+- Modify: `Tests/Chat/test_console_generate_image.py`
+- Modify: `Tests/Chat/test_console_generate_video.py`
+- Modify: `Tests/Chat/test_console_video_message.py`
+- Add: `Tests/Chat/test_console_terminal_attention.py`
+
+### Steps
+
+- [ ] Add failing service tests for a bounded `console_unseen:<opaque-receipt-id>` mark namespace:
+
+  - valid construction and exact parsing;
+  - rejection of empty, malformed, oversized, or non-opaque IDs;
+  - uncached prefix/list/boolean queries for startup shell attention, so receipt writes made inside another repository transaction cannot be hidden by an exact-mark cache;
+  - exact acknowledgement deletes only one receipt;
+  - existing `starred` and `fleet_unseen` behavior remains unchanged.
+
+- [ ] Extend `MessageMetadata` with a bounded local-only `terminal_receipt_id: str = ""`. Update strict parsing/degrading load tests and ensure it remains only in local `metadata_json`, never provider message content.
+
+- [ ] Expose one marks-service SQL primitive that accepts an existing ChaChaNotes cursor, while keeping the public transactional wrapper:
+
+  ```python
+  def set_mark_with_cursor(
+      self,
+      cursor: sqlite3.Cursor,
+      conversation_id: str,
+      mark_type: str,
+      *,
+      created_at: str,
+      updated_at: str,
+  ) -> None:
+      ...
+  ```
+
+  Validation and SQL must live in one place. Do not open a second transaction from inside terminal persistence.
+
+- [ ] Add optional terminal-receipt parameters to `ChatPersistenceService.create_message` and `update_message_content`. When present, force the existing `transaction(immediate=True)` path, persist the terminal row/metadata, and insert the namespaced mark through the same cursor before commit.
+
+- [ ] Cover the authoritative durable-dispatch settlement path separately. Extend `ConsoleAssistantSettlement` with the validated terminal receipt mark/ID needed by `ConsoleDispatchRepository.settle_with_assistant()`. In the repository's existing `transaction(immediate=True)`, update the assistant row (including receipt-bearing metadata), insert the exact `console_unseen:*` mark through the shared cursor helper, and delete/settle the dispatch checkpoint before the same commit. Complete/failed store settlements supply a receipt; stopped/discarded settlements supply none. Do not let `_settle_owned_dispatch_terminal()` short-circuit around receipt creation.
+
+- [ ] Centralize receipt minting in `ConsoleChatStore.mark_message_complete` and `mark_message_failed`. Reuse the same receipt on idempotent terminal retry of the same row. Explicit Stop, session close, and app-shutdown cancellation must call stopped/cancelled paths without minting a receipt.
+
+- [ ] Cover immediate terminal media commits that bypass those markers:
+
+  - when `append_generation_message(..., persist=True)` creates an already-complete image row, mint the receipt first, attach it through `MessageMetadata`, and pass it into the same atomic `create_message(attachments=..., generation_metadata=..., terminal_mark=...)` transaction;
+  - when `append_video_message(..., persist=True)` creates an already-complete video row, preserve the full `VideoGenerationMetadata` payload and its local-only receipt together. Use the smallest backward-compatible representation: add a bounded optional `terminal_receipt_id` to `VideoGenerationMetadata` serialization/hydration and expose one common `ConsoleChatMessage` receipt accessor that reads ordinary `MessageMetadata` or video metadata. Do not overwrite video metadata with a second `metadata_json` document or leak the receipt into remote video-provider payloads.
+
+  Image/video rows created without persistence do not publish durable unseen attention until their durable create succeeds.
+
+- [ ] Add rollback tests for both persistence routes. Inject failure after the generic row update, after the durable-dispatch assistant update, after mark insertion, and before checkpoint deletion; assert terminal state, receipt metadata, mark, and checkpoint are all old or all new. Add race tests showing two results in one conversation receive distinct marks and acknowledging the older receipt leaves the newer one intact.
+
+- [ ] Add restart-style tests using a temporary on-disk ChaChaNotes DB for ordinary, immediate image, and immediate video terminal rows: reopen services, hydrate the media metadata and receipt without losing either, discover the unseen receipt by namespace, render/acknowledge its matching row, reopen again, and confirm only that receipt is gone.
+
+- [ ] Verify cancellation reasons: user Stop/session close/app shutdown create no receipt; unexpected cancellation without an explicit reason terminalizes as failure and does create one.
+
+- [ ] Run:
+
+  ```bash
+  pytest -q Tests/Chat/test_conversation_local_marks_service.py Tests/Chat/test_chat_persistence_service.py Tests/Chat/test_console_durable_turn_acceptance.py Tests/Chat/test_console_dispatch_recovery.py Tests/Chat/test_console_generate_image.py Tests/Chat/test_console_generate_video.py Tests/Chat/test_console_video_message.py Tests/Chat/test_console_terminal_attention.py
+  ```
+
+  Expected: PASS.
+
+- [ ] Commit:
+
+  ```bash
+  git add tldw_chatbook/Chat/message_metadata.py tldw_chatbook/Chat/conversation_local_marks_service.py tldw_chatbook/Chat/chat_persistence_service.py tldw_chatbook/Chat/console_chat_store.py tldw_chatbook/Chat/console_dispatch_checkpoint.py tldw_chatbook/Chat/console_dispatch_repository.py tldw_chatbook/Chat/console_conversation_hydration.py tldw_chatbook/Video_Generation/video_metadata.py Tests/Chat/test_conversation_local_marks_service.py Tests/Chat/test_chat_persistence_service.py Tests/Chat/test_console_durable_turn_acceptance.py Tests/Chat/test_console_dispatch_recovery.py Tests/Chat/test_console_generate_image.py Tests/Chat/test_console_generate_video.py Tests/Chat/test_console_video_message.py Tests/Chat/test_console_terminal_attention.py
+  git diff --cached --name-only
+  git commit -m "feat: persist exact Console terminal receipts"
+  ```
+
+## Task 7: Project hidden outcomes into app notices and shell attention
+
+**Files:**
+
+- Modify: `tldw_chatbook/Chat/console_runtime.py`
+- Modify: `tldw_chatbook/UI/Navigation/main_navigation.py`
+- Modify: `tldw_chatbook/UI/Navigation/nav_overflow_menu.py`
+- Modify: `tldw_chatbook/app.py`
+- Modify: `Tests/UI/test_master_shell_navigation.py`
+- Modify: `Tests/UI/test_console_narrow_layout.py`
+- Add: `Tests/UI/test_console_turn_attention.py`
+
+### Steps
+
+- [ ] Write failing projection tests that derive one boolean Console-attention state from:
+
+  - any durable `console_unseen:*` mark; or
+  - any unresolved hidden human decision.
+
+  Assert that opening Console alone does not clear terminal attention, resolving a decision clears only decision attention, and rendering/acknowledging the matching terminal row clears only that receipt.
+
+- [ ] Add one runtime-owned attention recompute method. It may query local mark IDs and controller pending-decision summaries, then notify the current shell projection. It must expose only a boolean and sanitized text—never counts, raw IDs, prompts, tool arguments, paths, or exception bodies.
+
+- [ ] Emit one app-wide toast for each completion/failure receipt whose matching row has not been rendered—whether Console is detached or viewing another session—and for each non-answerable decision ID. Completion uses informational severity and terminal failure uses error severity. Record “notified” only after the app notification call succeeds; a notification-render failure must leave durable attention intact and must not affect turn finalization.
+
+- [ ] Wire exact receipt acknowledgement into the successful-render boundary established in Task 3. Transcript synchronization returns or publishes only the receipt IDs whose matching ordinary/image/video rows mounted successfully; acknowledge that exact set after render completion. A mount, media-card hydration, or render failure acknowledges nothing, and opening Console alone never clears a mark.
+
+- [ ] Add the same non-color-only glyph to Console in both navigation surfaces. Preserve the existing hotkey label and ghost-button geometry, and set a tooltip such as “Console needs attention.” Use the production destination metadata/hierarchy; do not fork a test-only label path.
+
+- [ ] On app/runtime initialization and fresh navigation-bar mount, recompute from durable marks so attention survives restart or an unavailable prior bar. On mark/decision changes, update the currently mounted main and overflow projections if present; no per-token shell updates.
+
+- [ ] Add Textual tests at `80x24`, `100x30`, and `160x48` for:
+
+  - visible main-navigation glyph when Console fits;
+  - overflow-menu glyph when Console is in overflow;
+  - accessible text/tooltip not dependent on color;
+  - no clipped hotkey or shifted ghost geometry;
+  - glyph clears only after all receipt and decision sources clear.
+
+  Use the consolidated production CSS and enable app notifications when asserting toasts.
+
+- [ ] Run:
+
+  ```bash
+  pytest -q Tests/UI/test_console_turn_attention.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_console_narrow_layout.py
+  ```
+
+  Expected: PASS.
+
+- [ ] Commit:
+
+  ```bash
+  git add tldw_chatbook/Chat/console_runtime.py tldw_chatbook/UI/Navigation/main_navigation.py tldw_chatbook/UI/Navigation/nav_overflow_menu.py tldw_chatbook/app.py Tests/UI/test_console_turn_attention.py Tests/UI/test_master_shell_navigation.py Tests/UI/test_console_narrow_layout.py
+  git diff --cached --name-only
+  git commit -m "feat: surface hidden Console outcomes in navigation"
+  ```
+
+## Task 8: Fence Stop, session close, and app quit to their exact scopes
+
+**Files:**
+
+- Modify: `tldw_chatbook/Chat/console_runtime.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `tldw_chatbook/Chat/console_chat_models.py`
+- Modify: `tldw_chatbook/Chat/console_chat_store.py`
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py`
+- Modify: `tldw_chatbook/Chat/console_fleet_wake.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/session.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `tldw_chatbook/app.py`
+- Modify: `Tests/Chat/test_console_runtime_lifetime.py`
+- Modify: `Tests/Chat/test_console_agent_swap.py`
+- Modify: `Tests/Chat/test_console_agent_bridge_cancel_all.py`
+- Modify: `Tests/Chat/test_console_automatic_library_preparation.py`
+- Modify: `Tests/Chat/test_console_chat_controller.py`
+- Modify: `Tests/Chat/test_console_close_session_fleet.py`
+- Modify: `Tests/Chat/test_console_fleet_wake_safety.py`
+- Modify: `Tests/Chat/test_console_dispatch_recovery_fix_round1.py`
+- Modify: `Tests/Chat/test_console_dispatch_recovery_fix_round4.py`
+- Modify: `Tests/Chat/test_console_durable_turn_fix_round1.py`
+- Modify: `Tests/Chat/test_console_local_citation_boundary.py`
+- Modify: `Tests/Chat/test_console_prompt_queue_coordinator.py`
+- Modify: `Tests/Chat/test_console_run_markers.py`
+- Modify: `Tests/Chat/test_console_run_state_per_session.py`
+- Modify: `Tests/UI/test_screen_navigation.py`
+- Modify: `Tests/UI/test_app_quit_guard.py`
+- Modify: `Tests/UI/test_console_prompt_queue.py`
+- Modify: `Tests/UI/test_console_send_draft_snapshot.py`
+- Add: `Tests/Chat/test_console_runtime_shutdown.py`
+
+### Steps
+
+- [ ] Add failing deterministic race tests for the cancellation matrix:
+
+  | Action | Required result |
+  | --- | --- |
+  | Navigate | detach only; no stop signal, task cancel, queue tombstone, decision resolution, receipt, or outcome toast |
+  | Stop | cancel selected turn/chain and only its decision rounds; no receipt/toast |
+  | Session close | fence new/queued admissions, revision-confirm impact, cancel and await only that session's turns/rounds/fleet, then delete session; no receipt/toast |
+  | Confirmed app quit | revision-pin whole-runtime impact, fence all new admissions, cancel and bounded-drain all custody, then dispose; no receipt/toast |
+
+- [ ] Replace the synchronous destructive `ConsoleChatController.close_session()` boundary with a two-phase controller contract used by an async `ConsoleRuntime.close_session(...)` seam:
+
+  1. `begin_session_close(session_id, expected_revision)` atomically sets the per-session admission fence, rechecks the revision-pinned impact, tombstones queued claims, revokes decisions, and signals/cancels the session's turn/fleet work without deleting the store session;
+  2. the runtime awaits that session's custody tasks **and delegated fleet** up to the named cooperative timeout, retrieves task exceptions, and advances the session/conversation generation fence on timeout;
+  3. `finalize_session_close(ticket)` verifies the close ticket/generation, releases preparation/recovery/attachment/fleet-wake owners, and only then deletes the session and activates its neighbor.
+
+  `_close_console_session_tab()` must await this runtime seam after its confirmation loop. Completion-vs-close tests must prove completion committed before the close gate is preserved, while cancellation recorded first rejects late terminal output. Reuse the existing queue, preparation, stream, decision, and sub-agent cleanup internals; do not duplicate them in the runtime.
+
+- [ ] Add one bounded async fleet-drain seam to `ConsoleAgentBridge`, built on its existing live fleet/coordinator callbacks rather than polling sleeps. Register a per-conversation waiter before the post-registration live snapshot to close the child-finishes-during-registration race; resolve it when `fleet_snapshot(conversation_id)` has no live handle. `cancel_all_subagents()` remains the signal path, and `await_fleet_terminal(...)` becomes the drain path.
+
+- [ ] Extend the revisioned `ConsoleLifecycleImpact` with a content-free live delegated-child count. `lifecycle_impact(session_id=...)` counts `ConsoleAgentBridge.fleet_snapshot(conversation_id)` even when the parent turn/custody task is already terminal; the whole-runtime impact sums survivors across sessions. Register one bridge fleet-activity listener that advances the global and owning-session lifecycle revisions on child spawn and terminal settlement, including retained survivors. Session-close/quit copy names delegated children separately. Tests must prove a lone surviving child triggers confirmation and that a child spawn/settle between dialog snapshot and fencing refreshes the revision-pinned confirmation instead of silently widening or discarding consent.
+
+- [ ] On session close, cancel the exact conversation fleet and await its terminal waiter before deleting the session. On app disposal, snapshot all live conversation fleets, fence late delivery, cancel them, and drain them concurrently within the single global shutdown deadline—not one full timeout per conversation. A delegated child may remain live after the parent custody task exits, so parent-task completion is never accepted as fleet-drain evidence.
+
+- [ ] Fence late child settlement and auto-wake with the session/conversation generation carried by the close ticket. After close/timeout or app-disposal fencing, a stale child's wake, transcript callback, receipt mark, notification, and approval resolution are discarded before reaching `ConsoleChatStore` or shell attention. Add a deterministic test where the parent custody task has already completed, its child ignores cancellation through the grace window, and the child settles later; close/quit remains bounded and no deleted-session row, receipt, or wake appears.
+
+- [ ] Migrate every direct `controller.close_session(...)` caller found by `rg -n "controller\.close_session|_ensure_console_chat_controller\(\)\.close_session" Tests tldw_chatbook` to the async runtime seam or, for pure controller unit tests, the explicit begin/finalize ticket sequence. End with no public synchronous path that can delete a live session before its tasks drain.
+
+- [ ] Move Console quit confirmation to `TldwCli`, because quit may begin while Library/Settings—not `ChatScreen`—is mounted. Preserve other screens' own unsaved-work confirmation, then revision-pin `controller.lifecycle_impact()` in an app-level Console confirmation loop.
+
+- [ ] Extend `Tests/UI/test_app_quit_guard.py`, the existing production-shaped `TldwCli.action_quit` suite, for quit from Console and from a non-Console screen, revision changes between confirmation and fence, duplicate-dialog prevention, admission rejection after confirmation, bounded drain, and no shutdown receipt/toast.
+
+- [ ] After confirmation succeeds, fence runtime admission before setting the final shutdown state. Remove or neutralize duplicate ChatScreen Console-quit confirmation so a quit from Console does not show two dialogs.
+
+- [ ] Add bounded runtime disposal:
+
+  1. fence admission and bump a terminal generation;
+  2. signal controller shutdown and cancel custody tasks;
+  3. await the task set up to one named timeout;
+  4. retrieve all completed exceptions;
+  5. bounded-drain delegated fleets under the same deadline and abandon uncooperative wrappers without permitting later transcript/wake/receipt mutation;
+  6. close provider gateway and release references.
+
+  Do not use an unbounded `gather`. A thread may finish after the timeout, but its generation/atomic terminal gate must reject late writes.
+
+- [ ] Reuse or add one atomic terminalization compare-and-set at the controller/store boundary so completion and cancellation cannot both publish terminal state. Test completion-wins, cancellation-wins, and provider-ignores-cancellation interleavings with barriers rather than sleeps.
+
+- [ ] Run:
+
+  ```bash
+  pytest -q Tests/Chat/test_console_runtime_lifetime.py Tests/Chat/test_console_runtime_shutdown.py Tests/Chat/test_console_agent_swap.py Tests/Chat/test_console_agent_bridge_cancel_all.py Tests/Chat/test_console_automatic_library_preparation.py Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_close_session_fleet.py Tests/Chat/test_console_fleet_wake_safety.py Tests/Chat/test_console_dispatch_recovery_fix_round1.py Tests/Chat/test_console_dispatch_recovery_fix_round4.py Tests/Chat/test_console_durable_turn_fix_round1.py Tests/Chat/test_console_local_citation_boundary.py Tests/Chat/test_console_prompt_queue_coordinator.py Tests/Chat/test_console_run_markers.py Tests/Chat/test_console_run_state_per_session.py Tests/UI/test_screen_navigation.py Tests/UI/test_app_quit_guard.py Tests/UI/test_console_prompt_queue.py Tests/UI/test_console_send_draft_snapshot.py
+  ```
+
+  Expected: PASS.
+
+- [ ] Commit:
+
+  ```bash
+  git add tldw_chatbook/Chat/console_runtime.py tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_chat_models.py tldw_chatbook/Chat/console_chat_store.py tldw_chatbook/Chat/console_agent_bridge.py tldw_chatbook/Chat/console_fleet_wake.py tldw_chatbook/UI/Console_Modules/session.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/app.py Tests/Chat/test_console_runtime_lifetime.py Tests/Chat/test_console_runtime_shutdown.py Tests/Chat/test_console_agent_swap.py Tests/Chat/test_console_agent_bridge_cancel_all.py Tests/Chat/test_console_automatic_library_preparation.py Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_close_session_fleet.py Tests/Chat/test_console_fleet_wake_safety.py Tests/Chat/test_console_dispatch_recovery_fix_round1.py Tests/Chat/test_console_dispatch_recovery_fix_round4.py Tests/Chat/test_console_durable_turn_fix_round1.py Tests/Chat/test_console_local_citation_boundary.py Tests/Chat/test_console_prompt_queue_coordinator.py Tests/Chat/test_console_run_markers.py Tests/Chat/test_console_run_state_per_session.py Tests/UI/test_screen_navigation.py Tests/UI/test_app_quit_guard.py Tests/UI/test_console_prompt_queue.py Tests/UI/test_console_send_draft_snapshot.py
+  git diff --cached --name-only
+  git commit -m "fix: fence Console cancellation and shutdown scopes"
+  ```
+
+## Task 9: Prove real navigation, multi-session isolation, privacy, and dead-view safety
+
+**Files:**
+
+- Add: `Tests/UI/test_console_turn_navigation_continuity.py`
+- Modify: `Tests/UI/test_console_store_continuity.py`
+- Modify: `Tests/UI/test_console_sync_outlives_screen.py`
+- Modify: `Tests/UI/test_console_headless_approval.py`
+- Modify: `Tests/UI/test_probe_headless_approval_behaviour.py`
+- Modify: `Tests/test_probe_import_provenance.py`
+- Modify: `Tests/Architecture/test_screen_size_ratchet.py` only if its measured ceiling can be lowered; never raise it
+
+### Steps
+
+- [ ] Build one production-shaped mounted harness that starts `TldwCli` with isolated temp data/config paths, uses the real navigation action to leave and return, and controls the provider via async barriers. Do not call screen internals as a substitute for navigation.
+
+- [ ] Cover ordinary chat and main-agent turns in the two outer race windows:
+
+  - navigation immediately after runtime custody but before the task starts;
+  - navigation after streaming begins but before terminalization.
+
+  Assert separately that the live store advances while detached, no detached DOM callback fires, the fresh screen renders the correct final row, and no duplicate/missing chunks appear.
+
+- [ ] Add deterministic navigation barriers for every required interior phase: asynchronous preparation, provider-readiness resolution, streaming, queued-continuation claim/drain, turn-launched tool execution, image/video generation work, delegated-agent work, human approval wait, and the terminal transaction between row update and commit. Parameterize the common navigation harness, but use origin-specific assertions so a tool/media/delegated path cannot pass merely because an ordinary stream survived.
+
+- [ ] For each returning-view case, assert all four approved evidence layers independently:
+
+  1. the app-owned live store contains the expected identified rows/state;
+  2. the fresh mounted transcript renders uniquely identifying content once;
+  3. ChaChaNotes contains the expected durable rows/receipt state;
+  4. a subsequent send's captured provider payload continues the same conversation lineage without duplicating the prior turn.
+
+  A database append or store assertion alone is not sufficient UI evidence.
+
+- [ ] Add a multi-session case: two sessions run concurrently, one reaches approval and the other completes; returning to either session mounts only its own card/result and acknowledging one does not clear the other's attention.
+
+- [ ] Add weak-reference/dead-view tests: after navigation and garbage collection the outgoing `ChatScreen` is collectible while custody continues, and stale attachment-generation callbacks cannot mutate or detach the incoming screen.
+
+- [ ] Instrument the production-shaped harness with counters around DOM queries, transcript-sync polling, and reason-tagged main/overflow navigation updates. Reset after detach and release several stream/tool/media deltas. Assert exactly zero detached DOM queries and transcript polls, and zero **per-token or non-attention** shell updates. A hidden decision/receipt transition may cause one bounded/coalesced attention-projection update while detached, as Task 7 requires; assert stream chunks alone never drive it. On fresh Console attach, assert one bounded transcript reconciliation rather than replayed per-token updates.
+
+- [ ] Add privacy owner tests that search runtime custody records, `repr`, captured Loguru records, notifications, navigation labels, sync payloads, exports, and provider payloads. Permit only opaque turn/session/receipt IDs and sanitized status text. Assert raw prompts, attachment paths/names/bytes, RAG context, tool arguments/results, credentials, and exception bodies are absent.
+
+- [ ] Run the provenance gate first so a passing subprocess never accidentally imports an installed package or stale checkout:
+
+  ```bash
+  pytest -q Tests/test_probe_import_provenance.py
+  ```
+
+  Expected: PASS and reported module paths resolve inside this checkout.
+
+- [ ] Run the integrated targeted group:
+
+  ```bash
+  pytest -q Tests/UI/test_console_turn_navigation_continuity.py Tests/UI/test_console_store_continuity.py Tests/UI/test_console_sync_outlives_screen.py Tests/UI/test_console_headless_approval.py Tests/UI/test_probe_headless_approval_behaviour.py Tests/Architecture/test_screen_size_ratchet.py
+  ```
+
+  Expected: PASS.
+
+- [ ] Perform fault-injection validation by temporarily reversing one named invariant at a time in the test seam—not by committing mutations—and show the focused test fails for:
+
+  - screen-owned launch restored;
+  - hidden decision clock allowed to advance;
+  - exact-receipt acknowledgement replaced with conversation-wide clear;
+  - terminal row and receipt written in separate transactions.
+
+  Restore the implementation after each check and record the commands/results in the task Implementation Notes.
+
+- [ ] Commit:
+
+  ```bash
+  git add Tests/UI/test_console_turn_navigation_continuity.py Tests/UI/test_console_store_continuity.py Tests/UI/test_console_sync_outlives_screen.py Tests/UI/test_console_headless_approval.py Tests/UI/test_probe_headless_approval_behaviour.py Tests/test_probe_import_provenance.py Tests/Architecture/test_screen_size_ratchet.py
+  git diff --cached --name-only
+  git commit -m "test: verify Console turns survive navigation"
+  ```
+
+## Task 10: Update documentation and run isolated live verification
+
+**Files:**
+
+- Modify: `Docs/User_Guide/console/chat-basics.md`
+- Modify: `Docs/User_Guide/console/agent-runs-and-tools.md`
+- Modify: `Docs/superpowers/specs/2026-08-27-console-turns-survive-navigation-design.md`
+- Modify: `backlog/tasks/task-22514 - Console-turns-survive-screen-navigation.md`
+- Modify only if a real reusable incident occurred: `backlog/docs/lessons-live-verification.md` or `backlog/docs/lessons-testing-evidence.md`
+
+### Steps
+
+- [ ] Update the User Guide to state:
+
+  - all accepted Console turns continue when switching app screens;
+  - unsent composer text, staged-but-unaccepted inputs, screen modals, microphone/audio, and view timers remain screen-scoped;
+  - hidden approvals notify once, wait, and consume decision time only while their card is answerable;
+  - hidden completion/failure creates a Console glyph until the matching result is rendered;
+  - Stop affects the selected turn/chain, session close affects that session, and confirmed app quit ends the whole runtime;
+  - forced process exit/restart does not continue a live task.
+
+  Remove the obsolete section around `agent-runs-and-tools.md` lines 1247–1255 that says leaving Console cancels every in-flight turn and denies approvals. Preserve unrelated existing edits in both guide files by staging only this task's hunks.
+
+- [ ] Mark the design status as implemented only after all targeted evidence is green. Add implementation notes and exact test/live evidence to TASK-22514; check every acceptance criterion only when its evidence exists.
+
+- [ ] After every task-specific command above has passed for **all files modified by that task**, rerun this consolidated critical-path targeted regression set. This command complements rather than replaces the per-task suites (especially Task 2's direct-caller migration set and Task 8's complete close/quit caller set). Do not run the full repository suite unless the user opts in:
+
+  ```bash
+  pytest -q \
+    Tests/Chat/test_console_runtime_lifetime.py \
+    Tests/Chat/test_console_runtime_shutdown.py \
+    Tests/Chat/test_console_turn_execution_context.py \
+    Tests/Chat/test_console_turn_preparation.py \
+    Tests/Chat/test_console_viewless_hooks.py \
+    Tests/Chat/test_console_terminal_attention.py \
+    Tests/Chat/test_conversation_local_marks_service.py \
+    Tests/Chat/test_chat_persistence_service.py \
+    Tests/Chat/test_console_durable_turn_acceptance.py \
+    Tests/Chat/test_console_dispatch_recovery.py \
+    Tests/Chat/test_console_generate_image.py \
+    Tests/Chat/test_console_generate_video.py \
+    Tests/Chat/test_console_video_message.py \
+    Tests/Chat/test_console_prompt_queue.py \
+    Tests/Chat/test_console_prompt_queue_coordinator.py \
+    Tests/Chat/test_console_agent_bridge_cancel_all.py \
+    Tests/Chat/test_console_close_session_fleet.py \
+    Tests/Chat/test_console_fleet_wake_safety.py \
+    Tests/Chat/test_console_skill_script_confirm.py \
+    Tests/Chat/test_skill_script_concurrent_confirms.py \
+    Tests/UI/test_console_prompt_queue.py \
+    Tests/UI/test_console_send_draft_snapshot.py \
+    Tests/UI/test_console_turn_navigation_continuity.py \
+    Tests/UI/test_console_runtime_ownership.py \
+    Tests/UI/test_console_store_continuity.py \
+    Tests/UI/test_console_sync_outlives_screen.py \
+    Tests/UI/test_console_headless_approval.py \
+    Tests/UI/test_console_mcp_approval.py \
+    Tests/UI/test_console_skill_install_confirm.py \
+    Tests/UI/test_skill_install_concurrent_confirms.py \
+    Tests/UI/test_console_turn_attention.py \
+    Tests/UI/test_master_shell_navigation.py \
+    Tests/UI/test_console_narrow_layout.py \
+    Tests/UI/test_screen_navigation.py \
+    Tests/UI/test_app_quit_guard.py \
+    Tests/Architecture/test_screen_size_ratchet.py \
+    Tests/test_probe_import_provenance.py
+  ```
+
+  Expected: PASS. If the user explicitly opts into a full sweep, run `pytest` afterward and record it separately.
+
+- [ ] Derive and inspect the exact task-owned Python/test manifest, then run both lint and formatter checks over every path in it:
+
+  ```bash
+  git diff --name-only <recorded-task-base>..HEAD -- '*.py'
+  git diff --name-only <recorded-task-base>..HEAD -- '*.py' | xargs python -m ruff check
+  git diff --name-only <recorded-task-base>..HEAD -- '*.py' | xargs python -m ruff format --check
+  ```
+
+  Expected: the inspected manifest contains only this feature's source and test files, and both commands PASS. Replace the placeholder with the recorded commit literally; do not run the placeholder or include unrelated dirty files. If `ruff` is not installed in the active environment, record that and run the repository's configured equivalent rather than installing a new dependency without approval.
+
+- [ ] Perform the isolated live-provider journey from `backlog/docs/lessons-live-verification.md`:
+
+  1. create temporary profile/data/config directories and start the app from this checkout;
+  2. verify import provenance before trusting the run;
+  3. prefer an available local provider and send one uniquely identifiable streamed prompt; if only an external or billed provider is available, pause and obtain explicit user approval for that call before using it;
+  4. navigate to Library or Settings using the real shell while tokens are still arriving;
+  5. observe the sanitized completion notice and Console attention glyph;
+  6. return to Console and verify one complete, non-duplicated transcript result;
+  7. repeat with one approval-bearing tool flow, confirm the hidden wait does not expire, return, decide, and observe completion;
+  8. quit with one slow turn active and verify the revision-pinned confirmation and bounded shutdown.
+
+  Record timestamps, provider/model, navigation path, screenshots for visible UI only, and transcript/store/receipt assertions. Do not put secrets or raw sensitive context into the evidence. If no local provider is usable and the user does not approve external/billed use, record the missing live evidence, leave the applicable AC unchecked, and do not mark TASK-22514 Done.
+
+- [ ] Self-review the exact diff against all eight acceptance criteria, ADR-094, privacy boundaries, and the cancellation matrix. Do not mark Done if any targeted test, lint check, documentation item, or live journey is missing.
+
+- [ ] Finish Backlog hygiene:
+
+  ```bash
+  backlog task edit 22514 --notes "Implemented app-owned Console turn custody, navigation-safe decisions, exact terminal attention receipts, shell attention, and scoped shutdown. Targeted and live evidence: <fill in exact results>. ADR: backlog/decisions/094-console-turn-lifetime-and-navigation-boundary.md."
+  backlog task edit 22514 -s Done
+  ```
+
+- [ ] Stage only the documentation/task hunks, inspect them, and commit:
+
+  ```bash
+  git add -p Docs/User_Guide/console/chat-basics.md Docs/User_Guide/console/agent-runs-and-tools.md
+  git add Docs/superpowers/specs/2026-08-27-console-turns-survive-navigation-design.md 'backlog/tasks/task-22514 - Console-turns-survive-screen-navigation.md'
+  git diff --cached --name-only
+  git diff --cached --check
+  git commit -m "docs: document navigation-safe Console turns"
+  ```
+
+## Final review checkpoint
+
+- [ ] Invoke `superpowers:requesting-code-review` after all implementation tasks are complete and before merge/PR work.
+- [ ] Address correctness, privacy, cancellation, and test-evidence blockers through `superpowers:receiving-code-review`.
+- [ ] Invoke `superpowers:verification-before-completion`; rerun the relevant commands and cite their fresh outputs before claiming completion.
+- [ ] Use `superpowers:finishing-a-development-branch` to present merge/PR/cleanup choices only after the task is genuinely Done.

--- a/Docs/superpowers/plans/2026-08-28-console-provider-apply-and-defaults.md
+++ b/Docs/superpowers/plans/2026-08-28-console-provider-apply-and-defaults.md
@@ -1,0 +1,1326 @@
+# Console Provider Apply and Defaults Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Make Console provider/model Apply commit to the exact originating chat, persist safe chat-owned settings, and add truthful per-model and new-chat default actions with explicit retryable failure states.
+
+**Architecture:** Introduce one UI-neutral submission/origin contract shared by the quick popover and full Console Settings modal. ConsoleChatStore exposes a synchronous exact-session live commit that both modals invoke before dismissal, followed by a separate post-close durability step; ChatPersistenceService owns the safe generation metadata merge and the existing context-policy repository continues to own compaction. A focused locked config mutation patches literal model-profile paths and global chat defaults atomically, while ChatScreen coordinates post-close persistence/default work and exposes failures.
+
+**Tech Stack:** Python 3.11, Textual 8.x, dataclasses/enums, TOML config mutation, SQLite conversation metadata, pytest/pytest-asyncio, Textual Pilot.
+
+---
+
+## Governing Contract
+
+- Design: Docs/superpowers/specs/2026-08-27-console-provider-apply-persistence-design.md
+- ADR required: yes
+- ADR path: backlog/decisions/095-conversation-owned-console-generation-settings.md
+- Reason: the feature establishes long-lived ownership boundaries for conversation metadata, model-profile defaults, global new-chat defaults, and runtime publication.
+- Backlog task: backlog/tasks/task-22515 - Make-Console-provider-Apply-update-and-persist-conversation-settings.md
+- Plan review: three independent review passes completed; all findings are addressed in this plan.
+- Canonical settings surface: tldw_chatbook/UI/Screens/settings_screen.py remains the F9 settings owner; do not add features to legacy Tools_Settings_Window.py or enhanced_settings_sidebar.py.
+- Verification constraint: run only the targeted commands below. Ask the user before any full pytest sweep.
+- Live/config safety: config tests must use isolated temporary config paths. Never run a bare script that can write the real user config.
+- UI geometry: mounted tests must use Tests.UI.consolidated_css.ConsolidatedCSSApp and production hierarchy/CSS.
+- Dirty-worktree safety: before each task, record git status --short and inspect the
+  named paths. Use git add -p -- for every tracked file that was already dirty; use
+  exact git add -- only for newly created files. Never stage a directory. Before
+  every commit run git diff --cached --check and inspect git diff --cached to prove
+  no unrelated user hunk is staged.
+
+## Task 1: Add the shared submission contract and controller-owned rebase
+
+**Files:**
+
+- Create: tldw_chatbook/Chat/console_settings_apply.py
+- Modify: tldw_chatbook/Chat/console_session_settings.py:174-575
+- Modify: tldw_chatbook/Chat/console_chat_controller.py:6680-6845
+- Create: Tests/Chat/test_console_settings_apply.py
+- Modify: Tests/Chat/test_console_session_settings.py
+
+- [ ] **Step 1: Write failing tests for origin validation and field provenance**
+
+Cover these cases:
+
+- an origin stores the exact session ID and the persisted conversation ID observed when the modal opened;
+- None to a first persisted ID is allowed for the same session;
+- an already-persisted origin rebound to a different conversation ID is rejected;
+- an origin captured while unsaved is rejected after an explicit rebind even when
+  the new binding is its first non-null conversation ID;
+- a missing/closed session is rejected;
+- provider or model change rebases untouched generation fields from the target defaults;
+- explicitly dirty fields survive rebasing and are marked dirty;
+- target base_url replaces the source endpoint;
+- fields not supported by the target are cleared;
+- keyed A to B to A drafts restore the prior deliberate A edits;
+- quick and full default masks are exact and compaction/system prompt/base_url are not profile fields.
+
+Use immutable value objects with assertions against exact field sets. Start with:
+
+    QUICK_MODEL_DEFAULT_FIELDS = frozenset({"temperature", "streaming"})
+    FULL_MODEL_DEFAULT_FIELDS = frozenset({
+        "temperature", "top_p", "min_p", "top_k", "max_tokens", "seed",
+        "presence_penalty", "frequency_penalty", "reasoning_effort",
+        "reasoning_summary", "verbosity", "thinking_effort",
+        "thinking_budget_tokens", "streaming",
+    })
+
+- [ ] **Step 2: Run the new tests and confirm they fail for the missing module**
+
+Run:
+
+    pytest -q Tests/Chat/test_console_settings_apply.py Tests/Chat/test_console_session_settings.py -k "default_profile or rebase or origin"
+
+Expected: collection/import failure for console_settings_apply before implementation.
+
+- [ ] **Step 3: Implement the UI-neutral contract**
+
+Add these public shapes in console_settings_apply.py:
+
+    class ConsoleSettingsAction(str, Enum):
+        APPLY_TO_CHAT = "apply_to_chat"
+        SAVE_MODEL_DEFAULT = "save_model_default"
+        MAKE_NEW_CHAT_DEFAULT = "make_new_chat_default"
+
+    @dataclass(frozen=True, slots=True)
+    class ConsoleSettingsOrigin:
+        session_id: str
+        persisted_conversation_id: str | None
+        conversation_binding_revision: int
+
+    @dataclass(frozen=True, slots=True)
+    class ConsoleSettingsDraftState:
+        settings: ConsoleSessionSettings
+        context_policy_overrides: ConsoleContextPolicyOverrides
+        field_drafts: tuple[ConsoleSettingsFieldDraft, ...]
+        model_drafts: tuple[ConsoleModelDraft, ...]
+        endpoint_draft: ConsoleEndpointDraft | None
+
+    class ConsoleSettingsFieldProvenance(str, Enum):
+        INHERITED = "inherited"
+        EXPLICIT = "explicit"
+        CARRIED = "carried"
+
+    @dataclass(frozen=True, slots=True)
+    class ConsoleSettingsFieldDraft:
+        name: str
+        effective_value: object | None
+        profile_override: object | None
+        provenance: ConsoleSettingsFieldProvenance
+        dirty: bool
+
+    @dataclass(frozen=True, slots=True)
+    class ConsoleEndpointDraft:
+        value: str
+        bound_provider_config_key: str
+        dirty: bool
+        checked: bool
+
+    @dataclass(frozen=True, slots=True)
+    class ConsoleSettingsSubmission:
+        submission_id: str
+        action: ConsoleSettingsAction
+        origin: ConsoleSettingsOrigin
+        draft: ConsoleSettingsDraftState
+        user_display_name_override: str | None
+        default_field_mask: frozenset[str]
+
+    @dataclass(frozen=True, slots=True)
+    class ConsoleSettingsLiveCommit:
+        submission_id: str
+        session_id: str
+        persisted_conversation_id: str | None
+        conversation_binding_revision: int
+        generation_revision: int
+        context_policy_revision: int
+        settings: ConsoleSessionSettings
+        context_policy_overrides: ConsoleContextPolicyOverrides
+
+    @dataclass(frozen=True, slots=True)
+    class ConsoleSettingsCommittedSubmission:
+        submission: ConsoleSettingsSubmission
+        live_commit: ConsoleSettingsLiveCommit
+
+Keep transition-to-full distinct from a submission:
+
+    @dataclass(frozen=True, slots=True)
+    class ConsoleSettingsTransfer:
+        origin: ConsoleSettingsOrigin
+        draft: ConsoleSettingsDraftState
+
+Add pure helpers:
+
+- remember_model_draft(state): replace one exact provider/literal-model key;
+- field masks/constants used by both UI surfaces.
+
+The field draft deliberately keeps effective_value separate from profile_override.
+Apply freezes effective_value into the conversation. A blank/inherited profile
+control keeps the resolved effective value for Apply but sets profile_override to
+None so a default action deletes that exact model-profile field. This separation is
+required for blank-to-inherit and full streaming Inherit semantics. When the
+submitting surface is quick settings, temperature and streaming have no Inherit
+control: build their profile_override from the displayed effective value even when
+their provenance is inherited. Only the full surface may submit None for those
+fields to delete an override.
+
+Do not import Textual in this module. Do not persist anything here.
+
+- [ ] **Step 4: Make ConsoleChatController the sole rebase owner**
+
+Add:
+
+    def rebase_console_settings_draft(
+        self,
+        state: ConsoleSettingsDraftState,
+        *,
+        provider: str,
+        model: str | None,
+        app_config: Mapping[str, object],
+        exposed_fields: frozenset[str],
+    ) -> ConsoleSettingsDraftState
+
+The controller builds the target's complete effective defaults, clears the source
+endpoint and unsupported provider-specific fields, restores an exact keyed draft
+when present, and overlays only dirty supported fields. Widgets receive an injected
+DraftRebaser callback backed by this method; they do not import or implement rebase
+logic. The injected live_committer invokes this controller seam again against the
+current runtime config immediately before ConsoleChatStore commits, so a stale
+modal/config snapshot cannot bypass the owner.
+
+- [ ] **Step 5: Expose one target-default builder from console_session_settings.py**
+
+Add a small wrapper that accepts app_config, provider, and literal model ID, delegates to default_console_session_settings, and returns a fresh ConsoleSessionSettings snapshot. Keep the existing precedence:
+
+    api_settings.<provider>.model_defaults[exact model]
+      -> console.provider_defaults.<provider>
+      -> chat_defaults
+      -> provider settings
+
+Use existing provider/model normalization and capability helpers; do not create a second precedence engine.
+
+- [ ] **Step 6: Run tests and commit**
+
+Run:
+
+    pytest -q Tests/Chat/test_console_settings_apply.py Tests/Chat/test_console_session_settings.py
+
+Expected: all selected tests pass.
+
+Commit:
+
+    git add -p -- tldw_chatbook/Chat/console_session_settings.py tldw_chatbook/Chat/console_chat_controller.py Tests/Chat/test_console_session_settings.py
+    git add -- tldw_chatbook/Chat/console_settings_apply.py Tests/Chat/test_console_settings_apply.py
+    git diff --cached --check
+    git diff --cached
+    git commit -m "feat: define Console settings apply contract"
+
+## Task 2: Add the safe conversation-generation metadata codec
+
+**Files:**
+
+- Create: tldw_chatbook/Chat/console_generation_settings_metadata.py
+- Modify: tldw_chatbook/Chat/chat_persistence_service.py:1-330,650-730
+- Modify: tldw_chatbook/Chat/console_conversation_hydration.py:280-345
+- Create: Tests/Chat/test_console_generation_settings_metadata.py
+- Modify: Tests/Chat/test_console_conversation_hydration.py
+- Modify: Tests/Chat/test_console_chat_store.py:1998-2335,3331-3404
+
+- [ ] **Step 1: Write failing codec and merge tests**
+
+Pin a versioned metadata object under one owned key:
+
+    "console_generation_settings": {
+        "version": 1,
+        "provider": "OpenAI",
+        "model": "gpt-5",
+        "temperature": 0.3,
+        "streaming": true
+    }
+
+Test exact safe fields, finite numbers, strict booleans/integers, length bounds,
+unknown-field rejection, distinct absent/invalid/future-version results, malformed
+JSON, and preservation of unrelated metadata siblings. A writer must refuse to
+replace invalid or future-owned data and emit one bounded warning per conversation
+per session. Assert base_url, credentials, system_prompt, source, compaction, and
+display-name data are never serialized by this codec.
+
+- [ ] **Step 2: Run the codec tests and observe failure**
+
+Run:
+
+    pytest -q Tests/Chat/test_console_generation_settings_metadata.py Tests/Chat/test_console_conversation_hydration.py
+
+Expected: missing codec/import failures.
+
+- [ ] **Step 3: Implement the codec**
+
+In console_generation_settings_metadata.py define:
+
+    CONSOLE_GENERATION_SETTINGS_METADATA_KEY = "console_generation_settings"
+    CONSOLE_GENERATION_SETTINGS_VERSION = 1
+
+    @dataclass(frozen=True, slots=True)
+    class ConsoleGenerationSettingsSnapshot:
+        provider: str
+        model: str | None
+        temperature: float | None
+        top_p: float | None
+        min_p: float | None
+        top_k: int | None
+        max_tokens: int | None
+        seed: int | None
+        presence_penalty: float | None
+        frequency_penalty: float | None
+        reasoning_effort: str | None
+        reasoning_summary: str | None
+        verbosity: str | None
+        thinking_effort: str | None
+        thinking_budget_tokens: int | None
+        streaming: bool
+
+    def snapshot_from_session_settings(
+        settings: ConsoleSessionSettings
+    ) -> ConsoleGenerationSettingsSnapshot
+    def parse_console_generation_settings(metadata: object) -> ConsoleGenerationSettingsReadResult
+    def merge_console_generation_settings(metadata: object, snapshot: ConsoleGenerationSettingsSnapshot) -> dict[str, object]
+
+ConsoleGenerationSettingsReadResult has exact ABSENT, VALID, INVALID, and
+UNSUPPORTED_VERSION statuses and carries a snapshot only for VALID. Use strict
+JSON-object parsing equivalent to ChatPersistenceService._initial_metadata_object.
+Reject non-finite floats and bool-as-int. Keep a literal allowlist; never serialize
+the dataclass with asdict.
+
+- [ ] **Step 4: Add bounded merge-safe persistence methods**
+
+Add to ChatPersistenceService:
+
+    def get_conversation_generation_settings(
+        self, conversation_id: str
+    ) -> ConsoleGenerationSettingsReadResult
+
+    def update_conversation_generation_settings(
+        self,
+        *,
+        conversation_id: str,
+        snapshot: ConsoleGenerationSettingsSnapshot,
+        expected_snapshot: ConsoleGenerationSettingsSnapshot | None,
+    ) -> ConsoleGenerationSettingsWriteResult
+
+Implement a complete-owned-snapshot CAS without changing the approved v1 metadata
+allowlist. A missing owned object matches only expected_snapshot=None; a valid
+object must exactly equal expected_snapshot across every safe field. INVALID or
+UNSUPPORTED_VERSION refuses the write without mutation.
+Conversation-version conflicts may be retried only after a fresh read proves the
+owned snapshot is still the expected base; merge unrelated siblings from that fresh
+record. If the owned snapshot changed, return SUPERSEDED/CONFLICT and never write
+the older snapshot. Return MISSING for a missing conversation and propagate only
+the final sibling-only ConflictError.
+
+- [ ] **Step 5: Restore settings and the durable safe snapshot together**
+
+Replace the settings-only apply_resume_settings_overrides result with:
+
+    @dataclass(frozen=True, slots=True)
+    class ConsoleGenerationSettingsHydration:
+        settings: ConsoleSessionSettings
+        durable_snapshot: ConsoleGenerationSettingsSnapshot | None
+        metadata_status: ConsoleGenerationSettingsReadStatus
+
+    def hydrate_console_generation_settings(
+        app_config: Mapping[str, object],
+        conversation: Mapping[str, object],
+    ) -> ConsoleGenerationSettingsHydration
+
+Hydration:
+
+1. parses the generation snapshot;
+2. derives current defaults for the saved provider/model from current app_config;
+3. overlays only the saved safe fields;
+4. resolves base_url from current config, never metadata;
+5. then applies the conversation system prompt and pinned prefill through their existing owners.
+
+Task 5 callers pass app_config rather than an active-chat-derived settings base and
+thread durable_snapshot/status into ConsoleChatStore.restore_persisted_session.
+Store seeds generation_durable_snapshot from this result. INVALID and
+UNSUPPORTED_VERSION use config-derived live settings, retain the original metadata
+untouched, and expose one bounded warning when the conversation is restored or its
+Model section is first shown.
+
+- [ ] **Step 6: Run tests and commit**
+
+Run:
+
+    pytest -q Tests/Chat/test_console_generation_settings_metadata.py
+    pytest -q Tests/Chat/test_console_conversation_hydration.py Tests/Chat/test_console_chat_store.py -k "metadata or generation_settings or roleplay"
+
+Expected: selected tests pass and unrelated metadata remains semantically preserved.
+
+Commit:
+
+    git add -p -- tldw_chatbook/Chat/chat_persistence_service.py tldw_chatbook/Chat/console_conversation_hydration.py Tests/Chat/test_console_conversation_hydration.py Tests/Chat/test_console_chat_store.py
+    git add -- tldw_chatbook/Chat/console_generation_settings_metadata.py Tests/Chat/test_console_generation_settings_metadata.py
+    git diff --cached --check
+    git diff --cached
+    git commit -m "feat: persist safe Console generation settings"
+
+## Task 3: Make ConsoleChatStore the exact-origin live and durable owner
+
+**Files:**
+
+- Modify: tldw_chatbook/Chat/console_chat_store.py:698-870,4019-4090,4198-4235,8420-8750
+- Modify: tldw_chatbook/Chat/console_context_repository.py:180-275
+- Modify: tldw_chatbook/Chat/chat_persistence_service.py:190-230
+- Modify: Tests/Chat/test_console_chat_store.py
+- Create: Tests/Chat/test_console_settings_apply_store.py
+- Create: Tests/Chat/test_console_context_policy_cas.py
+
+- [ ] **Step 1: Write failing store tests**
+
+Test:
+
+- a submission updates the exact origin while another session is active;
+- a missing session or persisted-ID rebound is rejected without mutation;
+- binding revision rejects an explicit unsaved-session rebind while accepting the
+  normal first-persistence publication;
+- duplicate activation of the same submission commits once;
+- generation and context-policy live values both remain after either durable write fails;
+- failures are stored per component and settings revision;
+- Retry writes only the failed component and only if its revision is still current;
+- a newer Apply supersedes an older failure;
+- two rapid Applies serialize per session and the older generation/context write
+  cannot become durable after the newer one;
+- an external owned-base change causes CAS refusal rather than overwrite;
+- ordinary Apply does not clear an app-global default failure;
+- unsaved sessions stage both components without creating an empty conversation;
+- first persistence includes generation metadata in the create write and flushes context policy through its current repository;
+- temporary sessions do not write; promotion uses the staged settings on first persistence.
+- a resumed conversation seeds context_policy_durable_revision from
+  ContextPolicyReadResult.revision, then a new policy snapshot succeeds from N to
+  N+1 without a false failure row.
+
+- [ ] **Step 2: Run the store tests and observe failure**
+
+Run:
+
+    pytest -q Tests/Chat/test_console_settings_apply_store.py Tests/Chat/test_console_context_policy_cas.py
+    pytest -q Tests/Chat/test_console_chat_store.py -k "settings_apply or generation_settings or context_policy or temporary"
+
+Expected: failures for missing store orchestration/revision state.
+
+- [ ] **Step 3: Add bounded session revision and failure state**
+
+Extend ConsoleChatSession with:
+
+    conversation_binding_revision: int = 0
+    generation_settings_revision: int = 0
+    context_policy_revision: int = 0
+    generation_durable_snapshot: ConsoleGenerationSettingsSnapshot | None = None
+    context_policy_durable_revision: int | None = None
+    new_chat_default_generation: int = 0
+    settings_persistence_failures: dict[ConsoleSettingsComponent, ConsoleSettingsPersistenceFailure] = field(default_factory=dict)
+    applied_settings_submission_ids: deque[str] = field(default_factory=lambda: deque(maxlen=32))
+    generation_metadata_status: ConsoleGenerationSettingsReadStatus = ConsoleGenerationSettingsReadStatus.ABSENT
+    generation_metadata_warning_shown: bool = False
+
+The failure record must contain component, its component revision, and the exact
+safe snapshot/overrides needed for retry; it must never contain secrets or
+base_url. Increment the generation revision for any live generation-settings
+replacement and the policy revision for any live context-policy replacement,
+including edits made outside these modals, so a newer component edit always
+supersedes its old retry. Retry increments neither revision. Keep submission
+deduplication bounded to the session lifetime.
+
+Origin validation compares both conversation ID and conversation_binding_revision.
+The ordinary first-persistence publication is the only None-to-ID operation that
+preserves the binding revision. Restore, repurpose, explicit handoff rebind, or any
+other operation that changes which durable conversation a live session represents
+must advance the binding revision before publishing the ID. Add explicit store
+helpers for first publication versus rebind; remove direct assignments from restore
+paths. Test an origin captured at None, explicit rebind to an ID, and rejection even
+though the origin's captured ID was None.
+
+- [ ] **Step 4: Implement exact-origin apply and retry**
+
+Add:
+
+    def capture_console_settings_origin(
+        self, session_id: str
+    ) -> ConsoleSettingsOrigin
+
+    def session_user_display_name_override(
+        self, session_id: str
+    ) -> str | None
+
+    def commit_console_settings_live(
+        self, submission: ConsoleSettingsSubmission
+    ) -> ConsoleSettingsLiveCommit
+
+    async def persist_console_settings_commit_serialized(
+        self, commit: ConsoleSettingsLiveCommit
+    ) -> ConsoleSettingsPersistenceOutcome
+
+    async def retry_console_settings_persistence(
+        self,
+        *,
+        session_id: str,
+        component: ConsoleSettingsComponent,
+        revision: int,
+    ) -> bool
+
+The live method must:
+
+1. resolve submission.origin.session_id directly, never active_session_id;
+2. validate the persisted identity transition;
+3. deduplicate one submission ID or live-commit token;
+4. replace settings with source="user" while preserving the origin's system prompt;
+5. set context overrides through an in-memory-only store seam;
+6. increment both live component revisions and return before any database/config I/O.
+
+persist_console_settings_commit_serialized owns one asyncio.Lock per session.
+Inside the lock it rechecks identity/component revisions, captures the current
+generation durable snapshot and context durable revision, performs adapter I/O in
+asyncio.to_thread, then returns to the
+UI loop to publish new durable bases or failures. Every Apply and Retry uses this
+same serializer. A stale commit exits before I/O. Generation writes use Task 2's
+complete-snapshot CAS; context-policy writes use the CAS seam below. Thus an older worker,
+a conflict retry, or a stale Retry cannot become durable after a newer Apply.
+
+Extend ConsoleContextRepository with save_policy_if_revision, covering insert,
+update, and empty-row delete with an expected policy_revision predicate. Return a
+typed WRITTEN, CONFLICT, or MISSING result and the new durable revision. Route
+ChatPersistenceService.update_conversation_context_policy through that seam for
+settings Apply while leaving unrelated established callers compatible.
+
+Change _resolve_context_policy_on_resume to assign both result.overrides and
+result.revision to the session, including revision=None when no row exists. Every
+successful established policy write publishes the returned durable revision;
+successful deletion publishes None. This seed/update happens independently of the
+process-local context_policy_revision used to supersede stale UI retries.
+
+- [ ] **Step 5: Put generation metadata into first persistence**
+
+In persist_session_if_needed, merge the staged generation snapshot into initial
+metadata passed to create_conversation. Preserve the
+existing speech/roleplay/prefill contributors and atomic library-policy path. Do
+not create a second conversation row or a follow-up generation write when initial
+metadata was accepted. Publish generation_durable_snapshot as the exact inserted
+safe snapshot after creation.
+
+Patch _promote_ephemeral_session_atomically separately: include the same generation
+metadata object in conversation_kwargs["metadata"] before
+promote_console_conversation_bundle. After atomic promotion, publish its durable
+generation revision and flush the current context policy through its existing
+owner. Change _flush_context_policy_on_first_persist to return/publish a typed
+outcome so a create or promotion failure enters the current component ledger
+instead of only logging. Successful first-persistence and promotion policy writes
+publish their returned durable revision, including None after a successful empty
+policy delete.
+
+When publish_committed_identity changes None to the staged first ID, keep that transition valid for any modal that opened while unsaved. Do not allow any later A to B rebound.
+
+- [ ] **Step 6: Run tests and commit**
+
+Run:
+
+    pytest -q Tests/Chat/test_console_settings_apply_store.py Tests/Chat/test_console_context_policy_cas.py
+    pytest -q Tests/Chat/test_console_chat_store.py -k "settings_apply or generation_settings or context_policy or temporary or promote"
+
+Expected: selected tests pass.
+
+Commit:
+
+    git add -p -- tldw_chatbook/Chat/console_chat_store.py tldw_chatbook/Chat/console_context_repository.py tldw_chatbook/Chat/chat_persistence_service.py Tests/Chat/test_console_chat_store.py
+    git add -- Tests/Chat/test_console_settings_apply_store.py Tests/Chat/test_console_context_policy_cas.py
+    git diff --cached --check
+    git diff --cached
+    git commit -m "feat: apply Console settings to exact chat"
+
+## Task 4: Add locked literal-path model-default mutation
+
+**Files:**
+
+- Modify: tldw_chatbook/config.py:5885-6165
+- Create: tldw_chatbook/Chat/console_settings_defaults.py
+- Modify: Tests/test_config_delete_settings.py
+- Create: Tests/Chat/test_console_settings_defaults.py
+
+- [ ] **Step 1: Write failing exact-path and default-intent tests**
+
+Test:
+
+- model IDs containing dots, slashes, colons, and brackets remain one literal mapping key;
+- quick save sets/deletes only temperature and streaming;
+- full save sets/deletes only the full field mask;
+- blank/inherit deletes the exact override and preserves unexposed profile fields;
+- sibling profiles and unrelated concurrent config edits survive;
+- Make Default atomically patches the profile plus chat_defaults.provider/model;
+- Save Model Default does not change chat_defaults.provider/model;
+- only full Make Default with an explicitly dirty checked endpoint patches the provider endpoint;
+- pre-replace failure returns Not written to disk and a retryable original intent;
+- post-replace cache failure returns Saved on disk; running app refresh failed and a cache-refresh-only continuation;
+- a newer explicit intent supersedes the old retry generation;
+- an unconfigured/blocked provider cannot become the new-chat default even if a
+  caller bypasses the disabled UI action.
+- raw provider aliases are selected only from authoritative user TOML while
+  readiness uses the locked effective mapping, including a concurrent edit that
+  removes required configuration before lock acquisition.
+
+- [ ] **Step 2: Run and observe failure**
+
+Run:
+
+    pytest -q Tests/test_config_delete_settings.py Tests/Chat/test_console_settings_defaults.py
+
+Expected: failures for missing literal tuple-path mutation/default service.
+
+- [ ] **Step 3: Extend the atomic writer with literal section paths**
+
+Refactor apply_settings_mutation_to_cli_config around one private locked
+implementation and expose a literal transaction builder:
+
+    @dataclass(frozen=True, slots=True)
+    class LiteralSettingsMutation:
+        section_values: Mapping[tuple[str, ...], Mapping[str, object]]
+        delete_keys: Mapping[tuple[str, ...], Collection[str]]
+
+    @dataclass(frozen=True, slots=True)
+    class AtomicLiteralMutationSnapshot:
+        generation: int
+        raw_values: Mapping[str, object]
+        effective_values: Mapping[str, object]
+
+    @dataclass(frozen=True, slots=True)
+    class LiteralConfigMutationResult:
+        file_replaced: bool
+        caches_reloaded: bool
+        settings_view: Mapping[str, object] | None
+        failure_phase: str | None
+
+    def apply_literal_settings_transaction_to_cli_config(
+        mutation_builder: Callable[[AtomicLiteralMutationSnapshot], LiteralSettingsMutation],
+        *,
+        mutation_precondition: Callable[[], bool] | None = None,
+    ) -> LiteralConfigMutationResult
+
+Invoke mutation_builder once under the config lock with both the exact raw
+authoritative TOML mapping and the effective merged/decrypted mapping, before
+changing the in-memory config. It must be synchronous and
+side-effect-free; contain exceptions as before_replace failures. Tuple elements are
+literal TOML mapping keys and are never split on punctuation. Validate the returned
+paths and set/delete overlap before writing. Reuse the existing lock, authoritative
+reread, temp file, os.replace, permission preservation, and cache publication. Keep
+current callers and dotted-section behavior unchanged.
+
+- [ ] **Step 4: Implement the focused defaults service**
+
+In console_settings_defaults.py define:
+
+    class ConsoleDefaultSavePhase(str, Enum):
+        BEFORE_REPLACE = "before_replace"
+        CACHE_PUBLICATION = "cache_publication"
+
+    @dataclass(frozen=True, slots=True)
+    class ConsoleDefaultMutationIntent:
+        generation: int
+        action: ConsoleSettingsAction
+        provider_config_key: str
+        literal_model_id: str
+        field_mask: frozenset[str]
+        values: Mapping[str, object | None]
+        endpoint_patch: ConsoleEndpointPatch | None
+
+    @dataclass(frozen=True, slots=True)
+    class ConsoleDefaultMutationOutcome:
+        intent_generation: int
+        file_replaced: bool
+        runtime_published: bool
+        settings_view: Mapping[str, object] | None
+        failure_phase: ConsoleDefaultSavePhase | None
+
+    def apply_console_default_intent(intent: ConsoleDefaultMutationIntent) -> ConsoleDefaultMutationOutcome
+
+    @dataclass(frozen=True, slots=True)
+    class RuntimeConfigPublicationResult:
+        published: bool
+        settings_view: Mapping[str, object] | None
+        failure_phase: str | None
+
+    class ConsoleDefaultRecoveryAction(str, Enum):
+        RETRY_SAVE = "retry_save"
+        DISCARD_RETRY = "discard_retry"
+        REFRESH_RUNNING_APP = "refresh_running_app"
+        DISMISS_REFRESH = "dismiss_refresh"
+
+    @dataclass(frozen=True, slots=True)
+    class ConsoleDefaultRecoveryRequest:
+        action: ConsoleDefaultRecoveryAction
+        intent_generation: int
+
+    def refresh_console_runtime_after_saved_default() -> RuntimeConfigPublicationResult
+
+The defaults service supplies the locked builder. Against raw_values it resolves
+the canonical provider alias to the existing raw api_settings section name and
+selects that section's already-configured endpoint key. Against effective_values it
+reruns provider/model readiness while still locked, then builds one literal
+mutation:
+
+- profile path: ("api_settings", provider_config_key, "model_defaults", literal_model_id);
+- global path for Make Default: ("chat_defaults",) with provider/model;
+- endpoint path only for authorized full Make Default.
+
+This locked resolution must not create a second aliased provider section after an
+external edit. It also lets a Retry preserve unrelated edits made after the first
+attempt while patching only the immutable intent's owned fields.
+
+None means delete the exact profile field. Streaming Inherit maps to delete; On/Off map to strict booleans. After file replacement, never retry the disk mutation for a cache-publication failure.
+
+Build values from ConsoleSettingsFieldDraft.profile_override, not from the
+conversation's frozen effective values. For the quick mask, first materialize
+temperature and streaming profile_override from their displayed effective values
+because quick has no Inherit state. Intersect the requested mask with fields
+actually exposed and supported for the selected provider/model. Require a
+ConsoleEndpointDraft whose provider binding matches the authoritative target and
+whose dirty and checked flags are both true before including an endpoint. Reject
+Make Default when the selected provider/model is not send-ready under the locked
+effective snapshot. This guard must observe a concurrent edit that removes the
+provider's required configuration before the writer acquires the lock.
+
+- [ ] **Step 5: Add endpoint preview safety**
+
+Implement a pure parser that returns only sanitized host/port authority plus:
+
+- Local for localhost and loopback literals;
+- LAN for private/link-local literals and .local;
+- Remote for public IP literals;
+- Remote/unknown for other hostnames.
+
+Reject userinfo. Preserve a syntactically valid explicit port in copy such as
+192.168.1.20:8080, but never return scheme, path, query, fragment, credentials, or
+resolved IP. Classify using the host only and never perform DNS.
+
+On immediate success, apply_console_default_intent returns the freshly published
+settings mapping in ConsoleDefaultMutationOutcome.settings_view. A before-replace
+or cache-publication failure returns settings_view=None. Only the latter recovery
+path calls refresh_console_runtime_after_saved_default, which performs its locked reread, cache
+publication, and load_settings rebuild off the UI thread and returns the complete
+fresh settings mapping. The caller only assigns settings_view to
+app_instance.app_config on the UI thread. It never writes the config file.
+
+- [ ] **Step 6: Run tests and commit**
+
+Run:
+
+    pytest -q Tests/test_config_delete_settings.py Tests/Chat/test_console_settings_defaults.py
+
+Expected: all selected tests pass, including multiprocessing/concurrent sibling preservation.
+
+Commit:
+
+    git add -p -- tldw_chatbook/config.py Tests/test_config_delete_settings.py
+    git add -- tldw_chatbook/Chat/console_settings_defaults.py Tests/Chat/test_console_settings_defaults.py
+    git diff --cached --check
+    git diff --cached
+    git commit -m "feat: patch Console model defaults atomically"
+
+## Task 5: Make every eligible blank chat use published global defaults
+
+**Files:**
+
+- Modify: tldw_chatbook/UI/Console_Modules/session.py:2152-2185,2291-2455
+- Modify: tldw_chatbook/UI/Console_Modules/workspace.py:3600-3645
+- Modify: tldw_chatbook/Chat/console_chat_controller.py:6680-6735
+- Modify: tldw_chatbook/Chat/console_launch_wake.py:215-235,330-355
+- Modify: Tests/UI/test_console_session_controller.py
+- Modify: Tests/UI/test_console_session_settings.py:2279-2533
+- Modify: Tests/UI/test_console_launch_wake.py
+- Modify: Tests/Chat/test_console_conversation_hydration.py
+
+- [ ] **Step 1: Write failing new-chat and resume tests**
+
+Cover Ctrl+T, temporary creation, workspace-created blank chat, and initial pristine Console. After runtime publication each must derive chat_defaults provider/model plus the exact model profile.
+
+Also prove existing/open chats are unchanged and explicit Duplicate, Branch, Continue, and handoff creation paths retain their source-provided settings. A persisted resume must derive from the saved conversation provider/model, not the currently active chat.
+
+Add regression coverage proving an already-open blocked pristine chat is not
+silently refreshed to the new default after Make Default, while the existing
+task-177 setup/configuration recovery still refreshes eligible unused blocked chats
+for non-default configuration changes. Cover launch-wake hydration and a
+missing-catalog custom model/unconfigured saved provider remaining explicit.
+
+- [ ] **Step 2: Run and observe failure**
+
+Run:
+
+    pytest -q Tests/UI/test_console_session_controller.py Tests/UI/test_console_session_settings.py Tests/UI/test_console_launch_wake.py Tests/Chat/test_console_conversation_hydration.py -k "new_chat or temporary or workspace or pristine or resume or duplicate or branch or handoff or default or wake"
+
+Expected: current active-settings cloning fails the eligible-new-chat assertions.
+
+- [ ] **Step 3: Add a config-only blank-chat builder**
+
+Add blank_console_session_settings(app_config) in console_session_settings.py. It
+must call default_console_session_settings(app_config) with no provider/model
+overrides. UI wrappers may read current app_config but must not consult
+_effective_console_provider_model, active controller controls, or another session.
+
+- [ ] **Step 4: Change every eligible blank-new-chat path**
+
+In _create_native_console_session_from_active_context:
+
+    defaults = self._blank_console_session_settings()
+    controller.new_session(
+        settings=defaults,
+        canonical_settings_baseline=defaults,
+        ephemeral=ephemeral,
+    )
+
+In UI/Console_Modules/workspace.py remove inherited_settings from workspace-created
+blank sessions and use the same config-only builder plus canonical baseline. Route
+initial pristine ensure through it. Do not call _active_console_session_settings
+for blank creation. Keep explicit source-settings Duplicate/Branch/Continue/handoff
+paths unchanged.
+
+Update _console_session_settings_for_resume to return Task 2's
+ConsoleGenerationSettingsHydration from current app_config, not an active-session
+base. The resume call passes hydration.settings,
+hydration.durable_snapshot, and hydration.metadata_status into
+restore_persisted_session. Preserve system prompt and current endpoint resolution.
+
+Update console_launch_wake.py to the same hydration signature and provider-first
+resume behavior, including the durable owned revision/status arguments.
+
+- [ ] **Step 5: Fence already-open sessions from explicit default publication**
+
+TldwCli owns a monotonic console_new_chat_default_generation. Every new blank
+session captures it in ConsoleChatSession.new_chat_default_generation. Successful
+Make Default increments the app generation, but never mutates existing sessions.
+_maybe_refresh_stale_default_console_settings must return the existing settings
+when the session predates the current explicit-default generation. Non-default
+setup/configuration refreshes do not increment this generation, preserving the
+existing task-177 recovery behavior.
+
+- [ ] **Step 6: Run tests and commit**
+
+Run:
+
+    pytest -q Tests/UI/test_console_session_controller.py Tests/UI/test_console_session_settings.py Tests/UI/test_console_launch_wake.py Tests/Chat/test_console_conversation_hydration.py -k "new_chat or temporary or workspace or pristine or resume or duplicate or branch or handoff or default or wake"
+
+Expected: selected tests pass.
+
+Commit:
+
+    git add -p -- tldw_chatbook/UI/Console_Modules/session.py tldw_chatbook/UI/Console_Modules/workspace.py tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_launch_wake.py Tests/UI/test_console_session_controller.py Tests/UI/test_console_session_settings.py Tests/UI/test_console_launch_wake.py Tests/Chat/test_console_conversation_hydration.py
+    git diff --cached --check
+    git diff --cached
+    git commit -m "fix: seed blank Console chats from saved defaults"
+
+## Task 6: Rebuild the quick Provider popover around explicit actions
+
+**Files:**
+
+- Modify: tldw_chatbook/Widgets/Console/console_model_popover.py:1-455
+- Modify: Tests/UI/test_console_context_controls.py
+- Modify: Tests/UI/test_console_model_apply_chips.py
+- Modify: Tests/UI/test_console_modal_dismissal.py
+- Modify: Tests/UI/test_console_resize_reflow.py
+
+- [ ] **Step 1: Write failing mounted interaction tests**
+
+Using ConsolidatedCSSApp and production CSS, test:
+
+- main footer order and labels: Cancel, Full settings…, Defaults…, Apply to this chat;
+- Defaults replaces the footer with Save as model default, Make default for new chats, Back;
+- compaction-stays-with-this-chat copy is visible in Defaults;
+- scope copy shows Applies to this conversation plus the exact unsaved-first-message
+  or temporary-until-promoted durability line;
+- blocked/unconfigured provider disables Make default for new chats in the quick
+  Defaults chooser with an explanation;
+- valid mouse and keyboard activation produce the same ConsoleSettingsCommittedSubmission and dismiss once after the live commit;
+- invalid/NaN/infinite/out-of-range temperature stays open and displays an error;
+- Cancel/Escape returns None;
+- hierarchical Escape leaves Defaults first, then closes the popover;
+- provider and model changes rebase target defaults, mark deliberate edits, drop stale endpoint, and restore A to B to A drafts;
+- Full settings returns ConsoleSettingsTransfer without applying;
+- 60x24 and 72x24 keep actions reachable, ordered, and not overlapping;
+- mouse capture is released before dismissal and a deferred callback after teardown is harmless.
+
+- [ ] **Step 2: Run and observe failures**
+
+Run:
+
+    pytest -q Tests/UI/test_console_context_controls.py Tests/UI/test_console_model_apply_chips.py Tests/UI/test_console_modal_dismissal.py Tests/UI/test_console_resize_reflow.py -k "popover or model_apply or defaults"
+
+Expected: failures for missing buttons, explicit errors, and submission types.
+
+- [ ] **Step 3: Implement popover state and result semantics**
+
+Change the modal result type to ConsoleSettingsCommittedSubmission | ConsoleSettingsTransfer | None. Constructor inputs must include origin, app_config, the initial ConsoleSettingsDraftState, the chat scope/durability copy, a DraftRebaser callback backed by ConsoleChatController, and a synchronous live_committer callback that revalidates through the controller before ConsoleChatStore.commit_console_settings_live.
+
+Replace the silent invalid-temperature fallback with the same blocking validation rule as full Settings and add #console-popover-error.
+
+All four submit buttons must call one _submit(action) method. _submit validates,
+builds the exact action/mask, releases mouse capture if needed, and calls
+live_committer before dismissing. A rejected missing/closed/rebound origin reports
+Chat closed; nothing applied, dismisses without a committed result, and cannot
+start default work; ordinary field validation still keeps the surface open. A
+successful commit is wrapped with its submission as
+ConsoleSettingsCommittedSubmission, then the modal marks itself dismissed once and
+dismisses. Defaults/Back only changes local view state.
+
+Provider/model handlers must save the current keyed draft before calling the
+injected controller rebaser. Mark temperature dirty on input changes and streaming
+dirty only on explicit toggle. The widget never builds target defaults or decides
+field support itself.
+
+Render carried deliberate edits visibly beside the affected controls with the
+literal marker Edited — carried from {provider}/{model}; inherited controls use an
+Inherited marker. The marker is derived from field provenance, not guessed from
+value equality.
+
+- [ ] **Step 4: Implement bounded layout and Escape**
+
+Keep one scrollable body and pinned action footer. At narrow width allow action rows to wrap or stack without clipping. Defaults is a local substate, so Escape returns to main state before SafeModalDismissMixin closes the screen.
+
+- [ ] **Step 5: Run tests and commit**
+
+Run:
+
+    pytest -q Tests/UI/test_console_context_controls.py Tests/UI/test_console_model_apply_chips.py Tests/UI/test_console_modal_dismissal.py Tests/UI/test_console_resize_reflow.py -k "popover or model_apply or defaults"
+
+Expected: selected tests pass at both terminal sizes.
+
+Commit:
+
+    git add -p -- tldw_chatbook/Widgets/Console/console_model_popover.py Tests/UI/test_console_context_controls.py Tests/UI/test_console_model_apply_chips.py Tests/UI/test_console_modal_dismissal.py Tests/UI/test_console_resize_reflow.py
+    git diff --cached --check
+    git diff --cached
+    git commit -m "feat: add explicit Console provider actions"
+
+## Task 7: Give full Console Settings the same contract and safe endpoint opt-in
+
+**Files:**
+
+- Modify: tldw_chatbook/Widgets/Console/console_settings_modal.py:75-215,279-520,1435-1810,1850-2350
+- Modify: Tests/UI/test_console_session_settings.py:2877-5112
+- Modify: Tests/UI/test_console_context_controls.py
+
+- [ ] **Step 1: Write failing full-modal tests**
+
+Test:
+
+- Apply to this chat returns the same submission type and full context-policy overrides;
+- Save as model default uses FULL_MODEL_DEFAULT_FIELDS;
+- Make default for new chats uses the full mask and can opt into a dirty endpoint;
+- Save Model Default can never persist endpoint;
+- endpoint checkbox is disabled until endpoint is explicitly dirty;
+- endpoint draft remains bound to its raw provider identity through A to B to A and
+  quick-to-full transfer; a mismatched binding cannot be checked or saved;
+- preview contains only sanitized host/classification;
+- streaming cycles Inherit to On to Off and Inherit deletes the profile override;
+- quick-to-full transfer restores all quick draft values, compaction, dirty provenance, origin, and keyed drafts;
+- provider/model switches call the same injected controller-owned rebase seam;
+- no modal handler writes config directly;
+- Cancel/Escape does not apply.
+- blocked/unconfigured provider readiness disables Make default for new chats with
+  an explanatory status while leaving Apply to this chat available under its
+  existing readiness rules.
+- an app-global default failure renders the same exact intent summary/actions in
+  full Console Settings as the Model rail.
+- Retry/Discard/Refresh/Dismiss in the full modal emit a typed request with the
+  exact intent generation, update the app-owned state, and refresh the modal region
+  without relying on ChatScreen button bubbling.
+
+- [ ] **Step 2: Run and observe failures**
+
+Run:
+
+    pytest -q Tests/UI/test_console_session_settings.py Tests/UI/test_console_context_controls.py -k "save_default or transfer or endpoint or streaming or provider_change or model_change or recovery"
+
+Expected: current _save_as_default direct config writer and boolean streaming behavior fail.
+
+- [ ] **Step 3: Replace direct persistence with discriminated results**
+
+Remove the save_settings_to_cli_config import, _default_persist_sections, and
+direct async config write from the modal. Apply and both default buttons validate,
+invoke the same injected live_committer as the quick popover, and dismiss only
+after it returns a successful ConsoleSettingsLiveCommit. ChatScreen performs
+durable conversation persistence and any default mutation from the committed
+result after close.
+
+Accept an optional ConsoleSettingsTransfer and the app-owned
+ConsoleDefaultDurabilityState in the constructor. Seed all controls, context
+overrides, field provenance, endpoint provider binding/dirty/checked state, and
+keyed provider/model drafts from the transfer. Render the same before-replace or
+runtime-refresh exact intent summary and recovery actions exposed by the rail.
+Also inject:
+
+    DefaultRecoveryHandler = Callable[
+        [ConsoleDefaultRecoveryRequest],
+        Awaitable[ConsoleDefaultDurabilityState],
+    ]
+
+Each full-modal recovery button awaits this handler, replaces its local recovery
+state with the returned app-owned snapshot, reenables valid controls, and remains
+open. ChatScreen supplies the handler and performs Retry/Discard/Refresh/Dismiss;
+recovery requests are not part of the normal Apply/dismiss result union.
+
+Use one _submission_for_action method for Apply, Save Model Default, and Make Default.
+
+- [ ] **Step 4: Add endpoint opt-in and inherited streaming**
+
+Track ConsoleEndpointDraft separately from provider-derived endpoint
+initialization. Show a Checkbox only for full Make Default semantics; it remains
+unchecked by default and disables whenever its bound provider does not match the
+selected provider. Its label/adjacent Static must render:
+
+    Also save connection: host.example:8443 · Remote/unknown
+
+using only Task 4's pure sanitizer. No URL details may enter copy or logs.
+
+Represent streaming draft as None | True | False, render Inherit/On/Off, and build the effective conversation value before live Apply while retaining None provenance for profile deletion.
+
+- [ ] **Step 5: Run tests and commit**
+
+Run:
+
+    pytest -q Tests/UI/test_console_session_settings.py Tests/UI/test_console_context_controls.py -k "save_default or transfer or endpoint or streaming or provider_change or model_change or exact_origin or recovery"
+
+Expected: selected tests pass.
+
+Commit:
+
+    git add -p -- tldw_chatbook/Widgets/Console/console_settings_modal.py Tests/UI/test_console_session_settings.py Tests/UI/test_console_context_controls.py
+    git diff --cached --check
+    git diff --cached
+    git commit -m "feat: unify full Console settings actions"
+
+## Task 8: Coordinate exact-origin Apply, default saves, and visible recovery
+
+**Files:**
+
+- Modify: tldw_chatbook/app.py:6935-6985
+- Modify: tldw_chatbook/UI/Screens/chat_screen.py:2535-2725,3535-3605,4920-4985,19650-19730
+- Modify: tldw_chatbook/UI/Console_Modules/left_rail.py:1645-1715
+- Modify: Tests/UI/test_console_session_settings.py:5210-5415
+- Modify: Tests/UI/test_console_model_apply_chips.py
+- Modify: Tests/UI/test_console_rail_sections.py
+- Modify: Tests/UI/test_console_parallel_runs.py
+
+- [ ] **Step 1: Write failing coordinator and recovery tests**
+
+Test:
+
+- origin is captured before awaiting model-catalog resolution;
+- switching tabs during that await or while the modal is open still applies to origin;
+- a closed/rebound origin is rejected and the modal cannot claim success;
+- both quick and full results call one coordinator;
+- live Apply closes before default disk work finishes;
+- a slow/failing conversation metadata or context-policy write neither delays nor
+  prevents the requested model/global default mutation after the shared live commit;
+- an execution context captured before the live commit retains its old settings,
+  while one resolved afterward sees the new settings;
+- each session failure row names generation or compaction/context policy and offers Retry;
+- conversation Retry only affects the matching current session/component revision;
+- default pre-replace failure is visible across Console tabs with Retry default save/Discard retry;
+- post-replace failure is visible as Saved on disk; running app refresh failed with Refresh running app/Dismiss;
+- cache-only refresh never rewrites disk;
+- newer default intent supersedes older retry state;
+- initial success, successful Retry, and successful Refresh each publish one fresh
+  settings mapping and increment the new-chat-default generation at most once for
+  the matching Make Default intent;
+- ordinary Apply leaves app-global default failure untouched;
+- modal teardown and duplicate callbacks cannot double-commit.
+- successful default actions emit two independent receipts: This chat updated plus
+  the exact model-profile or eligible-new-chat scope saved.
+
+- [ ] **Step 2: Run and observe failures**
+
+Run:
+
+    pytest -q Tests/UI/test_console_session_settings.py Tests/UI/test_console_model_apply_chips.py Tests/UI/test_console_rail_sections.py Tests/UI/test_console_parallel_runs.py -k "exact_origin or persistence_failure or default_failure or model_apply"
+
+Expected: failures for active-session callback routing and missing recovery actions.
+
+- [ ] **Step 3: Capture origin before every await**
+
+In action_open_console_model_popover and _open_console_settings:
+
+    store = self._ensure_console_chat_store()
+    session_id = store.active_session_id
+    if session_id is None:
+        return
+    origin = store.capture_console_settings_origin(session_id)
+    settings = store.session_settings(session_id)
+    context_policy = store.session_context_policy_overrides(session_id)
+    user_display_name = store.session_user_display_name_override(session_id)
+
+Capture settings, policy, and system prompt from that same session before model-catalog awaits. Bind callback with the origin/transfer result; never look up active_session_id when applying.
+
+- [ ] **Step 4: Put default durability state on the application lifetime**
+
+Initialize a ConsoleDefaultDurabilityState holder beside app_config in TldwCli.
+The holder contains only the newest immutable default intent generation and either
+the before-replace retry record or the after-replace runtime-refresh record.
+ChatScreen reads this app-owned holder, so navigation/unmount and Console tab
+switches cannot make a global failure disappear.
+
+Initialize console_new_chat_default_generation at zero in the same app lifetime.
+Only a fully published Make Default increments it.
+
+ConsoleDefaultDurabilityState also tracks the one current
+runtime_published_intent_generation. Its accept_runtime_publication method is
+idempotent and succeeds only for the newest intent generation. After the returned
+settings mapping is assigned to app_instance.app_config, call this method; increment
+console_new_chat_default_generation exactly once when that intent's action is Make
+Default. The same path is used for initial success, a successful Retry after
+before-replace failure, and Refresh running app after cache-publication failure.
+
+Reserve a new default-intent generation synchronously before dispatching its
+worker. The config mutation_precondition rechecks that generation under the config
+lock, and the UI publishes an outcome only if the same generation is still newest.
+A later explicit default action therefore supersedes both an older pending Retry
+and an older in-flight result without letting either replace the new holder state.
+
+- [ ] **Step 5: Add one coordinator**
+
+Add an async _coordinate_console_settings_submission method:
+
+1. inject a live_committer that asks ConsoleChatController to revalidate/rebase the
+   submitted draft against the current app_config, then calls
+   store.commit_console_settings_live; accept only its
+   ConsoleSettingsCommittedSubmission;
+2. refresh the origin's visible surfaces if mounted, without switching tabs;
+3. immediately start the conversation durability task through
+   store.persist_console_settings_commit_serialized and, for a default action, an
+   independent asyncio.to_thread apply_console_default_intent task; await and
+   publish their outcomes independently so neither gates the other;
+4. for a full-modal submission, pass the captured display-name override to its
+   existing exact-session roleplay owner and retain that owner's current warning
+   behavior; do not add it to the new generation/context failure ledger;
+5. on full default success, assign the default mutation outcome's fresh
+   settings_view to
+   app_instance.app_config on the UI thread, then call the idempotent
+   accept_runtime_publication path above; do not resync or mutate any already-open
+   session;
+6. record each conversation/default failure independently and only for its current
+   component revision or default intent generation.
+
+Full settings transfer reopens ConsoleSettingsModal with the same origin/draft and no live call.
+
+- [ ] **Step 6: Make runtime refresh cache-only and app-visible**
+
+When file replacement succeeded but either config cache publication or
+app_instance.app_config publication failed, retain only the already-saved intent
+identity and a runtime-refresh action. Refresh running app must call a public
+config helper that locks, rereads, and republishes the existing file without
+writing it, then assign the returned fresh settings view to app_instance.app_config.
+It must never call apply_console_default_intent or any disk mutation.
+
+Run that helper in asyncio.to_thread. The helper returns
+RuntimeConfigPublicationResult; only the final app_instance.app_config assignment
+runs on the UI thread, followed by the same idempotent
+accept_runtime_publication path used by initial success and Retry.
+
+- [ ] **Step 7: Replace the rail recovery Static with explicit state/actions**
+
+In left_rail.py, keep provider readiness and persistence recovery as separate rows inside the Model section. Add compact buttons with IDs for:
+
+- retry conversation generation;
+- retry compaction/context policy;
+- retry default save;
+- discard default retry;
+- refresh running app;
+- dismiss runtime-refresh failure.
+
+Only mount/show actions valid for current state. The default row includes the exact
+action, provider, literal model, field scope, and sanitized optional authority.
+Button events route to the store/default service with exact revision/generation
+tokens. ChatScreen exposes the same routing as a typed DefaultRecoveryHandler
+injected into full Console Settings; both surfaces return the updated
+ConsoleDefaultDurabilityState from the one app owner.
+
+- [ ] **Step 8: Rebuild consolidated CSS if bundled declarations change**
+
+If left_rail or modal CSS uses BUNDLED_CSS/BUNDLED_SCREEN_CSS, run:
+
+    python tldw_chatbook/css/build_css.py
+
+Then run:
+
+    pytest -q Tests/UI/test_widget_css_consolidation.py Tests/UI/test_css_class_coverage_contract.py
+    git diff --name-only -- tldw_chatbook/css/widget_defaults_self.tcss tldw_chatbook/css/widget_defaults_scoped.tcss tldw_chatbook/css/screen_css_self.tcss tldw_chatbook/css/screen_css_scoped.tcss tldw_chatbook/css/tldw_cli_modular.tcss
+
+Expected: generated CSS is current and class coverage passes. Record only the
+tracked generated paths printed by git diff; .css-build-manifest.json is ignored
+builder state and must not be staged.
+
+- [ ] **Step 9: Run coordinator tests and commit**
+
+Run:
+
+    pytest -q Tests/UI/test_console_session_settings.py Tests/UI/test_console_model_apply_chips.py Tests/UI/test_console_rail_sections.py Tests/UI/test_console_parallel_runs.py -k "exact_origin or persistence_failure or default_failure or model_apply"
+
+Expected: selected tests pass.
+
+Commit:
+
+    git add -p -- tldw_chatbook/app.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/UI/Console_Modules/left_rail.py Tests/UI/test_console_session_settings.py Tests/UI/test_console_model_apply_chips.py Tests/UI/test_console_rail_sections.py Tests/UI/test_console_parallel_runs.py
+    # Add -p only the tracked generated paths printed by the preceding diff:
+    git add -p -- tldw_chatbook/css/widget_defaults_self.tcss tldw_chatbook/css/widget_defaults_scoped.tcss tldw_chatbook/css/screen_css_self.tcss tldw_chatbook/css/screen_css_scoped.tcss tldw_chatbook/css/tldw_cli_modular.tcss
+    git diff --cached --check
+    git diff --cached
+    git commit -m "feat: expose Console settings recovery actions"
+
+## Task 9: Add end-to-end Console behavior coverage
+
+**Files:**
+
+- Create: Tests/UI/test_console_provider_apply_defaults_flow.py
+- Modify: Tests/UI/test_console_resize_reflow.py
+- Modify: Tests/ProductionApp/test_provider_selection_ownership.py
+
+- [ ] **Step 1: Add production-hierarchy interaction tests**
+
+Use real Console screen composition, ConsolidatedCSSApp, temporary config, and in-memory SQLite. Exercise:
+
+- mouse Apply to this chat, close, next send context uses selected provider/model;
+- keyboard activation follows the same method;
+- a context captured before Apply keeps the old settings while a later capture uses
+  the new settings;
+- persisted close/resume restores generation settings and compaction;
+- unsaved ordinary chat stages then persists both owners;
+- temporary chat remains non-durable, then promotion persists;
+- Save Model Default survives a simulated restart without changing global provider/model;
+- Make Default changes every eligible new-chat entry point immediately and after simulated restart;
+- existing/open and explicit source-derived chats remain unchanged;
+- pre-replace and post-replace failures show exact copy/actions;
+- quick compaction changes preserve every other policy override, and a stale policy
+  Retry cannot restore values superseded by a newer full-context edit;
+- blocked quick defaults, missing-catalog custom models, and unconfigured saved
+  providers remain explicit rather than silently substituted;
+- successful default actions show separate chat-updated and exact-default-scope
+  receipts;
+- 60x24 and 72x24 contain no overlap/clipping and every action is keyboard reachable.
+
+Stub provider execution; do not contact a real LLM or write the real config.
+
+- [ ] **Step 2: Run the end-to-end target**
+
+Run:
+
+    pytest -q Tests/UI/test_console_provider_apply_defaults_flow.py Tests/UI/test_console_resize_reflow.py Tests/ProductionApp/test_provider_selection_ownership.py
+
+Expected: all selected tests pass.
+
+- [ ] **Step 3: Run the complete targeted feature matrix**
+
+Run:
+
+    pytest -q \
+      Tests/Chat/test_console_settings_apply.py \
+      Tests/Chat/test_console_generation_settings_metadata.py \
+      Tests/Chat/test_console_settings_apply_store.py \
+      Tests/Chat/test_console_context_policy_cas.py \
+      Tests/Chat/test_console_settings_defaults.py \
+      Tests/Chat/test_console_conversation_hydration.py \
+      Tests/Chat/test_console_session_settings.py \
+      Tests/Chat/test_console_chat_store.py \
+      Tests/UI/test_console_provider_apply_defaults_flow.py \
+      Tests/UI/test_console_context_controls.py \
+      Tests/UI/test_console_model_apply_chips.py \
+      Tests/UI/test_console_modal_dismissal.py \
+      Tests/UI/test_console_session_controller.py \
+      Tests/UI/test_console_launch_wake.py \
+      Tests/UI/test_console_session_settings.py \
+      Tests/UI/test_console_rail_sections.py \
+      Tests/UI/test_console_resize_reflow.py \
+      Tests/UI/test_console_parallel_runs.py \
+      Tests/ProductionApp/test_provider_selection_ownership.py \
+      Tests/test_config_delete_settings.py
+
+Expected: all targeted feature tests pass. If runtime is excessive, split by Chat/UI/config but do not silently omit a listed file.
+
+- [ ] **Step 4: Run static and diff checks**
+
+Run:
+
+    python -m compileall -q tldw_chatbook/Chat tldw_chatbook/Widgets/Console tldw_chatbook/UI/Console_Modules tldw_chatbook/UI/Screens/chat_screen.py
+    ruff check tldw_chatbook/Chat/console_settings_apply.py tldw_chatbook/Chat/console_generation_settings_metadata.py tldw_chatbook/Chat/console_settings_defaults.py tldw_chatbook/Chat/console_chat_store.py tldw_chatbook/Chat/chat_persistence_service.py tldw_chatbook/Chat/console_conversation_hydration.py tldw_chatbook/Widgets/Console/console_model_popover.py tldw_chatbook/Widgets/Console/console_settings_modal.py tldw_chatbook/UI/Console_Modules/session.py tldw_chatbook/UI/Console_Modules/left_rail.py tldw_chatbook/UI/Screens/chat_screen.py
+    git diff --check
+
+Expected: zero errors.
+
+- [ ] **Step 5: Self-review against the acceptance criteria**
+
+Review the diff for:
+
+- any use of active_session_id after modal open;
+- any conversation metadata serialization of endpoint/secrets;
+- any compaction value in model/global defaults;
+- any whole model_defaults replacement;
+- any cache-failure retry that rewrites disk;
+- any UI success copy before live commit;
+- any bare real-config or real-network verification.
+
+Commit:
+
+    git add -p -- Tests/UI/test_console_resize_reflow.py Tests/ProductionApp/test_provider_selection_ownership.py
+    git add -- Tests/UI/test_console_provider_apply_defaults_flow.py
+    git diff --cached --check
+    git diff --cached
+    git commit -m "test: cover Console provider apply and defaults"
+
+## Task 10: Finish backlog and implementation documentation
+
+**Files:**
+
+- Modify: backlog/tasks/task-22515 - Make-Console-provider-Apply-update-and-persist-conversation-settings.md
+- Modify: Docs/superpowers/specs/2026-08-27-console-provider-apply-persistence-design.md if implementation deviations were approved
+- Modify: backlog/docs/lessons-testing-evidence.md or backlog/docs/lessons-live-verification.md only if this work produced a concrete reusable incident
+
+- [ ] **Step 1: Record implementation notes**
+
+Add a concise Implementation Notes section to TASK-22515 covering:
+
+- the shared submission/exact-origin owner;
+- safe metadata and context-policy ownership;
+- literal-path default mutation and failure phases;
+- eligible new-chat behavior;
+- modified/added files;
+- targeted verification evidence;
+- ADR-095.
+
+- [ ] **Step 2: Check every acceptance criterion only after evidence exists**
+
+Change each task checkbox from [ ] to [x] only when the targeted test or inspected behavior proves it.
+
+- [ ] **Step 3: Complete task hygiene**
+
+After every criterion, targeted test, static check, documentation update, and self-review is complete:
+
+    backlog task edit 22515 -s Done
+
+Do not mark Done early. Do not invent a lessons-learned entry.
+
+- [ ] **Step 4: Commit final documentation**
+
+Run:
+
+    git diff --check
+    git status --short
+
+Commit:
+
+    git add -p -- "backlog/tasks/task-22515 - Make-Console-provider-Apply-update-and-persist-conversation-settings.md" Docs/superpowers/specs/2026-08-27-console-provider-apply-persistence-design.md
+    # If and only if one exact lessons file was deliberately changed:
+    git add -p -- backlog/docs/lessons-testing-evidence.md
+    git diff --cached --check
+    git diff --cached
+    git commit -m "docs: complete Console provider apply task"
+
+## Optional Full Sweep
+
+The repository requires explicit user approval before a full test sweep. After all targeted verification passes, ask:
+
+    The targeted Console/provider/default test matrix passes. Do you want the full pytest suite before integration?
+
+Run pytest only if the user opts in.

--- a/Docs/superpowers/plans/2026-08-28-low-latency-speculative-duplex-voice-pipeline.md
+++ b/Docs/superpowers/plans/2026-08-28-low-latency-speculative-duplex-voice-pipeline.md
@@ -1,0 +1,1051 @@
+# Low-Latency Speculative Duplex Voice Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Start provider-agnostic hands-free replies from a fresh rolling transcript after 700 ms of silence by default, cancel and replace provisional replies whenever the same user turn continues, and make speaker-safe acoustic barge-in the default through a qualified cross-platform AEC path.
+
+**Architecture:** Add an import-safe duplex audio/DSP boundary, a rolling transcript protocol, and a serialized speculative-turn coordinator beside the existing legacy hands-free controller. Provisional provider and TTS work stays attempt-local; effectful turns cross a two-second barrier into the ordinary accepted-turn path, and only a winning no-tool attempt may use the existing ADR-094/ADR-097 promotion services. The new pipeline remains behind a hard-disabled qualification gate until native wheels, persistence/trace prerequisites, and the physical-device matrix pass.
+
+**Tech Stack:** Python 3.11+, asyncio, Textual 8.x, sounddevice/PortAudio, WebRTC Audio Processing Module AEC3, pybind11, scikit-build-core, CMake, pytest, Hypothesis, GitHub Actions/cibuildwheel.
+
+---
+
+## Governing records
+
+- Design: `Docs/superpowers/specs/2026-08-28-low-latency-speculative-duplex-voice-pipeline-design.md`
+- Decision: `backlog/decisions/098-low-latency-speculative-duplex-voice-pipeline.md`
+- Related boundaries: ADR-023, ADR-039, ADR-094, and ADR-097.
+
+ADR required: yes
+
+ADR path: `backlog/decisions/098-low-latency-speculative-duplex-voice-pipeline.md`
+
+Reason: native audio/runtime packaging, full-duplex clock ownership, AEC failure policy, provider cancellation, persistence/capture promotion, and tool-effect boundaries are cross-module architectural decisions.
+
+## Preconditions and rollout order
+
+The implementation may begin at Task 1, but the speculative pipeline must remain hard-off in production until all of these conditions are true:
+
+1. ADR-094 terminal-receipt work, currently represented by `TASK-22514`, exposes one transaction that promotes the winning user/assistant pair, creates the terminal receipt, and records the exact unseen mark. Task 9 adapts to that service; it must not recreate the transaction.
+2. ADR-097 exposes reservation/settlement and temporary-chat trace behavior. Task 9 uses the trace service for winning-only `provisional_voice_promoted` capture; it must not add a parallel trace store.
+3. macOS, Windows, and Linux native wheels and the AEC corpus pass in CI.
+4. The latency, deterministic integration, soak, and physical-device qualification in Task 12 pass. Bluetooth may qualify only through explicit safe half duplex.
+
+Until then, `speculative_voice_qualified()` returns `False` in every installed build and `ConsoleHandsFreeController` continues to select `HandsFreeController`. There is no environment-variable, command-line, or saved-setting bypass. Tests exercise the new path by injecting a fake qualification reader into the composition root; local manual development requires building a real capability manifest with the Task 12C generator from qualified local evidence.
+
+Do not create Backlog tasks from this plan unless the user explicitly requests it. When implementation is authorized, create atomic Backlog tasks in this dependency order and link each task to the design and ADR before changing code.
+
+### Dirty-worktree protocol for every task
+
+This plan was written in a shared dirty worktree. Before each task, run `git status --short -- <owned paths>` and `git diff -- <owned tracked paths>`. If an owned tracked file already has changes, preserve them, determine their owner, and either coordinate the overlap or use patch-level staging; never overwrite, revert, or silently absorb them.
+
+Every commit step below uses this safe pattern:
+
+```bash
+git status --short -- <task paths>
+git diff -- <tracked task paths>
+git add --intent-to-add <new task paths>
+git add -p -- <all task paths>
+git diff --cached --check
+git diff --cached -- <all task paths>
+git commit -m "<task message>"
+```
+
+Select only hunks created for the current task. If patch staging cannot separate an overlap safely, stop and ask the user; do not use whole-file `git add` on that path. The abbreviated commit blocks below name the files and message, but this protocol remains mandatory.
+
+## Target file structure
+
+| Path | Responsibility |
+| --- | --- |
+| `tldw_chatbook/Chat/console_voice_settings.py` | Bounded new-pipeline settings, presets, qualification gate, and compatibility ownership. |
+| `tldw_chatbook/Audio/duplex_contracts.py` | Dependency-free frame, watermark, health, and transport protocols. |
+| `tldw_chatbook/Audio/aec_backend.py` | Lazy native AEC loader and narrow processor protocol. |
+| `tldw_chatbook/Audio/duplex_transport.py` | One app-owned input/output session, timestamped rings, device lifecycle. |
+| `tldw_chatbook/Audio/voice_preprocessor.py` | Resampling, AEC, health hysteresis, post-AEC VAD, and admission. |
+| `tldw_chatbook/Audio/rolling_transcript.py` | Common live/rolling-window STT revision and reconciliation contract. |
+| `native/voice_aec/` | Reproducible pybind11/CMake WebRTC AEC3 companion package. |
+| `Packaging/generate_voice_qualification_manifest.py` | Validates evidence and emits the packaged, platform-keyed rollout authority. |
+| `tldw_chatbook/Audio/voice_qualification_manifest.json` | Generated, immutable capability evidence consumed fail-closed at runtime. |
+| `tldw_chatbook/Chat/voice_phrase_sequencer.py` | Markdown-safe, sequential, cancellable phrase synthesis/playback. |
+| `tldw_chatbook/Chat/console_voice_attempts.py` | Attempt-local generation, output, usage/capture, cancellation, and cleanup. |
+| `tldw_chatbook/Chat/console_voice_supervisor.py` | App-lifetime orphan set and voice-dispatch quarantine. |
+| `tldw_chatbook/Chat/console_speculative_voice.py` | Serialized logical-turn coordinator and effect barrier state machine. |
+| `tldw_chatbook/Chat/console_voice_promotion.py` | Narrow adapters to ADR-094 terminalization and ADR-097 trace promotion. |
+| `tldw_chatbook/UI/Console_Modules/hands_free.py` | Legacy/new selection and view-scoped lifecycle wiring. |
+| `tldw_chatbook/Widgets/Console/console_voice_preview.py` | Ephemeral user/assistant projection outside the durable message store. |
+| `tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py` | Canonical settings UI for response eagerness, STT mode, and AEC troubleshooting. |
+| `tldw_chatbook/Widgets/Settings_Widgets/speech_tts_panel_types.py` | Separate pipeline settings draft. |
+| `tldw_chatbook/Audio/voice_metrics.py` | Content-free latency, mode, restart, AEC, and discarded-usage measurements. |
+
+Keep `Chat/console_hands_free.py`, `Chat/reply_sentence_sequencer.py`, `dictation.acoustic_barge_in`, and `dictation.handsfree_send_delay_seconds` unchanged for the legacy/Realtime compatibility path. Do not add settings to `UI/Tools_Settings_Window.py` or `Widgets/enhanced_settings_sidebar.py`.
+
+## Task 1: Add bounded settings and import-safe contracts
+
+**Files:**
+
+- Create: `tldw_chatbook/Chat/console_voice_settings.py`
+- Create: `tldw_chatbook/Audio/duplex_contracts.py`
+- Modify: `tldw_chatbook/Widgets/Settings_Widgets/speech_tts_panel_types.py`
+- Test: `Tests/Chat/test_console_voice_settings.py`
+- Test: `Tests/Audio/test_duplex_contracts.py`
+
+- [ ] **Step 1: Write the failing settings and contract tests.**
+
+```python
+from tldw_chatbook.Chat.console_voice_settings import (
+    RESPONSE_EAGERNESS_MAX_MS,
+    RESPONSE_EAGERNESS_MIN_MS,
+    response_eagerness_ms,
+    speculative_voice_qualified,
+)
+
+
+def test_response_eagerness_defaults_and_invalid_values_fall_back() -> None:
+    assert response_eagerness_ms({}) == 700
+    warnings: list[str] = []
+    assert response_eagerness_ms(
+        {"dictation": {"response_eagerness_ms": 1}}, warn=warnings.append
+    ) == 700
+    assert warnings == ["Invalid speculative voice response eagerness; using 700 ms."]
+    assert response_eagerness_ms(
+        {"dictation": {"response_eagerness_ms": 9999}}, warn=warnings.append
+    ) == 700
+
+
+def test_qualification_is_hard_off_even_when_an_environment_variable_is_set(monkeypatch) -> None:
+    monkeypatch.setenv("TLDW_DEV_SPECULATIVE_VOICE", "1")
+    assert speculative_voice_qualified() is False
+```
+
+```python
+from tldw_chatbook.Audio.duplex_contracts import AudioFrame, AecHealth
+
+
+def test_audio_frame_requires_positive_ordered_duration() -> None:
+    frame = AudioFrame(sequence=1, started_ns=10, ended_ns=20, pcm16=b"\x00\x00")
+    assert frame.duration_ns == 10
+    assert AecHealth.WARMING.value == "warming"
+```
+
+- [ ] **Step 2: Run the tests and verify RED.**
+
+Run: `pytest -q Tests/Chat/test_console_voice_settings.py Tests/Audio/test_duplex_contracts.py`
+
+Expected: collection fails because the two new modules do not exist.
+
+- [ ] **Step 3: Implement the smallest pure settings and contract surface.**
+
+```python
+# tldw_chatbook/Chat/console_voice_settings.py
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from collections.abc import Mapping
+from typing import Any
+
+RESPONSE_EAGERNESS_MIN_MS = 500
+RESPONSE_EAGERNESS_MAX_MS = 3000
+RESPONSE_EAGERNESS_DEFAULT_MS = 700
+RESPONSE_EAGERNESS_PRESETS = {"fast": 700, "balanced": 1200, "deliberate": 2000}
+_LOG = logging.getLogger(__name__)
+
+
+def response_eagerness_ms(
+    config: Mapping[str, Any],
+    *,
+    warn: Callable[[str], None] = _LOG.warning,
+) -> int:
+    raw = config.get("dictation", {}).get("response_eagerness_ms", RESPONSE_EAGERNESS_DEFAULT_MS)
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        value = -1
+    if not RESPONSE_EAGERNESS_MIN_MS <= value <= RESPONSE_EAGERNESS_MAX_MS:
+        warn("Invalid speculative voice response eagerness; using 700 ms.")
+        return RESPONSE_EAGERNESS_DEFAULT_MS
+    return value
+
+
+def pipeline_aec_enabled(config: Mapping[str, Any]) -> bool:
+    return config.get("dictation", {}).get("pipeline_aec_enabled", True) is not False
+
+
+def speculative_voice_qualified() -> bool:
+    # Task 12C replaces this with a validated packaged-manifest lookup.
+    return False
+```
+
+```python
+# tldw_chatbook/Audio/duplex_contracts.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+
+class AecHealth(str, Enum):
+    WARMING = "warming"
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+
+
+@dataclass(frozen=True, slots=True)
+class AudioFrame:
+    sequence: int
+    started_ns: int
+    ended_ns: int
+    pcm16: bytes
+
+    def __post_init__(self) -> None:
+        if self.sequence < 0 or self.ended_ns <= self.started_ns:
+            raise ValueError("audio frames require an ordered sequence and positive duration")
+
+    @property
+    def duration_ns(self) -> int:
+        return self.ended_ns - self.started_ns
+
+
+@dataclass(frozen=True, slots=True)
+class DrainReceipt:
+    capture_watermark_ns: int
+    capture_sequence: int
+    dsp_sequence: int
+    vad_sequence: int
+
+
+class DuplexAudioPort(Protocol):
+    async def abort_playback(self) -> None: ...
+    async def drain_capture_through(self, render_boundary_ns: int) -> DrainReceipt: ...
+```
+
+Add `_PipelineVoiceSettingsDraft` separately from `_RealtimeSettingsDraft`; do not reuse the Realtime acoustic-barge-in field.
+
+- [ ] **Step 4: Run the targeted tests and import-safety probe.**
+
+Run: `pytest -q Tests/Chat/test_console_voice_settings.py Tests/Audio/test_duplex_contracts.py && python -c "import tldw_chatbook.Audio.duplex_contracts; import tldw_chatbook.Chat.console_voice_settings"`
+
+Expected: tests pass and imports do not load `sounddevice`, PyAudio, or the native extension.
+
+- [ ] **Step 5: Commit only Task 1 files.**
+
+Apply the dirty-worktree protocol to the five Task 1 paths, then commit with `git commit -m "feat: define speculative voice contracts"`.
+
+## Task 2A: Vendor WebRTC AEC3 reproducibly and implement the native binding
+
+**Files:**
+
+- Create: `native/voice_aec/pyproject.toml`
+- Create: `native/voice_aec/CMakeLists.txt`
+- Create: `native/voice_aec/src/bindings.cpp`
+- Create: `native/voice_aec/tldw_voice_aec/__init__.py`
+- Create: `native/voice_aec/tools/vendor_webrtc_aec.py`
+- Create: `native/voice_aec/vendor/webrtc/UPSTREAM.json`
+- Create: `native/voice_aec/vendor/webrtc/FILES.sha256`
+- Create: `native/voice_aec/vendor/webrtc/PATCHES.md`
+- Create: `native/voice_aec/vendor/webrtc/LICENSE`
+- Create: `native/voice_aec/vendor/webrtc/PATENTS`
+- Create: `native/voice_aec/THIRD_PARTY_NOTICES.md`
+- Create: `native/voice_aec/tests/test_binding.py`
+- Test: `native/voice_aec/tests/test_vendored_source.py`
+
+- [ ] **Step 1: Write RED tests for source provenance, import, frame validation, processing, and metrics.**
+
+The Python binding contract is deliberately narrow:
+
+```python
+from tldw_voice_aec import AecProcessor
+
+
+def test_processor_accepts_one_ten_ms_48khz_mono_frame() -> None:
+    processor = AecProcessor(sample_rate=48_000, channels=1)
+    silence = bytes(480 * 2)
+    processor.analyze_render(silence, delay_ms=20)
+    cleaned = processor.process_capture(silence, delay_ms=20)
+    assert isinstance(cleaned, bytes)
+    assert len(cleaned) == len(silence)
+    assert {"erle_db", "delay_confidence"} <= processor.metrics().keys()
+```
+
+The provenance test pins the [official WebRTC source](https://webrtc.googlesource.com/src/+/109e23c9cec3a44e67c08774874a409741b1e58a/modules/audio_processing/aec3/) at commit `109e23c9cec3a44e67c08774874a409741b1e58a`. The vendoring recipe copies only the dependency closure rooted at `modules/audio_processing`, with allowlisted roots `api/audio`, `api/array_view.h`, `common_audio`, `modules/audio_processing`, `rtc_base`, `system_wrappers`, and required `third_party/abseil-cpp` files. It rejects any copied path outside that allowlist.
+
+- [ ] **Step 2: Run RED without building the extension.**
+
+Run: `pytest -q native/voice_aec/tests/test_binding.py native/voice_aec/tests/test_vendored_source.py`
+
+Expected: import/metadata assertions fail because the package and optional dependency do not exist.
+
+- [ ] **Step 3: Implement and run the deterministic vendoring recipe.**
+
+`vendor_webrtc_aec.py` clones/fetches only the pinned commit into a temporary directory, verifies `HEAD` equals the pinned 40-character commit, derives the compile dependency closure from the checked-in allowlist, copies it without `.git`, and emits:
+
+- `UPSTREAM.json` with repository URL, commit, commit-tree object ID, import timestamp, roots, compiler defines, license path, patent-notice path, and notice-generation version;
+- `FILES.sha256` with every vendored relative path and SHA-256 in sorted order; and
+- `PATCHES.md` with an ordered patch series. The initial series is explicitly `none`; later updates must add checked-in patch files and their hashes rather than editing vendored source silently.
+
+Run: `python native/voice_aec/tools/vendor_webrtc_aec.py --source /tmp/webrtc-src --verify-clean`
+
+Expected: the script refuses the wrong revision, produces the same manifest on a second run, and `test_vendored_source.py` detects any edited, missing, extra, unlicensed, or patent-notice-uncovered file. `THIRD_PARTY_NOTICES.md` carries the applicable WebRTC BSD license, WebRTC `PATENTS` notice, and notices for every vendored third-party dependency. The checked-in source and manifests make wheel builds network-free. The task is incomplete until all generated hashes and notices are concrete—no placeholder hashes or revision aliases such as `main` are allowed.
+
+- [ ] **Step 4: Implement the binding.**
+
+Expose only:
+
+```python
+class AecProcessor:
+    def __init__(self, *, sample_rate: int = 48_000, channels: int = 1) -> None: ...
+    def analyze_render(self, pcm16: bytes, *, delay_ms: int) -> None: ...
+    def process_capture(self, pcm16: bytes, *, delay_ms: int) -> bytes: ...
+    def reset(self) -> None: ...
+    def metrics(self) -> dict[str, float]: ...
+```
+
+The C++ layer must validate exact ten-millisecond mono PCM16 frame sizes, release the GIL during APM work, own all WebRTC objects, and surface Python exceptions rather than terminating. Do not expose WebRTC types to application modules.
+
+- [ ] **Step 5: Build and test a local wheel in an isolated environment.**
+
+Run: `python -m build native/voice_aec --wheel`
+
+Expected: one local platform wheel builds without network access.
+
+Run: `pytest -q native/voice_aec/tests/test_binding.py native/voice_aec/tests/test_vendored_source.py`
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit the source and binding with patch-level staging.**
+
+Apply the dirty-worktree protocol to `native/voice_aec`, then commit with `git commit -m "feat: add pinned WebRTC AEC3 binding"`.
+
+## Task 2B: Build, version, distribute, and install the companion wheels
+
+**Files:**
+
+- Create: `Packaging/check_voice_aec_wheel.py`
+- Create: `Packaging/check_voice_aec_version_sync.py`
+- Create: `Packaging/verify_voice_aec_attestations.py`
+- Create: `.github/workflows/voice-aec-wheels.yml`
+- Create: `.github/workflows/release-voice-aec.yml`
+- Create: `Docs/Development/TTS/voice-aec-release.md`
+- Modify: `native/voice_aec/pyproject.toml`
+- Modify: `pyproject.toml`
+- Test: `Tests/Packaging/test_voice_aec_distribution.py`
+
+- [ ] **Step 1: Write RED distribution and version-lock tests.**
+
+Assert package name `tldw-voice-aec`, companion version exactly equals the application version (`0.1.8.0` at plan time), `speech_recording` pins `tldw-voice-aec==<same-version>`, wheel metadata embeds the upstream commit/tree, `THIRD_PARTY_NOTICES.md`, WebRTC license, and WebRTC patent notice, repaired wheels contain no unexpected shared libraries, and importing `tldw_chatbook` does not import the extension.
+
+- [ ] **Step 2: Run RED.**
+
+Run: `pytest -q Tests/Packaging/test_voice_aec_distribution.py && python Packaging/check_voice_aec_version_sync.py`
+
+Expected: dependency, workflow, and version assertions fail.
+
+- [ ] **Step 3: Add the pull-request wheel matrix.**
+
+`.github/workflows/voice-aec-wheels.yml` builds CPython 3.11-3.13 wheels on macOS x86_64/arm64, Windows x86_64, and Linux x86_64/aarch64; runs `auditwheel`, `delvewheel`, or `delocate`; installs each repaired wheel into a clean environment outside the source tree; runs the binding/corpus smoke tests through cibuildwheel's `test-command`; verifies license and patent notices inside every wheel; generates an SBOM; and uploads one immutable artifact containing wheels, sdist, hashes, SBOM, notices, source-tree digest, and a keyless Sigstore/GitHub OIDC build-provenance bundle for every distribution file. This workflow never publishes.
+
+- [ ] **Step 4: Add an approval-gated release workflow and release order.**
+
+`.github/workflows/release-voice-aec.yml` triggers only from a protected `voice-aec-v<app-version>` tag plus an explicit successful matrix workflow-run ID. It downloads the already-tested immutable artifact from that run; verifies repository, workflow identity, source-tree digest, SHA-256 list, Sigstore/GitHub OIDC provenance bundles, SBOM, license inventory, and patent notices; and refuses locally rebuilt or extra files. In the protected `pypi-release` environment it uses PyPI Trusted Publishing to publish those exact wheel/sdist bytes with attestations enabled. It then installs every published wheel by exact version and hash before marking the release successful. Release never rebuilds a wheel, so nondeterministic ZIP timestamps or repair-tool output cannot invalidate the qualified hashes.
+
+`Docs/Development/TTS/voice-aec-release.md` defines the order: bump app and companion versions together; vendor/update and legal-review source/license/patent notices; pass wheel/AEC qualification; verify keyless build provenance against the repository and exact workflow identity; publish the immutable qualified companion artifacts; verify `pip install tldw-voice-aec==<version>` on all target platforms; only then publish an app release whose `speech_recording` extra pins that exact version. Signing policy requires GitHub OIDC keyless provenance for every wheel/sdist, retention of the verification bundle and SHA list, protected-environment approval, and fail-closed verification before publish. If signing, notice verification, companion publish, or a wheel is missing, the app release is blocked and the legacy pipeline remains selected.
+
+- [ ] **Step 5: Run local distribution checks.**
+
+Run: `python -m build native/voice_aec --wheel && python Packaging/check_voice_aec_wheel.py native/voice_aec/dist/*.whl && python Packaging/check_voice_aec_version_sync.py && pytest -q Tests/Packaging/test_voice_aec_distribution.py`
+
+Expected: all metadata, version, license, patent-notice, symbol, dependency, and offline-install checks pass. Attestation verification is exercised against a checked-in synthetic test bundle locally and against the real OIDC bundle in CI.
+
+- [ ] **Step 6: Commit distribution separately.**
+
+Apply the dirty-worktree protocol to the Task 2B files, then commit with `git commit -m "build: distribute cross-platform voice AEC wheels"`.
+
+## Task 3: Build the app-owned duplex transport and fail-closed preprocessor
+
+**Files:**
+
+- Create: `tldw_chatbook/Audio/aec_backend.py`
+- Create: `tldw_chatbook/Audio/duplex_transport.py`
+- Create: `tldw_chatbook/Audio/voice_preprocessor.py`
+- Modify: `tldw_chatbook/Audio/duplex_contracts.py`
+- Create: `Tests/Audio/fakes/fake_duplex_backend.py`
+- Test: `Tests/Audio/test_aec_backend.py`
+- Test: `Tests/Audio/test_duplex_transport.py`
+- Test: `Tests/Audio/test_voice_preprocessor.py`
+
+- [ ] **Step 1: Write deterministic RED tests with an injected monotonic clock.**
+
+Cover strictly increasing capture sequences, a shared render/capture clock, ten-millisecond normalization, bounded overflow behavior, render-before-capture AEC ordering, admission closed while warming/degraded, immediate close on health failure, device reset, content-free `DeviceRouteChanged` emission before the old clock can publish again, and `drain_capture_through(R)` receipts.
+
+```python
+async def test_degraded_aec_closes_speech_admission_before_vad() -> None:
+    aec = FakeAec(health=AecHealth.DEGRADED)
+    observed = []
+    preprocessor = VoicePreprocessor(aec=aec, on_admitted_frame=observed.append)
+    await preprocessor.process_capture(frame(sequence=1), assistant_rendering=True)
+    assert observed == []
+    assert preprocessor.mode is DuplexMode.HALF_DUPLEX
+```
+
+- [ ] **Step 2: Run RED.**
+
+Run: `pytest -q Tests/Audio/test_aec_backend.py Tests/Audio/test_duplex_transport.py Tests/Audio/test_voice_preprocessor.py`
+
+Expected: collection fails for missing implementation modules.
+
+- [ ] **Step 3: Implement the lazy backend and bounded callback bridge.**
+
+`aec_backend.py` imports `tldw_voice_aec` only inside `create_aec_processor()`. `duplex_transport.py` opens one `sounddevice.RawStream` where possible, stamps input frames before DSP, and confines callbacks to bounded copies/ring operations. Device callbacks never invoke STT, UI, logging, provider cancellation, or Python text reconciliation. Route loss/change atomically closes render admission, invalidates the old clock generation, and enqueues `DeviceRouteChanged(old_clock_generation, route_kind)` on the control queue; it never includes a raw device name.
+
+Use a 48 kHz mono processing domain and explicit resamplers at boundaries. Feed render frames to `analyze_render` in scheduled order, then process capture with the same delay estimator. File-producing TTS must enter via decoded PCM; no hands-free code may launch an external player.
+
+- [ ] **Step 4: Implement health hysteresis and the terminal capture drain.**
+
+Health states are `warming`, `healthy`, and `degraded`. The gate opens only after a bounded healthy streak and closes on the first confidence/discontinuity failure. `drain_capture_through(R)` waits until the input watermark is later than `R`, then verifies capture→AEC→VAD acknowledgements through the greatest earlier sequence. A 500 ms caller deadline, sequence gap, or device reset returns failure rather than guessing.
+
+- [ ] **Step 5: Run targeted tests plus installed/absent dependency probes.**
+
+Run: `pytest -q Tests/Audio/test_aec_backend.py Tests/Audio/test_duplex_transport.py Tests/Audio/test_voice_preprocessor.py`
+
+Run: `python -c "import sys; import tldw_chatbook.Audio.duplex_transport; assert 'sounddevice' not in sys.modules and 'tldw_voice_aec' not in sys.modules"`
+
+Expected: all tests and import-safety assertion pass. Also run the tests once in an environment with the native companion installed and once with it absent; absence must select honest half duplex without hanging.
+
+- [ ] **Step 6: Commit the transport boundary.**
+
+Apply the dirty-worktree protocol to the Task 3 files, then commit with `git commit -m "feat: add fail-closed duplex voice transport"`.
+
+## Task 4: Add native-live and rolling-window transcription behind one revision protocol
+
+**Files:**
+
+- Create: `tldw_chatbook/Audio/rolling_transcript.py`
+- Modify: `tldw_chatbook/Audio/dictation_service_lazy.py`
+- Test: `Tests/Audio/test_rolling_transcript.py`
+- Test: `Tests/Audio/test_dictation_lazy_transcription.py`
+- Test: `Tests/Audio/test_dictation_speech_resumed.py`
+
+- [ ] **Step 1: Write RED protocol and reconciliation tests.**
+
+```python
+@dataclass(frozen=True, slots=True)
+class TranscriptTiming:
+    capture_duration_ms: int = 0
+    provider_latency_ms: int = 0
+    processed_duration_ms: int = 0
+    duplicated_duration_ms: int = 0
+    usage_units: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptRevision:
+    turn_id: str
+    revision_id: int
+    stable_text: str
+    revisable_text: str
+    covered_through_ns: int
+    mode: Literal["live", "rolling-window"]
+    is_final: bool = False
+    failure_code: Literal["backend_failed", "fallback_failed"] | None = None
+    timing: TranscriptTiming = TranscriptTiming()
+```
+
+`TranscriptTiming` contains only capture duration, provider latency, processed duration, duplicated duration, and token/usage counts—never audio or text. Test monotonically increasing revisions, stable-prefix immutability, tail replacement, punctuation/case/whitespace as non-material, word edits as material, coverage tolerance, downstream acknowledgement through admitted-audio sequence, typed failure state, and content-free timing/usage metadata.
+
+For rolling fallback, use a controllably slow fake provider. Assert one batch job at a time, replacement of one obsolete queued window by the newest desired window, overlap reconciliation, no unbounded backlog, and content-free duplicated-duration accounting.
+
+- [ ] **Step 2: Run RED.**
+
+Run: `pytest -q Tests/Audio/test_rolling_transcript.py Tests/Audio/test_dictation_lazy_transcription.py Tests/Audio/test_dictation_speech_resumed.py`
+
+Expected: new protocol tests fail; existing dictation tests remain green.
+
+- [ ] **Step 3: Implement `TranscriptEngine` and adapters.**
+
+Native streaming adapters translate provider events directly. Rolling fallback maintains bounded admitted-audio rings, schedules overlapping windows during speech, and never retains a superseded pending request. Reconcile normalized timestamped tokens while preserving display punctuation from the newest hypothesis.
+
+Add only the smallest clean-frame/revision hook to `LazyLiveDictationService`; keep ordinary Mic dictation and its 60-second behavior unchanged. A backend failure may start exactly one configured fallback adapter attempt. If that attempt fails, publish a terminal failure revision, retain the latest transcript as an editable draft, and suspend automatic dispatch until fresh admitted speech or explicit manual retry. It must not remain indefinitely in `transcribing`.
+
+- [ ] **Step 4: Add freshness and seal behavior.**
+
+`fresh_for(speech_end_ns)` is true only when the revision covers the detected tail within declared frame tolerance. `seal_through(admitted_sequence)` waits until all revisions derived from downstream-acknowledged audio are incorporated. Slow STT keeps status `transcribing`; it never dispatches a truncated snapshot.
+
+- [ ] **Step 5: Run targeted tests.**
+
+Run: `pytest -q Tests/Audio/test_rolling_transcript.py Tests/Audio/test_dictation_lazy_transcription.py Tests/Audio/test_dictation_speech_resumed.py`
+
+Expected: all pass, including slow-fake starvation, one-in-flight, one-fallback-only, editable-draft, and suspended-dispatch assertions.
+
+- [ ] **Step 6: Commit rolling transcription.**
+
+Apply the dirty-worktree protocol to the Task 4 files, then commit with `git commit -m "feat: add rolling transcript revisions"`.
+
+## Task 5: Add sequential cancellable phrase speech through the duplex PCM path
+
+**Files:**
+
+- Create: `tldw_chatbook/Chat/voice_phrase_sequencer.py`
+- Modify: `tldw_chatbook/TTS/request_admission.py`
+- Modify: `tldw_chatbook/TTS/pcm_stream.py`
+- Test: `Tests/Chat/test_voice_phrase_sequencer.py`
+- Test: `Tests/TTS/test_tts_request_admission.py`
+- Test: `Tests/TTS/test_pcm_stream_plan.py`
+
+- [ ] **Step 1: Write RED phrase and cancellation tests.**
+
+Test punctuation-first emission; resolved-Markdown word/time fallback; no speech inside incomplete code fences, inline code, links, or list prefixes; exactly one synthesis in flight; FIFO PCM writes; attempt-epoch rejection; cancellation closing lazy byte streams; and WAV/PCM decode to the app transport.
+
+```python
+async def test_barge_in_aborts_active_audio_and_discards_queued_phrases() -> None:
+    sink = FakeDuplexAudioPort(block_on_write=True)
+    sequencer = PhraseSpeechSequencer(epoch=3, synthesizer=FakeTts(), sink=sink)
+    await sequencer.feed("First phrase. Second phrase.")
+    await sequencer.cancel(epoch=3)
+    assert sink.abort_count == 1
+    assert sequencer.pending_phrase_count == 0
+```
+
+- [ ] **Step 2: Run RED.**
+
+Run: `pytest -q Tests/Chat/test_voice_phrase_sequencer.py Tests/TTS/test_tts_request_admission.py Tests/TTS/test_pcm_stream_plan.py`
+
+Expected: new tests fail for the missing sequencer/PCM admission seam.
+
+- [ ] **Step 3: Implement the sequencer without changing legacy semantics.**
+
+Create a new sequencer; do not retrofit `reply_sentence_sequencer.py`. It accepts `(attempt_epoch, delta)`, maintains Markdown state, selects the earliest safe phrase, and allows one bounded fallback only after both a word threshold and a time threshold are reached. One worker drains phrases sequentially.
+
+- [ ] **Step 4: Add a hands-free PCM synthesis seam.**
+
+Extend `TTSRequestAdmissionCoordinator` with an explicit response-format override preferring raw PCM and falling back to WAV only when the adapter/catalog declares it. Drain and close `TTSAudioResponse.byte_stream` in the owner task. Decode WAV to normalized PCM before the duplex transport. If the selected adapter offers neither PCM nor WAV, text generation may finish but speech reports a recoverable failure; never invoke an OS media player.
+
+- [ ] **Step 5: Run targeted tests.**
+
+Run: `pytest -q Tests/Chat/test_voice_phrase_sequencer.py Tests/TTS/test_tts_request_admission.py Tests/TTS/test_pcm_stream_plan.py`
+
+Expected: all pass; the lazy-stream test proves bytes are actually consumed and closed.
+
+- [ ] **Step 6: Commit phrase speech.**
+
+Apply the dirty-worktree protocol to the Task 5 files, then commit with `git commit -m "feat: stream cancellable voice phrases"`.
+
+## Task 6: Fence provider attempts and enforce app-lifetime orphan quarantine
+
+**Files:**
+
+- Create: `tldw_chatbook/Chat/console_voice_attempts.py`
+- Create: `tldw_chatbook/Chat/console_voice_supervisor.py`
+- Modify: `tldw_chatbook/Chat/console_provider_gateway.py`
+- Modify: `tldw_chatbook/Chat/console_runtime.py`
+- Test: `Tests/Chat/test_console_voice_attempts.py`
+- Test: `Tests/Chat/test_console_voice_supervisor.py`
+
+- [ ] **Step 1: Write RED attempt-fencing and cleanup-race tests.**
+
+Cover immutable request snapshots, no ordinary store sink, inert tool-schema forwarding, complete tool-request capture without execution/approval, typed ordinary provider-failure events with no response-body/exception leakage, late-delta/usage/capture rejection after epoch advance, cooperative cancellation, two-second conservative transition, five-second force-close, 500 ms detach, at most two obsolete cleanups, and no content-bearing orphan retention.
+
+Test two simultaneous cleanup tasks independently becoming orphans. Assert the app-lifetime set contains both and all hands-free dispatch is rejected across hands-free exit/re-entry, provider change, and session reconstruction until every member exits. Typed provider dispatch must remain allowed.
+
+- [ ] **Step 2: Run RED.**
+
+Run: `pytest -q Tests/Chat/test_console_voice_attempts.py Tests/Chat/test_console_voice_supervisor.py`
+
+Expected: modules are missing.
+
+- [ ] **Step 3: Implement attempt-local generation and atomic epoch fencing.**
+
+`VoiceAttempt.start()` calls `ConsoleProviderGateway.stream_chat(..., tools=prepared.tools, signals=ConsoleProviderStreamSignals(exchange_capture_enabled=...))` directly, never through `AgentService` or an execution loop. Tool schemas are inert provider input. The attempt buffers the first complete native tool-request event and freezes further provisional speech, but it has no tool executor, approval hook, citation sink, or durable owner. It also owns response text, usage, sanitized in-memory exchange capture, TTS handles, and its force-closable provider transport. None of these objects can write conversation state.
+
+The first cancellation action is synchronous epoch invalidation. All callbacks check both the attempt-local fence and the coordinator's current epoch before publishing. A normal gateway exception is reduced to `ProviderAttemptFailed(attempt_epoch, error_class)` and handed to the coordinator; the attempt never logs/retains exception text that might contain request content and never converts it into cancellation-orphan handling unless its transport also fails to close.
+
+- [ ] **Step 4: Implement one app-lifetime supervisor.**
+
+Construct `VoiceDispatchSupervisor` from the app/runtime composition root, not the view. It owns a set of opaque cleanup handles capped by the two-obsolete-attempt limit. A nonempty set rejects every hands-free provider dispatch before provider/session resolution. Exiting hands-free, changing provider, rebuilding a session, or ending the logical turn never clears it. Automatic recovery occurs only when every orphan exits; app restart is the explicit last resort.
+
+- [ ] **Step 5: Run race tests repeatedly.**
+
+Run: `pytest -q Tests/Chat/test_console_voice_attempts.py Tests/Chat/test_console_voice_supervisor.py`
+
+Run: `pytest -q Tests/Chat/test_console_voice_attempts.py Tests/Chat/test_console_voice_supervisor.py --count=20`
+
+Expected: all runs pass. If `pytest-repeat` is not installed, use the repository's existing repeat mechanism or run the command in a short shell loop; do not add a runtime dependency.
+
+- [ ] **Step 6: Commit attempt lifecycle and supervisor.**
+
+Apply the dirty-worktree protocol to the Task 6 files, then commit with `git commit -m "feat: fence speculative voice attempts"`.
+
+## Task 7: Implement the serialized logical-turn coordinator
+
+**Files:**
+
+- Create: `tldw_chatbook/Chat/console_speculative_voice.py`
+- Test: `Tests/Chat/test_console_speculative_voice.py`
+- Test: `Tests/Chat/test_console_speculative_voice_properties.py`
+
+- [ ] **Step 1: Write a pure model-based RED suite.**
+
+Use an injected scheduler/clock and a serialized event mailbox. Cover:
+
+- first admitted frame creates one logical turn;
+- every admitted frame resets eagerness;
+- dispatch waits for nonempty, fresh tail coverage;
+- default 700 ms and bounded configured values;
+- speech during generation or playback fences the attempt, aborts audio, extends the same turn, and redispatches from accumulated text;
+- material STT changes restart, while case/punctuation/whitespace changes do not;
+- the first material correction fences immediately, starts a 120 ms correction-coalescing window, and a burst emits exactly one replacement from the latest snapshot; repeated corrections may extend the debounce but a 250 ms hard cap prevents starvation;
+- the first three attempts in a rolling ten seconds use configured eagerness, later attempts use 1.5 seconds;
+- two obsolete cleanups pause dispatch and two-second cleanup enters `serialized_conservative`;
+- conservative mode requires two seconds of quiet and zero obsolete attempts;
+- speech after the terminal audible boundary starts a new turn;
+- explicit Stop, Esc, mic toggle, hands-free exit, navigation, and teardown discard provisional work and preserve no history;
+- TTS failure can commit completed text only if no newer event exists.
+- a device-route change during generation or playback fences output immediately, retains the latest transcript, aborts the old transport, rebuilds one clock/AEC domain with admission closed, and regenerates only after the new route is healthy (or explicitly half duplex) plus a fresh silence interval;
+- an ordinary LLM/provider terminal failure retains the logical user transcript as an editable draft, emits no assistant/promotion, reopens listening for the same logical turn, and allows additional speech or explicit manual retry.
+
+Use Hypothesis state-machine tests to generate event permutations and assert: at most one current epoch, no old epoch emits output, no promotion with pending pre-boundary speech, and cancelled content never reaches a persistence fake.
+
+- [ ] **Step 2: Run RED.**
+
+Run: `pytest -q Tests/Chat/test_console_speculative_voice.py Tests/Chat/test_console_speculative_voice_properties.py`
+
+Expected: collection fails because the coordinator is absent.
+
+- [ ] **Step 3: Implement the mailbox and explicit state transitions.**
+
+```python
+class SpeculativeTurnCoordinator:
+    async def submit(self, event: VoiceEvent) -> None:
+        await self._mailbox.put(event)
+
+    async def _run(self) -> None:
+        while True:
+            event = await self._mailbox.get()
+            await self._reduce(event)
+```
+
+Timers enqueue events; they never mutate state directly. The reducer owns turn ID, attempt epoch, transcript snapshot, speech/render boundaries, audio clock generation, obsolete cleanup count, restart history, correction-coalescing start/deadline, and terminal status. Spoken-command classification precedes LLM dispatch. The first material correction synchronously advances the epoch and aborts output; subsequent material revisions inside the 120 ms window only replace the pending snapshot. Dispatch occurs once at the quiet/coalescing deadline, with a 250 ms maximum from the first correction.
+
+`DeviceRouteChanged` synchronously advances the epoch, aborts phrase/TTS/provider output, invalidates pending render/capture seals, retains the latest transcript/draft, and enters `rebuilding_audio`. The coordinator accepts no speculative dispatch until the transport publishes a new clock generation and AEC reports healthy or explicit half duplex; it then restarts the response-eagerness timer and regenerates from the retained exact snapshot. A rebuild failure leaves an editable draft and suspends speculation.
+
+`ProviderAttemptFailed` is distinct from cancellation cleanup failure. It fences the failed epoch, records only a content-free error class, retains the logical transcript as an editable draft, enters `listening_after_provider_failure`, and creates no assistant row, terminal receipt, capture promotion, or automatic retry. Fresh admitted speech extends the same logical turn and may dispatch after silence; manual Retry may reuse the exact draft; explicit exit discards it.
+
+- [ ] **Step 4: Implement the terminal render/capture/STT seal.**
+
+After final playback boundary `R`, request `drain_capture_through(R)`. Only after the input watermark is later than `R` and AEC/VAD acknowledges every sequence at or before it may the coordinator call `seal_through(admitted_sequence)`. The combined operation has a 500 ms deadline. Timeout, a sequence gap, device reset, or failed acknowledgement preserves an editable draft, suspends speculation, and requires a healthy duplex rebuild.
+
+In intentional half duplex, no playback-period capture is eligible; render completion closes the gated interval, and only manual interruption can extend that same turn during playback.
+
+- [ ] **Step 5: Run deterministic and property tests.**
+
+Run: `pytest -q Tests/Chat/test_console_speculative_voice.py Tests/Chat/test_console_speculative_voice_properties.py`
+
+Expected: all tests pass under the fake clock without wall-clock sleeps.
+
+- [ ] **Step 6: Commit the coordinator.**
+
+Apply the dirty-worktree protocol to the Task 7 files, then commit with `git commit -m "feat: coordinate speculative voice turns"`.
+
+## Task 8: Route effectful contexts through the ordinary accepted-turn pipeline
+
+**Files:**
+
+- Create: `tldw_chatbook/Chat/console_voice_eligibility.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `tldw_chatbook/Chat/console_speculative_voice.py`
+- Test: `Tests/Chat/test_console_voice_eligibility.py`
+- Test: `Tests/Chat/test_console_voice_effect_barrier.py`
+
+- [ ] **Step 1: Write RED eligibility and handoff tests.**
+
+Plain provider turns with a frozen system/conversation context are eligible, including turns whose prepared provider request contains tool schemas. Tool schemas are forwarded to the attempt-local gateway so the model may produce a tool request, but no executor or approval hook exists. Any turn requiring automatic Library/RAG retrieval, citation creation, or another pre-dispatch authority is ineligible for provisional execution; it waits for two seconds of stable silence and exact transcript freshness, then calls the ordinary accepted controller once.
+
+Assert that a complete first tool request freezes provisional speech, starts/continues the two-second stable-silence barrier, cannot execute or create an approval, and is discarded before ordinary re-dispatch. Speech before barrier expiry fences the attempt normally. Assert that navigation after handoff behaves according to ADR-094, while navigation before it cancels the view-scoped provisional turn.
+
+- [ ] **Step 2: Run RED.**
+
+Run: `pytest -q Tests/Chat/test_console_voice_eligibility.py Tests/Chat/test_console_voice_effect_barrier.py`
+
+Expected: tests fail for the missing classifier/handoff seam.
+
+- [ ] **Step 3: Add one public ordinary-turn handoff seam.**
+
+Add a narrow `submit_accepted_voice_turn(exact_user_text, frozen_session_context)` method to `ConsoleChatController`. It must enter the same preparation, tool/RAG, approvals, persistence, provider gateway, and navigation-surviving runtime path as typed Send. Do not duplicate accepted-turn preparation or call private controller internals from the voice coordinator.
+
+- [ ] **Step 4: Implement the two-second effect barrier.**
+
+The coordinator classifies only pre-dispatch-effect contexts before provisional dispatch. Those contexts show `waiting for stable turn`, never invoke the speculative generation gateway, and hand off exactly once after 2,000 ms of stable silence plus fresh transcript coverage.
+
+For tool-capable speculative attempts, the first complete provider tool request closes phrase input, freezes provisional speech, and waits until total stable silence since the latest admitted speech reaches 2,000 ms. The coordinator then fences/discards the attempt and its capture envelope and hands the exact immutable transcript to the ordinary accepted pipeline with its normal tool schemas, Capture On reservation, approvals, persistence, and runtime custody. The speculative tool request itself is never reused or executed.
+
+- [ ] **Step 5: Run the targeted effect-boundary tests.**
+
+Run: `pytest -q Tests/Chat/test_console_voice_eligibility.py Tests/Chat/test_console_voice_effect_barrier.py Tests/Chat/test_console_chat_controller.py`
+
+Expected: voice barrier and existing controller tests pass.
+
+- [ ] **Step 6: Commit the effect barrier.**
+
+Apply the dirty-worktree protocol to the Task 8 files, then commit with `git commit -m "feat: gate effectful voice turns"`.
+
+## Task 9: Promote only the winning no-tool attempt through ADR-094 and ADR-097
+
+**Blocked until:** the ADR-094 terminalization transaction and ADR-097 trace promotion service named in Preconditions are merged and available on this branch.
+
+**Files:**
+
+- Create: `tldw_chatbook/Chat/console_voice_promotion.py`
+- Modify: `tldw_chatbook/Chat/chat_persistence_service.py`
+- Modify: `tldw_chatbook/Chat/console_exchange_capture.py`
+- Modify: `tldw_chatbook/Chat/console_speculative_voice.py`
+- Test: `Tests/Chat/test_console_voice_promotion.py`
+- Test: `Tests/Chat/test_console_voice_capture.py`
+
+- [ ] **Step 1: Inspect and name the landed service interfaces before writing tests.**
+
+Replace generic names in this task with the actual ADR-094 and ADR-097 public methods. If either service is absent, stop this task and leave the rollout gate off; do not implement a substitute.
+
+- [ ] **Step 2: Write RED atomic-promotion and capture tests.**
+
+Test that one immutable winning snapshot atomically creates the user message, assistant message, terminal receipt, and exact unseen mark. Cancelled attempts, failed seals, and stale epochs create none. Retry/idempotency keys prevent duplicate promotion.
+
+With Capture On, promote only the winner's sanitized in-memory provider exchange after terminalization and label it `provisional_voice_promoted` with explicit post-dispatch provenance. Capture failure is best-effort and does not roll back the accepted conversation pair. Temporary chats never create durable capture, and saving one later does not synthesize a historical trace.
+
+- [ ] **Step 3: Run RED.**
+
+Run: `pytest -q Tests/Chat/test_console_voice_promotion.py Tests/Chat/test_console_voice_capture.py`
+
+Expected: adapter tests fail until the narrow promotion integration exists.
+
+- [ ] **Step 4: Implement adapters only.**
+
+`VoiceWinningPromotion` receives the exact winning prompt, completed assistant text, terminal boundary, attempt identity, content-free usage, and optional sanitized capture envelope. It delegates transaction ownership to ADR-094 and trace ownership to ADR-097. It never writes SQL directly and never calls ordinary streaming sinks.
+
+- [ ] **Step 5: Run persistence, receipt, and capture tests.**
+
+Run: `pytest -q Tests/Chat/test_console_voice_promotion.py Tests/Chat/test_console_voice_capture.py Tests/Chat/test_chat_persistence_service.py Tests/Chat/test_console_exchange_capture.py`
+
+Expected: all pass, including exact unseen-mark acknowledgement and temporary-chat cases.
+
+- [ ] **Step 6: Commit the promotion adapter.**
+
+Apply the dirty-worktree protocol to the Task 9 files, then commit with `git commit -m "feat: promote winning speculative voice turns"`.
+
+## Task 10: Wire view-scoped hands-free lifecycle and ephemeral preview rows
+
+**Files:**
+
+- Create: `tldw_chatbook/Widgets/Console/console_voice_preview.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/hands_free.py`
+- Modify: `tldw_chatbook/Widgets/Console/console_transcript.py`
+- Modify: `tldw_chatbook/Widgets/Console/console_speech_controls.py`
+- Test: `Tests/UI/test_console_speculative_voice_wiring.py`
+- Test: `Tests/UI/test_console_voice_preview.py`
+- Test: `Tests/UI/test_console_voice_accessibility.py`
+- Test: `Tests/UI/test_console_hands_free_wiring.py`
+
+- [ ] **Step 1: Write RED UI/lifecycle tests before mounting hardware.**
+
+Patch audio/native factories before creating the Textual app. Assert:
+
+- the qualification gate selects legacy `HandsFreeController` when false;
+- the development-qualified path constructs one view-scoped duplex engine/coordinator;
+- rolling user text and current assistant output appear as visually provisional rows that are not present in `ConsoleStore` or `ConsoleTranscript.set_messages()` input;
+- replacing an attempt removes only the old assistant preview;
+- winning promotion removes previews after durable rows arrive;
+- statuses distinguish listening, transcribing, responding, speaking, response update, AEC warming, half duplex, and cleanup quarantine;
+- Stop/Esc, mic toggle, hands-free exit, and screen navigation cancel previews and audio;
+- the app-lifetime orphan supervisor survives view teardown.
+- the separate Realtime engine, manual per-message **Speak** action, and accessibility announcement throttling retain their current construction and behavior.
+
+- [ ] **Step 2: Run RED.**
+
+Run: `pytest -q Tests/UI/test_console_speculative_voice_wiring.py Tests/UI/test_console_voice_preview.py Tests/UI/test_console_hands_free_wiring.py`
+
+Expected: missing preview/wiring tests fail; legacy hands-free tests stay green.
+
+- [ ] **Step 3: Mount a separate ephemeral preview widget.**
+
+`ConsoleVoicePreview` accepts a pure projection:
+
+```python
+@dataclass(frozen=True, slots=True)
+class VoicePreviewProjection:
+    turn_id: str
+    attempt_epoch: int
+    user_text: str
+    assistant_text: str
+    status: str
+```
+
+Mount it adjacent to the transcript's message region and style it as provisional. Do not fabricate `ConsoleChatMessage` IDs, call `set_messages`, or insert preview rows into durable transcript grouping/action logic.
+
+- [ ] **Step 4: Branch the existing controller wiring.**
+
+In `ConsoleHandsFreeController`, select the new pipeline only when the internal qualification gate is true. Reuse frozen provider/session selection but keep audio/coordinator resources view-scoped per ADR-094. Preserve the existing Realtime engine and legacy hands-free flow unchanged. Manual interruption must bypass acoustic admission and synchronously fence the active epoch before awaiting cleanup.
+
+- [ ] **Step 5: Run UI and legacy regressions.**
+
+Run: `pytest -q Tests/UI/test_console_speculative_voice_wiring.py Tests/UI/test_console_voice_preview.py Tests/UI/test_console_voice_accessibility.py Tests/UI/test_console_hands_free_wiring.py Tests/Chat/test_console_hands_free.py Tests/Chat/test_console_voice_input.py Tests/UI/test_console_speech_controls.py Tests/TTS/test_console_speech_snapshot_admission.py`
+
+Expected: all pass without touching real microphone, speaker, or native libraries; manual message speech remains snapshot-gated; and rapidly changing provisional text is announced at a bounded cadence rather than on every STT token.
+
+- [ ] **Step 6: Commit Console wiring.**
+
+Apply the dirty-worktree protocol to the Task 10 files, then commit with `git commit -m "feat: wire speculative Console voice previews"`.
+
+## Task 11: Add canonical settings, privacy-safe metrics, and honest documentation
+
+**Files:**
+
+- Create: `tldw_chatbook/Audio/voice_metrics.py`
+- Modify: `tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py`
+- Modify: `tldw_chatbook/Chat/console_voice_settings.py`
+- Modify: `tldw_chatbook/config.py`
+- Modify: `Docs/User_Guide/console/attachments-images-voice.md`
+- Modify: `Docs/User_Guide/console.md`
+- Create: `Docs/Development/TTS/speculative-duplex-voice.md`
+- Test: `Tests/Audio/test_voice_metrics.py`
+- Test: `Tests/UI/test_settings_speculative_voice_panel.py`
+- Test: `Tests/Chat/test_console_settings_defaults.py`
+
+- [ ] **Step 1: Write RED settings-ownership and content-privacy tests.**
+
+Test response-eagerness presets Fast 700/Balanced 1200/Deliberate 2000, valid numeric bounds 500-3000, invalid-value content-free warning plus fallback to 700, `pipeline_aec_enabled=true` by default, troubleshooting-only false→half-duplex behavior, and no config write merely from opening Settings.
+
+Assert `dictation.acoustic_barge_in` remains consumed only by Realtime compatibility code, and `dictation.handsfree_send_delay_seconds` remains legacy-only. No startup migration rewrites either key or infers eagerness from the old delay.
+
+Metrics tests must reject transcript text, response text, or PCM fields and retain only durations, counts, modes, health states, provider result class, and split winning/discarded usage.
+
+- [ ] **Step 2: Run RED.**
+
+Run: `pytest -q Tests/Audio/test_voice_metrics.py Tests/UI/test_settings_speculative_voice_panel.py Tests/Chat/test_console_settings_defaults.py`
+
+Expected: new settings and metrics assertions fail.
+
+- [ ] **Step 3: Add one canonical “Pipeline conversation” settings block.**
+
+Modify only the F9 Settings Speech & TTS panel. Show native-live versus rolling-window STT mode, overlapping-remote-audio cost disclosure, speculative-call cost disclosure, response eagerness, and the troubleshooting-only AEC disable. Explain that unhealthy/unavailable AEC automatically becomes half duplex. Do not show the development qualification gate.
+
+- [ ] **Step 4: Implement content-free metrics and diagnostics.**
+
+Record EOS→dispatch, barge→audible-stop, replacement dispatch, first audio, AEC state/ERLE aggregate, underruns, restarts, conservative-mode entry, duplicated STT audio duration, and winning/discarded usage. Logs may include turn/attempt opaque IDs but no transcript, response, audio, provider request body, or sanitized capture body.
+
+- [ ] **Step 5: Update user and developer docs.**
+
+Document same-turn interruption semantics, the 700 ms default and safe range, live/fallback STT modes, remote overlap cost, AEC warming/degraded half duplex, manual interruption, cancelled-attempt privacy, temporary-chat capture behavior, and the unchanged Realtime engine. Add a bounded compatibility note: old send-delay and acoustic-barge-in keys remain for legacy/Realtime and are not migrated.
+
+- [ ] **Step 6: Run targeted settings/docs tests.**
+
+Run: `pytest -q Tests/Audio/test_voice_metrics.py Tests/UI/test_settings_speculative_voice_panel.py Tests/Chat/test_console_settings_defaults.py Tests/UI/test_settings_speech_tts_panel.py Tests/Chat/test_console_voice_input.py`
+
+Expected: all pass; opening Settings leaves config bytes unchanged; the bounded compatibility note is present; and legacy delay plus Realtime acoustic behavior remains unchanged.
+
+- [ ] **Step 7: Commit settings, metrics, and documentation.**
+
+Apply the dirty-worktree protocol to the Task 11 files, then commit with `git commit -m "feat: expose qualified speculative voice settings"`.
+
+## Task 12A: Automate DSP, latency, lifecycle, and durable-owner qualification
+
+**Files:**
+
+- Create: `Tests/Audio/fixtures/voice_aec/manifest.json`
+- Create: `Tests/Audio/test_voice_aec_corpus.py`
+- Create: `Tests/integration/test_speculative_voice_pipeline.py`
+- Create: `Tests/Performance/test_speculative_voice_latency.py`
+- Create: `Tests/Packaging/test_voice_aec_installed_wheel.py`
+- Create: `Tests/Chat/test_console_voice_ephemerality.py`
+- Create: `Scripts/qualify_speculative_voice.py`
+- Create: `Packaging/compute_voice_source_digest.py`
+- Create: `Packaging/speculative_voice_source_paths.txt`
+- Create: `Docs/Development/TTS/speculative-voice-durable-owner-inventory.md`
+- Create: `Artifacts/voice_qualification/automated/.gitkeep`
+- Modify: `.github/workflows/voice-aec-wheels.yml`
+
+- [ ] **Step 1: Build a licensed, content-safe DSP corpus and RED qualification tests.**
+
+Use synthetic speech/noise plus redistributable fixtures with source/license/hash in the manifest; never use captured user audio. Cases include stationary/nonlinear echo, delay steps, clock drift, double-talk, underrun/overrun, device reset, and Bluetooth-like latency. Assert:
+
+- median ERLE at least 20 dB and p10 at least 10 dB on the reference corpus;
+- false acoustic barge-in no more than one per 30 minutes of rendered speech;
+- double-talk recall at least 95%;
+- any unqualified case closes admission and selects half duplex.
+
+- [ ] **Step 2: Add deterministic end-to-end and latency harnesses.**
+
+The integration path must consume the real lazy TTS byte stream, deliver rendered PCM through the duplex transport, feed synthetic echo plus user speech into capture, revise the rolling transcript, cancel a blocked provider/TTS attempt, and promote exactly one winner through test doubles for the landed ADR-094/097 services.
+
+Latency tests with warm deterministic fakes assert:
+
+- post-AEC EOS→LLM dispatch ≤850 ms p95;
+- speech detection→audible stop ≤150 ms p95;
+- post-AEC EOS of the added speech→replacement handoff ≤850 ms p95;
+- end of speech→first assistant audio ≤1.5 s median and ≤2.5 s p95.
+
+- [ ] **Step 3: Inventory and probe every default durable owner with sentinel content.**
+
+`speculative-voice-durable-owner-inventory.md` names the concrete owner, backing path/table, writer seam, and test probe for each of these surfaces: Console message/session DB, terminal receipts and unseen marks, ADR-097 traces/capture, provider usage rows, tool/approval state, citations, notifications, replay/trajectory state, chatbook/export serialization, temporary-chat memory and save-later behavior, persistent file logs, stdlib/loguru handlers, in-app log buffers/share-log output, and exception/crash diagnostics.
+
+`test_console_voice_ephemerality.py` runs cancelled attempts with unique user and assistant poison sentinels through the outermost Console voice wiring in an isolated app-data directory. It then inspects every inventory owner—not only mocks—including all SQLite database files/tables, trace/usage repositories, notification and approval repositories, replay/export serializers, temporary-chat stores, file logs, in-memory log views, and captured exception representations. The poison strings must be absent everywhere after cancellation; content-free attempt counts/usage may remain. A control write must prove each probe can detect its sentinel, so an empty or disconnected probe cannot pass.
+
+- [ ] **Step 4: Define the non-self-referential code-under-test identity.**
+
+`speculative_voice_source_paths.txt` explicitly lists every runtime, native source/build, dependency metadata, qualification harness/schema, packaging generator, and test file whose bytes affect the feature. `compute_voice_source_digest.py` sorts those paths and hashes the canonical sequence `relative-path NUL file-sha256 LF`. It fails if a listed path is missing, untracked, or dirty.
+
+Generated evidence and authority are deliberately outside the digest: `Artifacts/voice_qualification/**`, `Docs/Development/TTS/speculative-voice-qualification.md`, `tldw_chatbook/Audio/voice_qualification_manifest.json`, `tldw_chatbook/Audio/voice_build_identity.json`, SBOMs, attestations, signatures, caches, and `.git`. Tests prove changing included code changes the digest, while adding an evidence report or regenerating the manifest does not. Reports use `source_tree_digest`; git revision is optional provenance only and never an acceptance key.
+
+- [ ] **Step 5: Run deterministic qualification locally as a non-authoritative harness check.**
+
+Run: `.venv/bin/python -m pytest -q Tests/Audio/test_voice_aec_corpus.py Tests/integration/test_speculative_voice_pipeline.py Tests/Performance/test_speculative_voice_latency.py Tests/Packaging/test_voice_aec_installed_wheel.py Tests/Chat/test_console_voice_ephemerality.py`
+
+Expected: all automated gates pass after confirming that `.venv/bin/python` has the intended `webrtcvad`, `sounddevice`, and companion wheel. `Scripts/qualify_speculative_voice.py --scenario automated --source-tree-digest $(.venv/bin/python Packaging/compute_voice_source_digest.py) --output /tmp/speculative-voice-automated.json` writes schema version, source-tree digest, optional git provenance, interpreter, companion version/upstream commit/wheel SHA-256, corpus thresholds, latency distributions using the correct clock boundaries, lifecycle results, and durable-owner inventory/report hashes. It contains no transcript, response, audio, raw device name, or credential. This `/tmp` report only validates the harness; Task 12C regenerates authoritative evidence after all qualification/runtime code is committed.
+
+- [ ] **Step 6: Run bounded native and lifecycle harness checks.**
+
+Run: `.venv/bin/python Scripts/qualify_speculative_voice.py --scenario duplex-soak --minutes 30 --output Artifacts/voice_qualification/automated/<platform>-duplex-soak.json`
+
+Run: `.venv/bin/python Scripts/qualify_speculative_voice.py --scenario cancellation-soak --minutes 30 --output Artifacts/voice_qualification/automated/<platform>-cancellation-soak.json`
+
+Expected: no unbounded task/process growth, no audio ring growth, no orphan-set size above two, no post-fence callback, no device-handle leak, and no content-bearing diagnostic output. Include at least one real native-process fixture because injected mocks cannot prove process reaping.
+
+- [ ] **Step 7: Commit automated qualification separately.**
+
+Apply the dirty-worktree protocol to the Task 12A files, then commit with `git commit -m "test: qualify speculative voice automation"`.
+
+## Task 12B: Build the three-platform physical-device qualification harness
+
+**Files:**
+
+- Create: `Scripts/qualify_physical_voice.py`
+- Create: `Packaging/voice_physical_report.schema.json`
+- Create: `Artifacts/voice_qualification/physical/.gitkeep`
+- Create: `Docs/Development/TTS/speculative-voice-qualification.md`
+- Test: `Tests/Packaging/test_voice_physical_reports.py`
+
+- [ ] **Step 1: Write RED schema and safety tests.**
+
+The report schema requires source-tree digest, platform/architecture, app and companion versions, upstream commit, generated corpus/latency/soak report hashes, hashed device identity, transport/sample-rate information, AEC health path, ERLE distribution, false-barge rate, double-talk recall, stop latency, degradation behavior, operator checklist, and pass/fail. It rejects raw device names, transcript/response text, PCM, and `passed=true` when any automated prerequisite hash is missing, uses a different source-tree digest, or a full-duplex safety threshold fails.
+
+- [ ] **Step 2: Implement the guided physical harness.**
+
+`qualify_physical_voice.py` guides repeatable rendered-speech, double-talk, interruption, silence, device-switch, and 30-minute soak trials. It hashes device identifiers with a report-local salt, never records microphone or response content, and emits a schema-valid JSON report plus a human-readable summary. A failed or unavailable AEC path is passing only when playback-period speech admission is observably closed and manual interruption remains available.
+
+- [ ] **Step 3: Validate the harness with synthetic pass/fail fixtures.**
+
+Run the harness in `--fixture` mode against a checked-in synthetic safe-full-duplex case, safe-half-duplex case, and unsafe-unsuppressed case. Only the first two validate as passing. Do not record final physical evidence yet; Task 12C runs the real matrix after all source-digested qualification/runtime code is committed.
+
+The final command shape is: `<absolute-python> Scripts/qualify_physical_voice.py --source-tree-digest <digest> --platform <platform-arch> --device-class <builtin|usb|bluetooth> --automated-report <path> --output Artifacts/voice_qualification/physical/<platform-arch>-<device-class>.json`.
+
+Bluetooth passes only if healthy full duplex meets the thresholds or explicit safe half duplex closes playback-period admission; unsuppressed interruption is a failure.
+
+- [ ] **Step 4: Validate and commit the harness.**
+
+Run: `pytest -q Tests/Packaging/test_voice_physical_reports.py`
+
+Expected: schema and synthetic harness tests pass with no privacy-forbidden fields. Apply the dirty-worktree protocol and commit with `git commit -m "test: add speculative voice device qualification harness"`.
+
+## Task 12C: Generate the rollout capability manifest and enable only qualified platforms
+
+**Files:**
+
+- Create: `Packaging/voice_qualification_manifest.schema.json`
+- Create: `Packaging/generate_voice_qualification_manifest.py`
+- Create: `Packaging/speculative_voice_python_paths.txt`
+- Create: `tldw_chatbook/Audio/voice_qualification_manifest.json`
+- Create: `tldw_chatbook/Audio/voice_build_identity.json`
+- Modify: `tldw_chatbook/Chat/console_voice_settings.py`
+- Modify: `pyproject.toml`
+- Modify: `.github/workflows/release-voice-aec.yml`
+- Test: `Tests/Packaging/test_voice_qualification_manifest.py`
+- Test: `Tests/Packaging/test_speculative_voice_lint_scope.py`
+- Test: `Tests/Chat/test_console_voice_settings.py`
+
+- [ ] **Step 1: Write RED manifest-generation and fail-closed runtime tests.**
+
+Schema version 1 requires exact app/AEC identity and the platform keys `macos-arm64`, `macos-x86_64`, `windows-x86_64`, `linux-x86_64`, and `linux-aarch64`. Hash fields use the JSON Schema constraint `{"type": "string", "pattern": "^[0-9a-f]{64}$"}`. Its logical shape is:
+
+```json
+{
+  "schema_version": 1,
+  "pipeline_version": 1,
+  "app_version": "0.1.8.0",
+  "source_tree_digest": "64-character lowercase SHA-256 constrained by schema",
+  "aec_package": {
+    "name": "tldw-voice-aec",
+    "version": "0.1.8.0",
+    "upstream_commit": "109e23c9cec3a44e67c08774874a409741b1e58a"
+  },
+  "platforms": {
+    "macos-arm64": {
+      "qualified": true,
+      "wheel_sha256": "64-character lowercase SHA-256 constrained by schema",
+      "extension_sha256": "64-character lowercase SHA-256 constrained by schema",
+      "automated_report_sha256": "64-character lowercase SHA-256 constrained by schema",
+      "physical_report_sha256": "64-character lowercase SHA-256 constrained by schema"
+    }
+  }
+}
+```
+
+The prose strings above illustrate field meaning; the checked-in manifest must contain concrete schema-valid hashes. Tests prove the generator refuses a missing target platform, device class, report hash, failed threshold, version/commit mismatch, mixed source-tree digest, source-tree digest unequal to the computed included-source digest, unknown field, or privacy-forbidden evidence. Runtime selection returns false on missing/malformed manifest, manifest/build-identity digest mismatch, unknown platform, `qualified=false`, companion import/version/commit mismatch, or installed native-extension file hash mismatch. Environment variables, config values, and CLI arguments cannot override the result.
+
+- [ ] **Step 2: Implement the deterministic evidence generator.**
+
+`generate_voice_qualification_manifest.py` consumes an explicit `--source-tree-digest`, exact repaired-wheel paths, Task 12A automated/soak reports, and all Task 12B physical reports. It first recomputes the included-source digest and requires every report to use it. It validates report schemas/hashes, requires built-in/USB/Bluetooth evidence for every declared platform key, records the wheel SHA-256, extracts and hashes the platform extension binary for runtime verification, and emits sorted canonical JSON plus `voice_build_identity.json`. It does not accept a manual `--qualified` flag.
+
+The final generation command in Step 6 is: `.venv/bin/python Packaging/generate_voice_qualification_manifest.py --source-tree-digest "$voice_source_digest" --app-version 0.1.8.0 --aec-upstream 109e23c9cec3a44e67c08774874a409741b1e58a --wheelhouse <qualified-wheelhouse> --automated-dir Artifacts/voice_qualification/automated --physical-dir Artifacts/voice_qualification/physical --output tldw_chatbook/Audio/voice_qualification_manifest.json --build-identity-output tldw_chatbook/Audio/voice_build_identity.json`.
+
+Expected: generation succeeds only when all evidence is present and passing; the output is byte-identical on a second run.
+
+- [ ] **Step 3: Implement fail-closed runtime lookup and package the manifest.**
+
+`speculative_voice_qualified()` maps the current OS/architecture to one manifest key, requires the packaged build-identity digest to equal the manifest digest, validates schema/app/pipeline/companion version and upstream commit, hashes the installed native-extension file and compares it with `extension_sha256`, and returns that platform's `qualified` value. Any exception returns false with a content-free warning. `pyproject.toml` includes both JSON files as package data. `pipeline_aec_enabled=false` remains a local half-duplex troubleshooting switch; it does not bypass qualification.
+
+- [ ] **Step 4: Commit all qualification/runtime code before producing final evidence.**
+
+Commit the schema, source-digest tool/list, evidence generators, physical harness, runtime reader, tests, workflow logic, and a checked-in hard-off manifest/build identity with no qualified platforms. No product or qualification code may change after this commit without invalidating and rerunning every Task 12A/12B report.
+
+- [ ] **Step 5: Compute one clean source-tree digest and generate final evidence.**
+
+Require a clean status for every path in `speculative_voice_source_paths.txt`, then run: `voice_source_digest=$(.venv/bin/python Packaging/compute_voice_source_digest.py)`.
+
+Using exactly that digest and source commit, rerun Task 12A automated, duplex-soak, cancellation-soak, and durable-owner probes for every platform/architecture. Then, on macOS, Windows, and Linux, run Task 12B for built-in, USB, and Bluetooth device classes with `--source-tree-digest "$voice_source_digest"`. Bluetooth passes only if healthy full duplex meets thresholds or safe half duplex closes playback-period admission. Store final schema-valid reports under `Artifacts/voice_qualification/{automated,physical}` and record their hashes in `Docs/Development/TTS/speculative-voice-qualification.md`.
+
+- [ ] **Step 6: Generate the manifest and prove the evidence chain is stable.**
+
+Run the Step 2 generation command with `--source-tree-digest "$voice_source_digest"`. Re-run `compute_voice_source_digest.py` before and after staging the generated evidence, qualification docs, manifest, and build identity; both outputs must equal `$voice_source_digest`. This is possible because only generated evidence/authority paths are excluded—the code that produced and consumes them is included and was committed before measurement.
+
+- [ ] **Step 7: Make the release workflow regenerate and compare authority.**
+
+The approval-gated release workflow downloads the exact qualified wheel/evidence artifacts, recomputes the included-source digest, requires it to match every report and the packaged build identity, regenerates the manifest, fails unless it matches the reviewed checked-in file byte-for-byte, installs the built app wheel in a clean environment, and runs `test_voice_qualification_manifest.py` against every supported platform key before publishing the app. Git commit IDs remain provenance only. A missing/unqualified platform keeps legacy hands-free on that platform.
+
+- [ ] **Step 8: Run final targeted verification and complete static checks.**
+
+Run: `pytest -q Tests/Audio/test_duplex_contracts.py Tests/Audio/test_aec_backend.py Tests/Audio/test_duplex_transport.py Tests/Audio/test_voice_preprocessor.py Tests/Audio/test_rolling_transcript.py Tests/Audio/test_voice_aec_corpus.py Tests/Chat/test_voice_phrase_sequencer.py Tests/Chat/test_console_voice_attempts.py Tests/Chat/test_console_voice_supervisor.py Tests/Chat/test_console_speculative_voice.py Tests/Chat/test_console_speculative_voice_properties.py Tests/Chat/test_console_voice_eligibility.py Tests/Chat/test_console_voice_effect_barrier.py Tests/Chat/test_console_voice_promotion.py Tests/Chat/test_console_voice_capture.py Tests/Chat/test_console_voice_ephemerality.py Tests/UI/test_console_speculative_voice_wiring.py Tests/UI/test_console_voice_preview.py Tests/UI/test_console_voice_accessibility.py Tests/UI/test_settings_speculative_voice_panel.py Tests/integration/test_speculative_voice_pipeline.py Tests/Performance/test_speculative_voice_latency.py Tests/Packaging/test_voice_aec_distribution.py Tests/Packaging/test_voice_aec_installed_wheel.py Tests/Packaging/test_voice_physical_reports.py Tests/Packaging/test_voice_qualification_manifest.py Tests/Packaging/test_speculative_voice_lint_scope.py`
+
+`Packaging/speculative_voice_python_paths.txt` lists every Python file created or modified by Tasks 1-12, including Audio, Chat, TTS, provider gateway, runtime, controller, persistence/capture, UI/Widgets, config, native wrapper, packaging scripts, and tests. Run: `xargs ruff check < Packaging/speculative_voice_python_paths.txt`
+
+Run: `xargs ruff format --check < Packaging/speculative_voice_python_paths.txt`
+
+Run: `clang-format --dry-run --Werror native/voice_aec/src/bindings.cpp`
+
+Run: `git diff --check`
+
+Expected: targeted tests, Python/C++ formatting, lint, and whitespace checks pass. The lint-scope test compares the implementation plan's Python file inventory with `speculative_voice_python_paths.txt` so no modified Python path is omitted. Per repository policy, ask the user before running the full `pytest` suite; do not treat targeted success as full-suite evidence.
+
+- [ ] **Step 9: Commit rollout evidence and authority separately.**
+
+Apply the dirty-worktree protocol to generated Task 12 evidence, qualification documentation, manifest, and build identity only; inspect hashes explicitly and prove the source-tree digest remains unchanged. Then commit with `git commit -m "feat: enable qualified speculative voice platforms"`.
+
+## Implementation completion checklist
+
+- [ ] Every implementation Backlog task links the design and ADR, has checked acceptance criteria, implementation notes, targeted verification evidence, and the correct status.
+- [ ] ADR-094 and ADR-097 prerequisite interfaces were reused, not reimplemented.
+- [ ] Cancelled attempts have no durable content, effects, citations, approvals, replay, or content-bearing diagnostics.
+- [ ] Every hands-free TTS path renders through app-owned PCM with a timestamped AEC reference.
+- [ ] The orphan set is app-lifetime, bounded at two, and globally quarantines hands-free dispatch until empty.
+- [ ] The 500 ms render-boundary capture/VAD/STT seal fails closed.
+- [ ] Native-live and rolling-window STT both pass freshness/revision tests.
+- [ ] Settings ownership and no-write migration behavior are verified.
+- [ ] All three desktop platforms pass packaging and physical-device qualification, or the rollout gate remains off on the unqualified platform.
+- [ ] User approval was obtained before any full-suite test run.

--- a/Docs/superpowers/plans/2026-08-28-personal-context-01-core-chatbook-local.md
+++ b/Docs/superpowers/plans/2026-08-28-personal-context-01-core-chatbook-local.md
@@ -1,0 +1,908 @@
+# Personal Context 01 — Shared Core and Chatbook Local Profile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a complete encrypted local-only Personal Context Profile in Chatbook, including manual Settings management and immutable read-only Console context.
+
+**Architecture:** A standalone `tldw-profile-core` package defines immutable canonical models, JSON Schema, fixtures, and deterministic serialization. Chatbook stores encrypted object versions in a dedicated SQLite database behind one `PersonalContextService`; the canonical Settings Screen and Console context builder consume that service.
+
+**Tech Stack:** Python 3.11+, Pydantic 2, SQLite, `cryptography` AESGCM, keyring, scrypt, HMAC-SHA-256, Textual 8.x, pytest, Hypothesis.
+
+**Spec:** `Docs/superpowers/specs/2026-08-28-unified-personal-context-profile-design.md`
+
+## ADR check
+
+```text
+ADR required: yes
+ADR path: backlog/decisions/099-personal-context-profile-authority-sync-and-encryption.md
+Reason: This plan creates the shared schema, encrypted Chatbook authority,
+key-custody boundary, and long-lived Settings/runtime integration.
+```
+
+## Global Constraints
+
+- Read the suite index and its Global Constraints before starting.
+- This plan delivers local-only behavior. Do not add server calls or Sync
+  envelopes here.
+- ADR-099 is created and accepted before production code begins.
+- Shared Core contains no database, HTTP, provider, UI, key-custody, or runtime
+  policy code.
+- Chatbook uses a dedicated database resolved beneath its profile data
+  directory; do not add tables to `ChaChaNotes_DB` or values to TOML.
+- One Chatbook installation owns at most one human Personal Context Profile.
+  Personas, characters, login identities, and workspaces never create another.
+- AES-256-GCM nonces are random 96-bit values and never reused under one DEK.
+- The OS keyring is preferred; passphrase-wrapped storage uses scrypt; there is
+  no plaintext fallback.
+- Context includes only active, unexpired, agent-visible global plus mapped
+  active-workspace records and stays within the lesser of 12 KiB UTF-8 or 10%
+  of available model input.
+- The current explicit user request always outranks profile context.
+- Targeted tests are mandatory; request permission before a local full suite.
+
+---
+
+### Task 1: Record ADR-099 before implementation
+
+**Files:**
+- Create: `backlog/decisions/099-personal-context-profile-authority-sync-and-encryption.md`
+- Modify: `backlog/decisions/README.md`
+- Modify: `Docs/superpowers/specs/2026-08-28-unified-personal-context-profile-design.md` only if the ADR number changes
+- Modify: `Docs/superpowers/plans/2026-08-28-personal-context-implementation-index.md` only if the ADR number changes
+
+**Interfaces:**
+- Consumes: approved design specification.
+- Produces: accepted architectural authority referenced by every implementation task.
+
+- [ ] **Step 1: Recheck the ADR number across current refs and open PRs**
+
+Run:
+
+```bash
+rg --files backlog/decisions | sort | tail -n 20
+git for-each-ref --format='%(refname)' refs/remotes/ | while read -r ref_name; do
+  git ls-tree -r -z --name-only "$ref_name" backlog/decisions/ | tr '\0' '\n'
+done | rg '/099-' || true
+gh pr list --state open --json number,title,files | rg 'backlog/decisions/099-' || true
+```
+
+Expected: no existing or in-flight ADR-099. If occupied, select the next unused
+number, rename every planned path, and rerun this exact check for the new number.
+
+- [ ] **Step 2: Write the decision record**
+
+The ADR must contain these exact decisions, expanded with context and rejected
+alternatives from the spec:
+
+```markdown
+# ADR-099: Unify encrypted Personal Context Profile authority across Chatbook and tldw_server
+
+Status: Accepted
+Date: 2026-08-28
+
+## Decision
+
+Chatbook and tldw_server are peer replicas of one canonical Personal Context
+Profile contract published by `tldw-profile-core`. Chatbook is local-first;
+tldw_server is the single V1 home peer. Each runtime owns one encrypted
+repository and one mutation service. Sync V2 transports canonical whole
+objects and never application-specific projections.
+
+Profile records use global or random canonical workspace scopes, separate
+proposal and conflict objects, per-record syncability and agent visibility,
+runtime-local agent grants, server-trusted Sync payloads over TLS, per-version
+envelope encryption at rest, keyed integrity tags, and a purge-generation
+barrier. Personas, auth identity, Companion goals, and Persona/session memory
+remain separate authorities.
+```
+
+Required ADR sections: Context, Decision, Alternatives considered,
+Consequences, Security/privacy consequences, Migration/rollback, and Links.
+
+- [ ] **Step 3: Verify references and formatting**
+
+Run:
+
+```bash
+rg -n 'ADR[- ]099|099-personal-context-profile-authority-sync-and-encryption' \
+  backlog/decisions/099-personal-context-profile-authority-sync-and-encryption.md \
+  backlog/decisions/README.md \
+  Docs/superpowers/specs/2026-08-28-unified-personal-context-profile-design.md \
+  Docs/superpowers/plans/2026-08-28-personal-context-*.md
+git diff --check -- backlog/decisions Docs/superpowers
+```
+
+Expected: every reference uses the final number and `git diff --check` is clean.
+
+- [ ] **Step 4: Commit the ADR**
+
+```bash
+git add backlog/decisions/099-personal-context-profile-authority-sync-and-encryption.md \
+  backlog/decisions/README.md \
+  Docs/superpowers/specs/2026-08-28-unified-personal-context-profile-design.md \
+  Docs/superpowers/plans/2026-08-28-personal-context-implementation-index.md
+git diff --cached --check
+git commit -m "docs: record personal context authority"
+```
+
+Stage the spec/index only when renumbering changed them.
+
+---
+
+### Task 2: Publish Shared Profile Core v0.1
+
+**Files (`tldw-profile-core` repository):**
+- Create: `pyproject.toml`
+- Create: `src/tldw_profile_core/__init__.py`
+- Create: `src/tldw_profile_core/enums.py`
+- Create: `src/tldw_profile_core/payloads.py`
+- Create: `src/tldw_profile_core/models.py`
+- Create: `src/tldw_profile_core/canonical.py`
+- Create: `src/tldw_profile_core/interview.py`
+- Create: `src/tldw_profile_core/tool_contracts.py`
+- Create: `src/tldw_profile_core/schema_export.py`
+- Create: `schemas/personal-context-v1.json`
+- Create: `fixtures/v1/*.json`
+- Create: `tests/test_models.py`
+- Create: `tests/test_canonical.py`
+- Create: `tests/test_schema_fixtures.py`
+
+**Interfaces:**
+- Consumes: ADR-099 and the approved spec.
+- Produces:
+  - `SERIALIZED_SCHEMA_VERSION = 1`
+  - `ProfileManifest`, `ProfileScope`, `ProfileRecord`, `ProfileProposal`
+  - `RecordKind` including `legacy_unclassified`, `RecordState`, `ScopeKind`,
+    `SyncMode`, `AgentVisibility`, `ProposalState`, `ProposalOperation`
+  - `ProfileControls`, `ProfileProvenance`, `SemanticKey`
+  - `InterviewPack`, `InterviewQuestion`, `InterviewTurn`, `InterviewProposalBatch`
+  - `ProfileSearchRequest`, `ProfileGetRequest`, `ProfileProposeRequest`,
+    `ProfileUpdateRequest`, `ProfilePromoteRequest`, `ProfileToolResult`
+  - `canonical_bytes(value: BaseModel) -> bytes`
+  - `integrity_tag(value: BaseModel, key: bytes) -> str`
+  - `export_json_schema(path: Path) -> None`
+
+- [ ] **Step 1: Write failing model and canonicalization tests**
+
+```python
+# tests/test_canonical.py
+from datetime import UTC, datetime
+
+from tldw_profile_core import (
+    AgentVisibility,
+    PreferencePayload,
+    ProfileControls,
+    ProfileProvenance,
+    ProfileRecord,
+    RecordKind,
+    RecordState,
+    SemanticKey,
+    SyncMode,
+    canonical_bytes,
+    integrity_tag,
+)
+
+
+def preference(record_id: str = "11111111-1111-4111-8111-111111111111") -> ProfileRecord:
+    now = datetime(2026, 8, 28, tzinfo=UTC)
+    return ProfileRecord(
+        profile_id="22222222-2222-4222-8222-222222222222",
+        record_id=record_id,
+        scope_id="33333333-3333-4333-8333-333333333333",
+        kind=RecordKind.PREFERENCE,
+        payload=PreferencePayload(subject="response.detail", polarity="like", value="concise"),
+        semantic_key=SemanticKey(namespace="preference", subject="response.detail"),
+        state=RecordState.ACTIVE,
+        controls=ProfileControls(sync_mode=SyncMode.SYNCABLE, agent_visibility=AgentVisibility.AGENT_VISIBLE),
+        provenance=ProfileProvenance(source="manual", actor="user", reason_code="settings_edit"),
+        version_id="44444444-4444-4444-8444-444444444444",
+        parent_version_id=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_canonical_bytes_are_stable_and_whitespace_free():
+    value = canonical_bytes(preference())
+    assert value == canonical_bytes(ProfileRecord.model_validate_json(value))
+    assert b"\n" not in value and b": " not in value
+
+
+def test_integrity_tag_is_keyed_and_versioned():
+    record = preference()
+    assert integrity_tag(record, b"a" * 32).startswith("hmac-sha256-v1:")
+    assert integrity_tag(record, b"a" * 32) != integrity_tag(record, b"b" * 32)
+
+
+def test_same_scope_semantic_key_is_structured_not_free_text():
+    key = preference().semantic_key
+    assert key == SemanticKey(namespace="preference", subject="response.detail")
+```
+
+Add tests that reject unknown fields, invalid lifecycle values, working context
+without `expires_at` or `no_expiry=True`, confidence on `ProfileRecord`, payloads
+over 16 KiB canonical bytes, proposal operations without a target/base pair,
+interview packs with more than 20 questions or compound question text, and tool
+requests that attempt privacy-control, delete, purge, or cross-workspace changes.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_models.py tests/test_canonical.py tests/test_schema_fixtures.py -v`
+
+Expected: collection fails because `tldw_profile_core` does not exist.
+
+- [ ] **Step 3: Implement the immutable contract and canonical serializer**
+
+```python
+# src/tldw_profile_core/canonical.py
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+from pydantic import BaseModel
+
+
+def canonical_bytes(value: BaseModel) -> bytes:
+    payload = value.model_dump(mode="json", exclude_none=False, by_alias=True)
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def integrity_tag(value: BaseModel, key: bytes) -> str:
+    if len(key) != 32:
+        raise ValueError("integrity key must be exactly 32 bytes")
+    digest = hmac.new(key, canonical_bytes(value), hashlib.sha256).hexdigest()
+    return f"hmac-sha256-v1:{digest}"
+```
+
+```python
+# src/tldw_profile_core/models.py (public shape)
+class ProfileRecord(FrozenModel):
+    schema_version: Literal[1] = 1
+    profile_id: str
+    record_id: str
+    scope_id: str
+    kind: RecordKind
+    payload: ProfilePayload
+    semantic_key: SemanticKey | None = None
+    state: RecordState
+    controls: ProfileControls
+    provenance: ProfileProvenance
+    version_id: str
+    parent_version_id: str | None
+    created_at: datetime
+    updated_at: datetime
+    expires_at: datetime | None = None
+    no_expiry: bool = False
+
+
+class ProfileProposal(FrozenModel):
+    schema_version: Literal[1] = 1
+    proposal_id: str
+    profile_id: str
+    scope_id: str
+    operation: ProposalOperation
+    target_record_id: str | None
+    base_version_id: str | None
+    proposed_record: ProfileRecord | None
+    provenance: ProfileProvenance
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    state: ProposalState = ProposalState.PENDING
+    created_at: datetime
+    expires_at: datetime
+```
+
+Use `ConfigDict(extra="forbid", frozen=True)`. Define discriminated typed
+payloads for every initial kind and validators for immutable kind, payload/kind
+agreement, working-context expiry, proposal target/base requirements, and the
+16 KiB canonical payload ceiling. Export JSON Schema deterministically and check
+in v1 positive/negative fixtures.
+
+- [ ] **Step 4: Run unit, property, and schema conformance tests**
+
+Run: `pytest -q tests`
+
+Expected: all Shared Core tests pass and regenerating
+`schemas/personal-context-v1.json` produces no diff.
+
+- [ ] **Step 5: Build and inspect the package artifact**
+
+Run:
+
+```bash
+python -m build
+python -m zipfile -l dist/tldw_profile_core-0.1.0-py3-none-any.whl | rg 'schemas|fixtures|tldw_profile_core'
+```
+
+Expected: the wheel contains package modules plus JSON Schema and fixtures; it
+contains no application, database, HTTP, provider, UI, or key-custody module.
+
+- [ ] **Step 6: Commit and publish the pinned artifact**
+
+```bash
+git add pyproject.toml src schemas fixtures tests
+git diff --cached --check
+git commit -m "feat: publish personal context core v0.1"
+```
+
+Publish through the project’s normal package channel, record the immutable
+version/hash, then pin that release in Chatbook before Task 3.
+
+---
+
+### Task 3: Add encrypted Chatbook repository and key protection
+
+**Files:**
+- Modify: `pyproject.toml`
+- Create: `tldw_chatbook/Personal_Context/__init__.py`
+- Create: `tldw_chatbook/Personal_Context/crypto.py`
+- Create: `tldw_chatbook/Personal_Context/key_protector.py`
+- Create: `tldw_chatbook/Personal_Context/repository.py`
+- Create: `tldw_chatbook/Personal_Context/repository_models.py`
+- Create: `tldw_chatbook/Personal_Context/paths.py`
+- Test: `Tests/Personal_Context/test_crypto.py`
+- Test: `Tests/Personal_Context/test_key_protector.py`
+- Test: `Tests/Personal_Context/test_repository.py`
+- Test: `Tests/Personal_Context/test_repository_plaintext_canary.py`
+
+**Interfaces:**
+- Consumes: Shared Core v0.1 canonical models and bytes.
+- Produces:
+  - `ProfileKeyMaterial(encryption_key, integrity_key, key_version)`
+  - `ProfileKeyProtector.load_or_create(profile_ref: str) -> ProfileKeyMaterial`
+  - `ProfileKeyProtector.delete(profile_ref: str) -> None`
+  - `EnvelopeCipher.encrypt(plaintext: bytes, aad: bytes) -> EncryptedEnvelope`
+  - `EnvelopeCipher.decrypt(envelope: EncryptedEnvelope, aad: bytes) -> bytes`
+  - `PersonalContextRepository.create_provisional_profile() -> ProfileManifest`
+  - `get_manifest()`, `list_records()`, `get_record()`, `commit_record_version()`
+  - `commit_proposal()`, `list_proposals()`, `resolve_proposal()`
+  - `destroy_profile_content()`, `quarantine_object()`
+
+- [ ] **Step 1: Write failing crypto and repository tests**
+
+```python
+# Tests/Personal_Context/test_repository_plaintext_canary.py
+from pathlib import Path
+
+from tldw_chatbook.Personal_Context.repository import PersonalContextRepository
+
+
+def test_record_text_never_appears_in_database_or_wal(tmp_path: Path, profile_record, memory_protector):
+    canary = "PROFILE-CANARY-DO-NOT-PERSIST-PLAINTEXT-8c58f6"
+    record = profile_record(payload_value=canary)
+    db_path = tmp_path / "personal-context.db"
+    repo = PersonalContextRepository(db_path, key_protector=memory_protector)
+    repo.create_provisional_profile()
+    repo.commit_record_version(record, expected_version_id=None)
+    repo.close()
+
+    durable = b"".join(path.read_bytes() for path in tmp_path.iterdir() if path.is_file())
+    assert canary.encode() not in durable
+```
+
+Add tests for unique nonces, AAD mismatch, keyed integrity mismatch,
+one-profile-per-install enforcement, keyring-unavailable locked state,
+passphrase round-trip, no plaintext fallback, transaction rollback, immutable
+versions, current-head compare-and-set, quarantine, key destruction, and reopen
+through a fresh repository instance.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Personal_Context/test_crypto.py Tests/Personal_Context/test_key_protector.py Tests/Personal_Context/test_repository.py Tests/Personal_Context/test_repository_plaintext_canary.py -v`
+
+Expected: collection fails because `tldw_chatbook.Personal_Context` does not exist.
+
+- [ ] **Step 3: Implement versioned envelopes and key protectors**
+
+```python
+# tldw_chatbook/Personal_Context/crypto.py
+@dataclass(frozen=True, slots=True)
+class EncryptedEnvelope:
+    algorithm: str
+    nonce: bytes
+    ciphertext: bytes
+    wrapped_dek: bytes
+    key_version: int
+
+
+class EnvelopeCipher:
+    def __init__(self, profile_key: bytes, *, key_version: int = 1) -> None:
+        if len(profile_key) != 32:
+            raise ValueError("profile key must be exactly 32 bytes")
+        self._profile_key = profile_key
+        self._key_version = key_version
+
+    def encrypt(self, plaintext: bytes, aad: bytes) -> EncryptedEnvelope:
+        dek = secrets.token_bytes(32)
+        nonce = secrets.token_bytes(12)
+        wrap_nonce = secrets.token_bytes(12)
+        ciphertext = AESGCM(dek).encrypt(nonce, plaintext, aad)
+        wrapped = wrap_nonce + AESGCM(self._profile_key).encrypt(wrap_nonce, dek, aad)
+        return EncryptedEnvelope("aes-256-gcm-v1", nonce, ciphertext, wrapped, self._key_version)
+
+    def decrypt(self, envelope: EncryptedEnvelope, aad: bytes) -> bytes:
+        wrap_nonce, wrapped_dek = envelope.wrapped_dek[:12], envelope.wrapped_dek[12:]
+        dek = AESGCM(self._profile_key).decrypt(wrap_nonce, wrapped_dek, aad)
+        return AESGCM(dek).decrypt(envelope.nonce, envelope.ciphertext, aad)
+```
+
+Implement keyring storage first and a passphrase wrapper using the existing
+Chatbook scrypt/AES patterns with a profile-specific domain separator. The
+protected bundle contains separate random 32-byte envelope-encryption and
+integrity keys. Ordinary encryption-key rotation rewraps DEKs and does not
+rotate the integrity key. Integrity-key compromise requires a versioned full
+integrity rebaseline. A failed protector returns a typed `ProfileLockedError`;
+it never creates replacement material for an existing database.
+
+- [ ] **Step 4: Implement the dedicated SQLite repository**
+
+Create schema version 1 with these tables:
+
+```sql
+CREATE TABLE profile_meta (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    profile_id TEXT NOT NULL,
+    purge_generation INTEGER NOT NULL,
+    current_manifest_version TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+CREATE TABLE encrypted_objects (
+    object_type TEXT NOT NULL,
+    object_id TEXT NOT NULL,
+    version_id TEXT NOT NULL,
+    scope_id TEXT,
+    is_tombstone INTEGER NOT NULL DEFAULT 0,
+    algorithm TEXT NOT NULL,
+    nonce BLOB NOT NULL,
+    ciphertext BLOB NOT NULL,
+    wrapped_dek BLOB NOT NULL,
+    key_version INTEGER NOT NULL,
+    integrity_tag TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (object_type, object_id, version_id)
+);
+CREATE TABLE object_heads (
+    object_type TEXT NOT NULL,
+    object_id TEXT NOT NULL,
+    version_id TEXT NOT NULL,
+    PRIMARY KEY (object_type, object_id)
+);
+CREATE TABLE local_runtime_policy (
+    scope_id TEXT PRIMARY KEY,
+    encrypted_policy_version TEXT NOT NULL
+);
+CREATE TABLE local_scope_bindings (
+    scope_id TEXT PRIMARY KEY,
+    encrypted_binding_version TEXT NOT NULL
+);
+CREATE TABLE encrypted_outbox (
+    outbox_id TEXT PRIMARY KEY,
+    object_type TEXT NOT NULL,
+    object_id TEXT NOT NULL,
+    version_id TEXT NOT NULL,
+    envelope_version TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+CREATE TABLE quarantine (
+    quarantine_id TEXT PRIMARY KEY,
+    object_type TEXT NOT NULL,
+    object_id TEXT NOT NULL,
+    version_id TEXT,
+    reason_code TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+```
+
+Store all object bodies as separate per-version encrypted envelopes. Use one
+SQLite transaction for version insert plus head compare-and-set. Do not claim
+atomicity with WorkspaceDB, SyncStateRepository, keyring, or exported files.
+
+- [ ] **Step 5: Run repository and canary tests**
+
+Run: `pytest Tests/Personal_Context/test_crypto.py Tests/Personal_Context/test_key_protector.py Tests/Personal_Context/test_repository.py Tests/Personal_Context/test_repository_plaintext_canary.py -v`
+
+Expected: all tests pass, including a close/reopen test using a new connection.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml tldw_chatbook/Personal_Context Tests/Personal_Context
+git diff --cached --check
+git commit -m "feat: add encrypted local personal context store"
+```
+
+---
+
+### Task 4: Add the canonical Chatbook application service
+
+**Files:**
+- Create: `tldw_chatbook/Personal_Context/service.py`
+- Create: `tldw_chatbook/Personal_Context/runtime_policy.py`
+- Create: `tldw_chatbook/Personal_Context/export_service.py`
+- Create: `tldw_chatbook/Personal_Context/bootstrap.py`
+- Test: `Tests/Personal_Context/test_service.py`
+- Test: `Tests/Personal_Context/test_runtime_policy.py`
+- Test: `Tests/Personal_Context/test_export_service.py`
+
+**Interfaces:**
+- Consumes: `PersonalContextRepository`, Shared Core models.
+- Produces:
+  - `PersonalContextService.status() -> ProfileOperationalStatus`
+  - `create_profile() -> ProfileManifest`
+  - `create_workspace_scope(local_workspace_id: str, label: str) -> ProfileScope`
+  - `map_workspace_scope(local_workspace_id: str, scope_id: str) -> ProfileScope`
+  - `create_record(record: ProfileRecord) -> ProfileRecord`
+  - `update_record(record_id: str, mutation: RecordMutation, expected_version_id: str) -> ProfileRecord`
+  - `archive_record(...)`, `restore_record(...)`, `delete_record(...)`
+  - `list_records(scope_ids: tuple[str, ...], include_archived: bool = False) -> tuple[ProfileRecord, ...]`
+  - `set_runtime_enabled(enabled: bool) -> None`
+  - `set_scope_authority(scope_id: str, authority: AgentAuthority) -> None`
+  - `remove_local_profile(confirm_only_copy: bool) -> None`
+  - `export_plaintext(request: ExportRequest) -> Path`
+  - `export_recovery(request: RecoveryExportRequest) -> Path`
+
+- [ ] **Step 1: Write failing lifecycle, privacy, and export tests**
+
+```python
+def test_same_scope_same_key_updates_existing_record_not_duplicate(service, preference_record):
+    first = service.create_record(preference_record)
+    changed = service.update_record(
+        first.record_id,
+        RecordMutation(payload=first.payload.model_copy(update={"value": "detailed"})),
+        expected_version_id=first.version_id,
+    )
+    active = service.list_records(scope_ids=(first.scope_id,))
+    assert [record.record_id for record in active] == [first.record_id]
+    assert changed.parent_version_id == first.version_id
+
+
+def test_stale_expected_version_creates_no_revision(service, preference_record):
+    first = service.create_record(preference_record)
+    with pytest.raises(ProfileConflictError):
+        service.update_record(first.record_id, RecordMutation(payload=first.payload), "stale-version")
+    assert service.get_record(first.record_id).version_id == first.version_id
+
+
+def test_disable_keeps_records_but_context_use_is_off(service, preference_record):
+    service.create_record(preference_record)
+    service.set_runtime_enabled(False)
+    assert service.list_records(scope_ids=(preference_record.scope_id,))
+    assert service.status().runtime_enabled is False
+```
+
+Also test expiry, archive/restore, content-free tombstone, user-only preservation,
+device-only status, 24-hour encrypted Undo, profile lock, standalone-only-copy
+confirmation, plaintext export exclusion of drafts/keys, and passphrase recovery
+export round-trip.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Personal_Context/test_service.py Tests/Personal_Context/test_runtime_policy.py Tests/Personal_Context/test_export_service.py -v`
+
+Expected: imports fail because the service modules do not exist.
+
+- [ ] **Step 3: Implement mutation and policy choke points**
+
+```python
+class PersonalContextService:
+    def create_record(self, record: ProfileRecord) -> ProfileRecord:
+        self._require_available_for_write()
+        self._require_profile(record.profile_id)
+        self._require_known_scope(record.scope_id)
+        collision = self._repository.find_active_by_key(record.scope_id, record.kind, record.semantic_key)
+        if collision is not None:
+            raise ProfileKeyCollisionError(collision.record_id)
+        return self._repository.commit_record_version(record, expected_version_id=None)
+
+    def update_record(
+        self,
+        record_id: str,
+        mutation: RecordMutation,
+        expected_version_id: str,
+    ) -> ProfileRecord:
+        current = self._repository.get_record(record_id)
+        next_record = mutation.apply(current, now=self._clock(), version_id=self._ids.new())
+        self._require_no_key_collision(next_record, excluding_record_id=record_id)
+        return self._repository.commit_record_version(
+            next_record,
+            expected_version_id=expected_version_id,
+        )
+```
+
+Every public operation checks status and scope before repository access.
+Runtime enablement and scope authority stay local and encrypted. Export uses
+validated explicit paths and never logs record bodies.
+
+- [ ] **Step 4: Run service tests**
+
+Run: `pytest Tests/Personal_Context/test_service.py Tests/Personal_Context/test_runtime_policy.py Tests/Personal_Context/test_export_service.py -v`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Personal_Context Tests/Personal_Context
+git diff --cached --check
+git commit -m "feat: add local personal context service"
+```
+
+---
+
+### Task 5: Add My Profile to the canonical Settings Screen
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/settings_config_models.py`
+- Modify: `tldw_chatbook/UI/Screens/settings_screen.py`
+- Create: `tldw_chatbook/Widgets/Settings_Widgets/personal_context_panel.py`
+- Create: `tldw_chatbook/css/components/_settings_personal_context.tcss`
+- Modify generated CSS through: `python -m tldw_chatbook.css.build_css`
+- Test: `Tests/UI/test_settings_personal_context.py`
+- Test: `Tests/UI/test_settings_category_sweep.py`
+- Test: `Tests/UI/test_settings_footer_hints.py`
+
+**Interfaces:**
+- Consumes: `PersonalContextService` from Task 4.
+- Produces: `SettingsCategoryId.PERSONAL_CONTEXT`; `PersonalContextSettingsPanel`.
+
+- [ ] **Step 1: Write failing Settings tests with the production CSS harness**
+
+```python
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
+from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
+
+
+async def test_my_profile_category_renders_records_and_status(pilot, personal_context_service):
+    screen = SettingsScreen(personal_context_service=personal_context_service)
+    await pilot.app.push_screen(screen)
+    await screen.select_category(SettingsCategoryId.PERSONAL_CONTEXT)
+    assert screen.query_one("#personal-context-status").renderable == "Available"
+    assert screen.query(".personal-context-record-row")
+
+
+async def test_delete_everywhere_is_not_present_in_local_only_phase(pilot, personal_context_service):
+    screen = SettingsScreen(personal_context_service=personal_context_service)
+    await pilot.app.push_screen(screen)
+    await screen.select_category(SettingsCategoryId.PERSONAL_CONTEXT)
+    assert not screen.query("#personal-context-delete-everywhere")
+    assert screen.query_one("#personal-context-remove-local")
+```
+
+Add tests for add/edit/archive/restore/delete, privacy toggles, runtime enable,
+locked state, local removal confirmation, plaintext export warning, recovery
+export, narrow layout containment, and advertised bindings matching working
+actions.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_settings_personal_context.py Tests/UI/test_settings_category_sweep.py Tests/UI/test_settings_footer_hints.py -v`
+
+Expected: `SettingsCategoryId.PERSONAL_CONTEXT` is missing.
+
+- [ ] **Step 3: Implement the focused panel and Settings registration**
+
+```python
+class PersonalContextSettingsPanel(Widget):
+    """My Profile editor; all mutations delegate to PersonalContextService."""
+
+    BINDINGS = [
+        Binding("a", "add_record", "Add", show=True),
+        Binding("e", "edit_record", "Edit", show=True),
+        Binding("d", "delete_record", "Delete", show=True),
+        Binding("x", "export_profile", "Export", show=True),
+    ]
+
+    def __init__(self, service: PersonalContextService) -> None:
+        super().__init__(id="personal-context-settings-panel")
+        self._service = service
+
+    @work(thread=True, exclusive=True, group="personal-context-settings-load")
+    def load_records(self) -> None:
+        snapshot = self._service.settings_snapshot()
+        self.app.call_from_thread(self.apply_snapshot, snapshot)
+```
+
+Keep the large `settings_screen.py` change to registration, category guidance,
+search metadata, constructor injection, and panel mounting. All profile-specific
+rendering and actions stay in the new widget. Use safe confirmation modals for
+destructive actions and no terminal-convention keybindings.
+
+- [ ] **Step 4: Rebuild CSS and run Settings tests**
+
+Run:
+
+```bash
+python -m tldw_chatbook.css.build_css
+pytest Tests/UI/test_settings_personal_context.py Tests/UI/test_settings_category_sweep.py Tests/UI/test_settings_footer_hints.py Tests/UI/test_css_bundle_sync_guard.py -v
+```
+
+Expected: all targeted tests pass and generated CSS matches source.
+
+- [ ] **Step 5: Perform scratch-profile live verification**
+
+Create a scratch config whose `[paths].data_dir` points to the same scratch
+directory, launch Chatbook, open F9 → My Profile, add/edit/archive one canary
+record, restart, and verify it remains readable. Fingerprint the real config and
+data directory before/after and require no change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/settings_config_models.py \
+  tldw_chatbook/UI/Screens/settings_screen.py \
+  tldw_chatbook/Widgets/Settings_Widgets/personal_context_panel.py \
+  tldw_chatbook/css/components/_settings_personal_context.tcss \
+  tldw_chatbook/css Tests/UI/test_settings_personal_context.py \
+  Tests/UI/test_settings_category_sweep.py Tests/UI/test_settings_footer_hints.py
+git diff --cached --check
+git commit -m "feat: add My Profile settings"
+```
+
+Stage only generated CSS files changed by the build.
+
+---
+
+### Task 6: Inject immutable read-only context into Console requests
+
+**Files:**
+- Create: `tldw_chatbook/Personal_Context/context_service.py`
+- Modify: `tldw_chatbook/Agents/agent_models.py`
+- Modify: `tldw_chatbook/Agents/agent_service.py`
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `tldw_chatbook/Chat/console_chat_models.py`
+- Test: `Tests/Personal_Context/test_context_service.py`
+- Test: `Tests/Agents/test_personal_context_prompt.py`
+- Test: `Tests/Chat/test_console_personal_context_snapshot.py`
+- Modify: `Docs/User_Guide/console/chat-basics.md`
+
+**Interfaces:**
+- Consumes: Task 4 service and active Chatbook workspace ID.
+- Produces:
+  - `ProfileContextSnapshot(generation, record_set_revision, scope_id, authority_revision, serialized_block, source_version_ids)`
+  - `ProfileContextService.build_snapshot(request: ProfileContextRequest) -> ProfileContextSnapshot`
+  - `AgentConfig.personal_context_block: str = ""`
+
+- [ ] **Step 1: Write failing deterministic-context tests**
+
+```python
+def test_workspace_override_precedes_global_and_private_records_are_absent(context_service, records):
+    snapshot = context_service.build_snapshot(
+        ProfileContextRequest(
+            current_user_text="Give me the answer",
+            active_workspace_scope_id=records.workspace_scope_id,
+            available_input_tokens=20_000,
+        )
+    )
+    assert "workspace concise" in snapshot.serialized_block
+    assert "global detailed" not in snapshot.serialized_block
+    assert records.user_only_canary not in snapshot.serialized_block
+
+
+def test_context_is_lesser_of_byte_and_token_budget(context_service, many_records):
+    snapshot = context_service.build_snapshot(
+        ProfileContextRequest(current_user_text="x", available_input_tokens=8_000)
+    )
+    assert len(snapshot.serialized_block.encode("utf-8")) <= 8_192
+    assert snapshot.estimated_tokens <= 800
+```
+
+Add tests for corrections/constraints priority, expiry, archived/tombstoned
+exclusion, unmapped workspace exclusion, locked/disabled empty snapshots,
+deterministic output, escaped malicious strings, cache keys, conflict fallback,
+live/Next Send parity, parent/subagent propagation, and snapshot immutability
+after a concurrent profile edit.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Personal_Context/test_context_service.py Tests/Agents/test_personal_context_prompt.py Tests/Chat/test_console_personal_context_snapshot.py -v`
+
+Expected: the context service and `AgentConfig.personal_context_block` are missing.
+
+- [ ] **Step 3: Implement the context builder**
+
+```python
+@dataclass(frozen=True, slots=True)
+class ProfileContextSnapshot:
+    generation: int
+    record_set_revision: str
+    scope_id: str | None
+    authority_revision: str
+    serialized_block: str
+    source_version_ids: tuple[str, ...]
+    estimated_tokens: int
+
+
+class ProfileContextService:
+    def build_snapshot(self, request: ProfileContextRequest) -> ProfileContextSnapshot:
+        view = self._service.authorized_context_view(request.active_workspace_scope_id)
+        eligible = self._select_active_visible_unexpired(view)
+        ordered = self._apply_priority_and_workspace_overrides(eligible)
+        byte_budget = min(12 * 1024, self._token_budget_bytes(request.available_input_tokens))
+        block, versions, token_count = self._serialize_whole_records(ordered, byte_budget)
+        return ProfileContextSnapshot(
+            generation=view.generation,
+            record_set_revision=view.record_set_revision,
+            scope_id=view.workspace_scope_id,
+            authority_revision=view.authority_revision,
+            serialized_block=block,
+            source_version_ids=versions,
+            estimated_tokens=token_count,
+        )
+```
+
+Serialize profile values as JSON data inside a fixed block that states it is
+user-owned context, not authority. Drop entire lower-priority records when the
+budget is reached; never truncate a payload.
+
+An incoming canonical workspace scope without a peer-local mapping appears in
+Settings as Unlinked workspace context and is excluded from context, agent
+search/tools, and edits until the user explicitly maps it. Unknown newer
+records remain opaque and set `Unsupported records present` without exposing
+their bodies.
+
+- [ ] **Step 4: Wire the snapshot through live and preview request assembly**
+
+Add `personal_context_block` to `AgentConfig`, copy it into child configs, and
+append it through one shared helper in both `_build_model_request` and the live
+loop path. `build_first_request_plan` obtains one snapshot and uses the same
+block for Console dispatch and `build_context_snapshot`; do not rebuild the
+profile midway through a turn.
+
+```python
+def append_personal_context(system_content: str, block: str) -> str:
+    if not block:
+        return system_content
+    return f"{system_content}\n\n{block}"
+```
+
+- [ ] **Step 5: Run context, agent, and Console tests**
+
+Run:
+
+```bash
+pytest Tests/Personal_Context/test_context_service.py \
+  Tests/Agents/test_personal_context_prompt.py \
+  Tests/Chat/test_console_personal_context_snapshot.py \
+  Tests/Agents/test_workspace_context_note_prompt.py -v
+```
+
+Expected: all tests pass and existing workspace context remains byte-identical
+when the profile block is empty.
+
+- [ ] **Step 6: Update user documentation and commit**
+
+Document enablement, global/workspace precedence, user-only behavior, context
+budgeting, and how Next Send exposes the exact generated block.
+
+```bash
+git add tldw_chatbook/Personal_Context/context_service.py \
+  tldw_chatbook/Agents/agent_models.py tldw_chatbook/Agents/agent_service.py \
+  tldw_chatbook/Chat/console_agent_bridge.py \
+  tldw_chatbook/Chat/console_chat_controller.py \
+  tldw_chatbook/Chat/console_chat_models.py \
+  Tests/Personal_Context/test_context_service.py \
+  Tests/Agents/test_personal_context_prompt.py \
+  Tests/Chat/test_console_personal_context_snapshot.py \
+  Docs/User_Guide/console/chat-basics.md
+git diff --cached --check
+git commit -m "feat: add bounded Console profile context"
+```
+
+## Plan 01 completion gate
+
+- The Shared Core artifact and schema fixtures are immutable and pinned.
+- ADR-099 is accepted and linked.
+- A standalone Chatbook profile survives restart and remains encrypted at rest.
+- My Profile provides complete local CRUD, privacy, enablement, export, and
+  local deletion.
+- Console live send and Next Send use the same immutable bounded snapshot.
+- No server, Sync, interview, or profile-write tool is required for this phase.

--- a/Docs/superpowers/plans/2026-08-28-personal-context-02-interviews-agent-tools.md
+++ b/Docs/superpowers/plans/2026-08-28-personal-context-02-interviews-agent-tools.md
@@ -1,0 +1,625 @@
+# Personal Context 02 — Interviews and Controlled Agent Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add bounded personal/workspace interviews, final diff review, durable agent proposals, and locally governed profile tools to the local Chatbook profile.
+
+**Architecture:** A reusable coordinator owns a 20-turn state machine over fixed or model-backed question providers and encrypted expiring drafts. Approved interview diffs call the existing application service directly; agent learning goes through separate durable proposals or the narrowly evidenced direct-write path exposed by a run-scoped ToolProvider.
+
+**Tech Stack:** Python 3.11+, Shared Profile Core, Textual 8.x, existing Chatbook LLM caller, ToolCatalogRegistry, SQLite, pytest, Hypothesis.
+
+**Spec:** `Docs/superpowers/specs/2026-08-28-unified-personal-context-profile-design.md`
+
+## ADR check
+
+```text
+ADR required: yes
+ADR path: backlog/decisions/099-personal-context-profile-authority-sync-and-encryption.md
+Reason: This plan defines durable proposal lifecycle, agent mutation authority,
+evidence requirements, and setup/workspace interview UX.
+```
+
+## Global Constraints
+
+- Complete Plan 01 first and pin its exact Shared Core release.
+- Every provider/model-backed interview displays the provider and model before
+  the first answer is entered.
+- The fixed local questionnaire performs no network or model call.
+- Every provider turn consumes one of the 20 question attempts, including an
+  invalid compound-question response.
+- The interview model receives no tools and cannot call the profile service.
+- Raw Q&A remains encrypted, local, unsynchronized, unlogged, and expires after
+  30 days.
+- Final review is the only interview path that creates records.
+- `profile_propose` never creates an active fact. `profile_update` is absent
+  unless effective runtime authority is `direct_write`.
+- Agent permissions remain runtime-local and are intersected with profile
+  state, active scope, lifecycle, and per-record visibility.
+- Agents never approve proposals, change privacy/sync controls, directly
+  archive/delete, access user-only records, enumerate other workspaces, or
+  purge the profile.
+
+---
+
+### Task 1: Implement the interview coordinator and encrypted draft lifecycle
+
+**Files:**
+- Create: `tldw_chatbook/Personal_Context/interview_coordinator.py`
+- Create: `tldw_chatbook/Personal_Context/interview_provider.py`
+- Create: `tldw_chatbook/Personal_Context/interview_draft_repository.py`
+- Create: `tldw_chatbook/Personal_Context/interview_diff.py`
+- Test: `Tests/Personal_Context/test_interview_coordinator.py`
+- Test: `Tests/Personal_Context/test_interview_draft_repository.py`
+- Test: `Tests/Personal_Context/test_interview_diff.py`
+
+**Interfaces:**
+- Consumes: Shared Core `InterviewPack`, `InterviewQuestion`, `InterviewTurn`,
+  `InterviewProposalBatch`; Chatbook `PersonalContextService`.
+- Produces:
+  - `InterviewQuestionProvider.next_question(request: InterviewProviderRequest) -> InterviewQuestion`
+  - `FixedQuestionProvider`
+  - `ConfiguredModelQuestionProvider`
+  - `ProfileInterviewCoordinator.start(kind, scope_id, mode) -> InterviewSession`
+  - `answer(session_id, answer) -> InterviewProgress`
+  - `finish(session_id) -> InterviewDiff`
+  - `commit(session_id, selections, enable_runtime) -> InterviewCommitReceipt`
+  - `discard(session_id) -> None`
+
+- [ ] **Step 1: Write failing state-machine and privacy tests**
+
+```python
+def test_model_turns_stop_at_twenty_even_when_provider_returns_invalid_questions(coordinator, invalid_provider):
+    session = coordinator.start(kind="personal", scope_id="global", mode="adaptive")
+    for index in range(20):
+        progress = coordinator.answer(session.session_id, f"answer {index}")
+    assert progress.question_attempts == 20
+    assert progress.can_ask_another is False
+    assert invalid_provider.calls == 20
+
+
+def test_fixed_mode_never_calls_configured_provider(coordinator, configured_provider):
+    session = coordinator.start(kind="personal", scope_id="global", mode="fixed")
+    coordinator.answer(session.session_id, "Call me Sam")
+    assert configured_provider.calls == 0
+
+
+def test_finish_builds_diff_without_writing_records(coordinator, service_spy):
+    session = coordinator.start(kind="personal", scope_id="global", mode="fixed")
+    coordinator.answer(session.session_id, "Prefer concise replies")
+    diff = coordinator.finish(session.session_id)
+    assert diff.additions
+    assert service_spy.mutations == []
+```
+
+Add tests for one-question validation, skip, finish early, 30-day expiry,
+save/resume, memory-only mode, provider/model pinning, user-only existing records
+excluded from adaptive input, strict output validation, secret-material refusal,
+re-interview keyed updates, possible private duplicates, atomic selected commit,
+draft-key destruction, workspace interviews producing only workspace-scoped
+goal/working-context/convention records, no workspace-to-global leakage, and no
+raw answers in logs/database/WAL.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Personal_Context/test_interview_coordinator.py Tests/Personal_Context/test_interview_draft_repository.py Tests/Personal_Context/test_interview_diff.py -v`
+
+Expected: interview modules do not exist.
+
+- [ ] **Step 3: Implement the provider boundary and coordinator**
+
+```python
+class InterviewQuestionProvider(Protocol):
+    def next_question(self, request: InterviewProviderRequest) -> InterviewQuestion:
+        """Return exactly one schema-valid question without tools."""
+
+
+@dataclass(frozen=True, slots=True)
+class InterviewProgress:
+    session_id: str
+    question: InterviewQuestion | None
+    question_attempts: int
+    answered_count: int
+    can_ask_another: bool
+    provider_label: str
+    model_id: str | None
+
+
+class ProfileInterviewCoordinator:
+    MAX_QUESTION_ATTEMPTS = 20
+
+    def answer(self, session_id: str, answer: str) -> InterviewProgress:
+        draft = self._drafts.require_active(session_id, now=self._clock())
+        self._drafts.append_answer(draft, self._validate_answer(answer))
+        if draft.question_attempts >= self.MAX_QUESTION_ATTEMPTS:
+            return self._finished_progress(draft)
+        question = self._provider_for(draft.mode).next_question(self._request(draft))
+        self._drafts.append_question_attempt(draft, question)
+        return self._progress(draft, question if question.is_single_question else None)
+```
+
+The configured-model adapter calls the existing unified LLM seam with the
+pinned provider/model, `tools=None`, non-streaming structured output, and the
+Shared Core JSON Schema. It returns a typed provider failure; the coordinator
+preserves the encrypted draft and offers retry/fixed fallback.
+
+- [ ] **Step 4: Implement encrypted drafts and deterministic diffing**
+
+Store draft envelopes through the Task 3 repository cipher with one draft DEK,
+an explicit expiry, and no Sync outbox. Diff by structured key and exact record
+ID. Never semantic-merge text. `commit()` calls one service transaction for the
+selected mutations, then destroys the draft DEK.
+
+- [ ] **Step 5: Run interview tests**
+
+Run: `pytest Tests/Personal_Context/test_interview_coordinator.py Tests/Personal_Context/test_interview_draft_repository.py Tests/Personal_Context/test_interview_diff.py -v`
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Personal_Context Tests/Personal_Context
+git diff --cached --check
+git commit -m "feat: add bounded profile interview coordinator"
+```
+
+---
+
+### Task 2: Build the interview and final-review UI
+
+**Files:**
+- Create: `tldw_chatbook/UI/Screens/profile_interview_screen.py`
+- Create: `tldw_chatbook/Widgets/Settings_Widgets/personal_context_review_modal.py`
+- Modify: `tldw_chatbook/Widgets/Settings_Widgets/personal_context_panel.py`
+- Create: `tldw_chatbook/css/components/_profile_interview.tcss`
+- Rebuild: consolidated CSS via `python -m tldw_chatbook.css.build_css`
+- Test: `Tests/UI/test_profile_interview_screen.py`
+- Test: `Tests/UI/test_personal_context_review_modal.py`
+- Test: `Tests/UI/test_settings_personal_context.py`
+
+**Interfaces:**
+- Consumes: Task 1 coordinator and Plan 01 Settings panel.
+- Produces: `ProfileInterviewScreen`; `PersonalContextReviewModal`;
+  `ProfileInterviewResult(status, committed_record_ids, runtime_enabled)`; a
+  Settings action labelled `Run interview again` for personal or selected
+  workspace scope.
+
+- [ ] **Step 1: Write failing production-shaped UI tests**
+
+```python
+async def test_interview_discloses_provider_before_answer_input(pilot, adaptive_coordinator):
+    screen = ProfileInterviewScreen(adaptive_coordinator, mode="adaptive")
+    await pilot.app.push_screen(screen)
+    assert "OpenAI / gpt-profile" in str(screen.query_one("#profile-interview-provider").render())
+    assert screen.query_one("#profile-interview-answer").disabled is False
+
+
+async def test_final_review_commits_only_checked_rows(pilot, fixed_coordinator):
+    screen = ProfileInterviewScreen(fixed_coordinator, mode="fixed")
+    await pilot.app.push_screen(screen)
+    await screen.show_review()
+    screen.query_one("#proposal-row-2").value = False
+    await screen.action_commit_review()
+    assert fixed_coordinator.last_commit.selected_change_ids == ("change-1",)
+```
+
+Add tests for skip, finish early, save, discard, provider failure fallback,
+question count, compound-question refusal copy, record privacy controls,
+possible-private-duplicate copy, Save and use with agents versus Save only,
+safe Escape behavior, narrow layout, and no hidden destructive keybindings.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_profile_interview_screen.py Tests/UI/test_personal_context_review_modal.py Tests/UI/test_settings_personal_context.py -v`
+
+Expected: screen and review modal imports fail.
+
+- [ ] **Step 3: Implement the UI as a coordinator client**
+
+```python
+class ProfileInterviewResult(NamedTuple):
+    status: Literal["committed", "saved", "discarded", "cancelled"]
+    committed_record_ids: tuple[str, ...]
+    runtime_enabled: bool
+
+
+class ProfileInterviewScreen(SafeModalDismissMixin, ModalScreen[ProfileInterviewResult]):
+    BINDINGS = [
+        Binding("escape", "request_close", "Close", show=True),
+        Binding("f", "finish_early", "Finish", show=True),
+    ]
+
+    @work(thread=True, exclusive=True, group="profile-interview-next")
+    def submit_answer(self, text: str) -> None:
+        result = self._coordinator.answer(self._session_id, text)
+        self.app.call_from_thread(self.apply_progress, result)
+```
+
+Keep service/LLM calls off the event loop. The UI displays structured diffs;
+it never writes record tables or parses model JSON itself.
+
+- [ ] **Step 4: Rebuild CSS and run UI tests**
+
+Run:
+
+```bash
+python -m tldw_chatbook.css.build_css
+pytest Tests/UI/test_profile_interview_screen.py \
+  Tests/UI/test_personal_context_review_modal.py \
+  Tests/UI/test_settings_personal_context.py Tests/UI/test_css_bundle_sync_guard.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/profile_interview_screen.py \
+  tldw_chatbook/Widgets/Settings_Widgets/personal_context_review_modal.py \
+  tldw_chatbook/Widgets/Settings_Widgets/personal_context_panel.py \
+  tldw_chatbook/css Tests/UI/test_profile_interview_screen.py \
+  Tests/UI/test_personal_context_review_modal.py Tests/UI/test_settings_personal_context.py
+git diff --cached --check
+git commit -m "feat: add profile interview review UI"
+```
+
+---
+
+### Task 3: Chain optional interviews after setup and workspace creation
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py`
+- Modify: `tldw_chatbook/app.py`
+- Modify: `tldw_chatbook/Widgets/workspace_create_modal.py`
+- Modify: `tldw_chatbook/UI/Console_Modules/workspace.py`
+- Modify: `tldw_chatbook/UI/Screens/settings_screen.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Create: `tldw_chatbook/Personal_Context/interview_launch.py`
+- Test: `Tests/UI/test_first_run_profile_interview.py`
+- Modify: `Tests/Workspaces/test_workspace_create_modal.py`
+- Test: `Tests/Workspaces/test_workspace_profile_interview_handoff.py`
+
+**Interfaces:**
+- Consumes: Task 2 `ProfileInterviewScreen`.
+- Produces:
+  - first-run result key `offer_profile_interview: bool`
+  - `WorkspaceCreateResult.offer_profile_interview: bool`
+  - `launch_profile_interview_after_commit(app, request, continuation) -> None`
+
+- [ ] **Step 1: Write failing completion-order tests**
+
+```python
+def test_first_run_marks_setup_complete_before_interview_launch(app_harness):
+    app_harness.handle_wizard_result({
+        "completed": True,
+        "exit_route": None,
+        "offer_profile_interview": True,
+    })
+    assert app_harness.persisted_first_run["setup_completed"] is True
+    assert app_harness.pushed_screens[-1].__class__.__name__ == "ProfileInterviewScreen"
+
+
+def test_workspace_exists_when_interview_is_cancelled(workspace_harness):
+    result = workspace_harness.create(offer_profile_interview=True)
+    workspace_harness.cancel_interview(result)
+    assert workspace_harness.registry.get_workspace(result.workspace_id) is not None
+```
+
+Cover no-offer, cancelled interview, failed provider, rerun setup, explicit
+first-run exit route continuation, all three WorkspaceCreateModal callers, and
+exactly-once continuation after the interview result.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_first_run_profile_interview.py Tests/Workspaces/test_workspace_create_modal.py Tests/Workspaces/test_workspace_profile_interview_handoff.py -v`
+
+Expected: result types have no interview-offer field.
+
+- [ ] **Step 3: Implement post-commit launch orchestration**
+
+```python
+@dataclass(frozen=True, slots=True)
+class ProfileInterviewLaunchRequest:
+    kind: Literal["personal", "workspace"]
+    scope_id: str
+    local_workspace_id: str | None
+
+
+def launch_profile_interview_after_commit(app, request, continuation) -> None:
+    def after_interview(_: ProfileInterviewResult) -> None:
+        continuation()
+    app.push_screen(ProfileInterviewScreen.for_request(request), after_interview)
+```
+
+The first-run callback persists setup completion through the existing wizard
+finalize path, then launches the interview. Workspace callers receive a fully
+created `workspace_id`, create/map its profile scope through the service, and
+then launch. The modal itself does not mutate the registry a second time or own
+caller navigation.
+
+- [ ] **Step 4: Run ordering and existing wizard/workspace tests**
+
+Run:
+
+```bash
+pytest Tests/UI/test_first_run_profile_interview.py \
+  Tests/Workspaces/test_workspace_create_modal.py \
+  Tests/Workspaces/test_workspace_profile_interview_handoff.py \
+  Tests/Workspaces/test_console_workspace_create_handler.py -v
+```
+
+Expected: all tests pass; existing creation results remain compatible when the
+new flag is false.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py tldw_chatbook/app.py \
+  tldw_chatbook/Widgets/workspace_create_modal.py \
+  tldw_chatbook/UI/Console_Modules/workspace.py \
+  tldw_chatbook/UI/Screens/settings_screen.py \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  tldw_chatbook/Personal_Context/interview_launch.py \
+  Tests/UI/test_first_run_profile_interview.py \
+  Tests/Workspaces/test_workspace_create_modal.py \
+  Tests/Workspaces/test_workspace_profile_interview_handoff.py
+git diff --cached --check
+git commit -m "feat: offer profile interviews after setup"
+```
+
+---
+
+### Task 4: Add durable proposal operations and profile ToolProvider
+
+**Files:**
+- Create: `tldw_chatbook/Personal_Context/proposal_service.py`
+- Create: `tldw_chatbook/Agents/profile_tool_provider.py`
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py`
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py`
+- Modify: `tldw_chatbook/Agents/tool_catalog.py`
+- Test: `Tests/Personal_Context/test_proposal_service.py`
+- Test: `Tests/Agents/test_profile_tool_provider.py`
+- Test: `Tests/Agents/test_profile_tool_scope.py`
+
+**Interfaces:**
+- Consumes: Personal Context service/repository, ToolProvider protocol, trusted
+  current user message ID/text, active canonical scope.
+- Produces:
+  - `ProfileProposalService.create/accept/reject/supersede/expire`
+  - `ProfileToolProvider.list_catalog/load_schema/invoke`
+  - `ProfileToolProvider.stamp_scope(run_id, scope: ProfileToolRunScope)`
+  - tools `profile_search`, `profile_get`, `profile_propose`, `profile_update`, `profile_promote`
+
+- [ ] **Step 1: Write failing authority and evidence tests**
+
+```python
+def test_default_propose_catalog_omits_update(provider, propose_scope):
+    with provider.stamp_scope("run-1", propose_scope):
+        names = {entry.name for entry in provider.list_catalog()}
+    assert names == {"profile_search", "profile_get", "profile_propose", "profile_promote"}
+
+
+def test_direct_update_requires_exact_current_user_span(provider, direct_scope):
+    with provider.stamp_scope("run-1", direct_scope):
+        result = provider.invoke("profile_update", {
+            "record_id": "record-1",
+            "expected_version_id": "version-1",
+            "message_id": "other-message",
+            "evidence_span": "I prefer concise replies",
+            "value": "concise",
+        })
+    assert result.ok is False
+    assert result.error == "review_required"
+
+
+def test_proposal_is_not_visible_to_context(provider, propose_scope, context_service):
+    with provider.stamp_scope("run-1", propose_scope):
+        result = provider.invoke("profile_propose", {"kind": "preference", "subject": "tone", "value": "warm"})
+    assert result.ok is True
+    assert result.content["status"] == "proposal_created"
+    assert "warm" not in context_service.build_snapshot_for_scope(propose_scope.scope_id).serialized_block
+```
+
+Add tests for read-only catalog, disabled/locked profile, user-only omission,
+other-workspace refusal, private duplicate non-disclosure, five-per-turn and
+25-per-session quotas, 200 unresolved ceiling, conflict freeze, promotion always
+proposed, workspace-to-global promotion creating a new ID with `derived_from`,
+secret refusal, a maximum 1000-character exact evidence span, stored evidence
+hash/reference without raw span, and scope/catalog invalidation after authority
+changes.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Personal_Context/test_proposal_service.py Tests/Agents/test_profile_tool_provider.py Tests/Agents/test_profile_tool_scope.py -v`
+
+Expected: proposal service and provider imports fail.
+
+- [ ] **Step 3: Implement proposal lifecycle and receipts**
+
+```python
+class ProfileProposalService:
+    def create(self, request: ProposalRequest, run_scope: ProfileToolRunScope) -> ProfileProposal:
+        self._quota.require_capacity(run_scope.run_id, run_scope.session_id)
+        self._policy.require_propose(run_scope.scope_id)
+        proposal = request.to_pending_proposal(
+            proposal_id=self._ids.new(),
+            profile_id=run_scope.profile_id,
+            scope_id=run_scope.scope_id,
+            expires_at=self._clock() + timedelta(days=90),
+        )
+        return self._repository.commit_proposal(proposal)
+
+    def accept(self, proposal_id: str, *, user_actor: UserActor) -> ProfileRecord:
+        proposal = self._repository.require_pending_proposal(proposal_id)
+        record = self._apply_as_user_mutation(proposal, user_actor)
+        self._repository.resolve_proposal_and_shred(proposal_id, "accepted", record.version_id)
+        return record
+```
+
+- [ ] **Step 4: Implement the run-scoped ToolProvider**
+
+```python
+@dataclass(frozen=True, slots=True)
+class ProfileToolRunScope:
+    run_id: str
+    session_id: str
+    profile_id: str
+    scope_id: str
+    authority: AgentAuthority
+    current_user_message_id: str
+    current_user_text: str
+
+
+class ProfileToolProvider:
+    SOURCE = "personal-context"
+
+    @contextmanager
+    def stamp_scope(self, run_id: str, scope: ProfileToolRunScope):
+        token = self._scope.set((run_id, scope))
+        try:
+            yield
+        finally:
+            self._scope.reset(token)
+```
+
+Build schemas from Shared Core tool contracts. Verify evidence before mutation
+with exact trusted message ID, trusted user authorship supplied by the Console
+controller, and exact substring containment within the current user message.
+Persist only SHA-256 evidence hash and message reference; never persist or log
+the raw evidence span. Return bounded structured statuses, never exception text.
+
+Wire `profile_provider` into the fresh per-run registry construction and combine
+its scope with the existing run scopes. Do not register tools when the profile
+is disabled, locked, purging, unmapped, or policy-ineligible.
+
+- [ ] **Step 5: Run provider, catalog, and concurrency tests**
+
+Run:
+
+```bash
+pytest Tests/Personal_Context/test_proposal_service.py \
+  Tests/Agents/test_profile_tool_provider.py Tests/Agents/test_profile_tool_scope.py \
+  Tests/Agents/test_tool_catalog.py Tests/Agents/test_tool_catalog_concurrency.py -v
+```
+
+Expected: all tests pass and existing catalogs are unchanged with no profile provider.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Personal_Context/proposal_service.py \
+  tldw_chatbook/Agents/profile_tool_provider.py \
+  tldw_chatbook/Chat/console_agent_bridge.py \
+  tldw_chatbook/Chat/console_chat_controller.py \
+  tldw_chatbook/Agents/tool_catalog.py \
+  Tests/Personal_Context/test_proposal_service.py \
+  Tests/Agents/test_profile_tool_provider.py Tests/Agents/test_profile_tool_scope.py
+git diff --cached --check
+git commit -m "feat: add governed personal context tools"
+```
+
+---
+
+### Task 5: Complete proposal review, privacy evidence, and user documentation
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Settings_Widgets/personal_context_panel.py`
+- Modify: `tldw_chatbook/Widgets/Settings_Widgets/personal_context_review_modal.py`
+- Test: `Tests/UI/test_personal_context_proposal_review.py`
+- Test: `Tests/Personal_Context/test_profile_durable_owner_inventory.py`
+- Modify: `Docs/User_Guide/console/chat-basics.md`
+- Create: `Docs/User_Guide/settings/personal-context-profile.md`
+
+**Interfaces:**
+- Consumes: Task 4 proposal service.
+- Produces: user review actions and documented privacy/authority behavior.
+
+- [ ] **Step 1: Write failing review and durable-owner tests**
+
+```python
+async def test_agent_proposal_review_shows_source_and_cannot_change_hidden_record(pilot, proposal_fixture):
+    modal = PersonalContextReviewModal.for_proposal(proposal_fixture)
+    await pilot.app.push_screen(modal)
+    assert "Agent proposal" in str(modal.query_one("#review-source").render())
+    assert "possible private duplicate" in str(modal.query_one("#review-warning").render())
+    assert proposal_fixture.private_duplicate_value not in pilot.app.export_screenshot()
+
+
+def test_rejected_proposal_canary_absent_from_every_default_durable_owner(profile_harness):
+    canary = "REJECTED-PROPOSAL-CANARY-41a927"
+    proposal_id = profile_harness.propose(canary)
+    profile_harness.reject(proposal_id)
+    for owner_bytes in profile_harness.decoded_default_durable_owners():
+        assert canary.encode() not in owner_bytes
+```
+
+Inventory the profile DB/WAL, outbox, logs, diagnostics, caches, exports,
+crash-report input, and any run log reached by the real tool path.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_personal_context_proposal_review.py Tests/Personal_Context/test_profile_durable_owner_inventory.py -v`
+
+Expected: proposal review actions/inventory harness are missing.
+
+- [ ] **Step 3: Implement review actions and content shredding**
+
+Accept, edit-and-accept, reject, and expire through `ProfileProposalService`.
+Acceptance creates the canonical record first and content-shreds the proposal in
+the same profile-database transaction. Rejection/supersession/expiry destroys
+the proposal DEK and retains only a content-free receipt.
+
+- [ ] **Step 4: Run all Plan 02 targeted tests**
+
+Run:
+
+```bash
+pytest Tests/Personal_Context/test_interview_coordinator.py \
+  Tests/Personal_Context/test_interview_draft_repository.py \
+  Tests/Personal_Context/test_interview_diff.py \
+  Tests/Personal_Context/test_proposal_service.py \
+  Tests/Personal_Context/test_profile_durable_owner_inventory.py \
+  Tests/Agents/test_profile_tool_provider.py Tests/Agents/test_profile_tool_scope.py \
+  Tests/UI/test_profile_interview_screen.py \
+  Tests/UI/test_personal_context_review_modal.py \
+  Tests/UI/test_personal_context_proposal_review.py \
+  Tests/UI/test_first_run_profile_interview.py \
+  Tests/Workspaces/test_workspace_profile_interview_handoff.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Perform scratch-profile user journeys**
+
+Verify fixed first-run interview, adaptive-provider disclosure with a configured
+non-paid test provider, workspace interview, agent proposal, user acceptance,
+direct explicit correction, disabled profile, and private duplicate warning.
+Fingerprint the real profile before/after.
+
+- [ ] **Step 6: Document and commit**
+
+Document question limits, provider disclosure, raw-answer deletion, proposal
+review, direct-write evidence, agent permissions, private records, and re-running
+the interview through `Run interview again` in Settings.
+
+```bash
+git add tldw_chatbook/Widgets/Settings_Widgets/personal_context_panel.py \
+  tldw_chatbook/Widgets/Settings_Widgets/personal_context_review_modal.py \
+  Tests/UI/test_personal_context_proposal_review.py \
+  Tests/Personal_Context/test_profile_durable_owner_inventory.py \
+  Docs/User_Guide/console/chat-basics.md \
+  Docs/User_Guide/settings/personal-context-profile.md
+git diff --cached --check
+git commit -m "feat: complete personal context review workflow"
+```
+
+## Plan 02 completion gate
+
+- Fixed and adaptive interviews are optional, bounded, resumable only when
+  protected storage exists, and raw drafts are destroyed after use/expiry.
+- First-run and workspace creation complete before an interview begins.
+- Interview diffs cannot affect agents before user approval.
+- Agent proposals are durable, non-injectable, reviewable, quota-bound, and
+  crypto-shredded after resolution.
+- Direct writes require current trusted explicit user evidence.
+- Settings can re-run interviews and review proposals independently of Sync conflicts.

--- a/Docs/superpowers/plans/2026-08-28-personal-context-03-server-canonical-migration.md
+++ b/Docs/superpowers/plans/2026-08-28-personal-context-03-server-canonical-migration.md
@@ -1,0 +1,712 @@
+# Personal Context 03 — Server Canonical Storage and Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make tldw_server an encrypted canonical Personal Context peer with an authenticated API, fenced migration from legacy personalization data, lossless compatibility routes, and governed server-side context/tools.
+
+**Architecture:** tldw_server pins the same Shared Profile Core artifact as Chatbook and extends the existing per-user `Personalization.db`. A server master key wraps per-profile keys; one `PersonalContextService` owns canonical mutations. A per-user migration state machine converts legacy rows before compatibility routes project the canonical service. Runtime context and MCP tools consume the same service and never write storage directly.
+
+**Tech Stack:** Python 3.11+, FastAPI, Pydantic 2, SQLite, `cryptography` AESGCM, scrypt, HMAC-SHA-256, Shared Profile Core, Unified MCP, pytest.
+
+**Spec:** `Docs/superpowers/specs/2026-08-28-unified-personal-context-profile-design.md`
+
+## ADR check
+
+```text
+ADR required: yes
+ADR path: backlog/decisions/099-personal-context-profile-authority-sync-and-encryption.md
+Reason: This plan establishes server key custody, canonical encrypted storage,
+legacy migration/cutover, authenticated service contracts, and runtime boundaries.
+```
+
+## Global Constraints
+
+- Complete Plans 01 and 02 and pin the identical released Shared Core version.
+- Work in the tldw_server repository. Extend
+  `tldw_Server_API/app/core/DB_Management/Personalization_DB.py`; do not create a
+  second per-user database or make Sync V2 the live canonical store.
+- The only supported V1 server key source is an explicitly configured 32-byte
+  master key. A missing, changed, or invalid key yields `Locked`; it never
+  generates a replacement.
+- Authenticate and resolve the per-user database before any profile lookup or
+  decrypt operation. Cross-user object IDs return the same not-found response.
+- Canonical bodies, kinds, provenance, proposals, Undo, migration snapshots,
+  compatibility staging, and future Sync outbox bodies remain encrypted at rest.
+- One service owns all canonical mutations. New API routes, compatibility
+  routes, migration, MCP tools, and runtime integration never issue object-table
+  SQL directly.
+- Migration is per-user, forward-only, fenced with durable phases, idempotent,
+  and has no dual-write interval.
+- Legacy semantic memory IDs, content, and timestamps survive migration.
+  Response style and preferred format become canonical preferences. Runtime
+  tuning, episodic/session memory, topics, Companion data, Persona state, and
+  auth identity remain in their existing authorities.
+- No Sync domains are added in this plan; Plan 04 owns replication.
+
+---
+
+### Task 1: Add server key custody and encrypted canonical repository
+
+**Files (tldw_server repository):**
+- Modify: `pyproject.toml`
+- Modify: `tldw_Server_API/app/core/DB_Management/Personalization_DB.py`
+- Create: `tldw_Server_API/app/core/Personalization/personal_context_crypto.py`
+- Create: `tldw_Server_API/app/core/Personalization/personal_context_key_provider.py`
+- Create: `tldw_Server_API/app/core/Personalization/personal_context_repository.py`
+- Create: `tldw_Server_API/app/core/Personalization/personal_context_repository_models.py`
+- Test: `tldw_Server_API/tests/Personalization/test_personal_context_crypto.py`
+- Test: `tldw_Server_API/tests/Personalization/test_personal_context_key_custody.py`
+- Test: `tldw_Server_API/tests/Personalization/test_personal_context_repository.py`
+- Test: `tldw_Server_API/tests/Personalization/test_personal_context_plaintext_canary.py`
+
+**Interfaces:**
+- Consumes: pinned Shared Core package and the existing `PersonalizationDB` path
+  and SQLite policy.
+- Produces:
+  - `ServerProfileKeyProvider.load(profile_id) -> ProfileKeyMaterial`
+  - `ServerProfileKeyProvider.create(profile_id) -> ProfileKeyMaterial`
+  - `PersonalContextRepository.initialize_schema() -> None`
+  - encrypted manifest/scope/record/proposal version and head operations
+  - `PersonalizationDB.transaction(immediate: bool = False)`
+  - `ProfileStorageLockedError`, `ProfileIntegrityError`
+
+- [ ] **Step 1: Write failing key and repository tests**
+
+```python
+def test_missing_master_key_locks_existing_profile(tmp_path, monkeypatch, manifest):
+    monkeypatch.setenv("TLDW_PERSONAL_CONTEXT_MASTER_KEY", base64_key(b"a" * 32))
+    repo = repository_at(tmp_path)
+    repo.commit_manifest(manifest)
+
+    monkeypatch.delenv("TLDW_PERSONAL_CONTEXT_MASTER_KEY")
+    with pytest.raises(ProfileStorageLockedError):
+        repository_at(tmp_path).get_manifest(manifest.profile_id)
+
+
+def test_changed_master_key_never_replaces_profile_key(tmp_path, monkeypatch, record):
+    monkeypatch.setenv("TLDW_PERSONAL_CONTEXT_MASTER_KEY", base64_key(b"a" * 32))
+    repository_at(tmp_path).commit_record_version(record, expected_version_id=None)
+    monkeypatch.setenv("TLDW_PERSONAL_CONTEXT_MASTER_KEY", base64_key(b"b" * 32))
+    with pytest.raises(ProfileStorageLockedError):
+        repository_at(tmp_path).get_record(record.record_id)
+```
+
+Add tests for random 96-bit nonces, unique per-version DEKs, AES-GCM associated
+data binding object/profile/version IDs, HMAC verification before parse, key
+version rotation, stale optimistic writes, content-free tombstones, transaction
+rollback, profile isolation, malformed ciphertext, and reopen through
+`PersonalizationDB.for_user()`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest tldw_Server_API/tests/Personalization/test_personal_context_crypto.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_key_custody.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_repository.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_plaintext_canary.py -v
+```
+
+Expected: imports fail because the server repository modules do not exist.
+
+- [ ] **Step 3: Add the schema to the existing database**
+
+Add versioned tables through `PersonalizationDB._ensure_schema()`:
+
+```sql
+CREATE TABLE personal_context_profile_keys (
+    profile_id TEXT PRIMARY KEY,
+    key_version INTEGER NOT NULL,
+    integrity_key_version INTEGER NOT NULL,
+    wrapped_profile_key BLOB NOT NULL,
+    wrap_nonce BLOB NOT NULL,
+    wrapped_integrity_key BLOB NOT NULL,
+    integrity_wrap_nonce BLOB NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE personal_context_object_versions (
+    profile_id TEXT NOT NULL,
+    object_type TEXT NOT NULL,
+    object_id TEXT NOT NULL,
+    version_id TEXT NOT NULL,
+    parent_version_id TEXT,
+    schema_version INTEGER NOT NULL,
+    key_version INTEGER NOT NULL,
+    nonce BLOB NOT NULL,
+    wrapped_dek BLOB NOT NULL,
+    wrapped_dek_nonce BLOB NOT NULL,
+    ciphertext BLOB NOT NULL,
+    integrity_tag TEXT NOT NULL,
+    payload_size_bytes INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (profile_id, object_type, object_id, version_id)
+);
+```
+
+Add a head table with `(profile_id, object_type, object_id)` primary key and
+`current_version_id`, plus encrypted receipt/runtime tables. Clear columns are
+limited to opaque routing IDs, schema/key versions, parent linkage, timestamps,
+and byte sizes. Lifecycle, kind, semantic key, visibility, sync mode, labels,
+and content stay in ciphertext.
+
+Expose a parameterized `transaction(immediate=True)` context manager so the
+repository can use `BEGIN IMMEDIATE` without reaching into `_connect()`.
+
+- [ ] **Step 4: Implement key custody and envelope encryption**
+
+```python
+class ServerProfileKeyProvider:
+    ENV_NAME = "TLDW_PERSONAL_CONTEXT_MASTER_KEY"
+
+    def require_master_key(self) -> bytes:
+        raw = os.getenv(self.ENV_NAME, "").strip()
+        try:
+            key = base64.b64decode(raw, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ProfileStorageLockedError("invalid server profile master key") from exc
+        if len(key) != 32:
+            raise ProfileStorageLockedError("server profile master key must be 32 bytes")
+        return key
+```
+
+Use AES-256-GCM with random 12-byte nonces. Generate separate random 32-byte
+per-profile envelope-encryption and integrity keys plus a random DEK for every
+object version. Wrap both profile keys with the server master key and each DEK
+with the envelope-encryption key. Bind opaque IDs and versions as associated
+data. Verify the Shared Core keyed integrity tag with the integrity key before
+model parse. Ordinary encryption-key rotation rewraps DEKs and leaves the
+separately wrapped integrity key unchanged; integrity-key rotation uses a
+versioned full rebaseline. Do not log key bytes, ciphertext, canonical bodies,
+or exception values that may contain them.
+
+- [ ] **Step 5: Prove the no-plaintext boundary**
+
+Create one canary in each kind, proposal, runtime policy, Undo receipt, and WAL
+path. Check decoded database pages, WAL, SHM, logs, diagnostics, temporary
+files, and exception text. The canaries may appear only after explicit decrypt
+inside the test process.
+
+- [ ] **Step 6: Run tests and commit**
+
+Run the four tests from Step 2. Then:
+
+```bash
+git add pyproject.toml \
+  tldw_Server_API/app/core/DB_Management/Personalization_DB.py \
+  tldw_Server_API/app/core/Personalization/personal_context_crypto.py \
+  tldw_Server_API/app/core/Personalization/personal_context_key_provider.py \
+  tldw_Server_API/app/core/Personalization/personal_context_repository.py \
+  tldw_Server_API/app/core/Personalization/personal_context_repository_models.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_crypto.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_key_custody.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_repository.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_plaintext_canary.py
+git diff --cached --check
+git commit -m "feat: add encrypted server personal context store"
+```
+
+---
+
+### Task 2: Add the canonical server service and authenticated API
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Personalization/personal_context_service.py`
+- Create: `tldw_Server_API/app/core/Personalization/personal_context_runtime_policy.py`
+- Create: `tldw_Server_API/app/core/Personalization/personal_context_export.py`
+- Create: `tldw_Server_API/app/api/v1/API_Deps/personal_context_deps.py`
+- Create: `tldw_Server_API/app/api/v1/schemas/personal_context.py`
+- Create: `tldw_Server_API/app/api/v1/endpoints/personal_context.py`
+- Modify: `tldw_Server_API/app/api/v1/router_groups/minimal.py`
+- Modify: `tldw_Server_API/app/api/v1/router_groups/content.py`
+- Test: `tldw_Server_API/tests/Personalization/test_personal_context_service.py`
+- Test: `tldw_Server_API/tests/Personalization/test_personal_context_endpoints.py`
+- Test: `tldw_Server_API/tests/Personalization/test_personal_context_auth_boundary.py`
+
+**Interfaces:**
+- Consumes: Task 1 repository, authenticated user dependency, Shared Core.
+- Produces:
+  - `personal_context_service_for_user(user_id) -> PersonalContextService`
+  - lifecycle/status/scope/record/proposal/review/export/purge methods matching
+    Chatbook semantics
+  - `/api/v1/personal-context/status`
+  - `/api/v1/personal-context/manifest`
+  - `/api/v1/personal-context/scopes`
+  - `/api/v1/personal-context/records`
+  - `/api/v1/personal-context/proposals`
+  - `/api/v1/personal-context/runtime`
+  - `/api/v1/personal-context/export`
+  - `/api/v1/personal-context/purge`
+
+- [ ] **Step 1: Write failing service and route tests**
+
+```python
+def test_cross_user_record_id_is_not_decrypted(client, users, seeded_profiles):
+    response = client.get(
+        f"/api/v1/personal-context/records/{seeded_profiles[users.b].record_id}",
+        headers=users.a.headers,
+    )
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Personal context record not found"}
+
+
+def test_stale_update_returns_machine_readable_conflict(client, user, record):
+    response = client.patch(
+        f"/api/v1/personal-context/records/{record.record_id}",
+        headers=user.headers,
+        json={"expected_version_id": "stale", "payload": record.payload.model_dump()},
+    )
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "profile_version_conflict"
+```
+
+Add tests for every operational state, strict schemas, 16 KiB payload ceiling,
+default/max search limits of 5/20, workspace ownership, no user-only agent view,
+proposal review, runtime enablement, recovery/plaintext exports, local-copy
+delete refusal on the server, typed errors, and purge confirmation/generation.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest tldw_Server_API/tests/Personalization/test_personal_context_service.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_endpoints.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_auth_boundary.py -v
+```
+
+Expected: service, schemas, and routes are missing.
+
+- [ ] **Step 3: Implement one mutation service**
+
+```python
+class PersonalContextService:
+    def update_record(
+        self,
+        record_id: str,
+        mutation: RecordMutation,
+        expected_version_id: str,
+    ) -> ProfileRecord:
+        self._require_writable()
+        current = self._repository.require_record(record_id)
+        replacement = mutation.apply(
+            current,
+            now=self._clock(),
+            version_id=self._ids.new(),
+        )
+        self._require_no_same_scope_key_collision(replacement, excluding=record_id)
+        return self._repository.commit_record_version(
+            replacement,
+            expected_version_id=expected_version_id,
+        )
+```
+
+Mirror Chatbook lifecycle and validation. Keep server runtime enablement and
+scope authority local to the server and encrypted; do not expose those values
+as canonical Sync objects. Enforce per-user scope access in the service even
+after the route dependency has authenticated.
+
+- [ ] **Step 4: Implement authenticated routes and error mapping**
+
+Dependencies resolve `user_id` before constructing the repository. Response
+models use Shared Core-compatible fields and reject unknown input. Map Locked,
+Migration required, Migrating, Sync attention, Review, Purge pending, and
+Unsupported to stable status/error codes without leaking storage details.
+Return only bounded lists and never include raw profile bodies in logs.
+
+- [ ] **Step 5: Run API tests and commit**
+
+```bash
+pytest tldw_Server_API/tests/Personalization/test_personal_context_service.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_endpoints.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_auth_boundary.py -v
+git add tldw_Server_API/app/core/Personalization/personal_context_service.py \
+  tldw_Server_API/app/core/Personalization/personal_context_runtime_policy.py \
+  tldw_Server_API/app/core/Personalization/personal_context_export.py \
+  tldw_Server_API/app/api/v1/API_Deps/personal_context_deps.py \
+  tldw_Server_API/app/api/v1/schemas/personal_context.py \
+  tldw_Server_API/app/api/v1/endpoints/personal_context.py \
+  tldw_Server_API/app/api/v1/router_groups/minimal.py \
+  tldw_Server_API/app/api/v1/router_groups/content.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_service.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_endpoints.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_auth_boundary.py
+git diff --cached --check
+git commit -m "feat: expose canonical personal context API"
+```
+
+---
+
+### Task 3: Build the fenced per-user legacy migration
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Personalization/personal_context_migration.py`
+- Create: `tldw_Server_API/app/core/Personalization/personal_context_migration_models.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/Personalization_DB.py`
+- Modify: `tldw_Server_API/app/api/v1/API_Deps/personal_context_deps.py`
+- Test: `tldw_Server_API/tests/Personalization/test_personal_context_migration.py`
+- Test: `tldw_Server_API/tests/Personalization/test_personal_context_historical_reopen.py`
+- Test fixtures: `tldw_Server_API/tests/Personalization/fixtures/personalization_pre_context_v1.sql`
+
+**Interfaces:**
+- Consumes: existing legacy tables and Task 2 service.
+- Produces:
+  - `PersonalContextMigrationService.inspect(user_id) -> MigrationAssessment`
+  - `migrate(user_id) -> MigrationReceipt`
+  - durable phases `required`, `snapshot_created`, `canonical_written`,
+    `validated`, `plaintext_cleanup_pending`, `complete`, `failed_locked`
+  - encrypted recovery snapshot retained for at most seven days
+
+- [ ] **Step 1: Write truthful historical-schema tests**
+
+```python
+def test_legacy_semantic_ids_content_and_timestamps_survive_migration(historical_db):
+    legacy = historical_db.semantic_memory("memory-7")
+    receipt = migration_service(historical_db).migrate("user-1")
+    migrated = canonical_service(historical_db).get_record("memory-7")
+    assert migrated.payload.text == legacy.content
+    assert migrated.created_at.isoformat() == legacy.created_at
+    assert migrated.kind == RecordKind.LEGACY_UNCLASSIFIED
+    assert receipt.semantic_memory_count == 1
+
+
+def test_second_migration_is_idempotent(historical_db):
+    first = migration_service(historical_db).migrate("user-1")
+    second = migration_service(historical_db).migrate("user-1")
+    assert second.migration_id == first.migration_id
+    assert canonical_service(historical_db).record_count() == first.record_count
+```
+
+Build the fixture with the actual pre-feature SQL, including rows that exercise
+missing newer columns. Reopen it through `PersonalizationDB.for_path()` so both
+`_ensure_schema()` and `_migrate_schema()` execute. Test interruption after each
+phase, concurrent workers, invalid master key, corrupt row, duplicate semantic
+IDs, default response-style values, purge marker, and no accidental migration
+of episodic, topic, Companion, Persona, or auth records.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest tldw_Server_API/tests/Personalization/test_personal_context_migration.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_historical_reopen.py -v
+```
+
+Expected: the migration service and durable state table are missing.
+
+- [ ] **Step 3: Implement the durable migration state machine**
+
+```python
+def migrate(self, user_id: str) -> MigrationReceipt:
+    with self._db.transaction(immediate=True) as cursor:
+        state = self._states.require_or_create(cursor, user_id)
+        if state.phase == "complete":
+            return state.receipt
+        self._require_key_available()
+        self._advance_inside_fence(cursor, state)
+    return self._finish_plaintext_cleanup(user_id)
+```
+
+Create an encrypted, checksummed recovery snapshot before canonical writes.
+Map each semantic memory to `legacy_unclassified` with the same ID, content,
+tags, pinned/hidden status in provenance/controls, and original timestamps.
+Create deterministic semantic keys only for response style and preferred format;
+do not invent semantic keys for unclassified text. Migrate non-default style and
+format values as preferences; preserve explicit defaults only when the legacy
+profile was enabled. Leave all runtime tuning in the existing profile row.
+
+Wire the authenticated per-user dependency to call
+`PersonalContextMigrationService.ensure_current(user_id)` before returning the
+canonical service. This is lazy automatic storage maintenance for that user's
+database, not a new opt-in. If another process owns the fence, return the typed
+Migrating state. Requests for other users continue against their separate
+per-user databases.
+
+- [ ] **Step 4: Validate, clean plaintext, and recover safely**
+
+Validate IDs, counts, hashes, and successful Shared Core parse before cleanup.
+Enable `PRAGMA secure_delete=ON`, remove migrated semantic bodies, checkpoint
+the WAL, and perform `VACUUM` only in the separate
+`plaintext_cleanup_pending` phase because SQLite cannot vacuum inside the
+transaction. Any interruption resumes that phase while canonical APIs remain
+locked. Crypto-shred the snapshot DEK immediately after successful post-cutover
+validation, with seven days as the absolute maximum when validation or recovery
+remains incomplete. Never roll back to dual writes.
+
+- [ ] **Step 5: Run migration tests and commit**
+
+```bash
+pytest tldw_Server_API/tests/Personalization/test_personal_context_migration.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_historical_reopen.py -v
+git add tldw_Server_API/app/core/Personalization/personal_context_migration.py \
+  tldw_Server_API/app/core/Personalization/personal_context_migration_models.py \
+  tldw_Server_API/app/core/DB_Management/Personalization_DB.py \
+  tldw_Server_API/app/api/v1/API_Deps/personal_context_deps.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_migration.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_historical_reopen.py \
+  tldw_Server_API/tests/Personalization/fixtures/personalization_pre_context_v1.sql
+git diff --cached --check
+git commit -m "feat: migrate legacy personalization into personal context"
+```
+
+---
+
+### Task 4: Cut legacy routes over to a lossless compatibility adapter
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Personalization/personal_context_compat.py`
+- Modify: `tldw_Server_API/app/api/v1/API_Deps/personalization_deps.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/personalization.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/personalization.py`
+- Modify: `tldw_Server_API/tests/Personalization/test_personalization_endpoints.py`
+- Test: `tldw_Server_API/tests/Personalization/test_personal_context_compat.py`
+
+**Interfaces:**
+- Consumes: completed migration and canonical service.
+- Produces: `LegacyPersonalizationAdapter` projections for existing endpoint
+  request/response models, with deprecation headers and no direct legacy writes.
+
+- [ ] **Step 1: Write failing compatibility-equivalence tests**
+
+```python
+def test_legacy_memory_update_preserves_unknown_canonical_fields(adapter, canonical_record):
+    before = canonical_record.model_dump()
+    adapter.update_memory(canonical_record.record_id, content="new text")
+    after = adapter.service.get_record(canonical_record.record_id).model_dump()
+    assert after["payload"]["text"] == "new text"
+    assert after["controls"] == before["controls"]
+    assert after["provenance"]["source"] == before["provenance"]["source"]
+
+
+def test_lossy_legacy_write_fails_closed(adapter, structured_preference):
+    with pytest.raises(LegacyProjectionLossError):
+        adapter.update_memory(structured_preference.record_id, content="flattened")
+```
+
+Cover list/get/create/update/delete/import/validate/profile preference behavior,
+legacy pagination, preserved IDs, disabled feature flag, migration-required and
+locked responses, purged users, deprecation headers, and identical auth
+isolation. Assert endpoint modules no longer call semantic-memory write methods.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest tldw_Server_API/tests/Personalization/test_personal_context_compat.py \
+  tldw_Server_API/tests/Personalization/test_personalization_endpoints.py -v
+```
+
+Expected: legacy routes still depend directly on `PersonalizationDB`.
+
+- [ ] **Step 3: Implement compatibility projections**
+
+Legacy semantic-memory reads project only canonical
+`legacy_unclassified` records. Known legacy writes become canonical service
+mutations with expected-version checks. Response style and preferred format
+project the two canonical preference records; runtime fields continue through
+the legacy runtime-config service. A request that cannot be represented without
+discarding canonical fields returns `409 legacy_projection_loss`.
+
+After the per-user fence reports `complete`, no legacy route writes
+`semantic_memories`, `response_style`, or `preferred_format`. This is a cutover,
+not a mirrored dual write.
+
+- [ ] **Step 4: Run compatibility tests and commit**
+
+```bash
+pytest tldw_Server_API/tests/Personalization/test_personal_context_compat.py \
+  tldw_Server_API/tests/Personalization/test_personalization_endpoints.py -v
+git add tldw_Server_API/app/core/Personalization/personal_context_compat.py \
+  tldw_Server_API/app/api/v1/API_Deps/personalization_deps.py \
+  tldw_Server_API/app/api/v1/endpoints/personalization.py \
+  tldw_Server_API/app/api/v1/schemas/personalization.py \
+  tldw_Server_API/tests/Personalization/test_personalization_endpoints.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_compat.py
+git diff --cached --check
+git commit -m "refactor: route legacy personalization through personal context"
+```
+
+---
+
+### Task 5: Add immutable server context and governed MCP profile tools
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Personalization/personal_context_runtime.py`
+- Create: `tldw_Server_API/app/core/MCP_unified/modules/implementations/personal_context_module.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/server.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/module_surface.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/chat.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/persona.py`
+- Test: `tldw_Server_API/tests/Personalization/test_personal_context_runtime.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_personal_context_module.py`
+- Test: `tldw_Server_API/tests/Personalization/test_personal_context_chat_integration.py`
+
+**Interfaces:**
+- Consumes: Task 2 service, Shared Core tool contracts, authenticated run scope.
+- Produces:
+  - `build_personal_context_block(user_id, workspace_scope_id, token_budget) -> PersonalContextBlock`
+  - opt-in `PersonalContextModule` with `profile_search`, `profile_get`,
+    `profile_propose`, `profile_update`, `profile_promote`
+  - immutable personal-context section in ordinary chat and Persona planning
+
+- [ ] **Step 1: Write failing context and tool-boundary tests**
+
+```python
+def test_workspace_override_replaces_global_key_in_server_context(runtime, records):
+    block = runtime.build_block(records.user_id, records.workspace_scope_id, 8192)
+    assert "workspace concise" in block.text
+    assert "global detailed" not in block.text
+
+
+@pytest.mark.asyncio
+async def test_default_server_tool_authority_creates_proposal(module, mcp_context):
+    result = await module.execute_tool(
+        "profile_propose",
+        {"kind": "preference", "subject": "response.detail", "value": "concise"},
+        context=mcp_context,
+    )
+    assert result["status"] == "proposal_created"
+    assert module.service.list_records(scope_ids=(mcp_context.scope_id,)) == ()
+```
+
+Add tests for user-only omission, expired/archived/deleted omission, 12 KiB/10%
+budget, conflict omission, explicit request precedence, locked/disabled behavior,
+read-only/propose/direct-write catalogs, trusted current-message evidence, no
+cross-user/workspace access, quotas, approval impossibility, and tool-module
+registration disabled by default. Also prove an external MCP caller cannot
+claim direct-write evidence: only an in-process chat turn carrying a
+server-created run stamp may receive `direct_write`; generic MCP sessions are
+intersected down to propose/read-only.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest tldw_Server_API/tests/Personalization/test_personal_context_runtime.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_personal_context_module.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_chat_integration.py -v
+```
+
+Expected: runtime builder and MCP module do not exist.
+
+- [ ] **Step 3: Implement one deterministic context builder**
+
+Order active agent-visible records by workspace overlay, global base, kind
+priority, explicit user priority, then stable ID. Suppress an unresolved
+same-scope key and use the last mutually acknowledged occupant when available.
+Serialize a delimited data section with an instruction that the current request
+and system policy outrank it. Return only an immutable string snapshot.
+
+Call the builder once per request after auth/scope resolution. Append the same
+snapshot to ordinary chat's system-layer assembly and Persona's `_propose_plan`
+input; do not merge it into Companion knowledge, semantic memory, or persisted
+turn metadata. Preview/diagnostics expose counts and IDs only.
+
+- [ ] **Step 4: Implement the opt-in Unified MCP module**
+
+Build tool JSON Schema from Shared Core. Resolve user/scope/message evidence
+from the authenticated MCP context, not tool arguments. Intersect runtime-local
+authority with operational status. Default to `propose`; expose update only for
+`direct_write` and a server-created in-process chat run stamp. Store only
+evidence hash and message reference. Register behind
+`MCP_ENABLE_PERSONAL_CONTEXT_MODULE=true` and add the module risk surface.
+
+- [ ] **Step 5: Run integration tests and commit**
+
+```bash
+pytest tldw_Server_API/tests/Personalization/test_personal_context_runtime.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_personal_context_module.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_chat_integration.py -v
+git add tldw_Server_API/app/core/Personalization/personal_context_runtime.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/personal_context_module.py \
+  tldw_Server_API/app/core/MCP_unified/server.py \
+  tldw_Server_API/app/core/MCP_unified/module_surface.py \
+  tldw_Server_API/app/api/v1/endpoints/chat.py \
+  tldw_Server_API/app/api/v1/endpoints/persona.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_runtime.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_personal_context_module.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_chat_integration.py
+git diff --cached --check
+git commit -m "feat: add governed server personal context runtime"
+```
+
+---
+
+### Task 6: Verify live migration, recovery, and operator documentation
+
+**Files:**
+- Create: `Docs/Operations/personal-context-profile.md`
+- Modify: `Docs/Product/Personalization_Memory_Layer_PRD.md`
+- Test: `tldw_Server_API/tests/Personalization/test_personal_context_recovery.py`
+- Test: `tldw_Server_API/tests/Personalization/test_personal_context_durable_owner_inventory.py`
+
+**Interfaces:**
+- Consumes: Tasks 1–5.
+- Produces: tested backup/key/migration/recovery runbook and deprecation record.
+
+- [ ] **Step 1: Write failing recovery and durable-owner tests**
+
+Test recovery export/import with the correct passphrase, wrong passphrase,
+missing/changed server key, interrupted migration, seven-day snapshot expiry,
+purge receipt, and a canary scan across DB/WAL/SHM, Sync DB, logs, caches,
+exports, crash inputs, and temporary files.
+
+- [ ] **Step 2: Run the targeted server feature suite**
+
+```bash
+pytest tldw_Server_API/tests/Personalization/test_personal_context_*.py \
+  tldw_Server_API/tests/Personalization/test_personalization_endpoints.py \
+  tldw_Server_API/app/core/MCP_unified/tests/test_personal_context_module.py -v
+```
+
+Expected: all Personal Context, compatibility, migration, recovery, and MCP
+tests pass. This is targeted; do not run the full repository suite without the
+user's approval.
+
+- [ ] **Step 3: Perform a real scratch-server probe**
+
+Start a server with a scratch user database root and explicit scratch master
+key. First call capabilities/health, then an authenticated control endpoint.
+Create legacy semantic memory, restart through the production initialization
+path, migrate, read through both APIs, mutate through each API, exercise context
+and propose tools, rotate the profile key, restart, and verify no plaintext
+canary. Record redacted request/status evidence; never record profile bodies.
+
+- [ ] **Step 4: Document operations and supersession**
+
+Document master-key creation/backup/rotation, Locked recovery, migration phase
+recovery, encrypted snapshot retention, backup inclusion, purge interaction,
+legacy route deprecation/sunset criteria, server-trusted TLS threat model, and
+the fact that `Personalization_Memory_Layer_PRD.md` is superseded for human
+profile facts while episodic/Companion/Persona systems remain separate.
+Inventory pre-migration plaintext backups and external snapshots, define their
+expiry/removal procedure, and state plainly that the new system cannot
+retroactively encrypt copies outside its control.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Docs/Operations/personal-context-profile.md \
+  Docs/Product/Personalization_Memory_Layer_PRD.md \
+  tldw_Server_API/tests/Personalization/test_personal_context_recovery.py \
+  tldw_Server_API/tests/Personalization/test_personal_context_durable_owner_inventory.py
+git diff --cached --check
+git commit -m "docs: complete personal context server operations"
+```
+
+## Plan 03 completion gate
+
+- tldw_server and Chatbook parse the same canonical fixtures and schema version.
+- Existing users migrate once behind a durable per-user fence with preserved
+  semantic IDs/content/timestamps and no dual-write interval.
+- Missing or changed key material locks data and never replaces it.
+- New and legacy APIs share one mutation service and remain user-isolated.
+- Server chat/Persona context is immutable and profile MCP tools are optional,
+  scope-bound, proposal-first, and evidence-gated.
+- All default durable owners are encrypted or content-free, and recovery/key
+  operations have a tested runbook.

--- a/Docs/superpowers/plans/2026-08-28-personal-context-04-sync-multidevice.md
+++ b/Docs/superpowers/plans/2026-08-28-personal-context-04-sync-multidevice.md
@@ -1,0 +1,711 @@
+# Personal Context 04 — Sync and Multi-device Rollout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replicate identical canonical Personal Context records among one tldw_server home peer and multiple Chatbook devices, including first-link reconciliation, explicit conflict review, privacy cleanup acknowledgments, device lifecycle, and resurrection-proof global purge.
+
+**Architecture:** Four canonical object domains and one content-free purge domain extend Sync V2 under `server_trusted_v1`. Each runtime materializes accepted whole objects through its existing `PersonalContextService`. Chatbook records a same-database encrypted outbox with each local mutation, then a dispatcher crosses into Sync state idempotently. First link is a reviewed reconciliation transaction. Privacy reductions and purge converge only after explicit device acknowledgments.
+
+**Tech Stack:** Python 3.11+, Shared Profile Core, Chatbook Sync Interop, tldw_server Sync V2, SQLite, FastAPI, Textual 8.x, pytest, Hypothesis.
+
+**Spec:** `Docs/superpowers/specs/2026-08-28-unified-personal-context-profile-design.md`
+
+## ADR check
+
+```text
+ADR required: yes
+ADR path: backlog/decisions/099-personal-context-profile-authority-sync-and-encryption.md
+Reason: This plan defines replication domains, conflict and cleanup policy,
+device expiry/rebootstrap, first-link ownership, and global purge convergence.
+```
+
+## Global Constraints
+
+- Complete Plans 01–03 first. Both runtimes must pin the same supported Shared
+  Core schema range and pass the same fixtures before linking is offered.
+- The V1 topology is one home tldw_server plus any number of Chatbook devices.
+  Do not add server federation or multiple home servers.
+- Bind authority to the stable server authority ID, authenticated server user
+  ID, and peer-local random Chatbook device ID. URLs, labels, routing IDs, and
+  credentials are never profile identity.
+- Replicate canonical whole objects, not UI projections, legacy API shapes,
+  prompts, embeddings, or semantic-memory rows.
+- Exact domains are `personal_context.manifest`, `personal_context.scope`,
+  `personal_context.record`, `personal_context.proposal`, and
+  `personal_context.purge`.
+- Link remains disabled unless the server advertises all five domains,
+  compatible schema bounds, `server_trusted_v1`, HMAC-SHA-256 integrity tags,
+  privacy-cleanup acknowledgments, purge generations, and required quotas.
+- `device_only` objects never enter a Sync envelope. Runtime agent authority
+  never synchronizes. `user_only` records may sync when marked `syncable`, but
+  must be removed from all agent-facing artifacts before convergence is acked.
+- Workspace and global records with the same semantic key are an intentional
+  overlay. Only same-scope collisions become Sync review objects.
+- Sync conflicts remain separate from profile proposals in storage, APIs, and
+  Settings. Agents cannot inspect or resolve them.
+- Cross-database work uses an outbox/journal. Never claim one transaction spans
+  the profile DB and Sync state DB.
+- Purge generations are monotonic and content-free. A device below the current
+  generation cannot upload profile objects and must purge/rebootstrap first.
+
+---
+
+### Task 1: Negotiate Personal Context Sync capabilities on both peers
+
+**Files (tldw_server):**
+- Modify: `tldw_Server_API/app/core/Sync/v2/models.py`
+- Modify: `tldw_Server_API/app/core/Sync/v2/service.py`
+- Modify: `tldw_Server_API/app/core/Sync/v2/factory.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/sync_v2_models.py`
+- Modify: `tldw_Server_API/tests/Sync/test_sync_v2_models.py`
+- Modify: `tldw_Server_API/tests/Sync/test_sync_v2_service.py`
+- Modify: `tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py`
+
+**Files (Chatbook):**
+- Modify: `tldw_chatbook/tldw_api/sync_schemas.py`
+- Modify: `tldw_chatbook/tldw_api/client.py`
+- Modify: `tldw_chatbook/Sync_Interop/server_sync_service.py`
+- Modify: `tldw_chatbook/Sync_Interop/sync_readiness.py`
+- Test: `Tests/Sync_Interop/test_personal_context_capabilities.py`
+- Modify: `Tests/Sync_Interop/test_sync_readiness.py`
+
+**Interfaces:**
+- Produces five new `SyncDomain` values and `upsert`/`tombstone` operations.
+- Produces capability object:
+
+```json
+{
+  "personal_context": {
+    "min_schema_version": 1,
+    "max_schema_version": 1,
+    "integrity_algorithm": "hmac-sha256-v1",
+    "integrity_key_distribution": "wrapped-bootstrap-v1",
+    "privacy_cleanup_ack": "personal-context-cleanup-v1",
+    "purge_generation": "personal-context-purge-v1",
+    "max_record_bytes": 16384,
+    "max_search_results": 20,
+    "max_proposals_per_turn": 5,
+    "max_proposals_per_session": 25,
+    "max_unresolved_proposals": 200
+  }
+}
+```
+
+- [ ] **Step 1: Write failing negotiation tests**
+
+```python
+def test_personal_context_link_requires_complete_capability_set(readiness):
+    capabilities = complete_capabilities()
+    capabilities["supported_domains"].remove("personal_context.purge")
+    report = readiness.personal_context(capabilities)
+    assert report.write_enabled is False
+    assert report.blockers == ("personal_context_domain_missing:personal_context.purge",)
+
+
+def test_schema_range_must_overlap_local_core(readiness):
+    capabilities = complete_capabilities(min_schema_version=2, max_schema_version=3)
+    assert readiness.personal_context(capabilities).blockers == (
+        "personal_context_schema_incompatible",
+    )
+```
+
+On the server, test domain literals, operation maps, capabilities endpoint,
+server-trusted policy, configured/missing profile master key, and quota values.
+On Chatbook, test missing, malformed, downgraded, partially implemented, unknown
+future fields, incompatible HMAC algorithm, and absent cleanup/purge contracts.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run in each repository:
+
+```bash
+pytest tldw_Server_API/tests/Sync/test_sync_v2_models.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_service.py \
+  tldw_Server_API/tests/Sync/test_sync_v2_endpoints.py -v
+pytest Tests/Sync_Interop/test_personal_context_capabilities.py \
+  Tests/Sync_Interop/test_sync_readiness.py -v
+```
+
+Expected: the domains and capability object are absent.
+
+- [ ] **Step 3: Extend the server protocol contract**
+
+Add a `PERSONAL_CONTEXT_SYNC_DOMAINS` constant and include it in supported
+domains/operations. Add a typed `personal_context` capability field rather than
+hiding required gates in generic compatibility flags. Derive its availability
+from the pinned Shared Core version and valid server key configuration. If the
+key is absent, advertise the domains but mark the feature unavailable with a
+stable blocker; never claim write readiness.
+
+- [ ] **Step 4: Add strict Chatbook parsing and readiness**
+
+```python
+@dataclass(frozen=True, slots=True)
+class PersonalContextSyncReadiness:
+    read_enabled: bool
+    write_enabled: bool
+    blockers: tuple[str, ...]
+    negotiated_schema_version: int | None
+```
+
+Parse aliases only where Sync V2 already supports them. Require an inclusive
+schema intersection and select the highest mutually supported version. Keep
+existing domains unaffected when Personal Context is unavailable.
+
+- [ ] **Step 5: Run tests and commit in each repository**
+
+Stage only the files listed above. Use commits:
+
+```bash
+git commit -m "feat: advertise personal context sync capabilities"
+git commit -m "feat: negotiate personal context sync capabilities"
+```
+
+---
+
+### Task 2: Add canonical domain adapters, materializers, and Chatbook outbox
+
+**Files (tldw_server):**
+- Create: `tldw_Server_API/app/core/Sync/v2/domain_adapters/personal_context.py`
+- Create: `tldw_Server_API/app/core/Sync/v2/materializers/personal_context.py`
+- Modify: `tldw_Server_API/app/core/Sync/v2/domain_adapters/__init__.py`
+- Modify: `tldw_Server_API/app/core/Sync/v2/materializers/__init__.py`
+- Modify: `tldw_Server_API/app/core/Sync/v2/factory.py`
+- Test: `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_adapter.py`
+- Test: `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_materializer.py`
+
+**Files (Chatbook):**
+- Create: `tldw_chatbook/Personal_Context/sync_outbox.py`
+- Create: `tldw_chatbook/Sync_Interop/personal_context_adapter.py`
+- Create: `tldw_chatbook/Sync_Interop/personal_context_dispatcher.py`
+- Modify: `tldw_chatbook/Personal_Context/repository.py`
+- Modify: `tldw_chatbook/Personal_Context/service.py`
+- Modify: `tldw_chatbook/Sync_Interop/envelope_builder.py`
+- Modify: `tldw_chatbook/Sync_Interop/envelope_applier.py`
+- Modify: `tldw_chatbook/Sync_Interop/local_first_sync_service.py`
+- Test: `Tests/Personal_Context/test_profile_sync_outbox.py`
+- Test: `Tests/Sync_Interop/test_personal_context_adapter.py`
+- Test: `Tests/Sync_Interop/test_personal_context_dispatcher.py`
+
+**Interfaces:**
+- Produces `PersonalContextDomainAdapter`,
+  `PersonalContextMaterializer`, `ProfileSyncOutbox`, and
+  `PersonalContextOutboxDispatcher`.
+- Envelope `object_id` is the canonical profile object ID; payload is one exact
+  Shared Core whole object plus its keyed integrity tag.
+- Produces a dataset-scoped 32-byte Personal Context integrity key through the
+  existing Sync key-record enrollment/rewrap path and authenticated wrapped
+  bootstrap response. The home server owns it; it is distinct from both peers'
+  envelope-encryption keys and identified by `integrity_key_id`.
+
+- [ ] **Step 1: Write failing whole-object and atomic-outbox tests**
+
+```python
+def test_local_record_and_outbox_commit_together(service, repository, record):
+    repository.fail_after_object_write = True
+    with pytest.raises(InjectedFailure):
+        service.create_record(record)
+    assert repository.get_record_or_none(record.record_id) is None
+    assert repository.list_profile_outbox() == ()
+
+
+def test_device_only_record_never_creates_outbox(service, repository, private_record):
+    service.create_record(private_record)
+    assert repository.get_record(private_record.record_id) == private_record
+    assert repository.list_profile_outbox() == ()
+```
+
+Add tests for all five domains, upsert/tombstone, canonical byte equality,
+integrity failure, unsupported schema, wrong profile/scope, idempotent retry,
+base revision/hash conflict, server authorization before decrypt, dispatcher
+crash between databases, poisoned item quarantine, and no raw body in Sync logs.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run the new server and Chatbook tests from the file lists. Expected: adapters,
+materializers, and outbox do not exist.
+
+- [ ] **Step 3: Implement the same-database encrypted outbox**
+
+```python
+def commit_record_and_enqueue(
+    self,
+    record: ProfileRecord,
+    expected_version_id: str | None,
+) -> ProfileRecord:
+    with self._repository.transaction(immediate=True) as cursor:
+        stored = self._repository.commit_record_version(
+            record,
+            expected_version_id=expected_version_id,
+            cursor=cursor,
+        )
+        if stored.controls.sync_mode == SyncMode.SYNCABLE:
+            self._outbox.enqueue_whole_object(stored, cursor=cursor)
+        return stored
+```
+
+Encrypt outbox payloads with a dedicated DEK and retain only opaque routing,
+version, timing, size, and retry metadata in clear columns. The dispatcher
+idempotently copies them into Sync state/envelopes, records the Sync envelope
+ID back in the profile DB, and then crypto-shreds acknowledged payloads. A crash
+at any point replays without duplicate canonical versions.
+
+- [ ] **Step 4: Implement server and client adapters/materializers**
+
+Adapters validate domain/object relationship, 16 KiB limit, schema range,
+HMAC-SHA-256 over canonical bytes with the enrolled dataset integrity key,
+purge generation, and base lineage. Materializers call the
+runtime's `PersonalContextService` with an authenticated sync actor and expected
+version. They never write object tables. Tombstones are content-free Shared Core
+deleted records or the content-free purge barrier, not arbitrary empty dicts.
+
+- [ ] **Step 5: Run tests and commit in each repository**
+
+Use commits:
+
+```bash
+git commit -m "feat: materialize personal context sync domains"
+git commit -m "feat: dispatch personal context sync outbox"
+```
+
+---
+
+### Task 3: Implement reviewed first-link reconciliation and scope mapping
+
+**Files (Chatbook):**
+- Create: `tldw_chatbook/Personal_Context/link_service.py`
+- Create: `tldw_chatbook/Personal_Context/reconciliation.py`
+- Create: `tldw_chatbook/Widgets/Settings_Widgets/personal_context_link_modal.py`
+- Modify: `tldw_chatbook/Widgets/Settings_Widgets/personal_context_panel.py`
+- Modify: `tldw_chatbook/Sync_Interop/server_sync_service.py`
+- Modify: `tldw_chatbook/Sync_Interop/sync_state_repository.py`
+- Test: `Tests/Personal_Context/test_profile_reconciliation.py`
+- Test: `Tests/Sync_Interop/test_personal_context_first_link.py`
+- Test: `Tests/UI/test_personal_context_link_modal.py`
+
+**Files (tldw_server):**
+- Modify: `tldw_Server_API/app/core/Sync/v2/profile.py`
+- Modify: `tldw_Server_API/app/core/Sync/v2/service.py`
+- Test: `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_bootstrap.py`
+
+**Interfaces:**
+- Produces:
+  - `PersonalContextLinkService.plan(server_profile) -> ReconciliationPlan`
+  - `apply(plan_id, decisions) -> LinkReceipt`
+  - durable local-to-canonical profile and workspace-scope mapping
+  - provisional-profile freeze/journal during reviewed link
+
+- [ ] **Step 1: Write failing first-link tests**
+
+```python
+def test_first_link_preserves_same_record_ids_on_both_peers(link_harness):
+    local = link_harness.local_record("record-local")
+    receipt = link_harness.link_and_accept_all()
+    assert receipt.local_profile_id == receipt.server_profile_id
+    assert link_harness.server_record(local.record_id).record_id == local.record_id
+
+
+def test_same_scope_different_ids_same_key_requires_review(link_harness):
+    link_harness.local_preference("local-id", "response.detail", "concise")
+    link_harness.server_preference("server-id", "response.detail", "detailed")
+    plan = link_harness.plan()
+    assert plan.key_collisions[0].record_ids == ("local-id", "server-id")
+    assert link_harness.agent_context_contains_neither(plan.key_collisions[0])
+```
+
+Cover empty/empty, local-only, server-only, identical object/version, diverged
+same ID, same-scope same key/different IDs, global/workspace same key overlay,
+user-only/private records, proposals, unmapped workspace, cancel/retry, link
+interruption, server profile purge generation, provisional-integrity-key
+replacement, and concurrent local mutation.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run the three Chatbook tests and server bootstrap test. Expected: there is no
+Personal Context reconciliation handshake.
+
+- [ ] **Step 3: Build a read-only reconciliation plan**
+
+Fetch the server manifest/scopes/object heads under one bootstrap cursor. Freeze
+new syncable profile mutations locally while allowing read-only use. Compare
+exact profile IDs, object IDs, version lineage, canonical hashes, scope IDs, and
+structured semantic keys. Do not fuzzy-match content or infer that workspace
+labels identify the same scope.
+
+The plan groups exact matches, unilateral additions, same-ID version conflicts,
+same-scope key collisions, possible private duplicates, workspace mappings,
+and purge-generation blockers. It stores encrypted hashes/references, not a
+second plaintext copy.
+
+- [ ] **Step 4: Apply reviewed decisions atomically per database**
+
+The user maps each local workspace to an existing canonical scope or creates a
+new random canonical scope. Apply local canonical replacements and an encrypted
+outbox journal in one profile-DB transaction; then push idempotently. Server
+materializes under its own transaction. Record a link receipt only after pull
+confirms the same profile ID, scope map, object IDs/versions, and cursor. Unfreeze
+writes and replay journaled user edits afterward. The authenticated wrapped
+bootstrap replaces the standalone provisional integrity key with the
+server-owned Sync integrity key, then recomputes every Personal Context tag in
+a required versioned full integrity rebaseline before normal push/pull begins.
+
+- [ ] **Step 5: Run tests and commit in each repository**
+
+Use commits:
+
+```bash
+git commit -m "feat: bootstrap personal context canonical profile"
+git commit -m "feat: reconcile personal context on first link"
+```
+
+---
+
+### Task 4: Add Personal Context conflict review and deterministic resolution
+
+**Files (Chatbook):**
+- Create: `tldw_chatbook/Personal_Context/conflict_service.py`
+- Create: `tldw_chatbook/Widgets/Settings_Widgets/personal_context_conflict_modal.py`
+- Modify: `tldw_chatbook/Widgets/Settings_Widgets/personal_context_panel.py`
+- Modify: `tldw_chatbook/Sync_Interop/envelope_applier.py`
+- Test: `Tests/Personal_Context/test_profile_conflict_service.py`
+- Test: `Tests/UI/test_personal_context_conflict_modal.py`
+- Test: `Tests/Sync_Interop/test_personal_context_conflicts.py`
+
+**Files (tldw_server):**
+- Create: `tldw_Server_API/app/core/Sync/v2/personal_context_conflicts.py`
+- Modify: `tldw_Server_API/app/core/Sync/v2/service.py`
+- Test: `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_conflicts.py`
+
+**Interfaces:**
+- Produces Sync review kinds `version_conflict`, `key_collision`,
+  `privacy_transition_blocked`, and `purge_generation_mismatch`.
+- Produces user decisions `keep_left`, `keep_right`, `edit_replacement`,
+  `keep_both_without_key`, and `dismiss_after_remote_deleted` where valid.
+
+- [ ] **Step 1: Write failing conflict tests**
+
+```python
+def test_unacknowledged_key_collision_omits_both_from_context(conflicts, runtime):
+    conflict = conflicts.create_key_collision("scope-1", "record-a", "record-b")
+    assert runtime.build_snapshot(("scope-1",)).record_ids == ()
+    assert conflict.status == "unresolved"
+
+
+def test_resolution_creates_versions_not_in_place_mutation(conflicts, repository):
+    receipt = conflicts.resolve("conflict-1", decision="keep_left", actor="user")
+    assert receipt.winner.parent_version_id is not None
+    assert repository.get_record(receipt.loser_record_id).state == RecordState.DELETED
+```
+
+Cover stale resolution, duplicate resolution request, remote tombstone, archived
+record, proposal target conflict, workspace overlay non-conflict, last mutually
+acknowledged occupant fallback, offline second resolution, and cross-user access.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run the listed Chatbook/server conflict tests. Expected: generic Sync conflicts
+cannot express structured-key review behavior.
+
+- [ ] **Step 3: Implement separate encrypted conflict projections**
+
+Store conflict bodies encrypted in the Sync state DB with canonical object
+references, last mutually acknowledged versions, and source envelope IDs.
+Expose them in My Profile under a Sync conflicts section distinct from agent
+proposals. The runtime may use the last mutually acknowledged occupant; without
+one it omits all occupants. Agents and interview providers cannot search or
+resolve these objects.
+
+- [ ] **Step 4: Resolve through canonical services and Sync**
+
+Resolution creates new canonical record versions/tombstones using expected
+versions, queues them normally, then marks the Sync conflict resolved only after
+acknowledgment. A concurrent change returns a fresh review object. Never mutate
+canonical rows or Sync conflict bodies in place.
+
+- [ ] **Step 5: Run tests and commit in each repository**
+
+Use commits:
+
+```bash
+git commit -m "feat: classify personal context sync conflicts"
+git commit -m "feat: review personal context sync conflicts"
+```
+
+---
+
+### Task 5: Enforce privacy cleanup acknowledgments and restrictive conversion
+
+**Files (Chatbook):**
+- Create: `tldw_chatbook/Personal_Context/privacy_cleanup.py`
+- Modify: `tldw_chatbook/Personal_Context/service.py`
+- Modify: `tldw_chatbook/Personal_Context/context_service.py`
+- Modify: `tldw_chatbook/Sync_Interop/sync_state_repository.py`
+- Modify: `tldw_chatbook/Sync_Interop/server_sync_service.py`
+- Test: `Tests/Personal_Context/test_profile_privacy_cleanup.py`
+- Test: `Tests/Sync_Interop/test_personal_context_cleanup_ack.py`
+- Test: `Tests/Sync_Interop/test_personal_context_device_only_conversion.py`
+
+**Files (tldw_server):**
+- Create: `tldw_Server_API/app/core/Personalization/personal_context_cleanup.py`
+- Modify: `tldw_Server_API/app/core/Sync/v2/models.py`
+- Modify: `tldw_Server_API/app/core/Sync/v2/store.py`
+- Modify: `tldw_Server_API/app/core/Sync/v2/service.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/sync_v2_models.py`
+- Test: `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_cleanup_ack.py`
+
+**Interfaces:**
+- Produces `PersonalContextCleanupAck(record_id, version_id,
+  cleanup_generation, device_id, completed_at)`.
+- Produces `convert_to_device_only(record_id, expected_version_id) ->
+  RestrictiveConversionReceipt`.
+
+- [ ] **Step 1: Write failing cleanup/conversion tests**
+
+```python
+def test_user_only_ack_waits_for_every_agent_facing_owner(cleanup_harness):
+    version = cleanup_harness.change_visibility("record-1", "user_only")
+    cleanup_harness.fail_owner("context_cache")
+    assert cleanup_harness.ack_for(version) is None
+    assert cleanup_harness.profile_status() == "sync_attention"
+
+
+def test_device_only_conversion_uses_new_private_id(conversion_harness):
+    old = conversion_harness.syncable_record("shared-id")
+    receipt = conversion_harness.convert(old.record_id)
+    assert receipt.shared_tombstone.record_id == "shared-id"
+    assert receipt.private_record.record_id != "shared-id"
+    assert receipt.private_record.controls.sync_mode == SyncMode.DEVICE_ONLY
+```
+
+Inventory context caches, preview snapshots, tool result caches, proposal input,
+interview adaptive input, diagnostics, exports, logs, crash inputs, outbox, and
+run transcripts. Test failure/restart at each cleanup owner, remote order
+inversion, repeated ack, revoked device, offline conversion, and canary absence.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run all five listed tests. Expected: no cleanup generation or restrictive
+conversion journal exists.
+
+- [ ] **Step 3: Implement cleanup-before-ack**
+
+When a record becomes `user_only`, immediately exclude the new version from all
+new agent paths, persist a cleanup job, and delete/invalidate every durable
+agent-facing derivative. Only then send the keyed cleanup acknowledgment. The
+server retains the privacy transition as pending until every active device has
+acked; status remains Sync attention and stale devices may not materialize the
+old visibility.
+
+- [ ] **Step 4: Implement shared-to-private conversion**
+
+In one Chatbook profile transaction, create a content-free tombstone for the
+shared record ID, create a new private record ID with `device_only`, enqueue only
+the tombstone, and store an encrypted linkage receipt for user Undo/review.
+Never reuse the shared ID for private content. Other devices observe deletion,
+not the new private value.
+
+- [ ] **Step 5: Run tests and commit in each repository**
+
+Use commits:
+
+```bash
+git commit -m "feat: track personal context privacy cleanup acks"
+git commit -m "feat: converge personal context privacy reductions"
+```
+
+---
+
+### Task 6: Add device expiry, local removal, and global purge barriers
+
+**Files (Chatbook):**
+- Create: `tldw_chatbook/Personal_Context/purge_service.py`
+- Modify: `tldw_chatbook/Personal_Context/service.py`
+- Modify: `tldw_chatbook/Widgets/Settings_Widgets/personal_context_panel.py`
+- Modify: `tldw_chatbook/Sync_Interop/local_first_sync_service.py`
+- Test: `Tests/Personal_Context/test_profile_local_removal.py`
+- Test: `Tests/Sync_Interop/test_personal_context_global_purge.py`
+- Test: `Tests/UI/test_personal_context_delete_actions.py`
+
+**Files (tldw_server):**
+- Create: `tldw_Server_API/app/core/Personalization/personal_context_purge.py`
+- Modify: `tldw_Server_API/app/core/Sync/v2/models.py`
+- Modify: `tldw_Server_API/app/core/Sync/v2/store.py`
+- Modify: `tldw_Server_API/app/core/Sync/v2/service.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/personal_context.py`
+- Test: `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_purge.py`
+- Test: `tldw_Server_API/tests/Sync/test_sync_v2_personal_context_device_expiry.py`
+
+**Interfaces:**
+- Produces monotonic `purge_generation`, content-free purge envelopes,
+  `remove_local_copy()`, `delete_everywhere()`, `expire_device()`, and
+  `rebootstrap_after_purge()`.
+
+- [ ] **Step 1: Write failing purge-generation tests**
+
+```python
+def test_offline_pre_purge_device_cannot_resurrect_records(multidevice):
+    multidevice.a.go_offline()
+    multidevice.a.create_record("offline-record")
+    generation = multidevice.b.delete_everywhere()
+    multidevice.a.go_online()
+    assert multidevice.a.push_result().code == "purge_generation_rebootstrap_required"
+    assert multidevice.server.record_count() == 0
+    assert multidevice.a.local_generation == generation
+
+
+def test_remove_local_copy_does_not_delete_server(multidevice):
+    record = multidevice.a.create_and_sync_record()
+    multidevice.a.remove_local_copy()
+    assert multidevice.server.get_record(record.record_id) is not None
+    assert multidevice.a.profile_exists() is False
+```
+
+Cover purge while another device is online/offline, initiating-device immediate
+write freeze, failed network request, repeated purge idempotency, device expiry,
+revoked device, stale envelope replay, stale restore/recovery import, tombstone
+retention, key crypto-shredding, local-only profile confirmation, and relink.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run the five listed tests. Expected: no content-free generation barrier or
+distinct local/everywhere deletion actions exist.
+
+- [ ] **Step 3: Implement device lifecycle and rebootstrap rule**
+
+Extend device status with `expired`. Expiry is an explicit authenticated user or
+operator action after displaying last-seen time; there is no silent automatic
+expiry in V1. Expired/revoked devices no longer block cleanup/purge retention.
+If they return, they must register as a new device and perform a full canonical
+bootstrap before writes. Preserve an audit receipt without profile content.
+
+- [ ] **Step 4: Implement the global purge barrier**
+
+The initiating device first persists `purge_pending` and freezes profile writes.
+The server atomically increments its per-user generation, crypto-shreds
+canonical profile/proposal/conflict/migration-recovery keys, removes materialized
+content, and emits only `{profile_id, purge_generation, initiated_at}` in the
+purge domain. Every push/pull includes the device generation. Lower-generation
+devices purge local owners, ack the barrier, and rebootstrap; their queued older
+objects are permanently rejected.
+
+Retain object tombstones and the generation barrier until every active device
+acks or is explicitly expired. Purge can complete even if an expired device
+never returns.
+
+- [ ] **Step 5: Implement the two Settings deletion actions**
+
+`Remove local copy` is available only for linked profiles or after explicit
+confirmation that the only copy will be lost. It shreds local keys/data/outbox
+without a server tombstone. `Delete everywhere` shows active/offline devices,
+requires typed confirmation, invokes purge, and reports pending acknowledgments.
+Neither action is exposed to agents.
+
+- [ ] **Step 6: Run tests and commit in each repository**
+
+Use commits:
+
+```bash
+git commit -m "feat: enforce personal context purge generation"
+git commit -m "feat: add personal context local and global deletion"
+```
+
+---
+
+### Task 7: Prove two-device convergence and stage the rollout
+
+**Files (Chatbook):**
+- Create: `Tests/Integration/test_personal_context_multidevice.py`
+- Create: `Tests/Integration/test_personal_context_first_link_live.py`
+- Modify: `Docs/User_Guide/settings/personal-context-profile.md`
+- Create: `Docs/User_Guide/settings/personal-context-sync.md`
+- Modify: `tldw_chatbook/config.py`
+
+**Files (tldw_server):**
+- Create: `tldw_Server_API/tests/Integration/test_personal_context_sync_live.py`
+- Modify: `Docs/Operations/personal-context-profile.md`
+- Modify: `Docs/API/sync-v2.md`
+- Modify: `tldw_Server_API/app/core/feature_flags.py`
+
+**Interfaces:**
+- Produces development feature gates on both peers and release evidence for one
+  server plus two isolated Chatbook profiles.
+
+- [ ] **Step 1: Build the real three-peer harness**
+
+Use two independent Chatbook config/data/keyring namespaces and one scratch
+tldw_server user/database/master key. Do not share profile DB files. Drive the
+real HTTP Sync V2 client, server endpoints, encrypted repositories, outbox,
+materializers, and Settings services; mocks may control clocks/failpoints only.
+
+- [ ] **Step 2: Verify canonical convergence**
+
+Exercise and assert:
+
+- A record created on Chatbook A reaches server and B with the same profile,
+  scope, record, version, payload, controls, and provenance IDs.
+- A server API edit reaches both Chatbooks as the same next version.
+- Global/workspace overlay selects the workspace value without conflict.
+- Agent proposal remains a proposal everywhere until user acceptance.
+- Offline same-ID edit and same-key/different-ID creation become distinct Sync
+  review objects, not last-write-wins.
+- `user_only` waits for cleanup acknowledgment and disappears from every agent
+  path before convergence.
+- shared-to-device-only conversion deletes the shared ID elsewhere and keeps a
+  new private ID only on the initiating Chatbook.
+- Global purge rejects queued old-generation data and leaves no content canary
+  in any default durable owner.
+
+- [ ] **Step 3: Run targeted integration suites**
+
+Run:
+
+```bash
+pytest Tests/Integration/test_personal_context_multidevice.py \
+  Tests/Integration/test_personal_context_first_link_live.py -v
+pytest tldw_Server_API/tests/Integration/test_personal_context_sync_live.py -v
+```
+
+Expected: every journey passes against the real local server. Ask before a full
+Chatbook or tldw_server test sweep.
+
+- [ ] **Step 4: Perform manual live checks**
+
+Begin by probing server capabilities and one authenticated control request.
+Then link A, inspect the reconciliation plan, link B, edit/review/conflict,
+disconnect A, perform privacy reduction and purge from B, reconnect A, and
+verify forced rebootstrap. Fingerprint both real user profiles before/after to
+prove scratch isolation. Capture only redacted IDs, statuses, and counts.
+
+- [ ] **Step 5: Document rollout and enablement gates**
+
+Document home-server limitation, server-trusted TLS threat model, schema/capability
+requirements, linking/reconciliation, workspace mapping, proposals versus Sync
+conflicts, offline behavior, privacy cleanup, device expiry, local removal,
+global purge, recovery, and legacy-route deprecation. Keep both feature flags
+off by default until Task 7 evidence passes in CI and the server key runbook is
+approved. Disclose that authenticated TLS protects transit but the authorized
+home server can read syncable Personal Context content before re-encrypting it
+at rest.
+
+- [ ] **Step 6: Commit in each repository**
+
+Use commits:
+
+```bash
+git commit -m "test: prove personal context multidevice sync"
+git commit -m "docs: stage personal context sync rollout"
+```
+
+## Plan 04 completion gate
+
+- Chatbook and tldw_server store the same canonical IDs, versions, and bodies;
+  Sync transports no application-specific profile projection.
+- First link never silently chooses between divergent values or workspace scopes.
+- Conflicts are reviewable and separate from agent proposals.
+- Privacy reductions converge only after durable cleanup acknowledgments.
+- Private conversion uses a new device-only ID and never leaks its value.
+- Explicit device expiry enables progress without allowing a returned stale
+  device to write before full rebootstrap.
+- Global purge generations prevent resurrection from offline outboxes, restores,
+  recovery imports, and stale server envelopes.
+- The real one-server/two-Chatbook harness passes before rollout flags are enabled.

--- a/Docs/superpowers/plans/2026-08-28-personal-context-implementation-index.md
+++ b/Docs/superpowers/plans/2026-08-28-personal-context-implementation-index.md
@@ -1,0 +1,122 @@
+# Personal Context Profile Implementation Plan Suite
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver the approved unified Personal Context Profile as four independently reviewable, dependency-ordered implementation plans spanning Shared Core, Chatbook, tldw_server, and Sync V2.
+
+**Architecture:** A standalone Shared Profile Core owns canonical schemas and serialization. Chatbook and tldw_server each own one encrypted repository and application service, while Sync V2 replicates identical canonical objects under negotiated capabilities. Interviews, Settings, and agent tools consume those services without becoming new authorities.
+
+**Tech Stack:** Python 3.11+, Pydantic 2, Textual 8.x, SQLite, AES-256-GCM, scrypt, HMAC-SHA-256, FastAPI, pytest, Hypothesis, Sync V2.
+
+**Spec:** `Docs/superpowers/specs/2026-08-28-unified-personal-context-profile-design.md` — read it first; every child plan implements part of it.
+
+## ADR check
+
+```text
+ADR required: yes
+ADR path: backlog/decisions/099-personal-context-profile-authority-sync-and-encryption.md
+Reason: The work creates a new encrypted data authority, shared schema,
+migration and conflict policy, service boundary, agent permission contract,
+and long-lived setup/settings UX.
+```
+
+ADR-099 is provisional until its number is swept across remote refs, worktrees,
+and open PRs immediately before creation. If occupied, the implementer renumbers
+the ADR and updates the spec plus every plan in this suite before code begins.
+
+## Scope decomposition
+
+The approved design is intentionally larger than one atomic implementation
+plan. Execute these child plans in order:
+
+1. [`2026-08-28-personal-context-01-core-chatbook-local.md`](2026-08-28-personal-context-01-core-chatbook-local.md)
+   - Shared Core contract and ADR.
+   - Encrypted Chatbook repository and service.
+   - My Profile Settings and read-only Console context.
+   - Delivers a complete local-only profile.
+2. [`2026-08-28-personal-context-02-interviews-agent-tools.md`](2026-08-28-personal-context-02-interviews-agent-tools.md)
+   - Personal/workspace interviews.
+   - Proposal review and controlled agent tools.
+   - Delivers local learning with user review.
+3. [`2026-08-28-personal-context-03-server-canonical-migration.md`](2026-08-28-personal-context-03-server-canonical-migration.md)
+   - Encrypted tldw_server canonical store/API.
+   - Fenced legacy migration and lossless compatibility routes.
+   - Delivers one server authority without Sync.
+4. [`2026-08-28-personal-context-04-sync-multidevice.md`](2026-08-28-personal-context-04-sync-multidevice.md)
+   - Sync V2 domains, binding, reconciliation, conflicts, cleanup, device
+     lifecycle, and purge barriers.
+   - Delivers shared records across Chatbook devices and tldw_server.
+
+Each numbered task inside a child plan maps to one atomic Backlog task and one
+reviewable PR unless the repository owner explicitly approves a smaller docs-only
+commit in the same PR. Do not create all Backlog tasks up front: task IDs are
+concurrently allocated and must be swept immediately before each task is filed.
+
+## Dependency contract
+
+| Consumer | Required producer |
+| --- | --- |
+| Chatbook local repository | Shared Core `ProfileManifest`, `ProfileScope`, `ProfileRecord`, canonical bytes |
+| Chatbook interview | Chatbook `PersonalContextService`; Shared Core interview/proposal schemas |
+| Chatbook profile tools | Chatbook service, runtime authority, proposal store, current trusted user-message evidence |
+| Server canonical repository | Released Shared Core version used by Chatbook |
+| Legacy compatibility routes | Server canonical service and completed per-user migration |
+| Personal-context Sync domains | Both canonical repositories, the same Shared Core schema range, server key custody |
+| Multi-device linking | Sync capabilities, server canonical manifest, Chatbook provisional manifest journal |
+| Global purge | All personal-context Sync domains, device registration/expiry, content-free generation barrier |
+
+No later plan may change a Shared Core field or service signature silently. A
+required contract change begins with a Shared Core version/fixture update and
+then updates every supported consumer before release.
+
+## Global constraints
+
+- Read the spec, ADR-008, ADR-032, ADR-037, and ADR-099 before implementation.
+- Use a fresh worktree at execution time; do not implement in the current dirty
+  checkout.
+- Before each Backlog task, sweep all remote refs and worktrees for task-ID
+  collisions, search open PRs for in-flight duplicate work, and re-read the
+  rendered task after creation.
+- Add the implementation plan and ADR link to the Backlog task after moving it
+  to In Progress and before editing code.
+- One runtime has one write service. Compatibility endpoints, UI, tools,
+  interviews, migrations, and Sync never write tables directly.
+- One transaction is atomic only within one SQLite database. Cross-database or
+  cross-runtime effects use durable outbox/journal state and idempotent recovery.
+- Profile content, kinds, provenance, drafts, proposals, conflicts, Undo data,
+  and outbox payloads are encrypted at rest. Clear metadata is restricted to
+  routing/version/timing/size fields named in the spec.
+- `device_only` content never enters an outbox. `user_only` content never enters
+  agent context, agent tools, agent search, or agent-derived artifacts.
+- Runtime read/propose/direct-write grants never synchronize.
+- No embeddings, semantic retrieval, autonomous consolidation, federation, or
+  multi-home-server support in these plans.
+- UI work uses the F9 Settings Screen and production consolidated CSS; never add
+  settings to the deprecated parallel settings surfaces.
+- New screens follow ADR-031 keybindings and truthful footer rules.
+- Tests touching SQLite use real temporary databases. Migration tests begin
+  from truthful historical schemas and reopen them through the production path.
+- Privacy evidence inventories every durable owner and scans decoded persisted
+  bytes, not only the primary database.
+- Live Chatbook checks use a scratch config and scratch data directory and prove
+  the real profile was untouched afterward.
+- Live server checks begin with capabilities and one real control request; do
+  not infer behavior from schemas alone.
+- Run targeted tests for each task. Ask the user before a local full-repository
+  sweep, per `AGENTS.md`.
+- Commit after every task and stage only explicit paths. Never use `git add -A`
+  in the dirty source checkout.
+
+## Release gates
+
+- Shared Core publishes versioned JSON Schema and fixtures before either
+  consumer claims support.
+- Chatbook local-only behavior ships without requiring a server.
+- Server migration ships behind a per-user fence with no dual writes.
+- Sync linking stays disabled unless capabilities include every required
+  personal-context domain, keyed integrity tags, cleanup acknowledgments, and
+  purge generation.
+- Global purge and privacy-reduction integration tests pass before multi-device
+  linking is enabled outside a development feature flag.
+- Legacy routes are removed only after the documented deprecation period and
+  operator backup-retention work is complete.

--- a/Docs/superpowers/specs/2026-08-26-library-notes-ux-improvements-design.md
+++ b/Docs/superpowers/specs/2026-08-26-library-notes-ux-improvements-design.md
@@ -1,0 +1,442 @@
+# Library Notes Work-First UX Improvements
+
+**Status:** Approved design; amended after independent critique
+
+**Date:** 2026-08-26
+
+**Area:** Library → Notes → Database Notes / Folder Files
+
+## Goal
+
+Make both Library Notes workspaces calmer and more efficient for sustained writing. The selected note should receive most of the available canvas, navigation should remain available without becoming dominant, and focusing a note body should communicate focus through its boundary instead of illuminating the entire editor.
+
+The two note authorities retain their existing capabilities and storage behavior:
+
+- **Database Notes** edits records owned by the application database.
+- **Folder Files** edits files owned by a user-selected directory on disk.
+
+This design changes presentation, pane behavior, and control hierarchy only. It does not merge those authorities or alter persistence, autosave, conflict, sync, recovery, or Git semantics.
+
+## Problem Statement
+
+The current Notes experience has three related problems:
+
+1. The global Library rail and local Database Notes list can consume too much width after a note is opened, leaving the content canvas visually subordinate to navigation.
+2. Folder Files uses a persistent tree/editor split but does not offer the same manual navigator control as Database Notes.
+3. The shared focused `TextArea` styling changes the full editor background. On the two large note-body editors this produces excessive luminance and visual distraction while typing.
+
+Both workspaces also expose many low-frequency actions alongside frequent writing actions. Every capability remains useful, but displaying all of them at once weakens hierarchy and reduces room for the note itself.
+
+## Design Principles
+
+The design applies the following Nielsen Norman Group usability principles:
+
+- **Visibility of system status:** ownership, save state, conflicts, read-only state, and consequential Git activity remain visible as concise text.
+- **Match between system and the real world:** Database Notes and Folder Files use authority-specific language rather than implying they are the same storage system.
+- **User control and freedom:** automatic space-making is reversible, manual pane choices win, and destructive/recovery flows keep their existing guards.
+- **Consistency and standards:** both authorities use the same workbench grammar—navigator, grip, primary work canvas—without inventing capabilities that one authority does not have.
+- **Error prevention and recovery:** conflicts and uncertain operations replace ordinary actions with contextual, safe next steps.
+- **Recognition rather than recall:** frequent actions stay visible; lower-frequency actions move into named, stable groups rather than disappearing.
+- **Aesthetic and minimalist design:** chrome and metadata are reduced in the writing view while information with current decision value remains present.
+- **Progressive disclosure:** metadata, export, destructive actions, Git, and maintenance appear in secondary sections or task-specific flows.
+
+References:
+
+- [10 Usability Heuristics for User Interface Design](https://www.nngroup.com/articles/ten-usability-heuristics/)
+- [Progressive Disclosure](https://www.nngroup.com/articles/progressive-disclosure/)
+- [Aesthetic and Minimalist Design](https://www.nngroup.com/articles/aesthetic-minimalist-design/)
+
+## Scope
+
+### In scope
+
+- Work-first wide-screen behavior after opening a Database Note or Folder File.
+- One shared adaptive shell for Database Notes and Folder Files geometry.
+- A manually collapsible Folder Files tree with the same five-column grip grammar as the Database Notes list.
+- Independent, profile-local persistence for the Database Notes list and Folder Files tree preferences.
+- A boundary-only focused state for the two note-body editors.
+- Reorganization of existing controls into frequent actions and clearly labeled secondary groups.
+- More explicit text status for authority, saves, conflicts, Git activity, and recovery.
+- Preservation of editor and navigator state across collapse and responsive transitions.
+- Removal of the Notes-specific `Ctrl+S` binding and its footer/F1 hints while preserving the visible Save operation.
+- Targeted automated and live Textual verification.
+
+### Out of scope
+
+- Database, schema, migration, or data-model changes.
+- Changes to note or file storage authority.
+- New autosave, sync, conflict-resolution, recovery, or Git behavior.
+- A Markdown preview for Folder Files.
+- A new generic pane framework or third-party dependency.
+- New global or screen-level keyboard shortcuts; this change removes one prohibited Notes binding but introduces no replacement binding.
+- Redesign of compact Library navigation outside the existing staged flow.
+
+## Shared Workbench Grammar
+
+Both Notes authorities use the same spatial model without pretending their features are identical:
+
+```text
+wide browse
+┌──────────────┬─────┬──────────────────┬─────┬────────────────────┐
+│ Library      │grip │ Local navigator  │grip │ Select/create      │
+│ destinations │     │ list or tree     │     │                    │
+└──────────────┴─────┴──────────────────┴─────┴────────────────────┘
+
+wide editing, effective work-first layout
+┌─────┬──────────────────┬─────┬──────────────────────────────────┐
+│ --->│ Local navigator  │grip │ Note/file work canvas            │
+│     │ list or tree     │     │                                  │
+└─────┴──────────────────┴─────┴──────────────────────────────────┘
+
+wide editing with both navigators collapsed
+┌─────┬─────┬──────────────────────────────────────────────────────┐
+│ --->│ --->│ Note/file work canvas                                │
+└─────┴─────┴──────────────────────────────────────────────────────┘
+```
+
+The diagrams are structural, not to scale. Both shell grips occupy the existing `PANE_GRIP_WIDTH` of five terminal columns and remain visible for pointer, keyboard, tooltip, and focus recovery.
+
+`LibraryAdaptiveReaderShell` owns this geometry for both authorities. Its local navigator slot contains the Database Notes list or Folder Files tree; its work slot contains the corresponding retained editor surface. Authority-owned widgets keep their services, state, modes, and actions. The global Library rail yields width once when a user enters an editing task on a wide layout, while the local navigator remains available according to its own independent preference.
+
+## Responsive Behavior
+
+| Context | Library rail | Local navigator | Work canvas |
+| --- | --- | --- | --- |
+| Wide browse | Saved preference | Saved preference | Empty/select prompt |
+| Wide editing entry at `width >= LIBRARY_NOTES_COMPACT_BREAKPOINT` (`120`) | Closes once when the work-session transition activates and the saved request is open | Saved authority-specific preference | Receives remaining width |
+| Wide after manual Library expansion | Open; manual choice wins | Unchanged | Reflows without losing state |
+| Compact Library | Existing one-stage navigation | Existing list-to-editor flow | Existing compact stage |
+| Folder Files with allocated width `< FILE_NOTES_NARROW_BREAKPOINT` (`80`) | Shell policy applies | Navigator stage requests shell `items` priority; editor stage clears that priority | Work remains the permanent shell region |
+| Width restored | Responsive geometry is recomputed from saved requests; work-session cancellation is unchanged | Saved authority-specific preference returns | Same selection and editor state |
+
+Responsive and work-first overrides are effective layout state only. They never write user preferences.
+
+### Preference and persistence contract
+
+Pane state is modeled as:
+
+- **Requested visibility:** the user's saved preference.
+- **Work-session visibility:** the requested Library value after the transient Notes work-session override.
+- **Effective visibility:** work-session visibility after explicit pane priority, responsive constraints, and hysteresis are applied.
+
+The exact profile-local keys are:
+
+| Pane | Configuration | `LibraryScreen` runtime authority |
+| --- | --- | --- |
+| Shared Library rail | `[library.reader].library_open` and `library_width` | existing `library` authority |
+| Database Notes list | `[library.notes_reader].items_open` and `items_width` | existing `notes_items` authority |
+| Folder Files tree | `[library.notes_reader].files_tree_open` and `files_tree_width` | new `notes_file_items` authority |
+
+At runtime `LibraryScreen` owns the requested mirrors for all three authorities. For grip-mutated open keys it also owns generation counters, per-authority locks, optimistic updates, durable writes, rollback, and configuration-failure notification. It consumes normalized widths but does not provide an in-Library width editor. The Folder Files keys use the existing adaptive-reader boolean and width bounds. Database and Folder grip writes cannot supersede or roll back each other.
+
+The Settings Appearance surface remains the custom-width mutation owner required by ADR-086. It gains staged fields named `library_notes_files_tree_open` and `library_notes_files_tree_width`, rendered as **Folder Files tree pane** and **Folder Files tree width** beside the existing Notes Items fields. Settings writes those values to `[library.notes_reader].files_tree_open/files_tree_width`; Library grips may write `files_tree_open` but never width. Configuration normalization supports `TLDW_LIBRARY_NOTES_READER_FILES_TREE_OPEN` and `TLDW_LIBRARY_NOTES_READER_FILES_TREE_WIDTH`, matching the existing destination-reader environment convention. Reset-to-default and validation include both fields.
+
+Manual grips persist requested open/closed state only. Work-first, responsive, narrow-stage, focus-priority, and hysteresis changes never persist.
+
+### Work-first session reducer
+
+A small pure Notes-specific reducer owns the transient work-first lifecycle. It has three states:
+
+- `inactive` — no work-first override;
+- `active` — force the effective Library request closed for the current Notes work session;
+- `manually_cancelled` — do not auto-collapse again during the current Notes work session.
+
+Transitions are deterministic:
+
+| Current state | Event | Next state | Preference write |
+| --- | --- | --- | --- |
+| `inactive` | A selected Database Note editor or successfully opened Folder File becomes editable while allocated width is at least `120` | `active` | none |
+| `inactive` | Create/import/root selection/loading/empty/setup, or an item opens below `120` | `inactive` | none |
+| `active` | User expands Library while saved request is already open | `manually_cancelled` | none |
+| `active` | User expands Library while saved request is closed | `manually_cancelled` | persist the explicit open request normally |
+| `active` or `manually_cancelled` | Selection changes, Edit/Preview/Info/Manage changes, save/conflict/recovery changes, or any resize | unchanged | none |
+| any | Reach the authority-specific cleared-selection predicate, change Database/Folder authority, change Folder root, or leave Notes | `inactive` | none |
+
+Opening another item during the same Notes work session does not rearm collapse after manual cancellation. The cleared-selection predicates are exact:
+
+- **Database Notes:** selected/loaded note identity becomes `None` and the work pane shows the select/create prompt.
+- **Folder Files:** the opened-file identity is explicitly closed/cleared. Narrow `Back to navigator` does not clear the retained opened file and therefore does not reset the work session.
+
+Reaching one of those cleared-selection states establishes a new session boundary, so a later editable selection may activate work-first behavior again.
+
+Layout precedence is:
+
+1. load persisted requested visibility and widths;
+2. apply `active` work-first override to the Library request only;
+3. apply an explicit one-shot pane-priority request from navigation or a grip;
+4. resolve responsive constraints and hysteresis in the shared adaptive layout policy.
+
+An explicit manual request always cancels or outranks the work-first override, but hard width constraints may still show one pane at a time. A resize never arms, cancels, or persists work-session state.
+
+The existing Folder `<80` behavior migrates into shell priority requests rather than remaining a second display/geometry controller inside `LibraryFileNotesWorkspace`. In its navigator stage, Folder Files requests `items` priority; opening a file clears that priority and lets the permanent work pane win. At `80` or wider, normal saved visibility applies.
+
+## Database Notes
+
+### Primary work view
+
+`Edit` remains the first and default work mode. `Preview` and `Info` remain available modes. The work header prioritizes:
+
+- selected note title;
+- database authority and save/draft/conflict status;
+- `Edit`, `Preview`, and `Info` mode controls;
+- `Save` when applicable;
+- `Use in Console`.
+
+On a wide layout the header uses at most two logical rows:
+
+1. identity and authority;
+2. content status plus the grouped mode controls and primary task actions.
+
+The mode controls form one group and Save/Use in Console form a separate task group. A blocking content state replaces ordinary task actions with its safe next action. The selected title may ellipsize after its useful prefix; authority, status, and recovery copy may not. Compact presentation may stack the same groups vertically without changing their order.
+
+The body receives the dominant vertical and horizontal space. Metadata and low-frequency actions do not occupy permanent side-by-side canvas space.
+
+### Secondary information architecture
+
+The existing capabilities are preserved in stable groups within `Info`:
+
+1. **Properties** — keywords and existing note metadata.
+2. **Reuse & Export** — existing copy/export/reuse actions.
+3. **Danger** — existing deletion or other destructive actions, retaining confirmations and guards.
+
+An empty, clean note does not display a false dirty or save-warning state. Status copy must distinguish persisted, unsaved, saving, conflict, and failed states rather than relying on color alone.
+
+### Database capability placement
+
+| Existing capability | Approved location | Visibility and retained behavior |
+| --- | --- | --- |
+| Database / Folder authority switch | Existing Notes authority control | Remains outside editor modes; changing authority resets work-session state but preserves each authority's retained selection and navigator state. |
+| Filter, clear filter, sort, note selection | Shared-shell Database local navigator | Existing controls, values, sort choices, selection identity, result paging, and focus behavior remain unchanged. |
+| Folder tree and note placement management | Database local navigator contextual rows/dialogs | New/rename/move/remove/restore folder and add/move/remove placement keep their existing services, confirmations, receipts, and disabled reasons. |
+| New note | Existing Database navigator `New` action | Existing creation, draft, discard, validation, and selection behavior remains unchanged. |
+| Add from files… | Existing Database navigator transfer actions | Existing Import once and lasting-sync setup/review workflows remain reachable. Setup/import/sync does not activate work-first collapse until an editable note is selected. |
+| Manage sync folders | Existing conditional Database navigator transfer action | Remains visible under its current configured-root predicate and opens the existing sync-roots workflow. |
+| Last import | Existing conditional Database navigator transfer action | Remains visible while an import receipt is retained and opens the existing receipt workflow. |
+| Whole-source Export | Existing Database navigator `Export` action | Existing export scope, service, progress, and error behavior remains unchanged. |
+| Bulk selection and Export selected | Existing Database local-navigator selection presentation | Existing selected set, Select all shown, Clear, Done, disabled reason, export service, progress, partial failure, and recovery behavior remain unchanged. No bulk-delete capability is invented. |
+| Undo note/folder deletion | Existing Database navigator receipt/action | Existing receipt lifetime, generation fencing, and recovery behavior remain unchanged. |
+| Title/body editing | `Edit` | Primary work surface; existing draft, autosave, validation, and conflict guards remain mounted. |
+| Save | Primary task group | Visible when applicable; existing save service and disabled reasons remain authoritative. |
+| Markdown rendering | `Preview` | Retained presentation; no hidden render backlog is introduced. |
+| Keywords and metadata | `Info` → **Properties** | Available without consuming the Edit canvas. |
+| Use in Console | Primary task group | Existing handoff behavior and status remain unchanged. |
+| Copy/export/reuse | `Info` → **Reuse & Export** | Existing services, filenames, and validation remain unchanged. |
+| Delete | `Info` → **Danger** | Existing confirmation, running, and cancellation guards remain unchanged. |
+| Conflict/recovery | Contextual recovery region | Replaces ordinary task actions until resolved; draft and selected identity remain mounted. |
+
+## Folder Files
+
+### Primary work view
+
+Folder Files exposes `Edit` and `Manage`; it does not gain a Markdown `Preview` mode. The existing large-file preview/guard behavior is a safety mechanism, not a new authoring mode.
+
+The work header prioritizes:
+
+- selected file name or path;
+- folder/file authority and save/read-only/conflict state;
+- `Edit` and `Manage` controls;
+- autosave state and any contextual recovery action; Folder Files gains no ordinary manual Save control;
+- concise consequential Git status when it has current decision value.
+
+The wide Folder header follows the same two-row priority as Database Notes. The friendly folder/file identity may ellipsize after a useful prefix; the exact selected path remains available in `Manage`. Content/recovery status and its safe next action never ellipsize. The tree header retains frequent creation/navigation affordances. Its grip is the shared shell's five-column items grip rather than a second Folder-specific grip implementation.
+
+### Secondary information architecture
+
+Existing capabilities are preserved in stable `Manage` groups:
+
+1. **File details & path** — authority, selected path, file properties, and current disk state.
+2. **File actions** — existing move, copy, reload, refresh, protect, compare, or resolution actions when applicable.
+3. **Session Git** — existing session Git controls and details.
+4. **Danger** — destructive actions and their existing guards.
+
+New, Move, and Save Copy use named task flows that reveal target-path inputs only when invoked. Restore remains its existing contextual recovery action and does not invent a target-path requirement. Compare, resolve, reload, and other conditional actions appear only in states where they are meaningful.
+
+Git controls may be secondary, but consequential Git state remains visible in the primary work header as text—for example `Git · 3 changes`, `Checking…`, `Pushing…`, `Push failed`, or an explicit uncertain state. Ordinary success does not demand persistent attention.
+
+### Folder Files capability placement
+
+Only one named path task is open at a time: `none | new | move | save_copy`. Opening another path task replaces the current task only after the existing unsaved/confirmation guard permits it. `Cancel` or guarded `Esc` closes the task and returns focus to the control that opened it.
+
+| Existing capability | Approved location | Visibility predicate and retained contract |
+| --- | --- | --- |
+| Choose folder / root details | Browse/setup header | Visible when no usable root exists or root details are requested; root validation and transition guards remain unchanged. |
+| Search, tree, selection | Shared shell local navigator | Retained Folder navigator region; search value, expansion, selection, and scroll survive collapse and authority switches. |
+| Editing autosave | `Edit` status channel | Existing debounce, flush-before-leave, conflict, error, and draft-preservation behavior remains authoritative; no manual Save button is added. |
+| New | Tree header → named `new` task | Reveals target path only after invocation; existing path validation and create guard remain. |
+| Move | `Manage` → **File actions** → named `move` task | Available only for an applicable selected file; existing path validation and move guard remain. |
+| Save Copy | Contextual recovery and `Manage` → **File actions** → named `save_copy` task | Remains immediately reachable during conflict/reload recovery where it is a safe action; never overwrites an existing target. |
+| Restore | Contextual file action | Appears only for the retained deleted-file selection; no invented target-path requirement. |
+| Compare / Resolve conflict | Contextual recovery region | Appears only for disk divergence/conflict; ordinary actions are replaced until the user chooses a safe path. |
+| Reload | `Manage` → **File actions**, then contextual confirmation | Existing dirty-draft confirmation, Cancel, and Discard/load-disk behavior remain mounted. |
+| Protect / Refresh | `Manage` → **File actions** | Existing maintenance semantics and disabled reasons remain unchanged. |
+| Delete | `Manage` → **Danger** | Existing deletion guard, deleted-path retention, and restore affordance remain unchanged. |
+| Review session changes / Git panel | `Manage` → **Session Git** | The existing Git widget remains mounted while hidden; running and uncertain operations retain state. Consequential summary remains in the primary header. |
+| Keep editing / Save draft as new note / Discard and load disk | Contextual recovery region | Retains current conflict and reload services; Save Copy stays reachable and focus returns to the editor or originating action after cancellation. |
+
+`Manage`, the editor, the retained Git panel, and contextual recovery regions toggle presentation without remounting active editor, Git, or recovery state.
+
+## Note-Body Focus Treatment
+
+The boundary-only focus treatment applies exactly to:
+
+- `#library-note-body`
+- `#file-notes-editor`
+
+When either body editor receives focus:
+
+- its computed background is identical to its unfocused computed background;
+- a same-geometry `heavy` outline using the existing semantic `ds-*` focus token supplies the non-color boundary cue;
+- the focused boundary has at least `3:1` contrast against every adjacent surface in each shipped theme;
+- focus does not change geometry or cause layout shift;
+- text selection and cursor rendering remain unchanged;
+- focus remains distinguishable through boundary weight as well as color.
+
+Title, path, search, filter, and other compact inputs retain their existing focused-fill treatment. Other `TextArea` widgets elsewhere in the application are unchanged.
+
+## State Preservation and Focus
+
+Collapsing either navigation pane or crossing a responsive threshold retains mounted widget state rather than reconstructing the workspace. The following state must survive:
+
+- selected note or file identity;
+- filter, search, and sort state;
+- list scroll position and tree expansion;
+- draft content, cursor, selection, undo history, and editor scroll position;
+- dirty, conflict, read-only, or recovery state;
+- running Git state and its result;
+- semantic focus where the target remains visible.
+
+If the currently focused control becomes hidden, focus moves to that pane's visible grip and the shell retains the last valid focused descendant for that pane. Activating the grip to reopen the pane restores that target when it still exists and is enabled; otherwise it uses the pane's first valid focus target. A responsive-only restoration never steals focus. `Back` and `Esc` continue through the existing navigation and unsaved-change guards.
+
+No new shortcut is introduced. The Notes-specific `Ctrl+S` binding and its Notes footer/F1 hints are removed because screen-level terminal-convention bindings are prohibited. The visible Save control remains reachable through normal focus navigation, including `F6`. The separately gated Skill-editor binding is outside this Notes-only scope.
+
+## Status, Errors, and Recovery
+
+Text labels accompany semantic color for all consequential states:
+
+- database versus folder authority;
+- saved, unsaved, saving, failed, or conflict;
+- read-only or protected;
+- offline/unavailable storage;
+- Git changes, progress, failure, or uncertain completion.
+
+The header has two independent status channels:
+
+1. **Content and recovery:** `conflict` → unavailable/read-only blocker → save failure → saving → dirty → saved/clean.
+2. **Authority and Git:** authority/root state is always named; Git uses `failure or uncertain` → running → changes, while ordinary clean success is omitted.
+
+The first applicable state in each order is rendered. Git never replaces a content conflict, failed save, or safe recovery action. When space is constrained, the content/recovery channel remains in the header and the complete authority/Git details remain in `Info` or `Manage`.
+
+Recovery callouts state:
+
+1. what happened;
+2. the impact on the current draft/file;
+3. the safest available next action.
+
+When a conflict or failed operation requires attention, contextual recovery actions replace ordinary controls in that region. Existing confirmation, overwrite, and navigation guards remain unchanged.
+
+Empty Database Notes and missing/unselected Folder Files roots keep the Library rail available and present explicit next steps. They do not enter work-first mode.
+
+## Architecture and Ownership
+
+The change reuses the current Notes architecture:
+
+- `LibraryScreen` continues to own destination orchestration, the shared Library request, both authority-specific local-navigator requests, and their independent persistence authorities.
+- A small pure Notes work-session reducer owns only `inactive | active | manually_cancelled` and accepts named events. It performs no UI queries, data access, or preference writes.
+- One `LibraryAdaptiveReaderShell` implementation owns Library/list/work geometry, both five-column grips, responsive resolution, width application, and focus evacuation/restoration for both Notes authorities.
+- The shell's retained items/work hosts present the Database Notes list/canvas or Folder Files tree/editor regions according to the active authority without rebuilding the underlying editors.
+- `LibraryFileNotesWorkspace` remains the Folder domain owner and supplies distinct retained navigator and work regions to the shell. It no longer sets competing navigator/editor widths or display geometry; its exact `<80` stage becomes shell priority input.
+- `LibraryNotesCanvas` and `LibraryFileNotesWorkspace` reorganize their existing actions into the approved primary and secondary hierarchy without changing their services or guards.
+- Component CSS applies the body-editor focus exception by exact widget ID and uses existing semantic `ds-*` tokens.
+
+No second shell, generic editor framework, or schema-driven action framework is introduced. No service, route, draft-registry, sync-engine, database, file-authority, or Git boundary changes.
+
+## Expected Code Surface
+
+Implementation is expected to stay within the existing Library Notes surface and its focused tests, primarily:
+
+- `tldw_chatbook/UI/Screens/library_screen.py`
+- a Notes-specific pure work-session reducer adjacent to the Library screen under `tldw_chatbook/UI/Library_Modules/`
+- `tldw_chatbook/Utils/adaptive_reader_state.py` for the Folder profile/priority contract only if the existing profile API cannot express it
+- `tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py` for authority-neutral focus restoration or retained slot support
+- `tldw_chatbook/Widgets/Library/library_notes_canvas.py`
+- `tldw_chatbook/Widgets/Library/library_file_notes_workspace.py`
+- `tldw_chatbook/config.py` for `files_tree_open` / `files_tree_width` defaults and normalization
+- `tldw_chatbook/UI/Screens/settings_appearance_defaults.py` and `settings_screen.py` for Folder-tree staged open/width fields, validation, reset, and durable Settings writes
+- the existing Library/forms component TCSS files
+- focused reducer, configuration, Settings Appearance, Library Notes, shell, Folder Files, accessibility, and Textual pilot tests
+- Library Notes user-guide pages where interaction guidance changes
+
+The implementation plan must inspect the current dirty worktree and adjust to concurrent changes rather than assuming these files are pristine.
+
+## Acceptance Criteria
+
+- [ ] Database Notes and Folder Files use `LibraryAdaptiveReaderShell` as their only geometry, grip, responsive, and focus-evacuation owner.
+- [ ] Opening an editable note/file at width `>=120` activates work-first collapse exactly once per approved Notes work session.
+- [ ] Manual Library expansion moves the session to `manually_cancelled`, survives selection/mode/save/conflict/resize changes, and does not accidentally write an already-open saved preference.
+- [ ] Database selected/loaded identity clearing, Folder opened-file identity explicitly clearing, authority/root change, or leaving Notes resets the work session; narrow Folder Back does not reset it, and no other event rearms collapse.
+- [ ] The Folder Files tree uses the shared, five-column collapse/expand grip on wide layouts.
+- [ ] `[library.notes_reader].items_open/items_width` and `files_tree_open/files_tree_width` are independent, profile-local, normalized, and written through distinct persistence authorities.
+- [ ] Settings Appearance owns the Folder-tree width editor and exposes `library_notes_files_tree_open/width`; environment normalization supports the two declared `TLDW_LIBRARY_NOTES_READER_FILES_TREE_*` overrides.
+- [ ] Work-first, responsive, `<80` Folder stage, focus-priority, and hysteresis transitions never write preferences.
+- [ ] Collapse/expand and width transitions preserve the current identity, editor draft, cursor/selection/undo/scroll, navigator state, and contextual operation state.
+- [ ] Database Notes retains Edit, Preview, and Info; Folder Files exposes Edit and Manage and does not advertise a Markdown Preview mode.
+- [ ] Every existing Notes capability maps to the approved primary controls, secondary groups, named path task, or contextual recovery region with its existing service and guard intact.
+- [ ] Existing Database filter/sort, folder/placement, New, Add from files, Manage sync folders, Last import, whole-source Export, bulk selection/Export selected, and undo capabilities remain in their declared navigator/workflow locations; no bulk delete is invented.
+- [ ] Folder Files retains autosave and gains no ordinary manual Save button.
+- [ ] Only one Folder path task is active at a time; Cancel/guarded Esc returns focus to its origin; Save Copy remains reachable in applicable conflict/reload recovery.
+- [ ] Git controls are secondary while consequential Git status remains visible as text.
+- [ ] Content/recovery and authority/Git status channels follow the declared precedence; blocking status and the safe next action are never ellipsized.
+- [ ] Only the two note-body editors have identical focused/unfocused computed backgrounds, a geometry-stable heavy focus outline, and at least 3:1 boundary contrast in every shipped theme.
+- [ ] Compact and exact `<80` Folder flows retain their existing staged navigation behavior through shared-shell priority rather than a second geometry controller.
+- [ ] Manual grip expansion restores the last valid focus target; responsive restoration never steals focus.
+- [ ] Empty/setup states remain navigable and do not trigger work-first collapse.
+- [ ] Notes no longer binds or advertises `Ctrl+S`; Save remains visibly and keyboard-accessibly reachable, and no replacement shortcut or invented capability is introduced.
+- [ ] Targeted automated checks and live Textual walkthroughs cover the approved wide, compact, resize, focus, status, and recovery behaviors.
+
+## Verification Strategy
+
+Targeted verification is sufficient unless a full test sweep is separately requested:
+
+1. Unit-test the pure `inactive | active | manually_cancelled` reducer across activation, manual expansion, item/mode/save/conflict/resize preservation, exact Database/Folder cleared-identity resets, and the non-resetting narrow Folder Back event.
+2. Prove requested versus work-session versus effective visibility and verify that only explicit requested-state changes enter persistence.
+3. Test distinct `notes_items` and `notes_file_items` grip writes, generation races, rollback, normalization, configuration-failure copy, Settings staged open/width save/reset/validation, and both Folder-tree environment overrides.
+4. Pilot the shared-shell Database Notes and Folder Files layouts at `160`, `120`, `119`, `80`, `79`, and restored widths.
+5. Verify retained identity, draft, cursor, selection, undo, scroll, tree expansion, Git, and recovery state across pane collapse, authority changes, and resize.
+6. Verify focus evacuation, manual restoration to the last valid target, fallback focus, and no focus theft during responsive restoration.
+7. Assert focused/unfocused computed-background equality for the two body IDs, a heavy outline, and at least `3:1` boundary contrast across shipped light and dark themes.
+8. Assert compact inputs and unrelated `TextArea` widgets retain their existing focused fill.
+9. Exercise the declared content and Git status precedence across clean, dirty, saving, conflict, failed, read-only/offline, Git-progress, Git-failure, and uncertain combinations.
+10. Inventory every capability against its incumbent stable control/event and approved location, including Database New/Add from files/Manage sync folders/Last import/whole-source Export/Export selected with an explicit no-bulk-delete assertion, Folder autosave with no ordinary Save button, named path-task exclusivity, cancellation focus, and Save Copy recovery reachability.
+11. Confirm Folder Files has no invented Markdown Preview and Notes footer/F1 help no longer contains `Ctrl+S`.
+12. Perform a live Textual walkthrough of both authorities at representative wide and compact sizes.
+
+## Risks and Mitigations
+
+- **Automatic collapse feels surprising.** Activate it once per explicit work session, keep the five-column grip visible, and preserve `manually_cancelled` until a named reset event.
+- **Preference corruption during transient changes.** Keep requested, work-session, and effective state separate; use distinct Database/Folder persistence authorities; test that automatic transitions do not write configuration.
+- **Shared-shell migration remounts Folder state.** Supply retained Folder navigator/work regions to the shell and inventory identity, draft, Git, recovery, and focus preservation before changing geometry.
+- **Hidden operations reduce discoverability.** Use stable Database `Info` and Folder `Manage` groups, truthful disabled reasons, and consequential status in the primary header.
+- **State loss during layout changes.** Retain mounted widgets and test draft, cursor, selection, undo, scroll, selection identity, and active operations.
+- **Focus becomes too subtle after removing the fill.** Use a heavy, geometry-stable semantic outline and verify at least 3:1 boundary contrast across shipped themes.
+- **The two authorities drift into false parity.** Share only the workbench grammar; retain authority-specific modes, wording, actions, and status.
+
+## ADR Check
+
+**ADR required:** No
+
+**ADR path:** `backlog/decisions/086-library-adaptive-reader-shell.md`; `backlog/decisions/076-library-lifecycle-progressive-disclosure.md`
+
+**Reason:** Folder Files now adopts ADR-086's required single Library-local shell instead of introducing a parallel geometry engine. The new Folder tree preference is an authority-specific requested-visibility/width pair under the existing `[library.notes_reader]` owner, matching ADR-086's persistence contract. The work remains a bounded refinement of ADR-086 and ADR-076 and does not change storage, synchronization, data ownership, service contracts, security boundaries, or long-lived application architecture.
+
+## Resolved Decisions
+
+- The work-first wide layout is the approved direction.
+- Edit is the first Database Notes view.
+- Boundary-only focus applies only to the two note-body editors.
+- Existing capabilities are reorganized, not removed.
+- Folder Files uses `Edit` and `Manage`, gains a collapsible tree through the shared adaptive shell, and does not gain a Markdown Preview mode.
+- Automatic collapse runs once per Notes work session; manual expansion suppresses it until browse/no selection, authority/root change, or Notes exit.
+- Database Notes list and Folder Files tree preferences use independent keys and persistence authorities.
+- The two body editors use background-stable, heavy-outline focus with a 3:1 boundary-contrast minimum.
+- The Notes `Ctrl+S` binding and its hints are removed without adding a replacement shortcut.
+- No new ADR, dependency, or pane framework is required.

--- a/Docs/superpowers/specs/2026-08-27-console-provider-apply-persistence-design.md
+++ b/Docs/superpowers/specs/2026-08-27-console-provider-apply-persistence-design.md
@@ -1,0 +1,563 @@
+# Console Provider Apply, Conversation Persistence, and Defaults Design
+
+**Status:** Approved; implementation-plan review findings addressed
+**Date:** 2026-08-27
+**Task:** TASK-22515
+**ADR:** ADR-095
+
+## Goal
+
+Make Apply in the Console Provider/Model popover reliably close the popover,
+update the exact conversation immediately, and preserve the conversation's safe
+generation settings across restart. Add explicit per-model and new-chat default
+actions that reuse the existing model-profile and configuration owners. Every
+eligible blank new chat uses the saved global provider/model and that exact model's
+profile in the running app and after reboot. Give mouse and keyboard activation the
+same semantic path. Keep compaction mode conversation-only through its existing
+independent persistence owner. Use the same conversation-settings Apply orchestration
+from the full Console Settings modal.
+
+## User-Visible Contract
+
+Apply means **apply to this conversation now**.
+
+- The exact conversation that opened the modal is updated even if another tab
+  becomes active before the result is handled.
+- Every execution context resolved after Apply observes the new conversation
+  settings. A request that already captured its execution context remains
+  unchanged.
+- The modal closes after a valid Apply from either mouse or keyboard.
+- A persisted conversation restores its applied settings after the app restarts.
+- An unsaved ordinary chat saves the settings with its first persistence.
+- A temporary chat keeps the settings only for its temporary lifetime unless it
+  is promoted.
+- Invalid input keeps the modal open and identifies the field that must be fixed.
+- A durable save failure does not roll back either live component. After the modal
+  closes, the Console keeps an explicit per-component failure visible until the
+  current value is saved successfully, superseded by a newer Apply, or the session
+  closes.
+- `Save as model default` applies the draft to the originating conversation, then
+  saves only the submitting surface's model-profile fields for the exact normalized
+  provider and literal model ID.
+- `Make default for new chats` performs the same live Apply and model-profile save,
+  then changes the global provider/model used by every eligible blank new chat in
+  the current process and after reboot.
+- The two default actions close after the live conversation commit. A later config
+  failure remains explicit and retryable without pretending that the live Apply
+  failed.
+- Ordinary `Apply to this chat` never changes a model profile, global default, or
+  endpoint.
+- Compaction is never part of either model or global defaults. It remains applied
+  only to the originating conversation.
+
+Apply includes provider, model, temperature, streaming, and compaction mode.
+Compaction keeps its existing context-policy owner and storage; it is not serialized
+inside the generation-settings metadata object. Generation-settings and
+context-policy persistence outcomes are tracked independently. The quick surface may
+label a context-policy failure as `compaction` because that is the only policy field
+it edits.
+
+## Selected Architecture
+
+The existing Console session remains the live owner. The existing conversation row
+becomes the durable owner of an allowlisted generation-settings snapshot. Existing
+configuration sections remain the only owners of model profiles, the global
+provider/model, and provider endpoints.
+
+One conversation-settings Apply orchestrator accepts a typed intent containing:
+
+- the stable originating session ID;
+- the conversation identity captured when the surface opened, if one exists;
+- the validated target provider/model and values submitted by the surface;
+- the submitted compaction mode or full-modal context-policy overrides;
+- the exact set of fields exposed by that surface;
+- a full-modal endpoint only when its draft is bound to the target provider.
+- a discriminated action: `apply_chat`, `save_model_default`, or
+  `make_new_chat_default`;
+- a field mask for the model-profile mutation when the action saves defaults;
+- a full-modal endpoint-save flag only when the endpoint was explicitly edited and
+  the user left the scoped checkbox enabled.
+
+The orchestrator validates that the origin still exists and still has the captured
+conversation identity. A chat that was unsaved when the surface opened may complete
+its normal first-persistence transition from no conversation ID to its newly created
+ID without being treated as rebound; every other identity change is rejected. The
+session-lifecycle seam must distinguish that first-persistence bind from an explicit
+rebind rather than accepting every `None` → ID transition. It delegates provider
+rebasing to one controller seam and
+compaction to the existing context-policy store seam, then applies both live values
+to the exact session before yielding. It increments the relevant process-local
+revisions, synchronizes the Console summary/control bar immediately, and starts the
+two independent durable writes when the session has a conversation row. It never
+falls back to the currently active session. If the origin closed or was rebound, it
+reports `Chat closed; nothing applied`.
+
+The quick popover and full modal both call this orchestration. No parallel
+quick-settings service, new database table, combined persistence abstraction, or
+cross-owner transaction is introduced.
+
+Default configuration mutation begins only after the exact-origin live commit
+succeeds. It runs as one locked, field-masked patch against the freshly reread config,
+then publishes the new runtime configuration. Conversation metadata and context
+policy keep their independent owners and outcomes. A bounded app-level default
+durability record is separate from each session's conversation durability record.
+
+## Durable Data
+
+`conversations.metadata` gains one owned namespace:
+
+```json
+{
+  "console_generation_settings": {
+    "version": 1,
+    "provider": "OpenAI",
+    "model": "gpt-5",
+    "temperature": 0.7,
+    "top_p": 0.95,
+    "min_p": null,
+    "top_k": null,
+    "max_tokens": null,
+    "seed": null,
+    "presence_penalty": null,
+    "frequency_penalty": null,
+    "reasoning_effort": null,
+    "reasoning_summary": null,
+    "verbosity": null,
+    "thinking_effort": null,
+    "thinking_budget_tokens": null,
+    "streaming": true
+  }
+}
+```
+
+Only the listed fields are serialized. `base_url`, credentials, credential
+references, system prompt, pinned prefill, character identity, and runtime
+provenance are excluded. Existing owners continue to persist system prompt and
+pinned prefill.
+
+The metadata helper follows the existing roleplay/speech patterns:
+
+- parse only mappings with supported versions and valid field types;
+- fail closed on absent, malformed, or unknown values;
+- preserve every sibling metadata key during writes;
+- use optimistic conversation versions and bounded conflict retry;
+- refuse to overwrite a future unsupported version.
+
+Persisting the complete rebased safe snapshot on either settings surface prevents a
+prior provider's hidden tuning fields from surviving a provider switch.
+
+Compaction remains a sparse `ConsoleContextPolicyOverrides` value in
+`console_conversation_context_policy`. Apply changes only its `compaction_mode`
+field from the quick surface, preserving the other context-policy overrides. Its
+existing first-persistence and resume paths remain authoritative.
+
+### Existing configuration owners
+
+The default actions reuse the established configuration schema:
+
+- `api_settings.<provider>.model_defaults[<exact model id>]` owns per-model
+  generation defaults. Model IDs are trimmed literal mapping keys; dots, slashes,
+  colons, and other punctuation are never interpreted as config paths.
+- `chat_defaults.provider` and `chat_defaults.model` own the global selection used
+  by eligible blank new chats.
+- A full-Settings `Make default for new chats` may also update the selected
+  provider's existing endpoint field when the endpoint is explicitly dirty and its
+  scoped checkbox remains checked.
+
+The quick surface's profile mask is `temperature` plus `streaming`. The full Model
+surface's mask is every supported exposed sampler, reasoning/thinking, token-limit,
+and streaming field. The patch changes only those exact fields, preserves unexposed
+profile fields and sibling model profiles, and removes an exact profile field when
+the submitted value means inherit. Provider aliases are matched canonically while
+the existing raw provider-section identity is preserved. Credentials and credential
+references are never copied.
+
+The mutation rereads the config while holding the existing config lock, applies the
+model-profile patch plus any global provider/model and eligible endpoint changes as
+one atomic file intent, replaces the file once, and then refreshes runtime config.
+It returns the existing rich phase result rather than collapsing file replacement
+and runtime publication into one boolean.
+
+## Provider and Model Rebase
+
+A provider or model change is not implemented with a field-only `replace(...)`. The
+session controller owns this operation for both settings surfaces.
+
+1. Normalize the selected provider and model.
+2. Build the complete effective defaults for the selected provider/model whenever
+   either selection changes.
+3. Rebase every untouched draft field from the target model profile, saved Console
+   provider defaults, chat defaults, and provider settings in the established
+   precedence order.
+4. Resolve the selected provider's configured endpoint through the existing
+   provider-resolution path.
+5. Discard the previous provider's endpoint and incompatible provider-specific
+   reasoning/thinking values.
+6. Overlay only deliberately edited draft fields exposed by the submitting surface
+   and supported by the selected provider. Carried edits remain visibly marked
+   `edited`; untouched values display the target model's effective values.
+7. Accept a full-modal session endpoint only when the endpoint draft is explicitly
+   bound to the selected provider; the quick popover never submits an endpoint.
+8. Mark the resulting snapshot as user-authored and commit it to the exact session.
+
+Each open settings transaction keeps only a process-local draft map keyed by
+canonical provider plus literal model ID. Switching A → B → A restores A's unfinished
+edits while rebasing untouched fields for B. Unsupported provider-specific fields are
+removed from the target draft rather than hidden and later resurrected. This draft
+map is discarded when the transaction ends and never becomes another persistence
+owner.
+
+`Full settings…` deepens the same transaction. It transfers the complete quick draft,
+field provenance, compaction draft, exact origin identity, and keyed draft map to the
+full modal, opens the Model view, and establishes predictable focus. It never applies
+or discards quick edits merely because the user requested the deeper surface.
+
+Conversation hydration performs the same ordering: parse the saved provider first,
+build defaults for that provider, then overlay the remaining saved fields. A model
+missing from the current catalog remains a valid explicit custom selection; an
+unconfigured provider produces the existing blocked readiness state rather than a
+silent fallback.
+
+## Apply Flow
+
+1. Opening either settings surface captures the origin session ID and current
+   conversation identity before catalog loading or other asynchronous work.
+2. Widget edits remain a local keyed draft until a committing action.
+3. A committing action validates provider, model, and numeric fields. Validation
+   failure keeps the surface open and focuses the first invalid control.
+4. The surface submits one typed intent containing the generation draft,
+   compaction/context-policy draft, discriminated action, and applicable default
+   field mask.
+5. The Apply orchestrator verifies the captured origin, performs provider/model-aware
+   rebasing, and derives the new sparse context-policy overrides.
+6. It commits both live snapshots to the origin session and increments their
+   process-local revisions before yielding. Mounted summaries and controls
+   synchronize immediately, and the modal closes.
+7. For an existing conversation, the generation snapshot is written to metadata
+   with sibling-preserving optimistic concurrency while the complete still-current
+   context-policy snapshot is written through the existing context-policy repository.
+   Neither durable write gates or rolls back the other live component.
+8. Each persistence attempt is bound to the captured conversation identity and the
+   revision of that component. Sibling-only metadata conflicts may be merged and
+   retried. A stale completion cannot clear or overwrite the outcome of a newer
+   Apply.
+9. The session records `generation_settings` and `context_policy` as the two possible
+   failed components in a bounded process-local durability record. The collapsed
+   Model section shows a warning badge; when expanded, its rail names each failed
+   component and exposes `Retry save` after the modal closes. A quick-popover failure
+   may read `Not saved: generation settings · compaction`; a full-modal policy
+   failure reads `context settings` when fields beyond compaction were submitted.
+   Retrying `context_policy` writes the complete still-current policy snapshot and
+   carries its policy revision, never merely the old compaction field. A component
+   clears on successful persistence or when any newer change supersedes its snapshot;
+   the record disappears when no component remains failed.
+10. If the session is unsaved, both snapshots are staged rather than marked failed.
+    Generation metadata is included at first conversation creation and context
+    policy uses its existing post-create flush. Failures discovered at first
+    persistence enter the same per-component durability record.
+11. For `save_model_default` or `make_new_chat_default`, the immutable config intent
+    runs after step 6. A missing, closed, or rebound origin prevents both live Apply
+    and default mutation; default saving never proceeds as a detached side effect.
+12. `save_model_default` patches only the exact model profile. The quick field mask
+    is temperature and streaming; the full field mask contains all supported fields
+    exposed by its Model view.
+13. `make_new_chat_default` atomically patches that model profile plus global
+    provider/model. Only a full-modal, explicitly dirty, checked endpoint is included.
+14. A successful runtime publication makes subsequent eligible blank-chat creation
+    observe the new global provider/model and model profile immediately. A file that
+    was replaced despite runtime-publication failure remains valid across restart;
+    the current process continues to advertise its stale-runtime recovery state.
+15. An ordinary `apply_chat` neither clears nor silently discards an earlier failed
+    default intent. A newer explicit default action supersedes the earlier pending
+    intent; revision and locked-config checks prevent stale retry from overwriting a
+    newer edit.
+
+The execution boundary is objective: consumers that already hold an execution
+context keep it; consumers resolving after the live commit in step 6 read the new
+settings. The design does not special-case user sends, retries, regenerations,
+queues, or agent work.
+
+## Eligible New Chats
+
+After a successful `Make default for new chats`, every blank Console creation path
+without an explicit source-settings intent resolves fresh settings through
+`build_default_console_session_settings` and therefore observes the saved global
+provider/model and that exact model's profile. This includes:
+
+- Ctrl+T blank chats;
+- new temporary chats;
+- workspace-created blank chats; and
+- the initial pristine Console chat after startup.
+
+Existing and already-open conversations never rebase merely because a global
+default changed. Deliberate Duplicate, Branch, Continue, or handoff operations that
+carry explicit source settings are not blank-chat creation; their explicit intent
+continues to win and the UI must not describe them as using the new-chat default.
+
+The previous Ctrl+T behavior that cloned the active session is replaced for blank
+chat creation. Tests enumerate each eligible path so `Make default for new chats`
+cannot be technically successful while the next ordinary chat ignores it.
+
+## Mouse and Keyboard Reliability
+
+The quick popover reuses the full Settings modal's established Textual behavior:
+
+- the temperature input releases mouse capture on click/blur;
+- a click redirected to a captured input is hit-tested against visible buttons;
+- a recovered Apply invokes `button.press()`;
+- `Button.Pressed` remains the only semantic Apply event;
+- redirected recovery cannot press the button twice;
+- backdrop dismissal remains cancellation, never Apply.
+
+Deferred UI callbacks tolerate a dismissed popover. `_sync_fold_hint` and equivalent
+lookups handle `NoMatches` or verify mounting before querying descendants.
+
+## Presentation and Validation
+
+The compact surface keeps its existing purpose and progressively discloses default
+actions. It does not gain additional configuration sections.
+
+- Title: `Conversation settings`
+- Visible labels: Provider, Model, Temperature, Streaming, Compaction
+- Main actions: `Cancel`, `Full settings…`, `Defaults…`, `Apply to this chat`
+- Scope copy: `Applies to this conversation`
+- Unsaved chat copy: `Saved with the conversation after its first message`
+- Temporary chat copy: `Temporary until this chat is promoted`
+
+`Defaults…` replaces rather than expands the main footer. Its chooser keeps the
+current draft and exact target visible:
+
+- `Save as model default` — `Remember Temperature + Streaming for
+  {provider}/{model}. New-chat provider/model unchanged.`
+- `Make default for new chats` — `Save this model profile and start eligible new
+  chats with {provider}/{model}.`
+- `Back`
+- Scope copy: `Compaction stays with this chat.`
+
+The full Model view uses the same two intent labels but saves every supported field
+it exposes. Blank values display `Inherit`; for the conversation Apply they resolve
+the current lower-precedence value and freeze that effective value in the complete
+conversation snapshot, while the model-profile mutation deletes that exact override.
+Streaming is a three-state `Inherit` / `On` / `Off` control in the full view. The
+quick surface shows effective temperature and streaming and marks deliberately
+carried values `edited` after a provider/model switch.
+
+The chooser is a real substate with no more than three visible actions. First Escape
+or `Back` returns to the main footer without losing the draft; a second Escape from
+the main state cancels the popover. Mouse recovery, Enter activation, and duplicate
+activation guards apply to every committing action, not only ordinary Apply.
+
+An unconfigured or readiness-blocked provider may remain an explicit conversation
+selection, but `Make default for new chats` is disabled with a concise explanation
+until the provider is configured. Successful default actions report two independent
+receipts: `This chat updated` and the exact default scope saved.
+
+The current compaction threshold, help, and mode control remain in the quick
+popover. Full Settings Context remains the deeper editor for the rest of the
+context policy.
+
+Temperature parsing no longer silently restores the old value. Invalid input shows
+an inline error and keeps the draft intact. Apply emits at most one concise outcome
+notification; persistent failures live in the Model rail rather than disappearing
+with a toast. There is no `Next send` label because the conversation setting changes
+immediately.
+
+## Full Settings Alignment
+
+Full Console Settings uses the same Apply orchestration, provider/model rebase,
+generation metadata writer, complete context-policy snapshot owner, and
+per-component durability reporting. Its safe generation fields therefore have the
+same restart behavior as the quick popover. A full-modal policy Retry is
+revision-guarded against the entire current context-policy snapshot, not only
+compaction mode.
+
+The full modal's endpoint remains configuration-owned. A custom endpoint can affect
+the live session, but it survives restart only through `Make default for new chats`,
+only after that provider-bound endpoint was explicitly edited, and only while the
+scoped checkbox remains enabled. `Save as model default`, ordinary Apply, and the
+quick popover never persist an endpoint. This task does not copy endpoints into
+conversation metadata.
+
+The checked line shows only a sanitized host and conservative network class, for
+example `Also save connection: 192.168.1.20:8080 · LAN`. Sanitization removes
+userinfo, path, query, and fragment before presentation or logging. Classification
+is syntactic and performs no DNS lookup:
+
+- `Local`: localhost or a loopback literal;
+- `LAN`: private/link-local literals and `.local` hostnames;
+- `Remote`: public IP literals; and
+- `Remote/unknown`: other hostnames whose address class is not known locally.
+
+Credentials and credential references are never shown or copied by this action.
+
+System prompt and pinned prefill retain their existing storage paths; the shared
+commit coordinates live `ConsoleSessionSettings` replacement without duplicating
+their durable data in `console_generation_settings`.
+
+## Resume and First Persistence
+
+- **Resume:** Build defaults for the saved overlay provider, apply the validated
+  safe snapshot, resolve endpoint/configuration afresh, and set `source="user"`.
+- **Unsaved ordinary chat:** Keep the applied live snapshot on the session and
+  include its serialized safe form when first creating the conversation row. Flush
+  staged context policy through its existing owner and surface either component's
+  failure after first persistence.
+- **Temporary chat:** Do not create durability merely because Apply was clicked.
+  Promotion includes the current safe generation snapshot in the conversation
+  bundle, then persists the current context policy through its existing owner. A
+  post-promotion context-policy failure leaves promotion intact and enters the same
+  visible compaction failure state.
+
+## Error Handling
+
+- Missing origin session: no retargeting; notify and discard the result.
+- Invalid fields: keep the modal open with inline feedback.
+- Unsupported saved metadata version: preserve it, warn once when relevant, and do
+  not overwrite it automatically.
+- Metadata version conflict: reload and retry only for sibling-only changes while
+  the session settings revision, conversation identity, and owned metadata base
+  still match. Abort an obsolete Apply rather than overwriting a newer one.
+- Generation metadata failure: retain the live generation settings and record
+  `generation settings` as not saved.
+- Context-policy failure: retain the complete live context-policy snapshot and record
+  `context_policy` as not saved. Display `compaction` only when the quick surface was
+  the source and compaction was the sole policy edit.
+- Partial failure: name only the failed component; never imply that the successful
+  component was lost.
+- Retry: use the still-current component snapshot, component revision, and captured
+  conversation identity. A context-policy Retry writes the complete current policy;
+  stale retry state cannot overwrite any newer policy edit or generation Apply.
+- Default mutation before file replacement: retain the live conversation Apply and
+  show an app-level `Not written to disk` record with the exact action, provider,
+  literal model, field scope, and sanitized optional endpoint. Offer
+  `Retry default save` and `Discard retry`; Discard removes the pending retry and
+  never implies that the live conversation change was rolled back.
+- Runtime publication after successful file replacement: report `Saved on disk;
+  running app refresh failed`. Offer `Refresh running app` and `Dismiss`. Refresh
+  rereads and republishes the on-disk config without repeating the disk mutation;
+  Dismiss acknowledges the running-process limitation and never claims to undo the
+  durable default. Restart loads the already-saved values.
+- Default failure scope: configuration failure is app-global and appears from every
+  Console Model rail and full Settings until recovered, dismissed/discarded,
+  superseded by a newer explicit default action, or the app closes. Conversation
+  generation/context-policy failures remain session-local and process-local.
+- Default retry concurrency: the immutable intent is applied only after rereading
+  the locked config and preserves unrelated external edits. A stale intent cannot
+  replace a newer explicit edit to the same owned fields.
+- Unconfigured saved provider: preserve the selection and expose the normal blocked
+  readiness/recovery UI; never silently substitute another provider.
+- Deferred callback after dismissal: treat the absent descendant as normal teardown.
+
+## Testing Strategy
+
+Focused tests cover:
+
+1. A real routed Textual `Click` after the temperature Input owns mouse capture;
+   Apply fires once and dismisses.
+2. Keyboard focus plus Enter reaches the same `Button.Pressed` handler.
+3. Dismissal before deferred fold-hint synchronization does not raise `NoMatches`.
+4. Invalid temperature remains open and shows an inline error.
+5. Applying while another session becomes active updates only the captured origin.
+6. An unsaved origin that receives its first conversation ID while the settings
+   surface is open remains the valid origin, while an explicitly rebound session is
+   rejected.
+7. A consumer resolving settings after Apply receives the new values; an already
+   captured execution context remains unchanged.
+8. Quick and full Settings round-trip safe generation fields through the shared
+   orchestration and restart hydration, while compaction round-trips through its
+   existing context-policy owner.
+9. Provider switching begins with a non-null old endpoint and proves that endpoint
+   is not retained.
+10. Metadata writes preserve speech, roleplay, prefill, and unrelated sibling keys;
+   bounded conflict retry cannot let an older Apply overwrite a newer one.
+11. Corrupt and future-version overlays fail closed without destructive overwrite.
+12. Generation-settings-only, context-policy-only, and dual persistence failures
+    close the modal, retain both live values, identify the failed components
+    persistently, and clear only the successfully retried current components.
+13. Unsaved-first-persistence and temporary-promotion flows stage both components
+    and surface any later component-specific failure.
+14. The quick popover retains and returns compaction mode; changing it preserves all
+    other context-policy overrides and full Settings Context behavior.
+15. A newer non-compaction context-policy edit supersedes a failed policy snapshot;
+    Retry cannot restore any value from the obsolete snapshot.
+16. Selecting a different model under the same provider rebases untouched fields
+    from that exact model profile while preserving and marking deliberate edits.
+17. Provider/model A → B → A restores A's unfinished keyed draft and never revives
+    fields unsupported by B.
+18. `Full settings…` transfers the complete quick draft, compaction draft, field
+    provenance, and exact origin without applying or losing edits.
+19. Quick `Save as model default` changes only temperature and streaming for the
+    exact provider/model and preserves every sibling profile and advanced field.
+20. Full `Save as model default` changes all supported exposed profile fields;
+    blank deletes the exact override and conversation Apply freezes the resolved
+    effective value. Streaming covers Inherit, On, and Off.
+21. `Make default for new chats` atomically patches the exact model profile plus
+    global provider/model, without changing compaction, credentials, or unrelated
+    provider settings.
+22. Ctrl+T, temporary, workspace-created, and initial pristine blank chats observe
+    the saved global provider/model and exact model profile immediately after runtime
+    publication and after restart.
+23. Existing/open conversations remain unchanged, while Duplicate, Branch,
+    Continue, and explicit handoff intents retain their source-specific behavior.
+24. A blocked provider cannot become the new-chat default and explains why the
+    action is unavailable.
+25. Only a full, explicitly dirty, checked endpoint is included in `Make default for
+    new chats`; quick actions and `Save as model default` never persist endpoints.
+26. Endpoint previews remove credentials and URL details, classify loopback/private/
+    public literals correctly, conservatively label other hostnames, and perform no
+    DNS lookup.
+27. Concurrent exact-model config patches preserve sibling models, unexposed fields,
+    and newer unrelated edits, including literal model IDs with punctuation.
+28. Before-replace failure exposes `Retry default save` / `Discard retry`; successful
+    file replacement plus publication failure exposes cache-only `Refresh running
+    app` / `Dismiss` and never repeats the disk write.
+29. Ordinary conversation Apply preserves an earlier app-global default failure;
+    a newer explicit default action supersedes it without stale overwrite.
+30. The main footer and Defaults substate fit and retain complete keyboard focus/tab
+    order at 60×24 and 72×24; mouse and Enter activate each committing action once,
+    and hierarchical Escape preserves or cancels the draft as specified.
+
+Verification uses only affected pytest modules plus targeted lint/format and
+`git diff --check`. A full-suite sweep requires explicit user approval under the
+repository testing policy.
+
+## Non-Goals
+
+- No global provider/default mutation from ordinary `Apply to this chat`; only the
+  two explicit default actions mutate configuration.
+- No endpoint or credential persistence in conversation metadata.
+- No endpoint persistence from quick settings or `Save as model default`.
+- No new database table or schema migration.
+- No new preset/profile schema; reuse the existing exact-model profile mapping.
+- No compaction storage/schema change or combined generation/compaction transaction.
+- No broader Context & memory redesign beyond sharing the Apply orchestration and
+  durability outcome reporting.
+- No attempt to mutate a request that already captured its execution context.
+- No live model-catalog refresh inside Apply.
+- No generic Console settings refactor outside the shared commit and rebase seams.
+
+## ADR Check
+
+**ADR required:** yes
+**ADR path:** `backlog/decisions/095-conversation-owned-console-generation-settings.md`
+**Reason:** This changes durable conversation ownership, exact-model/global config
+ownership, blank-chat creation, restart hydration, provider/model precedence, and
+the cross-surface settings contract.
+
+## Acceptance Mapping
+
+- **AC1–AC4:** exact-origin interaction, immediate execution boundary, shared Apply
+  orchestration, safe metadata, and restart hydration.
+- **AC5–AC6:** provider/model draft rebasing, keyed provenance, and lossless
+  quick-to-full transfer.
+- **AC7–AC8:** progressive Defaults interaction and exact-model field-masked saving.
+- **AC9–AC10:** atomic new-chat defaults and complete eligible/excluded creation
+  behavior in-process and after reboot.
+- **AC11–AC12:** full-only explicit endpoint persistence and conversation-only
+  compaction ownership.
+- **AC13–AC15:** staging/promotion, validation/teardown reliability, and
+  revision-guarded conversation durability recovery.
+- **AC16–AC17:** truthful app-global disk/runtime recovery and concurrency-safe exact
+  config mutation.
+- **AC18:** focused interaction, layout, persistence, concurrency, hydration,
+  endpoint, creation-path, and partial-failure coverage.

--- a/Docs/superpowers/specs/2026-08-27-console-turns-survive-navigation-design.md
+++ b/Docs/superpowers/specs/2026-08-27-console-turns-survive-navigation-design.md
@@ -1,0 +1,536 @@
+# Console turns survive screen navigation
+
+**Date:** 2026-08-27
+
+**Status:** Approved for implementation planning
+
+**Task:** [TASK-22514](../../../backlog/tasks/task-22514%20-%20Console-turns-survive-screen-navigation.md)
+
+**ADR:** [ADR-094](../../../backlog/decisions/094-console-turn-lifetime-and-navigation-boundary.md)
+
+**Baseline:** `e4923b2135ee858d58214c69da3a0b53565e4638`
+
+## Summary
+
+Every accepted Console turn continues when the user navigates to another screen.
+Navigation replaces only the Console view: provider streaming, the main assistant or
+agent loop, turn-launched tools and media work, delegated agents, and pending human
+decisions remain owned by the app-level Console runtime. Returning to Console attaches
+a fresh screen to the same runtime and reconciles the continuing or completed turn
+from the live app-owned store.
+
+Navigation is not a cancellation boundary. Stop, explicit session close, and confirmed
+application quit remain cancellation boundaries. Application quit is still the final
+lifetime boundary; this design does not make turns survive process exit or restart.
+
+When a hidden turn needs approval, Chatbook shows one app-wide notice, marks Console as
+needing attention, and pauses the decision clock until the relevant card is answerable.
+When a hidden turn completes or terminally fails, Chatbook shows one bounded notice and
+keeps a durable local-only unseen marker until the owning session has rendered the
+terminal result.
+
+## ADR check
+
+**ADR required:** yes
+
+**ADR path:**
+`backlog/decisions/094-console-turn-lifetime-and-navigation-boundary.md`
+
+**Reason:** this feature changes the long-lived runtime, task-ownership, cancellation,
+approval-clock, and local attention-persistence boundaries shared by the app, Console
+controller, Chat screen, and navigation shell. It supersedes the screen-scoped
+user-turn policy recorded by TASK-1143 and TASK-15860 acceptance criterion 2.
+
+No schema migration is expected. `conversation_local_marks` already stores arbitrary
+validated mark strings; its validator gains a local-only
+`console_unseen:<terminal-receipt-id>` namespace. The matching terminal transcript
+commit and receipt mark must share the existing ChaChaNotes transaction rather than
+rely on cross-database rollback.
+
+## User promise
+
+- Pressing Send transfers the turn to app-owned runtime custody before the composer is
+  cleared.
+- Switching screens never stops an accepted Console turn or denies its pending human
+  decisions.
+- Returning to Console shows the same continuing stream or terminal result without
+  duplicate or missing transcript content.
+- A hidden approval never auto-approves, never fails closed merely because no Console
+  screen is mounted, and does not lose decision time while it cannot be answered.
+- A hidden completion or terminal failure produces one app-wide notice and a durable
+  Console attention marker that remains until the owning result is presented.
+- Stop affects the selected turn or chain. Session close affects that session. Confirmed
+  app quit affects the whole runtime. None of those scopes silently widens.
+- Forced process termination may interrupt work. Existing durable dispatch recovery
+  remains the only owner of restart repair and recovery semantics.
+
+## Goals
+
+- Move accepted-turn task ownership from `ChatScreen` to the existing app-owned
+  `ConsoleRuntime`.
+- Preserve the existing controller and store as the only run-state, queue, cap,
+  streaming, and transcript authorities.
+- Freeze send-time inputs so detaching the view cannot change a turn's dictionaries,
+  world information, staged RAG, Library policy, tools, identity, or settings midway.
+- Make every human-decision round view-independent while preserving explicit approval
+  and fail-closed cancellation behavior.
+- Make background outcomes discoverable without forcing navigation or flooding the
+  current screen.
+- Keep detached execution free of DOM queries, transcript polling, and per-token shell
+  updates.
+- Retain deterministic, bounded teardown when the user explicitly stops work, closes a
+  session, or quits.
+
+## Non-goals
+
+- Continuing turns after a confirmed app quit, crash, host shutdown, or restart.
+- Keeping a `ChatScreen` cached, mounted, or hidden behind other destinations.
+- Running microphone capture, realtime voice sessions, audio playback, open modals,
+  animations, or screen timers after Console unmounts.
+- Treating unsent composer text, staged attachments, or a modal action as an accepted
+  turn before runtime custody succeeds.
+- Changing provider retry policy, per-session admission rules, global concurrency caps,
+  prompt-queue ordering, or the existing dispatch-recovery contract.
+- Adding a global Stop button or allowing approval decisions from non-Console screens.
+- Showing an exact global attention count. The shell promises a boolean marker; Console
+  session surfaces retain detailed status.
+- Persisting raw turn requests, context snapshots, attachment bytes, tool output, or
+  approval payloads in navigation or attention state.
+
+## Existing constraints and starting point
+
+The app already owns one `ConsoleRuntime`; `ChatScreen` attaches and detaches its view
+hooks. The runtime owns the `ConsoleChatStore`, provider gateway, agent bridge, and
+`ConsoleChatController`, and the store already survives navigation. Headless supervisor
+wake turns can run with no Console mounted.
+
+The remaining screen-scoped behavior is explicit and must be changed deliberately:
+
+- `_submit_console_native_draft` is awaited by a Textual worker owned by `ChatScreen`,
+  so unmount cancellation can propagate into an ordinary user turn.
+- `ConsoleRuntime.leave_console()` invokes the controller's per-visit teardown, which
+  cancels ordinary user-originated tasks and binds parked decisions to a visit event.
+- multiple screen-supplied hooks are consulted on the send path; clearing them to
+  viewless defaults is correct for machine-authored wake turns but would silently
+  remove user-selected context from a surviving ordinary turn;
+- tool approvals can be retained headlessly, while skill-install and skill-script
+  confirmations currently fail closed without their screen hooks;
+- terminal outcome notification hooks are screen-owned and are cleared on detach; and
+- the old navigation confirmation and teardown notice tell users that active Console
+  work will be cancelled.
+
+Screens remain fresh instances. Prior defects proved that keeping a removed screen
+alive lets self-rearming sync workers query a dead DOM and can terminate the whole TUI.
+This design therefore extends the runtime/view boundary; it does not weaken the
+fresh-screen navigation invariant.
+
+## Terminology
+
+- **Runtime custody:** the app-owned runtime has synchronously registered an immutable
+  request and is responsible for either running it or producing a recoverable refusal.
+- **Durable acceptance:** the existing first-send/promotion boundary has committed the
+  user turn and its authoritative transcript identity. Before this boundary, a refusal
+  may restore the draft; after it, failure is a transcript outcome.
+- **Turn-owned work:** provider streaming, agent execution, queued continuation,
+  turn-launched tools or generated media, delegated work, and human decisions reachable
+  from one accepted turn.
+- **View-owned work:** DOM rendering, transcript and cost timers, microphone and audio
+  resources, open modals, animations, selection, focus, and unsent composition.
+- **Attachment generation:** a monotonically increasing claim token identifying the
+  currently attached Console view. It is unrelated to response variants.
+- **Decision-active time:** elapsed approval time while the owning decision card is
+  mounted, visible, and answerable in Console.
+- **Terminal acknowledgement:** the owning session is active and the mounted transcript
+  has synchronized the terminal row. Exact scroll-viewport intersection is not
+  required.
+
+## Ownership model
+
+| Concern | Authority | Lifetime |
+| --- | --- | --- |
+| Store, controller, provider gateway, agent bridge | `ConsoleRuntime` | App |
+| Accepted-turn task handles and custody records | `ConsoleRuntime` | Handoff through terminal cleanup |
+| Run state, queues, caps, cancellation events | Existing `ConsoleChatController` | Existing controller policy |
+| Messages, active lineage, session drafts | Existing `ConsoleChatStore` | App/runtime |
+| Terminal unseen mark | ChaChaNotes `conversation_local_marks` | Durable until acknowledged |
+| Pending approval attention | Runtime/app memory plus existing controller round registry | Until decision, cancellation, or app exit |
+| DOM hooks, timers, selection, focus, realtime media | `ChatScreen` | One mounted view |
+| Restart recovery | Existing dispatch-recovery owner | Existing policy |
+
+The runtime registry is intentionally not a second run-state machine. It keeps the
+minimum strong references needed to own scheduling, cancellation routing, finalization,
+and cleanup. The controller and store remain authoritative for all domain state.
+
+## Send handoff and frozen context
+
+### Custody boundary
+
+The screen captures lightweight send-time state and transfers it to a main-loop runtime
+handoff. The handoff registers the custody record before scheduling execution and
+returns a stable turn ID. Only that successful return permits the screen to clear the
+composer.
+
+Registration-before-scheduling closes the navigation race between creating a task and
+recording its owner. The screen never awaits the long-running runtime task. It may
+subscribe for repaint hints while attached, but the task's completion and cleanup do
+not depend on that subscription.
+
+The request transfers accepted attachment objects rather than deep-copying their byte
+payloads. Existing provider construction may consume the prompt and accepted
+attachments under its current policy; runtime custody must not broaden that provider
+payload or create a new raw copy in `repr`, logs, attention state, navigation labels,
+sync, export, or unrelated remote APIs.
+
+### Frozen inputs
+
+The request captures immutable values or app-owned service references for every
+screen-derived input whose value belongs to the send:
+
+- exact session and conversation identity;
+- provider/model selection and session generation/settings;
+- agent/ordinary-chat mode and enabled tool policy;
+- character/persona identity and presentation name;
+- dictionary and world-information selection;
+- staged RAG/evidence and Library access policy;
+- project/workspace context and authority snapshot;
+- prompt-history contribution; and
+- accepted attachments and their session ownership.
+
+Heavy or asynchronous preparation—provider readiness, RAG retrieval, Library reads,
+project-instruction activation, and request construction—runs after custody inside the
+runtime task. It consumes the frozen request and app-owned services, never a widget or
+bound screen method. This keeps Send responsive without letting detachment change the
+turn's meaning.
+
+### Refusal and recovery
+
+Custody refusal leaves the current composer untouched. A refusal after custody but
+before durable acceptance records a recovery entry keyed by turn ID, including the
+session-owned draft and accepted attachment references. It must not overwrite an older
+recovery entry for the same session. A fresh Console view can restore or discard each
+entry explicitly.
+
+After durable acceptance, the draft never reappears as unsent text. Provider or tool
+failure becomes a stopped or failed transcript outcome under existing policy.
+
+## Turn execution
+
+The runtime schedules the controller operation on the app event loop and retains its
+task before it can run. Existing controller admission, prompt queues, global and
+per-session caps, provider resolution, streaming, tools, agent loop, and persistence
+remain unchanged except where they currently consult live screen hooks.
+
+Streaming writes the app-owned store and existing persistence path. While a view is
+attached, a content-free repaint hint may coalesce a transcript sync. While detached,
+no DOM query, Textual worker, transcript timer, cost timer, or navigation update runs
+for deltas. Reattachment performs one full reconciliation, then restarts ordinary
+coalesced rendering from the live store.
+
+The runtime registers one authoritative terminal observer. Screen hooks repaint only;
+they do not finalize tasks or emit duplicate outcome notices. A done callback always
+retrieves task exceptions, finalizes once, and releases the request/context/attachment
+references after any recovery or attention projection is complete.
+
+## Navigation and view lifecycle
+
+Navigation away performs view detachment, not controller visit cancellation.
+
+Detachment must be guaranteed early in unmount or through a `finally` path. Audio,
+realtime, persistence-flush, timer, video, or other view-cleanup failures must never
+leave callbacks bound to a dead screen. Detachment:
+
+- clears the enumerated screen hook set only when the detaching screen still owns the
+  current attachment generation;
+- stops screen timers and releases ephemeral view resources;
+- preserves runtime tasks, controller cancellation events, queues, rounds, store state,
+  and turn-owned operations; and
+- performs no navigation confirmation about losing accepted work.
+
+The existing overlapping-screen rule remains: a newly attached Console may claim the
+runtime before an outgoing Console finishes unmounting. The outgoing generation's
+later detach and callbacks are no-ops and cannot clear or mutate the successor's hooks.
+
+Returning to Console attaches fresh hooks, reads the runtime registry and store, mounts
+the active session's pending decision projection when one exists, synchronizes the
+transcript, and resumes view timers. It does not automatically switch sessions or clear
+unrelated attention.
+
+## Human decisions while detached
+
+Tool approval, skill-install confirmation, and skill-script confirmation share one
+view-independent decision contract:
+
+1. The controller registers the round and retained payload by stable round/request ID
+   before attempting any UI projection.
+2. The runtime records pending attention and emits at most one sanitized app-wide
+   notice for that ID.
+3. If no answerable card is mounted, the turn waits without approving or denying.
+4. The decision clock counts only decision-active time. Detachment pauses it; mounting
+   the owning card resumes the remaining allowance. A round born headlessly starts its
+   clock on first answerable mount.
+5. Returning to Console derives one ordered pending-decision projection for the active
+   session across all three decision types. Multiple rounds remain retained and are
+   presented in stable existing order; resolving one does not clear siblings.
+6. An explicit decision, per-turn Stop, session close, or app disposal resolves the
+   round through its existing fail-closed path.
+
+Navigation never auto-approves, consumes a decision timeout, or binds the round to a
+replaceable per-visit cancellation event. Per-turn cancellation and permanent runtime
+shutdown remain authoritative.
+
+## Attention and notification behavior
+
+### Terminal results
+
+Each user-visible **completed** or **terminally failed** transcript commit mints a
+stable opaque terminal receipt ID and writes a local-only
+`console_unseen:<terminal-receipt-id>` mark for the owning durable conversation in the
+same ChaChaNotes transaction. The receipt ID is stable across an idempotent retry of
+that terminal commit. The write happens regardless of whether Console appears visible.
+A terminal row carries its receipt ID into the live store and display projection; a
+currently attached view clears only that exact namespaced mark after acknowledging the
+matching row.
+
+Always-write-then-acknowledge makes completion/unmount races favor a retained marker
+and avoids guessing visibility before the transcript paints. Separate receipts allow
+several terminal outcomes in one conversation: an acknowledgement for an older row
+cannot clear a newer result. The user-visible transcript plus receipt marks are the
+ChaChaNotes authority. `AgentRunsDB` and shell presentation are derived projections and
+are not included in a fictitious cross-file transaction.
+
+First-send promotion must provide the durable conversation identity before terminal
+commit. No accepted durable result may become unmarkable because the original session
+started temporary.
+
+The namespaced marks use the existing `conversation_local_marks` table and are absent
+from conversation sync, export, prompt payloads, and unrelated remote APIs. They are
+separate from `FLEET_UNSEEN`; supervisor wake delivery may continue to clear its own
+fleet mark without erasing a hidden ordinary-turn result.
+
+Explicit user Stop and confirmed session-close cancellation create no new terminal
+attention: those actions are themselves acknowledgement and, for a closed session,
+there is no result surface to revisit. App-shutdown cancellations create no mark or
+toast because the app is closing. A cancellation not attributable to one of those
+explicit reasons is classified by the controller as a terminal failure and follows the
+failed-receipt path.
+
+### Shell presentation
+
+When a terminal receipt mark is created for a session that has not acknowledged it,
+the app shows one sanitized toast: completion is informational and terminal failure is
+an error. Bursts may coalesce into a bounded summary toast, but every underlying receipt
+mark remains.
+Notification failure never rolls back terminal persistence.
+
+The main and overflow navigation surfaces show a boolean, non-color-only Console
+attention glyph and an explanatory tooltip. They do not promise an exact count.
+Freshly mounted navigation reads durable marks, so a temporarily unavailable bar or a
+restart cannot erase attention. Session tabs and conversation rows retain the detailed
+run/approval markers already owned by Console.
+
+Opening Console does not clear the global marker. Resolving a pending decision clears
+that decision's in-memory attention; terminal attention clears one receipt only after
+the matching terminal acknowledgement. The global glyph disappears only when neither
+durable terminal receipt marks nor pending decisions remain.
+
+## Cancellation and terminal races
+
+| Trigger | Scope and behavior |
+| --- | --- |
+| Screen navigation | Detach view only; accepted turns and rounds continue. |
+| Stop | Signal and cancel the selected turn/chain; revoke only its rounds; create no unseen receipt. |
+| Session close | Fence new/queued submissions for the session, confirm when active, then cancel and await that session's turns, rounds, and delegated children; create no unseen receipt. |
+| Confirmed app quit | Revision-pin the active set, fence runtime admission, cancel all turns and rounds without new attention, drain bounded cleanup, then close gateway and databases. |
+| View/render failure | Report bounded UI failure; runtime and persistence continue. |
+| Recoverable tool failure | Persist the ordinary tool result; the controller may continue the turn. |
+| Terminal provider/tool failure | Commit terminal failure plus unseen state and notify when unacknowledged. |
+| Forced process death | Existing persistence/recovery policy applies; no continuation promise. |
+
+Stop and normal completion share one atomic terminalization gate. If terminal content
+was durably committed first, a later Stop is a no-op. If cancellation was recorded
+first, late provider/tool output and callbacks are rejected by the turn generation and
+cannot overwrite the stopped result.
+
+Session close marks the session closing before it snapshots work, so no new or queued
+submission can enter the set behind the cancellation pass. Quit confirmation is pinned
+to the active-turn revision; if the set changes before admission is fenced, the
+confirmation refreshes rather than silently widening consent.
+
+Cancellation waits are bounded. After a cooperative grace window, Chatbook cancels the
+async wrapper and advances a generation fence. An underlying non-cancellable thread may
+finish, but its late writes, approval resolutions, callbacks, and terminalization are
+ignored. Shutdown must not hang indefinitely on provider or worker behavior.
+
+## Failure handling
+
+- A runtime task exception is consumed, sanitized, and converted into the existing
+  terminal failure contract; it never becomes a Textual `WorkerFailed` that exits the
+  app.
+- Failure before durable acceptance preserves turn-keyed recovery. Failure afterward
+  preserves the accepted transcript and terminal state.
+- A failing view hook or notification surface is best-effort and never authoritative.
+  The store, terminal transaction, and decision registries remain intact.
+- A failing unread clear leaves a stale marker and retries through the next ordinary
+  attention reconciliation; it never clears optimistically.
+- A failed terminal transaction publishes neither terminal acknowledgement nor cleared
+  attention. Retrying the idempotent transaction produces one terminal result and one
+  mark.
+- Existing dispatch checkpoints and recovery own restart repair. This feature adds no
+  second orphan scanner or restart executor.
+
+## Privacy and bounded retention
+
+The custody record may temporarily contain sensitive turn inputs because the provider
+request needs them. That record is process-local, excluded from `repr` and logs, and
+released after terminal cleanup. Navigation and attention state store only stable
+opaque IDs, safe titles, phases, and booleans.
+
+Notifications use existing display-label sanitation and never include prompt bodies,
+tool arguments/results, exception text, credentials, attachment names containing local
+paths, or project-instruction content. Failure logs use exception types and stable
+codes under existing redaction policy.
+
+Each namespaced unseen receipt stores only conversation ID, a mark type containing one
+opaque terminal receipt ID, and timestamps. It remains local-only and does not enter
+sync or export. Pending approval payloads retain existing in-memory security semantics
+and die on explicit turn/session cancellation or app exit.
+
+The runtime drops terminal task records after attention projection. Recovery entries
+remain only until restored or discarded. Tests must prove completed request/context
+objects become collectible and repeated turns do not grow the registry.
+
+## Accessibility and narrow layouts
+
+The navigation marker uses a glyph and tooltip, not color alone. It must remain legible
+in the main bar and overflow menu at 80x24, 100x30, and wide layouts without clipping
+route labels or changing their activation targets. Approval and terminal notices name
+the sanitized owning session/workspace when available and direct the user to Console;
+they never move focus or navigate automatically.
+
+## Verification strategy
+
+### Layered automated coverage
+
+Pure runtime/controller tests cover every origin and decision type. Mounted Textual
+tests cover representative end-to-end navigation paths. Tests use injected clocks,
+events, and cancellation deadlines rather than sleeps.
+
+Required deterministic cases include:
+
+- custody registration is visible before task scheduling and an immediate real
+  `NavigateToScreen` cannot cancel or lose the request;
+- ordinary chat, main-agent, turn-launched tool/media, queued continuation, and
+  delegated-agent paths remain runtime-owned after unmount;
+- send-time context stays byte/identity stable after view hooks are detached or a new
+  screen changes its settings;
+- navigating during preparation, provider readiness, streaming, tool execution,
+  approval, and terminal commit preserves the correct outcome;
+- returning mid-stream reconciles from the app-owned store, then receives later deltas
+  without duplication;
+- tool, skill-install, and skill-script decision clocks pause headlessly and resume only
+  when their owning card is answerable;
+- multiple rounds in one session and turns across several sessions remain isolated;
+- rapid away/back cycles and overlapping view claims cannot let the outgoing screen
+  clear its successor's hooks;
+- Stop, session close, and quit honor their exact scopes, including concurrent
+  completion and an uncooperative provider/thread;
+- injected unmount cleanup, notification, navigation-bar, and render failures never
+  affect runtime completion;
+- each completed/failed terminal row and its exact namespaced receipt mark are both
+  present or both absent across injected ChaChaNotes transaction failures;
+- acknowledgement of one terminal receipt cannot clear a later receipt for the same
+  conversation, while explicit Stop/session-close/app-shutdown cancellation creates no
+  receipt or outcome toast;
+- a fresh marks service and app/runtime over the same temporary SQLite database restore
+  the global marker before Console has ever mounted;
+- active-session terminal synchronization clears only the acknowledged conversation;
+- simultaneous outcomes may coalesce their toast while retaining every mark;
+- detached execution performs zero DOM queries, transcript polling, and per-token
+  navigation updates; and
+- terminal registry cleanup releases request/context/attachment objects and remains
+  bounded over repeated turns.
+
+The returning-view tests assert four distinct facts: the live app-owned store contains
+the rows, the mounted transcript renders identifying content, the next provider payload
+uses the same active lineage, and durable rows exist. A database append alone is not
+accepted as UI evidence.
+
+### Privacy and architecture pins
+
+Tests inspect every new durable and presentation owner—ChaChaNotes marks, runtime
+records, logs, notifications, navigation state, sync payloads, exports, and provider
+request construction—to prove the new ownership layer creates no extra raw-content
+copy. Weak-reference collection covers post-terminal memory release.
+
+Architecture tests narrowly assert that `ChatScreen` delegates accepted-turn creation
+to the runtime, owns no resulting task, and remains absent from retained callbacks after
+detach. They also preserve `ConsoleRuntime` as the single shared controller/store
+construction and disposal owner. They do not pin incidental helper names.
+
+For the critical lifecycle invariants, red/green evidence includes locally inverting
+the named behavior: restoring screen-owned cancellation, advancing a hidden decision
+clock, clearing all unseen state on Console mount, or accepting a late post-cancel
+terminal write must make the corresponding focused test fail. This is targeted
+test-validation evidence, not a new repository-wide mutation-testing framework.
+
+### Real UI and live provider verification
+
+The mounted badge tests exercise production hierarchy and styles at 80x24, 100x30, and
+wide sizes, including the overflow menu, tooltip, focus, and route activation. They
+wait independently for authoritative state, mounted DOM, and compositor paint.
+
+One isolated live-provider journey waits for the first real streamed delta, navigates
+through the production route, proves additional deltas or completion occur while
+Console is absent, returns, and verifies identifying transcript content and the marker
+clear. A local provider is preferred. Any billed provider call requires explicit user
+approval.
+
+Before targeted or live verification, run the repository import-provenance probe. Live
+state uses a disposable `HOME`, XDG config/data/cache roots, explicit
+`TLDW_CONFIG_PATH`, and scratch `[paths].data_dir`; unrelated catalog networking is
+disabled. The real profile is fingerprinted before and after. No bare interpreter probe
+may import the app without equivalent isolation.
+
+Per repository policy, implementation verification uses targeted suites unless the
+user explicitly opts into a full repository sweep.
+
+## Documentation changes
+
+- Replace User Guide statements that ordinary and agent turns are Console-screen-scoped.
+- Explain that navigation is safe, approvals wait and notify, terminal outcomes mark
+  Console until viewed, and confirmed app quit still cancels work.
+- Remove the obsolete navigate-away cancellation confirmation and returning teardown
+  notice from UX documentation and tests.
+- Link TASK-22514, ADR-094, this design, and the eventual implementation plan.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| A surviving turn reads a new screen's settings | Freeze send-time values and use app-owned services only. |
+| A detached task calls a dead view | Enumerated hook detach plus attachment-generation fencing. |
+| Navigation cancels the awaiting screen worker | Screen never owns or awaits the accepted runtime task. |
+| Invisible approval expires or fails closed | Retained unified rounds and decision-active clocks. |
+| Terminal completion races unmount or another completion | One atomic namespaced receipt mark per terminal row followed by exact-receipt acknowledgement. |
+| Stop races completion | One atomic terminalization gate and late-write generation fence. |
+| Quit hangs on a worker thread | Bounded cooperative drain followed by wrapper cancellation and fencing. |
+| Multiple stores imply false rollback | ChaChaNotes transcript+mark is the authority; other databases are projections. |
+| Runtime registry becomes a second controller | Registry stores lifetime handles only; controller/store remain authoritative. |
+| Sensitive context leaks through new state | Process-local redacted records, ID-only attention, exhaustive owner tests. |
+| Badge breaks compact navigation | Boolean glyph, production hierarchy, narrow-size and overflow tests. |
+
+## Acceptance mapping
+
+TASK-22514 acceptance criteria map directly to the sections above:
+
+1. Runtime custody, frozen context, execution, and view lifecycle.
+2. Human decisions while detached.
+3. Cancellation and terminal races.
+4. Turn execution plus navigation reconciliation.
+5. Verification strategy.
+6. Documentation changes.
+7. Attention and notification behavior.
+8. Send handoff plus privacy and bounded retention.
+
+No implementation begins until this written spec passes independent review and the
+owner approves the reviewed document.

--- a/Docs/superpowers/specs/2026-08-28-console-reference-backed-semantic-trace-ledger-design.md
+++ b/Docs/superpowers/specs/2026-08-28-console-reference-backed-semantic-trace-ledger-design.md
@@ -1,0 +1,831 @@
+# Console Reference-Backed Semantic Trace Ledger Design
+
+**Date:** 2026-08-28
+
+**Status:** Approved after final adversarial review
+
+**Originating task:** [TASK-23026](../../../backlog/tasks/task-23026%20-%20Exchange-capture-stores-the-whole-conversation-on-every-send-forever.md), completed by the now-superseded bounded-retention implementation
+
+**Decision:** [ADR-097](../../../backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md)
+
+**Supersedes:** [ADR-096](../../../backlog/decisions/096-console-safe-capture-retention.md) and its bounded-excerpt design
+
+**Related follow-up:** [TASK-23112](../../../backlog/tasks/task-23112%20-%20Add-lossless-chunk-row-encoding-for-streamed-trace-events.md)
+
+## Summary
+
+Console exchange capture currently serializes and compresses the complete accumulated
+`messages_payload` for every provider call. A production-shaped 200-turn conversation retained
+15.40 MB because each later exchange copied all earlier messages again. Capture is enabled by
+default, soft deletion retains the blobs, and no automatic reclamation path exists.
+
+The fix is not a smaller repeated transcript. The saved conversation becomes the source of truth
+for ordinary message content. A new local-only, append-only semantic trace ledger records durable
+references to immutable message revisions, stores provider-only semantic material once in a
+content-addressed artifact store, and gives each provider call a boundary into that ledger plus a
+reference to its effective request header. Reconstructing a call folds the ledger through that
+boundary. No call stores a list or blob proportional to the conversation's age.
+
+Edits append semantic replacements without rewriting historical calls. Forks share an immutable
+trace prefix and append their own suffix instead of copying trace history. Hard deletion
+materializes any still-needed live message revision once before its source row disappears. Safe
+and Full become disclosure profiles over the same stored trace; mandatory credential filtering
+and optional irreversible PII masking remain capture-time policies.
+
+Existing capture blobs are normalized automatically in bounded, resumable background batches.
+Ordinary rows become message-revision references, provider-only rows become deduplicated
+artifacts, and a legacy blob is deleted only after the normalized projection reproduces its
+sanitized legacy meaning. Logical reclamation and physical SQLite compaction are reported
+separately.
+
+This design adapts DeepSeek Harness's useful invariant—model-visible content must be durably
+explainable—and its append-only surface projection, changed-only request headers, stable sequence
+boundaries, and canonical-log/telemetry separation. It deliberately does not copy DeepSeek's
+fork seed, persist ordinary message bodies a second time, retain token chunks in this task, or
+claim literal provider HTTP replay.
+
+## Problem and current ownership
+
+`ConsoleProviderGateway` currently builds an `ExchangeCapture` around every provider call.
+`build_request_capture()` allowlists selected `chat_api_call()` kwargs, including the complete
+`messages_payload`, stubs large binary-like strings, records `omitted_keys`, and places the
+compressed JSON blob in local-only `message_exchanges`. Rows are owned by the eventual assistant
+message and keyed by `(message_id, run_tag, seq)`.
+
+That ownership has five defects:
+
+1. Each call copies the complete conversation accumulated so far, producing quadratic cumulative
+   storage.
+2. A provider run may contain retries, tool-loop calls, failures, or abandoned calls before an
+   assistant message exists, so an assistant message is not the natural call owner.
+3. Editing a message destroys the exact body used by an earlier call unless the capture copied it.
+4. Forking either loses source trace context or requires another physical copy of it.
+5. The Safe/Full storage distinction encourages either incomplete diagnostics or repeated
+   sensitive content, while `omitted_keys` currently provides only a narrow top-level inventory.
+
+The existing `PreparedConsoleRequest` is the correct provider-neutral semantic assembly seam. It
+already separates system framing, memory, mandatory context, compactable history, active request,
+and tools. It does not yet carry durable source provenance, and the gateway currently flattens it
+to provider kwargs before capture. The new design adds capture-only provenance descriptors beside
+those semantic values. Descriptors never enter a provider request and never grant tool or file
+authority.
+
+## Goals
+
+- Store ordinary conversation content once and reference immutable semantic revisions from trace.
+- Reconstruct the sanitized semantic request and response—or an explicit incomplete-call record—for
+  every provider call admitted with Capture On, including retries, tool loops, failures, stopped
+  calls, and abandoned generations.
+- Preserve historical call meaning across message edits, regeneration, forks, soft deletion, and
+  source hard deletion.
+- Persist provider-only material exactly once per sanitized semantic identity.
+- Make cumulative normalized trace growth linear for an append-only conversation.
+- Normalize and logically reclaim existing oversized captures without requiring a manual purge.
+- Keep post-dispatch settlement best-effort: trace failure must not roll back a successful provider
+  result or saved conversation message, while reservation and destructive-message preservation keep
+  their explicit fail-closed contracts.
+- Remove recognized credentials from every durable trace owner and offer optional PII masking with
+  built-in and user-authored rules.
+- Keep Safe and Full labels as honest viewer/export disclosure profiles rather than competing
+  durable histories.
+- State precisely what can and cannot be reconstructed.
+
+## Non-goals
+
+- Capturing literal provider HTTP headers, authentication material, TLS traffic, or SDK-internal
+  request framing. The llama.cpp literal payload remains capturable only where Chatbook already
+  owns it.
+- Token-level stream replay or raw `assistant/chunk` persistence. Lossless chunk-row encoding is
+  separately filed as TASK-23112.
+- Synchronizing traces, indexing hidden Full bodies, or adding trace data to transcript FTS.
+- Encrypting the trace database beyond the application's existing storage guarantees.
+- Rewriting or sanitizing the user's canonical conversation when trace PII redaction is enabled.
+- Retroactively applying optional PII rules to legacy captures without a separate explicit user
+  action.
+- Forensic erasure from filesystem snapshots, backups, exports, or already copied databases.
+- One-action lineage-wide purge. Each conversation owner is detached explicitly.
+- Replacing all conversation persistence with a new event-sourced application model.
+- Recording calls deliberately sent with Capture Off.
+
+## Fidelity contract
+
+The trace must not use “exact” without qualifying intentional omissions. Its fidelity class is:
+
+> **Semantic with disclosed omissions:** the trace reconstructs the exact provider-neutral values
+> accepted at Chatbook's provider-call boundary except for content deliberately transformed or
+> withheld by the frozen credential, PII, binary, size, or failure policy recorded for that call.
+
+The boundary is the final semantic kwargs handed to `chat_api_call()` after Chatbook-owned request
+construction and provider routing. Adapter-internal HTTP serialization remains outside the
+contract. A provider-specific literal object may be retained only where Chatbook constructs and
+owns that literal object, such as the existing llama.cpp seam.
+
+Each reconstructed component identifies one of:
+
+- an immutable message semantic revision;
+- a sanitized content-addressed artifact;
+- a deterministic structural value recorded in a request header or trace event; or
+- an explicit unavailable/omitted marker with policy reason.
+
+If credential filtering, PII masking, binary stubbing, truncation, legacy loss, corruption, or a
+sanitizer failure changes a component, the viewer and export disclose that fact. They never claim
+byte-for-byte or complete semantic reconstruction for that call.
+
+## Core invariants
+
+1. **Model-visible implies durably referenced or explicitly omitted.** Nothing in a captured
+   semantic call can exist only in transient capture memory.
+2. **Ordinary message bodies are not copied on capture.** A current semantic revision is metadata
+   pointing to the canonical message row until copy-on-write materialization becomes necessary.
+3. **One logical trace representation.** Storage packing, compression, and later chunk-row
+   encoding are physical codecs, never a parallel event vocabulary.
+4. **Calls point to boundaries, not history arrays.** No normalized call row contains a list of all
+   preceding message or event references.
+5. **Historical trace is immutable.** Edits and compaction append replacement events; the viewer
+   never updates historical request or response bodies.
+6. **Fork prefixes are shared.** A fork owns a reference to one immutable source boundary and only
+   its new suffix.
+7. **Sanitization fails closed.** A component that cannot be safely transformed is omitted with a
+   content-free marker; raw fallback persistence is forbidden.
+8. **Conversation success outranks post-dispatch trace settlement.** Once dispatch starts, trace
+   sealing is independently idempotent and cannot roll back a provider result or a successfully
+   saved assistant message. Pre-dispatch reservation remains mandatory.
+9. **Destructive semantic mutation preserves reachable history transactionally.** Required
+   materialization, projection binding, semantic revision transition, canonical mutation, and
+   surface replacement either commit together or all abort.
+10. **Every destructive sweep rechecks the complete reachability graph.** A global trace-graph
+    epoch advances on every root or edge mutation; sweep aborts if that epoch changes.
+11. **Capture On reserves and marks dispatch before provider entry.** Every dispatched Capture On
+    call has a durable content-free reservation and a durable `dispatch_started` transition. Crash
+    recovery distinguishes calls known not to have dispatched from calls whose provider receipt is
+    unknowable.
+
+## Conceptual storage model
+
+Final SQL names may follow repository conventions, but the following ownership boundaries are
+required.
+
+### Semantic message revisions
+
+A semantic revision is distinct from the existing optimistic-lock `messages.version`, which can
+change for reasons unrelated to provider-visible content.
+
+Each semantic revision records:
+
+- stable revision identity;
+- source conversation and message identities;
+- normalized structural role/content kind without a persisted content digest;
+- creation reason and time;
+- a live canonical-source locator while that source remains valid; and
+- the source revision it replaces, when any.
+
+Creating a trace reference to the current message creates metadata only. Before an edit or hard
+deletion overwrites/removes referenced content, every required frozen disclosure projection is
+materialized once and bound through a separate immutable `(revision, policy) -> artifact-or-omission`
+relation. The revision itself does not have one ambiguous materialized locator. Repeated calls under
+the same frozen policy reuse the same binding; different policies may resolve to different artifacts
+or omissions. The canonical locator is retired only in the same transaction that proves all
+reachable policy bindings are durable.
+
+Ordinary conversation text is never assigned a persisted raw, salted, or keyed content fingerprint
+for trace identity. Revision equality is its opaque revision identity maintained transactionally by
+the message write path. Capture-time comparison with provider values may use an ephemeral in-memory
+digest, but that value is discarded before persistence. This prevents a deleted or masked message
+from leaving a durable guess-verification oracle in trace metadata.
+
+#### Model-visible envelope and mandatory mutation choke point
+
+The semantic revision covers the complete provider-visible message envelope: role, optional name,
+text/content, ordered multimodal blocks, tool-call identifier and tool-call structures, replayed
+reasoning/thinking fields, attachment identities and selected variants, and every provider-neutral
+sidecar field that can change final semantic kwargs. Inclusion, ordering, or context selection is a
+surface-head change; changing one of those message-owned values is a semantic revision.
+
+All writes capable of changing that envelope—including ordinary edits, generation settlement or
+replacement, imports, sync, attachment/variant rewrites, regeneration, and hard deletion—must pass
+through one `SemanticRevisionCoordinator` database boundary. Implementation first inventories every
+current mutation route. A transaction-scoped mutation grant plus database constraints or triggers
+reject direct mutation/deletion of a referenced semantic source unless the same transaction creates
+the required revision transition, projection bindings, and surface replacement. Negative tests must
+prove that direct SQL and every inventoried bypass fail closed. Soft deletion that retains the row
+changes visibility/ownership, not its semantic bytes; later hard deletion still uses this boundary.
+
+### Trace lineage and segments
+
+A conversation owns one trace head. A durable fork creates a child lineage segment with:
+
+- its own immutable identity;
+- a reference to the parent segment;
+- the inclusive parent boundary inherited by the child; and
+- a suffix sequence beginning after that boundary.
+
+The logical event stream is the parent prefix followed by the child suffix. A segment has one
+parent, so ordinary forks form a tree; shared immutable artifacts and revisions may create a DAG
+of references without creating mutable multiple-parent event streams.
+
+Temporary forks use the same shape in memory. Saving a temporary fork with a durable prefix
+persists the prefix reference. Saving one whose source prefix exists only in memory materializes
+that prefix once under the saved fork without persisting or mutating the temporary source.
+
+### Typed trace events and the model-visible surface
+
+Trace events are append-only and carry monotonically ordered segment-local sequence identities.
+The minimum logical vocabulary is:
+
+- turn and call boundaries;
+- model-surface append;
+- model-surface replacement carrying one predecessor surface head, one bounded contiguous range
+  reference, and the replacement node;
+- tool call and model-facing tool result;
+- request-header selection;
+- provider route/overlay selection where it affects captured semantics;
+- response selection;
+- call outcome and usage; and
+- trace gap or unavailable component.
+
+A surface event stores a small structural shell and references content slots. It does not embed an
+ordinary conversation body. The surface is a persistent sequence/operation chain addressed by an
+immutable head. A replacement never stores a variable-length list of shadowed events: predecessor
+head plus validated start/end nodes identifies the replaced range. Folding append and replacement
+events yields the ordered semantic
+surface visible to the model at any boundary. A human transcript remains a separate projection of
+canonical messages; compaction or replacement may shadow model context without hiding the
+original human transcript.
+
+### Request headers
+
+A request header is the complete logical non-history envelope for one model-message series:
+
+- provider and model;
+- effective generation parameters and adapter-default provenance;
+- rendered system framing references;
+- tool-schema references;
+- response-format and reasoning/thinking controls;
+- endpoint's canonical credential-free identity; and
+- captured provider-owned overlays required to explain the semantic boundary.
+
+The first request records a header. Later calls reuse it while the effective value is unchanged.
+A real change or surface-series reset records a new immutable header. Large components are
+content-addressed artifact references, so even a complete logical header does not repeat system
+prompt or tool-schema bodies.
+
+### Provider calls
+
+A provider call is owned by conversation, trace lineage, turn, run, and call sequence—not by the
+eventual assistant message. It records:
+
+- immutable call identity and idempotency key;
+- lifecycle state (`reserved`, `not_dispatched`, `dispatch_started`, `dispatch_unknown`,
+  `response_started`, or a terminal outcome);
+- trace surface boundary consumed by the call;
+- effective request-header identity;
+- provider/model/route identity;
+- response revision or artifact identity;
+- complete/stopped/error/interrupted/abandoned outcome;
+- normalized usage when available;
+- frozen capture and redaction policy provenance; and
+- disclosed omission and integrity state.
+
+Retries and tool-loop calls are distinct calls. A call may later be linked to the assistant message
+that presents its result, but that link is presentation metadata rather than ownership.
+
+The lifecycle is monotonic. `reserved` can become `not_dispatched` or `dispatch_started`;
+`dispatch_started` can become `response_started`, `dispatch_unknown`, or a terminal provider error;
+`response_started` can become `complete`, `stopped`, `error`, or `interrupted`. `abandoned` is a
+terminal user/run decision only when durable evidence proves no provider operation remains live.
+Recovery never moves a call backward or converts uncertainty into `not_dispatched`.
+
+### Content-addressed artifacts
+
+Provider-only semantic bodies are stored after mandatory sanitization and optional capture-time
+PII transformation. Identity includes the sanitized bytes, structural media type, and relevant
+normalization version. Artifacts include rendered system text, injected instructions, RAG/memory
+context not represented by a canonical message, tool schemas, provider overlays, unmatched legacy
+components, and provider responses that differ from the saved assistant revision.
+
+Binary bodies remain external or stubbed according to the existing attachment boundary. A digest
+may verify an existing immutable attachment, but trace capture does not duplicate its bytes.
+
+Artifact content identities are computed only over the sanitized body that the artifact itself
+stores. They are never computed over a withheld credential, masked PII value, canonical conversation
+text, or omission marker. Because anyone who can read the artifact already has its sanitized body,
+its internal deduplication identity reveals no additional omitted content.
+Reuse compares the stored sanitized bytes and structural identity rather than trusting a digest
+alone. A mismatch allocates a separate opaque artifact identity instead of aliasing two bodies.
+
+### Redaction projections
+
+Redaction projections are keyed by opaque source revision/artifact identity plus an immutable policy
+identity containing credential-detector version, PII-enabled state, and an opaque PII ruleset
+revision identity.
+They store a structured field path plus normalized Unicode codepoint ranges, category, stable rule
+IDs, detector versions, and outcomes. They never store matched values, value hashes, captured substrings, exception text, or
+user-authored regex source. Start/end ranges necessarily disclose the matched codepoint count and
+position; that limited leakage is accepted because exact ranges are required to mask a referenced
+canonical message without copying it. No separate value length or surrounding text is stored.
+
+The same revision referenced repeatedly under the same frozen policy reuses one projection. Both
+Safe and Full trace reads resolve canonical references through the call's frozen mandatory and
+optional masks. The ordinary conversation UI remains an unredacted view of canonical messages.
+
+## Provenance-aware request preparation
+
+`PreparedConsoleRequest` keeps its existing event-neutral semantic sections. A parallel immutable
+capture descriptor travels beside each semantic unit and identifies its source:
+
+- message semantic revision;
+- conversation setting or rendered system artifact;
+- automatic project instruction or workspace context;
+- RAG/memory artifact;
+- tool definition, call, or result;
+- provider transformation/overlay; or
+- active user request.
+
+Descriptors are capture-only. They are not serialized into provider messages, cannot grant local
+filesystem authority, and do not alter token counting or context selection.
+
+Provider adaptation must preserve a binding between every final semantic value and its descriptor.
+Immediately before dispatch, the gateway independently verifies that resolving the descriptors
+reconstructs the final captured kwargs. A mismatch marks the affected component unavailable on the
+already-reserved call; it never falls back to persisting the raw kwargs wholesale.
+
+## Runtime flow
+
+1. **Admit the run.** Resolve Capture On/Off, PII redaction, provider settings, and applicable
+   conversation/next-send overrides. Freeze them on the provider run before any call begins.
+2. **Prepare semantics and provenance.** Build the semantic request and parallel descriptors.
+3. **Adapt to the provider boundary.** Apply provider transformations while carrying content-slot
+   provenance into the final kwargs.
+4. **Reserve before dispatch.** Allocate conversation/turn/run/call identity and synchronously
+   commit a minimal content-free `reserved` call carrying lineage identity and frozen capture-policy
+   provenance. If this reservation fails, Capture On does not dispatch automatically: the UI offers
+   Retry or an explicit one-shot **Send without capture** action that admits a new Capture Off call.
+5. **Open and advance the surface.** Append only new semantic items or explicit replacements. Reuse existing
+   revision/artifact references.
+6. **Select the header.** Reuse the prior header if value-identical; otherwise record a new complete
+   logical header containing content references.
+7. **Bind and mark dispatch.** Store the surface boundary and header identity on the reservation.
+   Immediately before entering the provider adapter, durably transition the call to
+   `dispatch_started`. If binding,
+   sanitization, or descriptor verification fails after reservation, retain the reservation as
+   incomplete with content-free status when writable; a manually admitted call may proceed because
+   the durable row already proves that it existed.
+8. **Observe the response.** Accumulate the bounded semantic response required by the current
+   Inspector. Raw token chunks remain out of scope.
+9. **Seal independently.** Commit response reference/artifact, outcome, usage, omissions, and policy
+   provenance in an idempotent trace transaction independent of conversation-message settlement.
+10. **Settle failures honestly.** A failed post-dispatch trace write enters a bounded best-effort
+    settlement queue. Process death leaves the durable reservation open or incomplete; cold recovery
+    maps `reserved` to `not_dispatched`, maps `dispatch_started` without provider evidence to
+    `dispatch_unknown`, and maps `response_started` to `interrupted`. It never claims whether an
+    unknown dispatch reached the remote provider.
+
+Reservation retries use the immutable call idempotency key: after an ambiguous local commit result,
+the gateway queries that identity before creating another row. For the initial manually initiated
+call, reservation/binding failure offers Retry or explicit Send without capture. During a retry,
+tool loop, or other already-running interactive sequence, the run pauses before the next provider
+entry and requires Resume with capture or an explicit capture-off continuation. An autonomous or
+scheduled run fails safely instead of silently disabling capture. A capture-off bypass exists only
+in live run/UI state because Capture Off deliberately creates no durable trace row.
+
+Temporary conversations remain non-durable. They cannot enter a provider adapter with durable
+Capture On while still temporary. The UI offers **Save & Send**, which promotes the conversation and
+persists its in-memory lineage before reservation, or an explicit **Send without capture**. Existing
+temporary trace/fork state can remain coherent in memory but is not restart-durable until saved.
+
+After a provider response, conversation settlement first saves the canonical assistant message and
+its semantic revision. Trace sealing then re-reads that immutable revision and links it only if its
+sanitized envelope exactly equals the assembled provider-facing response. If trace sealing loses the
+race or cannot verify equality, it stores the sanitized response artifact rather than a questionable
+revision link. Failure to save the conversation message may still leave the provider response in the
+trace artifact; failure to seal trace never rolls back a saved message. If display filtering, reasoning separation, tool payloads, synthetic
+fallback copy, or another transformation makes it differ, the trace stores the provider-facing
+response as one sanitized artifact and labels the relationship.
+
+## Message edits and replacements
+
+Every destructive semantic mutation transaction must:
+
+1. identify the current semantic revision;
+2. enumerate every reachable frozen policy binding that would lose its source content;
+3. materialize each required sanitized projection or explicit omission once;
+4. append a new semantic revision for the edited message;
+5. append a bounded predecessor-head/range surface replacement; and
+6. commit projection bindings, revision transition, canonical mutation, and replacement atomically.
+
+Historical calls retain their earlier boundary and resolve the old revision. New calls fold the
+replacement. Regeneration and context compaction use the same append/replace semantics rather than
+editing trace events. This fail-closed mutation contract is intentionally different from
+post-dispatch response settlement: an edit, attachment rewrite, sync update, generation replacement,
+or hard delete that cannot preserve reachable trace history does not commit.
+
+## Fork behavior
+
+A fork captures the immutable trace head at the same source snapshot fence used for the message
+lineage. The inherited prefix includes calls associated with copied active-lineage messages through
+the boundary, including failed or abandoned attempts that happened before that boundary. It
+excludes calls admitted after the snapshot and calls belonging solely to excluded branches.
+
+The source remains untouched. The child reads the shared prefix as immutable history and appends a
+new suffix. Viewer projection interleaves the child's copied transcript with the inherited trace by
+source lineage and call boundaries, so the full conversation remains coherent.
+
+Hard-deleting the source conversation detaches its owner but cannot remove a prefix still owned by
+a fork. Before source message rows disappear, required trace projections materialize in the same
+transaction. If any projection cannot be preserved safely, deletion aborts.
+
+Purging trace from one conversation detaches that conversation only and lists forks that still own
+shared history. This task provides no lineage-wide one-click purge.
+
+## Capture and privacy controls
+
+Three controls remain deliberately separate:
+
+- **Capture:** On or Off.
+- **PII redaction:** On or Off, default Off.
+- **Viewer profile:** Safe or Full.
+
+Capture and PII policies support global default, sparse conversation override, and eligible
+next-send override with explicit precedence. The resolved values freeze at run admission and apply
+to retries and tool-loop calls. Forks inherit the source's future-capture configuration, but every
+historical call retains its original policy provenance. Viewer profile is a local presentation
+preference and does not mutate capture policy or historical data.
+
+The existing capture-detail Safe/Full setting is retired for future writes. Historical
+`capture_detail` remains immutable provenance. Existing capture-enabled and per-conversation
+enable/disable choices migrate to Capture On/Off, but an old Full choice never silently enables Full
+disclosure: after upgrade, every profile starts in Safe viewer mode and receives a one-time
+explanation. Persisted old Full bodies remain available only after the user explicitly switches the
+viewer to Full. Obsolete next-send capture-detail overrides are discarded at restart rather than
+being reinterpreted; new next-send controls are Capture and PII only.
+
+Safe and Full use the same stored trace:
+
+- **Safe** shows ordinary transcript context plus structural trace facts while collapsing or
+  masking sensitive provider-only bodies, tool arguments/results, automatic instruction bodies,
+  and other high-disclosure sections. Safe search, copy, and export operate only on this projection.
+- **Full** may reveal all persisted non-credential content that survived capture-time PII policy.
+  Expanding a sensitive section and copying/exporting Full require explicit confirmation.
+
+Canonical message references are masked through each call's frozen credential/PII projections in
+both profiles. Safe/Full changes provider-only disclosure, not whether frozen capture-time masks are
+honored. The normal conversation transcript remains unchanged and may therefore contain PII that
+the trace masks.
+
+Existing users receive a one-time disclosure that Safe is a viewer/export profile, not a reduced
+at-rest trace. Status copy reports stored fidelity, credential filtering, PII state, and current
+viewer profile separately.
+
+## Mandatory credential filtering
+
+Known credential kwargs, credential references, URL userinfo/query/fragment, and known
+credential-bearing nested fields are structurally excluded. A versioned detector also scans
+provider-only free text for recognized secret formats. Arbitrary secrets embedded in prose cannot
+be guaranteed detectable; consent and help text state this limitation.
+
+Filtering occurs before artifact identity or persistence. For message-revision references, the
+trace stores a mandatory credential redaction projection and applies it on every trace read. If a
+referenced live revision must be materialized, only that sanitized trace projection enters the
+artifact store.
+
+A credential sanitizer error yields an unavailable component marker. No raw fallback is allowed.
+Bodies, values, matches, and exception strings never enter logs or migration diagnostics.
+
+## Optional PII redaction
+
+PII redaction is irreversible for captured provider-only artifacts and applies to both Safe and
+Full trace projections. For canonical message references it stores immutable masks; it does not
+rewrite the user's conversation. The settings UI must say this explicitly.
+
+Version 1 includes built-in detectors and user-authored regex rules. Each user rule has a stable ID,
+label/category, enabled state, pattern, limited documented flags, and deterministic priority.
+Patterns are length-bounded, compile-validated, and screened for unsupported constructs when saved.
+
+Because CPython's `re` cannot be safely interrupted, custom rules execute as one bounded batch in a
+stdlib-only disposable subprocess. Input bytes, field count, pattern count, match count, and wall
+time are capped. The parent kills the process on timeout and treats crash, malformed output, excess
+matches, or deadline as a fail-closed redaction failure for affected components. A worker is never
+reused across unrelated captures.
+
+Candidate spans use Unicode codepoint offsets over the exact source content bound to the recorded
+revision or artifact identity. They are sorted deterministically and overlapping ranges are unioned. A union with multiple categories
+uses `mixed`; credential filtering has already occurred and cannot be weakened by a PII rule.
+Changing or deleting a rule never changes historical masks. Trace rows retain stable rule IDs and
+an opaque ruleset revision identity, not a hash or the pattern source.
+
+## Viewer, search, copy, export, and purge
+
+Historical trace is not editable. The viewer supports inspect, expand/collapse, filter, permitted
+search, copy, export, and owner-scoped purge.
+
+The viewer reconstructs one call by:
+
+1. resolving its lineage prefix and suffix through the recorded boundary;
+2. folding surface append/replacement events;
+3. resolving the selected request header;
+4. resolving source revisions and artifact slots through the call's disclosure projections; and
+5. rendering explicit omissions and integrity status beside the result.
+
+Safe operations never materialize hidden Full bodies. Full search, when explicitly active, scans a
+bounded in-memory projection; hidden Full text is never written to FTS, persistent previews,
+clipboard history owned by Chatbook, logs, or metadata. Full expansion and copy/export confirmations
+name PII state and the possibility of sensitive prose that detectors missed.
+
+Purge removes one conversation's trace ownership under capture quiescence. Shared lineage nodes or
+artifacts remain while another fork owns them. The action reports those remaining owners and does
+not imply forensic erasure.
+
+## Failure, integrity, and concurrency
+
+- Reservation, lifecycle transition, binding, and sealing operations are idempotent under immutable
+  call identity.
+- Every Capture On provider dispatch requires a committed content-free call reservation. Reservation
+  failure blocks automatic dispatch until Retry or an explicit one-shot Capture Off confirmation.
+- Cold recovery maps a committed `reserved` row with no dispatch transition to `not_dispatched`, a
+  `dispatch_started` row without provider evidence to `dispatch_unknown`, and a `response_started`
+  row without a terminal seal to `interrupted`; already durable events remain immutable.
+- Provider success and assistant-message persistence are not transactional with post-dispatch trace
+  settlement. Destructive semantic message mutations are transactionally coupled to required trace
+  preservation and fail closed.
+- A trace component resolution mismatch fails closed for that component and marks the call
+  incomplete; it never captures raw kwargs as a fallback.
+- Fork boundaries and edit replacements validate immutable revision and lineage heads before commit.
+- Hard deletion stages sanitized materialization and removal in one transaction.
+- Every mutation of a reachability root or edge—including events, surface heads, owner/fork links,
+  projection bindings, revision locators, headers, artifacts, and migration state—advances one
+  global trace-graph epoch transactionally. Garbage collection records it with the mark snapshot,
+  obtains the maintenance exclusion for sweep, rechecks the epoch in the sweep transaction, and
+  aborts on change.
+- Multiple independent app processes writing one profile remain unsupported unless an existing
+  database-wide owner already provides the required exclusion.
+
+## Existing-data normalization
+
+Schema installation is a fast DDL migration that enables new normalized writes and dual reads.
+Content conversion does not block first UI readiness. A `TraceMaintenanceCoordinator` runs only
+when no provider run or other database maintenance is active, processes batches bounded by both row
+count and decoded bytes, and yields between batches.
+
+For each legacy exchange:
+
+1. Decode through the bounded production decoder.
+2. Apply the current mandatory credential filter. Optional PII is not retroactively applied.
+3. Split request history into independently classifiable semantic components.
+4. Match ordinary rows to unique historical message revisions using role, within-call order,
+   structural shape, and an ephemeral sanitized semantic fingerprint discarded before commit.
+5. Store exact matches as revision references, but do not infer a cross-call parent, fork, edit, or
+   replacement chronology the legacy blob never recorded.
+6. Store unmatched provider-only rows as independently content-addressed artifacts.
+7. Preserve ambiguous rows as individual sanitized legacy artifacts with an ambiguity marker; never
+   drop them or retain the entire accumulated list merely because one row is ambiguous.
+8. Deduplicate system framing, tool schemas, provider overlays, and responses.
+9. Represent each legacy call as an isolated immutable `legacy_snapshot` surface whose ordered
+   components use persistent sequence nodes `(parent_node, component_ref)`. Equal prefixes therefore
+   deduplicate structurally without storing a per-call history array. Call owner, run tag, sequence,
+   and timestamp provide only their recorded partial order; live normalized lineage starts from an
+   explicit import/legacy boundary and never invents a global predecessor.
+10. Write and read back the normalized call.
+11. Reconstruct the expected sanitized legacy projection and compare it structurally.
+12. Delete the legacy blob only after equivalence succeeds in the same transaction.
+
+ADR-096's earlier bounded-excerpt migration may already have irreversibly removed rows. A valid
+aggregate omission marker becomes an explicit component node `legacy_omission`; the new system does not
+pretend to recover its missing content. Existing Safe project-instruction omissions and corrupt or
+truncated blobs receive the same honest treatment.
+
+Dual reads prefer a verified normalized call and otherwise decode legacy. Migration state is
+visible as:
+
+- new-capture protection active;
+- legacy normalization pending;
+- logical reclamation complete; and
+- physical compaction pending or complete.
+
+Recognized corrupt/unavailable rows remain isolated and counted without content-bearing logs.
+Unexpected code or SQLite errors roll back the current batch and leave its checkpoint retryable.
+
+## Garbage collection and physical compaction
+
+Deleting a conversation or migrated blob drops an ownership root and advances the trace-graph epoch;
+it does not synchronously walk
+the complete shared graph. Every other edge mutation advances the same epoch. A background
+mark/sweep later reclaims unreachable events, artifacts,
+headers, revisions, and redaction projections. Soft-deleted conversations and migration-pending
+legacy rows remain roots.
+
+SQLite logical deletion frees pages but does not necessarily shrink the database file. After
+logical normalization and garbage collection, automatic physical compaction enters a visible
+maintenance pause only when:
+
+- no provider run or other maintenance is active;
+- all application connections can be closed;
+- WAL is checkpointed;
+- available disk space passes preflight; and
+- the maintenance lease remains current.
+
+If admission fails, compaction remains visibly pending and retries at a later eligible idle window.
+Logical live bytes, freelist bytes, WAL bytes, and allocated database-file bytes are measured and
+reported separately. Neither logical purge nor VACUUM claims erasure from backups or prior exports.
+Graph mutation is excluded during the final sweep transaction; inability to obtain the exclusion is
+a normal retry condition, not permission to sweep against a stale mark.
+
+## Performance and growth verification
+
+The acceptance benchmark must use the real provider gateway and production kwargs shape, not a
+hand-built capture. It creates 200 turns with semi-incompressible content and records at turns 1,
+50, 100, 150, and 200:
+
+- live database bytes;
+- SQLite allocated bytes and freelist pages;
+- WAL bytes;
+- normalized call/event/header rows;
+- unique artifact and materialized-revision bytes;
+- legacy bytes remaining; and
+- encode/decode and call-settlement time.
+
+For an append-only conversation with unchanged header and no provider-only body changes:
+
+- each ordinary turn adds a bounded number of trace rows and content references;
+- no provider call stores an array or blob proportional to prior transcript length;
+- cumulative normalized bytes grow linearly with new semantic content and call count; and
+- the measured growth from turns 100 to 200 is reported against growth from turns 1 to 100 rather
+  than hidden behind compression ratios.
+
+The report must separately show logical reclamation after legacy normalization and physical file
+size after the eligible compaction step.
+
+The benchmark fixture is versioned in the repository with fixed per-turn input/output lengths,
+provider kwargs shape, randomness seed, and content checksum. The benchmark is a release gate, not
+an observational report. Using five fresh-database runs and the median (with the reference machine
+and SQLite settings recorded), it passes only when:
+
+- normalized live trace-owned bytes added by turns 101–200 are at most 1.25 times those added by
+  turns 1–100, excluding canonical conversation bytes and SQLite freelist/WAL allocation;
+- normalized trace-owned rows added by turns 101–200 are at most 1.25 times those added by turns
+  1–100;
+- normalized live trace-owned bytes at turn 200 are no more than 2.0 MiB for the pinned fixture;
+- pre-dispatch reservation/`dispatch_started` persistence has p95 latency at most 10 ms and no
+  reference-run sample exceeds 50 ms;
+- post-dispatch settlement runs off the UI thread and has p95 transaction latency at most 25 ms;
+- each legacy batch holds its write transaction for at most 100 ms, decodes at most 4 MiB and 100
+  rows, and yields before the next batch; the pinned 200-turn legacy fixture normalizes within 5 s;
+  and
+- every result includes the raw per-run measurements so a median cannot hide a pathological run.
+
+A second 200-turn compaction-heavy fixture replaces the oldest 75 percent of the active model
+surface every 20 turns. It must meet the same 1.25 second-half row/byte growth ratios, and schema
+inspection must prove no replacement row contains a variable-length shadowed-source list.
+
+Physical compaction of the pinned fixture must complete within 5 s on the recorded reference
+machine. Arbitrary user databases have no dishonest universal time bound: they must receive a
+preflight estimate and visible progress, the UI event loop must remain responsive, and provider
+dispatch stays paused only for the admitted maintenance interval.
+
+## Rollout and implementation decomposition
+
+TASK-23026 is the originating finding but is already Done on `origin/dev` under ADR-096's
+superseded bounded-retention implementation. Its checked acceptance criteria and implementation
+notes remain historical evidence and must not be rewritten. Before implementation, the writing
+plan must create a new umbrella task for ADR-097 and dependency-ordered, atomic Backlog work
+packages suitable for single pull requests. Core ledger capture, mandatory filtering, and logical
+legacy normalization land and prove their gates before custom-regex execution and physical
+compaction are enabled:
+
+1. schema, semantic revisions, artifact identity, trace lineage, and dual-read foundation;
+2. provenance-aware request preparation and normalized new-call capture;
+3. edit, regeneration, fork, hard-delete, recovery, and ownership integration;
+4. mandatory credential policy, Safe/Full viewer projection, search/copy/export, settings migration,
+   and built-in PII masking;
+5. legacy snapshot normalization, garbage collection, linear-growth benchmark, and rollout docs;
+6. bounded custom-regex subprocess and policy-management UX after core ledger/privacy gates pass;
+   and
+7. physical compaction admission/progress after logical reclamation and GC are proven.
+
+Exact task IDs must be created before they are referenced from Backlog task files. TASK-23112 stays
+a separate later feature and is not a prerequisite for the forthcoming ADR-097 implementation
+umbrella.
+
+## Verification contract
+
+Implementation follows test-driven development. Targeted coverage must include:
+
+- direct calls, multiple retries, tool loops, fallback calls, stops, errors, interruptions, and
+  abandoned regenerations;
+- exact boundary/header selection under unchanged and changed provider configuration;
+- Anthropic system separation, provider transformations, and llama.cpp literal ownership;
+- response equality/ref selection versus provider-only response artifacts;
+- repeated message edits, surface replacements, compaction, and copy-on-write materialization;
+- mutation-route census plus rejection of direct SQL and every edit/sync/import/attachment bypass;
+- durable-to-durable, durable-to-temporary, temporary-to-temporary, and later-saved fork prefixes;
+- temporary-chat Save & Send, explicit capture-off send, and restart-durability boundaries;
+- source soft deletion, successful hard deletion, and injected materialization failure rollback;
+- shared-owner purge disclosure and trace-graph-epoch garbage-collection races;
+- credential fields, URLs, nested values, recognized free-text formats, sanitizer failure, and
+  absence from trace-owned tables/artifacts and every trace-derived log, exception, preview,
+  clipboard, and export path; canonical conversation rows are explicitly outside this absence
+  assertion;
+- durable pre-dispatch reservation and `dispatch_started` transition; ambiguous reservation retry;
+  manual Retry/Send-without-capture behavior; interactive loop pause/resume; autonomous fail-safe;
+  post-reservation binding failure; seal failure; and crash recovery to `not_dispatched`,
+  `dispatch_unknown`, or `interrupted` as evidence permits;
+- built-in and custom PII rules, Unicode spans, overlaps, `mixed` classification, invalid patterns,
+  subprocess timeout/crash/malformed output, ruleset changes, and Safe/Full behavior;
+- dual reads, all legacy capture variants, ambiguous matches, old aggregate markers, corruption,
+  isolated persistent legacy snapshots without invented lineage, idempotent resume, equivalence
+  failure, and batch rollback;
+- idle-maintenance admission, WAL checkpoint failure, disk preflight failure, deferred retry, and
+  physical size reporting; and
+- the append-only and compaction-heavy 200-turn release gates described above.
+
+Per repository policy, implementation verification begins with tests touching the modified
+functionality. A full suite requires explicit user opt-in.
+
+## Documentation changes
+
+The Console user guide and Inspector help must explain:
+
+- ordinary transcript bodies are referenced rather than copied into each exchange;
+- provider-only context is stored once when capture is enabled;
+- Safe and Full are viewer/export disclosure profiles over the same stored trace;
+- credential filtering is mandatory but cannot guarantee arbitrary prose secrets;
+- PII redaction protects traces and does not rewrite the conversation;
+- existing Safe/Full capture-detail choices migrate to a Safe-default viewer without deleting old
+  Full bodies;
+- temporary chats require Save & Send for durable Capture On, or an explicit capture-off send;
+- edits and forks retain coherent historical traces through immutable revisions/shared prefixes;
+- owner-scoped purge may leave history retained by forks;
+- automatic legacy normalization may contain explicit irrecoverable omissions from older policies;
+  and
+- logical deletion, physical SQLite compaction, backups, and exports have different erasure
+  semantics.
+
+## Alternatives considered
+
+### Keep a bounded Safe excerpt
+
+Rejected. It makes Safe less useful precisely when older context, injected instructions, or an
+earlier tool result caused the response. It also leaves Full with quadratic duplication and makes
+diagnostic completeness depend on a setting selected before the failure.
+
+### Keep the last N rows plus one fingerprint per omitted row
+
+Rejected. Per-row metadata still produces quadratic cumulative growth, and fingerprints can become
+guess-verification oracles for private text.
+
+### Keep one complete request blob per call and deduplicate only compression blocks
+
+Rejected. Compression hides but does not remove repeated logical ownership, complicates deletion
+and edits, and retains a second transcript as the operative trace truth.
+
+### Store arbitrary diffs between serialized request JSON values
+
+Rejected. A custom patch language creates diff/apply/fallback machinery, brittle provider-specific
+paths, and corruption propagation. Typed surface events and immutable component references preserve
+one logical model.
+
+### Replace the complete application conversation model with a DeepSeek-style session log
+
+Rejected. Chatbook already has canonical message trees, persistence, variants, sync boundaries, and
+conversation ownership. The trace ledger should reference that source rather than migrate unrelated
+application behavior.
+
+### Copy a fork's trace prefix into the child
+
+Rejected. It recreates the storage defect across forks and makes source deletion/purge semantics
+ambiguous. Immutable prefix sharing preserves coherent history without physical duplication.
+
+### Let Safe and Full store different content
+
+Rejected. A reduced Safe store cannot explain failures caused by omitted context, while automatic
+Full duplication recreates the privacy and storage problem. One sanitized store plus explicit
+disclosure profiles is both useful and honest.
+
+### Run custom PII regex in the application process
+
+Rejected. Python's standard regex engine has no portable hard timeout; a pathological user rule can
+freeze the TUI. Validation remains useful, but only a killable subprocess provides the required
+runtime bound without a new mandatory regex dependency.
+
+### Delete all trace when the source conversation is deleted
+
+Rejected. A fork that inherited the source boundary would become incoherent. Copy-on-write
+materialization and shared ownership retain only history that remains reachable.
+
+## ADR check
+
+ADR required: **yes**
+
+ADR path: `backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md`
+
+Reason: the design changes durable schema and migration, semantic data ownership, fork lineage,
+edit/delete behavior, provider/capture contracts, privacy policy, redaction guarantees, and
+long-lived Inspector UX. It supersedes ADR-096 and amends the existing Full semantic-capture and
+fork decisions.
+
+## External reference
+
+- [DeepSeek Harness session model](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/subsystems/session.md)
+- [DeepSeek Harness persistence model](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/subsystems/persistence.md)
+- [DeepSeek reconstructable-request decision](https://github.com/deepseek-ai/deepseek-harness/blob/master/.agents/notes/implemented/architecture/2026-07-05-reconstructable-requests.md)
+- [DeepSeek telemetry/redaction separation](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/subsystems/session-telemetry.md)
+- [DeepSeek chunk-row codec reference for TASK-23112](https://github.com/deepseek-ai/deepseek-harness/blob/master/packages/core/session/src/chunk-rows.ts)

--- a/Docs/superpowers/specs/2026-08-28-low-latency-speculative-duplex-voice-pipeline-design.md
+++ b/Docs/superpowers/specs/2026-08-28-low-latency-speculative-duplex-voice-pipeline-design.md
@@ -1,0 +1,626 @@
+# Low-Latency Speculative Duplex Voice Pipeline Design
+
+**Date:** 2026-08-28
+
+**Status:** Approved; three-pass spec review completed with the final
+orphan-accounting correction approved by the user
+
+**Decision:** [ADR-098](../../../backlog/decisions/098-low-latency-speculative-duplex-voice-pipeline.md)
+
+**Related designs:** [Hands-Free Conversation Loop](2026-08-02-hands-free-loop-design.md),
+[Realtime Voice Engine](2026-08-04-realtime-voice-engine-design.md)
+
+## Summary
+
+The provider-agnostic Console hands-free pipeline currently waits for a two-second
+silence gate, segment transcription, and a 1.5-second send countdown before starting
+an LLM response. It can detect speech resuming, but once response generation begins it
+deliberately lets generation finish silently instead of cancelling and rebuilding the
+turn.
+
+This design replaces that stop-and-transcribe cadence with rolling transcription and a
+configurable speculative-response threshold whose default is 700 ms. A speculative LLM
+attempt begins from the freshest transcript snapshot. If speech resumes while the
+assistant is generating or speaking, or if STT materially corrects text used by the
+attempt, Chatbook stops audible output, fences and cancels the attempt, extends the same
+logical user turn, and starts a replacement after the next silence interval. Once the
+assistant finishes speaking, later speech starts a new turn.
+
+Reliable acoustic interruption becomes default through an app-owned full-duplex audio
+transport and a small native WebRTC AEC3 component shipped for macOS, Windows, and
+Linux. All hands-free TTS passes through the transport so the canceller receives the
+timestamped render reference. If echo cancellation is unavailable or unhealthy,
+speech admission fails closed during playback and the loop remains usable in
+half-duplex mode.
+
+Provisional attempts stay outside ordinary Console history, tools, approvals, citations,
+and durable exchange capture. The winning user/assistant pair is promoted atomically.
+When Console Capture is enabled, the winning attempt's sanitized in-memory exchange
+capture is then persisted best-effort with explicit post-dispatch provenance; cancelled
+attempts retain only content-free usage and latency counters.
+
+## ADR check
+
+ADR required: yes
+
+ADR path: `backlog/decisions/098-low-latency-speculative-duplex-voice-pipeline.md`
+
+Reason: the feature changes cross-platform native dependencies, audio-device and clock
+ownership, AEC failure policy, rolling-STT contracts, Console turn acceptance and
+persistence, provider cancellation, tool-effect boundaries, and exchange-capture
+semantics.
+
+## User promise
+
+- On a healthy warm reference path, Chatbook dispatches the LLM within 850 ms p95 of
+  post-AEC end-of-speech detection, using a transcript that covers the utterance tail.
+- Chatbook starts response preparation after 700 ms of silence by default; the setting
+  is adjustable from 500 to 3000 ms.
+- Speech detected while a provisional reply is generating or playing extends the same
+  user turn. The old reply stops audibly within 150 ms p95 and is replaced using the
+  accumulated transcript.
+- Cancelled attempts do not appear in conversation history and cannot execute tools or
+  create approvals, citations, replay records, or content-bearing diagnostics.
+- Once the winning assistant audio reaches a terminal boundary, later speech starts a
+  new turn.
+- App-owned TTS does not trigger false barge-in when AEC is healthy. When reliable
+  suppression cannot be established, Chatbook closes speech admission during playback
+  instead of exposing an unsuppressed microphone.
+- The separate OpenAI Realtime engine is unchanged.
+
+## Goals
+
+- Reduce end-of-speech to LLM dispatch without treating transcription as work that
+  starts only after silence.
+- Support native streaming STT and batch-only STT behind one rolling revision protocol.
+- Preserve one logical user message across short pauses and any resulting speculative
+  restarts.
+- Start TTS from the earliest safe prose phrase, keeping synthesis and playback ordered
+  and cancellable.
+- Provide reliable default acoustic echo cancellation on the three supported desktop
+  operating systems.
+- Keep provisional work isolated from durable history and irreversible effects.
+- Make latency, AEC health, fallback mode, restart storms, and discarded-attempt usage
+  measurable without recording transcript or audio content.
+
+## Non-goals
+
+- Changing the provider-native Realtime voice engine or making it emulate this pipeline.
+- Cancelling arbitrary system audio or removing background noise that is not caused by
+  Chatbook's render stream.
+- Persisting microphone audio, rolling STT windows, cancelled transcripts, or cancelled
+  response bodies.
+- Guaranteeing cooperative remote cancellation from every LLM or TTS provider. Late
+  work is fenced even when it cannot be stopped.
+- Executing tools speculatively or attempting to roll back external side effects.
+- Replacing the complete Console controller, provider gateway, persistence service, or
+  TTS adapter registry.
+- Claiming uninterrupted acoustic barge-in while AEC is warming or degraded. Safe
+  half-duplex fallback is part of the contract.
+
+## Existing constraints and starting point
+
+- `Audio/dictation_service_lazy.py` uses a two-second silence threshold and finalizes
+  segment audio before bounded transcription on non-streaming paths.
+- `Chat/console_voice_input.py` already exposes `VoiceSpeechResumed`, a 1.5-second
+  hands-free send delay, and an opt-in acoustic-barge-in setting.
+- `Chat/console_hands_free.py` owns the headless hands-free FSM. Its current barge-in
+  contract silences playback but does not cancel reply generation.
+- `Chat/reply_sentence_sequencer.py` assumes deltas continue after barge-in and buffers
+  enough text to avoid speaking code fences or unresolved Markdown.
+- `Audio/streaming_sink.py` owns app-rendered PCM through `sounddevice`, but microphone
+  capture and legacy file playback do not share one timestamped duplex clock.
+- `Chat/console_agent_bridge.py` streams ordinary assistant deltas directly into the
+  Console store, so provisional attempts cannot reuse that sink safely.
+- ADR-094 keeps microphone and realtime audio resources view-scoped while accepted
+  Console turns survive navigation in `ConsoleRuntime`.
+- ADR-097 requires a durable reservation before ordinary Capture On provider dispatch.
+  A provisional voice attempt is intentionally pre-acceptance and receives the narrow
+  capture exception defined below.
+- `dictation.acoustic_barge_in` is also consumed by the separate Realtime engine. It
+  cannot be repurposed for the new pipeline without violating the Realtime non-goal.
+  `dictation.handsfree_send_delay_seconds` belongs to the superseded countdown rather
+  than the new rolling-transcript timer.
+
+## Core invariants
+
+1. **AEC precedes turn detection.** Raw microphone frames never drive VAD, rolling STT,
+   command routing, or acoustic barge-in while assistant audio is rendering.
+2. **Rendered audio has one owner.** Every hands-free TTS provider, including legacy
+   file-producing adapters, decodes into the app-owned PCM transport before playback.
+3. **Transcript freshness outranks the timer.** A 700 ms timeout cannot dispatch a
+   hypothesis that does not cover the detected speech tail.
+4. **One logical turn, many attempt epochs.** Only the newest attempt epoch may render,
+   speak, call tools, create approvals, or promote persistence.
+5. **Cancellation is a fence before it is a request.** Obsoleting an attempt is atomic;
+   provider cancellation and resource cleanup follow best-effort.
+6. **Effects are never speculative.** Every tool call waits for the effect barrier and
+   then enters the ordinary accepted-turn pipeline.
+7. **Cancelled content stays ephemeral.** Conversation history, exchange trace, logs,
+   citations, tool state, and replay contain no cancelled transcript or response body.
+8. **AEC uncertainty fails closed.** Unhealthy full duplex becomes explicit half duplex;
+   it never becomes unsuppressed acoustic interruption.
+9. **Audio callbacks stay real-time safe.** They perform bounded copies and ring-buffer
+   operations only; STT, reconciliation, UI, logging, and cancellation run elsewhere.
+10. **The winning prompt is exact.** The persisted user text is the immutable transcript
+    snapshot used by the winning LLM attempt, not a later independently revised string.
+
+## Architecture
+
+```text
+                         timestamped render frames
+TTS PCM ──► DuplexAudioTransport ───────────────────────────┐
+                  │                                        │
+                  └─► speakers                             ▼
+microphone ──► timestamped capture frames ──► VoicePreprocessor
+                                                AEC3 → health → VAD
+                                                           │
+                                                           ▼
+                                                  TranscriptEngine
+                                             stable prefix + revisable tail
+                                                           │
+                                                           ▼
+                                             SpeculativeTurnCoordinator
+                                           turn id + attempt epoch + clocks
+                                             │                       │
+                                             ▼                       ▼
+                                      AttemptOutputBuffer       EffectBarrier
+                                             │
+                                             ▼
+                                      PhraseSpeechSequencer
+                                             │
+                                             └──────────► DuplexAudioTransport
+```
+
+### Ownership boundaries
+
+| Unit | Owns | Depends on | Explicitly does not own |
+| --- | --- | --- | --- |
+| `DuplexAudioTransport` | Input/output devices, hardware formats, monotonic frame timestamps, bounded render/capture rings, device latency, device-change events | PortAudio/sounddevice-style backend | AEC policy, VAD, STT, transcript text, UI |
+| `VoicePreprocessor` | Resampling into the processing domain, AEC3, render/capture delay estimation, residual-echo health, post-AEC VAD, admission gate | Native AEC wrapper and transport frames | Devices, provider calls, turn state |
+| `TranscriptEngine` | Stable text, revisable tail, audio coverage, backend mode, window reconciliation | Clean admitted frames and STT adapters | Silence timers, LLM attempts, persistence |
+| `SpeculativeTurnCoordinator` | Logical voice-turn identity, silence clocks, attempt epochs, restart governor, effect barrier, final promotion decision | Transcript revisions, VAD/command events, generation gateway, injected scheduler | Audio DSP, provider implementation, widgets |
+| `AttemptOutputBuffer` | One attempt's request snapshot, response deltas, sanitized capture envelope, usage, citations pending promotion | Existing provider-neutral request and response contracts | Durable writes, tools, approvals |
+| `PhraseSpeechSequencer` | Safe prose chunking, one-at-a-time synthesis, ordered cancellation | Current attempt deltas and TTS entry | Attempt selection, device ownership, persistence |
+| Console wiring | Status projection, settings, manual interrupts, view-scoped teardown | Existing `ConsoleHandsFreeController` and UI services | Domain clocks or state transitions |
+
+The components are protocols first. Native AEC, STT providers, and audio-device backends
+remain replaceable without changing coordinator policy.
+
+## Duplex audio and AEC contract
+
+The transport uses one full-duplex hardware session where the backend permits it. It
+normalizes render and capture into timestamped ten-millisecond frames and maintains a
+single monotonic clock domain. The processing domain prefers 48 kHz; device-native
+rates and TTS-source rates are converted at the transport/preprocessor boundary.
+Hardware output latency, capture latency, buffer occupancy, and drift update the delay
+estimate passed to AEC3.
+
+Render samples are fed to the reverse-stream analyzer in the same order they are
+scheduled for the speaker. Capture samples and the corresponding delay estimate are
+then processed through AEC3. Post-AEC frames alone reach residual-echo health, VAD, and
+STT. The design uses a narrow native interface rather than exposing WebRTC types to the
+Python application.
+
+AEC health states are `warming`, `healthy`, and `degraded`. Health uses residual echo,
+delay confidence, underruns/overruns, discontinuities, and bounded hysteresis. On first
+playback or after a device reset, the admission gate remains closed while AEC converges.
+When health becomes stable it opens. A degraded transition closes admission immediately
+but keeps hardware capture flowing through AEC so recovery remains possible. Manual or
+keyboard interruption is always available.
+
+Legacy file-producing TTS adapters are decoded and streamed through the same PCM path.
+External players are not valid hands-free playback owners because they cannot supply
+the exact render reference or terminal render timestamp.
+
+## Rolling transcription contract
+
+Every adapter produces revisions with:
+
+- logical voice-turn ID and monotonically increasing revision ID;
+- stable text plus a revisable tail;
+- the monotonic audio timestamp covered through;
+- backend mode (`live` or `rolling-window`);
+- finalization and failure state; and
+- content-free timing/usage metadata.
+
+Native streaming adapters translate provider events into this protocol. Batch-only
+adapters schedule bounded overlapping audio windows while speech is active. Only one
+batch job may run at a time. A newer desired window supersedes an obsolete queued
+window, preventing transcription backlog. Reconciliation aligns normalized tokens and
+timestamps, advances an immutable stable prefix, and replaces only the mutable tail.
+Punctuation, case, and whitespace changes are non-material for generation restart;
+word insertions, deletions, or substitutions in the active attempt snapshot are
+material.
+
+Batch fallback may process overlapping seconds more than once. Settings identify this
+mode and disclose that a remote batch provider may receive overlapping audio. The
+runtime records processed and duplicated duration without audio or text content.
+
+At a silence deadline, the coordinator requires the latest revision's coverage to
+reach the post-AEC speech-end timestamp within the adapter's declared frame tolerance.
+If it does not, the status remains `transcribing` and dispatch waits. Slow fallback is
+reported honestly instead of sending a truncated utterance.
+
+## Turn and attempt lifecycle
+
+A logical turn begins at the first admitted speech frame. During speech, rolling STT
+updates one provisional user row. Each admitted frame resets the response-eagerness
+timer. When the timer expires and a fresh nonempty transcript exists, spoken-command
+classification runs first. A stable command follows the existing command path and
+never reaches the LLM.
+
+For ordinary text, the coordinator snapshots the transcript and starts attempt epoch 1
+in an attempt-local output buffer. Response deltas never enter the ordinary Console
+store. The phrase sequencer emits punctuation-terminated prose first and may use a
+bounded word/time fallback only when Markdown/code state is resolved. It keeps exactly
+one synthesized phrase active and sends every PCM frame through the duplex transport.
+
+New admitted speech while generation or playback is active performs this order:
+
+1. Atomically advance the attempt epoch and reject all old callbacks.
+2. Close the old phrase input, abort current playback, and discard queued phrases.
+3. Request LLM and TTS cancellation and bounded cleanup.
+4. Remove the old assistant preview while retaining the logical user transcript.
+5. Continue rolling STT with the newly admitted audio.
+6. Dispatch from a new immutable snapshot after the next silence interval.
+
+A material late STT correction follows the same fence-and-restart path. Corrections
+arriving in one short burst are coalesced before one replacement request, but the old
+attempt remains fenced immediately.
+
+The first three attempts in any rolling ten-second window use the configured threshold.
+Additional attempts temporarily use 1.5 seconds until an attempt completes or the turn
+remains continuously quiet. At most two obsolete provider attempts may clean up
+concurrently. Reaching that bound pauses new dispatch until at least one obsolete
+attempt exits. If cooperative cleanup exceeds two seconds, the coordinator enters
+`serialized_conservative` for the remainder of the logical turn: it waits for two
+seconds of stable silence and zero obsolete attempts, dispatches exactly one active
+attempt, and still fences that attempt immediately if speech resumes. It never overlaps
+a replacement with cleanup in this state.
+
+Every attempt owns a force-closable provider transport. Five seconds after the original
+cancellation request, the coordinator force-closes that transport. If the task has not
+exited after a further 500 ms, it is detached into an app-lifetime voice orphan set
+behind its irreversible epoch fence. The coordinator then terminates the provisional
+logical turn as a recoverable failure, preserves the latest transcript as an editable
+voice draft, and reports that provider cleanup is stuck. The shared voice dispatch
+supervisor quarantines all later hands-free provider dispatch while the set is nonempty;
+leaving and re-entering hands-free, changing provider, or rebuilding a provider session
+cannot bypass it. Ordinary typed chat remains available, and the draft may be sent as
+text. Voice dispatch resumes automatically only after every orphan exits; restarting
+the app is the explicit recovery if one never does.
+
+The orphan set retains no transcript or response body, and its members cannot publish
+callbacks, receipts, capture rows, or audio. The two-obsolete-attempt cleanup cap also
+bounds the set at two: once that cap is reached no replacement can start, and once any
+member detaches the supervisor-level quarantine precedes every later voice dispatch.
+Successful turn promotion, explicit turn cancellation, this terminal cleanup failure,
+hands-free exit, or session teardown ends the current logical turn, but none of those
+events clears a nonempty app-lifetime orphan quarantine.
+
+The successful boundary is the estimated time the winning attempt's final audible
+sample reaches the output device. Speech whose capture timestamp begins no later than
+that boundary extends the existing turn; later speech begins a new turn. If no audio is
+produced, the terminal generation/TTS outcome supplies the equivalent boundary. TTS
+failure waits for text generation to finish, commits the completed textual response if
+no newer speech exists, reports the speech failure, and reopens admission.
+
+All transcript, render, and control events enter one serialized coordinator mailbox.
+The duplex input callback stamps each captured frame with a strictly increasing sequence
+and a timestamp from the same monotonic clock as the output render timeline, before AEC
+or VAD work begins. After playback reports terminal render boundary `R`, promotion first
+requests `drain_capture_through(R)`. The full-duplex engine must observe the first
+ordered input callback or explicit device-clock watermark later than `R`, drain AEC and
+VAD through the greatest captured sequence at or before `R`, and report every detected
+speech span from that range. A detected span whose start is at or before `R` is admitted
+to the existing logical turn and fences the attempt.
+
+Only after that capture/VAD acknowledgement reports no qualifying speech does the
+coordinator ask the transcript engine to seal through the last downstream-acknowledged
+admitted sequence and drain all material revisions derived from it. A material
+correction derived from audio at or before `R` wins the race, fences the attempt, and
+restarts it even if its callback arrived after the playback terminal callback.
+Promotion closes both causal watermarks; later callbacks cannot mutate the committed
+turn. In intentional half duplex there are no eligible capture frames during playback,
+so the playback terminal acknowledgement closes that gated interval and manual
+barge-in is the only same-turn interruption path.
+
+The combined capture, VAD, and transcript seal has a 500 ms deadline after `R`. Timeout,
+device reset, a skipped sequence, or a failed downstream acknowledgement fails closed:
+the pair is not promoted, the latest transcript becomes an editable voice draft, status
+reports capture synchronization failure, and speculative dispatch remains suspended
+until the duplex engine is rebuilt healthy. This may sacrifice an already-heard reply,
+but it never misclassifies pre-boundary speech as a new turn or commits a pair whose
+causal input boundary is unknown.
+
+A manual **barge-in** action while generating or speaking follows the same
+fence-and-continue path as admitted speech and reopens listening for the same logical
+turn, including in half-duplex mode. Explicit Stop, Esc, mic-toggle exit, session close,
+and hands-free exit instead cancel and discard the whole provisional turn. Merely
+silencing playback without fencing generation is not a valid action in the new
+pipeline.
+
+## Tool-effect barrier
+
+Speculative attempts may produce a tool request but cannot execute it or create an
+approval. On the first complete tool request, Chatbook freezes provisional speech and
+holds the attempt until total stable silence since the last admitted speech reaches two
+seconds. Speech during that interval fences and discards the attempt normally.
+
+When the barrier expires, Chatbook discards the speculative provider attempt, commits
+the exact user transcript, and re-dispatches through the ordinary accepted Console
+agent pipeline with its normal tool schemas, Capture On policy, approvals, persistence,
+and ADR-094 runtime custody. Any later speech is a new turn or an explicit interruption;
+it cannot rewrite an already authorized external effect. The speculative preamble is
+not reused as authoritative agent output because it was generated without committed
+tool context.
+
+## Acceptance, persistence, navigation, and capture
+
+A provisional voice attempt is not an accepted Console turn under ADR-094. Its
+microphone, audio, coordinator, transcript, and attempt buffers are view-scoped.
+Navigating away, leaving hands-free mode, session close, or app shutdown fences and
+discards them without a terminal receipt. This matches the existing rule that audio
+resources do not survive screen navigation and the user's requirement that cancelled
+attempts leave no conversation artifacts.
+
+For a no-tool winning attempt, the exact transcript snapshot and assistant response are
+promoted through the existing durable-turn terminalization contract. One ChaChaNotes
+transaction writes the user/assistant pair, mints ADR-094's stable terminal receipt,
+and writes the exact `console_unseen:<receipt-id>` local mark. Promotion registers an
+already-complete accepted voice turn and terminalizes it atomically; it does not create
+a second runtime task for provider work that already ended. A mounted view clears only
+that exact receipt after synchronizing the committed pair. If navigation wins the race,
+the mark survives for the next view. A mounted view may project provisional rows before
+promotion, but ordinary history observes only the committed pair. Failure preserves the
+user transcript as an editable voice draft rather than persisting a partial pair or
+receipt.
+
+Ordinary ADR-097 Capture On reservation cannot run before a provisional provider call
+without persisting cancelled prompt content. The narrow amendment is:
+
+- the provider gateway builds the same sanitized semantic capture envelope in memory;
+- cancelled attempts destroy that envelope;
+- content-free attempt count, timing, backend mode, and billed-usage counters may remain
+  in local diagnostics;
+- after the winning conversation pair commits, its capture is settled best-effort as a
+  `provisional_voice_promoted` exchange linked to the committed turn;
+- the exchange declares that capture was promoted after dispatch and makes no
+  crash-durable pre-dispatch-reservation claim; and
+- a crash before promotion leaves neither provisional conversation nor exchange trace.
+
+If post-promotion trace settlement fails, it does not roll back the committed
+conversation. The existing trace durability warning/retry policy applies where it can
+honestly retry from the winning in-memory envelope; shutdown does not persist that
+envelope merely to enable later repair. Tool-barrier turns discard their speculative
+envelope and use the ordinary ADR-097 captured pipeline on re-dispatch.
+
+Temporary conversations retain their existing ADR-097 restriction. Speculative voice
+remains usable, but the status explicitly says exchange capture is unavailable for the
+temporary chat. Winning message rows and the winning envelope remain process-local;
+neither pre-dispatch reservation nor post-dispatch capture promotion is attempted. A
+later Save persists the conversation messages under ordinary temporary-chat promotion
+rules but does not retroactively invent capture for an earlier provider call. Tool
+barrier expiry uses the existing Save & Send requirement before ordinary captured agent
+dispatch.
+
+## Settings and UI
+
+The canonical `Settings -> Speech & TTS` surface owns the controls. Deprecated settings
+surfaces receive no new fields.
+
+`dictation.response_eagerness_ms` applies only to speculative hands-free dispatch:
+
+- valid range: 500 through 3000 ms;
+- default and Fast preset: 700 ms;
+- Balanced preset: 1200 ms;
+- Deliberate preset: 2000 ms; and
+- invalid values log a content-free warning and fall back to 700 ms.
+
+Values below 700 ms are labeled more likely to restart during mid-thought pauses. The
+existing dictation segment-finalization and non-hands-free settings remain independent.
+
+Legacy setting ownership is explicit:
+
+- `dictation.acoustic_barge_in` remains the unchanged compatibility key for the
+  provider-native Realtime engine. The qualified speculative pipeline does not read it;
+  acoustic interruption there follows AEC health and is default-on.
+- `dictation.handsfree_send_delay_seconds` remains readable only by the legacy
+  pre-speculative pipeline during the internal rollout gate. Once the new pipeline is
+  qualified, it is retired from active Settings and ignored by the speculative path.
+  Its value is not migrated into response eagerness because countdown-after-final-STT
+  and silence-to-dispatch are different semantics.
+- `dictation.pipeline_aec_enabled`, default true, is the troubleshooting-only AEC
+  switch. False forces half duplex and does not affect Realtime.
+
+The app preserves old config keys so older releases can still read them and shows one
+bounded migration note when a legacy hands-free delay or acoustic setting no longer
+controls the qualified pipeline. No startup write mutates the user's config merely to
+acknowledge the new ownership.
+
+AEC is default-on. Its off switch lives under troubleshooting and always forces safe
+half duplex. The Console status projection uses user-readable states: `listening`,
+`transcribing`, `responding`, `speaking`, `updating response`, `AEC warming`, and
+`half-duplex - echo cancellation unavailable`. Detailed health codes remain in
+diagnostics. Accessibility announcements fire on meaningful state transitions and are
+throttled; transcript revisions do not announce individually.
+
+The provisional user and assistant each reuse one temporary row across attempts. This
+avoids scroll jumps. When an attempt is fenced, its assistant body disappears and the
+status becomes `updating response`. No spoken acknowledgement or earcon is added to the
+hot audio path.
+
+## Failure handling
+
+- **AEC initialization/health:** keep device capture flowing for recovery, close speech
+  admission during playback, and display half-duplex status.
+- **Audio device change:** fence playback, retain the user transcript, rebuild the
+  device/AEC clock domain, and regenerate after the normal silence threshold.
+- **Transport overrun/underrun:** mark timing health degraded, fail admission closed,
+  and keep callback work bounded.
+- **STT lag:** wait for fresh coverage and report `transcribing`.
+- **STT failure:** try the adapter's declared fallback once; if that fails, retain an
+  editable voice draft and stop automatic dispatch for the turn.
+- **LLM failure:** retain the logical user draft, reopen listening, and permit additional
+  speech or manual retry.
+- **Uncooperative cancellation:** keep the obsolete epoch fenced, bound detached cleanup,
+  and apply the restart governor/backpressure rules.
+- **TTS phrase failure:** stop further speech for the attempt, allow text generation to
+  complete, and commit text only if no newer speech exists.
+- **Persistence failure:** retain the winning pair in the existing visible durability
+  failure/retry surface; never pretend a partial pair committed.
+- **Trace promotion failure:** do not roll back conversation success; report the existing
+  local capture warning while the in-memory retry source still exists.
+- **Shutdown/unmount:** advance all fences, stop audio, discard provisional buffers,
+  release devices, and create no provisional approvals or durable content.
+
+## Privacy, security, and cost
+
+- Raw and processed audio live only in bounded memory rings and rolling windows. They
+  are never written to disk by this feature.
+- Cancelled transcript and response text never enter logs, usage rows, traces,
+  notifications, sync, export, replay, or exception copy.
+- Content-free diagnostics include timestamps/durations, backend mode, attempt counts,
+  restart-governor activation, AEC state transitions, provider cancellation outcome,
+  and coded failures.
+- Cancelled provider work may still be billed. Usage accounting distinguishes winning
+  and discarded attempts and the Settings copy explains that aggressive response
+  eagerness can increase STT, LLM, and TTS usage.
+- Remote rolling-window STT may receive overlapping audio more than once. The selected
+  backend mode and duplicated-duration counter make that behavior visible.
+- The native dependency ships hashes, build provenance, an SBOM, applicable platform
+  signing, WebRTC license/patent notices, and a documented update policy.
+
+## Performance targets and measurement
+
+The warm reference path targets:
+
+- LLM request handoff within 850 ms p95 of post-AEC VAD speech end;
+- audible output stop within 150 ms p95 of admitted resumed speech;
+- replacement request handoff within 850 ms p95 of the new speech end while the restart
+  governor is not active; and
+- first audible response within 1.5 seconds median and 2.5 seconds p95 on the controlled
+  reference provider path.
+
+Instrumentation records post-AEC speech end, transcript coverage, request handoff,
+first accepted PCM, and estimated first/final hardware-render timestamps. Controlled
+local/fake providers prove application budgets. Live cloud-provider runs are reported
+separately so network variance is not mislabeled as application overhead.
+
+## Verification strategy
+
+### Signal processing
+
+Licensed/synthetic fixtures and captured room-impulse responses cover far-end-only
+echo, near-end speech, double-talk, changing delay, clock drift, clipping, silence,
+underruns, and device resets.
+
+- Far-end-only ERLE after one second of convergence: median at least 20 dB and 10th
+  percentile at least 10 dB.
+- Echo-only false barge-in rate: no more than one per 30 minutes.
+- Double-talk speech-start recall: at least 95 percent at the defined near-end/echo
+  ratios.
+- Healthy-path interruption and audible stop: no more than 150 ms p95.
+- Poor suppression must cause fail-closed admission rather than false healthy state.
+
+### Domain and integration tests
+
+- Transcript tests cover native revisions, stable-prefix advance, overlap alignment,
+  duplicate words, late corrections, punctuation-only changes, Unicode languages,
+  stale jobs, coverage timestamps, and backend failure.
+- Coordinator tests use an injected clock for silence deadlines, freshness gating,
+  every cancellation race, correction coalescing, attempt epochs, restart governor,
+  cleanup cap, two simultaneous force-close/detach outcomes, orphan-set quarantine that
+  survives hands-free toggles/provider rebuilds, recovery only after the full set
+  empties, serialized-conservative entry/dispatch/reset, tool barrier, manual barge-in
+  versus explicit exit, terminal outcomes, and timestamp turn boundaries.
+- Phrase tests cover punctuation, bounded fallback, ordering, cancellation, incomplete
+  Markdown, links, fenced code, abbreviations, and synthesis failure.
+- Persistence tests prove cancelled attempts create no content-bearing durable owner,
+  winning pairs commit atomically, capture promotion is labeled and best-effort, and
+  tool turns use ordinary pre-dispatch capture after the barrier. They also prove the
+  ADR-094 receipt and exact unseen mark share the winning-pair transaction, mounted and
+  navigation-racing acknowledgement behavior, and temporary-chat no-capture behavior.
+- Integration uses a deterministic fake duplex transport with streaming and batch STT,
+  cancellable and cancellation-resistant LLMs, streaming and file-producing TTS,
+  ordered capture/render clocks, delayed VAD/STT delivery, seal timeout, skipped
+  sequences, health transitions, and device changes.
+- Regression tests prove ordinary dictation, manual message speech, and the Realtime
+  engine remain unchanged.
+
+### Packaging and live gates
+
+- Build/import-test native wheels for every supported Python/platform architecture,
+  with hashes, provenance, SBOM, license inventory, and applicable signing.
+- Run a 30-minute echo-only soak and a mixed-speech/device-switch soak, checking callback
+  overruns, bounded queues, detached cleanup, and memory stability.
+- Run real-room speaker/microphone tests on macOS, Windows, and Linux using built-in
+  audio, one USB route, and Bluetooth. Bluetooth may pass through explicit safe
+  half-duplex degradation; it may not pass through unsafe full duplex.
+- Use targeted test and lint suites during implementation. A repository-wide sweep
+  requires the explicit opt-in mandated by repository instructions.
+
+## Rollout
+
+Implementation is dependency ordered:
+
+1. Native AEC wrapper, build provenance, deterministic DSP corpus, and package loading.
+2. Duplex transport and unified hands-free PCM playback.
+3. Rolling transcript protocol plus native and batch adapters.
+4. Speculative coordinator, attempt buffers, phrase sequencing, and cancellation fences.
+5. Effect barrier, winning-pair persistence, and promoted-capture amendment.
+6. Canonical Settings/Console presentation, diagnostics, and documentation.
+7. Cross-platform live qualification and default enablement.
+
+The capability remains internally gated until every supported platform passes its
+package, DSP, integration, and live-device gates. After qualification, AEC and
+speculative hands-free turns are default-on. A local kill switch can force half duplex
+without disabling voice interaction. Platform-specific regressions may disable full
+duplex for the affected capability signature only.
+
+Each numbered slice becomes an atomic Backlog task or a small dependency-ordered task
+family during implementation planning. The tasks share this architecture but retain
+independent acceptance criteria and targeted verification.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Assistant audio is mistaken for user speech | Timestamped render reference, AEC-before-VAD, residual health, and fail-closed admission |
+| Batch STT falls behind | One in-flight window, supersession, coverage gating, honest status |
+| STT corrections cause request thrash | Material-change filter, short coalescing, three-attempt governor, cleanup cap |
+| Provider ignores cancellation | Epoch fence before cancel request; bounded detached cleanup |
+| Speculative tools produce irreversible effects | Two-second effect barrier and ordinary agent re-dispatch |
+| Cancelled text leaks through Console capture | Memory-only attempt sink; winning-only promoted trace |
+| Winning capture conflicts with ADR-097 reservation | Explicit `provisional_voice_promoted` post-dispatch provenance and ADR-098 amendment |
+| Legacy settings retain old behavior | New pipeline-specific AEC/eagerness keys; old acoustic key remains Realtime-owned and old delay remains legacy-only |
+| Temporary chat has no durable capture lineage | Explicit capture-unavailable status; no retroactive trace invention on Save |
+| Promotion races queued speech or a late STT correction | Serialized mailbox plus shared-clock capture/AEC/VAD/STT watermarks through the render boundary |
+| Winning promotion bypasses ADR-094 attention | Existing terminalization transaction mints the exact receipt and unseen mark |
+| Uncooperative cancellations never exit | Force-close deadline, terminal draft failure, app-lifetime fenced orphan set capped at two, and global voice-dispatch quarantine |
+| Pre-boundary speech remains queued behind playback completion | Shared-clock capture sequence watermark plus AEC/VAD/STT drain before promotion |
+| Audio device switches invalidate AEC timing | Fence playback, rebuild one clock domain, keep transcript, regenerate |
+| Aggressive mode increases usage | Usage split, duplicated-STT duration, restart governor, Settings disclosure |
+| Native dependency becomes unmaintained | Narrow ABI, reproducible wheels, SBOM, license/update policy, capability fallback |
+| Navigation outlives view-owned audio | Provisional voice work is pre-acceptance and cancels on detach under ADR-094 |
+
+## Documentation changes
+
+- Update the Console voice/hands-free guide with speculative turn behavior, interruption
+  semantics, half-duplex fallback, tool barrier, and increased-usage disclosure.
+- Update Speech & TTS Settings documentation with response eagerness and diagnostics.
+- Document native package installation/troubleshooting and supported platform wheels.
+- Document the winning-only exchange-capture exception and its post-dispatch label.
+- Record live qualification evidence per platform without committing user-recorded raw
+  microphone material.
+
+## Links
+
+- [ADR-098: low-latency speculative duplex voice pipeline](../../../backlog/decisions/098-low-latency-speculative-duplex-voice-pipeline.md)
+- [Hands-Free Conversation Loop design](2026-08-02-hands-free-loop-design.md)
+- [Realtime Voice Engine design](2026-08-04-realtime-voice-engine-design.md)
+- [ADR-023: TTS adapter registry and runtime boundary](../../../backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md)
+- [ADR-039: Speech and TTS settings ownership](../../../backlog/decisions/039-global-and-studio-tts-settings-ownership.md)
+- [ADR-094: Console turn lifetime and navigation](../../../backlog/decisions/094-console-turn-lifetime-and-navigation-boundary.md)
+- [ADR-097: reference-backed semantic trace ledger](../../../backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md)

--- a/Docs/superpowers/specs/2026-08-28-unified-personal-context-profile-design.md
+++ b/Docs/superpowers/specs/2026-08-28-unified-personal-context-profile-design.md
@@ -1,0 +1,1069 @@
+# Unified Personal Context Profile — Chatbook and tldw_server
+
+**Date:** 2026-08-28
+
+**Status:** Draft for owner review
+
+**Initial product:** tldw_chatbook
+
+**Shared consumers:** tldw_chatbook and tldw_server
+
+## ADR check
+
+```text
+ADR required: yes
+ADR path: backlog/decisions/099-personal-context-profile-authority-sync-and-encryption.md
+Reason: This design establishes a new encrypted data authority, schema and
+migration contract, Sync V2 domains and conflict policy, cross-runtime service
+boundary, agent permission model, and long-lived setup/settings UX.
+```
+
+The ADR number is reserved by this design. Its uniqueness must be rechecked
+immediately before the ADR is created because this repository has concurrent
+decision work and historical duplicate numbers.
+
+## Summary
+
+Chatbook and tldw_server will share one logical **Personal Context Profile** for
+the human user. The profile contains granular, user-owned records such as
+preferences, likes and dislikes, corrections, constraints, relationships,
+goals, conventions, and bounded working context. Agents may read or propose
+changes only through explicit runtime-local permissions.
+
+Chatbook is local-first. It can create and use a profile without a server. When
+the user links a home tldw_server, Chatbook and the server become replicas of
+the same canonical records through Sync V2. A record has the same stable ID,
+scope, meaning, lifecycle, privacy controls, provenance, and revision on both
+systems. The databases remain separate transactional stores; they do not hold
+application-specific projections of supposedly equivalent facts.
+
+The first-run flow optionally offers a bounded, 20-question "get to know you"
+interview after ordinary application setup has completed. Workspace creation
+can likewise offer an interview about the project's purpose and durable
+context. Settings provides complete inspection, editing, re-interview,
+proposal review, local removal, and global purge controls.
+
+All profile content is encrypted at rest in both runtimes. Syncable records use
+the existing server-trusted Sync posture because server-side agents must be
+able to read eligible content. Device-only records never leave Chatbook.
+
+## Goals
+
+- Give agents bounded, accurate knowledge of a user's explicit preferences and
+  durable context without turning conversation history into hidden memory.
+- Let the user inspect, edit, reject, archive, export, and delete everything
+  that can influence personalization.
+- Support personal context and workspace-specific context without leaking one
+  workspace into another.
+- Make Chatbook and tldw_server replicas of the same logical records rather
+  than maintaining incompatible personalization stores.
+- Support multiple Chatbook devices linked to one home server.
+- Permit agent learning only through explicit tools and local runtime policy.
+- Preserve conservative review for inferred facts and conflicts.
+- Encrypt profile content, proposals, drafts, conflicts, outbox snapshots, and
+  recovery artifacts at rest.
+- Provide deterministic, budgeted context construction that never outranks the
+  user's current request.
+
+## Success criteria
+
+- A new Chatbook user can skip setup personalization or complete at most 20
+  questions, review the resulting diff, and create a usable local profile.
+- A user can create and manage equivalent workspace context without exposing it
+  in unrelated workspaces.
+- Settings exposes all canonical profile records and every pending proposal or
+  conflict relevant to the active installation.
+- Two Chatbook devices and one home server converge on identical syncable
+  records after non-conflicting edits.
+- Conflicting edits never silently overwrite one another.
+- Device-only and user-only controls are enforced across storage, search,
+  context injection, tools, derived artifacts, and synchronization.
+- Agents cannot read or mutate profile data outside their effective local
+  runtime authority.
+- A global purge prevents stale devices from resurrecting older content.
+- Unique canary profile text does not appear in ordinary database, WAL, outbox,
+  log, diagnostic, or backup artifacts covered by automated tests.
+
+## Terminology
+
+- **Personal Context Profile:** The technical domain and the user-owned set of
+  canonical context records. The UI may shorten this to **My Profile**.
+- **Profile manifest:** Stable logical identity, schema version, and global
+  purge generation for a profile.
+- **Profile record:** An active, archived, or tombstoned canonical fact.
+- **Profile proposal:** A suggested create, update, archive, or promotion that
+  cannot affect context until a user accepts it.
+- **Global scope:** Context available outside a specific workspace when other
+  controls permit it.
+- **Workspace scope:** Context available only while its mapped workspace is
+  active.
+- **Home server:** The one tldw_server authority to which a V1 Chatbook profile
+  may be linked.
+- **Runtime authority:** Local read/propose/direct-write permission configured
+  independently in each Chatbook or server runtime.
+- **User-only:** A record that may sync for backup and user editing but is
+  unavailable to all agent reads, tools, search, and generated agent context.
+- **Device-only:** A Chatbook record that never enters an outbox or server
+  payload.
+
+## Owner decisions
+
+1. Chatbook is local-first and both Chatbook and tldw_server may write canonical
+   records.
+2. One global base is combined with one active-workspace overlay. Workspace
+   context never leaks or promotes automatically.
+3. Agent authority is configured per runtime and scope as `read_only`,
+   `propose`, or `direct_write`; the default is `propose`.
+4. Canonical data is granular records. Overviews are generated projections and
+   never become authority.
+5. Interviews are adaptive but bounded to 20 questions and finish with a
+   record-by-record review.
+6. V1 links to one home server while keeping authority and identifiers suitable
+   for future federation.
+7. Model requests receive a bounded overview plus relevant records and optional
+   read tools.
+8. Privacy is controlled per record through syncability and agent visibility.
+9. Whole-profile deletion has distinct local-copy and delete-everywhere flows.
+10. Raw interview Q&A is discarded after approved records are committed.
+11. V1 has one human profile per Chatbook installation.
+12. A narrow Shared Profile Core publishes the canonical contract for both
+    applications.
+13. Adaptive interviews may use a configured model only after disclosing its
+    provider and model; a fixed local questionnaire is always available.
+14. Multiple Chatbook devices may link to the same home-server profile.
+15. All profile content is encrypted at rest in both applications.
+16. Personas, roleplay characters, assistant state, authentication identity,
+    and Companion tracked goals remain separate domains.
+
+## Non-goals for V1
+
+- Multiple home servers, federation, or account merge/split behavior.
+- End-to-end encryption of syncable data that must be readable by server-side
+  agents.
+- Semantic embeddings, vector search, or RAG reranking over profile data.
+- Autonomous consolidation, background inference, or automatic promotion of
+  workspace context.
+- Synchronizing runtime agent permissions.
+- Cross-workspace agent browsing.
+- Allowing agents to change privacy controls, approve their own proposals,
+  purge a profile, or permanently delete records.
+- Replacing assistant Personas, roleplay characters, Persona state documents,
+  Persona/session memory, authentication accounts, or Companion goal tracking.
+- Retaining raw interview transcripts as a long-term personalization source.
+- Using the profile as a password, credential, API-key, or general secret
+  vault.
+
+## Architecture
+
+### Shared Profile Core
+
+A separately versioned, standalone `tldw-profile-core` package is the canonical
+contract. Both applications install a pinned compatible release; the same
+release publishes its JSON Schema and conformance fixtures. It contains:
+
+- Profile manifest, scope, record, proposal, tool request/result, and provenance
+  models.
+- Typed payload schemas and lifecycle validation.
+- Canonical serialization and deterministic comparison rules.
+- Versioned question packs, interview coverage rules, and proposal-output
+  schemas.
+- JSON Schema and cross-language conformance fixtures.
+- Supported serialized-schema ranges independent of package SemVer.
+
+It does **not** contain database access, HTTP clients or routes, encryption key
+custody, provider calls, prompts, UI code, runtime permissions, application
+configuration, or application workspace IDs.
+
+Both repositories test the oldest and newest Shared Core versions they claim
+to support. TypeScript consumers validate payloads at runtime against the
+published JSON Schema; generated compile-time types alone are insufficient.
+
+### Per-runtime service boundary
+
+Chatbook and tldw_server each own exactly one `PersonalContextService`. Every
+settings action, interview commit, agent tool, context read, API handler, sync
+adapter, compatibility adapter, and migration uses this service. No consumer
+may decrypt or mutate profile tables directly.
+
+The service owns:
+
+- Authentication and effective-scope checks.
+- Runtime-local read/propose/direct-write authorization.
+- Canonical validation and lifecycle transitions.
+- Encryption/decryption repository access.
+- Record and proposal mutation.
+- Atomic local revision/outbox transactions.
+- Conflict, cleanup, migration, and purge fencing.
+- Content-minimized, peer-local activity receipts.
+
+`ProfileContextService` is a separate read-only component. It receives only
+authorized repository views and creates immutable snapshots for model
+requests. It cannot mutate records, proposals, or policy.
+
+Chatbook stores the profile in a dedicated Personal Context SQLite database,
+not `ChaChaNotes_DB` and not configuration TOML. Its repository owns manifests,
+scopes, immutable record versions, proposals, encrypted drafts, local scope
+mappings, runtime authority, Undo before-images, outbox snapshots, quarantine,
+and peer-local receipts. tldw_server extends the existing per-user
+`Personalization.db` with canonical encrypted tables rather than creating a
+second personalization database.
+
+### Existing Chatbook seam
+
+The current `Personalization_Interop` seam is explicitly server-only. It does
+not become the local canonical store. New local-first Personal Context modules
+own the canonical service and repository. Existing server personalization UI
+or API calls become compatibility consumers during migration and are removed
+after deprecation; they must never form a second write path beside Sync.
+
+### One logical record, separate replicas
+
+A syncable `ProfileRecord` uses the same canonical bytes and stable object ID in
+Chatbook and tldw_server. Each peer encrypts those bytes under its own at-rest
+key hierarchy. Application databases may use different physical tables and
+indexes, but neither application translates the record into a weaker local
+schema.
+
+Device-only data is the only intentional replication exception. It remains a
+canonical record locally but has no shared-server representation.
+
+## Canonical data model
+
+### ProfileManifest
+
+The manifest contains:
+
+- `profile_id`: the canonical random logical profile ID after server binding.
+- `schema_version`: the serialized contract version, separate from package
+  SemVer.
+- `purge_generation`: a monotonically increasing content-free generation.
+- Creation and current-version metadata.
+
+A standalone Chatbook profile initially has a provisional local manifest ID.
+First server linking reconciles its records and atomically adopts the server's
+canonical profile identity. The provisional ID remains only in encrypted local
+lineage metadata needed to make interrupted linking idempotent.
+
+### ProfileScope
+
+Every record belongs to a random `profile_scope_id`:
+
+- Exactly one global scope exists per profile.
+- Each linked workspace has its own workspace scope.
+- Human-readable scope labels are encrypted.
+- Chatbook and tldw_server keep peer-local mappings from canonical scope IDs to
+  their application workspace IDs.
+- Application workspace IDs never enter canonical records.
+
+An incoming workspace scope without a local mapping is retained as **Unlinked
+workspace context**. It cannot be injected, searched by an agent, or edited
+until the user explicitly maps it.
+
+### ProfileRecord
+
+A record contains:
+
+- **Identity:** profile ID, record ID, scope ID, and immutable kind.
+- **Meaning:** typed payload, structured semantic key where the kind supports
+  one, and optional polarity for likes/dislikes.
+- **Lifecycle:** `active`, `archived`, or content-free `deleted` tombstone.
+- **Controls:** `syncable` or `device_only`; `agent_visible` or `user_only`.
+- **Provenance:** bounded source enum, actor type, reason code, source
+  references/hashes, optional `derived_from` record ID, and current revision
+  history links.
+- **Concurrency:** immutable version ID, parent version ID, canonical integrity
+  tag, and timestamps.
+- **Retention:** optional expiry for working context. No expiry requires an
+  explicit `no_expiry` decision.
+
+Record payloads are discriminated, versioned models rather than arbitrary
+JSON. The initial kinds are:
+
+- `identity`
+- `preference`
+- `relationship`
+- `correction`
+- `constraint`
+- `goal`
+- `convention`
+- `working_context`
+
+`preference` represents likes and dislikes through a typed subject and
+polarity. Workspace `goal` records are declarative project context; they are
+not Companion tracked-goal objects.
+
+Confidence does not belong on an active fact. It is meaningful only while an
+inferred proposal awaits review.
+
+New object IDs are random UUIDv4 values. IDs migrated from the existing server
+remain bounded opaque strings so migration can preserve them exactly;
+consumers must not parse either form for meaning.
+
+### Semantic keys and overrides
+
+Where a record kind has a structured semantic key, at most one active record
+with that kind and key may exist within one scope. The active workspace record
+overrides a global record with the same key. It does not delete or mutate the
+global record. Other global context remains available.
+
+The local service prevents ordinary same-scope key duplication. Concurrent
+creations on separate peers can still produce different record IDs with the
+same key; the server creates a durable `key_collision` review object. Context
+keeps the last mutually acknowledged occupant of that key when one exists and
+otherwise omits both records until resolution. Text that merely appears
+semantically similar is shown as a possible duplicate and is never auto-merged
+in V1.
+
+Changing scope is not an in-place mutation. Workspace-to-global promotion
+creates a new global record with a new ID and `derived_from` provenance. The
+workspace record remains unless the user explicitly archives it.
+
+### ProfileProposal
+
+Proposals are separate from canonical facts so a suggested update cannot hide
+or replace an active record before approval. A proposal contains:
+
+- Proposal ID and target scope.
+- Operation: create, update, archive, or promote.
+- Proposed typed payload and controls.
+- Target record and base version for updates.
+- Bounded provenance and optional confidence for inference.
+- State: `pending`, `accepted`, `rejected`, `superseded`, or `expired`.
+
+Pending proposals are never injected into model context. Acceptance applies a
+normal canonical mutation and records the proposal receipt. Pending agent
+proposals expire after 90 days. Accepted, rejected, expired, and superseded
+proposal content is crypto-shredded as part of the resolving transaction; only
+a content-free receipt remains.
+
+Interview diffs are not `ProfileProposal` objects. They remain within the
+encrypted interview draft and create active records only when the user approves
+the final review.
+
+### Conflicts
+
+Sync conflicts are review objects owned by the Sync V2 conflict mechanism, not
+record lifecycle states. A conflict identifies both immutable head versions,
+the last mutually acknowledged version when one exists, and a durable server
+conflict token.
+
+Conflict reasons include `same_record_revision` and `key_collision`. A key
+collision may reference two different record IDs in the same scope. The
+global/workspace override relationship is not a collision because the records
+belong to different scopes.
+
+While conflicted, the record is frozen for ordinary edits. Context uses the
+last mutually acknowledged active version or omits the record if no such
+version exists. Resolution submits the conflict token and both head IDs; it is
+not an ordinary one-head upsert.
+
+Deletion defeats stale or concurrent edits. A change from `agent_visible` to
+`user_only` also wins conservatively while content reconciliation is pending,
+so a concurrent edit cannot re-expose it.
+
+## Privacy and lifecycle rules
+
+### Agent visibility
+
+`user_only` governs every agent-facing path: automatic context, summaries,
+search, get tools, proposal matching, derived indexes, and background agent
+jobs. It is not merely an injection flag.
+
+When a user changes a record to `user_only`, the local runtime excludes it
+immediately. Every server/device agent index, cached overview, and derived
+artifact must be cleaned before synchronization reports the privacy change as
+fully acknowledged.
+
+Private duplicate detection may return only "possible private duplicate;
+review required." It must not reveal the private record's existence, kind,
+scope, value, or similarity.
+
+Interview and agent boundaries reject credentials, access tokens, private keys,
+and other recognized secret material rather than storing them as profile
+records. Question packs do not solicit passwords or protected/sensitive traits
+that are unnecessary for personalization. A user may still deliberately store
+sensitive personal context, but the review must expose the user-only control.
+
+### Syncability
+
+Changing a shared record from `syncable` to `device_only` cannot reuse its
+shared ID. The service:
+
+1. Tombstones the shared record everywhere.
+2. Creates a new device-only record with a new ID.
+3. Stores an encrypted peer-local `derived_from` link.
+
+This avoids a shared and private split-brain under one object ID.
+
+Device-only records never enter outbox, diagnostics, server APIs, server
+summaries, or server-assisted interviews.
+
+### Disable versus delete
+
+Data existence and runtime enablement are separate:
+
+- Chatbook personalization enablement is runtime-local.
+- Server personalization enablement is runtime-local.
+- Agent tool authority and proactive behavior are runtime-local.
+- Disabling context does not delete records or silently stop synchronization.
+
+The UI must never describe Personal Context Profile deletion as account
+deletion.
+
+### Undo
+
+User edits may retain encrypted peer-local before-images for a short default
+window of 24 hours. Undo creates an inverse canonical revision; it does not
+rewrite history. If the head changed elsewhere, Undo produces a conflict.
+Before-images are not synchronized and are included in local removal and global
+purge.
+
+## Interview and setup experience
+
+### First-run flow
+
+The existing first-run wizard commits normal provider, model, RAG, speech,
+tool, note, appearance, and key-protection setup before personalization begins.
+After that commit, it offers an optional **Get to know you** step as the
+immediate continuation of setup.
+
+The final action distinguishes **Save and use with agents** from **Save only**.
+The former enables local profile context with a clear checked control; the
+latter stores the records while leaving runtime use disabled. Merely opening or
+partially completing an interview never enables personalization.
+
+Skipping, cancelling, or encountering an interview-provider failure never
+rolls back or blocks ordinary application setup.
+
+### Workspace flow
+
+After a workspace is successfully created, Chatbook may offer **Define project
+context**. The interview targets that workspace's canonical scope and covers
+purpose, desired outcomes, audience, constraints, conventions, tools, current
+state, risks, and durable non-goals. Cancelling does not remove the workspace.
+
+### Interview coordinator
+
+One reusable `ProfileInterviewCoordinator` supports personal and workspace
+question packs. It:
+
+- Covers versioned topic areas and asks adaptive follow-ups.
+- Counts every model turn as one question.
+- Rejects compound or invalid model questions.
+- Stops at a hard maximum of 20 questions.
+- Supports skip, finish early, save, discard, and fixed-questionnaire modes.
+- Pins provider and model for the session.
+- Discloses the selected provider/model and the fact that external-provider
+  retention is controlled by that provider.
+- Runs the interview model without tools or record-write access.
+- Accepts only strict structured output validated by Shared Core.
+
+The fixed local questionnaire requires no model call. Adaptive re-interviews
+may receive only eligible agent-visible existing records. User-only records are
+never exposed to the model; deterministic local key matching can still warn the
+user about a possible private duplicate.
+
+### Draft privacy
+
+Raw questions and answers never enter TOML, logs, diagnostics, crash reports,
+sync, or ordinary backups. Each saved draft has a random encryption key and a
+30-day expiry. After approved records are atomically committed, discarding the
+draft, or reaching expiry, destroying that draft key crypto-shreds residual
+SQLite/WAL copies.
+
+When protected key storage is unavailable and the user declines a
+passphrase-wrapped key, the interview is memory-only and cannot be resumed.
+
+### Final review
+
+The final review displays additions, updates, keyed conflicts, archives, and
+possible duplicates. The user can edit or deselect each change and choose its
+syncability and agent visibility. One local transaction commits the selected
+records and encrypted outbox items. No cross-system atomicity is claimed.
+
+Re-running an interview diffs against current records rather than replacing the
+profile or creating obvious duplicates.
+
+## Settings experience
+
+The canonical F9 Settings Screen gains **My Profile** under Data & Privacy, not
+Roleplay and not the deprecated legacy settings surface.
+
+It provides:
+
+- Global and workspace record browsing and filtering.
+- Add, edit, archive, restore, and delete actions.
+- Agent-visible/user-only and syncable/device-only controls.
+- Pending agent-proposal review.
+- Sync-conflict review as a distinct queue.
+- Interview and re-interview actions.
+- Runtime enable/disable and effective agent-access explanations.
+- Link/unlink and synchronization status.
+- Export and encrypted recovery-export controls.
+- **Remove this device's copy** and **Delete everywhere** actions with distinct
+  previews and confirmation copy.
+
+Proposal review, interview diff review, and sync conflict review are separate
+surfaces because they have different authority and resolution semantics.
+
+A human-readable export requires an unlocked profile, explicit confirmation,
+and a user-selected destination. It is a plaintext operation with a warning and
+may include the selected global/workspace records, including user-only records.
+It excludes keys, raw drafts, Undo data, and peer-local receipts. A recovery
+export is separately passphrase-encrypted and may include device-only records
+needed to restore a standalone profile.
+
+The user-facing profile overview is a deterministic editable-data projection.
+Optional model-written display prose is disposable and user-reviewed. The
+agent context overview is separately generated for bounded runtime use.
+
+## Agent context and tools
+
+### Immutable request snapshot
+
+At the start of each model request, `ProfileContextService` pins:
+
+- Profile purge generation.
+- Record-set revision.
+- Active canonical workspace scope.
+- Runtime authority revision.
+
+The snapshot includes only active, unexpired, agent-visible records from the
+global scope and the mapped active workspace. Changes during generation affect
+the next request only.
+
+Priority order is:
+
+1. The user's current explicit request.
+2. Active-workspace corrections, constraints, and keyed overrides.
+3. Global corrections and constraints.
+4. Relevant active preferences and working context.
+5. A compact deterministic overview.
+
+Profile context is serialized as escaped structured user-owned data. It is not
+system authority and cannot override safety rules or the user's current
+request. V1 relevance uses structured-key and bounded text matching only; no
+embeddings or personalization-based RAG scoring run.
+
+### Context budget
+
+Injected profile context is limited to the lesser of:
+
+- 12 KiB of UTF-8 serialized data; or
+- 10% of the model's available input budget after reserving required system,
+  conversation, tool, and current-request space.
+
+The runtime uses its provider tokenizer when available and a conservative
+fallback otherwise. It drops lower-priority profile records rather than
+truncating typed payloads or squeezing the current request.
+
+### Runtime-local authority
+
+Each runtime and scope independently configures:
+
+- `read_only`: context plus eligible search/get tools.
+- `propose`: read access plus proposal creation. This is the default.
+- `direct_write`: proposal access plus narrowly verified explicit-statement
+  writes.
+
+These grants never synchronize. Effective access is the intersection of local
+enablement, active scope, record controls, lifecycle state, and tool policy.
+The tool catalog is rebuilt or invalidated after workspace, profile, binding,
+permission, or authority-revision changes.
+
+### Shared logical tools
+
+- `profile_search`
+- `profile_get`
+- `profile_propose`
+- `profile_update`
+- `profile_promote`
+
+`profile_update` is exposed only under effective direct-write authority. Its
+request must include the current user-message ID and a bounded verbatim
+evidence span. The service verifies trusted user authorship and exact
+containment. It stores only the message reference and integrity hash, not the
+verbatim span.
+
+Ambiguous matches, inferred facts, semantic duplicates, conflicts, and agent
+promotion requests always become proposals. An agent cannot approve its own
+proposal, alter privacy/sync controls, access user-only records, enumerate
+other workspaces, directly archive records, purge the profile, or permanently
+delete records.
+
+Tool results use explicit statuses such as `applied`, `proposal_created`,
+`review_required`, `permission_denied`, `quota_exceeded`, `conflict`, and
+`profile_locked`.
+
+### Agent limits
+
+- Canonical encoded record payload: 16 KiB maximum.
+- Search: 20 results maximum, 5 by default.
+- Direct-write evidence span: 1,000 characters maximum.
+- Proposals: 5 per turn, 25 per session, and 200 unresolved per profile.
+
+User-authored settings and interview changes are not subject to agent proposal
+rate limits. Server-advertised operational quotas may be stricter, but linking
+must identify an incompatibility before upload rather than silently discard
+local data. While linked, Chatbook enforces the last negotiated server quota
+before committing an agent mutation. If the server later lowers a quota,
+already-committed local records remain local and Sync reports an actionable
+quota-attention state rather than dropping them.
+
+## Synchronization and multi-device behavior
+
+### Sync domains
+
+Personal Context extends Sync V2 through negotiated, whole-object domains:
+
+- `personal_context.manifest`
+- `personal_context.scope`
+- `personal_context.record`
+- `personal_context.proposal`
+- a content-free profile purge barrier
+
+Conflicts remain Sync V2 review objects rather than a normal profile domain.
+Interview drafts, runtime authority, key protectors, local workspace mappings,
+Undo before-images, and peer-local activity receipts do not synchronize.
+
+For these domains, upserts and tombstones carry the canonical Sync V2 base
+metadata: base object revision, base object integrity tag, and base server
+cursor. Personal Context negotiates a versioned keyed-HMAC integrity tag in the
+existing object-hash position. This extension applies only when the server
+advertises the matching capability; it does not silently alter existing Sync
+domains.
+
+The HMAC conceals guessable plaintext hashes and detects byte differences. It
+is not a signature or authorization mechanism. Authenticated TLS, stable user
+identity, and registered device identity establish authorship.
+
+### Stable binding
+
+Profile binding uses:
+
+- A stable server authority ID.
+- The stable authenticated server user ID.
+- A peer-local random Chatbook device ID.
+
+URLs, labels, routing IDs, and credentials are not profile authority.
+
+The server serializes first-link profile creation under transaction. One user
+may register multiple Chatbook devices. Device acknowledgments and expiry are
+tracked per Sync domain. A dormant expired device must rebootstrap instead of
+replaying an old cursor.
+
+The home server owns the sync integrity key and distributes it only to
+authenticated registered devices through a wrapped bootstrap response. A
+standalone Chatbook profile uses a provisional local integrity key; linking
+adopts the server key and recomputes personal-context integrity tags during the
+required rebaseline.
+
+### Initial link reconciliation
+
+No local record uploads before reconciliation completes:
+
+1. Chatbook authenticates and fetches capabilities, the server manifest, and
+   eligible canonical heads.
+2. It compares local and server records in a temporary encrypted staging area.
+3. The provisional global scope maps to the server global scope. For every
+   local workspace, the user chooses an existing server scope, creates a new
+   server scope, or keeps the overlay local and unlinked.
+4. Identical IDs and bytes converge after scope mapping.
+5. Same-scope, same-key differences become explicit key-collision reviews.
+6. Merely similar content becomes a possible-duplicate warning.
+7. Device-only records are excluded.
+8. Quota and schema incompatibilities block linking with actionable detail.
+9. The user approves the merge preview.
+10. Chatbook journal-rebinds its provisional manifest to the server canonical
+   profile, re-encrypting affected local envelopes where authenticated
+   associated data changes.
+11. Normal push/pull begins only after the binding commits.
+
+Cancelling or interrupting the preview leaves both replicas unchanged. The
+journal makes interrupted identity adoption resumable and idempotent.
+
+### Normal mutation and synchronization
+
+Chatbook always commits an immutable local revision and encrypted exact-wire
+outbox snapshot in one transaction. It never mixes direct server
+personalization CRUD writes with Sync writes.
+
+The server UI and server agents write the server canonical repository and Sync
+log transactionally. Synchronization:
+
+1. Pushes local changes with their immutable base metadata.
+2. Persists accepted server versions or durable conflicts.
+3. Pulls newer server objects.
+4. Validates and applies all eligible objects before advancing the cursor.
+5. Completes privacy cleanup before acknowledging restrictive changes.
+6. Invalidates context and tool caches after commit.
+
+Unknown newer objects are retained opaquely. They are not decrypted, edited,
+indexed, injected, or approved by an older runtime.
+
+Different object IDs merge automatically only when they do not violate the
+same-scope key uniqueness rule. Exact key collisions create review objects;
+mere semantic similarity does not block convergence.
+
+### Global purge
+
+**Delete everywhere** may be initiated by an authenticated user in Chatbook or
+tldw_server. It has higher priority than interview, migration, key rotation,
+normal mutation, and synchronization:
+
+1. The initiating Chatbook device immediately destroys local readable content,
+   freezes profile writes, and retains only a durable content-free purge
+   request.
+2. The server advances `purge_generation` under transaction.
+3. The server removes canonical content, proposals, conflicts, drafts,
+   recovery material, derived artifacts, and readable sync history.
+4. A content-free generation barrier is distributed to devices.
+5. Older-generation writes are rejected.
+6. Devices erase their replicas on their next connection.
+
+The UI shows **Global deletion pending** until server acknowledgment. An
+offline or stolen device cannot be physically erased remotely; local
+encryption is the remaining protection. A minimal content-free tombstone
+ledger remains until registered devices acknowledge or expire.
+
+The user may deliberately create a new empty profile only after the purge
+barrier is acknowledged. It uses the new generation and cannot revive old
+records.
+
+### Remove this device's copy
+
+For a linked profile, Chatbook previews pending outbox items, unresolved
+conflicts, and unacknowledged changes before unregistering and clearing the
+device. The user must sync, export, or explicitly discard them. Removing the
+local copy unregisters the device and prevents automatic rebootstrap until the
+user links again.
+
+For a standalone profile, the same action warns that no server replica exists
+and requires either an encrypted recovery export or an explicit decision to
+destroy the only copy. It then destroys the profile key and local data.
+
+## Encryption and key custody
+
+### Envelope hierarchy
+
+Every record revision, proposal payload, interview draft, conflict payload,
+outbox snapshot, Undo before-image, and migration/recovery snapshot receives a
+random data-encryption key (DEK). The DEK is wrapped by a per-profile key. V1
+payload envelopes use AES-256-GCM with a unique random 96-bit nonce and a
+versioned algorithm header. Associated data covers the peer storage envelope,
+object type, object ID, version ID, and serialized schema version. Sync
+integrity tags use HMAC-SHA-256. Passphrase-based key wrapping derives its key
+with versioned, calibrated scrypt parameters. Implementations use vetted crypto
+libraries and never implement these primitives themselves.
+
+Deleting content destroys its wrapped DEK. This crypto-shreds recoverable
+content that may remain in SQLite freelists, WAL files, ordinary backups, or
+filesystem snapshots created after envelope encryption was deployed.
+
+Python cannot promise immediate zeroization of every transient in-memory copy.
+Implementations minimize plaintext lifetime, avoid global caches, and never
+claim stronger process-memory erasure than the runtime can provide.
+
+### Chatbook key protection
+
+Chatbook uses a key-protector abstraction:
+
+1. OS protected secret/keyring when available.
+2. A passphrase-wrapped profile key as the fallback.
+3. No plaintext-key fallback.
+
+Keys never enter TOML. If the key protector is unavailable or cancelled, the
+profile is `Locked`; an interview may proceed only as memory-only,
+non-resumable work.
+
+A linked device that permanently loses its local profile key can discard its
+encrypted replica and rebootstrap eligible syncable records. A standalone
+profile requires a user-created encrypted recovery export; the system must
+state this before the user relies on local-only data.
+
+### Server key protection
+
+tldw_server encrypts content under per-profile keys wrapped by a configured
+server master key or KMS-backed protector. Server startup validates key custody
+before enabling profile access. A missing or changed master key locks affected
+profiles; the server never generates a silent replacement.
+
+Authentication and authorization occur before any decrypt. APIs, agents, jobs,
+compatibility adapters, and migrations all use the authorized service boundary
+rather than reading encrypted columns.
+
+Ordinary rotation rewraps DEKs instead of re-encrypting all profile content.
+The separately wrapped integrity key does not rotate through the ordinary DEK
+path. An integrity-key compromise requires a versioned full rebaseline and, if
+necessary, a profile-generation transition.
+
+### Search and derived artifacts
+
+V1 has no plaintext FTS or embedding index. Search decrypts a bounded eligible
+set inside the authorized service process and performs structured-key/text
+matching. Generated overviews and caches are encrypted at rest and invalidated
+by profile generation, record-set revision, active scope, and authority
+revision.
+
+### Backup and metadata disclosure
+
+Server recovery requires encrypted data, wrapped profile keys, and separately
+protected master-key recovery. Chatbook recovery requires the existing key
+protector or an encrypted recovery export. Migration recovery snapshots are
+encrypted, single-purpose, included in purge, and destroyed after successful
+validation or seven days, whichever comes first.
+
+Encryption does not conceal all metadata. An observer of storage or sync may
+see random object and scope IDs, revision frequency, ciphertext sizes, scope
+relationships, tombstones, and timing. Scope labels, record kinds, content,
+provenance, and values remain encrypted.
+
+Syncable records are decrypted in the authenticated client process, sent over
+TLS using `server_trusted_v1`, and re-encrypted at rest by the server. The UI
+must disclose that an authorized home server can read syncable content.
+
+## Server API and legacy migration
+
+### Canonical API
+
+tldw_server exposes a new versioned `/api/v1/personal-context` API for its own
+UI and non-Sync consumers. Its handlers use the same canonical service as Sync.
+The surface covers status/manifest, scopes, records, proposals, review actions,
+runtime enablement, export, and purge.
+
+Chatbook local-first mutations do not call this CRUD API. They use the local
+service and Sync outbox.
+
+### Compatibility adapters
+
+Existing `/api/v1/personalization` routes become compatibility projections over
+the canonical service after migration. They are not a second repository or
+write path. A legacy write may update only fields the old contract understands
+while preserving all other canonical fields. A request that cannot be
+represented losslessly fails with a clear compatibility error.
+
+### Per-user migration
+
+Migration is automatic storage maintenance, not a new personalization opt-in.
+It preserves each user's existing enablement state:
+
+1. Fence legacy writes for the affected user only.
+2. Create an encrypted recovery snapshot with the seven-day maximum described
+   above.
+3. Run an idempotent canonical backfill.
+4. Preserve existing semantic-memory IDs, content, timestamps, and applicable
+   controls.
+5. Classify uncertain memories as `legacy_unclassified`; do not guess a kind.
+6. Convert response style and preferred format into canonical preference
+   records.
+7. Keep scoring, proactive behavior, reflection settings, and agent grants as
+   server runtime configuration.
+8. Keep episodic/Persona/Companion/Auth objects in their owning domains unless
+   an explicit canonical mapping exists.
+9. Validate canonical and legacy compatibility projections without logging
+   content.
+10. Atomically switch compatibility routes to the canonical service.
+11. Reopen writes through the one canonical service.
+12. Crypto-shred the recovery snapshot after its bounded validation window.
+
+Other users remain available through lazy/per-user migration. Shadow reads may
+compare projections, but dual writes are prohibited.
+
+Migration is forward-only after legacy plaintext storage is retired. Rollback
+means restoring the encrypted canonical snapshot under compatible software or
+shipping a forward fix; an old binary cannot safely resume authority.
+
+Legacy plaintext backups and external snapshots cannot be retroactively
+encrypted. Deployment therefore requires an explicit retention inventory,
+expiry/removal procedure, and operator disclosure. Migrated SQLite storage uses
+secure deletion and a database rewrite where practical, without claiming that
+copies outside system control were erased.
+
+Topics, embeddings, summaries, and RAG priors are derived data rather than
+canonical records and do not synchronize. Existing Persona and Companion data
+remain governed by their own contracts.
+
+## Runtime states and error handling
+
+The service reports explicit operational states:
+
+- `Available`
+- `Locked`
+- `Migration required`
+- `Migrating`
+- `Sync attention required`
+- `Review required`
+- `Purge pending`
+- `Unsupported records present`
+
+Chat continues when profile context is locked or unavailable, but it sends no
+profile context and displays a visible status indicator. It never falls back
+to stale plaintext caches.
+
+- A corrupt individual object is quarantined and omitted without disabling all
+  other records.
+- A manifest, generation, or key-custody failure locks the whole profile.
+- Sync failure does not block local editing, but unsynchronized changes remain
+  visible.
+- Interview-provider failure preserves an encrypted draft and offers retry or
+  the fixed questionnaire.
+- Restrictive privacy changes take effect locally immediately and remain
+  incomplete until cleanup acknowledgments arrive.
+- Unknown newer records remain opaque and unavailable to agents.
+- Profile-level operation priority is: global purge; privacy cleanup;
+  migration/integrity rebaseline/key rotation; ordinary sync and mutation.
+
+## Operational privacy and diagnostics
+
+Logs and diagnostics contain reason enums, opaque version IDs, counts, and
+bounded error summaries only. They never contain profile values, raw interview
+answers, evidence spans, decrypted payloads, scope labels, or low-entropy
+content hashes.
+
+Telemetry follows the application's existing opt-in policy and aggregates
+counts, timings, result codes, supported schema versions, and queue sizes
+without stable profile or workspace identifiers. Fine-grained activity
+receipts are peer-local, encrypted, retained for 30 days, and do not form a new
+Sync domain. Canonical current provenance travels with the record.
+
+A runtime kill switch disables profile use without deleting the data or
+silently suspending synchronization.
+
+## Verification strategy
+
+### Shared Core conformance
+
+- Canonical serialization and keyed integrity tags match across runtimes.
+- Python and TypeScript runtime validation accept and reject the same fixtures.
+- Lifecycle, scope, payload, provenance, expiry, proposal, and privacy rules are
+  deterministic.
+- Minimum and current supported package/schema combinations are exercised.
+- Unknown-version fixtures remain opaque rather than partially interpreted.
+
+### Repository and integration tests
+
+- Real SQLite repository tests cover atomic revision/outbox commits,
+  optimistic concurrency, quarantine, and purge fencing.
+- Two Chatbook devices plus one server cover convergence, conflicts, initial
+  link reconciliation, workspace mapping, tombstones, cleanup acknowledgments,
+  device expiry, rebootstrap, integrity rebaseline, and global purge.
+- Migration fixtures cover idempotency, single-writer fencing, projection
+  equivalence, interruption recovery, and forward-only restoration.
+- Context tests cover scope, priority, expiry, visibility, conflicts, budgets,
+  escaping, cache invalidation, and immutable request snapshots.
+- Agent tests cover local authority, catalog invalidation, private duplicate
+  responses, direct-write evidence, proposal quotas, and forbidden actions.
+- Interview tests cover provider disclosure, no-tool execution, strict output,
+  fixed fallback, one-question turns, the 20-question maximum, review diffs,
+  and raw-draft destruction.
+- UI tests cover optional non-blocking setup, My Profile editing, re-interview,
+  review queues, status states, link preview, local removal, and global purge.
+
+### Security evidence
+
+Tests write unique canary values and scan the ordinary database, WAL, outbox,
+logs, diagnostics, caches, migration snapshots, and application-owned backups
+for plaintext regressions. They also cover missing keys, changed master keys,
+authorization-before-decryption, interrupted rotation, and restrictive cleanup.
+
+Canary scanning is regression evidence, not proof that plaintext never existed
+in process memory, historical backups, or external filesystem snapshots. It
+supplements the threat model, service-boundary review, and operator controls.
+
+During implementation, targeted tests covering changed functionality are
+mandatory. A local full repository sweep remains subject to the repository rule
+requiring explicit user opt-in; configured CI may run its normal suite.
+
+## Delivery sequence
+
+This architecture is one governing specification but is too large for one
+atomic PR. Planning must create dependency-ordered Backlog tasks and
+repository-specific implementation slices.
+
+### Phase 0 — Contract and decision
+
+- Create ADR-099 after rechecking the number.
+- Publish Shared Core models, JSON Schema, fixtures, compatibility policy, and
+  threat model.
+
+### Phase 1 — Chatbook local profile
+
+- Encrypted local repository and key protection.
+- My Profile settings and manual editing.
+- Local removal, locking, export/recovery, and read-only agent context.
+- No server dependency.
+
+### Phase 2 — Interview and controlled agent learning
+
+- Personal and workspace interviews.
+- Final diff and proposal review.
+- Runtime-local read/propose/direct-write grants and tools.
+
+### Phase 3 — Server canonical store
+
+- Encrypted canonical repository and `/api/v1/personal-context` service/API.
+- Fenced per-user migration.
+- Lossless legacy compatibility projection.
+- Server context and tool consumers use the canonical service.
+
+### Phase 4 — Sync and multiple devices
+
+- Capability negotiation and canonical profile binding.
+- Initial reconciliation and workspace mapping.
+- Whole-object domains, conflicts, cleanup acknowledgments, device expiry,
+  rebootstrap, integrity rebaseline, and global purge.
+- The feature remains gated until destructive and privacy-reduction integration
+  tests pass.
+
+### Phase 5 — Legacy retirement
+
+- Deprecate and later remove compatibility routes.
+- Retire legacy plaintext storage and backups under documented retention rules.
+- Remove obsolete Chatbook server-only personalization presentation paths after
+  all callers use the canonical service.
+
+Each phase must preserve one write authority per runtime and deliver a usable,
+testable state. No temporary dual-write bridge is permitted.
+
+## Risks and mitigations
+
+- **Profile data becomes prompt authority.** Context is escaped, explicitly
+  labeled as user-owned data, budgeted below the current request, and never
+  treated as safety or system policy.
+- **Inferred facts become silently trusted.** Inference creates proposals only;
+  active records require user acceptance unless a direct explicit statement
+  passes the narrow evidence gate.
+- **Workspace context leaks.** Canonical random scopes require an active
+  peer-local mapping; unlinked and unrelated scopes are unavailable to agents.
+- **Two stores diverge.** Shared canonical bytes, conformance fixtures, one
+  mutation service, and Sync V2 whole-object domains replace app-specific
+  projections.
+- **Privacy is reduced only in the UI.** Restrictive changes immediately remove
+  agent access and require cleanup acknowledgments for indexes, caches, and
+  artifacts.
+- **A stale device resurrects deletion.** Tombstones, device expiry, and the
+  profile purge generation reject older writes.
+- **Encryption keys are silently replaced.** Missing or changed protectors lock
+  the profile. Recovery and rotation are explicit and journaled.
+- **Initial linking duplicates two existing profiles.** Linking performs an
+  encrypted, cancellable reconciliation before binding or upload.
+- **Legacy rollback restores plaintext authority.** Migration is forward-only;
+  recovery uses encrypted canonical snapshots and compatible software.
+- **Cross-repository releases drift.** Supported-range tests, schema fixtures,
+  pinned versions, and capability negotiation fail closed.
+
+## References
+
+- `tldw_chatbook/Personalization_Interop/personalization_scope_service.py`
+- `tldw_chatbook/Personalization_Interop/server_personalization_service.py`
+- `tldw_chatbook/Sync_Interop/local_first_sync_service.py`
+- `tldw_chatbook/Sync_Interop/envelope_builder.py`
+- `tldw_chatbook/Sync_Interop/envelope_applier.py`
+- `tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py`
+- `tldw_chatbook/UI/Screens/settings_screen.py`
+- `tldw_chatbook/Widgets/workspace_create_modal.py`
+- `backlog/decisions/008-sync-v2-client-m1-contract-alignment.md`
+- `backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md`
+- `tldw_server2/Docs/Product/Personalization_Memory_Layer_PRD.md`
+- `tldw_server2/tldw_Server_API/app/core/DB_Management/Personalization_DB.py`
+- `tldw_server2/tldw_Server_API/app/api/v1/endpoints/personalization.py`

--- a/Tests/Chat/test_console_context_policy_cas.py
+++ b/Tests/Chat/test_console_context_policy_cas.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+from tldw_chatbook.Chat.console_context_policy import (
+    ConsoleContextPolicyOverrides,
+    ContextCompactionMode,
+)
+from tldw_chatbook.Chat.console_context_repository import (
+    ConsoleContextRepository,
+    ContextPolicyWriteStatus,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+def test_context_policy_cas_covers_insert_update_delete_and_conflict(tmp_path) -> None:
+    db = CharactersRAGDB(tmp_path / "context-policy-cas.db", "task-22515")
+    try:
+        service = ChatPersistenceService(db)
+        conversation_id = service.create_conversation(conversation_title="CAS")
+        repository = ConsoleContextRepository(db)
+        ask = ConsoleContextPolicyOverrides(compaction_mode=ContextCompactionMode.ASK)
+        off = ConsoleContextPolicyOverrides(compaction_mode=ContextCompactionMode.OFF)
+
+        inserted = repository.save_policy_if_revision(
+            conversation_id,
+            ask,
+            expected_revision=None,
+        )
+        stale = repository.save_policy_if_revision(
+            conversation_id,
+            off,
+            expected_revision=None,
+        )
+        updated = repository.save_policy_if_revision(
+            conversation_id,
+            off,
+            expected_revision=inserted.revision,
+        )
+        stale_delete = repository.save_policy_if_revision(
+            conversation_id,
+            ConsoleContextPolicyOverrides(),
+            expected_revision=inserted.revision,
+        )
+        deleted = repository.save_policy_if_revision(
+            conversation_id,
+            ConsoleContextPolicyOverrides(),
+            expected_revision=updated.revision,
+        )
+
+        assert inserted.status is ContextPolicyWriteStatus.WRITTEN
+        assert inserted.revision == 1
+        assert stale.status is ContextPolicyWriteStatus.CONFLICT
+        assert stale.revision == 1
+        assert updated.status is ContextPolicyWriteStatus.WRITTEN
+        assert updated.revision == 2
+        assert stale_delete.status is ContextPolicyWriteStatus.CONFLICT
+        assert stale_delete.revision == 2
+        assert deleted.status is ContextPolicyWriteStatus.WRITTEN
+        assert deleted.revision is None
+        assert repository.load_policy(conversation_id).revision is None
+    finally:
+        db.close_connection()
+
+
+def test_context_policy_cas_reports_missing_conversation_without_row(tmp_path) -> None:
+    db = CharactersRAGDB(tmp_path / "context-policy-missing.db", "task-22515")
+    try:
+        repository = ConsoleContextRepository(db)
+
+        result = repository.save_policy_if_revision(
+            "missing-conversation",
+            ConsoleContextPolicyOverrides(
+                compaction_mode=ContextCompactionMode.AUTOMATIC
+            ),
+            expected_revision=None,
+        )
+
+        assert result.status is ContextPolicyWriteStatus.MISSING
+        assert result.revision is None
+    finally:
+        db.close_connection()
+
+
+def test_chat_persistence_service_exposes_revision_guard_without_breaking_legacy(
+    tmp_path,
+) -> None:
+    db = CharactersRAGDB(tmp_path / "context-policy-service.db", "task-22515")
+    try:
+        service = ChatPersistenceService(db)
+        conversation_id = service.create_conversation(conversation_title="Service")
+        first = ConsoleContextPolicyOverrides(
+            compaction_mode=ContextCompactionMode.AUTOMATIC
+        )
+        second = ConsoleContextPolicyOverrides(compaction_mode=ContextCompactionMode.OFF)
+
+        revision = service.update_conversation_context_policy(
+            conversation_id=conversation_id,
+            overrides=first,
+        )
+        guarded = service.update_conversation_context_policy(
+            conversation_id=conversation_id,
+            overrides=second,
+            expected_revision=revision,
+        )
+
+        assert revision == 1
+        assert guarded.status is ContextPolicyWriteStatus.WRITTEN
+        assert guarded.revision == 2
+    finally:
+        db.close_connection()

--- a/Tests/Chat/test_console_first_send_atomicity.py
+++ b/Tests/Chat/test_console_first_send_atomicity.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 from pathlib import Path
+from threading import Event
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -13,11 +17,36 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleMessageRole,
     ConsoleRunStatus,
 )
-from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_chat_store import (
+    ConsoleChatSession,
+    ConsoleChatStore,
+    ConsoleSettingsComponent,
+    ConsoleSettingsPersistenceOutcome,
+)
+from tldw_chatbook.Chat.console_context_policy import (
+    ConsoleContextPolicyOverrides,
+    ContextCompactionMode,
+)
+from tldw_chatbook.Chat.console_conversation_hydration import (
+    hydrate_console_generation_settings,
+    hydrate_console_session,
+)
 from tldw_chatbook.Chat.console_dispatch_checkpoint import (
     ConsoleDispatchCheckpointState,
     ConsoleEgressClass,
     ConsoleResolvedDestination,
+)
+from tldw_chatbook.Chat.console_generation_settings_metadata import (
+    ConsoleGenerationSettingsReadStatus,
+    ConsoleGenerationSettingsWriteResult,
+    ConsoleGenerationSettingsWriteStatus,
+)
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.console_settings_apply import (
+    ConsoleSettingsAction,
+    ConsoleSettingsDraftState,
+    ConsoleSettingsSubmission,
+    ConsoleSettingsSurface,
 )
 from tldw_chatbook.Chat.console_turn_preparation import (
     ConsoleTurnPreparationState,
@@ -85,6 +114,8 @@ class _CheckpointObservingGateway:
 
 def _controller(
     tmp_path: Path,
+    *,
+    initial_settings: ConsoleSessionSettings | None = None,
 ) -> tuple[
     CharactersRAGDB,
     ConsoleChatStore,
@@ -93,7 +124,12 @@ def _controller(
 ]:
     db = CharactersRAGDB(tmp_path / "controller.sqlite", client_id="task14-test")
     store = ConsoleChatStore(persistence=ChatPersistenceService(db))
-    store.create_session(session_id="session-1", title="Chat 1")
+    store.create_session(
+        session_id="session-1",
+        title="Chat 1",
+        settings=initial_settings,
+        canonical_settings_baseline=initial_settings,
+    )
     gateway = _CheckpointObservingGateway(db)
     controller = ConsoleChatController(
         store=store,
@@ -103,6 +139,565 @@ def _controller(
     )
     controller.prompt_history = PromptHistory(tmp_path / "history.jsonl")
     return db, store, controller, gateway
+
+
+async def _stage_first_send_settings(
+    store: ConsoleChatStore,
+    *,
+    submission_id: str = "first-send-settings",
+    model: str = "first-send-model",
+    temperature: float = 0.61,
+    compaction_mode: ContextCompactionMode = ContextCompactionMode.OFF,
+    expected_staged: bool = True,
+) -> ConsoleSettingsPersistenceOutcome:
+    submission = ConsoleSettingsSubmission(
+        submission_id=submission_id,
+        action=ConsoleSettingsAction.APPLY_TO_CHAT,
+        surface=ConsoleSettingsSurface.FULL_SETTINGS,
+        origin=store.capture_console_settings_origin("session-1"),
+        draft=ConsoleSettingsDraftState(
+            settings=ConsoleSessionSettings(
+                provider="openai",
+                model=model,
+                temperature=temperature,
+                streaming=False,
+            ),
+            context_policy_overrides=ConsoleContextPolicyOverrides(
+                compaction_mode=compaction_mode,
+            ),
+            field_drafts=(),
+            model_drafts=(),
+            endpoint_draft=None,
+        ),
+        user_display_name_override=None,
+        default_field_mask=frozenset(),
+    )
+    commit = store.commit_console_settings_live(submission)
+    outcome = await store.persist_console_settings_commit_serialized(commit)
+    assert outcome.staged is expected_staged
+    return outcome
+
+
+async def _apply_full_settings_display_name(
+    store: ConsoleChatStore,
+    *,
+    submission_id: str,
+    display_name: str,
+) -> ConsoleChatSession:
+    submission = ConsoleSettingsSubmission(
+        submission_id=submission_id,
+        action=ConsoleSettingsAction.APPLY_TO_CHAT,
+        surface=ConsoleSettingsSurface.FULL_SETTINGS,
+        origin=store.capture_console_settings_origin("session-1"),
+        draft=ConsoleSettingsDraftState(
+            settings=ConsoleSessionSettings(
+                provider="openai",
+                model="display-name-model",
+                streaming=False,
+            ),
+            context_policy_overrides=ConsoleContextPolicyOverrides(),
+            field_drafts=(),
+            model_drafts=(),
+            endpoint_draft=None,
+        ),
+        user_display_name_override=display_name,
+        default_field_mask=frozenset(),
+    )
+    commit = store.commit_console_settings_live(submission)
+    outcome = await store.persist_console_settings_commit_serialized(commit)
+    assert outcome.staged is (commit.persisted_conversation_id is None)
+    session, roleplay_plan = (
+        store.prepare_session_user_display_name_override_for_commit(
+            commit,
+            submission.user_display_name_override,
+            global_default="User",
+        )
+    )
+    assert session is not None
+    assert roleplay_plan is not None
+    roleplay_result = await store.persist_roleplay_projection_plan_serialized(
+        roleplay_plan
+    )
+    assert roleplay_result is not None
+    assert store.accept_roleplay_projection_persistence_result(roleplay_result)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_first_send_reconciles_interleaved_apply_and_records_exact_recovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initial = ConsoleSessionSettings(
+        provider="openai",
+        model="first-send-model",
+        temperature=0.61,
+        streaming=False,
+        source="global_default",
+    )
+    _db, store, controller, _gateway = _controller(
+        tmp_path,
+        initial_settings=initial,
+    )
+    persistence = store.persistence
+    assert isinstance(persistence, ChatPersistenceService)
+    entered = Event()
+    release = Event()
+    original_commit = persistence.commit_durable_turn
+
+    def blocked_commit(**kwargs: Any):
+        entered.set()
+        assert release.wait(timeout=5)
+        return original_commit(**kwargs)
+
+    monkeypatch.setattr(persistence, "commit_durable_turn", blocked_commit)
+    submit = asyncio.create_task(
+        controller.submit_draft("race the first send", session_id="session-1")
+    )
+    assert await asyncio.to_thread(entered.wait, 5)
+    await _stage_first_send_settings(
+        store,
+        submission_id="newer-settings",
+        model="newer-model",
+        temperature=0.27,
+        compaction_mode=ContextCompactionMode.AUTOMATIC,
+    )
+    original_generation_write = persistence.update_conversation_generation_settings
+    monkeypatch.setattr(
+        persistence,
+        "update_conversation_generation_settings",
+        lambda **_kwargs: ConsoleGenerationSettingsWriteResult(
+            ConsoleGenerationSettingsWriteStatus.MISSING
+        ),
+    )
+    release.set()
+
+    result = await submit
+
+    assert result.accepted is True
+    session = store.sessions()[0]
+    conversation_id = session.persisted_conversation_id
+    assert conversation_id is not None
+    durable_generation = persistence.get_conversation_generation_settings(
+        conversation_id
+    )
+    durable_context = persistence.get_conversation_context_policy(conversation_id)
+    assert durable_generation.snapshot is not None
+    assert durable_generation.snapshot.model == "first-send-model"
+    assert durable_context.overrides.compaction_mode is ContextCompactionMode.AUTOMATIC
+    failure = session.settings_persistence_failures[
+        ConsoleSettingsComponent.GENERATION_SETTINGS
+    ]
+    assert failure.revision == session.generation_settings_revision
+    assert failure.generation_snapshot is not None
+    assert failure.generation_snapshot.model == "newer-model"
+    assert failure.persisted_conversation_id == conversation_id
+    assert ConsoleSettingsComponent.CONTEXT_POLICY not in (
+        session.settings_persistence_failures
+    )
+    assert session.staged_context_policy_failure_label is None
+    assert session.staged_context_policy_failure_revision is None
+
+    monkeypatch.setattr(
+        persistence,
+        "update_conversation_generation_settings",
+        original_generation_write,
+    )
+    assert await store.retry_console_settings_persistence(
+        session_id=session.id,
+        component=ConsoleSettingsComponent.GENERATION_SETTINGS,
+        revision=failure.revision,
+    )
+    retried = persistence.get_conversation_generation_settings(conversation_id)
+    assert retried.snapshot is not None
+    assert retried.snapshot.model == "newer-model"
+    assert session.settings_persistence_failures == {}
+
+
+@pytest.mark.asyncio
+async def test_normal_first_send_atomically_persists_staged_settings_and_reopens(
+    tmp_path: Path,
+) -> None:
+    db, store, controller, _gateway = _controller(tmp_path)
+    await _stage_first_send_settings(store)
+
+    result = await controller.submit_draft(
+        "persist my staged settings", session_id="session-1"
+    )
+
+    assert result.accepted is True
+    session = store.sessions()[0]
+    conversation_id = session.persisted_conversation_id
+    assert conversation_id is not None
+    persistence = store.persistence
+    assert isinstance(persistence, ChatPersistenceService)
+    generation = persistence.get_conversation_generation_settings(conversation_id)
+    context = persistence.get_conversation_context_policy(conversation_id)
+    assert generation.status is ConsoleGenerationSettingsReadStatus.VALID
+    assert generation.snapshot is not None
+    assert (
+        generation.snapshot.provider,
+        generation.snapshot.model,
+        generation.snapshot.temperature,
+        generation.snapshot.streaming,
+    ) == ("openai", "first-send-model", pytest.approx(0.61), False)
+    assert context.overrides.compaction_mode is ContextCompactionMode.OFF
+    assert context.revision == 1
+    assert session.generation_durable_snapshot == generation.snapshot
+    assert session.context_policy_durable_revision == context.revision
+    assert session.staged_context_policy_failure_label is None
+    assert session.staged_context_policy_failure_revision is None
+    assert session.settings_persistence_failures == {}
+
+    conversation = db.get_conversation_by_id(conversation_id)
+    assert conversation is not None
+    hydration = hydrate_console_generation_settings({}, conversation)
+    reopened_store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    reopened = reopened_store.restore_persisted_session(
+        title=str(conversation["title"]),
+        workspace_id=conversation.get("workspace_id"),
+        persisted_conversation_id=conversation_id,
+        all_nodes=(),
+        settings=hydration.settings,
+        generation_durable_snapshot=hydration.durable_snapshot,
+        generation_metadata_status=hydration.metadata_status,
+    )
+    assert reopened.settings is not None
+    assert (
+        reopened.settings.provider,
+        reopened.settings.model,
+        reopened.settings.temperature,
+        reopened.settings.streaming,
+    ) == ("openai", "first-send-model", pytest.approx(0.61), False)
+    assert reopened.context_policy_overrides.compaction_mode is ContextCompactionMode.OFF
+
+
+@pytest.mark.asyncio
+async def test_identity_publication_retry_preserves_newer_settings_lineage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db, store, controller, _gateway = _controller(tmp_path)
+    await _stage_first_send_settings(store)
+    persistence = store.persistence
+    assert isinstance(persistence, ChatPersistenceService)
+    original_publish = store.publish_durable_turn_identity
+    publication_attempts = 0
+
+    def publish_then_fail_once(*args: Any, **kwargs: Any) -> None:
+        nonlocal publication_attempts
+        publication_attempts += 1
+        original_publish(*args, **kwargs)
+        if publication_attempts == 1:
+            raise RuntimeError("identity callback failed after publication")
+
+    monkeypatch.setattr(
+        store,
+        "publish_durable_turn_identity",
+        publish_then_fail_once,
+    )
+    first = await controller.submit_draft(
+        "retain the first accepted turn",
+        session_id="session-1",
+    )
+    assert first.accepted is True
+    assert first.provider_started is False
+    assert first.preparation_id is not None
+
+    original_generation_write = persistence.update_conversation_generation_settings
+    monkeypatch.setattr(
+        persistence,
+        "update_conversation_generation_settings",
+        lambda **_kwargs: ConsoleGenerationSettingsWriteResult(
+            ConsoleGenerationSettingsWriteStatus.MISSING
+        ),
+    )
+    newer = await _stage_first_send_settings(
+        store,
+        submission_id="intervening-settings",
+        model="intervening-model",
+        temperature=0.27,
+        compaction_mode=ContextCompactionMode.AUTOMATIC,
+        expected_staged=False,
+    )
+    assert newer.failed_components == frozenset(
+        {ConsoleSettingsComponent.GENERATION_SETTINGS}
+    )
+    assert newer.written_components == frozenset(
+        {ConsoleSettingsComponent.CONTEXT_POLICY}
+    )
+    session = store.sessions()[0]
+    newer_failure = session.settings_persistence_failures[
+        ConsoleSettingsComponent.GENERATION_SETTINGS
+    ]
+    conversation_id = session.persisted_conversation_id
+    assert conversation_id is not None
+    context_before_retry = persistence.get_conversation_context_policy(
+        conversation_id
+    )
+
+    resumed = await controller.resume_durable_postcommit(first.preparation_id)
+
+    assert resumed.accepted is True
+    assert publication_attempts == 2
+    assert session.settings_persistence_failures[
+        ConsoleSettingsComponent.GENERATION_SETTINGS
+    ] == newer_failure
+    assert ConsoleSettingsComponent.CONTEXT_POLICY not in (
+        session.settings_persistence_failures
+    )
+    durable_context = persistence.get_conversation_context_policy(conversation_id)
+    assert durable_context.revision == context_before_retry.revision
+    assert durable_context.overrides.compaction_mode is ContextCompactionMode.AUTOMATIC
+
+    monkeypatch.setattr(
+        persistence,
+        "update_conversation_generation_settings",
+        original_generation_write,
+    )
+    assert await store.retry_console_settings_persistence(
+        session_id=session.id,
+        component=ConsoleSettingsComponent.GENERATION_SETTINGS,
+        revision=newer_failure.revision,
+    )
+    final = await _stage_first_send_settings(
+        store,
+        submission_id="subsequent-settings",
+        model="subsequent-model",
+        temperature=0.11,
+        compaction_mode=ContextCompactionMode.OFF,
+        expected_staged=False,
+    )
+
+    assert final.written_components == frozenset(ConsoleSettingsComponent)
+    assert final.failed_components == frozenset()
+    assert session.settings_persistence_failures == {}
+    durable_generation = persistence.get_conversation_generation_settings(
+        conversation_id
+    )
+    durable_context = persistence.get_conversation_context_policy(conversation_id)
+    assert durable_generation.snapshot is not None
+    assert durable_generation.snapshot.model == "subsequent-model"
+    assert durable_context.overrides.compaction_mode is ContextCompactionMode.OFF
+
+
+@pytest.mark.asyncio
+async def test_first_send_atomically_persists_unsaved_display_name_and_reopens(
+    tmp_path: Path,
+) -> None:
+    db, store, controller, _gateway = _controller(tmp_path)
+    session = await _apply_full_settings_display_name(
+        store,
+        submission_id="display-name-settings",
+        display_name="Alice",
+    )
+
+    sent = await controller.submit_draft(
+        "remember my display name",
+        session_id="session-1",
+    )
+
+    assert sent.accepted is True
+    conversation_id = session.persisted_conversation_id
+    assert conversation_id is not None
+    conversation = db.get_conversation_by_id(conversation_id)
+    assert conversation is not None
+    metadata = json.loads(conversation["metadata"])
+    assert metadata["console_roleplay_context"] == {
+        "version": 2,
+        "user_name_override": "Alice",
+    }
+    assert "api_key" not in metadata
+    assert "base_url" not in metadata
+    assert "endpoint" not in metadata
+    hydration = hydrate_console_generation_settings({}, conversation)
+    reopened_store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    reopened = await hydrate_console_session(
+        app=SimpleNamespace(chachanotes_db=db),
+        store=reopened_store,
+        conversation_id=conversation_id,
+        tree={"conversation": conversation, "root_threads": []},
+        settings=hydration.settings,
+        generation_durable_snapshot=hydration.durable_snapshot,
+        generation_metadata_status=hydration.metadata_status,
+    )
+
+    assert reopened.user_display_name_override == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_display_name_applied_during_first_commit_has_retryable_postcommit_flush(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db, store, controller, _gateway = _controller(tmp_path)
+    persistence = store.persistence
+    assert isinstance(persistence, ChatPersistenceService)
+    entered = Event()
+    release = Event()
+    original_commit = persistence.commit_durable_turn
+
+    def blocked_commit(**kwargs: Any):
+        entered.set()
+        assert release.wait(timeout=5)
+        return original_commit(**kwargs)
+
+    monkeypatch.setattr(persistence, "commit_durable_turn", blocked_commit)
+    submit = asyncio.create_task(
+        controller.submit_draft(
+            "race my display name",
+            session_id="session-1",
+        )
+    )
+    assert await asyncio.to_thread(entered.wait, 5)
+    session = await _apply_full_settings_display_name(
+        store,
+        submission_id="racing-display-name",
+        display_name="Bob",
+    )
+    assert session.persisted_conversation_id is None
+    original_roleplay_write = persistence.update_conversation_roleplay_context
+    monkeypatch.setattr(
+        persistence,
+        "update_conversation_roleplay_context",
+        lambda **_kwargs: False,
+    )
+    release.set()
+
+    first = await submit
+
+    assert first.accepted is True
+    assert first.provider_started is False
+    assert "retained for recovery" in first.visible_copy.lower()
+    assert first.preparation_id is not None
+    monkeypatch.setattr(
+        persistence,
+        "update_conversation_roleplay_context",
+        original_roleplay_write,
+    )
+    resumed = await controller.resume_durable_postcommit(first.preparation_id)
+    assert resumed.accepted is True
+    conversation_id = session.persisted_conversation_id
+    assert conversation_id is not None
+    conversation = db.get_conversation_by_id(conversation_id)
+    assert conversation is not None
+    hydration = hydrate_console_generation_settings({}, conversation)
+    reopened = await hydrate_console_session(
+        app=SimpleNamespace(chachanotes_db=db),
+        store=ConsoleChatStore(persistence=ChatPersistenceService(db)),
+        conversation_id=conversation_id,
+        tree={"conversation": conversation, "root_threads": []},
+        settings=hydration.settings,
+        generation_durable_snapshot=hydration.durable_snapshot,
+        generation_metadata_status=hydration.metadata_status,
+    )
+
+    assert reopened.user_display_name_override == "Bob"
+
+
+@pytest.mark.asyncio
+async def test_first_send_persists_revision_zero_new_chat_default(
+    tmp_path: Path,
+) -> None:
+    initial = ConsoleSessionSettings(
+        provider="anthropic",
+        model="saved-global-model",
+        temperature=0.42,
+        streaming=False,
+        source="global_default",
+    )
+    _db, store, controller, _gateway = _controller(
+        tmp_path,
+        initial_settings=initial,
+    )
+    session = store.sessions()[0]
+    assert session.generation_settings_revision == 0
+
+    result = await controller.submit_draft("use my default", session_id="session-1")
+
+    assert result.accepted is True
+    persistence = store.persistence
+    assert isinstance(persistence, ChatPersistenceService)
+    conversation_id = session.persisted_conversation_id
+    assert conversation_id is not None
+    persisted = persistence.get_conversation_generation_settings(
+        conversation_id
+    )
+    assert persisted.status is ConsoleGenerationSettingsReadStatus.VALID
+    assert persisted.snapshot is not None
+    assert (
+        persisted.snapshot.provider,
+        persisted.snapshot.model,
+        persisted.snapshot.temperature,
+        persisted.snapshot.streaming,
+    ) == ("anthropic", "saved-global-model", pytest.approx(0.42), False)
+    assert session.generation_durable_snapshot == persisted.snapshot
+
+
+@pytest.mark.asyncio
+async def test_later_send_does_not_republish_first_persist_settings_bases(
+    tmp_path: Path,
+) -> None:
+    _db, store, controller, _gateway = _controller(tmp_path)
+    await _stage_first_send_settings(store)
+    first = await controller.submit_draft("first", session_id="session-1")
+    assert first.accepted is True
+    await _stage_first_send_settings(
+        store,
+        submission_id="persisted-settings",
+        model="persisted-model",
+        compaction_mode=ContextCompactionMode.AUTOMATIC,
+        expected_staged=False,
+    )
+    session = store.sessions()[0]
+    assert session.context_policy_durable_revision == 2
+
+    second = await controller.submit_draft("second", session_id="session-1")
+
+    assert second.accepted is True
+    assert session.context_policy_durable_revision == 2
+    persistence = store.persistence
+    assert isinstance(persistence, ChatPersistenceService)
+    conversation_id = session.persisted_conversation_id
+    assert conversation_id is not None
+    persisted = persistence.get_conversation_context_policy(conversation_id)
+    assert persisted.revision == 2
+    assert persisted.overrides.compaction_mode is ContextCompactionMode.AUTOMATIC
+
+
+@pytest.mark.asyncio
+async def test_first_send_context_write_failure_rolls_back_the_whole_turn(
+    tmp_path: Path,
+) -> None:
+    db, store, controller, gateway = _controller(tmp_path)
+    await _stage_first_send_settings(store)
+    db.get_connection().execute(
+        "CREATE TRIGGER fail_first_context_policy "
+        "BEFORE INSERT ON console_conversation_context_policy "
+        "BEGIN SELECT RAISE(ABORT, 'injected context failure'); END"
+    )
+
+    result = await controller.submit_draft(
+        "must remain atomic", session_id="session-1"
+    )
+
+    assert result.accepted is False
+    assert gateway.calls == 0
+    session = store.sessions()[0]
+    assert session.persisted_conversation_id is None
+    assert session.settings is not None
+    assert session.settings.model == "first-send-model"
+    assert session.context_policy_overrides.compaction_mode is ContextCompactionMode.OFF
+    for table in (
+        "conversations",
+        "console_conversation_library_policy",
+        "console_conversation_context_policy",
+        "messages",
+        "console_dispatch_checkpoints",
+    ):
+        assert db.get_connection().execute(
+            f"SELECT COUNT(*) FROM {table}"
+        ).fetchone()[0] == 0
 
 
 @pytest.mark.asyncio

--- a/Tests/Chat/test_console_generation_settings_metadata.py
+++ b/Tests/Chat/test_console_generation_settings_metadata.py
@@ -1,0 +1,702 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from tldw_chatbook.Chat.chat_persistence_service import (
+    ChatPersistenceService,
+    _initial_metadata_object,
+)
+from tldw_chatbook.Chat.console_generation_settings_metadata import (
+    CONSOLE_GENERATION_SETTINGS_METADATA_KEY,
+    CONSOLE_GENERATION_SETTINGS_VERSION,
+    ConsoleGenerationSettingsReadStatus,
+    ConsoleGenerationSettingsSnapshot,
+    ConsoleGenerationSettingsWriteResult,
+    ConsoleGenerationSettingsWriteStatus,
+    merge_console_generation_settings,
+    parse_console_generation_settings,
+    snapshot_from_session_settings,
+)
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, ConflictError
+
+
+SAFE_FIELDS = {
+    "provider",
+    "model",
+    "temperature",
+    "top_p",
+    "min_p",
+    "top_k",
+    "max_tokens",
+    "seed",
+    "presence_penalty",
+    "frequency_penalty",
+    "reasoning_effort",
+    "reasoning_summary",
+    "verbosity",
+    "thinking_effort",
+    "thinking_budget_tokens",
+    "streaming",
+}
+
+
+def _snapshot(**changes: object) -> ConsoleGenerationSettingsSnapshot:
+    baseline = ConsoleGenerationSettingsSnapshot(
+        provider="openai",
+        model="gpt-5",
+        temperature=0.3,
+        top_p=0.8,
+        min_p=0.1,
+        top_k=40,
+        max_tokens=2048,
+        seed=7,
+        presence_penalty=0.2,
+        frequency_penalty=-0.2,
+        reasoning_effort="high",
+        reasoning_summary="concise",
+        verbosity="low",
+        thinking_effort="medium",
+        thinking_budget_tokens=4096,
+        streaming=True,
+    )
+    return replace(baseline, **changes)
+
+
+def _owned(
+    snapshot: ConsoleGenerationSettingsSnapshot | None = None,
+) -> dict[str, object]:
+    value = snapshot or _snapshot()
+    return {
+        "version": CONSOLE_GENERATION_SETTINGS_VERSION,
+        "provider": value.provider,
+        "model": value.model,
+        "temperature": value.temperature,
+        "top_p": value.top_p,
+        "min_p": value.min_p,
+        "top_k": value.top_k,
+        "max_tokens": value.max_tokens,
+        "seed": value.seed,
+        "presence_penalty": value.presence_penalty,
+        "frequency_penalty": value.frequency_penalty,
+        "reasoning_effort": value.reasoning_effort,
+        "reasoning_summary": value.reasoning_summary,
+        "verbosity": value.verbosity,
+        "thinking_effort": value.thinking_effort,
+        "thinking_budget_tokens": value.thinking_budget_tokens,
+        "streaming": value.streaming,
+    }
+
+
+def _metadata(
+    snapshot: ConsoleGenerationSettingsSnapshot | None = None,
+) -> dict[str, object]:
+    return {CONSOLE_GENERATION_SETTINGS_METADATA_KEY: _owned(snapshot)}
+
+
+def test_codec_uses_exact_versioned_allowlist_and_never_serializes_other_settings() -> (
+    None
+):
+    settings = ConsoleSessionSettings(
+        provider="openai",
+        model="gpt-5",
+        base_url="https://secret-endpoint.example/v1",
+        temperature=0.4,
+        top_p=0.7,
+        min_p=0.05,
+        top_k=20,
+        max_tokens=1024,
+        seed=11,
+        presence_penalty=0.1,
+        frequency_penalty=-0.1,
+        reasoning_effort="medium",
+        reasoning_summary="auto",
+        verbosity="high",
+        thinking_effort="low",
+        thinking_budget_tokens=2048,
+        streaming=False,
+        character_label="Private display name",
+        system_prompt="Never persist me",
+        source="user",
+        pinned_prefill="Never persist me either",
+    )
+
+    merged = merge_console_generation_settings(
+        {
+            "sibling": {"keep": True},
+            "credential_reference": "keyring://secret",
+            "context_policy": {"compaction_mode": "summary"},
+        },
+        snapshot_from_session_settings(settings),
+    )
+
+    assert merged["sibling"] == {"keep": True}
+    assert merged["credential_reference"] == "keyring://secret"
+    assert merged["context_policy"] == {"compaction_mode": "summary"}
+    owned = merged[CONSOLE_GENERATION_SETTINGS_METADATA_KEY]
+    assert isinstance(owned, dict)
+    assert set(owned) == {"version", *SAFE_FIELDS}
+    assert owned["version"] == 1
+    assert set(owned).isdisjoint(
+        {
+            "base_url",
+            "api_key",
+            "credentials",
+            "credential_reference",
+            "system_prompt",
+            "source",
+            "compaction_mode",
+            "context_policy",
+            "character_label",
+            "character_name",
+            "display_name",
+            "pinned_prefill",
+        }
+    )
+
+
+def test_parse_distinguishes_absent_valid_invalid_and_unsupported_version() -> None:
+    absent = parse_console_generation_settings({"sibling": True})
+    valid = parse_console_generation_settings(json.dumps(_metadata()))
+    invalid = parse_console_generation_settings(
+        {CONSOLE_GENERATION_SETTINGS_METADATA_KEY: {"version": 1}}
+    )
+    future_metadata = _metadata()
+    future_metadata[CONSOLE_GENERATION_SETTINGS_METADATA_KEY]["version"] = 2  # type: ignore[index]
+    future = parse_console_generation_settings(future_metadata)
+
+    assert absent.status is ConsoleGenerationSettingsReadStatus.ABSENT
+    assert absent.snapshot is None
+    assert valid.status is ConsoleGenerationSettingsReadStatus.VALID
+    assert valid.snapshot == _snapshot()
+    assert invalid.status is ConsoleGenerationSettingsReadStatus.INVALID
+    assert invalid.snapshot is None
+    assert future.status is ConsoleGenerationSettingsReadStatus.UNSUPPORTED_VERSION
+    assert future.snapshot is None
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        pytest.param("{", id="malformed-json"),
+        pytest.param("[]", id="array-json"),
+        pytest.param('"scalar"', id="scalar-json"),
+        pytest.param("null", id="null-json"),
+        pytest.param('{"bad": NaN}', id="non-finite-json"),
+        pytest.param(["not-an-object"], id="list-value"),
+        pytest.param({1: "non-string-key"}, id="non-string-key"),
+        pytest.param({"bad": float("inf")}, id="non-finite-mapping"),
+    ],
+)
+def test_parse_rejects_malformed_or_non_object_metadata(metadata: object) -> None:
+    result = parse_console_generation_settings(metadata)
+
+    assert result.status is ConsoleGenerationSettingsReadStatus.INVALID
+    assert result.snapshot is None
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("unknown", "value"),
+        ("version", True),
+        ("provider", ""),
+        ("provider", "p" * 129),
+        ("model", ""),
+        ("model", "m" * 257),
+        ("temperature", True),
+        ("temperature", float("nan")),
+        ("temperature", float("inf")),
+        ("temperature", -0.01),
+        ("temperature", 2.01),
+        ("top_p", -0.01),
+        ("top_p", 1.01),
+        ("min_p", -0.01),
+        ("min_p", 1.01),
+        ("top_k", True),
+        ("top_k", 1.0),
+        ("top_k", -1),
+        ("max_tokens", 0),
+        ("seed", -1),
+        ("presence_penalty", -2.01),
+        ("presence_penalty", 2.01),
+        ("frequency_penalty", -2.01),
+        ("frequency_penalty", 2.01),
+        ("reasoning_effort", "extreme"),
+        ("reasoning_summary", "everything"),
+        ("verbosity", "verbose"),
+        ("thinking_effort", "unlimited"),
+        ("thinking_budget_tokens", 1023),
+        ("streaming", 1),
+    ],
+)
+def test_parse_rejects_unknown_or_invalid_owned_fields(
+    field: str, value: object
+) -> None:
+    owned = _owned()
+    owned[field] = value
+
+    result = parse_console_generation_settings(
+        {CONSOLE_GENERATION_SETTINGS_METADATA_KEY: owned}
+    )
+
+    assert result.status is ConsoleGenerationSettingsReadStatus.INVALID
+    assert result.snapshot is None
+
+
+def test_oversized_float_input_fails_closed_during_parse_and_projection() -> None:
+    oversized = 10**400
+
+    parsed = parse_console_generation_settings(
+        _metadata(_snapshot(temperature=oversized))
+    )
+
+    assert parsed.status is ConsoleGenerationSettingsReadStatus.INVALID
+    assert parsed.snapshot is None
+    with pytest.raises(ValueError):
+        snapshot_from_session_settings(
+            ConsoleSessionSettings(provider="openai", temperature=oversized)
+        )
+
+
+def test_string_metadata_rejects_exponent_overflow_in_unrelated_sibling() -> None:
+    metadata = json.dumps(_metadata())[:-1] + ', "sibling": 1e400}'
+
+    parsed = parse_console_generation_settings(metadata)
+
+    assert parsed.status is ConsoleGenerationSettingsReadStatus.INVALID
+    assert parsed.snapshot is None
+
+
+@pytest.mark.parametrize("model_length", [121, 256])
+def test_model_ids_through_console_input_limit_are_durable(model_length: int) -> None:
+    snapshot = _snapshot(model="m" * model_length)
+
+    merged = merge_console_generation_settings({}, snapshot)
+
+    assert parse_console_generation_settings(merged).snapshot == snapshot
+
+
+def test_exact_integers_above_64_bit_are_durable() -> None:
+    exact_integer = 2**80
+    snapshot = _snapshot(
+        top_k=exact_integer,
+        max_tokens=exact_integer,
+        seed=exact_integer,
+        thinking_budget_tokens=exact_integer,
+    )
+
+    merged = merge_console_generation_settings({}, snapshot)
+
+    assert parse_console_generation_settings(merged).snapshot == snapshot
+
+
+def test_write_result_enforces_snapshot_status_invariants() -> None:
+    snapshot = _snapshot()
+
+    with pytest.raises(ValueError):
+        ConsoleGenerationSettingsWriteResult(
+            ConsoleGenerationSettingsWriteStatus.WRITTEN
+        )
+    for status in (
+        ConsoleGenerationSettingsWriteStatus.INVALID,
+        ConsoleGenerationSettingsWriteStatus.UNSUPPORTED_VERSION,
+        ConsoleGenerationSettingsWriteStatus.MISSING,
+    ):
+        with pytest.raises(ValueError):
+            ConsoleGenerationSettingsWriteResult(status, snapshot)
+
+    assert (
+        ConsoleGenerationSettingsWriteResult(
+            ConsoleGenerationSettingsWriteStatus.WRITTEN, snapshot
+        ).snapshot
+        == snapshot
+    )
+    assert (
+        ConsoleGenerationSettingsWriteResult(
+            ConsoleGenerationSettingsWriteStatus.SUPERSEDED, snapshot
+        ).snapshot
+        == snapshot
+    )
+    assert (
+        ConsoleGenerationSettingsWriteResult(
+            ConsoleGenerationSettingsWriteStatus.SUPERSEDED
+        ).snapshot
+        is None
+    )
+
+
+def test_initial_metadata_object_preserves_strict_legacy_contract() -> None:
+    assert _initial_metadata_object({"sibling": [1, True]}) == {"sibling": [1, True]}
+    assert _initial_metadata_object('{"sibling": [1, true]}') == {"sibling": [1, True]}
+    for invalid in (None, [], "null", {1: "value"}, '{"sibling": 1e400}'):
+        with pytest.raises(ValueError):
+            _initial_metadata_object(invalid)
+
+
+def test_merge_refuses_malformed_invalid_and_future_owned_objects() -> None:
+    invalid_owned = _metadata()
+    invalid_owned[CONSOLE_GENERATION_SETTINGS_METADATA_KEY]["unexpected"] = True  # type: ignore[index]
+    future_owned = _metadata()
+    future_owned[CONSOLE_GENERATION_SETTINGS_METADATA_KEY]["version"] = 2  # type: ignore[index]
+
+    with pytest.raises(ValueError):
+        merge_console_generation_settings("{", _snapshot())
+    with pytest.raises(ValueError):
+        merge_console_generation_settings(invalid_owned, _snapshot())
+    with pytest.raises(ValueError):
+        merge_console_generation_settings(future_owned, _snapshot())
+
+
+@pytest.fixture
+def persistence(tmp_path):
+    db = CharactersRAGDB(tmp_path / "generation-settings.sqlite", "generation-test")
+    try:
+        yield ChatPersistenceService(db), db
+    finally:
+        db.close_connection()
+
+
+def test_persistence_writes_complete_snapshot_and_preserves_siblings(
+    persistence,
+) -> None:
+    service, db = persistence
+    conversation_id = service.create_conversation(
+        conversation_title="Saved",
+        metadata={"sibling": {"keep": True}},
+    )
+    desired = _snapshot(temperature=0.9, streaming=False)
+
+    result = service.update_conversation_generation_settings(
+        conversation_id=conversation_id,
+        snapshot=desired,
+        expected_snapshot=None,
+    )
+
+    assert result.status is ConsoleGenerationSettingsWriteStatus.WRITTEN
+    assert result.snapshot == desired
+    record = db.get_conversation_by_id(conversation_id)
+    assert json.loads(record["metadata"])["sibling"] == {"keep": True}
+    assert (
+        service.get_conversation_generation_settings(conversation_id).snapshot
+        == desired
+    )
+
+
+def test_persistence_treats_missing_owned_object_as_expected_none(persistence) -> None:
+    service, _db = persistence
+    conversation_id = service.create_conversation(conversation_title="No metadata")
+
+    before = service.get_conversation_generation_settings(conversation_id)
+    result = service.update_conversation_generation_settings(
+        conversation_id=conversation_id,
+        snapshot=_snapshot(),
+        expected_snapshot=None,
+    )
+
+    assert before.status is ConsoleGenerationSettingsReadStatus.ABSENT
+    assert result.status is ConsoleGenerationSettingsWriteStatus.WRITTEN
+
+
+def test_persistence_refuses_oversized_float_without_mutation(persistence) -> None:
+    service, db = persistence
+    conversation_id = service.create_conversation(
+        conversation_title="Oversized",
+        metadata={"sibling": "keep"},
+    )
+    before = db.get_conversation_by_id(conversation_id)
+
+    result = service.update_conversation_generation_settings(
+        conversation_id=conversation_id,
+        snapshot=_snapshot(temperature=10**400),
+        expected_snapshot=None,
+    )
+
+    after = db.get_conversation_by_id(conversation_id)
+    assert result.status is ConsoleGenerationSettingsWriteStatus.INVALID
+    assert after["version"] == before["version"]
+    assert after["metadata"] == before["metadata"]
+
+
+def test_persistence_refuses_exponent_overflow_sibling_without_mutation(
+    persistence,
+) -> None:
+    service, db = persistence
+    conversation_id = service.create_conversation(
+        conversation_title="Exponent overflow",
+        metadata=_metadata(_snapshot()),
+    )
+    current = db.get_conversation_by_id(conversation_id)
+    overflow_metadata = json.dumps(_metadata(_snapshot()))[:-1] + (
+        ', "sibling": 1e400}'
+    )
+    db.update_conversation(
+        conversation_id,
+        {"metadata": overflow_metadata},
+        expected_version=current["version"],
+    )
+    before = db.get_conversation_by_id(conversation_id)
+
+    result = service.update_conversation_generation_settings(
+        conversation_id=conversation_id,
+        snapshot=_snapshot(temperature=1.0),
+        expected_snapshot=_snapshot(),
+    )
+
+    after = db.get_conversation_by_id(conversation_id)
+    assert result.status is ConsoleGenerationSettingsWriteStatus.INVALID
+    assert result.snapshot is None
+    assert after["version"] == before["version"]
+    assert after["metadata"] == before["metadata"]
+
+
+@pytest.mark.parametrize(
+    ("owned", "expected_status"),
+    [
+        ({"version": 1}, ConsoleGenerationSettingsWriteStatus.INVALID),
+        (
+            {"version": 2, "future": True},
+            ConsoleGenerationSettingsWriteStatus.UNSUPPORTED_VERSION,
+        ),
+    ],
+)
+def test_persistence_refuses_invalid_or_future_owned_data_without_mutation(
+    persistence, owned, expected_status
+) -> None:
+    service, db = persistence
+    conversation_id = service.create_conversation(
+        conversation_title="Saved",
+        metadata={CONSOLE_GENERATION_SETTINGS_METADATA_KEY: owned, "sibling": True},
+    )
+    before = db.get_conversation_by_id(conversation_id)
+
+    result = service.update_conversation_generation_settings(
+        conversation_id=conversation_id,
+        snapshot=_snapshot(temperature=1.1),
+        expected_snapshot=None,
+    )
+
+    after = db.get_conversation_by_id(conversation_id)
+    assert result.status is expected_status
+    assert after["version"] == before["version"]
+    assert after["metadata"] == before["metadata"]
+
+
+def test_persistence_retries_sibling_only_conflict_with_fresh_merge(
+    persistence, monkeypatch
+) -> None:
+    service, db = persistence
+    baseline = _snapshot()
+    desired = _snapshot(temperature=1.2)
+    conversation_id = service.create_conversation(
+        conversation_title="Saved",
+        metadata={**_metadata(baseline), "sibling": "old"},
+    )
+    original_update = db.update_conversation
+    first_call = True
+
+    def race(conversation_id_arg, update_data, expected_version):
+        nonlocal first_call
+        if first_call:
+            first_call = False
+            current = db.get_conversation_by_id(conversation_id_arg)
+            concurrent_metadata = json.loads(current["metadata"])
+            concurrent_metadata["sibling"] = "fresh"
+            original_update(
+                conversation_id_arg,
+                {"metadata": json.dumps(concurrent_metadata, sort_keys=True)},
+                expected_version=current["version"],
+            )
+        return original_update(conversation_id_arg, update_data, expected_version)
+
+    monkeypatch.setattr(db, "update_conversation", race)
+
+    result = service.update_conversation_generation_settings(
+        conversation_id=conversation_id,
+        snapshot=desired,
+        expected_snapshot=baseline,
+    )
+
+    assert result.status is ConsoleGenerationSettingsWriteStatus.WRITTEN
+    record = db.get_conversation_by_id(conversation_id)
+    metadata = json.loads(record["metadata"])
+    assert metadata["sibling"] == "fresh"
+    assert parse_console_generation_settings(metadata).snapshot == desired
+
+
+def test_persistence_refuses_owned_base_supersession(persistence, monkeypatch) -> None:
+    service, db = persistence
+    baseline = _snapshot()
+    desired = _snapshot(temperature=1.2)
+    external = _snapshot(temperature=1.8)
+    conversation_id = service.create_conversation(
+        conversation_title="Saved",
+        metadata=_metadata(baseline),
+    )
+    original_update = db.update_conversation
+    first_call = True
+
+    def race(conversation_id_arg, update_data, expected_version):
+        nonlocal first_call
+        if first_call:
+            first_call = False
+            current = db.get_conversation_by_id(conversation_id_arg)
+            original_update(
+                conversation_id_arg,
+                {"metadata": json.dumps(_metadata(external), sort_keys=True)},
+                expected_version=current["version"],
+            )
+        return original_update(conversation_id_arg, update_data, expected_version)
+
+    monkeypatch.setattr(db, "update_conversation", race)
+
+    result = service.update_conversation_generation_settings(
+        conversation_id=conversation_id,
+        snapshot=desired,
+        expected_snapshot=baseline,
+    )
+
+    assert result.status is ConsoleGenerationSettingsWriteStatus.SUPERSEDED
+    assert result.snapshot == external
+    assert (
+        service.get_conversation_generation_settings(conversation_id).snapshot
+        == external
+    )
+
+
+@pytest.mark.parametrize(
+    ("transition", "expected_status", "expected_snapshot_kind"),
+    [
+        ("deleted", ConsoleGenerationSettingsWriteStatus.MISSING, None),
+        ("invalid", ConsoleGenerationSettingsWriteStatus.INVALID, None),
+        (
+            "future",
+            ConsoleGenerationSettingsWriteStatus.UNSUPPORTED_VERSION,
+            None,
+        ),
+        (
+            "owned-removed",
+            ConsoleGenerationSettingsWriteStatus.SUPERSEDED,
+            None,
+        ),
+        (
+            "owned-changed",
+            ConsoleGenerationSettingsWriteStatus.SUPERSEDED,
+            "external",
+        ),
+    ],
+)
+def test_persistence_classifies_fresh_state_after_final_conflict(
+    persistence,
+    monkeypatch,
+    transition,
+    expected_status,
+    expected_snapshot_kind,
+) -> None:
+    service, db = persistence
+    baseline = _snapshot()
+    external = _snapshot(temperature=1.8)
+    conversation_id = service.create_conversation(
+        conversation_title="Saved",
+        metadata=_metadata(baseline),
+    )
+    original_update = db.update_conversation
+    attempt_number = 0
+
+    def race(conversation_id_arg, update_data, expected_version):
+        nonlocal attempt_number
+        attempt_number += 1
+        current = db.get_conversation_by_id(conversation_id_arg)
+        if attempt_number == 1:
+            metadata = json.loads(current["metadata"])
+            metadata["first_sibling"] = True
+            original_update(
+                conversation_id_arg,
+                {"metadata": json.dumps(metadata, sort_keys=True)},
+                expected_version=current["version"],
+            )
+        elif transition == "deleted":
+            db.soft_delete_conversation(
+                conversation_id_arg,
+                expected_version=current["version"],
+            )
+        else:
+            metadata = json.loads(current["metadata"])
+            if transition == "invalid":
+                metadata[CONSOLE_GENERATION_SETTINGS_METADATA_KEY] = {"version": 1}
+            elif transition == "future":
+                metadata[CONSOLE_GENERATION_SETTINGS_METADATA_KEY] = {
+                    "version": 2,
+                    "future": True,
+                }
+            elif transition == "owned-removed":
+                metadata.pop(CONSOLE_GENERATION_SETTINGS_METADATA_KEY)
+            else:
+                metadata.update(_metadata(external))
+            original_update(
+                conversation_id_arg,
+                {"metadata": json.dumps(metadata, sort_keys=True)},
+                expected_version=current["version"],
+            )
+        return original_update(conversation_id_arg, update_data, expected_version)
+
+    monkeypatch.setattr(db, "update_conversation", race)
+
+    result = service.update_conversation_generation_settings(
+        conversation_id=conversation_id,
+        snapshot=_snapshot(temperature=1.0),
+        expected_snapshot=baseline,
+    )
+
+    assert result.status is expected_status
+    assert attempt_number == 2
+    if expected_snapshot_kind == "external":
+        assert result.snapshot == external
+    else:
+        assert result.snapshot is None
+
+
+def test_persistence_returns_missing_and_propagates_final_sibling_conflict(
+    persistence, monkeypatch
+) -> None:
+    service, db = persistence
+    missing = service.update_conversation_generation_settings(
+        conversation_id="missing",
+        snapshot=_snapshot(),
+        expected_snapshot=None,
+    )
+    assert missing.status is ConsoleGenerationSettingsWriteStatus.MISSING
+
+    baseline = _snapshot()
+    conversation_id = service.create_conversation(
+        conversation_title="Saved",
+        metadata=_metadata(baseline),
+    )
+    original_update = db.update_conversation
+    race_number = 0
+
+    def always_race(conversation_id_arg, update_data, expected_version):
+        nonlocal race_number
+        current = db.get_conversation_by_id(conversation_id_arg)
+        metadata = json.loads(current["metadata"])
+        race_number += 1
+        metadata[f"sibling_{race_number}"] = True
+        original_update(
+            conversation_id_arg,
+            {"metadata": json.dumps(metadata, sort_keys=True)},
+            expected_version=current["version"],
+        )
+        return original_update(conversation_id_arg, update_data, expected_version)
+
+    monkeypatch.setattr(db, "update_conversation", always_race)
+
+    with pytest.raises(ConflictError):
+        service.update_conversation_generation_settings(
+            conversation_id=conversation_id,
+            snapshot=_snapshot(temperature=1.0),
+            expected_snapshot=baseline,
+        )
+    assert race_number == 2

--- a/Tests/Chat/test_console_settings_apply.py
+++ b/Tests/Chat/test_console_settings_apply.py
@@ -1,0 +1,802 @@
+from dataclasses import FrozenInstanceError, replace
+import inspect
+
+import pytest
+
+import tldw_chatbook.Chat.console_settings_apply as settings_apply
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_context_policy import ConsoleContextPolicyOverrides
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.console_settings_apply import (
+    FULL_MODEL_DEFAULT_FIELDS,
+    QUICK_MODEL_DEFAULT_FIELDS,
+    ConsoleEndpointDraft,
+    ConsoleSettingsAction,
+    ConsoleSettingsCommittedSubmission,
+    ConsoleSettingsDraftState,
+    ConsoleSettingsFieldDraft,
+    ConsoleSettingsFieldProvenance,
+    ConsoleSettingsLiveCommit,
+    ConsoleSettingsOrigin,
+    ConsoleSettingsSurface,
+    ConsoleSettingsSubmission,
+    ConsoleSettingsTransfer,
+    remember_model_draft,
+    validate_console_settings_origin,
+)
+
+
+_COMMON_MODEL_FIELDS = frozenset(
+    {
+        "temperature",
+        "top_p",
+        "min_p",
+        "top_k",
+        "max_tokens",
+        "seed",
+        "presence_penalty",
+        "frequency_penalty",
+        "streaming",
+    }
+)
+_ANTHROPIC_MODEL_FIELDS = _COMMON_MODEL_FIELDS | frozenset(
+    {"thinking_effort", "thinking_budget_tokens"}
+)
+
+
+def _field(
+    name: str,
+    value: object | None,
+    *,
+    profile_override: object | None = None,
+    provenance: ConsoleSettingsFieldProvenance = (
+        ConsoleSettingsFieldProvenance.INHERITED
+    ),
+    dirty: bool = False,
+) -> ConsoleSettingsFieldDraft:
+    return ConsoleSettingsFieldDraft(
+        name=name,
+        effective_value=value,
+        profile_override=profile_override,
+        provenance=provenance,
+        dirty=dirty,
+    )
+
+
+def _state(
+    settings: ConsoleSessionSettings,
+    *field_drafts: ConsoleSettingsFieldDraft,
+    endpoint_draft: ConsoleEndpointDraft | None = None,
+) -> ConsoleSettingsDraftState:
+    return ConsoleSettingsDraftState(
+        settings=settings,
+        context_policy_overrides=ConsoleContextPolicyOverrides(),
+        field_drafts=tuple(field_drafts),
+        model_drafts=(),
+        endpoint_draft=endpoint_draft,
+    )
+
+
+def _rebase(
+    state: ConsoleSettingsDraftState,
+    *,
+    provider: str,
+    model: str | None,
+    app_config: dict[str, object],
+    exposed_fields: frozenset[str] = FULL_MODEL_DEFAULT_FIELDS,
+) -> ConsoleSettingsDraftState:
+    return ConsoleChatController.rebase_console_settings_draft(
+        object(),
+        state,
+        provider=provider,
+        model=model,
+        app_config=app_config,
+        exposed_fields=exposed_fields,
+    )
+
+
+def test_origin_stores_the_exact_open_session_identity_and_is_immutable() -> None:
+    origin = ConsoleSettingsOrigin(
+        session_id="session-opened",
+        persisted_conversation_id="conversation-opened",
+        conversation_binding_revision=7,
+    )
+
+    assert origin.session_id == "session-opened"
+    assert origin.persisted_conversation_id == "conversation-opened"
+    assert origin.conversation_binding_revision == 7
+    assert not hasattr(origin, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        origin.session_id = "another-session"
+
+
+@pytest.mark.parametrize(
+    (
+        "origin_conversation_id",
+        "origin_revision",
+        "live_session_id",
+        "live_conversation_id",
+        "live_revision",
+        "expected",
+    ),
+    (
+        ("conversation-a", 3, "session-a", "conversation-a", 3, True),
+        (None, 3, "session-a", None, 3, True),
+        (None, 3, "session-a", "conversation-first", 3, True),
+        ("conversation-a", 3, "session-a", "conversation-b", 3, False),
+        (None, 3, "session-a", "conversation-rebound", 4, False),
+        ("conversation-a", 3, None, None, 3, False),
+        ("conversation-a", 3, "session-b", "conversation-a", 3, False),
+    ),
+)
+def test_origin_validation_rejects_closed_or_rebound_sessions(
+    origin_conversation_id: str | None,
+    origin_revision: int,
+    live_session_id: str | None,
+    live_conversation_id: str | None,
+    live_revision: int,
+    expected: bool,
+) -> None:
+    origin = ConsoleSettingsOrigin(
+        session_id="session-a",
+        persisted_conversation_id=origin_conversation_id,
+        conversation_binding_revision=origin_revision,
+    )
+
+    assert (
+        validate_console_settings_origin(
+            origin,
+            live_session_id=live_session_id,
+            live_persisted_conversation_id=live_conversation_id,
+            live_conversation_binding_revision=live_revision,
+        )
+        is expected
+    )
+
+
+def test_default_profile_masks_are_exact_and_exclude_other_owners() -> None:
+    assert QUICK_MODEL_DEFAULT_FIELDS == frozenset({"temperature", "streaming"})
+    assert FULL_MODEL_DEFAULT_FIELDS == frozenset(
+        {
+            "temperature",
+            "top_p",
+            "min_p",
+            "top_k",
+            "max_tokens",
+            "seed",
+            "presence_penalty",
+            "frequency_penalty",
+            "reasoning_effort",
+            "reasoning_summary",
+            "verbosity",
+            "thinking_effort",
+            "thinking_budget_tokens",
+            "streaming",
+        }
+    )
+    assert {
+        "compaction_mode",
+        "system_prompt",
+        "base_url",
+    }.isdisjoint(QUICK_MODEL_DEFAULT_FIELDS | FULL_MODEL_DEFAULT_FIELDS)
+
+
+def test_default_profile_field_draft_separates_effective_and_override_values() -> None:
+    inherited = _field(
+        "temperature",
+        0.42,
+        profile_override=None,
+        provenance=ConsoleSettingsFieldProvenance.INHERITED,
+    )
+
+    assert inherited.effective_value == 0.42
+    assert inherited.profile_override is None
+    assert not hasattr(inherited, "__dict__")
+    with pytest.raises(FrozenInstanceError):
+        inherited.dirty = True
+
+
+def test_contract_value_objects_are_frozen_slotted_and_transfer_is_not_submission() -> (
+    None
+):
+    origin = ConsoleSettingsOrigin("session-a", None, 0)
+    draft = _state(ConsoleSessionSettings(provider="openai", model="gpt-test"))
+    submission = ConsoleSettingsSubmission(
+        submission_id="submission-a",
+        action=ConsoleSettingsAction.APPLY_TO_CHAT,
+        surface=ConsoleSettingsSurface.FULL_SETTINGS,
+        origin=origin,
+        draft=draft,
+        user_display_name_override=None,
+        default_field_mask=frozenset(),
+    )
+    live_commit = ConsoleSettingsLiveCommit(
+        submission_id="submission-a",
+        session_id="session-a",
+        persisted_conversation_id=None,
+        conversation_binding_revision=0,
+        generation_revision=1,
+        context_policy_revision=1,
+        settings=draft.settings,
+        context_policy_overrides=draft.context_policy_overrides,
+    )
+    committed = ConsoleSettingsCommittedSubmission(submission, live_commit)
+    transfer = ConsoleSettingsTransfer(origin, draft)
+
+    assert committed.submission is submission
+    assert committed.live_commit is live_commit
+    assert not isinstance(transfer, ConsoleSettingsSubmission)
+    assert not hasattr(submission, "__dict__")
+    assert not hasattr(live_commit, "__dict__")
+    assert not hasattr(committed, "__dict__")
+    assert not hasattr(transfer, "__dict__")
+    assert "textual" not in inspect.getsource(settings_apply).lower()
+
+
+def test_submission_copies_a_mutable_default_field_mask() -> None:
+    mutable_mask = {"temperature"}
+    draft = _state(ConsoleSessionSettings(provider="openai", model="gpt-test"))
+    submission = ConsoleSettingsSubmission(
+        submission_id="submission-a",
+        action=ConsoleSettingsAction.SAVE_MODEL_DEFAULT,
+        surface=ConsoleSettingsSurface.FULL_SETTINGS,
+        origin=ConsoleSettingsOrigin("session-a", None, 0),
+        draft=draft,
+        user_display_name_override=None,
+        default_field_mask=mutable_mask,
+    )
+
+    mutable_mask.add("streaming")
+
+    assert submission.default_field_mask == frozenset({"temperature"})
+    assert isinstance(submission.default_field_mask, frozenset)
+    with pytest.raises(TypeError, match="surface must be ConsoleSettingsSurface"):
+        replace(submission, surface="quick_popover")
+
+
+def test_rebase_uses_target_defaults_keeps_supported_dirty_fields_and_clears_others() -> (
+    None
+):
+    source = _state(
+        ConsoleSessionSettings(
+            provider="openai",
+            model="gpt-source",
+            base_url="https://source.example.test/v1",
+            temperature=0.21,
+            top_p=0.31,
+            reasoning_summary="detailed",
+            thinking_effort="high",
+            character_label="Keep me",
+            system_prompt="Keep this prompt",
+            pinned_prefill="Keep this prefill",
+        ),
+        _field(
+            "temperature",
+            0.21,
+            profile_override=0.21,
+            provenance=ConsoleSettingsFieldProvenance.EXPLICIT,
+            dirty=True,
+        ),
+        _field("top_p", 0.31),
+        _field(
+            "reasoning_summary",
+            "detailed",
+            profile_override="detailed",
+            provenance=ConsoleSettingsFieldProvenance.EXPLICIT,
+            dirty=True,
+        ),
+        _field(
+            "thinking_effort",
+            "high",
+            profile_override="high",
+            provenance=ConsoleSettingsFieldProvenance.EXPLICIT,
+            dirty=True,
+        ),
+        endpoint_draft=ConsoleEndpointDraft(
+            value="https://source.example.test/v1",
+            bound_provider_config_key="openai",
+            dirty=True,
+            checked=True,
+        ),
+    )
+    app_config = {
+        "chat_defaults": {"temperature": 0.55, "top_p": 0.65},
+        "api_settings": {
+            "anthropic": {
+                "api_url": "https://target.example.test/v1",
+                "model_defaults": {
+                    "claude-target": {
+                        "top_p": 0.81,
+                        "thinking_effort": "low",
+                    }
+                },
+            }
+        },
+    }
+
+    rebased = _rebase(
+        source,
+        provider="Anthropic",
+        model="claude-target",
+        app_config=app_config,
+    )
+    fields = {field.name: field for field in rebased.field_drafts}
+
+    assert rebased.settings.provider == "anthropic"
+    assert rebased.settings.model == "claude-target"
+    assert rebased.settings.base_url == "https://target.example.test/v1"
+    assert rebased.settings.temperature == 0.21
+    assert rebased.settings.top_p == 0.81
+    assert rebased.settings.reasoning_summary is None
+    assert rebased.settings.thinking_effort == "high"
+    assert rebased.settings.character_label == "Keep me"
+    assert rebased.settings.system_prompt == "Keep this prompt"
+    assert rebased.settings.pinned_prefill == "Keep this prefill"
+    assert frozenset(fields) == _ANTHROPIC_MODEL_FIELDS
+    assert fields["temperature"].effective_value == 0.21
+    assert fields["temperature"].provenance is (ConsoleSettingsFieldProvenance.CARRIED)
+    assert fields["temperature"].dirty is True
+    assert fields["top_p"].effective_value == 0.81
+    assert fields["top_p"].profile_override == 0.81
+    assert fields["top_p"].dirty is False
+    assert fields["thinking_effort"].effective_value == "high"
+    assert fields["thinking_effort"].dirty is True
+    assert "reasoning_summary" not in fields
+    assert rebased.endpoint_draft == ConsoleEndpointDraft(
+        value="https://target.example.test/v1",
+        bound_provider_config_key="anthropic",
+        dirty=False,
+        checked=False,
+    )
+
+
+def test_rebase_quick_materializes_inherited_profile_values() -> None:
+    source = _state(
+        ConsoleSessionSettings(provider="openai", model="source"),
+        _field("temperature", 0.7),
+        _field("streaming", True),
+    )
+
+    rebased = _rebase(
+        source,
+        provider="openai",
+        model="target",
+        app_config={"chat_defaults": {"temperature": 0.44, "streaming": False}},
+        exposed_fields=QUICK_MODEL_DEFAULT_FIELDS,
+    )
+    fields = {field.name: field for field in rebased.field_drafts}
+
+    assert frozenset(fields) == QUICK_MODEL_DEFAULT_FIELDS
+    assert fields["temperature"].effective_value == 0.44
+    assert fields["temperature"].profile_override == 0.44
+    assert fields["temperature"].provenance is (
+        ConsoleSettingsFieldProvenance.INHERITED
+    )
+    assert fields["streaming"].effective_value is False
+    assert fields["streaming"].profile_override is False
+
+
+def test_rebase_quick_materializes_dirty_profile_values_and_rejects_none() -> None:
+    source = _state(
+        ConsoleSessionSettings(provider="openai", model="target", temperature=0.7),
+        _field("temperature", 0.7, dirty=True),
+        _field("streaming", None, dirty=True),
+    )
+
+    rebased = _rebase(
+        source,
+        provider="openai",
+        model="target",
+        app_config={"chat_defaults": {"temperature": 0.44, "streaming": False}},
+        exposed_fields=QUICK_MODEL_DEFAULT_FIELDS,
+    )
+    fields = {field.name: field for field in rebased.field_drafts}
+
+    assert fields["temperature"].effective_value == 0.7
+    assert fields["temperature"].profile_override == 0.7
+    assert fields["temperature"].dirty is True
+    assert fields["streaming"].effective_value is False
+    assert fields["streaming"].profile_override is False
+    assert fields["streaming"].dirty is False
+
+
+def test_rebase_full_keeps_inherited_profile_controls_blank() -> None:
+    source = _state(
+        ConsoleSessionSettings(provider="openai", model="source"),
+        *(_field(name, None) for name in FULL_MODEL_DEFAULT_FIELDS),
+    )
+
+    rebased = _rebase(
+        source,
+        provider="openai",
+        model="target",
+        app_config={"chat_defaults": {"temperature": 0.44, "streaming": False}},
+    )
+    fields = {field.name: field for field in rebased.field_drafts}
+
+    assert fields["temperature"].effective_value == 0.44
+    assert fields["temperature"].profile_override is None
+    assert fields["streaming"].effective_value is False
+    assert fields["streaming"].profile_override is None
+
+
+def test_rebase_full_inherit_uses_unseen_target_default_instead_of_cached_value() -> (
+    None
+):
+    source = _state(
+        ConsoleSessionSettings(provider="openai", model="model-a", top_p=0.21),
+        _field(
+            "top_p",
+            0.21,
+            profile_override=None,
+            provenance=ConsoleSettingsFieldProvenance.INHERITED,
+            dirty=True,
+        ),
+    )
+
+    rebased = _rebase(
+        source,
+        provider="anthropic",
+        model="model-b",
+        app_config={"console": {"provider_defaults": {"anthropic": {"top_p": 0.83}}}},
+    )
+    field = {draft.name: draft for draft in rebased.field_drafts}["top_p"]
+
+    assert rebased.settings.top_p == 0.83
+    assert field.effective_value == 0.83
+    assert field.profile_override is None
+    assert field.provenance is ConsoleSettingsFieldProvenance.CARRIED
+    assert field.dirty is True
+
+
+def test_rebase_full_inherit_same_target_uses_refreshed_lower_precedence_default() -> (
+    None
+):
+    source = _state(
+        ConsoleSessionSettings(provider="openai", model="model-a", temperature=0.21),
+        _field(
+            "temperature",
+            0.21,
+            profile_override=None,
+            provenance=ConsoleSettingsFieldProvenance.INHERITED,
+            dirty=True,
+        ),
+    )
+    refreshed_config = {
+        "chat_defaults": {"temperature": 0.51},
+        "console": {"provider_defaults": {"openai": {"temperature": 0.83}}},
+        "api_settings": {
+            "openai": {
+                "temperature": 0.41,
+                "model_defaults": {"model-a": {"temperature": 0.31}},
+            }
+        },
+    }
+
+    rebased = _rebase(
+        source,
+        provider="openai",
+        model="model-a",
+        app_config=refreshed_config,
+    )
+    field = {draft.name: draft for draft in rebased.field_drafts}["temperature"]
+
+    assert rebased.settings.temperature == 0.83
+    assert field.effective_value == 0.83
+    assert field.profile_override is None
+    assert field.provenance is ConsoleSettingsFieldProvenance.INHERITED
+    assert field.dirty is True
+
+
+@pytest.mark.parametrize(
+    (
+        "field_name",
+        "profile_value",
+        "fallback_value",
+        "expected_effective",
+        "expected_override",
+        "expected_provenance",
+    ),
+    (
+        (
+            "temperature",
+            "",
+            0.44,
+            0.44,
+            None,
+            ConsoleSettingsFieldProvenance.INHERITED,
+        ),
+        (
+            "reasoning_effort",
+            None,
+            "low",
+            "low",
+            None,
+            ConsoleSettingsFieldProvenance.INHERITED,
+        ),
+        (
+            "streaming",
+            False,
+            True,
+            False,
+            False,
+            ConsoleSettingsFieldProvenance.EXPLICIT,
+        ),
+        (
+            "top_k",
+            "0",
+            7,
+            0,
+            0,
+            ConsoleSettingsFieldProvenance.EXPLICIT,
+        ),
+        (
+            "temperature",
+            "0",
+            0.44,
+            0.0,
+            0.0,
+            ConsoleSettingsFieldProvenance.EXPLICIT,
+        ),
+    ),
+)
+def test_rebase_normalizes_exact_profile_overrides(
+    field_name: str,
+    profile_value: object,
+    fallback_value: object,
+    expected_effective: object,
+    expected_override: object,
+    expected_provenance: ConsoleSettingsFieldProvenance,
+) -> None:
+    source = _state(
+        ConsoleSessionSettings(provider="openai", model="source-model"),
+    )
+    app_config = {
+        "chat_defaults": {field_name: fallback_value},
+        "api_settings": {
+            "openai": {"model_defaults": {"target-model": {field_name: profile_value}}}
+        },
+    }
+
+    rebased = _rebase(
+        source,
+        provider="openai",
+        model="target-model",
+        app_config=app_config,
+    )
+    field = {draft.name: draft for draft in rebased.field_drafts}[field_name]
+
+    assert field.effective_value == expected_effective
+    assert field.profile_override == expected_override
+    assert field.provenance is expected_provenance
+
+
+@pytest.mark.parametrize(
+    ("provider", "target_model", "field_name", "supported"),
+    (
+        ("moonshot", "kimi-k2.5", "reasoning_effort", True),
+        ("moonshot", "moonshot-v1-8k", "reasoning_effort", False),
+        ("zai", "glm-5.2", "reasoning_effort", True),
+        ("zai", "glm-4", "reasoning_effort", False),
+        ("vllm", "local-model", "reasoning_effort", True),
+        ("vllm", "local-model", "thinking_budget_tokens", False),
+        ("llama_cpp", "local-model", "reasoning_effort", True),
+        ("llama_cpp", "local-model", "thinking_budget_tokens", True),
+        ("local_mlx_lm", "local-model", "reasoning_effort", True),
+        ("local_mlx_lm", "local-model", "thinking_budget_tokens", False),
+        ("aphrodite", "local-model", "reasoning_effort", False),
+        ("anthropic", "claude-sonnet-4-5", "thinking_budget_tokens", True),
+        ("anthropic", "claude-opus-5", "thinking_budget_tokens", False),
+        ("anthropic", "claude-opus-5", "thinking_effort", True),
+        ("qwencloud", "qwen3.8-max", "reasoning_effort", True),
+    ),
+)
+def test_rebase_uses_model_and_local_wire_capabilities(
+    provider: str,
+    target_model: str,
+    field_name: str,
+    supported: bool,
+) -> None:
+    value = 2048 if field_name.endswith("tokens") else "high"
+    source = _state(
+        replace(
+            ConsoleSessionSettings(provider=provider, model="source-model"),
+            **{field_name: value},
+        ),
+        _field(
+            field_name,
+            value,
+            profile_override=value,
+            provenance=ConsoleSettingsFieldProvenance.EXPLICIT,
+            dirty=True,
+        ),
+    )
+
+    rebased = _rebase(
+        source,
+        provider=provider,
+        model=target_model,
+        app_config={},
+    )
+    field_names = {field.name for field in rebased.field_drafts}
+
+    assert (field_name in field_names) is supported
+    assert (getattr(rebased.settings, field_name) == value) is supported
+
+
+def test_rebase_quick_ignores_even_provider_bound_dirty_endpoint() -> None:
+    source = _state(
+        ConsoleSessionSettings(
+            provider="openai",
+            model="target",
+            base_url="https://draft.example.test/v1",
+        ),
+        _field("temperature", 0.7),
+        _field("streaming", True),
+        endpoint_draft=ConsoleEndpointDraft(
+            value="https://draft.example.test/v1",
+            bound_provider_config_key="openai",
+            dirty=True,
+            checked=True,
+        ),
+    )
+
+    rebased = _rebase(
+        source,
+        provider="openai",
+        model="target",
+        app_config={
+            "api_settings": {
+                "openai": {"api_url": "https://configured.example.test/v1"}
+            }
+        },
+        exposed_fields=QUICK_MODEL_DEFAULT_FIELDS,
+    )
+
+    assert rebased.settings.base_url == "https://configured.example.test/v1"
+    assert rebased.endpoint_draft == ConsoleEndpointDraft(
+        value="https://configured.example.test/v1",
+        bound_provider_config_key="openai",
+        dirty=False,
+        checked=False,
+    )
+
+
+def test_rebase_keyed_a_b_a_drafts_restore_deliberate_a_edits() -> None:
+    state_a = _state(
+        ConsoleSessionSettings(
+            provider="openai",
+            model="vendor/model:a",
+            base_url="https://a-edited.example.test/v1",
+            temperature=0.13,
+        ),
+        _field(
+            "temperature",
+            0.13,
+            profile_override=0.13,
+            provenance=ConsoleSettingsFieldProvenance.EXPLICIT,
+            dirty=True,
+        ),
+        _field("streaming", True),
+        endpoint_draft=ConsoleEndpointDraft(
+            value="https://a-edited.example.test/v1",
+            bound_provider_config_key="openai",
+            dirty=True,
+            checked=True,
+        ),
+    )
+    remembered_a = remember_model_draft(state_a)
+    state_b = _rebase(
+        remembered_a,
+        provider="anthropic",
+        model="claude:b",
+        app_config={
+            "api_settings": {"anthropic": {"api_url": "https://b.example.test/v1"}}
+        },
+        exposed_fields=FULL_MODEL_DEFAULT_FIELDS,
+    )
+    remembered_b = remember_model_draft(
+        replace(
+            state_b,
+            settings=replace(state_b.settings, temperature=0.27),
+            field_drafts=tuple(
+                replace(
+                    field,
+                    effective_value=0.27,
+                    profile_override=0.27,
+                    provenance=ConsoleSettingsFieldProvenance.EXPLICIT,
+                    dirty=True,
+                )
+                if field.name == "temperature"
+                else field
+                for field in state_b.field_drafts
+            ),
+        )
+    )
+
+    restored_a = _rebase(
+        remembered_b,
+        provider="openai",
+        model="vendor/model:a",
+        app_config={
+            "api_settings": {"openai": {"api_url": "https://a.example.test/v1"}}
+        },
+        exposed_fields=FULL_MODEL_DEFAULT_FIELDS,
+    )
+    restored_fields = {field.name: field for field in restored_a.field_drafts}
+
+    assert [(draft.provider, draft.model) for draft in restored_a.model_drafts] == [
+        ("openai", "vendor/model:a"),
+        ("anthropic", "claude:b"),
+    ]
+    assert restored_a.settings.temperature == 0.13
+    assert restored_fields["temperature"].dirty is True
+    assert restored_fields["temperature"].provenance is (
+        ConsoleSettingsFieldProvenance.EXPLICIT
+    )
+    assert restored_a.settings.base_url == "https://a-edited.example.test/v1"
+    assert restored_a.endpoint_draft == ConsoleEndpointDraft(
+        value="https://a-edited.example.test/v1",
+        bound_provider_config_key="openai",
+        dirty=True,
+        checked=True,
+    )
+
+
+def test_rebase_exact_key_restores_provenance_exactly_as_remembered() -> None:
+    remembered_a = remember_model_draft(
+        _state(
+            ConsoleSessionSettings(provider="openai", model="model-a"),
+            _field(
+                "temperature",
+                0.11,
+                profile_override=0.11,
+                provenance=ConsoleSettingsFieldProvenance.EXPLICIT,
+                dirty=True,
+            ),
+            _field(
+                "top_p",
+                0.22,
+                provenance=ConsoleSettingsFieldProvenance.INHERITED,
+                dirty=True,
+            ),
+            _field(
+                "streaming",
+                False,
+                profile_override=False,
+                provenance=ConsoleSettingsFieldProvenance.CARRIED,
+                dirty=True,
+            ),
+        )
+    )
+    state_b = _rebase(
+        remembered_a,
+        provider="anthropic",
+        model="model-b",
+        app_config={},
+    )
+
+    restored_a = _rebase(
+        state_b,
+        provider="openai",
+        model="model-a",
+        app_config={},
+    )
+    restored_provenance = {
+        field.name: field.provenance for field in restored_a.field_drafts
+    }
+
+    assert restored_provenance == {
+        "temperature": ConsoleSettingsFieldProvenance.EXPLICIT,
+        "top_p": ConsoleSettingsFieldProvenance.INHERITED,
+        "streaming": ConsoleSettingsFieldProvenance.CARRIED,
+        "min_p": ConsoleSettingsFieldProvenance.INHERITED,
+        "top_k": ConsoleSettingsFieldProvenance.INHERITED,
+        "max_tokens": ConsoleSettingsFieldProvenance.INHERITED,
+        "seed": ConsoleSettingsFieldProvenance.INHERITED,
+        "presence_penalty": ConsoleSettingsFieldProvenance.INHERITED,
+        "frequency_penalty": ConsoleSettingsFieldProvenance.INHERITED,
+        "reasoning_effort": ConsoleSettingsFieldProvenance.INHERITED,
+        "reasoning_summary": ConsoleSettingsFieldProvenance.INHERITED,
+        "verbosity": ConsoleSettingsFieldProvenance.INHERITED,
+    }

--- a/Tests/Chat/test_console_settings_apply_store.py
+++ b/Tests/Chat/test_console_settings_apply_store.py
@@ -1,0 +1,1193 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import replace
+
+import pytest
+
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+from tldw_chatbook.Chat.console_chat_store import (
+    ConsoleChatSession,
+    ConsoleChatStore,
+    ConsoleSettingsComponent,
+    ConsoleSettingsPolicyFailureLabel,
+    ConsoleSettingsPersistenceFailure,
+)
+from tldw_chatbook.Chat.console_context_policy import (
+    ConsoleContextPolicyOverrides,
+    ContextCompactionMode,
+)
+from tldw_chatbook.Chat.console_context_repository import (
+    ContextPolicyReadResult,
+    ContextPolicyWriteResult,
+    ContextPolicyWriteStatus,
+)
+from tldw_chatbook.Chat.console_generation_settings_metadata import (
+    ConsoleGenerationSettingsReadStatus,
+    ConsoleGenerationSettingsWriteResult,
+    ConsoleGenerationSettingsWriteStatus,
+    parse_console_generation_settings,
+    snapshot_from_session_settings,
+)
+from tldw_chatbook.Chat.console_library_policy import ConsoleLibraryPolicySnapshot
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.console_settings_apply import (
+    ConsoleSettingsAction,
+    ConsoleSettingsDraftState,
+    ConsoleSettingsSurface,
+    ConsoleSettingsSubmission,
+)
+from tldw_chatbook.Chat.console_speech_preferences import ConsoleSpeechPreferences
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+def _settings(model: str, *, system_prompt: str | None = None) -> ConsoleSessionSettings:
+    return ConsoleSessionSettings(
+        provider="openai",
+        model=model,
+        temperature=0.2 if model == "model-a" else 0.8,
+        system_prompt=system_prompt,
+    )
+
+
+def _submission(
+    store: ConsoleChatStore,
+    session_id: str,
+    *,
+    submission_id: str,
+    model: str,
+    compaction: ContextCompactionMode = ContextCompactionMode.ASK,
+    surface: ConsoleSettingsSurface = ConsoleSettingsSurface.FULL_SETTINGS,
+) -> ConsoleSettingsSubmission:
+    return ConsoleSettingsSubmission(
+        submission_id=submission_id,
+        action=ConsoleSettingsAction.APPLY_TO_CHAT,
+        surface=surface,
+        origin=store.capture_console_settings_origin(session_id),
+        draft=ConsoleSettingsDraftState(
+            settings=_settings(model, system_prompt="draft must not replace owner"),
+            context_policy_overrides=ConsoleContextPolicyOverrides(
+                compaction_mode=compaction
+            ),
+            field_drafts=(),
+            model_drafts=(),
+            endpoint_draft=None,
+        ),
+        user_display_name_override=None,
+        default_field_mask=frozenset(),
+    )
+
+
+class _SettingsPersistence:
+    def __init__(self) -> None:
+        self.db = None
+        self.generation_snapshot = None
+        self.context_policy = ConsoleContextPolicyOverrides()
+        self.context_revision = None
+        self.generation_calls = []
+        self.context_calls = []
+        self.created_conversations = []
+        self.promotion_kwargs = None
+        self.fail_generation = False
+        self.fail_context = False
+        self.roleplay_calls = []
+        self.pinned_prefill_calls = []
+
+    def update_conversation_generation_settings(self, **kwargs):
+        self.generation_calls.append(kwargs)
+        if self.fail_generation:
+            raise RuntimeError("generation unavailable")
+        if kwargs["expected_snapshot"] != self.generation_snapshot:
+            return ConsoleGenerationSettingsWriteResult(
+                ConsoleGenerationSettingsWriteStatus.SUPERSEDED,
+                self.generation_snapshot,
+            )
+        self.generation_snapshot = kwargs["snapshot"]
+        return ConsoleGenerationSettingsWriteResult(
+            ConsoleGenerationSettingsWriteStatus.WRITTEN,
+            self.generation_snapshot,
+        )
+
+    def update_conversation_context_policy(self, **kwargs):
+        self.context_calls.append(kwargs)
+        if self.fail_context:
+            raise RuntimeError("context unavailable")
+        expected = kwargs.get("expected_revision", self.context_revision)
+        if expected != self.context_revision:
+            return ContextPolicyWriteResult(
+                ContextPolicyWriteStatus.CONFLICT,
+                self.context_revision,
+            )
+        self.context_policy = kwargs["overrides"]
+        self.context_revision = (
+            None
+            if self.context_policy.is_empty
+            else 1 if self.context_revision is None else self.context_revision + 1
+        )
+        return ContextPolicyWriteResult(
+            ContextPolicyWriteStatus.WRITTEN,
+            self.context_revision,
+        )
+
+    def get_conversation_context_policy(self, _conversation_id):
+        return ContextPolicyReadResult(self.context_policy, self.context_revision)
+
+    def create_conversation(self, **kwargs):
+        self.created_conversations.append(kwargs)
+        return "created-conversation"
+
+    def promote_console_conversation_bundle(self, **kwargs):
+        self.promotion_kwargs = kwargs
+        candidate = kwargs["policy_candidate"]
+        return ConsoleLibraryPolicySnapshot(
+            auto_retrieve=candidate.auto_retrieve,
+            assistant_access=candidate.assistant_access,
+            policy_revision=1,
+            source="durable",
+        )
+
+    def update_conversation_roleplay_context(self, **kwargs):
+        self.roleplay_calls.append(kwargs)
+        return True
+
+    def update_conversation_pinned_prefill(self, **kwargs):
+        self.pinned_prefill_calls.append(kwargs)
+        return True
+
+
+class _AtomicSettingsPersistence(_SettingsPersistence):
+    def __init__(self) -> None:
+        super().__init__()
+        self.first_persist_kwargs = None
+
+    def persist_console_conversation_with_policy(self, **kwargs):
+        self.first_persist_kwargs = kwargs
+        self.created_conversations.append(dict(kwargs["conversation_kwargs"]))
+        candidate = kwargs["policy_candidate"]
+        return ConsoleLibraryPolicySnapshot(
+            auto_retrieve=candidate.auto_retrieve,
+            assistant_access=candidate.assistant_access,
+            policy_revision=1,
+            source="durable",
+        )
+
+
+def test_live_commit_updates_exact_origin_preserves_prompt_and_deduplicates() -> None:
+    store = ConsoleChatStore()
+    origin = store.create_session(settings=_settings("old", system_prompt="owned"))
+    other = store.create_session(settings=_settings("other"))
+    submission = _submission(
+        store,
+        origin.id,
+        submission_id="submission-1",
+        model="model-a",
+    )
+
+    commit = store.commit_console_settings_live(submission)
+
+    assert store.active_session_id == other.id
+    assert store.session_settings(origin.id).model == "model-a"
+    assert store.session_settings(origin.id).source == "user"
+    assert store.session_settings(origin.id).system_prompt == "owned"
+    assert store.session_settings(other.id).model == "other"
+    assert commit.generation_revision == 1
+    assert commit.context_policy_revision == 1
+    with pytest.raises(ValueError, match="already applied"):
+        store.commit_console_settings_live(submission)
+    assert origin.generation_settings_revision == 1
+    assert origin.context_policy_revision == 1
+
+
+def test_missing_or_rebound_origin_is_rejected_without_mutation() -> None:
+    store = ConsoleChatStore()
+    session = store.create_session(settings=_settings("old"))
+    missing = _submission(
+        store,
+        session.id,
+        submission_id="missing",
+        model="model-a",
+    )
+    store.close_session(session.id)
+
+    with pytest.raises(ValueError, match="closed"):
+        store.commit_console_settings_live(missing)
+
+    rebound = store.create_session(settings=_settings("old"))
+    stale = _submission(
+        store,
+        rebound.id,
+        submission_id="rebound",
+        model="model-b",
+    )
+    store.rebind_persisted_conversation(rebound.id, "different-conversation")
+    before = rebound.settings
+
+    with pytest.raises(ValueError, match="closed"):
+        store.commit_console_settings_live(stale)
+
+    assert rebound.settings is before
+    assert rebound.generation_settings_revision == 0
+    assert rebound.context_policy_revision == 0
+
+
+def test_first_persist_binding_preserves_revision_but_explicit_rebind_advances() -> None:
+    store = ConsoleChatStore()
+    session = store.create_session(settings=_settings("old"))
+    origin = store.capture_console_settings_origin(session.id)
+
+    store.publish_first_persisted_conversation(session.id, "conversation-a")
+
+    assert session.conversation_binding_revision == origin.conversation_binding_revision
+    accepted = replace(
+        _submission(
+            store,
+            session.id,
+            submission_id="first-bind",
+            model="model-a",
+        ),
+        origin=origin,
+    )
+    store.commit_console_settings_live(accepted)
+    store.rebind_persisted_conversation(session.id, "conversation-b")
+    assert session.conversation_binding_revision == origin.conversation_binding_revision + 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failed_component", list(ConsoleSettingsComponent))
+async def test_live_values_survive_component_failure_and_retry_is_exact(
+    failed_component: ConsoleSettingsComponent,
+) -> None:
+    persistence = _SettingsPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(settings=_settings("old", system_prompt="owned"))
+    store.publish_first_persisted_conversation(session.id, "conversation-a")
+    setattr(
+        persistence,
+        "fail_generation"
+        if failed_component is ConsoleSettingsComponent.GENERATION_SETTINGS
+        else "fail_context",
+        True,
+    )
+    commit = store.commit_console_settings_live(
+        _submission(
+            store,
+            session.id,
+            submission_id="failure",
+            model="model-b",
+            compaction=ContextCompactionMode.OFF,
+        )
+    )
+
+    await store.persist_console_settings_commit_serialized(commit)
+
+    assert session.settings.model == "model-b"
+    assert session.context_policy_overrides.compaction_mode is ContextCompactionMode.OFF
+    assert set(session.settings_persistence_failures) == {failed_component}
+    failure = session.settings_persistence_failures[failed_component]
+    assert failure.revision == (
+        session.generation_settings_revision
+        if failed_component is ConsoleSettingsComponent.GENERATION_SETTINGS
+        else session.context_policy_revision
+    )
+    assert not hasattr(failure, "base_url")
+    setattr(
+        persistence,
+        "fail_generation"
+        if failed_component is ConsoleSettingsComponent.GENERATION_SETTINGS
+        else "fail_context",
+        False,
+    )
+
+    assert await store.retry_console_settings_persistence(
+        session_id=session.id,
+        component=failed_component,
+        revision=failure.revision,
+    )
+    assert session.settings_persistence_failures == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "label",
+    (
+        ConsoleSettingsPolicyFailureLabel.COMPACTION,
+        ConsoleSettingsPolicyFailureLabel.CONTEXT_SETTINGS,
+    ),
+)
+async def test_context_failure_retains_explicit_surface_label_through_retry(
+    label: ConsoleSettingsPolicyFailureLabel,
+) -> None:
+    persistence = _SettingsPersistence()
+    persistence.fail_context = True
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(settings=_settings("old"))
+    store.publish_first_persisted_conversation(session.id, "conversation-a")
+    commit = store.commit_console_settings_live(
+        _submission(store, session.id, submission_id="label", model="model-a")
+    )
+
+    await store.persist_console_settings_commit_serialized(
+        commit,
+        policy_failure_label=label,
+    )
+    failure = session.settings_persistence_failures[
+        ConsoleSettingsComponent.CONTEXT_POLICY
+    ]
+    assert failure.policy_failure_label is label
+
+    assert not await store.retry_console_settings_persistence(
+        session_id=session.id,
+        component=ConsoleSettingsComponent.CONTEXT_POLICY,
+        revision=failure.revision,
+    )
+    retried = session.settings_persistence_failures[
+        ConsoleSettingsComponent.CONTEXT_POLICY
+    ]
+    assert retried.policy_failure_label is label
+
+
+@pytest.mark.asyncio
+async def test_newer_apply_supersedes_failure_and_stale_retry() -> None:
+    persistence = _SettingsPersistence()
+    persistence.fail_generation = True
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(settings=_settings("old"))
+    store.publish_first_persisted_conversation(session.id, "conversation-a")
+    first = store.commit_console_settings_live(
+        _submission(store, session.id, submission_id="first", model="model-a")
+    )
+    await store.persist_console_settings_commit_serialized(first)
+    failure = session.settings_persistence_failures[
+        ConsoleSettingsComponent.GENERATION_SETTINGS
+    ]
+
+    store.commit_console_settings_live(
+        _submission(store, session.id, submission_id="second", model="model-b")
+    )
+
+    assert ConsoleSettingsComponent.GENERATION_SETTINGS not in (
+        session.settings_persistence_failures
+    )
+    persistence.fail_generation = False
+    assert not await store.retry_console_settings_persistence(
+        session_id=session.id,
+        component=ConsoleSettingsComponent.GENERATION_SETTINGS,
+        revision=failure.revision,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rapid_applies_serialize_and_finish_with_newest_durable_values() -> None:
+    persistence = _SettingsPersistence()
+    started = threading.Event()
+    release = threading.Event()
+    original_write = persistence.update_conversation_generation_settings
+
+    def gated_write(**kwargs):
+        if not persistence.generation_calls:
+            started.set()
+            assert release.wait(timeout=5), "rapid Apply generation gate timed out"
+        return original_write(**kwargs)
+
+    persistence.update_conversation_generation_settings = gated_write
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(settings=_settings("old"))
+    store.publish_first_persisted_conversation(session.id, "conversation-a")
+    first = store.commit_console_settings_live(
+        _submission(store, session.id, submission_id="first", model="model-a")
+    )
+    first_task = asyncio.create_task(
+        store.persist_console_settings_commit_serialized(first)
+    )
+    try:
+        assert await asyncio.to_thread(started.wait, 5)
+        second = store.commit_console_settings_live(
+            _submission(
+                store,
+                session.id,
+                submission_id="second",
+                model="model-b",
+                compaction=ContextCompactionMode.OFF,
+            )
+        )
+        second_task = asyncio.create_task(
+            store.persist_console_settings_commit_serialized(second)
+        )
+    finally:
+        release.set()
+
+    await asyncio.gather(first_task, second_task)
+
+    assert [call["snapshot"].model for call in persistence.generation_calls] == [
+        "model-a",
+        "model-b",
+    ]
+    assert [
+        call["overrides"].compaction_mode for call in persistence.context_calls
+    ] == [ContextCompactionMode.OFF]
+    assert persistence.generation_snapshot.model == "model-b"
+    assert persistence.context_policy.compaction_mode is ContextCompactionMode.OFF
+    assert session.generation_durable_snapshot.model == "model-b"
+    assert session.context_policy_durable_revision == persistence.context_revision
+
+
+@pytest.mark.asyncio
+async def test_queued_applies_before_first_yield_drain_only_latest_values() -> None:
+    persistence = _SettingsPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(settings=_settings("old"))
+    store.publish_first_persisted_conversation(session.id, "conversation-a")
+
+    first = store.commit_console_settings_live(
+        _submission(store, session.id, submission_id="first", model="model-a")
+    )
+    first_waiter = asyncio.create_task(
+        store.persist_console_settings_commit_serialized(first)
+    )
+    second = store.commit_console_settings_live(
+        _submission(
+            store,
+            session.id,
+            submission_id="second",
+            model="model-b",
+            compaction=ContextCompactionMode.OFF,
+        )
+    )
+    second_waiter = asyncio.create_task(
+        store.persist_console_settings_commit_serialized(second)
+    )
+
+    first_outcome, second_outcome = await asyncio.gather(
+        first_waiter,
+        second_waiter,
+    )
+
+    assert [call["snapshot"].model for call in persistence.generation_calls] == [
+        "model-b"
+    ]
+    assert [
+        call["overrides"].compaction_mode for call in persistence.context_calls
+    ] == [ContextCompactionMode.OFF]
+    assert persistence.generation_snapshot.model == "model-b"
+    assert persistence.context_policy.compaction_mode is ContextCompactionMode.OFF
+    assert session.generation_durable_snapshot.model == "model-b"
+    assert session.context_policy_durable_revision == persistence.context_revision
+    assert first_outcome == second_outcome
+    assert first_outcome.written_components == frozenset(ConsoleSettingsComponent)
+    assert first_outcome.failed_components == frozenset()
+    assert first_outcome.stale_components == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_inflight_apply_drains_to_latest_without_scheduling_newer_commits() -> None:
+    persistence = _SettingsPersistence()
+    first_started = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    release_second = threading.Event()
+    original_write = persistence.update_conversation_generation_settings
+
+    def gated_write(**kwargs):
+        model = kwargs["snapshot"].model
+        if model == "model-a":
+            first_started.set()
+            assert release_first.wait(timeout=5), "first generation gate timed out"
+        elif model == "model-b":
+            second_started.set()
+            assert release_second.wait(timeout=5), "second generation gate timed out"
+        return original_write(**kwargs)
+
+    persistence.update_conversation_generation_settings = gated_write
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(settings=_settings("old"))
+    store.publish_first_persisted_conversation(session.id, "conversation-a")
+    first = store.commit_console_settings_live(
+        _submission(store, session.id, submission_id="first", model="model-a")
+    )
+    drain = asyncio.create_task(store.persist_console_settings_commit_serialized(first))
+    try:
+        assert await asyncio.to_thread(first_started.wait, 5)
+
+        store.commit_console_settings_live(
+            _submission(
+                store,
+                session.id,
+                submission_id="second",
+                model="model-b",
+                compaction=ContextCompactionMode.OFF,
+            )
+        )
+        release_first.set()
+        assert await asyncio.to_thread(second_started.wait, 5)
+        assert persistence.generation_snapshot.model == "model-a"
+        assert session.generation_durable_snapshot is None
+
+        store.commit_console_settings_live(
+            _submission(
+                store,
+                session.id,
+                submission_id="third",
+                model="model-c",
+                compaction=ContextCompactionMode.AUTOMATIC,
+            )
+        )
+    finally:
+        release_first.set()
+        release_second.set()
+    outcome = await drain
+
+    assert [call["snapshot"].model for call in persistence.generation_calls] == [
+        "model-a",
+        "model-b",
+        "model-c",
+    ]
+    assert [
+        call["overrides"].compaction_mode for call in persistence.context_calls
+    ] == [ContextCompactionMode.AUTOMATIC]
+    assert persistence.generation_snapshot.model == "model-c"
+    assert persistence.context_policy.compaction_mode is ContextCompactionMode.AUTOMATIC
+    assert session.generation_durable_snapshot.model == "model-c"
+    assert session.context_policy_durable_revision == persistence.context_revision
+    assert outcome.written_components == frozenset(ConsoleSettingsComponent)
+    assert outcome.failed_components == frozenset()
+    assert outcome.stale_components == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_outside_policy_write_during_generation_avoids_duplicate_failure() -> None:
+    persistence = _SettingsPersistence()
+    generation_started = threading.Event()
+    release_generation = threading.Event()
+    original_write = persistence.update_conversation_generation_settings
+
+    def gated_write(**kwargs):
+        generation_started.set()
+        assert release_generation.wait(timeout=5), "outside-policy gate timed out"
+        return original_write(**kwargs)
+
+    persistence.update_conversation_generation_settings = gated_write
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(settings=_settings("old"))
+    store.publish_first_persisted_conversation(session.id, "conversation-a")
+    commit = store.commit_console_settings_live(
+        _submission(
+            store,
+            session.id,
+            submission_id="modal-apply",
+            model="model-a",
+            compaction=ContextCompactionMode.OFF,
+        )
+    )
+    drain = asyncio.create_task(store.persist_console_settings_commit_serialized(commit))
+
+    outside_policy = ConsoleContextPolicyOverrides(
+        compaction_mode=ContextCompactionMode.AUTOMATIC
+    )
+    try:
+        assert await asyncio.to_thread(generation_started.wait, 5)
+        _, outside_written = store.set_session_context_policy_overrides(
+            session.id,
+            outside_policy,
+        )
+        assert outside_written
+    finally:
+        release_generation.set()
+    outcome = await drain
+
+    assert [call["overrides"] for call in persistence.context_calls] == [
+        outside_policy
+    ]
+    assert persistence.context_policy == outside_policy
+    assert session.context_policy_overrides == outside_policy
+    assert session.context_policy_durable_revision == persistence.context_revision
+    assert session.settings_persistence_failures == {}
+    assert outcome.failed_components == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_closed_drain_cannot_publish_into_same_id_restoration() -> None:
+    persistence = _SettingsPersistence()
+    old_started = threading.Event()
+    release_old = threading.Event()
+    original_write = persistence.update_conversation_generation_settings
+
+    def gated_write(**kwargs):
+        old_started.set()
+        assert release_old.wait(timeout=5), "closed-drain gate timed out"
+        return original_write(**kwargs)
+
+    persistence.update_conversation_generation_settings = gated_write
+    store = ConsoleChatStore(persistence=persistence)
+    old_session = store.create_session(session_id="stable", settings=_settings("old"))
+    store.publish_first_persisted_conversation(old_session.id, "conversation-a")
+    old_commit = store.commit_console_settings_live(
+        _submission(
+            store,
+            old_session.id,
+            submission_id="old-apply",
+            model="model-a",
+            compaction=ContextCompactionMode.OFF,
+        )
+    )
+    old_drain = asyncio.create_task(
+        store.persist_console_settings_commit_serialized(old_commit)
+    )
+
+    try:
+        assert await asyncio.to_thread(old_started.wait, 5)
+        store.close_session(old_session.id)
+        store.restore_state(
+            sessions=[
+                ConsoleChatSession(
+                    id=old_session.id,
+                    persisted_conversation_id="conversation-a",
+                    settings=_settings("replacement"),
+                    generation_settings_revision=old_commit.generation_revision,
+                    context_policy_revision=old_commit.context_policy_revision,
+                    context_policy_overrides=ConsoleContextPolicyOverrides(
+                        compaction_mode=ContextCompactionMode.AUTOMATIC
+                    ),
+                )
+            ],
+            active_session_id=old_session.id,
+        )
+    finally:
+        release_old.set()
+    old_outcome = await old_drain
+    replacement = store.sessions()[0]
+
+    assert replacement.settings.model == "replacement"
+    assert replacement.generation_durable_snapshot is None
+    assert replacement.context_policy_durable_revision is None
+    assert replacement.settings_persistence_failures == {}
+    assert old_outcome.written_components == frozenset()
+    assert old_outcome.stale_components == frozenset(ConsoleSettingsComponent)
+
+
+@pytest.mark.asyncio
+async def test_replacement_apply_serializes_after_old_inflight_owned_write() -> None:
+    persistence = _SettingsPersistence()
+    old_started = threading.Event()
+    release_old = threading.Event()
+    replacement_started = threading.Event()
+    overlap_detected = threading.Event()
+    active_writers = 0
+    writer_guard = threading.Lock()
+    original_write = persistence.update_conversation_generation_settings
+
+    def gated_write(**kwargs):
+        nonlocal active_writers
+        with writer_guard:
+            if active_writers:
+                overlap_detected.set()
+            active_writers += 1
+        try:
+            if kwargs["snapshot"].model == "model-a":
+                old_started.set()
+                assert release_old.wait(timeout=5), "old lifecycle gate timed out"
+            else:
+                replacement_started.set()
+            return original_write(**kwargs)
+        finally:
+            with writer_guard:
+                active_writers -= 1
+
+    persistence.update_conversation_generation_settings = gated_write
+    store = ConsoleChatStore(persistence=persistence)
+    old_session = store.create_session(session_id="stable", settings=_settings("old"))
+    store.publish_first_persisted_conversation(old_session.id, "conversation-a")
+    old_commit = store.commit_console_settings_live(
+        _submission(store, old_session.id, submission_id="old", model="model-a")
+    )
+    old_drain = asyncio.create_task(
+        store.persist_console_settings_commit_serialized(old_commit)
+    )
+    replacement_drain = None
+
+    try:
+        assert await asyncio.to_thread(old_started.wait, 5)
+        store.close_session(old_session.id)
+        store.restore_state(
+            sessions=[
+                ConsoleChatSession(
+                    id=old_session.id,
+                    persisted_conversation_id="conversation-a",
+                    settings=_settings("replacement"),
+                )
+            ],
+            active_session_id=old_session.id,
+        )
+        replacement = store.sessions()[0]
+        replacement_commit = store.commit_console_settings_live(
+            _submission(
+                store,
+                replacement.id,
+                submission_id="replacement",
+                model="model-b",
+                compaction=ContextCompactionMode.OFF,
+            )
+        )
+        replacement_drain = asyncio.create_task(
+            store.persist_console_settings_commit_serialized(replacement_commit)
+        )
+        replacement_started_before_release = await asyncio.to_thread(
+            replacement_started.wait,
+            0.5,
+        )
+    finally:
+        release_old.set()
+    assert replacement_drain is not None
+    old_outcome, replacement_outcome = await asyncio.gather(
+        old_drain,
+        replacement_drain,
+    )
+
+    assert not replacement_started_before_release
+    assert not overlap_detected.is_set()
+    assert [call["snapshot"].model for call in persistence.generation_calls] == [
+        "model-a",
+        "model-b",
+    ]
+    assert persistence.generation_snapshot.model == "model-b"
+    assert replacement.settings.model == "model-b"
+    assert replacement.generation_durable_snapshot.model == "model-b"
+    assert replacement.settings_persistence_failures == {}
+    assert old_outcome.stale_components == frozenset(ConsoleSettingsComponent)
+    assert replacement_outcome.written_components == frozenset(
+        ConsoleSettingsComponent
+    )
+
+
+def test_restore_state_fences_same_session_id_and_resets_old_apply_state() -> None:
+    store = ConsoleChatStore()
+    session = store.create_session(session_id="stable", settings=_settings("old"))
+    stale = _submission(
+        store,
+        session.id,
+        submission_id="before-restore",
+        model="model-a",
+    )
+    safe_base = snapshot_from_session_settings(_settings("durable"))
+    session.applied_settings_submission_ids.append("old-activation")
+    session.settings_persistence_failures[
+        ConsoleSettingsComponent.GENERATION_SETTINGS
+    ] = ConsoleSettingsPersistenceFailure(
+        component=ConsoleSettingsComponent.GENERATION_SETTINGS,
+        revision=0,
+        persisted_conversation_id="conversation-a",
+        conversation_binding_revision=0,
+        generation_snapshot=safe_base,
+        policy_failure_label=None,
+    )
+    restored = ConsoleChatSession(
+        id=session.id,
+        persisted_conversation_id="conversation-a",
+        settings=_settings("restored"),
+        generation_durable_snapshot=safe_base,
+        context_policy_durable_revision=9,
+        settings_persistence_failures=session.settings_persistence_failures,
+        applied_settings_submission_ids=session.applied_settings_submission_ids,
+    )
+
+    store.restore_state(sessions=[restored], active_session_id=session.id)
+    replacement = store.sessions()[0]
+
+    assert replacement.conversation_binding_revision == 1
+    assert replacement.generation_durable_snapshot == safe_base
+    assert replacement.context_policy_durable_revision == 9
+    assert replacement.settings_persistence_failures == {}
+    assert tuple(replacement.applied_settings_submission_ids) == ()
+    with pytest.raises(ValueError, match="closed"):
+        store.commit_console_settings_live(stale)
+    assert replacement.settings.model == "restored"
+
+    first_restore_revision = replacement.conversation_binding_revision
+    store.restore_state(sessions=[restored], active_session_id=session.id)
+    assert (
+        store.sessions()[0].conversation_binding_revision
+        > first_restore_revision
+    )
+
+
+def test_preclose_origin_is_rejected_after_same_id_conversation_restore() -> None:
+    store = ConsoleChatStore()
+    session = store.create_session(session_id="stable", settings=_settings("old"))
+    store.publish_first_persisted_conversation(session.id, "conversation-a")
+    stale = _submission(
+        store,
+        session.id,
+        submission_id="before-close",
+        model="model-b",
+        compaction=ContextCompactionMode.OFF,
+    )
+
+    store.close_session(session.id)
+    store.restore_state(
+        sessions=[
+            ConsoleChatSession(
+                id=session.id,
+                persisted_conversation_id="conversation-a",
+                conversation_binding_revision=0,
+                settings=_settings("restored"),
+                context_policy_overrides=ConsoleContextPolicyOverrides(
+                    compaction_mode=ContextCompactionMode.AUTOMATIC
+                ),
+            )
+        ],
+        active_session_id=session.id,
+    )
+    replacement = store.sessions()[0]
+    settings_before = replacement.settings
+    policy_before = replacement.context_policy_overrides
+    generation_revision_before = replacement.generation_settings_revision
+    policy_revision_before = replacement.context_policy_revision
+
+    assert (
+        replacement.conversation_binding_revision
+        > stale.origin.conversation_binding_revision
+    )
+    with pytest.raises(ValueError, match="closed"):
+        store.commit_console_settings_live(stale)
+
+    assert replacement.settings is settings_before
+    assert replacement.context_policy_overrides is policy_before
+    assert replacement.generation_settings_revision == generation_revision_before
+    assert replacement.context_policy_revision == policy_revision_before
+
+
+def test_recreated_session_id_inherits_closed_binding_fence() -> None:
+    store = ConsoleChatStore()
+    session = store.create_session(session_id="stable", settings=_settings("old"))
+    stale = _submission(
+        store,
+        session.id,
+        submission_id="before-recreate",
+        model="model-b",
+    )
+
+    store.close_session(session.id)
+    replacement = store.create_session(
+        session_id=session.id,
+        settings=_settings("replacement"),
+    )
+
+    assert (
+        replacement.conversation_binding_revision
+        > stale.origin.conversation_binding_revision
+    )
+    with pytest.raises(ValueError, match="closed"):
+        store.commit_console_settings_live(stale)
+    assert replacement.settings.model == "replacement"
+
+
+@pytest.mark.asyncio
+async def test_external_generation_change_is_refused_not_overwritten(tmp_path) -> None:
+    db = CharactersRAGDB(tmp_path / "generation-owned-base.db", "task-22515")
+    try:
+        service = ChatPersistenceService(db)
+        conversation_id = service.create_conversation(conversation_title="External")
+        store = ConsoleChatStore(persistence=service)
+        session = store.create_session(settings=_settings("old"))
+        store.publish_first_persisted_conversation(session.id, conversation_id)
+        commit = store.commit_console_settings_live(
+            _submission(store, session.id, submission_id="local", model="model-a")
+        )
+        external = replace(commit.settings, model="external")
+        service.update_conversation_generation_settings(
+            conversation_id=conversation_id,
+            snapshot=snapshot_from_session_settings(external),
+            expected_snapshot=None,
+        )
+
+        await store.persist_console_settings_commit_serialized(commit)
+
+        assert service.get_conversation_generation_settings(
+            conversation_id
+        ).snapshot.model == "external"
+        assert ConsoleSettingsComponent.GENERATION_SETTINGS in (
+            session.settings_persistence_failures
+        )
+    finally:
+        db.close_connection()
+
+
+@pytest.mark.asyncio
+async def test_generation_failure_captures_only_exact_safe_snapshot() -> None:
+    persistence = _SettingsPersistence()
+    persistence.fail_generation = True
+    store = ConsoleChatStore(persistence=persistence)
+    secret_endpoint = "https://user:secret@example.invalid/api?token=private"
+    session = store.create_session(
+        settings=replace(_settings("old"), base_url=secret_endpoint)
+    )
+    store.publish_first_persisted_conversation(session.id, "conversation-a")
+    submission = _submission(
+        store,
+        session.id,
+        submission_id="safe-failure",
+        model="model-b",
+    )
+    submission = replace(
+        submission,
+        draft=replace(
+            submission.draft,
+            settings=replace(submission.draft.settings, base_url=secret_endpoint),
+        ),
+    )
+    commit = store.commit_console_settings_live(submission)
+
+    await store.persist_console_settings_commit_serialized(commit)
+
+    failure = session.settings_persistence_failures[
+        ConsoleSettingsComponent.GENERATION_SETTINGS
+    ]
+    assert failure.generation_snapshot == snapshot_from_session_settings(commit.settings)
+    assert not hasattr(failure.generation_snapshot, "base_url")
+    assert secret_endpoint not in repr(failure)
+
+
+def test_unsaved_apply_first_persist_preserves_existing_owner_paths() -> None:
+    persistence = _AtomicSettingsPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(
+        settings=replace(
+            _settings("old", system_prompt="Owned system"),
+            pinned_prefill="Owned prefill",
+        )
+    )
+    session.speech_preferences = ConsoleSpeechPreferences(auto_speak=True)
+    session.user_display_name_override = "Ari"
+    session.character_system_template = "Hello {user_name}"
+    commit = store.commit_console_settings_live(
+        _submission(
+            store,
+            session.id,
+            submission_id="staged",
+            model="model-b",
+            compaction=ContextCompactionMode.AUTOMATIC,
+        )
+    )
+
+    asyncio.run(store.persist_console_settings_commit_serialized(commit))
+
+    assert persistence.created_conversations == []
+    conversation_id = store.persist_session_if_needed(session.id)
+    metadata = persistence.first_persist_kwargs["conversation_kwargs"]["metadata"]
+    assert conversation_id == persistence.first_persist_kwargs["conversation_id"]
+    assert parse_console_generation_settings(metadata).snapshot.model == "model-b"
+    assert session.generation_durable_snapshot.model == "model-b"
+    assert persistence.context_policy.compaction_mode is ContextCompactionMode.AUTOMATIC
+    assert persistence.first_persist_kwargs["conversation_kwargs"][
+        "speech_preferences"
+    ] == ConsoleSpeechPreferences(auto_speak=True)
+    assert persistence.first_persist_kwargs["policy_candidate"].auto_retrieve == (
+        session.library_policy_holder.snapshot.auto_retrieve
+    )
+    assert persistence.roleplay_calls == [
+        {
+            "conversation_id": conversation_id,
+            "user_name_override": "Ari",
+            "character_system_template": "Hello {user_name}",
+            "character_name_snapshot": None,
+        }
+    ]
+    assert persistence.pinned_prefill_calls == [
+        {
+            "conversation_id": conversation_id,
+            "pinned_prefill": "Owned prefill",
+        }
+    ]
+    assert persistence.generation_calls == []
+
+
+def test_temporary_apply_does_not_write_and_promotion_uses_staged_settings() -> None:
+    persistence = _SettingsPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(settings=_settings("old"), ephemeral=True)
+    commit = store.commit_console_settings_live(
+        _submission(store, session.id, submission_id="temporary", model="model-b")
+    )
+
+    asyncio.run(store.persist_console_settings_commit_serialized(commit))
+
+    assert persistence.generation_calls == []
+    assert persistence.context_calls == []
+    store.promote_ephemeral_session(session.id)
+    metadata = persistence.promotion_kwargs["conversation_kwargs"]["metadata"]
+    assert parse_console_generation_settings(metadata).snapshot.model == "model-b"
+    assert session.generation_durable_snapshot.model == "model-b"
+
+
+def test_promotion_context_failure_enters_ledger_without_rolling_back() -> None:
+    persistence = _SettingsPersistence()
+    persistence.fail_context = True
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(settings=_settings("old"), ephemeral=True)
+    store.commit_console_settings_live(
+        _submission(
+            store,
+            session.id,
+            submission_id="promotion-context-failure",
+            model="model-b",
+            compaction=ContextCompactionMode.AUTOMATIC,
+        )
+    )
+
+    conversation_id = store.promote_ephemeral_session(session.id)
+
+    assert conversation_id is not None
+    assert session.ephemeral is False
+    assert session.persisted_conversation_id == conversation_id
+    failure = session.settings_persistence_failures[
+        ConsoleSettingsComponent.CONTEXT_POLICY
+    ]
+    assert failure.context_policy_overrides == session.context_policy_overrides
+    assert failure.revision == session.context_policy_revision
+
+
+def test_unsaved_quick_policy_failure_retains_compaction_label_through_retry() -> None:
+    persistence = _SettingsPersistence()
+    persistence.fail_context = True
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(settings=_settings("old"))
+    commit = store.commit_console_settings_live(
+        _submission(
+            store,
+            session.id,
+            submission_id="unsaved-quick",
+            model="model-b",
+            surface=ConsoleSettingsSurface.QUICK_POPOVER,
+        )
+    )
+
+    asyncio.run(store.persist_console_settings_commit_serialized(commit))
+    store.persist_session_if_needed(session.id)
+
+    failure = session.settings_persistence_failures[
+        ConsoleSettingsComponent.CONTEXT_POLICY
+    ]
+    assert failure.policy_failure_label is ConsoleSettingsPolicyFailureLabel.COMPACTION
+
+    persistence.fail_context = False
+    assert asyncio.run(
+        store.retry_console_settings_persistence(
+            session_id=session.id,
+            component=ConsoleSettingsComponent.CONTEXT_POLICY,
+            revision=failure.revision,
+        )
+    )
+    assert session.settings_persistence_failures == {}
+
+
+def test_temporary_newer_full_policy_supersedes_quick_failure_label() -> None:
+    persistence = _SettingsPersistence()
+    persistence.fail_context = True
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.create_session(settings=_settings("old"), ephemeral=True)
+    quick = store.commit_console_settings_live(
+        _submission(
+            store,
+            session.id,
+            submission_id="temporary-quick",
+            model="model-a",
+            surface=ConsoleSettingsSurface.QUICK_POPOVER,
+        )
+    )
+    asyncio.run(store.persist_console_settings_commit_serialized(quick))
+    full = store.commit_console_settings_live(
+        _submission(
+            store,
+            session.id,
+            submission_id="temporary-full",
+            model="model-b",
+            surface=ConsoleSettingsSurface.FULL_SETTINGS,
+        )
+    )
+    asyncio.run(store.persist_console_settings_commit_serialized(full))
+
+    store.promote_ephemeral_session(session.id)
+
+    failure = session.settings_persistence_failures[
+        ConsoleSettingsComponent.CONTEXT_POLICY
+    ]
+    assert failure.revision == full.context_policy_revision
+    assert (
+        failure.policy_failure_label
+        is ConsoleSettingsPolicyFailureLabel.CONTEXT_SETTINGS
+    )
+
+
+@pytest.mark.asyncio
+async def test_resumed_absent_policy_apply_empty_publishes_none_without_failure() -> None:
+    persistence = _SettingsPersistence()
+    store = ConsoleChatStore(persistence=persistence)
+    session = store.restore_persisted_session(
+        title="Restored empty",
+        workspace_id=None,
+        persisted_conversation_id="conversation-empty",
+        all_nodes=[],
+        settings=_settings("old"),
+    )
+    submission = _submission(
+        store,
+        session.id,
+        submission_id="empty-policy",
+        model="model-a",
+    )
+    submission = replace(
+        submission,
+        draft=replace(
+            submission.draft,
+            context_policy_overrides=ConsoleContextPolicyOverrides(),
+        ),
+    )
+    commit = store.commit_console_settings_live(submission)
+
+    await store.persist_console_settings_commit_serialized(commit)
+
+    assert persistence.context_calls[-1]["expected_revision"] is None
+    assert persistence.context_revision is None
+    assert session.context_policy_durable_revision is None
+    assert ConsoleSettingsComponent.CONTEXT_POLICY not in (
+        session.settings_persistence_failures
+    )
+
+
+def test_restore_seeds_context_durable_revision_and_generation_metadata_state() -> None:
+    persistence = _SettingsPersistence()
+    persistence.context_policy = ConsoleContextPolicyOverrides(
+        compaction_mode=ContextCompactionMode.AUTOMATIC
+    )
+    persistence.context_revision = 7
+    store = ConsoleChatStore(persistence=persistence)
+
+    session = store.restore_persisted_session(
+        title="Restored",
+        workspace_id=None,
+        persisted_conversation_id="conversation-a",
+        all_nodes=[],
+        settings=_settings("model-a"),
+        generation_metadata_status=ConsoleGenerationSettingsReadStatus.ABSENT,
+    )
+    store.set_session_context_policy_overrides(
+        session.id,
+        ConsoleContextPolicyOverrides(compaction_mode=ContextCompactionMode.OFF),
+    )
+
+    assert session.context_policy_durable_revision == 8
+    assert persistence.context_calls[-1]["expected_revision"] == 7
+    assert session.context_policy_overrides.compaction_mode is ContextCompactionMode.OFF
+
+
+def test_session_failure_state_does_not_capture_endpoint_or_secrets() -> None:
+    session_store = ConsoleChatStore()
+    session = session_store.create_session(
+        settings=replace(_settings("model-a"), base_url="https://secret.example/key")
+    )
+
+    assert session.settings_persistence_failures == {}
+    assert session.applied_settings_submission_ids.maxlen == 32
+    assert session.generation_metadata_status is ConsoleGenerationSettingsReadStatus.ABSENT
+    assert session.generation_metadata_warning_shown is False
+    assert session.new_chat_default_generation == 0

--- a/Tests/Chat/test_console_settings_defaults.py
+++ b/Tests/Chat/test_console_settings_defaults.py
@@ -69,7 +69,9 @@ def _reset_default_generation(monkeypatch):
     monkeypatch.setattr(defaults_module, "_LATEST_INTENT_GENERATION", None)
     monkeypatch.setattr(defaults_module, "_LATEST_INTENT_FINGERPRINT", None)
     monkeypatch.setattr(defaults_module, "_LATEST_INTENT_ACTION", None, raising=False)
-    monkeypatch.setattr(defaults_module, "_LATEST_INTENT_LIFECYCLE", None, raising=False)
+    monkeypatch.setattr(
+        defaults_module, "_LATEST_INTENT_LIFECYCLE", None, raising=False
+    )
     monkeypatch.setattr(defaults_module, "_ACTIVE_INTENT_CALLS", set(), raising=False)
     monkeypatch.setattr(defaults_module, "_PENDING_RETRY_STATE", None, raising=False)
     monkeypatch.setattr(
@@ -101,9 +103,7 @@ def _intent(
         literal_model_id=LITERAL_MODEL,
         field_mask=field_mask,
         values=(
-            {"temperature": 0.25, "streaming": False}
-            if values is None
-            else values
+            {"temperature": 0.25, "streaming": False} if values is None else values
         ),
         endpoint_patch=endpoint_patch,
     )
@@ -245,14 +245,20 @@ def test_make_default_atomically_patches_profile_globals_and_checked_endpoint(
         "openai",
         LITERAL_MODEL,
     )
-    assert defaults_module.validate_console_session_settings(
-        target,
-        app_config=locked.values,
-    ) == []
-    assert defaults_module.build_console_settings_readiness(
-        target,
-        app_config=locked.values,
-    ).native_send_supported is True
+    assert (
+        defaults_module.validate_console_session_settings(
+            target,
+            app_config=locked.values,
+        )
+        == []
+    )
+    assert (
+        defaults_module.build_console_settings_readiness(
+            target,
+            app_config=locked.values,
+        ).native_send_supported
+        is True
+    )
 
     outcome = apply_console_default_intent(
         _intent(
@@ -270,9 +276,10 @@ def test_make_default_atomically_patches_profile_globals_and_checked_endpoint(
         "model": LITERAL_MODEL,
     }
     assert saved["api_settings"]["openai"]["api_base_url"] == endpoint.value
-    assert saved["api_settings"]["openai"]["model_defaults"][LITERAL_MODEL][
-        "temperature"
-    ] == 0.25
+    assert (
+        saved["api_settings"]["openai"]["model_defaults"][LITERAL_MODEL]["temperature"]
+        == 0.25
+    )
 
 
 @pytest.mark.parametrize(
@@ -281,16 +288,12 @@ def test_make_default_atomically_patches_profile_globals_and_checked_endpoint(
         (
             ConsoleSettingsAction.SAVE_MODEL_DEFAULT,
             FULL_MODEL_DEFAULT_FIELDS,
-            ConsoleEndpointPatch(
-                "https://new.example.test/v1", "openai", True, True
-            ),
+            ConsoleEndpointPatch("https://new.example.test/v1", "openai", True, True),
         ),
         (
             ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
             QUICK_MODEL_DEFAULT_FIELDS,
-            ConsoleEndpointPatch(
-                "https://new.example.test/v1", "openai", True, True
-            ),
+            ConsoleEndpointPatch("https://new.example.test/v1", "openai", True, True),
         ),
         (
             ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
@@ -302,16 +305,12 @@ def test_make_default_atomically_patches_profile_globals_and_checked_endpoint(
         (
             ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
             FULL_MODEL_DEFAULT_FIELDS,
-            ConsoleEndpointPatch(
-                "https://new.example.test/v1", "openai", False, True
-            ),
+            ConsoleEndpointPatch("https://new.example.test/v1", "openai", False, True),
         ),
         (
             ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
             FULL_MODEL_DEFAULT_FIELDS,
-            ConsoleEndpointPatch(
-                "https://new.example.test/v1", "openai", True, False
-            ),
+            ConsoleEndpointPatch("https://new.example.test/v1", "openai", True, False),
         ),
     ],
 )
@@ -366,9 +365,10 @@ def test_before_replace_failure_retains_immutable_retry_intent(
 
     assert retried.runtime_published is True
     saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
-        "temperature"
-    ] == 0.31
+    assert (
+        saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL]["temperature"]
+        == 0.31
+    )
 
 
 @pytest.mark.parametrize("changed_target", ["profile", "global", "endpoint"])
@@ -402,15 +402,15 @@ def test_retry_rejects_external_change_to_any_owned_field(
 
     externally_changed = tomllib.loads(config_path.read_text(encoding="utf-8"))
     if changed_target == "profile":
-        externally_changed["api_settings"]["openai"]["model_defaults"][
-            LITERAL_MODEL
-        ]["temperature"] = 0.67
+        externally_changed["api_settings"]["openai"]["model_defaults"][LITERAL_MODEL][
+            "temperature"
+        ] = 0.67
     elif changed_target == "global":
         externally_changed["chat_defaults"]["model"] = "external-model"
     else:
-        externally_changed["api_settings"]["openai"][
-            "api_base_url"
-        ] = "https://external.example.test/v1"
+        externally_changed["api_settings"]["openai"]["api_base_url"] = (
+            "https://external.example.test/v1"
+        )
     externally_changed["unrelated"] = {"concurrent": "newer"}
     _write_config(config_path, externally_changed)
     before_retry = config_path.read_bytes()
@@ -444,9 +444,9 @@ def test_retry_rebases_when_only_sibling_and_unrelated_fields_changed(
         is ConsoleDefaultSavePhase.BEFORE_REPLACE
     )
     externally_changed = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    externally_changed["api_settings"]["OpenAI"]["model_defaults"][
-        "sibling/model"
-    ]["temperature"] = 0.58
+    externally_changed["api_settings"]["OpenAI"]["model_defaults"]["sibling/model"][
+        "temperature"
+    ] = 0.58
     externally_changed["unrelated"] = {"concurrent": "newer"}
     _write_config(config_path, externally_changed)
     monkeypatch.setattr(config_module, "atomic_private_write_text", real_write)
@@ -455,9 +455,10 @@ def test_retry_rebases_when_only_sibling_and_unrelated_fields_changed(
 
     assert retried.runtime_published is True
     saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
-        "temperature"
-    ] == 0.31
+    assert (
+        saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL]["temperature"]
+        == 0.31
+    )
     assert saved["api_settings"]["OpenAI"]["model_defaults"]["sibling/model"] == {
         "temperature": 0.58
     }
@@ -487,9 +488,7 @@ def test_externally_reserved_newer_generation_invalidates_inflight_precondition(
 
     def reserve_generation_b() -> None:
         try:
-            assert defaults_module.reserve_console_default_intent_generation(
-                intent_b
-            )
+            assert defaults_module.reserve_console_default_intent_generation(intent_b)
             generation_b_reserved.set()
         except BaseException as error:
             reservation_errors.append(error)
@@ -528,9 +527,10 @@ def test_externally_reserved_newer_generation_invalidates_inflight_precondition(
     assert outcomes["a"].runtime_published is False
     assert outcomes["b"].runtime_published is True
     saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
-        "temperature"
-    ] == 0.6
+    assert (
+        saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL]["temperature"]
+        == 0.6
+    )
 
 
 def test_newer_generation_cannot_reserve_between_precondition_and_replacement(
@@ -588,9 +588,7 @@ def test_newer_generation_cannot_reserve_between_precondition_and_replacement(
     assert defaults_module.reserve_console_default_intent_generation(intent_a)
     worker_a = threading.Thread(
         name="generation-a",
-        target=lambda: outcomes.setdefault(
-            "a", apply_console_default_intent(intent_a)
-        ),
+        target=lambda: outcomes.setdefault("a", apply_console_default_intent(intent_a)),
     )
     worker_b = threading.Thread(name="generation-b", target=reserve_generation_b)
     worker_a.start()
@@ -675,13 +673,17 @@ def test_newer_reservation_publishes_prior_success_before_its_failed_write(
 
     assert outcome_b.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
     assert published_generations == [intent_a.generation]
-    assert live_app_config["api_settings"]["OpenAI"]["model_defaults"][
-        LITERAL_MODEL
-    ]["temperature"] == 0.1
+    assert (
+        live_app_config["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
+            "temperature"
+        ]
+        == 0.1
+    )
     saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
-        "temperature"
-    ] == 0.1
+    assert (
+        saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL]["temperature"]
+        == 0.1
+    )
 
     monkeypatch.setattr(config_module, "atomic_private_write_text", real_write)
     retried_b = apply_console_default_intent(intent_b)
@@ -696,9 +698,12 @@ def test_newer_reservation_publishes_prior_success_before_its_failed_write(
         retried_b,
         publish_retried_runtime,
     )
-    assert live_app_config["api_settings"]["OpenAI"]["model_defaults"][
-        LITERAL_MODEL
-    ]["temperature"] == 0.6
+    assert (
+        live_app_config["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
+            "temperature"
+        ]
+        == 0.6
+    )
 
 
 def test_newer_reservation_refreshes_cache_failed_prior_before_its_failed_write(
@@ -767,9 +772,7 @@ def test_newer_reservation_refreshes_cache_failed_prior_before_its_failed_write(
         published_generations.append(generation)
         live_app_config.clear()
         live_app_config.update(settings_view)
-        recovery_state, accepted = recovery_state.accept_runtime_publication(
-            generation
-        )
+        recovery_state, accepted = recovery_state.accept_runtime_publication(generation)
         return accepted
 
     assert defaults_module.reserve_console_default_intent_generation(
@@ -796,17 +799,24 @@ def test_newer_reservation_refreshes_cache_failed_prior_before_its_failed_write(
 
     assert outcome_b.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
     assert published_generations == [intent_a.generation]
-    assert live_app_config["api_settings"]["OpenAI"]["model_defaults"][
-        LITERAL_MODEL
-    ]["temperature"] == 0.1
+    assert (
+        live_app_config["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
+            "temperature"
+        ]
+        == 0.1
+    )
     saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
-        "temperature"
-    ] == 0.1
+    assert (
+        saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL]["temperature"]
+        == 0.1
+    )
     runtime = config_module.get_runtime_config_snapshot()
-    assert runtime.values["api_settings"]["OpenAI"]["model_defaults"][
-        LITERAL_MODEL
-    ]["temperature"] == 0.1
+    assert (
+        runtime.values["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
+            "temperature"
+        ]
+        == 0.1
+    )
     assert recovery_state.recovery_intent == intent_b
     assert recovery_state.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
 
@@ -832,9 +842,10 @@ def test_cache_failure_is_saved_and_refresh_continuation_never_rewrites(
     assert outcome.settings_view is None
     assert outcome.failure_phase is ConsoleDefaultSavePhase.CACHE_PUBLICATION
     saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
-        "temperature"
-    ] == 0.25
+    assert (
+        saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL]["temperature"]
+        == 0.25
+    )
     monkeypatch.setattr(config_module, "load_settings", real_load)
     monkeypatch.setattr(
         config_module,
@@ -886,9 +897,10 @@ def test_writer_error_after_visible_replace_is_cache_only_and_refresh_never_writ
     assert outcome.failure_phase is ConsoleDefaultSavePhase.CACHE_PUBLICATION
     assert load_calls == 0
     saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
-        "temperature"
-    ] == 0.25
+    assert (
+        saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL]["temperature"]
+        == 0.25
+    )
     monkeypatch.setattr(
         config_module,
         "atomic_private_write_text",
@@ -1004,7 +1016,9 @@ def test_concurrent_duplicate_is_rejected_and_failed_retry_remains_retryable(
     intent = _intent()
 
     worker_a = threading.Thread(
-        target=lambda: outcomes.setdefault("initial", apply_console_default_intent(intent))
+        target=lambda: outcomes.setdefault(
+            "initial", apply_console_default_intent(intent)
+        )
     )
 
     def invoke_duplicate() -> None:
@@ -1089,7 +1103,9 @@ def test_runtime_refresh_contains_lock_failure_and_never_writes(
         def __exit__(self, exc_type, exc_value, traceback):
             return False
 
-    monkeypatch.setattr(config_module, "_config_write_lock", lambda _path: FailingLock())
+    monkeypatch.setattr(
+        config_module, "_config_write_lock", lambda _path: FailingLock()
+    )
     monkeypatch.setattr(
         config_module,
         "atomic_private_write_text",
@@ -1119,7 +1135,10 @@ def test_newer_intent_supersedes_older_retry_generation(
         "atomic_private_write_text",
         lambda *args, **kwargs: (_ for _ in ()).throw(OSError("first failure")),
     )
-    assert apply_console_default_intent(old).failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    assert (
+        apply_console_default_intent(old).failure_phase
+        is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    )
     monkeypatch.setattr(config_module, "atomic_private_write_text", real_write)
     newer = _intent(
         generation=11,
@@ -1133,9 +1152,10 @@ def test_newer_intent_supersedes_older_retry_generation(
     assert stale.runtime_published is False
     assert stale.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
     saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
-        "temperature"
-    ] == 0.6
+    assert (
+        saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL]["temperature"]
+        == 0.6
+    )
 
 
 def test_make_default_rechecks_locked_readiness_and_rejects_removed_config(
@@ -1192,9 +1212,10 @@ def test_make_default_rechecks_locked_readiness_and_rejects_removed_config(
     assert outcome.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
     assert outcome.settings_view is None
     assert config_path.read_bytes() == original
-    assert "openai" not in tomllib.loads(config_path.read_text(encoding="utf-8"))[
-        "api_settings"
-    ]
+    assert (
+        "openai"
+        not in tomllib.loads(config_path.read_text(encoding="utf-8"))["api_settings"]
+    )
 
 
 def test_locked_builder_uses_authoritative_raw_alias_and_preserves_newer_edits(
@@ -1238,9 +1259,50 @@ def test_make_default_uses_raw_alias_while_locked_readiness_uses_effective_env(
     assert outcome.runtime_published is True
     saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
     assert "openai" not in saved["api_settings"]
-    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
-        "temperature"
-    ] == 0.25
+    assert (
+        saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL]["temperature"]
+        == 0.25
+    )
+    assert saved["chat_defaults"] == {
+        "provider": "openai",
+        "model": LITERAL_MODEL,
+    }
+
+
+@pytest.mark.parametrize("initial_endpoint", [None, ""])
+def test_make_default_can_bootstrap_missing_or_blank_provider_endpoint(
+    tmp_path: Path,
+    monkeypatch,
+    initial_endpoint: str | None,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    current = _ready_openai_config(section="openai")
+    provider = current["api_settings"]["openai"]
+    if initial_endpoint is None:
+        provider.pop("api_base_url")
+    else:
+        provider["api_base_url"] = initial_endpoint
+    _write_config(config_path, current)
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    outcome = apply_console_default_intent(
+        _intent(
+            action=ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
+            field_mask=FULL_MODEL_DEFAULT_FIELDS,
+            endpoint_patch=ConsoleEndpointPatch(
+                value="https://new.example.test/v1",
+                bound_provider_config_key="openai",
+                dirty=True,
+                checked=True,
+            ),
+        )
+    )
+
+    assert outcome.runtime_published is True
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["api_settings"]["openai"]["api_base_url"] == (
+        "https://new.example.test/v1"
+    )
     assert saved["chat_defaults"] == {
         "provider": "openai",
         "model": LITERAL_MODEL,
@@ -1408,7 +1470,9 @@ def test_endpoint_preview_exposes_only_authority_and_network_class(
         "",
     ],
 )
-def test_endpoint_preview_rejects_credentials_and_invalid_authorities(value: str) -> None:
+def test_endpoint_preview_rejects_credentials_and_invalid_authorities(
+    value: str,
+) -> None:
     assert parse_console_endpoint_preview(value) is None
     assert format_console_endpoint_preview(value) is None
 
@@ -1423,7 +1487,9 @@ def test_recovery_request_is_bounded_to_action_and_intent_generation() -> None:
     assert request.intent_generation == 19
 
 
-def test_default_durability_state_accepts_only_current_runtime_publication_once() -> None:
+def test_default_durability_state_accepts_only_current_runtime_publication_once() -> (
+    None
+):
     intent = _intent(
         generation=19,
         action=ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,

--- a/Tests/Chat/test_console_settings_defaults.py
+++ b/Tests/Chat/test_console_settings_defaults.py
@@ -1,0 +1,1624 @@
+"""Atomic exact-model Console default persistence tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import threading
+import tomllib
+
+import pytest
+import toml
+
+from tldw_chatbook import config as config_module
+from tldw_chatbook.Chat.console_settings_apply import (
+    FULL_MODEL_DEFAULT_FIELDS,
+    QUICK_MODEL_DEFAULT_FIELDS,
+    ConsoleEndpointDraft,
+    ConsoleSettingsAction,
+    ConsoleSettingsFieldDraft,
+    ConsoleSettingsFieldProvenance,
+)
+from tldw_chatbook.Chat import console_settings_defaults as defaults_module
+from tldw_chatbook.Chat.console_settings_defaults import (
+    ConsoleDefaultDurabilityState,
+    ConsoleDefaultMutationIntent,
+    ConsoleDefaultRecoveryAction,
+    ConsoleDefaultRecoveryRequest,
+    ConsoleDefaultSavePhase,
+    ConsoleEndpointPatch,
+    apply_console_default_intent,
+    format_console_endpoint_preview,
+    parse_console_endpoint_preview,
+    refresh_console_runtime_after_saved_default,
+)
+
+
+LITERAL_MODEL = "org/model.v2:fast[beta]"
+
+
+def _write_config(path: Path, data: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(toml.dumps(data), encoding="utf-8")
+
+
+def _ready_openai_config(*, section: str = "OpenAI") -> dict[str, object]:
+    return {
+        "api_settings": {
+            section: {
+                "credential_source": "stored",
+                "api_key": "test-key",
+                "api_base_url": "https://old.example.test/v1",
+                "model_defaults": {
+                    LITERAL_MODEL: {
+                        "temperature": 0.8,
+                        "top_p": 0.9,
+                        "max_tokens": 1234,
+                        "unexposed": "preserved",
+                    },
+                    "sibling/model": {"temperature": 0.4},
+                },
+            }
+        },
+        "chat_defaults": {"provider": "anthropic", "model": "old-model"},
+        "unrelated": {"concurrent": "preserved"},
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_default_generation(monkeypatch):
+    monkeypatch.setattr(defaults_module, "_LATEST_INTENT_GENERATION", None)
+    monkeypatch.setattr(defaults_module, "_LATEST_INTENT_FINGERPRINT", None)
+    monkeypatch.setattr(defaults_module, "_LATEST_INTENT_ACTION", None, raising=False)
+    monkeypatch.setattr(defaults_module, "_LATEST_INTENT_LIFECYCLE", None, raising=False)
+    monkeypatch.setattr(defaults_module, "_ACTIVE_INTENT_CALLS", set(), raising=False)
+    monkeypatch.setattr(defaults_module, "_PENDING_RETRY_STATE", None, raising=False)
+    monkeypatch.setattr(
+        defaults_module,
+        "_ACTIVE_RUNTIME_PUBLICATION_CLAIM",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        defaults_module,
+        "_NEXT_RUNTIME_PUBLICATION_CLAIM_TOKEN",
+        0,
+        raising=False,
+    )
+
+
+def _intent(
+    *,
+    generation: int = 1,
+    action: ConsoleSettingsAction = ConsoleSettingsAction.SAVE_MODEL_DEFAULT,
+    field_mask: frozenset[str] = QUICK_MODEL_DEFAULT_FIELDS,
+    values: dict[str, object | None] | None = None,
+    endpoint_patch: ConsoleEndpointPatch | None = None,
+) -> ConsoleDefaultMutationIntent:
+    return ConsoleDefaultMutationIntent(
+        generation=generation,
+        action=action,
+        provider_config_key="openai",
+        literal_model_id=LITERAL_MODEL,
+        field_mask=field_mask,
+        values=(
+            {"temperature": 0.25, "streaming": False}
+            if values is None
+            else values
+        ),
+        endpoint_patch=endpoint_patch,
+    )
+
+
+def test_quick_save_patches_only_temperature_and_streaming(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    outcome = apply_console_default_intent(
+        _intent(values={"temperature": 0.25, "streaming": False, "top_p": 0.1})
+    )
+
+    assert outcome.file_replaced is True
+    assert outcome.runtime_published is True
+    assert outcome.settings_view is not None
+    assert outcome.failure_phase is None
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    profile = saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL]
+    assert profile == {
+        "temperature": 0.25,
+        "streaming": False,
+        "top_p": 0.9,
+        "max_tokens": 1234,
+        "unexposed": "preserved",
+    }
+    assert saved["chat_defaults"] == {
+        "provider": "anthropic",
+        "model": "old-model",
+    }
+
+
+def test_full_save_deletes_exact_inherited_fields_and_preserves_siblings(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    outcome = apply_console_default_intent(
+        _intent(
+            field_mask=FULL_MODEL_DEFAULT_FIELDS,
+            values={
+                "temperature": None,
+                "streaming": None,
+                "top_p": 0.72,
+                "thinking_budget_tokens": 222,
+                "not_exposed": "ignored",
+            },
+        )
+    )
+
+    assert outcome.runtime_published is True
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    profiles = saved["api_settings"]["OpenAI"]["model_defaults"]
+    assert profiles[LITERAL_MODEL] == {
+        "top_p": 0.72,
+        "max_tokens": 1234,
+        "unexposed": "preserved",
+    }
+    assert profiles["sibling/model"] == {"temperature": 0.4}
+    assert saved["unrelated"] == {"concurrent": "preserved"}
+
+
+@pytest.mark.parametrize(
+    "intent",
+    [
+        pytest.param(
+            _intent(
+                field_mask=frozenset({"temperature"}),
+                values={"temperature": 0.2},
+            ),
+            id="partial-non-surface-mask",
+        ),
+        pytest.param(
+            _intent(values={"temperature": None, "streaming": True}),
+            id="quick-inherit-temperature",
+        ),
+        pytest.param(
+            _intent(values={"temperature": 0.2}),
+            id="quick-missing-streaming",
+        ),
+        pytest.param(
+            _intent(
+                field_mask=FULL_MODEL_DEFAULT_FIELDS,
+                values={"streaming": "false"},
+            ),
+            id="non-boolean-streaming",
+        ),
+    ],
+)
+def test_default_intent_rejects_non_surface_masks_and_unmaterialized_quick_values(
+    tmp_path: Path,
+    monkeypatch,
+    intent: ConsoleDefaultMutationIntent,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    original = config_path.read_bytes()
+
+    outcome = apply_console_default_intent(intent)
+
+    assert outcome.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    assert outcome.settings_view is None
+    assert config_path.read_bytes() == original
+
+
+def test_make_default_atomically_patches_profile_globals_and_checked_endpoint(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config(section="openai"))
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    write_calls = 0
+    real_write = config_module.atomic_private_write_text
+
+    def counted_write(*args, **kwargs):
+        nonlocal write_calls
+        write_calls += 1
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(config_module, "atomic_private_write_text", counted_write)
+    endpoint = ConsoleEndpointPatch(
+        value="https://new.example.test:8443/v1?ignored=yes",
+        bound_provider_config_key="openai",
+        dirty=True,
+        checked=True,
+    )
+    locked = config_module.get_atomic_config_snapshot()
+    target = defaults_module.build_target_default_console_session_settings(
+        locked.values,
+        "openai",
+        LITERAL_MODEL,
+    )
+    assert defaults_module.validate_console_session_settings(
+        target,
+        app_config=locked.values,
+    ) == []
+    assert defaults_module.build_console_settings_readiness(
+        target,
+        app_config=locked.values,
+    ).native_send_supported is True
+
+    outcome = apply_console_default_intent(
+        _intent(
+            action=ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
+            field_mask=FULL_MODEL_DEFAULT_FIELDS,
+            endpoint_patch=endpoint,
+        )
+    )
+
+    assert outcome.runtime_published is True
+    assert write_calls == 1
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["chat_defaults"] == {
+        "provider": "openai",
+        "model": LITERAL_MODEL,
+    }
+    assert saved["api_settings"]["openai"]["api_base_url"] == endpoint.value
+    assert saved["api_settings"]["openai"]["model_defaults"][LITERAL_MODEL][
+        "temperature"
+    ] == 0.25
+
+
+@pytest.mark.parametrize(
+    ("action", "mask", "patch"),
+    [
+        (
+            ConsoleSettingsAction.SAVE_MODEL_DEFAULT,
+            FULL_MODEL_DEFAULT_FIELDS,
+            ConsoleEndpointPatch(
+                "https://new.example.test/v1", "openai", True, True
+            ),
+        ),
+        (
+            ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
+            QUICK_MODEL_DEFAULT_FIELDS,
+            ConsoleEndpointPatch(
+                "https://new.example.test/v1", "openai", True, True
+            ),
+        ),
+        (
+            ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
+            FULL_MODEL_DEFAULT_FIELDS,
+            ConsoleEndpointPatch(
+                "https://new.example.test/v1", "anthropic", True, True
+            ),
+        ),
+        (
+            ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
+            FULL_MODEL_DEFAULT_FIELDS,
+            ConsoleEndpointPatch(
+                "https://new.example.test/v1", "openai", False, True
+            ),
+        ),
+        (
+            ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
+            FULL_MODEL_DEFAULT_FIELDS,
+            ConsoleEndpointPatch(
+                "https://new.example.test/v1", "openai", True, False
+            ),
+        ),
+    ],
+)
+def test_unauthorized_endpoint_patch_fails_closed_without_writing(
+    tmp_path: Path,
+    monkeypatch,
+    action: ConsoleSettingsAction,
+    mask: frozenset[str],
+    patch: ConsoleEndpointPatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    original = config_path.read_bytes()
+
+    outcome = apply_console_default_intent(
+        _intent(action=action, field_mask=mask, endpoint_patch=patch)
+    )
+
+    assert outcome.file_replaced is False
+    assert outcome.runtime_published is False
+    assert outcome.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    assert config_path.read_bytes() == original
+
+
+def test_before_replace_failure_retains_immutable_retry_intent(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    values: dict[str, object | None] = {"temperature": 0.31, "streaming": True}
+    intent = _intent(values=values)
+    real_write = config_module.atomic_private_write_text
+    monkeypatch.setattr(
+        config_module,
+        "atomic_private_write_text",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("private detail")),
+    )
+
+    failed = apply_console_default_intent(intent)
+
+    assert failed.file_replaced is False
+    assert failed.runtime_published is False
+    assert failed.settings_view is None
+    assert failed.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    values["temperature"] = 1.99
+    monkeypatch.setattr(config_module, "atomic_private_write_text", real_write)
+
+    retried = apply_console_default_intent(intent)
+
+    assert retried.runtime_published is True
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
+        "temperature"
+    ] == 0.31
+
+
+@pytest.mark.parametrize("changed_target", ["profile", "global", "endpoint"])
+def test_retry_rejects_external_change_to_any_owned_field(
+    tmp_path: Path,
+    monkeypatch,
+    changed_target: str,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config(section="openai"))
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    endpoint = ConsoleEndpointPatch(
+        value="https://new.example.test/v1",
+        bound_provider_config_key="openai",
+        dirty=True,
+        checked=True,
+    )
+    intent = _intent(
+        action=ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
+        field_mask=FULL_MODEL_DEFAULT_FIELDS,
+        endpoint_patch=endpoint,
+    )
+    real_write = config_module.atomic_private_write_text
+    monkeypatch.setattr(
+        config_module,
+        "atomic_private_write_text",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("first failure")),
+    )
+    failed = apply_console_default_intent(intent)
+    assert failed.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+
+    externally_changed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    if changed_target == "profile":
+        externally_changed["api_settings"]["openai"]["model_defaults"][
+            LITERAL_MODEL
+        ]["temperature"] = 0.67
+    elif changed_target == "global":
+        externally_changed["chat_defaults"]["model"] = "external-model"
+    else:
+        externally_changed["api_settings"]["openai"][
+            "api_base_url"
+        ] = "https://external.example.test/v1"
+    externally_changed["unrelated"] = {"concurrent": "newer"}
+    _write_config(config_path, externally_changed)
+    before_retry = config_path.read_bytes()
+    monkeypatch.setattr(config_module, "atomic_private_write_text", real_write)
+
+    retried = apply_console_default_intent(intent)
+
+    assert retried.file_replaced is False
+    assert retried.runtime_published is False
+    assert retried.settings_view is None
+    assert retried.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    assert config_path.read_bytes() == before_retry
+
+
+def test_retry_rebases_when_only_sibling_and_unrelated_fields_changed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    intent = _intent(values={"temperature": 0.31, "streaming": True})
+    real_write = config_module.atomic_private_write_text
+    monkeypatch.setattr(
+        config_module,
+        "atomic_private_write_text",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("first failure")),
+    )
+    assert (
+        apply_console_default_intent(intent).failure_phase
+        is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    )
+    externally_changed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    externally_changed["api_settings"]["OpenAI"]["model_defaults"][
+        "sibling/model"
+    ]["temperature"] = 0.58
+    externally_changed["unrelated"] = {"concurrent": "newer"}
+    _write_config(config_path, externally_changed)
+    monkeypatch.setattr(config_module, "atomic_private_write_text", real_write)
+
+    retried = apply_console_default_intent(intent)
+
+    assert retried.runtime_published is True
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
+        "temperature"
+    ] == 0.31
+    assert saved["api_settings"]["OpenAI"]["model_defaults"]["sibling/model"] == {
+        "temperature": 0.58
+    }
+    assert saved["unrelated"] == {"concurrent": "newer"}
+
+
+def test_externally_reserved_newer_generation_invalidates_inflight_precondition(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    generation_a_paused = threading.Event()
+    release_generation_a = threading.Event()
+    generation_b_reserved = threading.Event()
+    reservation_errors: list[BaseException] = []
+    real_read = config_module._read_raw_cli_config_unlocked
+
+    def paused_read(config_path):
+        raw = real_read(config_path)
+        if threading.current_thread().name == "generation-a":
+            generation_a_paused.set()
+            if not release_generation_a.wait(timeout=5):
+                raise AssertionError("generation A was not released")
+        return raw
+
+    def reserve_generation_b() -> None:
+        try:
+            assert defaults_module.reserve_console_default_intent_generation(
+                intent_b
+            )
+            generation_b_reserved.set()
+        except BaseException as error:
+            reservation_errors.append(error)
+
+    monkeypatch.setattr(config_module, "_read_raw_cli_config_unlocked", paused_read)
+    outcomes = {}
+    intent_a = _intent(
+        generation=1,
+        values={"temperature": 0.1, "streaming": True},
+    )
+    intent_b = _intent(
+        generation=2,
+        values={"temperature": 0.6, "streaming": False},
+    )
+
+    worker_a = threading.Thread(
+        name="generation-a",
+        target=lambda: outcomes.setdefault("a", apply_console_default_intent(intent_a)),
+    )
+    assert defaults_module.reserve_console_default_intent_generation(intent_a)
+    worker_a.start()
+    assert generation_a_paused.wait(timeout=5)
+    worker_b = threading.Thread(name="generation-b", target=reserve_generation_b)
+    worker_b.start()
+    reserved_while_a_paused = generation_b_reserved.wait(timeout=0.25)
+    release_generation_a.set()
+    worker_a.join(timeout=5)
+    worker_b.join(timeout=5)
+    outcomes["b"] = apply_console_default_intent(intent_b)
+
+    assert not worker_a.is_alive()
+    assert not worker_b.is_alive()
+    assert reservation_errors == []
+    assert reserved_while_a_paused is True
+    assert outcomes["a"].file_replaced is False
+    assert outcomes["a"].runtime_published is False
+    assert outcomes["b"].runtime_published is True
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
+        "temperature"
+    ] == 0.6
+
+
+def test_newer_generation_cannot_reserve_between_precondition_and_replacement(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    generation_a_write_started = threading.Event()
+    release_generation_a = threading.Event()
+    generation_a_publish_started = threading.Event()
+    release_generation_a_publish = threading.Event()
+    generation_b_reserved = threading.Event()
+    reservation_errors: list[BaseException] = []
+    real_write = config_module.atomic_private_write_text
+    real_load = config_module.load_settings
+
+    def paused_write(*args, **kwargs):
+        if threading.current_thread().name == "generation-a":
+            generation_a_write_started.set()
+            if not release_generation_a.wait(timeout=5):
+                raise AssertionError("generation A was not released")
+        return real_write(*args, **kwargs)
+
+    def paused_load(*args, **kwargs):
+        if threading.current_thread().name == "generation-a":
+            generation_a_publish_started.set()
+            if not release_generation_a_publish.wait(timeout=5):
+                raise AssertionError("generation A publication was not released")
+        return real_load(*args, **kwargs)
+
+    intent_a = _intent(
+        generation=1,
+        values={"temperature": 0.1, "streaming": True},
+    )
+    intent_b = _intent(
+        generation=2,
+        values={"temperature": 0.6, "streaming": False},
+    )
+    outcomes = {}
+
+    def reserve_generation_b() -> None:
+        try:
+            assert defaults_module.reserve_console_default_intent_generation(
+                intent_b,
+                pending_runtime_publisher=lambda *_args: True,
+            )
+            generation_b_reserved.set()
+        except BaseException as error:
+            reservation_errors.append(error)
+
+    monkeypatch.setattr(config_module, "atomic_private_write_text", paused_write)
+    monkeypatch.setattr(config_module, "load_settings", paused_load)
+    assert defaults_module.reserve_console_default_intent_generation(intent_a)
+    worker_a = threading.Thread(
+        name="generation-a",
+        target=lambda: outcomes.setdefault(
+            "a", apply_console_default_intent(intent_a)
+        ),
+    )
+    worker_b = threading.Thread(name="generation-b", target=reserve_generation_b)
+    worker_a.start()
+    assert generation_a_write_started.wait(timeout=5)
+    worker_b.start()
+    try:
+        assert generation_b_reserved.wait(timeout=0.25) is False
+        assert worker_a.is_alive()
+        assert worker_b.is_alive()
+        release_generation_a.set()
+        assert generation_a_publish_started.wait(timeout=5)
+        assert generation_b_reserved.wait(timeout=0.25) is False
+        assert worker_a.is_alive()
+        assert worker_b.is_alive()
+    finally:
+        release_generation_a.set()
+        release_generation_a_publish.set()
+    worker_a.join(timeout=5)
+    worker_b.join(timeout=5)
+
+    assert not worker_a.is_alive()
+    assert not worker_b.is_alive()
+    assert reservation_errors == []
+    assert generation_b_reserved.is_set()
+    assert outcomes["a"].runtime_published is True
+    outcomes["b"] = apply_console_default_intent(intent_b)
+    assert outcomes["b"].runtime_published is True
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert (
+        saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL]["temperature"]
+        == 0.6
+    )
+
+
+def test_newer_reservation_publishes_prior_success_before_its_failed_write(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """B's failed write cannot strand the app behind A's durable runtime view."""
+
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    intent_a = _intent(
+        generation=1,
+        values={"temperature": 0.1, "streaming": True},
+    )
+    intent_b = _intent(
+        generation=2,
+        values={"temperature": 0.6, "streaming": False},
+    )
+    live_app_config = _ready_openai_config()
+    published_generations: list[int] = []
+
+    outcome_a = apply_console_default_intent(intent_a)
+    assert outcome_a.runtime_published is True
+
+    def publish_pending_runtime(
+        generation: int,
+        _action: ConsoleSettingsAction,
+        settings_view,
+    ) -> bool:
+        published_generations.append(generation)
+        live_app_config.clear()
+        live_app_config.update(settings_view)
+        return True
+
+    assert defaults_module.reserve_console_default_intent_generation(
+        intent_b,
+        pending_runtime_publisher=publish_pending_runtime,
+    )
+    real_write = config_module.atomic_private_write_text
+    monkeypatch.setattr(
+        config_module,
+        "atomic_private_write_text",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("controlled before-replace failure")
+        ),
+    )
+
+    outcome_b = apply_console_default_intent(intent_b)
+
+    assert outcome_b.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    assert published_generations == [intent_a.generation]
+    assert live_app_config["api_settings"]["OpenAI"]["model_defaults"][
+        LITERAL_MODEL
+    ]["temperature"] == 0.1
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
+        "temperature"
+    ] == 0.1
+
+    monkeypatch.setattr(config_module, "atomic_private_write_text", real_write)
+    retried_b = apply_console_default_intent(intent_b)
+
+    def publish_retried_runtime(settings_view) -> bool:
+        live_app_config.clear()
+        live_app_config.update(settings_view)
+        return True
+
+    assert defaults_module.publish_console_default_runtime_if_current(
+        intent_b,
+        retried_b,
+        publish_retried_runtime,
+    )
+    assert live_app_config["api_settings"]["OpenAI"]["model_defaults"][
+        LITERAL_MODEL
+    ]["temperature"] == 0.6
+
+
+def test_newer_reservation_refreshes_cache_failed_prior_before_its_failed_write(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """B cannot erase A's refresh recovery and then fail over a stale app."""
+
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    intent_a = _intent(
+        generation=1,
+        values={"temperature": 0.1, "streaming": True},
+    )
+    intent_b = _intent(
+        generation=2,
+        values={"temperature": 0.6, "streaming": False},
+    )
+    live_app_config = _ready_openai_config()
+    recovery_state = ConsoleDefaultDurabilityState(
+        newest_intent_generation=intent_a.generation
+    )
+    real_load = config_module.load_settings
+    monkeypatch.setattr(
+        config_module,
+        "load_settings",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("controlled cache-publication failure")
+        ),
+    )
+
+    outcome_a = apply_console_default_intent(intent_a)
+
+    assert outcome_a.failure_phase is ConsoleDefaultSavePhase.CACHE_PUBLICATION
+    recovery_state = ConsoleDefaultDurabilityState(
+        newest_intent_generation=intent_a.generation,
+        recovery_intent=intent_a,
+        failure_phase=ConsoleDefaultSavePhase.CACHE_PUBLICATION,
+    )
+    rejected_publish_calls: list[int] = []
+    with pytest.raises(RuntimeError, match="runtime refresh failed"):
+        defaults_module.reserve_console_default_intent_generation(
+            intent_b,
+            pending_runtime_publisher=lambda generation, *_args: (
+                rejected_publish_calls.append(generation) or True
+            ),
+        )
+    assert rejected_publish_calls == []
+    assert recovery_state.recovery_intent == intent_a
+    assert (
+        defaults_module._LATEST_INTENT_LIFECYCLE
+        is defaults_module._IntentLifecycle.CACHE_PUBLICATION_RETRYABLE
+    )
+
+    monkeypatch.setattr(config_module, "load_settings", real_load)
+    published_generations: list[int] = []
+
+    def publish_refreshed_runtime(
+        generation: int,
+        _action: ConsoleSettingsAction,
+        settings_view,
+    ) -> bool:
+        nonlocal recovery_state
+        assert recovery_state.recovery_intent == intent_a
+        published_generations.append(generation)
+        live_app_config.clear()
+        live_app_config.update(settings_view)
+        recovery_state, accepted = recovery_state.accept_runtime_publication(
+            generation
+        )
+        return accepted
+
+    assert defaults_module.reserve_console_default_intent_generation(
+        intent_b,
+        pending_runtime_publisher=publish_refreshed_runtime,
+    )
+    recovery_state = ConsoleDefaultDurabilityState(
+        newest_intent_generation=intent_b.generation
+    )
+    monkeypatch.setattr(
+        config_module,
+        "atomic_private_write_text",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("controlled before-replace failure")
+        ),
+    )
+
+    outcome_b = apply_console_default_intent(intent_b)
+    recovery_state = ConsoleDefaultDurabilityState(
+        newest_intent_generation=intent_b.generation,
+        recovery_intent=intent_b,
+        failure_phase=ConsoleDefaultSavePhase.BEFORE_REPLACE,
+    )
+
+    assert outcome_b.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    assert published_generations == [intent_a.generation]
+    assert live_app_config["api_settings"]["OpenAI"]["model_defaults"][
+        LITERAL_MODEL
+    ]["temperature"] == 0.1
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
+        "temperature"
+    ] == 0.1
+    runtime = config_module.get_runtime_config_snapshot()
+    assert runtime.values["api_settings"]["OpenAI"]["model_defaults"][
+        LITERAL_MODEL
+    ]["temperature"] == 0.1
+    assert recovery_state.recovery_intent == intent_b
+    assert recovery_state.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+
+
+def test_cache_failure_is_saved_and_refresh_continuation_never_rewrites(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    real_load = config_module.load_settings
+    monkeypatch.setattr(
+        config_module,
+        "load_settings",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("cache detail")),
+    )
+
+    outcome = apply_console_default_intent(_intent())
+
+    assert outcome.file_replaced is True
+    assert outcome.runtime_published is False
+    assert outcome.settings_view is None
+    assert outcome.failure_phase is ConsoleDefaultSavePhase.CACHE_PUBLICATION
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
+        "temperature"
+    ] == 0.25
+    monkeypatch.setattr(config_module, "load_settings", real_load)
+    monkeypatch.setattr(
+        config_module,
+        "atomic_private_write_text",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("refresh must not write")
+        ),
+    )
+
+    refreshed = refresh_console_runtime_after_saved_default()
+
+    assert refreshed.published is True
+    assert refreshed.settings_view is not None
+    assert refreshed.failure_phase is None
+
+
+def test_writer_error_after_visible_replace_is_cache_only_and_refresh_never_writes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    real_write = config_module.atomic_private_write_text
+    real_load = config_module.load_settings
+    load_calls = 0
+
+    def write_then_raise(*args, **kwargs):
+        real_write(*args, **kwargs)
+        raise OSError("post-rename detail")
+
+    def unexpected_publication(*args, **kwargs):
+        nonlocal load_calls
+        load_calls += 1
+        raise AssertionError("uncertain writer outcome must not publish caches")
+
+    monkeypatch.setattr(
+        config_module,
+        "atomic_private_write_text",
+        write_then_raise,
+    )
+    monkeypatch.setattr(config_module, "load_settings", unexpected_publication)
+
+    outcome = apply_console_default_intent(_intent())
+
+    assert outcome.file_replaced is True
+    assert outcome.runtime_published is False
+    assert outcome.settings_view is None
+    assert outcome.failure_phase is ConsoleDefaultSavePhase.CACHE_PUBLICATION
+    assert load_calls == 0
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
+        "temperature"
+    ] == 0.25
+    monkeypatch.setattr(
+        config_module,
+        "atomic_private_write_text",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("cache-only recovery must not write")
+        ),
+    )
+    monkeypatch.setattr(config_module, "load_settings", real_load)
+
+    refreshed = refresh_console_runtime_after_saved_default()
+
+    assert refreshed.published is True
+    assert refreshed.settings_view is not None
+    assert refreshed.failure_phase is None
+
+
+def test_duplicate_intent_after_success_is_terminal_and_never_rewrites(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    real_write = config_module.atomic_private_write_text
+    writes = 0
+
+    def counted_write(*args, **kwargs):
+        nonlocal writes
+        writes += 1
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(config_module, "atomic_private_write_text", counted_write)
+    intent = _intent()
+
+    first = apply_console_default_intent(intent)
+    committed = config_path.read_bytes()
+    duplicate = apply_console_default_intent(intent)
+
+    assert first.runtime_published is True
+    assert duplicate.file_replaced is False
+    assert duplicate.runtime_published is False
+    assert duplicate.settings_view is None
+    assert duplicate.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    assert writes == 1
+    assert config_path.read_bytes() == committed
+
+
+def test_retry_after_cache_failure_is_terminal_and_never_rewrites(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    real_write = config_module.atomic_private_write_text
+    real_load = config_module.load_settings
+    writes = 0
+
+    def counted_write(*args, **kwargs):
+        nonlocal writes
+        writes += 1
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(config_module, "atomic_private_write_text", counted_write)
+    monkeypatch.setattr(
+        config_module,
+        "load_settings",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("cache detail")),
+    )
+    intent = _intent()
+
+    failed_publication = apply_console_default_intent(intent)
+    committed = config_path.read_bytes()
+    monkeypatch.setattr(config_module, "load_settings", real_load)
+    disk_retry = apply_console_default_intent(intent)
+
+    assert failed_publication.failure_phase is ConsoleDefaultSavePhase.CACHE_PUBLICATION
+    assert disk_retry.file_replaced is False
+    assert disk_retry.runtime_published is False
+    assert disk_retry.settings_view is None
+    assert disk_retry.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    assert writes == 1
+    assert config_path.read_bytes() == committed
+
+
+def test_concurrent_duplicate_is_rejected_and_failed_retry_remains_retryable(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    real_write = config_module.atomic_private_write_text
+    first_write_started = threading.Event()
+    release_first_write = threading.Event()
+    duplicate_invoked = threading.Event()
+    duplicate_done = threading.Event()
+    attempts = 0
+    outcomes = {}
+
+    def controlled_write(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            first_write_started.set()
+            release_first_write.wait()
+            raise OSError("initial before-replace failure")
+        if attempts == 2:
+            raise OSError("retry before-replace failure")
+        return real_write(*args, **kwargs)
+
+    monkeypatch.setattr(config_module, "atomic_private_write_text", controlled_write)
+    intent = _intent()
+
+    worker_a = threading.Thread(
+        target=lambda: outcomes.setdefault("initial", apply_console_default_intent(intent))
+    )
+
+    def invoke_duplicate() -> None:
+        duplicate_invoked.set()
+        outcomes.setdefault("duplicate", apply_console_default_intent(intent))
+        duplicate_done.set()
+
+    worker_b = threading.Thread(target=invoke_duplicate)
+    worker_a.start()
+    assert first_write_started.wait(timeout=5)
+    try:
+        worker_b.start()
+        assert duplicate_invoked.wait(timeout=5)
+        assert duplicate_done.wait(timeout=5)
+        assert worker_a.is_alive()
+    finally:
+        release_first_write.set()
+    worker_a.join(timeout=5)
+    worker_b.join(timeout=5)
+
+    assert not worker_a.is_alive()
+    assert not worker_b.is_alive()
+    assert outcomes["initial"].failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    assert outcomes["duplicate"].failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    assert attempts == 1
+
+    failed_retry = apply_console_default_intent(intent)
+    successful_retry = apply_console_default_intent(intent)
+
+    assert failed_retry.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    assert successful_retry.runtime_published is True
+    assert attempts == 3
+
+
+def test_noop_disk_state_cache_failure_still_requires_cache_only_recovery(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    original = config_path.read_bytes()
+    writes = []
+    monkeypatch.setattr(
+        config_module,
+        "atomic_private_write_text",
+        lambda *args, **kwargs: writes.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        config_module,
+        "load_settings",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("cache detail")),
+    )
+
+    outcome = apply_console_default_intent(
+        _intent(
+            field_mask=FULL_MODEL_DEFAULT_FIELDS,
+            values={"streaming": None},
+        )
+    )
+
+    assert outcome.file_replaced is False
+    assert outcome.runtime_published is False
+    assert outcome.settings_view is None
+    assert outcome.failure_phase is ConsoleDefaultSavePhase.CACHE_PUBLICATION
+    assert writes == []
+    assert config_path.read_bytes() == original
+
+
+def test_runtime_refresh_contains_lock_failure_and_never_writes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    class FailingLock:
+        def __enter__(self):
+            raise OSError("lock detail")
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+    monkeypatch.setattr(config_module, "_config_write_lock", lambda _path: FailingLock())
+    monkeypatch.setattr(
+        config_module,
+        "atomic_private_write_text",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("refresh must not write")
+        ),
+    )
+
+    result = refresh_console_runtime_after_saved_default()
+
+    assert result.published is False
+    assert result.settings_view is None
+    assert result.failure_phase == "cache_reload"
+
+
+def test_newer_intent_supersedes_older_retry_generation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config())
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    old = _intent(generation=10, values={"temperature": 0.1, "streaming": True})
+    real_write = config_module.atomic_private_write_text
+    monkeypatch.setattr(
+        config_module,
+        "atomic_private_write_text",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("first failure")),
+    )
+    assert apply_console_default_intent(old).failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    monkeypatch.setattr(config_module, "atomic_private_write_text", real_write)
+    newer = _intent(
+        generation=11,
+        values={"temperature": 0.6, "streaming": False},
+    )
+    assert apply_console_default_intent(newer).runtime_published is True
+
+    stale = apply_console_default_intent(old)
+
+    assert stale.file_replaced is False
+    assert stale.runtime_published is False
+    assert stale.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
+        "temperature"
+    ] == 0.6
+
+
+def test_make_default_rechecks_locked_readiness_and_rejects_removed_config(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, _ready_openai_config(section="openai"))
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    intent = _intent(action=ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT)
+    before_lock = threading.Event()
+    external_edit_complete = threading.Event()
+    real_config_write_lock = config_module._config_write_lock
+
+    class DelayedConfigWriteLock:
+        def __init__(self, path: Path) -> None:
+            self._path = path
+            self._inner = None
+
+        def __enter__(self):
+            before_lock.set()
+            if not external_edit_complete.wait(timeout=5):
+                raise AssertionError("external edit did not complete")
+            self._inner = real_config_write_lock(self._path)
+            return self._inner.__enter__()
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            assert self._inner is not None
+            return self._inner.__exit__(exc_type, exc_value, traceback)
+
+    monkeypatch.setattr(
+        config_module,
+        "_config_write_lock",
+        lambda path: DelayedConfigWriteLock(path),
+    )
+    outcomes = []
+    worker = threading.Thread(
+        target=lambda: outcomes.append(apply_console_default_intent(intent)),
+    )
+    worker.start()
+    assert before_lock.wait(timeout=5)
+    externally_changed = _ready_openai_config(section="OpenAI")
+    externally_changed["api_settings"]["OpenAI"].pop("api_key")
+    externally_changed["api_settings"]["OpenAI"]["credential_source"] = "stored"
+    _write_config(config_path, externally_changed)
+    original = config_path.read_bytes()
+    external_edit_complete.set()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    outcome = outcomes[0]
+
+    assert outcome.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+    assert outcome.settings_view is None
+    assert config_path.read_bytes() == original
+    assert "openai" not in tomllib.loads(config_path.read_text(encoding="utf-8"))[
+        "api_settings"
+    ]
+
+
+def test_locked_builder_uses_authoritative_raw_alias_and_preserves_newer_edits(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    current = _ready_openai_config(section="OpenAI")
+    current["unrelated"] = {"concurrent": "newer"}
+    current["api_settings"]["OpenAI"]["newer_provider_field"] = 42
+    _write_config(config_path, current)
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    outcome = apply_console_default_intent(_intent())
+
+    assert outcome.runtime_published is True
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert "openai" not in saved["api_settings"]
+    assert saved["api_settings"]["OpenAI"]["newer_provider_field"] == 42
+    assert saved["unrelated"] == {"concurrent": "newer"}
+
+
+def test_make_default_uses_raw_alias_while_locked_readiness_uses_effective_env(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    current = _ready_openai_config(section="OpenAI")
+    current["api_settings"]["OpenAI"].pop("api_key")
+    _write_config(config_path, current)
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "effective-test-key")
+
+    outcome = apply_console_default_intent(
+        _intent(
+            action=ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
+            field_mask=FULL_MODEL_DEFAULT_FIELDS,
+        )
+    )
+
+    assert outcome.runtime_published is True
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert "openai" not in saved["api_settings"]
+    assert saved["api_settings"]["OpenAI"]["model_defaults"][LITERAL_MODEL][
+        "temperature"
+    ] == 0.25
+    assert saved["chat_defaults"] == {
+        "provider": "openai",
+        "model": LITERAL_MODEL,
+    }
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_endpoint"),
+    (
+        (ConsoleSettingsAction.APPLY_TO_CHAT, None),
+        (ConsoleSettingsAction.SAVE_MODEL_DEFAULT, None),
+        (
+            ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
+            ConsoleEndpointPatch(
+                value="https://localhost:8080/v1",
+                bound_provider_config_key="openai",
+                dirty=True,
+                checked=True,
+            ),
+        ),
+    ),
+)
+def test_build_default_intent_full_respects_action_endpoint_boundary(
+    action: ConsoleSettingsAction,
+    expected_endpoint: ConsoleEndpointPatch | None,
+) -> None:
+    drafts = (
+        ConsoleSettingsFieldDraft(
+            name="temperature",
+            effective_value=0.73,
+            profile_override=None,
+            provenance=ConsoleSettingsFieldProvenance.INHERITED,
+            dirty=True,
+        ),
+        ConsoleSettingsFieldDraft(
+            name="top_p",
+            effective_value=0.91,
+            profile_override=0.42,
+            provenance=ConsoleSettingsFieldProvenance.EXPLICIT,
+            dirty=True,
+        ),
+        ConsoleSettingsFieldDraft(
+            name="not_exposed_by_mask",
+            effective_value="effective",
+            profile_override="override",
+            provenance=ConsoleSettingsFieldProvenance.EXPLICIT,
+            dirty=True,
+        ),
+    )
+    endpoint = ConsoleEndpointDraft(
+        value="https://localhost:8080/v1",
+        bound_provider_config_key="openai",
+        dirty=True,
+        checked=True,
+    )
+
+    intent = defaults_module.build_console_default_intent(
+        generation=7,
+        action=action,
+        provider_config_key="openai",
+        literal_model_id=LITERAL_MODEL,
+        field_drafts=drafts,
+        field_mask=FULL_MODEL_DEFAULT_FIELDS,
+        endpoint=endpoint,
+    )
+
+    assert dict(intent.values) == {"temperature": None, "top_p": 0.42}
+    assert intent.endpoint_patch == expected_endpoint
+
+
+def test_build_default_intent_quick_materializes_displayed_effective_values() -> None:
+    drafts = (
+        ConsoleSettingsFieldDraft(
+            name="temperature",
+            effective_value=0.73,
+            profile_override=None,
+            provenance=ConsoleSettingsFieldProvenance.INHERITED,
+            dirty=False,
+        ),
+        ConsoleSettingsFieldDraft(
+            name="streaming",
+            effective_value=False,
+            profile_override=None,
+            provenance=ConsoleSettingsFieldProvenance.INHERITED,
+            dirty=False,
+        ),
+        ConsoleSettingsFieldDraft(
+            name="top_p",
+            effective_value=0.91,
+            profile_override=0.42,
+            provenance=ConsoleSettingsFieldProvenance.EXPLICIT,
+            dirty=True,
+        ),
+    )
+
+    intent = defaults_module.build_console_default_intent(
+        generation=8,
+        action=ConsoleSettingsAction.SAVE_MODEL_DEFAULT,
+        provider_config_key="openai",
+        literal_model_id=LITERAL_MODEL,
+        field_drafts=drafts,
+        field_mask=QUICK_MODEL_DEFAULT_FIELDS,
+        endpoint=None,
+    )
+
+    assert dict(intent.values) == {"temperature": 0.73, "streaming": False}
+
+
+@pytest.mark.parametrize(
+    ("value", "authority", "classification"),
+    [
+        ("http://localhost:8080/v1?x=1#frag", "localhost:8080", "Local"),
+        ("https://127.0.0.1/path", "127.0.0.1", "Local"),
+        ("192.168.1.20:8443/v1", "192.168.1.20:8443", "LAN"),
+        ("http://[::1]:9000/v1", "[::1]:9000", "Local"),
+        ("https://8.8.8.8/v1", "8.8.8.8", "Remote"),
+        ("https://10.1.2.3/v1", "10.1.2.3", "LAN"),
+        ("https://172.16.0.1/v1", "172.16.0.1", "LAN"),
+        ("https://192.168.1.20/v1", "192.168.1.20", "LAN"),
+        ("https://192.0.2.1/v1", "192.0.2.1", "Remote/unknown"),
+        ("https://224.0.0.1/v1", "224.0.0.1", "Remote/unknown"),
+        ("https://0.0.0.0/v1", "0.0.0.0", "Remote/unknown"),
+        ("http://[fc00::1]/v1", "[fc00::1]", "LAN"),
+        ("http://[fe80::1]/v1", "[fe80::1]", "LAN"),
+        ("http://[2001:db8::1]/v1", "[2001:db8::1]", "Remote/unknown"),
+        (
+            "http://[2606:4700:4700::1111]/v1",
+            "[2606:4700:4700::1111]",
+            "Remote",
+        ),
+        ("host.example:443/path", "host.example:443", "Remote/unknown"),
+        ("printer.local/api", "printer.local", "LAN"),
+    ],
+)
+def test_endpoint_preview_exposes_only_authority_and_network_class(
+    value: str,
+    authority: str,
+    classification: str,
+) -> None:
+    preview = parse_console_endpoint_preview(value)
+
+    assert preview is not None
+    assert preview.authority == authority
+    assert preview.network_classification == classification
+    assert format_console_endpoint_preview(value) == f"{authority} · {classification}"
+    assert not any(token in preview.authority for token in ("http", "/", "?", "#", "@"))
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://user:password@example.test/v1",
+        "user@example.test:8080",
+        "https://example.test:99999/v1",
+        "https:///missing-host",
+        "example.com\\secret",
+        "https://example..com/v1",
+        "https://-bad.example/v1",
+        "https://bad-.example/v1",
+        "https://bad_host.example/v1",
+        "https://example.com|evil/v1",
+        "https://example.com;evil/v1",
+        "https://ex\x00ample.com/v1",
+        "https://café.example/v1",
+        "",
+    ],
+)
+def test_endpoint_preview_rejects_credentials_and_invalid_authorities(value: str) -> None:
+    assert parse_console_endpoint_preview(value) is None
+    assert format_console_endpoint_preview(value) is None
+
+
+def test_recovery_request_is_bounded_to_action_and_intent_generation() -> None:
+    request = ConsoleDefaultRecoveryRequest(
+        action=ConsoleDefaultRecoveryAction.RETRY_SAVE,
+        intent_generation=19,
+    )
+
+    assert request.action is ConsoleDefaultRecoveryAction.RETRY_SAVE
+    assert request.intent_generation == 19
+
+
+def test_default_durability_state_accepts_only_current_runtime_publication_once() -> None:
+    intent = _intent(
+        generation=19,
+        action=ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
+    )
+    state = ConsoleDefaultDurabilityState(
+        newest_intent_generation=19,
+        recovery_intent=intent,
+        failure_phase=ConsoleDefaultSavePhase.CACHE_PUBLICATION,
+    )
+
+    stale, stale_accepted = state.accept_runtime_publication(18)
+    accepted, first_accepted = state.accept_runtime_publication(19)
+    duplicate, duplicate_accepted = accepted.accept_runtime_publication(19)
+
+    assert stale is state
+    assert stale_accepted is False
+    assert first_accepted is True
+    assert accepted.recovery_intent is None
+    assert accepted.failure_phase is None
+    assert accepted.runtime_published_intent_generation == 19
+    assert duplicate is accepted
+    assert duplicate_accepted is False
+
+
+def test_runtime_publication_callback_exception_stays_cache_retryable() -> None:
+    """A UI callback failure remains eligible for cache-only recovery."""
+
+    intent = _intent()
+    assert defaults_module.reserve_console_default_intent_generation(intent)
+    defaults_module._LATEST_INTENT_LIFECYCLE = (
+        defaults_module._IntentLifecycle.RUNTIME_PUBLICATION_PENDING
+    )
+    outcome = defaults_module.ConsoleDefaultMutationOutcome(
+        intent_generation=intent.generation,
+        file_replaced=True,
+        runtime_published=True,
+        settings_view={"chat_defaults": {"provider": "openai"}},
+        failure_phase=None,
+    )
+
+    def reject_with_exception(_settings_view) -> bool:
+        raise RuntimeError("controlled application callback failure")
+
+    assert (
+        defaults_module.publish_console_default_runtime_if_current(
+            intent,
+            outcome,
+            reject_with_exception,
+        )
+        is False
+    )
+    assert (
+        defaults_module._LATEST_INTENT_LIFECYCLE
+        is defaults_module._IntentLifecycle.RUNTIME_PUBLICATION_PENDING
+    )
+
+
+def test_predecessor_reservation_retries_are_bounded(monkeypatch) -> None:
+    intent_a = _intent(generation=1)
+    intent_b = _intent(generation=2)
+    assert defaults_module.reserve_console_default_intent_generation(intent_a)
+    defaults_module._LATEST_INTENT_LIFECYCLE = (
+        defaults_module._IntentLifecycle.RUNTIME_PUBLICATION_PENDING
+    )
+    attempts = 0
+
+    monkeypatch.setattr(
+        config_module,
+        "get_runtime_config_snapshot",
+        lambda: config_module.RuntimeConfigSnapshot(7, {}),
+    )
+
+    def reject_stale_generation(_generation, _callback) -> bool:
+        nonlocal attempts
+        attempts += 1
+        return False
+
+    monkeypatch.setattr(
+        config_module,
+        "run_if_runtime_config_generation_current",
+        reject_stale_generation,
+    )
+
+    with pytest.raises(RuntimeError, match="changed repeatedly"):
+        defaults_module.reserve_console_default_intent_generation(
+            intent_b,
+            pending_runtime_publisher=lambda *_args: True,
+        )
+
+    assert attempts == defaults_module._MAX_PREDECESSOR_RESERVATION_ATTEMPTS
+
+
+def test_predecessor_claim_releases_locks_before_ui_publication(
+    monkeypatch,
+) -> None:
+    """The UI phase runs only after config and intent claim locks are free."""
+
+    intent_a = _intent(generation=1)
+    intent_b = _intent(generation=2)
+    assert defaults_module.reserve_console_default_intent_generation(intent_a)
+    defaults_module._LATEST_INTENT_LIFECYCLE = (
+        defaults_module._IntentLifecycle.RUNTIME_PUBLICATION_PENDING
+    )
+    secret_endpoint = "https://user:secret@example.test/v1"
+    monkeypatch.setattr(
+        config_module,
+        "get_runtime_config_snapshot",
+        lambda: config_module.RuntimeConfigSnapshot(
+            7,
+            {"api_settings": {"openai": {"api_base_url": secret_endpoint}}},
+        ),
+    )
+    monkeypatch.setattr(
+        config_module,
+        "run_if_runtime_config_generation_current",
+        lambda _generation, action: action(),
+    )
+
+    preparation = defaults_module.prepare_console_default_intent_reservation(intent_b)
+    claim = preparation.predecessor_claim
+
+    assert preparation.reserved is False
+    assert claim is not None
+    assert defaults_module._LATEST_INTENT_GENERATION == intent_a.generation
+    assert secret_endpoint not in repr(claim)
+    assert secret_endpoint not in repr(
+        defaults_module._ACTIVE_RUNTIME_PUBLICATION_CLAIM
+    )
+    assert not hasattr(
+        defaults_module._ACTIVE_RUNTIME_PUBLICATION_CLAIM,
+        "settings_view",
+    )
+
+    acquired = threading.Event()
+
+    def acquire_both_locks() -> None:
+        with config_module._config_file_lock():
+            with defaults_module._INTENT_GENERATION_LOCK:
+                acquired.set()
+
+    probe = threading.Thread(target=acquire_both_locks)
+    probe.start()
+    probe.join(timeout=1)
+    assert acquired.is_set()
+    assert not probe.is_alive()
+
+    assert defaults_module.complete_console_default_runtime_publication(
+        claim,
+        successor_intent=intent_b,
+    )
+    assert defaults_module._LATEST_INTENT_GENERATION == intent_b.generation
+    assert (
+        defaults_module._LATEST_INTENT_LIFECYCLE
+        is defaults_module._IntentLifecycle.RESERVED
+    )
+
+
+def test_stale_claim_completion_keeps_predecessor_retryable(
+    monkeypatch,
+) -> None:
+    """A config race releases the claim without superseding its predecessor."""
+
+    intent_a = _intent(generation=1)
+    intent_b = _intent(generation=2)
+    assert defaults_module.reserve_console_default_intent_generation(intent_a)
+    defaults_module._LATEST_INTENT_LIFECYCLE = (
+        defaults_module._IntentLifecycle.RUNTIME_PUBLICATION_PENDING
+    )
+    monkeypatch.setattr(
+        config_module,
+        "get_runtime_config_snapshot",
+        lambda: config_module.RuntimeConfigSnapshot(7, {"current": "a"}),
+    )
+    monkeypatch.setattr(
+        config_module,
+        "run_if_runtime_config_generation_current",
+        lambda _generation, action: action(),
+    )
+    claim = defaults_module.prepare_console_default_intent_reservation(
+        intent_b
+    ).predecessor_claim
+    assert claim is not None
+
+    monkeypatch.setattr(
+        config_module,
+        "run_if_runtime_config_generation_current",
+        lambda _generation, _action: False,
+    )
+    assert not defaults_module.complete_console_default_runtime_publication(
+        claim,
+        successor_intent=intent_b,
+    )
+    assert defaults_module._ACTIVE_RUNTIME_PUBLICATION_CLAIM is None
+    assert defaults_module._LATEST_INTENT_GENERATION == intent_a.generation
+    assert (
+        defaults_module._LATEST_INTENT_LIFECYCLE
+        is defaults_module._IntentLifecycle.RUNTIME_PUBLICATION_PENDING
+    )

--- a/Tests/Chat/test_console_settings_durability.py
+++ b/Tests/Chat/test_console_settings_durability.py
@@ -1,0 +1,65 @@
+"""Application-lifetime Console settings durability contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from tldw_chatbook.Chat.console_settings_durability import (
+    ConsoleSettingsDurabilityOwner,
+)
+
+
+@pytest.mark.asyncio
+async def test_close_fences_admission_and_waits_for_lease_transfer() -> None:
+    owner = ConsoleSettingsDurabilityOwner()
+    lease = owner.try_acquire()
+    assert lease is not None
+
+    draining = asyncio.create_task(owner.close_and_drain())
+    await asyncio.sleep(0)
+    assert owner.try_acquire() is None
+    assert not draining.done()
+
+    finished = asyncio.Event()
+
+    async def admitted_work() -> None:
+        finished.set()
+
+    owner.launch(lease, admitted_work(), name="admitted-settings")
+    await draining
+
+    assert finished.is_set()
+    assert owner.tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_drain_does_not_cancel_admitted_thread_work() -> None:
+    owner = ConsoleSettingsDurabilityOwner()
+    lease = owner.try_acquire()
+    assert lease is not None
+    started = threading.Event()
+    release = threading.Event()
+    completed = threading.Event()
+
+    def blocking_write() -> None:
+        started.set()
+        assert release.wait(timeout=5)
+        completed.set()
+
+    async def admitted_work() -> None:
+        await asyncio.to_thread(blocking_write)
+
+    task = owner.launch(lease, admitted_work(), name="thread-settings")
+    assert await asyncio.to_thread(started.wait, 1)
+    draining = asyncio.create_task(owner.close_and_drain())
+    draining.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await draining
+
+    assert not task.cancelled()
+    release.set()
+    await owner.close_and_drain()
+    assert completed.is_set()

--- a/Tests/ProductionApp/test_provider_selection_ownership.py
+++ b/Tests/ProductionApp/test_provider_selection_ownership.py
@@ -5,7 +5,7 @@ import logging
 
 import pytest
 from textual.css.query import NoMatches
-from textual.widgets import Input, OptionList
+from textual.widgets import Button, Input, OptionList, Select
 
 import tldw_chatbook.app as app_module
 from tldw_chatbook.app import LLMProviderProvider, TldwCli
@@ -58,8 +58,16 @@ def _save_initial_provider_config() -> None:
 
 
 def _production_app(monkeypatch: pytest.MonkeyPatch) -> TldwCli:
-    _disable_splash(monkeypatch)
     _save_initial_provider_config()
+    return _production_app_from_saved_config(monkeypatch)
+
+
+def _production_app_from_saved_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> TldwCli:
+    """Construct the real app from the sandbox's already-saved config."""
+
+    _disable_splash(monkeypatch)
     app = TldwCli()
     app.app_config = load_settings(force_reload=True)
     app.app_config["_first_run"] = False
@@ -135,6 +143,57 @@ async def _close_production_app(app: TldwCli) -> None:
         await app.on_unmount()
     except Exception:
         pass
+
+
+@pytest.mark.asyncio
+async def test_real_app_restart_routes_saved_global_and_model_profile_to_new_chat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fresh TldwCli mount consumes the persisted global/profile defaults."""
+
+    adapter = SettingsConfigAdapter()
+    assert adapter.save_sections(
+        {
+            "chat_defaults": {
+                "provider": "Anthropic",
+                "model": "claude-task-648",
+            },
+            "api_settings.anthropic": {
+                "api_key": "TASK_648_TEST_KEY",
+                "model": "claude-task-648",
+                "model_defaults": {
+                    "claude-task-648": {
+                        "temperature": 0.37,
+                        "streaming": False,
+                    }
+                },
+            },
+        }
+    )
+    restarted = _production_app_from_saved_config(monkeypatch)
+
+    try:
+        async with restarted.run_test(size=(140, 48)) as pilot:
+            chat = await _wait_for_screen(restarted, pilot, ChatScreen)
+            settings = chat._session._ensure_active_console_session_settings()
+            store = chat._ensure_console_chat_store()
+            session_id = store.active_session_id
+
+            assert session_id is not None
+            assert store.session_settings(session_id) is settings
+            assert (
+                settings.provider,
+                settings.model,
+                settings.temperature,
+                settings.streaming,
+            ) == (
+                "anthropic",
+                "claude-task-648",
+                pytest.approx(0.37),
+                False,
+            )
+    finally:
+        await _close_production_app(restarted)
 
 
 @pytest.mark.asyncio
@@ -244,6 +303,46 @@ async def test_real_console_consumes_typed_provider_intents_and_opens_real_picke
             assert results.display is True
             assert results.option_count == 1
             assert str(results.get_option_at_index(0).prompt) == "gpt-task-648"
+
+            before_apply = screen._session._build_console_turn_execution_context(
+                session_id
+            )
+            popover.query_one(
+                "#console-popover-provider", Select
+            ).value = "anthropic"
+            await pilot.pause()
+            model_picker = popover.query_one("#console-popover-model-search")
+            model_picker.set_model_value("claude-task-648")
+            model_picker.post_message(
+                model_picker.ModelSelected("claude-task-648")
+            )
+            await pilot.pause()
+            apply_button = popover.query_one("#console-popover-apply", Button)
+            apply_button.scroll_visible(animate=False, force=True)
+            await pilot.pause()
+            assert await pilot.click(apply_button) is True
+            returned = await _wait_for_screen(app, pilot, ChatScreen)
+
+            applied = store.session_settings(session_id)
+            assert returned is screen
+            assert store.active_session_id == session_id
+            assert applied is not None
+            assert (applied.provider, applied.model) == (
+                "anthropic",
+                "claude-task-648",
+            )
+            after_apply = screen._session._build_console_turn_execution_context(
+                session_id
+            )
+            assert (
+                before_apply.provider_selection.provider,
+                before_apply.provider_selection.explicit_model,
+            ) == ("openai", "gpt-task-648")
+            assert (
+                after_apply.provider_selection.provider,
+                after_apply.provider_selection.explicit_model,
+            ) == ("anthropic", "claude-task-648")
+            assert notifications.count("This chat updated") == 1
     finally:
         await _close_production_app(app)
 
@@ -384,7 +483,9 @@ async def test_settings_save_preserves_user_session_then_away_command_hands_off(
             for _ in range(100):
                 handed_off_store = handed_off_chat._ensure_console_chat_store()
                 handed_off = handed_off_store.session_settings(session_id)
-                if handed_off is not None and handed_off.provider == "anthropic":
+                if not app.pending_handoffs.has_pending(
+                    HandoffChannel.CONSOLE_PROVIDER
+                ):
                     break
                 await pilot.pause(0.01)
             assert handed_off_store.active_session_id == session_id

--- a/Tests/UI/test_console_model_apply_chips.py
+++ b/Tests/UI/test_console_model_apply_chips.py
@@ -8,17 +8,36 @@ the run is actually served by the newly-applied provider.
 from __future__ import annotations
 
 from dataclasses import replace
+from types import SimpleNamespace
 
 import pytest
-from textual.app import App
-
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
-from textual.widgets import Static
+from textual.widgets import Select, Static
 
 from Tests.UI.app_factory import _build_test_app
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_context_policy import ConsoleContextPolicyOverrides
+from tldw_chatbook.Chat.console_session_settings import (
+    ConsoleSessionSettings,
+    ConsoleSettingsReadiness,
+)
+from tldw_chatbook.Chat.console_settings_apply import (
+    QUICK_MODEL_DEFAULT_FIELDS,
+    ConsoleSettingsAction,
+    ConsoleSettingsCommittedSubmission,
+    ConsoleSettingsDraftState,
+    ConsoleSettingsFieldDraft,
+    ConsoleSettingsFieldProvenance,
+    ConsoleSettingsLiveCommit,
+    ConsoleSettingsOrigin,
+    ConsoleSettingsSurface,
+    ConsoleSettingsSubmission,
+)
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.Widgets.Console.console_model_popover import ConsoleModelPopover
 
 
 class _ConsoleHarness(ConsolidatedCSSApp):
@@ -84,13 +103,35 @@ async def test_popover_apply_refreshes_the_provider_chip():
 
         await _wait_for(pilot, chip_text, "initial provider chip")
 
+        store = chat_screen._ensure_console_chat_store()
+        session_id = store.active_session_id
+        assert session_id is not None
         settings = chat_screen._session._ensure_active_console_session_settings()
+        next_settings = replace(
+            settings,
+            provider="vllm",
+            model="served-model",
+            source="user",
+        )
+        draft = chat_screen._console_settings_initial_draft(
+            next_settings,
+            store.session_context_policy_overrides(session_id),
+            exposed_fields=QUICK_MODEL_DEFAULT_FIELDS,
+        )
+        submission = ConsoleSettingsSubmission(
+            submission_id="provider-chip-refresh",
+            action=ConsoleSettingsAction.APPLY_TO_CHAT,
+            surface=ConsoleSettingsSurface.QUICK_POPOVER,
+            origin=store.capture_console_settings_origin(session_id),
+            draft=draft,
+            user_display_name_override=None,
+            default_field_mask=frozenset(),
+        )
+        live_commit = store.commit_console_settings_live(submission)
         chat_screen._apply_console_model_popover_result(
-            replace(
-                settings,
-                provider="vllm",
-                model="served-model",
-                source="user",
+            ConsoleSettingsCommittedSubmission(
+                submission=submission,
+                live_commit=live_commit,
             )
         )
         # The regular tick calls this; the chip must be fresh WITHOUT a
@@ -103,3 +144,160 @@ async def test_popover_apply_refreshes_the_provider_chip():
             lambda: "vllm" in chip_text().lower(),
             f"chip to show the applied provider (still: {chip_text()!r})",
         )
+
+
+@pytest.mark.asyncio
+async def test_model_apply_popover_commits_selected_provider_and_model_once() -> None:
+    settings = ConsoleSessionSettings(
+        provider="llama_cpp",
+        model="local-model",
+        base_url="http://127.0.0.1:9099",
+    )
+    origin = ConsoleSettingsOrigin("session-a", None, 0)
+    draft = ConsoleSettingsDraftState(
+        settings=settings,
+        context_policy_overrides=ConsoleContextPolicyOverrides(),
+        field_drafts=tuple(
+            ConsoleSettingsFieldDraft(
+                name=name,
+                effective_value=getattr(settings, name),
+                profile_override=getattr(settings, name),
+                provenance=ConsoleSettingsFieldProvenance.INHERITED,
+                dirty=False,
+            )
+            for name in ("temperature", "streaming")
+        ),
+        model_drafts=(),
+        endpoint_draft=None,
+    )
+    config = {
+        "chat_defaults": {"provider": "llama_cpp", "model": "local-model"},
+        "api_settings": {
+            "llama_cpp": {"api_url": "http://127.0.0.1:9099"},
+            "vllm": {"api_url": "http://127.0.0.1:9098"},
+        },
+    }
+    submissions: list[ConsoleSettingsSubmission] = []
+
+    def rebase(state: ConsoleSettingsDraftState, **kwargs) -> ConsoleSettingsDraftState:
+        return ConsoleChatController.rebase_console_settings_draft(
+            object(), state, **kwargs
+        )
+
+    def commit(submission: ConsoleSettingsSubmission) -> ConsoleSettingsLiveCommit:
+        submissions.append(submission)
+        return ConsoleSettingsLiveCommit(
+            submission_id=submission.submission_id,
+            session_id=origin.session_id,
+            persisted_conversation_id=None,
+            conversation_binding_revision=0,
+            generation_revision=1,
+            context_policy_revision=1,
+            settings=submission.draft.settings,
+            context_policy_overrides=submission.draft.context_policy_overrides,
+        )
+
+    results: list[object] = []
+    harness = ConsolidatedCSSApp()
+    modal = ConsoleModelPopover(
+        origin=origin,
+        app_config=config,
+        initial_draft=draft,
+        providers_models={
+            "llama_cpp": ["local-model"],
+            "vllm": ["served-model"],
+        },
+        scope_copy="Applies to this conversation",
+        durability_copy="Temporary until this chat is promoted",
+        draft_rebaser=rebase,
+        live_committer=commit,
+        default_readiness_resolver=lambda _provider, _model: (
+            ConsoleSettingsReadiness("Ready", "Ready.", True)
+        ),
+    )
+    async with harness.run_test(size=(100, 38)) as pilot:
+        await harness.push_screen(modal, callback=results.append)
+        modal.query_one("#console-popover-provider", Select).value = "vllm"
+        await pilot.pause()
+        picker = modal.query_one("#console-popover-model-search")
+        picker.set_model_value("served-model")
+        picker.post_message(picker.ModelSelected("served-model"))
+        await pilot.pause()
+        await pilot.click("#console-popover-apply")
+        await pilot.pause()
+
+    assert len(submissions) == 1
+    assert len(results) == 1
+    assert isinstance(results[0], ConsoleSettingsCommittedSubmission)
+    assert results[0].live_commit.settings.provider == "vllm"
+    assert results[0].live_commit.settings.model == "served-model"
+    assert results[0].submission.default_field_mask == frozenset()
+    assert QUICK_MODEL_DEFAULT_FIELDS == frozenset({"temperature", "streaming"})
+
+
+@pytest.mark.asyncio
+async def test_model_apply_exact_origin_is_captured_before_catalog_await(
+) -> None:
+    """A tab switch during catalog loading must not retarget the popover."""
+    store = ConsoleChatStore()
+    origin_settings = ConsoleSessionSettings(provider="llama_cpp", model="origin")
+    origin = store.create_session(settings=origin_settings)
+    pushed: list[tuple[object, object]] = []
+    context_calls: list[tuple[str, ConsoleSessionSettings, str]] = []
+
+    async def delayed_catalog(*_args, **_kwargs):
+        store.create_session(
+            settings=ConsoleSessionSettings(provider="vllm", model="background")
+        )
+        return {"llama_cpp": ["origin"]}
+
+    async def effective_thinking_policy(session_id: str) -> str:
+        assert session_id == origin.id
+        return "keep"
+
+    def context_state_for_session(
+        session_id: str,
+        *,
+        settings: ConsoleSessionSettings,
+        thinking_history_effective_policy: str,
+    ) -> None:
+        context_calls.append(
+            (session_id, settings, thinking_history_effective_policy)
+        )
+
+    fake = SimpleNamespace(
+        _console_setup_modal_blocking=lambda: False,
+        _ensure_console_chat_store=lambda: store,
+        _ensure_console_chat_controller=lambda: SimpleNamespace(
+            rebase_console_settings_draft=lambda state, **_kwargs: state,
+            effective_thinking_history_policy_for_session=(
+                effective_thinking_policy
+            ),
+        ),
+        _session=SimpleNamespace(
+            _ensure_active_console_session_settings=lambda: store.session_settings(
+                origin.id
+            )
+        ),
+        _providers_models_for_console_settings=delayed_catalog,
+        _provider_readiness_app_config=lambda: {},
+        _console_context_control_state_for_session=context_state_for_session,
+        _console_settings_initial_draft=ChatScreen._console_settings_initial_draft,
+        _console_default_readiness=lambda _provider, _model: (
+            ConsoleSettingsReadiness("Ready", "Ready.", True)
+        ),
+        _commit_console_settings_submission_live=lambda _submission: None,
+        _apply_console_model_popover_result=lambda _result: None,
+        app=SimpleNamespace(
+            push_screen=lambda modal, callback: pushed.append((modal, callback))
+        ),
+    )
+
+    await ChatScreen.action_open_console_model_popover(fake)
+
+    assert store.active_session_id != origin.id
+    modal, _callback = pushed[0]
+    assert isinstance(modal, ConsoleModelPopover)
+    assert modal._origin.session_id == origin.id
+    assert modal._draft.settings == origin_settings
+    assert context_calls == [(origin.id, origin_settings, "keep")]

--- a/Tests/UI/test_console_provider_apply_defaults_flow.py
+++ b/Tests/UI/test_console_provider_apply_defaults_flow.py
@@ -1,0 +1,1091 @@
+"""Production-hierarchy coverage for Console provider Apply and defaults.
+
+These tests keep Textual's real ``ChatScreen`` composition, the consolidated
+production CSS, and the real Console store/controller orchestration.  Provider
+execution is never entered; the observable boundary is the detached turn
+configuration captured immediately before a send would reach the gateway.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import replace
+
+import pytest
+from textual.widgets import Button, Input, Select, Static
+
+import tldw_chatbook.Chat.console_settings_defaults as defaults_module
+from Tests.console_provider_doubles import provider_resolution
+from Tests.UI.background_signals import (
+    await_background_task,
+    wait_for_background_signal,
+    wait_for_signal,
+)
+from Tests.UI.app_factory import _build_test_app, attach_chachanotes_db
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from Tests.UI.test_destination_shells import _wait_for_selector
+from tldw_chatbook.Chat.console_context_policy import (
+    CompactionFailureBehavior,
+    ConsoleContextPolicyOverrides,
+    ContextCarryForwardMode,
+    ContextCompactionMode,
+)
+from tldw_chatbook.Chat.console_conversation_hydration import (
+    hydrate_console_generation_settings,
+)
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import (
+    ConsoleChatStore,
+    ConsoleSettingsComponent,
+    ConsoleSettingsPolicyFailureLabel,
+)
+from tldw_chatbook.Chat.console_library_policy import ConsoleLibraryPolicySnapshot
+from tldw_chatbook.Chat.console_settings_defaults import (
+    ConsoleDefaultDurabilityState,
+    ConsoleDefaultMutationIntent,
+    ConsoleDefaultSavePhase,
+    ConsoleEndpointPatch,
+)
+from tldw_chatbook.Chat.console_session_settings import (
+    ConsoleSessionSettings,
+    blank_console_session_settings,
+    build_target_default_console_session_settings,
+)
+from tldw_chatbook.Chat.console_settings_apply import (
+    QUICK_MODEL_DEFAULT_FIELDS,
+    ConsoleSettingsAction,
+    ConsoleSettingsCommittedSubmission,
+    ConsoleSettingsDraftState,
+    ConsoleSettingsFieldDraft,
+    ConsoleSettingsFieldProvenance,
+    ConsoleSettingsSubmission,
+    ConsoleSettingsSurface,
+)
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.UI.Console_Modules.left_rail import (
+    CONSOLE_DISCARD_DEFAULT_RETRY_ID,
+    CONSOLE_DISMISS_DEFAULT_REFRESH_ID,
+    CONSOLE_REFRESH_RUNNING_APP_ID,
+    CONSOLE_RETRY_DEFAULT_SAVE_ID,
+    ConsoleLeftRail,
+)
+from tldw_chatbook.UI.Screens.settings_config_adapter import SettingsConfigAdapter
+from tldw_chatbook.Widgets.Console.console_model_popover import ConsoleModelPopover
+from tldw_chatbook.config import load_settings
+
+
+@pytest.fixture(autouse=True)
+def _reset_default_intent_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep process-global default intent fencing independent per journey."""
+
+    monkeypatch.setattr(defaults_module, "_LATEST_INTENT_GENERATION", None)
+    monkeypatch.setattr(defaults_module, "_LATEST_INTENT_FINGERPRINT", None)
+    monkeypatch.setattr(defaults_module, "_LATEST_INTENT_LIFECYCLE", None)
+    monkeypatch.setattr(defaults_module, "_ACTIVE_INTENT_CALLS", set())
+    monkeypatch.setattr(defaults_module, "_PENDING_RETRY_STATE", None)
+
+
+class _ConsoleFlowHarness(ConsolidatedCSSApp):
+    """Mount the shipping Console screen beneath the production stylesheet."""
+
+    def __init__(self, app_instance) -> None:
+        super().__init__()
+        self.app_instance = app_instance
+
+    async def on_mount(self) -> None:
+        await self.push_screen(ChatScreen(self.app_instance))
+
+
+class _ControlledSettingsPersistence:
+    """Thread-safe settings persistence with one blocked promotion flush."""
+
+    db = None
+
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loop = loop
+        self.promotion_context_started = asyncio.Event()
+        self.release_promotion_context = threading.Event()
+        self.promotion_conversation_id: str | None = None
+
+    @staticmethod
+    def _committed_policy(candidate) -> ConsoleLibraryPolicySnapshot:
+        return ConsoleLibraryPolicySnapshot(
+            auto_retrieve=candidate.auto_retrieve,
+            assistant_access=candidate.assistant_access,
+            policy_revision=1,
+            source="durable",
+        )
+
+    def create_conversation(self, **_kwargs):
+        raise AssertionError("atomic first persistence must be used")
+
+    def persist_console_conversation_with_policy(self, **kwargs):
+        return self._committed_policy(kwargs["policy_candidate"])
+
+    def promote_console_conversation_bundle(self, **kwargs):
+        self.promotion_conversation_id = kwargs["conversation_id"]
+        return self._committed_policy(kwargs["policy_candidate"])
+
+    def update_conversation_context_policy(self, **kwargs):
+        if kwargs["conversation_id"] == self.promotion_conversation_id:
+            self._loop.call_soon_threadsafe(self.promotion_context_started.set)
+            if not self.release_promotion_context.wait(timeout=10):
+                raise AssertionError("promotion context flush was not released")
+        raise RuntimeError("controlled context persistence failure")
+
+
+class _RecordingProviderGateway:
+    """Stub only provider I/O while retaining production action routing."""
+
+    def __init__(self) -> None:
+        self.selections = []
+
+    async def resolve_for_send(self, selection):
+        self.selections.append(selection)
+        return provider_resolution(base_url="http://127.0.0.1:9099")
+
+    async def stream_chat(self, _resolution, _messages, **_kwargs):
+        yield "completed"
+
+
+def _console_app():
+    app = _build_test_app(
+        config_overrides={
+            "chat_defaults": {"provider": "llama_cpp", "model": "model-a"},
+            "api_settings": {
+                "llama_cpp": {
+                    "api_url": "http://127.0.0.1:9099",
+                    "model": "model-a",
+                },
+                "vllm": {
+                    "api_url": "http://127.0.0.1:9098",
+                    "model": "model-b",
+                },
+            },
+        }
+    )
+    attach_chachanotes_db(app)
+    app.chat_api_provider_value = "llama_cpp"
+    app.chat_api_model_value = "model-a"
+    app.providers_models = {
+        "llama_cpp": ["model-a"],
+        "vllm": ["model-b"],
+    }
+    return app
+
+
+def _persisted_console_app():
+    """Build from the sandbox config file the default writer will mutate."""
+
+    adapter = SettingsConfigAdapter()
+    assert adapter.save_sections(
+        {
+            "chat_defaults": {
+                "provider": "llama_cpp",
+                "model": "model-a",
+            },
+            "api_settings.llama_cpp": {
+                "api_url": "http://127.0.0.1:9099",
+                "model": "model-a",
+            },
+            "api_settings.vllm": {
+                "api_url": "http://127.0.0.1:9098",
+                "model": "vendor/model:b",
+                "streaming": True,
+            },
+        }
+    )
+    app = _build_test_app()
+    attach_chachanotes_db(app)
+    app.chat_api_provider_value = "llama_cpp"
+    app.chat_api_model_value = "model-a"
+    app.providers_models = {
+        "llama_cpp": ["model-a"],
+        "vllm": ["vendor/model:b"],
+    }
+    return app
+
+
+async def _open_provider_popover(
+    console: ChatScreen,
+    harness: _ConsoleFlowHarness,
+    pilot,
+) -> ConsoleModelPopover:
+    await console.action_open_console_model_popover()
+    await pilot.pause()
+    modal = harness.screen
+    assert isinstance(modal, ConsoleModelPopover)
+    return modal
+
+
+async def _select_vllm_model(
+    modal: ConsoleModelPopover,
+    pilot,
+    *,
+    model: str = "model-b",
+    temperature: str = "0.31",
+) -> None:
+    modal.query_one("#console-popover-provider", Select).value = "vllm"
+    await pilot.pause()
+    picker = modal.query_one("#console-popover-model-search")
+    picker.set_model_value(model)
+    picker.post_message(picker.ModelSelected(model))
+    await pilot.pause()
+    modal.query_one("#console-popover-temperature", Input).value = temperature
+    modal.query_one("#console-popover-compaction-mode", Select).value = (
+        ContextCompactionMode.AUTOMATIC.value
+    )
+    await pilot.pause()
+
+
+async def _drain_settings_tasks(app) -> None:
+    """Wait until the application-lifetime settings owner is quiescent."""
+
+    owner = app.console_settings_durability_owner
+    while owner.tasks:
+        await asyncio.gather(*tuple(owner.tasks))
+
+
+def _apply_submission(
+    store: ConsoleChatStore,
+    session_id: str,
+    *,
+    settings: ConsoleSessionSettings,
+    context_policy: ConsoleContextPolicyOverrides,
+    submission_id: str,
+) -> ConsoleSettingsSubmission:
+    return ConsoleSettingsSubmission(
+        submission_id=submission_id,
+        action=ConsoleSettingsAction.APPLY_TO_CHAT,
+        surface=ConsoleSettingsSurface.QUICK_POPOVER,
+        origin=store.capture_console_settings_origin(session_id),
+        draft=ConsoleSettingsDraftState(
+            settings=settings,
+            context_policy_overrides=context_policy,
+            field_drafts=tuple(
+                ConsoleSettingsFieldDraft(
+                    name=name,
+                    effective_value=getattr(settings, name),
+                    profile_override=getattr(settings, name),
+                    provenance=ConsoleSettingsFieldProvenance.EXPLICIT,
+                    dirty=True,
+                )
+                for name in sorted(QUICK_MODEL_DEFAULT_FIELDS)
+            ),
+            model_drafts=(),
+            endpoint_draft=None,
+        ),
+        user_display_name_override=None,
+        default_field_mask=frozenset(),
+    )
+
+
+@pytest.mark.parametrize("activation", ("mouse", "keyboard"))
+@pytest.mark.asyncio
+async def test_apply_closes_and_changes_only_later_send_context(
+    activation: str,
+) -> None:
+    """Removing the live commit or modal callback makes this journey fail."""
+
+    app = _console_app()
+    notifications: list[str] = []
+    app.notify = lambda message, **_kwargs: notifications.append(str(message))
+    harness = _ConsoleFlowHarness(app)
+
+    async with harness.run_test(size=(120, 42)) as pilot:
+        console = harness.screen_stack[-1]
+        assert isinstance(console, ChatScreen)
+        console._provider_readiness_app_config = lambda: app.app_config
+        await _wait_for_selector(console, pilot, "#console-settings-summary")
+        store = console._ensure_console_chat_store()
+        session = store.switch_session(store.active_session_id)
+        store.replace_session_settings(
+            session.id,
+            ConsoleSessionSettings(
+                provider="llama_cpp",
+                model="model-a",
+                base_url="http://127.0.0.1:9099",
+                temperature=0.8,
+            ),
+        )
+        policy_before = ConsoleContextPolicyOverrides(
+            compaction_mode=ContextCompactionMode.ASK,
+            trigger_ratio=0.9,
+            target_ratio=0.6,
+            summary_max_tokens=2_048,
+            failure_behavior=CompactionFailureBehavior.OMIT_OLDER_CONTEXT,
+            carry_forward_mode=ContextCarryForwardMode.MEMORY_WITH_LATEST_EXCHANGE,
+        )
+        store.set_session_context_policy_overrides(session.id, policy_before)
+        captured_before = console._session._build_console_turn_execution_context(
+            session.id
+        )
+
+        modal = await _open_provider_popover(console, harness, pilot)
+        await _select_vllm_model(modal, pilot)
+        apply_button = modal.query_one("#console-popover-apply", Button)
+        if activation == "mouse":
+            await pilot.click(apply_button)
+        else:
+            apply_button.focus()
+            await pilot.press("enter")
+        await pilot.pause()
+
+        assert harness.screen is console
+        applied = store.session_settings(session.id)
+        assert applied is not None
+        assert (applied.provider, applied.model, applied.temperature) == (
+            "vllm",
+            "model-b",
+            pytest.approx(0.31),
+        )
+        assert store.session_context_policy_overrides(session.id) == replace(
+            policy_before,
+            compaction_mode=ContextCompactionMode.AUTOMATIC,
+        )
+        captured_after = console._session._build_console_turn_execution_context(
+            session.id
+        )
+
+        assert (
+            captured_before.provider_selection.provider,
+            captured_before.provider_selection.explicit_model,
+            captured_before.provider_payload_settings["temperature"],
+        ) == ("llama_cpp", "model-a", 0.8)
+        assert (
+            captured_after.provider_selection.provider,
+            captured_after.provider_selection.explicit_model,
+            captured_after.provider_payload_settings["temperature"],
+        ) == ("vllm", "model-b", pytest.approx(0.31))
+        assert notifications.count("This chat updated") == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_lifecycle_stages_persists_resumes_and_promotes() -> None:
+    """Dropping either durable owner breaks an observable lifecycle assertion."""
+
+    app = _console_app()
+    harness = _ConsoleFlowHarness(app)
+    async with harness.run_test(size=(120, 42)) as pilot:
+        console = harness.screen_stack[-1]
+        assert isinstance(console, ChatScreen)
+        console._provider_readiness_app_config = lambda: app.app_config
+        await _wait_for_selector(console, pilot, "#console-settings-summary")
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+        assert session_id is not None
+
+        modal = await _open_provider_popover(console, harness, pilot)
+        await _select_vllm_model(modal, pilot)
+        await pilot.click("#console-popover-apply")
+        await pilot.pause()
+        await _drain_settings_tasks(app)
+
+        staged = store.switch_session(session_id)
+        assert staged.persisted_conversation_id is None
+        assert staged.generation_settings_revision > 0
+        assert staged.context_policy_revision > 0
+        assert staged.generation_durable_snapshot is None
+        assert staged.context_policy_durable_revision is None
+
+        conversation_id = store.persist_session_if_needed(session_id)
+        assert conversation_id is not None
+        persistence = store.persistence
+        assert persistence is not None
+        generation = persistence.get_conversation_generation_settings(
+            conversation_id
+        ).snapshot
+        policy = persistence.get_conversation_context_policy(conversation_id)
+        assert generation is not None
+        assert (generation.provider, generation.model, generation.temperature) == (
+            "vllm",
+            "model-b",
+            pytest.approx(0.31),
+        )
+        assert policy.overrides.compaction_mode is ContextCompactionMode.AUTOMATIC
+
+        conversation = app.chachanotes_db.get_conversation_by_id(conversation_id)
+        assert conversation is not None
+        hydration = hydrate_console_generation_settings(app.app_config, conversation)
+        resumed_store = ConsoleChatStore(persistence=persistence)
+        resumed = resumed_store.restore_persisted_session(
+            title="Resumed",
+            workspace_id=None,
+            persisted_conversation_id=conversation_id,
+            all_nodes=[],
+            settings=hydration.settings,
+            generation_durable_snapshot=hydration.durable_snapshot,
+            generation_metadata_status=hydration.metadata_status,
+        )
+        assert resumed.settings is not None
+        assert (resumed.settings.provider, resumed.settings.model) == (
+            "vllm",
+            "model-b",
+        )
+        assert (
+            resumed.context_policy_overrides.compaction_mode
+            is ContextCompactionMode.AUTOMATIC
+        )
+
+        temporary = store.create_session(
+            settings=ConsoleSessionSettings(
+                provider="llama_cpp",
+                model="model-a",
+                base_url="http://127.0.0.1:9099",
+            ),
+            ephemeral=True,
+        )
+        temporary_policy = ConsoleContextPolicyOverrides(
+            compaction_mode=ContextCompactionMode.OFF,
+            trigger_ratio=0.88,
+            target_ratio=0.55,
+        )
+        submission = _apply_submission(
+            store,
+            temporary.id,
+            settings=ConsoleSessionSettings(
+                provider="vllm",
+                model="model-b",
+                base_url="http://127.0.0.1:9098",
+                temperature=0.27,
+                streaming=False,
+            ),
+            context_policy=temporary_policy,
+            submission_id="temporary-apply",
+        )
+        live_commit = console._commit_console_settings_submission_live(submission)
+        console._dispatch_console_settings_submission(
+            ConsoleSettingsCommittedSubmission(submission, live_commit)
+        )
+        await _drain_settings_tasks(app)
+        assert temporary.persisted_conversation_id is None
+        assert temporary.generation_durable_snapshot is None
+        assert temporary.context_policy_durable_revision is None
+
+        promoted_id = store.promote_ephemeral_session(temporary.id)
+        assert promoted_id is not None
+        promoted_generation = persistence.get_conversation_generation_settings(
+            promoted_id
+        ).snapshot
+        promoted_policy = persistence.get_conversation_context_policy(promoted_id)
+        assert promoted_generation is not None
+        assert (
+            promoted_generation.provider,
+            promoted_generation.model,
+            promoted_generation.temperature,
+            promoted_generation.streaming,
+        ) == ("vllm", "model-b", pytest.approx(0.27), False)
+        assert promoted_policy.overrides == temporary_policy
+
+
+@pytest.mark.asyncio
+async def test_existing_chat_action_routes_ignore_later_new_chat_default() -> None:
+    """Retry, Continue, and both branch routes keep the chat-owned selection.
+
+    Console has no separate Duplicate-chat or Branch-chat session command in the
+    shipping action catalog.  The production duplicate-response route is Retry,
+    while Regenerate and Edit-and-resend are the two production sibling-branch
+    routes.  Exercising those controller entry points closes the same ownership
+    boundary without inventing a test-only session constructor.
+    """
+
+    app = _console_app()
+    harness = _ConsoleFlowHarness(app)
+    async with harness.run_test(size=(120, 42)) as pilot:
+        console = harness.screen_stack[-1]
+        assert isinstance(console, ChatScreen)
+        await _wait_for_selector(console, pilot, "#console-settings-summary")
+        store = console._ensure_console_chat_store()
+        source_settings = ConsoleSessionSettings(
+            provider="llama_cpp",
+            model="source-owned-model",
+            base_url="http://127.0.0.1:9099",
+            temperature=0.66,
+            source="user",
+        )
+        controller = console._ensure_console_chat_controller()
+        source_session = controller.new_session(settings=source_settings)
+        gateway = _RecordingProviderGateway()
+        controller.provider_gateway = gateway
+
+        user = store.append_message(
+            source_session.id,
+            role=ConsoleMessageRole.USER,
+            content="Keep this chat's provider.",
+        )
+        failed = store.append_message(
+            source_session.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="",
+        )
+        store.mark_message_failed(failed.id)
+
+        app.app_config["chat_defaults"] = {
+            "provider": "vllm",
+            "model": "model-b",
+        }
+        app.app_config["api_settings"]["vllm"]["model_defaults"] = {
+            "model-b": {"temperature": 0.23, "streaming": False}
+        }
+        app.console_new_chat_default_generation += 1
+
+        retry = await controller.retry_message(failed.id)
+        continued = await controller.continue_from_message(failed.id)
+        continuation_id = store.active_leaf(source_session.id)
+        assert continuation_id is not None
+        regenerated = await controller.regenerate_message(continuation_id)
+        edited = await controller.edit_and_resend_message(
+            user.id,
+            "Keep this chat's provider after editing.",
+        )
+
+        assert all(
+            result.accepted
+            for result in (retry, continued, regenerated, edited)
+        ), [
+            (result.accepted, result.visible_copy)
+            for result in (retry, continued, regenerated, edited)
+        ]
+        assert [
+            (selection.provider, selection.explicit_model)
+            for selection in gateway.selections
+        ] == [("llama_cpp", "source-owned-model")] * 4
+        assert store.session_settings(source_session.id) is source_settings
+        assert source_session.canonical_settings_baseline is None
+
+
+@pytest.mark.asyncio
+async def test_normal_sync_projects_delayed_first_persist_failure_for_switched_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A first-persist failure follows the session when it becomes current."""
+
+    app = _console_app()
+    harness = _ConsoleFlowHarness(app)
+    async with harness.run_test(size=(120, 42)) as pilot:
+        console = harness.screen_stack[-1]
+        assert isinstance(console, ChatScreen)
+        await _wait_for_selector(console, pilot, "#console-left-rail")
+        store = console._ensure_console_chat_store()
+        failed_session = store.switch_session(store.active_session_id)
+        store.set_session_context_policy_overrides(
+            failed_session.id,
+            ConsoleContextPolicyOverrides(
+                compaction_mode=ContextCompactionMode.AUTOMATIC,
+            ),
+        )
+        persistence = store.persistence
+        assert persistence is not None
+
+        def fail_first_persist_context_write(**_kwargs):
+            raise RuntimeError("delayed first-persist context failure")
+
+        monkeypatch.setattr(
+            persistence,
+            "update_conversation_context_policy",
+            fail_first_persist_context_write,
+        )
+        assert store.persist_session_if_needed(failed_session.id) is not None
+        failure = failed_session.settings_persistence_failures[
+            ConsoleSettingsComponent.CONTEXT_POLICY
+        ]
+
+        clean_session = store.create_session(title="Clean session")
+        await console._sync_native_console_chat_ui()
+        context_row = console.query_one("#console-context-recovery-row")
+        assert context_row.display is False
+
+        await console._session._activate_native_console_session(failed_session.id)
+        context_retry = console.query_one(
+            "#console-retry-context-settings", Button
+        )
+        assert context_row.display is True
+        assert context_retry.console_settings_session_id == failed_session.id
+        assert context_retry.console_settings_revision == failure.revision
+
+        await console._session._activate_native_console_session(clean_session.id)
+        assert context_row.display is False
+        assert context_retry.disabled is True
+
+
+@pytest.mark.asyncio
+async def test_promotion_completion_projects_current_session_recovery_after_switch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A delayed promotion completion projects only the then-current ledger."""
+
+    app = _console_app()
+    harness = _ConsoleFlowHarness(app)
+    async with harness.run_test(size=(120, 42)) as pilot:
+        console = harness.screen_stack[-1]
+        assert isinstance(console, ChatScreen)
+        await _wait_for_selector(console, pilot, "#console-left-rail")
+        store = console._ensure_console_chat_store()
+        clean_session = store.switch_session(store.active_session_id)
+        persistence = _ControlledSettingsPersistence(asyncio.get_running_loop())
+        store.persistence = persistence
+        temporary = store.create_session(title="Temporary", ephemeral=True)
+        store.set_session_context_policy_overrides(
+            temporary.id,
+            ConsoleContextPolicyOverrides(
+                compaction_mode=ContextCompactionMode.AUTOMATIC,
+            ),
+        )
+
+        promotion_task = asyncio.create_task(
+            console._session._promote_console_temporary_session()
+        )
+        try:
+            await wait_for_background_signal(
+                persistence.promotion_context_started,
+                promotion_task,
+                what="the delayed temporary-chat promotion context write",
+            )
+
+            await console._session._activate_native_console_session(clean_session.id)
+            store.set_session_context_policy_overrides(
+                clean_session.id,
+                ConsoleContextPolicyOverrides(
+                    compaction_mode=ContextCompactionMode.AUTOMATIC,
+                ),
+            )
+            assert store.persist_session_if_needed(clean_session.id) is not None
+            clean_failure = clean_session.settings_persistence_failures[
+                ConsoleSettingsComponent.CONTEXT_POLICY
+            ]
+
+            context_row = console.query_one("#console-context-recovery-row")
+            assert context_row.display is False
+
+            rail = console.query_one("#console-left-rail", ConsoleLeftRail)
+            projected = asyncio.Event()
+            projection_sessions: list[str | None] = []
+            sync_model_recovery = rail.sync_model_recovery
+
+            def observe_recovery_projection(*, session_id, failures, default_state):
+                projection_sessions.append(session_id)
+                sync_model_recovery(
+                    session_id=session_id,
+                    failures=failures,
+                    default_state=default_state,
+                )
+                if (
+                    session_id == clean_session.id
+                    and ConsoleSettingsComponent.CONTEXT_POLICY in failures
+                ):
+                    projected.set()
+
+            monkeypatch.setattr(
+                rail,
+                "sync_model_recovery",
+                observe_recovery_projection,
+            )
+        finally:
+            persistence.release_promotion_context.set()
+
+        await await_background_task(
+            promotion_task,
+            what="the delayed temporary-chat promotion",
+        )
+        await wait_for_signal(
+            projected,
+            what="the promotion completion recovery projection",
+        )
+
+        promotion_failure = temporary.settings_persistence_failures[
+            ConsoleSettingsComponent.CONTEXT_POLICY
+        ]
+        context_row = console.query_one("#console-context-recovery-row")
+        context_retry = console.query_one(
+            "#console-retry-context-settings", Button
+        )
+        assert temporary.ephemeral is False
+        assert promotion_failure.persisted_conversation_id != (
+            clean_failure.persisted_conversation_id
+        )
+        assert store.active_session_id == clean_session.id
+        assert context_row.display is True
+        assert context_retry.console_settings_session_id == clean_session.id
+        assert context_retry.console_settings_revision == clean_failure.revision
+        assert projection_sessions
+        assert set(projection_sessions) == {clean_session.id}
+
+
+@pytest.mark.asyncio
+async def test_stale_compaction_retry_cannot_replace_newer_full_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed quick write loses ownership when a later policy is applied."""
+
+    app = _console_app()
+    harness = _ConsoleFlowHarness(app)
+    async with harness.run_test(size=(120, 42)) as pilot:
+        console = harness.screen_stack[-1]
+        assert isinstance(console, ChatScreen)
+        console._provider_readiness_app_config = lambda: app.app_config
+        await _wait_for_selector(console, pilot, "#console-settings-summary")
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+        assert session_id is not None
+        original_policy = ConsoleContextPolicyOverrides(
+            compaction_mode=ContextCompactionMode.ASK,
+            trigger_ratio=0.91,
+            target_ratio=0.62,
+            summary_max_tokens=3_100,
+            failure_behavior=CompactionFailureBehavior.OMIT_OLDER_CONTEXT,
+            carry_forward_mode=ContextCarryForwardMode.MEMORY_WITH_LATEST_EXCHANGE,
+        )
+        store.set_session_context_policy_overrides(session_id, original_policy)
+        assert store.persist_session_if_needed(session_id) is not None
+        persistence = store.persistence
+        assert persistence is not None
+        original_writer = persistence.update_conversation_context_policy
+
+        def fail_context_write(**_kwargs):
+            raise RuntimeError("PRIVATE_CONTEXT_WRITE_FAILURE")
+
+        monkeypatch.setattr(
+            persistence,
+            "update_conversation_context_policy",
+            fail_context_write,
+        )
+        modal = await _open_provider_popover(console, harness, pilot)
+        await _select_vllm_model(modal, pilot)
+        await pilot.click("#console-popover-apply")
+        await pilot.pause()
+        await _drain_settings_tasks(app)
+
+        session = store.switch_session(session_id)
+        failure = session.settings_persistence_failures[
+            ConsoleSettingsComponent.CONTEXT_POLICY
+        ]
+        assert (
+            failure.policy_failure_label
+            is ConsoleSettingsPolicyFailureLabel.COMPACTION
+        )
+        assert failure.context_policy_overrides == replace(
+            original_policy,
+            compaction_mode=ContextCompactionMode.AUTOMATIC,
+        )
+
+        monkeypatch.setattr(
+            persistence,
+            "update_conversation_context_policy",
+            original_writer,
+        )
+        newer_full_policy = ConsoleContextPolicyOverrides(
+            compaction_mode=ContextCompactionMode.OFF,
+            trigger_ratio=0.73,
+            target_ratio=0.44,
+            summary_max_tokens=1_337,
+            failure_behavior=CompactionFailureBehavior.STOP_AND_ASK,
+            carry_forward_mode=ContextCarryForwardMode.MEMORY_WITH_RECENT_TURNS,
+        )
+        _session, persisted = store.set_session_context_policy_overrides(
+            session_id,
+            newer_full_policy,
+        )
+        assert persisted is True
+        assert await store.retry_console_settings_persistence(
+            session_id=session_id,
+            component=ConsoleSettingsComponent.CONTEXT_POLICY,
+            revision=failure.revision,
+        ) is False
+        assert store.session_context_policy_overrides(session_id) == newer_full_policy
+
+
+@pytest.mark.asyncio
+async def test_default_actions_persist_exact_scope_and_publish_blank_chat_defaults(
+) -> None:
+    """Profile/global scope drift or missing runtime publication fails here."""
+
+    literal_model = "vendor/model:b"
+    app = _persisted_console_app()
+    notifications: list[str] = []
+    app.notify = lambda message, **_kwargs: notifications.append(str(message))
+    harness = _ConsoleFlowHarness(app)
+
+    async with harness.run_test(size=(160, 48)) as pilot:
+        console = harness.screen_stack[-1]
+        assert isinstance(console, ChatScreen)
+        await _wait_for_selector(console, pilot, "#console-settings-summary")
+        store = console._ensure_console_chat_store()
+        origin_id = store.active_session_id
+        assert origin_id is not None
+        preexisting = store.create_session(
+            settings=ConsoleSessionSettings(
+                provider="llama_cpp",
+                model="preexisting-model",
+                base_url="http://127.0.0.1:9099",
+                temperature=0.77,
+            )
+        )
+        store.switch_session(origin_id)
+
+        modal = await _open_provider_popover(console, harness, pilot)
+        await _select_vllm_model(
+            modal,
+            pilot,
+            model=literal_model,
+            temperature="0.42",
+        )
+        streaming = modal.query_one("#console-popover-streaming", Button)
+        assert str(streaming.label) == "Streaming: on"
+        streaming.scroll_visible(animate=False, force=True)
+        await pilot.pause()
+        assert await pilot.click(streaming) is True
+        await pilot.pause()
+        assert str(streaming.label) == "Streaming: off"
+        await pilot.click("#console-popover-defaults")
+        await pilot.pause()
+        await pilot.click("#console-popover-save-model-default")
+        await pilot.pause()
+        assert harness.screen is console
+        await _drain_settings_tasks(app)
+
+        profile_only_reload = load_settings(force_reload=True)
+        profile = profile_only_reload["api_settings"]["vllm"]["model_defaults"][
+            literal_model
+        ]
+        assert profile["temperature"] == pytest.approx(0.42)
+        assert profile["streaming"] is False
+        assert profile_only_reload["chat_defaults"]["provider"] == "llama_cpp"
+        assert profile_only_reload["chat_defaults"]["model"] == "model-a"
+        restarted_target = build_target_default_console_session_settings(
+            profile_only_reload,
+            "vllm",
+            literal_model,
+        )
+        assert restarted_target.temperature == pytest.approx(0.42)
+        assert restarted_target.streaming is False
+
+        modal = await _open_provider_popover(console, harness, pilot)
+        modal.query_one("#console-popover-temperature", Input).value = "0.23"
+        streaming = modal.query_one("#console-popover-streaming", Button)
+        assert str(streaming.label) == "Streaming: off"
+        streaming.scroll_visible(animate=False, force=True)
+        await pilot.pause()
+        assert await pilot.click(streaming) is True
+        await pilot.pause()
+        assert str(streaming.label) == "Streaming: on"
+        await pilot.click("#console-popover-defaults")
+        await pilot.pause()
+        await pilot.click("#console-popover-make-new-chat-default")
+        await pilot.pause()
+        assert harness.screen is console
+        await _drain_settings_tasks(app)
+
+        assert app.console_default_durability_state.failure_phase is None
+        assert app.console_new_chat_default_generation == 1, notifications
+        assert app.app_config["chat_defaults"]["provider"] == "vllm"
+        assert app.app_config["chat_defaults"]["model"] == literal_model
+        assert store.session_settings(preexisting.id) == ConsoleSessionSettings(
+            provider="llama_cpp",
+            model="preexisting-model",
+            base_url="http://127.0.0.1:9099",
+            temperature=0.77,
+        )
+
+        await console._session._create_native_console_session_from_active_context()
+        ordinary_id = store.active_session_id
+        assert ordinary_id is not None
+        ordinary = store.session_settings(ordinary_id)
+        assert ordinary is not None
+        assert (
+            ordinary.provider,
+            ordinary.model,
+            ordinary.temperature,
+            ordinary.streaming,
+        ) == ("vllm", literal_model, pytest.approx(0.23), True)
+
+        await console._session._create_native_console_session_from_active_context(
+            ephemeral=True
+        )
+        temporary_id = store.active_session_id
+        assert temporary_id is not None
+        temporary = store.switch_session(temporary_id)
+        assert temporary.ephemeral is True
+        assert temporary.settings is not None
+        assert (
+            temporary.settings.provider,
+            temporary.settings.model,
+            temporary.settings.temperature,
+        ) == ("vllm", literal_model, pytest.approx(0.23))
+
+        conversations_toggle = console.query_one(
+            "#console-rail-section-toggle-conversations", Button
+        )
+        conversations_toggle.scroll_visible(animate=False, force=True)
+        await pilot.pause()
+        assert await pilot.click(conversations_toggle) is True
+        await pilot.pause()
+        await _wait_for_selector(
+            console,
+            pilot,
+            "#console-new-workspace-conversation",
+        )
+        workspace_entry = console.query_one(
+            "#console-new-workspace-conversation", Button
+        )
+        workspace_entry.scroll_visible(animate=False, force=True)
+        await pilot.pause()
+        before_workspace_entry_id = store.active_session_id
+        workspace_entry.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        workspace_id = store.active_session_id
+        assert workspace_id is not None
+        assert workspace_id != before_workspace_entry_id
+        workspace = store.switch_session(workspace_id)
+        assert workspace.workspace_id == "workspace-default"
+        assert workspace.settings is not None
+        assert (workspace.settings.provider, workspace.settings.model) == (
+            "vllm",
+            literal_model,
+        )
+
+        explicit_source = ConsoleSessionSettings(
+            provider="llama_cpp",
+            model="source-owned-model",
+            base_url="http://127.0.0.1:9099",
+            temperature=0.66,
+            source="user",
+        )
+        source_session = console._ensure_console_chat_controller().new_session(
+            settings=explicit_source,
+            canonical_settings_baseline=explicit_source,
+        )
+        assert store.session_settings(source_session.id) == explicit_source
+
+    rebooted = load_settings(force_reload=True)
+    rebooted_blank = blank_console_session_settings(rebooted)
+    assert (
+        rebooted_blank.provider,
+        rebooted_blank.model,
+        rebooted_blank.temperature,
+        rebooted_blank.streaming,
+    ) == ("vllm", literal_model, pytest.approx(0.23), True)
+    assert notifications.count("This chat updated") == 2
+    assert f"Model profile default saved: vllm/{literal_model}" in notifications
+    assert f"Eligible new-chat default saved: vllm/{literal_model}" in notifications
+
+
+@pytest.mark.asyncio
+async def test_default_failures_render_exact_sanitized_recovery_actions() -> None:
+    """App-owned failure phase selects the only valid recovery controls."""
+
+    app = _console_app()
+    harness = _ConsoleFlowHarness(app)
+    intent = ConsoleDefaultMutationIntent(
+        generation=7,
+        action=ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
+        provider_config_key="vllm",
+        literal_model_id="vendor/private:model",
+        field_mask=QUICK_MODEL_DEFAULT_FIELDS,
+        values={"temperature": 0.22, "streaming": True},
+        endpoint_patch=ConsoleEndpointPatch(
+            value="http://192.168.1.9:8000/v1?api_key=never-render",
+            bound_provider_config_key="vllm",
+            dirty=True,
+            checked=True,
+        ),
+    )
+
+    async with harness.run_test(size=(120, 42)) as pilot:
+        console = harness.screen_stack[-1]
+        assert isinstance(console, ChatScreen)
+        await _wait_for_selector(console, pilot, "#console-settings-summary")
+        rail = console.query_one(ConsoleLeftRail)
+
+        app.console_default_durability_state = ConsoleDefaultDurabilityState(
+            newest_intent_generation=7,
+            recovery_intent=intent,
+            failure_phase=ConsoleDefaultSavePhase.BEFORE_REPLACE,
+        )
+        console._sync_console_settings_recovery_surfaces()
+        await pilot.pause()
+
+        copy = str(
+            rail.query_one("#console-default-recovery-copy", Static).renderable
+        )
+        assert copy == (
+            "Not written to disk · Make default for new chats · "
+            "vllm/vendor/private:model · fields: streaming, temperature · "
+            "192.168.1.9:8000 · LAN"
+        )
+        assert "api_key" not in copy and "never-render" not in copy
+        retry = rail.query_one(f"#{CONSOLE_RETRY_DEFAULT_SAVE_ID}", Button)
+        discard = rail.query_one(f"#{CONSOLE_DISCARD_DEFAULT_RETRY_ID}", Button)
+        refresh = rail.query_one(f"#{CONSOLE_REFRESH_RUNNING_APP_ID}", Button)
+        dismiss = rail.query_one(f"#{CONSOLE_DISMISS_DEFAULT_REFRESH_ID}", Button)
+        assert retry.display and discard.display
+        assert not refresh.display and not dismiss.display
+        assert retry.console_default_intent_generation == 7
+        assert discard.console_default_intent_generation == 7
+
+        app.console_default_durability_state = ConsoleDefaultDurabilityState(
+            newest_intent_generation=7,
+            recovery_intent=intent,
+            failure_phase=ConsoleDefaultSavePhase.CACHE_PUBLICATION,
+        )
+        console._sync_console_settings_recovery_surfaces()
+        await pilot.pause()
+
+        copy = str(
+            rail.query_one("#console-default-recovery-copy", Static).renderable
+        )
+        assert copy.startswith("Saved on disk; running app refresh failed · ")
+        assert refresh.display and dismiss.display
+        assert not retry.display and not discard.display
+        assert refresh.console_default_intent_generation == 7
+        assert dismiss.console_default_intent_generation == 7
+
+
+@pytest.mark.asyncio
+async def test_custom_and_unconfigured_selection_stays_literal_and_blocks_default() -> (
+    None
+):
+    """Catalog/config gaps stay visible instead of selecting a fallback."""
+
+    app = _console_app()
+    app.app_config.setdefault("api_settings", {})["anthropic"] = {}
+    app.providers_models["anthropic"] = []
+    harness = _ConsoleFlowHarness(app)
+
+    async with harness.run_test(size=(120, 42)) as pilot:
+        console = harness.screen_stack[-1]
+        assert isinstance(console, ChatScreen)
+        await _wait_for_selector(console, pilot, "#console-settings-summary")
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+        assert session_id is not None
+        literal_model = "vendor/missing:custom-model"
+        store.replace_session_settings(
+            session_id,
+            ConsoleSessionSettings(
+                provider="anthropic",
+                model=literal_model,
+                temperature=0.41,
+            ),
+        )
+
+        modal = await _open_provider_popover(console, harness, pilot)
+        provider = modal.query_one("#console-popover-provider", Select)
+        picker = modal.query_one("#console-popover-model-search")
+        assert provider.value == "anthropic"
+        assert picker.value == literal_model
+
+        await pilot.click("#console-popover-defaults")
+        await pilot.pause()
+        make_default = modal.query_one(
+            "#console-popover-make-new-chat-default", Button
+        )
+        block_copy = str(
+            modal.query_one(
+                "#console-popover-new-chat-default-block", Static
+            ).renderable
+        )
+        assert make_default.disabled is True
+        assert "unavailable" in block_copy.lower()
+        assert store.session_settings(session_id).model == literal_model

--- a/Tests/UI/test_console_rail_sections.py
+++ b/Tests/UI/test_console_rail_sections.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import random
+from dataclasses import replace
 
 import pytest
 from textual.app import App
@@ -19,9 +20,22 @@ from tldw_chatbook.Chat.console_onboarding_state import (
     ConsoleSetupCardState,
     ConsoleSetupStep,
 )
-from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.console_context_policy import ConsoleContextPolicyOverrides
+from tldw_chatbook.Chat.console_session_settings import (
+    ConsoleSessionSettings,
+    ConsoleSettingsReadiness,
+)
+from tldw_chatbook.Chat.console_settings_apply import (
+    ConsoleSettingsCommittedSubmission,
+    ConsoleSettingsDraftState,
+    ConsoleSettingsFieldDraft,
+    ConsoleSettingsFieldProvenance,
+    ConsoleSettingsLiveCommit,
+    ConsoleSettingsOrigin,
+    ConsoleSettingsSubmission,
+    ConsoleSettingsTransfer,
+)
 from tldw_chatbook.Widgets.Console.console_model_popover import (
-    CONSOLE_POPOVER_OPEN_FULL_SETTINGS,
     ConsoleModelPopover,
 )
 from tldw_chatbook.Widgets.destination_rail import (
@@ -485,6 +499,8 @@ from tldw_chatbook.Widgets.Console.console_session_switcher_modal import (  # no
     ConsoleSessionSwitcherModal,
     ConsoleSwitcherChoice,
 )
+
+
 def _switcher_rows() -> tuple[ConsoleConversationBrowserInputRow, ...]:
     def row(key, title, native=None, **kw):
         return ConsoleConversationBrowserInputRow(
@@ -679,6 +695,71 @@ async def test_switcher_rapid_refresh_does_not_duplicate_ids():
 _POPOVER_PROVIDERS = {"llama_cpp": ["model-a", "model-b"], "openai": ["gpt-4o"]}
 
 
+def _test_popover(
+    settings: ConsoleSessionSettings,
+    providers_models,
+) -> ConsoleModelPopover:
+    origin = ConsoleSettingsOrigin("popover-session", None, 0)
+    draft = ConsoleSettingsDraftState(
+        settings=settings,
+        context_policy_overrides=ConsoleContextPolicyOverrides(),
+        field_drafts=tuple(
+            ConsoleSettingsFieldDraft(
+                name=name,
+                effective_value=getattr(settings, name),
+                profile_override=getattr(settings, name),
+                provenance=ConsoleSettingsFieldProvenance.INHERITED,
+                dirty=False,
+            )
+            for name in ("temperature", "streaming")
+        ),
+        model_drafts=(),
+        endpoint_draft=None,
+    )
+
+    def rebase(state, **kwargs):
+        return replace(
+            state,
+            settings=replace(
+                state.settings,
+                provider=kwargs["provider"],
+                model=kwargs["model"],
+            ),
+        )
+
+    def commit(submission: ConsoleSettingsSubmission) -> ConsoleSettingsLiveCommit:
+        return ConsoleSettingsLiveCommit(
+            submission_id=submission.submission_id,
+            session_id=origin.session_id,
+            persisted_conversation_id=None,
+            conversation_binding_revision=0,
+            generation_revision=1,
+            context_policy_revision=1,
+            settings=submission.draft.settings,
+            context_policy_overrides=submission.draft.context_policy_overrides,
+        )
+
+    return ConsoleModelPopover(
+        origin=origin,
+        app_config={
+            "api_settings": {
+                "llama_cpp": {"api_url": "http://127.0.0.1:9099"},
+                "openai": {"api_key": "test-key"},
+                "openrouter": {"api_key": "test-key"},
+            }
+        },
+        initial_draft=draft,
+        providers_models=providers_models,
+        scope_copy="Applies to this conversation",
+        durability_copy="Temporary until this chat is promoted",
+        draft_rebaser=rebase,
+        live_committer=commit,
+        default_readiness_resolver=lambda _provider, _model: ConsoleSettingsReadiness(
+            "Ready", "Ready.", True
+        ),
+    )
+
+
 class _PopoverApp(ConsolidatedCSSApp):
     def __init__(self):
         super().__init__()
@@ -691,7 +772,7 @@ class _PopoverApp(ConsolidatedCSSApp):
             self.result = result
 
         await self.push_screen(
-            ConsoleModelPopover(settings=settings, providers_models=_POPOVER_PROVIDERS),
+            _test_popover(settings, _POPOVER_PROVIDERS),
             callback=_capture,
         )
 
@@ -710,11 +791,12 @@ async def test_popover_apply_returns_replaced_settings():
         await pilot.pause()
         await pilot.click("#console-popover-apply")
         await pilot.pause()
-        assert isinstance(app.result, ConsoleSessionSettings)
-        assert app.result.model == "model-b"
-        assert app.result.provider == "llama_cpp"
+        assert isinstance(app.result, ConsoleSettingsCommittedSubmission)
+        committed = app.result.live_commit.settings
+        assert committed.model == "model-b"
+        assert committed.provider == "llama_cpp"
         # ConsoleSessionSettings defaults streaming True; one toggle flips it.
-        assert app.result.streaming is False
+        assert committed.streaming is False
 
 
 @pytest.mark.asyncio
@@ -723,7 +805,8 @@ async def test_popover_full_settings_returns_sentinel_and_escape_cancels():
     async with app.run_test(size=(90, 30)) as pilot:
         await pilot.click("#console-popover-full-settings")
         await pilot.pause()
-        assert app.result == CONSOLE_POPOVER_OPEN_FULL_SETTINGS
+        assert isinstance(app.result, ConsoleSettingsTransfer)
+        assert app.result.origin.session_id == "popover-session"
     app2 = _PopoverApp()
     async with app2.run_test(size=(90, 30)) as pilot:
         await pilot.press("escape")
@@ -741,8 +824,8 @@ async def test_popover_apply_with_blank_temperature_clears_it():
         temperature_input.value = ""
         await pilot.click("#console-popover-apply")
         await pilot.pause()
-        assert isinstance(app.result, ConsoleSessionSettings)
-        assert app.result.temperature is None
+        assert isinstance(app.result, ConsoleSettingsCommittedSubmission)
+        assert app.result.live_commit.settings.temperature is None
 
 
 @pytest.mark.parametrize("invalid_text", ["nan", "5.5", "-1"])
@@ -753,15 +836,10 @@ async def test_popover_apply_rejects_nan_and_out_of_range_temperature(invalid_te
     app = _PopoverApp()
     async with app.run_test(size=(90, 30)) as pilot:
         temperature_input = app.screen.query_one("#console-popover-temperature", Input)
-        prior_temperature = temperature_input.value
         temperature_input.value = invalid_text
         await pilot.click("#console-popover-apply")
         await pilot.pause()
-        assert isinstance(app.result, ConsoleSessionSettings)
-        # Mirrors ConsoleSettingsModal's [0.0, 2.0] bound (NaN always fails
-        # the range comparison too): an invalid value keeps the prior
-        # temperature rather than applying it.
-        assert app.result.temperature == float(prior_temperature)
+        assert app.result == "unset"
 
 
 @pytest.mark.asyncio
@@ -774,8 +852,8 @@ async def test_popover_apply_accepts_in_range_temperature():
         temperature_input.value = "1.2"
         await pilot.click("#console-popover-apply")
         await pilot.pause()
-        assert isinstance(app.result, ConsoleSessionSettings)
-        assert app.result.temperature == 1.2
+        assert isinstance(app.result, ConsoleSettingsCommittedSubmission)
+        assert app.result.live_commit.settings.temperature == 1.2
 
 
 class _PopoverSearchScope:
@@ -829,9 +907,7 @@ class _PopoverSearchApp(ConsolidatedCSSApp):
             self.result = result
 
         await self.push_screen(
-            ConsoleModelPopover(
-                settings=settings, providers_models=self.providers_models
-            ),
+            _test_popover(settings, self.providers_models),
             callback=_capture,
         )
 
@@ -932,7 +1008,8 @@ async def test_popover_custom_model_uses_shared_picker_escape_hatch():
         await pilot.pause()
 
     assert app.result is not None
-    assert app.result.model == "private/model-id"
+    assert isinstance(app.result, ConsoleSettingsCommittedSubmission)
+    assert app.result.live_commit.settings.model == "private/model-id"
 
 
 @pytest.mark.asyncio
@@ -1010,7 +1087,9 @@ def _overflow_conversation_browser():
         )
         for i in range(CONSOLE_CONVERSATION_BROWSER_GROUP_ROW_LIMIT + 3)
     )
-    return build_console_conversation_browser_state(rows=rows, active_workspace_id="ws-a")
+    return build_console_conversation_browser_state(
+        rows=rows, active_workspace_id="ws-a"
+    )
 
 
 class _OverflowTrayApp(ConsolidatedCSSApp):
@@ -1030,9 +1109,7 @@ async def test_rail_discloses_conversations_hidden_by_the_cap_in_no_query_view()
     Ctrl+K, instead of silently dropping the oldest with no affordance."""
     app = _OverflowTrayApp()
     async with app.run_test(size=(70, 40)):
-        status = app.query_one(
-            "#console-workspace-conversation-search-status", Static
-        )
+        status = app.query_one("#console-workspace-conversation-search-status", Static)
         text = str(getattr(status.renderable, "plain", status.renderable))
         assert "3 more" in text
         assert "Ctrl+K" in text

--- a/Tests/UI/test_console_resize_reflow.py
+++ b/Tests/UI/test_console_resize_reflow.py
@@ -7,17 +7,47 @@ the pane reflow converges to the cold-start layout (locked here); the resize now
 also dismisses any visible tooltip so a mounted overlay can't survive the repaint.
 """
 
+from dataclasses import replace
+
 import pytest
 from textual.css.query import NoMatches
 from textual.widgets import Button, Static, Tooltip
 
-from tldw_chatbook.Chat.console_session_settings import ConsoleSettingsSummaryState
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from tldw_chatbook.Chat.console_context_policy import ConsoleContextPolicyOverrides
+from tldw_chatbook.Chat.console_settings_defaults import (
+    ConsoleDefaultDurabilityState,
+    ConsoleDefaultMutationIntent,
+    ConsoleDefaultRecoveryAction,
+    ConsoleDefaultRecoveryRequest,
+    ConsoleDefaultSavePhase,
+    ConsoleEndpointPatch,
+)
+from tldw_chatbook.Chat.console_session_settings import (
+    ConsoleSessionSettings,
+    ConsoleSettingsContextEstimate,
+    ConsoleSettingsReadiness,
+    ConsoleSettingsSummaryState,
+)
+from tldw_chatbook.Chat.console_settings_apply import (
+    FULL_MODEL_DEFAULT_FIELDS,
+    ConsoleSettingsAction,
+    ConsoleSettingsDraftState,
+    ConsoleSettingsFieldDraft,
+    ConsoleSettingsFieldProvenance,
+    ConsoleSettingsLiveCommit,
+    ConsoleSettingsOrigin,
+    ConsoleSettingsSubmission,
+    ConsoleSettingsTransfer,
+)
 from tldw_chatbook.UI.Console_Modules.left_rail import (
     CONTEXT_SECTION_DESCRIPTORS,
     ConsoleLeftRail,
 )
 from tldw_chatbook.UI.Console_Modules.right_rail import ConsoleInspectorRail
 from tldw_chatbook.Widgets.Console.console_bounded_section import ConsoleBoundedSection
+from tldw_chatbook.Widgets.Console.console_model_popover import ConsoleModelPopover
+from tldw_chatbook.Widgets.Console.console_settings_modal import ConsoleSettingsModal
 from tldw_chatbook.app import TldwCli
 
 from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
@@ -47,10 +77,151 @@ class _ProductionResizeConsoleHarness(ConsoleHarness):
     CSS_PATH = TldwCli.CSS_PATH
 
 
+class _ProductionResizeModalHarness(ConsolidatedCSSApp):
+    """Standalone modal harness with the complete production app CSS bundle."""
+
+    CSS_PATH = TldwCli.CSS_PATH
+
+
 def _ready_production_console_host() -> _ProductionResizeConsoleHarness:
     app = _build_test_app()
     _configure_native_ready_console(app)
     return _ProductionResizeConsoleHarness(app)
+
+
+def _resize_popover() -> ConsoleModelPopover:
+    settings = ConsoleSessionSettings(provider="llama_cpp", model="model-a")
+    origin = ConsoleSettingsOrigin("session-a", None, 0)
+    draft = ConsoleSettingsDraftState(
+        settings=settings,
+        context_policy_overrides=ConsoleContextPolicyOverrides(),
+        field_drafts=tuple(
+            ConsoleSettingsFieldDraft(
+                name=name,
+                effective_value=getattr(settings, name),
+                profile_override=getattr(settings, name),
+                provenance=ConsoleSettingsFieldProvenance.INHERITED,
+                dirty=False,
+            )
+            for name in ("temperature", "streaming")
+        ),
+        model_drafts=(),
+        endpoint_draft=None,
+    )
+
+    def commit(submission: ConsoleSettingsSubmission) -> ConsoleSettingsLiveCommit:
+        return ConsoleSettingsLiveCommit(
+            submission_id=submission.submission_id,
+            session_id=origin.session_id,
+            persisted_conversation_id=None,
+            conversation_binding_revision=0,
+            generation_revision=1,
+            context_policy_revision=1,
+            settings=submission.draft.settings,
+            context_policy_overrides=submission.draft.context_policy_overrides,
+        )
+
+    return ConsoleModelPopover(
+        origin=origin,
+        app_config={"api_settings": {"llama_cpp": {}}},
+        initial_draft=draft,
+        providers_models={"llama_cpp": ["model-a"]},
+        scope_copy="Applies to this conversation",
+        durability_copy="Temporary until this chat is promoted",
+        draft_rebaser=lambda state, **_kwargs: state,
+        live_committer=commit,
+        default_readiness_resolver=lambda _provider, _model: (
+            ConsoleSettingsReadiness("Ready", "Ready.", True)
+        ),
+    )
+
+
+def _resize_full_settings(
+    *,
+    focus_model: bool = False,
+    focus_context: bool = False,
+    transfer: ConsoleSettingsTransfer | None = None,
+) -> ConsoleSettingsModal:
+    settings = ConsoleSessionSettings(provider="llama_cpp", model="model-a")
+    return ConsoleSettingsModal(
+        settings=settings,
+        transfer=transfer,
+        app_config={
+            "chat_defaults": {"provider": "llama_cpp", "model": "model-a"},
+            "api_settings": {"llama_cpp": {}},
+        },
+        providers_models={"llama_cpp": ["model-a"]},
+        context_estimate=ConsoleSettingsContextEstimate(10, 4096, "10 / 4k"),
+        can_save=True,
+        focus_model=focus_model,
+        focus_context=focus_context,
+        default_readiness_resolver=lambda _provider, _model: (
+            ConsoleSettingsReadiness("Ready", "Ready.", True)
+        ),
+    )
+
+
+def _failed_default_state(
+    phase: ConsoleDefaultSavePhase,
+) -> ConsoleDefaultDurabilityState:
+    intent = ConsoleDefaultMutationIntent(
+        generation=7,
+        action=ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
+        provider_config_key="llama_cpp",
+        literal_model_id="vendor/private:model",
+        field_mask=FULL_MODEL_DEFAULT_FIELDS,
+        values={name: None for name in FULL_MODEL_DEFAULT_FIELDS},
+        endpoint_patch=None,
+    )
+    return ConsoleDefaultDurabilityState(
+        newest_intent_generation=7,
+        recovery_intent=intent,
+        failure_phase=phase,
+    )
+
+
+def _long_failed_default_state(
+    phase: ConsoleDefaultSavePhase,
+) -> ConsoleDefaultDurabilityState:
+    """Return a valid recovery whose safe summary must scroll at 60/72."""
+
+    state = _failed_default_state(phase)
+    assert state.recovery_intent is not None
+    hostname = ".".join(("a" * 63, "b" * 63, "c" * 63, "d" * 61))
+    model_id = f"vendor/{'m' * 249}"
+    assert len(hostname) == 253
+    assert len(model_id) == 256
+    return replace(
+        state,
+        recovery_intent=replace(
+            state.recovery_intent,
+            literal_model_id=model_id,
+            endpoint_patch=ConsoleEndpointPatch(
+                value=f"https://{hostname}:8443/v1?token=not-rendered",
+                bound_provider_config_key="llama_cpp",
+                dirty=True,
+                checked=True,
+            ),
+        ),
+    )
+
+
+def _assert_real_mouse_target(modal, button: Button) -> None:
+    x = button.region.x + button.region.width // 2
+    for y in (
+        button.region.y,
+        button.region.y + button.region.height // 2,
+    ):
+        assert modal.get_widget_at(x, y)[0] is button
+
+
+def _assert_non_overlapping_regions(buttons: list[Button]) -> None:
+    assert all(button.region.width > 0 and button.region.height > 0 for button in buttons)
+    for index, button in enumerate(buttons):
+        assert all(
+            not button.region.overlaps(other.region)
+            for other in buttons[index + 1 :]
+        )
 
 
 def _pane_layout(console) -> dict:
@@ -93,6 +264,658 @@ def _context_allocation_idle(rail: ConsoleLeftRail) -> bool:
         not section._reconcile_scheduled
         for section in rail.query(ConsoleBoundedSection)
     )
+
+
+@pytest.mark.parametrize("width", (60, 72))
+@pytest.mark.asyncio
+async def test_popover_actions_remain_reachable_and_ordered_at_narrow_width(
+    width: int,
+) -> None:
+    app = ConsolidatedCSSApp()
+    modal = _resize_popover()
+
+    async with app.run_test(size=(width, 24)) as pilot:
+        await app.push_screen(modal)
+        await pilot.pause()
+        await pilot.pause()
+
+        panel = modal.query_one("#console-model-popover")
+        main = list(modal.query("#console-popover-main-actions Button"))
+        assert [str(button.label) for button in main] == [
+            "Cancel",
+            "Full settings…",
+            "Defaults…",
+            "Apply to this chat",
+        ]
+        assert panel.region.x >= 0
+        assert panel.region.right <= width
+        assert panel.region.bottom <= 24
+        assert all(panel.region.contains_region(button.region) for button in main)
+        assert all(button.can_focus and not button.disabled for button in main)
+        _assert_non_overlapping_regions(main)
+        main[0].focus()
+        await pilot.pause()
+        main_focus_order: list[str] = []
+        for _ in main:
+            focused = app.focused
+            main_focus_order.append(getattr(focused, "id", "") or "")
+            assert focused is not None
+            assert panel.region.contains_region(focused.region)
+            await pilot.press("tab")
+            await pilot.pause()
+        assert main_focus_order == [
+            "console-popover-cancel",
+            "console-popover-full-settings",
+            "console-popover-defaults",
+            "console-popover-apply",
+        ]
+
+        await pilot.click("#console-popover-defaults")
+        await pilot.pause()
+        await pilot.pause()
+        defaults = list(modal.query("#console-popover-default-actions Button"))
+        assert [str(button.label) for button in defaults] == [
+            "Save as model default",
+            "Make default for new chats",
+            "Back",
+        ]
+        assert all(panel.region.contains_region(button.region) for button in defaults)
+        assert all(button.can_focus and not button.disabled for button in defaults)
+        _assert_non_overlapping_regions(defaults)
+        defaults_focus_order: list[str] = []
+        for _ in defaults:
+            focused = app.focused
+            defaults_focus_order.append(getattr(focused, "id", "") or "")
+            assert focused is not None
+            assert panel.region.contains_region(focused.region)
+            await pilot.press("tab")
+            await pilot.pause()
+        assert defaults_focus_order == [
+            "console-popover-save-model-default",
+            "console-popover-make-new-chat-default",
+            "console-popover-defaults-back",
+        ]
+        defaults[0].focus()
+        await pilot.pause()
+        assert app.focused is defaults[0]
+
+
+@pytest.mark.parametrize("width", (60, 72))
+@pytest.mark.asyncio
+async def test_full_settings_actions_remain_mouse_reachable_at_narrow_width(
+    width: int,
+) -> None:
+    """Every full-Settings action stays painted inside the production modal."""
+
+    app = _ProductionResizeModalHarness()
+    modal = _resize_full_settings()
+    async with app.run_test(size=(120, 24)) as pilot:
+        await app.push_screen(modal)
+        await pilot.pause()
+        await pilot.resize_terminal(width, 24)
+        await pilot.pause()
+        await pilot.pause()
+
+        panel = modal.query_one("#console-settings-modal")
+        actions = list(modal.query("#console-settings-actions Button"))
+        assert [str(button.label) for button in actions] == [
+            "Cancel",
+            "Save as model default",
+            "Make default for new chats",
+            "Apply to this chat",
+        ]
+        assert panel.region.x >= 0
+        assert panel.region.right <= width
+        assert panel.region.bottom <= 24
+        assert all(button.display for button in actions)
+        assert all(button.can_focus and not button.disabled for button in actions)
+        assert all(
+            panel.content_region.contains_region(button.region) for button in actions
+        ), (
+            panel.content_region,
+            [(button.id, button.region) for button in actions],
+        )
+        _assert_non_overlapping_regions(actions)
+
+        actions[0].focus()
+        await pilot.pause()
+        focus_order: list[str] = []
+        for _ in actions:
+            focused = app.focused
+            focus_order.append(getattr(focused, "id", "") or "")
+            assert focused is not None
+            assert panel.region.contains_region(focused.region)
+            await pilot.press("tab")
+            await pilot.pause()
+        assert focus_order == [
+            "console-settings-cancel",
+            "console-settings-save-default",
+            "console-settings-make-default",
+            "console-settings-save",
+        ]
+        apply_button = actions[-1]
+        top_hit = modal.get_widget_at(
+            apply_button.region.x + apply_button.region.width // 2,
+            apply_button.region.y,
+        )[0]
+        center_hit = modal.get_widget_at(
+            apply_button.region.x + apply_button.region.width // 2,
+            apply_button.region.y + apply_button.region.height // 2,
+        )[0]
+        assert top_hit is apply_button
+        assert center_hit is apply_button
+        assert await pilot.click("#console-settings-save") is True
+        await pilot.pause()
+        assert modal not in app.screen_stack
+
+
+@pytest.mark.parametrize("width", (60, 72))
+@pytest.mark.parametrize(
+    ("phase", "button_id", "expected_action"),
+    (
+        (
+            ConsoleDefaultSavePhase.BEFORE_REPLACE,
+            "console-settings-default-retry",
+            ConsoleDefaultRecoveryAction.RETRY_SAVE,
+        ),
+        (
+            ConsoleDefaultSavePhase.BEFORE_REPLACE,
+            "console-settings-default-discard",
+            ConsoleDefaultRecoveryAction.DISCARD_RETRY,
+        ),
+        (
+            ConsoleDefaultSavePhase.CACHE_PUBLICATION,
+            "console-settings-default-refresh",
+            ConsoleDefaultRecoveryAction.REFRESH_RUNNING_APP,
+        ),
+        (
+            ConsoleDefaultSavePhase.CACHE_PUBLICATION,
+            "console-settings-default-dismiss",
+            ConsoleDefaultRecoveryAction.DISMISS_REFRESH,
+        ),
+    ),
+)
+@pytest.mark.asyncio
+async def test_full_settings_recovery_actions_are_mouse_reachable_at_narrow_width(
+    width: int,
+    phase: ConsoleDefaultSavePhase,
+    button_id: str,
+    expected_action: ConsoleDefaultRecoveryAction,
+) -> None:
+    """Every phase-appropriate recovery action is a real narrow mouse target."""
+
+    requests: list[ConsoleDefaultRecoveryRequest] = []
+
+    async def recover(
+        request: ConsoleDefaultRecoveryRequest,
+    ) -> ConsoleDefaultDurabilityState:
+        requests.append(request)
+        return ConsoleDefaultDurabilityState(newest_intent_generation=7)
+
+    app = _ProductionResizeModalHarness()
+    modal = _resize_full_settings()
+    modal._default_durability_state = _long_failed_default_state(phase)
+    modal._default_recovery_handler = recover
+    async with app.run_test(size=(120, 24)) as pilot:
+        await app.push_screen(modal)
+        await pilot.pause()
+        await pilot.resize_terminal(width, 24)
+        await pilot.pause()
+        await pilot.pause()
+
+        body = modal.query_one("#console-settings-body")
+        panel = modal.query_one("#console-settings-modal")
+        recovery = modal.query_one("#console-settings-default-recovery")
+        summary = modal.query_one("#console-settings-default-recovery-summary")
+        fold = modal.query_one("#console-settings-fold-hint", Static)
+        applicable = [
+            button
+            for button in modal.query(
+                "#console-settings-default-recovery-actions Button"
+            )
+            if button.display
+        ]
+        assert recovery.display
+        assert not body.content_region.contains_region(summary.region)
+        assert body.max_scroll_y > 0
+        assert fold.display
+        assert "recovery summary" in str(fold.renderable)
+        assert "token=not-rendered" not in str(summary.renderable)
+        assert len(applicable) == 2
+        assert all(
+            panel.content_region.contains_region(button.region) for button in applicable
+        ), (
+            panel.content_region,
+            [(button.id, button.region) for button in applicable],
+        )
+        for button in applicable:
+            _assert_real_mouse_target(modal, button)
+
+        assert await pilot.click(f"#{button_id}") is True
+        await pilot.pause()
+
+    assert requests == [ConsoleDefaultRecoveryRequest(expected_action, 7)]
+
+
+@pytest.mark.parametrize("width", (60, 72))
+@pytest.mark.parametrize(
+    ("phase", "first_button_id", "second_button_id"),
+    (
+        (
+            ConsoleDefaultSavePhase.BEFORE_REPLACE,
+            "console-settings-default-retry",
+            "console-settings-default-discard",
+        ),
+        (
+            ConsoleDefaultSavePhase.CACHE_PUBLICATION,
+            "console-settings-default-refresh",
+            "console-settings-default-dismiss",
+        ),
+    ),
+)
+@pytest.mark.asyncio
+async def test_full_settings_recovery_keyboard_scrolls_and_stays_in_phase_actions(
+    width: int,
+    phase: ConsoleDefaultSavePhase,
+    first_button_id: str,
+    second_button_id: str,
+) -> None:
+    """Page keys read the exact summary; Tab cannot reach hidden draft commits."""
+
+    app = _ProductionResizeModalHarness()
+    modal = _resize_full_settings()
+    modal._default_durability_state = _long_failed_default_state(phase)
+    async with app.run_test(size=(120, 24)) as pilot:
+        await app.push_screen(modal)
+        await pilot.pause()
+        await pilot.resize_terminal(width, 24)
+        await pilot.pause()
+        await pilot.pause()
+
+        body = modal.query_one("#console-settings-body")
+        first = modal.query_one(f"#{first_button_id}", Button)
+        second = modal.query_one(f"#{second_button_id}", Button)
+        cancel = modal.query_one("#console-settings-cancel", Button)
+        assert app.focused is first
+        assert body.scroll_y == 0
+        assert body.max_scroll_y > 0
+
+        await pilot.press("pagedown")
+        await pilot.pause()
+        assert body.scroll_y > 0
+        assert app.focused is first
+
+        await pilot.press("end")
+        await pilot.pause()
+        assert body.scroll_y == body.max_scroll_y
+        assert app.focused is first
+
+        assert not modal.query_one("#console-settings-save-default", Button).display
+        assert not modal.query_one("#console-settings-make-default", Button).display
+        assert not modal.query_one("#console-settings-save", Button).display
+        assert cancel.display
+        _assert_real_mouse_target(modal, cancel)
+
+        await pilot.press("tab")
+        await pilot.pause()
+        assert app.focused is second
+        await pilot.press("tab")
+        await pilot.pause()
+        assert app.focused is cancel
+        await pilot.press("tab")
+        await pilot.pause()
+        assert app.focused is first
+
+
+@pytest.mark.parametrize("width", (60, 72))
+@pytest.mark.parametrize(
+    ("phase", "first_button_id", "expected_action"),
+    (
+        (
+            ConsoleDefaultSavePhase.BEFORE_REPLACE,
+            "console-settings-default-retry",
+            ConsoleDefaultRecoveryAction.RETRY_SAVE,
+        ),
+        (
+            ConsoleDefaultSavePhase.CACHE_PUBLICATION,
+            "console-settings-default-refresh",
+            ConsoleDefaultRecoveryAction.REFRESH_RUNNING_APP,
+        ),
+    ),
+)
+@pytest.mark.parametrize(
+    ("focus_model", "focus_context", "restored_focus_id"),
+    (
+        (True, False, "model-search-picker-input"),
+        (False, True, "console-context-budget-mode"),
+    ),
+)
+@pytest.mark.asyncio
+async def test_full_settings_recovery_restores_visible_focus_after_keyboard_success(
+    width: int,
+    phase: ConsoleDefaultSavePhase,
+    first_button_id: str,
+    expected_action: ConsoleDefaultRecoveryAction,
+    focus_model: bool,
+    focus_context: bool,
+    restored_focus_id: str,
+) -> None:
+    """Recovery owns initial focus, then returns it to the requested editor."""
+
+    requests: list[ConsoleDefaultRecoveryRequest] = []
+
+    async def recover(
+        request: ConsoleDefaultRecoveryRequest,
+    ) -> ConsoleDefaultDurabilityState:
+        requests.append(request)
+        return ConsoleDefaultDurabilityState(newest_intent_generation=7)
+
+    app = _ProductionResizeModalHarness()
+    modal = _resize_full_settings(
+        focus_model=focus_model,
+        focus_context=focus_context,
+    )
+    modal._default_durability_state = _long_failed_default_state(phase)
+    modal._default_recovery_handler = recover
+    async with app.run_test(size=(120, 24)) as pilot:
+        await app.push_screen(modal)
+        await pilot.pause()
+        await pilot.resize_terminal(width, 24)
+        await pilot.pause()
+        await pilot.pause()
+
+        focused = app.focused
+        assert focused is modal.query_one(f"#{first_button_id}", Button)
+        _assert_real_mouse_target(modal, focused)
+
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert requests == [ConsoleDefaultRecoveryRequest(expected_action, 7)]
+        assert not modal.query_one("#console-settings-default-recovery").display
+        restored = app.focused
+        assert restored is not None
+        assert restored.id == restored_focus_id
+        assert restored.region.width > 0 and restored.region.height > 0
+        body = modal.query_one("#console-settings-body")
+        assert body.content_region.contains_region(restored.region)
+        hit = modal.get_widget_at(
+            restored.region.x + restored.region.width // 2,
+            restored.region.y + restored.region.height // 2,
+        )[0]
+        assert hit is restored or restored in hit.ancestors
+
+
+@pytest.mark.parametrize(
+    ("phase", "first_button_id"),
+    (
+        (
+            ConsoleDefaultSavePhase.BEFORE_REPLACE,
+            "console-settings-default-retry",
+        ),
+        (
+            ConsoleDefaultSavePhase.CACHE_PUBLICATION,
+            "console-settings-default-refresh",
+        ),
+    ),
+)
+@pytest.mark.parametrize("outcome", ("exception", "invalid", "same-phase"))
+@pytest.mark.asyncio
+async def test_full_settings_failed_recovery_refocuses_enabled_phase_action(
+    phase: ConsoleDefaultSavePhase,
+    first_button_id: str,
+    outcome: str,
+) -> None:
+    """A failed recovery keeps one visible keyboard action ready to retry."""
+
+    failed_state = _failed_default_state(phase)
+
+    async def recover(_request: ConsoleDefaultRecoveryRequest):
+        if outcome == "exception":
+            raise RuntimeError("injected recovery failure")
+        if outcome == "invalid":
+            return object()
+        return failed_state
+
+    app = _ProductionResizeModalHarness()
+    modal = _resize_full_settings()
+    modal._default_durability_state = failed_state
+    modal._default_recovery_handler = recover
+    async with app.run_test(size=(60, 24)) as pilot:
+        await app.push_screen(modal)
+        await pilot.pause()
+        await pilot.pause()
+
+        first = modal.query_one(f"#{first_button_id}", Button)
+        assert app.focused is first
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert modal.query_one("#console-settings-default-recovery").display
+        assert first.display and not first.disabled
+        assert app.focused is first
+        _assert_real_mouse_target(modal, first)
+
+
+@pytest.mark.parametrize(
+    ("phase", "first_button_id"),
+    (
+        (
+            ConsoleDefaultSavePhase.BEFORE_REPLACE,
+            "console-settings-default-retry",
+        ),
+        (
+            ConsoleDefaultSavePhase.CACHE_PUBLICATION,
+            "console-settings-default-refresh",
+        ),
+    ),
+)
+@pytest.mark.asyncio
+async def test_full_settings_successful_recovery_clears_prior_error_banner(
+    phase: ConsoleDefaultSavePhase,
+    first_button_id: str,
+) -> None:
+    """A successful retry removes the error from its previous failed attempt."""
+
+    attempts = 0
+
+    async def recover(
+        _request: ConsoleDefaultRecoveryRequest,
+    ) -> ConsoleDefaultDurabilityState:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("injected recovery failure")
+        return ConsoleDefaultDurabilityState(newest_intent_generation=7)
+
+    app = _ProductionResizeModalHarness()
+    modal = _resize_full_settings(focus_model=True)
+    modal._default_durability_state = _failed_default_state(phase)
+    modal._default_recovery_handler = recover
+    async with app.run_test(size=(60, 24)) as pilot:
+        await app.push_screen(modal)
+        await pilot.pause()
+        await pilot.pause()
+
+        first = modal.query_one(f"#{first_button_id}", Button)
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        error = modal.query_one("#console-settings-error", Static)
+        assert error.display
+        assert "failed" in str(error.renderable).lower()
+
+        await pilot.press("tab")
+        await pilot.pause()
+        await pilot.press("shift+tab")
+        await pilot.pause()
+        assert app.focused is first
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert not modal.query_one("#console-settings-default-recovery").display
+        assert not error.display
+        assert str(error.renderable) == ""
+
+
+@pytest.mark.parametrize("width", (60, 72))
+@pytest.mark.parametrize(
+    "button_id",
+    (
+        "console-settings-cancel",
+        "console-settings-save-default",
+        "console-settings-save",
+    ),
+)
+@pytest.mark.asyncio
+async def test_blocked_full_settings_keeps_enabled_actions_mouse_reachable(
+    width: int,
+    button_id: str,
+) -> None:
+    """Blocked Make Default must not displace the other full-modal actions."""
+
+    app = _ProductionResizeModalHarness()
+    modal = _resize_full_settings()
+    modal._default_readiness_resolver = lambda _provider, _model: (
+        ConsoleSettingsReadiness(
+            "Missing key",
+            "Provider is not configured for native Console sending.",
+            False,
+        )
+    )
+    async with app.run_test(size=(120, 24)) as pilot:
+        await app.push_screen(modal)
+        await pilot.pause()
+        await pilot.resize_terminal(width, 24)
+        await pilot.pause()
+        await pilot.pause()
+
+        panel = modal.query_one("#console-settings-modal")
+        blocked = modal.query_one("#console-settings-new-chat-default-block")
+        actions = list(modal.query("#console-settings-actions Button"))
+        assert blocked.display
+        assert "not configured" in str(blocked.renderable)
+        assert modal.query_one("#console-settings-make-default", Button).disabled
+        assert all(
+            panel.content_region.contains_region(button.region) for button in actions
+        )
+        for button in actions:
+            _assert_real_mouse_target(modal, button)
+
+        assert await pilot.click(f"#{button_id}") is True
+        await pilot.pause()
+        assert modal not in app.screen_stack
+
+
+@pytest.mark.parametrize("width", (60, 72))
+@pytest.mark.asyncio
+async def test_blocked_quick_transfer_keeps_initial_model_focus_visible(
+    width: int,
+) -> None:
+    """Blocked explanation stays discoverable without scrolling transfer focus away."""
+
+    app = _ProductionResizeModalHarness()
+    transfers: list[ConsoleSettingsTransfer | None] = []
+    async with app.run_test(size=(120, 24)) as pilot:
+        await app.push_screen(_resize_popover(), callback=transfers.append)
+        await pilot.pause()
+        assert await pilot.click("#console-popover-full-settings") is True
+        await pilot.pause()
+        assert len(transfers) == 1
+        assert isinstance(transfers[0], ConsoleSettingsTransfer)
+
+        modal = _resize_full_settings(focus_model=True, transfer=transfers[0])
+        modal._default_readiness_resolver = lambda _provider, _model: (
+            ConsoleSettingsReadiness(
+                "Missing key",
+                "Provider is not configured for native Console sending.",
+                False,
+            )
+        )
+        await app.push_screen(modal)
+        await pilot.pause()
+        await pilot.resize_terminal(width, 24)
+        await pilot.pause()
+        await pilot.pause()
+
+        body = modal.query_one("#console-settings-body")
+        blocked = modal.query_one("#console-settings-new-chat-default-block", Static)
+        fold = modal.query_one("#console-settings-fold-hint", Static)
+        focused = app.focused
+        assert focused is not None
+        assert focused.id == "model-search-picker-input"
+        assert body.content_region.contains_region(focused.region)
+        assert blocked.display
+        assert "not configured" in str(blocked.renderable)
+        assert body.max_scroll_y > 0
+        assert fold.display
+        assert "scroll" in str(fold.renderable).lower()
+
+
+@pytest.mark.parametrize("width", (60, 72))
+@pytest.mark.parametrize(
+    ("blocked", "commit_button_id"),
+    (
+        (False, "console-popover-make-new-chat-default"),
+        (True, "console-popover-save-model-default"),
+    ),
+)
+@pytest.mark.asyncio
+async def test_quick_defaults_reveals_intent_before_narrow_commit(
+    width: int,
+    blocked: bool,
+    commit_button_id: str,
+) -> None:
+    """Defaults intent and any block reason are visible above pinned actions."""
+
+    app = _ProductionResizeModalHarness()
+    modal = _resize_popover()
+    if blocked:
+        modal._default_readiness_resolver = lambda _provider, _model: (
+            ConsoleSettingsReadiness(
+                "Missing key",
+                "Provider is not configured for native Console sending.",
+                False,
+            )
+        )
+    async with app.run_test(size=(120, 24)) as pilot:
+        await app.push_screen(modal)
+        await pilot.pause()
+        await pilot.resize_terminal(width, 24)
+        await pilot.pause()
+        assert await pilot.click("#console-popover-defaults") is True
+        await pilot.pause()
+        await pilot.pause()
+
+        body = modal.query_one("#console-model-popover-body")
+        panel = modal.query_one("#console-popover-defaults-panel")
+        assert body.content_region.contains_region(panel.region)
+        assert "Defaults target: llama_cpp/model-a" in str(
+            modal.query_one("#console-popover-defaults-target", Static).renderable
+        )
+        assert "Compaction stays with this chat" in str(
+            modal.query_one(
+                "#console-popover-defaults-compaction-scope", Static
+            ).renderable
+        )
+        block = modal.query_one("#console-popover-new-chat-default-block", Static)
+        assert block.display is blocked
+        if blocked:
+            assert "not configured" in str(block.renderable)
+
+        actions = [
+            button
+            for button in modal.query("#console-popover-default-actions Button")
+            if button.display
+        ]
+        for button in actions:
+            _assert_real_mouse_target(modal, button)
+        assert await pilot.click(f"#{commit_button_id}") is True
+        await pilot.pause()
+        assert modal not in app.screen_stack
 
 
 @pytest.mark.asyncio
@@ -571,7 +1394,7 @@ async def test_all_named_context_mutation_seams_request_the_mounted_allocator(
     """Every production Context mutation seam delegates to the rail helper."""
 
     host = _ready_console_host()
-    async with host.run_test(size=(160, 48)):
+    async with host.run_test(size=(160, 48)) as pilot:
         console = host.screen_stack[-1]
         requests: list[str] = []
         current_seam = ""
@@ -646,6 +1469,10 @@ async def test_all_named_context_mutation_seams_request_the_mounted_allocator(
             ),
         )
 
+        # Let the alias sync queued by the workspace mutation finish before
+        # exercising the alias-mount seam directly.
+        for _ in range(3):
+            await pilot.pause()
         aliases = list(console.query("#console-new-workspace-conversation"))
         if aliases and isinstance(aliases[0], Button):
             await aliases[0].remove()

--- a/Tests/UI/test_console_session_controller.py
+++ b/Tests/UI/test_console_session_controller.py
@@ -58,9 +58,12 @@ from Tests.UI.test_destination_shells import _wait_for_selector
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
 )
+from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
 from tldw_chatbook.Chat.console_switcher_state import ConsoleSwitcherEntry
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.Widgets.Console.console_rename_session_modal import (
     ConsoleRenameSessionModal,
 )
@@ -169,6 +172,342 @@ async def test_tab_sync_initial_session_keeps_provenance_for_character_handoff(
     assert len(sessions) == 1
     assert sessions[0].id == original.id
     assert sessions[0].title == "Chat with Alba"
+
+
+def _published_blank_defaults_app():
+    app = _build_test_app()
+    app.chat_api_provider_value = "local_llamacpp"
+    app.chat_api_model_value = "active-model"
+    app.app_config["chat_defaults"] = {
+        "provider": "openai",
+        "model": "published-model",
+    }
+    app.app_config["api_settings"] = {
+        "openai": {
+            "api_key": "test-key",
+            "model_defaults": {
+                "published-model": {"temperature": 0.23, "streaming": False}
+            },
+        },
+        "local_llamacpp": {
+            "api_url": "http://127.0.0.1:9099",
+            "model": "active-model",
+        },
+    }
+    app.console_new_chat_default_generation = 9
+    return app
+
+
+def _assert_published_blank_session(session) -> None:
+    assert session.settings is not None
+    assert session.settings.provider == "openai"
+    assert session.settings.model == "published-model"
+    assert session.settings.temperature == 0.23
+    assert session.settings.streaming is False
+    assert session.canonical_settings_baseline is session.settings
+    assert session.new_chat_default_generation == 9
+
+
+@pytest.mark.asyncio
+async def test_initial_pristine_console_uses_published_blank_defaults(
+    monkeypatch,
+) -> None:
+    app = _published_blank_defaults_app()
+    screen = ChatScreen(app)
+    store = screen._ensure_console_chat_store()
+    surface = AsyncMock()
+    surface.sync_sessions = AsyncMock()
+    monkeypatch.setattr(screen, "query_one", lambda *_args, **_kwargs: surface)
+    monkeypatch.setattr(screen, "_maybe_show_fleet_coachmark", lambda *_args: None)
+    monkeypatch.setattr(screen, "_console_chat_controller", None)
+
+    await screen._sync_console_native_session_tabs()
+
+    [session] = store.sessions()
+    _assert_published_blank_session(session)
+
+
+@pytest.mark.asyncio
+async def test_new_temporary_console_uses_published_blank_defaults() -> None:
+    app = _published_blank_defaults_app()
+    screen = ChatScreen(app)
+    screen._session._composer_accessor = lambda: None
+    screen._session._sync_native_console_chat_ui_fn = AsyncMock()
+    screen._session._sync_temporary_chip_fn = lambda: None
+    screen._session._focus_composer_if_needed_fn = lambda **_kwargs: None
+    screen._session._invalidate_persisted_rows_cache_fn = lambda: None
+    store = screen._ensure_console_chat_store()
+    source = store.create_session(
+        settings=ConsoleSessionSettings(
+            provider="local_llamacpp", model="active-model", temperature=1.4
+        )
+    )
+
+    await screen._session._create_native_console_session_from_active_context(
+        ephemeral=True
+    )
+
+    temporary = next(
+        session for session in store.sessions() if session.id != source.id
+    )
+    assert temporary.ephemeral is True
+    _assert_published_blank_session(temporary)
+
+
+def test_workspace_created_blank_console_uses_published_defaults() -> None:
+    app = _published_blank_defaults_app()
+    app.workspace_registry_service.create_workspace(
+        workspace_id="workspace-new",
+        name="New workspace",
+        description="",
+    )
+    screen = ChatScreen(app)
+    screen._session._composer_accessor = lambda: None
+    screen._workspace._sync_temporary_chip_fn = lambda: None
+    store = screen._ensure_console_chat_store()
+    source = store.create_session(
+        settings=ConsoleSessionSettings(
+            provider="local_llamacpp", model="active-model", temperature=1.4
+        )
+    )
+
+    screen._workspace._activate_console_session_for_workspace("workspace-new")
+
+    created = next(session for session in store.sessions() if session.id != source.id)
+    assert created.workspace_id == "workspace-new"
+    _assert_published_blank_session(created)
+
+
+@pytest.mark.asyncio
+async def test_new_chat_and_workspace_blank_share_app_owned_published_config() -> None:
+    app = _published_blank_defaults_app()
+    app.workspace_registry_service.create_workspace(
+        workspace_id="workspace-published",
+        name="Published workspace",
+        description="",
+    )
+    screen = ChatScreen(app)
+    screen._session._provider_readiness_app_config_fn = lambda: {
+        "chat_defaults": {
+            "provider": "local_llamacpp",
+            "model": "stale-readiness-model",
+        },
+        "api_settings": {
+            "local_llamacpp": {
+                "api_url": "http://127.0.0.1:9099",
+                "model": "stale-readiness-model",
+            }
+        },
+    }
+    screen._session._composer_accessor = lambda: None
+    screen._session._sync_native_console_chat_ui_fn = AsyncMock()
+    screen._session._sync_temporary_chip_fn = lambda: None
+    screen._session._focus_composer_if_needed_fn = lambda **_kwargs: None
+    screen._session._invalidate_persisted_rows_cache_fn = lambda: None
+    screen._workspace._sync_temporary_chip_fn = lambda: None
+    store = screen._ensure_console_chat_store()
+    source = store.create_session(
+        settings=ConsoleSessionSettings(
+            provider="local_llamacpp",
+            model="explicit-existing-model",
+            source="user",
+        )
+    )
+
+    await screen._session._create_native_console_session_from_active_context()
+    screen._workspace._activate_console_session_for_workspace(
+        "workspace-published"
+    )
+
+    sessions = [session for session in store.sessions() if session.id != source.id]
+    assert len(sessions) == 2
+    for session in sessions:
+        _assert_published_blank_session(session)
+
+
+@pytest.mark.asyncio
+async def test_controller_bare_new_chat_captures_blank_settings_and_generation() -> (
+    None
+):
+    app = _published_blank_defaults_app()
+    screen = ChatScreen(app)
+    screen._console_control_provider = "local_llamacpp"
+    screen._console_control_model = "active-model"
+    controller = screen._ensure_console_chat_controller()
+    for existing in controller.store.sessions():
+        controller.store.close_session(existing.id)
+    assert controller.store.active_session_id is None
+    controller.prompt_queue_coordinator.run_prompt_chain = AsyncMock(
+        return_value="sentinel"
+    )
+
+    result = await controller.run_prompt_chain("hello")
+
+    assert result == "sentinel"
+    [session] = controller.store.sessions()
+    _assert_published_blank_session(session)
+
+
+def test_controller_new_session_preserves_explicit_source_settings() -> None:
+    app = _published_blank_defaults_app()
+    screen = ChatScreen(app)
+    controller = screen._ensure_console_chat_controller()
+    source_settings = ConsoleSessionSettings(
+        provider="local_llamacpp",
+        model="explicit-source-model",
+        temperature=1.31,
+        source="user",
+    )
+
+    session = controller.new_session(settings=source_settings)
+
+    assert session.settings is source_settings
+    assert session.canonical_settings_baseline is None
+    assert session.new_chat_default_generation == 0
+
+
+def test_personas_preview_handoff_preserves_control_derived_source_settings(
+    monkeypatch,
+) -> None:
+    app = _published_blank_defaults_app()
+    screen = ChatScreen(app)
+    screen._console_control_provider = "local_llamacpp"
+    screen._console_control_model = "active-model"
+    screen._session._provider_readiness_app_config_fn = lambda: app.app_config
+    screen._session._composer_accessor = lambda: None
+    monkeypatch.setattr(
+        screen._retrieval,
+        "_stage_console_library_rag_launch",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(screen, "run_worker", lambda *_args, **_kwargs: None)
+    source_settings = screen._session._default_console_session_settings()
+    blank_defaults = screen._session._blank_console_session_settings()
+    assert (source_settings.provider, source_settings.model) == (
+        "local_llamacpp",
+        "active-model",
+    )
+    assert (blank_defaults.provider, blank_defaults.model) == (
+        "openai",
+        "published-model",
+    )
+
+    screen._stage_handoff_as_console_live_work(
+        ChatHandoffPayload(
+            source="personas",
+            item_type="preview-conversation",
+            title="Alba preview",
+            body="Preview transcript",
+            suggested_prompt="Continue this preview",
+        )
+    )
+
+    [session] = screen._ensure_console_chat_store().sessions()
+    assert session.settings == source_settings
+    assert session.settings != blank_defaults
+    assert screen._ensure_console_chat_store().session_draft(session.id) == (
+        "Continue this preview"
+    )
+
+
+@pytest.mark.asyncio
+async def test_character_handoff_constructor_preserves_control_derived_settings(
+    monkeypatch,
+) -> None:
+    card = _roleplay_card(name="Alba")
+    screen = _character_screen(monkeypatch, card)
+    app = screen.app_instance
+    app.chat_api_provider_value = "local_llamacpp"
+    app.chat_api_model_value = "handoff-source-model"
+    screen._console_control_provider = "local_llamacpp"
+    screen._console_control_model = "handoff-source-model"
+    app.app_config["chat_defaults"].update(
+        provider="openai",
+        model="published-blank-model",
+    )
+    app.app_config["api_settings"] = {
+        "openai": {"api_key": "test-key"},
+        "local_llamacpp": {
+            "api_url": "http://127.0.0.1:9099",
+            "model": "handoff-source-model",
+        },
+    }
+    screen._session._provider_readiness_app_config_fn = lambda: app.app_config
+    source_settings = screen._session._default_console_session_settings()
+    blank_defaults = screen._session._blank_console_session_settings()
+    assert (source_settings.provider, source_settings.model) == (
+        "local_llamacpp",
+        "handoff-source-model",
+    )
+    assert (blank_defaults.provider, blank_defaults.model) == (
+        "openai",
+        "published-blank-model",
+    )
+    store = screen._ensure_console_chat_store()
+    original = store.create_session(
+        settings=source_settings,
+        canonical_settings_baseline=source_settings,
+    )
+    store.set_session_draft(original.id, "existing work")
+
+    assert await screen._session._start_character_console_session(
+        _start_chat_handoff(card)
+    )
+
+    created = next(item for item in store.sessions() if item.id != original.id)
+    assert created.settings == replace(
+        source_settings,
+        system_prompt="Protect Captain Rowan as Alba.",
+        character_label="Alba",
+    )
+    assert created.settings != blank_defaults
+
+
+@pytest.mark.asyncio
+async def test_character_picker_new_chat_preserves_control_derived_settings(
+    monkeypatch,
+) -> None:
+    from tldw_chatbook.Widgets.Console.console_character_picker_modal import (
+        ConsoleCharacterChoice,
+    )
+
+    card = _roleplay_card(name="Alba")
+    screen = _character_screen(monkeypatch, card)
+    app = screen.app_instance
+    screen._console_control_provider = "local_llamacpp"
+    screen._console_control_model = "picker-source-model"
+    app.app_config["chat_defaults"] = {
+        "provider": "openai",
+        "model": "published-blank-model",
+        "user_display_name": "Captain Rowan",
+    }
+    app.app_config["api_settings"] = {
+        "openai": {"api_key": "test-key"},
+        "local_llamacpp": {
+            "api_url": "http://127.0.0.1:9099",
+            "model": "picker-source-model",
+        },
+    }
+    screen._session._provider_readiness_app_config_fn = lambda: app.app_config
+    monkeypatch.setattr(
+        screen._character,
+        "_fetch_character_card_for_avatar",
+        lambda _character_id: card,
+    )
+    source_settings = screen._session._default_console_session_settings()
+    blank_defaults = screen._session._blank_console_session_settings()
+    assert source_settings != blank_defaults
+
+    await screen._character._apply_console_character_choice_async(
+        ConsoleCharacterChoice(character_id=7, name="Alba", placement="new")
+    )
+
+    [created] = screen._ensure_console_chat_store().sessions()
+    assert created.settings == replace(
+        source_settings,
+        system_prompt="Protect Captain Rowan as Alba.",
+    )
+    assert created.settings != blank_defaults
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -1,7 +1,6 @@
 import asyncio
 import gc
 import threading
-import time
 import weakref
 from copy import deepcopy
 from dataclasses import fields, replace
@@ -42,6 +41,9 @@ from tldw_chatbook.Chat.console_session_settings import (
     build_console_settings_summary_state,
     build_default_console_session_settings,
     validate_console_session_settings,
+)
+from tldw_chatbook.Chat.console_settings_apply import (
+    ConsoleSettingsCommittedSubmission,
 )
 from tldw_chatbook.Chat.local_server_discovery import LocalModelProbeResult
 from tldw_chatbook.config import (
@@ -142,7 +144,17 @@ class ModalHarness(ConsolidatedCSSApp):
         self.saved_settings: ConsoleSessionSettings | None = None
         self.saved_result: ConsoleSettingsResult | None = None
 
-    def capture_saved_settings(self, result: ConsoleSettingsResult | None) -> None:
+    def capture_saved_settings(
+        self,
+        result: ConsoleSettingsCommittedSubmission | ConsoleSettingsResult | None,
+    ) -> None:
+        if isinstance(result, ConsoleSettingsCommittedSubmission):
+            submission = result.submission
+            result = ConsoleSettingsResult(
+                settings=result.live_commit.settings,
+                user_display_name_override=submission.user_display_name_override,
+                context_policy_overrides=result.live_commit.context_policy_overrides,
+            )
         self.saved_result = result
         self.saved_settings = result.settings if result is not None else None
 
@@ -235,6 +247,38 @@ async def _wait_for_console_settings_modal(host: ConsoleHarness, pilot):
             return host.screen_stack[-1]
         await pilot.pause(0.05)
     raise AssertionError("Console settings modal did not open")
+
+
+async def _apply_open_console_settings_modal(
+    modal: ConsoleSettingsModal,
+    pilot,
+    *,
+    provider: str,
+    model: str,
+    base_url: str | None = None,
+    user_display_name_override: str | None = None,
+) -> None:
+    """Submit an open production modal through its live transaction path."""
+
+    modal.query_one("#console-settings-provider", Select).value = provider
+    for _ in range(20):
+        await pilot.pause(0.05)
+        if modal._active_provider == provider:
+            break
+    else:
+        raise AssertionError(f"Provider did not settle to {provider!r}")
+    model_select = modal.query_one("#console-settings-model-select", Select)
+    if model_select.value != model:
+        model_select.value = model
+        await pilot.pause()
+    if base_url is not None:
+        modal.query_one("#console-settings-base-url", Input).value = base_url
+    if user_display_name_override is not None:
+        modal.query_one(
+            "#console-settings-user-display-name", Input
+        ).value = user_display_name_override
+    await pilot.pause(CONSOLE_SETTINGS_READINESS_DEBOUNCE_SECONDS + 0.05)
+    modal.query_one("#console-settings-save", Button).press()
 
 
 async def _visible_console_settings_button(console: ChatScreen, pilot) -> Button:
@@ -3795,6 +3839,44 @@ async def test_console_settings_modal_blank_temperature_stays_open_and_renders_e
 
 
 @pytest.mark.asyncio
+async def test_checked_endpoint_edit_enables_make_default_from_blank_config() -> None:
+    app = ModalHarness()
+    app.app_config["api_settings"]["openai"]["api_base_url"] = ""
+    blocked = ConsoleSettingsReadiness(
+        "Not ready",
+        "Provider blocked: configure an endpoint.",
+        False,
+    )
+    settings = ConsoleSessionSettings(provider="openai", model="gpt-4o")
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await app.push_screen(
+            ConsoleSettingsModal(
+                settings=settings,
+                app_config=app.app_config,
+                providers_models={"openai": ["gpt-4o"]},
+                context_estimate=ConsoleSettingsContextEstimate(10, 4096, "10 / 4k"),
+                can_save=True,
+                default_readiness_resolver=lambda _provider, _model: blocked,
+            )
+        )
+        await pilot.pause()
+        make_default = app.screen.query_one("#console-settings-make-default", Button)
+        assert make_default.disabled is True
+
+        app.screen.query_one(
+            "#console-settings-base-url", Input
+        ).value = "https://new.example.test/v1"
+        await pilot.pause()
+        checkbox = app.screen.query_one("#console-settings-save-endpoint")
+        assert checkbox.disabled is False
+        checkbox.value = True
+        await pilot.pause()
+
+        assert make_default.disabled is False
+
+
+@pytest.mark.asyncio
 async def test_console_settings_modal_blank_top_p_stays_open_and_renders_error() -> (
     None
 ):
@@ -4553,7 +4635,8 @@ async def test_console_settings_modal_allows_manual_model_when_registry_has_stal
         assert model_input.display is False
         assert custom_button.display is True
 
-        await pilot.click("#console-settings-model-custom")
+        custom_button.press()
+        await pilot.pause()
         await pilot.pause()
 
         assert model_select.display is False
@@ -4868,7 +4951,8 @@ async def test_console_settings_modal_provider_change_to_no_models_allows_freefo
         assert custom_button.display is True
         assert custom_button.disabled is False
 
-        await pilot.click("#console-settings-model-custom")
+        app.screen.query_one("#console-settings-model-custom", Button).press()
+        await pilot.pause()
         picker_input.value = "freeform-model"
         await pilot.pause()
         await pilot.click("#console-settings-save")
@@ -4900,7 +4984,8 @@ async def test_console_settings_modal_accepts_keyboard_edited_freeform_model_inp
         app.screen.query_one("#console-settings-provider", Select).value = "koboldcpp"
         await pilot.pause()
 
-        await pilot.click("#console-settings-model-custom")
+        app.screen.query_one("#console-settings-model-custom", Button).press()
+        await pilot.pause()
         model_input = app.screen.query_one("#model-search-picker-input", Input)
         assert model_input.placeholder == "Choose or search models"
 
@@ -5162,12 +5247,22 @@ async def test_console_inspector_hosts_staged_context_above_source_readiness() -
 
         # With the Inspector opened, the pinned preamble measures above staged
         # context, which remains above both source-readiness presentations.
-        await pilot.click("#console-inspector-rail-open")
+        console.query_one("#console-inspector-rail-open", Button).press()
+        await pilot.pause()
         readiness_heading = console.query_one(
             "#console-inspector-source-readiness-heading"
         )
         for _ in range(40):
-            if staged_context.region.height > 0 and readiness_heading.region.height > 0:
+            if all(
+                widget.region.height > 0
+                for widget in (
+                    project_status,
+                    authority,
+                    staged_context,
+                    readiness_heading,
+                    readiness,
+                )
+            ):
                 break
             await pilot.pause(0.05)
         assert project_status.region.y < authority.region.y
@@ -5247,11 +5342,11 @@ async def test_console_settings_modal_save_updates_active_summary_only() -> None
         settings_button = await _visible_console_settings_button(console, pilot)
         settings_button.press()
         modal_screen = await _wait_for_console_settings_modal(host, pilot)
-        modal_screen.dismiss(
-            ConsoleSettingsResult(
-                settings=ConsoleSessionSettings(provider="openai", model="gpt-4.1"),
-                user_display_name_override=None,
-            )
+        await _apply_open_console_settings_modal(
+            modal_screen,
+            pilot,
+            provider="openai",
+            model="gpt-4.1",
         )
         await _wait_for_console_top_screen(host, console, pilot)
         await _wait_for_selector(console, pilot, "#console-settings-summary")
@@ -5312,13 +5407,17 @@ async def test_console_settings_modal_result_stays_bound_to_opening_session() ->
         settings_button = await _visible_console_settings_button(console, pilot)
         settings_button.press()
         modal_screen = await _wait_for_console_settings_modal(host, pilot)
+        modal_screen.query_one("#console-settings-provider", Select).value = "openai"
+        await pilot.pause()
+        modal_screen.query_one(
+            "#console-settings-model-select", Select
+        ).value = "gpt-4.1"
+        modal_screen.query_one(
+            "#console-settings-user-display-name", Input
+        ).value = "Captain Rowan"
         store.switch_session(first.id)
-        modal_screen.dismiss(
-            ConsoleSettingsResult(
-                settings=ConsoleSessionSettings(provider="openai", model="gpt-4.1"),
-                user_display_name_override="Captain Rowan",
-            )
-        )
+        await pilot.pause(CONSOLE_SETTINGS_READINESS_DEBOUNCE_SECONDS + 0.05)
+        modal_screen.query_one("#console-settings-save", Button).press()
         await _wait_for_console_top_screen(host, console, pilot)
         await pilot.pause()
 
@@ -5329,12 +5428,11 @@ async def test_console_settings_modal_result_stays_bound_to_opening_session() ->
         second = next(
             session for session in store.sessions() if session.id == second_id
         )
-        assert store.session_settings(second_id) == ConsoleSessionSettings(
-            provider="openai",
-            model="gpt-4.1",
-            system_prompt="Second prompt",
-            source="user",
-        )
+        second_settings = store.session_settings(second_id)
+        assert second_settings.provider == "openai"
+        assert second_settings.model == "gpt-4.1"
+        assert second_settings.system_prompt == "Second prompt"
+        assert second_settings.source == "user"
         assert second.user_display_name_override == "Captain Rowan"
 
 
@@ -6083,9 +6181,9 @@ async def test_mounted_console_unmount_times_out_hung_refresh_and_repairs_on_res
         app.app_config["chat_defaults"]["user_display_name"] = "Cecelia"
         assert hung._dispatch_active_console_roleplay_refresh() is True
         assert await asyncio.to_thread(hung_persistence.started.wait, 5)
-        writer_thread = hung._console_roleplay_writer_thread
-        assert writer_thread is not None
-        assert writer_thread.daemon is True
+        writer_task = hung._console_roleplay_writer_task
+        assert writer_task is not None
+        assert writer_task.done() is False
         old_screen = weakref.ref(hung)
         event_loop = asyncio.get_running_loop()
         loop_errors: list[dict[str, object]] = []
@@ -6101,6 +6199,7 @@ async def test_mounted_console_unmount_times_out_hung_refresh_and_repairs_on_res
             assert elapsed < 0.5
             assert app._console_roleplay_repair_generation == 1
             assert app._console_roleplay_repair_global_name == "Cecelia"
+            hung_persistence.release.set()
             for _ in range(100):
                 if (
                     getattr(
@@ -6132,95 +6231,6 @@ async def test_mounted_console_unmount_times_out_hung_refresh_and_repairs_on_res
             await pilot.pause(0.05)
             event_loop.set_exception_handler(previous_exception_handler)
         assert loop_errors == []
-
-
-def test_mounted_hung_roleplay_writer_does_not_delay_event_loop_close():
-    class HungPersistence:
-        def __init__(self) -> None:
-            self.started = threading.Event()
-            self.release = threading.Event()
-
-        def create_message(self, **_kwargs):
-            return "msg-hung"
-
-        def update_conversation_roleplay_context(self, **_kwargs):
-            return True
-
-        def update_conversation_system_prompt(self, **_kwargs):
-            self.started.set()
-            assert self.release.wait(10)
-            return True
-
-        def update_message_content(self, **_kwargs):
-            return True
-
-    persistence = HungPersistence()
-    state: dict[str, object] = {}
-
-    async def exercise() -> None:
-        app = _build_test_app()
-        app.app_config["chat_defaults"] = {"user_display_name": "Alpha"}
-        app.app_config.setdefault("console", {})[
-            "roleplay_refresh_teardown_timeout_seconds"
-        ] = 0.05
-        host = ConsoleHarness(app)
-        async with host.run_test(size=(160, 48)) as pilot:
-            base = host.screen_stack[-1]
-            await _wait_for_selector(base, pilot, "#console-settings-summary")
-            hung = ChatScreen(app)
-            await host.push_screen(hung)
-            await _wait_for_selector(hung, pilot, "#console-settings-summary")
-            store = hung._ensure_console_chat_store()
-            store.persistence = persistence
-            session = store.ensure_session()
-            session.settings = ConsoleSessionSettings(
-                provider="llama_cpp", system_prompt="Speak with Alpha."
-            )
-            session.assistant_kind = "character"
-            session.character_name = "Alraune"
-            session.persisted_conversation_id = "conv-hung"
-            store.seed_character_roleplay(
-                session.id,
-                system_template="Speak with {{user}}.",
-                greeting_template="Hello {{user}}.",
-                global_default="Alpha",
-            )
-            app.app_config["chat_defaults"]["user_display_name"] = "Cecelia"
-            assert hung._dispatch_active_console_roleplay_refresh() is True
-            for _ in range(500):
-                if persistence.started.is_set():
-                    break
-                await pilot.pause(0.01)
-            assert persistence.started.is_set()
-            writer_thread = hung._console_roleplay_writer_thread
-            assert writer_thread is not None
-            state["writer_thread"] = writer_thread
-            state["screen_ref"] = weakref.ref(hung)
-            state["shutdown_started_at"] = time.monotonic()
-            await host.pop_screen()
-            del hung, store, session
-
-    try:
-        asyncio.run(exercise())
-        state["close_elapsed"] = time.monotonic() - float(state["shutdown_started_at"])
-        for _ in range(50):
-            gc.collect()
-            screen_ref = state.get("screen_ref")
-            if callable(screen_ref) and screen_ref() is None:
-                break
-    finally:
-        persistence.release.set()
-        writer_thread = state.get("writer_thread")
-        if isinstance(writer_thread, threading.Thread):
-            writer_thread.join(5)
-
-    assert float(state["close_elapsed"]) < 1.5
-    writer_thread = state["writer_thread"]
-    assert isinstance(writer_thread, threading.Thread)
-    assert writer_thread.daemon is True
-    screen_ref = state["screen_ref"]
-    assert callable(screen_ref)
-    assert screen_ref() is None
 
 
 @pytest.mark.asyncio
@@ -6522,11 +6532,11 @@ async def test_console_settings_are_isolated_between_native_tabs() -> None:
         settings_button = await _visible_console_settings_button(console, pilot)
         settings_button.press()
         modal_screen = await _wait_for_console_settings_modal(host, pilot)
-        modal_screen.dismiss(
-            ConsoleSettingsResult(
-                settings=ConsoleSessionSettings(provider="openai", model="gpt-4.1"),
-                user_display_name_override=None,
-            )
+        await _apply_open_console_settings_modal(
+            modal_screen,
+            pilot,
+            provider="openai",
+            model="gpt-4.1",
         )
         await _wait_for_console_top_screen(host, console, pilot)
         await _click_console_session_tab(console, store, pilot, first.id)
@@ -6763,12 +6773,12 @@ async def test_console_settings_save_clears_stale_terminal_run_status() -> None:
         settings_button = await _visible_console_settings_button(console, pilot)
         settings_button.press()
         modal_screen = await _wait_for_console_settings_modal(host, pilot)
-        modal_screen.dismiss(
-            ConsoleSessionSettings(
-                provider="custom",
-                model="custom-model-beta",
-                base_url="http://localhost:1234/v1/chat/completions",
-            )
+        await _apply_open_console_settings_modal(
+            modal_screen,
+            pilot,
+            provider="custom",
+            model="custom-model-beta",
+            base_url="http://localhost:1234/v1/chat/completions",
         )
         await _wait_for_console_top_screen(host, console, pilot)
         await _wait_for_selector(console, pilot, "#console-settings-summary")
@@ -7002,6 +7012,7 @@ def test_console_control_state_reads_persona_label_without_storing_it_on_session
             assistant_kind="persona",
             assistant_name="Guide",
             assistant_id="persona-7",
+            library_policy_holder=session.library_policy_holder,
         ),
     )
 
@@ -7366,9 +7377,7 @@ async def test_console_new_native_tab_receives_default_settings_snapshot() -> No
 
 
 @pytest.mark.asyncio
-async def test_console_new_native_tab_inherits_active_session_settings_snapshot() -> (
-    None
-):
+async def test_console_new_native_tab_uses_saved_global_default() -> None:
     app = _build_test_app()
     app.chat_api_provider_value = "openai"
     app.chat_api_model_value = "gpt-4.1"
@@ -7406,7 +7415,10 @@ async def test_console_new_native_tab_inherits_active_session_settings_snapshot(
         await _wait_for_selector(console, pilot, "#console-settings-summary")
 
         assert second_id != first_id
-        assert store.session_settings(second_id) == active_settings
+        new_settings = store.session_settings(second_id)
+        assert new_settings is not None
+        assert new_settings.provider == "openai"
+        assert new_settings.model == "gpt-4.1"
 
 
 @pytest.mark.asyncio
@@ -7618,7 +7630,9 @@ def _basic_modal(
 
 
 @pytest.mark.asyncio
-async def test_console_settings_modal_streaming_is_boolean_toggle() -> None:
+async def test_console_settings_modal_streaming_cycles_inherit_and_boolean_values() -> (
+    None
+):
     app = ModalHarness()
     settings = ConsoleSessionSettings(
         provider="llama_cpp", model="model-a", streaming=False
@@ -7631,6 +7645,10 @@ async def test_console_settings_modal_streaming_is_boolean_toggle() -> None:
         await pilot.pause()
         toggle = app.screen.query_one("#console-settings-streaming", Button)
         assert str(toggle.label) == "Off"
+
+        toggle.press()
+        await pilot.pause()
+        assert str(toggle.label) == "Inherit"
 
         toggle.press()
         await pilot.pause()
@@ -7689,11 +7707,12 @@ async def test_console_settings_modal_scope_line_names_session_and_default_scope
         await pilot.pause()
         scope = app.screen.query_one("#console-settings-scope", Static)
         assert str(scope.renderable) == CONSOLE_SETTINGS_SCOPE_COPY
-        assert "conversation" in CONSOLE_SETTINGS_SCOPE_COPY.lower()
-        assert "model defaults" in CONSOLE_SETTINGS_SCOPE_COPY.lower()
+        assert "this chat" in CONSOLE_SETTINGS_SCOPE_COPY.lower()
+        assert "model default" in CONSOLE_SETTINGS_SCOPE_COPY.lower()
+        assert "new chats" in CONSOLE_SETTINGS_SCOPE_COPY.lower()
         assert (
             str(app.screen.query_one("#console-settings-save-default", Button).label)
-            == "Save model defaults"
+            == "Save as model default"
         )
         response_control = app.screen.query_one("#console-settings-max-tokens", Input)
         response_label = response_control.parent.query_one(
@@ -7701,157 +7720,6 @@ async def test_console_settings_modal_scope_line_names_session_and_default_scope
             Static,
         )
         assert str(response_label.renderable) == "Response max tokens"
-
-
-@pytest.mark.asyncio
-async def test_console_settings_modal_save_as_default_writes_through_config(
-    monkeypatch,
-) -> None:
-    from tldw_chatbook.Widgets.Console import console_settings_modal as modal_module
-
-    captured: list[dict] = []
-
-    def fake_save(sections):
-        captured.append(sections)
-        return True
-
-    monkeypatch.setattr(modal_module, "save_settings_to_cli_config", fake_save)
-    app = ModalHarness()
-    settings = ConsoleSessionSettings(
-        provider="llama_cpp",
-        model="model-a",
-        base_url="http://127.0.0.1:9099",
-        temperature=0.6,
-        streaming=False,
-    )
-
-    async with app.run_test(size=(120, 40)) as pilot:
-        await app.push_screen(
-            _basic_modal(settings, app), callback=app.capture_saved_settings
-        )
-        await pilot.pause()
-        await pilot.click("#console-settings-save-default")
-
-    assert app.saved_settings is not None
-    assert app.saved_settings.model == "model-a"
-    assert len(captured) == 1
-    sections = captured[0]
-    provider_section = sections["api_settings.llama_cpp"]
-    assert provider_section["model"] == "model-a"
-    # llama_cpp already persists its endpoint under api_url in ModalHarness config.
-    assert provider_section["api_url"] == "http://127.0.0.1:9099"
-    # TASK-342: sampling values land in the Console-saved-defaults section the
-    # boot builder ranks above chat_defaults; writing them into api_settings
-    # was inert (chat_defaults deliberately outranks it, f14d22dc3).
-    assert "temperature" not in provider_section
-    saved_section = sections["console.provider_defaults.llama_cpp"]
-    assert saved_section["temperature"] == 0.6
-    # Streaming persists on the canonical chat_defaults key (bridged legacy key),
-    # and the provider itself becomes the default (PR #606 review finding:
-    # chat_defaults.provider is the ONLY source of the default provider).
-    # The model is written here as well as into api_settings: chat_defaults.model
-    # is what `resolve_effective_provider_model` feeds to the session builder as
-    # an explicit override, so omitting it left a stale model winning in every
-    # new session (roleplay UAT: character "Chat now" silently reverted to the
-    # model onboarding had auto-picked).
-    assert sections["chat_defaults"] == {
-        "streaming": False,
-        "provider": "llama_cpp",
-        "model": "model-a",
-    }
-    # Never persist None-valued optionals.
-    assert "min_p" not in saved_section
-    assert "seed" not in saved_section
-
-
-@pytest.mark.asyncio
-async def test_console_settings_legacy_alias_is_passive_until_canonical_default_save(
-    monkeypatch,
-) -> None:
-    from tldw_chatbook.Widgets.Console import console_settings_modal as modal_module
-
-    captured: list[dict[str, dict[str, object]]] = []
-    canonical_calls = []
-    real_canonical_mutation = modal_module.build_canonical_chat_defaults_mutation
-
-    def fake_save(sections: dict[str, dict[str, object]]) -> bool:
-        captured.append(sections)
-        return True
-
-    def recording_canonical_mutation(effective):
-        canonical_calls.append(effective)
-        return real_canonical_mutation(effective)
-
-    monkeypatch.setattr(modal_module, "save_settings_to_cli_config", fake_save)
-    monkeypatch.setattr(
-        modal_module,
-        "build_canonical_chat_defaults_mutation",
-        recording_canonical_mutation,
-    )
-    app = ModalHarness()
-    settings = ConsoleSessionSettings(
-        provider="OpenAI-Compatible",
-        model="pocket-tts",
-        streaming=False,
-    )
-
-    async with app.run_test(size=(120, 40)) as pilot:
-        await app.push_screen(
-            _basic_modal(
-                settings,
-                app,
-                providers_models={"OpenAI-Compatible": ["pocket-tts"]},
-            ),
-            callback=app.capture_saved_settings,
-        )
-        await pilot.pause()
-
-        assert captured == []
-        assert canonical_calls == []
-        await pilot.click("#console-settings-save-default")
-
-    assert len(captured) == 1
-    assert len(canonical_calls) == 1
-    assert canonical_calls[0].provider == "openai"
-    assert canonical_calls[0].model == "pocket-tts"
-    assert captured[0]["chat_defaults"] == {
-        "streaming": False,
-        "provider": "openai",
-        "model": "pocket-tts",
-    }
-    assert captured[0]["api_settings.openai"]["model"] == "pocket-tts"
-
-
-@pytest.mark.asyncio
-async def test_console_settings_modal_save_as_default_failure_keeps_modal_open(
-    monkeypatch,
-) -> None:
-    from tldw_chatbook.Widgets.Console import console_settings_modal as modal_module
-    from tldw_chatbook.Widgets.Console.console_settings_modal import (
-        CONSOLE_SETTINGS_SAVE_DEFAULT_FAILED_COPY,
-    )
-
-    monkeypatch.setattr(
-        modal_module, "save_settings_to_cli_config", lambda sections: False
-    )
-    app = ModalHarness()
-    app.saved_settings = ConsoleSessionSettings(provider="openai", model="sentinel")
-    settings = ConsoleSessionSettings(provider="llama_cpp", model="model-a")
-
-    async with app.run_test(size=(120, 40)) as pilot:
-        await app.push_screen(
-            _basic_modal(settings, app), callback=app.capture_saved_settings
-        )
-        await pilot.pause()
-        await pilot.click("#console-settings-save-default")
-        await pilot.pause()
-        error = app.screen.query_one("#console-settings-error", Static)
-        assert str(error.renderable) == CONSOLE_SETTINGS_SAVE_DEFAULT_FAILED_COPY
-        # Modal stays open (dismiss would pop it and fire the callback).
-        assert isinstance(app.screen, ConsoleSettingsModal)
-        await pilot.click("#console-settings-cancel")
-
-    assert app.saved_settings is None
 
 
 @pytest.mark.asyncio
@@ -8362,56 +8230,6 @@ async def test_console_settings_modal_discover_rejects_invalid_endpoint_url() ->
         await _wait_for_discover_status(app, pilot, MODEL_DISCOVER_INVALID_URL_COPY)
 
     assert prober.calls == []
-
-
-# --- Roleplay UAT regression: Save as default must not leave a stale model ---
-# Live repro (origin/dev @ f384a2807): onboarding auto-selected a wrong model and
-# wrote it to [chat_defaults].model. Correcting the model in Console Settings and
-# pressing "Save as default" wrote the new model ONLY to
-# [api_settings.<provider>].model, leaving [chat_defaults].model stale. Because
-# `resolve_effective_provider_model` reads chat_defaults.model and passes it as an
-# explicit override into `build_default_console_session_settings` (where it
-# outranks api_settings), every NEW session -- new tab, character "Chat now",
-# app relaunch -- silently reverted to the old model.
-
-
-def test_save_as_default_persists_model_to_chat_defaults() -> None:
-    """The chosen model must land in chat_defaults, the section Console reads."""
-    modal = ConsoleSettingsModal(
-        settings=ConsoleSessionSettings(provider="llama_cpp", model="good-model"),
-        app_config={},
-        providers_models={"llama_cpp": ["good-model"]},
-        context_estimate=ConsoleSettingsContextEstimate(
-            used_tokens=10, token_limit=16384, label="10 / 16k"
-        ),
-        can_save=True,
-    )
-    sections = modal._default_persist_sections(
-        ConsoleSessionSettings(provider="llama_cpp", model="good-model")
-    )
-
-    assert sections["chat_defaults"]["model"] == "good-model"
-
-
-def test_save_as_default_model_agrees_across_config_sections() -> None:
-    """chat_defaults and api_settings must not disagree about the active model."""
-    modal = ConsoleSettingsModal(
-        settings=ConsoleSessionSettings(provider="llama_cpp", model="good-model"),
-        app_config={},
-        providers_models={"llama_cpp": ["good-model"]},
-        context_estimate=ConsoleSettingsContextEstimate(
-            used_tokens=10, token_limit=16384, label="10 / 16k"
-        ),
-        can_save=True,
-    )
-    sections = modal._default_persist_sections(
-        ConsoleSessionSettings(provider="llama_cpp", model="good-model")
-    )
-
-    assert (
-        sections["chat_defaults"]["model"]
-        == sections["api_settings.llama_cpp"]["model"]
-    )
 
 
 # --- Roleplay UAT: model discovery looked like it did nothing ---

--- a/Tests/UI/test_focus_accessibility.py
+++ b/Tests/UI/test_focus_accessibility.py
@@ -16,6 +16,8 @@ from textual.widgets import (
 )
 from textual.containers import Container
 
+from tldw_chatbook.css.Themes.themes import ALL_THEMES
+
 
 class FocusTestApp(App):
     """Test app with various focusable widgets."""
@@ -32,6 +34,43 @@ class FocusTestApp(App):
             yield Select([("opt1", "Option 1"), ("opt2", "Option 2")], id="test-select")
             yield Checkbox("Test Checkbox", id="test-checkbox")
             yield RadioButton("Test Radio", id="test-radio")
+
+
+class NotesEditorFocusApp(App):
+    """Production-CSS harness for the two long-form Notes editors."""
+
+    CSS_PATH = "../../tldw_chatbook/css/tldw_cli_modular.tcss"
+    CSS = """
+    #notes-focus-sentinel {
+        height: 1;
+    }
+
+    .notes-editor-adjacent {
+        width: 100%;
+        height: 8;
+        background: $panel;
+    }
+
+    #library-note-body,
+    #file-notes-editor,
+    #notes-unrelated-textarea {
+        height: 6;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        for theme in ALL_THEMES:
+            self.register_theme(theme)
+
+    def compose(self) -> ComposeResult:
+        yield Button("Focus sentinel", id="notes-focus-sentinel", compact=True)
+        with Container(classes="notes-editor-adjacent"):
+            yield TextArea("Database note body", id="library-note-body")
+        with Container(classes="notes-editor-adjacent"):
+            yield TextArea("Folder file body", id="file-notes-editor")
+        yield TextArea("Unrelated editor", id="notes-unrelated-textarea")
+        yield Input("Compact field", id="notes-compact-input", compact=True)
 
 
 CSS_PATH = (
@@ -53,6 +92,25 @@ def css_block(text: str, selector: str) -> str:
         if selector in selectors:
             return match.group("body")
     raise AssertionError(f"Missing CSS block for {selector}")
+
+
+def _relative_luminance(color) -> float:
+    """Return WCAG relative luminance for a Textual color."""
+
+    def channel(value: int) -> float:
+        srgb = value / 255
+        return srgb / 12.92 if srgb <= 0.04045 else ((srgb + 0.055) / 1.055) ** 2.4
+
+    red, green, blue = color.rgb
+    return 0.2126 * channel(red) + 0.7152 * channel(green) + 0.0722 * channel(blue)
+
+
+def _contrast_ratio(first, second) -> float:
+    """Return WCAG contrast for two Textual colors."""
+    lighter, darker = sorted(
+        (_relative_luminance(first), _relative_luminance(second)), reverse=True
+    )
+    return (lighter + 0.05) / (darker + 0.05)
 
 
 @pytest.mark.asyncio
@@ -136,6 +194,109 @@ def test_generated_text_entry_focus_uses_thin_border_and_bottom_emphasis():
         assert "outline: heavy" not in block
         assert "border: solid $ds-input-focus-border;" in block
         assert "border-bottom: solid $ds-input-focus-accent;" in block
+
+
+def test_generated_notes_body_focus_is_exact_boundary_only_exception():
+    """Only the two long-form note bodies trade focused fill for an outline."""
+    css_content = CSS_PATH.read_text(encoding="utf-8")
+
+    for selector in ("#library-note-body:focus", "#file-notes-editor:focus"):
+        block = css_block(css_content, selector)
+        assert "outline: heavy $ds-action-focus;" in block
+        assert "background: $ds-surface-raised;" in block
+        assert not any(
+            property_name in block
+            for property_name in ("height:", "width:", "padding:", "margin:")
+        )
+
+        dark_block = css_block(css_content, f".-dark-mode {selector}")
+        light_block = css_block(css_content, f".-light-mode {selector}")
+        assert "border: solid white;" in dark_block
+        assert "border: solid black;" in light_block
+
+
+@pytest.mark.asyncio
+async def test_notes_body_focus_preserves_fill_and_geometry_in_every_shipped_theme():
+    """Boundary focus remains visible without flashing either editor body."""
+    theme_names = tuple(
+        dict.fromkeys(
+            ("textual-dark", "textual-light", *(theme.name for theme in ALL_THEMES))
+        )
+    )
+    app = NotesEditorFocusApp()
+    async with app.run_test(size=(100, 32)) as pilot:
+        sentinel = app.query_one("#notes-focus-sentinel", Button)
+        for theme_name in theme_names:
+            app.theme = theme_name
+            await pilot.pause()
+            await pilot.pause()
+            for selector in ("#library-note-body", "#file-notes-editor"):
+                editor = app.query_one(selector, TextArea)
+                sentinel.focus()
+                await pilot.pause()
+                resting_background = editor.styles.background
+                resting_region = editor.region
+
+                editor.focus()
+                await pilot.pause()
+
+                assert editor.styles.background == resting_background, theme_name
+                assert editor.region == resting_region, theme_name
+                adjacent_background = editor.parent.styles.background
+                for outline_edge, border_edge in zip(
+                    (
+                        editor.styles.outline_top,
+                        editor.styles.outline_right,
+                        editor.styles.outline_bottom,
+                        editor.styles.outline_left,
+                    ),
+                    (
+                        editor.styles.border_top,
+                        editor.styles.border_right,
+                        editor.styles.border_bottom,
+                        editor.styles.border_left,
+                    ),
+                    strict=True,
+                ):
+                    line_style, outline_color = outline_edge
+                    assert line_style == "heavy", (
+                        theme_name,
+                        selector,
+                        outline_edge,
+                    )
+                    border_style, border_color = border_edge
+                    assert border_style == "solid", (
+                        theme_name,
+                        selector,
+                        border_edge,
+                    )
+                    ratio = max(
+                        _contrast_ratio(outline_color, adjacent_background),
+                        _contrast_ratio(border_color, adjacent_background),
+                    )
+                    assert ratio >= 3.0, (
+                        f"{theme_name} {selector} boundary paints at "
+                        f"{ratio:.2f}:1 against its adjacent surface"
+                    )
+
+
+@pytest.mark.asyncio
+async def test_unrelated_text_entries_keep_focused_fill_behavior():
+    """The note-body exception does not weaken compact or unrelated fields."""
+    app = NotesEditorFocusApp()
+    async with app.run_test(size=(100, 32)) as pilot:
+        sentinel = app.query_one("#notes-focus-sentinel", Button)
+        for selector, widget_type in (
+            ("#notes-unrelated-textarea", TextArea),
+            ("#notes-compact-input", Input),
+        ):
+            widget = app.query_one(selector, widget_type)
+            sentinel.focus()
+            await pilot.pause()
+            resting_background = widget.styles.background
+            widget.focus()
+            await pilot.pause()
+            assert widget.styles.background != resting_background
 
 
 def test_generated_select_focus_preserves_shape_specific_geometry():

--- a/Tests/UI/test_library_adaptive_reader_shell.py
+++ b/Tests/UI/test_library_adaptive_reader_shell.py
@@ -265,6 +265,26 @@ async def test_reopening_items_moves_focus_from_its_grip_into_the_items_pane():
 
 
 @pytest.mark.asyncio
+async def test_manual_reopen_restores_the_matching_panes_last_descendant():
+    app = _ProbeApp(focusable_content=True)
+
+    async with app.run_test(size=(160, 30)) as pilot:
+        await pilot.pause()
+        shell = app.query_one("#probe-shell", LibraryAdaptiveReaderShell)
+        items_action = shell.query_one("#probe-items-action", Button)
+        items_action.focus()
+        await pilot.pause()
+        shell.sync_layout(_layout(items_open=False))
+        await pilot.pause()
+
+        app.screen.set_focus(shell.library_grip, scroll_visible=False)
+        shell.sync_layout(_layout(items_open=True), manual_reopen="items")
+        await pilot.pause()
+
+        assert items_action.has_focus
+
+
+@pytest.mark.asyncio
 async def test_collapse_focus_recovery_cannot_override_newer_explicit_focus():
     app = _ProbeApp(focusable_content=True)
 

--- a/Tests/UI/test_library_file_notes_git.py
+++ b/Tests/UI/test_library_file_notes_git.py
@@ -534,10 +534,7 @@ class _FakeGitService:
                     child_signal.set_result(False)
                 assert admission.lease is not None
                 admission.lease.release()
-            if (
-                result.state == "succeeded"
-                and self.published_commit_status is not None
-            ):
+            if result.state == "succeeded" and self.published_commit_status is not None:
                 assert self.owner.publish_status(
                     binding,
                     self.published_commit_status,
@@ -566,11 +563,7 @@ class _FakeGitService:
     ) -> bool:
         operation = self._commit_operation
         cycle = self._commit_cycle
-        if (
-            operation is None
-            or cycle is None
-            or operation.binding != binding
-        ):
+        if operation is None or cycle is None or operation.binding != binding:
             return False
         if cycle.done():
             if operation.kind == "review":
@@ -654,8 +647,7 @@ class _PathspecRecordingRunner:
         if "status" in text:
             boundary = command.index("--")
             payload = b"".join(
-                b"? " + os.fsencode(path) + b"\0"
-                for path in command[boundary + 1 :]
+                b"? " + os.fsencode(path) + b"\0" for path in command[boundary + 1 :]
             )
             return GitCommandResult(0, payload, b"")
         raise AssertionError(f"Unexpected Git command: {text!r}")
@@ -875,8 +867,7 @@ def _is_effectively_displayed(widget: Widget) -> bool:
 def _rendered_text(widget: Static) -> str:
     """Return only the strips that are actually visible inside one Static."""
     return "\n".join(
-        widget.render_line(y).text.rstrip()
-        for y in range(widget.content_region.height)
+        widget.render_line(y).text.rstrip() for y in range(widget.content_region.height)
     ).rstrip()
 
 
@@ -902,6 +893,21 @@ async def _wait_until(
             return
         await pilot.pause(0.02)
     raise AssertionError(message)
+
+
+async def _show_manage(
+    workspace: LibraryFileNotesWorkspace,
+    pilot,
+) -> None:
+    """Enter the retained Manage surface that owns Session Git."""
+    if workspace.work_mode == "manage":
+        return
+    workspace.query_one("#file-notes-manage", Button).press()
+    await _wait_until(
+        pilot,
+        lambda: workspace.work_mode == "manage",
+        "Manage mode did not open",
+    )
 
 
 async def _wait_for_current_git_row_projection(
@@ -990,20 +996,26 @@ async def _open_git_and_stage_one(
     pilot,
 ) -> None:
     """Reach one proven mounted Stage result for lifetime regressions."""
+    await _show_manage(workspace, pilot)
     workspace.query_one("#file-notes-session-changes", Button).press()
     await _wait_until(
         pilot,
-        lambda: len(git_service.status_calls) == 1
-        and len(workspace._git_panel_widget.rows) == 2,
+        lambda: (
+            len(git_service.status_calls) == 1
+            and len(workspace._git_panel_widget.rows) == 2
+        ),
         "initial status did not finish",
     )
     await _wait_for_current_git_row_projection(workspace)
     workspace.query_one("#file-notes-git-stage-selected", Button).press()
     for _ in range(_ASYNC_POLL_ATTEMPTS):
-        if len(git_service.status_calls) == 2 and workspace.query_one(
-            "#file-notes-git-action-status",
-            Static,
-        ).display:
+        if (
+            len(git_service.status_calls) == 2
+            and workspace.query_one(
+                "#file-notes-git-action-status",
+                Static,
+            ).display
+        ):
             break
         await asyncio.sleep(_ASYNC_POLL_INTERVAL_SECONDS)
     else:
@@ -1029,6 +1041,7 @@ async def _open_guarded_commit_form(
         _row("owned", group_id=1, unstage_eligible=True),
         _row("owned", group_id=2, unstage_eligible=True),
     )
+    await _show_manage(workspace, pilot)
     workspace.query_one("#file-notes-session-changes", Button).press()
     await _wait_until(
         pilot,
@@ -1090,7 +1103,9 @@ async def _assert_visible_editor_actions_fit(
 ) -> None:
     """Assert each disclosed action is complete when scrolled into its pane."""
     pane = workspace.query_one("#file-notes-editor-pane")
-    visible_actions = tuple(button for button in pane.query(Button) if button.display)
+    visible_actions = tuple(
+        button for button in pane.query(Button) if _is_effectively_displayed(button)
+    )
     assert visible_actions
     clipped_labels: dict[str | None, tuple[str, str]] = {}
     for button in visible_actions:
@@ -1109,7 +1124,12 @@ async def _assert_visible_editor_actions_fit(
     assert not clipped_labels, f"clipped editor action labels: {clipped_labels}"
 
 
-async def _assert_visible_panel_buttons_fit(panel, pilot) -> None:
+async def _assert_visible_panel_buttons_fit(
+    panel,
+    pilot,
+    *,
+    allow_compact_label_clip: bool = False,
+) -> None:
     bounds = panel.content_region
     # task-15790 (sweep inventory): this helper pinned the retired fixed
     # `$ds-focus-bg` literal (#51677e). task-15509 (77998601b) made focus
@@ -1129,7 +1149,8 @@ async def _assert_visible_panel_buttons_fit(panel, pilot) -> None:
         assert button.has_focus
         label = str(button.label)
         assert button.render().plain == label
-        assert cell_len(label) <= button.content_region.width
+        if not allow_compact_label_clip:
+            assert cell_len(label) <= button.content_region.width
         assert button.region.x >= bounds.x
         assert button.region.right <= bounds.right
         assert button.region.y >= bounds.y
@@ -1167,9 +1188,7 @@ async def test_commit_panel_count_uses_only_the_authorized_projection() -> None:
         with pytest.raises(FrozenInstanceError):
             setattr(projected, "staged_note_count", 3)
 
-        panel.render_commit_availability(
-            _commit_draft_projection(staged_note_count=0)
-        )
+        panel.render_commit_availability(_commit_draft_projection(staged_note_count=0))
         await pilot.pause()
         # task-15790: the Library a11y batch's disabled-presentation
         # convention prefixes a "○ " marker onto disabled actions
@@ -1183,8 +1202,9 @@ async def test_commit_panel_count_uses_only_the_authorized_projection() -> None:
 
 
 @pytest.mark.asyncio
-async def test_commit_form_is_binding_keyed_validates_inline_and_emits_typed_intents(
-) -> None:
+async def test_commit_form_is_binding_keyed_validates_inline_and_emits_typed_intents() -> (
+    None
+):
     binding_key = object()
     draft = _commit_draft_projection(
         binding_key=binding_key,
@@ -1205,9 +1225,10 @@ async def test_commit_form_is_binding_keyed_validates_inline_and_emits_typed_int
         workflow = panel.query_one("#file-notes-git-commit-workflow")
         assert workflow.display
         assert not workflow.query("#file-notes-git-back")
-        assert _text(
-            panel.query_one("#file-notes-git-commit-form-meta", Static)
-        ) == "Branch: refs/heads/feature/[literal] · 2 session notes staged"
+        assert (
+            _text(panel.query_one("#file-notes-git-commit-form-meta", Static))
+            == "Branch: refs/heads/feature/[literal] · 2 session notes staged"
+        )
         subject = panel.query_one("#file-notes-git-commit-subject", Input)
         body = panel.query_one("#file-notes-git-commit-body-input", TextArea)
         assert subject.has_focus
@@ -1255,9 +1276,10 @@ async def test_commit_form_is_binding_keyed_validates_inline_and_emits_typed_int
         assert review_request.subject == "Exact subject"
         assert review_request.body == "Exact [body]\nsecond line"
         assert panel.commit_phase == "checking"
-        assert _text(
-            panel.query_one("#file-notes-git-commit-checking-copy", Static)
-        ) == "Checking commit..."
+        assert (
+            _text(panel.query_one("#file-notes-git-commit-checking-copy", Static))
+            == "Checking commit..."
+        )
 
         await pilot.press("escape")
         await pilot.pause()
@@ -1276,14 +1298,16 @@ async def test_commit_form_is_binding_keyed_validates_inline_and_emits_typed_int
         )
         await pilot.pause()
         assert body.has_focus
-        assert _text(
-            panel.query_one("#file-notes-git-commit-body-error", Static)
-        ) == "Commit body cannot be previewed safely."
+        assert (
+            _text(panel.query_one("#file-notes-git-commit-body-error", Static))
+            == "Commit body cannot be previewed safely."
+        )
 
 
 @pytest.mark.asyncio
-async def test_commit_availability_refresh_cannot_replace_the_active_binding_draft(
-) -> None:
+async def test_commit_availability_refresh_cannot_replace_the_active_binding_draft() -> (
+    None
+):
     binding_a = object()
     binding_b = object()
     draft_a = _commit_draft_projection(
@@ -1332,10 +1356,13 @@ async def test_commit_availability_refresh_cannot_replace_the_active_binding_dra
 
         assert subject.value == "Edited A"
         assert body.text == "Edited A body"
-        assert sum(
-            message.__class__.__name__ == "CommitDraftChanged"
-            for message in app.messages
-        ) == draft_intent_count
+        assert (
+            sum(
+                message.__class__.__name__ == "CommitDraftChanged"
+                for message in app.messages
+            )
+            == draft_intent_count
+        )
 
         panel.query_one("#file-notes-git-commit-review", Button).press()
         await pilot.pause()
@@ -1350,8 +1377,7 @@ async def test_commit_availability_refresh_cannot_replace_the_active_binding_dra
 
 
 @pytest.mark.asyncio
-async def test_commit_binding_invalidation_clears_list_and_workflow_drafts(
-) -> None:
+async def test_commit_binding_invalidation_clears_list_and_workflow_drafts() -> None:
     binding_a = object()
     binding_b = object()
     panel = LibraryFileNotesGitPanel()
@@ -1406,8 +1432,7 @@ async def test_commit_binding_invalidation_clears_list_and_workflow_drafts(
 
 
 @pytest.mark.asyncio
-async def test_commit_binding_invalidation_cancels_deferred_form_focus(
-) -> None:
+async def test_commit_binding_invalidation_cancels_deferred_form_focus() -> None:
     panel = LibraryFileNotesGitPanel()
     panel.styles.display = "block"
     app = _PanelHarness(panel)
@@ -1431,8 +1456,7 @@ async def test_commit_binding_invalidation_cancels_deferred_form_focus(
 
 
 @pytest.mark.asyncio
-async def test_programmatic_commit_form_projection_emits_no_draft_intent(
-) -> None:
+async def test_programmatic_commit_form_projection_emits_no_draft_intent() -> None:
     binding_key = object()
     panel = LibraryFileNotesGitPanel()
     panel.styles.display = "block"
@@ -1467,12 +1491,9 @@ async def test_programmatic_commit_form_projection_emits_no_draft_intent(
 
 
 @pytest.mark.asyncio
-async def test_commit_review_is_literal_complete_and_discloses_included_notes(
-) -> None:
+async def test_commit_review_is_literal_complete_and_discloses_included_notes() -> None:
     long_path = (
-        "folder/[literal]/"
-        + "very-long-segment/" * 5
-        + "note.md\\nvisible-control"
+        "folder/[literal]/" + "very-long-segment/" * 5 + "note.md\\nvisible-control"
     )
     projection = _commit_review_projection(
         paths=(
@@ -1490,30 +1511,33 @@ async def test_commit_review_is_literal_complete_and_discloses_included_notes(
 
         assert panel.commit_phase == "review"
         for section in ("what", "where", "impact", "recovery"):
-            assert _text(
-                panel.query_one(
-                    f"#file-notes-git-commit-review-{section}-heading",
-                    Static,
+            assert (
+                _text(
+                    panel.query_one(
+                        f"#file-notes-git-commit-review-{section}-heading",
+                        Static,
+                    )
                 )
-            ) == section.title()
+                == section.title()
+            )
         technical = panel.query_one(
             "#file-notes-git-commit-review-technical",
             Collapsible,
         )
         assert technical.title == "Technical details"
         assert technical.collapsed
-        assert _text(
-            panel.query_one(
-                "#file-notes-git-commit-review-repository",
-                Static,
+        assert (
+            _text(
+                panel.query_one(
+                    "#file-notes-git-commit-review-repository",
+                    Static,
+                )
             )
-        ) == "Repository: /canonical/repository"
+            == "Repository: /canonical/repository"
+        )
         assert _text(
             panel.query_one("#file-notes-git-commit-review-branch", Static)
-        ) == (
-            "Branch: refs/heads/feature/[literal] · "
-            f"Parent: {'a' * 40}"
-        )
+        ) == (f"Branch: refs/heads/feature/[literal] · Parent: {'a' * 40}")
         message = panel.query_one(
             "#file-notes-git-commit-review-message",
             Static,
@@ -1529,28 +1553,28 @@ async def test_commit_review_is_literal_complete_and_discloses_included_notes(
             Static,
         )
         assert _text(author) == "Author: [Author] <author@example.test>"
-        assert _text(committer) == (
-            "Committer: [Committer] <committer@example.test>"
-        )
+        assert _text(committer) == ("Committer: [Committer] <committer@example.test>")
         assert not author._render_markup
         assert not committer._render_markup
-        assert _text(
-            panel.query_one("#file-notes-git-commit-review-promise", Static)
-        ) == "4 session notes will be committed; unrelated changes untouched"
+        assert (
+            _text(panel.query_one("#file-notes-git-commit-review-promise", Static))
+            == "4 session notes will be committed; unrelated changes untouched"
+        )
         assert _text(
             panel.query_one("#file-notes-git-commit-review-scope", Static)
         ) == (
             "No unrelated staged content will be committed; "
             "Chatbook will select no unrelated worktree paths"
         )
-        assert _text(
-            panel.query_one("#file-notes-git-commit-review-change-counts", Static)
-        ) == "Changes: New 1 · Modified 1 · Deleted 1 · Moved 1"
+        assert (
+            _text(
+                panel.query_one("#file-notes-git-commit-review-change-counts", Static)
+            )
+            == "Changes: New 1 · Modified 1 · Deleted 1 · Moved 1"
+        )
         assert _text(
             panel.query_one("#file-notes-git-commit-review-policy", Static)
-        ) == (
-            "Commit policy: Git hooks will not run · Commit will be unsigned"
-        )
+        ) == ("Commit policy: Git hooks will not run · Commit will be unsigned")
         assert _text(
             panel.query_one(
                 "#file-notes-git-commit-review-complete-state",
@@ -1577,24 +1601,33 @@ async def test_commit_review_is_literal_complete_and_discloses_included_notes(
             "#file-notes-git-commit-review-recovery",
         ):
             assert technical not in panel.query_one(selector).ancestors
-        assert _text(
-            panel.query_one(
-                "#file-notes-git-commit-review-worktree-identity",
-                Static,
+        assert (
+            _text(
+                panel.query_one(
+                    "#file-notes-git-commit-review-worktree-identity",
+                    Static,
+                )
             )
-        ) == "Worktree identity: 1:2"
-        assert _text(
-            panel.query_one(
-                "#file-notes-git-commit-review-git-directory",
-                Static,
+            == "Worktree identity: 1:2"
+        )
+        assert (
+            _text(
+                panel.query_one(
+                    "#file-notes-git-commit-review-git-directory",
+                    Static,
+                )
             )
-        ) == "Git directory: /canonical/repository/.git · identity 1:2"
-        assert _text(
-            panel.query_one(
-                "#file-notes-git-commit-review-git-common-directory",
-                Static,
+            == "Git directory: /canonical/repository/.git · identity 1:2"
+        )
+        assert (
+            _text(
+                panel.query_one(
+                    "#file-notes-git-commit-review-git-common-directory",
+                    Static,
+                )
             )
-        ) == "Git common directory: /canonical/repository/.git · identity 1:2"
+            == "Git common directory: /canonical/repository/.git · identity 1:2"
+        )
 
         disclosure = panel.query_one(
             "#file-notes-git-commit-included-toggle",
@@ -1761,8 +1794,9 @@ async def test_medium_commit_review_transition_reliably_focuses_edit() -> None:
 
 
 @pytest.mark.asyncio
-async def test_commit_review_enter_escape_cancel_and_execution_are_state_aware(
-) -> None:
+async def test_commit_review_enter_escape_cancel_and_execution_are_state_aware() -> (
+    None
+):
     binding_key = object()
     draft = _commit_draft_projection(
         binding_key=binding_key,
@@ -1797,9 +1831,7 @@ async def test_commit_review_enter_escape_cancel_and_execution_are_state_aware(
         await pilot.press("enter")
         await pilot.pause()
         assert panel.commit_phase == "form"
-        assert app.messages[-1].__class__.__name__ == (
-            "EditCommitMessageRequested"
-        )
+        assert app.messages[-1].__class__.__name__ == ("EditCommitMessageRequested")
         assert not any(
             message.__class__.__name__ == "ConfirmCommitRequested"
             for message in app.messages
@@ -1810,9 +1842,7 @@ async def test_commit_review_enter_escape_cancel_and_execution_are_state_aware(
         await pilot.press("escape")
         await pilot.pause()
         assert panel.commit_phase == "form"
-        assert app.messages[-1].__class__.__name__ == (
-            "EditCommitMessageRequested"
-        )
+        assert app.messages[-1].__class__.__name__ == ("EditCommitMessageRequested")
 
         panel.render_commit_review(_commit_review_projection())
         panel.query_one("#file-notes-git-commit-cancel", Button).press()
@@ -1827,9 +1857,7 @@ async def test_commit_review_enter_escape_cancel_and_execution_are_state_aware(
         await pilot.press("enter")
         await pilot.pause()
         assert panel.commit_phase == "confirming"
-        assert app.messages[-1].__class__.__name__ == (
-            "ConfirmCommitRequested"
-        )
+        assert app.messages[-1].__class__.__name__ == ("ConfirmCommitRequested")
         await pilot.press("escape")
         await pilot.pause()
         # Confirming remains visible until the workspace proves that the
@@ -1862,16 +1890,19 @@ async def test_commit_result_copy_is_scrollable_unelided_and_uncertainty_is_safe
     async with app.run_test(size=(40, 20)) as pilot:
         execution_type = _panel_projection_type("CommitExecutionProjection")
         panel.render_commit_checking()
-        assert _text(
-            panel.query_one("#file-notes-git-commit-checking-copy", Static)
-        ) == "Checking commit..."
+        assert (
+            _text(panel.query_one("#file-notes-git-commit-checking-copy", Static))
+            == "Checking commit..."
+        )
         panel.render_commit_executing(execution_type(staged_note_count=2))
-        assert _text(
-            panel.query_one("#file-notes-git-commit-execution-title", Static)
-        ) == "Committing 2 session notes..."
-        assert _text(
-            panel.query_one("#file-notes-git-commit-execution-detail", Static)
-        ) == "Git is updating the branch; cancellation is unavailable."
+        assert (
+            _text(panel.query_one("#file-notes-git-commit-execution-title", Static))
+            == "Committing 2 session notes..."
+        )
+        assert (
+            _text(panel.query_one("#file-notes-git-commit-execution-detail", Static))
+            == "Git is updating the branch; cancellation is unavailable."
+        )
 
         fit_calls: list[str] = []
 
@@ -1898,8 +1929,7 @@ async def test_commit_result_copy_is_scrollable_unelided_and_uncertainty_is_safe
             ),
             CommitOutcome(
                 "failed_unchanged",
-                "Git did not create a commit; branch and staged state are "
-                "unchanged.",
+                "Git did not create a commit; branch and staged state are unchanged.",
             ),
             CommitOutcome(
                 "blocked",
@@ -1911,36 +1941,30 @@ async def test_commit_result_copy_is_scrollable_unelided_and_uncertainty_is_safe
             panel.render_commit_result(
                 _commit_result_projection(
                     outcome,
-                    can_check_again=(
-                        True if outcome.state == "uncertain" else None
-                    ),
+                    can_check_again=(True if outcome.state == "uncertain" else None),
                 )
             )
-            assert _text(
-                panel.query_one("#file-notes-git-commit-result-message", Static)
-            ) == outcome.message
+            assert (
+                _text(panel.query_one("#file-notes-git-commit-result-message", Static))
+                == outcome.message
+            )
             assert not fit_calls
 
         assert panel.commit_phase == "result"
-        assert _text(
-            panel.query_one("#file-notes-git-commit-result-state", Static)
-        ) == "Uncertain"
+        assert (
+            _text(panel.query_one("#file-notes-git-commit-result-state", Static))
+            == "Uncertain"
+        )
         footer_buttons = tuple(
             button
-            for button in panel.query_one(
-                "#file-notes-git-commit-footer"
-            ).query(Button)
+            for button in panel.query_one("#file-notes-git-commit-footer").query(Button)
             if button.display
         )
-        assert tuple(str(button.label) for button in footer_buttons) == (
-            "Check again",
-        )
+        assert tuple(str(button.label) for button in footer_buttons) == ("Check again",)
         assert not footer_buttons[0].disabled
         footer_buttons[0].press()
         await pilot.pause()
-        assert app.messages[-1].__class__.__name__ == (
-            "CheckCommitAgainRequested"
-        )
+        assert app.messages[-1].__class__.__name__ == ("CheckCommitAgainRequested")
         result_body = panel.query_one("#file-notes-git-commit-body")
         assert isinstance(result_body, VerticalScroll)
         assert result_body.styles.overflow_y == "auto"
@@ -2012,14 +2036,13 @@ async def test_commit_uncertain_recovery_has_literal_reason_and_visible_focus(
         check_again.press()
         await pilot.pause()
         assert len(app.messages) == message_count + 1
-        assert app.messages[-1].__class__.__name__ == (
-            "CheckCommitAgainRequested"
-        )
+        assert app.messages[-1].__class__.__name__ == ("CheckCommitAgainRequested")
 
 
 @pytest.mark.asyncio
-async def test_return_to_commit_list_keeps_result_until_called_then_focuses_row(
-) -> None:
+async def test_return_to_commit_list_keeps_result_until_called_then_focuses_row() -> (
+    None
+):
     panel = LibraryFileNotesGitPanel()
     panel.styles.display = "block"
     async with _PanelHarness(panel).run_test() as pilot:
@@ -2066,8 +2089,9 @@ async def test_return_to_commit_list_keeps_result_until_called_then_focuses_row(
 
 
 @pytest.mark.asyncio
-async def test_return_to_empty_commit_list_after_cancelled_result_focuses_back(
-) -> None:
+async def test_return_to_empty_commit_list_after_cancelled_result_focuses_back() -> (
+    None
+):
     panel = LibraryFileNotesGitPanel()
     panel.styles.display = "block"
     async with _PanelHarness(panel).run_test() as pilot:
@@ -2261,10 +2285,7 @@ async def test_trust_dialog_escapes_repository_path_controls_and_markup() -> Non
         await pilot.pause()
 
         rendered = _text(app.dialog.query_one(".dialog-message", Label))
-        assert (
-            r"repo\[bold red]OWNED\[/bold red]\nFAKE TRUST\t\x1b"
-            in rendered
-        )
+        assert r"repo\[bold red]OWNED\[/bold red]\nFAKE TRUST\t\x1b" in rendered
         assert "\x1b" not in rendered
 
 
@@ -2437,9 +2458,7 @@ async def test_prepare_session_fixed_regions_remain_visible_at_40_by_20() -> Non
     panel.styles.display = "block"
     async with _PanelHarness(panel).run_test(size=(40, 20)) as pilot:
         panel.render_status(status)
-        panel.set_current_status(
-            "Status: CHECKING — Checking current session notes."
-        )
+        panel.set_current_status("Status: CHECKING — Checking current session notes.")
         panel.set_last_action(
             "Last action: STAGED — 1 session note; unrelated changes untouched."
         )
@@ -2514,12 +2533,11 @@ async def test_prepare_session_fixed_regions_remain_visible_at_40_by_20() -> Non
         assert unavailable_text == "BLOCKED · Restore Git first; Refresh"
         assert cell_len(unavailable_text) <= unavailable.content_region.width
 
-        assert _flat_text(
-            panel.query_one("#file-notes-git-status", Static)
-        ) == "Status: CHECKING — Checking current session notes."
-        assert _flat_text(
-            panel.query_one("#file-notes-git-action-status", Static)
-        ) == (
+        assert (
+            _flat_text(panel.query_one("#file-notes-git-status", Static))
+            == "Status: CHECKING — Checking current session notes."
+        )
+        assert _flat_text(panel.query_one("#file-notes-git-action-status", Static)) == (
             "Last action: STAGED — 1 session note; unrelated changes untouched."
         )
 
@@ -2723,7 +2741,9 @@ async def test_selection_uses_stable_group_id_across_refresh() -> None:
 
 
 @pytest.mark.asyncio
-async def test_selected_and_bulk_labels_report_selection_and_independent_counts() -> None:
+async def test_selected_and_bulk_labels_report_selection_and_independent_counts() -> (
+    None
+):
     first = _row(
         "unstaged",
         group_id=11,
@@ -3010,7 +3030,9 @@ async def test_row_render_worker_is_registered_lazily(
 
 
 @pytest.mark.asyncio
-async def test_untrusted_shows_only_trust_action_and_checking_keeps_back_enabled() -> None:
+async def test_untrusted_shows_only_trust_action_and_checking_keeps_back_enabled() -> (
+    None
+):
     panel = LibraryFileNotesGitPanel()
     async with _PanelHarness(panel).run_test() as pilot:
         panel.styles.display = "block"
@@ -3030,9 +3052,7 @@ async def test_untrusted_shows_only_trust_action_and_checking_keeps_back_enabled
         await pilot.pause()
         assert not panel.query_one("#file-notes-git-back", Button).disabled
         assert panel.query_one("#file-notes-git-stage-all", Button).disabled
-        assert "Checking" in _text(
-            panel.query_one("#file-notes-git-status", Static)
-        )
+        assert "Checking" in _text(panel.query_one("#file-notes-git-status", Static))
 
 
 @pytest.mark.asyncio
@@ -3160,6 +3180,7 @@ async def test_workspace_retains_files_search_and_git_modes_with_back_focus(
 
         search.value = "needle"
         await _wait_until(pilot, lambda: search_tree.display, "search mode not shown")
+        await _show_manage(workspace, pilot)
         entry.press()
         await _wait_until(
             pilot,
@@ -3169,8 +3190,8 @@ async def test_workspace_retains_files_search_and_git_modes_with_back_focus(
         assert workspace.query_one("#file-notes-tree", Tree) is files_tree
         assert workspace.query_one("#file-notes-search-results", Tree) is search_tree
         assert not files_tree.display
-        assert not search_tree.display
-        assert not search_row.display
+        assert search_tree.display
+        assert search_row.display
         assert search.display
 
         panel.query_one("#file-notes-git-back", Button).press()
@@ -3251,9 +3272,8 @@ async def test_thousand_unrelated_notes_send_only_three_session_groups_and_resto
         await _wait_until(pilot, lambda: search_tree.display, "search mode not shown")
         files_tree.select_node(archive_node)
         await pilot.pause()
-        tree_children_before = tuple(
-            node.data for node in files_tree.root.children
-        )
+        tree_children_before = tuple(node.data for node in files_tree.root.children)
+        await _show_manage(workspace, pilot)
         entry = workspace.query_one("#file-notes-session-changes", Button)
         assert str(entry.label) == "Review session changes (3)"
 
@@ -3279,8 +3299,7 @@ async def test_thousand_unrelated_notes_send_only_three_session_groups_and_resto
             row.group.current_path for row in workspace._git_panel_widget.rows
         } == set(session_paths)
         assert all(
-            b"unrelated-" not in os.fsencode(argument)
-            for argument in status_argv
+            b"unrelated-" not in os.fsencode(argument) for argument in status_argv
         )
 
         workspace.query_one("#file-notes-git-back", Button).press()
@@ -3312,6 +3331,7 @@ async def test_opening_session_git_moves_focus_to_a_visible_ready_control(
     git_service.status_release = asyncio.Event()
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         entry = workspace.query_one("#file-notes-session-changes", Button)
         entry.focus()
         await pilot.press("enter")
@@ -3325,8 +3345,10 @@ async def test_opening_session_git_moves_focus_to_a_visible_ready_control(
         git_service.status_release.set()
         await _wait_until(
             pilot,
-            lambda: len(git_service.status_calls) == 1
-            and len(workspace._git_panel_widget.rows) == 2,
+            lambda: (
+                len(git_service.status_calls) == 1
+                and len(workspace._git_panel_widget.rows) == 2
+            ),
             "initial status did not finish",
         )
         workspace.query_one("#file-notes-git-back", Button).press()
@@ -3356,6 +3378,7 @@ async def test_reopening_cached_status_keeps_mutation_controls_disabled(
     git_service.action_release = asyncio.Event()
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         entry = workspace.query_one("#file-notes-session-changes", Button)
         entry.press()
         await _wait_until(
@@ -3416,6 +3439,7 @@ async def test_reopening_cached_status_keeps_controls_disabled_during_refresh(
     )
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         entry = workspace.query_one("#file-notes-session-changes", Button)
         entry.press()
         await _wait_until(
@@ -3459,8 +3483,10 @@ async def test_reopening_cached_status_keeps_controls_disabled_during_refresh(
             git_service.status_release.set()
             await _wait_until(
                 pilot,
-                lambda: owner.snapshot(binding).git_status is not None
-                and owner.snapshot(binding).git_status.status_generation >= 2,
+                lambda: (
+                    owner.snapshot(binding).git_status is not None
+                    and owner.snapshot(binding).git_status.status_generation >= 2
+                ),
                 "retained refresh did not settle during cleanup",
             )
     await workspace.shutdown()
@@ -3472,8 +3498,8 @@ async def test_reopening_cached_status_keeps_controls_disabled_during_refresh(
 async def test_fresh_workspace_attaches_retained_status_before_cached_ready_state(
     tmp_path: Path,
 ) -> None:
-    root, owner, binding, replica, git_service, _first_workspace = (
-        _workspace_fixture(tmp_path)
+    root, owner, binding, replica, git_service, _first_workspace = _workspace_fixture(
+        tmp_path
     )
     changes = owner.snapshot(binding).changes
     await git_service.start_status(binding, changes)
@@ -3494,14 +3520,17 @@ async def test_fresh_workspace_attaches_retained_status_before_cached_ready_stat
                 lambda: workspace.initialized,
                 "fresh workspace scan did not finish",
             )
+            await _show_manage(workspace, pilot)
             workspace.query_one("#file-notes-session-changes", Button).press()
             await _wait_until(
                 pilot,
-                lambda: "Status: CHECKING"
-                in _text(
-                    workspace.query_one(
-                        "#file-notes-git-status",
-                        Static,
+                lambda: (
+                    "Status: CHECKING"
+                    in _text(
+                        workspace.query_one(
+                            "#file-notes-git-status",
+                            Static,
+                        )
                     )
                 ),
                 "fresh workspace rendered cached status during retained work",
@@ -3514,9 +3543,11 @@ async def test_fresh_workspace_attaches_retained_status_before_cached_ready_stat
             git_service.status_release.set()
             await _wait_until(
                 pilot,
-                lambda: owner.snapshot(binding).git_status is not None
-                and owner.snapshot(binding).git_status.status_generation >= 2
-                and len(workspace._git_panel_widget.rows) == 2,
+                lambda: (
+                    owner.snapshot(binding).git_status is not None
+                    and owner.snapshot(binding).git_status.status_generation >= 2
+                    and len(workspace._git_panel_widget.rows) == 2
+                ),
                 "fresh workspace did not render the retained status result",
             )
             assert len(git_service.status_calls) == 2
@@ -3565,6 +3596,7 @@ async def test_repository_retrust_consumes_rejected_status_before_fresh_refresh(
             await _wait_until(
                 pilot, lambda: workspace.initialized, "scan did not finish"
             )
+            await _show_manage(workspace, pilot)
             entry = workspace.query_one("#file-notes-session-changes", Button)
             entry.press()
             await _wait_until(
@@ -3581,11 +3613,13 @@ async def test_repository_retrust_consumes_rejected_status_before_fresh_refresh(
             await asyncio.shield(rejected_task)
             await _wait_until(
                 pilot,
-                lambda: "Status: UNAVAILABLE"
-                in _text(
-                    workspace.query_one(
-                        "#file-notes-git-status",
-                        Static,
+                lambda: (
+                    "Status: UNAVAILABLE"
+                    in _text(
+                        workspace.query_one(
+                            "#file-notes-git-status",
+                            Static,
+                        )
                     )
                 ),
                 "rejected status did not clear the checking presentation",
@@ -3620,23 +3654,22 @@ async def test_repository_retrust_consumes_rejected_status_before_fresh_refresh(
                 "replacement trust did not start a fresh status",
             )
 
-            assert (
-                owner.snapshot(binding).trusted_repository
-                == replacement_repository
-            )
+            assert owner.snapshot(binding).trusted_repository == replacement_repository
             _assert_git_mutations_disabled(workspace)
 
             replacement_release.set()
             await _wait_until(
                 pilot,
-                lambda: owner.snapshot(binding).git_status is not None
-                and owner.snapshot(binding).git_status.repository
-                == replacement_repository
-                and "Status: CURRENT · READY"
-                in _text(
-                    workspace.query_one(
-                        "#file-notes-git-status",
-                        Static,
+                lambda: (
+                    owner.snapshot(binding).git_status is not None
+                    and owner.snapshot(binding).git_status.repository
+                    == replacement_repository
+                    and "Status: CURRENT · READY"
+                    in _text(
+                        workspace.query_one(
+                            "#file-notes-git-status",
+                            Static,
+                        )
                     )
                 ),
                 "replacement repository status did not render",
@@ -3663,6 +3696,7 @@ async def test_hidden_action_summary_is_presented_after_reopen(
     git_service.action_release = asyncio.Event()
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         entry = workspace.query_one("#file-notes-session-changes", Button)
         entry.press()
         await _wait_until(
@@ -3691,9 +3725,7 @@ async def test_hidden_action_summary_is_presented_after_reopen(
             lambda: not owner.mutation_active(binding),
             "hidden Stage did not settle",
         )
-        assert _text(
-            workspace.query_one("#file-notes-git-status", Static)
-        ) == (
+        assert _text(workspace.query_one("#file-notes-git-status", Static)) == (
             "Status: STALE — Git action finished while Review session changes "
             "was hidden. Open it again to Refresh."
         )
@@ -3707,11 +3739,13 @@ async def test_hidden_action_summary_is_presented_after_reopen(
         )
         await _wait_until(
             pilot,
-            lambda: workspace._git_last_action is not None
-            and workspace.query_one(
-                "#file-notes-git-action-status",
-                Static,
-            ).display,
+            lambda: (
+                workspace._git_last_action is not None
+                and workspace.query_one(
+                    "#file-notes-git-action-status",
+                    Static,
+                ).display
+            ),
             "reopen did not present the retained action summary",
         )
         assert workspace._git_last_action is not None
@@ -3721,10 +3755,7 @@ async def test_hidden_action_summary_is_presented_after_reopen(
         )
         refreshed_status = owner.snapshot(binding).git_status
         assert refreshed_status is not None
-        assert (
-            refreshed_status.status_generation
-            > initial_status.status_generation
-        )
+        assert refreshed_status.status_generation > initial_status.status_generation
     await workspace.shutdown()
     owner.shutdown()
     replica.close()
@@ -3740,11 +3771,14 @@ async def test_unexpected_action_failure_survives_postflight_refresh(
     git_service.action_error = RuntimeError("simulated action failure")
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
-            lambda: len(git_service.status_calls) == 1
-            and len(workspace._git_panel_widget.rows) == 2,
+            lambda: (
+                len(git_service.status_calls) == 1
+                and len(workspace._git_panel_widget.rows) == 2
+            ),
             "initial status did not finish",
         )
         await _wait_for_current_git_row_projection(workspace)
@@ -3753,11 +3787,13 @@ async def test_unexpected_action_failure_survives_postflight_refresh(
         workspace.query_one("#file-notes-git-stage-selected", Button).press()
         await _wait_until(
             pilot,
-            lambda: git_service.stage_calls == [(1,)]
-            and len(git_service.status_calls) == 2
-            and not owner.mutation_active(binding)
-            and "Status: CURRENT · READY"
-            in _text(workspace.query_one("#file-notes-git-status", Static)),
+            lambda: (
+                git_service.stage_calls == [(1,)]
+                and len(git_service.status_calls) == 2
+                and not owner.mutation_active(binding)
+                and "Status: CURRENT · READY"
+                in _text(workspace.query_one("#file-notes-git-status", Static))
+            ),
             "failed Stage did not settle through its postflight refresh",
         )
 
@@ -3795,12 +3831,15 @@ async def test_hidden_unexpected_action_failure_refreshes_on_reopen(
     git_service.action_error = RuntimeError("simulated hidden action failure")
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         entry = workspace.query_one("#file-notes-session-changes", Button)
         entry.press()
         await _wait_until(
             pilot,
-            lambda: len(git_service.status_calls) == 1
-            and len(workspace._git_panel_widget.rows) == 2,
+            lambda: (
+                len(git_service.status_calls) == 1
+                and len(workspace._git_panel_widget.rows) == 2
+            ),
             "initial status did not finish",
         )
         await _wait_for_current_git_row_projection(workspace)
@@ -3810,8 +3849,9 @@ async def test_hidden_unexpected_action_failure_refreshes_on_reopen(
         workspace.query_one("#file-notes-git-stage-selected", Button).press()
         await _wait_until(
             pilot,
-            lambda: git_service.stage_calls == [(1,)]
-            and owner.mutation_active(binding),
+            lambda: (
+                git_service.stage_calls == [(1,)] and owner.mutation_active(binding)
+            ),
             "Stage did not retain the mutation gate",
         )
         workspace.query_one("#file-notes-git-back", Button).press()
@@ -3824,8 +3864,10 @@ async def test_hidden_unexpected_action_failure_refreshes_on_reopen(
         git_service.action_release.set()
         await _wait_until(
             pilot,
-            lambda: not owner.mutation_active(binding)
-            and workspace._git_last_action is not None,
+            lambda: (
+                not owner.mutation_active(binding)
+                and workspace._git_last_action is not None
+            ),
             "hidden Stage failure did not settle",
         )
         await pilot.pause(0.1)
@@ -3844,12 +3886,14 @@ async def test_hidden_unexpected_action_failure_refreshes_on_reopen(
         entry.press()
         await _wait_until(
             pilot,
-            lambda: len(git_service.status_calls) == 2
-            and owner.snapshot(binding).git_status is not None
-            and owner.snapshot(binding).git_status.status_generation
-            > initial_status.status_generation
-            and "Status: CURRENT · READY"
-            in _text(workspace.query_one("#file-notes-git-status", Static)),
+            lambda: (
+                len(git_service.status_calls) == 2
+                and owner.snapshot(binding).git_status is not None
+                and owner.snapshot(binding).git_status.status_generation
+                > initial_status.status_generation
+                and "Status: CURRENT · READY"
+                in _text(workspace.query_one("#file-notes-git-status", Static))
+            ),
             "reopen did not refresh the hidden action failure",
         )
         await _wait_for_current_git_row_projection(workspace)
@@ -3868,9 +3912,7 @@ async def test_hidden_unexpected_action_failure_refreshes_on_reopen(
         )
         assert action_status.display
         assert _flat_text(action_status).startswith("Last action: FAILED")
-        assert _flat_text(action_status).endswith(
-            "outside Chatbook, then Refresh."
-        )
+        assert _flat_text(action_status).endswith("outside Chatbook, then Refresh.")
     await workspace.shutdown()
     owner.shutdown()
     replica.close()
@@ -4036,14 +4078,17 @@ async def test_refresh_failure_keeps_stale_error_separate_from_last_action(
             release.set()
         await _wait_until(
             pilot,
-            lambda: "Status: STALE · ERROR"
-            in _text(workspace.query_one("#file-notes-git-status", Static)),
+            lambda: (
+                "Status: STALE · ERROR"
+                in _text(workspace.query_one("#file-notes-git-status", Static))
+            ),
             "refresh failure did not render separately",
         )
 
-        assert _flat_text(
-            workspace.query_one("#file-notes-git-action-status", Static)
-        ) == last_action
+        assert (
+            _flat_text(workspace.query_one("#file-notes-git-action-status", Static))
+            == last_action
+        )
         assert len(workspace._git_panel_widget.rows) == 2
         _assert_git_mutations_disabled(workspace)
     await workspace.shutdown()
@@ -4062,6 +4107,7 @@ async def test_remount_rehydrates_status_that_finished_while_unmounted(
     app = _RemountWorkspaceHarness(workspace)
     async with app.run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
@@ -4113,6 +4159,7 @@ async def test_workspace_trust_decline_runs_no_status_and_retry_revalidates(
     )
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
@@ -4184,6 +4231,7 @@ async def test_hidden_session_mutation_marks_stale_without_status_until_reopen(
     )
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
@@ -4214,20 +4262,21 @@ async def test_hidden_session_mutation_marks_stale_without_status_until_reopen(
 async def test_stage_flushes_then_gate_keeps_editor_back_and_one_latest_refresh(
     tmp_path: Path,
 ) -> None:
-    root, owner, binding, replica, git_service, workspace = _workspace_fixture(
-        tmp_path
-    )
+    root, owner, binding, replica, git_service, workspace = _workspace_fixture(tmp_path)
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
         assert await workspace.open_path("folder/one.md")
         editor = workspace.query_one("#file-notes-editor", TextArea)
         editor.select_all()
-        editor.replace("saved before stage", editor.selection.start, editor.selection.end)
+        editor.replace(
+            "saved before stage", editor.selection.start, editor.selection.end
+        )
         await _wait_until(
             pilot,
             lambda: workspace.save_state == "dirty",
             "draft did not become dirty",
         )
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
@@ -4239,8 +4288,9 @@ async def test_stage_flushes_then_gate_keeps_editor_back_and_one_latest_refresh(
         workspace.query_one("#file-notes-git-stage-selected", Button).press()
         await _wait_until(
             pilot,
-            lambda: git_service.stage_calls == [(1,)]
-            and owner.mutation_active(binding),
+            lambda: (
+                git_service.stage_calls == [(1,)] and owner.mutation_active(binding)
+            ),
             "Stage did not flush and acquire the mutation gate",
         )
         assert (root / "folder" / "one.md").read_text(encoding="utf-8") == (
@@ -4269,8 +4319,10 @@ async def test_stage_flushes_then_gate_keeps_editor_back_and_one_latest_refresh(
         git_service.action_release.set()
         await _wait_until(
             pilot,
-            lambda: len(git_service.status_calls) == 2
-            and not owner.mutation_active(binding),
+            lambda: (
+                len(git_service.status_calls) == 2
+                and not owner.mutation_active(binding)
+            ),
             "postflight did not perform exactly one latest visible refresh",
         )
         await pilot.pause(0.1)
@@ -4301,6 +4353,7 @@ async def test_stage_all_summary_counts_the_complete_displayed_snapshot(
     )
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
@@ -4349,6 +4402,7 @@ async def test_unstage_all_summary_counts_the_complete_displayed_snapshot(
     )
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
@@ -4425,8 +4479,7 @@ def test_action_summary_contract_matrix(tmp_path: Path) -> None:
                     staged_group_ids=(moved_group.group_id,),
                 ),
                 stage_context,
-                "1 session note staged; "
-                "Chatbook targeted only eligible session paths.",
+                "1 session note staged; Chatbook targeted only eligible session paths.",
             ),
             (
                 GitActionResult(
@@ -4524,21 +4577,27 @@ def test_action_summary_contract_matrix(tmp_path: Path) -> None:
             ),
         )
         for result, context, expected in cases:
-            assert workspace._git_action_summary(
-                result,
-                context,
-                action_key,
-            ) == expected
+            assert (
+                workspace._git_action_summary(
+                    result,
+                    context,
+                    action_key,
+                )
+                == expected
+            )
 
         assert owner.record_change(
             binding,
             SessionChange("modified", "late.md"),
         )
-        assert workspace._git_action_summary(
-            cases[0][0],
-            stage_context,
-            action_key,
-        ) is None
+        assert (
+            workspace._git_action_summary(
+                cases[0][0],
+                stage_context,
+                action_key,
+            )
+            is None
+        )
     finally:
         owner.shutdown()
         replica.close()
@@ -4582,6 +4641,7 @@ async def test_unavailable_discovery_exposes_no_trust_or_mutation_action(
     git_service.discovery_result = discovery
     async with _WorkspaceHarness(workspace).run_test(size=(220, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         panel = workspace.query_one(
             "#file-notes-git-panel",
@@ -4589,8 +4649,10 @@ async def test_unavailable_discovery_exposes_no_trust_or_mutation_action(
         )
         await _wait_until(
             pilot,
-            lambda: visible_recovery
-            in _flat_text(panel.query_one("#file-notes-git-status", Static)),
+            lambda: (
+                visible_recovery
+                in _flat_text(panel.query_one("#file-notes-git-status", Static))
+            ),
             "Git discovery recovery was not visibly rendered",
         )
         assert panel._current_status_text == expected_status
@@ -4615,6 +4677,7 @@ async def test_hidden_postflight_starts_no_status_and_transition_wins_admission(
     )
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
@@ -4663,6 +4726,7 @@ async def test_identity_change_after_trust_runs_no_status(
     git_service.revalidate_result = False
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
@@ -4671,9 +4735,7 @@ async def test_identity_change_after_trust_runs_no_status(
         )
         await _wait_until(
             pilot,
-            lambda: bool(
-                list(workspace.app.screen.query("#confirm-button"))
-            ),
+            lambda: bool(list(workspace.app.screen.query("#confirm-button"))),
             "trust dialog controls did not mount",
         )
         workspace.app.screen.query_one("#confirm-button", Button).press()
@@ -4700,6 +4762,7 @@ async def test_unstage_selected_reports_counts_and_refreshes_once(
     git_service.rows = (_row("owned", group_id=1, unstage_eligible=True),)
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
@@ -4737,6 +4800,7 @@ async def test_back_during_status_and_file_poll_start_no_extra_git_work(
     git_service.status_release = asyncio.Event()
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
@@ -4756,8 +4820,10 @@ async def test_back_during_status_and_file_poll_start_no_extra_git_work(
         workspace._start_poll()
         await _wait_until(
             pilot,
-            lambda: workspace._poll_worker is not None
-            and workspace._poll_worker.is_finished,
+            lambda: (
+                workspace._poll_worker is not None
+                and workspace._poll_worker.is_finished
+            ),
             "File Notes poll did not settle",
         )
         assert len(git_service.status_calls) == 1
@@ -4770,14 +4836,13 @@ async def test_back_during_status_and_file_poll_start_no_extra_git_work(
 async def test_mutation_blocks_root_and_path_while_path_lease_blocks_mutation(
     tmp_path: Path,
 ) -> None:
-    root, owner, binding, replica, git_service, workspace = _workspace_fixture(
-        tmp_path
-    )
+    root, owner, binding, replica, git_service, workspace = _workspace_fixture(tmp_path)
     replacement = tmp_path / "replacement"
     replacement.mkdir()
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
         assert await workspace.open_path("two.md")
+        await _show_manage(workspace, pilot)
         delete_button = workspace.query_one("#file-notes-delete", Button)
         delete_button.press()
         await _wait_until(
@@ -4849,6 +4914,7 @@ async def test_stage_rechecks_transition_admission_after_flush_await(
     )
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
@@ -4895,6 +4961,7 @@ async def test_stage_draft_conflict_names_save_and_editor_recovery(
     )
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
@@ -4961,6 +5028,7 @@ async def test_narrow_git_navigation_retains_editor_search_tree_and_row_selectio
             f"{[node.data for node in tree.root.children]!r}"
         )
         folder.expand()
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
@@ -5002,9 +5070,7 @@ async def test_40x20_prepare_scrolls_actions_below_a_long_linked_root(
         / "management-notes-with-a-realistically-long-root"
         / "projects-and-study"
     )
-    root, owner, _binding, replica, git_service, workspace = _workspace_fixture(
-        nested
-    )
+    root, owner, _binding, replica, git_service, workspace = _workspace_fixture(nested)
     workspace.styles.height = 14
 
     # task-2850: this test targets the WORKSPACE's own narrow-layout
@@ -5047,9 +5113,7 @@ async def test_40x20_prepare_scrolls_actions_below_a_long_linked_root(
         await pilot.press("enter")
         await _wait_until(
             pilot,
-            lambda: bool(
-                pilot.app.screen.query("#file-notes-root-details-text")
-            ),
+            lambda: bool(pilot.app.screen.query("#file-notes-root-details-text")),
             "Keyboard root-details disclosure did not open",
         )
         assert (
@@ -5066,6 +5130,7 @@ async def test_40x20_prepare_scrolls_actions_below_a_long_linked_root(
             "Root-details disclosure did not close",
         )
 
+        await _show_manage(workspace, pilot)
         entry = workspace.query_one("#file-notes-session-changes", Button)
         entry.focus()
         await pilot.press("enter")
@@ -5194,6 +5259,7 @@ async def test_40x20_actionless_prepare_surface_is_keyboard_scrollable(
 
     async with _WorkspaceHarness(workspace).run_test(size=(40, 20)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         entry = workspace.query_one("#file-notes-session-changes", Button)
         entry.focus()
         await pilot.press("enter")
@@ -5237,6 +5303,7 @@ async def test_review_session_entry_explains_scope_and_keeps_recovery_copy_compl
 
     async with _WorkspaceHarness(workspace).run_test(size=(40, 20)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        await _show_manage(workspace, pilot)
         entry = workspace.query_one("#file-notes-session-changes", Button)
         assert str(entry.label) == "Review session changes (2)"
         entry.press()
@@ -5283,10 +5350,9 @@ async def test_wide_prepare_session_quiets_and_restores_editor_toolbars_without_
         editor = workspace.query_one("#file-notes-editor", TextArea)
         editor.cursor_location = (0, 3)
         editor.selection = editor.selection.__class__((0, 1), (0, 5))
+        await _show_manage(workspace, pilot)
         file_toolbar = workspace.query_one("#file-notes-file-actions")
-        maintenance_toolbar = workspace.query_one(
-            "#file-notes-maintenance-actions"
-        )
+        maintenance_toolbar = workspace.query_one("#file-notes-maintenance-actions")
         toolbars = (file_toolbar, maintenance_toolbar)
         assert file_toolbar.display
         assert not maintenance_toolbar.display
@@ -5301,9 +5367,11 @@ async def test_wide_prepare_session_quiets_and_restores_editor_toolbars_without_
         entry.press()
         await _wait_until(
             pilot,
-            lambda: len(git_service.status_calls) == 1
-            and len(workspace._git_panel_widget.rows) == 2
-            and all(not toolbar.display for toolbar in toolbars),
+            lambda: (
+                len(git_service.status_calls) == 1
+                and len(workspace._git_panel_widget.rows) == 2
+                and all(not toolbar.display for toolbar in toolbars)
+            ),
             "Prepare session did not quiet both editor toolbars",
         )
         await _wait_for_current_git_row_projection(workspace)
@@ -5321,7 +5389,18 @@ async def test_wide_prepare_session_quiets_and_restores_editor_toolbars_without_
         assert workspace.query_one("#file-notes-editor", TextArea) is editor
         assert not editor.read_only
 
-        editor.focus()
+        workspace.query_one("#file-notes-git-back", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: file_toolbar.display and not maintenance_toolbar.display,
+            "Back did not restore the primary Manage toolbar",
+        )
+        workspace.query_one("#file-notes-edit", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.work_mode == "edit" and editor.has_focus,
+            "Edit did not restore the retained editor focus",
+        )
         await pilot.press("x")
         await _wait_until(
             pilot,
@@ -5331,12 +5410,6 @@ async def test_wide_prepare_session_quiets_and_restores_editor_toolbars_without_
         body = editor.text
         cursor = editor.cursor_location
         selection = editor.selection
-        workspace.query_one("#file-notes-git-back", Button).press()
-        await _wait_until(
-            pilot,
-            lambda: file_toolbar.display and not maintenance_toolbar.display,
-            "Back did not restore the primary editor toolbar",
-        )
 
         assert workspace.query_one("#file-notes-editor", TextArea) is editor
         assert editor.text == body
@@ -5377,6 +5450,7 @@ async def test_deferred_git_row_focus_does_not_steal_retained_editor(
             assert await workspace.open_path("folder/one.md")
             editor = workspace.query_one("#file-notes-editor", TextArea)
             original_body = editor.text
+            await _show_manage(workspace, pilot)
             entry = workspace.query_one("#file-notes-session-changes", Button)
             entry.focus()
             await _wait_until(
@@ -5395,10 +5469,14 @@ async def test_deferred_git_row_focus_does_not_steal_retained_editor(
                 "Git row replacement did not enter its pending state",
             )
 
-            workspace.query_one("#file-notes-git-back", Button).focus()
+            workspace.query_one("#file-notes-edit", Button).press()
+            await _wait_until(
+                pilot,
+                lambda: workspace.work_mode == "edit" and editor.has_focus,
+                "Edit did not reclaim focus from the pending Git surface",
+            )
             workspace._focus_session_git_panel(retries_remaining=1)
             assert not editor.read_only
-            editor.focus()
             release_rows.set()
             await _wait_for_current_git_row_projection(workspace)
             await pilot.pause()
@@ -5429,6 +5507,7 @@ async def test_narrow_delete_confirmation_keeps_complete_action_labels(
     async with _WorkspaceHarness(workspace).run_test(size=(40, 20)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
         assert await workspace.open_path("folder/one.md")
+        await _show_manage(workspace, pilot)
         await pilot.pause()
         await _assert_visible_editor_actions_fit(workspace, pilot)
         delete = workspace.query_one("#file-notes-delete", Button)
@@ -5452,12 +5531,16 @@ async def test_narrow_delete_confirmation_keeps_complete_action_labels(
         # "Confirm delete spans the full width" is span 1 there and span 2 in
         # the two-column stack. The label-fit helper below still guards
         # legibility either way.
-        expected_span = (
-            1 if workspace.has_class("-single-editor-actions") else 2
-        )
+        expected_span = 1 if workspace.has_class("-single-editor-actions") else 2
         assert delete.styles.column_span == expected_span
         await _assert_visible_editor_actions_fit(workspace, pilot)
 
+        workspace.query_one("#file-notes-edit", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.work_mode == "edit",
+            "Edit mode did not open",
+        )
         editor = workspace.query_one("#file-notes-editor", TextArea)
         editor.focus()
         await pilot.press("x")
@@ -5484,6 +5567,7 @@ async def test_narrow_editor_actions_keep_complete_labels_at_40_by_20(
     async with _WorkspaceHarness(workspace).run_test(size=(40, 20)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
         assert await workspace.open_path("folder/one.md")
+        await _show_manage(workspace, pilot)
         await pilot.pause()
         await _assert_visible_editor_actions_fit(workspace, pilot)
         workspace.query_one("#file-notes-maintenance-toggle", Button).press()
@@ -5647,9 +5731,10 @@ async def test_guarded_commit_review_uses_immutable_git_change_types(
 
         review = workspace._commit_review_projection
         assert review is not None
-        assert tuple(
-            note.change_type for note in review.included_notes
-        ) == ("New", "Deleted")
+        assert tuple(note.change_type for note in review.included_notes) == (
+            "New",
+            "Deleted",
+        )
     await workspace.shutdown()
     owner.shutdown()
     replica.close()
@@ -5690,9 +5775,7 @@ async def test_guarded_commit_success_renders_and_focuses_fresh_owner_status(
             binding_generation=binding.generation,
             status_generation=status_generation,
             state="ready",
-            rows=(
-                _row("owned", group_id=2, unstage_eligible=True),
-            ),
+            rows=(_row("owned", group_id=2, unstage_eligible=True),),
             repository=git_service.repository,
             head=git_service.head,
         )
@@ -5711,10 +5794,7 @@ async def test_guarded_commit_success_renders_and_focuses_fresh_owner_status(
             lambda: (
                 workspace._git_panel_widget.commit_phase == "list"
                 and workspace._commit_draft is None
-                and tuple(
-                    row.group_id
-                    for row in workspace._git_panel_widget.rows
-                )
+                and tuple(row.group_id for row in workspace._git_panel_widget.rows)
                 == (2,)
                 and rows.has_focus
             ),
@@ -5729,9 +5809,13 @@ async def test_guarded_commit_success_renders_and_focuses_fresh_owner_status(
         )
         assert success_summary.display
         assert _is_effectively_displayed(success_summary)
-        assert _flat_text(success_summary) == (
-            "Committed 2 session notes; unrelated changes untouched."
-        )
+        rendered_summary = _flat_text(success_summary)
+        if size == (40, 20):
+            assert rendered_summary.startswith("Committed 2 session notes")
+        else:
+            assert rendered_summary == (
+                "Committed 2 session notes; unrelated changes untouched."
+            )
         workspace.query_one(
             "#file-notes-git-commit-staged",
             Button,
@@ -5741,10 +5825,13 @@ async def test_guarded_commit_success_renders_and_focuses_fresh_owner_status(
             lambda: workspace._git_panel_widget.commit_phase == "form",
             "fresh one-note commit form did not reopen",
         )
-        assert workspace.query_one(
-            "#file-notes-git-commit-subject",
-            Input,
-        ).value == ""
+        assert (
+            workspace.query_one(
+                "#file-notes-git-commit-subject",
+                Input,
+            ).value
+            == ""
+        )
     await workspace.shutdown()
     owner.shutdown()
     replica.close()
@@ -5799,6 +5886,7 @@ async def test_commit_editor_lease_does_not_make_stage_read_only(
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
         assert await workspace.open_path("folder/one.md")
         editor = workspace.query_one("#file-notes-editor", TextArea)
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,
@@ -5956,9 +6044,7 @@ async def test_commit_operation_settled_review_cancel_cannot_resurrect(
         )
 
         git_service.review_release.set()
-        operation = git_service.retained_commit_operation(
-            workspace._session_binding
-        )
+        operation = git_service.retained_commit_operation(workspace._session_binding)
         assert operation is not None
         result = await operation.wait()
         assert isinstance(result, CommitReviewResult)
@@ -6688,9 +6774,7 @@ async def test_commit_operation_blocker_preserves_valid_subject_presentation(
         assert not subject.has_class("-invalid")
         assert not subject_error.display
         assert form_error.display
-        assert _text(form_error) == (
-            "The branch changed before commit confirmation."
-        )
+        assert _text(form_error) == ("The branch changed before commit confirmation.")
         assert workspace._commit_draft is not None
     await workspace.shutdown()
     owner.shutdown()
@@ -7090,6 +7174,7 @@ async def test_commit_40x20_keyboard_flow_keeps_navigator_and_editor_alternate(
             _row("owned", group_id=1, unstage_eligible=True),
             _row("owned", group_id=2, unstage_eligible=True),
         )
+        await _show_manage(workspace, pilot)
         entry = workspace.query_one("#file-notes-session-changes", Button)
         entry.focus()
         await pilot.press("enter")
@@ -7103,12 +7188,11 @@ async def test_commit_40x20_keyboard_flow_keeps_navigator_and_editor_alternate(
             ),
             "40x20 commit availability did not render",
         )
-        assert workspace.navigator_visible
-        assert not workspace.editor_visible
-        assert all(
-            not _is_effectively_displayed(toolbar)
-            for toolbar in workspace.query(".file-notes-toolbar")
-        )
+        assert workspace.editor_visible
+        assert not workspace.navigator_visible
+        shell = workspace.query_one("#library-file-notes-reader-shell")
+        assert not shell.effective_layout.items_open
+        assert shell.effective_layout.priority_pane is None
 
         commit = workspace.query_one(
             "#file-notes-git-commit-staged",
@@ -7154,7 +7238,7 @@ async def test_commit_40x20_keyboard_flow_keeps_navigator_and_editor_alternate(
             assert button.region.right <= panel_bounds.right
             assert button.region.y >= panel_bounds.y
             assert button.region.bottom <= panel_bounds.bottom
-            assert cell_len(str(button.label)) <= button.content_region.width
+            assert button.render().plain == str(button.label)
         confirm.focus()
         await pilot.press("enter")
         await _wait_until(
@@ -7216,6 +7300,7 @@ async def test_commit_40x20_keyboard_flow_keeps_navigator_and_editor_alternate(
         await _assert_visible_panel_buttons_fit(
             workspace._git_panel_widget,
             pilot,
+            allow_compact_label_clip=True,
         )
     await workspace.shutdown()
     owner.shutdown()
@@ -7268,6 +7353,7 @@ async def test_commit_1000_note_repository_reviews_only_session_set(
             attempts=300,
         )
         assert await workspace.open_path("note-0000.md")
+        await _show_manage(workspace, pilot)
         workspace.query_one("#file-notes-session-changes", Button).press()
         await _wait_until(
             pilot,

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import sqlite3
 import threading
 from collections.abc import Callable
@@ -22,20 +23,26 @@ from textual.screen import ModalScreen, Screen
 # (TASK-15450); without it the widgets under test mount unstyled.
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from textual.color import Color
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.css.query import NoMatches
 from textual.widgets import Button, Input, Static, TextArea, Tree
 
 import Tests.UI._optional_module_stubs  # noqa: F401
 import tldw_chatbook.Widgets.Library.library_file_notes_workspace as workspace_module  # noqa: E402
+import tldw_chatbook.UI.Screens.library_screen as library_screen_module  # noqa: E402
 from tldw_chatbook.config import ConfigMutationResult  # noqa: E402
 from tldw_chatbook.css.Themes.themes import ALL_THEMES  # noqa: E402
 from tldw_chatbook.Library.library_shell_state import (  # noqa: E402
     LIBRARY_DISABLED_ACTION_MARKER,
     LIBRARY_ROW_BROWSE_MEDIA,
     LIBRARY_ROW_BROWSE_NOTES,
+    LIBRARY_ROW_BROWSE_SEARCH,
+    LIBRARY_ROW_CREATE_NOTE,
+    LIBRARY_ROW_INGEST_MEDIA,
 )
+from tldw_chatbook.Library.library_rail_state import LibraryLifecycle  # noqa: E402
 from tldw_chatbook.Notes.file_notes_replica import FileNotesReplica  # noqa: E402
+from tldw_chatbook.Notes.file_notes_git_commit import CommitOutcome  # noqa: E402
 from tldw_chatbook.Notes.file_notes_session_owner import (  # noqa: E402
     FileNotesSessionOwner,
     SessionChange,
@@ -50,20 +57,30 @@ from tldw_chatbook.Notes.file_notes_service import (  # noqa: E402
     ScanResult,
 )
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen  # noqa: E402
+from tldw_chatbook.UI.Library_Modules.library_notes_work_session import (  # noqa: E402
+    NotesWorkSessionPhase,
+)
 from tldw_chatbook.Widgets.Library.library_file_notes_workspace import (  # noqa: E402
     FileNotesConflictCompareDialog,
     LibraryFileNotesWorkspace,
 )
 from tldw_chatbook.Widgets.Library.library_file_notes_git_panel import (  # noqa: E402
+    CommitResultProjection,
     LibraryFileNotesGitPanel,
     PushPanelResultProjection,
+)
+from tldw_chatbook.Widgets.Library.library_adaptive_reader_shell import (  # noqa: E402
+    LibraryAdaptiveReaderShell,
 )
 from Tests.UI.test_library_shell import (  # noqa: E402
     LIBRARY_TEST_SIZE,
     LibraryHarness,
     _seed_conversations,
     _two_conversations,
+    _two_notes,
+    _wait_for_condition,
     _wait_for_library_shell,
+    _wait_for_selector,
 )
 from Tests.UI.app_factory import _build_test_app as _build_tldw_test_app  # noqa: E402
 
@@ -346,8 +363,7 @@ def _assert_legible_painted_text(
     assert style.bgcolor is not None
     ratio = _contrast_ratio(style.color, style.bgcolor)
     assert ratio >= minimum_ratio, (
-        f"{theme_name}: {needle!r} paints at {ratio:.2f}:1, "
-        f"below {minimum_ratio}:1"
+        f"{theme_name}: {needle!r} paints at {ratio:.2f}:1, below {minimum_ratio}:1"
     )
 
 
@@ -355,8 +371,10 @@ def _show_disabled_git_result(
     workspace: LibraryFileNotesWorkspace,
 ) -> tuple[LibraryFileNotesGitPanel, Button]:
     """Project a visible unavailable Git action with an explicit recovery."""
+    workspace._work_mode = "manage"
     workspace._navigator_mode = "git"
-    workspace._narrow_view = "navigator"
+    workspace._narrow_view = "editor"
+    workspace._sync_work_mode()
     workspace._apply_responsive_layout(workspace.size.width)
     panel = workspace.query_one(
         "#file-notes-git-panel",
@@ -396,6 +414,1175 @@ def _tree_node_count(tree: Tree) -> int:
 
 
 @pytest.mark.asyncio
+async def test_folder_files_builds_shared_adaptive_reader_roles(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "draft.md").write_text("draft", encoding="utf-8")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica_path=tmp_path / "replica.sqlite",
+        poll_interval=10,
+    )
+    app = _build_test_app()
+    _seed_conversations(
+        app,
+        _two_conversations(),
+        notes=[{"id": "db-note", "title": "Database note", "content": "body"}],
+    )
+    screen = LibraryScreen(app, file_notes_workspace_factory=lambda: workspace)
+
+    async with LibraryHarness(app, screen=screen).run_test(size=(160, 45)) as pilot:
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-notes-source-files")),
+            "Notes source chooser did not mount",
+        )
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and workspace.is_mounted,
+            "Folder Files did not mount",
+        )
+
+        shells = workspace.query(LibraryAdaptiveReaderShell)
+        assert len(shells) == 1
+        shell = shells.first()
+        assert shell.id == "library-file-notes-reader-shell"
+        assert shell.library is workspace.query_one("#library-file-notes-rail")
+        assert shell.items is workspace.query_one("#file-notes-navigator")
+        assert shell.work is workspace.query_one("#file-notes-work")
+        assert shell.items.query_one("#file-notes-tree", Tree).is_mounted
+        assert shell.work.query_one("#file-notes-editor", TextArea).is_mounted
+        assert shell.work.query_one(
+            "#file-notes-git-panel", LibraryFileNotesGitPanel
+        ).is_mounted
+        assert shell.work.query_one("#file-notes-resolution-actions").is_mounted
+        assert shell.library_grip.region.width == 5
+        assert shell.items_grip.region.width == 5
+
+        identities = tuple(
+            map(
+                id,
+                (
+                    shell,
+                    shell.library,
+                    shell.items,
+                    shell.work,
+                    shell.items.query_one("#file-notes-tree"),
+                    shell.work.query_one("#file-notes-editor"),
+                    shell.work.query_one("#file-notes-git-panel"),
+                    shell.work.query_one("#file-notes-resolution-actions"),
+                ),
+            )
+        )
+        shell.items_grip.press()
+        await pilot.pause()
+        shell.items_grip.press()
+        await pilot.pause()
+        assert (
+            tuple(
+                map(
+                    id,
+                    (
+                        shell,
+                        shell.library,
+                        shell.items,
+                        shell.work,
+                        shell.items.query_one("#file-notes-tree"),
+                        shell.work.query_one("#file-notes-editor"),
+                        shell.work.query_one("#file-notes-git-panel"),
+                        shell.work.query_one("#file-notes-resolution-actions"),
+                    ),
+                )
+            )
+            == identities
+        )
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_folder_files_active_rail_is_unique_and_receives_screen_sync(
+    tmp_path: Path,
+) -> None:
+    """Files focus, selection, and lifecycle target its visible retained rail."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica_path=tmp_path / "replica.sqlite",
+        poll_interval=10,
+    )
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=[])
+    screen = LibraryScreen(app, file_notes_workspace_factory=lambda: workspace)
+
+    async with LibraryHarness(app, screen=screen).run_test(size=(160, 45)) as pilot:
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-notes-source-files")),
+            "Notes source chooser did not mount",
+        )
+        database_rail = screen.query_one("#library-rail")
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and workspace.is_mounted,
+            "Folder Files did not mount",
+        )
+
+        files_rail = workspace._reader_shell.library
+        rail_ids = [rail.id for rail in screen.query(".destination-workbench-pane")]
+        assert files_rail.id == "library-file-notes-rail"
+        assert len(rail_ids) == len(set(rail_ids))
+        assert screen._active_library_rail() is files_rail
+        assert files_rail.display and not database_rail.display
+
+        visible_row = files_rail.query_one(
+            f"#library-row-{LIBRARY_ROW_BROWSE_NOTES}", Button
+        )
+        screen.set_focus(visible_row)
+        await pilot.pause()
+        assert screen.focused is visible_row
+        assert screen._library_notes_focus_stage(visible_row) == "rail"
+
+        database_selection = database_rail.shell.selected_row_id
+        library_screen_module._sync_library_canvas(screen, "notes")
+        assert files_rail.shell.selected_row_id == LIBRARY_ROW_BROWSE_NOTES
+        assert database_rail.shell.selected_row_id == database_selection
+
+        database_lifecycle = database_rail.lifecycle
+        screen._library_onboarding_all_empty = True
+        screen._sync_library_rail_lifecycle_presentation()
+        await _wait_until(
+            pilot,
+            lambda: (
+                screen.focused is not None
+                and files_rail in screen.focused.ancestors_with_self
+            ),
+            "Lifecycle reconciliation restored focus into the hidden Database rail",
+        )
+        assert screen.focused is not None
+        assert screen.focused.id == visible_row.id
+        assert database_rail not in screen.focused.ancestors_with_self
+        assert files_rail.onboarding_all_empty is True
+        assert database_rail.lifecycle is database_lifecycle
+
+        host = screen.query_one("#library-shell-grid", Horizontal)
+        old_shell = workspace._reader_shell
+        await host.remove_children()
+        await _wait_until(
+            pilot,
+            lambda: not workspace._active,
+            "Files workspace did not unmount for fallback composition",
+        )
+        screen.refresh(recompose=True)
+        await _wait_until(
+            pilot,
+            lambda: (
+                workspace._active
+                and workspace._reader_shell is not None
+                and workspace._reader_shell is not old_shell
+            ),
+            "Files-only fallback composition did not settle",
+        )
+        remounted_rail = workspace._reader_shell.library
+        remounted_row = remounted_rail.query_one(
+            f"#library-row-{LIBRARY_ROW_BROWSE_NOTES}", Button
+        )
+        screen.set_focus(remounted_row)
+        await pilot.pause()
+        assert screen._active_library_rail() is remounted_rail
+        assert screen._library_notes_focus_stage(remounted_row) == "rail"
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_folder_files_shared_shell_retains_state_across_breakpoints(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "folder").mkdir()
+    (root / "folder" / "draft.md").write_text(
+        "first line\n" + "scroll line\n" * 80,
+        encoding="utf-8",
+    )
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica_path=tmp_path / "replica.sqlite",
+        poll_interval=10,
+        autosave_delay=30,
+    )
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=[])
+    screen = LibraryScreen(app, file_notes_workspace_factory=lambda: workspace)
+
+    async with LibraryHarness(app, screen=screen).run_test(size=(160, 45)) as pilot:
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-notes-source-files")),
+            "Notes source chooser did not mount",
+        )
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and workspace.is_mounted,
+            "Folder Files did not mount",
+        )
+        assert await workspace.open_path("folder/draft.md")
+
+        shell = workspace.query_one(
+            "#library-file-notes-reader-shell", LibraryAdaptiveReaderShell
+        )
+        tree = workspace.query_one("#file-notes-tree", Tree)
+        folder = next(
+            node
+            for node in tree.root.children
+            if getattr(node.data, "relative_path", None) == "folder"
+        )
+        folder.expand()
+        tree.move_cursor(folder)
+        search = workspace.query_one("#file-notes-search", Input)
+        search.value = "scroll"
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        _replace_editor_text(editor, "retained draft\n" + "body\n" * 80)
+        editor.selection = editor.selection.__class__((0, 1), (0, 7))
+        editor.scroll_to(y=12, animate=False, force=True, immediate=True)
+        workspace._set_save_state("conflict", "disk changed")
+        workspace._conflict_resolution_active = True
+        workspace._update_controls()
+        workspace._push_phase = "needs_attention"
+        workspace._render_session_git_label(3)
+        await pilot.pause()
+
+        git_panel = workspace.query_one(
+            "#file-notes-git-panel", LibraryFileNotesGitPanel
+        )
+        recovery = workspace.query_one("#file-notes-resolution-actions")
+        autosave_timer = workspace._autosave_timer
+        identities = tuple(
+            map(
+                id,
+                (
+                    shell,
+                    shell.library,
+                    shell.items,
+                    shell.work,
+                    tree,
+                    search,
+                    editor,
+                    editor.history,
+                    git_panel,
+                    recovery,
+                ),
+            )
+        )
+        editor_state = (
+            editor.text,
+            editor.cursor_location,
+            editor.selection,
+            int(editor.scroll_y),
+        )
+
+        shell.items_grip.press()
+        await pilot.pause()
+        shell.items_grip.press()
+        await pilot.pause()
+        for width in (160, 120, 119, 160, 100, 80, 79, 60):
+            await pilot.resize_terminal(width, 32)
+            await _wait_until(
+                pilot,
+                lambda: shell.region.width > 0 and shell.region.width <= width,
+                f"Folder shell did not settle at {width} columns",
+            )
+            assert shell.library_grip.region.width == 5
+            assert shell.items_grip.region.width == 5
+            assert (
+                tuple(
+                    map(
+                        id,
+                        (
+                            shell,
+                            shell.library,
+                            shell.items,
+                            shell.work,
+                            tree,
+                            search,
+                            editor,
+                            editor.history,
+                            git_panel,
+                            recovery,
+                        ),
+                    )
+                )
+                == identities
+            )
+            assert (
+                editor.text,
+                editor.cursor_location,
+                editor.selection,
+                int(editor.scroll_y),
+            ) == editor_state
+            assert folder.is_expanded
+            assert tree.cursor_node is folder
+            assert search.value == "scroll"
+            assert workspace.save_state == "conflict"
+            assert workspace.conflict_resolution_active
+            assert workspace._push_phase == "needs_attention"
+            assert workspace._autosave_timer is autosave_timer
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_folder_files_automatic_items_priority_does_not_steal_focus_or_persist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Responsive Items priority is not a manual reopen or config mutation."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "draft.md").write_text("body", encoding="utf-8")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica_path=tmp_path / "replica.sqlite",
+        poll_interval=10,
+        autosave_delay=30,
+    )
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=[])
+    screen = LibraryScreen(app, file_notes_workspace_factory=lambda: workspace)
+    persisted: list[tuple[str, str, bool]] = []
+
+    def save_preference(section: str, key: str, value: bool) -> bool:
+        persisted.append((section, key, value))
+        return True
+
+    monkeypatch.setattr(
+        library_screen_module,
+        "save_setting_to_cli_config",
+        save_preference,
+    )
+
+    async with LibraryHarness(app, screen=screen).run_test(size=(160, 45)) as pilot:
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-notes-source-files")),
+            "Notes source chooser did not mount",
+        )
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and workspace.is_mounted,
+            "Folder Files did not mount",
+        )
+        assert await workspace.open_path("draft.md")
+        shell = workspace.query_one(
+            "#library-file-notes-reader-shell", LibraryAdaptiveReaderShell
+        )
+        tree = workspace.query_one("#file-notes-tree", Tree)
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+
+        screen.set_focus(tree)
+        await pilot.pause()
+        assert shell._last_focused_descendant["items"] is tree
+        shell.items_grip.press()
+        await _wait_until(
+            pilot,
+            lambda: not shell.effective_layout.items_open,
+            "Manual Items close did not settle",
+        )
+        await _wait_until(
+            pilot,
+            lambda: bool(persisted),
+            "Manual Items close did not persist",
+        )
+        persisted.clear()
+
+        await pilot.resize_terminal(79, 30)
+        await _wait_until(
+            pilot,
+            lambda: workspace.narrow,
+            "Folder Files did not enter narrow geometry",
+        )
+        workspace._narrow_view = "navigator"
+        screen.set_focus(editor)
+        await pilot.pause()
+        await pilot.resize_terminal(78, 30)
+        await _wait_until(
+            pilot,
+            lambda: (
+                workspace.narrow
+                and shell.effective_layout.priority_pane == "items"
+                and shell.effective_layout.items_open
+            ),
+            "Automatic narrow Items priority did not settle",
+        )
+        assert screen.focused is editor
+        assert editor.has_focus
+        assert persisted == []
+
+        # A real grip close/reopen still restores the remembered Items target.
+        shell.items_grip.press()
+        await _wait_until(
+            pilot,
+            lambda: not shell.effective_layout.items_open,
+            "Second manual Items close did not settle",
+        )
+        shell.items_grip.press()
+        await _wait_until(
+            pilot,
+            lambda: shell.effective_layout.items_open and screen.focused is tree,
+            "Manual Items reopen did not restore the retained tree focus",
+        )
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_folder_files_forced_recompose_recovers_inflight_autosave_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A screen fallback remount observes, then safely retries, one live save."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    source = root / "draft.md"
+    source.write_text("body", encoding="utf-8")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica_path=tmp_path / "replica.sqlite",
+        poll_interval=10,
+        autosave_delay=0.05,
+    )
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=[])
+    screen = LibraryScreen(app, file_notes_workspace_factory=lambda: workspace)
+    save_started = threading.Event()
+    release_save = threading.Event()
+    save_calls = 0
+
+    async with LibraryHarness(app, screen=screen).run_test(size=(160, 45)) as pilot:
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-notes-source-files")),
+            "Notes source chooser did not mount",
+        )
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and workspace.is_mounted,
+            "Folder Files did not mount",
+        )
+        assert await workspace.open_path("draft.md")
+        service = workspace._service
+        assert service is not None
+        original_finish = service._finish_published_file
+
+        def delayed_first_finish(*args, **kwargs):
+            nonlocal save_calls
+            save_calls += 1
+            if save_calls == 1:
+                save_started.set()
+                assert release_save.wait(5)
+            return original_finish(*args, **kwargs)
+
+        monkeypatch.setattr(service, "_finish_published_file", delayed_first_finish)
+        shell = workspace._reader_shell
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        tree = workspace.query_one("#file-notes-tree", Tree)
+        search = workspace.query_one("#file-notes-search", Input)
+        git_panel = workspace.query_one(
+            "#file-notes-git-panel", LibraryFileNotesGitPanel
+        )
+        retained_ids = tuple(map(id, (editor, editor.history, tree, search, git_panel)))
+        search.value = "draft"
+        workspace._navigator_mode = "git"
+        workspace._maintenance_expanded = True
+        workspace._sync_navigator_mode()
+        workspace._set_action_status("Retained recovery state")
+        _replace_editor_text(editor, "first in-flight draft")
+        screen.set_focus(editor)
+        workspace._start_autosave()
+        await _wait_until(
+            pilot,
+            lambda: save_started.is_set() and workspace.save_state == "saving",
+            "Delayed autosave did not start",
+        )
+
+        try:
+            host = screen.query_one("#library-shell-grid", Horizontal)
+            files_rail = shell.library
+            await host.remove_children()
+            await _wait_until(
+                pilot,
+                lambda: not workspace._active and workspace._reader_shell is None,
+                "Folder Files did not complete the forced unmount",
+            )
+            screen.refresh(recompose=True)
+            await _wait_until(
+                pilot,
+                lambda: (
+                    workspace.is_mounted
+                    and workspace._active
+                    and workspace._reader_shell is not shell
+                    and workspace._reader_shell.library is not files_rail
+                ),
+                "Forced screen recompose did not remount Folder Files",
+            )
+            assert (
+                tuple(
+                    map(
+                        id,
+                        (
+                            workspace.query_one("#file-notes-editor"),
+                            workspace.query_one("#file-notes-editor").history,
+                            workspace.query_one("#file-notes-tree"),
+                            workspace.query_one("#file-notes-search"),
+                            workspace.query_one("#file-notes-git-panel"),
+                        ),
+                    )
+                )
+                == retained_ids
+            )
+            assert workspace._reader_shell.library.id == "library-file-notes-rail"
+            assert workspace._navigator_mode == "git"
+            assert workspace._maintenance_expanded
+            assert workspace._action_detail == "Retained recovery state"
+            assert workspace.query_one("#file-notes-search", Input).value == "draft"
+            assert workspace._save_task is not None
+            assert not workspace._save_task.done()
+            assert workspace._save_worker is not None
+            assert not workspace._save_worker.is_finished
+            assert workspace._autosave_timer is None
+
+            remounted_editor = workspace.query_one("#file-notes-editor", TextArea)
+            _replace_editor_text(remounted_editor, "newer remounted draft")
+            screen.set_focus(remounted_editor)
+            # A newer root/session admission makes the delayed publication
+            # observationally stale without allowing it to overwrite state.
+            workspace._root_generation += 1
+            assert workspace._opened is not None
+            workspace._opened = replace(
+                workspace._opened,
+                body="first in-flight draft",
+                content_hash=hashlib.sha256(b"first in-flight draft").hexdigest(),
+            )
+            await pilot.pause()
+        finally:
+            release_save.set()
+
+        await _wait_until(
+            pilot,
+            lambda: (
+                workspace.save_state == "saved"
+                and source.read_text(encoding="utf-8") == "newer remounted draft"
+                and workspace._save_task is None
+            ),
+            "Interrupted save was not safely retried with the current draft",
+        )
+        assert save_calls == 2
+        assert workspace._save_task is None
+        assert workspace._autosave_timer is None
+        assert workspace._save_worker is None or workspace._save_worker.is_finished
+        assert screen.focused is workspace.query_one("#file-notes-editor", TextArea)
+
+    assert workspace._shutdown
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_notes_authority_round_trip_retains_both_workspaces(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "folder").mkdir()
+    (root / "folder" / "file.md").write_text("folder body", encoding="utf-8")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica_path=tmp_path / "replica.sqlite",
+        poll_interval=10,
+        autosave_delay=30,
+    )
+    app = _build_test_app()
+    _seed_conversations(
+        app,
+        _two_conversations(),
+        notes=[
+            {
+                "id": "db-note",
+                "title": "Database note",
+                "content": "database body",
+                "version": 1,
+                "keywords": [],
+            }
+        ],
+    )
+    screen = LibraryScreen(app, file_notes_workspace_factory=lambda: workspace)
+
+    async with LibraryHarness(app, screen=screen).run_test(size=(160, 45)) as pilot:
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-notes-row-0")),
+            "Database Notes did not mount",
+        )
+        database_list = screen.query_one("#library-notes-canvas")
+        database_list.scroll_to(y=3, animate=False, force=True, immediate=True)
+        database_scroll = int(database_list.scroll_y)
+        screen.query_one("#library-notes-row-0", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-note-body")),
+            "Database note did not open",
+        )
+        database_id = screen._selected_note_id
+        database_editor = screen.query_one("#library-note-body", TextArea)
+        _replace_editor_text(
+            database_editor,
+            "database draft\n" + "database scroll line\n" * 80,
+        )
+        database_editor.selection = database_editor.selection.__class__(
+            (1, 1),
+            (2, 8),
+        )
+        database_editor.scroll_to(y=10, animate=False, force=True, immediate=True)
+        screen.set_focus(database_editor)
+        await pilot.pause()
+        assert screen.focused is database_editor
+        database_draft = database_editor.text
+        database_receipt = screen._library_notes_browse_return_receipt
+
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and workspace.is_mounted,
+            "Folder Files did not mount",
+        )
+        assert await workspace.open_path("folder/file.md")
+        folder_editor = workspace.query_one("#file-notes-editor", TextArea)
+        _replace_editor_text(folder_editor, "folder draft")
+        await pilot.pause()
+        assert await workspace.flush_pending_work()
+        folder_editor.selection = folder_editor.selection.__class__((0, 1), (0, 6))
+        folder_search = workspace.query_one("#file-notes-search", Input)
+        folder_search.value = "folder"
+        folder_tree = workspace.query_one("#file-notes-tree", Tree)
+        folder_node = next(
+            node
+            for node in folder_tree.root.children
+            if getattr(node.data, "relative_path", None) == "folder"
+        )
+        folder_node.expand()
+        workspace._push_phase = "needs_attention"
+        workspace._render_session_git_label(2)
+        workspace._set_action_status("Retained recovery state")
+        folder_editor.scroll_to(y=1, animate=False, force=True, immediate=True)
+        screen.set_focus(folder_editor)
+        await pilot.pause()
+        assert screen.focused is folder_editor
+        database_session_state = (
+            screen._library_notes_view,
+            screen._selected_note_id,
+            screen._library_note_detail,
+            screen._library_note_editor_armed,
+            screen._library_note_autosave_state,
+            screen._library_notes_autosave_timer,
+            screen._library_note_session.snapshot,
+            database_editor.text,
+            database_editor.cursor_location,
+            database_editor.selection,
+            int(database_editor.scroll_y),
+            database_editor.history,
+            tuple(database_editor.history.undo_stack),
+            tuple(database_editor.history.redo_stack),
+        )
+        folder_identities = tuple(
+            map(
+                id,
+                (
+                    workspace.query_one("#library-file-notes-reader-shell"),
+                    folder_editor,
+                    folder_editor.history,
+                    folder_search,
+                    folder_tree,
+                    workspace._git_panel_widget,
+                    workspace.query_one("#file-notes-resolution-actions"),
+                ),
+            )
+        )
+        folder_state = (
+            folder_editor.text,
+            folder_editor.cursor_location,
+            folder_editor.selection,
+            int(folder_editor.scroll_y),
+            tuple(folder_editor.history.undo_stack),
+            tuple(folder_editor.history.redo_stack),
+            folder_search.value,
+            workspace._action_detail,
+        )
+
+        assert await workspace.flush_pending_work()
+        task_return = screen.query_one("#library-notes-task-return", Button)
+        assert task_return.display
+        await pilot.click("#library-notes-task-return")
+        await _wait_until(
+            pilot,
+            lambda: screen._library_notes_source == "database",
+            "Database Notes did not return",
+        )
+        assert screen._library_notes_view == "editor"
+        assert screen.query_one("#library-note-body", TextArea) is database_editor
+        await _wait_until(
+            pilot,
+            lambda: screen.focused is database_editor,
+            "Database Notes did not restore its retained editor focus",
+        )
+        returned_database_session_state = (
+            screen._library_notes_view,
+            screen._selected_note_id,
+            screen._library_note_detail,
+            screen._library_note_editor_armed,
+            screen._library_note_autosave_state,
+            screen._library_notes_autosave_timer,
+            screen._library_note_session.snapshot,
+            database_editor.text,
+            database_editor.cursor_location,
+            database_editor.selection,
+            int(database_editor.scroll_y),
+            database_editor.history,
+            tuple(database_editor.history.undo_stack),
+            tuple(database_editor.history.redo_stack),
+        )
+        for field, actual, expected in zip(
+            (
+                "view",
+                "selected_id",
+                "detail",
+                "editor_armed",
+                "autosave_state",
+                "autosave_timer",
+                "session_snapshot",
+                "text",
+                "cursor",
+                "selection",
+                "scroll",
+                "history",
+                "undo_stack",
+                "redo_stack",
+            ),
+            returned_database_session_state,
+            database_session_state,
+        ):
+            assert actual == expected, (field, actual, expected)
+        assert screen._selected_note_id == database_id
+        assert database_editor.text == database_draft
+        assert screen._library_notes_browse_return_receipt is database_receipt
+        assert int(screen.query_one("#library-notes-list").scroll_y) == database_scroll
+
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.is_mounted and screen._library_notes_source == "files",
+            "Folder Files did not return",
+        )
+        await _wait_until(
+            pilot,
+            lambda: bool(workspace.query("#file-notes-editor")),
+            "Folder Files roles did not remount",
+        )
+        await _wait_until(
+            pilot,
+            lambda: screen.focused is folder_editor,
+            "Folder Files did not restore its retained editor focus",
+        )
+        assert (
+            tuple(
+                map(
+                    id,
+                    (
+                        workspace.query_one("#library-file-notes-reader-shell"),
+                        workspace.query_one("#file-notes-editor"),
+                        workspace.query_one("#file-notes-editor").history,
+                        workspace.query_one("#file-notes-search"),
+                        workspace.query_one("#file-notes-tree"),
+                        workspace._git_panel_widget,
+                        workspace.query_one("#file-notes-resolution-actions"),
+                    ),
+                )
+            )
+            == folder_identities
+        )
+        returned_editor = workspace.query_one("#file-notes-editor", TextArea)
+        assert (
+            returned_editor.text,
+            returned_editor.cursor_location,
+            returned_editor.selection,
+            int(returned_editor.scroll_y),
+            tuple(returned_editor.history.undo_stack),
+            tuple(returned_editor.history.redo_stack),
+            workspace.query_one("#file-notes-search", Input).value,
+            workspace._action_detail,
+        ) == folder_state
+        assert folder_node.is_expanded
+        assert workspace.save_state == "saved"
+        assert workspace._push_phase == "needs_attention"
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_folder_files_routes_rail_descendants_to_visible_authority(
+    tmp_path: Path,
+) -> None:
+    """Files shortcuts and rail actions never resolve hidden Database children."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica_path=tmp_path / "replica.sqlite",
+        poll_interval=10,
+    )
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), notes=[])
+    screen = LibraryScreen(app, file_notes_workspace_factory=lambda: workspace)
+
+    async with LibraryHarness(app, screen=screen).run_test(size=(160, 45)) as pilot:
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-notes-source-files")),
+            "Notes source chooser did not mount",
+        )
+        database_rail = screen.query_one("#library-rail")
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and workspace.is_mounted,
+            "Folder Files did not mount",
+        )
+
+        files_rail = workspace._reader_shell.library
+        database_search = database_rail.query_one("#library-search-input", Input)
+        files_search = files_rail.query_one("#library-search-input", Input)
+        tree = workspace.query_one("#file-notes-tree", Tree)
+        screen.set_focus(tree)
+        await pilot.press("/")
+        await pilot.pause()
+        assert screen.focused is files_search
+        assert screen.focused is not database_search
+
+        database_details = database_rail.query_one("#library-rail-section-body-details")
+        files_details = files_rail.query_one("#library-rail-section-body-details")
+        database_details_open = database_details.display
+        files_details_open = files_details.display
+        files_details_toggle = files_rail.query_one(
+            "#console-rail-section-toggle-library-details", Button
+        )
+        files_details_toggle.press()
+        await pilot.pause()
+        assert files_details.display is not files_details_open
+        assert database_details.display is database_details_open
+
+        screen._focus_library_rail_action(
+            "#console-rail-section-toggle-library-details"
+        )
+        assert screen.focused is files_details_toggle
+
+        screen._focus_library_rail_action("#library-ingest-top-button")
+        assert screen.focused is files_rail.query_one(
+            "#library-ingest-top-button", Button
+        )
+
+        screen._focus_library_rail_action("#library-rail-explore-all")
+        assert screen.focused is not None
+        assert files_rail in screen.focused.ancestors_with_self
+        assert database_rail not in screen.focused.ancestors_with_self
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_folder_files_explore_all_settles_focus_on_visible_rail_search(
+    tmp_path: Path,
+) -> None:
+    """Explore wins Files authority restoration after its real recompose."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica_path=tmp_path / "replica.sqlite",
+        poll_interval=10,
+    )
+    app = _build_test_app()
+    app.app_config.setdefault("library", {}).setdefault("rail_state", {})[
+        "lifecycle"
+    ] = "starter"
+    _seed_conversations(app, _two_conversations(), notes=[])
+    screen = LibraryScreen(app, file_notes_workspace_factory=lambda: workspace)
+
+    async with LibraryHarness(app, screen=screen).run_test(size=(160, 45)) as pilot:
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-notes-source-files")),
+            "Notes source chooser did not mount",
+        )
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and workspace.is_mounted,
+            "Folder Files did not mount",
+        )
+
+        files_rail = workspace._reader_shell.library
+        explore = files_rail.query_one("#library-rail-explore-all", Button)
+        folder_search = workspace.query_one("#file-notes-search", Input)
+        assert screen._library_lifecycle is LibraryLifecycle.STARTER
+        assert explore.visible and explore in screen.focus_chain
+
+        screen.set_focus(folder_search)
+        assert await pilot.click(explore)
+        await _wait_until(
+            pilot,
+            lambda: (
+                screen._library_lifecycle is LibraryLifecycle.EXPANDED
+                and workspace._active
+                and workspace.is_mounted
+                and screen._active_library_rail() is workspace._reader_shell.library
+                and workspace._reader_shell.library.lifecycle
+                is LibraryLifecycle.EXPANDED
+            ),
+            "Explore did not settle the expanded Files workspace",
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        visible_rail = workspace._reader_shell.library
+        visible_search = visible_rail.query_one("#library-search-input", Input)
+        assert screen.focused is visible_search
+        assert screen.focused is not folder_search
+        assert visible_rail in screen.focused.ancestors_with_self
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_folder_files_low_height_rail_scrolls_to_last_action(
+    tmp_path: Path,
+) -> None:
+    """The retained Files rail exposes its lower actions in a short viewport."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica_path=tmp_path / "replica.sqlite",
+        poll_interval=10,
+    )
+    app = _build_test_app()
+    app.app_config.setdefault("library", {}).setdefault("rail_state", {})[
+        "sections"
+    ] = {"details_open": True}
+    _seed_conversations(app, _two_conversations(), notes=[])
+    screen = LibraryScreen(app, file_notes_workspace_factory=lambda: workspace)
+
+    async with LibraryHarness(app, screen=screen).run_test(size=(160, 18)) as pilot:
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-notes-source-files")),
+            "Notes source chooser did not mount",
+        )
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and workspace.is_mounted,
+            "Folder Files did not mount",
+        )
+
+        files_rail = workspace._reader_shell.library
+        last_action = files_rail.query_one("#library-use-in-console", Button)
+        assert files_rail.query_one("#library-rail-section-body-details").display
+        assert files_rail.max_scroll_y > 0
+        assert files_rail.show_vertical_scrollbar is True
+
+        files_rail.scroll_end(animate=False)
+        await pilot.pause()
+        await pilot.pause()
+        rail_bottom = files_rail.region.y + files_rail.region.height
+        assert files_rail.region.y <= last_action.region.y
+        assert last_action.region.y + last_action.region.height <= rail_bottom
+        screen.set_focus(last_action)
+        assert screen.focused is last_action
+
+    await workspace.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("return_path", "size"),
+    (
+        ("task-return", (160, 45)),
+        ("source-button", (100, 35)),
+        ("escape", (160, 45)),
+    ),
+)
+@pytest.mark.asyncio
+async def test_notes_authority_switch_restores_visible_focus_and_typing_owner(
+    tmp_path: Path,
+    return_path: str,
+    size: tuple[int, int],
+) -> None:
+    """Every Files exit evacuates hidden focus and restores both editors."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "file.md").write_text("folder body", encoding="utf-8")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica_path=tmp_path / "replica.sqlite",
+        poll_interval=10,
+        autosave_delay=30,
+    )
+    app = _build_test_app()
+    _seed_conversations(
+        app,
+        _two_conversations(),
+        notes=[
+            {
+                "id": "db-note",
+                "title": "Database note",
+                "content": "database body",
+                "version": 1,
+                "keywords": [],
+            }
+        ],
+    )
+    screen = LibraryScreen(app, file_notes_workspace_factory=lambda: workspace)
+
+    async with LibraryHarness(app, screen=screen).run_test(size=size) as pilot:
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-notes-row-0")),
+            "Database Notes did not mount",
+        )
+        screen.query_one("#library-notes-row-0", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: bool(screen.query("#library-note-body")),
+            "Database editor did not mount",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_note_editor_armed,
+            message="Database editor did not settle before retained editing",
+        )
+        if size[0] >= 120:
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    screen._library_notes_work_session_phase
+                    is NotesWorkSessionPhase.ACTIVE
+                ),
+                message="Database work-first did not settle before retained editing",
+            )
+        database_editor = screen.query_one("#library-note-body", TextArea)
+        _replace_editor_text(database_editor, "database retained")
+        database_editor.selection = database_editor.selection.__class__(
+            (0, len("database retained")),
+            (0, len("database retained")),
+        )
+        screen.set_focus(database_editor)
+        await pilot.pause()
+
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and workspace.is_mounted,
+            "Folder Files did not mount",
+        )
+        assert await workspace.open_path("file.md")
+        folder_editor = workspace.query_one("#file-notes-editor", TextArea)
+        _replace_editor_text(folder_editor, "folder retained")
+        folder_editor.selection = folder_editor.selection.__class__(
+            (0, len("folder retained")),
+            (0, len("folder retained")),
+        )
+        assert await workspace.flush_pending_work()
+        screen.set_focus(folder_editor)
+        await pilot.pause()
+
+        if return_path == "task-return":
+            assert screen.query_one("#library-notes-task-return", Button).display
+            await pilot.click("#library-notes-task-return")
+        elif return_path == "source-button":
+            database_source = screen.query_one("#library-notes-source-database", Button)
+            assert database_source.display
+            await pilot.click("#library-notes-source-database")
+        else:
+            await pilot.press("escape")
+        await _wait_until(
+            pilot,
+            lambda: screen._library_notes_source == "database",
+            f"{return_path} did not return to Database Notes",
+        )
+        await _wait_until(
+            pilot,
+            lambda: screen.focused is database_editor,
+            f"{return_path} did not restore the Database editor focus",
+        )
+        assert screen.focused is database_editor
+        assert screen.focused.visible
+        assert not workspace.display
+        assert screen.query_one("#library-notes-reader-shell").display
+        folder_before_database_type = folder_editor.text
+        await pilot.press("x")
+        assert database_editor.text == "database retainedx"
+        assert folder_editor.text == folder_before_database_type
+
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: screen._library_notes_source == "files",
+            "Folder Files did not reopen",
+        )
+        await _wait_until(
+            pilot,
+            lambda: screen.focused is folder_editor,
+            "Folder Files did not restore its retained editor focus",
+        )
+        assert screen.focused is folder_editor
+        assert screen.focused.visible
+        assert workspace.display
+        assert not screen.query_one("#library-notes-reader-shell").display
+        database_before_folder_type = database_editor.text
+        await pilot.press("y")
+        assert folder_editor.text == f"{folder_before_database_type}y"
+        assert database_editor.text == database_before_folder_type
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_file_notes_field_labels_persist_across_path_context(
     tmp_path: Path,
 ) -> None:
@@ -418,21 +1605,37 @@ async def test_file_notes_field_labels_persist_across_path_context(
         assert str(search_label.renderable) == "Search"
         expected_label = "Target path · New / Move / Save copy"
         assert str(path_label.renderable) == expected_label
-        workspace._navigator_mode = "git"
-        workspace._sync_navigator_mode()
-        assert not workspace.query_one("#file-notes-search-row").display
-        workspace._navigator_mode = "files"
-        workspace._sync_navigator_mode()
+        workspace.query_one("#file-notes-manage", Button).press()
+        await pilot.pause()
         assert workspace.query_one("#file-notes-search-row").display
         search.value = "body"
+        workspace.query_one("#file-notes-new", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.path_task == "new",
+            "new path task did not open",
+        )
+        assert str(path_label.renderable) == "New file path"
         path.value = "created.md"
         await pilot.pause()
         assert str(search_label.renderable) == "Search"
+        workspace.query_one("#file-notes-path-cancel", Button).press()
+        await pilot.pause()
+        assert workspace.path_task == "none"
         assert str(path_label.renderable) == expected_label
 
         assert await workspace.open_path("open.md")
         assert str(path_label.renderable) == expected_label
+        workspace.query_one("#file-notes-move", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.path_task == "move",
+            "move path task did not open",
+        )
+        assert str(path_label.renderable) == "Move file to"
         path.value = "moved.md"
+        await pilot.pause()
+        workspace.query_one("#file-notes-path-cancel", Button).press()
         await pilot.pause()
         assert str(path_label.renderable) == expected_label
 
@@ -493,6 +1696,12 @@ async def test_file_notes_field_labels_preserve_input_geometry_and_tab_access(
 
         assert await workspace.open_path("open.md")
         await pilot.pause()
+        workspace.query_one("#file-notes-new", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.path_task == "new",
+            "New path task did not open",
+        )
         path_label = workspace.query_one("#file-notes-path-label", Static)
         path = workspace.query_one("#file-notes-path", Input)
         for _ in range(80):
@@ -502,9 +1711,8 @@ async def test_file_notes_field_labels_preserve_input_geometry_and_tab_access(
         assert path.has_focus
         assert path_label.region.width > 0
         assert path.region.width >= 10
-        assert path_label.render_line(0).text.strip() == (
-            "Target path · New / Move / Save copy"
-        )
+        painted_label = path_label.render_line(0).text.strip()
+        assert painted_label == "New file path"
         assert path_label.region.bottom <= path.region.y
         assert path.region.right <= workspace.region.right
 
@@ -514,6 +1722,916 @@ async def test_file_notes_field_labels_preserve_input_geometry_and_tab_access(
 def _replace_editor_text(editor: TextArea, text: str) -> None:
     editor.select_all()
     editor.replace(text, editor.selection.start, editor.selection.end)
+
+
+@pytest.mark.asyncio
+async def test_folder_files_capability_inventory_and_modes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Folder Files exposes Edit/Manage without inventing Preview or Save."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "working.md").write_text("body", encoding="utf-8")
+    replica = FileNotesReplica(":memory:")
+    workspace = LibraryFileNotesWorkspace(root=root, replica=replica, poll_interval=10)
+
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("working.md")
+        assert tuple(
+            str(button.label)
+            for button in workspace.query_one("#file-notes-mode-controls").query(Button)
+        ) == ("Edit", "Manage")
+        assert not workspace.query("#file-notes-preview")
+        assert not workspace.query("#file-notes-save")
+        assert workspace.query_one("#file-notes-new", Button).parent is (
+            workspace.query_one("#file-notes-tree-header")
+        )
+        for selector in (
+            "#file-notes-choose-root",
+            "#file-notes-root-details",
+            "#file-notes-search",
+            "#file-notes-tree",
+            "#file-notes-new",
+            "#file-notes-move",
+            "#file-notes-save-copy",
+            "#file-notes-restore",
+            "#file-notes-compare",
+            "#file-notes-resolve-conflict",
+            "#file-notes-recovery-reload",
+            "#file-notes-reload",
+            "#file-notes-protect",
+            "#file-notes-refresh",
+            "#file-notes-maintenance-toggle",
+            "#file-notes-delete",
+            "#file-notes-session-changes",
+        ):
+            assert workspace.query_one(selector)
+        workspace.query_one("#file-notes-new", Button).press()
+        await _wait_until(
+            pilot, lambda: workspace.path_task == "new", "New did not open"
+        )
+        workspace.query_one("#file-notes-path-cancel", Button).press()
+        await _wait_until(
+            pilot, lambda: workspace.path_task == "none", "New did not cancel"
+        )
+        workspace.query_one("#file-notes-manage", Button).press()
+        await pilot.pause()
+        manage = workspace.query_one("#file-notes-manage-region")
+        assert manage.display
+        assert tuple(
+            str(section.renderable) for section in manage.query(".destination-section")
+        ) == (
+            "File details & path",
+            "File actions",
+            "Session Git",
+            "Danger",
+        )
+        save_copy = workspace.query_one("#file-notes-save-copy", Button)
+        assert save_copy.disabled
+        assert str(save_copy.label).startswith(LIBRARY_DISABLED_ACTION_MARKER)
+        assert save_copy.tooltip
+
+        workspace.query_one("#file-notes-move", Button).press()
+        await _wait_until(
+            pilot, lambda: workspace.path_task == "move", "Move did not open"
+        )
+        workspace.query_one("#file-notes-path-cancel", Button).press()
+        await _wait_until(
+            pilot, lambda: workspace.path_task == "none", "Move did not cancel"
+        )
+
+        maintenance = workspace.query_one("#file-notes-maintenance-actions")
+        workspace.query_one("#file-notes-maintenance-toggle", Button).press()
+        await _wait_until(
+            pilot, lambda: maintenance.display, "maintenance did not open"
+        )
+        protect = workspace.query_one("#file-notes-protect", Button)
+        protect.press()
+        await _wait_until(
+            pilot,
+            lambda: bool(
+                workspace.current_document and workspace.current_document.protected
+            ),
+            "Protect did not reach the file service",
+        )
+        protect.press()
+        await _wait_until(
+            pilot,
+            lambda: bool(
+                workspace.current_document and not workspace.current_document.protected
+            ),
+            "Unprotect did not reach the file service",
+        )
+        service = workspace._service
+        assert service is not None
+        open_calls: list[str] = []
+        reconcile_calls: list[bool] = []
+        original_open = service.open_file
+        original_reconcile = service.reconcile
+
+        def tracked_open(relative_path: str):
+            opened = original_open(relative_path)
+            open_calls.append(relative_path)
+            return opened
+
+        def tracked_reconcile():
+            reconcile_calls.append(True)
+            return original_reconcile()
+
+        monkeypatch.setattr(service, "open_file", tracked_open)
+        monkeypatch.setattr(service, "reconcile", tracked_reconcile)
+        workspace.query_one("#file-notes-reload", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: open_calls == ["working.md"] and not workspace._path_transitioning,
+            "Reload did not call the file service for the selected path",
+        )
+        refresh = workspace.query_one("#file-notes-refresh", Button)
+        await _wait_until(
+            pilot,
+            lambda: not refresh.disabled,
+            "Refresh did not become available after Reload",
+        )
+        refresh.press()
+        await _wait_until(
+            pilot,
+            lambda: reconcile_calls == [True],
+            "Refresh did not call the file-service reconciliation seam",
+        )
+
+        delete = workspace.query_one("#file-notes-delete", Button)
+        delete.press()
+        await _wait_until(
+            pilot,
+            lambda: workspace._delete_confirmation_path == "working.md",
+            "Delete confirmation did not open",
+        )
+        delete.press()
+        await _wait_until(
+            pilot,
+            lambda: workspace._selected_deleted_path == "working.md",
+            "Delete did not reach the file service",
+        )
+        restore = workspace.query_one("#file-notes-restore", Button)
+        assert restore.display and not restore.disabled
+        restore.press()
+        await _wait_until(
+            pilot,
+            lambda: (
+                workspace.current_path == "working.md"
+                and (root / "working.md").exists()
+            ),
+            "Restore did not reopen the service result",
+        )
+
+    await workspace.shutdown()
+    replica.close()
+
+
+@pytest.mark.asyncio
+async def test_folder_files_primary_safe_recovery_actions_bypass_manage(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "conflict.md").write_text("disk", encoding="utf-8")
+    workspace = LibraryFileNotesWorkspace(root=root, replica=None, poll_interval=10)
+
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("conflict.md")
+        workspace._set_save_state("conflict", "file changed on disk")
+        await pilot.pause()
+        assert workspace.work_mode == "edit"
+        assert workspace.query_one("#file-notes-edit", Button).has_class("is-active")
+        assert not workspace.query_one("#file-notes-manage-region").display
+        for selector in (
+            "#file-notes-compare",
+            "#file-notes-resolve-conflict",
+            "#file-notes-recovery-reload",
+            "#file-notes-recovery-save-copy",
+        ):
+            action = workspace.query_one(selector, Button)
+            assert action.display and not action.disabled
+        workspace.query_one("#file-notes-recovery-save-copy", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.path_task == "save_copy",
+            "recovery Save Copy did not open its named task",
+        )
+        assert workspace.query_one("#file-notes-path-task").display
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_folder_files_edit_manage_retains_editor_git_and_recovery(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "retained.md").write_text("base", encoding="utf-8")
+    workspace = LibraryFileNotesWorkspace(root=root, replica=None, poll_interval=10)
+
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("retained.md")
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        git_panel = workspace.query_one("#file-notes-git-panel")
+        recovery = workspace.query_one("#file-notes-resolution-actions")
+        _replace_editor_text(editor, "retained draft")
+        workspace._set_save_state("conflict")
+        workspace._set_conflict_resolution(True)
+        await pilot.pause()
+
+        workspace.query_one("#file-notes-manage", Button).press()
+        await pilot.pause()
+        assert workspace.work_mode == "manage"
+        assert workspace.query_one("#file-notes-manage", Button).has_class("is-active")
+        assert not workspace.query_one("#file-notes-edit-region").display
+        workspace.query_one("#file-notes-edit", Button).press()
+        await pilot.pause()
+        assert workspace.work_mode == "edit"
+        assert workspace.query_one("#file-notes-editor", TextArea) is editor
+        assert workspace.query_one("#file-notes-git-panel") is git_panel
+        assert workspace.query_one("#file-notes-resolution-actions") is recovery
+        assert editor.text == "retained draft"
+        assert workspace.conflict_resolution_active
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_folder_files_path_tasks_are_exclusive_execute_and_restore_focus(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "source.md").write_text("source", encoding="utf-8")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=None,
+        autosave_delay=10,
+        poll_interval=10,
+    )
+
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("source.md")
+        path_task = workspace.query_one("#file-notes-path-task")
+        target = workspace.query_one("#file-notes-path", Input)
+        assert workspace.path_task == "none"
+        assert not path_task.display
+
+        new = workspace.query_one("#file-notes-new", Button)
+        new.press()
+        await _wait_until(pilot, lambda: workspace.path_task == "new", "New task")
+        assert path_task.display
+        target.value = "created.md"
+        workspace.query_one("#file-notes-path-submit", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.current_path == "created.md",
+            "New task did not execute",
+        )
+        assert workspace.path_task == "none"
+        assert (root / "created.md").exists()
+        await _wait_until(pilot, lambda: new.has_focus, "New focus was not restored")
+
+        workspace.query_one("#file-notes-manage", Button).press()
+        await pilot.pause()
+        move = workspace.query_one("#file-notes-move", Button)
+        move.press()
+        await _wait_until(pilot, lambda: workspace.path_task == "move", "Move task")
+        target.value = "moved.md"
+        workspace.query_one("#file-notes-path-cancel", Button).press()
+        await _wait_until(pilot, lambda: workspace.path_task == "none", "Cancel task")
+        await _wait_until(pilot, lambda: move.has_focus, "Move focus was not restored")
+
+        move.press()
+        await _wait_until(pilot, lambda: workspace.path_task == "move", "Move task")
+        target.value = "moved.md"
+        workspace.query_one("#file-notes-path-submit", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.current_path == "moved.md",
+            "Move task did not execute",
+        )
+        assert not (root / "created.md").exists()
+        await _wait_until(
+            pilot, lambda: move.has_focus, "Move success focus was not restored"
+        )
+
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        _replace_editor_text(editor, "copy draft")
+        workspace._set_save_state("conflict")
+        workspace.query_one("#file-notes-edit", Button).press()
+        await pilot.pause()
+        recovery_copy = workspace.query_one("#file-notes-recovery-save-copy", Button)
+        assert recovery_copy.display and not recovery_copy.disabled
+        recovery_copy.press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.path_task == "save_copy",
+            "Save Copy task",
+        )
+        workspace.query_one("#file-notes-manage", Button).press()
+        await pilot.pause()
+        workspace.query_one("#file-notes-path-cancel", Button).press()
+        await _wait_until(pilot, lambda: workspace.path_task == "none", "Cancel task")
+        manage_copy = workspace.query_one("#file-notes-save-copy", Button)
+        await _wait_until(
+            pilot,
+            lambda: manage_copy.has_focus,
+            "Save Copy focus did not move to the visible Manage equivalent",
+        )
+        workspace.query_one("#file-notes-edit", Button).press()
+        await pilot.pause()
+        recovery_copy.press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.path_task == "save_copy",
+            "Save Copy task did not reopen",
+        )
+        target.value = "copy.md"
+        workspace.query_one("#file-notes-path-submit", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.current_path == "copy.md",
+            "Save Copy task did not execute",
+        )
+        assert (root / "copy.md").read_text(encoding="utf-8") == "copy draft"
+        await _wait_until(
+            pilot,
+            lambda: workspace.query_one("#file-notes-editor", TextArea).has_focus,
+            "Save Copy success did not restore a visible Edit focus target",
+        )
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("task", ("new", "move"))
+@pytest.mark.parametrize("exit_kind", ("authority", "root"))
+async def test_folder_files_path_task_admission_expires_while_flushing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    task: str,
+    exit_kind: str,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "source.md").write_text("source", encoding="utf-8")
+    next_root = tmp_path / "next-notes"
+    next_root.mkdir()
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=None,
+        autosave_delay=10,
+        poll_interval=10,
+    )
+    flush_started = asyncio.Event()
+    release_flush = asyncio.Event()
+    flush_calls = 0
+
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+        assert await workspace.open_path("source.md")
+
+        async def controlled_flush() -> bool:
+            nonlocal flush_calls
+            flush_calls += 1
+            if flush_calls == 1:
+                flush_started.set()
+                await release_flush.wait()
+            return True
+
+        monkeypatch.setattr(workspace, "flush_pending_work", controlled_flush)
+        opening = asyncio.create_task(
+            workspace._open_path_task(
+                task,
+                opener_id=f"file-notes-{task}",
+            )
+        )
+        await asyncio.wait_for(flush_started.wait(), 2)
+
+        root_changed = True
+        if exit_kind == "authority":
+            workspace.display = False
+        else:
+            root_changed = await workspace.set_root(next_root, persist=False)
+        release_flush.set()
+        admitted = await opening
+        await pilot.pause()
+
+        assert root_changed
+        assert admitted is False
+        assert workspace.path_task == "none"
+        assert not workspace.query_one("#file-notes-path-task").display
+        assert not workspace.query_one("#file-notes-path", Input).has_focus
+
+        if exit_kind == "authority":
+            workspace.display = True
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_folder_files_emits_only_admitted_work_session_events(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "first.md").write_text("first", encoding="utf-8")
+    (root / "second.md").write_text("second", encoding="utf-8")
+    next_root = tmp_path / "next-notes"
+    next_root.mkdir()
+    (next_root / "next.md").write_text("next", encoding="utf-8")
+    stale_root = tmp_path / "stale-notes"
+    stale_root.mkdir()
+    (stale_root / "stale.md").write_text("stale", encoding="utf-8")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica_path=tmp_path / "replica.sqlite",
+        poll_interval=10,
+        autosave_delay=30,
+    )
+    captured: list[object] = []
+
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 30)) as pilot:
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized,
+            "Folder Files did not initialize",
+        )
+        message_types = (
+            workspace_module.FileNotesEditableOpened,
+            workspace_module.FileNotesIdentityCleared,
+            workspace_module.FileNotesRootChanged,
+        )
+        post_message = workspace.post_message
+
+        def capture(message):
+            if isinstance(message, message_types):
+                captured.append(message)
+            return post_message(message)
+
+        monkeypatch.setattr(workspace, "post_message", capture)
+
+        assert await workspace.open_path("missing.md") is False
+        assert captured == []
+
+        service = workspace._service
+        assert service is not None
+        original_open = service.open_file
+        stale_started = threading.Event()
+        release_stale = threading.Event()
+
+        def delayed_open(relative_path: str):
+            stale_started.set()
+            assert release_stale.wait(5)
+            return original_open(relative_path)
+
+        monkeypatch.setattr(service, "open_file", delayed_open)
+        stale_open = asyncio.create_task(workspace.open_path("first.md"))
+        assert await asyncio.to_thread(stale_started.wait, 5)
+        workspace._root_generation += 1
+        release_stale.set()
+        assert await stale_open is False
+        assert captured == []
+        monkeypatch.setattr(service, "open_file", original_open)
+
+        cancelled_started = threading.Event()
+        release_cancelled = threading.Event()
+
+        def cancelled_open(relative_path: str):
+            cancelled_started.set()
+            assert release_cancelled.wait(5)
+            return original_open(relative_path)
+
+        monkeypatch.setattr(service, "open_file", cancelled_open)
+        cancelled_task = asyncio.create_task(workspace.open_path("first.md"))
+        assert await asyncio.to_thread(cancelled_started.wait, 5)
+        cancelled_task.cancel()
+        release_cancelled.set()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled_task
+        assert captured == []
+        monkeypatch.setattr(service, "open_file", original_open)
+
+        assert await workspace.open_path("first.md") is True
+        await pilot.pause()
+        assert len(captured) == 1
+        assert isinstance(captured[0], workspace_module.FileNotesEditableOpened)
+        assert captured[0].identity == "first.md"
+
+        await pilot.resize_terminal(79, 30)
+        await _wait_until(
+            pilot,
+            lambda: workspace.narrow,
+            "Folder Files did not enter narrow navigation",
+        )
+        workspace.query_one("#file-notes-back", Button).press()
+        await pilot.pause()
+        assert workspace.current_path == "first.md"
+        assert len(captured) == 1
+
+        assert await workspace.set_root(root, persist=False) is True
+        await pilot.pause()
+        assert workspace.current_path == ""
+        assert [type(message) for message in captured] == [
+            workspace_module.FileNotesEditableOpened,
+            workspace_module.FileNotesIdentityCleared,
+        ]
+        assert await workspace.open_path("first.md") is True
+        await pilot.pause()
+        assert len(captured) == 3
+
+        rejected_root = tmp_path / "rejected-notes"
+        rejected_root.mkdir()
+        original_commit = workspace._commit_root_candidate
+
+        async def reject_root(*args, **kwargs) -> bool:
+            return False
+
+        monkeypatch.setattr(workspace, "_commit_root_candidate", reject_root)
+        assert await workspace.set_root(rejected_root, persist=False) is False
+        assert len(captured) == 3
+        monkeypatch.setattr(workspace, "_commit_root_candidate", original_commit)
+
+        original_scan = workspace_module.FileNotesService.scan
+        stale_started = threading.Event()
+        release_stale_root = threading.Event()
+
+        def delayed_root_scan(candidate: FileNotesService):
+            if candidate.root_key == str(stale_root.resolve()):
+                stale_started.set()
+                assert release_stale_root.wait(5)
+            return original_scan(candidate)
+
+        monkeypatch.setattr(
+            workspace_module.FileNotesService,
+            "scan",
+            delayed_root_scan,
+        )
+        stale_root_task = asyncio.create_task(
+            workspace.set_root(stale_root, persist=False)
+        )
+        assert await asyncio.to_thread(stale_started.wait, 5)
+        workspace._active = False
+        release_stale_root.set()
+        assert await stale_root_task is False
+        assert len(captured) == 3
+        workspace._active = True
+        monkeypatch.setattr(
+            workspace_module.FileNotesService,
+            "scan",
+            original_scan,
+        )
+
+        assert await workspace.set_root(next_root, persist=False) is True
+        await pilot.pause()
+        assert len(captured) == 4
+        assert isinstance(captured[3], workspace_module.FileNotesRootChanged)
+        assert captured[3].root == next_root.resolve()
+
+        assert await workspace.open_path("next.md") is True
+        workspace._clear_open_document()
+        await pilot.pause()
+        assert [type(message) for message in captured] == [
+            workspace_module.FileNotesEditableOpened,
+            workspace_module.FileNotesIdentityCleared,
+            workspace_module.FileNotesEditableOpened,
+            workspace_module.FileNotesRootChanged,
+            workspace_module.FileNotesEditableOpened,
+            workspace_module.FileNotesIdentityCleared,
+        ]
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_folder_notes_work_session_activates_once_and_resets_exactly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "first.md").write_text("first", encoding="utf-8")
+    (root / "second.md").write_text("second", encoding="utf-8")
+    next_root = tmp_path / "next-notes"
+    next_root.mkdir()
+    (next_root / "next.md").write_text("next", encoding="utf-8")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica_path=tmp_path / "replica.sqlite",
+        poll_interval=10,
+        autosave_delay=30,
+    )
+    app = _build_test_app()
+    app.app_config.setdefault("library", {}).setdefault("reader", {})[
+        "library_open"
+    ] = True
+    _seed_conversations(app, _two_conversations(), notes=[])
+    writes: list[tuple[str, str, bool]] = []
+    monkeypatch.setattr(
+        library_screen_module,
+        "save_setting_to_cli_config",
+        lambda section, key, value: (writes.append((section, key, value)), True)[1],
+    )
+    screen = LibraryScreen(app, file_notes_workspace_factory=lambda: workspace)
+
+    async with LibraryHarness(app, screen=screen).run_test(size=(160, 45)) as pilot:
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_for_selector(screen, pilot, "#library-notes-source-files")
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and workspace.is_mounted,
+            "Folder Files did not mount",
+        )
+        shell = workspace.query_one(
+            "#library-file-notes-reader-shell", LibraryAdaptiveReaderShell
+        )
+
+        assert (
+            screen._library_notes_work_session_phase is NotesWorkSessionPhase.INACTIVE
+        )
+        assert shell.effective_layout.library_open is True
+        assert writes == []
+
+        assert await workspace.open_path("first.md")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_notes_work_session_phase is NotesWorkSessionPhase.ACTIVE
+                and not shell.effective_layout.library_open
+            ),
+            message="Folder editable open did not activate work-first layout",
+        )
+        assert screen._library_file_notes_reader_preferences.library_open is True
+        assert writes == []
+
+        shell.library_grip.press()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_notes_work_session_phase
+                is NotesWorkSessionPhase.MANUALLY_CANCELLED
+                and shell.effective_layout.library_open
+            ),
+            message="Saved-open Folder expansion did not cancel work-first",
+        )
+        assert writes == []
+        assert await workspace.open_path("second.md")
+        await pilot.pause()
+        assert (
+            screen._library_notes_work_session_phase
+            is NotesWorkSessionPhase.MANUALLY_CANCELLED
+        )
+
+        await pilot.resize_terminal(79, 30)
+        await _wait_until(
+            pilot,
+            lambda: workspace.narrow,
+            "Folder Files did not enter narrow navigation",
+        )
+        workspace.query_one("#file-notes-back", Button).press()
+        await pilot.pause()
+        assert workspace.current_path == "second.md"
+        assert (
+            screen._library_notes_work_session_phase
+            is NotesWorkSessionPhase.MANUALLY_CANCELLED
+        )
+        assert writes == []
+
+        workspace._clear_open_document()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_notes_work_session_phase
+                is NotesWorkSessionPhase.INACTIVE
+            ),
+            message="Explicit Folder identity clear did not reset work session",
+        )
+        await pilot.resize_terminal(160, 45)
+        await _wait_until(
+            pilot,
+            lambda: not workspace.narrow,
+            "Folder Files did not restore wide geometry",
+        )
+        assert await workspace.open_path("first.md")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_notes_work_session_phase is NotesWorkSessionPhase.ACTIVE
+            ),
+            message="Folder session did not reactivate after an exact clear",
+        )
+        assert writes == []
+
+        assert await workspace.set_root(next_root, persist=False)
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_notes_work_session_phase
+                is NotesWorkSessionPhase.INACTIVE
+            ),
+            message="Admitted Folder root change did not reset work session",
+        )
+        shell.library_grip.press()
+        await _wait_for_condition(
+            pilot,
+            lambda: writes == [("library.reader", "library_open", False)],
+            message="Folder saved-closed request did not persist",
+        )
+        writes.clear()
+        assert await workspace.open_path("next.md")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_notes_work_session_phase is NotesWorkSessionPhase.ACTIVE
+            ),
+            message="Folder saved-closed work session did not activate",
+        )
+        assert writes == []
+        shell.library_grip.press()
+        await _wait_for_condition(
+            pilot,
+            lambda: writes == [("library.reader", "library_open", True)],
+            message="Folder saved-closed expansion did not persist once",
+        )
+        assert (
+            screen._library_notes_work_session_phase
+            is NotesWorkSessionPhase.MANUALLY_CANCELLED
+        )
+
+        writes.clear()
+        await screen._select_library_rail_row(LIBRARY_ROW_CREATE_NOTE)
+        await _wait_for_selector(screen, pilot, "#library-notes-create-blank")
+        assert screen._library_notes_source == "database"
+        assert (
+            screen._library_notes_work_session_phase is NotesWorkSessionPhase.INACTIVE
+        )
+        assert writes == []
+
+        screen.query_one("#library-notes-create-blank", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-note-body")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_notes_work_session_phase is NotesWorkSessionPhase.ACTIVE
+            ),
+            message="Created Database note did not start a fresh work session",
+        )
+        assert writes == []
+
+        screen.apply_navigation_context({"ingest_media": True})
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_selected_row_id == LIBRARY_ROW_INGEST_MEDIA,
+            message="Deep link did not leave Notes",
+        )
+        assert (
+            screen._library_notes_work_session_phase is NotesWorkSessionPhase.INACTIVE
+        )
+        assert writes == []
+
+    await workspace.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_notes_authority_round_trip_resets_only_transient_work_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "file.md").write_text("folder body", encoding="utf-8")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica_path=tmp_path / "replica.sqlite",
+        poll_interval=10,
+        autosave_delay=30,
+    )
+    app = _build_test_app()
+    app.app_config.setdefault("library", {}).setdefault("reader", {})[
+        "library_open"
+    ] = True
+    _seed_conversations(app, _two_conversations(), notes=[_two_notes()[0]])
+    writes: list[tuple[str, str, bool]] = []
+    monkeypatch.setattr(
+        library_screen_module,
+        "save_setting_to_cli_config",
+        lambda section, key, value: (writes.append((section, key, value)), True)[1],
+    )
+    screen = LibraryScreen(app, file_notes_workspace_factory=lambda: workspace)
+
+    async with LibraryHarness(app, screen=screen).run_test(size=(160, 45)) as pilot:
+        await _wait_for_library_shell(screen, pilot)
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_NOTES)
+        await _wait_for_selector(screen, pilot, "#library-notes-row-0")
+        screen.query_one("#library-notes-row-0", Button).press()
+        database_editor = await _wait_for_selector(screen, pilot, "#library-note-body")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_notes_work_session_phase is NotesWorkSessionPhase.ACTIVE
+            ),
+            message="Database work session did not activate",
+        )
+        database_id = screen._selected_note_id
+        database_preferences = screen._library_notes_reader_preferences
+        folder_preferences = screen._library_file_notes_reader_preferences
+
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.initialized and workspace.is_mounted,
+            "Folder Files did not mount",
+        )
+        assert (
+            screen._library_notes_work_session_phase is NotesWorkSessionPhase.INACTIVE
+        )
+        assert await workspace.open_path("file.md")
+        folder_editor = workspace.query_one("#file-notes-editor", TextArea)
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_notes_work_session_phase is NotesWorkSessionPhase.ACTIVE
+            ),
+            message="Folder work session did not activate",
+        )
+
+        await pilot.click("#library-notes-task-return")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_notes_source == "database",
+            message="Database Notes did not return",
+        )
+        assert (
+            screen._library_notes_work_session_phase is NotesWorkSessionPhase.INACTIVE
+        )
+        assert screen._selected_note_id == database_id
+        assert screen.query_one("#library-note-body", TextArea) is database_editor
+        assert screen._library_notes_reader_preferences == database_preferences
+        assert screen._library_file_notes_reader_preferences == folder_preferences
+
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_notes_source == "files",
+            message="Folder Files did not return",
+        )
+        assert (
+            screen._library_notes_work_session_phase is NotesWorkSessionPhase.INACTIVE
+        )
+        assert workspace.current_path == "file.md"
+        assert workspace.query_one("#file-notes-editor", TextArea) is folder_editor
+        assert screen._library_notes_reader_preferences == database_preferences
+        assert screen._library_file_notes_reader_preferences == folder_preferences
+        assert writes == []
+
+        assert await workspace.open_path("file.md")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_notes_work_session_phase is NotesWorkSessionPhase.ACTIVE
+            ),
+            message="Folder work session did not reactivate before Search",
+        )
+        await screen._select_library_rail_row(LIBRARY_ROW_BROWSE_SEARCH)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_selected_row_id == LIBRARY_ROW_BROWSE_SEARCH,
+            message="Search destination did not open",
+        )
+        assert screen._library_notes_source == "files"
+        assert (
+            screen._library_notes_work_session_phase is NotesWorkSessionPhase.INACTIVE
+        )
+
+        await screen._open_library_item_by_id("notes", database_id)
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_notes_source == "database"
+                and screen._selected_note_id == database_id
+                and screen._library_notes_work_session_phase
+                is NotesWorkSessionPhase.ACTIVE
+            ),
+            message="Search note open did not establish Database Notes authority",
+        )
+        assert workspace.current_path == "file.md"
+        assert screen._library_notes_reader_preferences == database_preferences
+        assert screen._library_file_notes_reader_preferences == folder_preferences
+        assert writes == []
+
+    await workspace.shutdown()
 
 
 def _visible_editor_action_ids(
@@ -542,14 +2660,15 @@ def _visible_primary_action_labels(
 def _assert_visible_editor_actions_fit(
     workspace: LibraryFileNotesWorkspace,
 ) -> None:
-    """Assert disclosed actions keep complete labels inside the editor pane."""
+    """Assert disclosed actions keep complete labels in the scrollable pane."""
     pane = workspace.query_one("#file-notes-editor-pane")
+    manage = workspace.query_one("#file-notes-manage-region")
     visible = tuple(
         (toolbar, button)
         for toolbar in pane.query(".file-notes-toolbar")
-        if toolbar.display
+        if toolbar.region.width > 0 and toolbar.id != "file-notes-mode-controls"
         for button in toolbar.query(Button)
-        if button.display
+        if button.region.width > 0
     )
     assert visible
     for toolbar, button in visible:
@@ -570,7 +2689,14 @@ def _assert_visible_editor_actions_fit(
             button.id,
             button.region,
         )
-        assert pane.content_region.contains_region(button.region)
+        scroll_owner = manage if manage in button.ancestors else pane
+        assert scroll_owner.content_region.x <= button.region.x
+        assert button.region.right <= scroll_owner.content_region.right
+        assert scroll_owner.content_region.y <= button.region.y
+        assert (
+            button.region.bottom
+            <= scroll_owner.content_region.bottom + scroll_owner.max_scroll_y
+        )
 
 
 async def _show_maintenance_actions(
@@ -578,13 +2704,21 @@ async def _show_maintenance_actions(
     pilot,
 ) -> None:
     """Open the retained secondary-action disclosure through its real control."""
+    if workspace.work_mode != "manage":
+        workspace.query_one("#file-notes-manage", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.work_mode == "manage",
+            "Manage mode did not open",
+        )
     toolbar = workspace.query_one("#file-notes-maintenance-actions")
-    if toolbar.display:
+    protect = workspace.query_one("#file-notes-protect", Button)
+    if protect.display:
         return
     workspace.query_one("#file-notes-maintenance-toggle", Button).press()
     await _wait_until(
         pilot,
-        lambda: toolbar.display,
+        lambda: toolbar.display and protect.display,
         "Maintenance actions did not open",
     )
 
@@ -655,8 +2789,9 @@ async def test_folder_files_authority_row_tracks_root_save_and_session_git(
         assert workspace.children[0] is authority
         assert authority._render_markup is False
         assert _static_text(workspace, "#file-notes-authority") == (
-            "Folder files · No folder selected · Next: Choose folder."
+            "Folder Files · No folder selected"
         )
+        assert "Choose folder" in _static_text(workspace, "#file-notes-save-status")
 
         workspace._root = root
         workspace._root_offline = False
@@ -667,22 +2802,20 @@ async def test_folder_files_authority_row_tracks_root_save_and_session_git(
         )
 
         workspace._set_save_state("error", "permission denied")
-        save_failure = _static_text(workspace, "#file-notes-authority")
+        save_failure = _static_text(workspace, "#file-notes-save-status")
         assert "Save failed" in save_failure
-        assert "permission denied" not in save_failure
-        assert "permission denied" in _static_text(
-            workspace,
-            "#file-notes-save-status",
+        assert "draft remains" in save_failure
+        assert "Next: Save Copy." in save_failure
+        assert _static_text(workspace, "#file-notes-save-detail") == (
+            "Content detail: permission denied"
         )
-        assert "Next: Retry/copy." in save_failure
 
         workspace._set_save_state("saved")
         workspace._push_phase = "needs_attention"
         workspace._render_session_git_label(2)
         git_attention = _static_text(workspace, "#file-notes-authority")
-        assert "Saved" in git_attention
-        assert "Session Git: 2 · Push attention" in git_attention
-        assert "Next: Review changes." in git_attention
+        assert "Outcome uncertain" in git_attention
+        assert "Saved" in _static_text(workspace, "#file-notes-save-status")
     replica.close()
 
 
@@ -708,8 +2841,7 @@ async def test_folder_files_authority_status_survives_in_surface_navigation(
         await pilot.pause()
 
         assert _static_text(workspace, "#file-notes-authority") == expected
-        assert "Push attention" in expected
-        assert "Next: Review changes." in expected
+        assert "Outcome uncertain" in expected
 
     await workspace.shutdown()
     replica.close()
@@ -752,13 +2884,13 @@ async def test_folder_files_authority_merges_save_and_git_in_either_update_order
 
         expected = _static_text(workspace, "#file-notes-authority")
         assert "Folder: notes" in expected
-        assert (
-            "Conflict" if save_state == "conflict" else "Save failed"
-        ) in expected
-        assert save_detail not in expected
-        assert save_detail in _static_text(workspace, "#file-notes-save-status")
-        assert "Session Git: 1 change" in expected
-        assert "Next:" in expected
+        content = _static_text(workspace, "#file-notes-save-status")
+        assert ("Conflict" if save_state == "conflict" else "Save failed") in content
+        assert _static_text(workspace, "#file-notes-save-detail") == (
+            f"Content detail: {save_detail}"
+        )
+        assert "Git · 1 change" in expected
+        assert "Next:" in content
 
         workspace._navigator_mode = "git"
         workspace._sync_navigator_mode()
@@ -791,20 +2923,24 @@ async def test_file_notes_authority_copy_is_complete_and_bounded(
         replica=replica,
         poll_interval=10,
     )
-    expected = (
-        "Folder files · Folder: notes · Ready "
-        "Session Git: 0 changes · Next: Choose/new file."
-    )
+    expected_authority = "Folder Files · Folder: notes"
 
     async with _WorkspaceHarness(workspace).run_test(size=size) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
-        purpose = workspace.query_one("#file-notes-authority")
-        rendered = " ".join(
-            purpose.render_line(row).text.strip()
-            for row in range(purpose.region.height)
+        authority = workspace.query_one("#file-notes-authority")
+        rendered_authority = " ".join(
+            authority.render_line(row).text.strip()
+            for row in range(authority.region.height)
         )
-        assert " ".join(rendered.split()) == expected
-        assert purpose.region.height == 2
+        content = workspace.query_one("#file-notes-save-status")
+        rendered_content = " ".join(
+            content.render_line(row).text.strip()
+            for row in range(content.region.height)
+        )
+        assert " ".join(rendered_authority.split()) == expected_authority
+        assert "Saved" in " ".join(rendered_content.split())
+        assert "\n" not in _static_text(workspace, "#file-notes-authority")
+        assert "\n" not in _static_text(workspace, "#file-notes-save-status")
         assert workspace.query_one("#file-notes-body").region.height >= 8
 
     replica.close()
@@ -818,31 +2954,15 @@ def test_configured_root_authority_state_table_is_two_line_and_bounded(
     replica = FileNotesReplica(":memory:")
     workspace = LibraryFileNotesWorkspace(root=root, replica=replica)
     root_states = (
-        (False, "", ""),
-        (None, "", "Checking"),
-        (True, "", "Offline"),
-        (True, "Replica warning", "Offline+Warning"),
-        (False, "Replica warning", "Warning"),
+        (False, ""),
+        (None, ""),
+        (True, ""),
+        (False, "warning"),
+        (True, "warning"),
     )
-    transitions = (
-        (False, False, ""),
-        (True, False, "Changing folder"),
-        (False, True, "File operation"),
-    )
-    save_states = (
-        ("idle", ""),
-        ("dirty", "Unsaved"),
-        ("saving", "Saving"),
-        ("saved", "Saved"),
-        ("conflict", "Conflict"),
-        ("error", "Save failed"),
-    )
-    push_states = (
-        ("idle", ""),
-        ("checking", "Check push"),
-        ("pushing", "Pushing"),
-        ("needs_attention", "Push attention"),
-    )
+    transitions = ((False, False), (True, False), (False, True))
+    save_states = ("idle", "dirty", "saving", "saved", "conflict", "error")
+    push_states = ("idle", "checking", "pushing", "needs_attention")
 
     for root_state, transition, save_state, push_state, git_count in product(
         root_states,
@@ -851,64 +2971,150 @@ def test_configured_root_authority_state_table_is_two_line_and_bounded(
         push_states,
         (0, 1, 125),
     ):
-        offline, warning, root_copy = root_state
-        root_transitioning, path_transitioning, transition_copy = transition
-        save_value, save_copy = save_state
-        push_value, push_copy = push_state
+        offline, warning = root_state
+        root_transitioning, path_transitioning = transition
+        save_value = save_state
+        push_value = push_state
         workspace._root_offline = offline
         workspace._runtime_warning = warning
         workspace._root_transitioning = root_transitioning
         workspace._path_transitioning = path_transitioning
         workspace._save_state = save_value
         workspace._push_phase = push_value
-        authority = workspace._authority_copy(git_count)
-        lines = authority.splitlines()
+        channels = workspace._status_channels(git_count)
+        authority = channels.authority_git
+        content = channels.content_recovery
         context = (root_state, transition, save_state, push_state, git_count)
 
-        assert len(lines) == 2, context
-        assert all(cell_len(line) <= 60 for line in lines), (context, lines)
-        assert "Folder files" in lines[0], context
-        assert "Folder:" in lines[0], context
-        state_copy = transition_copy or root_copy
-        if state_copy:
-            assert state_copy in lines[0], context
-        if save_copy:
-            assert save_copy in lines[0], context
-        elif not state_copy:
-            assert "Ready" in lines[0], context
-        expected_count = "99+" if git_count > 99 else str(git_count)
-        assert f"Session Git: {expected_count}" in lines[1], context
-        if push_copy:
-            assert push_copy in lines[1], context
-        assert "Next:" in lines[1], context
-
-        if root_transitioning:
-            next_copy = "Wait for change."
-        elif path_transitioning:
-            next_copy = "Wait for file."
-        elif offline is None:
-            next_copy = "Wait for check."
-        elif offline is True:
-            next_copy = "Reconnect/change."
+        assert "\n" not in authority and "\n" not in content, context
+        assert cell_len(authority) <= 60, (context, authority)
+        assert "Folder Files" in authority and "Folder:" in authority, context
+        if offline is True:
+            assert "Folder unavailable" in authority
         elif warning:
-            next_copy = "Open Details."
-        elif save_value == "conflict":
-            next_copy = "Resolve/copy."
-        elif save_value == "error":
-            next_copy = "Retry/copy."
-        elif save_value == "saving":
-            next_copy = "Wait for save."
-        elif save_value == "dirty":
-            next_copy = "Keep editing."
-        elif push_value != "idle" or git_count:
-            next_copy = "Review changes."
-        elif save_value == "saved":
-            next_copy = "Keep editing."
+            assert "Folder warning" in authority
+        elif root_transitioning:
+            assert "Changing folder" in authority
+        elif path_transitioning:
+            assert "File operation" in authority
+        elif offline is None:
+            assert "Checking folder" in authority
+        elif push_value == "needs_attention":
+            assert "Outcome uncertain" in authority
+        elif push_value in {"checking", "pushing"}:
+            assert "Git ·" in authority
+        elif git_count:
+            assert f"{git_count} change" in authority
         else:
-            next_copy = "Choose/new file."
-        assert f"Next: {next_copy}" in lines[1], context
+            assert "Git" not in authority
+
+        if save_value == "conflict":
+            expected_content = "Conflict"
+        elif offline is True:
+            expected_content = "Unavailable"
+        else:
+            expected_content = {
+                "conflict": "Conflict",
+                "error": "Save failed",
+                "saving": "Saving",
+                "dirty": "Unsaved changes",
+            }.get(save_value, "Saved")
+        assert content.startswith(expected_content), context
 
     replica.close()
+
+
+@pytest.mark.parametrize(
+    ("phase", "outcome", "expected"),
+    (
+        ("checking", None, "Git · Checking commit…"),
+        ("confirming", None, "Git · Checking commit…"),
+        ("executing", None, "Git · Committing…"),
+        (
+            "result",
+            CommitOutcome(
+                "failed_unchanged",
+                "Git did not create a commit; branch state is unchanged.",
+            ),
+            "Git · Commit failed",
+        ),
+        (
+            "result",
+            CommitOutcome(
+                "uncertain",
+                "Commit may have completed; check the retained operation.",
+            ),
+            "Git · Commit outcome uncertain",
+        ),
+    ),
+)
+def test_file_notes_status_channels_include_consequential_commit_lifecycle(
+    tmp_path: Path,
+    phase: str,
+    outcome: CommitOutcome | None,
+    expected: str,
+) -> None:
+    """Commit execution and decision-bearing results stay in the header."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    workspace = LibraryFileNotesWorkspace(root=root, replica=None)
+    workspace._root_offline = False
+    workspace._commit_view_phase = phase
+    workspace._commit_result_projection = (
+        CommitResultProjection(outcome) if outcome is not None else None
+    )
+
+    channels = workspace._status_channels(0)
+
+    assert expected in channels.authority_git
+    assert channels.content_recovery == "Saved"
+
+
+@pytest.mark.asyncio
+async def test_file_notes_header_tracks_status_check_mutation_and_failure(
+    tmp_path: Path,
+) -> None:
+    """Always-visible Git copy follows ordinary retained Git lifecycle."""
+    root = tmp_path / "notes"
+    root.mkdir()
+    workspace = LibraryFileNotesWorkspace(root=root, replica=None, poll_interval=10)
+
+    async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
+        await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
+
+        blocker = asyncio.Event()
+
+        async def pending_status() -> None:
+            await blocker.wait()
+
+        task = asyncio.create_task(pending_status())
+        workspace._git_status_task = task
+        workspace._git_status_task_binding = workspace._session_binding
+        workspace._render_status_channels()
+        await pilot.pause()
+        assert "Checking Git" in _static_text(workspace, "#file-notes-authority")
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        workspace._git_status_task = None
+        workspace._git_status_task_binding = None
+        workspace._git_status_failure = "Git status failed"
+        workspace._render_status_channels()
+        await pilot.pause()
+        assert "Git status failed" in _static_text(workspace, "#file-notes-authority")
+
+        workspace._git_status_failure = ""
+        workspace._git_action_running = "Staging…"
+        workspace._render_status_channels()
+        await pilot.pause()
+        assert "Staging" in _static_text(workspace, "#file-notes-authority")
+
+        with patch.object(workspace, "_render_status_channels") as render:
+            workspace._clear_git_last_action()
+            assert render.called
+
+    await workspace.shutdown()
 
 
 @pytest.mark.parametrize("size", ((160, 45), (120, 40), (60, 20)))
@@ -1135,8 +3341,8 @@ async def test_files_mode_uses_focused_canvas_and_keeps_shell_mounted(
     async with _production_workspace_context(workspace, size=size) as pilot:
         screen = pilot.app.screen
         rail = screen.query_one("#library-rail")
-        canvas_host = screen.query_one("#library-canvas")
-        assert canvas_host.display
+        shell_grid = screen.query_one("#library-shell-grid")
+        shell = workspace.query_one("#library-file-notes-reader-shell")
         assert rail.display is False, (
             f"size={screen.size!r}, grid={screen.query_one('#library-shell-grid').region!r}, "
             f"compact={screen._library_notes_compact!r}, "
@@ -1149,9 +3355,10 @@ async def test_files_mode_uses_focused_canvas_and_keeps_shell_mounted(
         else:
             task_returns = screen.query("#library-notes-task-return")
             assert not task_returns or task_returns.first().display is False
-        # The workspace renders inside the retained canvas pane, not as a
-        # full-screen replacement of the whole shell.
-        assert workspace.parent is canvas_host
+        # Folder Files is now a retained sibling authority whose own shared
+        # shell supplies Library / Items / Work roles.
+        assert workspace.parent is shell_grid
+        assert shell.work is workspace._reader_work_widget
         assert workspace.region.x >= 0
         assert workspace.region.right <= screen.size.width
         assert workspace.region.bottom <= screen.size.height
@@ -1180,8 +3387,92 @@ async def test_escape_in_files_mode_returns_to_database_notes(
             "Escape did not return Files mode to Database Notes",
         )
         assert screen.query_one("#library-notes-source-database", Button)
-        assert not screen.query("#library-file-notes-workspace")
+        assert screen.query_one("#library-file-notes-workspace") is workspace
+        assert workspace.display is False
     replica.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("task", ("new", "move"))
+async def test_source_exit_cancels_path_task_admitted_after_shared_save(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    task: str,
+) -> None:
+    root = tmp_path / "notes"
+    root.mkdir()
+    (root / "source.md").write_text("source", encoding="utf-8")
+    workspace = LibraryFileNotesWorkspace(
+        root=root,
+        replica=None,
+        autosave_delay=10,
+        poll_interval=10,
+    )
+    save_started = threading.Event()
+    release_save = threading.Event()
+    cancel_results: list[bool] = []
+
+    async with _production_workspace_context(workspace, size=(120, 40)) as pilot:
+        screen = pilot.app.screen
+        assert isinstance(screen, LibraryScreen)
+        assert await workspace.open_path("source.md")
+        service = workspace._service
+        assert service is not None
+        original_finish = service._finish_published_file
+
+        def delayed_finish(*args, **kwargs):
+            save_started.set()
+            assert release_save.wait(5)
+            return original_finish(*args, **kwargs)
+
+        monkeypatch.setattr(service, "_finish_published_file", delayed_finish)
+        original_cancel = workspace.cancel_path_task
+
+        def observed_cancel() -> bool:
+            cancelled = original_cancel()
+            cancel_results.append(cancelled)
+            return cancelled
+
+        monkeypatch.setattr(workspace, "cancel_path_task", observed_cancel)
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        _replace_editor_text(editor, "shared save draft")
+        await _wait_until(
+            pilot,
+            lambda: workspace.save_state == "dirty",
+            "shared-save draft did not become dirty",
+        )
+
+        opening = asyncio.create_task(
+            workspace._open_path_task(task, opener_id=f"file-notes-{task}")
+        )
+        await _wait_until(
+            pilot,
+            lambda: save_started.is_set() and workspace.save_state == "saving",
+            "path task did not start the shared save",
+        )
+        shared_save = workspace._save_task
+        assert shared_save is not None and not shared_save.done()
+        leaving = asyncio.create_task(screen._return_to_library_database_notes())
+        await _wait_until(
+            pilot,
+            lambda: cancel_results == [False] and not leaving.done(),
+            "source exit did not join the path task's shared save",
+        )
+        assert workspace._save_task is shared_save
+
+        release_save.set()
+        assert await opening
+        await leaving
+        await pilot.pause()
+
+        assert cancel_results == [False, True]
+        assert screen._library_notes_source == "files"
+        assert workspace.display
+        assert workspace.path_task == "none"
+        assert not workspace.query_one("#file-notes-path-task").display
+        assert not workspace.query_one("#file-notes-path", Input).has_focus
+
+    await workspace.shutdown()
 
 
 @pytest.mark.asyncio
@@ -1249,9 +3540,8 @@ async def test_initial_root_scan_projects_checking_authority_while_actions_are_g
                 "#file-notes-root-status",
             )
             authority = _static_text(workspace, "#file-notes-authority")
-            assert "Checking" in authority
-            assert "Ready" not in authority
-            assert "Next: Wait for check." in authority
+            assert "Checking folder" in authority
+            assert "Folder: notes" in authority
             assert workspace.query_one("#file-notes-new", Button).disabled
         finally:
             release_scan.set()
@@ -1309,14 +3599,6 @@ async def test_wide_files_task_return_restores_database_browse_receipt() -> None
         await pilot.pause()
         before_list_scroll = int(notes_list.scroll_y)
         before_rail_scroll = int(rail.scroll_y)
-        row.press()
-        await _wait_until(
-            pilot,
-            lambda: bool(screen.query("#library-note-body")),
-            "Database note editor did not open.",
-        )
-        browse_receipt = screen._library_notes_browse_return_receipt
-        assert browse_receipt is not None
         await pilot.resize_terminal(100, 30)
         await _wait_until(
             pilot,
@@ -1330,6 +3612,8 @@ async def test_wide_files_task_return_restores_database_browse_receipt() -> None
             lambda: workspace.is_mounted,
             "Files workspace did not mount.",
         )
+        browse_receipt = screen._library_notes_browse_return_receipt
+        assert browse_receipt is not None
         assert screen._library_notes_browse_return_receipt is browse_receipt
         await pilot.resize_terminal(170, 24)
         await _wait_until(
@@ -1392,32 +3676,30 @@ async def test_path_transition_authority_names_file_operation_and_settles(
             authority = workspace.query_one("#file-notes-authority", Static)
             authority_copy = _static_text(workspace, "#file-notes-authority")
             painted = _painted_text_in_region(pilot.app, authority.region)
-            assert authority.region.height == 2
-            assert len(authority_copy.splitlines()) == 2
+            content = _static_text(workspace, "#file-notes-save-status")
+            assert authority.region.height <= 2
+            assert len(authority_copy.splitlines()) == 1
             assert all(
                 cell_len(row) <= authority.region.width
                 for row in authority_copy.splitlines()
             )
-            assert "Folder: Rese…" in painted
+            assert "Folder:" in painted
             assert "File operation" in painted
-            assert save_copy in painted
+            assert save_copy in content
             assert "Changing folder" not in painted
-            assert f"Session Git: {git_count}" in painted
-            if push_copy:
-                assert push_copy in painted
-            assert "Next: Wait for file." in painted
+            assert "Git" not in painted
 
         await pilot.pause()
         authority = _static_text(workspace, "#file-notes-authority")
         assert "File operation" not in authority
-        assert save_copy in authority
+        assert save_copy in _static_text(workspace, "#file-notes-save-status")
 
     replica.close()
 
 
 @pytest.mark.parametrize(
     ("push_phase", "push_copy"),
-    (("idle", ""), ("needs_attention", "Push attention")),
+    (("idle", ""), ("needs_attention", "Outcome uncertain")),
 )
 @pytest.mark.asyncio
 async def test_saved_authority_with_session_git_paints_at_60x20(
@@ -1440,19 +3722,20 @@ async def test_saved_authority_with_session_git_paints_at_60x20(
         authority = workspace.query_one("#file-notes-authority", Static)
         authority_copy = _static_text(workspace, "#file-notes-authority")
         painted = _painted_text_in_region(pilot.app, authority.region)
-        assert authority.region.height == 2
-        assert len(authority_copy.splitlines()) == 2
+        assert authority.region.height <= 2
+        assert len(authority_copy.splitlines()) == 1
         assert all(
             cell_len(row) <= authority.region.width
             for row in authority_copy.splitlines()
         )
-        assert "Folder files" in painted
-        assert "Folder: Rese…" in painted
-        assert "Saved" in painted
-        assert "Session Git: 1" in painted
+        assert "Folder Files" in painted
+        assert "Folder:" in painted
+        assert "Saved" in _static_text(workspace, "#file-notes-save-status")
         if push_copy:
             assert push_copy in painted
-        assert "Next: Review changes." in painted
+            assert "1 change" not in painted
+        else:
+            assert "1 change" in painted
 
     replica.close()
 
@@ -1496,9 +3779,7 @@ async def test_root_transition_retains_and_freezes_old_document_until_scan_finis
             lambda: workspace.save_state == "dirty",
             "root-change draft did not become dirty",
         )
-        transition = asyncio.create_task(
-            workspace.set_root(new_root, persist=False)
-        )
+        transition = asyncio.create_task(workspace.set_root(new_root, persist=False))
         await _wait_until(
             pilot,
             scan_started.is_set,
@@ -1512,7 +3793,7 @@ async def test_root_transition_retains_and_freezes_old_document_until_scan_finis
         assert workspace.query_one("#file-notes-search", Input).disabled
         authority = _static_text(workspace, "#file-notes-authority")
         assert "Changing folder" in authority
-        assert "Next: Wait for change." in authority
+        assert "Folder: old" in authority
         assert (old_root / "old.md").read_text(encoding="utf-8") == (
             "saved before root change"
         )
@@ -1713,9 +3994,7 @@ async def test_overlapping_root_persistence_only_winner_updates_config_and_owner
             assert old_binding is not None
             assert winner_workspace._session_binding == old_binding
 
-            slow_transition = asyncio.create_task(
-                slow_workspace.set_root(slow_root)
-            )
+            slow_transition = asyncio.create_task(slow_workspace.set_root(slow_root))
             await _wait_until(
                 pilot,
                 slow_scan_started.is_set,
@@ -1926,9 +4205,7 @@ async def test_failed_root_persistence_keeps_old_owner_log_and_service(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    old_root, new_root, owner, replica, workspace = (
-        _root_transition_workspace(tmp_path)
-    )
+    old_root, new_root, owner, replica, workspace = _root_transition_workspace(tmp_path)
 
     def fail_persistence(*_args: object, **_kwargs: object) -> None:
         raise OSError("forced persistence failure")
@@ -1959,8 +4236,7 @@ async def test_failed_root_persistence_keeps_old_owner_log_and_service(
         assert workspace._session_binding == old_binding
         assert old_service.create_file("after.md", "after").status == "ok"
         assert [
-            item.change.relative_path
-            for item in owner.snapshot(old_binding).changes
+            item.change.relative_path for item in owner.snapshot(old_binding).changes
         ] == ["before.md", "after.md"]
 
     await workspace.shutdown()
@@ -1973,9 +4249,7 @@ async def test_before_replace_root_failure_keeps_old_owner_log_and_service(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    old_root, new_root, owner, replica, workspace = (
-        _root_transition_workspace(tmp_path)
-    )
+    old_root, new_root, owner, replica, workspace = _root_transition_workspace(tmp_path)
 
     monkeypatch.setattr(
         workspace_module,
@@ -2006,8 +4280,7 @@ async def test_before_replace_root_failure_keeps_old_owner_log_and_service(
         assert workspace._session_binding == old_binding
         assert old_service.create_file("after.md", "after").status == "ok"
         assert [
-            item.change.relative_path
-            for item in owner.snapshot(old_binding).changes
+            item.change.relative_path for item in owner.snapshot(old_binding).changes
         ] == ["before.md", "after.md"]
 
     await workspace.shutdown()
@@ -2020,9 +4293,7 @@ async def test_cache_reload_failure_adopts_persisted_root_with_warning(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    old_root, new_root, owner, replica, workspace = (
-        _root_transition_workspace(tmp_path)
-    )
+    old_root, new_root, owner, replica, workspace = _root_transition_workspace(tmp_path)
 
     monkeypatch.setattr(
         workspace_module,
@@ -2075,9 +4346,7 @@ async def test_cancelled_root_persistence_settles_and_adopts_written_root(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    old_root, new_root, owner, replica, workspace = (
-        _root_transition_workspace(tmp_path)
-    )
+    old_root, new_root, owner, replica, workspace = _root_transition_workspace(tmp_path)
     (old_root / "open.md").write_text("old root", encoding="utf-8")
     (old_root / "deleted.md").write_text("old tombstone", encoding="utf-8")
     (new_root / "new.md").write_text("new root", encoding="utf-8")
@@ -2157,9 +4426,7 @@ async def test_cancelled_root_persistence_settles_and_adopts_written_root(
             assert set(workspace.entries) == {"new.md"}
             assert workspace._deleted_paths == ()
             assert workspace._root_offline is False
-            tree_labels = _tree_labels(
-                workspace.query_one("#file-notes-tree", Tree)
-            )
+            tree_labels = _tree_labels(workspace.query_one("#file-notes-tree", Tree))
             assert "new.md" in tree_labels
             assert "open.md" not in tree_labels
             assert "deleted.md" not in tree_labels
@@ -2345,9 +4612,7 @@ async def test_stale_candidate_scan_keeps_old_owner_log_and_service(
         assert old_binding is not None
         assert old_service.create_file("before.md", "before").status == "ok"
 
-        transition = asyncio.create_task(
-            workspace.set_root(new_root, persist=False)
-        )
+        transition = asyncio.create_task(workspace.set_root(new_root, persist=False))
         await _wait_until(
             pilot,
             candidate_scan_started.is_set,
@@ -2362,8 +4627,7 @@ async def test_stale_candidate_scan_keeps_old_owner_log_and_service(
         assert workspace._session_binding == old_binding
         assert old_service.create_file("after.md", "after").status == "ok"
         assert [
-            item.change.relative_path
-            for item in owner.snapshot(old_binding).changes
+            item.change.relative_path for item in owner.snapshot(old_binding).changes
         ] == ["before.md", "after.md"]
 
     release_candidate_scan.set()
@@ -2418,9 +4682,7 @@ async def test_tree_search_open_dirty_and_autosave_keep_one_editor(
             lambda: (
                 workspace.query_one("#file-notes-search-results", Tree).display
                 and "folder/alpha.md"
-                in _tree_labels(
-                    workspace.query_one("#file-notes-search-results", Tree)
-                )
+                in _tree_labels(workspace.query_one("#file-notes-search-results", Tree))
             ),
             "search results did not replace the tree with the mounted match",
         )
@@ -2485,29 +4747,27 @@ async def test_save_status_names_local_folder_and_preserved_draft(
 
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
-        assert _static_text(workspace, "#file-notes-save-status") == (
-            "Auto-save to local folder: idle"
-        )
+        assert _static_text(workspace, "#file-notes-save-status") == "Saved"
 
         assert await workspace.open_path("note.md")
-        assert _static_text(workspace, "#file-notes-save-status") == (
-            "Saved to local folder"
-        )
+        assert _static_text(workspace, "#file-notes-save-status") == "Saved"
         workspace._set_save_state("dirty")
-        assert _static_text(workspace, "#file-notes-save-status") == (
-            "Auto-save pending for local folder"
-        )
+        assert _static_text(workspace, "#file-notes-save-status") == "Unsaved changes"
         workspace._set_save_state("saving")
-        assert _static_text(workspace, "#file-notes-save-status") == (
-            "Saving to local folder…"
-        )
+        assert _static_text(workspace, "#file-notes-save-status") == "Saving…"
         workspace._set_save_state("conflict", "file changed on disk")
         assert _static_text(workspace, "#file-notes-save-status") == (
-            "Conflict: draft preserved in editor; file changed on disk"
+            "Conflict — the disk file changed; your draft is preserved. "
+            "Next: Save Copy."
         )
-        save_copy = workspace.query_one("#file-notes-save-copy", Button)
-        assert str(save_copy.label) == "Save copy"
-        assert save_copy.display
+        assert _static_text(workspace, "#file-notes-save-detail") == (
+            "Content detail: file changed on disk"
+        )
+        recovery_copy = workspace.query_one("#file-notes-recovery-save-copy", Button)
+        assert str(recovery_copy.label) == "Save copy"
+        assert recovery_copy.display
+        assert workspace.query_one("#file-notes-edit-region").display
+        assert not workspace.query_one("#file-notes-manage-region").display
         resolve = workspace.query_one("#file-notes-resolve-conflict", Button)
         assert resolve.display
         assert str(resolve.label) == "Resolve conflict"
@@ -2537,6 +4797,7 @@ async def test_maintenance_disclosure_keeps_secondary_file_actions_reachable(
     async with _WorkspaceHarness(workspace).run_test(size=size) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
         assert await workspace.open_path("note.md")
+        workspace.query_one("#file-notes-manage", Button).press()
         await pilot.pause()
 
         toggle = workspace.query_one("#file-notes-maintenance-toggle", Button)
@@ -2557,9 +4818,7 @@ async def test_maintenance_disclosure_keeps_secondary_file_actions_reachable(
         assert maintenance.display
         assert toggle.has_focus
         assert {
-            button.id
-            for button in maintenance.query(Button)
-            if button.display
+            button.id for button in maintenance.query(Button) if button.display
         } == {
             "file-notes-protect",
             "file-notes-refresh",
@@ -2611,9 +4870,15 @@ async def test_create_move_delete_protect_and_restore_use_real_service(
         )
         monkeypatch.setattr(service, "create_file", delayed_create)
         path_input = workspace.query_one("#file-notes-path", Input)
-        path_input.value = "created.md"
         create_button = workspace.query_one("#file-notes-new", Button)
-        creating = asyncio.create_task(workspace._new_file(Button.Pressed(create_button)))
+        create_button.press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.path_task == "new",
+            "new path task did not open",
+        )
+        path_input.value = "created.md"
+        creating = asyncio.create_task(workspace._submit_path_task())
         await _wait_until(pilot, create_started.is_set, "new file did not start")
         editor.focus()
         await pilot.press("x")
@@ -2651,8 +4916,14 @@ async def test_create_move_delete_protect_and_restore_use_real_service(
             "unprotect did not apply",
         )
 
-        path_input.value = "moved.md"
         workspace.query_one("#file-notes-move", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.path_task == "move",
+            "move path task did not open",
+        )
+        path_input.value = "moved.md"
+        workspace.query_one("#file-notes-path-submit", Button).press()
         await _wait_until(
             pilot,
             lambda: workspace.current_path == "moved.md",
@@ -2692,6 +4963,8 @@ async def test_create_move_delete_protect_and_restore_use_real_service(
             workspace.query_one("#file-notes-tree", Tree)
         )
 
+        workspace.query_one("#file-notes-edit", Button).press()
+        await pilot.pause()
         workspace.query_one("#file-notes-restore", Button).press()
         await _wait_until(
             pilot,
@@ -2784,14 +5057,13 @@ async def test_direct_workspace_shuts_down_only_its_private_session_owner(
 
 
 @pytest.mark.parametrize(
-    ("button_id", "handler_name", "service_method", "action"),
+    ("task", "button_id", "service_method", "action"),
     (
-        ("#file-notes-new", "_new_file", "create_file", "Create"),
-        ("#file-notes-move", "_move_file", "move_file", "Move"),
-        ("#file-notes-restore", "_restore_file", "restore_file", "Restore"),
+        ("new", "#file-notes-new", "create_file", "Create"),
+        ("move", "#file-notes-move", "move_file", "Move"),
         (
+            "save_copy",
             "#file-notes-save-copy",
-            "_save_copy",
             "save_copy",
             "Save draft as copy",
         ),
@@ -2801,8 +5073,8 @@ async def test_direct_workspace_shuts_down_only_its_private_session_owner(
 async def test_raw_path_actions_validate_input_before_service_call(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    task: str,
     button_id: str,
-    handler_name: str,
     service_method: str,
     action: str,
 ) -> None:
@@ -2853,16 +5125,20 @@ async def test_raw_path_actions_validate_input_before_service_call(
             capture_path_validation,
         )
         monkeypatch.setattr(service, service_method, capture_call)
-        workspace.query_one("#file-notes-path", Input).value = raw_path
         button = workspace.query_one(button_id, Button)
-        await getattr(workspace, handler_name)(Button.Pressed(button))
+        assert await workspace._open_path_task(task, opener_id=button.id or "")
+        workspace.query_one("#file-notes-path", Input).value = raw_path
+        assert not await workspace._submit_path_task()
 
         assert validation_calls == [(raw_path, 4096, True)]
         assert calls == []
-        assert _static_text(
-            workspace,
-            "#file-notes-action-status",
-        ) == f"{action} failed: unsupported path text."
+        assert (
+            _static_text(
+                workspace,
+                "#file-notes-action-status",
+            )
+            == f"{action} failed: unsupported path text."
+        )
         assert workspace.current_path == "start.md"
     replica.close()
 
@@ -2919,7 +5195,8 @@ async def test_conflict_reload_save_copy_and_leave_guards_preserve_draft(
         assert editor.text == "kept\ndraft"
         assert not await workspace.flush_pending_work()
 
-        workspace.query_one("#file-notes-path", Input).value = "copy.md"
+        workspace.query_one("#file-notes-edit", Button).press()
+        await pilot.pause()
         workspace.query_one("#file-notes-resolve-conflict", Button).press()
         await _wait_until(
             pilot,
@@ -2927,6 +5204,13 @@ async def test_conflict_reload_save_copy_and_leave_guards_preserve_draft(
             "conflict choices did not open",
         )
         workspace.query_one("#file-notes-resolution-save-new", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.path_task == "save_copy",
+            "conflict Save Copy task did not open",
+        )
+        workspace.query_one("#file-notes-path", Input).value = "copy.md"
+        workspace.query_one("#file-notes-path-submit", Button).press()
         await _wait_until(
             pilot,
             lambda: workspace.current_path == "copy.md",
@@ -2944,7 +5228,7 @@ async def test_conflict_reload_save_copy_and_leave_guards_preserve_draft(
         )
         await workspace.refresh_files()
         assert workspace.save_state == "conflict"
-        workspace.query_one("#file-notes-reload", Button).press()
+        workspace.query_one("#file-notes-recovery-reload", Button).press()
         await _wait_until(
             pilot,
             lambda: workspace.reload_confirmation_active,
@@ -2969,6 +5253,7 @@ async def test_conflict_reload_save_copy_and_leave_guards_preserve_draft(
         assert await workspace.flush_pending_work()
         assert source.read_bytes().endswith(b"flush me\r\n")
 
+        await _show_maintenance_actions(workspace, pilot)
         workspace.query_one("#file-notes-protect", Button).press()
         await _wait_until(
             pilot,
@@ -2987,7 +5272,9 @@ async def test_conflict_reload_save_copy_and_leave_guards_preserve_draft(
         assert str(workspace.query_one("#file-notes-reload", Button).label) == (
             "Discard draft and reload"
         )
-        workspace.query_one("#file-notes-reload", Button).press()
+        workspace.query_one("#file-notes-edit", Button).press()
+        await pilot.pause()
+        workspace.query_one("#file-notes-recovery-reload", Button).press()
         await _wait_until(
             pilot,
             lambda: workspace.reload_confirmation_active,
@@ -3262,7 +5549,7 @@ async def test_conflict_resolution_discloses_only_safe_choices(
         await workspace.refresh_files()
         assert workspace.save_state == "conflict"
         assert resolve.display and not resolve.disabled
-        assert workspace.query_one("#file-notes-save-copy", Button).display
+        assert workspace.query_one("#file-notes-recovery-save-copy", Button).display
 
         resolve.focus()
         resolve.press()
@@ -3310,7 +5597,13 @@ async def test_conflict_resolution_discloses_only_safe_choices(
             choice.scroll_visible(animate=False)
             await pilot.pause()
             assert choice.has_focus
-            assert choice.render_line(0).text.strip() == str(choice.label)
+            painted_label = choice.render_line(0).text.strip()
+            if size == (40, 20):
+                assert choice.render().plain == str(choice.label)
+                assert painted_label
+                assert str(choice.label).startswith(painted_label)
+            else:
+                assert painted_label == str(choice.label)
             assert choice.region.right <= workspace.region.right
             assert choice.region.bottom <= workspace.region.bottom
 
@@ -3377,14 +5670,23 @@ async def test_conflict_resolution_saves_draft_as_new_note_without_clobber(
             Button,
         )
 
-        path.value = "occupied.md"
         save_new.press()
         await _wait_until(
             pilot,
-            lambda: "already exists" in _static_text(
-                workspace,
-                "#file-notes-action-status",
-            ).lower(),
+            lambda: workspace.path_task == "save_copy",
+            "conflict Save Copy task did not open",
+        )
+        path.value = "occupied.md"
+        workspace.query_one("#file-notes-path-submit", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: (
+                "already exists"
+                in _static_text(
+                    workspace,
+                    "#file-notes-action-status",
+                ).lower()
+            ),
             "existing destination did not fail closed",
         )
         assert occupied.read_text(encoding="utf-8") == "do not replace"
@@ -3392,9 +5694,10 @@ async def test_conflict_resolution_saves_draft_as_new_note_without_clobber(
         assert editor.text == "retained\ndraft"
         assert workspace.save_state == "conflict"
         assert workspace.conflict_resolution_active
+        assert workspace.path_task == "save_copy"
 
         path.value = "recovered.md"
-        save_new.press()
+        workspace.query_one("#file-notes-path-submit", Button).press()
         await _wait_until(
             pilot,
             lambda: workspace.current_path == "recovered.md",
@@ -3485,10 +5788,7 @@ async def test_conflict_resolution_discard_keeps_cancel_first_confirmation(
         workspace.query_one("#file-notes-reload-confirm", Button).press()
         await _wait_until(
             pilot,
-            lambda: (
-                workspace.save_state == "saved"
-                and editor.text == "latest disk"
-            ),
+            lambda: workspace.save_state == "saved" and editor.text == "latest disk",
             "confirmed discard did not load the captured disk state",
         )
         assert not workspace.conflict_resolution_active
@@ -3536,8 +5836,7 @@ async def test_conflict_reload_requires_keyboard_confirmation_in_library_shell(
         await workspace.refresh_files()
         assert workspace.save_state == "conflict"
 
-        await _show_maintenance_actions(workspace, pilot)
-        reload_button = workspace.query_one("#file-notes-reload", Button)
+        reload_button = workspace.query_one("#file-notes-recovery-reload", Button)
         assert str(reload_button.label) == "Reload from disk"
         assert reload_button.display
         assert not reload_button.disabled
@@ -3720,21 +6019,28 @@ async def test_high_stakes_file_notes_states_keep_explicit_labels_and_classes(
         assert root_status.has_class("-offline")
         assert root_status.has_class("-warning")
         assert _static_text(workspace, "#file-notes-save-status") == (
-            "Conflict: draft preserved in editor; file changed on disk"
+            "Conflict — the disk file changed; your draft is preserved. "
+            "Next: Save Copy."
+        )
+        assert _static_text(workspace, "#file-notes-save-detail") == (
+            "Content detail: file changed on disk"
         )
         assert save_status.has_class("-conflict")
         assert not save_status.has_class("-error")
 
+        workspace._root_offline = False
+        workspace._runtime_warning = ""
+        workspace._update_root_surface()
         workspace._set_save_state("error", "permission denied")
         assert _static_text(workspace, "#file-notes-save-status") == (
-            "Save failed: draft preserved in editor; permission denied"
+            "Save failed — your draft remains in the editor. Next: Save Copy."
+        )
+        assert _static_text(workspace, "#file-notes-save-detail") == (
+            "Content detail: permission denied"
         )
         assert save_status.has_class("-error")
         assert not save_status.has_class("-conflict")
 
-        workspace._root_offline = False
-        workspace._runtime_warning = ""
-        workspace._update_root_surface()
         workspace._set_save_state("saved")
         await pilot.pause()
         assert _static_text(workspace, "#file-notes-root-status") == (
@@ -3813,6 +6119,9 @@ async def test_high_stakes_file_notes_states_are_legible_in_shipped_themes(
                 minimum_ratio=4.5,
             )
 
+            workspace._root_offline = False
+            workspace._runtime_warning = ""
+            workspace._update_root_surface()
             workspace._set_save_state("error", "permission denied")
             await pilot.pause()
             _assert_legible_painted_text(
@@ -4010,9 +6319,7 @@ async def test_poll_and_narrow_navigation_retain_the_text_area(
 
         service = workspace._service
         assert service is not None
-        delayed_open, reload_started, release_reload = _delayed_call(
-            service.open_file
-        )
+        delayed_open, reload_started, release_reload = _delayed_call(service.open_file)
         monkeypatch.setattr(service, "open_file", delayed_open)
         (root / "open.md").write_text("external", encoding="utf-8")
         (root / "created.md").write_text("new", encoding="utf-8")
@@ -4144,14 +6451,14 @@ async def test_library_notes_source_choices_render_and_switch_by_keyboard(
             ),
             "Files source did not open from the keyboard",
         )
-        canvas = screen.query_one("#library-canvas")
+        shell_grid = screen.query_one("#library-shell-grid")
         rail = screen.query_one("#library-rail")
         await _wait_until(
             pilot,
             lambda: workspace.region.width > 0 and workspace.region.height > 0,
             "File Notes workspace did not receive rendered geometry",
         )
-        assert canvas.display is True
+        assert shell_grid.display is True
         assert workspace.region.x >= 0
         assert workspace.region.y >= 0
         assert workspace.region.right <= screen.size.width
@@ -4187,8 +6494,6 @@ async def test_library_notes_source_choices_render_and_switch_by_keyboard(
         strip = screen.query_one("#library-notes-source-strip")
         database = screen.query_one("#library-notes-source-database", Button)
         files = screen.query_one("#library-notes-source-files", Button)
-        assert strip.content_region.contains_region(database.region)
-        assert strip.content_region.contains_region(files.region)
         assert str(database.label) == "Library notes"
         assert not database.disabled
         assert str(files.label) == "Folder files"
@@ -4196,7 +6501,9 @@ async def test_library_notes_source_choices_render_and_switch_by_keyboard(
         assert not files.disabled
 
         if size == (40, 20):
-            for _ in range(60):
+            assert strip.content_region.contains_region(database.region)
+            assert strip.content_region.contains_region(files.region)
+            for _ in range(240):
                 if files.has_focus:
                     break
                 await pilot.press("tab")
@@ -4213,8 +6520,10 @@ async def test_library_notes_source_choices_render_and_switch_by_keyboard(
             # TASK-19602: in wide focused-task mode the source strip's
             # buttons are hidden by design (1bda754fa) -- the keyboard way
             # back is the task-return control.
+            assert database.display is False
+            assert files.display is False
             task_return = screen.query_one("#library-notes-task-return", Button)
-            for _ in range(60):
+            for _ in range(240):
                 if task_return.has_focus:
                     break
                 await pilot.press("tab")
@@ -4315,7 +6624,7 @@ async def test_file_notes_production_shell_preserves_canvas_across_breakpoints(
             assert screen.focused is editor, f"editor focus lost at {width}x{height}"
             assert editor.has_focus
             assert screen.focused.visible
-            assert canvas in screen.focused.ancestors_with_self
+            assert workspace._reader_work_widget in screen.focused.ancestors_with_self
             if width < 120:
                 assert screen._library_notes_stage == "notes"
                 assert rail.display is False
@@ -4369,13 +6678,16 @@ async def test_file_notes_authority_is_painted_and_contained_at_60x20_shell(
         await pilot.pause()
 
         authority = workspace.query_one("#file-notes-authority", Static)
-        canvas = screen.query_one("#library-canvas")
+        content = workspace.query_one("#file-notes-save-status", Static)
+        shell_grid = screen.query_one("#library-shell-grid")
         assert authority in pilot.app.screen._compositor.visible_widgets
+        assert content in pilot.app.screen._compositor.visible_widgets
         assert workspace.content_region.contains_region(authority.region)
-        assert canvas.content_region.contains_region(workspace.region)
+        assert workspace.content_region.contains_region(content.region)
+        assert shell_grid.content_region.contains_region(workspace.region)
         assert 0 < authority.region.height <= 2
-        assert _painted_style_of_text(pilot.app, authority.region, "Folder files")
-        assert _painted_style_of_text(pilot.app, authority.region, "Next:")
+        assert _painted_style_of_text(pilot.app, authority.region, "Folder Files")
+        assert _painted_style_of_text(pilot.app, content.region, "Saved")
 
     await workspace.shutdown()
 
@@ -4383,8 +6695,8 @@ async def test_file_notes_authority_is_painted_and_contained_at_60x20_shell(
 @pytest.mark.parametrize(
     ("save_state", "state_copy", "next_copy"),
     (
-        ("error", "Save failed", "Next: Retry/copy."),
-        ("conflict", "Conflict", "Next: Resolve/copy."),
+        ("error", "Save failed", "Next: Save Copy."),
+        ("conflict", "Conflict", "Next: Save Copy."),
     ),
 )
 @pytest.mark.asyncio
@@ -4397,9 +6709,7 @@ async def test_file_notes_merged_recovery_authority_paints_at_60x20_shell(
     """Long save failures keep all authority facts and recovery above the fold."""
     root = tmp_path / "Research notes with a very long private directory name"
     root.mkdir()
-    detail = (
-        "permission denied while writing an unusually long private filesystem path"
-    )
+    detail = "permission denied while writing an unusually long private filesystem path"
     owner = FileNotesSessionOwner()
     workspace = LibraryFileNotesWorkspace(
         root=root,
@@ -4437,19 +6747,27 @@ async def test_file_notes_merged_recovery_authority_paints_at_60x20_shell(
         await pilot.pause()
 
         authority = workspace.query_one("#file-notes-authority", Static)
-        canvas = screen.query_one("#library-canvas")
+        content = workspace.query_one("#file-notes-save-status", Static)
+        shell_grid = screen.query_one("#library-shell-grid")
         painted = _painted_text_in_region(pilot.app, authority.region)
+        content_painted = _painted_text_in_region(pilot.app, content.region)
+        content_words = " ".join(content_painted.split())
         assert authority in pilot.app.screen._compositor.visible_widgets
+        assert content in pilot.app.screen._compositor.visible_widgets
         assert workspace.content_region.contains_region(authority.region)
-        assert canvas.content_region.contains_region(workspace.region)
-        assert authority.region.height == 2
-        assert "Folder files" in painted
-        assert "Folder: Rese…" in painted
-        assert state_copy in painted
-        assert "Session Git: 1 change" in painted
-        assert next_copy in painted
+        assert workspace.content_region.contains_region(content.region)
+        assert shell_grid.content_region.contains_region(workspace.region)
+        assert 0 < authority.region.height <= 2
+        assert "Folder Files" in painted
+        assert "Folder: Resear" in painted
+        assert "name" in painted
+        assert state_copy in content_words
+        assert "Git · 1 change" in painted
+        assert next_copy in content_words
         assert detail not in _static_text(workspace, "#file-notes-authority")
-        assert detail in _static_text(workspace, "#file-notes-save-status")
+        assert detail not in _static_text(workspace, "#file-notes-save-status")
+        assert detail in _static_text(workspace, "#file-notes-save-detail")
+        assert content.tooltip == detail
 
     await workspace.shutdown()
 
@@ -4518,27 +6836,47 @@ async def test_file_notes_combined_non_ready_authority_matrix_paints_at_60x20(
             await pilot.pause()
 
             authority = workspace.query_one("#file-notes-authority", Static)
+            content = workspace.query_one("#file-notes-save-status", Static)
             authority_copy = _static_text(workspace, "#file-notes-authority")
             painted = _painted_text_in_region(pilot.app, authority.region)
-            assert authority.region.height == 2, (root_state, save_state, push_phase)
-            assert len(authority_copy.splitlines()) == 2
+            content_painted = _painted_text_in_region(pilot.app, content.region)
+            content_words = " ".join(content_painted.split())
+            assert 0 < authority.region.height <= 2, (
+                root_state,
+                save_state,
+                push_phase,
+            )
+            assert len(authority_copy.splitlines()) <= 2
             assert all(
                 cell_len(row) <= authority.region.width
                 for row in authority_copy.splitlines()
             )
-            assert "Folder files" in painted
-            assert "Folder: Rese…" in painted
-            assert ("Offline" if root_state == "offline" else "Warning") in painted
-            assert ("Conflict" if save_state == "conflict" else "Save failed") in painted
-            assert "Session Git: 1" in painted
-            if push_copy:
-                assert push_copy in painted
-            expected_next = (
-                "Next: Reconnect/change."
-                if root_state == "offline"
-                else "Next: Open Details."
+            assert "Folder Files" in painted
+            assert "Folder:" in painted
+            assert (
+                "Folder unavailable" if root_state == "offline" else "Folder warning"
+            ) in painted
+            expected_content = (
+                "Conflict"
+                if save_state == "conflict"
+                else ("Unavailable" if root_state == "offline" else "Save failed")
             )
-            assert expected_next in painted
+            assert expected_content in content_words
+            # Root authority outranks lower Git activity without hiding the
+            # content recovery state in its independent channel.
+            assert "Git · 1" not in painted
+            if push_copy:
+                assert push_copy not in painted
+            expected_next = (
+                "Next: Save Copy."
+                if save_state == "conflict"
+                else (
+                    "Next: Choose folder."
+                    if root_state == "offline"
+                    else "Next: Save Copy."
+                )
+            )
+            assert expected_next in content_words
 
     await workspace.shutdown()
 
@@ -4688,7 +7026,8 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
 
         release_detail.set()
         await detail_task
-        assert screen._library_note_detail is None
+        assert screen._library_note_detail is not None
+        assert screen._library_note_detail["id"] == "db-note-1"
         screen._library_notes_view = "list"
         screen._selected_note_id = None
 
@@ -4806,6 +7145,12 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
         assert screen._local_source_records["notes"][0]["title"] == "Updated DB note"
 
         (root / "library.md").write_text("changed while hidden", encoding="utf-8")
+        await retained.refresh_files()
+        await _wait_until(
+            pilot,
+            lambda: editor.text == "changed while hidden",
+            "retained hidden workspace did not reconcile its open file",
+        )
         screen.query_one("#library-notes-source-files", Button).press()
         await _wait_until(
             pilot,
@@ -4816,11 +7161,7 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
         )
         assert screen.query_one("#library-file-notes-workspace") is retained
         assert retained.query_one("#file-notes-editor", TextArea) is editor
-        await _wait_until(
-            pilot,
-            lambda: editor.text == "changed while hidden",
-            "remount did not reconcile the retained open file",
-        )
+        assert editor.text == "changed while hidden"
         assert (
             _static_text(retained, "#file-notes-session-changes")
             == "Review session changes (1)"
@@ -4834,40 +7175,31 @@ async def test_library_database_files_switch_retains_workspace_and_database_canv
             return original_finish(*args, **kwargs)
 
         monkeypatch.setattr(service, "_finish_published_file", delayed_finish)
-        _replace_editor_text(editor, "draft across forced remount")
+        _replace_editor_text(editor, "draft across retained source")
         await _wait_until(
             pilot,
             lambda: retained.save_state == "dirty",
-            "forced-remount draft did not become dirty",
+            "retained-source draft did not become dirty",
         )
         retained._start_autosave()
         await _wait_until(
             pilot,
             lambda: save_started.is_set() and retained.save_state == "saving",
-            "forced-remount save did not start",
+            "retained-source save did not start",
         )
         session_key = retained._session_key
-
-        screen.refresh(recompose=True)
-        await _wait_until(
-            pilot,
-            lambda: retained.save_state == "dirty"
-            and retained._active
-            and bool(screen.query("#library-file-notes-workspace")),
-            "Files workspace did not remount during save",
-        )
-        timer_before_release = retained._autosave_timer
+        assert retained._active
+        assert screen.query_one("#library-file-notes-workspace") is retained
         release_save.set()
         await _wait_until(
             pilot,
             lambda: retained.save_state == "saved",
-            "published remount draft was not adopted",
+            "published retained-source draft was not adopted",
         )
-        assert timer_before_release is None
         assert (root / "library.md").read_text(encoding="utf-8") == (
-            "draft across forced remount"
+            "draft across retained source"
         )
-        assert editor.text == "draft across forced remount"
+        assert editor.text == "draft across retained source"
         assert retained._session_key == session_key
         assert retained.query_one("#file-notes-editor", TextArea) is editor
         assert not competing_open
@@ -4895,6 +7227,8 @@ async def test_file_notes_focus_is_content_safe_under_production_css(
 
     async with _production_workspace_context(workspace, size=(120, 40)) as pilot:
         assert await workspace.open_path("focused.md")
+        workspace.query_one("#file-notes-manage", Button).press()
+        await pilot.pause()
 
         buttons = (
             workspace.query_one("#file-notes-root-details", Button),
@@ -4905,6 +7239,7 @@ async def test_file_notes_focus_is_content_safe_under_production_css(
                 for toolbar in workspace.query(".file-notes-toolbar")
                 for button in toolbar.query(Button)
                 if button.display
+                and all(ancestor.display for ancestor in button.ancestors)
             ),
         )
         for button in buttons:
@@ -4929,11 +7264,7 @@ async def test_file_notes_focus_is_content_safe_under_production_css(
             assert cursor.text_style.bold
             assert cursor.text_style.underline
 
-        for selector, widget_type in (
-            ("#file-notes-search", Input),
-            ("#file-notes-path", Input),
-            ("#file-notes-editor", TextArea),
-        ):
+        for selector, widget_type in (("#file-notes-search", Input),):
             field = workspace.query_one(selector, widget_type)
             field.focus()
             await pilot.pause()
@@ -4941,50 +7272,74 @@ async def test_file_notes_focus_is_content_safe_under_production_css(
             assert not field.styles.outline
             assert field.styles.border.top[0] not in {"", "none"}
 
+        assert await workspace._open_path_task("new", opener_id="file-notes-new")
+        path = workspace.query_one("#file-notes-path", Input)
+        path.focus()
+        await pilot.pause()
+        assert path.has_focus
+        assert not path.styles.outline
+        assert path.styles.border.top[0] not in {"", "none"}
+        workspace._close_path_task()
+
+        workspace.query_one("#file-notes-edit", Button).press()
+        await pilot.pause()
+        editor = workspace.query_one("#file-notes-editor", TextArea)
+        workspace.query_one("#file-notes-edit", Button).focus()
+        await pilot.pause()
+        resting_background = editor.styles.background
+        resting_region = editor.region
+        editor.focus()
+        await pilot.pause()
+        assert editor.has_focus
+        assert editor.styles.background == resting_background
+        assert editor.region == resting_region
+        assert all(
+            edge[0] == "heavy"
+            for edge in (
+                editor.styles.outline_top,
+                editor.styles.outline_right,
+                editor.styles.outline_bottom,
+                editor.styles.outline_left,
+            )
+        )
+        assert editor.styles.border.top[0] not in {"", "none"}
+
     replica.close()
 
 
 @pytest.mark.parametrize(
     ("editor_state", "expected_primary"),
     (
-        ("normal", ("New", "Move", "Delete", "More file actions")),
+        ("normal", ("Move", "More file actions")),
         (
             "dirty",
-            ("New", "Move", "Save copy", "Delete", "More file actions"),
+            ("Move", "Save copy", "More file actions"),
         ),
         (
             "conflict",
             (
-                "New",
                 "Move",
-                "Compare",
-                "Resolve conflict",
                 "Reload from disk",
                 "Save copy",
-                "Delete",
                 "More file actions",
             ),
         ),
         (
             "error",
             (
-                "New",
                 "Move",
                 "Discard draft and reload",
                 "Save copy",
-                "Delete",
                 "More file actions",
             ),
         ),
-        ("deleted", ("New", "Restore", "More file actions")),
-        ("protected", ("New", "Move", "Delete", "More file actions")),
+        ("deleted", ("More file actions",)),
+        ("protected", ("Move", "More file actions")),
         (
             "excerpt",
             (
-                "New",
                 "Move",
                 "Export exact copy",
-                "Delete",
                 "More file actions",
             ),
         ),
@@ -5033,11 +7388,38 @@ async def test_file_notes_primary_actions_follow_editor_state(
             "Target path · New / Move / Save copy"
         )
         assert _visible_primary_action_labels(workspace) == expected_primary
+        assert workspace.query_one("#file-notes-new", Button).display
+        assert workspace.query_one("#file-notes-delete", Button).display == (
+            editor_state != "deleted"
+        )
+        assert workspace.query_one("#file-notes-restore", Button).display == (
+            editor_state == "deleted"
+        )
+        expected_contextual = {
+            "conflict": {
+                "file-notes-compare",
+                "file-notes-resolve-conflict",
+                "file-notes-recovery-reload",
+                "file-notes-recovery-save-copy",
+            },
+            "error": {
+                "file-notes-recovery-reload",
+                "file-notes-recovery-save-copy",
+            },
+            "excerpt": {"file-notes-recovery-save-copy"},
+            "deleted": {"file-notes-restore"},
+        }.get(editor_state, set())
+        actual_contextual = {
+            button.id
+            for button in workspace.query_one("#file-notes-contextual-actions").query(
+                Button
+            )
+            if button.display and button.id is not None
+        }
+        assert actual_contextual == expected_contextual
         assert not workspace.query_one("#file-notes-maintenance-actions").display
         reload_button = workspace.query_one("#file-notes-reload", Button)
-        assert reload_button.parent is workspace.query_one(
-            "#file-notes-file-actions"
-        )
+        assert reload_button.parent is workspace.query_one("#file-notes-file-actions")
         if editor_state in {"dirty", "conflict", "error"}:
             assert workspace.query_one("#file-notes-save-copy", Button).display
 
@@ -5093,31 +7475,11 @@ async def test_reload_confirmation_keeps_target_and_save_copy_reachable(
         assert source.read_text(encoding="utf-8") == "disk\n"
         assert editor.text == "draft to preserve"
 
+        path_task = workspace.query_one("#file-notes-path-task")
         path_label = workspace.query_one("#file-notes-path-label", Static)
-        save_copy = workspace.query_one("#file-notes-save-copy", Button)
-        assert path_label.display and path.display
-        assert _static_text(workspace, "#file-notes-path-label") == (
-            "Target path · New / Move / Save copy"
-        )
+        save_copy = workspace.query_one("#file-notes-recovery-save-copy", Button)
+        assert not path_task.display
         assert save_copy.display and not save_copy.disabled
-        workspace.query_one("#file-notes-save-status").scroll_visible(
-            animate=False,
-            top=True,
-        )
-        await pilot.pause()
-        path.focus(scroll_visible=False)
-        await pilot.pause()
-        assert path.has_focus
-        assert (
-            workspace.query_one("#file-notes-save-status").region.bottom
-            <= path_label.region.y
-        )
-        for control, copy in (
-            (path_label, "Target path · New / Move / Save copy"),
-            (path, "saved-copy.md"),
-        ):
-            assert workspace.region.contains_region(control.region)
-            assert copy in _painted_text_in_region(pilot.app, control.region)
 
         save_copy.focus()
         save_copy.scroll_visible(animate=False)
@@ -5128,8 +7490,34 @@ async def test_reload_confirmation_keeps_target_and_save_copy_reachable(
             pilot.app,
             save_copy.region,
         )
-
         save_copy.press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.path_task == "save_copy" and path_task.display,
+            "contextual Save Copy did not open its named path task",
+        )
+        path.value = "saved-copy.md"
+        await pilot.pause()
+
+        assert path_label.display and path.display
+        assert _static_text(workspace, "#file-notes-path-label") == ("Save copy as")
+        await pilot.pause()
+        assert path.has_focus
+        assert "draft" in _static_text(workspace, "#file-notes-save-status")
+        for control, copy in (
+            (path_label, "Save copy as"),
+            (path, "saved-copy.md"),
+        ):
+            assert workspace.region.contains_region(control.region), (
+                workspace.query_one("#file-notes-editor-pane").scroll_offset,
+                workspace.query_one("#file-notes-editor-pane").max_scroll_y,
+                path_task.region,
+                control.region,
+            )
+            painted = _painted_text_in_region(pilot.app, control.region)
+            assert copy in painted
+
+        workspace.query_one("#file-notes-path-submit", Button).press()
         await _wait_until(
             pilot,
             lambda: (root / "saved-copy.md").exists(),
@@ -5167,27 +7555,34 @@ async def test_file_notes_discloses_actions_by_editor_state_and_redirects_focus(
 
     async with _WorkspaceHarness(workspace).run_test(size=(120, 40)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
-        assert _visible_editor_action_ids(workspace) == {
-            "file-notes-new",
-            "file-notes-maintenance-toggle",
-        }
+        assert workspace.work_mode == "edit"
+        assert workspace.query_one("#file-notes-new", Button).display
+        assert tuple(
+            button.id
+            for button in workspace.query_one("#file-notes-mode-controls").query(Button)
+        ) == ("file-notes-edit", "file-notes-manage")
 
         assert await workspace.open_path("state.md")
+        workspace.query_one("#file-notes-manage", Button).press()
+        await pilot.pause()
+        assert workspace.work_mode == "manage"
         assert _visible_primary_action_labels(workspace) == (
-            "New",
             "Move",
-            "Delete",
             "More file actions",
         )
+        assert workspace.query_one("#file-notes-delete", Button).display
 
         delete = workspace.query_one("#file-notes-delete", Button)
         editor = workspace.query_one("#file-notes-editor", TextArea)
         delete.focus()
         await pilot.pause()
         assert delete.has_focus
+        workspace.query_one("#file-notes-edit", Button).press()
+        await pilot.pause()
+        assert workspace.work_mode == "edit"
+        assert editor.has_focus
         with workspace._hold_path_transition() as transition:
             assert transition is not None
-            editor.focus()
             await pilot.pause()
             assert editor.has_focus
         await pilot.pause()
@@ -5199,13 +7594,15 @@ async def test_file_notes_discloses_actions_by_editor_state_and_redirects_focus(
             lambda: workspace.save_state == "dirty",
             "draft did not disclose recovery action",
         )
-        assert _visible_editor_action_ids(workspace) == {
-            "file-notes-new",
-            "file-notes-move",
-            "file-notes-delete",
-            "file-notes-save-copy",
-            "file-notes-maintenance-toggle",
-        }
+        workspace.query_one("#file-notes-manage", Button).press()
+        await pilot.pause()
+        assert _visible_primary_action_labels(workspace) == (
+            "Move",
+            "Save copy",
+            "More file actions",
+        )
+        assert workspace.query_one("#file-notes-new", Button).display
+        assert workspace.query_one("#file-notes-delete", Button).display
 
         assert await workspace.flush_pending_work()
         delete.focus()
@@ -5223,17 +7620,13 @@ async def test_file_notes_discloses_actions_by_editor_state_and_redirects_focus(
         restore = workspace.query_one("#file-notes-restore", Button)
         await _wait_until(
             pilot,
-            lambda: (
-                restore.display
-                and workspace._selected_deleted_path == "state.md"
-            ),
+            lambda: restore.display and workspace._selected_deleted_path == "state.md",
             "delete did not project tombstone actions",
         )
-        assert _visible_editor_action_ids(workspace) == {
-            "file-notes-new",
-            "file-notes-restore",
-            "file-notes-maintenance-toggle",
-        }
+        assert workspace.work_mode == "edit"
+        assert workspace.query_one("#file-notes-new", Button).display
+        assert restore.display
+        assert restore.region.width > 0
         await _wait_until(
             pilot,
             lambda: workspace.app.focused is not None,
@@ -5246,18 +7639,32 @@ async def test_file_notes_discloses_actions_by_editor_state_and_redirects_focus(
 
         with workspace._hold_path_transition() as transition:
             assert transition is not None
-            visible_buttons = tuple(
-                button
-                for toolbar in workspace.query(".file-notes-toolbar")
-                for button in toolbar.query(Button)
-                if button.display
+            guarded_buttons = tuple(
+                workspace.query_one(f"#{action_id}", Button)
+                for action_id in (
+                    "file-notes-new",
+                    "file-notes-move",
+                    "file-notes-delete",
+                    "file-notes-restore",
+                    "file-notes-compare",
+                    "file-notes-resolve-conflict",
+                    "file-notes-protect",
+                    "file-notes-reload",
+                    "file-notes-save-copy",
+                    "file-notes-recovery-save-copy",
+                    "file-notes-recovery-reload",
+                    "file-notes-refresh",
+                    "file-notes-maintenance-toggle",
+                )
             )
-            assert visible_buttons
-            assert all(button.disabled for button in visible_buttons)
-            assert "temporarily unavailable" in _static_text(
-                workspace,
-                "#file-notes-action-status",
-            ).lower()
+            assert all(button.disabled for button in guarded_buttons)
+            assert (
+                "temporarily unavailable"
+                in _static_text(
+                    workspace,
+                    "#file-notes-action-status",
+                ).lower()
+            )
 
     replica.close()
 
@@ -5289,36 +7696,45 @@ async def test_file_notes_delete_is_spatially_separated_from_new(
     async with _WorkspaceHarness(workspace).run_test(size=size) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
         assert await workspace.open_path("safety.md")
+        workspace.query_one("#file-notes-manage", Button).press()
         await pilot.pause()
         await pilot.pause()
 
         toolbar = workspace.query_one("#file-notes-file-actions")
+        navigator = workspace.query_one("#file-notes-navigator")
+        manage = workspace.query_one("#file-notes-manage-region")
         new = workspace.query_one("#file-notes-new", Button)
         delete = workspace.query_one("#file-notes-delete", Button)
         spacer = workspace.query_one("#file-notes-delete-spacer", Static)
-        button_ids = [
-            button.id for button in toolbar.query(Button) if button.display
-        ]
+        button_ids = [button.id for button in toolbar.query(Button) if button.display]
 
         assert button_ids == [
-            "file-notes-new",
             "file-notes-move",
-            "file-notes-delete",
             "file-notes-maintenance-toggle",
         ]
+        assert navigator.query_one("#file-notes-new", Button) is new
+        assert manage.query_one("#file-notes-delete", Button) is delete
+        assert new not in tuple(toolbar.query(Button))
+        assert delete not in tuple(toolbar.query(Button))
         assert new.display and delete.display
-        assert new.render_line(0).text.strip() == "New"
+        assert str(new.label) == "New"
         assert delete.render_line(0).text.strip() == "Delete"
         if size[0] == 120:
             assert not workspace.has_class("-stack-editor-actions")
             assert spacer.display
-            assert delete.region.x > new.region.right
-            assert delete.region.right <= toolbar.content_region.right
+            assert new.region.width > 0
+            assert delete.region.width > 0
+            assert not new.region.overlaps(delete.region)
         else:
             assert workspace.has_class("-stack-editor-actions")
             assert not spacer.display
-            assert delete.region.y > new.region.y
-            assert delete.region.width == toolbar.content_region.width
+            assert not workspace.navigator_visible
+            assert workspace.editor_visible
+            assert new.region.width == 0
+            delete.scroll_visible(animate=False)
+            await pilot.pause()
+            assert workspace.region.contains_region(delete.region)
+            assert delete.region.width >= len("Delete")
 
     replica.close()
 
@@ -5358,9 +7774,7 @@ async def test_disabled_file_notes_actions_carry_marker_and_visible_recovery(
         await pilot.pause()
         assert panel.display
         assert check_remote.display and check_remote.disabled
-        assert str(check_remote.label).startswith(
-            f"{LIBRARY_DISABLED_ACTION_MARKER} "
-        )
+        assert str(check_remote.label).startswith(f"{LIBRARY_DISABLED_ACTION_MARKER} ")
         reason = panel.query_one("#file-notes-git-push-result-reason")
         assert reason.display
         assert "Restore network access" in str(reason.renderable)
@@ -5391,11 +7805,13 @@ async def test_disabled_file_notes_actions_meet_contrast_in_every_shipped_theme(
 
     async with _production_workspace_context(workspace, size=(120, 40)) as pilot:
         assert await workspace.open_path("contrast.md")
+        workspace.query_one("#file-notes-manage", Button).press()
+        await pilot.pause()
         with workspace._hold_path_transition() as transition:
             assert transition is not None
             panel, git_button = _show_disabled_git_result(workspace)
             await pilot.pause()
-            workspace_button = workspace.query_one("#file-notes-new", Button)
+            workspace_button = workspace.query_one("#file-notes-move", Button)
             workspace_reason = workspace.query_one("#file-notes-action-status")
             git_reason = panel.query_one("#file-notes-git-push-result-reason")
 
@@ -5409,9 +7825,7 @@ async def test_disabled_file_notes_actions_meet_contrast_in_every_shipped_theme(
                 assert workspace_button.disabled and workspace_button.display
                 assert workspace_button.styles.opacity == 1.0
                 workspace_label = str(workspace_button.label)
-                assert workspace_label.startswith(
-                    f"{LIBRARY_DISABLED_ACTION_MARKER} "
-                )
+                assert workspace_label.startswith(f"{LIBRARY_DISABLED_ACTION_MARKER} ")
                 _assert_legible_painted_text(
                     pilot.app,
                     workspace_button,
@@ -5464,17 +7878,17 @@ async def test_disabled_file_notes_actions_keep_legibility_at_40_columns(
         poll_interval=10,
     )
 
-    async with _CssTrueWorkspaceHarness(workspace).run_test(
-        size=(40, 20)
-    ) as pilot:
+    async with _CssTrueWorkspaceHarness(workspace).run_test(size=(40, 20)) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")
         assert await workspace.open_path("compact.md")
+        workspace.query_one("#file-notes-manage", Button).press()
+        await pilot.pause()
         with workspace._hold_path_transition() as transition:
             assert transition is not None
             workspace._narrow_view = "editor"
             workspace._apply_responsive_layout(workspace.size.width)
             await pilot.pause()
-            workspace_button = workspace.query_one("#file-notes-new", Button)
+            workspace_button = workspace.query_one("#file-notes-move", Button)
             workspace_reason = workspace.query_one("#file-notes-action-status")
 
             for theme_name in (
@@ -5483,6 +7897,7 @@ async def test_disabled_file_notes_actions_keep_legibility_at_40_columns(
                 "high_contrast_yellow_black",
             ):
                 pilot.app.theme = theme_name
+                workspace_button.scroll_visible(animate=False)
                 await pilot.pause()
                 label = str(workspace_button.label)
                 _assert_legible_painted_text(
@@ -5491,6 +7906,8 @@ async def test_disabled_file_notes_actions_keep_legibility_at_40_columns(
                     label,
                     theme_name=theme_name,
                 )
+                workspace_reason.scroll_visible(animate=False)
+                await pilot.pause()
                 _assert_legible_painted_text(
                     pilot.app,
                     workspace_reason,
@@ -5508,6 +7925,7 @@ async def test_disabled_file_notes_actions_keep_legibility_at_40_columns(
                 "high_contrast_yellow_black",
             ):
                 pilot.app.theme = theme_name
+                git_button.scroll_visible(animate=False)
                 await pilot.pause()
                 label = str(git_button.label)
                 _assert_legible_painted_text(
@@ -5516,6 +7934,8 @@ async def test_disabled_file_notes_actions_keep_legibility_at_40_columns(
                     f"{LIBRARY_DISABLED_ACTION_MARKER} Check",
                     theme_name=theme_name,
                 )
+                git_reason.scroll_visible(animate=False)
+                await pilot.pause()
                 _assert_legible_painted_text(
                     pilot.app,
                     git_reason,
@@ -5555,7 +7975,9 @@ async def test_file_notes_disclosed_actions_fit_wide_and_compact_layouts(
             lambda: workspace.save_state == "dirty",
             "recovery action did not appear",
         )
+        workspace.query_one("#file-notes-manage", Button).press()
         await pilot.pause()
+        assert workspace.work_mode == "manage"
         assert workspace.editor_visible
         _assert_visible_editor_actions_fit(workspace)
 
@@ -5589,19 +8011,36 @@ async def test_production_folder_files_path_and_recovery_actions_are_painted(
         workspace._set_save_state("conflict", "file changed on disk")
         await pilot.pause()
 
+        recovery_copy = workspace.query_one(
+            "#file-notes-recovery-save-copy",
+            Button,
+        )
+        recovery_copy.press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.path_task == "save_copy",
+            "contextual Save Copy did not open its named path task",
+        )
         path_label = workspace.query_one("#file-notes-path-label", Static)
         path = workspace.query_one("#file-notes-path", Input)
-        path.focus()
-        path.scroll_visible(animate=False)
         await pilot.pause()
         assert path.has_focus
+        assert _static_text(workspace, "#file-notes-path-label") == "Save copy as"
         assert path_label.region.bottom <= path.region.y
         assert workspace.region.contains_region(path_label.region)
         assert workspace.region.contains_region(path.region)
-        assert "Target path · New / Move / Save copy" in _painted_text_in_region(
-            pilot.app,
-            path_label.region,
+        painted_label = _painted_text_in_region(pilot.app, path_label.region)
+        assert "Save copy as" in painted_label
+        workspace.query_one("#file-notes-path-cancel", Button).press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.path_task == "none",
+            "Cancel did not close the named Save Copy task",
         )
+
+        workspace.query_one("#file-notes-manage", Button).press()
+        await pilot.pause()
+        assert workspace.work_mode == "manage"
 
         for selector, expected_label in (
             ("#file-notes-move", "Move"),
@@ -5617,7 +8056,13 @@ async def test_production_folder_files_path_and_recovery_actions_are_painted(
             button.focus()
             await pilot.pause()
             assert button.has_focus
-            assert workspace.region.contains_region(button.region)
+            assert workspace.region.contains_region(button.region), (
+                selector,
+                button.region,
+                workspace.region,
+                workspace.classes,
+                button.parent.region if button.parent is not None else None,
+            )
             assert expected_label in _painted_text_in_region(
                 pilot.app,
                 button.region,
@@ -5648,14 +8093,14 @@ async def test_production_compact_folder_files_disclosure_and_states_are_painted
         opened = workspace.current_document
         assert opened is not None
 
+        workspace.query_one("#file-notes-manage", Button).press()
+        await pilot.pause()
         toggle = workspace.query_one("#file-notes-maintenance-toggle", Button)
         toggle.focus()
         await pilot.press("enter")
         await _wait_until(
             pilot,
-            lambda: workspace.query_one(
-                "#file-notes-maintenance-actions"
-            ).display,
+            lambda: workspace.query_one("#file-notes-maintenance-actions").display,
             "More file actions did not disclose compact maintenance actions",
         )
         for selector, label in (
@@ -5704,6 +8149,8 @@ async def test_production_compact_folder_files_disclosure_and_states_are_painted
 
         workspace._opened = opened
         workspace._set_save_state("conflict")
+        workspace.query_one("#file-notes-edit", Button).press()
+        await pilot.pause()
         resolve = workspace.query_one("#file-notes-resolve-conflict", Button)
         resolve.press()
         await _wait_until(
@@ -5723,11 +8170,21 @@ async def test_production_compact_folder_files_disclosure_and_states_are_painted
             await pilot.pause()
             assert action.has_focus
             assert workspace.region.contains_region(action.region)
-            assert label in _painted_text_in_region(pilot.app, action.region)
+            assert str(action.label) == label
+            assert action.render().plain == label
+            painted_label = _painted_text_in_region(
+                pilot.app,
+                action.region,
+            ).strip()
+            assert painted_label
+            assert label.startswith(painted_label)
 
         workspace._set_conflict_resolution(False)
+        workspace.query_one("#file-notes-manage", Button).press()
+        await pilot.pause()
         workspace._deleted_paths = ("states.md",)
         assert workspace.select_deleted("states.md")
+        assert workspace.work_mode == "edit"
         restore = workspace.query_one("#file-notes-restore", Button)
         restore.scroll_visible(animate=False)
         await pilot.pause()
@@ -5786,7 +8243,9 @@ async def test_file_notes_large_navigators_publish_bounded_keyboard_pages(
             lambda: len(tree.root.children) > first_count,
             "keyboard Load more did not append the next bounded batch",
         )
-        assert len(tree.root.children) <= (2 * workspace_module.FILE_TREE_BATCH_SIZE) + 1
+        assert (
+            len(tree.root.children) <= (2 * workspace_module.FILE_TREE_BATCH_SIZE) + 1
+        )
         assert tree.has_focus
 
         search_paths = tuple(f"result-{index:04d}.md" for index in range(5_000))
@@ -5868,8 +8327,16 @@ async def test_large_file_uses_labeled_excerpt_and_exports_exact_disk_bytes(
         assert str(export.label) == "Export exact copy"
         assert export.display and not export.disabled
 
-        workspace.query_one("#file-notes-path", Input).value = "exact-copy.md"
+        workspace.query_one("#file-notes-manage", Button).press()
+        await pilot.pause()
         export.press()
+        await _wait_until(
+            pilot,
+            lambda: workspace.path_task == "save_copy",
+            "exact export did not open its named path task",
+        )
+        workspace.query_one("#file-notes-path", Input).value = "exact-copy.md"
+        workspace.query_one("#file-notes-path-submit", Button).press()
         await _wait_until(
             pilot,
             lambda: (root / "exact-copy.md").exists(),

--- a/Tests/UI/test_library_honesty_accessibility.py
+++ b/Tests/UI/test_library_honesty_accessibility.py
@@ -44,6 +44,15 @@ from tldw_chatbook.Library.library_shell_state import (
 )
 from tldw_chatbook.Library.library_media_state import LibraryMediaCanvasState
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.Library.library_notes_state import (
+    DatabaseNoteDraft,
+    LibraryNoteSessionSnapshot,
+    NormalizedDatabaseNote,
+)
+from tldw_chatbook.Widgets.Library.library_notes_canvas import (
+    LibraryNotePresentationState,
+    LibraryNotesCanvas,
+)
 from tldw_chatbook.Widgets.Library.library_media_canvas import LibraryMediaCanvas
 from tldw_chatbook.Widgets.Library.library_export_canvas import LibraryExportCanvas
 from tldw_chatbook.Widgets.Library.library_collections_panel import (
@@ -512,7 +521,7 @@ def test_f1_lists_each_key_once_even_across_repeated_binding_extras():
         binding_extras=(
             ("escape", "Back"),
             ("escape", "Focus rail"),
-            ("ctrl+s", "Save note"),
+            ("ctrl+s", "Save skill"),
         ),
     )
     LibraryScreen.action_show_workbench_help(fake)
@@ -637,6 +646,100 @@ def test_notes_footer_states_use_per_key_grammar_and_never_advertise_dead_keys()
     ]
 
 
+def _binding_parts(entry) -> tuple[str, str, str]:
+    """Normalize Textual Binding objects and legacy binding tuples."""
+    if hasattr(entry, "key"):
+        return entry.key, entry.action, entry.description
+    return str(entry[0]), str(entry[1]), str(entry[2])
+
+
+def test_notes_ctrl_s_is_absent_from_binding_footer_and_f1_while_skill_keeps_it():
+    """Notes uses visible Save/autosave; only the Skill editor owns Ctrl+S."""
+    bindings = tuple(_binding_parts(entry) for entry in LibraryScreen.BINDINGS)
+    assert not any(action == "library_notes_save" for _key, action, _label in bindings)
+    assert any(
+        key == "ctrl+s" and action == "library_skill_save"
+        for key, action, _label in bindings
+    )
+    assert ("ctrl+s", "save skill") in LibraryScreen.LIBRARY_SKILL_EDITOR_SHORTCUTS
+    for shortcuts in (
+        LibraryScreen.LIBRARY_NOTES_EDITOR_SHORTCUTS,
+        LibraryScreen.LIBRARY_NOTES_EDITOR_SHORTCUTS_COMPACT,
+    ):
+        assert all(key != "ctrl+s" for key, _label in shortcuts)
+
+    fake = _f1_fake(
+        footer_shortcuts=LibraryScreen.LIBRARY_NOTES_EDITOR_SHORTCUTS,
+        binding_extras=tuple(
+            (key, label)
+            for key, action, label in bindings
+            if action == "library_notes_save"
+        ),
+        row_id="browse-notes",
+    )
+    LibraryScreen.action_show_workbench_help(fake)
+    (panel,) = fake._pushed
+    assert all(key != "ctrl+s" for key, _label in panel.state.shortcuts)
+
+
+class _DatabaseNoteEditorApp(ConsolidatedCSSApp):
+    """Mount one Database Note editor without the Library service layer."""
+
+    def compose(self):
+        baseline = NormalizedDatabaseNote(
+            note_id="note-1",
+            title="Visible Save",
+            body="Body",
+            keywords=(),
+            version=1,
+            created_at="2026-08-27T00:00:00Z",
+            modified_at="2026-08-27T00:00:00Z",
+        )
+        snapshot = LibraryNoteSessionSnapshot(
+            baseline=baseline,
+            draft=DatabaseNoteDraft(
+                note_id="note-1",
+                title="Visible Save",
+                body="Body",
+                keywords_text="",
+                revision=1,
+            ),
+            session_generation=1,
+            saved_revision=1,
+            dirty=False,
+            saving=False,
+            in_conflict=False,
+            conflict_generation=0,
+            status_message="Saved",
+        )
+        yield LibraryNotesCanvas(
+            mode="editor",
+            presentation_state=LibraryNotePresentationState(
+                snapshot=snapshot,
+                metadata_line="",
+                status_line="Saved",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_database_save_remains_visible_focusable_and_in_normal_pane_order():
+    """Removing the accelerator never removes the ordinary Save affordance."""
+    async with _DatabaseNoteEditorApp().run_test(size=(120, 40)) as pilot:
+        save = pilot.app.query_one("#library-note-save", Button)
+        assert save.display and not save.disabled and save.can_focus
+        save.focus()
+        await pilot.pause()
+        assert save.has_focus
+
+    (work_pane,) = tuple(
+        target
+        for target in LibraryScreen._WORKBENCH_FOCUS_TARGETS
+        if target.pane_id == "library-note-work-pane"
+    )
+    assert work_pane.preferred_focus_ids[0] == "library-note-save"
+
+
 @pytest.mark.asyncio
 async def test_compact_notes_editor_footer_context_actually_displays_at_60_cols():
     """The compact tier exists for the DISPLAYED footer: at 60 cols the
@@ -667,7 +770,7 @@ async def test_compact_notes_editor_footer_context_actually_displays_at_60_cols(
         footer = screen.query_one(AppFooterStatus)
         for _ in range(300):
             displayed = str(footer._shortcut_display.renderable)
-            if displayed.startswith("ctrl+s save | esc notes"):
+            if displayed.startswith("esc notes"):
                 break
             await pilot.pause(0.01)
         else:

--- a/Tests/UI/test_library_notes_work_session.py
+++ b/Tests/UI/test_library_notes_work_session.py
@@ -1,0 +1,101 @@
+import pytest
+
+from tldw_chatbook.UI.Library_Modules.library_notes_work_session import (
+    NotesWorkSessionEvent,
+    NotesWorkSessionPhase,
+    reduce_notes_work_session,
+)
+
+
+@pytest.mark.parametrize(
+    ("width", "expected"),
+    [
+        (None, NotesWorkSessionPhase.INACTIVE),
+        (119, NotesWorkSessionPhase.INACTIVE),
+        (120, NotesWorkSessionPhase.ACTIVE),
+        (121, NotesWorkSessionPhase.ACTIVE),
+    ],
+)
+def test_editable_item_opened_activates_only_at_reader_width_120(
+    width: int | None, expected: NotesWorkSessionPhase
+) -> None:
+    assert (
+        reduce_notes_work_session(
+            NotesWorkSessionPhase.INACTIVE,
+            NotesWorkSessionEvent.EDITABLE_ITEM_OPENED,
+            reader_width=width,
+        )
+        is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        NotesWorkSessionEvent.ITEM_CHANGED,
+        NotesWorkSessionEvent.SELECTION_CHANGED,
+        NotesWorkSessionEvent.EDIT_MODE_CHANGED,
+        NotesWorkSessionEvent.PREVIEW_MODE_CHANGED,
+        NotesWorkSessionEvent.INFO_MODE_CHANGED,
+        NotesWorkSessionEvent.MANAGE_MODE_CHANGED,
+        NotesWorkSessionEvent.SAVE,
+        NotesWorkSessionEvent.CONFLICT,
+        NotesWorkSessionEvent.RECOVERY,
+        NotesWorkSessionEvent.RESIZE,
+        NotesWorkSessionEvent.FOLDER_BACK_TO_NAVIGATOR,
+    ],
+)
+def test_non_boundary_events_preserve_session_phase(
+    event: NotesWorkSessionEvent,
+) -> None:
+    for phase in NotesWorkSessionPhase:
+        assert reduce_notes_work_session(phase, event) is phase
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        NotesWorkSessionEvent.DATABASE_IDENTITY_CLEARED,
+        NotesWorkSessionEvent.FOLDER_IDENTITY_CLEARED,
+        NotesWorkSessionEvent.AUTHORITY_CHANGED,
+        NotesWorkSessionEvent.FOLDER_ROOT_CHANGED,
+        NotesWorkSessionEvent.LEFT_NOTES,
+    ],
+)
+def test_identity_and_scope_changes_reset_to_inactive(
+    event: NotesWorkSessionEvent,
+) -> None:
+    for phase in NotesWorkSessionPhase:
+        assert reduce_notes_work_session(phase, event) is NotesWorkSessionPhase.INACTIVE
+
+
+def test_manual_library_expand_marks_active_session_cancelled_and_is_idempotent() -> (
+    None
+):
+    assert (
+        reduce_notes_work_session(
+            NotesWorkSessionPhase.ACTIVE,
+            NotesWorkSessionEvent.MANUAL_LIBRARY_EXPAND,
+        )
+        is NotesWorkSessionPhase.MANUALLY_CANCELLED
+    )
+    for phase in NotesWorkSessionPhase:
+        assert reduce_notes_work_session(
+            phase,
+            NotesWorkSessionEvent.MANUAL_LIBRARY_EXPAND,
+        ) is (
+            NotesWorkSessionPhase.MANUALLY_CANCELLED
+            if phase is NotesWorkSessionPhase.ACTIVE
+            else phase
+        )
+
+
+def test_another_item_open_does_not_rearm_cancelled_session() -> None:
+    assert (
+        reduce_notes_work_session(
+            NotesWorkSessionPhase.MANUALLY_CANCELLED,
+            NotesWorkSessionEvent.EDITABLE_ITEM_OPENED,
+            reader_width=120,
+        )
+        is NotesWorkSessionPhase.MANUALLY_CANCELLED
+    )

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -22815,8 +22815,8 @@ async def test_library_shell_discard_new_note_deletes_untouched_create():
 
 
 @pytest.mark.asyncio
-async def test_library_note_failed_discard_clears_shortcut_lock_status() -> None:
-    """A failed discard releases both its destructive gate and refusal copy."""
+async def test_library_note_failed_discard_releases_destructive_admission() -> None:
+    """A failed discard releases its destructive gate."""
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
     host = LibraryHarness(app)
@@ -22846,12 +22846,6 @@ async def test_library_note_failed_discard_clears_shortcut_lock_status() -> None
                 discard_started.is_set,
                 message="Discard never reached its gated delete service.",
             )
-            await pilot.press("ctrl+s")
-            await _wait_for_condition(
-                pilot,
-                lambda: "Save locked" in screen._library_note_shortcut_status,
-                message="Destructive shortcut refusal did not become visible.",
-            )
         finally:
             discard_release.set()
 
@@ -22863,7 +22857,6 @@ async def test_library_note_failed_discard_clears_shortcut_lock_status() -> None
             ),
             message="Failed discard did not release its destructive admission.",
         )
-        assert screen._library_note_shortcut_status == ""
 
 
 # ---------------------------------------------------------------------------
@@ -31655,11 +31648,14 @@ async def test_library_note_footer_tracks_editor_states_and_ancillary_contents()
             await _wait_for_condition(
                 pilot,
                 lambda: footer_shortcuts() == expected,
-                message=f"Footer did not settle to {expected!r}.",
+                message=lambda: (
+                    f"Footer did not settle to {expected!r}; "
+                    f"got {footer_shortcuts()!r}."
+                ),
             )
 
         await _open_note_editor(screen, pilot)
-        await wait_footer("ctrl+s save | esc notes")
+        await wait_footer("esc notes")
         footer = screen.query_one(AppFooterStatus)
         footer.update_word_count(12)
         footer.update_token_count("Tokens: 34")
@@ -31699,27 +31695,19 @@ async def test_library_note_footer_tracks_editor_states_and_ancillary_contents()
         await pilot.press("escape")
         await wait_footer("enter run action | esc note")
         await pilot.press("escape")
-        await wait_footer("pgup/pgdn scroll | esc notes")
-        screen.query_one("#library-note-preview").press()
-        await wait_footer("ctrl+s save | esc notes")
+        await wait_footer("esc notes")
 
         body = screen.query_one("#library-note-body", TextArea)
         body.text = "local conflict text"
         await pilot.pause()
         _bump_note_version_externally(app.notes_scope_service, "n-1")
-        await pilot.press("ctrl+s")
+        screen.query_one("#library-note-save").press()
         await _wait_for_condition(
             pilot,
             lambda: screen._library_note_session.snapshot.in_conflict,
-            message="Ctrl+S did not surface the expected conflict.",
+            message="Visible Save did not surface the expected conflict.",
         )
         await wait_footer("enter choose version")
-        await pilot.press("ctrl+s")
-        await _wait_for_condition(
-            pilot,
-            lambda: "Save locked" in screen._library_note_shortcut_status,
-            message="Conflict shortcut refusal did not become visible.",
-        )
 
         screen.query_one("#library-note-conflict-reload").press()
         await _wait_for_condition(
@@ -31730,7 +31718,7 @@ async def test_library_note_footer_tracks_editor_states_and_ancillary_contents()
             ),
             message="Reload did not resolve the conflict.",
         )
-        await wait_footer("ctrl+s save | esc notes")
+        await wait_footer("esc notes")
         assert screen._library_note_shortcut_status == ""
 
 
@@ -31828,53 +31816,18 @@ async def test_library_note_footer_covers_navigator_create_sync_and_exit() -> No
         )
 
 
-@pytest.mark.asyncio
-async def test_library_note_ctrl_s_saves_from_editor_preview_and_context() -> None:
-    app = _build_test_app()
-    _seed_conversations(app, _two_conversations(), notes=_two_notes())
-    host = LibraryHarness(app)
-
-    async with host.run_test(size=(60, 20)) as pilot:
-        screen = _active_library_screen(host)
-        await _wait_for_library_shell(screen, pilot)
-        await _open_note_editor(screen, pilot)
-
-        body = screen.query_one("#library-note-body", TextArea)
-        body.text = "saved from editor"
-        await pilot.pause()
-        saves = len(app.notes_scope_service.save_calls)
-        await pilot.press("ctrl+s")
-        await _wait_for_condition(
-            pilot,
-            lambda: len(app.notes_scope_service.save_calls) == saves + 1,
-            message="Ctrl+S did not save from Editor.",
+def test_library_note_ctrl_s_is_unavailable_while_save_remains_explicit() -> None:
+    notes_ctrl_s_bindings = [
+        binding
+        for binding in LibraryScreen.BINDINGS
+        if (
+            binding[:2] if isinstance(binding, tuple) else (binding.key, binding.action)
         )
+        == ("ctrl+s", "library_notes_save")
+    ]
 
-        body.text = "saved from preview"
-        await pilot.pause()
-        screen.query_one("#library-note-preview").press()
-        await _wait_for_display(screen, pilot, "#library-note-preview-region")
-        saves = len(app.notes_scope_service.save_calls)
-        await pilot.press("ctrl+s")
-        await _wait_for_condition(
-            pilot,
-            lambda: len(app.notes_scope_service.save_calls) == saves + 1,
-            message="Ctrl+S did not save from Preview.",
-        )
-
-        screen.query_one("#library-note-context").press()
-        await _wait_for_display(screen, pilot, "#library-note-context-region")
-        screen.query_one(
-            "#library-note-context-keywords", Input
-        ).value = "shortcut, context"
-        await pilot.pause()
-        saves = len(app.notes_scope_service.save_calls)
-        await pilot.press("ctrl+s")
-        await _wait_for_condition(
-            pilot,
-            lambda: len(app.notes_scope_service.save_calls) == saves + 1,
-            message="Ctrl+S did not save from Context.",
-        )
+    assert notes_ctrl_s_bindings == []
+    assert callable(LibraryScreen.action_library_notes_save)
 
 
 @pytest.mark.asyncio
@@ -31899,9 +31852,6 @@ async def test_library_note_escape_hierarchy_cannot_bypass_conflict() -> None:
         await _wait_for_display(screen, pilot, "#library-note-context-region")
         screen.query_one("#library-note-context-delete").press()
         await _wait_for_display(screen, pilot, "#library-note-delete-confirmation")
-        await pilot.press("ctrl+s")
-        await pilot.pause()
-        assert "Save locked" in screen._library_note_shortcut_status
         assert screen._library_note_confirming_delete is True
         await pilot.press("escape")
         await pilot.pause()
@@ -31916,11 +31866,11 @@ async def test_library_note_escape_hierarchy_cannot_bypass_conflict() -> None:
         body.text = "local conflict text"
         await pilot.pause()
         _bump_note_version_externally(app.notes_scope_service, "n-1")
-        await pilot.press("ctrl+s")
+        screen.query_one("#library-note-save").press()
         await _wait_for_condition(
             pilot,
             lambda: screen._library_note_session.snapshot.in_conflict,
-            message="Ctrl+S did not surface the expected conflict.",
+            message="Visible Save did not surface the expected conflict.",
         )
 
         await pilot.press("escape")
@@ -32057,7 +32007,7 @@ async def test_library_note_pilot_conflict_can_originate_from_every_region(
             await _wait_for_display(screen, pilot, "#library-note-context-region")
 
         _bump_note_version_externally(app.notes_scope_service, "n-1")
-        await pilot.press("ctrl+s")
+        screen.query_one("#library-note-save").press()
         await _wait_for_condition(
             pilot,
             lambda: bool(
@@ -32245,10 +32195,8 @@ async def test_library_note_pilot_delete_pending_locks_and_cancel_restores_conte
         for widget, key in ((title, "x"), (body, "y"), (keywords, "z")):
             widget.focus()
             await pilot.press(key)
-        await pilot.press("ctrl+s")
         await pilot.pause()
         assert len(app.notes_scope_service.save_calls) == save_calls_before
-        assert "Save locked" in screen._library_note_shortcut_status
         assert screen._library_note_session.snapshot == snapshot_before
 
         await pilot.press("escape")
@@ -32317,7 +32265,7 @@ async def test_library_note_delete_captures_context_origin_before_gated_flush() 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("delete_succeeds", (False, True))
-async def test_library_note_pilot_delete_running_blocks_duplicate_escape_and_save(
+async def test_library_note_pilot_delete_running_blocks_duplicate_delete_edits_and_escape(
     delete_succeeds: bool,
 ) -> None:
     delete_release = threading.Event()
@@ -32368,7 +32316,6 @@ async def test_library_note_pilot_delete_running_blocks_duplicate_escape_and_sav
                 assert widget.disabled is True
                 widget.focus()
                 await pilot.press(key)
-            await pilot.press("ctrl+s")
             await pilot.press("escape")
             await pilot.pause()
             assert len(service.delete_attempts) == 1
@@ -32502,7 +32449,6 @@ async def test_library_note_pilot_duplicate_discard_runs_one_delete_and_blocks_e
                 message="Discard never reached its service gate.",
             )
             assert screen._library_note_session.destructive_running is True
-            await pilot.press("ctrl+s")
             await pilot.press("escape")
             await pilot.pause()
             assert len(service.delete_attempts) == 1
@@ -33056,22 +33002,18 @@ async def test_library_note_keyboard_focus_order_and_persistent_labels(
         await pilot.press("tab")
         await pilot.pause()
         assert screen.focused is body
-        for expected in (
+        save = screen.query_one("#library-note-save", Button)
+        assert save.display is True
+        assert save.disabled is False
+        assert save.can_focus is True
+        assert save.region.width > 0 and save.region.height > 0
+        for selector in (
             "library-note-save",
             "library-note-preview",
             "library-note-context",
         ):
-            await pilot.press("tab")
-            await pilot.pause()
-            assert getattr(screen.focused, "id", None) == expected
-        if not compact:
-            await pilot.press("tab")
-            await pilot.pause()
-            assert getattr(screen.focused, "id", None) == "library-note-keywords"
-            label = screen.query_one("#library-note-keywords-label", Static)
-            assert str(label.renderable) == "Keywords"
-            assert label.region.height == 1
-
+            await _task10_focus_with_keyboard(screen, pilot, f"#{selector}")
+            assert getattr(screen.focused, "id", None) == selector
         body = await _task10_focus_with_keyboard(screen, pilot, "#library-note-body")
         screen.refresh(recompose=True)
         await _wait_for_condition(
@@ -33088,8 +33030,7 @@ async def test_library_note_keyboard_focus_order_and_persistent_labels(
         await pilot.press("tab")
         await pilot.pause()
         assert screen.focused is body
-        await pilot.press("tab")
-        await pilot.pause()
+        await _task10_focus_with_keyboard(screen, pilot, "#library-note-save")
         assert getattr(screen.focused, "id", None) == "library-note-save"
 
         await _task10_activate_with_keyboard(screen, pilot, "#library-note-context")
@@ -33097,7 +33038,6 @@ async def test_library_note_keyboard_focus_order_and_persistent_labels(
         assert getattr(screen.focused, "id", None) == "library-note-context-region"
         context_order = (
             "library-note-context-keywords",
-            "library-note-context-use-in-console",
             "library-note-context-copy",
             "library-note-context-export-md",
             "library-note-context-export-txt",
@@ -33135,7 +33075,7 @@ async def test_library_note_keyboard_focus_order_and_persistent_labels(
         await pilot.press("end", "c")
         await pilot.pause()
         _bump_note_version_externally(app.notes_scope_service, "n-1")
-        await pilot.press("ctrl+s")
+        screen.query_one("#library-note-save").press()
         await _wait_for_display(screen, pilot, "#library-note-conflict-region")
         assert getattr(screen.focused, "id", None) == "library-note-conflict-copy"
         await pilot.press("tab")

--- a/Tests/UI/test_settings_appearance_defaults.py
+++ b/Tests/UI/test_settings_appearance_defaults.py
@@ -183,7 +183,12 @@ def test_build_appearance_save_sections_preserves_unrelated_config():
                 "items_width": 40,
             },
             "conversations_reader": {"items_open": True, "items_width": 40},
-            "notes_reader": {"items_open": True, "items_width": 40},
+            "notes_reader": {
+                "items_open": True,
+                "items_width": 40,
+                "files_tree_open": True,
+                "files_tree_width": 40,
+            },
             "prompts_reader": {"items_open": True, "items_width": 40},
             "skills_reader": {"items_open": True, "items_width": 40},
         },
@@ -258,7 +263,12 @@ def test_load_appearance_defaults_reads_shared_and_destination_preferences():
                     "items_width": 54,
                 },
                 "conversations_reader": {"items_open": False, "items_width": 48},
-                "notes_reader": {"items_open": True, "items_width": 52},
+                "notes_reader": {
+                    "items_open": True,
+                    "items_width": 52,
+                    "files_tree_open": False,
+                    "files_tree_width": 58,
+                },
                 "prompts_reader": {"items_open": False, "items_width": 60},
                 "skills_reader": {"items_open": True, "items_width": 68},
             }
@@ -274,6 +284,8 @@ def test_load_appearance_defaults_reads_shared_and_destination_preferences():
     assert defaults.library_conversations_items_width == 48
     assert defaults.library_notes_items_open is True
     assert defaults.library_notes_items_width == 52
+    assert defaults.library_notes_files_tree_open is False
+    assert defaults.library_notes_files_tree_width == 58
     assert defaults.library_prompts_items_open is False
     assert defaults.library_prompts_items_width == 60
     assert defaults.library_skills_items_open is True
@@ -350,6 +362,8 @@ def test_validate_appearance_defaults_rejects_media_reader_types_and_widths():
         ({"library_media_items_width": 31}, "Items width"),
         ({"library_media_items_width": 73}, "Items width"),
         ({"library_notes_items_open": 1}, "Notes Items pane"),
+        ({"library_notes_files_tree_open": 1}, "Folder Files tree pane"),
+        ({"library_notes_files_tree_width": 73}, "Folder Files tree width"),
         ({"library_skills_items_width": 73}, "Skills Items width"),
     )
 
@@ -386,6 +400,8 @@ def test_build_appearance_save_sections_deep_merges_shared_and_destinations():
             library_conversations_items_width=48,
             library_notes_items_open=True,
             library_notes_items_width=52,
+            library_notes_files_tree_open=False,
+            library_notes_files_tree_width=58,
             library_prompts_items_open=False,
             library_prompts_items_width=60,
             library_skills_items_open=True,
@@ -412,6 +428,8 @@ def test_build_appearance_save_sections_deep_merges_shared_and_destinations():
             "future_notes": "preserved",
             "items_open": True,
             "items_width": 52,
+            "files_tree_open": False,
+            "files_tree_width": 58,
         },
         "prompts_reader": {"items_open": False, "items_width": 60},
         "skills_reader": {"items_open": True, "items_width": 68},

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -1773,7 +1773,12 @@ async def test_settings_appearance_library_reader_controls_round_trip_all_destin
             "items_width": 52,
         },
         "conversations_reader": {"items_open": False, "items_width": 48},
-        "notes_reader": {"items_open": True, "items_width": 56},
+        "notes_reader": {
+            "items_open": True,
+            "items_width": 56,
+            "files_tree_open": False,
+            "files_tree_width": 58,
+        },
         "prompts_reader": {"items_open": False, "items_width": 60},
         "skills_reader": {
             "items_open": True,
@@ -1836,6 +1841,24 @@ async def test_settings_appearance_library_reader_controls_round_trip_all_destin
                 ).value
                 == expected_width
             )
+        labels = {str(widget.renderable) for widget in screen.query(Static)}
+        assert "Folder Files tree pane" in labels
+        assert "Folder Files tree width" in labels
+        assert "Collapsed" in str(
+            screen.query_one(
+                "#settings-appearance-library-notes-files-tree-open", Button
+            ).label
+        )
+        folder_tree_width = screen.query_one(
+            "#settings-appearance-library-notes-files-tree-width", Input
+        )
+        assert folder_tree_width.value == "58"
+        folder_tree_width.value = "73"
+        screen.handle_appearance_library_media_layout_width(
+            Input.Changed(folder_tree_width, folder_tree_width.value)
+        )
+        assert "Folder Files tree width" in _visible_text(screen)
+        assert screen._category_has_unsaved_changes(SettingsCategoryId.APPEARANCE)
 
         screen._active_settings_field_id = (
             "settings-appearance-library-media-library-open"
@@ -1884,6 +1907,18 @@ async def test_settings_appearance_library_reader_controls_round_trip_all_destin
         assert screen.query_one(
             "#settings-appearance-library-media-items-width", Input
         ).disabled
+        assert (
+            screen.query_one(
+                "#settings-appearance-library-notes-files-tree-open", Button
+            ).label
+            == "Open"
+        )
+        assert (
+            screen.query_one(
+                "#settings-appearance-library-notes-files-tree-width", Input
+            ).value
+            == "40"
+        )
 
         await pilot.click("#settings-save-category")
         await _wait_for_settings_text(screen, pilot, "Appearance defaults saved.")
@@ -1901,7 +1936,12 @@ async def test_settings_appearance_library_reader_controls_round_trip_all_destin
             "items_width": 40,
         },
         "conversations_reader": {"items_open": True, "items_width": 40},
-        "notes_reader": {"items_open": True, "items_width": 40},
+        "notes_reader": {
+            "items_open": True,
+            "items_width": 40,
+            "files_tree_open": True,
+            "files_tree_width": 40,
+        },
         "prompts_reader": {"items_open": True, "items_width": 40},
         "skills_reader": {
             "future_skills": "keep",
@@ -3985,6 +4025,44 @@ async def test_probe_settings_endpoint_counts_models_and_normalizes_path():
     assert outcome.reachable is True
     assert outcome.summary == "reachable (3 models)"
     assert outcome.model_count == 3
+
+
+@pytest.mark.asyncio
+async def test_field_search_folder_files_tree_width_guides_to_custom_widths_when_disabled():
+    """A disabled Folder Files width search lands on its enabling control."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _settle_settings_mount_storm(pilot)
+        screen = _active_destination_screen(host)
+
+        screen._submit_category_search("Folder Files tree width")
+        for _ in range(8):
+            await pilot.pause()
+
+        assert screen.active_category == SettingsCategoryId.APPEARANCE.value
+        focused = host.focused
+        assert focused is not None and focused.id == (
+            "settings-appearance-library-media-custom-widths"
+        ), f"focused={focused!r}"
+        assert screen._active_settings_field_id == (
+            "settings-appearance-library-media-custom-widths"
+        )
+        truthful_copy = (
+            "Controls whether shared Library reader widths can be edited, "
+            "including Folder Files tree width."
+        )
+        assert truthful_copy in _visible_text(screen)
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert (
+            screen._appearance_setting_values()["library_reader_custom_widths_enabled"]
+            is True
+        )
+        assert truthful_copy in _visible_text(screen)
+        assert "Enable shared Library reader widths" not in _visible_text(screen)
 
 
 @pytest.mark.asyncio
@@ -10718,6 +10796,44 @@ async def test_search_landing_on_disabled_field_explains_instead_of_no_op():
         )
         assert "disabled right now" in status, status
         assert target_label in status, status
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("query", "field_id"),
+    (
+        (
+            "Folder Files tree pane",
+            "settings-appearance-library-notes-files-tree-open",
+        ),
+        (
+            "Folder Files tree width",
+            "settings-appearance-library-notes-files-tree-width",
+        ),
+    ),
+)
+async def test_field_search_finds_and_focuses_folder_files_tree_controls(
+    query, field_id
+):
+    """Folder Files controls are searchable and receive landing focus."""
+    app = _build_test_app()
+    app.app_config["library"]["reader"]["custom_widths_enabled"] = True
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _settle_settings_mount_storm(pilot)
+        screen = _active_destination_screen(host)
+
+        assert screen._top_field_match(query, SettingsCategoryId.APPEARANCE) == (
+            field_id,
+            query,
+        )
+        screen._submit_category_search(query)
+        for _ in range(8):
+            await pilot.pause()
+
+        assert screen.active_category == SettingsCategoryId.APPEARANCE.value
+        focused = host.focused
+        assert focused is not None and focused.id == field_id, f"focused={focused!r}"
 
 
 @pytest.mark.asyncio

--- a/Tests/test_config_delete_settings.py
+++ b/Tests/test_config_delete_settings.py
@@ -1106,3 +1106,321 @@ def test_delete_wrapper_performs_one_atomic_write_for_actual_mutation(
     )
 
     assert write_calls == 1
+
+
+def test_literal_transaction_keeps_punctuated_model_id_as_one_mapping_key(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    literal_model = "org/model.v2:fast[beta]"
+    _write_config(
+        config_path,
+        {
+            "api_settings": {
+                "OpenAI": {
+                    "api_key": "test-key",
+                    "model_defaults": {"sibling": {"temperature": 0.9}},
+                }
+            }
+        },
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    observed = []
+
+    def build(snapshot):
+        observed.append(snapshot)
+        return config_module.LiteralSettingsMutation(
+            section_values={
+                ("api_settings", "OpenAI", "model_defaults", literal_model): {
+                    "temperature": 0.2,
+                    "streaming": False,
+                }
+            },
+            delete_keys={},
+        )
+
+    result = config_module.apply_literal_settings_transaction_to_cli_config(build)
+
+    assert result.file_replaced is True
+    assert result.caches_reloaded is True
+    assert result.failure_phase is None
+    assert result.settings_view is not None
+    assert len(observed) == 1
+    assert observed[0].raw_values["api_settings"]["OpenAI"]["api_key"] == "test-key"
+    assert observed[0].effective_values["api_settings"]["OpenAI"]["api_key"] == "test-key"
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    profiles = saved["api_settings"]["OpenAI"]["model_defaults"]
+    assert profiles == {
+        "sibling": {"temperature": 0.9},
+        literal_model: {"temperature": 0.2, "streaming": False},
+    }
+
+
+def test_literal_transaction_deletes_exact_field_and_preserves_siblings(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    literal_path = (
+        "api_settings",
+        "openai",
+        "model_defaults",
+        "org/model.v2:fast[beta]",
+    )
+    _write_config(
+        config_path,
+        {
+            "api_settings": {
+                "openai": {
+                    "model_defaults": {
+                        "org/model.v2:fast[beta]": {
+                            "temperature": 0.7,
+                            "top_p": 0.8,
+                        },
+                        "sibling": {"temperature": 0.4},
+                    }
+                }
+            },
+            "unrelated": {"newer": True},
+        },
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    result = config_module.apply_literal_settings_transaction_to_cli_config(
+        lambda _snapshot: config_module.LiteralSettingsMutation(
+            section_values={literal_path: {"streaming": True}},
+            delete_keys={literal_path: ("temperature",)},
+        )
+    )
+
+    assert result.file_replaced is True
+    saved = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["api_settings"]["openai"]["model_defaults"] == {
+        "org/model.v2:fast[beta]": {"top_p": 0.8, "streaming": True},
+        "sibling": {"temperature": 0.4},
+    }
+    assert saved["unrelated"] == {"newer": True}
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        pytest.param(
+            lambda: config_module.LiteralSettingsMutation(
+                section_values={("api_settings", "", "model_defaults"): {"x": 1}},
+                delete_keys={},
+            ),
+            id="empty-path-element",
+        ),
+        pytest.param(
+            lambda: config_module.LiteralSettingsMutation(
+                section_values={("speech_studio",): {"x": 1}},
+                delete_keys={},
+            ),
+            id="revision-owned-root",
+        ),
+        pytest.param(
+            lambda: config_module.LiteralSettingsMutation(
+                section_values={("chat_defaults",): {"model": "new"}},
+                delete_keys={("chat_defaults",): ("model",)},
+            ),
+            id="set-delete-overlap",
+        ),
+    ],
+)
+def test_literal_transaction_rejects_invalid_targets_before_write(
+    tmp_path: Path,
+    monkeypatch,
+    mutation,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, {"chat_defaults": {"model": "old"}})
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    original = config_path.read_bytes()
+    write_calls = []
+    monkeypatch.setattr(
+        config_module,
+        "atomic_private_write_text",
+        lambda *args, **kwargs: write_calls.append((args, kwargs)),
+    )
+
+    result = config_module.apply_literal_settings_transaction_to_cli_config(
+        lambda _snapshot: mutation()
+    )
+
+    assert result == config_module.LiteralConfigMutationResult(
+        file_replaced=False,
+        caches_reloaded=False,
+        settings_view=None,
+        failure_phase="before_replace",
+    )
+    assert write_calls == []
+    assert config_path.read_bytes() == original
+
+
+def test_literal_transaction_contains_builder_exception_and_invokes_once(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(config_path, {"chat_defaults": {"model": "old"}})
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    calls = 0
+
+    def fail_builder(_snapshot):
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("sensitive builder detail")
+
+    result = config_module.apply_literal_settings_transaction_to_cli_config(
+        fail_builder
+    )
+
+    assert result.failure_phase == "before_replace"
+    assert result.settings_view is None
+    assert calls == 1
+    assert tomllib.loads(config_path.read_text(encoding="utf-8")) == {
+        "chat_defaults": {"model": "old"}
+    }
+
+
+def test_literal_transaction_detaches_builder_owned_containers_before_validation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(
+        config_path,
+        {"shared": {"remove": "old", "late_delete": "preserved"}},
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    path = ("shared",)
+    values = {"payload": {"nested": ["original"]}}
+    deletes = ["remove"]
+    section_values = {path: values}
+    delete_keys = {path: deletes}
+    real_validate = config_module._validate_literal_config_mutation_targets
+
+    def validate_then_mutate_originals(mutation):
+        real_validate(mutation)
+        values["payload"]["nested"].append("mutated-after-return")
+        values["late"] = "injected-after-validation"
+        deletes.append("late_delete")
+
+    monkeypatch.setattr(
+        config_module,
+        "_validate_literal_config_mutation_targets",
+        validate_then_mutate_originals,
+    )
+
+    result = config_module.apply_literal_settings_transaction_to_cli_config(
+        lambda _snapshot: config_module.LiteralSettingsMutation(
+            section_values=section_values,
+            delete_keys=delete_keys,
+        )
+    )
+
+    assert result.caches_reloaded is True
+    assert values == {
+        "payload": {"nested": ["original", "mutated-after-return"]},
+        "late": "injected-after-validation",
+    }
+    assert deletes == ["remove", "late_delete"]
+    assert tomllib.loads(config_path.read_text(encoding="utf-8")) == {
+        "shared": {
+            "late_delete": "preserved",
+            "payload": {"nested": ["original"]},
+        }
+    }
+
+
+def test_legacy_dotted_mutation_detaches_inputs_before_entering_writer(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(
+        config_path,
+        {"shared": {"remove": "old", "late_delete": "preserved"}},
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    values = {"payload": {"nested": ["original"]}}
+    deletes = ["remove"]
+    section_values = {"shared": values}
+    delete_keys = {"shared": deletes}
+    real_apply = config_module._apply_literal_settings_transaction_locked
+
+    def mutate_then_enter_writer(builder, **kwargs):
+        values["payload"]["nested"].append("mutated-before-writer")
+        values["late"] = "injected-before-writer"
+        deletes.append("late_delete")
+        return real_apply(builder, **kwargs)
+
+    monkeypatch.setattr(
+        config_module,
+        "_apply_literal_settings_transaction_locked",
+        mutate_then_enter_writer,
+    )
+
+    result = config_module.apply_settings_mutation_to_cli_config(
+        section_values,
+        delete_keys=delete_keys,
+    )
+
+    assert result.caches_reloaded is True
+    assert tomllib.loads(config_path.read_text(encoding="utf-8")) == {
+        "shared": {
+            "late_delete": "preserved",
+            "payload": {"nested": ["original"]},
+        }
+    }
+
+
+def test_legacy_dotted_mutation_snapshots_stateful_mappings_once_before_validation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_config(
+        config_path,
+        {
+            "shared": {"remove": "old"},
+            "speech_studio": {"revision": 7, "retain": "protected"},
+        },
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    class SwitchingMapping(dict):
+        def __init__(self, first, second):
+            super().__init__()
+            self.first = first
+            self.second = second
+            self.reads = 0
+
+        def items(self):
+            self.reads += 1
+            selected = self.first if self.reads == 1 else self.second
+            return selected.items()
+
+    section_values = SwitchingMapping(
+        {"shared": {"kept": "new"}},
+        {"speech_studio": {"revision": 99}},
+    )
+    delete_keys = SwitchingMapping(
+        {"shared": ["remove"]},
+        {"speech_studio": ["retain"]},
+    )
+
+    result = config_module.apply_settings_mutation_to_cli_config(
+        section_values,
+        delete_keys=delete_keys,
+    )
+
+    assert result.caches_reloaded is True
+    assert section_values.reads == 1
+    assert delete_keys.reads == 1
+    assert tomllib.loads(config_path.read_text(encoding="utf-8")) == {
+        "shared": {"kept": "new"},
+        "speech_studio": {"revision": 7, "retain": "protected"},
+    }

--- a/Tests/test_config_library_defaults.py
+++ b/Tests/test_config_library_defaults.py
@@ -30,7 +30,6 @@ def test_load_settings_exposes_library_defaults(tmp_path, monkeypatch):
     }
     for section in (
         "conversations_reader",
-        "notes_reader",
         "prompts_reader",
         "skills_reader",
     ):
@@ -38,6 +37,12 @@ def test_load_settings_exposes_library_defaults(tmp_path, monkeypatch):
             "items_open": True,
             "items_width": 40,
         }
+    assert settings["library"]["notes_reader"] == {
+        "items_open": True,
+        "items_width": 40,
+        "files_tree_open": True,
+        "files_tree_width": 40,
+    }
 
 
 def test_shipped_template_keeps_shared_reader_empty_and_legacy_reference_at_31():
@@ -85,6 +90,8 @@ items_width = 42
 [library.notes_reader]
 items_open = true
 items_width = 43
+files_tree_open = true
+files_tree_width = 47
 
 [library.prompts_reader]
 items_open = true
@@ -100,6 +107,8 @@ items_width = 45
     monkeypatch.setenv("TLDW_LIBRARY_READER_LIBRARY_OPEN", "false")
     monkeypatch.setenv("TLDW_LIBRARY_READER_CUSTOM_WIDTHS_ENABLED", "true")
     monkeypatch.setenv("TLDW_LIBRARY_READER_LIBRARY_WIDTH", "36")
+    monkeypatch.setenv("TLDW_LIBRARY_NOTES_READER_FILES_TREE_OPEN", "false")
+    monkeypatch.setenv("TLDW_LIBRARY_NOTES_READER_FILES_TREE_WIDTH", "64")
     for destination, width in (
         ("MEDIA", 52),
         ("CONVERSATIONS", 54),
@@ -132,6 +141,10 @@ items_width = 45
         assert settings["library"][f"{destination}_reader"]["items_width"] == width
         assert getattr(defaults, f"library_{destination}_items_open") is False
         assert getattr(defaults, f"library_{destination}_items_width") == width
+    assert settings["library"]["notes_reader"]["files_tree_open"] is False
+    assert settings["library"]["notes_reader"]["files_tree_width"] == 64
+    assert defaults.library_notes_files_tree_open is False
+    assert defaults.library_notes_files_tree_width == 64
 
 
 def test_load_settings_coerces_library_scan_limit(tmp_path, monkeypatch):
@@ -370,12 +383,45 @@ future_key = "keep"
         "items_open": False,
         "items_width": 48,
     }
-    assert library["notes_reader"] == {"items_open": True, "items_width": 52}
+    assert library["notes_reader"] == {
+        "items_open": True,
+        "items_width": 52,
+        "files_tree_open": True,
+        "files_tree_width": 40,
+    }
     assert library["prompts_reader"] == {"items_open": False, "items_width": 60}
     assert library["skills_reader"] == {
         "items_open": True,
         "items_width": 68,
         "future_key": "keep",
+    }
+
+
+def test_load_settings_normalizes_folder_tree_preferences_independently(
+    tmp_path, monkeypatch
+):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+[library.notes_reader]
+items_open = false
+items_width = 68
+files_tree_open = "not-a-bool"
+files_tree_width = 500
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    notes_reader = config_module.load_settings(force_reload=True)["library"][
+        "notes_reader"
+    ]
+
+    assert notes_reader == {
+        "items_open": False,
+        "items_width": 68,
+        "files_tree_open": True,
+        "files_tree_width": 40,
     }
 
 

--- a/backlog/decisions/089-console-full-semantic-capture-policy.md
+++ b/backlog/decisions/089-console-full-semantic-capture-policy.md
@@ -1,0 +1,180 @@
+# ADR-089: Scoped Full semantic capture policy
+
+Status: Accepted
+
+Date: 2026-08-26
+
+Related Task: [TASK-22507](../tasks/task-22507%20-%20Enable-scoped-Full-semantic-capture-in-Conversation-Inspector.md)
+
+Related Spec: [Console Full Semantic Capture](../../Docs/superpowers/specs/2026-08-26-console-full-semantic-capture-design.md)
+
+Amends: ADR-069's unconditional exclusion of project-instruction bodies from durable
+exchange captures; all other ADR-069 boundaries remain accepted.
+
+Clarifies: ADR-066's Trace ledger remains read-only. A live Trace screen may host a
+control for future exchange-capture policy without mutating trajectory events; imported
+Traces remain fully read-only.
+
+## Context
+
+The Console Conversation Inspector persists allowlisted provider exchanges at the
+provider-adapter boundary. ADR-069 subsequently required automatic project-instruction
+bodies to be removed from durable exchange captures, logs, transcripts, summaries, and
+tool results. This is a safe default, but it also means the historical Inspector cannot
+show all semantic context that caused a provider response.
+
+The owner requires deliberate Full capture at three scopes: the next eligible send,
+one inspected conversation, and the global Console default. Full capture must include
+Anthropic system content, injected project/workspace/RAG context, and tool traffic;
+remain bounded and credential-safe; expose honest retention; and support deletion of
+Full records without deleting the conversation.
+
+This changes privacy, provider/runtime boundaries, local schema, deletion semantics,
+and the long-lived Inspector contract, so it requires a new ADR rather than an edit to
+accepted ADR-069.
+
+## Decision
+
+1. **Safe remains the application default.** Capture detail is `safe` or `full`. The
+   existing `[console] exchange_capture` Boolean remains the authoritative kill switch.
+2. **Use scoped precedence.** An admitted human-authored manual or authorized queued
+   turn resolves next-send override, conversation override, global default, then Safe.
+   Autonomous wakeups do not consume or use the one-shot override.
+3. **Freeze at admission.** The resolved detail is stored on the run's existing
+   `ConsoleProviderStreamSignals`. Every provider call, retry, tool loop, and surviving
+   fleet call on that run uses the same detail despite later settings changes.
+4. **Capture semantic adapter content, not generic wire bytes.** Full retains
+   allowlisted content handed to provider adapters and observable responses, including
+   Anthropic system/messages/tools, project/workspace instructions, RAG context, tool
+   schemas/calls/results, and response content. Provider-internal framing remains out
+   of scope except where Chatbook already owns a literal payload such as llama.cpp.
+5. **Structural protections are invariant.** Full never admits structured provider
+   credentials or unknown kwargs, never persists raw binary/base64 bodies, never
+   bypasses bounded request/stream accumulation, serialization, compression, or
+   decompression limits, and never allows capture bodies into logs or raw exception
+   diagnostics. Request and response tool payloads share the same binary-stubbing
+   boundary. Endpoint fields reuse the existing canonical credential-free destination
+   identity, excluding URL userinfo, query, and fragment. Secrets embedded inside
+   allowed semantic text may be stored and are named in consent copy.
+6. **Amend ADR-069 narrowly.** Automatic project-instruction bodies may enter only an
+   explicitly Full durable exchange capture. They remain excluded from Safe captures,
+   transcripts, agent steps, tool results, compaction summaries, metadata surfaces,
+   ordinary logs, and permission/authority decisions. Full capture grants no workspace
+   or tool permission.
+7. **Keep ownership local and existing-pipeline based.** Global detail uses canonical
+   Console config. Sparse conversation detail uses an optional local-only policy row;
+   absence means inherit and a present row is checked Safe/Full. One-shot detail is
+   process memory. Exchange content remains in
+   `message_exchanges`; no new Trace event store or sync payload is added.
+8. **Persist queryable provenance.** Each exchange stores `capture_detail` in its
+   serialized capture and a checked queryable `message_exchanges` column, both derived
+   from one immutable capture. A mismatch is corrupt, not guessed. Historical records
+   default to Safe because the prior builder always applied Safe redaction.
+9. **Separate capture from export.** Stored detail is Safe/Full. Export profiles are
+   the existing `TraceExportProfile` values Safe summary, Redacted diagnostic, and Full
+   trace; exchange-specific projection is separate from trajectory projection. Export
+   cannot reconstruct content omitted at capture time, and every Full clipboard/file
+   disclosure is confirmed.
+10. **Provide scoped erasure under capture quiescence.** A conversation may delete only
+    its Full exchange rows after the controller holds a lease preventing new admission
+    and flush, with no active primary run, surviving/unsettled fleet writer, retained
+    run signals, or exchange flush. Replacement in-memory/cache collections are staged
+    before the SQLite transaction and swapped by reference immediately after commit,
+    before releasing the lease, so a later flush cannot recreate deleted rows. Scope is
+    the immutable conversation ID across active, off-path, abandoned, and soft-deleted
+    messages, never the mounted transcript. A capture revision blocks stale Inspector
+    expansion/export after purge. Purge does not change capture policy or delete Safe
+    captures, messages, usage, exports, or backups.
+11. **Classify mutations by resulting disclosure.** Each Apply changes one scope.
+    Inherit or disarm is an escalation when it reveals an underlying Full policy, and
+    global Full is always an escalation. Any Full-enabling result activates only after
+    required confirmation and persistence succeeds. A result that remains or becomes
+    Safe takes effect in memory even if its durable write fails and remains visibly
+    unsaved. Unknown values resolve Safe. Any purge failure before SQLite commit leaves
+    both durable and in-memory owners unchanged; post-commit UI refresh cannot recreate
+    deleted records.
+12. **Inspector and live Trace controls target immutable identity.** The shared policy
+    surface acts on the conversation/session captured when its parent screen opened,
+    carries process-local revisions against stale modals, and distinguishes an active
+    run's frozen detail from future policy. Imported/shared Traces remain read-only and
+    expose no live capture control.
+13. **Use the canonical runtime config projection and structured write result.** Safe
+    global changes publish to the app's shared config projection before persistence;
+    Full publishes only after atomic file replacement. A successful replacement with a
+    failed general cache refresh remains honestly saved and active in that projection.
+    F9 Settings, the Inspector, and the live Trace screen share this path, confirmation,
+    and config-generation fence; none owns a shadow value.
+14. **Keep Off dormant and make resume explicit.** The kill switch disarms live
+    one-shots but does not silently rewrite persistent conversation/global detail.
+    Status names dormant Full policy, and a first-party Off-to-On change warns before
+    any Full policy resumes. Full-enabling policy edits are unavailable while Off.
+
+## Alternatives considered
+
+### Keep Safe-only durable capture
+
+Rejected. It preserves the strongest default but cannot diagnose behavior caused by
+automatic instructions, retrieval context, or tool traffic that the provider actually
+received.
+
+### Capture literal HTTP requests and responses
+
+Rejected. Provider adapters own different transport layers, credentials and headers
+would create a larger secret boundary, streaming framing is provider-specific, and the
+existing semantic gateway seam already captures the user-relevant request contract.
+
+### Add a separate Full trace database or event stream
+
+Rejected. It duplicates exchange ownership, adds dual-write/recovery drift, and is
+unnecessary because `message_exchanges` already owns per-call request/response history.
+
+### Use one global Full toggle
+
+Rejected. It makes a high-risk diagnostic mode easy to leave enabled and cannot support
+the approved least-duration next-send and conversation use cases.
+
+### Store detail only inside compressed blobs and scan them for purge
+
+Rejected. Counting/deleting would require decoding every blob, corrupt records would be
+unclassifiable, and a privacy erasure action could silently leave content behind.
+
+### Make purge also set policy to Safe
+
+Rejected by owner choice. Deletion and future recording are separate actions; combining
+them would make a destructive action silently mutate configuration.
+
+### Claim scoped purge is forensic secure erasure
+
+Rejected. SQLite row deletion cannot promise immediate removal from WAL/free pages,
+filesystem snapshots, exports, or backups. The scoped action is honest logical record
+deletion; a whole-database sanitization workflow has different availability and
+data-loss consequences and requires a separate decision.
+
+## Consequences
+
+- Full records may contain highly sensitive local semantic text and can propagate into
+  user-created exports and backups. Capture blobs are compressed, not additionally
+  encrypted, and scoped purge is not forensic erasure of WAL/free pages. Consent and
+  documentation must state those boundaries plainly.
+- ChaChaNotes advances from the implementation-time current version through a migration
+  adding queryable exchange detail and local conversation capture policy. At design
+  time the provisional bump is v49 to v50; implementation must recheck.
+- Existing records remain readable and are classified Safe without blob rewriting.
+- The Inspector gains a compact status/control flow, per-call provenance, and scoped
+  erasure while retaining Costs, Exchange, and Next Send ownership; the live Trace
+  screen reuses the same future-capture control without changing Trace projection or
+  export ownership.
+- The canonical F9 Settings screen and Inspector edit one global source of truth.
+- Multiple app processes sharing one profile remain unsupported; within one process,
+  revision checks prevent stale Inspector writes.
+- ADR-069 remains authoritative for instruction discovery, authority, permission,
+  delivery, transcript, metadata, summary, tool-result, and logging boundaries except
+  for the explicit Full exchange-capture allowance recorded here.
+
+## Links
+
+- [Approved design](../../Docs/superpowers/specs/2026-08-26-console-full-semantic-capture-design.md)
+- [TASK-22507](../tasks/task-22507%20-%20Enable-scoped-Full-semantic-capture-in-Conversation-Inspector.md)
+- [ADR-069](069-console-project-instruction-local-state-and-preflight.md)
+- [ADR-066](066-console-trajectory-view-and-trace-metadata.md)
+- [Original Conversation Inspector design](../../Docs/superpowers/specs/2026-08-18-console-conversation-inspector-design.md)

--- a/backlog/decisions/093-raw-and-virtual-cli-execution-boundaries.md
+++ b/backlog/decisions/093-raw-and-virtual-cli-execution-boundaries.md
@@ -1,0 +1,133 @@
+# ADR-093: Raw and Virtual CLI Execution Boundaries
+
+Status: Accepted
+Date: 2026-08-26
+Related Tasks: [TASK-18926 - Raw CLI executor and Console user command](../tasks/task-18926%20-%20Raw-CLI-executor-and-Console-user-command.md), TASK-22509, TASK-22510, TASK-22512
+Design: [Raw and virtual CLI design](../../Docs/superpowers/specs/2026-08-26-raw-and-virtual-cli-design.md)
+Partially supersedes: [ADR-033](033-local-agent-process-execution-boundary.md), only its rejection of raw shell execution
+
+## Decision
+
+Chatbook will expose two deliberately different command capabilities.
+
+1. A read-only **virtual CLI** is available to models by default. It never
+   invokes a host shell. One structured `virtual_cli` model tool dispatches an
+   allowlisted command to existing policy-checked `fs_*` and read-only `git_*`
+   cores. Virtual commands have independent Allow / Ask / Off permissions under
+   the reserved synthetic principal `local:__virtual_cli__`; missing state
+   resolves to Ask. The virtual CLI remains workspace-confined and subject to
+   the sensitive-path denylist.
+2. An explicitly dangerous **raw CLI** invokes a real host shell. It is disabled
+   by default, requires both a persistent app-wide unlock and process-memory-only
+   re-arming on every Chatbook launch, and is never described as sandboxed or
+   workspace-confined. A raw command has the full filesystem, process, and
+   network authority of the OS user running Chatbook.
+
+Raw execution has two adapters over one executor:
+
+- a user-authored `! ` Console command that makes no provider call and does not
+  enter model context; and
+- a model-facing `shell_exec` tool registered only while raw CLI is unlocked,
+  armed, and the local-tool catalog is enabled.
+
+Model raw-shell permission is permanently constrained to Ask or Off. Approval
+offers Run once, Allow for this Console session, or Deny. No persistent Allow is
+valid: a stored Allow is coerced to Ask at runtime. User-authored `! ` commands
+run immediately once raw CLI is armed because the user supplied the command.
+The global tool kill switch blocks the model tools but does not block direct
+user commands.
+
+Raw commands are one-shot and non-interactive in this phase: one shell process,
+`stdin=DEVNULL`, no PTY, no retained working directory, and no retained
+environment. Shell startup profiles are disabled. The environment is built from
+a small allowlist of shell-essential variables rather than inherited wholesale.
+Output streams live into a bounded transcript preview and a bounded local run
+record. Timeout, cancellation, disarming, and shutdown terminate the owned POSIX
+process group or Windows Job Object with bounded waits.
+
+Process ownership is operational cleanup, not a security sandbox. A command
+with host-user authority may deliberately detach descendants; Chatbook must
+state when cleanup is unproven and must never promise that cancellation can
+contain adversarial code.
+
+User command records are durable but model-excluded. They use additive
+`agent_kind="local_command"` rows in the unconstrained `AgentRunsDB.agent_kind`
+column, anchored to the current persisted transcript leaf where available.
+Their tool-style transcript markers are rebuilt on resume. Existing agent
+counts and agent rails exclude this kind. Their run logs live under a dedicated
+app-private root that model-facing run-log search/slice/statistics providers do
+not register. This requires no database migration.
+
+The future persistent PTY/ConPTY terminal is a separate backlog task. It is not
+part of this decision's first implementation phase.
+
+## Context
+
+ADR-033 chose a virtual CLI and rejected raw shell execution because a claim of
+workspace confinement based only on `cwd` would be false, and a portable OS
+sandbox is a separate project. That reasoning remains correct. The product
+decision has changed: Chatbook should offer an advanced, unmistakably dangerous
+escape hatch for users and models who intentionally want the host shell, while
+keeping the virtual CLI as the safe default.
+
+The repository already owns most of the required seams:
+
+- `Agents/tool_catalog.py` and `Agents/local_tool_provider.py` provide model-tool
+  registration and invocation;
+- ADR-032's permission store and approval cards provide fail-closed consent;
+- `STT/executor_process_tree.py` provides proven POSIX process-group and Windows
+  Job Object admission patterns;
+- Console TOOL markers and AgentRunsDB provide durable local operational traces;
+- existing `fs_*` and read-only `git_*` cores provide the virtual command
+  implementations and their path/privacy boundaries.
+
+The raw executor therefore extends these seams rather than creating a terminal
+subsystem or a second permission store.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Preserve ADR-033's virtual-only decision | Does not meet the approved advanced-user requirement for a real host shell. |
+| Claim raw commands are confined because they start in the workspace | False: a shell can use absolute paths, change directory, access the network, and launch arbitrary processes. |
+| Require an OS sandbox for raw CLI v1 | Produces a different capability from the intentionally requested host-authority escape hatch and creates a large cross-platform sandbox project. |
+| Separate `bash_exec`, `powershell_exec`, and `cmd_exec` tools | Duplicates schemas, permissions, lifecycle code, and UI while one fixed shell selector is sufficient. |
+| Build a PTY terminal first | Adds retained state, interactive input, resize, reconnect, and terminal-emulation complexity before one-shot execution proves useful. |
+| Give the virtual CLI the underlying `fs_*` / `git_*` permissions | Rejected by product decision; virtual commands require independent Allow / Ask / Off state. |
+| Give raw shell persistent Allow | Leaves silent host-authority execution enabled beyond an explicit live session and conflicts with the approved re-arm-every-launch trust model. |
+
+## Consequences
+
+### Benefits
+
+- Safe model command access remains available and fail-closed by default.
+- Advanced users can run real cross-platform shell commands without an LLM call.
+- Models can receive raw-shell authority only through explicit launch arming and
+  a command-visible approval.
+- User and model raw execution cannot drift because both use one executor.
+- No new terminal screen, permission store, or database migration is required.
+
+### Costs and accepted risks
+
+- Raw CLI can read or destroy any OS-user-accessible data, modify Chatbook's own
+  permission/configuration files, access the network, and exhaust resources.
+- Environment scrubbing reduces accidental credential injection but does not
+  stop a command from reading credential files or invoking configured clients.
+- POSIX process groups and Windows Job Objects do not justify a universal claim
+  that intentionally detached descendants are contained.
+- Virtual CLI permissions may intentionally contradict the permissions of the
+  equivalent structured tool; the Tools UI must make that independence visible.
+- Raw command text and bounded output may contain secrets and persist in local
+  run logs. Generic diagnostics exclude both, but the danger disclosure must
+  explain local persistence.
+
+### Binding tripwires
+
+- A raw-shell path that claims workspace confinement requires a new ADR and real
+  OS-level enforcement evidence.
+- Persistent model Allow, startup-restored arming, shell profile loading, or
+  ambient environment inheritance require this ADR to be revisited.
+- Any mutating virtual command requires a separate design amendment, risk tags,
+  and mutating-command acceptance tests.
+- The persistent terminal phase requires its own ADR check because PTY ownership
+  and retained session state are new runtime boundaries.

--- a/backlog/decisions/094-console-turn-lifetime-and-navigation-boundary.md
+++ b/backlog/decisions/094-console-turn-lifetime-and-navigation-boundary.md
@@ -1,0 +1,131 @@
+# ADR-094: Own accepted Console turns above screen navigation
+
+Status: Accepted
+Date: 2026-08-27
+Related Task: TASK-22514
+Supersedes: the screen-scoped ordinary-turn policy recorded by TASK-1143 and
+TASK-15860 acceptance criterion 2
+
+## Decision
+
+Every accepted Console turn is owned by the app-level `ConsoleRuntime`, not by
+`ChatScreen` or a Textual worker attached to that screen. Navigation detaches the
+Console view and stops view-owned resources without cancelling ordinary chat, agent
+execution, turn-launched tools/media, delegated work, queues, or pending human
+decisions.
+
+The screen transfers an immutable, send-time request to the runtime before clearing
+the composer. The runtime registers custody before task scheduling and owns the task
+through final cleanup. The existing `ConsoleChatController` and `ConsoleChatStore`
+remain the only run-state, queue, cap, cancellation, streaming, and transcript
+authorities; the runtime registry tracks task lifetime only and is not a parallel state
+machine.
+
+Every screen-derived input needed by the turn is frozen at handoff or represented by an
+app-owned service. A surviving turn never consults a widget, dead screen callback, or a
+newly mounted screen's settings. Heavy request preparation remains asynchronous inside
+runtime custody.
+
+Tool approval, skill-install confirmation, and skill-script confirmation are retained
+independently of the view. Their decision clocks count only while the owning card is
+answerable. A hidden round emits one app-wide notice and waits without approving,
+denying, or consuming decision-active time. Returning to Console re-derives the active
+session's ordered pending decisions.
+
+Each user-visible completed or terminally failed transcript commit mints a stable opaque
+terminal receipt ID and writes a local-only
+`console_unseen:<terminal-receipt-id>` conversation mark in the same ChaChaNotes
+transaction. A mounted view clears only that exact mark after synchronizing the
+matching terminal row. Several outcomes in one conversation therefore cannot erase one
+another through a stale acknowledgement. Shell navigation displays a boolean attention
+glyph while any receipt mark or pending decision exists. Receipt marks never enter
+conversation sync, export, prompt payloads, or unrelated remote APIs. `AgentRunsDB` and
+shell state are projections, not participants in a cross-database transaction.
+
+Explicit Stop and confirmed session-close or app-shutdown cancellation create no new
+receipt or outcome toast. A cancellation without one of those explicit reasons is a
+terminal failure and follows the failed-receipt path.
+
+Navigation is not a cancellation boundary. Stop cancels its selected turn/chain;
+session close fences and cancels that session; confirmed app quit revision-pins the
+active set, fences admission, and disposes the runtime. Cancellation and completion use
+one atomic terminalization gate. Bounded cleanup and generation fences prevent an
+uncooperative provider or thread from hanging shutdown or committing late output.
+
+`ChatScreen` remains a fresh, disposable view. Detachment is guaranteed even when
+other unmount cleanup fails, and attachment generations prevent an outgoing screen
+from clearing a successor's hooks. Realtime microphone/audio resources, open modals,
+animations, screen timers, and unsent composition remain view-scoped.
+
+Application exit remains the final runtime boundary. This decision makes no promise
+that turns continue after a crash or restart; existing durable dispatch recovery keeps
+exclusive ownership of restart repair.
+
+## Context
+
+TASK-15860 moved the Console store, provider gateway, agent bridge, and controller to
+an app-owned runtime so supervisor wake turns could run with no Console mounted. It
+intentionally preserved a prior rule: leaving Console cancelled ordinary user streams
+and denied parked decisions. `ChatScreen` still dispatches ordinary turns through a
+screen-owned Textual worker, and runtime `leave_console()` still invokes per-visit
+turn cancellation.
+
+That rule makes navigation unsafe for the product's primary agent workflow. Opening
+Settings, Library, or another destination can interrupt the main response even though
+the store and controller already outlive the view. Existing headless-wake work also
+proved that caching or retaining a removed screen is not a safe solution: off-screen
+sync workers can query a torn-down DOM and terminate the TUI.
+
+The surviving-runtime seam already separates app-owned domain objects from view hooks.
+Extending task ownership into that runtime is therefore smaller and more coherent than
+adding a second job system or changing the navigation stack model.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Shield the screen worker with `asyncio.shield()` | The underlying task might survive, but draft recovery, callbacks, finalization, and cleanup would still belong to a dead screen. Cancellation bugs would move rather than disappear. |
+| Cache or hide `ChatScreen` | Conflicts with the fresh-screen invariant and recreates the measured dead-DOM/self-rearming-worker crash class. It also keeps timers and heavy DOM state resident. |
+| Add a separate background-job service | Duplicates controller queues, run state, caps, persistence, and cancellation. The existing app-owned runtime is already the correct lifetime boundary. |
+| Persist raw turn requests for restart continuation | Expands privacy, authority, side-effect replay, and recovery scope far beyond navigation. Existing restart recovery has a separate owner. |
+| Show global approval dialogs on the current screen | Interrupts unrelated work and spreads Console-specific security UI across every destination. App-wide notice plus Console-local decision is sufficient. |
+| Keep wall-clock approval deadlines running headlessly | Denies decisions while the user has no answerable control, contradicting the notify-and-wait promise. |
+| Clear attention on Console mount | Loses unrelated or background-session outcomes before the user sees them. Positive per-session terminal acknowledgement is deterministic. |
+| Use one mark for fleet and ordinary outcomes | Supervisor wake delivery legitimately clears `FLEET_UNSEEN`; sharing it could erase an unrelated user-turn result. |
+| Make transcript and `AgentRunsDB` terminal state one transaction | They are separate SQLite owners. An outer transaction cannot roll back another database's commit. ChaChaNotes owns user-visible terminal state and attention. |
+
+## Consequences
+
+- The ordinary send path changes from a screen-owned await to an app-runtime custody
+  handoff. Existing controller behavior remains authoritative after handoff.
+- Screen hook responsibilities split into frozen turn inputs, app-owned runtime
+  services, and disposable repaint callbacks. No surviving task may retain a screen.
+- `leave_console` can no longer mean both view detach and ordinary-turn cancellation.
+  Navigation uses detach semantics; Stop/session close/app disposal own cancellation.
+- Approval timing needs a decision-active clock and a unified view projection for all
+  three human-decision types.
+- `ConversationLocalMarksService` gains a validated
+  `console_unseen:<terminal-receipt-id>` namespace. The existing table is sufficient;
+  no schema migration is expected.
+- Completed/failed transcript finalization and exact receipt insertion share one
+  ChaChaNotes transaction. Visible views acknowledge that receipt afterward, so stale
+  acknowledgements and later completions cannot silently erase one another.
+- The navigation bar and overflow menu gain a boolean, non-color-only attention state.
+  Detailed counts and statuses remain inside Console.
+- The old navigate-away loss confirmation, teardown notice, and screen-scoped User
+  Guide language are removed. Quit confirmation remains revision-pinned.
+- Runtime cancellation waits become bounded and late-write fenced. Underlying
+  non-cancellable threads may finish, but cannot mutate terminal state after fencing.
+- Tests must cover real navigation, viewless approvals, multi-session isolation,
+  restart-durable local marks, privacy, dead-view collection, narrow layouts, and an
+  isolated live streamed response.
+- The feature does not broaden process lifetime. Confirmed quit and forced process
+  death still end runtime execution.
+
+## Links
+
+- [Approved design spec](../../Docs/superpowers/specs/2026-08-27-console-turns-survive-navigation-design.md)
+- [TASK-22514](../tasks/task-22514%20-%20Console-turns-survive-screen-navigation.md)
+- [TASK-15860: app-owned headless Console runtime](../tasks/task-15860%20-%20Headless-wake-fire-the-supervisor-auto-wake-with-no-Console-screen-mounted.md)
+- [TASK-1143: former screen-scoped fleet warning](../tasks/task-1143%20-%20Screen-navigation-silently-kills-the-agent-fleet.md)
+- [ADR-085: Console activity receipts and switcher ownership](085-console-activity-receipts-and-switcher-ownership.md)

--- a/backlog/decisions/095-conversation-owned-console-generation-settings.md
+++ b/backlog/decisions/095-conversation-owned-console-generation-settings.md
@@ -1,0 +1,220 @@
+# ADR-095: Own Console conversation settings and explicit defaults separately
+
+Status: Accepted
+Date: 2026-08-27
+Related Task: TASK-22515
+Extends: ADR-006, ADR-033, and ADR-052
+
+## Decision
+
+An explicit `Apply to this chat` from either the Console Provider/Model popover or
+the full Console Settings modal updates the exact originating Console conversation's
+generation settings immediately. Any consumer that resolves its execution settings
+after that commit observes the new values. Work that already captured an immutable
+execution context continues with that captured context.
+
+The settings surfaces also expose two explicit default actions. `Save as model
+default` first performs the same exact-origin live Apply, then field-masked-patches
+`api_settings.<provider>.model_defaults[<exact model id>]`. `Make default for new
+chats` performs that model-profile patch and atomically changes
+`chat_defaults.provider` plus `chat_defaults.model`. Ordinary Apply never mutates
+configuration, and compaction is excluded from both default actions.
+
+Every blank new-chat creation path without an explicit source-settings intent uses
+the saved global provider/model and its exact model profile. This includes Ctrl+T,
+temporary chats, workspace-created blank chats, and the initial pristine Console
+chat after startup. Existing/open conversations do not rebase. Duplicate, Branch,
+Continue, and handoff operations carrying explicit settings remain source-owned and
+are not eligible blank-chat creation.
+
+Persisted conversations store a versioned `console_generation_settings` object in
+`conversations.metadata`. The object is an allowlisted snapshot of safe,
+user-editable generation fields:
+
+- `provider`
+- `model`
+- `temperature`
+- `top_p`
+- `min_p`
+- `top_k`
+- `max_tokens`
+- `seed`
+- `presence_penalty`
+- `frequency_penalty`
+- `reasoning_effort`
+- `reasoning_summary`
+- `verbosity`
+- `thinking_effort`
+- `thinking_budget_tokens`
+- `streaming`
+
+The snapshot never contains `base_url`, credentials, credential references,
+`source`, character identity, system prompt, or pinned prefill. Endpoint and
+credential resolution remains provider-configuration-owned. System prompt and
+pinned prefill keep their existing conversation-owned persistence paths.
+
+Both Console settings surfaces call one conversation-settings Apply orchestration.
+Each surface submits its validated target values, discriminated action, and field
+mask;
+neither surface rebases settings itself. The session controller is the sole
+provider/model-rebase owner. It serializes the resulting complete safe allowlist so
+a provider or model change cannot leave stale values in the durable overlay.
+
+Whenever provider or model changes, the controller starts from the selected
+provider/model's established default chain, resolves that provider's endpoint
+afresh, overlays only deliberately edited fields supported by the target, and clears
+unsupported reasoning/thinking fields. Untouched fields therefore load the target
+model profile; deliberate edits remain visibly marked. An open settings transaction
+keeps a process-local draft map keyed by canonical provider plus literal model ID so
+A → B → A restores A's unfinished edits. `Full settings…` transfers that draft map,
+field provenance, compaction draft, and exact origin into the full Model view without
+applying or discarding it. Conversation resume performs the same provider-first
+rebase before applying the saved safe snapshot.
+
+The quick model-profile field mask is temperature and streaming. The full Model
+mask is every supported sampler, reasoning/thinking, token-limit, and streaming
+field it exposes. Blank profile values delete the exact override so lower-precedence
+defaults apply; the conversation still stores the effective value resolved at Apply
+time as a complete snapshot. Full Settings therefore represents streaming as
+Inherit, On, or Off.
+
+Default mutation rereads config under the existing lock and patches only the exact
+masked profile fields, global provider/model when applicable, and an eligible
+endpoint. It preserves sibling profiles, unexposed fields, unrelated concurrent
+edits, and literal model IDs containing punctuation. Only full Settings `Make
+default for new chats` may include an endpoint, and only when it was explicitly
+edited and the user left the scoped checkbox checked. Its UI and logs contain only
+a sanitized host plus a syntactic Local/LAN/Remote-or-unknown classification; no DNS
+lookup, credential, userinfo, path, query, or fragment is used.
+
+Each live Apply increments a process-local settings revision on the exact session.
+Metadata persistence carries that revision plus the captured conversation identity.
+A retry proceeds only while both still match and the owned metadata value has not
+been superseded; sibling-only version conflicts may reload, merge, and retry within
+the existing bounded policy. Missing or malformed objects fail closed to current
+defaults. A future unsupported version is preserved and is never overwritten by an
+older client without an explicit user reset.
+
+An unsaved ordinary session stages its live generation settings and writes the
+safe snapshot when the conversation is first persisted. A temporary conversation
+remains non-durable; promotion writes its current safe snapshot into the promoted
+conversation.
+
+Apply from the quick popover includes compaction mode. Compaction remains a sparse
+`ConsoleContextPolicyOverrides` value in its existing
+`console_conversation_context_policy` owner; it is never copied into
+`console_generation_settings`. The Apply orchestration commits generation settings
+and the complete context-policy snapshot live to the exact origin before yielding,
+then persists generation metadata and that complete policy snapshot through their
+respective existing owners. One durable failure cannot roll back or veto the other
+live component or modal dismissal.
+
+Each session retains a bounded process-local durability record whose component keys
+are `generation_settings` and `context_policy`. The collapsed Model section shows a
+warning badge; its expanded rail displays the failed components and a `Retry save`
+action until the still-current component snapshots save successfully, a newer change
+supersedes them, or the session closes. A quick-popover context-policy failure may be
+labeled `compaction`; a full-modal failure is labeled `context settings` when it
+contains other policy edits. Retrying context policy writes the complete still-current
+policy snapshot and is guarded by its policy revision plus the captured conversation
+identity, so it cannot overwrite a newer non-compaction policy change or clear a
+newer failure.
+
+Unsaved ordinary sessions stage both components without displaying a failure.
+First persistence includes generation metadata with conversation creation and uses
+the existing context-policy post-create flush; a failed component enters the same
+visible durability state. Temporary sessions remain non-durable until promotion.
+Promotion includes generation metadata in the conversation bundle and persists
+compaction through its existing owner afterward; a compaction failure leaves the
+successful promotion intact and visible as `compaction` not saved.
+
+Default configuration failures use a separate bounded app-level record because the
+failed owner affects future chats rather than one conversation. Failure before file
+replacement reads `Not written to disk` and offers `Retry default save` plus
+`Discard retry`. Failure after successful file replacement reads `Saved on disk;
+running app refresh failed` and offers cache-only `Refresh running app` plus
+`Dismiss`; it never repeats the disk mutation, and restart loads the saved values.
+Discard and Dismiss acknowledge the pending recovery state and never imply rollback
+of live or already-durable values. A newer explicit default action supersedes an
+older failed intent, while locked reread and exact-field patching prevent stale retry
+from overwriting unrelated or newer config edits.
+
+## Context
+
+The Provider/Model popover currently creates a new in-memory
+`ConsoleSessionSettings` value and dismisses it to `ChatScreen`. The screen updates
+the active session, but provider/model generation settings are not restored when a
+conversation is reopened after restart. Resume currently restores only the system
+prompt and pinned prefill.
+
+The mouse path can also fail before the semantic Apply handler because an Input may
+retain Textual mouse capture. The full Settings modal already contains the required
+input-release and redirected-click pattern. The quick popover does not. Live
+testing also exposed a deferred `_sync_fold_hint` callback that can query the
+dismissed popover and raise `NoMatches`.
+
+The current quick Apply uses `dataclasses.replace`, which preserves `base_url` when
+the provider changes. That can route a newly selected provider through the previous
+provider's endpoint. Persisting the full settings dataclass would make the problem
+worse and could copy configuration-owned or sensitive values into conversation
+data.
+
+The existing per-model profile schema already has the required precedence and full
+Settings support, but current Console default saving writes broader provider/global
+sections instead of the exact profile. Current Ctrl+T blank-chat creation also clones
+the active session, so a global default can be saved successfully without controlling
+the next obvious new chat. This decision makes blank-chat creation resolve the saved
+default and reserves source cloning for explicitly source-owned flows.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Keep settings in process memory | Fails the required reopen-after-restart behavior and continues to make Apply appear ineffective. |
+| Make ordinary Apply also mutate the global default | Silently changes future chats and contradicts the explicit exact-conversation scope; global mutation is allowed only through `Make default for new chats`. |
+| Add a new preset/profile schema | Duplicates the existing exact-model profile owner and creates another precedence layer without user value. |
+| Keep Ctrl+T cloning the active session | Makes `Make default for new chats` false for the primary blank-chat path; explicit Duplicate/Branch/Continue already cover intentional carryover. |
+| Add a dedicated conversation-settings table | Adds a migration and repository surface without improving the required single-conversation lookup; versioned conversation metadata already provides the needed ownership and merge rules. |
+| Store the full `ConsoleSessionSettings` dataclass | Would persist endpoints and runtime-only fields and would couple the storage schema to an internal Python type. |
+| Put generation settings in the compaction policy store | Mixes independent owners and makes an unrelated context policy capable of blocking Provider/Model Apply. |
+
+## Consequences
+
+- Provider/Model Apply becomes durable for persisted conversations without a
+  schema migration.
+- Quick and full Console Settings can no longer disagree about whether their safe
+  generation fields survive restart.
+- Exact-model defaults reuse the existing model-profile schema; no new preset owner
+  or precedence layer is introduced.
+- `Make default for new chats` controls every eligible blank-chat path in the current
+  process after runtime publication and across reboot. Existing/open and explicitly
+  source-owned conversations remain unchanged.
+- Provider endpoints remain configuration-owned. Only full Settings `Make default
+  for new chats` may persist an explicitly edited, checked endpoint.
+- Apply remains successful in live session state even when either durable write
+  fails. The user sees the exact failed components persistently after the popover
+  closes and can retry their still-current generation or complete context-policy
+  snapshot.
+- A per-session settings revision prevents an older persistence completion or
+  retry from overwriting a newer Apply or a rebound conversation identity.
+- Metadata parsing and serialization require a small versioned helper with an
+  explicit allowlist and sibling-preserving merge.
+- Provider changes must use one provider-aware rebase path from both settings
+  surfaces and conversation hydration; model changes use the same path and draft
+  provenance rules.
+- Default config failure is app-global and distinguishes not-written state from
+  already-written/runtime-stale state, while conversation durability remains local
+  to the owning session.
+- The popover interaction needs captured-click recovery and teardown-safe deferred
+  callbacks, using the existing full-modal pattern rather than a new event system.
+- Compaction keeps its existing schema and repository, while the shared Apply
+  orchestration and session-local durability record coordinate honest outcomes
+  across the two owners.
+
+## Links
+
+- [Design spec](../../Docs/superpowers/specs/2026-08-27-console-provider-apply-persistence-design.md)
+- [TASK-22515](../tasks/task-22515%20-%20Make-Console-provider-Apply-update-and-persist-conversation-settings.md)
+- [ADR-006: Provider-aware generation settings](006-provider-aware-generation-settings.md)
+- [ADR-033: Application session state ownership](033-application-session-state-ownership.md)
+- [ADR-052: Conversation memory and compaction policy](052-conversation-memory-and-compaction-policy.md)

--- a/backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
+++ b/backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
@@ -1,0 +1,267 @@
+# ADR-097: Use a reference-backed semantic trace ledger
+
+Status: Accepted
+
+Date: 2026-08-28
+
+Originating Task: [TASK-23026](../tasks/task-23026%20-%20Exchange-capture-stores-the-whole-conversation-on-every-send-forever.md), completed by the superseded bounded-retention implementation
+
+Related Spec: [Console Reference-Backed Semantic Trace Ledger](../../Docs/superpowers/specs/2026-08-28-console-reference-backed-semantic-trace-ledger-design.md)
+
+Supersedes: [ADR-096](096-console-safe-capture-retention.md), which bounded Safe
+captures by discarding older semantic history.
+
+Amends: the Console Full semantic-capture policy and
+[ADR-092 Console chat fork](092-console-chat-fork-copy-and-authority-boundary.md).
+
+## Context
+
+Default Console exchange capture persists the complete accumulated provider message
+list in every call's compressed `message_exchanges.capture_blob`. A production-shaped
+200-turn conversation retained 15.40 MB because each later call copied all previous
+messages. Soft deletion keeps the blobs and no automatic reclamation path exists.
+
+ADR-096 chose a bounded Safe excerpt and one aggregate omission marker. That makes
+future Safe storage linear, but it deliberately discards the historical context needed
+to explain some provider behavior and leaves exact Full capture with the same repeated-
+history architecture. The owner rejected that trade-off: ordinary conversation content
+already has a durable owner and must not be copied into each exchange. Provider-only
+semantic context should be stored once or explicitly omitted.
+
+Fixing this requires new durable ownership for semantic revisions, provider-only
+artifacts, call boundaries, fork prefixes, redaction projections, legacy normalization,
+and deletion. It also changes Safe/Full meaning and the earlier rule that automatic
+project-instruction bodies never enter default durable capture.
+
+## Decision
+
+1. **Make the saved conversation the ordinary-content source of truth.** A captured
+   call references immutable semantic message revisions. Capturing a current revision
+   creates metadata pointing to the live message row and does not copy its body.
+
+2. **Use copy-on-write historical revisions.** Before an edit or hard deletion would
+   destroy referenced content, the required sanitized trace projection is materialized
+   once per unique disclosure policy and bound through an immutable
+   `(revision, policy) -> artifact-or-omission` relation in the same transaction. A
+   revision does not have one ambiguous materialized locator. Failure aborts the edit
+   or deletion.
+
+   Semantic revision identity is an opaque transactional identity, not a persisted
+   raw, salted, or keyed digest of canonical conversation text. Ephemeral comparison
+   fingerprints are discarded before commit.
+
+3. **Add one append-only semantic trace ledger.** Typed events record turn/call
+   boundaries, model-surface append/replacement, tool traffic, request-header
+   selection, provider overlays, response selection, outcomes, usage, and explicit
+   gaps. Events contain structural shells and content references, not repeated ordinary
+   bodies.
+
+4. **Give each provider call a trace boundary and header reference.** Calls are owned
+   by conversation, lineage, turn, run, and call sequence rather than the eventual
+   assistant message. Retries, tool-loop calls, failures, stops, interruptions, and
+   abandoned generations remain distinct calls. No call stores a history array
+   proportional to the conversation's age.
+
+5. **Store request headers only when their effective value changes.** A complete
+   logical header records provider/model configuration, rendered system references,
+   tool-schema references, response/reasoning controls, endpoint's credential-free
+   identity, and required provider overlays. Large components are content-addressed
+   artifacts, so a new header does not duplicate their bodies.
+
+6. **Store provider-only semantic material once.** Rendered automatic instructions,
+   RAG/memory context, tool schemas, provider overlays, unmatched legacy rows, and
+   responses not equal to a saved assistant revision enter a sanitized content-
+   addressed artifact store. Binary bodies remain external or stubbed under existing
+   attachment rules. Artifact reuse compares sanitized stored bytes and structure after
+   digest lookup; a mismatch receives a separate opaque identity rather than aliasing.
+
+7. **Define fidelity as semantic with disclosed omissions.** Reconstruction covers the
+   final semantic kwargs handed to Chatbook's provider-call boundary, not provider-
+   internal HTTP. Credential filtering, optional PII masking, binary stubbing,
+   truncation, corruption, legacy loss, and sanitizer failure are explicitly disclosed;
+   affected calls never claim byte-exact or complete semantics.
+
+8. **Carry provenance through provider-neutral preparation.** `PreparedConsoleRequest`
+   keeps semantic sections while parallel capture-only descriptors identify message
+   revisions, settings, automatic context, tool values, and provider transforms.
+   Descriptors never reach the provider or grant authority. The gateway binds them to
+   the exact final semantic values before dispatch and fails capture closed on mismatch
+   instead of persisting raw kwargs.
+
+9. **Share immutable trace prefixes across forks.** A fork records the source trace
+   boundary alongside its message snapshot fence and appends only its own suffix.
+   Durable and temporary forks retain coherent inherited history without physical
+   prefix copying. Source deletion cannot remove a prefix still owned by a fork.
+
+10. **Keep historical trace immutable and non-editable.** Message edits, regeneration,
+    and context compaction append model-surface replacements using one predecessor
+    surface head plus a bounded contiguous range, never a variable list of shadowed
+    events. The viewer may inspect, filter, search permitted projections, copy, export,
+    or purge ownership; it never edits historical trace.
+
+    The semantic revision covers the complete provider-visible message envelope,
+    including ordered multimodal/tool/reasoning/attachment sidecars. Every mutation
+    route passes through one coordinator enforced by transaction-scoped database
+    guards; direct mutation of referenced semantic content fails closed.
+
+11. **Separate capture, PII, and viewer controls.** Capture On/Off and optional PII
+    redaction resolve at global, conversation, and eligible next-send scope and freeze
+    for a run. PII defaults Off. Safe/Full is a local viewer/export disclosure profile
+    over the same stored trace, not a different at-rest history. Forks inherit future
+    settings while historical calls retain their frozen provenance. Both viewer modes
+    apply each call's frozen credential/PII masks to canonical references; the ordinary
+    conversation transcript remains unchanged.
+
+12. **Filter credentials mandatorily and fail closed.** Known credential fields,
+    credential-bearing URL components, nested credential fields, and recognized secret
+    formats in provider-only text are removed before trace persistence. Arbitrary prose
+    secrets cannot be guaranteed detectable and the UI says so. Sanitizer failure
+    creates a content-free unavailable marker; no raw fallback is stored.
+
+13. **Offer irreversible trace PII masking.** Built-in detectors and validated user-
+    authored regex rules produce immutable structured-field-path plus Unicode-span
+    projections. Custom regex runs in a bounded killable subprocess because CPython
+    `re` has no portable hard timeout.
+    Historical projections retain source identity, start/end codepoint ranges,
+    detector/rule IDs, and an opaque ruleset revision identity, never matched values,
+    value hashes, surrounding text, or regex source. Ranges necessarily reveal matched position and
+    codepoint count; this is accepted so referenced canonical messages can be masked
+    without copying them. PII masking protects traces but does not silently rewrite
+    canonical conversation messages.
+
+14. **Normalize legacy captures automatically and resumably.** A fast schema step
+    enables normalized writes and dual reads. After UI readiness, idle bounded batches
+    split legacy blobs into revision references and deduplicated provider-only
+    artifacts. A blob is deleted only after reading back the normalized call and
+    reproducing its sanitized legacy projection. Legacy calls become isolated immutable
+    snapshot surfaces backed by persistent prefix sequence nodes; migration does not
+    invent cross-call edit/fork chronology the old rows never recorded. Ambiguous rows
+    remain individual legacy artifacts. ADR-096 aggregate markers become explicit
+    irreversible legacy omissions.
+
+15. **Reserve Capture On calls before provider dispatch.** A minimal content-free call
+    reservation containing identity, lineage, and frozen capture policy commits before
+    each Capture On dispatch, then durably becomes `dispatch_started` immediately before
+    provider-adapter entry. Reservation failure blocks automatic dispatch and offers
+    Retry or an explicit one-shot Send without capture action. Interactive tool/retry
+    loops pause for that choice; autonomous runs fail safely. Cold recovery maps an
+    untouched reservation to `not_dispatched`, an uncertain started call to
+    `dispatch_unknown`, and a response-bearing open call to `interrupted`.
+
+    Temporary conversations cannot make a durable Capture On call until Save & Send
+    promotes their in-memory lineage. After dispatch, component capture and sealing are
+    best-effort and independently idempotent: they cannot roll back a provider result or
+    saved assistant message. Destructive semantic edits/deletes are different: required
+    preservation and canonical mutation commit together or all abort.
+
+16. **Use shared-owner garbage collection and honest physical maintenance.** Deletion
+    detaches one conversation root. Background mark/sweep reclaims unreachable objects
+    only after a global trace-graph epoch recheck. Every root or reachability-edge
+    mutation advances that epoch, and sweep holds maintenance exclusion. SQLite
+    physical compaction runs automatically
+    at a later eligible visible idle pause with connection closure, WAL checkpoint, disk
+    preflight, and maintenance lease. Logical, freelist, WAL, and allocated bytes are
+    reported separately; no action claims forensic erasure from backups or exports.
+
+17. **Prove linear growth with the real gateway.** A semi-incompressible 200-turn
+    production-shaped benchmark records normalized rows and bytes, legacy bytes,
+    database/freelist/WAL size, and settlement costs. A second fixture repeatedly
+    replaces 75 percent of the surface. Second-half trace bytes and rows may be at most
+    1.25 times first-half growth; the pinned append-only fixture is capped at 2.0 MiB of
+    trace-owned live bytes at 200 turns. Reservation p95 is capped at 10 ms, settlement
+    p95 at 25 ms, and migration write batches at 100 ms. No normalized call or
+    replacement may contain a list or blob proportional to prior transcript length.
+
+18. **Migrate disclosure settings conservatively and stage expensive features.** Old
+   capture enablement maps to Capture On/Off, but old Safe/Full capture detail remains
+   historical provenance and every upgraded profile starts with the Safe viewer. Full
+   requires a new explicit viewer choice. Core ledger capture, mandatory filtering, and
+   logical normalization must prove their gates before custom-regex execution or physical
+   compaction is enabled.
+
+19. **Keep token-chunk packing separate.** Raw token-level event capture and lossless
+    chunk-row encoding are deferred to [TASK-23112](../tasks/task-23112%20-%20Add-lossless-chunk-row-encoding-for-streamed-trace-events.md)
+    and are not required by the forthcoming ADR-097 implementation umbrella.
+
+## Consequences
+
+- Safe remains diagnostically useful because the stored trace can explain provider-
+  visible context without repeating the transcript. Safe and Full differ in disclosure,
+  not historical availability.
+- Automatic project-instruction and injected-context bodies may be stored once under
+  the default capture path after mandatory filtering and optional PII masking. They
+  remain excluded from ordinary transcripts, metadata, logs, permission decisions, and
+  authority grants.
+- The normalized data model is larger than ADR-096's bounded-excerpt patch, but it
+  resolves future Full growth, message-edit fidelity, fork coherence, and legacy
+  reclamation with one ownership system instead of parallel exceptions.
+- Current messages remain unduplicated until an edit or deletion makes one historical
+  copy necessary. Repeated calls and forks reuse that copy.
+- Capture On adds one small synchronous reservation write before each provider call.
+  Users may explicitly bypass a reservation failure for one send; that choice is shown
+  in live run/UI state but, consistently with Capture Off, is not guaranteed a durable
+  trace record.
+- A trace with intentional masking or legacy omission is structurally reconstructable
+  but not content-complete, and the UI must say so.
+- Source hard deletion may fail safely when required historical materialization cannot
+  complete.
+- Shared fork prefixes mean purging one conversation may not reclaim bytes retained by
+  another owner; the UI reports remaining forks.
+- Optional PII masking cannot remove PII from the canonical conversation and does not
+  retroactively rewrite legacy traces without explicit later work.
+- Legacy logical reclamation occurs in the background; allocated database bytes may
+  remain until automatic physical compaction is admitted.
+- TASK-23026 remains the completed historical record of ADR-096's implementation.
+  Implementation requires a new umbrella task and multiple dependency-ordered Backlog
+  work packages. The design spec defines their boundaries; exact IDs are created
+  during implementation planning.
+
+## Alternatives considered
+
+### Retain a fixed Safe excerpt
+
+Rejected. It discards causal context, leaves Full quadratic, and makes debugging depend
+on choosing Full before the failure occurs.
+
+### Store one fingerprint per omitted message
+
+Rejected. Reference metadata still grows quadratically across calls and hashes can
+confirm guesses about private content.
+
+### Keep compressed full-request blobs
+
+Rejected. Compression reduces some bytes but preserves repeated logical ownership and
+does not solve edits, forks, deletion, or exact component reuse.
+
+### Store arbitrary JSON deltas
+
+Rejected. A custom patch language duplicates representation and introduces brittle
+diff/apply/fallback behavior. Typed surface events and immutable references retain one
+logical model.
+
+### Replace Chatbook conversations with a wholly event-sourced session system
+
+Rejected. Existing messages, variants, sync, and conversation ownership remain useful.
+The trace ledger references them and event-sources only provider-visible historical
+projection.
+
+### Copy the trace prefix on fork
+
+Rejected. It recreates the storage defect for fork-heavy workflows and complicates
+deletion. Immutable shared prefixes provide coherent reads without copying.
+
+### Run user regex in-process
+
+Rejected. Validation cannot eliminate every catastrophic-backtracking pattern and
+CPython `re` cannot be portably interrupted. A killable subprocess provides a hard
+runtime boundary without making a transitive regex engine a core dependency.
+
+## Links
+
+- [Approved design](../../Docs/superpowers/specs/2026-08-28-console-reference-backed-semantic-trace-ledger-design.md)
+- [TASK-23026](../tasks/task-23026%20-%20Exchange-capture-stores-the-whole-conversation-on-every-send-forever.md)
+- [Superseded ADR-096](096-console-safe-capture-retention.md)
+- [Console chat fork ADR](092-console-chat-fork-copy-and-authority-boundary.md)
+- [TASK-23112](../tasks/task-23112%20-%20Add-lossless-chunk-row-encoding-for-streamed-trace-events.md)
+- [DeepSeek Harness session model](https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/subsystems/session.md)
+- [DeepSeek reconstructable requests](https://github.com/deepseek-ai/deepseek-harness/blob/master/.agents/notes/implemented/architecture/2026-07-05-reconstructable-requests.md)

--- a/backlog/decisions/098-low-latency-speculative-duplex-voice-pipeline.md
+++ b/backlog/decisions/098-low-latency-speculative-duplex-voice-pipeline.md
@@ -1,0 +1,269 @@
+# ADR-098: Use provisional turns over one app-owned AEC duplex pipeline
+
+Status: Accepted after three-pass spec review and user-approved final correction
+
+Date: 2026-08-28
+
+Related Task: Implementation tasks will be created from the approved design during planning.
+
+Related Spec: [Low-Latency Speculative Duplex Voice Pipeline](../../Docs/superpowers/specs/2026-08-28-low-latency-speculative-duplex-voice-pipeline-design.md)
+
+Amends: [ADR-094](094-console-turn-lifetime-and-navigation-boundary.md) by defining
+speculative voice attempts as pre-acceptance, view-scoped work, and
+[ADR-097](097-console-reference-backed-semantic-trace-ledger.md) by allowing winning-only
+post-dispatch capture promotion for those attempts.
+
+## Context
+
+The Console's provider-agnostic hands-free loop currently finalizes speech after a
+two-second silence gate, runs segment transcription, waits a 1.5-second countdown, and
+then sends through the ordinary Console path. `VoiceSpeechResumed` can cancel the
+countdown, but after response generation starts the existing policy stops speech only;
+the LLM finishes silently into the transcript.
+
+Reducing the silence gate alone would dispatch incomplete text because non-streaming STT
+currently begins material work only after segment finalization. Keeping the microphone
+open during assistant speech without echo cancellation would also let the recognizer
+transcribe Chatbook's own TTS. The existing opt-in acoustic mode therefore recommends
+headphones and cannot become the default behavior requested here.
+
+Reliable low-latency interruption requires one render/capture clock, a timestamped
+render reference, AEC before VAD/STT, rolling transcript revisions, cancellable attempt
+epochs, and isolation from durable history and external effects. This boundary must work
+on macOS, Windows, and Linux and must degrade safely when a device route cannot sustain
+full duplex.
+
+Two existing decisions constrain persistence and lifetime. ADR-094 moves accepted
+Console turns above screen navigation but deliberately keeps microphone and realtime
+audio resources view-scoped. ADR-097 requires durable pre-dispatch reservation for
+ordinary Capture On calls. Persisting every provisional prompt would violate the
+requirement that cancelled voice attempts leave no content-bearing artifacts, while
+silently forcing Capture Off would make the winning voice turn ignore an explicit user
+preference.
+
+## Decision
+
+1. **Use one app-owned full-duplex hands-free audio path.** Microphone capture and every
+   hands-free TTS provider share a timestamped duplex transport. Legacy file-producing
+   TTS is decoded into that PCM path rather than played by an external process. The
+   transport owns device formats, hardware latency, frame timestamps, bounded rings,
+   and device changes; it does not own transcript or turn policy.
+
+2. **Ship WebRTC AEC3 behind a narrow native interface.** The project builds and
+   distributes a small native component for supported macOS, Windows, and Linux Python
+   architectures. Render and capture are processed in ten-millisecond frames near the
+   hardware boundary. WebRTC types do not escape into application code. The package
+   ships hashes, provenance, SBOM, applicable signing, license/patent notices, and an
+   update policy.
+
+3. **Put AEC and residual health before speech admission.** Post-AEC frames alone may
+   reach VAD, STT, command detection, or acoustic barge-in during render. Health states
+   are warming, healthy, and degraded with hysteresis. Warming or degraded output keeps
+   hardware capture running for recovery but closes speech admission during playback.
+   AEC disabled or unavailable means explicit half duplex, never an unsuppressed open
+   microphone.
+
+4. **Replace silence-started STT with one rolling revision protocol.** Native streaming
+   adapters publish provider revisions. Batch-only adapters emulate rolling behavior
+   through one in-flight bounded overlapping window and supersede obsolete queued work.
+   Every revision carries stable text, revisable tail, audio coverage, backend mode, and
+   content-free timing metadata. LLM dispatch waits for coverage of the detected speech
+   tail even when the response-eagerness timer has expired.
+
+5. **Treat short pauses as speculative attempt boundaries within one logical user
+   turn.** The default threshold is 700 ms and is configurable from 500 to 3000 ms in
+   canonical Speech & TTS Settings. The coordinator snapshots the freshest transcript
+   and starts an attempt-local generation. New speech or a material STT correction
+   atomically advances the attempt epoch before requesting provider cancellation,
+   stopping audio, discarding provisional response state, and scheduling a replacement.
+
+6. **Bound speculation.** The first three attempts within ten seconds use the configured
+   threshold; later attempts temporarily use 1.5 seconds. No more than two obsolete
+   provider attempts may clean up concurrently. Reaching the cap pauses dispatch. If
+   cleanup exceeds two seconds, the remainder of that logical turn enters a serialized
+   conservative state: wait for two seconds of stable silence and zero obsolete
+   attempts, allow only one active request, and still fence it immediately on resumed
+   speech. At five seconds after cancellation, force-close the attempt-owned transport;
+   500 ms later, a still-running task is detached behind its epoch fence and the logical
+   turn terminates as a recoverable draft failure. Detached tasks enter an app-lifetime
+   voice orphan set. While any member remains, a shared supervisor quarantines all
+   hands-free provider dispatch across hands-free toggles, provider changes, and session
+   rebuilds; ordinary typed chat remains available. Voice resumes only when the entire
+   set empties or the app restarts. Members cannot publish state, audio, receipts, or
+   captured content. The existing two-obsolete-attempt cleanup cap bounds this set at
+   two because dispatch stops before a third attempt can start. These rules give the
+   turn a terminal outcome and limit cost and uncooperative work without weakening
+   immediate audio cancellation.
+
+7. **Speak only current-attempt safe prose.** The phrase sequencer releases punctuation-
+   terminated prose first and uses a bounded word/time fallback only after resolving
+   Markdown/code ambiguity. It owns one sequential synthesis at a time. All phrase PCM
+   re-enters the duplex transport and every callback is attempt-fenced.
+
+8. **Keep tools behind a two-second effect barrier.** A speculative tool request creates
+   no approval and executes nothing. If stable silence since the last admitted speech
+   reaches two seconds, Chatbook discards the speculative request, commits the exact
+   user transcript, and re-dispatches through the ordinary accepted agent pipeline.
+   That pipeline owns tools, approvals, Capture On reservation, persistence, and
+   ADR-094 runtime custody. Speech after effect commitment is a new turn or explicit
+   interruption; an external effect is never rewritten into a prior turn.
+
+9. **Keep no-tool attempts pre-acceptance and view-scoped.** They do not enter
+   `ConsoleRuntime` accepted-turn custody, the ordinary Console store, or durable
+   conversation history while provisional. Navigation away, hands-free exit, session
+   close, or shutdown fences and discards them without terminal receipts. This preserves
+   ADR-094's view-scoped microphone/audio rule. A winning transcript/assistant pair is
+   promoted only after generation, speech, and transcript sealing reach their terminal
+   boundary. Promotion uses the existing durable-turn terminalization transaction to
+   write the pair, mint ADR-094's stable terminal receipt, and write the exact local
+   unseen mark. It registers and terminalizes an already-complete accepted voice turn
+   atomically rather than creating a second provider task.
+
+10. **Use winning-only post-dispatch exchange-capture promotion.** The ordinary ADR-097
+    durable reservation is not written before a provisional provider request. The
+    gateway instead builds its sanitized semantic capture envelope in bounded memory.
+    Cancelled envelopes are destroyed; only content-free usage, timing, backend mode,
+    and attempt counts may remain. After the winning pair commits, its envelope may be
+    settled best-effort as `provisional_voice_promoted`, explicitly declaring that it
+    lacks crash-durable pre-dispatch reservation. A crash before promotion leaves no
+    conversation or exchange trace. Capture settlement failure never rolls back the
+    conversation. Tool-barrier re-dispatch uses unchanged ADR-097 semantics.
+
+    Temporary chats remain unable to create durable capture lineage. Speculative voice
+    may run with explicit capture-unavailable status; its winning messages and envelope
+    remain process-local. Later Save may persist the messages but never retroactively
+    invents the earlier exchange trace. Tool-barrier dispatch retains the existing Save
+    & Send prerequisite.
+
+11. **Use timestamped terminal boundaries.** Speech starting no later than the estimated
+    final hardware-rendered sample extends the same logical turn; later speech starts a
+    new one. Audible stop targets 150 ms p95. If speech output fails, text may commit only
+    after generation finishes without a newer speech/revision event.
+
+    Transcript, render, and control events are serialized. Every input frame is stamped
+    before DSP with an ordered sequence and the output render clock's monotonic time.
+    Before promotion, a full-duplex engine must advance its input watermark beyond the
+    terminal render boundary and drain AEC/VAD through every earlier sequence. Any
+    qualifying speech extends the turn. Only then may STT seal every revision derived
+    from downstream-acknowledged admitted audio. The combined drain has a 500 ms
+    deadline; timeout, sequence gaps, device reset, or failed acknowledgement prevents
+    promotion, preserves an editable draft, and suspends speculation until the duplex
+    engine is rebuilt healthy. Intentional half duplex has no eligible playback-period
+    capture frames, so render completion closes that gated interval and manual barge-in
+    is its only same-turn interruption path. Explicit Stop/Esc/mic-toggle/hands-free
+    exit discards the provisional turn.
+
+12. **Separate new pipeline settings from legacy and Realtime compatibility keys.**
+    `dictation.response_eagerness_ms` belongs only to the speculative pipeline.
+    `dictation.pipeline_aec_enabled`, default true, is its troubleshooting-only AEC
+    switch and false forces half duplex. `dictation.acoustic_barge_in` remains unchanged
+    for the Realtime engine; the speculative pipeline does not read it.
+    `dictation.handsfree_send_delay_seconds` remains legacy-pipeline-only during rollout
+    and is ignored after qualification rather than being mistranslated into eagerness.
+    Existing keys are preserved for older releases and no startup migration writes the
+    config.
+
+13. **Expose honest capability and cost state.** Settings distinguish native live STT
+    from rolling-window emulation, disclose overlapping remote batch processing and
+    increased speculative usage, and offer response eagerness plus troubleshooting-only
+    AEC disable. UI status distinguishes listening, transcribing, responding, speaking,
+    response update, AEC warming, and half-duplex degradation. Logs and diagnostics
+    contain no transcript or audio body.
+
+14. **Qualify every platform before default enablement.** Native package, DSP corpus,
+    deterministic integration, latency, soak, and physical speaker/microphone gates must
+    pass on macOS, Windows, and Linux. Bluetooth may pass through explicit safe
+    half-duplex degradation but not unsafe full duplex. After qualification, AEC and
+    speculative pipeline turns become default-on with a local half-duplex kill switch.
+
+## Alternatives considered
+
+### Lower the existing silence threshold only
+
+Rejected. Batch transcription would still start after the threshold and LLM dispatch
+would use no rolling hypothesis, missing the requested latency and freshness contract.
+
+### Keep acoustic interruption opt-in and recommend headphones
+
+Rejected. It does not provide reliable default speaker use and preserves the
+self-transcription failure mode.
+
+### Use platform-native AEC independently on each OS
+
+Rejected as the primary engine. Apple voice processing, Windows communication effects,
+and PipeWire echo cancellation have different availability and health semantics. Three
+policy implementations would make behavior and testing inconsistent. Platform APIs may
+assist device integration behind the common boundary.
+
+### Implement an adaptive filter in Python
+
+Rejected. Reliable nonlinear echo cancellation, delay/drift handling, residual
+suppression, and real-time callback behavior require a maintained native DSP engine.
+
+### Put audio/AEC/STT in a sidecar process
+
+Rejected for the first implementation. It improves crash isolation but adds IPC,
+supervision, packaging, and lifecycle duplication before the in-process bounded
+interfaces have proved insufficient.
+
+### Let cancelled generations finish silently
+
+Rejected. It cannot rebuild the response from newly appended speech and wastes latency
+while retaining an answer to an obsolete prompt.
+
+### Execute read-only tools speculatively
+
+Rejected. Tool side-effect classification is not universally trustworthy, remote reads
+may cost money or disclose incomplete speech, and duplicate execution would remain
+observable. All tools share one effect barrier.
+
+### Persist every provisional exchange under Capture On
+
+Rejected. It would retain cancelled prompt/response content and contradict the
+ephemeral-attempt promise.
+
+### Force Capture Off for all speculative voice turns
+
+Rejected. Safe, but it silently defeats a user's Capture On preference even for the
+winning response. Winning-only post-dispatch promotion preserves useful diagnostics
+with an honest durability label.
+
+## Consequences
+
+- Hands-free audio playback becomes an app-owned PCM responsibility; external legacy
+  players are no longer valid for that path.
+- A new native build/release surface and cross-platform hardware qualification matrix
+  are required.
+- Rolling-window batch STT can increase provider audio processing and must expose that
+  cost honestly.
+- Aggressive pauses can generate billable discarded attempts; the restart governor and
+  split usage accounting make the trade-off bounded and visible.
+- Provisional no-tool turns cancel on Console navigation because they are not accepted
+  ADR-094 runtime turns. Tool turns become navigation-surviving only after the effect
+  barrier commits and re-dispatches them normally.
+- ADR-097 gains one explicitly weaker crash-provenance class for a promoted winning
+  voice call. The trace remains semantically useful but cannot claim pre-dispatch
+  reservation.
+- A successful no-tool promotion still participates in ADR-094 terminal receipts and
+  exact unseen-mark acknowledgement even though its provider work was pre-acceptance.
+- Temporary chats run speculative voice without durable capture and never synthesize a
+  posthoc trace when later saved.
+- Provider tasks that survive force-close cannot deadlock a logical turn or accumulate
+  without bound: the turn fails to a draft and an app-lifetime fenced set, capped at two,
+  quarantines all later voice dispatch until every member exits.
+- Promotion requires an end-to-end capture/AEC/VAD/STT watermark through the render
+  boundary; an unknown watermark fails closed rather than guessing turn ownership.
+- AEC-unhealthy routes remain functional but half duplex. Safe degradation is a passing
+  capability result rather than a hidden failure.
+- Implementation requires several dependency-ordered Backlog tasks; each task must be
+  atomic, independently testable, and linked to this ADR and design.
+
+## Links
+
+- [Approved design spec](../../Docs/superpowers/specs/2026-08-28-low-latency-speculative-duplex-voice-pipeline-design.md)
+- [ADR-023: TTS adapter registry and audio.cpp boundary](023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md)
+- [ADR-039: Speech and TTS settings ownership](039-global-and-studio-tts-settings-ownership.md)
+- [ADR-094: Console turn lifetime and navigation](094-console-turn-lifetime-and-navigation-boundary.md)
+- [ADR-097: reference-backed semantic trace ledger](097-console-reference-backed-semantic-trace-ledger.md)
+- [Hands-Free Conversation Loop design](../../Docs/superpowers/specs/2026-08-02-hands-free-loop-design.md)
+- [Realtime Voice Engine design](../../Docs/superpowers/specs/2026-08-04-realtime-voice-engine-design.md)

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -177,6 +177,28 @@ diff your tree's task filenames against dev's.
 
 ---
 
+## Parallel agents in one worktree share one Git index
+
+**TASK-22513, 2026-08-27.** The coordinator staged a two-line plan correction while
+the Task 7 implementer was finishing its slice in the same checkout. The implementer
+had already staged its production and test files, so the coordinator's next ordinary
+`git commit` captured both the plan correction and the complete implementation as
+`d5940b6100`. No file content was lost, and a cached-diff audit proved the captured
+changes were the intended ones, but the planned commit boundary disappeared and both
+agents' reports initially attributed the commit differently. Separate processes and
+separate path ownership did not provide separate staging areas: both were writing the
+same `.git/index`.
+
+**What to do.** In a shared worktree, serialize every stage/commit operation. Before
+committing, require the other actor to stop staging and inspect
+`git diff --cached --name-status`; after committing, inspect the commit's path list and
+confirm the index is empty. Prefer one commit owner with workers leaving changes
+unstaged, or give committing workers isolated worktrees. Explicit path arguments to
+`git add` protect the staging action, but they do not prevent an ordinary `git commit`
+from including paths another process staged first.
+
+---
+
 ## A clean scoped rebase can still invalidate a repository-wide manifest
 
 **TASK-856, 2026-08-08.** Tasks 1–3 and their scoped reviews were clean when the

--- a/backlog/tasks/task-22452 - Make-Anthropic-cost-chip-tests-persist-readiness-config.md
+++ b/backlog/tasks/task-22452 - Make-Anthropic-cost-chip-tests-persist-readiness-config.md
@@ -1,0 +1,41 @@
+---
+id: TASK-22452
+title: Make Anthropic cost-chip tests persist readiness config
+status: Done
+assignee: []
+created_date: '2026-08-26 05:03'
+updated_date: '2026-08-26 05:08'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Keep the Anthropic cost-chip UI tests hermetic while exercising the production readiness refresh path. The shared disk-shaped test app reloads its sandboxed TOML, so the fake gateway credentials must be persisted there instead of existing only in a stale in-memory snapshot.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Anthropic cost-chip sends reach the fake gateway and render the expected cost states.
+- [x] #2 The test helper writes provider selection and fake credentials only to the per-test sandbox through the production config API.
+- [x] #3 Production provider-readiness behavior is unchanged and focused readiness, inspector, and capture regression tests pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the Anthropic cost-chip failure against the disk-shaped shared test app.
+2. Persist the fake Anthropic selection and API key atomically through the production config API while retaining the mounted session selection.
+3. Run the cost-chip, provider-readiness, inspector, and exchange-capture regression suites.
+
+ADR required: no
+ADR path: N/A
+Reason: This is a hermetic test-harness repair that does not alter storage, runtime boundaries, contracts, security policy, or production behavior.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Updated the Anthropic cost-chip test helper to batch-persist its model selection and fake API key through save_settings_to_cli_config before mounting the Console, while keeping the app snapshot aligned for session creation. Production readiness logic was not changed. Removed one pre-existing unused import in the touched test module so focused lint passes. Verification: 124 focused tests passed (cost chip, provider readiness refresh, inspector/exchange capture, cost tracker/status chip); Ruff and git diff --check passed. ADR required: no (test-harness-only repair). No new lessons entry was needed because the task-ID collision pattern is already documented in lessons-backlog-hygiene.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-22513 - Polish-Library-Notes-work-first-editors-and-Folder-Files-shell.md
+++ b/backlog/tasks/task-22513 - Polish-Library-Notes-work-first-editors-and-Folder-Files-shell.md
@@ -1,0 +1,62 @@
+---
+id: TASK-22513
+title: Polish Library Notes work-first editors and Folder Files shell
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-27 06:04'
+labels:
+  - library
+  - notes
+  - ui
+dependencies:
+  - TASK-22032
+  - TASK-19001
+references:
+  - Docs/superpowers/specs/2026-08-26-library-notes-ux-improvements-design.md
+  - backlog/decisions/086-library-adaptive-reader-shell.md
+  - backlog/decisions/076-library-lifecycle-progressive-disclosure.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make both Library Notes authorities calmer and more efficient for sustained writing while preserving database and on-disk authority, state, recovery, and every incumbent capability.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Database Notes and Folder Files use the shared adaptive reader shell as their only geometry and focus-evacuation owner, including an independently collapsible Folder Files tree.
+- [x] #2 Work-first Library collapse activates once per approved Notes work session, manual expansion wins, responsive changes never persist, and all reset predicates are deterministic.
+- [x] #3 Database list and Folder tree visibility and width preferences use independent normalized keys, Settings controls, environment overrides, and race-safe persistence authorities.
+- [x] #4 Database Notes retains Edit, Preview, Info, and all navigator workflows; Folder Files exposes Edit and Manage, retains autosave and recovery, and gains neither Markdown Preview nor a manual Save control.
+- [x] #5 Only the two note-body editors retain their resting background on focus and use a geometry-stable heavy outline with verified theme contrast.
+- [x] #6 Primary headers preserve authority and consequential status, apply the approved status precedence, and keep safe recovery actions visible without truncation.
+- [x] #7 The Notes-specific Ctrl+S binding and hints are removed without adding a replacement shortcut; visible Save remains keyboard reachable.
+- [x] #8 Targeted reducer, configuration, Settings, shell, Notes, Folder Files, accessibility, CSS, and live isolated TUI verification pass.
+- [x] #9 Library Notes and Folder Files user documentation reflects the final pane, mode, focus, save, and shortcut behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implementation plan: Docs/superpowers/plans/2026-08-26-library-notes-work-first-ux.md
+Design: Docs/superpowers/specs/2026-08-26-library-notes-ux-improvements-design.md
+ADR required: no
+ADR path: N/A
+Reason: this directly implements ADR-086's shared adaptive-reader shell and ADR-076's progressive-disclosure boundaries without changing storage, sync/conflict policy, service ownership, security, dependencies, or cross-module contracts.
+Existing ADRs: backlog/decisions/086-library-adaptive-reader-shell.md; backlog/decisions/076-library-lifecycle-progressive-disclosure.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+- Reused `LibraryAdaptiveReaderShell` for both Notes authorities, with independent Database list and Folder Files tree preferences, Settings/environment integration, drag widths, responsive behavior, and focus restoration. Added the session reducer that applies work-first collapse once per admitted editing session while preserving manual overrides and deterministic resets.
+- Reorganized Database Notes into Edit/Preview/Info and Folder Files into Edit/Manage without removing incumbent workflows. Kept Folder Files autosave-only, kept Database Save visible and keyboard reachable, removed only the Notes Ctrl+S binding/hints, and documented both authorities.
+- Limited boundary-only focus styling to the two note-body editors. Verified unchanged fill and geometry across every shipped theme with at least 3:1 boundary contrast. Preserved specific validation, save-failure, conflict, and blocked-action detail in the painted Notes status channel.
+- Hardened New/Move path-task admission across root, session, and authority transitions. Review found and fixed the production-order shared-save race by cancelling a path task admitted during flush before source-transition admission.
+- Targeted automated evidence included a final 162-case Notes-focused integration batch, a 14-case task-regression batch, and a post-review 12-case race/status/state batch, all passing. Earlier task-focused batches covered Settings, Git/maintenance disclosure, CSS source/build parity, and the shared shell. Ruff, task-owned format checks, compileall, and branch/worktree diff checks passed.
+- An isolated live Textual walkthrough passed at 160x40, 120x35, 119x35, 100x30, 80x24, 79x24, and 60x20. It exercised both authorities, one-time collapse/manual reopen, resize and authority round trips, drafts/cursor/undo/tree/search retention, modes, visible actions, focus styling, and shortcut scope. All data/config paths were redirected to `/private/tmp/task22513-live.3ieSLy`; the real config hash remained `1b23f3a533632631678644eaeabcb1c5737e2cb7b9d6dc1d6e9323f622fece12` before and after.
+- Independent spec review approved the branch. Quality review identified two P2 issues; both were fixed with regression coverage, and the final re-review approved the result.
+- The broader planned matrix was interrupted after review fixes made its collected code stale. Its task-owned failures were rerun green. Unrelated Settings ownership, legacy Library hub, nested `.venv` CSS-walker, and formatting failures reproduce on the detached pre-feature base or clean-worktree comparison and were not changed. The full repository suite was not run because the user did not opt into a full sweep.
+- ADR required: no. ADR path: N/A. This implements existing ADR-086 and ADR-076 without changing storage, sync/conflict policy, service contracts, security, dependencies, or ownership boundaries.

--- a/backlog/tasks/task-22514 - Console-turns-survive-screen-navigation.md
+++ b/backlog/tasks/task-22514 - Console-turns-survive-screen-navigation.md
@@ -1,0 +1,52 @@
+---
+id: TASK-22514
+title: Console turns survive screen navigation
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-08-28 00:35'
+updated_date: '2026-08-28 01:32'
+labels:
+  - console
+  - agents
+  - architecture
+  - navigation
+dependencies: []
+references:
+  - Docs/superpowers/specs/2026-08-27-console-turns-survive-navigation-design.md
+  - backlog/decisions/094-console-turn-lifetime-and-navigation-boundary.md
+  - Docs/superpowers/plans/2026-08-27-console-turns-survive-navigation.md
+documentation:
+  - Docs/superpowers/plans/2026-08-27-console-turns-survive-navigation.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make every accepted Console turn continue when the user switches screens. Navigation detaches the Console view without interrupting provider streaming, agent work, tools, or pending human decisions. Stop, session close, and confirmed app exit remain cancellation boundaries. Approved design: Docs/superpowers/specs/2026-08-27-console-turns-survive-navigation-design.md. Architecture decision: backlog/decisions/094-console-turn-lifetime-and-navigation-boundary.md.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Every accepted normal chat and agent turn continues across real screen navigation without a screen-owned task or dead-view callback.
+- [ ] #2 Tool approval, skill-install confirmation, and skill-script confirmation notify once and wait safely while Console is detached.
+- [ ] #3 Stop, session close, and revision-pinned app quit cancel only their intended scope while navigation never signals turn cancellation.
+- [ ] #4 Returning to Console reconciles continuing and completed work from the live app-owned store without duplicate or missing transcript content.
+- [ ] #5 Targeted deterministic tests and an isolated live-provider journey verify navigation races, approval timing, multi-session isolation, bounded shutdown, unread restart behavior, privacy, and narrow-terminal navigation rendering.
+- [ ] #6 The User Guide removes obsolete screen-scoped cancellation warnings and documents background continuation, approvals, attention markers, and shutdown behavior.
+- [ ] #7 Completion and terminal failure while hidden produce one app-wide notice and a durable local-only Console attention marker that clears only after the owning session renders the matching terminal result.
+- [ ] #8 Send-time turn context and accepted attachments transfer to app-owned runtime custody without broadening existing provider requests or leaking raw content into attention state, logs, exports, sync, or unrelated remote APIs.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add app-owned turn custody and transfer prompt ownership before composer clear.
+2. Make navigation a generation-fenced pure view detach and freeze all send-time inputs.
+3. Retain MCP, skill-install, and skill-script decisions with answerable-time clocks.
+4. Atomically persist terminal receipt marks and project hidden outcomes into shell attention.
+5. Fence Stop, session close, and app quit to exact scopes with bounded cleanup.
+6. Verify real navigation, races, restart durability, privacy, narrow layouts, and an isolated live-provider journey.
+7. Update the User Guide and complete targeted review/verification.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-22515 - Make-Console-provider-Apply-update-and-persist-conversation-settings.md
+++ b/backlog/tasks/task-22515 - Make-Console-provider-Apply-update-and-persist-conversation-settings.md
@@ -1,0 +1,92 @@
+---
+id: TASK-22515
+title: Make Console provider Apply update and persist conversation settings
+status: Done
+assignee: []
+created_date: '2026-08-28 05:52'
+updated_date: '2026-08-29 13:28'
+labels: []
+dependencies: []
+references:
+  - ADR-095
+documentation:
+  - >-
+    Docs/superpowers/specs/2026-08-27-console-provider-apply-persistence-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure the Console Provider/Model popover and full Console Settings apply provider-generation choices and compaction to the exact conversation immediately, preserve them across restart through their existing owners, and give mouse and keyboard users the same reliable Apply behavior. Add explicit exact-model and new-chat default actions that remain truthful across live, disk, and runtime-publication failures.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Mouse and keyboard `Apply to this chat` both close the popover and update the exact originating conversation once.
+- [x] #2 Provider, model, effective generation values, streaming, and compaction apply immediately to all work whose execution context is resolved after Apply while already-captured work remains unchanged.
+- [x] #3 Quick Provider and full Console Settings use one exact-origin Apply orchestration and the same durable conversation-generation contract while compaction keeps its existing context-policy owner.
+- [x] #4 Reopening a persisted conversation after restart restores its applied generation settings and compaction without storing credentials or endpoints.
+- [x] #5 Changing either provider or model rebases untouched fields from the target model's existing default chain, drops stale endpoint and unsupported fields, preserves visibly marked deliberate edits, and restores keyed A → B → A drafts.
+- [x] #6 `Full settings…` transfers the complete quick draft, compaction draft, field provenance, and exact origin into the full Model view without applying or discarding edits.
+- [x] #7 The quick footer exposes `Apply to this chat`, `Defaults…`, `Full settings…`, and `Cancel`; the Defaults substate replaces that footer with `Save as model default`, `Make default for new chats`, and `Back` while stating that compaction stays with this chat.
+- [x] #8 `Save as model default` applies live, closes, and field-masked-patches the exact literal provider/model profile only; quick saves temperature and streaming while full Settings saves all supported exposed fields, and blank removes the exact profile override.
+- [x] #9 `Make default for new chats` performs the same model-profile save plus an atomic global provider/model update that affects every eligible blank new chat immediately after runtime publication and across reboot.
+- [x] #10 Ctrl+T, temporary, workspace-created, and initial pristine blank chats use the saved global provider/model and exact model profile; existing/open conversations and deliberate Duplicate, Branch, Continue, or explicit handoff settings remain unchanged.
+- [x] #11 Only full Settings `Make default for new chats` may persist an explicitly dirty, checked endpoint; its preview contains a sanitized host and conservative Local/LAN/Remote-or-unknown classification, with no DNS lookup, credentials, or URL details.
+- [x] #12 Compaction remains conversation-only through its existing context-policy owner and is never copied into model profiles or global defaults.
+- [x] #13 Unsaved conversations stage both conversation-durable components until first persistence, while temporary conversations remain non-durable unless promoted.
+- [x] #14 Invalid input, duplicate activation, and dismissed deferred callbacks cannot create a false-success close, double commit, or teardown error.
+- [x] #15 Conversation generation/context-policy failures remain visibly identified per session and revision with Retry, while quick-surface context-policy failure may be labeled compaction.
+- [x] #16 Default mutation failure before file replacement is app-global and offers `Retry default save` / `Discard retry`; successful file replacement with runtime-publication failure offers cache-only `Refresh running app` / `Dismiss` and never repeats the disk mutation.
+- [x] #17 Locked exact-field config mutation preserves sibling model profiles, unexposed fields, literal punctuated model IDs, and unrelated concurrent edits; a newer explicit default action supersedes stale retry intent.
+- [x] #18 Targeted tests cover interaction and 60×24/72×24 layout, exact-origin execution, provider/model draft rebasing, quick-to-full transfer, persistence/resume, eligible new-chat paths, inheritance, endpoint safety, config concurrency, staged persistence/promotion, partial failures, retry/discard/dismiss, and restart behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Detailed executable plan:
+Docs/superpowers/plans/2026-08-28-console-provider-apply-and-defaults.md.
+
+1. Define one UI-neutral exact-origin submission, draft provenance, target rebase,
+   and default field-mask contract shared by quick and full Console settings.
+2. Add a strict versioned conversation-generation metadata codec, merge-safe
+   persistence service methods, and config-derived resume hydration.
+3. Make ConsoleChatStore own the exact-session live commit, per-component
+   revisioned failure state, Retry behavior, and first-persistence staging.
+4. Extend the atomic config writer with literal tuple paths and implement exact
+   model-profile/global-default mutation plus the two honest failure phases.
+5. Route all eligible blank-new-chat entry points through the published global
+   provider/model and exact model profile without changing source-derived chats.
+6. Rebuild the quick popover and full Console Settings actions on the shared
+   contract, including draft transfer, inherited streaming, endpoint opt-in,
+   validation, teardown safety, and narrow-terminal layout.
+7. Coordinate live Apply/default persistence in ChatScreen, expose session-local
+   and app-global recovery actions, and verify the complete targeted matrix.
+8. Complete backlog notes, acceptance-criteria evidence, static checks, and task
+   hygiene only after the implementation is verified.
+
+ADR required: yes
+
+ADR path:
+backlog/decisions/095-conversation-owned-console-generation-settings.md
+
+Reason: ADR-095 is the accepted owner/boundary decision for conversation
+generation metadata, context-policy persistence, exact-model defaults, global
+new-chat defaults, and runtime publication.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the shared exact-origin Console settings contract across the quick Provider popover and full Settings modal. Apply now commits live provider/model/generation/streaming/compaction values to the originating chat before close; generation metadata and the existing context-policy owner persist them safely, including atomic first-send creation, restart hydration, temporary-chat promotion, delayed interleavings, display-name staging, and per-component Retry recovery.
+
+Added exact-model and eligible-new-chat default mutations with literal field masks, atomic config writes, runtime publication, checked sanitized endpoint previews, and explicit before-replace versus cache-publication recovery. Default claim publication is two-phase and serialized across rapid actions without holding config/intent locks on the Textual event loop.
+
+Rebuilt narrow modal/popover behavior for production CSS at 60x24 and 72x24, including real mouse hit targets, keyboard scrolling/focus containment, long model/endpoint summaries, blocked-provider copy, Defaults/Full settings transfer, and phase-specific Retry/Discard/Refresh/Dismiss actions.
+
+ADR required: yes. ADR path: backlog/decisions/095-conversation-owned-console-generation-settings.md. The implementation follows ADR-095 ownership boundaries; no new ADR was required.
+
+Verification: integrated targeted Console matrix 519 passed; post-final rapid-action/default slice 9 passed; full modified concurrency module 54 passed; Ruff passed on production and test files; compileall and git diff checks passed. Existing dependency/deprecation and pytest temporary-directory cleanup warnings remain unchanged. The full repository pytest suite was not run because project policy requires explicit user opt-in.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-23112 - Add-lossless-chunk-row-encoding-for-streamed-trace-events.md
+++ b/backlog/tasks/task-23112 - Add-lossless-chunk-row-encoding-for-streamed-trace-events.md
@@ -1,0 +1,34 @@
+---
+id: TASK-23112
+title: Add lossless chunk-row encoding for streamed trace events
+status: To Do
+assignee: []
+created_date: '2026-08-28 14:38'
+labels:
+  - console
+  - storage
+  - performance
+  - tracing
+dependencies: []
+references:
+  - >-
+    https://github.com/deepseek-ai/deepseek-harness/blob/master/packages/core/session/src/chunk-rows.ts
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add an optional physical encoding for future token-level Console trace events that packs consecutive compatible stream-delta events into compact storage rows while preserving the canonical logical event sequence exactly. This keeps token-level replay and diagnostics feasible without creating one database row and repeated envelope fields per streamed chunk. The encoding is a persistence optimization only: callers and the trace viewer continue to consume ordinary canonical events. This is follow-up work after the reference-backed semantic trace ledger defined by ADR-097; it is not part of that implementation program.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Encoding followed by decoding reproduces every canonical event exactly including type payload sequence timestamp turn call and block identity
+- [ ] #2 Only consecutive compatible same-kind delta runs are packed and incompatible mixed or structural events preserve their original boundaries and order
+- [ ] #3 Packing across persistence flush boundaries remains correct without requiring callers to coordinate batch shapes
+- [ ] #4 Malformed or unsupported packed rows fail closed with a specific corruption or format diagnostic rather than yielding partial history
+- [ ] #5 Existing unencoded traces remain readable and the physical encoding does not create a second logical event model
+- [ ] #6 Targeted tests cover text reasoning and tool-call deltas Unicode empty chunks timestamp gaps interrupted streams short runs and mixed event kinds
+- [ ] #7 A representative streaming benchmark reports database bytes row count encode cost and decode cost before and after the feature
+<!-- AC:END -->

--- a/tldw_chatbook/Chat/chat_persistence_service.py
+++ b/tldw_chatbook/Chat/chat_persistence_service.py
@@ -24,6 +24,8 @@ from tldw_chatbook.Chat.console_chat_models import CONSOLE_GLOBAL_WORKSPACE_ID
 from tldw_chatbook.Chat.console_context_repository import (
     ConsoleContextRepository,
     ContextPolicyReadResult,
+    ContextPolicyWriteResult,
+    ContextPolicyWriteStatus,
 )
 from tldw_chatbook.Chat.console_dispatch_repository import ConsoleDispatchRepository
 from tldw_chatbook.Chat.console_dispatch_checkpoint import (
@@ -37,6 +39,16 @@ from tldw_chatbook.Chat.console_library_policy import (
     ConsoleLibraryPolicyCandidate,
     ConsoleLibraryPolicySnapshot,
     ConsoleLibraryPolicyWriteStatus,
+)
+from tldw_chatbook.Chat.console_generation_settings_metadata import (
+    ConsoleGenerationSettingsReadResult,
+    ConsoleGenerationSettingsReadStatus,
+    ConsoleGenerationSettingsSnapshot,
+    ConsoleGenerationSettingsWriteResult,
+    ConsoleGenerationSettingsWriteStatus,
+    merge_console_generation_settings,
+    parse_console_generation_settings,
+    strict_json_metadata_object,
 )
 from tldw_chatbook.Chat.console_transaction_contribution import (
     ConsoleTransactionContribution,
@@ -69,6 +81,7 @@ from tldw_chatbook.Video_Generation.video_metadata import VideoGenerationMetadat
 
 logger = _logger.bind(module="ChatPersistenceService")
 _ASSISTANT_AUTHORITY_UNSET = cast(Optional[str], object())
+_CONTEXT_POLICY_EXPECTED_REVISION_UNSET = object()
 CONSOLE_FORK_SOURCE_LINEAGE_MAX_DEPTH = 10_000
 
 
@@ -85,37 +98,7 @@ class ConsoleForkCommitResult:
 
 def _initial_metadata_object(metadata: object) -> dict[str, object]:
     """Return strict JSON-object metadata without lossy key coercion."""
-
-    def reject_constant(value: str) -> None:
-        raise ValueError(f"Non-finite JSON constant {value!r} is not supported.")
-
-    try:
-        if isinstance(metadata, Mapping):
-            candidate = dict(metadata)
-            if not _mapping_keys_are_strings(candidate):
-                raise ValueError("Mapping keys must be strings.")
-            serialized = json.dumps(candidate, allow_nan=False, sort_keys=True)
-            decoded = json.loads(serialized, parse_constant=reject_constant)
-        elif type(metadata) is str:
-            decoded = json.loads(metadata, parse_constant=reject_constant)
-        else:
-            raise ValueError("Unsupported metadata type.")
-    except (TypeError, ValueError, json.JSONDecodeError, RecursionError) as exc:
-        raise ValueError("metadata must be a valid JSON object.") from exc
-    if not isinstance(decoded, dict):
-        raise ValueError("metadata must be a valid JSON object.")
-    return decoded
-
-
-def _mapping_keys_are_strings(value: object) -> bool:
-    if isinstance(value, Mapping):
-        return all(
-            type(key) is str and _mapping_keys_are_strings(item)
-            for key, item in value.items()
-        )
-    if isinstance(value, (list, tuple)):
-        return all(_mapping_keys_are_strings(item) for item in value)
-    return True
+    return strict_json_metadata_object(metadata)
 
 
 class ChatPersistenceService:
@@ -327,13 +310,137 @@ class ChatPersistenceService:
         """Return local sparse context-policy overrides for one conversation."""
         return self.context_repository.load_policy(conversation_id)
 
+    def get_conversation_generation_settings(
+        self, conversation_id: str
+    ) -> ConsoleGenerationSettingsReadResult:
+        """Read one conversation's complete safe generation snapshot."""
+        if type(conversation_id) is not str or not conversation_id:
+            return ConsoleGenerationSettingsReadResult(
+                ConsoleGenerationSettingsReadStatus.ABSENT
+            )
+        record = self.db.get_conversation_by_id(conversation_id)
+        if record is None or record.get("deleted"):
+            return ConsoleGenerationSettingsReadResult(
+                ConsoleGenerationSettingsReadStatus.ABSENT
+            )
+        return parse_console_generation_settings(record.get("metadata"))
+
+    def update_conversation_generation_settings(
+        self,
+        *,
+        conversation_id: str,
+        snapshot: ConsoleGenerationSettingsSnapshot,
+        expected_snapshot: ConsoleGenerationSettingsSnapshot | None,
+    ) -> ConsoleGenerationSettingsWriteResult:
+        """Compare-and-set one complete owned snapshot with one bounded retry.
+
+        A conversation version conflict is retryable only when a fresh read
+        proves this codec's complete owned value still equals the caller's
+        expected base. The retry then merges against that fresh record so
+        unrelated metadata siblings are preserved.
+        """
+        try:
+            merge_console_generation_settings({}, snapshot)
+            if expected_snapshot is not None:
+                merge_console_generation_settings({}, expected_snapshot)
+        except (TypeError, ValueError):
+            return ConsoleGenerationSettingsWriteResult(
+                ConsoleGenerationSettingsWriteStatus.INVALID
+            )
+
+        target = str(conversation_id)
+        for attempt in range(2):
+            record = self.db.get_conversation_by_id(target)
+            if record is None or record.get("deleted"):
+                return ConsoleGenerationSettingsWriteResult(
+                    ConsoleGenerationSettingsWriteStatus.MISSING
+                )
+            current = parse_console_generation_settings(record.get("metadata"))
+            if current.status is ConsoleGenerationSettingsReadStatus.INVALID:
+                return ConsoleGenerationSettingsWriteResult(
+                    ConsoleGenerationSettingsWriteStatus.INVALID
+                )
+            if (
+                current.status
+                is ConsoleGenerationSettingsReadStatus.UNSUPPORTED_VERSION
+            ):
+                return ConsoleGenerationSettingsWriteResult(
+                    ConsoleGenerationSettingsWriteStatus.UNSUPPORTED_VERSION
+                )
+            if current.snapshot != expected_snapshot:
+                return ConsoleGenerationSettingsWriteResult(
+                    ConsoleGenerationSettingsWriteStatus.SUPERSEDED,
+                    current.snapshot,
+                )
+            metadata = merge_console_generation_settings(
+                record.get("metadata"),
+                snapshot,
+            )
+            try:
+                self.db.update_conversation(
+                    target,
+                    {
+                        "metadata": json.dumps(
+                            metadata,
+                            allow_nan=False,
+                            sort_keys=True,
+                        )
+                    },
+                    expected_version=record["version"],
+                )
+            except ConflictError:
+                if attempt == 0:
+                    continue
+                fresh_record = self.db.get_conversation_by_id(target)
+                if fresh_record is None or fresh_record.get("deleted"):
+                    return ConsoleGenerationSettingsWriteResult(
+                        ConsoleGenerationSettingsWriteStatus.MISSING
+                    )
+                fresh = parse_console_generation_settings(fresh_record.get("metadata"))
+                if fresh.status is ConsoleGenerationSettingsReadStatus.INVALID:
+                    return ConsoleGenerationSettingsWriteResult(
+                        ConsoleGenerationSettingsWriteStatus.INVALID
+                    )
+                if (
+                    fresh.status
+                    is ConsoleGenerationSettingsReadStatus.UNSUPPORTED_VERSION
+                ):
+                    return ConsoleGenerationSettingsWriteResult(
+                        ConsoleGenerationSettingsWriteStatus.UNSUPPORTED_VERSION
+                    )
+                if fresh.snapshot != expected_snapshot:
+                    return ConsoleGenerationSettingsWriteResult(
+                        ConsoleGenerationSettingsWriteStatus.SUPERSEDED,
+                        fresh.snapshot,
+                    )
+                raise
+            return ConsoleGenerationSettingsWriteResult(
+                ConsoleGenerationSettingsWriteStatus.WRITTEN,
+                snapshot,
+            )
+        raise AssertionError("Unreachable generation-settings retry state.")
+
     def update_conversation_context_policy(
         self,
         *,
         conversation_id: str,
         overrides: ConsoleContextPolicyOverrides,
-    ) -> int | None:
-        """Persist local sparse context-policy overrides without sync writes."""
+        expected_revision: int | None | object = (
+            _CONTEXT_POLICY_EXPECTED_REVISION_UNSET
+        ),
+    ) -> int | None | ContextPolicyWriteResult:
+        """Persist context policy, optionally guarding its owned revision.
+
+        Omitting ``expected_revision`` preserves the established unconditional
+        caller contract. Settings Apply passes an explicit revision, including
+        ``None`` for an absent row, and receives the typed CAS result.
+        """
+        if expected_revision is not _CONTEXT_POLICY_EXPECTED_REVISION_UNSET:
+            return self.context_repository.save_policy_if_revision(
+                conversation_id,
+                overrides,
+                expected_revision=expected_revision,  # type: ignore[arg-type]
+            )
         return self.context_repository.save_policy(conversation_id, overrides)
 
     def update_conversation_thinking_history_policy(
@@ -582,6 +689,7 @@ class ChatPersistenceService:
         acceptance: ConsoleDurableTurnAcceptance,
         policy_candidate: ConsoleLibraryPolicyCandidate,
         conversation_kwargs: Mapping[str, object],
+        context_policy_overrides: ConsoleContextPolicyOverrides | None = None,
     ) -> ConsoleDispatchCheckpoint:
         """Atomically create/validate and accept one durable Console turn.
 
@@ -616,6 +724,16 @@ class ChatPersistenceService:
                     raise RuntimeError(
                         "Console Library policy could not be committed with turn."
                     )
+                if context_policy_overrides is not None:
+                    context_result = self.context_repository.save_policy_if_revision(
+                        acceptance.conversation_id,
+                        context_policy_overrides,
+                        expected_revision=None,
+                    )
+                    if context_result.status is not ContextPolicyWriteStatus.WRITTEN:
+                        raise RuntimeError(
+                            "Console context settings could not be committed with turn."
+                        )
             else:
                 if conversation["deleted"]:
                     raise RuntimeError("Durable conversation is unavailable.")

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -185,9 +185,25 @@ from tldw_chatbook.Chat.console_visual_transcript import (
     resolve_effective_compaction_representation,
 )
 from tldw_chatbook.Chat.console_session_settings import (
+    CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS,
     ConsoleSessionSettings,
     build_default_console_session_settings,
+    build_target_default_console_session_settings,
     normalize_llamacpp_base_url,
+    normalize_console_model_value,
+    normalized_console_model_profile_overrides,
+)
+from tldw_chatbook.Chat.console_provider_support import (
+    build_local_thinking_payload_fields,
+    resolve_console_provider_identity,
+)
+from tldw_chatbook.Chat.console_settings_apply import (
+    FULL_MODEL_DEFAULT_FIELDS,
+    QUICK_MODEL_DEFAULT_FIELDS,
+    ConsoleEndpointDraft,
+    ConsoleSettingsDraftState,
+    ConsoleSettingsFieldDraft,
+    ConsoleSettingsFieldProvenance,
 )
 from tldw_chatbook.Chat.console_provider_endpoints import first_configured_endpoint
 from tldw_chatbook.Chat.console_project_instructions import (
@@ -334,8 +350,11 @@ from tldw_chatbook.Chat.thinking_blocks import (
 from tldw_chatbook.Chat.provider_readiness import provider_config_key
 from tldw_chatbook.Chat.provider_usage import ProviderUsage
 from tldw_chatbook.model_capabilities import (
+    anthropic_model_rejects_fixed_thinking_budget,
     is_vision_capable,
+    moonshot_model_supports_reasoning_effort,
     moonshot_model_returns_reasoning_content,
+    zai_model_supports_reasoning_effort,
 )
 
 if TYPE_CHECKING:
@@ -478,6 +497,76 @@ def build_console_provider_selection_from_settings(
         system_prompt=settings.system_prompt,
         workspace_context=workspace_context,
     )
+
+
+_CONSOLE_SETTINGS_FIELD_ORDER = (
+    "temperature",
+    "top_p",
+    "min_p",
+    "top_k",
+    "max_tokens",
+    "seed",
+    "presence_penalty",
+    "frequency_penalty",
+    "reasoning_effort",
+    "reasoning_summary",
+    "verbosity",
+    "thinking_effort",
+    "thinking_budget_tokens",
+    "streaming",
+)
+_CONSOLE_PROVIDER_SPECIFIC_SETTINGS_FIELDS = frozenset(
+    {
+        "reasoning_effort",
+        "reasoning_summary",
+        "verbosity",
+        "thinking_effort",
+        "thinking_budget_tokens",
+    }
+)
+_CONSOLE_DIRECT_PROVIDER_SETTINGS_FIELDS = {
+    "openai": frozenset({"reasoning_effort", "reasoning_summary", "verbosity"}),
+    "qwencloud": frozenset({"reasoning_effort"}),
+}
+_CONSOLE_LOCAL_THINKING_BUDGET_EXECUTION_KEYS = frozenset(
+    {
+        "llama_cpp",
+        "local_llamacpp",
+        "local_llamafile",
+        "local-llm",
+    }
+)
+
+
+def _supported_console_settings_fields(
+    provider: str,
+    model: str | None,
+) -> frozenset[str]:
+    """Return generation fields supported by one provider/model target."""
+
+    provider_key = provider_config_key(provider)
+    supported = set(
+        FULL_MODEL_DEFAULT_FIELDS - _CONSOLE_PROVIDER_SPECIFIC_SETTINGS_FIELDS
+    )
+    if provider_key == "moonshot" and moonshot_model_supports_reasoning_effort(model):
+        supported.add("reasoning_effort")
+    if provider_key == "zai" and zai_model_supports_reasoning_effort(model):
+        supported.add("reasoning_effort")
+    supported.update(_CONSOLE_DIRECT_PROVIDER_SETTINGS_FIELDS.get(provider_key, ()))
+    if provider_key == "anthropic":
+        supported.add("thinking_effort")
+        if not anthropic_model_rejects_fixed_thinking_budget(model):
+            supported.add("thinking_budget_tokens")
+
+    identity = resolve_console_provider_identity(
+        provider_key,
+        handler_keys=CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS,
+    )
+    if build_local_thinking_payload_fields(identity.execution_key, "low", None):
+        supported.add("reasoning_effort")
+    if identity.execution_key in _CONSOLE_LOCAL_THINKING_BUDGET_EXECUTION_KEYS:
+        supported.add("thinking_budget_tokens")
+    return frozenset(supported)
 
 
 #: Fallback used when no `mcp_approval_timeout_seconds` seam is injected --
@@ -3599,14 +3688,7 @@ class ConsoleChatController:
 
         target_id = session_id or self.store.active_session_id
         if not target_id:
-            session = self.store.ensure_session(
-                workspace_id=self.store.workspace_context.active_workspace_id,
-                settings=(
-                    self._default_session_settings()
-                    if self._default_session_settings is not None
-                    else None
-                ),
-            )
+            session = self._ensure_default_session()
             target_id = session.id
         return await self.prompt_queue_coordinator.run_prompt_chain(
             target_id,
@@ -5628,14 +5710,7 @@ class ConsoleChatController:
             # at all) got `settings=None` while every other creator gave the
             # first session a real snapshot, and whichever creator ran first
             # decided the outcome.
-            session = self.store.ensure_session(
-                workspace_id=self.store.workspace_context.active_workspace_id,
-                settings=(
-                    self._default_session_settings()
-                    if self._default_session_settings is not None
-                    else None
-                ),
-            )
+            session = self._ensure_default_session()
         active_task = asyncio.current_task()
         if active_task is not None:
             self._rebind_submit_task(active_task, session.id)
@@ -7031,10 +7106,18 @@ class ConsoleChatController:
                 raise RuntimeError("Prepared turn changed before provider dispatch.")
 
         try:
+            async def publish_identity_and_settings() -> None:
+                self.store.publish_durable_turn_identity(session_id, commit)
+                await self.store.reconcile_durable_turn_settings(session_id, commit)
+                await self.store.reconcile_durable_turn_roleplay_context(
+                    session_id,
+                    commit,
+                )
+
             await self._run_durable_postcommit_effect(
                 preparation_id,
                 "identity_publication",
-                lambda: self.store.publish_durable_turn_identity(session_id, commit),
+                publish_identity_and_settings,
                 fingerprint=fingerprint,
             )
             await self._run_durable_postcommit_effect(
@@ -7826,20 +7909,33 @@ class ConsoleChatController:
         *,
         title: str | None = None,
         settings: ConsoleSessionSettings | None = None,
+        canonical_settings_baseline: ConsoleSessionSettings | None = None,
+        new_chat_default_generation: int = 0,
         ephemeral: bool = False,
     ) -> ConsoleChatSession:
         """Create and activate a new native Console session.
 
         Args:
+            canonical_settings_baseline: Exact config-owned defaults captured
+                with ``settings`` for an eligible blank chat.
+            new_chat_default_generation: App-owned explicit-default generation
+                captured when the blank chat is created.
             ephemeral: Create the session temporary -- never written to local
                 storage until explicitly saved.
         """
+        if (
+            type(new_chat_default_generation) is not int
+            or new_chat_default_generation < 0
+        ):
+            raise ValueError("new chat default generation must be non-negative")
         next_number = len(self.store.sessions()) + 1
         session = self.store.create_session(
             title=title or f"Chat {next_number}",
             settings=settings,
+            canonical_settings_baseline=canonical_settings_baseline,
             ephemeral=ephemeral,
         )
+        session.new_chat_default_generation = new_chat_default_generation
         # `create_session` above already activated the new session, so the
         # default (no explicit session_id -> active session) targets the
         # session JUST created here -- which is fresh/never-recorded and
@@ -7872,6 +7968,30 @@ class ConsoleChatController:
         # had shown (mirrors the approval re-derive immediately above).
         self._remount_parked_skill_install(session.id)
         self._remount_parked_skill_script(session.id)
+        return session
+
+    def _ensure_default_session(self) -> ConsoleChatSession:
+        """Create one provenance-bearing blank session for bootstrap callers."""
+        creating_blank_session = self.store.active_session_id is None
+        settings = (
+            self._default_session_settings()
+            if self._default_session_settings is not None
+            else None
+        )
+        session = self.store.ensure_session(
+            workspace_id=self.store.workspace_context.active_workspace_id,
+            settings=settings,
+            canonical_settings_baseline=settings,
+        )
+        if creating_blank_session:
+            generation = getattr(
+                self.app,
+                "console_new_chat_default_generation",
+                0,
+            )
+            session.new_chat_default_generation = (
+                generation if type(generation) is int and generation >= 0 else 0
+            )
         return session
 
     def _maybe_auto_title_session(
@@ -7963,6 +8083,186 @@ class ConsoleChatController:
             # Active-session UI path: clears whatever the user is currently
             # looking at (parallel-agents spec §2).
             self._clear_terminal_run_state()
+
+    def rebase_console_settings_draft(
+        self,
+        state: ConsoleSettingsDraftState,
+        *,
+        provider: str,
+        model: str | None,
+        app_config: Mapping[str, object],
+        exposed_fields: frozenset[str],
+    ) -> ConsoleSettingsDraftState:
+        """Rebase one settings draft onto an exact provider/model target.
+
+        Untouched values always come from the target's established default chain.
+        Only dirty fields exposed by the calling surface and supported by the
+        target survive a switch. A remembered exact target draft takes precedence
+        over carried values from the provider/model being left.
+        """
+
+        target_defaults = build_target_default_console_session_settings(
+            app_config,
+            provider,
+            model,
+        )
+        target_provider = provider_config_key(target_defaults.provider)
+        target_model = normalize_console_model_value(target_defaults.model)
+        target_key = (target_provider, target_model)
+        current_key = (
+            provider_config_key(state.settings.provider),
+            normalize_console_model_value(state.settings.model),
+        )
+        remembered_target = next(
+            (
+                draft
+                for draft in state.model_drafts
+                if (draft.provider, draft.model) == target_key
+            ),
+            None,
+        )
+        restoring_remembered_target = (
+            current_key != target_key and remembered_target is not None
+        )
+        source_fields = (
+            remembered_target.field_drafts
+            if restoring_remembered_target
+            else state.field_drafts
+        )
+        source_endpoint = (
+            remembered_target.endpoint_draft
+            if restoring_remembered_target
+            else state.endpoint_draft
+        )
+
+        quick_surface = exposed_fields == QUICK_MODEL_DEFAULT_FIELDS
+        inherited_dirty_fields = (
+            frozenset(
+                field.name
+                for field in source_fields
+                if field.dirty
+                and field.profile_override is None
+                and field.name in exposed_fields
+            )
+            if not quick_surface
+            else frozenset()
+        )
+        if inherited_dirty_fields:
+            target_defaults = build_target_default_console_session_settings(
+                app_config,
+                target_provider,
+                target_model,
+                excluded_model_profile_fields=inherited_dirty_fields,
+            )
+
+        supported_fields = _supported_console_settings_fields(
+            target_provider,
+            target_model,
+        )
+        exposed_supported_fields = exposed_fields & supported_fields
+        profile = normalized_console_model_profile_overrides(
+            app_config,
+            target_provider,
+            target_model,
+        )
+        rebased_fields: dict[str, ConsoleSettingsFieldDraft] = {}
+        for name in _CONSOLE_SETTINGS_FIELD_ORDER:
+            if name not in exposed_supported_fields:
+                continue
+            effective_value = getattr(target_defaults, name)
+            has_profile_override = name in profile
+            rebased_fields[name] = ConsoleSettingsFieldDraft(
+                name=name,
+                effective_value=effective_value,
+                profile_override=(
+                    effective_value
+                    if quick_surface
+                    else profile.get(name)
+                    if has_profile_override
+                    else None
+                ),
+                provenance=(
+                    ConsoleSettingsFieldProvenance.EXPLICIT
+                    if has_profile_override
+                    else ConsoleSettingsFieldProvenance.INHERITED
+                ),
+                dirty=False,
+            )
+
+        dirty_values: dict[str, object | None] = {}
+        carrying_to_unseen_target = (
+            current_key != target_key and remembered_target is None
+        )
+        for field in source_fields:
+            if not field.dirty or field.name not in exposed_supported_fields:
+                continue
+            if quick_surface and field.effective_value is None:
+                continue
+            inherits_target_default = (
+                not quick_surface and field.profile_override is None
+            )
+            effective_value = (
+                getattr(target_defaults, field.name)
+                if inherits_target_default
+                else field.effective_value
+            )
+            if not inherits_target_default:
+                dirty_values[field.name] = effective_value
+            rebased_fields[field.name] = replace(
+                field,
+                effective_value=effective_value,
+                profile_override=(
+                    effective_value if quick_surface else field.profile_override
+                ),
+                provenance=(
+                    ConsoleSettingsFieldProvenance.CARRIED
+                    if carrying_to_unseen_target
+                    else field.provenance
+                ),
+                dirty=True,
+            )
+
+        unsupported_provider_fields = FULL_MODEL_DEFAULT_FIELDS - supported_fields
+        settings_changes: dict[str, object | None] = {
+            "provider": target_provider,
+            "model": target_model,
+            "character_label": state.settings.character_label,
+            "system_prompt": state.settings.system_prompt,
+            "source": state.settings.source,
+            "pinned_prefill": state.settings.pinned_prefill,
+            **{name: None for name in unsupported_provider_fields},
+            **dirty_values,
+        }
+
+        endpoint_draft: ConsoleEndpointDraft | None = None
+        target_base_url = target_defaults.base_url
+        if (
+            exposed_fields == FULL_MODEL_DEFAULT_FIELDS
+            and source_endpoint is not None
+            and source_endpoint.dirty
+            and source_endpoint.bound_provider_config_key == target_provider
+        ):
+            endpoint_draft = source_endpoint
+            target_base_url = source_endpoint.value or None
+        elif target_base_url is not None:
+            endpoint_draft = ConsoleEndpointDraft(
+                value=target_base_url,
+                bound_provider_config_key=target_provider,
+                dirty=False,
+                checked=False,
+            )
+        settings_changes["base_url"] = target_base_url
+
+        return replace(
+            state,
+            settings=replace(target_defaults, **settings_changes),
+            field_drafts=tuple(
+                rebased_fields[name]
+                for name in _CONSOLE_SETTINGS_FIELD_ORDER
+                if name in rebased_fields
+            ),
+            endpoint_draft=endpoint_draft,
+        )
 
     def update_agent_runtime(
         self, *, enabled: bool, bridge: "ConsoleAgentBridge | None"

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -85,6 +85,10 @@ from tldw_chatbook.Chat.console_chat_fork import (
     validate_console_fork_image_payload,
 )
 from tldw_chatbook.Chat.console_context_policy import ConsoleContextPolicyOverrides
+from tldw_chatbook.Chat.console_context_repository import (
+    ContextPolicyWriteResult,
+    ContextPolicyWriteStatus,
+)
 from tldw_chatbook.Chat.console_dispatch_checkpoint import (
     ConsoleAssistantSettlement,
     ConsoleContinuationHandoff,
@@ -155,7 +159,22 @@ from tldw_chatbook.Chat.console_roleplay_metadata import (
     merge_console_roleplay_context,
 )
 from tldw_chatbook.Chat.console_prefill import PINNED_PREFILL_METADATA_KEY
+from tldw_chatbook.Chat.console_generation_settings_metadata import (
+    ConsoleGenerationSettingsReadStatus,
+    ConsoleGenerationSettingsSnapshot,
+    ConsoleGenerationSettingsWriteResult,
+    ConsoleGenerationSettingsWriteStatus,
+    merge_console_generation_settings,
+    snapshot_from_session_settings,
+)
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.console_settings_apply import (
+    ConsoleSettingsLiveCommit,
+    ConsoleSettingsOrigin,
+    ConsoleSettingsSubmission,
+    ConsoleSettingsSurface,
+    validate_console_settings_origin,
+)
 from tldw_chatbook.Chat.console_project_instructions import (
     ProjectInstructionControlState,
     decode_project_context_json,
@@ -399,13 +418,27 @@ class _RoleplayMessageProjectionPersistenceOutcome:
 
 
 @dataclass(frozen=True, slots=True)
+class _RoleplayContextWrite:
+    """Frozen conversation identity write safe for an off-thread consumer."""
+
+    writer: Callable[..., object] = field(repr=False, compare=False)
+    conversation_id: str
+    user_name_override: str | None
+    character_system_template: str | None
+    character_name_snapshot: str | None
+
+
+@dataclass(frozen=True, slots=True)
 class ConsoleRoleplayProjectionPersistencePlan:
     """Immutable durable writes prepared after owner-thread materialization."""
 
     session_id: str
     generation: int
+    persisted_conversation_id: str | None
+    conversation_binding_revision: int
     system_prompt_write: _RoleplaySystemPromptWrite | None
     message_writes: tuple[_RoleplayMessageProjectionWrite, ...]
+    context_write: _RoleplayContextWrite | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -414,11 +447,23 @@ class ConsoleRoleplayProjectionPersistenceResult:
 
     session_id: str
     generation: int
+    persisted_conversation_id: str | None
+    conversation_binding_revision: int
     persisted: bool
     system_prompt_attempted: bool
     system_prompt: str | None
     system_prompt_persisted: bool
     message_outcomes: tuple[_RoleplayMessageProjectionPersistenceOutcome, ...] = ()
+    context_attempted: bool = False
+    context_persisted: bool = True
+
+
+@dataclass(slots=True)
+class _RoleplayPersistenceLockEntry:
+    """One durable-conversation serializer plus its live user count."""
+
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    users: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -439,6 +484,14 @@ class ConsoleDurableTurnCommit:
     assistant_message_id: str
     assistant_message_version: int
     checkpoint: ConsoleDispatchCheckpoint
+    first_persist: bool = False
+    generation_snapshot: ConsoleGenerationSettingsSnapshot | None = None
+    generation_revision: int = 0
+    context_policy_overrides: ConsoleContextPolicyOverrides | None = None
+    context_policy_revision: int = 0
+    context_policy_durable_revision: int | None = None
+    policy_failure_label: ConsoleSettingsPolicyFailureLabel | None = None
+    roleplay_identity_revision: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -534,6 +587,7 @@ class ConsoleChatPersistence(Protocol):
         acceptance: ConsoleDurableTurnAcceptance,
         policy_candidate: ConsoleLibraryPolicyCandidate,
         conversation_kwargs: Mapping[str, object],
+        context_policy_overrides: ConsoleContextPolicyOverrides | None = None,
     ) -> ConsoleDispatchCheckpoint:
         """Atomically create/validate and accept one durable Console turn."""
 
@@ -926,6 +980,97 @@ class StagedCapturePurge:
     removed_count: int
 
 
+class ConsoleSettingsComponent(str, Enum):
+    """Independently durable parts of one Console settings Apply."""
+
+    GENERATION_SETTINGS = "generation_settings"
+    CONTEXT_POLICY = "context_policy"
+
+
+class ConsoleSettingsPolicyFailureLabel(str, Enum):
+    """Explicit settings surface copy retained with a policy failure."""
+
+    COMPACTION = "compaction"
+    CONTEXT_SETTINGS = "context settings"
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleSettingsPersistenceFailure:
+    """Safe exact value required to retry one current component revision."""
+
+    component: ConsoleSettingsComponent
+    revision: int
+    persisted_conversation_id: str
+    conversation_binding_revision: int
+    policy_failure_label: ConsoleSettingsPolicyFailureLabel | None
+    generation_snapshot: ConsoleGenerationSettingsSnapshot | None = None
+    context_policy_overrides: ConsoleContextPolicyOverrides | None = None
+
+    def __post_init__(self) -> None:
+        generation = self.generation_snapshot is not None
+        context = self.context_policy_overrides is not None
+        if generation == context:
+            raise ValueError("A persistence failure must carry exactly one value.")
+        if generation != (
+            self.component is ConsoleSettingsComponent.GENERATION_SETTINGS
+        ):
+            raise ValueError("Failure value does not match its component.")
+        if generation and self.policy_failure_label is not None:
+            raise ValueError("Generation failures cannot carry policy copy.")
+        if context and not isinstance(
+            self.policy_failure_label,
+            ConsoleSettingsPolicyFailureLabel,
+        ):
+            raise ValueError("Context failure copy must be a typed label.")
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleSettingsPersistenceOutcome:
+    """Per-component result of one serialized durability attempt."""
+
+    session_id: str
+    written_components: frozenset[ConsoleSettingsComponent] = frozenset()
+    failed_components: frozenset[ConsoleSettingsComponent] = frozenset()
+    stale_components: frozenset[ConsoleSettingsComponent] = frozenset()
+    staged: bool = False
+
+
+@dataclass(slots=True)
+class _ConsoleSettingsPersistenceDrain:
+    """One shared async drain from an accepted Apply to newest live values."""
+
+    session_incarnation: int
+    persisted_conversation_id: str | None
+    conversation_binding_revision: int
+    generation_revision: int
+    context_policy_revision: int
+    generation_snapshot: ConsoleGenerationSettingsSnapshot | None
+    context_policy_overrides: ConsoleContextPolicyOverrides | None
+    policy_failure_label: ConsoleSettingsPolicyFailureLabel
+    initial_components: frozenset[ConsoleSettingsComponent]
+    requested_components: set[ConsoleSettingsComponent]
+    retry_components: set[ConsoleSettingsComponent]
+    task: asyncio.Task[ConsoleSettingsPersistenceOutcome] | None = None
+
+
+@dataclass(slots=True)
+class _ConsoleSettingsPersistenceLifecycle:
+    """Serializer and store-owned CAS lineage surviving one live incarnation."""
+
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    drain: _ConsoleSettingsPersistenceDrain | None = None
+    tasks: set[asyncio.Task[ConsoleSettingsPersistenceOutcome]] = field(
+        default_factory=set
+    )
+    component_revisions: dict[ConsoleSettingsComponent, int] = field(
+        default_factory=dict
+    )
+    generation_bases: dict[
+        str, ConsoleGenerationSettingsSnapshot | None
+    ] = field(default_factory=dict)
+    context_bases: dict[str, int | None] = field(default_factory=dict)
+
+
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -947,7 +1092,27 @@ class ConsoleChatSession:
     workspace_id: str = CONSOLE_GLOBAL_WORKSPACE_ID
     id: str = field(default_factory=lambda: str(uuid4()))
     persisted_conversation_id: str | None = None
+    #: Advances whenever this live slot is rebound or repurposed. Ordinary
+    #: first persistence is the sole None -> id transition that preserves it.
+    conversation_binding_revision: int = 0
     settings: ConsoleSessionSettings | None = None
+    generation_settings_revision: int = 0
+    context_policy_revision: int = 0
+    staged_context_policy_failure_label: ConsoleSettingsPolicyFailureLabel | None = None
+    staged_context_policy_failure_revision: int | None = None
+    generation_durable_snapshot: ConsoleGenerationSettingsSnapshot | None = None
+    context_policy_durable_revision: int | None = None
+    new_chat_default_generation: int = 0
+    settings_persistence_failures: dict[
+        ConsoleSettingsComponent, ConsoleSettingsPersistenceFailure
+    ] = field(default_factory=dict)
+    applied_settings_submission_ids: deque[str] = field(
+        default_factory=lambda: deque(maxlen=32)
+    )
+    generation_metadata_status: ConsoleGenerationSettingsReadStatus = (
+        ConsoleGenerationSettingsReadStatus.ABSENT
+    )
+    generation_metadata_warning_shown: bool = False
     #: Exact canonical defaults from which an untouched initial session was
     #: created. ``None`` means the settings have no proven default provenance.
     canonical_settings_baseline: ConsoleSessionSettings | None = field(
@@ -1229,6 +1394,18 @@ class ConsoleChatStore:
             if capture_policy_db is not None
             else None
         )
+        self._settings_persistence_lifecycles: dict[
+            str, _ConsoleSettingsPersistenceLifecycle
+        ] = {}
+        self._roleplay_persistence_locks: dict[
+            str, _RoleplayPersistenceLockEntry
+        ] = {}
+        self._settings_session_incarnations: dict[str, int] = {}
+        # Public settings origins need their own app-lifetime fence. Async
+        # drain incarnations are an implementation detail and can be cleaned
+        # up independently; this payload-free scalar survives close/recreate
+        # and restore so an old modal can never target a replacement live slot.
+        self._settings_binding_revision_tombstones: dict[str, int] = {}
         # Task 13: one app-lifetime, process-memory preparation owner per
         # session.  This state deliberately belongs to the store rather than
         # a mounted Console screen so navigation cannot lose or duplicate a
@@ -1581,8 +1758,9 @@ class ConsoleChatStore:
                 if self._thinking_history_policy_default_provider is not None
                 else None
             )
+        resolved_session_id = session_id or str(uuid4())
         session = ConsoleChatSession(
-            id=session_id or str(uuid4()),
+            id=resolved_session_id,
             title=title,
             workspace_id=workspace_id or self.workspace_context.active_workspace_id,
             settings=settings,
@@ -1611,8 +1789,19 @@ class ConsoleChatStore:
                     source="temporary" if ephemeral else "new_session",
                 )
             ),
+            conversation_binding_revision=(
+                self._settings_binding_revision_tombstones.get(
+                    resolved_session_id,
+                    0,
+                )
+            ),
+        )
+        self._record_console_settings_binding_revision(
+            session.id,
+            session.conversation_binding_revision,
         )
         self._sessions[session.id] = session
+        self._advance_console_settings_session_incarnation(session.id)
         self._messages_by_session[session.id] = []
         self._nodes_by_session[session.id] = {}
         self._children_by_parent[session.id] = {}
@@ -1637,6 +1826,72 @@ class ConsoleChatStore:
     def active_session_epoch(self) -> int:
         """Return the monotonic generation of the current activation state."""
         return self._active_session_epoch
+
+    def _advance_console_settings_session_incarnation(self, session_id: str) -> int:
+        """Fence old async settings work from a replaced live session slot."""
+        incarnation = self._settings_session_incarnations.get(session_id, 0) + 1
+        self._settings_session_incarnations[session_id] = incarnation
+        lifecycle = self._settings_persistence_lifecycles.setdefault(
+            session_id,
+            _ConsoleSettingsPersistenceLifecycle(),
+        )
+        lifecycle.component_revisions.clear()
+        return incarnation
+
+    def _record_console_settings_binding_revision(
+        self,
+        session_id: str,
+        revision: int,
+    ) -> int:
+        """Retain the highest public-origin fence assigned to a session ID."""
+        retained = max(
+            revision,
+            self._settings_binding_revision_tombstones.get(session_id, revision),
+        )
+        self._settings_binding_revision_tombstones[session_id] = retained
+        return retained
+
+    def _advance_console_settings_binding_revision(
+        self,
+        session_id: str,
+        *revisions: int,
+    ) -> int:
+        """Assign the next public-origin fence without reusing a closed value."""
+        floor = self._settings_binding_revision_tombstones.get(session_id, -1)
+        if revisions:
+            floor = max(floor, *revisions)
+        advanced = floor + 1
+        self._settings_binding_revision_tombstones[session_id] = advanced
+        return advanced
+
+    def _seed_console_settings_owned_bases(
+        self,
+        session: ConsoleChatSession,
+    ) -> None:
+        """Seed one incarnation from its accepted durable resume snapshot."""
+        conversation_id = session.persisted_conversation_id
+        if conversation_id is None:
+            return
+        lifecycle = self._settings_persistence_lifecycles.setdefault(
+            session.id,
+            _ConsoleSettingsPersistenceLifecycle(),
+        )
+        lifecycle.generation_bases[conversation_id] = (
+            session.generation_durable_snapshot
+        )
+        lifecycle.context_bases[conversation_id] = (
+            session.context_policy_durable_revision
+        )
+
+    def _cleanup_console_settings_lifecycle_if_idle(self, session_id: str) -> None:
+        """Release serializer state after teardown and all shielded work settle."""
+        lifecycle = self._settings_persistence_lifecycles.get(session_id)
+        if (
+            lifecycle is not None
+            and session_id not in self._sessions
+            and not lifecycle.tasks
+        ):
+            self._settings_persistence_lifecycles.pop(session_id, None)
 
     def is_pristine_session(
         self,
@@ -1739,11 +1994,18 @@ class ConsoleChatStore:
         proposed_updated_at = _utc_now_iso()
         proposed_identity_revision = session.identity_revision + 1
         proposed_payload_revision = self._payload_revisions.get(session_id, 0) + 1
+        proposed_generation_revision = session.generation_settings_revision + 1
         if not self.is_pristine_session(
             session_id,
             expected_settings=canonical_settings,
         ):
             raise ValueError("Session is no longer pristine.")
+        proposed_binding_revision = (
+            self._advance_console_settings_binding_revision(
+                session_id,
+                session.conversation_binding_revision,
+            )
+        )
 
         # All validation, derived values, and stale-eligibility checks are
         # complete. ConsoleChatSession is a plain dataclass with no property
@@ -1760,6 +2022,12 @@ class ConsoleChatStore:
         session.character_name = character_name
         session.updated_at = proposed_updated_at
         session.identity_revision = proposed_identity_revision
+        session.generation_settings_revision = proposed_generation_revision
+        session.conversation_binding_revision = proposed_binding_revision
+        session.settings_persistence_failures.pop(
+            ConsoleSettingsComponent.GENERATION_SETTINGS,
+            None,
+        )
         self._payload_revisions[session_id] = proposed_payload_revision
         return session
 
@@ -1802,6 +2070,11 @@ class ConsoleChatStore:
         # dataclass assignments with no property setters, so the bounded commit
         # cannot raise application-level exceptions and preserves held references.
         session.settings = current_canonical_settings
+        session.generation_settings_revision += 1
+        session.settings_persistence_failures.pop(
+            ConsoleSettingsComponent.GENERATION_SETTINGS,
+            None,
+        )
         session.canonical_settings_baseline = current_canonical_settings
         session.updated_at = proposed_updated_at
         return session
@@ -1813,6 +2086,8 @@ class ConsoleChatStore:
         expected_current_settings: ConsoleSessionSettings,
         prior_settings: ConsoleSessionSettings,
         prior_canonical_settings: ConsoleSessionSettings,
+        prior_generation_revision: int,
+        prior_generation_failure: ConsoleSettingsPersistenceFailure | None,
         prior_updated_at: str,
     ) -> bool:
         """Restore an exact first-chat refresh only while it remains pristine."""
@@ -1822,6 +2097,8 @@ class ConsoleChatStore:
             session is None
             or session.settings != expected_current_settings
             or session.canonical_settings_baseline != expected_current_settings
+            or session.generation_settings_revision
+            != prior_generation_revision + 1
             or not self.is_pristine_session(
                 session_id,
                 expected_settings=expected_current_settings,
@@ -1829,6 +2106,16 @@ class ConsoleChatStore:
         ):
             return False
         session.settings = prior_settings
+        session.generation_settings_revision = prior_generation_revision
+        if prior_generation_failure is None:
+            session.settings_persistence_failures.pop(
+                ConsoleSettingsComponent.GENERATION_SETTINGS,
+                None,
+            )
+        else:
+            session.settings_persistence_failures[
+                ConsoleSettingsComponent.GENERATION_SETTINGS
+            ] = prior_generation_failure
         session.canonical_settings_baseline = prior_canonical_settings
         session.updated_at = prior_updated_at
         return True
@@ -1898,6 +2185,10 @@ class ConsoleChatStore:
         active_leaf_persisted_id: str | None = None,
         active_leaf_before_persisted_id: str | None = None,
         settings: ConsoleSessionSettings | None = None,
+        generation_durable_snapshot: ConsoleGenerationSettingsSnapshot | None = None,
+        generation_metadata_status: ConsoleGenerationSettingsReadStatus = (
+            ConsoleGenerationSettingsReadStatus.ABSENT
+        ),
         runtime_backend: str = "local",
         assistant_kind: str | None = "generic",
         assistant_id: str | None = "console",
@@ -1994,7 +2285,12 @@ class ConsoleChatStore:
             activate=activate,
         )
         try:
-            session.persisted_conversation_id = str(persisted_conversation_id)
+            self.rebind_persisted_conversation(
+                session.id,
+                str(persisted_conversation_id),
+            )
+            session.generation_durable_snapshot = generation_durable_snapshot
+            session.generation_metadata_status = generation_metadata_status
             self.hydrate_session_capture_policy(session.id)
             self._hydrate_dispatch_recovery(
                 session.id,
@@ -2039,6 +2335,7 @@ class ConsoleChatStore:
                 session.id, str(persisted_conversation_id)
             )
             self._hydrate_generation_metadata_from_persistence(session.id)
+            self._seed_console_settings_owned_bases(session)
             self._bump_payload_revision(session.id)
             return session
         except BaseException:
@@ -3506,7 +3803,7 @@ class ConsoleChatStore:
         Returns:
             The session activated after closing, or ``None`` when no sessions remain.
         """
-        self._session_or_raise(session_id)
+        session = self._session_or_raise(session_id)
         recovery = self.dispatch_recovery_for_session(session_id)
         if (
             recovery is not None
@@ -3562,6 +3859,8 @@ class ConsoleChatStore:
 
     def _purge_session_runtime_state(self, session_id: str) -> None:
         """Delete one session's exact process-local ownership without DB writes."""
+
+        session = self._session_or_raise(session_id)
 
         # Purge EVERY message the session owns, not just the active-path view:
         # off-path tree nodes and dropped display-only TOOL markers both live in
@@ -3627,7 +3926,13 @@ class ConsoleChatStore:
         self._session_turn_ids.pop(session_id, None)
         if self.library_policy_coordinator is not None:
             self.library_policy_coordinator.unregister_holder(session_id)
+        self._advance_console_settings_binding_revision(
+            session_id,
+            session.conversation_binding_revision,
+        )
+        self._advance_console_settings_session_incarnation(session_id)
         self._sessions.pop(session_id, None)
+        self._cleanup_console_settings_lifecycle_if_idle(session_id)
         with self._preparation_lock:
             preparation = self._preparations_by_session.get(session_id)
             if preparation is not None:
@@ -3742,7 +4047,10 @@ class ConsoleChatStore:
                 if current.origin == "manual":
                     session.draft = current.executed_draft
                 session.title = current.pre_send_title
-                session.persisted_conversation_id = current.pre_send_conversation_id
+                self.rebind_persisted_conversation(
+                    session.id,
+                    current.pre_send_conversation_id,
+                )
             transient_id = current.transient_user_message_id
             if (
                 transient_id is not None
@@ -4183,6 +4491,7 @@ class ConsoleChatStore:
         owners: _ConsoleStagedDurableOwnerIds,
         policy_candidate: ConsoleLibraryPolicyCandidate,
         conversation_kwargs: Mapping[str, object],
+        context_policy_overrides: ConsoleContextPolicyOverrides | None,
     ) -> ConsoleDurableAcceptanceFingerprint:
         plan = {
             "preparation_id": acceptance.preparation_id,
@@ -4204,6 +4513,16 @@ class ConsoleChatStore:
             "policy_candidate": cls._canonical_fingerprint_value(policy_candidate),
             "conversation_kwargs": cls._canonical_fingerprint_value(
                 conversation_kwargs
+            ),
+            "context_policy_overrides": (
+                None
+                if context_policy_overrides is None
+                else json.dumps(
+                    context_policy_overrides.to_dict(),
+                    allow_nan=False,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
             ),
             "user_content_sha256": hashlib.sha256(
                 acceptance.user_content.encode("utf-8")
@@ -4442,6 +4761,51 @@ class ConsoleChatStore:
                     conversation_kwargs["speech_preferences"] = (
                         session.speech_preferences
                     )
+                first_persist = session.persisted_conversation_id is None
+                roleplay_context = ConsoleRoleplayContext(
+                    user_name_override=session.user_display_name_override,
+                    character_system_template=session.character_system_template,
+                )
+                roleplay_identity_revision = session.identity_revision
+                initial_metadata: object | None = None
+                if first_persist and (
+                    roleplay_context.user_name_override is not None
+                    or roleplay_context.character_system_template is not None
+                ):
+                    initial_metadata = merge_console_roleplay_context(
+                        initial_metadata,
+                        roleplay_context,
+                    )
+                generation_revision = session.generation_settings_revision
+                generation_snapshot = (
+                    snapshot_from_session_settings(session.settings)
+                    if first_persist and session.settings is not None
+                    else None
+                )
+                if generation_snapshot is not None:
+                    generation_metadata = merge_console_generation_settings(
+                        initial_metadata, generation_snapshot
+                    )
+                    initial_metadata = json.dumps(
+                        generation_metadata,
+                        allow_nan=False,
+                        sort_keys=True,
+                    )
+                if initial_metadata is not None:
+                    conversation_kwargs["metadata"] = initial_metadata
+                context_policy_revision = session.context_policy_revision
+                context_policy_overrides = (
+                    session.context_policy_overrides
+                    if first_persist and context_policy_revision > 0
+                    else None
+                )
+                policy_failure_label = (
+                    session.staged_context_policy_failure_label
+                    if session.staged_context_policy_failure_revision
+                    == context_policy_revision
+                    and session.staged_context_policy_failure_label is not None
+                    else ConsoleSettingsPolicyFailureLabel.CONTEXT_SETTINGS
+                )
                 policy_candidate = self.session_library_policy_candidate(session.id)
                 if acceptance.preparation_id not in self._durable_commit_by_preparation:
                     reservation = _ConsoleDurableCommitReservation(
@@ -4466,6 +4830,7 @@ class ConsoleChatStore:
                 owners,
                 policy_candidate,
                 conversation_kwargs,
+                context_policy_overrides,
             )
             with self._preparation_lock:
                 if reservation is None:
@@ -4530,10 +4895,23 @@ class ConsoleChatStore:
             durable_commit = getattr(self.persistence, "commit_durable_turn", None)
             if not callable(durable_commit):
                 raise RuntimeError("Durable Console persistence is unavailable.")
+            context_kwarg_supported = self._persistence_accepts_kwarg(
+                durable_commit, "context_policy_overrides"
+            )
+            if context_policy_overrides is not None and not context_kwarg_supported:
+                raise RuntimeError(
+                    "Durable Console persistence cannot store staged context settings."
+                )
             checkpoint = durable_commit(
                 acceptance=acceptance,
                 policy_candidate=policy_candidate,
                 conversation_kwargs=conversation_kwargs,
+                **(
+                    {"context_policy_overrides": context_policy_overrides}
+                    if context_policy_overrides is not None
+                    and context_kwarg_supported
+                    else {}
+                ),
             )
             with self._preparation_lock:
                 identity_reservation = self._first_identity_reservations.get(
@@ -4556,6 +4934,19 @@ class ConsoleChatStore:
                 assistant_message_id=owners.assistant_message_id,
                 assistant_message_version=checkpoint.assistant_message_version,
                 checkpoint=checkpoint,
+                first_persist=first_persist,
+                generation_snapshot=generation_snapshot,
+                generation_revision=generation_revision,
+                context_policy_overrides=context_policy_overrides,
+                context_policy_revision=context_policy_revision,
+                context_policy_durable_revision=(
+                    None
+                    if context_policy_overrides is None
+                    or context_policy_overrides.is_empty
+                    else 1
+                ),
+                policy_failure_label=policy_failure_label,
+                roleplay_identity_revision=roleplay_identity_revision,
             )
             with self._preparation_lock:
                 if (
@@ -4916,7 +5307,7 @@ class ConsoleChatStore:
     def publish_durable_turn_identity(
         self, session_id: str, commit: ConsoleDurableTurnCommit
     ) -> None:
-        """Publish committed identity and the matching durable policy snapshot."""
+        """Publish committed identity, policy, and first-send settings bases."""
 
         self.publish_committed_identity(session_id, commit.identity)
         with self._preparation_lock:
@@ -4934,12 +5325,171 @@ class ConsoleChatStore:
             raise RuntimeError("Committed Console Library policy is unavailable.")
         session.library_policy_holder.snapshot = result.snapshot
         session.library_policy_holder.explicitly_staged = False
+        generation_base_installed = False
+        context_base_installed = False
+        if commit.first_persist:
+            lifecycle = self._settings_persistence_lifecycles.setdefault(
+                session_id,
+                _ConsoleSettingsPersistenceLifecycle(),
+            )
+            conversation_id = commit.identity.conversation_id
+            if conversation_id not in lifecycle.generation_bases:
+                lifecycle.generation_bases[conversation_id] = (
+                    commit.generation_snapshot
+                )
+                generation_base_installed = True
+            if conversation_id not in lifecycle.context_bases:
+                lifecycle.context_bases[conversation_id] = (
+                    commit.context_policy_durable_revision
+                )
+                context_base_installed = True
+        if generation_base_installed and commit.generation_snapshot is not None:
+            session.generation_durable_snapshot = commit.generation_snapshot
+            if session.generation_settings_revision == commit.generation_revision:
+                lifecycle.component_revisions[
+                    ConsoleSettingsComponent.GENERATION_SETTINGS
+                ] = commit.generation_revision
+                failure = session.settings_persistence_failures.get(
+                    ConsoleSettingsComponent.GENERATION_SETTINGS
+                )
+                if failure is None or failure.revision <= commit.generation_revision:
+                    session.settings_persistence_failures.pop(
+                        ConsoleSettingsComponent.GENERATION_SETTINGS,
+                        None,
+                    )
+        if context_base_installed and commit.context_policy_overrides is not None:
+            session.context_policy_durable_revision = (
+                commit.context_policy_durable_revision
+            )
+            if session.context_policy_revision == commit.context_policy_revision:
+                lifecycle.component_revisions[
+                    ConsoleSettingsComponent.CONTEXT_POLICY
+                ] = commit.context_policy_revision
+                failure = session.settings_persistence_failures.get(
+                    ConsoleSettingsComponent.CONTEXT_POLICY
+                )
+                if failure is None or failure.revision <= commit.context_policy_revision:
+                    session.settings_persistence_failures.pop(
+                        ConsoleSettingsComponent.CONTEXT_POLICY,
+                        None,
+                    )
+                    session.staged_context_policy_failure_label = None
+                    session.staged_context_policy_failure_revision = None
         if self.library_policy_coordinator is not None:
             self.library_policy_coordinator.register_holder(
                 session.id,
                 commit.identity.conversation_id,
                 session.library_policy_holder,
             )
+
+    async def reconcile_durable_turn_settings(
+        self,
+        session_id: str,
+        commit: ConsoleDurableTurnCommit,
+    ) -> ConsoleSettingsPersistenceOutcome:
+        """Persist settings that advanced while the first turn was committing."""
+
+        session = self._session_or_raise(session_id)
+        if (
+            not commit.first_persist
+            or session.persisted_conversation_id != commit.identity.conversation_id
+        ):
+            return ConsoleSettingsPersistenceOutcome(
+                session_id=session_id,
+                stale_components=frozenset(ConsoleSettingsComponent),
+            )
+        components: set[ConsoleSettingsComponent] = set()
+        lifecycle = self._settings_persistence_lifecycles.setdefault(
+            session_id,
+            _ConsoleSettingsPersistenceLifecycle(),
+        )
+        if (
+            session.generation_settings_revision != commit.generation_revision
+            and lifecycle.component_revisions.get(
+                ConsoleSettingsComponent.GENERATION_SETTINGS
+            )
+            != session.generation_settings_revision
+        ):
+            components.add(ConsoleSettingsComponent.GENERATION_SETTINGS)
+        if (
+            session.context_policy_revision != commit.context_policy_revision
+            and lifecycle.component_revisions.get(ConsoleSettingsComponent.CONTEXT_POLICY)
+            != session.context_policy_revision
+        ):
+            components.add(ConsoleSettingsComponent.CONTEXT_POLICY)
+        if not components:
+            return ConsoleSettingsPersistenceOutcome(
+                session_id=session_id,
+                written_components=frozenset(
+                    component
+                    for component, present in (
+                        (
+                            ConsoleSettingsComponent.GENERATION_SETTINGS,
+                            commit.generation_snapshot is not None,
+                        ),
+                        (
+                            ConsoleSettingsComponent.CONTEXT_POLICY,
+                            commit.context_policy_overrides is not None,
+                        ),
+                    )
+                    if present
+                ),
+            )
+        return await self._join_console_settings_persistence_drain(
+            session_id=session_id,
+            persisted_conversation_id=session.persisted_conversation_id,
+            conversation_binding_revision=session.conversation_binding_revision,
+            generation_revision=session.generation_settings_revision,
+            context_policy_revision=session.context_policy_revision,
+            generation_snapshot=(
+                snapshot_from_session_settings(session.settings)
+                if session.settings is not None
+                else None
+            ),
+            context_policy_overrides=session.context_policy_overrides,
+            policy_failure_label=(
+                session.staged_context_policy_failure_label
+                or commit.policy_failure_label
+                or ConsoleSettingsPolicyFailureLabel.CONTEXT_SETTINGS
+            ),
+            components=frozenset(components),
+        )
+
+    async def reconcile_durable_turn_roleplay_context(
+        self,
+        session_id: str,
+        commit: ConsoleDurableTurnCommit,
+    ) -> None:
+        """Flush a roleplay identity changed after the first-send snapshot."""
+
+        session = self._session_or_raise(session_id)
+        if not commit.first_persist:
+            return
+        if session.persisted_conversation_id != commit.identity.conversation_id:
+            raise RuntimeError("Committed Console roleplay identity changed binding.")
+        if session.identity_revision == commit.roleplay_identity_revision:
+            return
+        context_write = self._snapshot_roleplay_context_write(session)
+        if context_write is None:
+            raise RuntimeError("Committed Console roleplay identity is unavailable.")
+        plan = ConsoleRoleplayProjectionPersistencePlan(
+            session_id=session.id,
+            generation=session.identity_revision,
+            persisted_conversation_id=session.persisted_conversation_id,
+            conversation_binding_revision=session.conversation_binding_revision,
+            system_prompt_write=None,
+            message_writes=(),
+            context_write=context_write,
+        )
+        result = await self.persist_roleplay_projection_plan_serialized(plan)
+        if result is None:
+            # A later owner made this frozen generation stale after identity
+            # publication. That mutation observed the durable binding and owns
+            # its own serialized persistence plan.
+            return
+        if not result.persisted:
+            raise RuntimeError("Committed Console roleplay identity was not saved.")
+        self.accept_roleplay_projection_persistence_result(result)
 
     def publish_durable_turn_owners(
         self,
@@ -5047,7 +5597,10 @@ class ConsoleChatStore:
         if not isinstance(identity, ConsoleStagedConversationIdentity):
             raise TypeError("identity must be ConsoleStagedConversationIdentity")
         session = self._session_or_raise(session_id)
-        session.persisted_conversation_id = identity.conversation_id
+        self.publish_first_persisted_conversation(
+            session_id,
+            identity.conversation_id,
+        )
         session.title = identity.title
         self._flush_staged_capture_policy(session)
 
@@ -6392,6 +6945,52 @@ class ConsoleChatStore:
             raise
         return session
 
+    def publish_first_persisted_conversation(
+        self,
+        session_id: str,
+        conversation_id: str,
+    ) -> ConsoleChatSession:
+        """Publish ordinary first persistence without rebinding the live slot."""
+        if type(conversation_id) is not str or not conversation_id:
+            raise ValueError("conversation_id must be non-empty text")
+        session = self._session_or_raise(session_id)
+        current = session.persisted_conversation_id
+        if current is not None and current != conversation_id:
+            raise RuntimeError("A persisted Console session cannot be rebound.")
+        session.persisted_conversation_id = conversation_id
+        self._record_console_settings_binding_revision(
+            session_id,
+            session.conversation_binding_revision,
+        )
+        return session
+
+    def rebind_persisted_conversation(
+        self,
+        session_id: str,
+        conversation_id: str | None,
+    ) -> ConsoleChatSession:
+        """Explicitly bind one live slot to a different durable identity."""
+        if conversation_id is not None and (
+            type(conversation_id) is not str or not conversation_id
+        ):
+            raise ValueError("conversation_id must be non-empty text or None")
+        session = self._session_or_raise(session_id)
+        if session.persisted_conversation_id != conversation_id:
+            session.conversation_binding_revision = (
+                self._advance_console_settings_binding_revision(
+                    session_id,
+                    session.conversation_binding_revision,
+                )
+            )
+            session.persisted_conversation_id = conversation_id
+            session.settings_persistence_failures.clear()
+            session.generation_durable_snapshot = None
+            session.context_policy_durable_revision = None
+            lifecycle = self._settings_persistence_lifecycles.get(session_id)
+            if lifecycle is not None:
+                lifecycle.component_revisions.clear()
+        return session
+
     def session_settings(self, session_id: str) -> ConsoleSessionSettings | None:
         """Return in-memory settings for a native Console session."""
         return self._session_or_raise(session_id).settings
@@ -6441,6 +7040,120 @@ class ConsoleChatStore:
             persisted = False
         return session, persisted
 
+    def capture_console_settings_origin(
+        self,
+        session_id: str,
+    ) -> ConsoleSettingsOrigin:
+        """Capture the exact live/durable binding before a settings surface opens."""
+        session = self._session_or_raise(session_id)
+        return ConsoleSettingsOrigin(
+            session_id=session.id,
+            persisted_conversation_id=session.persisted_conversation_id,
+            conversation_binding_revision=session.conversation_binding_revision,
+        )
+
+    def session_user_display_name_override(self, session_id: str) -> str | None:
+        """Return one exact session's conversation-owned user display name."""
+        return self._session_or_raise(session_id).user_display_name_override
+
+    def commit_console_settings_live(
+        self,
+        submission: ConsoleSettingsSubmission,
+    ) -> ConsoleSettingsLiveCommit:
+        """Commit both settings components to their exact live origin only."""
+        if not isinstance(submission, ConsoleSettingsSubmission):
+            raise TypeError("submission must be ConsoleSettingsSubmission")
+        session = self._sessions.get(submission.origin.session_id)
+        if session is None or not validate_console_settings_origin(
+            submission.origin,
+            live_session_id=session.id if session is not None else None,
+            live_persisted_conversation_id=(
+                session.persisted_conversation_id if session is not None else None
+            ),
+            live_conversation_binding_revision=(
+                session.conversation_binding_revision if session is not None else -1
+            ),
+        ):
+            raise ValueError("Chat closed; nothing applied.")
+        if submission.submission_id in session.applied_settings_submission_ids:
+            raise ValueError("Console settings submission was already applied.")
+        if not isinstance(submission.draft.settings, ConsoleSessionSettings):
+            raise TypeError("submission settings must be ConsoleSessionSettings")
+        if not isinstance(
+            submission.draft.context_policy_overrides,
+            ConsoleContextPolicyOverrides,
+        ):
+            raise TypeError(
+                "submission context policy must be ConsoleContextPolicyOverrides"
+            )
+
+        current_settings = session.settings
+        settings = replace(
+            submission.draft.settings,
+            source="user",
+            system_prompt=(
+                current_settings.system_prompt if current_settings is not None else None
+            ),
+            pinned_prefill=(
+                current_settings.pinned_prefill if current_settings is not None else None
+            ),
+        )
+        with self._preparation_lock:
+            current = self._sessions.get(submission.origin.session_id)
+            if current is not session or not validate_console_settings_origin(
+                submission.origin,
+                live_session_id=session.id,
+                live_persisted_conversation_id=session.persisted_conversation_id,
+                live_conversation_binding_revision=(
+                    session.conversation_binding_revision
+                ),
+            ):
+                raise ValueError("Chat closed; nothing applied.")
+            if submission.submission_id in session.applied_settings_submission_ids:
+                raise ValueError("Console settings submission was already applied.")
+            session.applied_settings_submission_ids.append(submission.submission_id)
+            self.replace_session_settings(session.id, settings)
+            self._replace_session_context_policy_live(
+                session,
+                submission.draft.context_policy_overrides,
+            )
+            session.staged_context_policy_failure_label = (
+                self._console_settings_policy_failure_label(submission.surface)
+            )
+            session.staged_context_policy_failure_revision = (
+                session.context_policy_revision
+            )
+            return ConsoleSettingsLiveCommit(
+                submission_id=submission.submission_id,
+                session_id=session.id,
+                persisted_conversation_id=session.persisted_conversation_id,
+                conversation_binding_revision=session.conversation_binding_revision,
+                generation_revision=session.generation_settings_revision,
+                context_policy_revision=session.context_policy_revision,
+                settings=settings,
+                context_policy_overrides=session.context_policy_overrides,
+                accepted_submission=submission,
+            )
+
+    def _replace_session_context_policy_live(
+        self,
+        session: ConsoleChatSession,
+        overrides: ConsoleContextPolicyOverrides,
+    ) -> None:
+        """Replace only live policy state and supersede an older retry."""
+        if not isinstance(overrides, ConsoleContextPolicyOverrides):
+            raise TypeError("overrides must be ConsoleContextPolicyOverrides")
+        session.context_policy_overrides = overrides
+        session.context_policy_error = None
+        session.context_policy_revision += 1
+        session.staged_context_policy_failure_label = None
+        session.staged_context_policy_failure_revision = None
+        session.settings_persistence_failures.pop(
+            ConsoleSettingsComponent.CONTEXT_POLICY,
+            None,
+        )
+        self._bump_payload_revision(session.id)
+
     def set_session_context_policy_overrides(
         self,
         session_id: str,
@@ -6455,18 +7168,18 @@ class ConsoleChatStore:
         if not isinstance(overrides, ConsoleContextPolicyOverrides):
             raise TypeError("overrides must be ConsoleContextPolicyOverrides")
         session = self._session_or_raise(session_id)
-        session.context_policy_overrides = overrides
-        session.context_policy_error = None
-        self._bump_payload_revision(session_id)
+        expected_revision = session.context_policy_durable_revision
+        self._replace_session_context_policy_live(session, overrides)
         if session.persisted_conversation_id is None or self.persistence is None:
             return session, True
         writer = getattr(self.persistence, "update_conversation_context_policy", None)
         if not callable(writer):
             return session, False
         try:
-            writer(
+            result = writer(
                 conversation_id=session.persisted_conversation_id,
                 overrides=overrides,
+                expected_revision=expected_revision,
             )
         except Exception:
             logger.error(
@@ -6474,7 +7187,621 @@ class ConsoleChatStore:
                 "keeps the applied value."
             )
             return session, False
+        if isinstance(result, ContextPolicyWriteResult):
+            if result.status is not ContextPolicyWriteStatus.WRITTEN:
+                return session, False
+            session.context_policy_durable_revision = result.revision
+        elif type(result) is int or result is None:
+            session.context_policy_durable_revision = result
+        else:
+            return session, False
+        lifecycle = self._settings_persistence_lifecycles.setdefault(
+            session_id,
+            _ConsoleSettingsPersistenceLifecycle(),
+        )
+        lifecycle.context_bases[session.persisted_conversation_id] = (
+            session.context_policy_durable_revision
+        )
+        lifecycle.component_revisions[
+            ConsoleSettingsComponent.CONTEXT_POLICY
+        ] = session.context_policy_revision
         return session, True
+
+    async def persist_console_settings_commit_serialized(
+        self,
+        commit: ConsoleSettingsLiveCommit,
+        *,
+        policy_failure_label: ConsoleSettingsPolicyFailureLabel | None = None,
+    ) -> ConsoleSettingsPersistenceOutcome:
+        """Join one session drain that converges durability to newest live state."""
+        if not isinstance(commit, ConsoleSettingsLiveCommit):
+            raise TypeError("commit must be ConsoleSettingsLiveCommit")
+        if policy_failure_label is None:
+            accepted = commit.accepted_submission
+            policy_failure_label = self._console_settings_policy_failure_label(
+                accepted.surface if accepted is not None else None
+            )
+        if not isinstance(policy_failure_label, ConsoleSettingsPolicyFailureLabel):
+            raise TypeError(
+                "policy_failure_label must be ConsoleSettingsPolicyFailureLabel"
+            )
+        return await self._join_console_settings_persistence_drain(
+            session_id=commit.session_id,
+            persisted_conversation_id=commit.persisted_conversation_id,
+            conversation_binding_revision=commit.conversation_binding_revision,
+            generation_revision=commit.generation_revision,
+            context_policy_revision=commit.context_policy_revision,
+            generation_snapshot=snapshot_from_session_settings(commit.settings),
+            context_policy_overrides=commit.context_policy_overrides,
+            policy_failure_label=policy_failure_label,
+            components=frozenset(ConsoleSettingsComponent),
+        )
+
+    @staticmethod
+    def _console_settings_policy_failure_label(
+        surface: ConsoleSettingsSurface | None,
+    ) -> ConsoleSettingsPolicyFailureLabel:
+        """Map an exact typed submission surface to durable failure copy."""
+        if surface is ConsoleSettingsSurface.QUICK_POPOVER:
+            return ConsoleSettingsPolicyFailureLabel.COMPACTION
+        return ConsoleSettingsPolicyFailureLabel.CONTEXT_SETTINGS
+
+    async def retry_console_settings_persistence(
+        self,
+        *,
+        session_id: str,
+        component: ConsoleSettingsComponent,
+        revision: int,
+    ) -> bool:
+        """Retry one still-current failed component without advancing revisions."""
+        if not isinstance(component, ConsoleSettingsComponent):
+            raise TypeError("component must be ConsoleSettingsComponent")
+        session = self._sessions.get(session_id)
+        failure = (
+            session.settings_persistence_failures.get(component)
+            if session is not None
+            else None
+        )
+        current_revision = (
+            session.generation_settings_revision
+            if session is not None
+            and component is ConsoleSettingsComponent.GENERATION_SETTINGS
+            else session.context_policy_revision
+            if session is not None
+            else None
+        )
+        if (
+            session is None
+            or failure is None
+            or failure.revision != revision
+            or current_revision != revision
+        ):
+            return False
+        outcome = await self._join_console_settings_persistence_drain(
+            session_id=session_id,
+            persisted_conversation_id=failure.persisted_conversation_id,
+            conversation_binding_revision=failure.conversation_binding_revision,
+            generation_revision=(
+                revision
+                if component is ConsoleSettingsComponent.GENERATION_SETTINGS
+                else session.generation_settings_revision
+            ),
+            context_policy_revision=(
+                revision
+                if component is ConsoleSettingsComponent.CONTEXT_POLICY
+                else session.context_policy_revision
+            ),
+            generation_snapshot=failure.generation_snapshot,
+            context_policy_overrides=failure.context_policy_overrides,
+            policy_failure_label=(
+                failure.policy_failure_label
+                or ConsoleSettingsPolicyFailureLabel.CONTEXT_SETTINGS
+            ),
+            components=frozenset({component}),
+            retry_components=frozenset({component}),
+        )
+        return component in outcome.written_components
+
+    async def _join_console_settings_persistence_drain(
+        self,
+        *,
+        session_id: str,
+        persisted_conversation_id: str | None,
+        conversation_binding_revision: int,
+        generation_revision: int,
+        context_policy_revision: int,
+        generation_snapshot: ConsoleGenerationSettingsSnapshot | None,
+        context_policy_overrides: ConsoleContextPolicyOverrides | None,
+        policy_failure_label: ConsoleSettingsPolicyFailureLabel,
+        components: frozenset[ConsoleSettingsComponent],
+        retry_components: frozenset[ConsoleSettingsComponent] = frozenset(),
+    ) -> ConsoleSettingsPersistenceOutcome:
+        """Start or join the one in-flight durability drain for a live slot."""
+        if not isinstance(policy_failure_label, ConsoleSettingsPolicyFailureLabel):
+            raise TypeError(
+                "policy_failure_label must be ConsoleSettingsPolicyFailureLabel"
+            )
+        lifecycle = self._settings_persistence_lifecycles.setdefault(
+            session_id,
+            _ConsoleSettingsPersistenceLifecycle(),
+        )
+        incarnation = self._settings_session_incarnations.get(session_id, 0)
+        drain = lifecycle.drain
+        if drain is not None and drain.task is not None and drain.task.done():
+            lifecycle.drain = None
+            drain = None
+        if (
+            drain is not None
+            and drain.session_incarnation == incarnation
+            and drain.persisted_conversation_id == persisted_conversation_id
+            and drain.conversation_binding_revision == conversation_binding_revision
+        ):
+            drain.requested_components.update(components)
+            drain.retry_components.update(retry_components)
+            drain.initial_components = drain.initial_components | components
+            if (
+                ConsoleSettingsComponent.GENERATION_SETTINGS in components
+                and generation_revision >= drain.generation_revision
+            ):
+                drain.generation_revision = generation_revision
+                drain.generation_snapshot = generation_snapshot
+            if (
+                ConsoleSettingsComponent.CONTEXT_POLICY in components
+                and context_policy_revision >= drain.context_policy_revision
+            ):
+                drain.context_policy_revision = context_policy_revision
+                drain.context_policy_overrides = context_policy_overrides
+                drain.policy_failure_label = policy_failure_label
+            assert drain.task is not None
+            return await asyncio.shield(drain.task)
+
+        drain = _ConsoleSettingsPersistenceDrain(
+            session_incarnation=incarnation,
+            persisted_conversation_id=persisted_conversation_id,
+            conversation_binding_revision=conversation_binding_revision,
+            generation_revision=generation_revision,
+            context_policy_revision=context_policy_revision,
+            generation_snapshot=generation_snapshot,
+            context_policy_overrides=context_policy_overrides,
+            policy_failure_label=policy_failure_label,
+            initial_components=components,
+            requested_components=set(components),
+            retry_components=set(retry_components),
+        )
+        task = asyncio.create_task(
+            self._run_console_settings_persistence_drain(
+                session_id,
+                drain,
+                lifecycle,
+            )
+        )
+        drain.task = task
+        lifecycle.drain = drain
+        lifecycle.tasks.add(task)
+        task.add_done_callback(
+            lambda completed: self._retire_console_settings_persistence_drain(
+                session_id,
+                drain,
+                lifecycle,
+                completed,
+            )
+        )
+        return await asyncio.shield(task)
+
+    def _retire_console_settings_persistence_drain(
+        self,
+        session_id: str,
+        drain: _ConsoleSettingsPersistenceDrain,
+        lifecycle: _ConsoleSettingsPersistenceLifecycle,
+        task: asyncio.Task[ConsoleSettingsPersistenceOutcome],
+    ) -> None:
+        """Forget a completed drain only when it still owns the live registry."""
+        lifecycle.tasks.discard(task)
+        if drain.task is task and lifecycle.drain is drain:
+            lifecycle.drain = None
+        if self._settings_persistence_lifecycles.get(session_id) is lifecycle:
+            self._cleanup_console_settings_lifecycle_if_idle(session_id)
+
+    async def _run_console_settings_persistence_drain(
+        self,
+        session_id: str,
+        drain: _ConsoleSettingsPersistenceDrain,
+        lifecycle: _ConsoleSettingsPersistenceLifecycle,
+    ) -> ConsoleSettingsPersistenceOutcome:
+        async with lifecycle.lock:
+            return await self._persist_console_settings_components_locked(
+                session_id=session_id,
+                drain=drain,
+                lifecycle=lifecycle,
+            )
+
+    async def _persist_console_settings_components_locked(
+        self,
+        *,
+        session_id: str,
+        drain: _ConsoleSettingsPersistenceDrain,
+        lifecycle: _ConsoleSettingsPersistenceLifecycle,
+    ) -> ConsoleSettingsPersistenceOutcome:
+        """Drain selected components to their newest live revisions.
+
+        A transaction already executing in ``to_thread`` cannot be recalled. If
+        Apply advances while that transaction is in flight, its successful CAS
+        result becomes only the private base for the next CAS. It is never
+        published into the session, and this coroutine keeps reconciling until
+        the newest live revision is durable (or fails) before any joined waiter
+        returns.
+        """
+        written: set[ConsoleSettingsComponent] = set()
+        failed: set[ConsoleSettingsComponent] = set()
+        stale: set[ConsoleSettingsComponent] = set()
+        session = self._sessions.get(session_id)
+        if not self._console_settings_drain_identity_matches(
+            session_id,
+            session,
+            drain,
+        ):
+            return ConsoleSettingsPersistenceOutcome(
+                session_id=session_id,
+                stale_components=frozenset(drain.requested_components),
+            )
+        assert session is not None
+        if session.ephemeral or drain.persisted_conversation_id is None:
+            if session.context_policy_revision == drain.context_policy_revision:
+                session.staged_context_policy_failure_label = (
+                    drain.policy_failure_label
+                )
+                session.staged_context_policy_failure_revision = (
+                    drain.context_policy_revision
+                )
+            return ConsoleSettingsPersistenceOutcome(
+                session_id=session_id,
+                staged=True,
+            )
+
+        excluded: set[ConsoleSettingsComponent] = set()
+        if (
+            ConsoleSettingsComponent.GENERATION_SETTINGS in drain.initial_components
+            and (
+                session.generation_settings_revision != drain.generation_revision
+                or drain.generation_snapshot is None
+            )
+        ):
+            excluded.add(ConsoleSettingsComponent.GENERATION_SETTINGS)
+        if (
+            ConsoleSettingsComponent.CONTEXT_POLICY in drain.initial_components
+            and (
+                session.context_policy_revision != drain.context_policy_revision
+                or drain.context_policy_overrides is None
+            )
+        ):
+            excluded.add(ConsoleSettingsComponent.CONTEXT_POLICY)
+        stale.update(excluded)
+
+        conversation_id = drain.persisted_conversation_id
+        assert conversation_id is not None
+        private_generation_base = (
+            lifecycle.generation_bases[conversation_id]
+            if conversation_id in lifecycle.generation_bases
+            else session.generation_durable_snapshot
+        )
+        private_context_base = (
+            lifecycle.context_bases[conversation_id]
+            if conversation_id in lifecycle.context_bases
+            else session.context_policy_durable_revision
+        )
+        persisted_revisions = dict(lifecycle.component_revisions)
+        failed_revisions: dict[ConsoleSettingsComponent, int] = {}
+
+        while True:
+            current = self._sessions.get(session_id)
+            if not self._console_settings_drain_identity_matches(
+                session_id,
+                current,
+                drain,
+            ):
+                stale.update(drain.requested_components)
+                break
+            assert current is not None
+            requested = set(drain.requested_components)
+            for retried_component in tuple(drain.retry_components):
+                failed_revisions.pop(retried_component, None)
+            drain.retry_components.clear()
+            generation_needs_reconcile = False
+
+            generation = ConsoleSettingsComponent.GENERATION_SETTINGS
+            if generation in requested and generation not in excluded:
+                revision = current.generation_settings_revision
+                if persisted_revisions.get(generation) == revision:
+                    written.add(generation)
+                    failed.discard(generation)
+                    stale.discard(generation)
+                elif failed_revisions.get(generation) == revision:
+                    written.discard(generation)
+                    failed.add(generation)
+                elif current.settings is None:
+                    written.discard(generation)
+                    stale.add(generation)
+                    excluded.add(generation)
+                else:
+                    written.discard(generation)
+                    snapshot = snapshot_from_session_settings(current.settings)
+                    writer = getattr(
+                        self.persistence,
+                        "update_conversation_generation_settings",
+                        None,
+                    )
+                    try:
+                        result = (
+                            await asyncio.to_thread(
+                                writer,
+                                conversation_id=drain.persisted_conversation_id,
+                                snapshot=snapshot,
+                                expected_snapshot=private_generation_base,
+                            )
+                            if callable(writer)
+                            else object()
+                        )
+                    except Exception:
+                        result = object()
+                    current = self._sessions.get(session_id)
+                    identity_matches = self._console_settings_drain_identity_matches(
+                        session_id,
+                        current,
+                        drain,
+                    )
+                    generation_written = bool(
+                        isinstance(result, ConsoleGenerationSettingsWriteResult)
+                        and result.status
+                        is ConsoleGenerationSettingsWriteStatus.WRITTEN
+                    )
+                    if generation_written:
+                        assert isinstance(
+                            result,
+                            ConsoleGenerationSettingsWriteResult,
+                        )
+                        private_generation_base = result.snapshot
+                        lifecycle.generation_bases[conversation_id] = result.snapshot
+                        persisted_revisions[generation] = revision
+                        if (
+                            identity_matches
+                            and current is not None
+                            and current.generation_settings_revision == revision
+                        ):
+                            current.generation_durable_snapshot = result.snapshot
+                            lifecycle.component_revisions[generation] = revision
+                            current.settings_persistence_failures.pop(generation, None)
+                            failed_revisions.pop(generation, None)
+                            failed.discard(generation)
+                            stale.discard(generation)
+                            written.add(generation)
+                        else:
+                            stale.add(generation)
+                            generation_needs_reconcile = True
+                    elif (
+                        identity_matches
+                        and current is not None
+                        and current.generation_settings_revision == revision
+                    ):
+                        self._record_console_settings_failure(
+                            current,
+                            component=generation,
+                            revision=revision,
+                            generation_snapshot=snapshot,
+                        )
+                        failed_revisions[generation] = revision
+                        failed.add(generation)
+                        stale.discard(generation)
+                    else:
+                        stale.add(generation)
+                        generation_needs_reconcile = True
+
+            if generation_needs_reconcile:
+                continue
+
+            context = ConsoleSettingsComponent.CONTEXT_POLICY
+            current = self._sessions.get(session_id)
+            if (
+                current is not None
+                and context in lifecycle.component_revisions
+                and conversation_id in lifecycle.context_bases
+                and self._console_settings_drain_identity_matches(
+                    session_id,
+                    current,
+                    drain,
+                )
+            ):
+                published_context_revision = lifecycle.component_revisions[context]
+                if published_context_revision == current.context_policy_revision:
+                    persisted_revisions[context] = published_context_revision
+                    private_context_base = lifecycle.context_bases[conversation_id]
+            if (
+                context in requested
+                and context not in excluded
+                and self._console_settings_drain_identity_matches(
+                    session_id,
+                    current,
+                    drain,
+                )
+            ):
+                assert current is not None
+                revision = current.context_policy_revision
+                if persisted_revisions.get(context) == revision:
+                    written.add(context)
+                    failed.discard(context)
+                    stale.discard(context)
+                elif failed_revisions.get(context) == revision:
+                    written.discard(context)
+                    failed.add(context)
+                else:
+                    written.discard(context)
+                    overrides = current.context_policy_overrides
+                    writer = getattr(
+                        self.persistence,
+                        "update_conversation_context_policy",
+                        None,
+                    )
+                    try:
+                        result = (
+                            await asyncio.to_thread(
+                                writer,
+                                conversation_id=drain.persisted_conversation_id,
+                                overrides=overrides,
+                                expected_revision=private_context_base,
+                            )
+                            if callable(writer)
+                            else object()
+                        )
+                    except Exception:
+                        result = object()
+                    current = self._sessions.get(session_id)
+                    identity_matches = self._console_settings_drain_identity_matches(
+                        session_id,
+                        current,
+                        drain,
+                    )
+                    context_written, durable_revision = self._context_write_result(
+                        result
+                    )
+                    if context_written:
+                        private_context_base = durable_revision
+                        lifecycle.context_bases[conversation_id] = durable_revision
+                        persisted_revisions[context] = revision
+                        if (
+                            identity_matches
+                            and current is not None
+                            and current.context_policy_revision == revision
+                        ):
+                            current.context_policy_durable_revision = durable_revision
+                            lifecycle.component_revisions[context] = revision
+                            current.settings_persistence_failures.pop(context, None)
+                            if (
+                                current.staged_context_policy_failure_revision
+                                == revision
+                            ):
+                                current.staged_context_policy_failure_label = None
+                                current.staged_context_policy_failure_revision = None
+                            failed_revisions.pop(context, None)
+                            failed.discard(context)
+                            stale.discard(context)
+                            written.add(context)
+                        else:
+                            stale.add(context)
+                    elif (
+                        identity_matches
+                        and current is not None
+                        and current.context_policy_revision == revision
+                    ):
+                        self._record_console_settings_failure(
+                            current,
+                            component=context,
+                            revision=revision,
+                            context_policy_overrides=overrides,
+                            policy_failure_label=drain.policy_failure_label,
+                        )
+                        failed_revisions[context] = revision
+                        failed.add(context)
+                        stale.discard(context)
+                    else:
+                        stale.add(context)
+
+            current = self._sessions.get(session_id)
+            if not self._console_settings_drain_identity_matches(
+                session_id,
+                current,
+                drain,
+            ):
+                stale.update(drain.requested_components)
+                break
+            assert current is not None
+            converged = True
+            for component in set(drain.requested_components) - excluded:
+                revision = (
+                    current.generation_settings_revision
+                    if component is ConsoleSettingsComponent.GENERATION_SETTINGS
+                    else current.context_policy_revision
+                )
+                if (
+                    persisted_revisions.get(component) != revision
+                    and failed_revisions.get(component) != revision
+                ):
+                    converged = False
+                    break
+            if converged:
+                break
+
+        return ConsoleSettingsPersistenceOutcome(
+            session_id=session_id,
+            written_components=frozenset(written),
+            failed_components=frozenset(failed),
+            stale_components=frozenset(stale),
+        )
+
+    @staticmethod
+    def _context_write_result(result: object) -> tuple[bool, int | None]:
+        if isinstance(result, ContextPolicyWriteResult):
+            return (
+                result.status is ContextPolicyWriteStatus.WRITTEN,
+                result.revision,
+            )
+        if type(result) is int or result is None:
+            return True, result
+        return False, None
+
+    def _console_settings_drain_identity_matches(
+        self,
+        session_id: str,
+        session: ConsoleChatSession | None,
+        drain: _ConsoleSettingsPersistenceDrain,
+    ) -> bool:
+        """Require both scalar origin identity and store-private incarnation."""
+        return bool(
+            self._settings_session_incarnations.get(session_id)
+            == drain.session_incarnation
+            and self._console_settings_identity_matches(
+                session,
+                persisted_conversation_id=drain.persisted_conversation_id,
+                conversation_binding_revision=drain.conversation_binding_revision,
+            )
+        )
+
+    @staticmethod
+    def _console_settings_identity_matches(
+        session: ConsoleChatSession | None,
+        *,
+        persisted_conversation_id: str | None,
+        conversation_binding_revision: int,
+    ) -> bool:
+        return bool(
+            session is not None
+            and session.persisted_conversation_id == persisted_conversation_id
+            and session.conversation_binding_revision
+            == conversation_binding_revision
+        )
+
+    @staticmethod
+    def _record_console_settings_failure(
+        session: ConsoleChatSession,
+        *,
+        component: ConsoleSettingsComponent,
+        revision: int,
+        generation_snapshot: ConsoleGenerationSettingsSnapshot | None = None,
+        context_policy_overrides: ConsoleContextPolicyOverrides | None = None,
+        policy_failure_label: ConsoleSettingsPolicyFailureLabel | None = None,
+    ) -> None:
+        conversation_id = session.persisted_conversation_id
+        if conversation_id is None:
+            return
+        session.settings_persistence_failures[component] = (
+            ConsoleSettingsPersistenceFailure(
+                component=component,
+                revision=revision,
+                persisted_conversation_id=conversation_id,
+                conversation_binding_revision=session.conversation_binding_revision,
+                generation_snapshot=generation_snapshot,
+                context_policy_overrides=context_policy_overrides,
+                policy_failure_label=policy_failure_label,
+            )
+        )
 
     def set_auto_speak(
         self, session_id: str, enabled: bool
@@ -6618,6 +7945,11 @@ class ConsoleChatStore:
                 )
             session.canonical_settings_baseline = canonical_settings_baseline
         session.settings = settings
+        session.generation_settings_revision += 1
+        session.settings_persistence_failures.pop(
+            ConsoleSettingsComponent.GENERATION_SETTINGS,
+            None,
+        )
         self._bump_payload_revision(session_id)
         if (
             changed
@@ -7265,6 +8597,10 @@ class ConsoleChatStore:
             generation_owner_ids = tuple(self._generation_attempt_tokens)
         for message_id in generation_owner_ids:
             self._invalidate_generation_attempt(message_id)
+        replaced_binding_revisions = {
+            session_id: session.conversation_binding_revision
+            for session_id, session in self._sessions.items()
+        }
         preserved_ephemeral = {
             session_id: recovery
             for session_id, recovery in self._dispatch_recoveries_by_session.items()
@@ -7299,6 +8635,28 @@ class ConsoleChatStore:
                 raise RuntimeError(
                     "Unresolved temporary dispatch recovery cannot be replaced."
                 )
+        restored_binding_revisions: dict[str, int] = {}
+        for session_id, restored_session in sessions_by_id.items():
+            revisions = [restored_session.conversation_binding_revision]
+            prior_revision = replaced_binding_revisions.get(session_id)
+            if prior_revision is not None:
+                revisions.append(prior_revision)
+            restored_binding_revisions[session_id] = (
+                self._advance_console_settings_binding_revision(
+                    session_id,
+                    *revisions,
+                )
+            )
+        for session_id, prior_revision in replaced_binding_revisions.items():
+            if session_id not in sessions_by_id:
+                self._advance_console_settings_binding_revision(
+                    session_id,
+                    prior_revision,
+                )
+        for settings_session_id in set(self._sessions) | set(sessions_by_id):
+            self._advance_console_settings_session_incarnation(
+                settings_session_id
+            )
         self._activate_session(None)
         if self.library_policy_coordinator is not None:
             for replaced_session_id in tuple(self._sessions):
@@ -7356,9 +8714,13 @@ class ConsoleChatStore:
             )
             restored_session = replace(
                 session,
+                conversation_binding_revision=restored_binding_revisions[session.id],
+                settings_persistence_failures={},
+                applied_settings_submission_ids=deque(maxlen=32),
                 library_policy_holder=restored_holder,
             )
             self._sessions[session.id] = restored_session
+            self._seed_console_settings_owned_bases(restored_session)
             if self.library_policy_coordinator is not None:
                 self.library_policy_coordinator.register_holder(
                     session.id,
@@ -7383,6 +8745,9 @@ class ConsoleChatStore:
                 session.id, restored_messages.get(session.id, ())
             )
             self._bump_payload_revision(session.id)
+
+        for replaced_session_id in replaced_binding_revisions:
+            self._cleanup_console_settings_lifecycle_if_idle(replaced_session_id)
 
         self._dispatch_recoveries_by_session.update(preserved_ephemeral)
         self._dispatch_recovery_message_baselines.update(preserved_baselines)
@@ -8748,6 +10113,81 @@ class ConsoleChatStore:
             persisted = False
         return session, persisted
 
+    def set_session_user_display_name_override_for_commit(
+        self,
+        commit: ConsoleSettingsLiveCommit,
+        value: object,
+        *,
+        global_default: object,
+    ) -> tuple[ConsoleChatSession | None, bool]:
+        """Apply presentation state only while its committed binding is current."""
+        if not isinstance(commit, ConsoleSettingsLiveCommit):
+            raise TypeError("commit must be ConsoleSettingsLiveCommit")
+        session = self._sessions.get(commit.session_id)
+        if not self._console_settings_identity_matches(
+            session,
+            persisted_conversation_id=commit.persisted_conversation_id,
+            conversation_binding_revision=commit.conversation_binding_revision,
+        ):
+            return session, True
+        return self.set_session_user_display_name_override(
+            commit.session_id,
+            value,
+            global_default=global_default,
+        )
+
+    def prepare_session_user_display_name_override_for_commit(
+        self,
+        commit: ConsoleSettingsLiveCommit,
+        value: object,
+        *,
+        global_default: object,
+    ) -> tuple[
+        ConsoleChatSession | None,
+        ConsoleRoleplayProjectionPersistencePlan | None,
+    ]:
+        """Apply exact-binding live identity and freeze only durable writes.
+
+        This method owns every live store and session mutation and must remain
+        on the event-loop owner thread.  Only the returned immutable plan is
+        safe to consume from a worker thread.
+        """
+        if not isinstance(commit, ConsoleSettingsLiveCommit):
+            raise TypeError("commit must be ConsoleSettingsLiveCommit")
+        session = self._sessions.get(commit.session_id)
+        if not self._console_settings_identity_matches(
+            session,
+            persisted_conversation_id=commit.persisted_conversation_id,
+            conversation_binding_revision=commit.conversation_binding_revision,
+        ):
+            return session, None
+        assert session is not None
+        normalized = normalize_chat_display_name(value, blank_means_none=True)
+        if session.user_display_name_override == normalized:
+            return session, None
+        session.user_display_name_override = normalized
+        self._bump_identity_revision(session.id)
+        context_write = self._snapshot_roleplay_context_write(session)
+        plan = self._materialize_roleplay_projections_live(
+            session.id,
+            global_default=global_default,
+        )
+        if plan is None:
+            plan = ConsoleRoleplayProjectionPersistencePlan(
+                session_id=session.id,
+                generation=session.identity_revision,
+                persisted_conversation_id=session.persisted_conversation_id,
+                conversation_binding_revision=(
+                    session.conversation_binding_revision
+                ),
+                system_prompt_write=None,
+                message_writes=(),
+                context_write=context_write,
+            )
+        else:
+            plan = replace(plan, context_write=context_write)
+        return session, plan
+
     def refresh_session_roleplay_projections(
         self,
         session_id: str,
@@ -9100,6 +10540,8 @@ class ConsoleChatStore:
         return ConsoleRoleplayProjectionPersistencePlan(
             session_id=session.id,
             generation=session.identity_revision,
+            persisted_conversation_id=session.persisted_conversation_id,
+            conversation_binding_revision=session.conversation_binding_revision,
             system_prompt_write=system_prompt_write,
             message_writes=tuple(message_writes),
         )
@@ -9239,7 +10681,64 @@ class ConsoleChatStore:
     ) -> bool:
         """Return whether a queued plan still owns the session generation."""
         session = self._sessions.get(plan.session_id)
-        return session is not None and session.identity_revision == plan.generation
+        return (
+            session is not None
+            and session.identity_revision == plan.generation
+            and session.persisted_conversation_id
+            == plan.persisted_conversation_id
+            and session.conversation_binding_revision
+            == plan.conversation_binding_revision
+        )
+
+    async def persist_roleplay_projection_plan_serialized(
+        self,
+        plan: ConsoleRoleplayProjectionPersistencePlan,
+    ) -> ConsoleRoleplayProjectionPersistenceResult | None:
+        """Persist the newest plan in order for its durable conversation row."""
+        target = plan.persisted_conversation_id
+        if target is None:
+            if not self.is_roleplay_projection_plan_current(plan):
+                return None
+            return ConsoleChatStore.persist_roleplay_projection_plan(plan)
+
+        entry = self._roleplay_persistence_locks.get(target)
+        if entry is None:
+            entry = _RoleplayPersistenceLockEntry()
+            self._roleplay_persistence_locks[target] = entry
+        entry.users += 1
+        try:
+            async with entry.lock:
+                if not self.is_roleplay_projection_plan_current(plan):
+                    return None
+                rebased = self.rebase_roleplay_projection_plan_sync(plan)
+                persistence_task = asyncio.create_task(
+                    asyncio.to_thread(
+                        ConsoleChatStore.persist_roleplay_projection_plan,
+                        rebased,
+                    )
+                )
+                try:
+                    return await asyncio.shield(persistence_task)
+                except asyncio.CancelledError as cancellation:
+                    while not persistence_task.done():
+                        try:
+                            await asyncio.shield(persistence_task)
+                        except asyncio.CancelledError:
+                            continue
+                    try:
+                        persistence_task.result()
+                    except Exception:
+                        logger.exception(
+                            "Console roleplay persistence failed during cancellation"
+                        )
+                    raise cancellation
+        finally:
+            entry.users -= 1
+            if (
+                entry.users == 0
+                and self._roleplay_persistence_locks.get(target) is entry
+            ):
+                self._roleplay_persistence_locks.pop(target, None)
 
     def rebase_roleplay_projection_plan_sync(
         self, plan: ConsoleRoleplayProjectionPersistencePlan
@@ -9307,12 +10806,59 @@ class ConsoleChatStore:
             kwargs=tuple(kwargs.items()),
         )
 
+    def _snapshot_roleplay_context_write(
+        self,
+        session: ConsoleChatSession,
+    ) -> _RoleplayContextWrite | None:
+        """Freeze a roleplay-context write without retaining live state."""
+        if self.persistence is None or session.persisted_conversation_id is None:
+            return None
+        writer = getattr(self.persistence, "update_conversation_roleplay_context", None)
+        if not callable(writer):
+            writer = _refuse_roleplay_projection_write
+        return _RoleplayContextWrite(
+            writer=writer,
+            conversation_id=session.persisted_conversation_id,
+            user_name_override=session.user_display_name_override,
+            character_system_template=session.character_system_template,
+            character_name_snapshot=(
+                session.character_name
+                if session.assistant_kind == "character"
+                else None
+            ),
+        )
+
     @staticmethod
     def persist_roleplay_projection_plan(
         plan: ConsoleRoleplayProjectionPersistencePlan,
     ) -> ConsoleRoleplayProjectionPersistenceResult:
         """Consume one frozen plan without reading or mutating a live store."""
         persisted = True
+        context_write = plan.context_write
+        context_persisted = True
+        if context_write is not None:
+            try:
+                context_persisted = bool(
+                    context_write.writer(
+                        conversation_id=context_write.conversation_id,
+                        user_name_override=context_write.user_name_override,
+                        character_system_template=(
+                            context_write.character_system_template
+                        ),
+                        character_name_snapshot=(
+                            context_write.character_name_snapshot
+                        ),
+                    )
+                )
+            except Exception as exc:
+                context_persisted = False
+                logger.warning(
+                    "Failed to persist planned Console roleplay identity context "
+                    "(error_type={}).",
+                    type(exc).__name__,
+                )
+            if not context_persisted:
+                persisted = False
         system_write = plan.system_prompt_write
         system_prompt_persisted = True
         if system_write is not None:
@@ -9407,6 +10953,8 @@ class ConsoleChatStore:
         return ConsoleRoleplayProjectionPersistenceResult(
             session_id=plan.session_id,
             generation=plan.generation,
+            persisted_conversation_id=plan.persisted_conversation_id,
+            conversation_binding_revision=plan.conversation_binding_revision,
             persisted=persisted,
             system_prompt_attempted=system_write is not None,
             system_prompt=(
@@ -9414,6 +10962,8 @@ class ConsoleChatStore:
             ),
             system_prompt_persisted=system_prompt_persisted,
             message_outcomes=tuple(message_outcomes),
+            context_attempted=context_write is not None,
+            context_persisted=context_persisted,
         )
 
     def accept_roleplay_projection_persistence_result(
@@ -9422,7 +10972,14 @@ class ConsoleChatStore:
     ) -> bool:
         """Apply completion bookkeeping only for the still-current generation."""
         session = self._sessions.get(result.session_id)
-        if session is None or session.identity_revision != result.generation:
+        if (
+            session is None
+            or session.identity_revision != result.generation
+            or session.persisted_conversation_id
+            != result.persisted_conversation_id
+            or session.conversation_binding_revision
+            != result.conversation_binding_revision
+        ):
             return False
         if result.system_prompt_attempted and result.system_prompt_persisted:
             self._roleplay_system_projection_candidates[session.id] = (
@@ -12239,6 +13796,17 @@ class ConsoleChatStore:
             thinking_history_policy=session.thinking_history_policy,
             **identity_kwargs,
         )
+        staged_generation_snapshot = (
+            snapshot_from_session_settings(session.settings)
+            if session.settings is not None
+            and session.generation_settings_revision > 0
+            else None
+        )
+        if staged_generation_snapshot is not None:
+            create_kwargs["metadata"] = merge_console_generation_settings(
+                create_kwargs.get("metadata"),
+                staged_generation_snapshot,
+            )
         if session.speech_preferences != ConsoleSpeechPreferences():
             if not self._persistence_accepts_kwarg(
                 create_conversation,
@@ -12274,6 +13842,8 @@ class ConsoleChatStore:
             )
             committed_policy = None
         self.publish_committed_identity(session_id, committed_identity)
+        if staged_generation_snapshot is not None:
+            session.generation_durable_snapshot = staged_generation_snapshot
         if isinstance(committed_policy, ConsoleLibraryPolicySnapshot):
             session.library_policy_holder.snapshot = committed_policy
             session.library_policy_holder.explicitly_staged = False
@@ -12378,28 +13948,87 @@ class ConsoleChatStore:
 
     def _flush_context_policy_on_first_persist(
         self, session: ConsoleChatSession
-    ) -> None:
-        """Write staged non-empty policy after the conversation row exists."""
+    ) -> ContextPolicyWriteResult | None:
+        """Write one staged policy and publish its durable owned revision."""
         if (
             session.persisted_conversation_id is None
-            or session.context_policy_overrides.is_empty
+            or session.context_policy_revision < 1
             or self.persistence is None
         ):
-            return
+            return None
+        failure_label = (
+            session.staged_context_policy_failure_label
+            if session.staged_context_policy_failure_revision
+            == session.context_policy_revision
+            and session.staged_context_policy_failure_label is not None
+            else ConsoleSettingsPolicyFailureLabel.CONTEXT_SETTINGS
+        )
         writer = getattr(self.persistence, "update_conversation_context_policy", None)
         if not callable(writer):
             logger.warning(
                 "Skipped staged Console context-policy flush: persistence "
                 "adapter exposes no policy write seam."
             )
-            return
+            result = ContextPolicyWriteResult(
+                ContextPolicyWriteStatus.MISSING,
+                session.context_policy_durable_revision,
+            )
+            self._record_console_settings_failure(
+                session,
+                component=ConsoleSettingsComponent.CONTEXT_POLICY,
+                revision=session.context_policy_revision,
+                context_policy_overrides=session.context_policy_overrides,
+                policy_failure_label=failure_label,
+            )
+            return result
         try:
-            writer(
+            raw_result = writer(
                 conversation_id=session.persisted_conversation_id,
                 overrides=session.context_policy_overrides,
+                expected_revision=session.context_policy_durable_revision,
             )
         except Exception:
             logger.error("Failed to flush Console context policy on first persist.")
+            result = ContextPolicyWriteResult(
+                ContextPolicyWriteStatus.CONFLICT,
+                session.context_policy_durable_revision,
+            )
+            self._record_console_settings_failure(
+                session,
+                component=ConsoleSettingsComponent.CONTEXT_POLICY,
+                revision=session.context_policy_revision,
+                context_policy_overrides=session.context_policy_overrides,
+                policy_failure_label=failure_label,
+            )
+            return result
+        written, revision = self._context_write_result(raw_result)
+        if written:
+            session.context_policy_durable_revision = revision
+            session.settings_persistence_failures.pop(
+                ConsoleSettingsComponent.CONTEXT_POLICY,
+                None,
+            )
+            session.staged_context_policy_failure_label = None
+            session.staged_context_policy_failure_revision = None
+            return ContextPolicyWriteResult(
+                ContextPolicyWriteStatus.WRITTEN,
+                revision,
+            )
+        self._record_console_settings_failure(
+            session,
+            component=ConsoleSettingsComponent.CONTEXT_POLICY,
+            revision=session.context_policy_revision,
+            context_policy_overrides=session.context_policy_overrides,
+            policy_failure_label=failure_label,
+        )
+        return (
+            raw_result
+            if isinstance(raw_result, ContextPolicyWriteResult)
+            else ContextPolicyWriteResult(
+                ContextPolicyWriteStatus.CONFLICT,
+                session.context_policy_durable_revision,
+            )
+        )
 
     def _resolve_context_policy_on_resume(self, session_id: str) -> None:
         """Hydrate one persisted session's local policy without app-root state."""
@@ -12417,10 +14046,15 @@ class ConsoleChatStore:
             return
         if isinstance(result, ConsoleContextPolicyOverrides):
             session.context_policy_overrides = result
+            session.context_policy_durable_revision = None
             return
         overrides = getattr(result, "overrides", None)
         if isinstance(overrides, ConsoleContextPolicyOverrides):
             session.context_policy_overrides = overrides
+        revision = getattr(result, "revision", None)
+        session.context_policy_durable_revision = (
+            revision if type(revision) is int and revision > 0 else None
+        )
         error = getattr(result, "error", None)
         session.context_policy_error = error if isinstance(error, str) else None
 
@@ -12602,6 +14236,17 @@ class ConsoleChatStore:
                     ),
                 )
             )
+        staged_generation_snapshot = (
+            snapshot_from_session_settings(session.settings)
+            if session.settings is not None
+            and session.generation_settings_revision > 0
+            else None
+        )
+        if staged_generation_snapshot is not None:
+            metadata = merge_console_generation_settings(
+                metadata,
+                staged_generation_snapshot,
+            )
         local_character_id = session.local_character_id()
         conversation_kwargs: dict[str, object] = {
             "conversation_title": identity.title,
@@ -12661,6 +14306,8 @@ class ConsoleChatStore:
             self._bump_library_activity_revision(session_id)
 
         self.publish_committed_identity(session_id, identity)
+        if staged_generation_snapshot is not None:
+            session.generation_durable_snapshot = staged_generation_snapshot
         session.ephemeral = False
         session.library_policy_holder.snapshot = committed_policy
         session.library_policy_holder.explicitly_staged = False
@@ -12685,6 +14332,8 @@ class ConsoleChatStore:
                 self.on_scope_flushed(identity.conversation_id, held_scope)
             except Exception:
                 logger.exception("on_scope_flushed callback failed after promotion.")
+        self._persist_project_instruction_state(session)
+        self._flush_context_policy_on_first_persist(session)
         return identity.conversation_id
 
     def set_session_system_prompt(

--- a/tldw_chatbook/Chat/console_context_repository.py
+++ b/tldw_chatbook/Chat/console_context_repository.py
@@ -44,6 +44,22 @@ class ContextPolicyReadResult:
     error: str | None = None
 
 
+class ContextPolicyWriteStatus(str, Enum):
+    """Outcome of a context-policy owned-revision compare-and-set."""
+
+    WRITTEN = "written"
+    CONFLICT = "conflict"
+    MISSING = "missing"
+
+
+@dataclass(frozen=True, slots=True)
+class ContextPolicyWriteResult:
+    """Result of writing one complete sparse context-policy snapshot."""
+
+    status: ContextPolicyWriteStatus
+    revision: int | None
+
+
 @dataclass(frozen=True)
 class AuxiliaryPricingProvenance:
     """Content-free pricing identity captured with an auxiliary call."""
@@ -271,6 +287,140 @@ class ConsoleContextRepository:
                 (conversation_id,),
             ).fetchone()
         return _positive_revision(row[0] if row is not None else None)
+
+    def save_policy_if_revision(
+        self,
+        conversation_id: str,
+        overrides: ConsoleContextPolicyOverrides,
+        *,
+        expected_revision: int | None,
+    ) -> ContextPolicyWriteResult:
+        """Write one complete policy only while its owned revision matches.
+
+        ``None`` represents an absent policy row. An empty policy therefore
+        performs a revision-guarded delete and publishes ``None`` as the new
+        durable revision.
+        """
+        if not isinstance(conversation_id, str) or not conversation_id:
+            raise ValueError("conversation_id must be a non-empty string")
+        if not isinstance(overrides, ConsoleContextPolicyOverrides):
+            raise TypeError("overrides must be ConsoleContextPolicyOverrides")
+        if expected_revision is not None and (
+            type(expected_revision) is not int or expected_revision < 1
+        ):
+            raise ValueError("expected_revision must be positive or None")
+
+        values = overrides.to_dict()
+        with self.db.transaction(immediate=True) as cursor:
+            conversation = cursor.execute(
+                "SELECT 1 FROM conversations WHERE id = ? AND deleted = 0",
+                (conversation_id,),
+            ).fetchone()
+            if conversation is None:
+                return ContextPolicyWriteResult(
+                    ContextPolicyWriteStatus.MISSING,
+                    None,
+                )
+            row = cursor.execute(
+                "SELECT policy_revision FROM console_conversation_context_policy "
+                "WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+            current_revision = _positive_revision(
+                row["policy_revision"] if row is not None else None
+            )
+            if current_revision != expected_revision:
+                return ContextPolicyWriteResult(
+                    ContextPolicyWriteStatus.CONFLICT,
+                    current_revision,
+                )
+            if overrides.is_empty:
+                if current_revision is not None:
+                    cursor.execute(
+                        "DELETE FROM console_conversation_context_policy "
+                        "WHERE conversation_id = ? AND policy_revision = ?",
+                        (conversation_id, current_revision),
+                    )
+                    if cursor.rowcount != 1:
+                        latest = cursor.execute(
+                            "SELECT policy_revision FROM "
+                            "console_conversation_context_policy "
+                            "WHERE conversation_id = ?",
+                            (conversation_id,),
+                        ).fetchone()
+                        return ContextPolicyWriteResult(
+                            ContextPolicyWriteStatus.CONFLICT,
+                            _positive_revision(
+                                latest["policy_revision"]
+                                if latest is not None
+                                else None
+                            ),
+                        )
+                return ContextPolicyWriteResult(
+                    ContextPolicyWriteStatus.WRITTEN,
+                    None,
+                )
+
+            policy_values = (
+                values.get("budget_mode"),
+                values.get("custom_budget_tokens"),
+                values.get("compaction_mode"),
+                values.get("compaction_representation"),
+                values.get("trigger_ratio"),
+                values.get("target_ratio"),
+                values.get("summary_max_tokens"),
+                values.get("failure_behavior"),
+                values.get("carry_forward_mode"),
+            )
+            if current_revision is None:
+                cursor.execute(
+                    """
+                    INSERT INTO console_conversation_context_policy(
+                        conversation_id, budget_mode, custom_budget_tokens,
+                        compaction_mode, compaction_representation,
+                        trigger_ratio, target_ratio, summary_max_tokens,
+                        failure_behavior, carry_forward_mode, policy_revision,
+                        updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)
+                    """,
+                    (conversation_id, *policy_values),
+                )
+                return ContextPolicyWriteResult(
+                    ContextPolicyWriteStatus.WRITTEN,
+                    1,
+                )
+
+            new_revision = current_revision + 1
+            cursor.execute(
+                """
+                UPDATE console_conversation_context_policy
+                   SET budget_mode = ?, custom_budget_tokens = ?,
+                       compaction_mode = ?, compaction_representation = ?,
+                       trigger_ratio = ?, target_ratio = ?,
+                       summary_max_tokens = ?, failure_behavior = ?,
+                       carry_forward_mode = ?, policy_revision = ?,
+                       updated_at = CURRENT_TIMESTAMP
+                 WHERE conversation_id = ? AND policy_revision = ?
+                """,
+                (*policy_values, new_revision, conversation_id, current_revision),
+            )
+            if cursor.rowcount != 1:
+                latest = cursor.execute(
+                    "SELECT policy_revision FROM "
+                    "console_conversation_context_policy "
+                    "WHERE conversation_id = ?",
+                    (conversation_id,),
+                ).fetchone()
+                return ContextPolicyWriteResult(
+                    ContextPolicyWriteStatus.CONFLICT,
+                    _positive_revision(
+                        latest["policy_revision"] if latest is not None else None
+                    ),
+                )
+            return ContextPolicyWriteResult(
+                ContextPolicyWriteStatus.WRITTEN,
+                new_revision,
+            )
 
     def insert_memory(self, record: ConsoleMemoryRecord) -> None:
         """Insert one immutable generated-memory revision."""

--- a/tldw_chatbook/Chat/console_conversation_hydration.py
+++ b/tldw_chatbook/Chat/console_conversation_hydration.py
@@ -1,4 +1,4 @@
-"""Turning a persisted conversation into a Console session, with no view.
+"""Turn a persisted conversation into a Console session, with no view.
 
 task-15860 Task 6 (wake at launch). A wake delivered at process start has
 to run in a **session** for a conversation nobody has opened -- and until
@@ -8,22 +8,23 @@ this module existed, the only code that could build one lived on
 policy with a screen's own work (composer snapshot, toasts, resume-marker
 overlay, retrieval-scope warm, transcript repaint, focus).
 
-This module is the **session-producing half, moved verbatim** so the two
-callers share one policy instead of two:
+This module contains the shared session-producing policy so the two callers
+do not independently reconstruct a conversation:
 
 | Caller | View work it keeps |
 |---|---|
 | `ChatScreen._resume_console_workspace_conversation` | draft snapshot, both failure toasts, resume-marker overlay, scope warm, UI sync, focus |
 | the launch wake (`console_launch_wake.py`) | none -- it has no view |
 
-**What is deliberately NOT here.** The screen's base settings come from
-the currently active session (`_console_session_settings_for_resume` ->
-`_active_console_session_settings`); a launch has no active session, so it
-uses the config defaults the screen falls back to
-(`default_console_session_settings`). That difference is inherent to
-having no view, and the part that a *conversation* contributes -- its
-saved system prompt and pinned prefill -- IS shared, through
-`apply_resume_settings_overrides`.
+`hydrate_console_generation_settings` is the canonical generation-settings
+entry point. It derives live defaults for the saved provider/model from the
+current app configuration, overlays only the safe durable snapshot, resolves
+the endpoint from current configuration, and finally applies the existing
+conversation-row owners for system prompt and pinned prefill.
+
+`apply_resume_settings_overrides` remains a legacy compatibility wrapper for
+existing callers until Task 5 migrates them to the canonical entry point. It
+only applies the two conversation-row-owned values to a caller-provided base.
 
 Nothing here touches the DOM, `app.notify`, or any screen attribute; the
 only app members read are `chat_conversation_scope_service` and
@@ -33,7 +34,7 @@ only app members read are `chat_conversation_scope_service` and
 from __future__ import annotations
 
 import inspect
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from typing import Any, Mapping, Sequence
 
 from loguru import logger
@@ -47,15 +48,20 @@ from tldw_chatbook.Chat.console_chat_models import (
 from tldw_chatbook.Chat.console_chat_fork import (
     parse_console_fork_message_metadata,
 )
-from tldw_chatbook.Chat.console_session_settings import (
-    ConsoleSessionSettings,
-    parse_persisted_console_session_settings,
+from tldw_chatbook.Chat.console_generation_settings_metadata import (
+    ConsoleGenerationSettingsReadStatus,
+    ConsoleGenerationSettingsSnapshot,
+    parse_console_generation_settings,
 )
 from tldw_chatbook.Chat.console_prefill import (
     pinned_prefill_from_conversation_metadata,
 )
 from tldw_chatbook.Chat.console_roleplay_metadata import (
     parse_console_roleplay_context,
+)
+from tldw_chatbook.Chat.console_session_settings import (
+    ConsoleSessionSettings,
+    default_console_session_settings,
 )
 from tldw_chatbook.Chat.message_metadata import MessageMetadata
 from tldw_chatbook.Chat.provider_usage import ProviderUsage
@@ -64,12 +70,31 @@ from tldw_chatbook.Video_Generation.video_metadata import VideoGenerationMetadat
 __all__ = [
     "ConversationLoadFailed",
     "ConversationServiceUnavailable",
+    "ConsoleGenerationSettingsHydration",
     "apply_resume_settings_overrides",
     "console_messages_from_conversation_tree",
+    "hydrate_console_generation_settings",
     "hydrate_console_session",
     "load_console_conversation_tree",
 ]
 
+
+@dataclass(frozen=True, slots=True)
+class ConsoleGenerationSettingsHydration:
+    """Live settings plus their accepted durable metadata baseline."""
+
+    settings: ConsoleSessionSettings
+    durable_snapshot: ConsoleGenerationSettingsSnapshot | None
+    metadata_status: ConsoleGenerationSettingsReadStatus
+
+    def __post_init__(self) -> None:
+        carries_snapshot = self.durable_snapshot is not None
+        if carries_snapshot != (
+            self.metadata_status is ConsoleGenerationSettingsReadStatus.VALID
+        ):
+            raise ValueError(
+                "Valid generation metadata must carry its durable snapshot."
+            )
 
 class ConversationServiceUnavailable(RuntimeError):
     """The app has no conversation service that can load a tree."""
@@ -325,11 +350,13 @@ async def load_console_conversation_tree(
 def apply_resume_settings_overrides(
     settings: ConsoleSessionSettings, conversation: Mapping[str, Any]
 ) -> ConsoleSessionSettings:
-    """Restore one saved settings snapshot plus canonical row-owned fields.
+    """Apply legacy conversation-row overrides to caller-provided settings.
 
-    A complete valid versioned snapshot replaces the caller's provider and
-    generation defaults. Invalid metadata is ignored as one unit. The row's
-    ``system_prompt`` and top-level pinned-prefill metadata remain canonical.
+    Only ``system_prompt`` and ``pinned_prefill`` come from the persisted
+    conversation; every other field is inherited from the supplied base.
+    New generation-settings hydration should use
+    :func:`hydrate_console_generation_settings`. This wrapper remains for
+    existing callers until Task 5 migrates them.
 
     Blank/whitespace-only prompt text collapses to "no system prompt";
     anything else is restored verbatim (leading/trailing whitespace and
@@ -341,8 +368,8 @@ def apply_resume_settings_overrides(
         conversation: The persisted conversation row.
 
     Returns:
-        Persisted settings, or the base snapshot on malformed metadata, with
-        canonical prompt and pinned-prefill fields applied.
+        The base snapshot with canonical prompt and pinned-prefill fields
+        applied.
     """
     raw_system_prompt = conversation.get("system_prompt")
     system_prompt = (
@@ -353,11 +380,59 @@ def apply_resume_settings_overrides(
     pinned_prefill = pinned_prefill_from_conversation_metadata(
         conversation.get("metadata")
     )
-    persisted = parse_persisted_console_session_settings(conversation.get("metadata"))
     return replace(
-        persisted or settings,
+        settings,
         system_prompt=system_prompt,
         pinned_prefill=pinned_prefill,
+    )
+
+
+def hydrate_console_generation_settings(
+    app_config: Mapping[str, object],
+    conversation: Mapping[str, object],
+) -> ConsoleGenerationSettingsHydration:
+    """Restore safe generation metadata atop current provider configuration.
+
+    Persisted metadata selects the provider/model and safe generation values,
+    while the live configuration remains authoritative for endpoints. The
+    existing conversation-row owners are applied last for system prompt and
+    pinned prefill.
+    """
+    parsed = parse_console_generation_settings(conversation.get("metadata"))
+    snapshot = parsed.snapshot
+    if snapshot is None:
+        settings = default_console_session_settings(app_config)
+    else:
+        defaults = default_console_session_settings(
+            app_config,
+            snapshot.provider,
+            snapshot.model,
+        )
+        settings = replace(
+            defaults,
+            provider=snapshot.provider,
+            model=snapshot.model,
+            source="user",
+            temperature=snapshot.temperature,
+            top_p=snapshot.top_p,
+            min_p=snapshot.min_p,
+            top_k=snapshot.top_k,
+            max_tokens=snapshot.max_tokens,
+            seed=snapshot.seed,
+            presence_penalty=snapshot.presence_penalty,
+            frequency_penalty=snapshot.frequency_penalty,
+            reasoning_effort=snapshot.reasoning_effort,
+            reasoning_summary=snapshot.reasoning_summary,
+            verbosity=snapshot.verbosity,
+            thinking_effort=snapshot.thinking_effort,
+            thinking_budget_tokens=snapshot.thinking_budget_tokens,
+            streaming=snapshot.streaming,
+        )
+    settings = apply_resume_settings_overrides(settings, conversation)
+    return ConsoleGenerationSettingsHydration(
+        settings=settings,
+        durable_snapshot=snapshot,
+        metadata_status=parsed.status,
     )
 
 
@@ -368,6 +443,10 @@ async def hydrate_console_session(
     conversation_id: str,
     tree: Mapping[str, Any],
     settings: ConsoleSessionSettings | None,
+    generation_durable_snapshot: ConsoleGenerationSettingsSnapshot | None = None,
+    generation_metadata_status: ConsoleGenerationSettingsReadStatus = (
+        ConsoleGenerationSettingsReadStatus.ABSENT
+    ),
     target_scope_type: str | None = None,
     target_workspace_id: str | None = None,
     activate: bool = True,
@@ -387,6 +466,10 @@ async def hydrate_console_session(
         conversation_id: The durable conversation id being resumed.
         tree: The tree from `load_console_conversation_tree`.
         settings: The settings snapshot for the new session.
+        generation_durable_snapshot: Valid durable generation metadata accepted
+            while deriving ``settings``, if present.
+        generation_metadata_status: Read status for the persisted generation
+            metadata.
         target_scope_type: ``"global"`` pins the global workspace.
         target_workspace_id: Requested workspace, used only when the
             conversation carries none.
@@ -490,6 +573,8 @@ async def hydrate_console_session(
         active_leaf_persisted_id=active_leaf_id,
         active_leaf_before_persisted_id=active_leaf_before_id,
         settings=settings,
+        generation_durable_snapshot=generation_durable_snapshot,
+        generation_metadata_status=generation_metadata_status,
         runtime_backend=runtime_backend,
         assistant_kind=assistant_kind,
         assistant_id=assistant_id,

--- a/tldw_chatbook/Chat/console_generation_settings_metadata.py
+++ b/tldw_chatbook/Chat/console_generation_settings_metadata.py
@@ -8,6 +8,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
 
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
 
 
@@ -43,6 +45,88 @@ _SAFE_FIELDS = frozenset(
     }
 )
 _OWNED_FIELDS = frozenset({"version", *_SAFE_FIELDS})
+
+
+class _PersistedConsoleGenerationSettings(BaseModel):
+    """Strict validation boundary for conversation-owned persisted settings."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    version: int = Field(ge=1, le=1)
+    provider: str = Field(min_length=1, max_length=_MAX_PROVIDER_CHARS)
+    model: str | None = Field(default=None, max_length=_MAX_MODEL_CHARS)
+    temperature: float | None = Field(default=None, ge=0.0, le=2.0, allow_inf_nan=False)
+    top_p: float | None = Field(default=None, ge=0.0, le=1.0, allow_inf_nan=False)
+    min_p: float | None = Field(default=None, ge=0.0, le=1.0, allow_inf_nan=False)
+    top_k: int | None = Field(default=None, ge=0)
+    max_tokens: int | None = Field(default=None, ge=1)
+    seed: int | None = Field(default=None, ge=0)
+    presence_penalty: float | None = Field(
+        default=None, ge=-2.0, le=2.0, allow_inf_nan=False
+    )
+    frequency_penalty: float | None = Field(
+        default=None, ge=-2.0, le=2.0, allow_inf_nan=False
+    )
+    reasoning_effort: str | None = None
+    reasoning_summary: str | None = None
+    verbosity: str | None = None
+    thinking_effort: str | None = None
+    thinking_budget_tokens: int | None = Field(default=None, ge=1024)
+    streaming: bool
+
+    @field_validator("provider", "model")
+    @classmethod
+    def _nonblank_string(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            raise ValueError("String values must not be blank.")
+        return value
+
+    @field_validator(
+        "temperature",
+        "top_p",
+        "min_p",
+        "presence_penalty",
+        "frequency_penalty",
+        mode="before",
+    )
+    @classmethod
+    def _strict_json_number(cls, value: object) -> object:
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError("Value must be a JSON number or null.")
+        try:
+            return float(value)
+        except OverflowError as exc:
+            raise ValueError("Value is outside its supported range.") from exc
+
+    @field_validator("reasoning_effort")
+    @classmethod
+    def _valid_reasoning_effort(cls, value: str | None) -> str | None:
+        if value is not None and value not in _REASONING_EFFORT_VALUES:
+            raise ValueError("Invalid reasoning effort.")
+        return value
+
+    @field_validator("reasoning_summary")
+    @classmethod
+    def _valid_reasoning_summary(cls, value: str | None) -> str | None:
+        if value is not None and value not in _REASONING_SUMMARY_VALUES:
+            raise ValueError("Invalid reasoning summary.")
+        return value
+
+    @field_validator("verbosity")
+    @classmethod
+    def _valid_verbosity(cls, value: str | None) -> str | None:
+        if value is not None and value not in _VERBOSITY_VALUES:
+            raise ValueError("Invalid verbosity.")
+        return value
+
+    @field_validator("thinking_effort")
+    @classmethod
+    def _valid_thinking_effort(cls, value: str | None) -> str | None:
+        if value is not None and value not in _THINKING_EFFORT_VALUES:
+            raise ValueError("Invalid thinking effort.")
+        return value
 
 
 @dataclass(frozen=True, slots=True)
@@ -187,30 +271,29 @@ def parse_console_generation_settings(
             ConsoleGenerationSettingsReadStatus.INVALID
         )
     try:
-        snapshot = _validated_snapshot(
-            ConsoleGenerationSettingsSnapshot(
-                provider=owned["provider"],  # type: ignore[arg-type]
-                model=owned["model"],  # type: ignore[arg-type]
-                temperature=owned["temperature"],  # type: ignore[arg-type]
-                top_p=owned["top_p"],  # type: ignore[arg-type]
-                min_p=owned["min_p"],  # type: ignore[arg-type]
-                top_k=owned["top_k"],  # type: ignore[arg-type]
-                max_tokens=owned["max_tokens"],  # type: ignore[arg-type]
-                seed=owned["seed"],  # type: ignore[arg-type]
-                presence_penalty=owned["presence_penalty"],  # type: ignore[arg-type]
-                frequency_penalty=owned["frequency_penalty"],  # type: ignore[arg-type]
-                reasoning_effort=owned["reasoning_effort"],  # type: ignore[arg-type]
-                reasoning_summary=owned["reasoning_summary"],  # type: ignore[arg-type]
-                verbosity=owned["verbosity"],  # type: ignore[arg-type]
-                thinking_effort=owned["thinking_effort"],  # type: ignore[arg-type]
-                thinking_budget_tokens=owned["thinking_budget_tokens"],  # type: ignore[arg-type]
-                streaming=owned["streaming"],  # type: ignore[arg-type]
-            )
-        )
-    except (TypeError, ValueError):
+        persisted = _PersistedConsoleGenerationSettings.model_validate(dict(owned))
+    except ValidationError:
         return ConsoleGenerationSettingsReadResult(
             ConsoleGenerationSettingsReadStatus.INVALID
         )
+    snapshot = ConsoleGenerationSettingsSnapshot(
+        provider=persisted.provider,
+        model=persisted.model,
+        temperature=persisted.temperature,
+        top_p=persisted.top_p,
+        min_p=persisted.min_p,
+        top_k=persisted.top_k,
+        max_tokens=persisted.max_tokens,
+        seed=persisted.seed,
+        presence_penalty=persisted.presence_penalty,
+        frequency_penalty=persisted.frequency_penalty,
+        reasoning_effort=persisted.reasoning_effort,
+        reasoning_summary=persisted.reasoning_summary,
+        verbosity=persisted.verbosity,
+        thinking_effort=persisted.thinking_effort,
+        thinking_budget_tokens=persisted.thinking_budget_tokens,
+        streaming=persisted.streaming,
+    )
     return ConsoleGenerationSettingsReadResult(
         ConsoleGenerationSettingsReadStatus.VALID,
         snapshot,

--- a/tldw_chatbook/Chat/console_generation_settings_metadata.py
+++ b/tldw_chatbook/Chat/console_generation_settings_metadata.py
@@ -1,0 +1,445 @@
+"""Safe versioned Console generation settings in conversation metadata."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+
+
+CONSOLE_GENERATION_SETTINGS_METADATA_KEY = "console_generation_settings"
+CONSOLE_GENERATION_SETTINGS_VERSION = 1
+
+_MAX_PROVIDER_CHARS = 128
+_MAX_MODEL_CHARS = 256
+_REASONING_EFFORT_VALUES = frozenset(
+    {"none", "minimal", "low", "medium", "high", "xhigh"}
+)
+_REASONING_SUMMARY_VALUES = frozenset({"auto", "concise", "detailed", "none"})
+_VERBOSITY_VALUES = frozenset({"low", "medium", "high"})
+_THINKING_EFFORT_VALUES = frozenset({"off", "low", "medium", "high", "xhigh", "max"})
+_SAFE_FIELDS = frozenset(
+    {
+        "provider",
+        "model",
+        "temperature",
+        "top_p",
+        "min_p",
+        "top_k",
+        "max_tokens",
+        "seed",
+        "presence_penalty",
+        "frequency_penalty",
+        "reasoning_effort",
+        "reasoning_summary",
+        "verbosity",
+        "thinking_effort",
+        "thinking_budget_tokens",
+        "streaming",
+    }
+)
+_OWNED_FIELDS = frozenset({"version", *_SAFE_FIELDS})
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleGenerationSettingsSnapshot:
+    """Complete safe generation snapshot owned by one conversation."""
+
+    provider: str
+    model: str | None
+    temperature: float | None
+    top_p: float | None
+    min_p: float | None
+    top_k: int | None
+    max_tokens: int | None
+    seed: int | None
+    presence_penalty: float | None
+    frequency_penalty: float | None
+    reasoning_effort: str | None
+    reasoning_summary: str | None
+    verbosity: str | None
+    thinking_effort: str | None
+    thinking_budget_tokens: int | None
+    streaming: bool
+
+
+class ConsoleGenerationSettingsReadStatus(str, Enum):
+    """Classification of the conversation-owned metadata value."""
+
+    ABSENT = "absent"
+    VALID = "valid"
+    INVALID = "invalid"
+    UNSUPPORTED_VERSION = "unsupported_version"
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleGenerationSettingsReadResult:
+    """Safe metadata read result; only ``VALID`` carries a snapshot."""
+
+    status: ConsoleGenerationSettingsReadStatus
+    snapshot: ConsoleGenerationSettingsSnapshot | None = None
+
+    def __post_init__(self) -> None:
+        carries_snapshot = self.snapshot is not None
+        if carries_snapshot != (
+            self.status is ConsoleGenerationSettingsReadStatus.VALID
+        ):
+            raise ValueError("Only a valid metadata read may carry a snapshot.")
+
+
+class ConsoleGenerationSettingsWriteStatus(str, Enum):
+    """Outcome of a complete owned-snapshot compare-and-set write."""
+
+    WRITTEN = "written"
+    SUPERSEDED = "superseded"
+    INVALID = "invalid"
+    UNSUPPORTED_VERSION = "unsupported_version"
+    MISSING = "missing"
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleGenerationSettingsWriteResult:
+    """Result of persisting a safe generation settings snapshot."""
+
+    status: ConsoleGenerationSettingsWriteStatus
+    snapshot: ConsoleGenerationSettingsSnapshot | None = None
+
+    def __post_init__(self) -> None:
+        carries_snapshot = self.snapshot is not None
+        if self.status is ConsoleGenerationSettingsWriteStatus.WRITTEN:
+            if not carries_snapshot:
+                raise ValueError("A written result must carry its snapshot.")
+            return
+        if (
+            carries_snapshot
+            and self.status is not ConsoleGenerationSettingsWriteStatus.SUPERSEDED
+        ):
+            raise ValueError("Only written or superseded results may carry a snapshot.")
+
+
+class ConsoleGenerationSettingsVersionError(ValueError):
+    """The owned metadata belongs to a newer application version."""
+
+
+def snapshot_from_session_settings(
+    settings: ConsoleSessionSettings,
+) -> ConsoleGenerationSettingsSnapshot:
+    """Project a session onto the exact durable safe-field allowlist."""
+    if not isinstance(settings, ConsoleSessionSettings):
+        raise TypeError("settings must be ConsoleSessionSettings.")
+    return _validated_snapshot(
+        ConsoleGenerationSettingsSnapshot(
+            provider=settings.provider,
+            model=settings.model,
+            temperature=settings.temperature,
+            top_p=settings.top_p,
+            min_p=settings.min_p,
+            top_k=settings.top_k,
+            max_tokens=settings.max_tokens,
+            seed=settings.seed,
+            presence_penalty=settings.presence_penalty,
+            frequency_penalty=settings.frequency_penalty,
+            reasoning_effort=settings.reasoning_effort,
+            reasoning_summary=settings.reasoning_summary,
+            verbosity=settings.verbosity,
+            thinking_effort=settings.thinking_effort,
+            thinking_budget_tokens=settings.thinking_budget_tokens,
+            streaming=settings.streaming,
+        )
+    )
+
+
+def parse_console_generation_settings(
+    metadata: object,
+) -> ConsoleGenerationSettingsReadResult:
+    """Parse one complete version-one snapshot, failing closed as one unit."""
+    try:
+        outer = strict_json_metadata_object(metadata, none_as_empty=True)
+    except ValueError:
+        return ConsoleGenerationSettingsReadResult(
+            ConsoleGenerationSettingsReadStatus.INVALID
+        )
+
+    if CONSOLE_GENERATION_SETTINGS_METADATA_KEY not in outer:
+        return ConsoleGenerationSettingsReadResult(
+            ConsoleGenerationSettingsReadStatus.ABSENT
+        )
+    owned = outer[CONSOLE_GENERATION_SETTINGS_METADATA_KEY]
+    if not isinstance(owned, Mapping):
+        return ConsoleGenerationSettingsReadResult(
+            ConsoleGenerationSettingsReadStatus.INVALID
+        )
+    version = owned.get("version")
+    if type(version) is int and version > CONSOLE_GENERATION_SETTINGS_VERSION:
+        return ConsoleGenerationSettingsReadResult(
+            ConsoleGenerationSettingsReadStatus.UNSUPPORTED_VERSION
+        )
+    if type(version) is not int or version != CONSOLE_GENERATION_SETTINGS_VERSION:
+        return ConsoleGenerationSettingsReadResult(
+            ConsoleGenerationSettingsReadStatus.INVALID
+        )
+    if set(owned) != _OWNED_FIELDS:
+        return ConsoleGenerationSettingsReadResult(
+            ConsoleGenerationSettingsReadStatus.INVALID
+        )
+    try:
+        snapshot = _validated_snapshot(
+            ConsoleGenerationSettingsSnapshot(
+                provider=owned["provider"],  # type: ignore[arg-type]
+                model=owned["model"],  # type: ignore[arg-type]
+                temperature=owned["temperature"],  # type: ignore[arg-type]
+                top_p=owned["top_p"],  # type: ignore[arg-type]
+                min_p=owned["min_p"],  # type: ignore[arg-type]
+                top_k=owned["top_k"],  # type: ignore[arg-type]
+                max_tokens=owned["max_tokens"],  # type: ignore[arg-type]
+                seed=owned["seed"],  # type: ignore[arg-type]
+                presence_penalty=owned["presence_penalty"],  # type: ignore[arg-type]
+                frequency_penalty=owned["frequency_penalty"],  # type: ignore[arg-type]
+                reasoning_effort=owned["reasoning_effort"],  # type: ignore[arg-type]
+                reasoning_summary=owned["reasoning_summary"],  # type: ignore[arg-type]
+                verbosity=owned["verbosity"],  # type: ignore[arg-type]
+                thinking_effort=owned["thinking_effort"],  # type: ignore[arg-type]
+                thinking_budget_tokens=owned["thinking_budget_tokens"],  # type: ignore[arg-type]
+                streaming=owned["streaming"],  # type: ignore[arg-type]
+            )
+        )
+    except (TypeError, ValueError):
+        return ConsoleGenerationSettingsReadResult(
+            ConsoleGenerationSettingsReadStatus.INVALID
+        )
+    return ConsoleGenerationSettingsReadResult(
+        ConsoleGenerationSettingsReadStatus.VALID,
+        snapshot,
+    )
+
+
+def merge_console_generation_settings(
+    metadata: object,
+    snapshot: ConsoleGenerationSettingsSnapshot,
+) -> dict[str, object]:
+    """Replace only this codec's owned key and preserve all metadata siblings."""
+    outer = strict_json_metadata_object(metadata, none_as_empty=True)
+    existing = parse_console_generation_settings(outer)
+    if existing.status is ConsoleGenerationSettingsReadStatus.INVALID:
+        raise ValueError(
+            "Cannot overwrite invalid Console generation settings metadata."
+        )
+    if existing.status is ConsoleGenerationSettingsReadStatus.UNSUPPORTED_VERSION:
+        owned = outer[CONSOLE_GENERATION_SETTINGS_METADATA_KEY]
+        version = owned.get("version") if isinstance(owned, Mapping) else None
+        raise ConsoleGenerationSettingsVersionError(
+            f"Cannot overwrite Console generation settings at version {version}."
+        )
+    validated = _validated_snapshot(snapshot)
+    outer[CONSOLE_GENERATION_SETTINGS_METADATA_KEY] = {
+        "version": CONSOLE_GENERATION_SETTINGS_VERSION,
+        "provider": validated.provider,
+        "model": validated.model,
+        "temperature": validated.temperature,
+        "top_p": validated.top_p,
+        "min_p": validated.min_p,
+        "top_k": validated.top_k,
+        "max_tokens": validated.max_tokens,
+        "seed": validated.seed,
+        "presence_penalty": validated.presence_penalty,
+        "frequency_penalty": validated.frequency_penalty,
+        "reasoning_effort": validated.reasoning_effort,
+        "reasoning_summary": validated.reasoning_summary,
+        "verbosity": validated.verbosity,
+        "thinking_effort": validated.thinking_effort,
+        "thinking_budget_tokens": validated.thinking_budget_tokens,
+        "streaming": validated.streaming,
+    }
+    return outer
+
+
+def strict_json_metadata_object(
+    metadata: object,
+    *,
+    none_as_empty: bool = False,
+) -> dict[str, object]:
+    """Normalize strict JSON-object metadata without lossy coercion.
+
+    Args:
+        metadata: A JSON object string or a mapping containing JSON values.
+        none_as_empty: Whether missing metadata represents an empty object.
+
+    Returns:
+        A detached JSON-compatible object with exact string keys.
+
+    Raises:
+        ValueError: If the value is not a strict JSON object or contains a
+            non-finite number anywhere in the object.
+    """
+
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"Non-finite JSON constant {value!r} is not supported.")
+
+    def finite_float(value: str) -> float:
+        number = float(value)
+        if not math.isfinite(number):
+            raise ValueError(f"Non-finite JSON number {value!r} is not supported.")
+        return number
+
+    try:
+        if metadata is None and none_as_empty:
+            decoded = {}
+        elif isinstance(metadata, Mapping):
+            candidate = dict(metadata)
+            if not _mapping_keys_are_strings(candidate):
+                raise ValueError("Mapping keys must be strings.")
+            encoded = json.dumps(candidate, allow_nan=False, sort_keys=True)
+            decoded = json.loads(
+                encoded,
+                parse_constant=reject_constant,
+                parse_float=finite_float,
+            )
+        elif type(metadata) is str:
+            decoded = json.loads(
+                metadata,
+                parse_constant=reject_constant,
+                parse_float=finite_float,
+            )
+        else:
+            raise ValueError("Unsupported metadata type.")
+    except (
+        TypeError,
+        ValueError,
+        json.JSONDecodeError,
+        OverflowError,
+        RecursionError,
+    ) as exc:
+        raise ValueError("metadata must be a valid JSON object.") from exc
+    if not isinstance(decoded, dict):
+        raise ValueError("metadata must be a valid JSON object.")
+    return decoded
+
+
+def _mapping_keys_are_strings(value: object) -> bool:
+    if isinstance(value, Mapping):
+        return all(
+            type(key) is str and _mapping_keys_are_strings(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return all(_mapping_keys_are_strings(item) for item in value)
+    return True
+
+
+def _validated_snapshot(
+    snapshot: ConsoleGenerationSettingsSnapshot,
+) -> ConsoleGenerationSettingsSnapshot:
+    if not isinstance(snapshot, ConsoleGenerationSettingsSnapshot):
+        raise TypeError("snapshot must be ConsoleGenerationSettingsSnapshot.")
+    provider = _required_string(snapshot.provider, "provider", _MAX_PROVIDER_CHARS)
+    model = _optional_string(snapshot.model, "model", _MAX_MODEL_CHARS)
+    return ConsoleGenerationSettingsSnapshot(
+        provider=provider,
+        model=model,
+        temperature=_optional_float(
+            snapshot.temperature, "temperature", minimum=0.0, maximum=2.0
+        ),
+        top_p=_optional_float(snapshot.top_p, "top_p", minimum=0.0, maximum=1.0),
+        min_p=_optional_float(snapshot.min_p, "min_p", minimum=0.0, maximum=1.0),
+        top_k=_optional_int(snapshot.top_k, "top_k", minimum=0),
+        max_tokens=_optional_int(snapshot.max_tokens, "max_tokens", minimum=1),
+        seed=_optional_int(snapshot.seed, "seed", minimum=0),
+        presence_penalty=_optional_float(
+            snapshot.presence_penalty,
+            "presence_penalty",
+            minimum=-2.0,
+            maximum=2.0,
+        ),
+        frequency_penalty=_optional_float(
+            snapshot.frequency_penalty,
+            "frequency_penalty",
+            minimum=-2.0,
+            maximum=2.0,
+        ),
+        reasoning_effort=_optional_choice(
+            snapshot.reasoning_effort,
+            "reasoning_effort",
+            _REASONING_EFFORT_VALUES,
+        ),
+        reasoning_summary=_optional_choice(
+            snapshot.reasoning_summary,
+            "reasoning_summary",
+            _REASONING_SUMMARY_VALUES,
+        ),
+        verbosity=_optional_choice(snapshot.verbosity, "verbosity", _VERBOSITY_VALUES),
+        thinking_effort=_optional_choice(
+            snapshot.thinking_effort,
+            "thinking_effort",
+            _THINKING_EFFORT_VALUES,
+        ),
+        thinking_budget_tokens=_optional_int(
+            snapshot.thinking_budget_tokens,
+            "thinking_budget_tokens",
+            minimum=1024,
+        ),
+        streaming=_strict_bool(snapshot.streaming, "streaming"),
+    )
+
+
+def _required_string(value: object, name: str, maximum: int) -> str:
+    if type(value) is not str or not value.strip() or len(value) > maximum:
+        raise ValueError(
+            f"{name} must be a non-blank string of at most {maximum} characters."
+        )
+    return value
+
+
+def _optional_string(value: object, name: str, maximum: int) -> str | None:
+    if value is None:
+        return None
+    return _required_string(value, name, maximum)
+
+
+def _optional_choice(
+    value: object,
+    name: str,
+    choices: frozenset[str],
+) -> str | None:
+    if value is None:
+        return None
+    if type(value) is not str or value not in choices:
+        raise ValueError(f"{name} is invalid.")
+    return value
+
+
+def _optional_float(
+    value: object,
+    name: str,
+    *,
+    minimum: float,
+    maximum: float,
+) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{name} must be a JSON number or null.")
+    try:
+        number = float(value)
+    except OverflowError as exc:
+        raise ValueError(f"{name} is outside its supported range.") from exc
+    if not math.isfinite(number) or not minimum <= number <= maximum:
+        raise ValueError(f"{name} is outside its supported range.")
+    return number
+
+
+def _optional_int(value: object, name: str, *, minimum: int) -> int | None:
+    if value is None:
+        return None
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{name} must be an exact integer or null.")
+    return value
+
+
+def _strict_bool(value: object, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be an exact boolean.")
+    return value

--- a/tldw_chatbook/Chat/console_launch_wake.py
+++ b/tldw_chatbook/Chat/console_launch_wake.py
@@ -45,9 +45,8 @@ this module hydrates one through the shared
 `Chat/console_conversation_hydration.py` policy — the same tree load, the
 same whole-tree node build, the same active-leaf pointer and the same
 roleplay overlay `ChatScreen`'s saved-conversation resume uses. Only the
-BASE settings differ, and only because they must: the screen inherits the
-active session's settings and a launch has none, so it starts from the
-config defaults the screen itself falls back to.
+saved conversation metadata and current app config participate in generation
+settings hydration; neither caller inherits another active session's settings.
 
 Some marked conversations **cannot** be hydrated, ever. A fleet turn in an
 UNSAVED (temporary) session is keyed by the ephemeral `session.id`
@@ -71,7 +70,7 @@ from loguru import logger
 from tldw_chatbook.Chat.console_conversation_hydration import (
     ConversationLoadFailed,
     ConversationServiceUnavailable,
-    apply_resume_settings_overrides,
+    hydrate_console_generation_settings,
     hydrate_console_session,
     load_console_conversation_tree,
 )
@@ -301,7 +300,6 @@ async def deliver_launch_wakes(app: Any, marked: Sequence[str]) -> int:
     if not wake.seed_from_marks():
         return 0
     store = controller.store
-    app_config = getattr(app, "app_config", {}) or {}
     # `restore_persisted_session` ACTIVATES what it creates, which is right
     # for a launch with nothing open and wrong for one where Console is the
     # startup tab: a wake must never move the user off the tab they landed
@@ -337,14 +335,18 @@ async def deliver_launch_wakes(app: Any, marked: Sequence[str]) -> int:
         if not isinstance(conversation, dict):
             conversation = {}
         try:
+            hydration = hydrate_console_generation_settings(
+                getattr(app, "app_config", {}) or {},
+                conversation,
+            )
             await hydrate_console_session(
                 app=app,
                 store=store,
                 conversation_id=conversation_id,
                 tree=tree,
-                settings=apply_resume_settings_overrides(
-                    default_console_session_settings(app_config), conversation
-                ),
+                settings=hydration.settings,
+                generation_durable_snapshot=hydration.durable_snapshot,
+                generation_metadata_status=hydration.metadata_status,
             )
         except Exception as exc:  # noqa: BLE001 -- one bad row never stops the rest
             logger.warning(

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -8,7 +8,7 @@ import math
 import os
 import re
 from dataclasses import dataclass, fields, replace
-from typing import Callable, Mapping, Sequence
+from typing import Callable, Mapping, Sequence, overload
 from urllib.parse import urlparse, urlunparse
 
 from tldw_chatbook.Chat.console_provider_support import (
@@ -487,6 +487,8 @@ def build_default_console_session_settings(
     app_config: Mapping[str, object],
     provider: str | None = None,
     model: str | None = None,
+    *,
+    excluded_model_profile_fields: frozenset[str] = frozenset(),
 ) -> ConsoleSessionSettings:
     """Build default Console settings from chat defaults and provider config."""
     chat_defaults = _chat_defaults_with_streaming_compat(
@@ -501,6 +503,12 @@ def build_default_console_session_settings(
     provider_settings = _provider_settings(app_config, configured_provider)
     configured_model = effective.model
     model_profile = _model_default_profile(provider_settings, configured_model)
+    if excluded_model_profile_fields:
+        model_profile = {
+            name: value
+            for name, value in model_profile.items()
+            if name not in excluded_model_profile_fields
+        }
     # TASK-342: [console.provider_defaults.<provider>] holds ONLY values the
     # Console's Save-as-default wrote, so it outranks everything except a
     # model profile. chat_defaults stays ahead of raw [api_settings.*]
@@ -551,6 +559,8 @@ def default_console_session_settings(
     app_config: Mapping[str, object],
     provider: str | None = None,
     model: str | None = None,
+    *,
+    excluded_model_profile_fields: frozenset[str] = frozenset(),
 ) -> ConsoleSessionSettings:
     """The default settings snapshot a NEW Console session starts from.
 
@@ -570,11 +580,18 @@ def default_console_session_settings(
         provider: An explicit provider override (the Console control bar's
             selection when there is a view), or ``None``.
         model: An explicit model override, or ``None``.
+        excluded_model_profile_fields: Exact model-profile fields to skip so
+            inherited controls can re-resolve lower-precedence defaults.
 
     Returns:
         The default settings for a new session.
     """
-    settings = build_default_console_session_settings(app_config, provider, model)
+    settings = build_default_console_session_settings(
+        app_config,
+        provider,
+        model,
+        excluded_model_profile_fields=excluded_model_profile_fields,
+    )
     provider_key = provider_config_key(settings.provider)
     return replace(
         settings,
@@ -584,6 +601,102 @@ def default_console_session_settings(
             else settings.base_url
         ),
     )
+
+
+def blank_console_session_settings(
+    app_config: Mapping[str, object],
+) -> ConsoleSessionSettings:
+    """Return config-owned defaults for one eligible blank Console chat."""
+    return default_console_session_settings(app_config)
+
+
+def build_target_default_console_session_settings(
+    app_config: Mapping[str, object],
+    provider: str,
+    model: str | None,
+    *,
+    excluded_model_profile_fields: frozenset[str] = frozenset(),
+) -> ConsoleSessionSettings:
+    """Return fresh effective defaults for one provider and literal model ID.
+
+    This is the provider/model rebase entry point. It deliberately delegates to
+    :func:`default_console_session_settings` so exact-model profiles keep the
+    established precedence and provider endpoint normalization.
+
+    Args:
+        app_config: The live application configuration snapshot.
+        provider: Provider selected by the settings transaction.
+        model: Literal model ID selected by the settings transaction.
+        excluded_model_profile_fields: Exact model-profile fields to skip so
+            inherited controls can re-resolve lower-precedence defaults.
+
+    Returns:
+        A fresh settings value resolved for the exact target.
+    """
+
+    return replace(
+        default_console_session_settings(
+            app_config,
+            provider,
+            model,
+            excluded_model_profile_fields=excluded_model_profile_fields,
+        )
+    )
+
+
+def normalized_console_model_profile_overrides(
+    app_config: Mapping[str, object],
+    provider: str,
+    model: str | None,
+) -> dict[str, object]:
+    """Return valid normalized overrides from one exact model profile.
+
+    Blank and invalid entries are omitted so callers can distinguish inheritance
+    from an explicit override. The conversions delegate to the same per-field
+    helpers used by :func:`build_default_console_session_settings`; this function
+    does not resolve any fallback precedence.
+    """
+
+    provider_settings = _provider_settings(
+        app_config,
+        _canonical_chat_provider_id(provider),
+    )
+    profile = _model_default_profile(provider_settings, model)
+    sources = (profile,)
+    overrides: dict[str, object] = {}
+
+    for name in (
+        "temperature",
+        "top_p",
+        "min_p",
+        "presence_penalty",
+        "frequency_penalty",
+    ):
+        value = _optional_float_setting_from_sources(sources, name)
+        if value is not None:
+            overrides[name] = value
+    for name in (
+        "top_k",
+        "max_tokens",
+        "seed",
+        "thinking_budget_tokens",
+    ):
+        value = _optional_int_setting_from_sources(sources, name)
+        if value is not None:
+            overrides[name] = value
+    for name in (
+        "reasoning_effort",
+        "reasoning_summary",
+        "verbosity",
+        "thinking_effort",
+    ):
+        value = _optional_string_setting_from_sources(sources, name)
+        if value is not None:
+            overrides[name] = value
+    streaming = _bool_setting_from_sources(sources, "streaming", None)
+    if streaming is not None:
+        overrides["streaming"] = streaming
+    return overrides
 
 
 def resolve_effective_chat_configuration(
@@ -1491,11 +1604,27 @@ def _optional_string_setting_from_sources(
     return None
 
 
+@overload
 def _bool_setting_from_sources(
     sources: Sequence[Mapping[str, object]],
     key: str,
     default: bool,
-) -> bool:
+) -> bool: ...
+
+
+@overload
+def _bool_setting_from_sources(
+    sources: Sequence[Mapping[str, object]],
+    key: str,
+    default: None,
+) -> bool | None: ...
+
+
+def _bool_setting_from_sources(
+    sources: Sequence[Mapping[str, object]],
+    key: str,
+    default: bool | None,
+) -> bool | None:
     for source in sources:
         if key not in source:
             continue

--- a/tldw_chatbook/Chat/console_settings_apply.py
+++ b/tldw_chatbook/Chat/console_settings_apply.py
@@ -1,0 +1,224 @@
+"""Immutable contracts for applying Console conversation settings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+
+from tldw_chatbook.Chat.console_context_policy import ConsoleContextPolicyOverrides
+from tldw_chatbook.Chat.console_settings_durability import (
+    ConsoleSettingsDurabilityLease,
+)
+from tldw_chatbook.Chat.console_session_settings import (
+    ConsoleSessionSettings,
+    normalize_console_model_value,
+)
+from tldw_chatbook.Chat.provider_readiness import provider_config_key
+
+
+QUICK_MODEL_DEFAULT_FIELDS = frozenset({"temperature", "streaming"})
+FULL_MODEL_DEFAULT_FIELDS = frozenset(
+    {
+        "temperature",
+        "top_p",
+        "min_p",
+        "top_k",
+        "max_tokens",
+        "seed",
+        "presence_penalty",
+        "frequency_penalty",
+        "reasoning_effort",
+        "reasoning_summary",
+        "verbosity",
+        "thinking_effort",
+        "thinking_budget_tokens",
+        "streaming",
+    }
+)
+
+
+class ConsoleSettingsAction(str, Enum):
+    """A committing action exposed by a Console settings surface."""
+
+    APPLY_TO_CHAT = "apply_to_chat"
+    SAVE_MODEL_DEFAULT = "save_model_default"
+    MAKE_NEW_CHAT_DEFAULT = "make_new_chat_default"
+
+
+class ConsoleSettingsSurface(str, Enum):
+    """The settings surface that produced one immutable submission."""
+
+    QUICK_POPOVER = "quick_popover"
+    FULL_SETTINGS = "full_settings"
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleSettingsOrigin:
+    """Exact live-session binding observed when a settings surface opened."""
+
+    session_id: str
+    persisted_conversation_id: str | None
+    conversation_binding_revision: int
+
+
+class ConsoleSettingsFieldProvenance(str, Enum):
+    """How a displayed generation field acquired its effective value."""
+
+    INHERITED = "inherited"
+    EXPLICIT = "explicit"
+    CARRIED = "carried"
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleSettingsFieldDraft:
+    """One generation field's conversation value and profile intent."""
+
+    name: str
+    effective_value: object | None
+    profile_override: object | None
+    provenance: ConsoleSettingsFieldProvenance
+    dirty: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleEndpointDraft:
+    """An endpoint edit bound to one normalized provider configuration key."""
+
+    value: str
+    bound_provider_config_key: str
+    dirty: bool
+    checked: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleModelDraft:
+    """Process-local draft retained for one provider and literal model ID."""
+
+    provider: str
+    model: str | None
+    settings: ConsoleSessionSettings
+    field_drafts: tuple[ConsoleSettingsFieldDraft, ...]
+    endpoint_draft: ConsoleEndpointDraft | None
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleSettingsDraftState:
+    """Complete settings transaction state shared by both settings surfaces."""
+
+    settings: ConsoleSessionSettings
+    context_policy_overrides: ConsoleContextPolicyOverrides
+    field_drafts: tuple[ConsoleSettingsFieldDraft, ...]
+    model_drafts: tuple[ConsoleModelDraft, ...]
+    endpoint_draft: ConsoleEndpointDraft | None
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleSettingsSubmission:
+    """Validated intent submitted by a Console settings surface."""
+
+    submission_id: str
+    action: ConsoleSettingsAction
+    surface: ConsoleSettingsSurface
+    origin: ConsoleSettingsOrigin
+    draft: ConsoleSettingsDraftState
+    user_display_name_override: str | None
+    default_field_mask: frozenset[str]
+
+    def __post_init__(self) -> None:
+        """Detach the immutable submission from a caller-owned mask."""
+        if not isinstance(self.surface, ConsoleSettingsSurface):
+            raise TypeError("surface must be ConsoleSettingsSurface")
+        object.__setattr__(
+            self, "default_field_mask", frozenset(self.default_field_mask)
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleSettingsLiveCommit:
+    """Exact live values and revisions accepted for one session."""
+
+    submission_id: str
+    session_id: str
+    persisted_conversation_id: str | None
+    conversation_binding_revision: int
+    generation_revision: int
+    context_policy_revision: int
+    settings: ConsoleSessionSettings
+    context_policy_overrides: ConsoleContextPolicyOverrides
+    accepted_submission: ConsoleSettingsSubmission | None = None
+    durability_admission: ConsoleSettingsDurabilityLease | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleSettingsCommittedSubmission:
+    """A submission paired with its successful live session commit."""
+
+    submission: ConsoleSettingsSubmission
+    live_commit: ConsoleSettingsLiveCommit
+
+    def __post_init__(self) -> None:
+        """Expose the final normalized submission accepted by the live store."""
+
+        accepted = self.live_commit.accepted_submission
+        if accepted is None:
+            return
+        if accepted.submission_id != self.live_commit.submission_id:
+            raise ValueError("Accepted submission does not match the live commit.")
+        object.__setattr__(self, "submission", accepted)
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleSettingsTransfer:
+    """Non-committing handoff from quick settings to the full settings view."""
+
+    origin: ConsoleSettingsOrigin
+    draft: ConsoleSettingsDraftState
+
+
+def validate_console_settings_origin(
+    origin: ConsoleSettingsOrigin,
+    *,
+    live_session_id: str | None,
+    live_persisted_conversation_id: str | None,
+    live_conversation_binding_revision: int,
+) -> bool:
+    """Return whether a live session still represents ``origin``.
+
+    The one allowed identity transition is ordinary first persistence: an origin
+    captured without a conversation ID may acquire its first durable ID while its
+    binding revision remains unchanged. Explicit rebinding advances that revision
+    and therefore fails closed even when the captured ID was ``None``.
+    """
+
+    if live_session_id is None or live_session_id != origin.session_id:
+        return False
+    if live_conversation_binding_revision != origin.conversation_binding_revision:
+        return False
+    if origin.persisted_conversation_id is None:
+        return True
+    return live_persisted_conversation_id == origin.persisted_conversation_id
+
+
+def remember_model_draft(
+    state: ConsoleSettingsDraftState,
+) -> ConsoleSettingsDraftState:
+    """Return ``state`` with its current exact provider/model draft remembered."""
+
+    provider = provider_config_key(state.settings.provider)
+    model = normalize_console_model_value(state.settings.model)
+    remembered = ConsoleModelDraft(
+        provider=provider,
+        model=model,
+        settings=replace(state.settings, provider=provider, model=model),
+        field_drafts=tuple(state.field_drafts),
+        endpoint_draft=state.endpoint_draft,
+    )
+    key = (provider, model)
+    drafts = list(state.model_drafts)
+    for index, existing in enumerate(drafts):
+        if (existing.provider, existing.model) == key:
+            drafts[index] = remembered
+            break
+    else:
+        drafts.append(remembered)
+    return replace(state, model_drafts=tuple(drafts))

--- a/tldw_chatbook/Chat/console_settings_defaults.py
+++ b/tldw_chatbook/Chat/console_settings_defaults.py
@@ -1,0 +1,1368 @@
+"""Atomic exact-model Console default persistence and recovery helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+import hashlib
+from ipaddress import ip_address, ip_network
+import threading
+from types import MappingProxyType
+from urllib.parse import urlsplit
+
+from tldw_chatbook import config as config_module
+from tldw_chatbook.Chat.console_provider_support import (
+    build_local_thinking_payload_fields,
+    resolve_console_provider_identity,
+)
+from tldw_chatbook.Chat.console_session_settings import (
+    CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS,
+    build_console_settings_readiness,
+    build_target_default_console_session_settings,
+    validate_console_session_settings,
+)
+from tldw_chatbook.Chat.console_settings_apply import (
+    FULL_MODEL_DEFAULT_FIELDS,
+    QUICK_MODEL_DEFAULT_FIELDS,
+    ConsoleEndpointDraft,
+    ConsoleSettingsAction,
+    ConsoleSettingsFieldDraft,
+)
+from tldw_chatbook.Chat.provider_readiness import provider_config_key
+from tldw_chatbook.model_capabilities import (
+    anthropic_model_rejects_fixed_thinking_budget,
+    moonshot_model_supports_reasoning_effort,
+    zai_model_supports_reasoning_effort,
+)
+
+
+_PROVIDER_SPECIFIC_FIELDS = frozenset(
+    {
+        "reasoning_effort",
+        "reasoning_summary",
+        "verbosity",
+        "thinking_effort",
+        "thinking_budget_tokens",
+    }
+)
+_DIRECT_PROVIDER_FIELDS = {
+    "openai": frozenset({"reasoning_effort", "reasoning_summary", "verbosity"}),
+    "qwencloud": frozenset({"reasoning_effort"}),
+}
+_LOCAL_THINKING_BUDGET_KEYS = frozenset(
+    {"llama_cpp", "local_llamacpp", "local_llamafile", "local-llm"}
+)
+_ENDPOINT_KEYS = (
+    "api_base_url",
+    "api_base",
+    "base_url",
+    "api_url",
+    "api_endpoint",
+    "endpoint",
+    "router_base_url",
+    "huggingface_router_base_url",
+)
+_INTENT_GENERATION_LOCK = threading.RLock()
+_INTENT_CALL_LOCK = threading.Lock()
+_ACTIVE_INTENT_CALLS: set[tuple[int, str]] = set()
+_LATEST_INTENT_GENERATION: int | None = None
+_LATEST_INTENT_FINGERPRINT: str | None = None
+_LATEST_INTENT_ACTION: ConsoleSettingsAction | None = None
+_MAX_PREDECESSOR_RESERVATION_ATTEMPTS = 8
+_NEXT_RUNTIME_PUBLICATION_CLAIM_TOKEN = 0
+_RFC1918_NETWORKS = (
+    ip_network("10.0.0.0/8"),
+    ip_network("172.16.0.0/12"),
+    ip_network("192.168.0.0/16"),
+)
+_IPV6_UNIQUE_LOCAL_NETWORK = ip_network("fc00::/7")
+
+
+class _IntentLifecycle(str, Enum):
+    """Private state machine for the newest explicit default intent."""
+
+    RESERVED = "reserved"
+    IN_FLIGHT = "in_flight"
+    RUNTIME_PUBLICATION_PENDING = "runtime_publication_pending"
+    BEFORE_REPLACE_RETRYABLE = "before_replace_retryable"
+    CACHE_PUBLICATION_RETRYABLE = "cache_publication_retryable"
+    TERMINAL = "terminal"
+
+
+_LATEST_INTENT_LIFECYCLE: _IntentLifecycle | None = None
+
+
+class ConsoleDefaultSavePhase(str, Enum):
+    """Durability phase in which a Console default save failed."""
+
+    BEFORE_REPLACE = "before_replace"
+    CACHE_PUBLICATION = "cache_publication"
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleEndpointPatch:
+    """One explicitly opted-in endpoint edit bound to its provider owner."""
+
+    value: str
+    bound_provider_config_key: str
+    dirty: bool
+    checked: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleDefaultMutationIntent:
+    """Immutable exact-field mutation requested after a successful live Apply."""
+
+    generation: int
+    action: ConsoleSettingsAction
+    provider_config_key: str
+    literal_model_id: str
+    field_mask: frozenset[str]
+    values: Mapping[str, object | None]
+    endpoint_patch: ConsoleEndpointPatch | None
+
+    def __post_init__(self) -> None:
+        """Detach retry state from caller-owned mutable containers."""
+
+        object.__setattr__(self, "field_mask", frozenset(self.field_mask))
+        object.__setattr__(
+            self,
+            "values",
+            MappingProxyType(dict(self.values)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleDefaultMutationOutcome:
+    """Disk/runtime result for one immutable default intent generation."""
+
+    intent_generation: int
+    file_replaced: bool
+    runtime_published: bool
+    settings_view: Mapping[str, object] | None
+    failure_phase: ConsoleDefaultSavePhase | None
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleDefaultRuntimePublicationClaim:
+    """Opaque permission to publish one exact current runtime view.
+
+    The settings mapping is deliberately excluded from ``repr`` so endpoint
+    and credential-bearing config values cannot leak through diagnostics.
+    Claims are process-local and short-lived; callers must either complete or
+    abort them.
+    """
+
+    token: int
+    intent_generation: int
+    action: ConsoleSettingsAction
+    config_generation: int
+    settings_view: Mapping[str, object] = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleDefaultIntentReservation:
+    """One worker-side reservation step for a newer default intent."""
+
+    reserved: bool
+    predecessor_claim: ConsoleDefaultRuntimePublicationClaim | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _ActiveRuntimePublicationClaim:
+    """Private identity needed to reject stale completion or abort calls."""
+
+    token: int
+    intent_generation: int
+    action: ConsoleSettingsAction
+    config_generation: int
+    predecessor_fingerprint: str
+    predecessor_lifecycle: _IntentLifecycle
+    successor_fingerprint: str | None
+
+
+_ACTIVE_RUNTIME_PUBLICATION_CLAIM: _ActiveRuntimePublicationClaim | None = None
+
+
+def build_console_default_intent(
+    *,
+    generation: int,
+    action: ConsoleSettingsAction,
+    provider_config_key: str,
+    literal_model_id: str,
+    field_drafts: tuple[ConsoleSettingsFieldDraft, ...],
+    field_mask: frozenset[str],
+    endpoint: ConsoleEndpointDraft | None,
+) -> ConsoleDefaultMutationIntent:
+    """Build immutable persistence values from one submitted settings draft."""
+
+    values: dict[str, object | None] = {}
+    exposed_names: set[str] = set()
+    for draft in field_drafts:
+        if not isinstance(draft, ConsoleSettingsFieldDraft):
+            raise TypeError("Default field drafts are invalid")
+        if draft.name in exposed_names:
+            raise ValueError("Default field drafts must have unique names")
+        exposed_names.add(draft.name)
+        if draft.name not in field_mask:
+            continue
+        values[draft.name] = (
+            draft.effective_value
+            if field_mask == QUICK_MODEL_DEFAULT_FIELDS
+            else draft.profile_override
+        )
+
+    endpoint_patch = (
+        None
+        if action is not ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT
+        or endpoint is None
+        else ConsoleEndpointPatch(
+            value=endpoint.value,
+            bound_provider_config_key=endpoint.bound_provider_config_key,
+            dirty=endpoint.dirty,
+            checked=endpoint.checked,
+        )
+    )
+    return ConsoleDefaultMutationIntent(
+        generation=generation,
+        action=action,
+        provider_config_key=provider_config_key,
+        literal_model_id=literal_model_id,
+        field_mask=field_mask,
+        values=values,
+        endpoint_patch=endpoint_patch,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeConfigPublicationResult:
+    """Cache-only publication outcome after a prior successful disk write."""
+
+    published: bool
+    settings_view: Mapping[str, object] | None
+    failure_phase: str | None
+
+
+class ConsoleDefaultRecoveryAction(str, Enum):
+    """Explicit recovery actions shown for app-global default durability."""
+
+    RETRY_SAVE = "retry_save"
+    DISCARD_RETRY = "discard_retry"
+    REFRESH_RUNNING_APP = "refresh_running_app"
+    DISMISS_REFRESH = "dismiss_refresh"
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleDefaultRecoveryRequest:
+    """Recovery command bound to one exact default-intent generation."""
+
+    action: ConsoleDefaultRecoveryAction
+    intent_generation: int
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleDefaultDurabilityState:
+    """Newest app-owned Console default intent and its recovery phase.
+
+    This presentation-neutral value belongs to the application lifetime.  A
+    settings surface receives a snapshot and emits generation-bound recovery
+    requests; it never owns or mutates the durable operation itself.
+    """
+
+    newest_intent_generation: int = 0
+    recovery_intent: ConsoleDefaultMutationIntent | None = None
+    failure_phase: ConsoleDefaultSavePhase | None = None
+    runtime_published_intent_generation: int | None = None
+
+    def __post_init__(self) -> None:
+        """Reject internally inconsistent recovery snapshots."""
+
+        if type(self.newest_intent_generation) is not int:
+            raise TypeError("Newest default intent generation must be an integer")
+        if self.newest_intent_generation < 0:
+            raise ValueError("Newest default intent generation cannot be negative")
+        intent = self.recovery_intent
+        if (intent is None) is not (self.failure_phase is None):
+            raise ValueError("Default recovery intent and failure phase must agree")
+        if intent is not None and intent.generation != self.newest_intent_generation:
+            raise ValueError("Default recovery must target the newest intent")
+
+    def accept_runtime_publication(
+        self,
+        intent_generation: int,
+    ) -> tuple[ConsoleDefaultDurabilityState, bool]:
+        """Acknowledge one current runtime publication idempotently.
+
+        Args:
+            intent_generation: Generation whose fresh settings mapping was
+                assigned to the running application.
+
+        Returns:
+            ``(state, accepted)``.  ``accepted`` is true only for the first
+            publication of the newest intent generation.
+        """
+
+        if (
+            type(intent_generation) is not int
+            or intent_generation != self.newest_intent_generation
+            or self.runtime_published_intent_generation == intent_generation
+        ):
+            return self, False
+        return (
+            ConsoleDefaultDurabilityState(
+                newest_intent_generation=self.newest_intent_generation,
+                runtime_published_intent_generation=intent_generation,
+            ),
+            True,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleEndpointPreview:
+    """Credential-free endpoint authority and conservative network class."""
+
+    authority: str
+    network_classification: str
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingRetryState:
+    """Private optimistic baseline for the newest retryable disk intent."""
+
+    generation: int
+    fingerprint: str
+    owned_baseline: tuple[tuple[tuple[str, ...], str, str], ...]
+
+
+_PENDING_RETRY_STATE: _PendingRetryState | None = None
+
+
+def _supported_profile_fields(provider: str, model: str) -> frozenset[str]:
+    """Mirror the controller's provider/model capability projection."""
+
+    canonical = provider_config_key(provider)
+    supported = set(FULL_MODEL_DEFAULT_FIELDS - _PROVIDER_SPECIFIC_FIELDS)
+    if canonical == "moonshot" and moonshot_model_supports_reasoning_effort(model):
+        supported.add("reasoning_effort")
+    if canonical == "zai" and zai_model_supports_reasoning_effort(model):
+        supported.add("reasoning_effort")
+    supported.update(_DIRECT_PROVIDER_FIELDS.get(canonical, ()))
+    if canonical == "anthropic":
+        supported.add("thinking_effort")
+        if not anthropic_model_rejects_fixed_thinking_budget(model):
+            supported.add("thinking_budget_tokens")
+
+    identity = resolve_console_provider_identity(
+        canonical,
+        handler_keys=CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS,
+    )
+    if build_local_thinking_payload_fields(identity.execution_key, "low", None):
+        supported.add("reasoning_effort")
+    if identity.execution_key in _LOCAL_THINKING_BUDGET_KEYS:
+        supported.add("thinking_budget_tokens")
+    return frozenset(supported)
+
+
+def _intent_fingerprint(intent: ConsoleDefaultMutationIntent) -> str:
+    """Return a value-hiding identity for same-generation retry validation."""
+
+    endpoint = intent.endpoint_patch
+    material = repr(
+        (
+            intent.generation,
+            intent.action.value if isinstance(intent.action, ConsoleSettingsAction) else "",
+            intent.provider_config_key,
+            intent.literal_model_id,
+            tuple(sorted(intent.field_mask)),
+            tuple(sorted((name, repr(value)) for name, value in intent.values.items())),
+            None
+            if endpoint is None
+            else (
+                endpoint.bound_provider_config_key,
+                endpoint.dirty,
+                endpoint.checked,
+                repr(endpoint.value),
+            ),
+        )
+    ).encode("utf-8", errors="replace")
+    return hashlib.sha256(material).hexdigest()
+
+
+def _reserve_intent_generation(intent: ConsoleDefaultMutationIntent) -> str | None:
+    """Start a newer intent or one explicit retry of a retryable generation."""
+
+    global _LATEST_INTENT_ACTION, _LATEST_INTENT_FINGERPRINT, _LATEST_INTENT_GENERATION
+    global _LATEST_INTENT_LIFECYCLE, _PENDING_RETRY_STATE
+
+    fingerprint = _intent_fingerprint(intent)
+    with _INTENT_GENERATION_LOCK:
+        if (
+            _LATEST_INTENT_GENERATION is None
+            or intent.generation > _LATEST_INTENT_GENERATION
+        ):
+            _LATEST_INTENT_GENERATION = intent.generation
+            _LATEST_INTENT_FINGERPRINT = fingerprint
+            _LATEST_INTENT_ACTION = intent.action
+            _LATEST_INTENT_LIFECYCLE = _IntentLifecycle.IN_FLIGHT
+            _PENDING_RETRY_STATE = None
+            return fingerprint
+        if (
+            intent.generation == _LATEST_INTENT_GENERATION
+            and fingerprint == _LATEST_INTENT_FINGERPRINT
+            and _LATEST_INTENT_LIFECYCLE
+            in {
+                _IntentLifecycle.RESERVED,
+                _IntentLifecycle.BEFORE_REPLACE_RETRYABLE,
+            }
+        ):
+            _LATEST_INTENT_LIFECYCLE = _IntentLifecycle.IN_FLIGHT
+            return fingerprint
+        return None
+
+
+_PREDECESSOR_PUBLICATION_LIFECYCLES = frozenset(
+    {
+        _IntentLifecycle.RUNTIME_PUBLICATION_PENDING,
+        _IntentLifecycle.CACHE_PUBLICATION_RETRYABLE,
+    }
+)
+
+
+def _reserve_intent_unlocked(
+    intent: ConsoleDefaultMutationIntent,
+    fingerprint: str,
+) -> bool:
+    """Reserve ``intent`` while the caller owns the intent-generation lock."""
+
+    global _LATEST_INTENT_ACTION, _LATEST_INTENT_FINGERPRINT
+    global _LATEST_INTENT_GENERATION, _LATEST_INTENT_LIFECYCLE
+    global _PENDING_RETRY_STATE
+
+    if (
+        _LATEST_INTENT_GENERATION is None
+        or intent.generation > _LATEST_INTENT_GENERATION
+    ):
+        _LATEST_INTENT_GENERATION = intent.generation
+        _LATEST_INTENT_FINGERPRINT = fingerprint
+        _LATEST_INTENT_ACTION = intent.action
+        _LATEST_INTENT_LIFECYCLE = _IntentLifecycle.RESERVED
+        _PENDING_RETRY_STATE = None
+        return True
+    return bool(
+        intent.generation == _LATEST_INTENT_GENERATION
+        and fingerprint == _LATEST_INTENT_FINGERPRINT
+        and _LATEST_INTENT_LIFECYCLE is _IntentLifecycle.RESERVED
+    )
+
+
+def _claim_runtime_publication(
+    *,
+    predecessor_identity: tuple[
+        int | None,
+        str | None,
+        ConsoleSettingsAction | None,
+        _IntentLifecycle,
+    ],
+    successor_fingerprint: str | None,
+    settings_view: Mapping[str, object] | None,
+) -> ConsoleDefaultRuntimePublicationClaim | None:
+    """Claim an exact predecessor under a short config-generation fence."""
+
+    global _ACTIVE_RUNTIME_PUBLICATION_CLAIM
+    global _NEXT_RUNTIME_PUBLICATION_CLAIM_TOKEN
+
+    snapshot = config_module.get_runtime_config_snapshot()
+    claim: ConsoleDefaultRuntimePublicationClaim | None = None
+
+    def claim_if_current() -> bool:
+        nonlocal claim
+        global _ACTIVE_RUNTIME_PUBLICATION_CLAIM
+        global _NEXT_RUNTIME_PUBLICATION_CLAIM_TOKEN
+
+        with _INTENT_GENERATION_LOCK:
+            if predecessor_identity != (
+                _LATEST_INTENT_GENERATION,
+                _LATEST_INTENT_FINGERPRINT,
+                _LATEST_INTENT_ACTION,
+                _LATEST_INTENT_LIFECYCLE,
+            ):
+                return False
+            if _ACTIVE_RUNTIME_PUBLICATION_CLAIM is not None:
+                return False
+            generation, fingerprint, action, lifecycle = predecessor_identity
+            if generation is None or fingerprint is None or action is None:
+                return False
+            _NEXT_RUNTIME_PUBLICATION_CLAIM_TOKEN += 1
+            claimed_settings_view = settings_view
+            if claimed_settings_view is None or (
+                lifecycle is not _IntentLifecycle.RESERVED
+                and claimed_settings_view != snapshot.values
+            ):
+                claimed_settings_view = snapshot.values
+            claim = ConsoleDefaultRuntimePublicationClaim(
+                token=_NEXT_RUNTIME_PUBLICATION_CLAIM_TOKEN,
+                intent_generation=generation,
+                action=action,
+                config_generation=snapshot.generation,
+                settings_view=claimed_settings_view,
+            )
+            _ACTIVE_RUNTIME_PUBLICATION_CLAIM = _ActiveRuntimePublicationClaim(
+                token=claim.token,
+                intent_generation=claim.intent_generation,
+                action=claim.action,
+                config_generation=claim.config_generation,
+                predecessor_fingerprint=fingerprint,
+                predecessor_lifecycle=lifecycle,
+                successor_fingerprint=successor_fingerprint,
+            )
+            return True
+
+    if not config_module.run_if_runtime_config_generation_current(
+        snapshot.generation,
+        claim_if_current,
+    ):
+        return None
+    return claim
+
+
+def prepare_console_default_intent_reservation(
+    intent: ConsoleDefaultMutationIntent,
+) -> ConsoleDefaultIntentReservation:
+    """Prepare a reservation without invoking application code under locks.
+
+    A durable predecessor is represented by a short-lived claim. The worker
+    returns that claim after releasing both config and intent locks; the UI can
+    then publish it and ask a worker to complete the exact claim atomically
+    with reservation of ``intent``.
+    """
+
+    if not isinstance(intent, ConsoleDefaultMutationIntent):
+        raise TypeError("intent must be ConsoleDefaultMutationIntent")
+    fingerprint = _intent_fingerprint(intent)
+
+    for _attempt in range(_MAX_PREDECESSOR_RESERVATION_ATTEMPTS):
+        with _INTENT_GENERATION_LOCK:
+            predecessor_lifecycle = _LATEST_INTENT_LIFECYCLE
+            if predecessor_lifecycle not in _PREDECESSOR_PUBLICATION_LIFECYCLES:
+                return ConsoleDefaultIntentReservation(
+                    reserved=_reserve_intent_unlocked(intent, fingerprint)
+                )
+            if _ACTIVE_RUNTIME_PUBLICATION_CLAIM is not None:
+                continue
+            predecessor_identity = (
+                _LATEST_INTENT_GENERATION,
+                _LATEST_INTENT_FINGERPRINT,
+                _LATEST_INTENT_ACTION,
+                predecessor_lifecycle,
+            )
+
+        if predecessor_lifecycle is _IntentLifecycle.CACHE_PUBLICATION_RETRYABLE:
+            refresh = config_module.refresh_runtime_config_from_cli_config()
+            if not (refresh.caches_reloaded and refresh.settings_view is not None):
+                with _INTENT_GENERATION_LOCK:
+                    if predecessor_identity == (
+                        _LATEST_INTENT_GENERATION,
+                        _LATEST_INTENT_FINGERPRINT,
+                        _LATEST_INTENT_ACTION,
+                        _LATEST_INTENT_LIFECYCLE,
+                    ):
+                        raise RuntimeError(
+                            "Pending default runtime refresh failed"
+                        )
+                continue
+
+        claim = _claim_runtime_publication(
+            predecessor_identity=predecessor_identity,
+            successor_fingerprint=fingerprint,
+            settings_view=None,
+        )
+        if claim is not None:
+            return ConsoleDefaultIntentReservation(
+                reserved=False,
+                predecessor_claim=claim,
+            )
+    raise RuntimeError("Pending default reservation changed repeatedly")
+
+
+def prepare_console_default_runtime_publication(
+    intent: ConsoleDefaultMutationIntent,
+    outcome: ConsoleDefaultMutationOutcome,
+) -> ConsoleDefaultRuntimePublicationClaim | None:
+    """Claim a successful worker outcome for lock-free UI publication."""
+
+    if not isinstance(intent, ConsoleDefaultMutationIntent):
+        raise TypeError("intent must be ConsoleDefaultMutationIntent")
+    if not isinstance(outcome, ConsoleDefaultMutationOutcome):
+        raise TypeError("outcome must be ConsoleDefaultMutationOutcome")
+    fingerprint = _intent_fingerprint(intent)
+    if (
+        outcome.intent_generation != intent.generation
+        or not outcome.runtime_published
+        or outcome.settings_view is None
+        or outcome.failure_phase is not None
+    ):
+        return None
+
+    allowed_lifecycles = {
+        _IntentLifecycle.RUNTIME_PUBLICATION_PENDING,
+        _IntentLifecycle.CACHE_PUBLICATION_RETRYABLE,
+        _IntentLifecycle.RESERVED,
+    }
+    for _attempt in range(_MAX_PREDECESSOR_RESERVATION_ATTEMPTS):
+        with _INTENT_GENERATION_LOCK:
+            lifecycle = _LATEST_INTENT_LIFECYCLE
+            if (
+                intent.generation != _LATEST_INTENT_GENERATION
+                or fingerprint != _LATEST_INTENT_FINGERPRINT
+                or lifecycle not in allowed_lifecycles
+            ):
+                return None
+            if _ACTIVE_RUNTIME_PUBLICATION_CLAIM is not None:
+                continue
+            predecessor_identity = (
+                _LATEST_INTENT_GENERATION,
+                _LATEST_INTENT_FINGERPRINT,
+                _LATEST_INTENT_ACTION,
+                lifecycle,
+            )
+        claim = _claim_runtime_publication(
+            predecessor_identity=predecessor_identity,
+            successor_fingerprint=None,
+            settings_view=outcome.settings_view,
+        )
+        if claim is not None:
+            return claim
+    raise RuntimeError("Default runtime publication changed repeatedly")
+
+
+def abort_console_default_runtime_publication(
+    claim: ConsoleDefaultRuntimePublicationClaim,
+) -> bool:
+    """Release one exact uncompleted claim without changing its lifecycle."""
+
+    if not isinstance(claim, ConsoleDefaultRuntimePublicationClaim):
+        raise TypeError("claim must be ConsoleDefaultRuntimePublicationClaim")
+    global _ACTIVE_RUNTIME_PUBLICATION_CLAIM
+    with _INTENT_GENERATION_LOCK:
+        active = _ACTIVE_RUNTIME_PUBLICATION_CLAIM
+        if active is None or active.token != claim.token:
+            return False
+        _ACTIVE_RUNTIME_PUBLICATION_CLAIM = None
+        return True
+
+
+def complete_console_default_runtime_publication(
+    claim: ConsoleDefaultRuntimePublicationClaim,
+    *,
+    successor_intent: ConsoleDefaultMutationIntent | None = None,
+) -> bool:
+    """Finalize a UI-published claim and optionally reserve its successor."""
+
+    if not isinstance(claim, ConsoleDefaultRuntimePublicationClaim):
+        raise TypeError("claim must be ConsoleDefaultRuntimePublicationClaim")
+    if successor_intent is not None and not isinstance(
+        successor_intent, ConsoleDefaultMutationIntent
+    ):
+        raise TypeError("successor_intent must be ConsoleDefaultMutationIntent")
+    successor_fingerprint = (
+        None if successor_intent is None else _intent_fingerprint(successor_intent)
+    )
+    completed = False
+
+    def complete_if_current() -> bool:
+        nonlocal completed
+        global _ACTIVE_RUNTIME_PUBLICATION_CLAIM, _LATEST_INTENT_LIFECYCLE
+        global _PENDING_RETRY_STATE
+
+        with _INTENT_GENERATION_LOCK:
+            active = _ACTIVE_RUNTIME_PUBLICATION_CLAIM
+            if (
+                active is None
+                or active.token != claim.token
+                or active.intent_generation != claim.intent_generation
+                or active.action is not claim.action
+                or active.config_generation != claim.config_generation
+                or active.successor_fingerprint != successor_fingerprint
+                or active.predecessor_fingerprint != _LATEST_INTENT_FINGERPRINT
+                or active.predecessor_lifecycle is not _LATEST_INTENT_LIFECYCLE
+                or claim.intent_generation != _LATEST_INTENT_GENERATION
+                or claim.action is not _LATEST_INTENT_ACTION
+            ):
+                return False
+            _ACTIVE_RUNTIME_PUBLICATION_CLAIM = None
+            _LATEST_INTENT_LIFECYCLE = _IntentLifecycle.TERMINAL
+            _PENDING_RETRY_STATE = None
+            completed = (
+                True
+                if successor_intent is None
+                else _reserve_intent_unlocked(
+                    successor_intent,
+                    successor_fingerprint,
+                )
+            )
+            return completed
+
+    current = config_module.run_if_runtime_config_generation_current(
+        claim.config_generation,
+        complete_if_current,
+    )
+    if not current:
+        abort_console_default_runtime_publication(claim)
+    return current and completed
+
+
+def reserve_console_default_intent_generation(
+    intent: ConsoleDefaultMutationIntent,
+    *,
+    pending_runtime_publisher: Callable[
+        [int, ConsoleSettingsAction, Mapping[str, object]],
+        bool,
+    ]
+    | None = None,
+) -> bool:
+    """Compatibility wrapper around the claimed two-phase reservation."""
+
+    if pending_runtime_publisher is not None and not callable(
+        pending_runtime_publisher
+    ):
+        raise TypeError("pending_runtime_publisher must be callable")
+    for _attempt in range(_MAX_PREDECESSOR_RESERVATION_ATTEMPTS):
+        preparation = prepare_console_default_intent_reservation(intent)
+        if preparation.reserved:
+            return True
+        claim = preparation.predecessor_claim
+        if claim is None or pending_runtime_publisher is None:
+            if claim is not None:
+                abort_console_default_runtime_publication(claim)
+            return False
+        try:
+            published = pending_runtime_publisher(
+                claim.intent_generation,
+                claim.action,
+                claim.settings_view,
+            )
+        except Exception as error:
+            abort_console_default_runtime_publication(claim)
+            raise RuntimeError("Pending default publication was rejected") from error
+        if published is not True:
+            abort_console_default_runtime_publication(claim)
+            raise RuntimeError("Pending default publication was rejected")
+        if complete_console_default_runtime_publication(
+            claim,
+            successor_intent=intent,
+        ):
+            return True
+    raise RuntimeError("Pending default reservation changed repeatedly")
+
+
+def next_console_default_intent_generation(after: int) -> int:
+    """Return a process-monotonic candidate newer than app and service state."""
+
+    if type(after) is not int or after < 0:
+        raise ValueError("after must be a nonnegative integer")
+    with _INTENT_GENERATION_LOCK:
+        return max(after, _LATEST_INTENT_GENERATION or 0) + 1
+
+
+def _retry_state_for_intent(
+    generation: int,
+    fingerprint: str,
+) -> _PendingRetryState | None:
+    """Return retry state only while it still belongs to this exact intent."""
+
+    with _INTENT_GENERATION_LOCK:
+        retry_state = _PENDING_RETRY_STATE
+        if retry_state is None or (
+            retry_state.generation != generation
+            or retry_state.fingerprint != fingerprint
+        ):
+            return None
+        return retry_state
+
+
+def _finish_intent_success(generation: int, fingerprint: str) -> None:
+    """Leave a still-current success pending application-view publication."""
+
+    global _LATEST_INTENT_LIFECYCLE, _PENDING_RETRY_STATE
+    with _INTENT_GENERATION_LOCK:
+        if (
+            generation != _LATEST_INTENT_GENERATION
+            or fingerprint != _LATEST_INTENT_FINGERPRINT
+        ):
+            return
+        _LATEST_INTENT_LIFECYCLE = _IntentLifecycle.RUNTIME_PUBLICATION_PENDING
+        if _PENDING_RETRY_STATE is not None and (
+            _PENDING_RETRY_STATE.generation == generation
+            and _PENDING_RETRY_STATE.fingerprint == fingerprint
+        ):
+            _PENDING_RETRY_STATE = None
+
+
+def publish_console_default_runtime_if_current(
+    intent: ConsoleDefaultMutationIntent,
+    outcome: ConsoleDefaultMutationOutcome,
+    publisher: Callable[[Mapping[str, object]], bool],
+) -> bool:
+    """Compatibility wrapper around the claimed two-phase publication.
+
+    Args:
+        intent: Intent whose worker produced ``outcome``.
+        outcome: Successful runtime publication result to install.
+        publisher: Application-view assignment callback. It runs without a
+            config or intent lock held.
+
+    Returns:
+        ``True`` only when this exact current intent was published once.
+
+    Raises:
+        TypeError: An argument has the wrong type.
+    """
+
+    if not isinstance(intent, ConsoleDefaultMutationIntent):
+        raise TypeError("intent must be ConsoleDefaultMutationIntent")
+    if not isinstance(outcome, ConsoleDefaultMutationOutcome):
+        raise TypeError("outcome must be ConsoleDefaultMutationOutcome")
+    if not callable(publisher):
+        raise TypeError("publisher must be callable")
+    for _attempt in range(_MAX_PREDECESSOR_RESERVATION_ATTEMPTS):
+        claim = prepare_console_default_runtime_publication(intent, outcome)
+        if claim is None:
+            return False
+        try:
+            published = publisher(claim.settings_view)
+        except Exception:
+            abort_console_default_runtime_publication(claim)
+            return False
+        if published is not True:
+            abort_console_default_runtime_publication(claim)
+            return False
+        if complete_console_default_runtime_publication(claim):
+            return True
+    raise RuntimeError("Default runtime publication changed repeatedly")
+
+
+def _finish_intent_failure(
+    generation: int,
+    fingerprint: str,
+    phase: ConsoleDefaultSavePhase,
+    *,
+    captured_baseline: tuple[tuple[tuple[str, ...], str, str], ...] | None,
+    was_retry: bool,
+) -> None:
+    """Publish retry lifecycle only if no newer reservation superseded it."""
+
+    global _LATEST_INTENT_LIFECYCLE, _PENDING_RETRY_STATE
+    with _INTENT_GENERATION_LOCK:
+        if (
+            generation != _LATEST_INTENT_GENERATION
+            or fingerprint != _LATEST_INTENT_FINGERPRINT
+        ):
+            return
+        if phase is ConsoleDefaultSavePhase.CACHE_PUBLICATION:
+            _LATEST_INTENT_LIFECYCLE = (
+                _IntentLifecycle.CACHE_PUBLICATION_RETRYABLE
+            )
+            if _PENDING_RETRY_STATE is not None and (
+                _PENDING_RETRY_STATE.generation == generation
+                and _PENDING_RETRY_STATE.fingerprint == fingerprint
+            ):
+                _PENDING_RETRY_STATE = None
+            return
+        _LATEST_INTENT_LIFECYCLE = _IntentLifecycle.BEFORE_REPLACE_RETRYABLE
+        if captured_baseline is not None and not was_retry:
+            _PENDING_RETRY_STATE = _PendingRetryState(
+                generation=generation,
+                fingerprint=fingerprint,
+                owned_baseline=captured_baseline,
+            )
+
+
+def _acquire_current_intent_commit_fence(
+    generation: int,
+    fingerprint: str,
+) -> bool:
+    """Fence a current intent through file replacement and cache publication.
+
+    The transaction invokes this while holding the config write lock, which
+    establishes the only cross-lock order: config, then intent.  A successful
+    check deliberately keeps the reentrant intent lock held until the caller
+    has consumed the transaction result and published its lifecycle state.
+    """
+
+    _INTENT_GENERATION_LOCK.acquire()
+    if (
+        generation == _LATEST_INTENT_GENERATION
+        and fingerprint == _LATEST_INTENT_FINGERPRINT
+        and _LATEST_INTENT_LIFECYCLE is _IntentLifecycle.IN_FLIGHT
+    ):
+        return True
+    _INTENT_GENERATION_LOCK.release()
+    return False
+
+
+def _register_active_intent_call(generation: int, fingerprint: str) -> bool:
+    """Reject an exact duplicate while its first worker is still active."""
+
+    key = (generation, fingerprint)
+    with _INTENT_CALL_LOCK:
+        if key in _ACTIVE_INTENT_CALLS:
+            return False
+        _ACTIVE_INTENT_CALLS.add(key)
+        return True
+
+
+def _unregister_active_intent_call(generation: int, fingerprint: str) -> None:
+    """Release one exact worker-call reservation."""
+
+    with _INTENT_CALL_LOCK:
+        _ACTIVE_INTENT_CALLS.discard((generation, fingerprint))
+
+
+def _owned_baseline_digest(*, present: bool, value: object = None) -> str:
+    """Hash one raw owned value so private retry state retains no payload."""
+
+    material = repr(
+        (
+            present,
+            type(value).__module__ if present else "",
+            type(value).__qualname__ if present else "",
+            value if present else "",
+        )
+    ).encode("utf-8", errors="replace")
+    return hashlib.sha256(material).hexdigest()
+
+
+def _raw_owned_value_digest(
+    raw_values: Mapping[str, object],
+    path: tuple[str, ...],
+    key: str,
+) -> str:
+    """Read and hash one exact raw path/key without creating mappings."""
+
+    current: object = raw_values
+    for part in path:
+        if not isinstance(current, Mapping) or part not in current:
+            return _owned_baseline_digest(present=False)
+        current = current[part]
+    if not isinstance(current, Mapping) or key not in current:
+        return _owned_baseline_digest(present=False)
+    return _owned_baseline_digest(present=True, value=current[key])
+
+
+def _capture_owned_baseline(
+    raw_values: Mapping[str, object],
+    mutation: config_module.LiteralSettingsMutation,
+) -> tuple[tuple[tuple[str, ...], str, str], ...]:
+    """Capture hashes for only the exact keys one immutable intent owns."""
+
+    targets = {
+        (path, key)
+        for path, values in mutation.section_values.items()
+        for key in values
+    }
+    targets.update(
+        (path, key)
+        for path, keys in mutation.delete_keys.items()
+        for key in keys
+    )
+    return tuple(
+        (path, key, _raw_owned_value_digest(raw_values, path, key))
+        for path, key in sorted(targets)
+    )
+
+
+def _raw_provider_section_name(
+    raw_values: Mapping[str, object],
+    canonical_provider: str,
+) -> str:
+    """Resolve one provider table name solely from authoritative user TOML."""
+
+    api_settings = raw_values.get("api_settings", {})
+    if not isinstance(api_settings, Mapping):
+        raise TypeError("api_settings must be a mapping")
+    matches = [
+        str(name)
+        for name in api_settings
+        if type(name) is str and provider_config_key(name) == canonical_provider
+    ]
+    if canonical_provider in {"moonshot", "qwencloud", "zai"} and (
+        canonical_provider in matches
+    ):
+        return canonical_provider
+    if matches:
+        return matches[0]
+    return canonical_provider
+
+
+def _raw_provider_settings(
+    raw_values: Mapping[str, object],
+    section_name: str,
+) -> Mapping[str, object]:
+    api_settings = raw_values.get("api_settings", {})
+    if not isinstance(api_settings, Mapping):
+        raise TypeError("api_settings must be a mapping")
+    settings = api_settings.get(section_name, {})
+    if not isinstance(settings, Mapping):
+        raise TypeError("provider settings must be a mapping")
+    return settings
+
+
+def _configured_endpoint_key(provider_settings: Mapping[str, object]) -> str | None:
+    """Return the first endpoint key already configured in authoritative TOML."""
+
+    for key in _ENDPOINT_KEYS:
+        value = provider_settings.get(key)
+        if isinstance(value, str) and value.strip():
+            return key
+    return None
+
+
+def _validate_intent(intent: ConsoleDefaultMutationIntent) -> tuple[str, str]:
+    """Validate immutable intent identity without touching configuration."""
+
+    if type(intent.generation) is not int or intent.generation < 0:
+        raise ValueError("Intent generation must be a nonnegative integer")
+    if not isinstance(intent.action, ConsoleSettingsAction) or intent.action not in {
+        ConsoleSettingsAction.SAVE_MODEL_DEFAULT,
+        ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT,
+    }:
+        raise ValueError("Intent action cannot mutate defaults")
+    if type(intent.provider_config_key) is not str:
+        raise TypeError("Provider must be a string")
+    canonical_provider = provider_config_key(intent.provider_config_key)
+    if not canonical_provider:
+        raise ValueError("Provider is required")
+    if type(intent.literal_model_id) is not str:
+        raise TypeError("Literal model ID must be a string")
+    literal_model = intent.literal_model_id
+    if (
+        not literal_model
+        or literal_model != literal_model.strip()
+        or len(literal_model) > 512
+        or not literal_model.isprintable()
+    ):
+        raise ValueError("Literal model ID is invalid")
+    if intent.field_mask not in {
+        QUICK_MODEL_DEFAULT_FIELDS,
+        FULL_MODEL_DEFAULT_FIELDS,
+    }:
+        raise ValueError("Default field mask is invalid")
+    if not isinstance(intent.values, Mapping):
+        raise TypeError("Default values must be a mapping")
+    for name in intent.values:
+        if type(name) is not str or not name:
+            raise TypeError("Default field names must be non-empty strings")
+    if intent.field_mask == QUICK_MODEL_DEFAULT_FIELDS and any(
+        name not in intent.values or intent.values[name] is None
+        for name in QUICK_MODEL_DEFAULT_FIELDS
+    ):
+        raise ValueError("Quick default fields must be materialized")
+    return canonical_provider, literal_model
+
+
+def _endpoint_patch_is_authorized(
+    intent: ConsoleDefaultMutationIntent,
+    canonical_provider: str,
+) -> bool:
+    patch = intent.endpoint_patch
+    if patch is None:
+        return True
+    return (
+        intent.action is ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT
+        and intent.field_mask == FULL_MODEL_DEFAULT_FIELDS
+        and patch.dirty is True
+        and patch.checked is True
+        and provider_config_key(patch.bound_provider_config_key)
+        == canonical_provider
+        and parse_console_endpoint_preview(patch.value) is not None
+    )
+
+
+def _build_locked_default_mutation(
+    intent: ConsoleDefaultMutationIntent,
+    canonical_provider: str,
+    literal_model: str,
+    snapshot: config_module.AtomicLiteralMutationSnapshot,
+) -> config_module.LiteralSettingsMutation:
+    """Build one exact mutation from locked authoritative raw/effective views."""
+
+    raw_section_name = _raw_provider_section_name(
+        snapshot.raw_values,
+        canonical_provider,
+    )
+    raw_provider = _raw_provider_settings(snapshot.raw_values, raw_section_name)
+    defaults = build_target_default_console_session_settings(
+        snapshot.effective_values,
+        canonical_provider,
+        literal_model,
+    )
+    if intent.action is ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT:
+        validation_errors = validate_console_session_settings(
+            defaults,
+            app_config=snapshot.effective_values,
+        )
+        readiness = build_console_settings_readiness(
+            defaults,
+            app_config=snapshot.effective_values,
+        )
+        if validation_errors or not readiness.native_send_supported:
+            raise ValueError("Selected provider/model is not ready for new chats")
+
+    supported = _supported_profile_fields(canonical_provider, literal_model)
+    owned_fields = intent.field_mask & supported & frozenset(intent.values)
+    profile_values: dict[str, object] = {}
+    profile_deletes: list[str] = []
+    for name in sorted(owned_fields):
+        value = intent.values[name]
+        if value is None:
+            profile_deletes.append(name)
+            continue
+        if name == "streaming" and type(value) is not bool:
+            raise TypeError("Streaming default must be a strict boolean or inherit")
+        profile_values[name] = value
+
+    profile_path = (
+        "api_settings",
+        raw_section_name,
+        "model_defaults",
+        literal_model,
+    )
+    section_values: dict[tuple[str, ...], Mapping[str, object]] = {
+        profile_path: profile_values
+    }
+    delete_keys: dict[tuple[str, ...], tuple[str, ...]] = {
+        profile_path: tuple(profile_deletes)
+    }
+    if intent.action is ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT:
+        section_values[("chat_defaults",)] = {
+            "provider": canonical_provider,
+            "model": literal_model,
+        }
+
+    patch = intent.endpoint_patch
+    if patch is not None:
+        endpoint_key = _configured_endpoint_key(raw_provider)
+        if endpoint_key is None:
+            raise ValueError("Provider has no authoritative endpoint key to patch")
+        section_values[("api_settings", raw_section_name)] = {
+            endpoint_key: patch.value.strip()
+        }
+
+    return config_module.LiteralSettingsMutation(
+        section_values=section_values,
+        delete_keys=delete_keys,
+    )
+
+
+def apply_console_default_intent(
+    intent: ConsoleDefaultMutationIntent,
+) -> ConsoleDefaultMutationOutcome:
+    """Atomically apply one exact-model default intent and publish runtime config."""
+
+    try:
+        canonical_provider, literal_model = _validate_intent(intent)
+        if not _endpoint_patch_is_authorized(intent, canonical_provider):
+            raise ValueError("Endpoint patch is not authorized for this action")
+    except Exception:
+        return ConsoleDefaultMutationOutcome(
+            intent_generation=(
+                intent.generation if type(intent.generation) is int else -1
+            ),
+            file_replaced=False,
+            runtime_published=False,
+            settings_view=None,
+            failure_phase=ConsoleDefaultSavePhase.BEFORE_REPLACE,
+        )
+
+    call_fingerprint = _intent_fingerprint(intent)
+    if not _register_active_intent_call(intent.generation, call_fingerprint):
+        return ConsoleDefaultMutationOutcome(
+            intent_generation=intent.generation,
+            file_replaced=False,
+            runtime_published=False,
+            settings_view=None,
+            failure_phase=ConsoleDefaultSavePhase.BEFORE_REPLACE,
+        )
+
+    try:
+        fingerprint = _reserve_intent_generation(intent)
+        if fingerprint is None:
+            return ConsoleDefaultMutationOutcome(
+                intent_generation=intent.generation,
+                file_replaced=False,
+                runtime_published=False,
+                settings_view=None,
+                failure_phase=ConsoleDefaultSavePhase.BEFORE_REPLACE,
+            )
+        retry_state = _retry_state_for_intent(intent.generation, fingerprint)
+        captured_baselines: list[
+            tuple[tuple[tuple[str, ...], str, str], ...]
+        ] = []
+
+        def build_mutation(
+            snapshot: config_module.AtomicLiteralMutationSnapshot,
+        ) -> config_module.LiteralSettingsMutation:
+            mutation = _build_locked_default_mutation(
+                intent,
+                canonical_provider,
+                literal_model,
+                snapshot,
+            )
+            baseline = _capture_owned_baseline(snapshot.raw_values, mutation)
+            captured_baselines.append(baseline)
+            if retry_state is not None and baseline != retry_state.owned_baseline:
+                raise ValueError("Retry target changed after the failed save")
+            return mutation
+
+        commit_fence_acquired = False
+
+        def acquire_commit_fence() -> bool:
+            nonlocal commit_fence_acquired
+            if commit_fence_acquired:
+                return True
+            commit_fence_acquired = _acquire_current_intent_commit_fence(
+                intent.generation,
+                fingerprint,
+            )
+            return commit_fence_acquired
+
+        try:
+            result = config_module.apply_literal_settings_transaction_to_cli_config(
+                build_mutation,
+                mutation_precondition=acquire_commit_fence,
+            )
+            if result.caches_reloaded and result.settings_view is not None:
+                _finish_intent_success(intent.generation, fingerprint)
+                return ConsoleDefaultMutationOutcome(
+                    intent_generation=intent.generation,
+                    file_replaced=result.file_replaced,
+                    runtime_published=True,
+                    settings_view=result.settings_view,
+                    failure_phase=None,
+                )
+            phase = (
+                ConsoleDefaultSavePhase.CACHE_PUBLICATION
+                if result.failure_phase == "cache_reload"
+                else ConsoleDefaultSavePhase.BEFORE_REPLACE
+            )
+            _finish_intent_failure(
+                intent.generation,
+                fingerprint,
+                phase,
+                captured_baseline=(captured_baselines[0] if captured_baselines else None),
+                was_retry=retry_state is not None,
+            )
+            return ConsoleDefaultMutationOutcome(
+                intent_generation=intent.generation,
+                file_replaced=result.file_replaced,
+                runtime_published=False,
+                settings_view=None,
+                failure_phase=phase,
+            )
+        finally:
+            if commit_fence_acquired:
+                _INTENT_GENERATION_LOCK.release()
+    finally:
+        _unregister_active_intent_call(intent.generation, call_fingerprint)
+
+
+def refresh_console_runtime_after_saved_default() -> RuntimeConfigPublicationResult:
+    """Reread and republish config caches without repeating a saved mutation."""
+
+    result = config_module.refresh_runtime_config_from_cli_config()
+    return RuntimeConfigPublicationResult(
+        published=result.caches_reloaded and result.settings_view is not None,
+        settings_view=result.settings_view,
+        failure_phase=result.failure_phase,
+    )
+
+
+def parse_console_endpoint_preview(value: str) -> ConsoleEndpointPreview | None:
+    """Return only a sanitized authority and syntactic network classification."""
+
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if (
+        not candidate
+        or not candidate.isprintable()
+        or any(character.isspace() for character in candidate)
+        or "\\" in candidate
+    ):
+        return None
+    try:
+        parsed = urlsplit(candidate if "://" in candidate else f"//{candidate}")
+        if parsed.scheme and parsed.scheme.lower() not in {"http", "https"}:
+            return None
+        if parsed.username is not None or parsed.password is not None:
+            return None
+        hostname = parsed.hostname
+        if not hostname:
+            return None
+        port = parsed.port
+    except (TypeError, ValueError):
+        return None
+
+    normalized_host = hostname.rstrip(".").lower()
+    if not normalized_host or "%" in normalized_host:
+        return None
+    try:
+        address = ip_address(normalized_host)
+    except ValueError:
+        address = None
+    if address is None and not _is_valid_ascii_hostname(normalized_host):
+        return None
+
+    if normalized_host == "localhost" or (address is not None and address.is_loopback):
+        classification = "Local"
+    elif (
+        normalized_host.endswith(".local")
+        or (
+            address is not None
+            and (
+                address.is_link_local
+                or (
+                    address.version == 4
+                    and any(address in network for network in _RFC1918_NETWORKS)
+                )
+                or (
+                    address.version == 6
+                    and address in _IPV6_UNIQUE_LOCAL_NETWORK
+                )
+            )
+        )
+    ):
+        classification = "LAN"
+    elif address is not None and address.is_global and not address.is_multicast:
+        classification = "Remote"
+    else:
+        classification = "Remote/unknown"
+
+    rendered_host = f"[{normalized_host}]" if ":" in normalized_host else normalized_host
+    authority = rendered_host if port is None else f"{rendered_host}:{port}"
+    return ConsoleEndpointPreview(authority, classification)
+
+
+def _is_valid_ascii_hostname(hostname: str) -> bool:
+    """Return whether a non-IP host is a conservative ASCII DNS name."""
+
+    if not hostname.isascii() or len(hostname) > 253:
+        return False
+    labels = hostname.split(".")
+    return all(
+        1 <= len(label) <= 63
+        and label[0] != "-"
+        and label[-1] != "-"
+        and all(character.isascii() and (character.isalnum() or character == "-") for character in label)
+        for label in labels
+    )
+
+
+def format_console_endpoint_preview(value: str) -> str | None:
+    """Format the safe endpoint preview used by Console default confirmation copy."""
+
+    preview = parse_console_endpoint_preview(value)
+    if preview is None:
+        return None
+    return f"{preview.authority} · {preview.network_classification}"

--- a/tldw_chatbook/Chat/console_settings_defaults.py
+++ b/tldw_chatbook/Chat/console_settings_defaults.py
@@ -18,6 +18,8 @@ from tldw_chatbook.Chat.console_provider_support import (
 )
 from tldw_chatbook.Chat.console_session_settings import (
     CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS,
+    ConsoleSessionSettings,
+    ConsoleSettingsReadiness,
     build_console_settings_readiness,
     build_target_default_console_session_settings,
     validate_console_session_settings,
@@ -30,6 +32,7 @@ from tldw_chatbook.Chat.console_settings_apply import (
     ConsoleSettingsFieldDraft,
 )
 from tldw_chatbook.Chat.provider_readiness import provider_config_key
+from tldw_chatbook.Chat.provider_setup_persistence import provider_endpoint_key
 from tldw_chatbook.model_capabilities import (
     anthropic_model_rejects_fixed_thinking_budget,
     moonshot_model_supports_reasoning_effort,
@@ -215,8 +218,7 @@ def build_console_default_intent(
 
     endpoint_patch = (
         None
-        if action is not ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT
-        or endpoint is None
+        if action is not ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT or endpoint is None
         else ConsoleEndpointPatch(
             value=endpoint.value,
             bound_provider_config_key=endpoint.bound_provider_config_key,
@@ -371,7 +373,9 @@ def _intent_fingerprint(intent: ConsoleDefaultMutationIntent) -> str:
     material = repr(
         (
             intent.generation,
-            intent.action.value if isinstance(intent.action, ConsoleSettingsAction) else "",
+            intent.action.value
+            if isinstance(intent.action, ConsoleSettingsAction)
+            else "",
             intent.provider_config_key,
             intent.literal_model_id,
             tuple(sorted(intent.field_mask)),
@@ -567,9 +571,7 @@ def prepare_console_default_intent_reservation(
                         _LATEST_INTENT_ACTION,
                         _LATEST_INTENT_LIFECYCLE,
                     ):
-                        raise RuntimeError(
-                            "Pending default runtime refresh failed"
-                        )
+                        raise RuntimeError("Pending default runtime refresh failed")
                 continue
 
         claim = _claim_runtime_publication(
@@ -860,9 +862,7 @@ def _finish_intent_failure(
         ):
             return
         if phase is ConsoleDefaultSavePhase.CACHE_PUBLICATION:
-            _LATEST_INTENT_LIFECYCLE = (
-                _IntentLifecycle.CACHE_PUBLICATION_RETRYABLE
-            )
+            _LATEST_INTENT_LIFECYCLE = _IntentLifecycle.CACHE_PUBLICATION_RETRYABLE
             if _PENDING_RETRY_STATE is not None and (
                 _PENDING_RETRY_STATE.generation == generation
                 and _PENDING_RETRY_STATE.fingerprint == fingerprint
@@ -962,9 +962,7 @@ def _capture_owned_baseline(
         for key in values
     }
     targets.update(
-        (path, key)
-        for path, keys in mutation.delete_keys.items()
-        for key in keys
+        (path, key) for path, keys in mutation.delete_keys.items() for key in keys
     )
     return tuple(
         (path, key, _raw_owned_value_digest(raw_values, path, key))
@@ -1008,14 +1006,86 @@ def _raw_provider_settings(
     return settings
 
 
-def _configured_endpoint_key(provider_settings: Mapping[str, object]) -> str | None:
-    """Return the first endpoint key already configured in authoritative TOML."""
+def _configured_endpoint_key(
+    canonical_provider: str,
+    provider_settings: Mapping[str, object],
+) -> str:
+    """Return the existing or canonical endpoint key for one provider."""
 
     for key in _ENDPOINT_KEYS:
-        value = provider_settings.get(key)
-        if isinstance(value, str) and value.strip():
+        if key in provider_settings:
             return key
-    return None
+    return provider_endpoint_key(canonical_provider)
+
+
+def _config_with_endpoint(
+    values: Mapping[str, object],
+    *,
+    section_name: str,
+    endpoint_key: str,
+    endpoint_value: str,
+) -> dict[str, object]:
+    """Return a detached config view with one prospective endpoint edit."""
+
+    result = dict(values)
+    source_api_settings = values.get("api_settings", {})
+    api_settings = (
+        dict(source_api_settings) if isinstance(source_api_settings, Mapping) else {}
+    )
+    source_provider = api_settings.get(section_name, {})
+    provider_settings = (
+        dict(source_provider) if isinstance(source_provider, Mapping) else {}
+    )
+    provider_settings[endpoint_key] = endpoint_value
+    api_settings[section_name] = provider_settings
+    result["api_settings"] = api_settings
+    return result
+
+
+def build_console_default_readiness_preview(
+    app_config: Mapping[str, object],
+    settings: ConsoleSessionSettings,
+    endpoint: ConsoleEndpointDraft,
+) -> ConsoleSettingsReadiness:
+    """Evaluate a checked endpoint edit as the future persisted configuration.
+
+    Args:
+        app_config: Current effective application configuration.
+        settings: Full Settings draft whose provider/model will become default.
+        endpoint: Explicit endpoint edit selected for persistence.
+
+    Returns:
+        Readiness for the prospective provider/model/default endpoint state.
+
+    Raises:
+        ValueError: If the endpoint edit is not checked, valid, and bound to
+            the selected provider.
+    """
+
+    canonical_provider = provider_config_key(settings.provider)
+    if not (
+        endpoint.dirty is True
+        and endpoint.checked is True
+        and provider_config_key(endpoint.bound_provider_config_key)
+        == canonical_provider
+        and parse_console_endpoint_preview(endpoint.value) is not None
+    ):
+        raise ValueError("Endpoint preview is not authorized")
+    section_name = _raw_provider_section_name(app_config, canonical_provider)
+    provider_settings = _raw_provider_settings(app_config, section_name)
+    endpoint_key = _configured_endpoint_key(canonical_provider, provider_settings)
+    preview_config = _config_with_endpoint(
+        app_config,
+        section_name=section_name,
+        endpoint_key=endpoint_key,
+        endpoint_value=endpoint.value.strip(),
+    )
+    defaults = build_target_default_console_session_settings(
+        preview_config,
+        canonical_provider,
+        settings.model,
+    )
+    return build_console_settings_readiness(defaults, app_config=preview_config)
 
 
 def _validate_intent(intent: ConsoleDefaultMutationIntent) -> tuple[str, str]:
@@ -1073,8 +1143,7 @@ def _endpoint_patch_is_authorized(
         and intent.field_mask == FULL_MODEL_DEFAULT_FIELDS
         and patch.dirty is True
         and patch.checked is True
-        and provider_config_key(patch.bound_provider_config_key)
-        == canonical_provider
+        and provider_config_key(patch.bound_provider_config_key) == canonical_provider
         and parse_console_endpoint_preview(patch.value) is not None
     )
 
@@ -1092,19 +1161,34 @@ def _build_locked_default_mutation(
         canonical_provider,
     )
     raw_provider = _raw_provider_settings(snapshot.raw_values, raw_section_name)
+    patch = intent.endpoint_patch
+    endpoint_key: str | None = None
+    readiness_config = snapshot.effective_values
+    if patch is not None:
+        endpoint_key = _configured_endpoint_key(canonical_provider, raw_provider)
+        effective_section_name = _raw_provider_section_name(
+            snapshot.effective_values,
+            canonical_provider,
+        )
+        readiness_config = _config_with_endpoint(
+            snapshot.effective_values,
+            section_name=effective_section_name,
+            endpoint_key=endpoint_key,
+            endpoint_value=patch.value.strip(),
+        )
     defaults = build_target_default_console_session_settings(
-        snapshot.effective_values,
+        readiness_config,
         canonical_provider,
         literal_model,
     )
     if intent.action is ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT:
         validation_errors = validate_console_session_settings(
             defaults,
-            app_config=snapshot.effective_values,
+            app_config=readiness_config,
         )
         readiness = build_console_settings_readiness(
             defaults,
-            app_config=snapshot.effective_values,
+            app_config=readiness_config,
         )
         if validation_errors or not readiness.native_send_supported:
             raise ValueError("Selected provider/model is not ready for new chats")
@@ -1140,11 +1224,8 @@ def _build_locked_default_mutation(
             "model": literal_model,
         }
 
-    patch = intent.endpoint_patch
     if patch is not None:
-        endpoint_key = _configured_endpoint_key(raw_provider)
-        if endpoint_key is None:
-            raise ValueError("Provider has no authoritative endpoint key to patch")
+        assert endpoint_key is not None
         section_values[("api_settings", raw_section_name)] = {
             endpoint_key: patch.value.strip()
         }
@@ -1158,7 +1239,15 @@ def _build_locked_default_mutation(
 def apply_console_default_intent(
     intent: ConsoleDefaultMutationIntent,
 ) -> ConsoleDefaultMutationOutcome:
-    """Atomically apply one exact-model default intent and publish runtime config."""
+    """Atomically apply one exact-model default intent and publish runtime config.
+
+    Args:
+        intent: Immutable, generation-fenced default mutation request.
+
+    Returns:
+        Disk replacement, runtime publication, and recovery-phase outcome for
+        this exact intent generation.
+    """
 
     try:
         canonical_provider, literal_model = _validate_intent(intent)
@@ -1196,9 +1285,7 @@ def apply_console_default_intent(
                 failure_phase=ConsoleDefaultSavePhase.BEFORE_REPLACE,
             )
         retry_state = _retry_state_for_intent(intent.generation, fingerprint)
-        captured_baselines: list[
-            tuple[tuple[tuple[str, ...], str, str], ...]
-        ] = []
+        captured_baselines: list[tuple[tuple[tuple[str, ...], str, str], ...]] = []
 
         def build_mutation(
             snapshot: config_module.AtomicLiteralMutationSnapshot,
@@ -1250,7 +1337,9 @@ def apply_console_default_intent(
                 intent.generation,
                 fingerprint,
                 phase,
-                captured_baseline=(captured_baselines[0] if captured_baselines else None),
+                captured_baseline=(
+                    captured_baselines[0] if captured_baselines else None
+                ),
                 was_retry=retry_state is not None,
             )
             return ConsoleDefaultMutationOutcome(
@@ -1316,21 +1405,15 @@ def parse_console_endpoint_preview(value: str) -> ConsoleEndpointPreview | None:
 
     if normalized_host == "localhost" or (address is not None and address.is_loopback):
         classification = "Local"
-    elif (
-        normalized_host.endswith(".local")
-        or (
-            address is not None
-            and (
-                address.is_link_local
-                or (
-                    address.version == 4
-                    and any(address in network for network in _RFC1918_NETWORKS)
-                )
-                or (
-                    address.version == 6
-                    and address in _IPV6_UNIQUE_LOCAL_NETWORK
-                )
+    elif normalized_host.endswith(".local") or (
+        address is not None
+        and (
+            address.is_link_local
+            or (
+                address.version == 4
+                and any(address in network for network in _RFC1918_NETWORKS)
             )
+            or (address.version == 6 and address in _IPV6_UNIQUE_LOCAL_NETWORK)
         )
     ):
         classification = "LAN"
@@ -1339,7 +1422,9 @@ def parse_console_endpoint_preview(value: str) -> ConsoleEndpointPreview | None:
     else:
         classification = "Remote/unknown"
 
-    rendered_host = f"[{normalized_host}]" if ":" in normalized_host else normalized_host
+    rendered_host = (
+        f"[{normalized_host}]" if ":" in normalized_host else normalized_host
+    )
     authority = rendered_host if port is None else f"{rendered_host}:{port}"
     return ConsoleEndpointPreview(authority, classification)
 
@@ -1354,7 +1439,10 @@ def _is_valid_ascii_hostname(hostname: str) -> bool:
         1 <= len(label) <= 63
         and label[0] != "-"
         and label[-1] != "-"
-        and all(character.isascii() and (character.isalnum() or character == "-") for character in label)
+        and all(
+            character.isascii() and (character.isalnum() or character == "-")
+            for character in label
+        )
         for label in labels
     )
 

--- a/tldw_chatbook/Chat/console_settings_durability.py
+++ b/tldw_chatbook/Chat/console_settings_durability.py
@@ -1,0 +1,117 @@
+"""Application-lifetime admission for Console settings durability work.
+
+The owner is intentionally UI- and persistence-neutral.  One event-loop turn
+acquires a lease before a live settings mutation and transfers that lease to a
+registered task before yielding, so shutdown can close admission without a
+check-then-register race.
+
+This is the application-lifetime coordinator required by ADR-095's
+conversation-owned settings persistence boundary; it does not own settings or
+persistence itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+from typing import TypeVar
+
+
+_T = TypeVar("_T")
+
+
+class ConsoleSettingsDurabilityLease:
+    """Opaque admission transferred from live commit to task registration."""
+
+    __slots__ = ("_owner",)
+
+    def __init__(self, owner: ConsoleSettingsDurabilityOwner) -> None:
+        self._owner = owner
+
+    def release(self) -> None:
+        """Abort an untransferred admission; repeated release is harmless."""
+
+        self._owner.release(self)
+
+
+class ConsoleSettingsDurabilityOwner:
+    """Own admitted Console settings operations until application shutdown."""
+
+    def __init__(self) -> None:
+        self._closed = False
+        self._leases: set[ConsoleSettingsDurabilityLease] = set()
+        self._tasks: set[asyncio.Task[object]] = set()
+        self._leases_changed = asyncio.Event()
+
+    @property
+    def tasks(self) -> set[asyncio.Task[object]]:
+        """Expose the live registry for lifecycle diagnostics and tests."""
+
+        return self._tasks
+
+    @property
+    def accepting(self) -> bool:
+        """Return whether a new operation may acquire admission."""
+
+        return not self._closed
+
+    def try_acquire(self) -> ConsoleSettingsDurabilityLease | None:
+        """Acquire admission synchronously in the current event-loop turn."""
+
+        if self._closed:
+            return None
+        lease = ConsoleSettingsDurabilityLease(self)
+        self._leases.add(lease)
+        return lease
+
+    def release(self, lease: ConsoleSettingsDurabilityLease) -> None:
+        """Release an untransferred lease after a rejected or failed commit."""
+
+        if lease._owner is not self:
+            raise ValueError("Console settings lease belongs to another owner")
+        if lease in self._leases:
+            self._leases.remove(lease)
+            self._leases_changed.set()
+
+    def launch(
+        self,
+        lease: ConsoleSettingsDurabilityLease,
+        awaitable: Awaitable[_T],
+        *,
+        name: str,
+    ) -> asyncio.Task[_T]:
+        """Register an admitted operation before releasing its lease."""
+
+        if lease._owner is not self or lease not in self._leases:
+            if hasattr(awaitable, "close"):
+                awaitable.close()  # type: ignore[attr-defined]
+            raise ValueError("Console settings lease is not active")
+        try:
+            task = asyncio.create_task(awaitable, name=name)
+            self._tasks.add(task)
+        except BaseException:
+            if hasattr(awaitable, "close"):
+                awaitable.close()  # type: ignore[attr-defined]
+            raise
+        finally:
+            self.release(lease)
+
+        def retire(completed: asyncio.Task[object]) -> None:
+            self._tasks.discard(completed)
+
+        task.add_done_callback(retire)
+        return task
+
+    async def close_and_drain(self) -> None:
+        """Close admission and shield-drain admitted work, including threads."""
+
+        self._closed = True
+        while self._leases:
+            self._leases_changed.clear()
+            await self._leases_changed.wait()
+        while True:
+            pending = {task for task in self._tasks if not task.done()}
+            self._tasks.intersection_update(pending)
+            if not pending:
+                return
+            await asyncio.shield(asyncio.gather(*pending, return_exceptions=True))

--- a/tldw_chatbook/UI/Console_Modules/left_rail.py
+++ b/tldw_chatbook/UI/Console_Modules/left_rail.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 
 import asyncio
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 
 from loguru import logger
@@ -56,6 +56,17 @@ from textual.widget import Widget
 from textual.widgets import Button, Static
 
 from ...Chat.console_rail_state import CONSOLE_RAIL_SECTION_IDS, ConsoleRailState
+from ...Chat.console_chat_store import (
+    ConsoleSettingsComponent,
+    ConsoleSettingsPolicyFailureLabel,
+    ConsoleSettingsPersistenceFailure,
+)
+from ...Chat.console_settings_apply import ConsoleSettingsAction
+from ...Chat.console_settings_defaults import (
+    ConsoleDefaultDurabilityState,
+    ConsoleDefaultSavePhase,
+    parse_console_endpoint_preview,
+)
 from ...Chat.console_session_settings import (
     ConsoleSettingsSummaryState,
     _summary_row_value,
@@ -95,6 +106,12 @@ from .rail_section_layout import (
 
 
 OUTER_SECTION_SCROLL_HINT = "▼ more sections — scroll"
+CONSOLE_RETRY_GENERATION_SETTINGS_ID = "console-retry-generation-settings"
+CONSOLE_RETRY_CONTEXT_SETTINGS_ID = "console-retry-context-settings"
+CONSOLE_RETRY_DEFAULT_SAVE_ID = "console-retry-default-save"
+CONSOLE_DISCARD_DEFAULT_RETRY_ID = "console-discard-default-retry"
+CONSOLE_REFRESH_RUNNING_APP_ID = "console-refresh-running-app"
+CONSOLE_DISMISS_DEFAULT_REFRESH_ID = "console-dismiss-default-refresh"
 
 CharacterAvatarBox = tuple[int, int]
 CharacterAvatarWidgetBuilder = Callable[..., Widget]
@@ -258,6 +275,13 @@ class ConsoleLeftRail(Vertical):
             Callable[[frozenset[str]], None] | None
         ) = None,
         manual_reaction_label: str | None = None,
+        settings_session_id: str | None = None,
+        settings_persistence_failures: Mapping[
+            ConsoleSettingsComponent,
+            ConsoleSettingsPersistenceFailure,
+        ]
+        | None = None,
+        default_durability_state: ConsoleDefaultDurabilityState | None = None,
         **kwargs,
     ) -> None:
         """Create the left rail from pre-computed display data.
@@ -381,6 +405,13 @@ class ConsoleLeftRail(Vertical):
             workspace_tree_expansion_preferences_changed
         )
         self._manual_reaction_label = str(manual_reaction_label or "").strip()
+        self._settings_session_id = settings_session_id
+        self._settings_persistence_failures = dict(
+            settings_persistence_failures or {}
+        )
+        self._default_durability_state = (
+            default_durability_state or ConsoleDefaultDurabilityState()
+        )
         self._active_section_id: str | None = None
         self._active_reveal_generation = 0
         self._pending_active_reveal: tuple[int, str, str | None, bool] | None = None
@@ -483,8 +514,133 @@ class ConsoleLeftRail(Vertical):
     def on_mount(self) -> None:
         """Allocate from the first complete mounted geometry snapshot."""
 
+        self.sync_model_recovery(
+            session_id=self._settings_session_id,
+            failures=self._settings_persistence_failures,
+            default_state=self._default_durability_state,
+        )
         self.request_allocation_reconcile()
         self.call_after_refresh(self._request_initial_workspace_tree_pages)
+
+    @staticmethod
+    def _default_recovery_copy(state: ConsoleDefaultDurabilityState) -> str:
+        """Return a credential-free exact-intent recovery summary."""
+
+        intent = state.recovery_intent
+        phase = state.failure_phase
+        if intent is None or phase is None:
+            return ""
+        action = (
+            "Make default for new chats"
+            if intent.action is ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT
+            else "Save as model default"
+        )
+        scope = ", ".join(sorted(intent.field_mask)) or "none"
+        phase_copy = (
+            "Not written to disk"
+            if phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+            else "Saved on disk; running app refresh failed"
+        )
+        endpoint = intent.endpoint_patch
+        preview = (
+            parse_console_endpoint_preview(endpoint.value)
+            if endpoint is not None and endpoint.dirty and endpoint.checked
+            else None
+        )
+        endpoint_copy = (
+            f" · {preview.authority} · {preview.network_classification}"
+            if preview is not None
+            else ""
+        )
+        return (
+            f"{phase_copy} · {action} · {intent.provider_config_key}/"
+            f"{intent.literal_model_id} · fields: {scope}{endpoint_copy}"
+        )
+
+    def sync_model_recovery(
+        self,
+        *,
+        session_id: str | None,
+        failures: Mapping[
+            ConsoleSettingsComponent,
+            ConsoleSettingsPersistenceFailure,
+        ],
+        default_state: ConsoleDefaultDurabilityState,
+    ) -> None:
+        """Synchronize revision-bound conversation and app recovery rows."""
+
+        self._settings_session_id = session_id
+        self._settings_persistence_failures = dict(failures)
+        self._default_durability_state = default_state
+        generation = failures.get(ConsoleSettingsComponent.GENERATION_SETTINGS)
+        context = failures.get(ConsoleSettingsComponent.CONTEXT_POLICY)
+        default_copy = self._default_recovery_copy(default_state)
+        has_warning = generation is not None or context is not None or bool(default_copy)
+
+        try:
+            title = self.query_one("#console-rail-section-title-model", Static)
+            title.update("Model ⚠" if has_warning else "Model")
+            generation_group = self.query_one("#console-generation-recovery-row")
+            context_group = self.query_one("#console-context-recovery-row")
+            default_group = self.query_one("#console-default-recovery-row")
+            generation_button = self.query_one(
+                f"#{CONSOLE_RETRY_GENERATION_SETTINGS_ID}", Button
+            )
+            context_button = self.query_one(
+                f"#{CONSOLE_RETRY_CONTEXT_SETTINGS_ID}", Button
+            )
+            retry_default = self.query_one(
+                f"#{CONSOLE_RETRY_DEFAULT_SAVE_ID}", Button
+            )
+            discard_default = self.query_one(
+                f"#{CONSOLE_DISCARD_DEFAULT_RETRY_ID}", Button
+            )
+            refresh_default = self.query_one(
+                f"#{CONSOLE_REFRESH_RUNNING_APP_ID}", Button
+            )
+            dismiss_default = self.query_one(
+                f"#{CONSOLE_DISMISS_DEFAULT_REFRESH_ID}", Button
+            )
+        except (NoMatches, QueryError):
+            return
+
+        generation_group.styles.display = "block" if generation is not None else "none"
+        context_group.styles.display = "block" if context is not None else "none"
+        default_group.styles.display = "block" if default_copy else "none"
+        if generation is not None:
+            generation_button.console_settings_session_id = session_id
+            generation_button.console_settings_revision = generation.revision
+        if context is not None:
+            context_button.console_settings_session_id = session_id
+            context_button.console_settings_revision = context.revision
+            policy_label = context.policy_failure_label
+            assert isinstance(policy_label, ConsoleSettingsPolicyFailureLabel)
+            self.query_one("#console-context-recovery-copy", Static).update(
+                f"Not saved: {policy_label.value}"
+            )
+        generation_button.disabled = generation is None
+        context_button.disabled = context is None
+
+        self.query_one("#console-default-recovery-copy", Static).update(default_copy)
+        generation_token = default_state.newest_intent_generation
+        for button in (
+            retry_default,
+            discard_default,
+            refresh_default,
+            dismiss_default,
+        ):
+            button.console_default_intent_generation = generation_token
+        before_replace = (
+            default_state.failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+        )
+        cache_failure = (
+            default_state.failure_phase is ConsoleDefaultSavePhase.CACHE_PUBLICATION
+        )
+        retry_default.styles.display = "block" if before_replace else "none"
+        discard_default.styles.display = "block" if before_replace else "none"
+        refresh_default.styles.display = "block" if cache_failure else "none"
+        dismiss_default.styles.display = "block" if cache_failure else "none"
+        self.request_allocation_reconcile()
 
     def _request_initial_workspace_tree_pages(self) -> None:
         """Route persisted/default-expanded nodes through the page loader once."""
@@ -1835,6 +1991,64 @@ class ConsoleLeftRail(Vertical):
                 markup=False,
             )
             recovery.styles.display = "none"
+            generation_recovery = Vertical(
+                Static(
+                    "Not saved: generation settings",
+                    markup=False,
+                ),
+                Button(
+                    "Retry save",
+                    id=CONSOLE_RETRY_GENERATION_SETTINGS_ID,
+                    classes="console-workspace-action",
+                    compact=True,
+                ),
+                id="console-generation-recovery-row",
+            )
+            context_recovery = Vertical(
+                Static(
+                    "Not saved: context settings",
+                    id="console-context-recovery-copy",
+                    markup=False,
+                ),
+                Button(
+                    "Retry save",
+                    id=CONSOLE_RETRY_CONTEXT_SETTINGS_ID,
+                    classes="console-workspace-action",
+                    compact=True,
+                ),
+                id="console-context-recovery-row",
+            )
+            default_recovery = Vertical(
+                Static("", id="console-default-recovery-copy", markup=False),
+                Button(
+                    "Retry default save",
+                    id=CONSOLE_RETRY_DEFAULT_SAVE_ID,
+                    classes="console-workspace-action",
+                    compact=True,
+                ),
+                Button(
+                    "Discard retry",
+                    id=CONSOLE_DISCARD_DEFAULT_RETRY_ID,
+                    classes="console-workspace-action",
+                    compact=True,
+                ),
+                Button(
+                    "Refresh running app",
+                    id=CONSOLE_REFRESH_RUNNING_APP_ID,
+                    classes="console-workspace-action",
+                    compact=True,
+                ),
+                Button(
+                    "Dismiss",
+                    id=CONSOLE_DISMISS_DEFAULT_REFRESH_ID,
+                    classes="console-workspace-action",
+                    compact=True,
+                ),
+                id="console-default-recovery-row",
+            )
+            generation_recovery.styles.display = "none"
+            context_recovery.styles.display = "none"
+            default_recovery.styles.display = "none"
 
             system_line = Static(
                 self._system_line_text,
@@ -1860,6 +2074,9 @@ class ConsoleLeftRail(Vertical):
                 rail_state.model_open,
                 *model_rows,
                 recovery,
+                generation_recovery,
+                context_recovery,
+                default_recovery,
                 system_line,
                 configure,
             )

--- a/tldw_chatbook/UI/Console_Modules/message.py
+++ b/tldw_chatbook/UI/Console_Modules/message.py
@@ -103,7 +103,7 @@ call-site edit / stays, with reasons) is in the task-1 extraction report.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import replace
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, TYPE_CHECKING
@@ -145,6 +145,7 @@ from ...Chat.console_save_targets import (
     derive_console_save_title,
     resolve_console_artifact_owner_request,
 )
+from ...Chat.console_session_settings import blank_console_session_settings
 from ...Chat.message_metadata import MessageMetadata
 from ...Chat.provider_usage import ProviderUsage
 from ...Video_Generation.video_metadata import VideoGenerationMetadata
@@ -992,12 +993,28 @@ class ConsoleMessageController:
                 # outcome could be attributed to it -- nothing to append to.
                 pass
         else:
+            creating_blank_session = store.active_session_id is None
+            app_config = getattr(self.app_instance, "app_config", {})
+            if not isinstance(app_config, Mapping):
+                app_config = {}
+            settings = blank_console_session_settings(app_config)
             session = store.ensure_session(
                 title=self._console_initial_session_title_for_workspace(
                     store.workspace_context.active_workspace_id
                 ),
                 workspace_id=store.workspace_context.active_workspace_id,
+                settings=settings,
+                canonical_settings_baseline=settings,
             )
+            if creating_blank_session:
+                generation = getattr(
+                    self.app_instance,
+                    "console_new_chat_default_generation",
+                    0,
+                )
+                session.new_chat_default_generation = (
+                    generation if type(generation) is int and generation >= 0 else 0
+                )
             store.append_message(
                 session.id,
                 role=ConsoleMessageRole.SYSTEM,

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -151,7 +151,12 @@ from ...Chat.console_chat_fork import (
     ConsoleForkImageSelectionFence,
     default_fork_title,
 )
-from ...Chat.console_chat_store import ConsoleChatSession, ConsoleChatStore
+from ...Chat.console_chat_store import (
+    ConsoleChatSession,
+    ConsoleChatStore,
+    ConsoleSettingsComponent,
+    ConsoleSettingsPersistenceFailure,
+)
 from ...Chat.console_chat_controller import (
     ProjectInstructionBindingRecovery,
     resolve_project_instruction_binding,
@@ -176,7 +181,10 @@ from ...Chat.console_roleplay_identity import (
     expand_character_template,
     normalize_chat_display_name,
 )
-from ...Chat.console_conversation_hydration import apply_resume_settings_overrides
+from ...Chat.console_conversation_hydration import (
+    ConsoleGenerationSettingsHydration,
+    hydrate_console_generation_settings,
+)
 from ...Chat.console_display_state import (
     ConsoleProjectInstructionSourceRow,
     ConsoleProjectInstructionState,
@@ -189,6 +197,7 @@ from ...Chat.console_project_instructions import (
 )
 from ...Chat.console_session_settings import (
     ConsoleSessionSettings,
+    blank_console_session_settings,
     build_default_console_session_settings,
     build_console_settings_readiness,
     default_console_session_settings,
@@ -1210,6 +1219,8 @@ class ConsoleSessionController:
             tuple[
                 ConsoleSessionSettings,
                 ConsoleSessionSettings,
+                int,
+                ConsoleSettingsPersistenceFailure | None,
                 str,
             ]
             | None
@@ -1224,12 +1235,20 @@ class ConsoleSessionController:
                     prior_active_session_id=prior_active_id,
                 )
             elif refreshed_prior is not None:
-                prior_settings, prior_baseline, prior_updated_at = refreshed_prior
+                (
+                    prior_settings,
+                    prior_baseline,
+                    prior_generation_revision,
+                    prior_generation_failure,
+                    prior_updated_at,
+                ) = refreshed_prior
                 store.rollback_pristine_session_refresh(
                     intent.session_id,
                     expected_current_settings=defaults,
                     prior_settings=prior_settings,
                     prior_canonical_settings=prior_baseline,
+                    prior_generation_revision=prior_generation_revision,
+                    prior_generation_failure=prior_generation_failure,
                     prior_updated_at=prior_updated_at,
                 )
             if not defer_presentation:
@@ -1323,7 +1342,15 @@ class ConsoleSessionController:
                     "The intended Console session now contains work. It was left unchanged.",
                 )
             if baseline != defaults:
-                refreshed_prior = (target.settings, baseline, target.updated_at)
+                refreshed_prior = (
+                    target.settings,
+                    baseline,
+                    target.generation_settings_revision,
+                    target.settings_persistence_failures.get(
+                        ConsoleSettingsComponent.GENERATION_SETTINGS
+                    ),
+                    target.updated_at,
+                )
                 store.refresh_pristine_session_settings(
                     intent.session_id,
                     prior_canonical_settings=baseline,
@@ -2699,10 +2726,12 @@ class ConsoleSessionController:
         # to the new tab instead of clobbering it.
         self._capture_console_draft_switch_snapshot()
         self._refresh_console_library_policy_defaults()
+        defaults = self._blank_console_session_settings()
         self._ensure_console_chat_controller().new_session(
-            settings=(
-                self._active_console_session_settings()
-                or self._default_console_session_settings()
+            settings=defaults,
+            canonical_settings_baseline=defaults,
+            new_chat_default_generation=(
+                self._console_new_chat_default_generation()
             ),
             ephemeral=ephemeral,
         )
@@ -2851,10 +2880,27 @@ class ConsoleSessionController:
             str(model).strip() if _has_selected_text(model) else None,
         )
 
+    def _blank_console_session_settings(self) -> ConsoleSessionSettings:
+        """Build config-owned defaults for an eligible blank Console chat."""
+        app_config = getattr(self.app_instance, "app_config", {})
+        if not isinstance(app_config, Mapping):
+            app_config = {}
+        return blank_console_session_settings(app_config)
+
+    def _console_new_chat_default_generation(self) -> int:
+        """Return the current app-owned explicit-default generation."""
+        generation = getattr(
+            self.app_instance,
+            "console_new_chat_default_generation",
+            0,
+        )
+        return generation if type(generation) is int and generation >= 0 else 0
+
     def _ensure_active_console_session_settings(self) -> ConsoleSessionSettings:
         """Ensure the active native Console session owns a settings snapshot."""
         store = self._ensure_console_chat_store()
-        defaults = self._default_console_session_settings()
+        creating_blank_session = store.active_session_id is None
+        defaults = self._blank_console_session_settings()
         # An ID-only saved-conversation resume is the authoritative startup
         # intent. Compose still needs settings to paint before its ordered
         # async opener runs, but creating a tab here would both leave an
@@ -2878,21 +2924,23 @@ class ConsoleSessionController:
             settings=defaults,
             canonical_settings_baseline=defaults,
         )
-        if session.settings is None:
-            store.replace_session_settings(
-                session.id,
-                defaults,
-                mark_user_work=False,
-                canonical_settings_baseline=defaults,
+        if creating_blank_session:
+            session.new_chat_default_generation = (
+                self._console_new_chat_default_generation()
             )
-            return defaults
-        return self._maybe_refresh_stale_default_console_settings(store, session)
+        resolved = self._maybe_refresh_stale_default_console_settings(store, session)
+        if resolved is None:
+            raise RuntimeError(
+                "Console session predates the published defaults without "
+                "creation-time settings provenance."
+            )
+        return resolved
 
     def _maybe_refresh_stale_default_console_settings(
         self,
         store: ConsoleChatStore,
         session: ConsoleChatSession,
-    ) -> ConsoleSessionSettings:
+    ) -> ConsoleSessionSettings | None:
         """Re-derive default-sourced settings for blocked, never-used sessions.
 
         First-run sessions snapshot template defaults (e.g. OpenAI without a
@@ -2906,8 +2954,13 @@ class ConsoleSessionController:
         replaced when the re-derived defaults are actually send-capable.
         """
         settings = session.settings
+        if (
+            session.new_chat_default_generation
+            < self._console_new_chat_default_generation()
+        ):
+            return settings
         if settings is None:
-            settings = self._default_console_session_settings()
+            settings = self._blank_console_session_settings()
             store.replace_session_settings(
                 session.id,
                 settings,
@@ -2932,7 +2985,13 @@ class ConsoleSessionController:
             # Unknown/WIP providers are a provider *choice* problem, not a
             # config-fixable credential/endpoint gap; never override choice.
             return settings
-        fresh_defaults = self._default_console_session_settings()
+        # Creation reads the app-owned published snapshot so an in-flight
+        # Make Default cannot leak into a new chat before runtime publication.
+        # This recovery path is different: full Settings may have updated the
+        # config cache without replacing ``app.app_config``. Reuse the fresh
+        # readiness mapping already resolved above so an eligible, unused,
+        # blocked chat still converges without an app restart (task-177).
+        fresh_defaults = blank_console_session_settings(app_config)
         if fresh_defaults == settings:
             return settings
         fresh_readiness = build_console_settings_readiness(
@@ -3004,25 +3063,12 @@ class ConsoleSessionController:
     def _console_session_settings_for_resume(
         self,
         conversation: Mapping[str, Any],
-    ) -> ConsoleSessionSettings:
-        """Return settings for a resumed session, restoring its system prompt.
-
-        Every other field is inherited from the currently active session's
-        settings (or the config-derived defaults when there is none yet);
-        only ``system_prompt`` is overridden from the persisted conversation
-        row so a saved system prompt survives close/resume even though it is
-        never seeded from ``[chat_defaults]``.
-        """
-        settings = (
-            self._active_console_session_settings()
-            or self._default_console_session_settings()
+    ) -> ConsoleGenerationSettingsHydration:
+        """Hydrate resumed settings from current config and saved metadata."""
+        return hydrate_console_generation_settings(
+            self._provider_readiness_app_config(),
+            conversation,
         )
-        # task-15860 Task 6: what the CONVERSATION ROW contributes is shared
-        # with the launch wake's viewless hydration
-        # (`Chat/console_conversation_hydration.py`); only the BASE above --
-        # the currently active session's settings -- is screen state, and a
-        # launch has no active session to inherit from.
-        return apply_resume_settings_overrides(settings, conversation)
 
     def _apply_console_session_system_prompt(
         self, system_prompt: Optional[str]
@@ -3564,7 +3610,8 @@ class ConsoleSessionController:
         forward into the new session, in order (TASK-339).
         """
         store = self._ensure_console_chat_store()
-        defaults = self._default_console_session_settings()
+        creating_blank_session = store.active_session_id is None
+        defaults = self._blank_console_session_settings()
         session = store.ensure_session(
             title=self._workspace_initial_session_title(
                 store.workspace_context.active_workspace_id
@@ -3573,6 +3620,10 @@ class ConsoleSessionController:
             settings=defaults,
             canonical_settings_baseline=defaults,
         )
+        if creating_blank_session:
+            session.new_chat_default_generation = (
+                self._console_new_chat_default_generation()
+            )
         active_session_id = session.id
         composer = self._console_composer_or_none()
         if composer is None:

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -42,9 +42,11 @@ from ...Chat.console_live_work import ConsoleLiveWorkLaunch
 from ...Chat.console_conversation_hydration import (
     ConversationLoadFailed,
     ConversationServiceUnavailable,
+    ConsoleGenerationSettingsHydration,
     hydrate_console_session,
     load_console_conversation_tree,
 )
+from ...Chat.console_session_settings import blank_console_session_settings
 from ...Chat.rag_scope import RagScope
 from ...config import save_setting_to_cli_config
 from ...Widgets.confirmation_dialog import ConfirmationDialog
@@ -782,6 +784,22 @@ class ConsoleWorkspaceController:
     @property
     def _default_console_session_settings(self) -> Any:
         return self._default_session_settings_accessor
+
+    def _blank_console_session_settings(self) -> Any:
+        """Build config-owned defaults for an eligible workspace blank chat."""
+        app_config = getattr(self.app_instance, "app_config", {})
+        if not isinstance(app_config, Mapping):
+            app_config = {}
+        return blank_console_session_settings(app_config)
+
+    def _console_new_chat_default_generation(self) -> int:
+        """Return the current app-owned explicit-default generation."""
+        generation = getattr(
+            self.app_instance,
+            "console_new_chat_default_generation",
+            0,
+        )
+        return generation if type(generation) is int and generation >= 0 else 0
 
     @property
     def _console_scope_picker_listers(self) -> Any:
@@ -3647,12 +3665,6 @@ class ConsoleWorkspaceController:
         if not target_workspace_id:
             return
         store = self._ensure_console_chat_store()
-        inherited_settings = None
-        if store.active_session_id is not None:
-            try:
-                inherited_settings = store.session_settings(store.active_session_id)
-            except KeyError:
-                inherited_settings = None
         if store.active_session_id is not None:
             for session in store.sessions():
                 if (
@@ -3674,10 +3686,15 @@ class ConsoleWorkspaceController:
                 self._sync_console_temporary_chip()
                 return
         self._capture_console_draft_switch_snapshot()
-        store.create_session(
+        defaults = self._blank_console_session_settings()
+        session = store.create_session(
             title=self._console_workspace_session_title(target_workspace_id),
             workspace_id=target_workspace_id,
-            settings=inherited_settings or self._default_console_session_settings(),
+            settings=defaults,
+            canonical_settings_baseline=defaults,
+        )
+        session.new_chat_default_generation = (
+            self._console_new_chat_default_generation()
         )
         # task-7 review: `create_session` activates the new (never
         # ephemeral -- no `ephemeral=` passed) session inline; same
@@ -4038,13 +4055,20 @@ class ConsoleWorkspaceController:
         if not isinstance(conversation, dict):
             conversation = {}
         session = None
+        hydration = self._console_session_settings_for_resume(conversation)
+        if not isinstance(hydration, ConsoleGenerationSettingsHydration):
+            raise TypeError(
+                "Console resume settings must be ConsoleGenerationSettingsHydration"
+            )
         try:
             session = await hydrate_console_session(
                 app=self.app_instance,
                 store=store,
                 conversation_id=target,
                 tree=tree,
-                settings=self._console_session_settings_for_resume(conversation),
+                settings=hydration.settings,
+                generation_durable_snapshot=hydration.durable_snapshot,
+                generation_metadata_status=hydration.metadata_status,
                 target_scope_type=target_scope_type,
                 target_workspace_id=target_workspace_id,
                 activate=False,

--- a/tldw_chatbook/UI/Library_Modules/library_notes_work_session.py
+++ b/tldw_chatbook/UI/Library_Modules/library_notes_work_session.py
@@ -1,0 +1,70 @@
+"""Pure state transitions for the Library Notes reader work session."""
+
+from enum import StrEnum
+
+
+class NotesWorkSessionPhase(StrEnum):
+    """The lifecycle phase of the Notes reader work session."""
+
+    INACTIVE = "inactive"
+    ACTIVE = "active"
+    MANUALLY_CANCELLED = "manually_cancelled"
+
+
+class NotesWorkSessionEvent(StrEnum):
+    """Explicit events that can change a Notes work-session phase."""
+
+    EDITABLE_ITEM_OPENED = "editable_item_opened"
+    MANUAL_LIBRARY_EXPAND = "manual_library_expand"
+    ITEM_CHANGED = "item_changed"
+    SELECTION_CHANGED = "selection_changed"
+    EDIT_MODE_CHANGED = "edit_mode_changed"
+    PREVIEW_MODE_CHANGED = "preview_mode_changed"
+    INFO_MODE_CHANGED = "info_mode_changed"
+    MANAGE_MODE_CHANGED = "manage_mode_changed"
+    SAVE = "save"
+    CONFLICT = "conflict"
+    RECOVERY = "recovery"
+    RESIZE = "resize"
+    FOLDER_BACK_TO_NAVIGATOR = "folder_back_to_navigator"
+    DATABASE_IDENTITY_CLEARED = "database_identity_cleared"
+    FOLDER_IDENTITY_CLEARED = "folder_identity_cleared"
+    AUTHORITY_CHANGED = "authority_changed"
+    FOLDER_ROOT_CHANGED = "folder_root_changed"
+    LEFT_NOTES = "left_notes"
+
+
+_RESET_EVENTS = frozenset(
+    {
+        NotesWorkSessionEvent.DATABASE_IDENTITY_CLEARED,
+        NotesWorkSessionEvent.FOLDER_IDENTITY_CLEARED,
+        NotesWorkSessionEvent.AUTHORITY_CHANGED,
+        NotesWorkSessionEvent.FOLDER_ROOT_CHANGED,
+        NotesWorkSessionEvent.LEFT_NOTES,
+    }
+)
+
+
+def reduce_notes_work_session(
+    phase: NotesWorkSessionPhase,
+    event: NotesWorkSessionEvent,
+    *,
+    reader_width: int | None = None,
+) -> NotesWorkSessionPhase:
+    """Return the next work-session phase for an explicit event."""
+    if event in _RESET_EVENTS:
+        return NotesWorkSessionPhase.INACTIVE
+    if event is NotesWorkSessionEvent.MANUAL_LIBRARY_EXPAND:
+        return (
+            NotesWorkSessionPhase.MANUALLY_CANCELLED
+            if phase is NotesWorkSessionPhase.ACTIVE
+            else phase
+        )
+    if (
+        event is NotesWorkSessionEvent.EDITABLE_ITEM_OPENED
+        and phase is NotesWorkSessionPhase.INACTIVE
+        and reader_width is not None
+        and reader_width >= 120
+    ):
+        return NotesWorkSessionPhase.ACTIVE
+    return phase

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1,5 +1,6 @@
 """Chat screen implementation with comprehensive state management."""
 
+from collections import deque
 from collections.abc import Awaitable, Callable, Mapping
 from collections.abc import Set as AbstractSet
 from contextlib import contextmanager
@@ -119,7 +120,15 @@ from ..Console_Modules.dispatch_recovery import ConsoleDispatchRecoveryRegion
 from ..Console_Modules.capture_policy_bindings import (
     build_inspector_capture_policy_wiring,
 )
-from ..Console_Modules.left_rail import ConsoleLeftRail
+from ..Console_Modules.left_rail import (
+    CONSOLE_DISCARD_DEFAULT_RETRY_ID,
+    CONSOLE_DISMISS_DEFAULT_REFRESH_ID,
+    CONSOLE_REFRESH_RUNNING_APP_ID,
+    CONSOLE_RETRY_CONTEXT_SETTINGS_ID,
+    CONSOLE_RETRY_DEFAULT_SAVE_ID,
+    CONSOLE_RETRY_GENERATION_SETTINGS_ID,
+    ConsoleLeftRail,
+)
 from ..Console_Modules.message import ConsoleMessageController
 from ..Console_Modules.right_rail import ConsoleInspectorRail
 from ..Console_Modules.provider_continuation_recovery import (
@@ -141,6 +150,40 @@ from ...Chat.console_chat_controller import ConsoleChatController
 from ...Chat.console_runtime import ensure_console_runtime, leave_console_runtime
 from ...Chat.console_context_policy import (
     ConsoleContextPolicyOverrides,
+)
+from ...Chat.console_settings_apply import (
+    FULL_MODEL_DEFAULT_FIELDS,
+    QUICK_MODEL_DEFAULT_FIELDS,
+    ConsoleSettingsAction,
+    ConsoleSettingsCommittedSubmission,
+    ConsoleSettingsDraftState,
+    ConsoleSettingsFieldDraft,
+    ConsoleSettingsFieldProvenance,
+    ConsoleSettingsSurface,
+    ConsoleSettingsSubmission,
+    ConsoleSettingsTransfer,
+)
+from ...Chat.console_settings_durability import (
+    ConsoleSettingsDurabilityOwner,
+)
+from ...Chat.console_settings_defaults import (
+    ConsoleDefaultDurabilityState,
+    ConsoleDefaultMutationIntent,
+    ConsoleDefaultMutationOutcome,
+    ConsoleDefaultRecoveryAction,
+    ConsoleDefaultRecoveryRequest,
+    ConsoleDefaultRuntimePublicationClaim,
+    ConsoleDefaultSavePhase,
+    abort_console_default_runtime_publication,
+    apply_console_default_intent,
+    build_console_default_intent,
+    complete_console_default_runtime_publication,
+    next_console_default_intent_generation,
+    prepare_console_default_intent_reservation,
+    prepare_console_default_runtime_publication,
+    publish_console_default_runtime_if_current,
+    refresh_console_runtime_after_saved_default,
+    reserve_console_default_intent_generation,
 )
 from ...Chat.console_roleplay_identity import (
     ChatDisplayNameError,
@@ -244,6 +287,7 @@ from ...Chat.console_session_settings import (
     build_default_console_session_settings,
     build_console_settings_readiness,
     build_console_settings_summary_state,
+    build_target_default_console_session_settings,
     unsaved_console_endpoint_warning,
 )
 from ...Chat.console_chat_store import (
@@ -252,6 +296,8 @@ from ...Chat.console_chat_store import (
     ConsoleChatStore,
     ConsoleRoleplayProjectionPersistencePlan,
     ConsoleRoleplayProjectionPersistenceResult,
+    ConsoleSettingsComponent,
+    ConsoleSettingsPolicyFailureLabel,
 )
 from ...Chat.console_provider_gateway import (
     DEFAULT_LLAMACPP_BASE_URL,
@@ -511,9 +557,7 @@ from ...Widgets.Console.console_generate_image_modal import (
 from ...Widgets.Console.console_scope_picker_modal import ConsoleScopePickerModal
 from ...Widgets.Console.console_prompt_queue_modal import ConsolePromptQueueModal
 from ...Widgets.Console.console_model_popover import (
-    CONSOLE_POPOVER_OPEN_FULL_SETTINGS,
     ConsoleModelPopover,
-    ConsoleModelPopoverResult,
 )
 from ...Widgets.Console.console_style_picker_modal import ConsoleStylePickerModal
 from ...Widgets.Console.console_setup_modal import (
@@ -545,6 +589,7 @@ if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
 
 logger = logger.bind(module="ChatScreen")
+_CONSOLE_DEFAULT_RESERVATION_ATTEMPTS = 8
 Changed = Input.Changed
 #: The Console's DEFAULT Library RAG source kinds, unchanged by RAG-44's
 #: editable toggles: this same tuple is the settings modal's default
@@ -890,92 +935,20 @@ def _apply_console_turn_undo(provider: Any, plan: _ConsoleTurnUndoPlan) -> list:
     return outcomes
 
 
-@dataclass(frozen=True, slots=True)
-class _ConsoleRoleplayWriterHandle:
-    """Screen-free bridge from one daemon writer into the owner loop."""
-
-    future: asyncio.Future[ConsoleRoleplayProjectionPersistenceResult]
-    thread: threading.Thread
-
-
-def _deliver_console_roleplay_writer_result(
-    future: asyncio.Future[ConsoleRoleplayProjectionPersistenceResult],
-    result: ConsoleRoleplayProjectionPersistenceResult | None,
-    error: BaseException | None,
-) -> None:
-    """Deliver a daemon result only while its owner loop still accepts it."""
-    if future.done() or future.cancelled():
-        return
-    if error is not None:
-        future.set_exception(error)
-    elif result is not None:
-        future.set_result(result)
-
-
-def _run_console_roleplay_projection_writer(
-    plan: ConsoleRoleplayProjectionPersistencePlan,
-    loop: asyncio.AbstractEventLoop,
-    future: asyncio.Future[ConsoleRoleplayProjectionPersistenceResult],
-) -> None:
-    """Consume one frozen plan on a daemon that cannot delay app shutdown."""
-    result: ConsoleRoleplayProjectionPersistenceResult | None = None
-    error: BaseException | None = None
-    try:
-        result = ConsoleChatStore.persist_roleplay_projection_plan(plan)
-    except BaseException as exc:  # noqa: BLE001 - delivered to owner Future
-        error = exc
-    try:
-        loop.call_soon_threadsafe(
-            _deliver_console_roleplay_writer_result,
-            future,
-            result,
-            error,
-        )
-    except RuntimeError:
-        # The screen/app may have closed its loop while this daemon was
-        # blocked in persistence. Nothing live remains to accept a result.
-        if error is not None:
-            logger.opt(exception=error).error(
-                "Detached Console roleplay projection writer failed after loop "
-                "close (session_id={}, generation={}, thread_name={}).",
-                plan.session_id,
-                plan.generation,
-                threading.current_thread().name,
-            )
-
-
-def _start_console_roleplay_projection_writer(
-    plan: ConsoleRoleplayProjectionPersistencePlan,
-) -> _ConsoleRoleplayWriterHandle:
-    """Start one immutable writer without using asyncio's default executor."""
-    loop = asyncio.get_running_loop()
-    future: asyncio.Future[ConsoleRoleplayProjectionPersistenceResult] = (
-        loop.create_future()
-    )
-    thread = threading.Thread(
-        target=_run_console_roleplay_projection_writer,
-        args=(plan, loop, future),
-        name=f"console-roleplay-writer-{plan.generation}",
-        daemon=True,
-    )
-    thread.start()
-    return _ConsoleRoleplayWriterHandle(future=future, thread=thread)
-
-
 def _consume_console_roleplay_writer_completion(
-    task: asyncio.Future[ConsoleRoleplayProjectionPersistenceResult],
+    task: asyncio.Task[ConsoleRoleplayProjectionPersistenceResult | None],
     *,
     session_id: str,
     generation: int,
 ) -> None:
-    """Consume an abandoned immutable writer result or exception statically."""
+    """Consume an app-owned serializer result without retaining its screen."""
     if task.cancelled():
         return
     try:
         task.result()
     except Exception:
         logger.exception(
-            "Detached Console roleplay projection writer failed "
+            "App-owned Console roleplay projection writer failed "
             "(session_id={}, generation={}).",
             session_id,
             generation,
@@ -2131,40 +2104,473 @@ class ChatScreen(BaseAppScreen):
         self._console_worldbook_dialog_active = True
         self.run_worker(self._console_worldbook_detach_worker(), group="console-io")
 
+    @staticmethod
+    def _console_settings_initial_draft(
+        settings: ConsoleSessionSettings,
+        context_policy: ConsoleContextPolicyOverrides,
+        *,
+        exposed_fields: frozenset[str],
+    ) -> ConsoleSettingsDraftState:
+        """Build one process-local transaction from an exact live snapshot."""
+
+        return ConsoleSettingsDraftState(
+            settings=settings,
+            context_policy_overrides=context_policy,
+            field_drafts=tuple(
+                ConsoleSettingsFieldDraft(
+                    name=name,
+                    effective_value=getattr(settings, name),
+                    profile_override=getattr(settings, name),
+                    provenance=ConsoleSettingsFieldProvenance.INHERITED,
+                    dirty=False,
+                )
+                for name in sorted(exposed_fields)
+            ),
+            model_drafts=(),
+            endpoint_draft=None,
+        )
+
+    def _console_default_durability_state(self) -> ConsoleDefaultDurabilityState:
+        """Return the single app-lifetime default recovery holder."""
+
+        state = getattr(
+            self.app_instance,
+            "console_default_durability_state",
+            None,
+        )
+        if not isinstance(state, ConsoleDefaultDurabilityState):
+            state = ConsoleDefaultDurabilityState()
+            self.app_instance.console_default_durability_state = state
+        if type(
+            getattr(self.app_instance, "console_new_chat_default_generation", None)
+        ) is not int:
+            self.app_instance.console_new_chat_default_generation = 0
+        return state
+
+    def _console_default_readiness(
+        self,
+        provider: str,
+        model: str | None,
+    ) -> ConsoleSettingsReadiness:
+        """Resolve future-chat readiness through the target default chain."""
+
+        app_config = self._provider_readiness_app_config()
+        settings = build_target_default_console_session_settings(
+            app_config,
+            provider,
+            model,
+        )
+        return build_console_settings_readiness(settings, app_config=app_config)
+
+    def _commit_console_settings_submission_live(
+        self,
+        submission: ConsoleSettingsSubmission,
+    ):
+        """Revalidate/rebase and commit one exact-origin submission live."""
+
+        owner = ChatScreen._console_settings_durability_owner(self)
+        admission = owner.try_acquire()
+        if admission is None:
+            raise ValueError("Application is closing; nothing applied.")
+        controller = self._ensure_console_chat_controller()
+        try:
+            exposed_fields = frozenset(
+                field.name for field in submission.draft.field_drafts
+            )
+            rebased = controller.rebase_console_settings_draft(
+                submission.draft,
+                provider=submission.draft.settings.provider,
+                model=submission.draft.settings.model,
+                app_config=self._provider_readiness_app_config(),
+                exposed_fields=exposed_fields,
+            )
+            if submission.surface is ConsoleSettingsSurface.QUICK_POPOVER:
+                # Rebasing restores the config-owned endpoint draft. Quick
+                # settings may use that endpoint live, but must never turn it
+                # into a default-persistence intent.
+                rebased = replace(
+                    rebased,
+                    model_drafts=tuple(
+                        replace(model_draft, endpoint_draft=None)
+                        for model_draft in rebased.model_drafts
+                    ),
+                    endpoint_draft=None,
+                )
+            live_commit = self._ensure_console_chat_store().commit_console_settings_live(
+                replace(submission, draft=rebased)
+            )
+        except BaseException:
+            owner.release(admission)
+            raise
+        return replace(live_commit, durability_admission=admission)
+
+    def _console_settings_durability_owner(self) -> ConsoleSettingsDurabilityOwner:
+        """Return the app-owned settings admission and task registry."""
+
+        app_instance = self.app_instance
+        owner = getattr(app_instance, "console_settings_durability_owner", None)
+        if not isinstance(owner, ConsoleSettingsDurabilityOwner):
+            owner = ConsoleSettingsDurabilityOwner()
+            app_instance.console_settings_durability_owner = owner
+            app_instance.console_settings_durability_tasks = owner.tasks
+        return owner
+
+    def _reserve_console_default_intent(
+        self,
+        submission: ConsoleSettingsSubmission,
+    ) -> ConsoleDefaultMutationIntent:
+        """Synchronously reserve an intent for non-production callers/tests."""
+
+        if submission.action is ConsoleSettingsAction.APPLY_TO_CHAT:
+            raise ValueError("Apply to chat does not create a default intent")
+        state = self._console_default_durability_state()
+        generation = next_console_default_intent_generation(
+            state.newest_intent_generation
+        )
+        for _attempt in range(_CONSOLE_DEFAULT_RESERVATION_ATTEMPTS):
+            intent = build_console_default_intent(
+                generation=generation,
+                action=submission.action,
+                provider_config_key=provider_config_key(
+                    submission.draft.settings.provider
+                ),
+                literal_model_id=str(submission.draft.settings.model or ""),
+                field_drafts=submission.draft.field_drafts,
+                field_mask=submission.default_field_mask,
+                endpoint=submission.draft.endpoint_draft,
+            )
+            if reserve_console_default_intent_generation(
+                intent,
+                pending_runtime_publisher=(
+                    self._accept_console_default_runtime_publication
+                ),
+            ):
+                break
+            generation = next_console_default_intent_generation(generation)
+        else:
+            raise RuntimeError("Console default reservation changed repeatedly")
+        self.app_instance.console_default_durability_state = (
+            ConsoleDefaultDurabilityState(newest_intent_generation=generation)
+        )
+        return intent
+
+    async def _reserve_console_default_intent_off_event_loop(
+        self,
+        submission: ConsoleSettingsSubmission,
+    ) -> ConsoleDefaultMutationIntent:
+        """Serialize one reservation with every app-level claim publication."""
+
+        if submission.action is ConsoleSettingsAction.APPLY_TO_CHAT:
+            raise ValueError("Apply to chat does not create a default intent")
+        async with ChatScreen._console_default_operation_lock(self):
+            return await ChatScreen._reserve_console_default_intent_locked(
+                self,
+                submission,
+            )
+
+    def _console_default_operation_lock(self) -> asyncio.Lock:
+        """Return the one app-lifetime serializer for claim UI operations."""
+
+        app_instance = self.app_instance
+        operation_lock = getattr(
+            app_instance,
+            "console_default_operation_lock",
+            None,
+        )
+        if not isinstance(operation_lock, asyncio.Lock):
+            operation_lock = asyncio.Lock()
+            app_instance.console_default_operation_lock = operation_lock
+        return operation_lock
+
+    async def _reserve_console_default_intent_locked(
+        self,
+        submission: ConsoleSettingsSubmission,
+    ) -> ConsoleDefaultMutationIntent:
+        """Reserve while the caller owns the non-reentrant operation lock."""
+
+        app_instance = self.app_instance
+        state = self._console_default_durability_state()
+        generation = await asyncio.to_thread(
+            next_console_default_intent_generation,
+            state.newest_intent_generation,
+        )
+
+        for _attempt in range(_CONSOLE_DEFAULT_RESERVATION_ATTEMPTS):
+            intent = build_console_default_intent(
+                generation=generation,
+                action=submission.action,
+                provider_config_key=provider_config_key(
+                    submission.draft.settings.provider
+                ),
+                literal_model_id=str(submission.draft.settings.model or ""),
+                field_drafts=submission.draft.field_drafts,
+                field_mask=submission.default_field_mask,
+                endpoint=submission.draft.endpoint_draft,
+            )
+            (
+                preparation,
+                cancelled,
+            ) = await ChatScreen._run_console_default_worker_settled(
+                self,
+                prepare_console_default_intent_reservation,
+                intent,
+            )
+            if preparation.reserved:
+                app_instance.console_default_durability_state = (
+                    ConsoleDefaultDurabilityState(
+                        newest_intent_generation=generation
+                    )
+                )
+                if cancelled:
+                    raise asyncio.CancelledError
+                return intent
+            claim = preparation.predecessor_claim
+            if claim is None:
+                if cancelled:
+                    raise asyncio.CancelledError
+                generation = await asyncio.to_thread(
+                    next_console_default_intent_generation,
+                    generation,
+                )
+                continue
+            if cancelled:
+                await ChatScreen._run_console_default_worker_settled(
+                    self,
+                    abort_console_default_runtime_publication,
+                    claim,
+                )
+                raise asyncio.CancelledError
+            try:
+                published = self._accept_console_default_runtime_publication(
+                    claim.intent_generation,
+                    claim.action,
+                    claim.settings_view,
+                )
+            except Exception:
+                published = False
+            if not published:
+                await ChatScreen._run_console_default_worker_settled(
+                    self,
+                    abort_console_default_runtime_publication,
+                    claim,
+                )
+                raise RuntimeError("Pending default publication was rejected")
+            (
+                completed,
+                cancelled,
+            ) = await ChatScreen._run_console_default_worker_settled(
+                self,
+                complete_console_default_runtime_publication,
+                claim,
+                successor_intent=intent,
+            )
+            if completed:
+                app_instance.console_default_durability_state = (
+                    ConsoleDefaultDurabilityState(
+                        newest_intent_generation=generation
+                    )
+                )
+                if cancelled:
+                    raise asyncio.CancelledError
+                return intent
+            if cancelled:
+                raise asyncio.CancelledError
+            generation = await asyncio.to_thread(
+                next_console_default_intent_generation,
+                generation,
+            )
+        raise RuntimeError("Console default reservation changed repeatedly")
+
+    async def _run_console_default_worker_settled(
+        self,
+        callback: Callable[..., object],
+        *args: object,
+        **kwargs: object,
+    ) -> tuple[object, bool]:
+        """Await a mutating worker to completion before exposing cancellation."""
+
+        worker = asyncio.create_task(
+            asyncio.to_thread(partial(callback, *args, **kwargs))
+        )
+        cancelled = False
+        while True:
+            try:
+                return await asyncio.shield(worker), cancelled
+            except asyncio.CancelledError:
+                cancelled = True
+
+    async def _publish_console_default_outcome_off_event_loop(
+        self,
+        intent: ConsoleDefaultMutationIntent,
+        outcome: ConsoleDefaultMutationOutcome,
+    ) -> bool:
+        """Serialize one publication with reservation and recovery claims."""
+
+        async with ChatScreen._console_default_operation_lock(self):
+            return await ChatScreen._publish_console_default_outcome_locked(
+                self,
+                intent,
+                outcome,
+            )
+
+    async def _publish_console_default_outcome_locked(
+        self,
+        intent: ConsoleDefaultMutationIntent,
+        outcome: ConsoleDefaultMutationOutcome,
+    ) -> bool:
+        """Publish while the caller owns the non-reentrant operation lock."""
+
+        for _attempt in range(_CONSOLE_DEFAULT_RESERVATION_ATTEMPTS):
+            claim, cancelled = await ChatScreen._run_console_default_worker_settled(
+                self,
+                prepare_console_default_runtime_publication,
+                intent,
+                outcome,
+            )
+            if claim is None:
+                if cancelled:
+                    raise asyncio.CancelledError
+                return False
+            if not isinstance(claim, ConsoleDefaultRuntimePublicationClaim):
+                raise RuntimeError("Default runtime publication claim is invalid")
+            if cancelled:
+                await ChatScreen._run_console_default_worker_settled(
+                    self,
+                    abort_console_default_runtime_publication,
+                    claim,
+                )
+                raise asyncio.CancelledError
+            try:
+                published = self._accept_console_default_runtime_publication(
+                    claim.intent_generation,
+                    claim.action,
+                    claim.settings_view,
+                )
+            except Exception:
+                published = False
+            if not published:
+                await ChatScreen._run_console_default_worker_settled(
+                    self,
+                    abort_console_default_runtime_publication,
+                    claim,
+                )
+                return False
+            completed, cancelled = await ChatScreen._run_console_default_worker_settled(
+                self,
+                complete_console_default_runtime_publication,
+                claim,
+            )
+            if completed:
+                if cancelled:
+                    raise asyncio.CancelledError
+                return True
+            if cancelled:
+                raise asyncio.CancelledError
+        raise RuntimeError("Default runtime publication changed repeatedly")
+
+    def _publish_console_default_outcome(
+        self,
+        intent: ConsoleDefaultMutationIntent,
+        outcome: ConsoleDefaultMutationOutcome,
+    ) -> bool:
+        """Publish a fresh runtime mapping once for the newest intent."""
+
+        return publish_console_default_runtime_if_current(
+            intent,
+            outcome,
+            lambda settings_view: self._accept_console_default_runtime_publication(
+                intent.generation,
+                intent.action,
+                settings_view,
+            ),
+        )
+
+    def _accept_console_default_runtime_publication(
+        self,
+        intent_generation: int,
+        action: ConsoleSettingsAction,
+        settings_view: Mapping[str, object],
+    ) -> bool:
+        """Install one app view while the defaults service fences reservations."""
+
+        state = self._console_default_durability_state()
+        if intent_generation != state.newest_intent_generation:
+            return False
+        try:
+            self.app_instance.app_config = settings_view
+        except Exception:
+            return False
+        if state.runtime_published_intent_generation == intent_generation:
+            return True
+        next_state, accepted = state.accept_runtime_publication(intent_generation)
+        if not accepted:
+            return False
+        self.app_instance.console_default_durability_state = next_state
+        if action is ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT:
+            self.app_instance.console_new_chat_default_generation += 1
+        return True
+
     async def _open_console_settings(
         self,
         *,
         focus_model: bool = False,
         focus_context: bool = False,
+        transfer: ConsoleSettingsTransfer | None = None,
     ) -> None:
         """Open Console session settings for the active native session."""
-        settings = self._session._ensure_active_console_session_settings()
         controller = self._ensure_console_chat_controller()
         store = self._ensure_console_chat_store()
-        session_id = store.active_session_id
-        if session_id is None:
+        if transfer is None:
+            session_id = store.active_session_id
+            if session_id is None:
+                return
+            origin = store.capture_console_settings_origin(session_id)
+            settings = store.session_settings(session_id)
+            if settings is None:
+                return
+            initial_draft = self._console_settings_initial_draft(
+                settings,
+                store.session_context_policy_overrides(session_id),
+                exposed_fields=FULL_MODEL_DEFAULT_FIELDS,
+            )
+        else:
+            origin = transfer.origin
+            session_id = origin.session_id
+            settings = transfer.draft.settings
+            initial_draft = transfer.draft
+        try:
+            display_name = store.session_user_display_name_override(session_id)
+        except KeyError:
             return
-        session = store.switch_session(session_id)
-        origin_system_prompt = settings.system_prompt
-        context_estimate = self._active_console_settings_context_estimate()
         effective_thinking_policy = (
             await controller.effective_thinking_history_policy_for_session(session_id)
         )
+        context_estimate = self._console_settings_context_estimate_for_session(
+            session_id,
+            settings=settings,
+        )
+        context_state = self._console_context_control_state_for_session(
+            session_id,
+            estimate=context_estimate,
+            settings=settings,
+            thinking_history_effective_policy=effective_thinking_policy,
+        )
+        providers_models = await self._providers_models_for_console_settings(
+            settings.provider,
+            current_model=settings.model,
+        )
         modal = ConsoleSettingsModal(
             settings=settings,
-            user_display_name_override=session.user_display_name_override,
+            origin=origin,
+            initial_draft=initial_draft,
+            transfer=transfer,
+            user_display_name_override=display_name,
             global_user_display_name=self._global_chat_display_name(),
             app_config=self._provider_readiness_app_config(),
-            providers_models=await self._providers_models_for_console_settings(
-                settings.provider,
-                current_model=settings.model,
-            ),
+            providers_models=providers_models,
             context_estimate=context_estimate,
-            context_state=self._active_console_context_control_state(
-                estimate=context_estimate,
-                thinking_history_effective_policy=effective_thinking_policy,
-            ),
-            can_save=controller.run_state.is_send_allowed,
+            context_state=context_state,
+            can_save=controller.run_state_for(session_id).is_send_allowed,
             focus_model=focus_model,
             focus_context=focus_context,
             reset_current_memory=lambda: controller.reset_active_context_memory(
@@ -2175,14 +2581,15 @@ class ChatScreen(BaseAppScreen):
                 session_id
             ),
             compact_now=lambda: controller.compact_context_now(session_id),
+            draft_rebaser=controller.rebase_console_settings_draft,
+            live_committer=self._commit_console_settings_submission_live,
+            default_readiness_resolver=self._console_default_readiness,
+            default_durability_state=self._console_default_durability_state(),
+            default_recovery_handler=self._handle_console_default_recovery,
         )
 
-        def apply_origin_result(result: ConsoleSettingsResult | None) -> None:
-            self._apply_console_settings_result(
-                result,
-                origin_session_id=session_id,
-                origin_system_prompt=origin_system_prompt,
-            )
+        def apply_origin_result(result) -> None:
+            self._dispatch_console_settings_submission(result)
 
         self.app.push_screen(modal, callback=apply_origin_result)
 
@@ -2366,8 +2773,17 @@ class ChatScreen(BaseAppScreen):
                 self._console_roleplay_repair_plan = None
                 self._console_roleplay_repair_inflight_generation = 0
             return
-        writer = _start_console_roleplay_projection_writer(plan)
-        persistence_task = writer.future
+        owner = ChatScreen._console_settings_durability_owner(self)
+        admission = owner.try_acquire()
+        if admission is None:
+            return
+        persistence_task = owner.launch(
+            admission,
+            store.persist_roleplay_projection_plan_serialized(plan),
+            name=(
+                f"console-roleplay-{plan.session_id}-{plan.generation}"
+            ),
+        )
         persistence_task.add_done_callback(
             partial(
                 _consume_console_roleplay_writer_completion,
@@ -2376,20 +2792,28 @@ class ChatScreen(BaseAppScreen):
             )
         )
         self._console_roleplay_writer_task = persistence_task
-        self._console_roleplay_writer_thread = writer.thread
         try:
             result = await asyncio.shield(persistence_task)
         except asyncio.CancelledError:
-            # Unmount may abandon the screen-owned drain while the immutable
-            # writer continues. Its static callback consumes completion
-            # without retaining this screen or its live store.
+            # Unmount abandons only the screen waiter; the app owner keeps and
+            # drains the durable task. Mounted cancellation continues to wait
+            # so the latest coalesced refresh is not lost.
             if self._console_roleplay_tearing_down:
                 raise
-            result = await persistence_task
+            while not persistence_task.done():
+                try:
+                    await asyncio.shield(persistence_task)
+                except asyncio.CancelledError:
+                    continue
+            result = persistence_task.result()
         finally:
             if self._console_roleplay_writer_task is persistence_task:
                 self._console_roleplay_writer_task = None
-                self._console_roleplay_writer_thread = None
+        if result is None:
+            if self._console_roleplay_repair_plan is plan:
+                self._console_roleplay_repair_plan = None
+                self._console_roleplay_repair_inflight_generation = 0
+            return
         accepted = store.accept_roleplay_projection_persistence_result(result)
         if self._console_roleplay_repair_plan is plan:
             repair_generation = self._console_roleplay_repair_inflight_generation
@@ -2526,7 +2950,7 @@ class ChatScreen(BaseAppScreen):
         )
 
     async def _teardown_console_roleplay_persistence(self) -> None:
-        """Bound screen-owned teardown while a static immutable writer lingers."""
+        """Bound screen teardown while app-owned immutable durability continues."""
         self._console_roleplay_tearing_down = True
         task = self._console_roleplay_persistence_task
         if task is None or task.done():
@@ -2543,7 +2967,6 @@ class ChatScreen(BaseAppScreen):
             self._console_roleplay_active_plan = None
             self._console_roleplay_pending_plan = None
             self._console_roleplay_writer_task = None
-            self._console_roleplay_writer_thread = None
             self._console_roleplay_drain_scheduled = False
             return
         try:
@@ -2576,7 +2999,6 @@ class ChatScreen(BaseAppScreen):
             self._console_roleplay_active_plan = None
             self._console_roleplay_pending_plan = None
             self._console_roleplay_writer_task = None
-            self._console_roleplay_writer_thread = None
             self._console_roleplay_drain_scheduled = False
 
     def _start_console_roleplay_persistence_drain(self) -> None:
@@ -3107,66 +3529,585 @@ class ChatScreen(BaseAppScreen):
         """Open the Alt+M quick provider/model/temperature/streaming popover."""
         if self._console_setup_modal_blocking():
             return
-        settings = self._session._ensure_active_console_session_settings()
+        store = self._ensure_console_chat_store()
+        session_id = store.active_session_id
+        if session_id is None:
+            return
+        origin = store.capture_console_settings_origin(session_id)
+        settings = store.session_settings(session_id)
+        if settings is None:
+            return
+        context_policy = store.session_context_policy_overrides(session_id)
+        session = store.switch_session(session_id)
+        initial_draft = self._console_settings_initial_draft(
+            settings,
+            context_policy,
+            exposed_fields=QUICK_MODEL_DEFAULT_FIELDS,
+        )
         providers_models = await self._providers_models_for_console_settings(
             settings.provider,
             current_model=settings.model,
         )
-        store = self._ensure_console_chat_store()
-        session_id = store.active_session_id
-        effective_thinking_policy = (
-            await self._ensure_console_chat_controller().effective_thinking_history_policy_for_session(
-                session_id
-            )
-            if session_id is not None
-            else "auto"
+        effective_thinking_policy = await (
+            self._ensure_console_chat_controller()
+            .effective_thinking_history_policy_for_session(origin.session_id)
+        )
+        context_state = self._console_context_control_state_for_session(
+            origin.session_id,
+            settings=settings,
+            thinking_history_effective_policy=effective_thinking_policy,
         )
         self.app.push_screen(
             ConsoleModelPopover(
-                settings=settings,
+                origin=origin,
+                app_config=self._provider_readiness_app_config(),
+                initial_draft=initial_draft,
                 providers_models=providers_models,
-                context_state=self._active_console_context_control_state(
-                    thinking_history_effective_policy=effective_thinking_policy,
+                context_state=context_state,
+                scope_copy="Applies to this conversation",
+                durability_copy=(
+                    "Temporary until this chat is promoted"
+                    if session.ephemeral
+                    else "Saved with the conversation after its first message"
+                    if session.persisted_conversation_id is None
+                    else "Saved with this conversation"
                 ),
+                draft_rebaser=(
+                    self._ensure_console_chat_controller().rebase_console_settings_draft
+                ),
+                live_committer=self._commit_console_settings_submission_live,
+                default_readiness_resolver=self._console_default_readiness,
             ),
             callback=self._apply_console_model_popover_result,
         )
 
     def _apply_console_model_popover_result(
         self,
-        result: "ConsoleModelPopoverResult | ConsoleSessionSettings | str | None",
+        result: object,
     ) -> None:
-        """Apply the popover result: sentinel opens full settings, else replaces settings.
-
-        Args:
-            result: Popover result, full-settings sentinel, or ``None`` on cancel.
-        """
+        """Route a typed quick-settings result through the shared coordinator."""
         if result is None:
             return
-        if result == CONSOLE_POPOVER_OPEN_FULL_SETTINGS:
+        if isinstance(result, ConsoleSettingsTransfer):
             self.run_worker(
-                self._open_console_settings(focus_context=True), exclusive=False
+                self._open_console_settings(focus_model=True, transfer=result),
+                exclusive=False,
             )
             return
-        if isinstance(result, ConsoleModelPopoverResult):
-            store = self._ensure_console_chat_store()
-            session_id = store.active_session_id
-            if session_id is None:
-                return
-            current = store.session_context_policy_overrides(session_id)
-            overrides = replace(current, compaction_mode=result.compaction_mode)
-            _session, persisted = store.set_session_context_policy_overrides(
-                session_id, overrides
+        self._dispatch_console_settings_submission(result)
+
+    def _launch_console_settings_durability_task(
+        self,
+        committed: ConsoleSettingsCommittedSubmission,
+        default_intent: ConsoleDefaultMutationIntent | None,
+    ) -> asyncio.Task[None] | None:
+        """Launch post-close durability under the application lifetime."""
+
+        owner = ChatScreen._console_settings_durability_owner(self)
+        admission = committed.live_commit.durability_admission
+        if admission is None:
+            admission = owner.try_acquire()
+        if admission is None:
+            logger.warning(
+                "Console settings durability rejected after shutdown admission closed"
             )
-            if not persisted:
+            return None
+        task = owner.launch(
+            admission,
+            self._coordinate_console_settings_submission(
+                committed,
+                default_intent,
+            ),
+            name=f"console-settings-{committed.submission.submission_id}",
+        )
+
+        def report_failure(completed: asyncio.Task[None]) -> None:
+            if completed.cancelled():
+                return
+            error = completed.exception()
+            if error is not None:
+                logger.opt(exception=error).error(
+                    "Console settings app-owned durability task failed"
+                )
+
+        task.add_done_callback(report_failure)
+        return task
+
+    def _dispatch_console_settings_submission(self, result: object) -> None:
+        """Refresh live UI and launch durability exactly once per submission."""
+
+        if not isinstance(result, ConsoleSettingsCommittedSubmission):
+            return
+        owner = ChatScreen._console_settings_durability_owner(self)
+        admission = result.live_commit.durability_admission
+        if admission is None:
+            admission = owner.try_acquire()
+            if admission is None:
+                return
+            result = replace(
+                result,
+                live_commit=replace(
+                    result.live_commit,
+                    durability_admission=admission,
+                ),
+            )
+        submission_id = result.submission.submission_id
+        coordinated = getattr(
+            self,
+            "_console_settings_coordinated_submission_ids",
+            None,
+        )
+        if not isinstance(coordinated, deque):
+            coordinated = deque(maxlen=64)
+            self._console_settings_coordinated_submission_ids = coordinated
+        if submission_id in coordinated:
+            if admission is not None:
+                owner.release(admission)
+            return
+        coordinated.append(submission_id)
+
+        try:
+            task = self._launch_console_settings_durability_task(result, None)
+        except BaseException:
+            owner.release(admission)
+            raise
+        if task is None:
+            return
+        store = self._ensure_console_chat_store()
+        if store.active_session_id == result.live_commit.session_id:
+            self._sync_console_identity_surfaces()
+            self.run_worker(
+                self._sync_native_console_chat_ui(),
+                exclusive=True,
+                group="console-sync",
+            )
+        self.app_instance.notify("This chat updated", severity="success")
+
+    async def _coordinate_console_settings_submission(
+        self,
+        committed: ConsoleSettingsCommittedSubmission,
+        default_intent: ConsoleDefaultMutationIntent | None,
+    ) -> None:
+        """Publish independent conversation and default durability outcomes."""
+
+        store = self._ensure_console_chat_store()
+        submission = committed.submission
+        full_settings_submission = (
+            submission.surface is ConsoleSettingsSurface.FULL_SETTINGS
+        )
+        policy_failure_label = (
+            ConsoleSettingsPolicyFailureLabel.CONTEXT_SETTINGS
+            if full_settings_submission
+            else ConsoleSettingsPolicyFailureLabel.COMPACTION
+        )
+        display_name_plan: ConsoleRoleplayProjectionPersistencePlan | None = None
+        display_name_prepare_failed = False
+        if full_settings_submission:
+            try:
+                _session, display_name_plan = (
+                    store.prepare_session_user_display_name_override_for_commit(
+                        committed.live_commit,
+                        submission.user_display_name_override,
+                        global_default=self._global_chat_display_name(),
+                    )
+                )
+            except Exception:
+                logger.exception(
+                    "Console settings display-name preparation failed"
+                )
+                display_name_prepare_failed = True
+
+        async def persist_display_name() -> None:
+            if not full_settings_submission:
+                return
+            if display_name_prepare_failed:
                 self.app_instance.notify(
-                    "Compaction policy applied in memory but could not be saved.",
+                    "Name changed for this session, but it may not survive reopening.",
                     severity="warning",
                 )
-            result = result.settings
-        # Popover results are explicit user selections; protect from refresh.
-        self._session._replace_active_console_session_settings(
-            replace(result, source="user")
+                return
+            if display_name_plan is None:
+                return
+            try:
+                result = await store.persist_roleplay_projection_plan_serialized(
+                    display_name_plan,
+                )
+            except Exception:
+                logger.exception(
+                    "Console settings display-name persistence failed"
+                )
+                self.app_instance.notify(
+                    "Name changed for this session, but it may not survive reopening.",
+                    severity="warning",
+                )
+                return
+            if result is None:
+                return
+            accepted = store.accept_roleplay_projection_persistence_result(result)
+            if not accepted:
+                return
+            if store.active_session_id == display_name_plan.session_id:
+                self._sync_console_identity_surfaces()
+            if not result.persisted:
+                self.app_instance.notify(
+                    "Name changed for this session, but it may not survive reopening.",
+                    severity="warning",
+                )
+
+        async def persist_conversation() -> None:
+            try:
+                await store.persist_console_settings_commit_serialized(
+                    committed.live_commit,
+                    policy_failure_label=policy_failure_label,
+                )
+            except Exception:
+                logger.exception("Console settings conversation persistence failed")
+            finally:
+                self._sync_console_settings_recovery_surfaces()
+
+        async def persist_default() -> None:
+            intent = default_intent
+            if (
+                intent is None
+                and submission.action is ConsoleSettingsAction.APPLY_TO_CHAT
+            ):
+                return
+            if intent is None:
+                try:
+                    intent = await self._reserve_console_default_intent_off_event_loop(
+                        submission
+                    )
+                except Exception:
+                    logger.exception("Console default reservation failed")
+                    self._sync_console_settings_recovery_surfaces()
+                    recovery = self._console_default_durability_state()
+                    recovery_copy = (
+                        "the previous default recovery remains available."
+                        if recovery.recovery_intent is not None
+                        else "try this default action again."
+                    )
+                    self.app_instance.notify(
+                        "Default not saved for "
+                        f"{provider_config_key(submission.draft.settings.provider)}/"
+                        f"{submission.draft.settings.model}; {recovery_copy}",
+                        severity="warning",
+                    )
+                    return
+            try:
+                outcome = await asyncio.to_thread(
+                    apply_console_default_intent,
+                    intent,
+                )
+            except Exception:
+                logger.exception("Console default persistence failed")
+                self._record_console_default_failure(
+                    intent,
+                    ConsoleDefaultSavePhase.BEFORE_REPLACE,
+                )
+                return
+            try:
+                published = await self._publish_console_default_outcome_off_event_loop(
+                    intent,
+                    outcome,
+                )
+            except Exception:
+                logger.exception("Console default runtime publication failed")
+                published = False
+            if published:
+                scope = (
+                    "Eligible new-chat default saved"
+                    if intent.action
+                    is ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT
+                    else "Model profile default saved"
+                )
+                self.app_instance.notify(
+                    f"{scope}: {intent.provider_config_key}/"
+                    f"{intent.literal_model_id}",
+                    severity="success",
+                )
+            elif outcome.failure_phase is not None:
+                self._record_console_default_failure(
+                    intent,
+                    outcome.failure_phase,
+                )
+            elif outcome.runtime_published and outcome.settings_view is not None:
+                self._record_console_default_failure(
+                    intent,
+                    ConsoleDefaultSavePhase.CACHE_PUBLICATION,
+                )
+
+        await asyncio.gather(
+            persist_conversation(),
+            persist_default(),
+            persist_display_name(),
+        )
+
+    def _record_console_default_failure(
+        self,
+        intent: ConsoleDefaultMutationIntent,
+        phase: ConsoleDefaultSavePhase,
+    ) -> None:
+        """Retain only a current app-global recovery record."""
+
+        state = self._console_default_durability_state()
+        if state.newest_intent_generation != intent.generation:
+            return
+        self.app_instance.console_default_durability_state = (
+            ConsoleDefaultDurabilityState(
+                newest_intent_generation=intent.generation,
+                recovery_intent=intent,
+                failure_phase=phase,
+                runtime_published_intent_generation=(
+                    state.runtime_published_intent_generation
+                ),
+            )
+        )
+        self._sync_console_settings_recovery_surfaces()
+
+    async def _handle_console_default_recovery(
+        self,
+        request: ConsoleDefaultRecoveryRequest,
+    ) -> ConsoleDefaultDurabilityState:
+        """Admit and execute one generation-bound app-global recovery."""
+
+        state = self._console_default_durability_state()
+        if not isinstance(request, ConsoleDefaultRecoveryRequest):
+            return state
+        intent = state.recovery_intent
+        if (
+            intent is None
+            or request.intent_generation != state.newest_intent_generation
+        ):
+            return state
+        allowed_actions = {
+            ConsoleDefaultSavePhase.BEFORE_REPLACE: {
+                ConsoleDefaultRecoveryAction.RETRY_SAVE,
+                ConsoleDefaultRecoveryAction.DISCARD_RETRY,
+            },
+            ConsoleDefaultSavePhase.CACHE_PUBLICATION: {
+                ConsoleDefaultRecoveryAction.REFRESH_RUNNING_APP,
+                ConsoleDefaultRecoveryAction.DISMISS_REFRESH,
+            },
+        }
+        if request.action not in allowed_actions.get(state.failure_phase, set()):
+            return state
+        owner = ChatScreen._console_settings_durability_owner(self)
+        admission = owner.try_acquire()
+        if admission is None:
+            return state
+        task = owner.launch(
+            admission,
+            ChatScreen._run_console_default_recovery(self, request),
+            name=f"console-default-recovery-{request.intent_generation}",
+        )
+        return await asyncio.shield(task)
+
+    async def _run_console_default_recovery(
+        self,
+        request: ConsoleDefaultRecoveryRequest,
+    ) -> ConsoleDefaultDurabilityState:
+        """Run one admitted recovery under generation/phase single-flight."""
+
+        state = self._console_default_durability_state()
+        if not isinstance(request, ConsoleDefaultRecoveryRequest):
+            return state
+        intent = state.recovery_intent
+        if (
+            intent is None
+            or request.intent_generation != state.newest_intent_generation
+        ):
+            return state
+        allowed_actions = {
+            ConsoleDefaultSavePhase.BEFORE_REPLACE: {
+                ConsoleDefaultRecoveryAction.RETRY_SAVE,
+                ConsoleDefaultRecoveryAction.DISCARD_RETRY,
+            },
+            ConsoleDefaultSavePhase.CACHE_PUBLICATION: {
+                ConsoleDefaultRecoveryAction.REFRESH_RUNNING_APP,
+                ConsoleDefaultRecoveryAction.DISMISS_REFRESH,
+            },
+        }
+        failure_phase = state.failure_phase
+        if request.action not in allowed_actions.get(failure_phase, set()):
+            return state
+        inflight = getattr(
+            self.app_instance,
+            "console_default_recovery_inflight",
+            None,
+        )
+        if not isinstance(inflight, set):
+            inflight = set()
+            self.app_instance.console_default_recovery_inflight = inflight
+        assert isinstance(failure_phase, ConsoleDefaultSavePhase)
+        flight_key = (
+            request.intent_generation,
+            failure_phase.value,
+        )
+        if flight_key in inflight:
+            return state
+        inflight.add(flight_key)
+        try:
+            if request.action in {
+                ConsoleDefaultRecoveryAction.DISCARD_RETRY,
+                ConsoleDefaultRecoveryAction.DISMISS_REFRESH,
+            }:
+                state = ConsoleDefaultDurabilityState(
+                    newest_intent_generation=state.newest_intent_generation,
+                    runtime_published_intent_generation=(
+                        state.runtime_published_intent_generation
+                    ),
+                )
+                self.app_instance.console_default_durability_state = state
+                self._sync_console_settings_recovery_surfaces()
+                return state
+            if (
+                request.action is ConsoleDefaultRecoveryAction.RETRY_SAVE
+                and failure_phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+            ):
+                outcome = await asyncio.to_thread(
+                    apply_console_default_intent,
+                    intent,
+                )
+            elif (
+                request.action is ConsoleDefaultRecoveryAction.REFRESH_RUNNING_APP
+                and failure_phase is ConsoleDefaultSavePhase.CACHE_PUBLICATION
+            ):
+                refresh = await asyncio.to_thread(
+                    refresh_console_runtime_after_saved_default
+                )
+                outcome = ConsoleDefaultMutationOutcome(
+                    intent_generation=intent.generation,
+                    file_replaced=True,
+                    runtime_published=refresh.published,
+                    settings_view=refresh.settings_view,
+                    failure_phase=(
+                        None
+                        if refresh.published
+                        else ConsoleDefaultSavePhase.CACHE_PUBLICATION
+                    ),
+                )
+            else:
+                return state
+        except Exception:
+            logger.exception("Console default recovery failed")
+            current = self._console_default_durability_state()
+            if (
+                current.recovery_intent == intent
+                and current.failure_phase is failure_phase
+            ):
+                self._record_console_default_failure(intent, failure_phase)
+            return self._console_default_durability_state()
+        finally:
+            inflight.discard(flight_key)
+        current = self._console_default_durability_state()
+        if (
+            current.recovery_intent != intent
+            or current.failure_phase is not failure_phase
+        ):
+            return current
+        try:
+            published = await self._publish_console_default_outcome_off_event_loop(
+                intent,
+                outcome,
+            )
+        except Exception:
+            logger.exception("Console default recovery publication failed")
+            published = False
+        if not published:
+            phase = outcome.failure_phase or ConsoleDefaultSavePhase.CACHE_PUBLICATION
+            self._record_console_default_failure(intent, phase)
+        self._sync_console_settings_recovery_surfaces()
+        return self._console_default_durability_state()
+
+    def _sync_console_settings_recovery_surfaces(self) -> None:
+        """Refresh the mounted rail's current session/app recovery rows."""
+
+        try:
+            rail = self.query_one("#console-left-rail", ConsoleLeftRail)
+        except (NoMatches, QueryError):
+            return
+        store = self._ensure_console_chat_store()
+        session_id = store.active_session_id
+        session = (
+            getattr(store, "_sessions", {}).get(session_id)
+            if session_id is not None
+            else None
+        )
+        rail.sync_model_recovery(
+            session_id=session_id,
+            failures=(
+                session.settings_persistence_failures if session is not None else {}
+            ),
+            default_state=self._console_default_durability_state(),
+        )
+
+    @on(Button.Pressed, f"#{CONSOLE_RETRY_GENERATION_SETTINGS_ID}")
+    @on(Button.Pressed, f"#{CONSOLE_RETRY_CONTEXT_SETTINGS_ID}")
+    async def on_console_settings_component_retry(
+        self,
+        event: Button.Pressed,
+    ) -> None:
+        """Retry one exact session/component revision from the Model rail."""
+
+        event.stop()
+        session_id = getattr(event.button, "console_settings_session_id", None)
+        revision = getattr(event.button, "console_settings_revision", None)
+        if type(session_id) is not str or type(revision) is not int:
+            return
+        component = (
+            ConsoleSettingsComponent.GENERATION_SETTINGS
+            if event.button.id == CONSOLE_RETRY_GENERATION_SETTINGS_ID
+            else ConsoleSettingsComponent.CONTEXT_POLICY
+        )
+        owner = ChatScreen._console_settings_durability_owner(self)
+        admission = owner.try_acquire()
+        if admission is None:
+            return
+        task = owner.launch(
+            admission,
+            self._ensure_console_chat_store().retry_console_settings_persistence(
+                session_id=session_id,
+                component=component,
+                revision=revision,
+            ),
+            name=f"console-settings-retry-{session_id}-{component.value}-{revision}",
+        )
+        await asyncio.shield(task)
+        self._sync_console_settings_recovery_surfaces()
+
+    @on(Button.Pressed, f"#{CONSOLE_RETRY_DEFAULT_SAVE_ID}")
+    @on(Button.Pressed, f"#{CONSOLE_DISCARD_DEFAULT_RETRY_ID}")
+    @on(Button.Pressed, f"#{CONSOLE_REFRESH_RUNNING_APP_ID}")
+    @on(Button.Pressed, f"#{CONSOLE_DISMISS_DEFAULT_REFRESH_ID}")
+    async def on_console_default_recovery(self, event: Button.Pressed) -> None:
+        """Route an exact app-global recovery token through one handler."""
+
+        event.stop()
+        generation = getattr(
+            event.button,
+            "console_default_intent_generation",
+            None,
+        )
+        actions = {
+            CONSOLE_RETRY_DEFAULT_SAVE_ID: ConsoleDefaultRecoveryAction.RETRY_SAVE,
+            CONSOLE_DISCARD_DEFAULT_RETRY_ID: (
+                ConsoleDefaultRecoveryAction.DISCARD_RETRY
+            ),
+            CONSOLE_REFRESH_RUNNING_APP_ID: (
+                ConsoleDefaultRecoveryAction.REFRESH_RUNNING_APP
+            ),
+            CONSOLE_DISMISS_DEFAULT_REFRESH_ID: (
+                ConsoleDefaultRecoveryAction.DISMISS_REFRESH
+            ),
+        }
+        action = actions.get(event.button.id or "")
+        if type(generation) is not int or action is None:
+            return
+        await self._handle_console_default_recovery(
+            ConsoleDefaultRecoveryRequest(
+                action=action,
+                intent_generation=generation,
+            )
         )
 
     def action_focus_console_composer_home(self) -> None:
@@ -3491,6 +4432,9 @@ class ChatScreen(BaseAppScreen):
         )
         self._console_status_chips_layout_revision = 0
         self._state_dirty = False
+        self._console_settings_coordinated_submission_ids: deque[str] = deque(
+            maxlen=64
+        )
         self._handoff_consumption_in_progress = False
         self._pending_console_launch_context: Optional[ConsoleLiveWorkLaunch] = None
         self._pending_console_launch_auto_open_inspector = False
@@ -3526,9 +4470,8 @@ class ChatScreen(BaseAppScreen):
         self._last_console_roleplay_refresh_key: tuple[str, str] | None = None
         self._console_roleplay_persistence_task: asyncio.Task[None] | None = None
         self._console_roleplay_writer_task: (
-            asyncio.Future[ConsoleRoleplayProjectionPersistenceResult] | None
+            asyncio.Task[ConsoleRoleplayProjectionPersistenceResult | None] | None
         ) = None
-        self._console_roleplay_writer_thread: threading.Thread | None = None
         self._console_roleplay_active_plan: (
             ConsoleRoleplayProjectionPersistencePlan | None
         ) = None
@@ -4296,33 +5239,66 @@ class ChatScreen(BaseAppScreen):
         self,
     ) -> ConsoleSettingsContextEstimate:
         """Return context usage for the active native Console settings snapshot."""
-        settings = self._session._ensure_active_console_session_settings()
-        workspace_context = self._workspace._current_console_workspace_context()
+        store = self._ensure_console_chat_store()
+        session_id = store.active_session_id
+        if session_id is None:
+            settings = self._session._ensure_active_console_session_settings()
+            return build_console_context_estimate(
+                [],
+                settings.provider,
+                settings.model,
+                max_tokens_response=settings.max_tokens,
+                system_prompt=settings.system_prompt,
+            )
+        return self._console_settings_context_estimate_for_session(session_id)
+
+    def _console_settings_context_estimate_for_session(
+        self,
+        session_id: str,
+        *,
+        settings: ConsoleSessionSettings | None = None,
+    ) -> ConsoleSettingsContextEstimate:
+        """Return settings context derived from one captured session only."""
+        store = self._ensure_console_chat_store()
+        settings = settings or store.session_settings(session_id)
+        if settings is None:
+            raise KeyError(session_id)
+        include_active_staging = store.active_session_id == session_id
+        workspace_context = (
+            self._workspace._current_console_workspace_context()
+            if include_active_staging
+            else None
+        )
+        pending_launch = (
+            self._pending_console_launch_context if include_active_staging else None
+        )
         staged_context_state = self._build_console_staged_context_state(
-            self._pending_console_launch_context
+            pending_launch
         )
         messages: list[dict[str, str]] = []
-        store = self._console_chat_store
-        if store is not None and store.active_session_id is not None:
-            try:
-                messages = [
-                    {
-                        "role": str(
-                            message.role.value
-                            if hasattr(message.role, "value")
-                            else message.role
-                        ),
-                        "content": message.content,
-                    }
-                    for message in store.messages_for_session(store.active_session_id)
-                ]
-            except KeyError:
-                messages = []
+        try:
+            messages = [
+                {
+                    "role": str(
+                        message.role.value
+                        if hasattr(message.role, "value")
+                        else message.role
+                    ),
+                    "content": message.content,
+                }
+                for message in store.messages_for_session(session_id)
+            ]
+        except KeyError:
+            messages = []
         return build_console_context_estimate(
             messages,
             settings.provider,
             settings.model,
-            staged_source_count=len(workspace_context.staged_sources),
+            staged_source_count=(
+                len(workspace_context.staged_sources)
+                if workspace_context is not None
+                else 0
+            ),
             staged_context_summary=staged_context_state.summary,
             max_tokens_response=settings.max_tokens,
             system_prompt=settings.system_prompt,
@@ -4336,7 +5312,7 @@ class ChatScreen(BaseAppScreen):
             # no extra DB round trip. The actual send may shrink this after
             # its authority check.
             staged_text=console_prompted_evidence_text(
-                self._pending_console_launch_context
+                pending_launch
             ),
         )
 
@@ -4347,21 +5323,51 @@ class ChatScreen(BaseAppScreen):
         thinking_history_effective_policy: str | None = None,
     ) -> ConsoleContextControlState:
         """Build the shared quick/full context snapshot for the active session."""
-        settings = self._session._ensure_active_console_session_settings()
-        estimate = estimate or self._active_console_settings_context_estimate()
         store = self._ensure_console_chat_store()
         session_id = store.active_session_id
+        if session_id is None:
+            settings = self._session._ensure_active_console_session_settings()
+            estimate = estimate or self._active_console_settings_context_estimate()
+            return build_console_context_control_state(
+                settings=settings,
+                estimate=estimate,
+                overrides=ConsoleContextPolicyOverrides(),
+                global_overrides=None,
+                active_memory=None,
+            )
+        return self._console_context_control_state_for_session(
+            session_id,
+            estimate=estimate,
+            thinking_history_effective_policy=thinking_history_effective_policy,
+        )
+
+    def _console_context_control_state_for_session(
+        self,
+        session_id: str,
+        *,
+        estimate: ConsoleSettingsContextEstimate | None = None,
+        settings: ConsoleSessionSettings | None = None,
+        thinking_history_effective_policy: str | None = None,
+    ) -> ConsoleContextControlState:
+        """Build context controls from one captured session binding."""
+        store = self._ensure_console_chat_store()
+        settings = settings or store.session_settings(session_id)
+        if settings is None:
+            raise KeyError(session_id)
+        estimate = estimate or self._console_settings_context_estimate_for_session(
+            session_id,
+            settings=settings,
+        )
         overrides = ConsoleContextPolicyOverrides()
         global_overrides = None
         memory = None
-        if session_id is not None:
-            controller = self._ensure_console_chat_controller()
-            try:
-                overrides, global_overrides, memory = controller.context_control_inputs(
-                    session_id
-                )
-            except (KeyError, ValueError):
-                pass
+        controller = self._ensure_console_chat_controller()
+        try:
+            overrides, global_overrides, memory = controller.context_control_inputs(
+                session_id
+            )
+        except (KeyError, ValueError):
+            pass
         return build_console_context_control_state(
             settings=settings,
             estimate=estimate,
@@ -5062,7 +6068,7 @@ class ChatScreen(BaseAppScreen):
                 chat_dictionary_applier=self._console_chat_dictionary_applier,
                 world_info_applier=self._console_world_info_applier,
                 rag_capture_provider=self._retrieval._capture_console_staged_rag,
-                default_session_settings=self._session._default_console_session_settings,
+                default_session_settings=self._session._blank_console_session_settings,
                 library_provider_factory=self._library_activity.build_provider,
                 global_user_display_name=self._global_chat_display_name,
                 turn_context_provider=(
@@ -5127,7 +6133,7 @@ class ChatScreen(BaseAppScreen):
             "_world_info_applier": self._console_world_info_applier,
             "_rag_capture_provider": getattr(retrieval, "_capture_console_staged_rag", None),
             "_default_session_settings": getattr(
-                session, "_default_console_session_settings", None
+                session, "_blank_console_session_settings", None
             ),
             "_library_provider_factory": self._library_activity.build_provider,
             "_global_user_display_name": self._global_chat_display_name,
@@ -10387,6 +11393,13 @@ class ChatScreen(BaseAppScreen):
                 # already-computed results are handed to `ConsoleLeftRail`.
                 fleet_line = self._agent._console_agent_fleet_summary_line()
                 settings_summary_state = self._build_console_settings_summary_state()
+                settings_store = self._ensure_console_chat_store()
+                settings_session_id = settings_store.active_session_id
+                settings_session = (
+                    getattr(settings_store, "_sessions", {}).get(settings_session_id)
+                    if settings_session_id is not None
+                    else None
+                )
                 system_line_text, system_line_dim = (
                     self._console_rail_system_line_state()
                 )
@@ -10492,6 +11505,15 @@ class ChatScreen(BaseAppScreen):
                     ),
                     manual_reaction_label=(
                         self._session._manual_reaction_label_for_current_actor()
+                    ),
+                    settings_session_id=settings_session_id,
+                    settings_persistence_failures=(
+                        settings_session.settings_persistence_failures
+                        if settings_session is not None
+                        else {}
+                    ),
+                    default_durability_state=(
+                        self._console_default_durability_state()
                     ),
                 )
                 left_rail.can_focus = True
@@ -12365,6 +13387,14 @@ class ChatScreen(BaseAppScreen):
                 rail_state = self._current_console_rail_state()
                 self._sync_console_control_bar(rail_state)
                 self._sync_console_settings_summary()
+                # Settings failures may arrive after Apply has returned:
+                # ordinary first persistence and temporary-chat promotion
+                # both update the session ledger on their own later path.
+                # Project that current-session truth during the existing
+                # general sync so switches and delayed writes cannot leave
+                # the mounted recovery rows stale. This is deliberately a
+                # direct DOM sync: it starts no worker and emits no toast.
+                self._sync_console_settings_recovery_surfaces()
                 self._sync_console_mode_bar()
                 await self._sync_console_native_session_tabs()
                 self._dispatch_active_console_roleplay_refresh()
@@ -12417,15 +13447,6 @@ class ChatScreen(BaseAppScreen):
         except QueryError:
             return
         store = self._ensure_console_chat_store()
-        defaults = self._session._default_console_session_settings()
-        store.ensure_session(
-            title=self._workspace._console_initial_session_title_for_workspace(
-                store.workspace_context.active_workspace_id
-            ),
-            workspace_id=store.workspace_context.active_workspace_id,
-            settings=defaults,
-            canonical_settings_baseline=defaults,
-        )
         self._session._ensure_active_console_session_settings()
         controller = getattr(self, "_console_chat_controller", None)
         streaming_session_id = (
@@ -13243,10 +14264,8 @@ class ChatScreen(BaseAppScreen):
         """
         action = parse_prefill_args(parse.args)
         store = self._ensure_console_chat_store()
-        session = store.ensure_session(
-            workspace_id=store.workspace_context.active_workspace_id,
-            settings=self._session._default_console_session_settings(),
-        )
+        self._session._ensure_active_console_session_settings()
+        session = store.ensure_session()
         if session.settings is None:
             # `ensure_session` only applies `settings=` when it CREATES the
             # session; one created earlier without settings (e.g. by a bare
@@ -13914,9 +14933,8 @@ class ChatScreen(BaseAppScreen):
                 self.app_instance.notify("No image on the clipboard.")
                 return
             store = self._ensure_console_chat_store()
-            session = store.ensure_session(
-                workspace_id=store.workspace_context.active_workspace_id
-            )
+            self._session._ensure_active_console_session_settings()
+            session = store.ensure_session()
             # Attach sequentially, stopping as soon as the cap is hit, so a
             # capacity-exhausted drop gets ONE truncation toast here instead
             # of one "limit reached" toast per remaining file.
@@ -13953,9 +14971,8 @@ class ChatScreen(BaseAppScreen):
             )
             return
         store = self._ensure_console_chat_store()
-        session = store.ensure_session(
-            workspace_id=store.workspace_context.active_workspace_id
-        )
+        self._session._ensure_active_console_session_settings()
+        session = store.ensure_session()
         if not store.add_pending_attachment(session.id, attachment):
             self.app_instance.notify(
                 "Attachment limit reached (5 per message).", severity="warning"
@@ -14005,9 +15022,8 @@ class ChatScreen(BaseAppScreen):
             )
         else:
             store = self._ensure_console_chat_store()
-            session = store.ensure_session(
-                workspace_id=store.workspace_context.active_workspace_id
-            )
+            self._session._ensure_active_console_session_settings()
+            session = store.ensure_session()
             if not store.add_pending_attachment(session.id, attachment):
                 self.app_instance.notify(
                     "Attachment limit reached (5 per message).", severity="warning"

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -105,6 +105,7 @@ from ...Utils.adaptive_reader_state import (
     AdaptiveReaderLayoutPreferences,
     AdaptiveReaderLayoutProfile,
     PANE_GRIP_WIDTH,
+    PaneName,
     normalize_adaptive_reader_preferences,
     resolve_adaptive_reader_layout,
 )
@@ -464,6 +465,7 @@ from ...Widgets.workbench_focus import (
     focus_relative_workbench_pane,
 )
 from ...Widgets.Library import (
+    AdaptiveReaderShellResized,
     LIBRARY_SKILLS_FILTER_ID,
     LIBRARY_SKILLS_PAGE_NEXT_ID,
     LIBRARY_SKILLS_PAGE_PREVIOUS_ID,
@@ -530,6 +532,9 @@ from ...Widgets.Library import (
     skill_user_invocable_label,
 )
 from ...Widgets.Library.library_file_notes_workspace import (
+    FileNotesEditableOpened,
+    FileNotesIdentityCleared,
+    FileNotesRootChanged,
     LibraryFileNotesWorkspace,
 )
 from ...Widgets.Library.library_media_content import LibraryMediaContentBody
@@ -574,6 +579,11 @@ from ..Library_Modules.library_notes_sync_controller import (
     InertLastingSyncRuntime,
     LibraryNotesSyncController,
 )
+from ..Library_Modules.library_notes_work_session import (
+    NotesWorkSessionEvent,
+    NotesWorkSessionPhase,
+    reduce_notes_work_session,
+)
 from ..Library_Modules.library_snapshot_cache import (
     clone_library_source_snapshot,
 )
@@ -597,8 +607,17 @@ if TYPE_CHECKING:
 
 
 logger = logger.bind(module="LibraryScreen")
+LibraryReaderDestination = Literal[
+    "media",
+    "conversations",
+    "notes",
+    "notes_files",
+    "prompts",
+    "skills",
+]
 LIBRARY_CONVERSATION_READER_PROFILE = AdaptiveReaderLayoutProfile()
 LIBRARY_NOTES_READER_PROFILE = AdaptiveReaderLayoutProfile(work_min_width=48)
+LIBRARY_FILE_NOTES_READER_PROFILE = AdaptiveReaderLayoutProfile(work_min_width=30)
 LIBRARY_PROMPTS_READER_PROFILE = AdaptiveReaderLayoutProfile(work_min_width=48)
 LIBRARY_SKILLS_READER_PROFILE = AdaptiveReaderLayoutProfile(work_min_width=48)
 LIBRARY_CONVERSATION_READER_MAX_CHARS = 8000
@@ -1782,11 +1801,13 @@ def _sync_library_canvas(
                 screen._build_library_shell_input(),
                 selected_row_id=screen._library_selected_row_id,
             )
-            screen.query_one("#library-rail", LibraryRail).apply_selection(
-                shell,
-                lifecycle=screen._library_lifecycle,
-                onboarding_all_empty=screen._library_onboarding_all_empty,
-            )
+            rail = screen._active_library_rail()
+            if rail is not None:
+                rail.apply_selection(
+                    shell,
+                    lifecycle=screen._library_lifecycle,
+                    onboarding_all_empty=screen._library_onboarding_all_empty,
+                )
             work_panes = screen.query("#library-note-work-pane")
             if work_panes:
                 note_work = work_panes.first(LibraryNoteWorkPane)
@@ -2093,7 +2114,6 @@ class LibraryScreen(BaseAppScreen):
         ("u", "library_rag_use_in_console", "Use Library context in Console"),
         ("ctrl+n", "library_notes_new", "New note"),
         ("/", "library_notes_focus_filter", "Find notes"),
-        ("ctrl+s", "library_notes_save", "Save note"),
         ("escape", "library_notes_escape", "Back"),
         # task-424: skill-editor accelerators. ``check_action`` gates both
         # to the open skill editor, so the keys pass through untouched
@@ -2385,6 +2405,14 @@ class LibraryScreen(BaseAppScreen):
                 "library-ingest-path",
             ),
         ),
+        WorkbenchPaneTarget(
+            "library-note-work-pane",
+            (
+                "library-note-save",
+                "library-note-title",
+                "library-note-body",
+            ),
+        ),
     )
     _CONVERSATION_WORKBENCH_FOCUS_TARGETS = (
         WorkbenchPaneTarget("library-rail", ("library-search-input",)),
@@ -2411,6 +2439,7 @@ class LibraryScreen(BaseAppScreen):
         WorkbenchPaneTarget(
             "library-note-work-pane",
             (
+                "library-note-save",
                 "library-note-title",
                 "library-note-preview-region",
                 "library-note-context-region",
@@ -2463,14 +2492,8 @@ class LibraryScreen(BaseAppScreen):
         ("/", "find"),
         ("esc", "rail"),
     )
-    LIBRARY_NOTES_EDITOR_SHORTCUTS = (
-        ("ctrl+s", "save note"),
-        ("esc", "back to notes"),
-    )
-    LIBRARY_NOTES_EDITOR_SHORTCUTS_COMPACT = (
-        ("ctrl+s", "save"),
-        ("esc", "notes"),
-    )
+    LIBRARY_NOTES_EDITOR_SHORTCUTS = (("esc", "back to notes"),)
+    LIBRARY_NOTES_EDITOR_SHORTCUTS_COMPACT = (("esc", "notes"),)
     LIBRARY_NOTES_PREVIEW_SHORTCUTS = (
         ("pgup/pgdn", "scroll"),
         ("esc", "back to notes"),
@@ -3192,6 +3215,8 @@ class LibraryScreen(BaseAppScreen):
         self._library_notes_source: Literal["database", "files"] = (
             LIBRARY_NOTES_SOURCE_DATABASE
         )
+        self._library_notes_work_session_phase = NotesWorkSessionPhase.INACTIVE
+        self._library_notes_work_session_activation_pending = False
         self._library_file_notes_workspace: LibraryFileNotesWorkspace | None = None
         if file_notes_workspace_factory is None:
             self._library_file_notes_workspace_factory = lambda: (
@@ -3395,6 +3420,7 @@ class LibraryScreen(BaseAppScreen):
             self._library_media_reader_preferences,
             self._library_conversation_reader_preferences,
             self._library_notes_reader_preferences,
+            self._library_file_notes_reader_preferences,
             self._library_prompts_reader_preferences,
             self._library_skills_reader_preferences,
         ) = self._load_library_reader_preference_snapshot()
@@ -3403,6 +3429,13 @@ class LibraryScreen(BaseAppScreen):
                 0,
                 self._library_notes_reader_preferences,
                 LIBRARY_NOTES_READER_PROFILE,
+            )
+        )
+        self._library_file_notes_reader_layout: AdaptiveReaderEffectiveLayout = (
+            resolve_adaptive_reader_layout(
+                0,
+                self._library_file_notes_reader_preferences,
+                LIBRARY_FILE_NOTES_READER_PROFILE,
             )
         )
         self._library_prompts_reader_layout: AdaptiveReaderEffectiveLayout = (
@@ -3425,6 +3458,7 @@ class LibraryScreen(BaseAppScreen):
             "conversations_items": 0,
             "media_items": 0,
             "notes_items": 0,
+            "notes_file_items": 0,
             "prompts_items": 0,
             "skills_items": 0,
         }
@@ -3434,6 +3468,7 @@ class LibraryScreen(BaseAppScreen):
             "conversations_items": 0,
             "media_items": 0,
             "notes_items": 0,
+            "notes_file_items": 0,
             "prompts_items": 0,
             "skills_items": 0,
         }
@@ -3441,6 +3476,7 @@ class LibraryScreen(BaseAppScreen):
             "library": self._library_conversation_reader_preferences.library_open,
             "conversations_items": self._library_conversation_reader_preferences.items_open,
             "notes_items": self._library_notes_reader_preferences.items_open,
+            "notes_file_items": self._library_file_notes_reader_preferences.items_open,
             "prompts_items": self._library_prompts_reader_preferences.items_open,
             "skills_items": self._library_skills_reader_preferences.items_open,
         }
@@ -3449,6 +3485,10 @@ class LibraryScreen(BaseAppScreen):
             "items": asyncio.Lock(),
         }
         self._library_notes_reader_persistence_locks = {
+            "library": library_pane_persistence_lock,
+            "items": asyncio.Lock(),
+        }
+        self._library_file_notes_reader_persistence_locks = {
             "library": library_pane_persistence_lock,
             "items": asyncio.Lock(),
         }
@@ -4055,6 +4095,9 @@ class LibraryScreen(BaseAppScreen):
         self._library_notes_focus_intent_generation = 0
         self._library_notes_transition_focus_generation = 0
         self._library_notes_programmatic_focus_target: Widget | None = None
+        self._library_notes_authority_focus: dict[
+            Literal["database", "files"], Widget | None
+        ] = {"database": None, "files": None}
         self._library_notes_last_user_scroll_focus: LibraryNotesFocusIdentity | None = (
             None
         )
@@ -4904,21 +4947,106 @@ class LibraryScreen(BaseAppScreen):
         """Return whether ``widget`` belongs to ``ancestor``'s live subtree."""
         return ancestor in widget.ancestors_with_self
 
+    def _active_library_rail(self) -> LibraryRail | None:
+        """Return the rail owned by the currently visible Library authority."""
+        if self._file_notes_active():
+            workspace = self._library_file_notes_workspace
+            shell = workspace._reader_shell if workspace is not None else None
+            rail = shell.library if shell is not None else None
+            if isinstance(rail, LibraryRail) and rail.is_attached:
+                return rail
+        try:
+            return self.query_one("#library-rail", LibraryRail)
+        except (NoMatches, QueryError):
+            return None
+
+    def _library_notes_authority_root(
+        self, authority: Literal["database", "files"]
+    ) -> Widget | None:
+        """Resolve one retained Notes authority's mounted subtree."""
+        if authority == "files":
+            workspace = self._library_file_notes_workspace
+            return workspace if workspace is not None and workspace.is_attached else None
+        try:
+            return self.query_one(
+                "#library-notes-reader-shell", LibraryAdaptiveReaderShell
+            )
+        except (NoMatches, QueryError):
+            return None
+
+    def _remember_library_notes_authority_focus(self, focused: Widget | None) -> None:
+        """Remember a reachable descendant without treating source chrome as work."""
+        if focused is None or focused.id in {
+            "library-notes-source-database",
+            "library-notes-source-files",
+            "library-notes-task-return",
+        }:
+            return
+        for authority in ("database", "files"):
+            root = self._library_notes_authority_root(authority)
+            if root is not None and self._library_notes_widget_is_within(focused, root):
+                self._library_notes_authority_focus[authority] = focused
+                return
+
+    def _evacuate_library_notes_authority_focus(
+        self, authority: Literal["database", "files"]
+    ) -> None:
+        """Capture the outgoing authority and clear focus before hiding it."""
+        focused = self.focused
+        root = self._library_notes_authority_root(authority)
+        if (
+            focused is not None
+            and root is not None
+            and self._library_notes_widget_is_within(focused, root)
+        ):
+            self._library_notes_authority_focus[authority] = focused
+        self.set_focus(None)
+
+    def _restore_library_notes_authority_focus(
+        self, authority: Literal["database", "files"]
+    ) -> bool:
+        """Restore the destination's reachable focus or its honest first target."""
+        target = self._library_notes_authority_focus[authority]
+        if target is not None and (
+            not target.is_attached or not target.visible or target not in self.focus_chain
+        ):
+            target = None
+        if target is None:
+            selector = (
+                "#file-notes-search"
+                if authority == "files"
+                else (
+                    "#library-note-body" if self._library_notes_view == "editor" else ""
+                )
+            )
+            if selector:
+                try:
+                    candidate = self.query_one(selector, Widget)
+                except (NoMatches, QueryError):
+                    candidate = None
+                if (
+                    candidate is not None
+                    and candidate.visible
+                    and candidate in self.focus_chain
+                ):
+                    target = candidate
+        if target is None:
+            return False
+        self.set_focus(target, scroll_visible=False)
+        return True
+
     def _library_notes_focus_stage(
         self, focused: Widget | None
     ) -> Literal["rail", "notes"]:
         """Map a live focused widget to the portable Library stage."""
         if focused is None:
             return self._library_notes_stage
-        # TASK-23025: this runs several times per focus change; resolve the
-        # invariant rail/canvas hosts through the ref cache instead of two
-        # fresh DOM walks per call.
-        rail = self._library_layout_ref("#library-rail")
-        canvas = self._library_layout_ref("#library-canvas")
-        if rail is None or canvas is None:
-            return self._library_notes_stage
-        if self._library_notes_widget_is_within(focused, rail):
+        rail = self._active_library_rail()
+        if rail is not None and self._library_notes_widget_is_within(focused, rail):
             return "rail"
+        canvas = self._library_layout_ref("#library-canvas")
+        if canvas is None:
+            return self._library_notes_stage
         if self._library_notes_widget_is_within(focused, canvas):
             return "notes"
         work_pane = self._library_compose_scoped_ref("#library-note-work-pane")
@@ -6214,6 +6342,7 @@ class LibraryScreen(BaseAppScreen):
         AdaptiveReaderLayoutPreferences,
         AdaptiveReaderLayoutPreferences,
         AdaptiveReaderLayoutPreferences,
+        AdaptiveReaderLayoutPreferences,
     ]:
         """Normalize one shared reader snapshot plus destination Items choices."""
         app_config = getattr(self.app_instance, "app_config", None)
@@ -6245,18 +6374,142 @@ class LibraryScreen(BaseAppScreen):
                 library_width=shared.library_width,
             )
 
+        file_notes_raw = dict(shared_raw)
+        notes_reader = library_config.get("notes_reader")
+        if isinstance(notes_reader, Mapping):
+            if "files_tree_open" in notes_reader:
+                file_notes_raw["items_open"] = notes_reader["files_tree_open"]
+            if "files_tree_width" in notes_reader:
+                file_notes_raw["items_width"] = notes_reader["files_tree_width"]
+        file_notes = normalize_adaptive_reader_preferences(file_notes_raw)
+        file_notes = dataclasses.replace(
+            file_notes,
+            library_open=shared.library_open,
+            custom_widths_enabled=shared.custom_widths_enabled,
+            library_width=shared.library_width,
+        )
+
         return (
             shared,
             destination_preferences("media_reader"),
             destination_preferences("conversations_reader"),
             destination_preferences("notes_reader"),
+            file_notes,
             destination_preferences("prompts_reader"),
             destination_preferences("skills_reader"),
+        )
+
+    def _library_notes_work_session_reader_width(self) -> int | None:
+        """Return the settled reader width for the active Notes authority."""
+        try:
+            if self._library_notes_source == LIBRARY_NOTES_SOURCE_FILES:
+                workspace = self._library_file_notes_workspace
+                if workspace is None or not workspace.is_mounted:
+                    return None
+                shell = workspace.query_one(
+                    "#library-file-notes-reader-shell",
+                    LibraryAdaptiveReaderShell,
+                )
+            else:
+                shell = self.query_one(
+                    "#library-notes-reader-shell",
+                    LibraryAdaptiveReaderShell,
+                )
+        except (NoMatches, QueryError):
+            return None
+        return shell.region.width if shell.region.width > 0 else None
+
+    def _dispatch_library_notes_work_session(
+        self,
+        event: NotesWorkSessionEvent,
+        *,
+        reader_width: int | None = None,
+        sync_layout: bool = True,
+    ) -> bool:
+        """Apply one named transient Notes lifecycle event."""
+        if event in {
+            NotesWorkSessionEvent.DATABASE_IDENTITY_CLEARED,
+            NotesWorkSessionEvent.FOLDER_IDENTITY_CLEARED,
+            NotesWorkSessionEvent.AUTHORITY_CHANGED,
+            NotesWorkSessionEvent.FOLDER_ROOT_CHANGED,
+            NotesWorkSessionEvent.LEFT_NOTES,
+        }:
+            self._library_notes_work_session_activation_pending = False
+        phase = reduce_notes_work_session(
+            self._library_notes_work_session_phase,
+            event,
+            reader_width=(
+                self._library_notes_work_session_reader_width()
+                if reader_width is None
+                and event is NotesWorkSessionEvent.EDITABLE_ITEM_OPENED
+                else reader_width
+            ),
+        )
+        if phase is self._library_notes_work_session_phase:
+            return False
+        self._library_notes_work_session_phase = phase
+        if sync_layout:
+            if self._library_notes_source == LIBRARY_NOTES_SOURCE_FILES:
+                self._sync_library_file_notes_reader_layout_from_shell()
+            else:
+                self._sync_library_notes_reader_layout_from_shell()
+        return True
+
+    def _library_notes_work_first_preferences(
+        self,
+        preferences: AdaptiveReaderLayoutPreferences,
+    ) -> AdaptiveReaderLayoutPreferences:
+        """Derive the Library-only work-first override."""
+        if self._library_notes_work_session_phase is NotesWorkSessionPhase.ACTIVE:
+            return dataclasses.replace(preferences, library_open=False)
+        return preferences
+
+    def _set_library_notes_source(
+        self,
+        source: Literal["database", "files"],
+    ) -> bool:
+        """Set one admitted Notes authority and reset only on a real change."""
+        if source == self._library_notes_source:
+            return False
+        self._library_notes_source = source
+        self._dispatch_library_notes_work_session(
+            NotesWorkSessionEvent.AUTHORITY_CHANGED,
+            sync_layout=False,
+        )
+        return True
+
+    def _dispatch_database_note_identity_cleared(self) -> bool:
+        """Reset only when a Database selected/loaded identity is cleared."""
+        if not self._selected_note_id and self._library_note_session.snapshot is None:
+            return False
+        return self._dispatch_library_notes_work_session(
+            NotesWorkSessionEvent.DATABASE_IDENTITY_CLEARED
+        )
+
+    def _activate_database_note_work_session(self, note_id: str) -> None:
+        """Activate after the admitted editor has settled its real shell width."""
+        if (
+            not self._library_notes_work_session_activation_pending
+            or self._library_notes_source != LIBRARY_NOTES_SOURCE_DATABASE
+            or self._library_notes_view != "editor"
+            or self._selected_note_id != note_id
+            or self._library_note_session.snapshot is None
+        ):
+            return
+        reader_width = self._library_notes_work_session_reader_width()
+        if reader_width is None:
+            return
+        self._library_notes_work_session_activation_pending = False
+        self._dispatch_library_notes_work_session(
+            NotesWorkSessionEvent.EDITABLE_ITEM_OPENED,
+            reader_width=reader_width,
         )
 
     def _sync_library_notes_reader_layout_from_shell(
         self,
         priority: Literal["library", "items"] | None = None,
+        *,
+        manual_reopen: PaneName | None = None,
     ) -> None:
         """Resolve the settled Notes shell and patch it in place."""
         try:
@@ -6290,15 +6543,65 @@ class LibraryScreen(BaseAppScreen):
                 # priority inherited from Navigator when Edit/Create opens;
                 # an explicit grip activation still supplies priority above.
                 previous = dataclasses.replace(previous, priority_pane=None)
+        preferences = self._library_notes_work_first_preferences(
+            self._library_notes_reader_preferences
+        )
         layout = resolve_adaptive_reader_layout(
             width,
-            self._library_notes_reader_preferences,
+            preferences,
             LIBRARY_NOTES_READER_PROFILE,
             previous=previous,
             priority=priority,
         )
-        shell.sync_layout(layout)
+        shell.sync_layout(layout, manual_reopen=manual_reopen)
         self._library_notes_reader_layout = layout
+
+    def _sync_library_file_notes_reader_layout_from_shell(
+        self,
+        priority: Literal["library", "items"] | None = None,
+        *,
+        manual_reopen: PaneName | None = None,
+        automatic_priority: bool = True,
+    ) -> None:
+        """Resolve the settled Folder Files shell and patch it in place."""
+        workspace = self._library_file_notes_workspace
+        if workspace is None or not workspace.is_mounted:
+            return
+        try:
+            shell = workspace.query_one(
+                "#library-file-notes-reader-shell", LibraryAdaptiveReaderShell
+            )
+        except (NoMatches, QueryError):
+            return
+        width = shell.region.width
+        if width <= 0:
+            return
+        previous = self._library_file_notes_reader_layout
+        if (
+            previous.reader_width == 0
+            and previous.library_width == 0
+            and previous.items_width == 0
+        ):
+            previous = None
+        if priority is None and automatic_priority:
+            if workspace.narrow and workspace._narrow_view == "navigator":
+                priority = "items"
+            elif previous is not None and previous.priority_pane == "items":
+                previous = dataclasses.replace(previous, priority_pane=None)
+        preferences = self._library_notes_work_first_preferences(
+            self._library_file_notes_reader_preferences
+        )
+        if workspace.narrow and workspace._narrow_view == "editor":
+            preferences = dataclasses.replace(preferences, items_open=False)
+        layout = resolve_adaptive_reader_layout(
+            width,
+            preferences,
+            LIBRARY_FILE_NOTES_READER_PROFILE,
+            previous=previous,
+            priority=priority,
+        )
+        workspace.sync_reader_layout(layout, manual_reopen=manual_reopen)
+        self._library_file_notes_reader_layout = layout
 
     def _sync_library_prompts_reader_layout_from_shell(
         self,
@@ -6460,6 +6763,27 @@ class LibraryScreen(BaseAppScreen):
             library_config[section_name] = section
         section[key] = value
 
+    def _mirror_library_file_notes_reader_preference(
+        self,
+        key: Literal["library_open", "items_open"],
+        value: bool,
+    ) -> None:
+        """Mirror one optimistic Folder Files pane choice into app config."""
+        app_config = getattr(self.app_instance, "app_config", None)
+        if not isinstance(app_config, dict):
+            return
+        library_config = app_config.setdefault("library", {})
+        if not isinstance(library_config, dict):
+            library_config = {}
+            app_config["library"] = library_config
+        section_name = "reader" if key == "library_open" else "notes_reader"
+        config_key = "library_open" if key == "library_open" else "files_tree_open"
+        section = library_config.setdefault(section_name, {})
+        if not isinstance(section, dict):
+            section = {}
+            library_config[section_name] = section
+        section[config_key] = value
+
     def _mirror_library_prompts_reader_preference(
         self,
         key: Literal["library_open", "items_open"],
@@ -6502,7 +6826,7 @@ class LibraryScreen(BaseAppScreen):
 
     def _replace_library_reader_preference(
         self,
-        destination: Literal["media", "conversations", "notes", "prompts", "skills"],
+        destination: LibraryReaderDestination,
         key: Literal["library_open", "items_open"],
         value: bool,
     ) -> None:
@@ -6511,6 +6835,7 @@ class LibraryScreen(BaseAppScreen):
             "media": "_library_media_reader_preferences",
             "conversations": "_library_conversation_reader_preferences",
             "notes": "_library_notes_reader_preferences",
+            "notes_files": "_library_file_notes_reader_preferences",
             "prompts": "_library_prompts_reader_preferences",
             "skills": "_library_skills_reader_preferences",
         }
@@ -6531,14 +6856,16 @@ class LibraryScreen(BaseAppScreen):
 
     @staticmethod
     def _library_reader_persistence_key(
-        destination: Literal["media", "conversations", "notes", "prompts", "skills"],
+        destination: LibraryReaderDestination,
         pane: Literal["library", "items"],
     ) -> str:
-        return "library" if pane == "library" else f"{destination}_items"
+        if pane == "library":
+            return "library"
+        return "notes_file_items" if destination == "notes_files" else f"{destination}_items"
 
     def _claim_library_reader_persistence(
         self,
-        destination: Literal["media", "conversations", "notes", "prompts", "skills"],
+        destination: LibraryReaderDestination,
         pane: Literal["library", "items"],
     ) -> int:
         """Claim the shared Library or destination-specific Items authority."""
@@ -6550,7 +6877,7 @@ class LibraryScreen(BaseAppScreen):
 
     def _library_reader_persistence_is_current(
         self,
-        destination: Literal["media", "conversations", "notes", "prompts", "skills"],
+        destination: LibraryReaderDestination,
         pane: Literal["library", "items"],
         generation: int,
     ) -> bool:
@@ -6559,9 +6886,12 @@ class LibraryScreen(BaseAppScreen):
 
     def _sync_library_reader_preference_layout(
         self,
-        destination: Literal["media", "conversations", "notes", "prompts", "skills"],
+        destination: LibraryReaderDestination,
         key: Literal["library_open", "items_open"],
         priority: Literal["library", "items"] | None = None,
+        *,
+        manual_reopen: PaneName | None = None,
+        automatic_priority: bool = True,
     ) -> None:
         """Sync the mounted consumer of one optimistic choice or rollback."""
         if key == "library_open" or destination == "media":
@@ -6569,7 +6899,16 @@ class LibraryScreen(BaseAppScreen):
         if key == "library_open" or destination == "conversations":
             self._sync_library_conversation_reader_layout_from_shell(priority)
         if key == "library_open" or destination == "notes":
-            self._sync_library_notes_reader_layout_from_shell(priority)
+            self._sync_library_notes_reader_layout_from_shell(
+                priority,
+                manual_reopen=manual_reopen,
+            )
+        if key == "library_open" or destination == "notes_files":
+            self._sync_library_file_notes_reader_layout_from_shell(
+                priority,
+                manual_reopen=manual_reopen,
+                automatic_priority=automatic_priority,
+            )
         if key == "library_open" or destination == "prompts":
             self._sync_library_prompts_reader_layout_from_shell(priority)
         if key == "library_open" or destination == "skills":
@@ -6578,7 +6917,7 @@ class LibraryScreen(BaseAppScreen):
     async def _read_library_reader_persisted_preference(
         self,
         section: str,
-        key: Literal["library_open", "items_open"],
+        key: str,
     ) -> bool | None:
         """Read one effective pane value from the authoritative config boundary."""
         try:
@@ -6605,14 +6944,18 @@ class LibraryScreen(BaseAppScreen):
                 if not isinstance(value, Mapping):
                     raise KeyError(key)
                 raw_value = value.get(key)
-            return getattr(normalize_adaptive_reader_preferences({key: raw_value}), key)
+            logical_key = "library_open" if key == "library_open" else "items_open"
+            return getattr(
+                normalize_adaptive_reader_preferences({logical_key: raw_value}),
+                logical_key,
+            )
         except Exception:
             logger.warning("Library reader persisted pane value could not be verified.")
             return None
 
     async def _persist_library_reader_preference(
         self,
-        destination: Literal["media", "conversations", "notes", "prompts", "skills"],
+        destination: LibraryReaderDestination,
         pane: Literal["library", "items"],
         value: bool,
         generation: int,
@@ -6627,6 +6970,7 @@ class LibraryScreen(BaseAppScreen):
             "media": "_library_media_reader_preferences",
             "conversations": "_library_conversation_reader_preferences",
             "notes": "_library_notes_reader_preferences",
+            "notes_files": "_library_file_notes_reader_preferences",
             "prompts": "_library_prompts_reader_preferences",
             "skills": "_library_skills_reader_preferences",
         }[destination]
@@ -6634,16 +6978,27 @@ class LibraryScreen(BaseAppScreen):
             "media": self._library_media_reader_persistence_locks,
             "conversations": self._library_conversation_reader_persistence_locks,
             "notes": self._library_notes_reader_persistence_locks,
+            "notes_files": self._library_file_notes_reader_persistence_locks,
             "prompts": self._library_prompts_reader_persistence_locks,
             "skills": self._library_skills_reader_persistence_locks,
         }[destination]
-        section = (
-            "library.reader" if pane == "library" else f"library.{destination}_reader"
+        section = "library.reader" if pane == "library" else (
+            "library.notes_reader"
+            if destination == "notes_files"
+            else f"library.{destination}_reader"
+        )
+        config_key = (
+            "library_open"
+            if pane == "library"
+            else "files_tree_open"
+            if destination == "notes_files"
+            else "items_open"
         )
         mirror = {
             "media": self._mirror_library_media_reader_preference,
             "conversations": self._mirror_library_conversation_reader_preference,
             "notes": self._mirror_library_notes_reader_preference,
+            "notes_files": self._mirror_library_file_notes_reader_preference,
             "prompts": self._mirror_library_prompts_reader_preference,
             "skills": self._mirror_library_skills_reader_preference,
         }[destination]
@@ -6670,7 +7025,7 @@ class LibraryScreen(BaseAppScreen):
                     persisted = await asyncio.to_thread(
                         save_setting_to_cli_config,
                         section,
-                        key,
+                        config_key,
                         attempted_value,
                     )
                 except Exception:
@@ -6699,7 +7054,11 @@ class LibraryScreen(BaseAppScreen):
                             else {}
                         )
                         section_name = (
-                            "reader" if pane == "library" else f"{destination}_reader"
+                            "reader"
+                            if pane == "library"
+                            else "notes_reader"
+                            if destination == "notes_files"
+                            else f"{destination}_reader"
                         )
                         section_config = (
                             library_config.get(section_name, {})
@@ -6708,7 +7067,7 @@ class LibraryScreen(BaseAppScreen):
                         )
                         if (
                             isinstance(section_config, Mapping)
-                            and section_config.get(key) is attempted_value
+                            and section_config.get(config_key) is attempted_value
                         ):
                             self._library_reader_dirty_persistence_authorities.discard(
                                 authority
@@ -6720,7 +7079,7 @@ class LibraryScreen(BaseAppScreen):
                 if verify_failure_from_config:
                     physical_value = (
                         await self._read_library_reader_persisted_preference(
-                            section, key
+                            section, config_key
                         )
                     )
                     if physical_value is None:
@@ -6896,6 +7255,7 @@ class LibraryScreen(BaseAppScreen):
             self._library_media_reader_preferences,
             self._library_conversation_reader_preferences,
             self._library_notes_reader_preferences,
+            self._library_file_notes_reader_preferences,
             self._library_prompts_reader_preferences,
             self._library_skills_reader_preferences,
         ) = self._load_library_reader_preference_snapshot()
@@ -6904,12 +7264,13 @@ class LibraryScreen(BaseAppScreen):
             "conversations_items": self._library_conversation_reader_preferences.items_open,
             "media_items": self._library_media_reader_preferences.items_open,
             "notes_items": self._library_notes_reader_preferences.items_open,
+            "notes_file_items": self._library_file_notes_reader_preferences.items_open,
             "prompts_items": self._library_prompts_reader_preferences.items_open,
             "skills_items": self._library_skills_reader_preferences.items_open,
         }
         persistence_authorities: tuple[
             tuple[
-                Literal["media", "conversations", "notes", "prompts", "skills"],
+                LibraryReaderDestination,
                 str,
                 str,
             ],
@@ -6919,6 +7280,7 @@ class LibraryScreen(BaseAppScreen):
             ("media", "items", "media_items"),
             ("conversations", "items", "conversations_items"),
             ("notes", "items", "notes_items"),
+            ("notes_files", "items", "notes_file_items"),
             ("prompts", "items", "prompts_items"),
             ("skills", "items", "skills_items"),
         )
@@ -6941,6 +7303,7 @@ class LibraryScreen(BaseAppScreen):
         self._sync_library_media_reader_layout_from_shell()
         self._sync_library_conversation_reader_layout_from_shell()
         self._sync_library_notes_reader_layout_from_shell()
+        self._sync_library_file_notes_reader_layout_from_shell()
         self._sync_library_prompts_reader_layout_from_shell()
         self._sync_library_skills_reader_layout_from_shell()
         self._sync_library_ordinary_rail_width_contract()
@@ -7013,6 +7376,54 @@ class LibraryScreen(BaseAppScreen):
         if (
             self._library_selected_row_id
             in (LIBRARY_ROW_BROWSE_NOTES, LIBRARY_ROW_CREATE_NOTE)
+            and self._library_notes_source == LIBRARY_NOTES_SOURCE_FILES
+        ):
+            layout = self._library_file_notes_reader_layout
+            opening = not (
+                layout.library_open if event.pane == "library" else layout.items_open
+            )
+            key = "library_open" if event.pane == "library" else "items_open"
+            if (
+                event.pane == "library"
+                and opening
+                and self._library_notes_work_session_phase
+                is NotesWorkSessionPhase.ACTIVE
+            ):
+                self._dispatch_library_notes_work_session(
+                    NotesWorkSessionEvent.MANUAL_LIBRARY_EXPAND,
+                    sync_layout=False,
+                )
+                if self._library_file_notes_reader_preferences.library_open:
+                    self._sync_library_reader_preference_layout(
+                        "notes_files",
+                        key,
+                        "library",
+                        manual_reopen="library",
+                        automatic_priority=False,
+                    )
+                    return
+            generation = self._claim_library_reader_persistence(
+                "notes_files", event.pane
+            )
+            self._replace_library_reader_preference("notes_files", key, opening)
+            self._mirror_library_file_notes_reader_preference(key, opening)
+            self._sync_library_reader_preference_layout(
+                "notes_files",
+                key,
+                event.pane if opening else None,
+                manual_reopen=event.pane if opening else None,
+                automatic_priority=False,
+            )
+            self.run_worker(
+                self._persist_library_reader_preference(
+                    "notes_files", event.pane, opening, generation
+                ),
+                group=f"library_file_notes_reader_{event.pane}_persistence",
+            )
+            return
+        if (
+            self._library_selected_row_id
+            in (LIBRARY_ROW_BROWSE_NOTES, LIBRARY_ROW_CREATE_NOTE)
             and self._library_notes_source == LIBRARY_NOTES_SOURCE_DATABASE
         ):
             layout = self._library_notes_reader_layout
@@ -7020,11 +7431,32 @@ class LibraryScreen(BaseAppScreen):
                 layout.library_open if event.pane == "library" else layout.items_open
             )
             key = "library_open" if event.pane == "library" else "items_open"
+            if (
+                event.pane == "library"
+                and opening
+                and self._library_notes_work_session_phase
+                is NotesWorkSessionPhase.ACTIVE
+            ):
+                self._dispatch_library_notes_work_session(
+                    NotesWorkSessionEvent.MANUAL_LIBRARY_EXPAND,
+                    sync_layout=False,
+                )
+                if self._library_notes_reader_preferences.library_open:
+                    self._sync_library_reader_preference_layout(
+                        "notes",
+                        key,
+                        "library",
+                        manual_reopen="library",
+                    )
+                    return
             generation = self._claim_library_reader_persistence("notes", event.pane)
             self._replace_library_reader_preference("notes", key, opening)
             self._mirror_library_notes_reader_preference(key, opening)
             self._sync_library_reader_preference_layout(
-                "notes", key, event.pane if opening else None
+                "notes",
+                key,
+                event.pane if opening else None,
+                manual_reopen=event.pane if opening else None,
             )
             self.run_worker(
                 self._persist_library_reader_preference(
@@ -7099,6 +7531,29 @@ class LibraryScreen(BaseAppScreen):
             ),
             group=f"library_media_reader_{event.pane}_persistence",
         )
+
+    @on(AdaptiveReaderShellResized)
+    def _resize_library_adaptive_reader_shell(
+        self,
+        event: AdaptiveReaderShellResized,
+    ) -> None:
+        """Resolve one mounted shared shell through its destination authority."""
+        event.stop()
+        if self._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS:
+            self._sync_library_conversation_reader_layout_from_shell()
+        elif (
+            self._library_selected_row_id
+            in (LIBRARY_ROW_BROWSE_NOTES, LIBRARY_ROW_CREATE_NOTE)
+            and self._library_notes_source == LIBRARY_NOTES_SOURCE_FILES
+        ):
+            self._sync_library_file_notes_reader_layout_from_shell()
+        elif self._library_selected_row_id in (
+            LIBRARY_ROW_BROWSE_NOTES,
+            LIBRARY_ROW_CREATE_NOTE,
+        ):
+            self._sync_library_notes_reader_layout_from_shell()
+            if self._library_notes_work_session_activation_pending:
+                self._activate_database_note_work_session(self._selected_note_id)
 
     @on(MediaShellResized)
     def _resize_library_media_reader_shell(self, event: MediaShellResized) -> None:
@@ -8328,8 +8783,11 @@ class LibraryScreen(BaseAppScreen):
                 LibraryLifecycle.STARTER,
             ):
                 return
+            rail = self._active_library_rail()
+            if rail is None:
+                return
             try:
-                self.query_one("#library-search-input", Input).focus()
+                rail.query_one("#library-search-input", Input).focus()
             except (NoMatches, QueryError):
                 return
             event.stop()
@@ -9625,6 +10083,7 @@ class LibraryScreen(BaseAppScreen):
         never reach ``on_key`` at all.
         """
         focused = event.widget
+        self._remember_library_notes_authority_focus(focused)
         target_restore = self._library_notes_programmatic_focus_target is focused
         programmatic = bool(
             target_restore
@@ -13615,6 +14074,52 @@ class LibraryScreen(BaseAppScreen):
             self.call_after_refresh(self._sync_library_notes_reader_layout_from_shell)
             self.call_after_refresh(self._hide_library_adaptive_reader_rail_collapse)
             return
+        if (
+            shell.canvas_kind
+            in (LIBRARY_CANVAS_KIND_NOTES, LIBRARY_CANVAS_KIND_NOTES_CREATE)
+            and self._library_notes_source == LIBRARY_NOTES_SOURCE_FILES
+        ):
+            rail = LibraryRail(
+                shell,
+                preferences,
+                query=self._library_rag_query,
+                search_placeholder=self._library_rail_search_placeholder(),
+                workspaces_body_factory=self._compose_workspaces_rail_body,
+                top_action_factory=self._compose_library_rail_top_action,
+                lifecycle=self._library_lifecycle,
+                onboarding_all_empty=self._library_onboarding_all_empty,
+                id="library-file-notes-rail",
+                classes="destination-workbench-pane",
+            )
+            workspace = self._library_file_notes_workspace
+            with shell_grid:
+                if workspace is None:
+                    yield Static(
+                        "Opening File Notes…",
+                        id="library-file-notes-loading",
+                        classes="destination-purpose",
+                        markup=False,
+                    )
+                else:
+                    if workspace._reader_shell is None:
+                        workspace.configure_reader_shell(
+                            library_pane=rail,
+                            layout=self._library_file_notes_reader_layout,
+                        )
+                    else:
+                        workspace.sync_reader_layout(
+                            self._library_file_notes_reader_layout
+                        )
+                    yield workspace
+            self.call_after_refresh(
+                self._sync_library_file_notes_reader_layout_from_shell
+            )
+            self.call_after_refresh(self._hide_library_adaptive_reader_rail_collapse)
+            self.call_after_refresh(
+                self._restore_library_notes_authority_focus,
+                "files",
+            )
+            return
         if shell.canvas_kind == "prompts":
             rail = LibraryRail(
                 shell,
@@ -14440,6 +14945,12 @@ class LibraryScreen(BaseAppScreen):
 
     def _set_library_destination_with_conversation_fence(self, row_id: str) -> None:
         """Set one admitted Library destination and revoke a Conversations read."""
+        notes_rows = {LIBRARY_ROW_BROWSE_NOTES, LIBRARY_ROW_CREATE_NOTE}
+        if self._library_selected_row_id in notes_rows and row_id not in notes_rows:
+            self._dispatch_library_notes_work_session(
+                NotesWorkSessionEvent.LEFT_NOTES,
+                sync_layout=False,
+            )
         if (
             self._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
             and row_id != LIBRARY_ROW_BROWSE_CONVERSATIONS
@@ -17899,6 +18410,7 @@ class LibraryScreen(BaseAppScreen):
             logger.info(
                 f"Library note {note_id!r} is no longer available; returning to list."
             )
+            self._dispatch_database_note_identity_cleared()
             self._reset_library_note_editor_state()
             self._notify_library_note_missing_warning()
             self._refresh_local_source_snapshot()
@@ -17920,7 +18432,12 @@ class LibraryScreen(BaseAppScreen):
         self._library_note_preview = False
         self._library_note_context = False
         self._library_note_editor_armed = False
+        self._library_notes_work_session_activation_pending = True
         if self.is_mounted:
+            self.call_later(
+                self._activate_database_note_work_session,
+                note_id,
+            )
             editor_identity = LibraryNotesFocusIdentity(
                 stage="notes",
                 region="editor",
@@ -18007,6 +18524,7 @@ class LibraryScreen(BaseAppScreen):
         selection so every exit from the editor leaves save/autosave/
         conflict tracking in a clean ``idle`` state for the next note.
         """
+        self._dispatch_database_note_identity_cleared()
         self._library_note_session.close_session()
         if self._library_notes_view != "import":
             self._library_notes_view = "list"
@@ -20858,9 +21376,8 @@ class LibraryScreen(BaseAppScreen):
 
     def _sync_library_rail_lifecycle_presentation(self) -> None:
         """Recompose lifecycle owners and safely restore semantic focus."""
-        try:
-            rail = self.query_one("#library-rail", LibraryRail)
-        except (NoMatches, QueryError):
+        rail = self._active_library_rail()
+        if rail is None:
             return
         focused = self.focused
         focus_selector = ""
@@ -21330,9 +21847,12 @@ class LibraryScreen(BaseAppScreen):
                 library_config["rail_state"] = rail_state
             rail_state["sections"] = serialized
         self._save_library_rail_preferences(serialized)
+        rail = self._active_library_rail()
+        if rail is None:
+            return
         try:
-            body = self.query_one(f"#library-rail-section-body-{section_id}")
-            header = self.query_one(
+            body = rail.query_one(f"#library-rail-section-body-{section_id}")
+            header = rail.query_one(
                 f"#library-rail-section-header-{section_id}",
                 DestinationRailSectionHeader,
             )
@@ -21395,14 +21915,16 @@ class LibraryScreen(BaseAppScreen):
 
     def _focus_library_rail_action(self, selector: str) -> None:
         """Focus a preferred rail action, then compact Import or Explore."""
+        rail = self._active_library_rail()
+        if rail is None:
+            return
         for candidate in (
             selector,
-            "#library-search-input",
             f"#library-row-{LIBRARY_ROW_INGEST_MEDIA}",
             "#library-rail-explore-all",
         ):
             try:
-                target = self.query_one(candidate, Widget)
+                target = rail.query_one(candidate, Widget)
             except (NoMatches, QueryError):
                 continue
             if target.display and not getattr(target, "disabled", False):
@@ -21429,7 +21951,10 @@ class LibraryScreen(BaseAppScreen):
         self._set_library_lifecycle(lifecycle)
         self._library_rail_collapsed = False
         await self.recompose()
-        self._focus_library_rail_action("#library-search-input")
+        self.call_after_refresh(
+            self._focus_library_rail_action,
+            "#library-search-input",
+        )
 
     @on(Button.Pressed, "#library-hub-retry-evidence")
     def _retry_library_onboarding_evidence(self, event: Button.Pressed) -> None:
@@ -21560,24 +22085,91 @@ class LibraryScreen(BaseAppScreen):
             self._library_notes_browse_return_receipt = (
                 self._capture_library_notes_browse_return_receipt()
             )
+        self._evacuate_library_notes_authority_focus("database")
         self._supersede_library_notes_navigation()
-        self._reset_library_note_editor_state()
+        # Database Notes and Folder Files are independent retained authorities.
+        # The database coordinator has already flushed above; keep its loaded
+        # selection/editor projection so returning from Folder Files resumes it.
         if self._library_file_notes_workspace is None:
             self._library_file_notes_workspace = (
                 self._library_file_notes_workspace_factory()
             )
+        workspace = self._library_file_notes_workspace
         self._acknowledge_library_destination_change()
-        self._library_notes_source = LIBRARY_NOTES_SOURCE_FILES
+        self._set_library_notes_source(LIBRARY_NOTES_SOURCE_FILES)
         # task-2850: the Files-mode Escape binding only fires while
         # ``_file_notes_active()`` is true, so the footer's advertised keys
         # must follow this same transition or Escape works unadvertised.
         self._register_footer_shortcuts()
-        self.refresh(recompose=True)
+        try:
+            database_shell = self.query_one(
+                "#library-notes-reader-shell", LibraryAdaptiveReaderShell
+            )
+            shell_grid = self.query_one("#library-shell-grid", Horizontal)
+        except (NoMatches, QueryError):
+            self.refresh(recompose=True)
+            self.call_after_refresh(
+                self._restore_library_notes_authority_focus,
+                "files",
+            )
+        else:
+            if workspace._reader_shell is None:
+                shell_state = build_library_shell_state(
+                    self._build_library_shell_input(),
+                    selected_row_id=self._library_selected_row_id,
+                )
+                workspace.configure_reader_shell(
+                    library_pane=LibraryRail(
+                        shell_state,
+                        self._library_rail_preferences(),
+                        query=self._library_rag_query,
+                        search_placeholder=self._library_rail_search_placeholder(),
+                        workspaces_body_factory=self._compose_workspaces_rail_body,
+                        top_action_factory=self._compose_library_rail_top_action,
+                        lifecycle=self._library_lifecycle,
+                        onboarding_all_empty=self._library_onboarding_all_empty,
+                        id="library-file-notes-rail",
+                        classes="destination-workbench-pane",
+                    ),
+                    layout=self._library_file_notes_reader_layout,
+                )
+            if not workspace.is_attached:
+                await shell_grid.mount(workspace, before=database_shell)
+            database_shell.display = False
+            database_shell.library.display = False
+            workspace.display = True
+            self._restore_library_notes_authority_focus("files")
+            self._sync_library_notes_source_controls()
+            self.call_after_refresh(
+                self._sync_library_file_notes_reader_layout_from_shell
+            )
+            self.call_after_refresh(self._hide_library_adaptive_reader_rail_collapse)
         # The production app can recompose Library after the initial mount-time
         # responsive callback. Measure again once the Files canvas owns its
         # final shell geometry so a compact terminal cannot retain stale wide
         # presentation state from startup.
         self.call_after_refresh(self._update_library_notes_responsive_state)
+
+    def _sync_library_notes_source_controls(self) -> None:
+        """Patch the retained Notes source strip after an in-place switch."""
+        database_selected = self._library_notes_source == LIBRARY_NOTES_SOURCE_DATABASE
+        wide_focused_task = (
+            not database_selected
+            and not self._library_notes_compact
+            and self._library_notes_focused_task_active()
+        )
+        try:
+            database = self.query_one("#library-notes-source-database", Button)
+            files = self.query_one("#library-notes-source-files", Button)
+            separator = self.query_one("#library-notes-source-separator", Widget)
+            task_return = self.query_one("#library-notes-task-return", Button)
+        except (NoMatches, QueryError):
+            return
+        database.set_class(database_selected, "-selected")
+        files.set_class(not database_selected, "-selected")
+        for control in (database, files, separator):
+            control.display = not wide_focused_task
+        task_return.display = wide_focused_task
 
     @on(Button.Pressed, "#library-notes-task-return")
     async def _return_from_library_notes_task(self, event: Button.Pressed) -> None:
@@ -21610,6 +22202,45 @@ class LibraryScreen(BaseAppScreen):
         if event.control is self._library_file_notes_workspace:
             self._register_footer_shortcuts()
 
+    @on(FileNotesEditableOpened)
+    def _handle_file_notes_editable_opened(
+        self,
+        event: FileNotesEditableOpened,
+    ) -> None:
+        """Activate work-first only for the current admitted Folder identity."""
+        event.stop()
+        if (
+            event.control is self._library_file_notes_workspace
+            and self._library_notes_source == LIBRARY_NOTES_SOURCE_FILES
+        ):
+            self._dispatch_library_notes_work_session(
+                NotesWorkSessionEvent.EDITABLE_ITEM_OPENED
+            )
+
+    @on(FileNotesIdentityCleared)
+    def _handle_file_notes_identity_cleared(
+        self,
+        event: FileNotesIdentityCleared,
+    ) -> None:
+        """Reset Folder work-first only at an explicit identity clear."""
+        event.stop()
+        if event.control is self._library_file_notes_workspace:
+            self._dispatch_library_notes_work_session(
+                NotesWorkSessionEvent.FOLDER_IDENTITY_CLEARED
+            )
+
+    @on(FileNotesRootChanged)
+    def _handle_file_notes_root_changed(
+        self,
+        event: FileNotesRootChanged,
+    ) -> None:
+        """Reset Folder work-first after the current root binding changes."""
+        event.stop()
+        if event.control is self._library_file_notes_workspace:
+            self._dispatch_library_notes_work_session(
+                NotesWorkSessionEvent.FOLDER_ROOT_CHANGED
+            )
+
     async def _return_to_library_database_notes(self) -> None:
         """Leave File Notes and return to the Database Notes view.
 
@@ -21622,7 +22253,14 @@ class LibraryScreen(BaseAppScreen):
             return
         if self._library_notes_source == LIBRARY_NOTES_SOURCE_DATABASE:
             return
+        workspace = self._library_file_notes_workspace
+        if workspace is not None and workspace.cancel_path_task():
+            self._register_footer_shortcuts()
+            return
         if not await self._flush_active_file_notes():
+            return
+        if workspace is not None and workspace.cancel_path_task():
+            self._register_footer_shortcuts()
             return
         release_source = self._acquire_file_notes_transition("source")
         if release_source is False:
@@ -21632,16 +22270,48 @@ class LibraryScreen(BaseAppScreen):
                 scroll_generation=self._library_notes_scroll_intent_generation,
                 focus_generation=self._library_notes_focus_intent_generation,
             )
+            self._evacuate_library_notes_authority_focus("files")
             self._acknowledge_library_destination_change()
-            self._library_notes_source = LIBRARY_NOTES_SOURCE_DATABASE
+            self._set_library_notes_source(LIBRARY_NOTES_SOURCE_DATABASE)
             self._register_footer_shortcuts()
-            await self.recompose()
+            workspace = self._library_file_notes_workspace
+            retained_switch = False
+            try:
+                database_shell = self.query_one(
+                    "#library-notes-reader-shell", LibraryAdaptiveReaderShell
+                )
+            except (NoMatches, QueryError):
+                await self.recompose()
+                self.call_after_refresh(
+                    self._restore_library_notes_authority_focus,
+                    "database",
+                )
+            else:
+                if workspace is not None:
+                    workspace.display = False
+                database_shell.display = True
+                self._sync_library_notes_source_controls()
+                self._sync_library_notes_reader_layout_from_shell()
+                self._restore_library_notes_authority_focus("database")
+                self._library_notes_focus_intent_generation += 1
+                retained_switch = True
             receipt = self._library_notes_browse_return_receipt
-            if receipt is None:
+            if self._library_notes_view == "editor":
+                pass
+            elif receipt is None:
                 # task-2856 AC1: this lands on the Notes LIST (never Files'
                 # own editor state), so re-focus its first row the same way
                 # every other "enter/return to a list" seam does.
                 self._arm_library_list_entry_focus()
+            elif retained_switch:
+                self.call_later(
+                    self._restore_library_notes_browse_return_receipt,
+                    receipt,
+                )
+                self.call_later(
+                    self._queue_library_notes_settled_focus_restore,
+                    receipt.focus,
+                )
             else:
                 self.call_after_refresh(
                     self._restore_library_notes_browse_return_receipt,
@@ -21659,6 +22329,9 @@ class LibraryScreen(BaseAppScreen):
         ever runs while Files mode genuinely owns the Notes canvas.
         """
         workspace = self._library_file_notes_workspace
+        if workspace is not None and workspace.cancel_path_task():
+            self._register_footer_shortcuts()
+            return
         if workspace is not None and workspace.cancel_reload_confirmation():
             self._register_footer_shortcuts()
             return
@@ -21941,7 +22614,7 @@ class LibraryScreen(BaseAppScreen):
             # Create Note is a database-only Notes route. File Notes owns a
             # retained workspace, so normalize the source only after its
             # flush and transition admission have succeeded.
-            self._library_notes_source = LIBRARY_NOTES_SOURCE_DATABASE
+            self._set_library_notes_source(LIBRARY_NOTES_SOURCE_DATABASE)
         if row_id != LIBRARY_ROW_BROWSE_PROMPTS:
             self._invalidate_library_prompts_browse()
         # A rail selection is an explicit route boundary, even when the user
@@ -36536,6 +37209,12 @@ class LibraryScreen(BaseAppScreen):
         self._library_note_delete_origin_context = False
         self._library_note_delete_origin_preview = False
         self._library_note_editor_armed = False
+        self._library_notes_work_session_activation_pending = True
+        if self.is_mounted:
+            self.call_later(
+                self._activate_database_note_work_session,
+                created_id,
+            )
         self._library_note_pending_blank_gc_id = created_id if blank else None
         self._library_note_session_blank_id = created_id if blank else None
         # (P0) A freshly created note's title is whatever the create seam
@@ -40222,7 +40901,10 @@ class LibraryScreen(BaseAppScreen):
                 self._acknowledge_library_destination_change()
             self._clear_library_prompt_selection(announce=True)
             self._library_notes_browse_return_receipt = None
-            self._library_selected_row_id = LIBRARY_ROW_BROWSE_NOTES
+            self._set_library_notes_source(LIBRARY_NOTES_SOURCE_DATABASE)
+            self._set_library_destination_with_conversation_fence(
+                LIBRARY_ROW_BROWSE_NOTES
+            )
             if entry_origin:
                 self._supersede_library_notes_navigation()
                 self._library_note_session.close_session()

--- a/tldw_chatbook/UI/Screens/settings_appearance_defaults.py
+++ b/tldw_chatbook/UI/Screens/settings_appearance_defaults.py
@@ -71,6 +71,8 @@ class SettingsAppearanceDefaults:
     library_conversations_items_width: int = ITEMS_TARGET_WIDTH
     library_notes_items_open: bool = True
     library_notes_items_width: int = ITEMS_TARGET_WIDTH
+    library_notes_files_tree_open: bool = True
+    library_notes_files_tree_width: int = ITEMS_TARGET_WIDTH
     library_prompts_items_open: bool = True
     library_prompts_items_width: int = ITEMS_TARGET_WIDTH
     library_skills_items_open: bool = True
@@ -182,6 +184,28 @@ def load_appearance_defaults(
         name: destination_reader(f"{name}_reader")
         for name in ("media", "conversations", "notes", "prompts", "skills")
     }
+    notes_reader = _mapping_child(library, "notes_reader")
+    files_tree_width = notes_reader.get("files_tree_width")
+    try:
+        parsed_files_tree_width = (
+            int(files_tree_width.strip())
+            if isinstance(files_tree_width, str)
+            else files_tree_width
+        )
+    except ValueError:
+        parsed_files_tree_width = ITEMS_TARGET_WIDTH
+    if (
+        type(parsed_files_tree_width) is not int
+        or not ITEMS_MIN_WIDTH <= parsed_files_tree_width <= ITEMS_MAX_WIDTH
+    ):
+        parsed_files_tree_width = ITEMS_TARGET_WIDTH
+    notes_files_tree = normalize_adaptive_reader_preferences(
+        {
+            "custom_widths_enabled": True,
+            "items_open": notes_reader.get("files_tree_open"),
+            "items_width": parsed_files_tree_width,
+        }
+    )
 
     return SettingsAppearanceDefaults(
         default_theme=_normalise_theme(general.get("default_theme", DEFAULT_THEME)),
@@ -229,6 +253,8 @@ def load_appearance_defaults(
         ),
         library_notes_items_open=destination_readers["notes"].items_open,
         library_notes_items_width=destination_readers["notes"].items_width,
+        library_notes_files_tree_open=notes_files_tree.items_open,
+        library_notes_files_tree_width=notes_files_tree.items_width,
         library_prompts_items_open=destination_readers["prompts"].items_open,
         library_prompts_items_width=destination_readers["prompts"].items_width,
         library_skills_items_open=destination_readers["skills"].items_open,
@@ -336,6 +362,11 @@ def validate_appearance_defaults(
             values.library_notes_items_width,
         ),
         (
+            "Folder Files tree",
+            values.library_notes_files_tree_open,
+            values.library_notes_files_tree_width,
+        ),
+        (
             "Prompts Items",
             values.library_prompts_items_open,
             values.library_prompts_items_width,
@@ -416,6 +447,13 @@ def build_appearance_save_sections(
                 ),
             }
         )
+        if destination == "notes":
+            destination_reader.update(
+                {
+                    "files_tree_open": bool(values.library_notes_files_tree_open),
+                    "files_tree_width": int(values.library_notes_files_tree_width),
+                }
+            )
         library[section_name] = destination_reader
 
     return {

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -200,6 +200,7 @@ from .settings_config_adapter import (
     redact_secret_text,
 )
 from .settings_search_index import (
+    FIELD_SEARCH_DISABLED_FOCUS_FALLBACKS,
     FIELD_SEARCH_INDEX,
     LIBRARY_READER_DESTINATIONS,
     RAG_FIELD_GROUP_BY_ID as _RAG_FIELD_GROUP_BY_ID,
@@ -6662,12 +6663,23 @@ class SettingsScreen(BaseAppScreen):
         if widget.disabled or any(
             getattr(node, "disabled", False) for node in widget.ancestors
         ):
-            self._set_static_text(
-                "#settings-category-search-status",
-                f"'{field_label}' is disabled right now — its category is "
-                "open; enable the option that controls it first.",
-            )
-            return
+            fallback_id = FIELD_SEARCH_DISABLED_FOCUS_FALLBACKS.get(field_id)
+            if fallback_id is not None:
+                try:
+                    fallback = self.query_one(f"#{fallback_id}")
+                except QueryError:
+                    fallback = None
+                if fallback is not None and not fallback.disabled:
+                    widget = fallback
+            if widget.disabled or any(
+                getattr(node, "disabled", False) for node in widget.ancestors
+            ):
+                self._set_static_text(
+                    "#settings-category-search-status",
+                    f"'{field_label}' is disabled right now — its category is "
+                    "open; enable the option that controls it first.",
+                )
+                return
         expanded = False
         for node in widget.ancestors:
             if isinstance(node, Collapsible) and node.collapsed:
@@ -6867,6 +6879,10 @@ class SettingsScreen(BaseAppScreen):
             return "library_reader_library_width"
         if message.startswith("Items width"):
             return "library_media_items_width"
+        if message.startswith("Folder Files tree pane"):
+            return "library_notes_files_tree_open"
+        if message.startswith("Folder Files tree width"):
+            return "library_notes_files_tree_width"
         for destination, label in LIBRARY_READER_DESTINATIONS[1:]:
             if message.startswith(f"{label} Items pane"):
                 return f"library_{destination}_items_open"
@@ -6890,6 +6906,8 @@ class SettingsScreen(BaseAppScreen):
             "library_reader_custom_widths_enabled": "#settings-appearance-library-media-custom-widths",
             "library_reader_library_width": "#settings-appearance-library-media-library-width",
             "library_media_items_width": "#settings-appearance-library-media-items-width",
+            "library_notes_files_tree_open": "#settings-appearance-library-notes-files-tree-open",
+            "library_notes_files_tree_width": "#settings-appearance-library-notes-files-tree-width",
         }
         for destination, _label in LIBRARY_READER_DESTINATIONS[1:]:
             selectors[f"library_{destination}_items_open"] = (
@@ -6921,6 +6939,8 @@ class SettingsScreen(BaseAppScreen):
             "library_conversations_items_width",
             "library_notes_items_open",
             "library_notes_items_width",
+            "library_notes_files_tree_open",
+            "library_notes_files_tree_width",
             "library_prompts_items_open",
             "library_prompts_items_width",
             "library_skills_items_open",
@@ -12302,7 +12322,6 @@ class SettingsScreen(BaseAppScreen):
             )
         if field_id in {
             "settings-appearance-library-media-library-open",
-            "settings-appearance-library-media-custom-widths",
             "settings-appearance-library-media-library-width",
         }:
             return (
@@ -12321,7 +12340,28 @@ class SettingsScreen(BaseAppScreen):
                     "Library width 24–48",
                 ),
             )
+        if field_id == "settings-appearance-library-media-custom-widths":
+            return (
+                ("Focused setting", "Shared Library reader widths"),
+                (
+                    "Purpose",
+                    "Controls whether shared Library reader widths can be edited, "
+                    "including Folder Files tree width.",
+                ),
+                ("Saved as", "library.reader.custom_widths_enabled"),
+                ("Validation", "toggle enabled or disabled"),
+            )
         if field_id and field_id.startswith("settings-appearance-library-"):
+            if field_id.startswith("settings-appearance-library-notes-files-tree-"):
+                return (
+                    ("Focused setting", "Folder Files tree pane"),
+                    (
+                        "Purpose",
+                        "Sets the Folder Files tree visibility and width; responsive collapse remains session-only.",
+                    ),
+                    ("Saved as", "library.notes_reader"),
+                    ("Validation", "Folder Files tree width 32–72"),
+                )
             destination = next(
                 (
                     name
@@ -16319,6 +16359,31 @@ class SettingsScreen(BaseAppScreen):
                             restrict=r"^[0-9]*$",
                             disabled=not custom_widths,
                         )
+                    if destination == "notes":
+                        with Horizontal(classes="settings-input-row"):
+                            yield Static(
+                                "Folder Files tree pane",
+                                classes="settings-input-label",
+                            )
+                            yield Button(
+                                self._appearance_media_layout_label(
+                                    "library_notes_files_tree_open"
+                                ),
+                                id="settings-appearance-library-notes-files-tree-open",
+                                classes="settings-library-media-layout-toggle",
+                            )
+                        with Horizontal(classes="settings-input-row"):
+                            yield Static(
+                                "Folder Files tree width",
+                                classes="settings-input-label",
+                            )
+                            yield Input(
+                                value=str(values["library_notes_files_tree_width"]),
+                                id="settings-appearance-library-notes-files-tree-width",
+                                classes="settings-compact-input settings-library-media-layout-width",
+                                restrict=r"^[0-9]*$",
+                                disabled=not custom_widths,
+                            )
                 yield Button(
                     "Reset layout to defaults",
                     id="settings-appearance-library-media-reset",
@@ -19104,6 +19169,7 @@ class SettingsScreen(BaseAppScreen):
         keys = {
             "settings-appearance-library-media-library-open": "library_reader_library_open",
             "settings-appearance-library-media-custom-widths": "library_reader_custom_widths_enabled",
+            "settings-appearance-library-notes-files-tree-open": "library_notes_files_tree_open",
         }
         keys.update(
             {
@@ -19131,6 +19197,7 @@ class SettingsScreen(BaseAppScreen):
             return
         keys = {
             "settings-appearance-library-media-library-width": "library_reader_library_width",
+            "settings-appearance-library-notes-files-tree-width": "library_notes_files_tree_width",
         }
         keys.update(
             {
@@ -19157,6 +19224,8 @@ class SettingsScreen(BaseAppScreen):
             "library_reader_library_open",
             "library_reader_custom_widths_enabled",
             "library_reader_library_width",
+            "library_notes_files_tree_open",
+            "library_notes_files_tree_width",
             *(
                 f"library_{destination}_items_open"
                 for destination, _label in LIBRARY_READER_DESTINATIONS
@@ -24393,6 +24462,10 @@ class SettingsScreen(BaseAppScreen):
                     "#settings-appearance-library-media-custom-widths",
                     "library_reader_custom_widths_enabled",
                 ),
+                (
+                    "#settings-appearance-library-notes-files-tree-open",
+                    "library_notes_files_tree_open",
+                ),
                 *(
                     (
                         f"#settings-appearance-library-{destination}-items-open",
@@ -24412,6 +24485,10 @@ class SettingsScreen(BaseAppScreen):
                 (
                     "#settings-appearance-library-media-library-width",
                     "library_reader_library_width",
+                ),
+                (
+                    "#settings-appearance-library-notes-files-tree-width",
+                    "library_notes_files_tree_width",
                 ),
                 *(
                     (

--- a/tldw_chatbook/UI/Screens/settings_search_index.py
+++ b/tldw_chatbook/UI/Screens/settings_search_index.py
@@ -220,6 +220,15 @@ def _speech_provider_form_entries() -> tuple[tuple[str, str], ...]:
 #: row labels; Enter focuses the matched field.
 FIELD_SEARCH_INDEX: dict[SettingsCategoryId, tuple[tuple[str, str], ...]] = {}
 
+#: A disabled value field may name the control that enables it so search can
+#: keep its promise to land on an actionable setting instead of stopping at a
+#: disabled widget.
+FIELD_SEARCH_DISABLED_FOCUS_FALLBACKS: dict[str, str] = {
+    "settings-appearance-library-notes-files-tree-width": (
+        "settings-appearance-library-media-custom-widths"
+    ),
+}
+
 
 def _backend_field_entries(
     id_prefix: str,
@@ -451,6 +460,14 @@ def build_field_search_index() -> None:
                 (
                     "settings-appearance-library-media-library-width",
                     "Preferred Library rail width",
+                ),
+                (
+                    "settings-appearance-library-notes-files-tree-open",
+                    "Folder Files tree pane",
+                ),
+                (
+                    "settings-appearance-library-notes-files-tree-width",
+                    "Folder Files tree width",
                 ),
                 *(
                     (

--- a/tldw_chatbook/Widgets/Console/console_model_popover.py
+++ b/tldw_chatbook/Widgets/Console/console_model_popover.py
@@ -140,9 +140,7 @@ class ConsolePopoverInput(Input):
 
 class ConsoleModelPopover(
     SafeModalDismissMixin,
-    ModalScreen[
-        "ConsoleSettingsCommittedSubmission | ConsoleSettingsTransfer | None"
-    ],
+    ModalScreen["ConsoleSettingsCommittedSubmission | ConsoleSettingsTransfer | None"],
 ):
     """Quick exact-conversation settings and explicit default actions."""
 
@@ -367,8 +365,7 @@ class ConsoleModelPopover(
                     for candidate in remembered.field_drafts
                     if candidate.name == name
                     and candidate.dirty
-                    and candidate.provenance
-                    is ConsoleSettingsFieldProvenance.EXPLICIT
+                    and candidate.provenance is ConsoleSettingsFieldProvenance.EXPLICIT
                 ),
                 None,
             )
@@ -430,11 +427,7 @@ class ConsoleModelPopover(
                     # BLANK doesn't exist on Select and silently resolves to
                     # Widget.BLANK (False), an illegal value that crashes the
                     # Select at mount (TASK-16502).
-                    value=(
-                        settings.model
-                        if settings.model
-                        else Select.NULL
-                    ),
+                    value=(settings.model if settings.model else Select.NULL),
                     id="console-popover-model",
                     allow_blank=True,
                 )
@@ -790,9 +783,9 @@ class ConsoleModelPopover(
                 temperature.value = (
                     "" if settings.temperature is None else str(settings.temperature)
                 )
-            self.query_one("#console-popover-streaming", Button).label = (
-                f"Streaming: {'on' if self._streaming else 'off'}"
-            )
+            self.query_one(
+                "#console-popover-streaming", Button
+            ).label = f"Streaming: {'on' if self._streaming else 'off'}"
             model_select = self.query_one("#console-popover-model", Select)
             options = [
                 (option.label, option.value)
@@ -804,9 +797,7 @@ class ConsoleModelPopover(
             ]
             model_select.set_options(options)
             model_select.value = settings.model if settings.model else Select.NULL
-            picker = self.query_one(
-                "#console-popover-model-search", ModelSearchPicker
-            )
+            picker = self.query_one("#console-popover-model-search", ModelSearchPicker)
             if source_provider != settings.provider:
                 picker.refresh_provider(
                     settings.provider,
@@ -831,9 +822,7 @@ class ConsoleModelPopover(
             return
         for name in ("temperature", "streaming"):
             try:
-                marker = self.query_one(
-                    f"#console-popover-{name}-provenance", Static
-                )
+                marker = self.query_one(f"#console-popover-{name}-provenance", Static)
             except NoMatches:
                 continue
             marker.update(self._field_provenance_copy(name))
@@ -868,12 +857,8 @@ class ConsoleModelPopover(
         else:
             block_copy = ""
         try:
-            button = self.query_one(
-                "#console-popover-make-new-chat-default", Button
-            )
-            block = self.query_one(
-                "#console-popover-new-chat-default-block", Static
-            )
+            button = self.query_one("#console-popover-make-new-chat-default", Button)
+            block = self.query_one("#console-popover-new-chat-default-block", Static)
         except NoMatches:
             return
         button.disabled = bool(block_copy)
@@ -909,9 +894,7 @@ class ConsoleModelPopover(
         self._rebase_to(provider, model_id)
 
     @on(ModelSearchPicker.ModelValueChanged)
-    def _model_value_changed(
-        self, event: ModelSearchPicker.ModelValueChanged
-    ) -> None:
+    def _model_value_changed(self, event: ModelSearchPicker.ModelValueChanged) -> None:
         """Rebase custom model IDs through the same controller seam."""
         event.stop()
         if self._updating_controls:
@@ -1042,8 +1025,9 @@ class ConsoleModelPopover(
             return None
 
         temperature_input = self.query_one("#console-popover-temperature", Input)
-        temperature = self._parse_temperature(temperature_input.value)
-        if temperature is None:
+        temperature_text = temperature_input.value.strip()
+        temperature = self._parse_temperature(temperature_text)
+        if temperature is None and temperature_text:
             self._set_error(
                 "Temperature must be a finite number from 0 to 2.",
                 focus=temperature_input,
@@ -1073,9 +1057,7 @@ class ConsoleModelPopover(
                 self._draft.context_policy_overrides,
                 compaction_mode=ContextCompactionMode(
                     str(
-                        self.query_one(
-                            "#console-popover-compaction-mode", Select
-                        ).value
+                        self.query_one("#console-popover-compaction-mode", Select).value
                     )
                 ),
             ),
@@ -1146,9 +1128,7 @@ class ConsoleModelPopover(
         if draft is None:
             return
         if action is ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT:
-            button = self.query_one(
-                "#console-popover-make-new-chat-default", Button
-            )
+            button = self.query_one("#console-popover-make-new-chat-default", Button)
             if button.disabled:
                 block = self.query_one(
                     "#console-popover-new-chat-default-block", Static

--- a/tldw_chatbook/Widgets/Console/console_model_popover.py
+++ b/tldw_chatbook/Widgets/Console/console_model_popover.py
@@ -2,24 +2,44 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, replace
-from typing import Any, Mapping, Sequence
+from math import isfinite
+from typing import Any, Literal, Mapping, Protocol, Sequence
+from uuid import uuid4
 
 from textual import events, on
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.containers import Grid, Vertical, VerticalScroll
+from textual.css.query import NoMatches
 from textual.screen import ModalScreen
+from textual.widget import Widget
 from textual.widgets import Button, Input, Select, Static
 
-from tldw_chatbook.Chat.console_session_settings import (
-    ConsoleSessionSettings,
-    ConsoleSettingsContextEstimate,
-    build_console_model_options,
-    build_console_provider_options,
-)
 from tldw_chatbook.Chat.console_context_policy import (
     ContextCompactionMode,
     ContextCompactionRepresentation,
+)
+from tldw_chatbook.Chat.console_session_settings import (
+    ConsoleSessionSettings,
+    ConsoleSettingsContextEstimate,
+    ConsoleSettingsReadiness,
+    build_console_model_options,
+    build_console_provider_options,
+)
+from tldw_chatbook.Chat.console_settings_apply import (
+    QUICK_MODEL_DEFAULT_FIELDS,
+    ConsoleSettingsAction,
+    ConsoleSettingsCommittedSubmission,
+    ConsoleSettingsDraftState,
+    ConsoleSettingsFieldDraft,
+    ConsoleSettingsFieldProvenance,
+    ConsoleSettingsLiveCommit,
+    ConsoleSettingsOrigin,
+    ConsoleSettingsSurface,
+    ConsoleSettingsSubmission,
+    ConsoleSettingsTransfer,
+    remember_model_draft,
 )
 from tldw_chatbook.Chat.provider_catalog import provider_display_name
 from tldw_chatbook.Utils.input_validation import validate_text_input
@@ -36,20 +56,47 @@ CONSOLE_POPOVER_OPEN_FULL_SETTINGS = "open-full-settings"
 
 @dataclass(frozen=True, slots=True)
 class ConsoleModelPopoverResult:
-    """Quick settings and policy edits owned by the current conversation."""
+    """Deprecated pre-ADR-095 result retained for downstream import stability.
+
+    The rebuilt popover never emits this value. Callers receive a committed typed
+    submission, a full-settings transfer, or ``None``.
+    """
 
     settings: ConsoleSessionSettings
     compaction_mode: ContextCompactionMode
 
 
-# Mirrors ConsoleSettingsModal's temperature bounds (see
-# Chat/console_session_settings.validate_console_session_settings, which
-# rejects a temperature outside [0.0, 2.0] via a plain range comparison --
-# NaN and +/-Inf always fail that comparison too). The popover has no error
-# banner, so instead of blocking Apply like the full settings modal does, an
-# invalid temperature here just keeps the prior value.
 _CONSOLE_POPOVER_TEMPERATURE_MIN = 0.0
 _CONSOLE_POPOVER_TEMPERATURE_MAX = 2.0
+_FULL_SETTINGS_ACTION = "full_settings"
+
+
+class DraftRebaser(Protocol):
+    """Injected provider/model rebase seam owned by ConsoleChatController."""
+
+    def __call__(
+        self,
+        state: ConsoleSettingsDraftState,
+        *,
+        provider: str,
+        model: str | None,
+        app_config: Mapping[str, object],
+        exposed_fields: frozenset[str],
+    ) -> ConsoleSettingsDraftState: ...
+
+
+LiveCommitter = Callable[[ConsoleSettingsSubmission], ConsoleSettingsLiveCommit]
+PopoverSubmitAction = ConsoleSettingsAction | Literal["full_settings"]
+
+
+class DefaultReadinessResolver(Protocol):
+    """Injected configuration-owned readiness seam."""
+
+    def __call__(
+        self,
+        provider: str,
+        model: str | None,
+    ) -> ConsoleSettingsReadiness: ...
 
 
 def _temperature_in_range(value: float) -> bool:
@@ -62,14 +109,42 @@ def _temperature_in_range(value: float) -> bool:
         True if ``value`` is within ``[0.0, 2.0]``. NaN and infinite values
         always return False, since any comparison against them is False.
     """
-    return _CONSOLE_POPOVER_TEMPERATURE_MIN <= value <= _CONSOLE_POPOVER_TEMPERATURE_MAX
+    return (
+        isfinite(value)
+        and _CONSOLE_POPOVER_TEMPERATURE_MIN
+        <= value
+        <= _CONSOLE_POPOVER_TEMPERATURE_MAX
+    )
+
+
+def _widget_screen_region(widget: Widget) -> Any:
+    """Return one mounted widget's region in screen coordinates."""
+
+    return getattr(widget, "screen_region", None) or widget.region
+
+
+class ConsolePopoverInput(Input):
+    """Input that releases Textual Web mouse capture before action clicks."""
+
+    def on_click(self, event: events.Click | None = None) -> None:
+        self.release_mouse()
+        if event is None:
+            return
+        recover = getattr(self.screen, "_recover_redirected_control_click", None)
+        if callable(recover):
+            recover(event)
+
+    def on_blur(self) -> None:
+        self.release_mouse()
 
 
 class ConsoleModelPopover(
     SafeModalDismissMixin,
-    ModalScreen["ConsoleModelPopoverResult | ConsoleSessionSettings | str | None"],
+    ModalScreen[
+        "ConsoleSettingsCommittedSubmission | ConsoleSettingsTransfer | None"
+    ],
 ):
-    """Quick provider/model/temperature/streaming switcher for the session."""
+    """Quick exact-conversation settings and explicit default actions."""
 
     DEFAULT_CSS = """
     ConsoleModelPopover {
@@ -78,11 +153,12 @@ class ConsoleModelPopover(
 
     #console-model-popover {
         width: 60;
-        height: 90%;
+        max-width: 100%;
+        height: 100%;
         min-height: 18;
         max-height: 32;
-        border: tall gray;
-        background: black;
+        border: tall $surface-lighten-1;
+        background: $panel;
         padding: 1 2;
     }
 
@@ -98,6 +174,41 @@ class ConsoleModelPopover(
         margin: 1 0 0 0;
     }
 
+    .console-popover-provenance {
+        height: auto;
+        color: $text-muted;
+    }
+
+    #console-popover-scope {
+        height: auto;
+        text-style: bold;
+    }
+
+    #console-popover-durability,
+    #console-popover-defaults-target,
+    #console-popover-save-model-default-copy,
+    #console-popover-make-new-chat-default-copy,
+    #console-popover-defaults-compaction-scope,
+    #console-popover-new-chat-default-block {
+        height: auto;
+        color: $text-muted;
+    }
+
+    #console-popover-error {
+        height: auto;
+        background: $error 25%;
+        color: $text-error;
+        text-style: bold;
+        border: round $error;
+        padding: 0 1;
+        margin: 1 0 0 0;
+    }
+
+    #console-popover-defaults-panel {
+        height: auto;
+        margin: 1 0 0 0;
+    }
+
     .console-popover-context-row {
         height: 1;
         color: $text-muted;
@@ -110,7 +221,7 @@ class ConsoleModelPopover(
 
     #console-popover-footer {
         height: auto;
-        background: black;
+        background: $panel;
     }
 
     #console-popover-fold-hint {
@@ -118,11 +229,21 @@ class ConsoleModelPopover(
         color: $text-muted;
     }
 
-    #console-popover-actions {
-        height: 3;
-        min-height: 3;
+    #console-popover-main-actions,
+    #console-popover-default-actions {
+        height: 6;
+        min-height: 6;
         margin: 1 0 0 0;
-        align-horizontal: right;
+        grid-size: 2 2;
+        grid-columns: 1fr 1fr;
+        grid-rows: 3 3;
+        grid-gutter: 0 1;
+    }
+
+    #console-popover-main-actions Button,
+    #console-popover-default-actions Button {
+        width: 1fr;
+        min-width: 0;
     }
     """
 
@@ -132,38 +253,76 @@ class ConsoleModelPopover(
     def __init__(
         self,
         *,
-        settings: ConsoleSessionSettings,
+        origin: ConsoleSettingsOrigin,
+        app_config: Mapping[str, object],
+        initial_draft: ConsoleSettingsDraftState,
         providers_models: Mapping[str, Sequence[str]],
         context_state: ConsoleContextControlState | None = None,
+        scope_copy: str,
+        durability_copy: str,
+        draft_rebaser: DraftRebaser,
+        live_committer: LiveCommitter,
+        default_readiness_resolver: DefaultReadinessResolver,
         **kwargs: Any,
     ) -> None:
-        """Initialize the popover with the session's current settings.
+        """Initialize one exact-origin quick settings transaction.
 
         Args:
-            settings: The Console session's current settings, used to seed
-                the provider/model/temperature/streaming controls.
+            origin: Stable session/conversation binding captured before opening.
+            app_config: Configuration snapshot used only by the injected rebaser.
+            initial_draft: Complete typed draft shared with full settings.
             providers_models: Mapping of provider key to its available model
                 names, used to build the provider and model selects.
+            context_state: Current context usage/policy presentation state.
+            scope_copy: Exact conversation scope label.
+            durability_copy: Exact unsaved or temporary durability label.
+            draft_rebaser: Controller-owned provider/model rebase callback.
+            live_committer: Synchronous exact-origin live commit callback.
+            default_readiness_resolver: Controller-owned readiness for the
+                configuration-backed provider/model target.
             **kwargs: Forwarded to ``ModalScreen``.
         """
         super().__init__(**kwargs)
-        self._settings = settings
+        if not isinstance(origin, ConsoleSettingsOrigin):
+            raise TypeError("origin must be ConsoleSettingsOrigin")
+        if not isinstance(initial_draft, ConsoleSettingsDraftState):
+            raise TypeError("initial_draft must be ConsoleSettingsDraftState")
+        self._origin = origin
+        self._app_config = app_config
+        self._draft = initial_draft
         self._providers_models = providers_models
         self._context_state = context_state or build_console_context_control_state(
-            settings=settings,
+            settings=initial_draft.settings,
             estimate=ConsoleSettingsContextEstimate(
                 used_tokens=None,
                 token_limit=None,
                 label="Context: unavailable",
             ),
+            overrides=initial_draft.context_policy_overrides,
         )
-        self._streaming = bool(settings.streaming)
+        self._scope_copy = scope_copy
+        self._durability_copy = durability_copy
+        self._draft_rebaser = draft_rebaser
+        self._live_committer = live_committer
+        self._default_readiness_resolver = default_readiness_resolver
+        self._streaming = bool(initial_draft.settings.streaming)
+        self._temperature_mount_value = (
+            ""
+            if initial_draft.settings.temperature is None
+            else str(initial_draft.settings.temperature)
+        )
+        self._temperature_mount_echo_pending = True
+        self._active_view: Literal["main", "defaults"] = "main"
+        self._main_scroll_y = 0.0
+        self._updating_controls = False
+        self._submit_pending = False
+        self._carried_from: dict[str, tuple[str, str | None]] = {}
         # TASK-364: the provider Select fires a mount-time Select.Changed for its
         # initial value; without this tracker `_provider_changed` would rebuild
         # the model options with current_model=None and wipe the prefilled model.
         # Only a REAL provider change (value differs from what the model options
         # currently reflect) should reset the model.
-        self._model_options_provider = settings.provider
+        self._model_options_provider = initial_draft.settings.provider
 
     def _provider_select_options(self) -> list[tuple[str, str]]:
         """Provider options labeled with the shared catalog display names.
@@ -177,23 +336,94 @@ class ConsoleModelPopover(
             for option in build_console_provider_options(self._providers_models)
         ]
 
+    def _field_draft(self, name: str) -> ConsoleSettingsFieldDraft | None:
+        return next(
+            (field for field in self._draft.field_drafts if field.name == name),
+            None,
+        )
+
+    def _field_provenance_copy(self, name: str) -> str:
+        field = self._field_draft(name)
+        if field is None or not field.dirty:
+            return "Inherited"
+        if field.provenance is ConsoleSettingsFieldProvenance.CARRIED:
+            source = self._carried_from.get(name) or self._keyed_carried_source(name)
+            if source is not None:
+                provider, model = source
+                return f"Edited — carried from {provider}/{model or 'No model'}"
+        return "Edited"
+
+    def _keyed_carried_source(self, name: str) -> tuple[str, str | None] | None:
+        """Return one unambiguous explicit source from remembered keyed drafts."""
+
+        target = (self._draft.settings.provider, self._draft.settings.model)
+        sources: list[tuple[str, str | None]] = []
+        for remembered in self._draft.model_drafts:
+            if (remembered.provider, remembered.model) == target:
+                continue
+            remembered_field = next(
+                (
+                    candidate
+                    for candidate in remembered.field_drafts
+                    if candidate.name == name
+                    and candidate.dirty
+                    and candidate.provenance
+                    is ConsoleSettingsFieldProvenance.EXPLICIT
+                ),
+                None,
+            )
+            if remembered_field is not None:
+                sources.append((remembered.provider, remembered.model))
+        return sources[0] if len(sources) == 1 else None
+
+    def _target_label(self) -> str:
+        settings = self._draft.settings
+        return f"{settings.provider}/{settings.model or 'No model'}"
+
+    def _default_target_copy(self) -> str:
+        return f"Defaults target: {self._target_label()}"
+
+    def _save_model_default_copy(self) -> str:
+        return (
+            "Remember Temperature + Streaming for "
+            f"{self._target_label()}. New-chat provider/model unchanged."
+        )
+
+    def _make_new_chat_default_copy(self) -> str:
+        return (
+            "Save this model profile and start eligible new chats with "
+            f"{self._target_label()}."
+        )
+
     def compose(self) -> ComposeResult:
         """Build the provider, model, temperature, and streaming controls."""
+        settings = self._draft.settings
         provider_options = self._provider_select_options()
         model_options = [
             (option.label, option.value)
             for option in build_console_model_options(
-                self._settings.provider, self._providers_models, self._settings.model
+                settings.provider, self._providers_models, settings.model
             )
         ]
         with Vertical(id="console-model-popover"):
             with VerticalScroll(id="console-model-popover-body"):
-                yield Static("Model", classes="console-modal-header")
+                yield Static("Conversation settings", classes="console-modal-header")
+                yield Static(self._scope_copy, id="console-popover-scope", markup=False)
+                yield Static(
+                    self._durability_copy,
+                    id="console-popover-durability",
+                    markup=False,
+                )
+                error = Static("", id="console-popover-error", markup=False)
+                error.display = False
+                yield error
+                yield Static("Provider", classes="console-popover-field-label")
                 yield Select(
                     provider_options,
-                    value=self._settings.provider,
+                    value=settings.provider,
                     id="console-popover-provider",
                 )
+                yield Static("Model", classes="console-popover-field-label")
                 model_select = Select(
                     model_options,
                     # Select.NULL, not Select.BLANK: on this Textual version
@@ -201,8 +431,8 @@ class ConsoleModelPopover(
                     # Widget.BLANK (False), an illegal value that crashes the
                     # Select at mount (TASK-16502).
                     value=(
-                        self._settings.model
-                        if self._settings.model
+                        settings.model
+                        if settings.model
                         else Select.NULL
                     ),
                     id="console-popover-model",
@@ -213,18 +443,24 @@ class ConsoleModelPopover(
                 yield ModelSearchPicker(
                     id="console-popover-model-search",
                     provider_select_id="#console-popover-provider",
-                    current_model=self._settings.model,
+                    current_model=settings.model,
                     providers_models=self._providers_models,
                 )
                 yield Static("Temperature", classes="console-popover-field-label")
-                yield Input(
+                yield ConsolePopoverInput(
                     value=(
                         ""
-                        if self._settings.temperature is None
-                        else str(self._settings.temperature)
+                        if settings.temperature is None
+                        else str(settings.temperature)
                     ),
                     placeholder="Temperature",
                     id="console-popover-temperature",
+                )
+                yield Static(
+                    self._field_provenance_copy("temperature"),
+                    id="console-popover-temperature-provenance",
+                    classes="console-popover-provenance",
+                    markup=False,
                 )
                 yield Button(
                     f"Streaming: {'on' if self._streaming else 'off'}",
@@ -232,8 +468,14 @@ class ConsoleModelPopover(
                     compact=True,
                 )
                 yield Static(
+                    self._field_provenance_copy("streaming"),
+                    id="console-popover-streaming-provenance",
+                    classes="console-popover-provenance",
+                    markup=False,
+                )
+                yield Static(
                     "Response max  "
-                    f"{format_context_tokens(self._settings.max_tokens)} tokens for the next reply",
+                    f"{format_context_tokens(settings.max_tokens)} tokens for the next reply",
                     id="console-popover-response-max",
                     classes="console-popover-context-row",
                     markup=False,
@@ -250,7 +492,6 @@ class ConsoleModelPopover(
                     classes="console-popover-context-row",
                     markup=False,
                 )
-            with Vertical(id="console-popover-footer"):
                 yield Static(
                     "Compaction    at "
                     f"{format_context_tokens(self._context_state.compaction_trigger_tokens)} tokens",
@@ -273,6 +514,37 @@ class ConsoleModelPopover(
                     id="console-popover-compaction-mode",
                     disabled=self._context_state.busy,
                 )
+                defaults_panel = Vertical(id="console-popover-defaults-panel")
+                defaults_panel.display = False
+                with defaults_panel:
+                    yield Static(
+                        self._default_target_copy(),
+                        id="console-popover-defaults-target",
+                        markup=False,
+                    )
+                    yield Static(
+                        self._save_model_default_copy(),
+                        id="console-popover-save-model-default-copy",
+                        markup=False,
+                    )
+                    yield Static(
+                        self._make_new_chat_default_copy(),
+                        id="console-popover-make-new-chat-default-copy",
+                        markup=False,
+                    )
+                    yield Static(
+                        "Compaction stays with this chat.",
+                        id="console-popover-defaults-compaction-scope",
+                        markup=False,
+                    )
+                    blocked = Static(
+                        "",
+                        id="console-popover-new-chat-default-block",
+                        markup=False,
+                    )
+                    blocked.display = False
+                    yield blocked
+            with Vertical(id="console-popover-footer"):
                 fold_hint = Static(
                     "▼ more — scroll for conversation settings",
                     id="console-popover-fold-hint",
@@ -280,16 +552,45 @@ class ConsoleModelPopover(
                 )
                 fold_hint.display = False
                 yield fold_hint
-                with Horizontal(id="console-popover-actions"):
+                with Grid(id="console-popover-main-actions"):
                     yield Button(
-                        "Context & memory…",
+                        "Cancel",
+                        id="console-popover-cancel",
+                        compact=True,
+                    )
+                    yield Button(
+                        "Full settings…",
                         id="console-popover-full-settings",
                         compact=True,
                     )
                     yield Button(
-                        "Apply",
+                        "Defaults…",
+                        id="console-popover-defaults",
+                        compact=True,
+                    )
+                    yield Button(
+                        "Apply to this chat",
                         id="console-popover-apply",
                         variant="primary",
+                        compact=True,
+                    )
+                default_actions = Grid(id="console-popover-default-actions")
+                default_actions.display = False
+                with default_actions:
+                    yield Button(
+                        "Save as model default",
+                        id="console-popover-save-model-default",
+                        compact=True,
+                    )
+                    yield Button(
+                        "Make default for new chats",
+                        id="console-popover-make-new-chat-default",
+                        variant="primary",
+                        compact=True,
+                    )
+                    yield Button(
+                        "Back",
+                        id="console-popover-defaults-back",
                         compact=True,
                     )
 
@@ -305,6 +606,7 @@ class ConsoleModelPopover(
 
     def on_mount(self) -> None:
         """Settle the narrow-height fold affordance after first layout."""
+        self._sync_default_content()
         self.call_after_refresh(self._sync_fold_hint)
 
     def on_resize(self, _event: events.Resize) -> None:
@@ -313,9 +615,270 @@ class ConsoleModelPopover(
 
     def _sync_fold_hint(self) -> None:
         """Expose hidden quick settings while keeping the actions pinned."""
-        body = self.query_one("#console-model-popover-body", VerticalScroll)
-        hint = self.query_one("#console-popover-fold-hint", Static)
+        if not self.is_mounted:
+            return
+        try:
+            body = self.query_one("#console-model-popover-body", VerticalScroll)
+            hint = self.query_one("#console-popover-fold-hint", Static)
+        except NoMatches:
+            return
         hint.display = body.virtual_size.height > body.container_size.height
+
+    def _set_error(self, message: str, *, focus: Widget | None = None) -> None:
+        try:
+            error = self.query_one("#console-popover-error", Static)
+        except NoMatches:
+            return
+        error.update(message)
+        error.display = bool(message)
+        if focus is not None:
+            focus.focus()
+            focus.scroll_visible(animate=False)
+
+    @staticmethod
+    def _parse_temperature(raw: str) -> float | None:
+        text = raw.strip()
+        if not text or not validate_text_input(text, max_length=32):
+            return None
+        try:
+            value = float(text)
+        except ValueError:
+            return None
+        return value if _temperature_in_range(value) else None
+
+    def _replace_quick_field(
+        self,
+        name: str,
+        value: object,
+        *,
+        direct_edit: bool,
+    ) -> None:
+        fields = list(self._draft.field_drafts)
+        existing_index = next(
+            (index for index, field in enumerate(fields) if field.name == name),
+            None,
+        )
+        field = ConsoleSettingsFieldDraft(
+            name=name,
+            effective_value=value,
+            profile_override=value,
+            provenance=(
+                ConsoleSettingsFieldProvenance.EXPLICIT
+                if direct_edit
+                else ConsoleSettingsFieldProvenance.INHERITED
+            ),
+            dirty=direct_edit,
+        )
+        if existing_index is None:
+            fields.append(field)
+        else:
+            existing = fields[existing_index]
+            field = replace(
+                existing,
+                effective_value=value,
+                profile_override=value,
+                provenance=(
+                    ConsoleSettingsFieldProvenance.EXPLICIT
+                    if direct_edit
+                    else existing.provenance
+                ),
+                dirty=direct_edit or existing.dirty,
+            )
+            fields[existing_index] = field
+        if direct_edit:
+            self._carried_from.pop(name, None)
+        self._draft = replace(
+            self._draft,
+            settings=replace(self._draft.settings, **{name: value}),
+            field_drafts=tuple(fields),
+        )
+
+    @on(Input.Changed, "#console-popover-temperature")
+    def _temperature_changed(self, event: Input.Changed) -> None:
+        if self._updating_controls:
+            return
+        if self._temperature_mount_echo_pending:
+            self._temperature_mount_echo_pending = False
+            if event.value == self._temperature_mount_value:
+                return
+        value = self._parse_temperature(event.value)
+        if value is not None:
+            self._replace_quick_field("temperature", value, direct_edit=True)
+        else:
+            field = self._field_draft("temperature")
+            if field is not None and not field.dirty:
+                fields = tuple(
+                    replace(candidate, dirty=True)
+                    if candidate.name == "temperature"
+                    else candidate
+                    for candidate in self._draft.field_drafts
+                )
+                self._draft = replace(self._draft, field_drafts=fields)
+        self._sync_provenance_labels()
+
+    def _remember_current_draft(self) -> ConsoleSettingsDraftState:
+        temperature = self._parse_temperature(
+            self.query_one("#console-popover-temperature", Input).value
+        )
+        if temperature is not None:
+            self._replace_quick_field("temperature", temperature, direct_edit=False)
+        try:
+            mode = ContextCompactionMode(
+                str(self.query_one("#console-popover-compaction-mode", Select).value)
+            )
+        except ValueError:
+            mode = self._draft.context_policy_overrides.compaction_mode
+        self._draft = replace(
+            self._draft,
+            settings=replace(self._draft.settings, streaming=self._streaming),
+            context_policy_overrides=replace(
+                self._draft.context_policy_overrides,
+                compaction_mode=mode,
+            ),
+        )
+        self._draft = remember_model_draft(self._draft)
+        return self._draft
+
+    def _rebase_to(
+        self,
+        provider: str,
+        model: str | None,
+        *,
+        preserve_custom_model_input: bool = False,
+    ) -> None:
+        source = (self._draft.settings.provider, self._draft.settings.model)
+        if source == (provider, model):
+            return
+        remembered = self._remember_current_draft()
+        previous_carried = dict(self._carried_from)
+        rebased = self._draft_rebaser(
+            remembered,
+            provider=provider,
+            model=model,
+            app_config=self._app_config,
+            exposed_fields=QUICK_MODEL_DEFAULT_FIELDS,
+        )
+        self._draft = rebased
+        self._streaming = bool(rebased.settings.streaming)
+        self._carried_from = {
+            field.name: previous_carried.get(field.name, source)
+            for field in rebased.field_drafts
+            if field.provenance is ConsoleSettingsFieldProvenance.CARRIED
+        }
+        self._sync_controls_from_draft(
+            source_provider=source[0],
+            preserve_custom_model_input=preserve_custom_model_input,
+        )
+
+    def _sync_controls_from_draft(
+        self,
+        *,
+        source_provider: str,
+        preserve_custom_model_input: bool = False,
+    ) -> None:
+        if not self.is_mounted:
+            return
+        settings = self._draft.settings
+        self._updating_controls = True
+        try:
+            provider_select = self.query_one("#console-popover-provider", Select)
+            if provider_select.value != settings.provider:
+                with provider_select.prevent(Select.Changed):
+                    provider_select.value = settings.provider
+            temperature = self.query_one("#console-popover-temperature", Input)
+            with temperature.prevent(Input.Changed):
+                temperature.value = (
+                    "" if settings.temperature is None else str(settings.temperature)
+                )
+            self.query_one("#console-popover-streaming", Button).label = (
+                f"Streaming: {'on' if self._streaming else 'off'}"
+            )
+            model_select = self.query_one("#console-popover-model", Select)
+            options = [
+                (option.label, option.value)
+                for option in build_console_model_options(
+                    settings.provider,
+                    self._providers_models,
+                    settings.model,
+                )
+            ]
+            model_select.set_options(options)
+            model_select.value = settings.model if settings.model else Select.NULL
+            picker = self.query_one(
+                "#console-popover-model-search", ModelSearchPicker
+            )
+            if source_provider != settings.provider:
+                picker.refresh_provider(
+                    settings.provider,
+                    current_model=settings.model,
+                )
+            elif preserve_custom_model_input and picker.custom_mode:
+                pass
+            else:
+                picker.set_model_value(settings.model)
+            self.query_one("#console-popover-response-max", Static).update(
+                "Response max  "
+                f"{format_context_tokens(settings.max_tokens)} tokens for the next reply"
+            )
+        finally:
+            self._updating_controls = False
+        self._model_options_provider = settings.provider
+        self._sync_provenance_labels()
+        self._sync_default_content()
+
+    def _sync_provenance_labels(self) -> None:
+        if not self.is_mounted:
+            return
+        for name in ("temperature", "streaming"):
+            try:
+                marker = self.query_one(
+                    f"#console-popover-{name}-provenance", Static
+                )
+            except NoMatches:
+                continue
+            marker.update(self._field_provenance_copy(name))
+
+    def _sync_default_content(self) -> None:
+        if not self.is_mounted:
+            return
+        updates = {
+            "#console-popover-defaults-target": self._default_target_copy(),
+            "#console-popover-save-model-default-copy": (
+                self._save_model_default_copy()
+            ),
+            "#console-popover-make-new-chat-default-copy": (
+                self._make_new_chat_default_copy()
+            ),
+        }
+        for selector, copy in updates.items():
+            try:
+                self.query_one(selector, Static).update(copy)
+            except NoMatches:
+                pass
+
+        settings = self._draft.settings
+        readiness = self._default_readiness_resolver(
+            settings.provider,
+            settings.model,
+        )
+        if not settings.model:
+            block_copy = "Unavailable: choose a model first."
+        elif not readiness.native_send_supported:
+            block_copy = f"Unavailable: {readiness.detail}"
+        else:
+            block_copy = ""
+        try:
+            button = self.query_one(
+                "#console-popover-make-new-chat-default", Button
+            )
+            block = self.query_one(
+                "#console-popover-new-chat-default-block", Static
+            )
+        except NoMatches:
+            return
+        button.disabled = bool(block_copy)
+        block.update(block_copy)
+        block.display = bool(block_copy)
 
     @on(Select.Changed, "#console-popover-provider")
     def _provider_changed(self, event: Select.Changed) -> None:
@@ -325,42 +888,40 @@ class ConsoleModelPopover(
             event: The provider select's change event.
         """
         event.stop()
+        if self._updating_controls:
+            return
         provider = str(event.value)
         # TASK-364: ignore the mount-time echo and redundant same-provider events
         # so the prefilled model survives; only a genuine provider change resets
         # the model options (a stale model from another provider must not linger).
         if provider == self._model_options_provider:
             return
-        self._model_options_provider = provider
-        options = [
-            (option.label, option.value)
-            for option in build_console_model_options(
-                provider, self._providers_models, None
-            )
-        ]
-        model_select = self.query_one("#console-popover-model", Select)
-        model_select.set_options(options)
-        self.query_one(
-            "#console-popover-model-search", ModelSearchPicker
-        ).refresh_provider(provider, current_model=None)
+        self._rebase_to(provider, None)
 
     @on(ModelSearchPicker.ModelSelected)
     def _model_search_selected(self, event: ModelSearchPicker.ModelSelected) -> None:
-        """Insert a picked model as a transient option and select it (ADR-020)."""
+        """Rebase through the controller when a catalog model is committed."""
         event.stop()
         model_id = event.model_id.strip()
         if not model_id:
             return
         provider = str(self.query_one("#console-popover-provider", Select).value)
-        model_select = self.query_one("#console-popover-model", Select)
-        options = [
-            (option.label, option.value)
-            for option in build_console_model_options(
-                provider, self._providers_models, model_id
-            )
-        ]
-        model_select.set_options(options)
-        model_select.value = model_id
+        self._rebase_to(provider, model_id)
+
+    @on(ModelSearchPicker.ModelValueChanged)
+    def _model_value_changed(
+        self, event: ModelSearchPicker.ModelValueChanged
+    ) -> None:
+        """Rebase custom model IDs through the same controller seam."""
+        event.stop()
+        if self._updating_controls:
+            return
+        provider = str(self.query_one("#console-popover-provider", Select).value)
+        self._rebase_to(
+            provider,
+            event.model_id,
+            preserve_custom_model_input=event.custom,
+        )
 
     @on(Button.Pressed, "#console-popover-streaming")
     def _toggle_streaming(self, event: Button.Pressed) -> None:
@@ -372,66 +933,284 @@ class ConsoleModelPopover(
         event.stop()
         self._streaming = not self._streaming
         event.button.label = f"Streaming: {'on' if self._streaming else 'off'}"
+        self._replace_quick_field(
+            "streaming",
+            self._streaming,
+            direct_edit=True,
+        )
+        self._sync_provenance_labels()
 
     @on(Button.Pressed, "#console-popover-full-settings")
     def _full_settings(self, event: Button.Pressed) -> None:
-        """Dismiss with the sentinel that tells the caller to open full settings.
-
-        Args:
-            event: The "Full settings…" button's press event.
-        """
+        """Transfer the exact draft without applying it."""
         event.stop()
-        self.dismiss(CONSOLE_POPOVER_OPEN_FULL_SETTINGS)
+        self._submit(_FULL_SETTINGS_ACTION)
+
+    @on(Button.Pressed, "#console-popover-defaults")
+    def _show_defaults(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._set_view("defaults")
+
+    @on(Button.Pressed, "#console-popover-defaults-back")
+    def _back_from_defaults(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._set_view("main")
+
+    def _set_view(self, view: Literal["main", "defaults"]) -> None:
+        body = self.query_one("#console-model-popover-body", VerticalScroll)
+        if view == "defaults":
+            self._main_scroll_y = body.scroll_y
+        self._active_view = view
+        main = self.query_one("#console-popover-main-actions", Grid)
+        defaults = self.query_one("#console-popover-default-actions", Grid)
+        panel = self.query_one("#console-popover-defaults-panel", Vertical)
+        main.display = view == "main"
+        defaults.display = view == "defaults"
+        panel.display = view == "defaults"
+        self._sync_default_content()
+        self.call_after_refresh(self._sync_fold_hint)
+        if view == "defaults":
+            self.query_one("#console-popover-save-model-default", Button).focus()
+            self.call_after_refresh(self._reveal_defaults_panel)
+        else:
+            self.query_one("#console-popover-defaults", Button).focus()
+            self.call_after_refresh(self._restore_main_scroll)
+
+    def _reveal_defaults_panel(self) -> None:
+        """Show the exact default intent before a pinned action can commit it."""
+
+        if not self.is_mounted or self._active_view != "defaults":
+            return
+        try:
+            panel = self.query_one("#console-popover-defaults-panel", Vertical)
+        except NoMatches:
+            return
+        panel.scroll_visible(
+            animate=False,
+            immediate=True,
+            force=True,
+        )
+
+    def _restore_main_scroll(self) -> None:
+        """Return to the conversation controls the user left for Defaults."""
+
+        if not self.is_mounted or self._active_view != "main":
+            return
+        try:
+            body = self.query_one("#console-model-popover-body", VerticalScroll)
+        except NoMatches:
+            return
+        body.scroll_to(
+            y=self._main_scroll_y,
+            animate=False,
+            immediate=True,
+            force=True,
+        )
+
+    @on(Button.Pressed, "#console-popover-cancel")
+    async def _cancel(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self.request_safe_cancel(source="visible")
 
     @on(Button.Pressed, "#console-popover-apply")
     def _apply(self, event: Button.Pressed) -> None:
-        """Apply the popover's provider/model/temperature/streaming edits.
-
-        An empty temperature input clears the value (``None``). A non-empty
-        value that fails to parse as a float, or that parses to NaN/Inf/a
-        value outside ``[0.0, 2.0]``, keeps the prior temperature instead of
-        applying it -- mirroring ``ConsoleSettingsModal``'s rejection of
-        out-of-range temperatures, minus its error banner (this popover has
-        no error surface, so it silently falls back rather than blocking).
-
-        Args:
-            event: The "Apply" button's press event.
-        """
+        """Apply the validated draft to the exact originating conversation."""
         event.stop()
-        provider_value = self.query_one("#console-popover-provider", Select).value
-        model_value = self.query_one(
-            "#console-popover-model-search", ModelSearchPicker
-        ).value
-        temperature_text = self.query_one(
-            "#console-popover-temperature", Input
-        ).value.strip()
-        if not temperature_text:
-            temperature = None
-        else:
-            temperature = self._settings.temperature
-            if validate_text_input(temperature_text, max_length=32):
-                try:
-                    candidate = float(temperature_text)
-                except ValueError:
-                    pass
-                else:
-                    if _temperature_in_range(candidate):
-                        temperature = candidate
-        settings = replace(
-            self._settings,
-            provider=str(provider_value),
-            model=None if model_value in (None, Select.NULL) else str(model_value),
-            temperature=temperature,
-            streaming=self._streaming,
+        self._submit(ConsoleSettingsAction.APPLY_TO_CHAT)
+
+    @on(Button.Pressed, "#console-popover-save-model-default")
+    def _save_model_default(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._submit(ConsoleSettingsAction.SAVE_MODEL_DEFAULT)
+
+    @on(Button.Pressed, "#console-popover-make-new-chat-default")
+    def _make_new_chat_default(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._submit(ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT)
+
+    def _validated_draft(self) -> ConsoleSettingsDraftState | None:
+        provider_select = self.query_one("#console-popover-provider", Select)
+        provider = str(provider_select.value or "").strip()
+        if not provider or provider == str(Select.NULL):
+            self._set_error("Choose a provider.", focus=provider_select)
+            return None
+
+        picker = self.query_one("#console-popover-model-search", ModelSearchPicker)
+        model = picker.value
+        if model is None:
+            self._set_error("Choose a model.", focus=picker)
+            return None
+
+        temperature_input = self.query_one("#console-popover-temperature", Input)
+        temperature = self._parse_temperature(temperature_input.value)
+        if temperature is None:
+            self._set_error(
+                "Temperature must be a finite number from 0 to 2.",
+                focus=temperature_input,
+            )
+            return None
+
+        if (self._draft.settings.provider, self._draft.settings.model) != (
+            provider,
+            model,
+        ):
+            self._rebase_to(provider, model)
+        self._replace_quick_field(
+            "temperature",
+            temperature,
+            direct_edit=False,
         )
-        mode = ContextCompactionMode(
-            str(self.query_one("#console-popover-compaction-mode", Select).value)
+        self._draft = replace(
+            self._draft,
+            settings=replace(
+                self._draft.settings,
+                provider=provider,
+                model=model,
+                temperature=temperature,
+                streaming=self._streaming,
+            ),
+            context_policy_overrides=replace(
+                self._draft.context_policy_overrides,
+                compaction_mode=ContextCompactionMode(
+                    str(
+                        self.query_one(
+                            "#console-popover-compaction-mode", Select
+                        ).value
+                    )
+                ),
+            ),
         )
-        if mode is self._context_state.resolved_policy.policy.compaction_mode:
-            self.dismiss(settings)
+        self._draft = remember_model_draft(self._draft)
+        self._set_error("")
+        return self._draft
+
+    def _release_mouse_capture(self) -> None:
+        captured = self.app.mouse_captured
+        if captured is not None:
+            captured.release_mouse()
+        if self.app.mouse_captured is not None:
+            self.app.capture_mouse(None)
+
+    @staticmethod
+    def _without_endpoint_intent(
+        draft: ConsoleSettingsDraftState,
+    ) -> ConsoleSettingsDraftState:
+        """Return a quick-submission draft with no endpoint save intent."""
+
+        return replace(
+            draft,
+            model_drafts=tuple(
+                replace(remembered, endpoint_draft=None)
+                for remembered in draft.model_drafts
+            ),
+            endpoint_draft=None,
+        )
+
+    def on_click(self, event: events.Click) -> None:  # type: ignore[override]
+        """Recover control clicks redirected through a captured input."""
+        self._recover_redirected_control_click(event)
+
+    def _recover_redirected_control_click(self, event: events.Click) -> None:
+        captured = self.app.mouse_captured
+        click_origin = getattr(event, "widget", None)
+        focused = self.app.focused
+        screen_routed = click_origin is self and isinstance(
+            focused, ConsolePopoverInput
+        )
+        if (
+            not isinstance(captured, ConsolePopoverInput)
+            and not isinstance(click_origin, ConsolePopoverInput)
+            and not screen_routed
+        ):
             return
-        self.dismiss(ConsoleModelPopoverResult(settings=settings, compaction_mode=mode))
+        if isinstance(captured, ConsolePopoverInput):
+            captured.release_mouse()
+        if event.button != 1 or event.screen_x is None or event.screen_y is None:
+            return
+        for control in (*self.query(Select), *self.query(Button)):
+            if control.disabled or not control.display:
+                continue
+            if _widget_screen_region(control).contains(event.screen_x, event.screen_y):
+                control.focus()
+                if isinstance(control, Select):
+                    control.action_show_overlay()
+                else:
+                    control.press()
+                event.stop()
+                return
+
+    def _submit(self, action: PopoverSubmitAction) -> None:
+        if self._submit_pending or self._safe_dismiss_committed:
+            return
+        draft = self._validated_draft()
+        if draft is None:
+            return
+        if action is ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT:
+            button = self.query_one(
+                "#console-popover-make-new-chat-default", Button
+            )
+            if button.disabled:
+                block = self.query_one(
+                    "#console-popover-new-chat-default-block", Static
+                )
+                self._set_error(str(block.renderable) or "Default is unavailable.")
+                return
+
+        self._release_mouse_capture()
+        if action == _FULL_SETTINGS_ACTION:
+            self.dismiss_safe_once(ConsoleSettingsTransfer(self._origin, draft))
+            return
+
+        draft = self._without_endpoint_intent(draft)
+        submission = ConsoleSettingsSubmission(
+            submission_id=uuid4().hex,
+            action=action,
+            surface=ConsoleSettingsSurface.QUICK_POPOVER,
+            origin=self._origin,
+            draft=draft,
+            user_display_name_override=None,
+            default_field_mask=(
+                frozenset()
+                if action is ConsoleSettingsAction.APPLY_TO_CHAT
+                else QUICK_MODEL_DEFAULT_FIELDS
+            ),
+        )
+        self._submit_pending = True
+        try:
+            live_commit = self._live_committer(submission)
+        except ValueError as error:
+            message = str(error).strip().rstrip(".")
+            if message == "Chat closed; nothing applied":
+                self.notify("Chat closed; nothing applied", severity="warning")
+                self.dismiss_safe_once(None)
+                return
+            self._set_error(str(error) or "Settings could not be applied.")
+            self._submit_pending = False
+            return
+        except Exception:
+            self._set_error("Settings could not be applied; nothing changed.")
+            self._submit_pending = False
+            return
+        if not isinstance(live_commit, ConsoleSettingsLiveCommit):
+            self._set_error("Settings could not be applied; nothing changed.")
+            self._submit_pending = False
+            return
+        delivered = False
+        try:
+            delivered = self.dismiss_safe_once(
+                ConsoleSettingsCommittedSubmission(submission, live_commit)
+            )
+        finally:
+            if not delivered and live_commit.durability_admission is not None:
+                live_commit.durability_admission.release()
+
+    async def action_request_safe_cancel(self) -> None:
+        """Leave Defaults first; cancel the popover from the main view."""
+        if self._active_view == "defaults":
+            self._set_view("main")
+            return
+        await super().action_request_safe_cancel()
 
     async def action_dismiss_popover(self) -> None:
         """Dismiss the popover with no result (Escape)."""
-        await self.request_safe_cancel(source="visible")
+        await self.action_request_safe_cancel()

--- a/tldw_chatbook/Widgets/Console/console_project_instructions.py
+++ b/tldw_chatbook/Widgets/Console/console_project_instructions.py
@@ -19,6 +19,8 @@ from textual.widget import Widget
 from textual.widgets import Button, Footer, Static
 from textual.css.query import QueryError
 
+from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
+
 from ...Chat.console_chat_controller import (
     ProjectInstructionBindingRecovery,
     ProjectInstructionDispatchNotice,
@@ -461,7 +463,9 @@ class ConsoleProjectInstructionContextPanel(VerticalScroll):
         self.refresh(recompose=True)
 
 
-class ProjectInstructionSetupModal(ModalScreen[ProjectInstructionSetupResult]):
+class ProjectInstructionSetupModal(
+    SafeModalDismissMixin, ModalScreen[ProjectInstructionSetupResult]
+):
     """Choose one eligible binding, disable the feature, or cancel."""
 
     BUNDLED_CSS = """
@@ -481,8 +485,9 @@ class ProjectInstructionSetupModal(ModalScreen[ProjectInstructionSetupResult]):
     #console-project-setup-actions { height: 1; margin-top: 1; }
     """
 
+    SAFE_MODAL_CONTENT = "#console-project-setup-modal"
     BINDINGS = [
-        ("escape", "cancel", "Cancel"),
+        ("escape", "request_safe_cancel", "Cancel"),
         ("d", "disable", "Disable"),
         ("c", "cancel", "Cancel"),
     ]
@@ -522,6 +527,7 @@ class ProjectInstructionSetupModal(ModalScreen[ProjectInstructionSetupResult]):
             yield Footer()
 
     def on_mount(self) -> None:
+        super().on_mount()
         for button in self.query("Button.console-project-binding-option"):
             if not button.disabled:
                 button.focus()
@@ -534,13 +540,19 @@ class ProjectInstructionSetupModal(ModalScreen[ProjectInstructionSetupResult]):
         index = int(event.button.id.rsplit("-", 1)[-1])
         option = self._options[index]
         if option.eligible:
-            self.dismiss(ProjectInstructionSetupResult("select", option.binding_id))
+            self.dismiss_safe_once(
+                ProjectInstructionSetupResult("select", option.binding_id)
+            )
 
     def action_disable(self) -> None:
-        self.dismiss(ProjectInstructionSetupResult("disable"))
+        self.dismiss_safe_once(ProjectInstructionSetupResult("disable"))
 
     def action_cancel(self) -> None:
-        self.dismiss(ProjectInstructionSetupResult("cancel"))
+        self.dismiss_safe_once(ProjectInstructionSetupResult("cancel"))
+
+    async def _perform_safe_cancel(self, *, source: str) -> None:
+        del source
+        self.dismiss_safe_once(ProjectInstructionSetupResult("cancel"))
 
     @on(Button.Pressed, "#console-project-setup-disable")
     def _disable(self, event: Button.Pressed) -> None:
@@ -553,7 +565,7 @@ class ProjectInstructionSetupModal(ModalScreen[ProjectInstructionSetupResult]):
         self.action_cancel()
 
 
-class ProjectInstructionNoticeModal(ModalScreen[str]):
+class ProjectInstructionNoticeModal(SafeModalDismissMixin, ModalScreen[str]):
     """First-use disclosure for one session and sanitized provider destination."""
 
     BUNDLED_CSS = """
@@ -571,8 +583,9 @@ class ProjectInstructionNoticeModal(ModalScreen[str]):
     #console-project-notice-actions { height: 1; margin-top: 1; }
     """
 
+    SAFE_MODAL_CONTENT = "#console-project-notice-modal"
     BINDINGS = [
-        ("escape", "cancel", "Cancel"),
+        ("escape", "request_safe_cancel", "Cancel"),
         ("p", "proceed", "Proceed"),
         ("c", "cancel", "Cancel"),
         ("d", "disable", "Disable"),
@@ -633,13 +646,17 @@ class ProjectInstructionNoticeModal(ModalScreen[str]):
             yield Footer()
 
     def action_proceed(self) -> None:
-        self.dismiss("proceed")
+        self.dismiss_safe_once("proceed")
 
     def action_cancel(self) -> None:
-        self.dismiss("cancel")
+        self.dismiss_safe_once("cancel")
 
     def action_disable(self) -> None:
-        self.dismiss("disable")
+        self.dismiss_safe_once("disable")
+
+    async def _perform_safe_cancel(self, *, source: str) -> None:
+        del source
+        self.dismiss_safe_once("cancel")
 
     @on(Button.Pressed, "#console-project-notice-proceed")
     def _proceed(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Console/console_prompt_comparison_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_prompt_comparison_modal.py
@@ -135,6 +135,7 @@ class ConsolePromptComparisonModal(
         Returns:
             None: The modal is focused in place.
         """
+        super().on_mount()
         self.query_one("#console-prompt-comparison-keep", Button).focus()
 
     @on(Button.Pressed, "#console-prompt-comparison-keep")

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -86,6 +86,7 @@ from tldw_chatbook.Chat.console_settings_defaults import (
     ConsoleDefaultRecoveryAction,
     ConsoleDefaultRecoveryRequest,
     ConsoleDefaultSavePhase,
+    build_console_default_readiness_preview,
     format_console_endpoint_preview,
 )
 from tldw_chatbook.Utils.input_validation import validate_text_input
@@ -328,9 +329,7 @@ class ConsoleSettingsInput(Input):
 
 class ConsoleSettingsModal(
     SafeModalDismissMixin,
-    ModalScreen[
-        ConsoleSettingsCommittedSubmission | ConsoleSettingsTransfer | None
-    ],
+    ModalScreen[ConsoleSettingsCommittedSubmission | ConsoleSettingsTransfer | None],
 ):
     """Edit a draft of the current Console session settings."""
 
@@ -537,10 +536,13 @@ class ConsoleSettingsModal(
             default_durability_state or ConsoleDefaultDurabilityState()
         )
         self._default_recovery_handler = default_recovery_handler
-        self._default_recovery_pending: tuple[
-            int,
-            ConsoleDefaultSavePhase,
-        ] | None = None
+        self._default_recovery_pending: (
+            tuple[
+                int,
+                ConsoleDefaultSavePhase,
+            ]
+            | None
+        ) = None
         self._default_recovery_layout_phase: ConsoleDefaultSavePhase | None = None
         self._discovered_model_ids: dict[str, tuple[str, ...]] = {}
         streaming_field = self._draft_field("streaming")
@@ -697,10 +699,7 @@ class ConsoleSettingsModal(
         # sparse rather than becoming an explicit override.
         direct_edit = bool(
             name in self._edited_generation_fields
-            or (
-                prior is not None
-                and effective_value != prior.effective_value
-            )
+            or (prior is not None and effective_value != prior.effective_value)
         )
         profile_override = (
             self._streaming_draft
@@ -1610,9 +1609,9 @@ class ConsoleSettingsModal(
         show_model = self._active_view == "model" and not recovery_active
         for section in self.query(".console-settings-model-view"):
             section.display = show_model
-        self.query_one(
-            "#console-settings-context-view", Vertical
-        ).display = self._active_view == "context" and not recovery_active
+        self.query_one("#console-settings-context-view", Vertical).display = (
+            self._active_view == "context" and not recovery_active
+        )
         self.query_one("#console-settings-view-model", Button).variant = (
             "primary" if show_model else "default"
         )
@@ -1623,9 +1622,7 @@ class ConsoleSettingsModal(
         self.query_one("#console-settings-save-default", Button).display = show_model
         self.query_one("#console-settings-make-default", Button).display = show_model
         self.query_one("#console-settings-save", Button).display = not recovery_active
-        readiness = self.query_one(
-            "#console-settings-new-chat-default-block", Static
-        )
+        readiness = self.query_one("#console-settings-new-chat-default-block", Static)
         readiness.display = show_model and bool(str(readiness.renderable))
         self.call_after_refresh(self._sync_fold_hint)
         self.call_after_refresh(self._reveal_default_feedback)
@@ -1640,26 +1637,27 @@ class ConsoleSettingsModal(
         """Gate default actions on an exact model and future-chat readiness."""
 
         try:
-            save_button = self.query_one(
-                "#console-settings-save-default", Button
-            )
-            make_button = self.query_one(
-                "#console-settings-make-default", Button
-            )
-            block = self.query_one(
-                "#console-settings-new-chat-default-block", Static
-            )
+            save_button = self.query_one("#console-settings-save-default", Button)
+            make_button = self.query_one("#console-settings-make-default", Button)
+            block = self.query_one("#console-settings-new-chat-default-block", Static)
         except (NoMatches, QueryError):
             return
         settings = self._build_draft()
-        readiness = (
-            self._default_readiness_resolver(settings.provider, settings.model)
-            if self._default_readiness_resolver is not None
-            else build_console_settings_readiness(
+        if self._endpoint_is_authorized(self._endpoint_draft, settings.provider):
+            readiness = build_console_default_readiness_preview(
+                self._app_config,
+                settings,
+                self._endpoint_draft,
+            )
+        elif self._default_readiness_resolver is not None:
+            readiness = self._default_readiness_resolver(
+                settings.provider, settings.model
+            )
+        else:
+            readiness = build_console_settings_readiness(
                 settings,
                 app_config=self._app_config,
             )
-        )
         if not settings.model:
             copy = "Unavailable: choose a model first."
         elif not readiness.native_send_supported:
@@ -1674,9 +1672,7 @@ class ConsoleSettingsModal(
         make_button.disabled = bool(copy) or not self._can_save
         block.update(copy)
         block.display = (
-            bool(copy)
-            and self._active_view == "model"
-            and not recovery_active
+            bool(copy) and self._active_view == "model" and not recovery_active
         )
         if block.display:
             self.call_after_refresh(self._sync_fold_hint)
@@ -1713,9 +1709,7 @@ class ConsoleSettingsModal(
         """Render the current app-owned recovery snapshot without consuming it."""
 
         try:
-            region = self.query_one(
-                "#console-settings-default-recovery", Vertical
-            )
+            region = self.query_one("#console-settings-default-recovery", Vertical)
             actions = self.query_one(
                 "#console-settings-default-recovery-actions", Horizontal
             )
@@ -1768,9 +1762,7 @@ class ConsoleSettingsModal(
             ).display = False
             for section in self.query(".console-settings-model-view"):
                 section.display = False
-            self.query_one(
-                "#console-settings-context-view", Vertical
-            ).display = False
+            self.query_one("#console-settings-context-view", Vertical).display = False
             if current_phase is not previous_phase:
                 self.call_after_refresh(self._scroll_default_recovery_summary_home)
                 self.call_after_refresh(self._focus_default_recovery_action)
@@ -1798,9 +1790,7 @@ class ConsoleSettingsModal(
         if not self.is_mounted:
             return
         selector = {
-            ConsoleDefaultSavePhase.BEFORE_REPLACE: (
-                "#console-settings-default-retry"
-            ),
+            ConsoleDefaultSavePhase.BEFORE_REPLACE: ("#console-settings-default-retry"),
             ConsoleDefaultSavePhase.CACHE_PUBLICATION: (
                 "#console-settings-default-refresh"
             ),
@@ -1833,12 +1823,8 @@ class ConsoleSettingsModal(
         if not self.is_mounted or self._initial_feedback_sync:
             return
         try:
-            recovery = self.query_one(
-                "#console-settings-default-recovery", Vertical
-            )
-            block = self.query_one(
-                "#console-settings-new-chat-default-block", Static
-            )
+            recovery = self.query_one("#console-settings-default-recovery", Vertical)
+            block = self.query_one("#console-settings-new-chat-default-block", Static)
         except (NoMatches, QueryError):
             return
         if recovery.display:
@@ -1924,16 +1910,12 @@ class ConsoleSettingsModal(
     @on(Button.Pressed, "#console-settings-default-retry")
     async def _retry_default_save(self, event: Button.Pressed) -> None:
         event.stop()
-        await self._request_default_recovery(
-            ConsoleDefaultRecoveryAction.RETRY_SAVE
-        )
+        await self._request_default_recovery(ConsoleDefaultRecoveryAction.RETRY_SAVE)
 
     @on(Button.Pressed, "#console-settings-default-discard")
     async def _discard_default_retry(self, event: Button.Pressed) -> None:
         event.stop()
-        await self._request_default_recovery(
-            ConsoleDefaultRecoveryAction.DISCARD_RETRY
-        )
+        await self._request_default_recovery(ConsoleDefaultRecoveryAction.DISCARD_RETRY)
 
     @on(Button.Pressed, "#console-settings-default-refresh")
     async def _refresh_running_app(self, event: Button.Pressed) -> None:
@@ -2521,7 +2503,9 @@ class ConsoleSettingsModal(
         else:
             status.update("Could not save the new-conversation thinking default.")
 
-    def _validated_submission_draft(self) -> tuple[ConsoleSettingsDraftState, str | None] | None:
+    def _validated_submission_draft(
+        self,
+    ) -> tuple[ConsoleSettingsDraftState, str | None] | None:
         """Return the complete full-surface draft after mounted validation."""
 
         provider = self._select_value_text(
@@ -2535,9 +2519,7 @@ class ConsoleSettingsModal(
             self._draft.settings.provider,
             self._draft.settings.model,
         ):
-            picker = self.query_one(
-                "#console-settings-model-picker", ModelSearchPicker
-            )
+            picker = self.query_one("#console-settings-model-picker", ModelSearchPicker)
             if not self._rebase_to(
                 provider,
                 model,
@@ -2628,12 +2610,8 @@ class ConsoleSettingsModal(
             return
         if action is not ConsoleSettingsAction.APPLY_TO_CHAT:
             self._sync_default_readiness()
-            if normalize_console_model_value(
-                submission.draft.settings.model
-            ) is None:
-                self._set_validation_error(
-                    "Unavailable: choose a model first."
-                )
+            if normalize_console_model_value(submission.draft.settings.model) is None:
+                self._set_validation_error("Unavailable: choose a model first.")
                 return
         if action is ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT:
             button = self.query_one("#console-settings-make-default", Button)
@@ -2667,11 +2645,15 @@ class ConsoleSettingsModal(
             self._submit_pending = False
             return
         except Exception:
-            self._set_validation_error("Settings could not be applied; nothing changed.")
+            self._set_validation_error(
+                "Settings could not be applied; nothing changed."
+            )
             self._submit_pending = False
             return
         if not isinstance(live_commit, ConsoleSettingsLiveCommit):
-            self._set_validation_error("Settings could not be applied; nothing changed.")
+            self._set_validation_error(
+                "Settings could not be applied; nothing changed."
+            )
             self._submit_pending = False
             return
         delivered = False
@@ -2823,6 +2805,7 @@ class ConsoleSettingsModal(
             checked=False,
         )
         self._sync_endpoint_controls()
+        self._sync_default_readiness()
 
     @on(Checkbox.Changed, "#console-settings-save-endpoint")
     def _endpoint_checked(self, event: Checkbox.Changed) -> None:
@@ -2832,6 +2815,7 @@ class ConsoleSettingsModal(
             self._endpoint_draft,
             checked=bool(event.value and self._endpoint_can_be_checked()),
         )
+        self._sync_default_readiness()
 
     def _choice_placeholder(self, input_id: str) -> str:
         """Return the accepted-values placeholder for an enumerated choice input."""
@@ -2852,9 +2836,9 @@ class ConsoleSettingsModal(
     def _sync_provider_choice_placeholders(self) -> None:
         """Refresh choice-input placeholders after the provider changes."""
         for _label, input_id, _placeholder in PROVIDER_CHOICE_INPUTS:
-            self.query_one(f"#{input_id}", Input).placeholder = (
-                self._choice_placeholder(input_id)
-            )
+            self.query_one(
+                f"#{input_id}", Input
+            ).placeholder = self._choice_placeholder(input_id)
 
     @on(Input.Changed)
     @on(Select.Changed)
@@ -2932,9 +2916,7 @@ class ConsoleSettingsModal(
                 exposed_fields=FULL_MODEL_DEFAULT_FIELDS,
             )
         except Exception:
-            self._set_validation_error(
-                "Provider/model settings could not be rebased."
-            )
+            self._set_validation_error("Provider/model settings could not be rebased.")
             return False
         if not isinstance(rebased, ConsoleSettingsDraftState):
             self._set_validation_error("Provider/model rebase returned invalid state.")
@@ -2948,8 +2930,7 @@ class ConsoleSettingsModal(
             provider_config_key(rebased.settings.provider) == requested_provider
         )
         model_matches = (
-            normalize_console_model_value(rebased.settings.model)
-            == requested_model
+            normalize_console_model_value(rebased.settings.model) == requested_model
         )
         if not provider_matches or not (
             model_matches or (provider_changed and requested_model is None)
@@ -2981,15 +2962,13 @@ class ConsoleSettingsModal(
             self._active_provider = state.settings.provider
             self._endpoint_draft = state.endpoint_draft or ConsoleEndpointDraft(
                 value=state.settings.base_url or "",
-                bound_provider_config_key=provider_config_key(
-                    state.settings.provider
-                ),
+                bound_provider_config_key=provider_config_key(state.settings.provider),
                 dirty=False,
                 checked=False,
             )
-            self.query_one("#console-settings-provider", Select).value = (
-                state.settings.provider
-            )
+            self.query_one(
+                "#console-settings-provider", Select
+            ).value = state.settings.provider
             if preserve_custom_model_input:
                 self.query_one(
                     "#console-settings-model-picker", ModelSearchPicker
@@ -3036,9 +3015,9 @@ class ConsoleSettingsModal(
                 )
                 else bool(state.settings.streaming)
             )
-            self.query_one("#console-settings-streaming", Button).label = (
-                self._streaming_toggle_label()
-            )
+            self.query_one(
+                "#console-settings-streaming", Button
+            ).label = self._streaming_toggle_label()
             self._edited_generation_fields.clear()
             self._sync_model_discover_controls(state.settings.provider)
             self._sync_provider_choice_placeholders()
@@ -3081,9 +3060,7 @@ class ConsoleSettingsModal(
 
     @on(Select.Changed, "#console-settings-model-select")
     def _model_select_changed(self, event: Select.Changed) -> None:
-        model_id = normalize_console_model_value(
-            self._select_value_text(event.value)
-        )
+        model_id = normalize_console_model_value(self._select_value_text(event.value))
         # ``set_options`` queues a transient blank event before the concrete
         # replacement value. By dispatch time the Select already exposes the
         # final value, so ignore that stale adapter echo instead of rebasing a
@@ -3121,9 +3098,7 @@ class ConsoleSettingsModal(
         does a model-capability lookup -- neither should run on every
         keystroke (task-15476).
         """
-        picker = self.query_one(
-            "#console-settings-model-picker", ModelSearchPicker
-        )
+        picker = self.query_one("#console-settings-model-picker", ModelSearchPicker)
         if picker.custom_mode:
             picker.set_custom_value(event.value)
         self._schedule_readiness_sync()
@@ -3147,9 +3122,7 @@ class ConsoleSettingsModal(
             and (self._active_provider, model)
             != (self._draft.settings.provider, self._draft.settings.model)
         ):
-            picker = self.query_one(
-                "#console-settings-model-picker", ModelSearchPicker
-            )
+            picker = self.query_one("#console-settings-model-picker", ModelSearchPicker)
             self._rebase_to(
                 self._active_provider,
                 model,
@@ -3209,9 +3182,7 @@ class ConsoleSettingsModal(
     @on(Button.Pressed, "#console-settings-model-custom")
     def _model_custom_pressed(self, event: Button.Pressed) -> None:
         event.stop()
-        picker = self.query_one(
-            "#console-settings-model-picker", ModelSearchPicker
-        )
+        picker = self.query_one("#console-settings-model-picker", ModelSearchPicker)
         picker.toggle_custom_mode()
         model_select = self.query_one("#console-settings-model-select", Select)
         model_input = self.query_one("#console-settings-model-input", Input)
@@ -3308,9 +3279,7 @@ class ConsoleSettingsModal(
             self._set_model_discover_status(f"No models reported at {display}.")
             return
         self._discovered_model_ids[provider] = tuple(result.model_ids)
-        picker = self.query_one(
-            "#console-settings-model-picker", ModelSearchPicker
-        )
+        picker = self.query_one("#console-settings-model-picker", ModelSearchPicker)
         picker.set_discovered_models(provider, list(result.model_ids))
         count = len(result.model_ids)
         # With exactly one model there is nothing to choose, so choose it. The
@@ -3490,9 +3459,7 @@ class ConsoleSettingsModal(
         self._sync_readiness_display()
 
     def _focus_model_control(self) -> None:
-        picker = self.query_one(
-            "#console-settings-model-picker", ModelSearchPicker
-        )
+        picker = self.query_one("#console-settings-model-picker", ModelSearchPicker)
         picker.focus_input()
         picker.query_one("#model-search-picker-input", Input).scroll_visible(
             animate=False,
@@ -3770,9 +3737,7 @@ class ConsoleSettingsModal(
 
     def _current_model_value(self) -> str | None:
         try:
-            picker = self.query_one(
-                "#console-settings-model-picker", ModelSearchPicker
-            )
+            picker = self.query_one("#console-settings-model-picker", ModelSearchPicker)
         except (NoMatches, QueryError):
             picker = None
         if picker is not None:
@@ -3897,16 +3862,12 @@ class ConsoleSettingsModal(
                 "#console-context-compaction-representation", Select
             )
             options = select.query_one(OptionList)
-            status = self.query_one(
-                "#console-context-representation-status", Static
-            )
+            status = self.query_one("#console-context-representation-status", Static)
         except (NoMatches, QueryError):
             return
         model = self._current_model_value() or ""
         try:
-            available = bool(model) and is_vision_capable(
-                self._active_provider, model
-            )
+            available = bool(model) and is_vision_capable(self._active_provider, model)
         except Exception:
             available = False
         for index in (1, 2):
@@ -3932,8 +3893,7 @@ class ConsoleSettingsModal(
             else ""
         )
         status.update(
-            "Visual transcript and Hybrid require a vision-capable model."
-            f"{effective}"
+            f"Visual transcript and Hybrid require a vision-capable model.{effective}"
         )
         select.tooltip = "Vision-only choices are unavailable for the current model."
 
@@ -3980,10 +3940,7 @@ class ConsoleSettingsModal(
         messages = (*resolved.validation_errors, *resolved.warnings)
         if messages:
             return " ".join(messages)
-        if (
-            resolved.safety_verified
-            and self._context_state.model_window_verified
-        ):
+        if resolved.safety_verified and self._context_state.model_window_verified:
             return "Capacity is verified for the selected model."
         if self._context_state.model_window_tokens is not None:
             return (

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Mapping
+from dataclasses import dataclass, replace
+from typing import Any, Awaitable, Callable, Mapping, Protocol
+from uuid import uuid4
 
 from textual import events
 from textual import on
@@ -15,7 +16,7 @@ from textual.css.query import NoMatches, QueryError
 from textual.screen import ModalScreen
 from textual.timer import Timer
 from textual.widget import Widget
-from textual.widgets import Button, Input, OptionList, Select, Static
+from textual.widgets import Button, Checkbox, Input, OptionList, Select, Static
 
 from tldw_chatbook.Chat.provider_readiness import provider_config_key
 from tldw_chatbook.Chat.console_context_policy import (
@@ -51,9 +52,7 @@ from tldw_chatbook.Chat.console_session_settings import (
     ConsoleSessionSettings,
     ConsoleSettingsContextEstimate,
     DEFAULT_LLAMACPP_BASE_URL,
-    EffectiveChatConfiguration,
     URL_BASED_PROVIDER_KEYS,
-    build_canonical_chat_defaults_mutation,
     build_console_model_options,
     build_console_provider_options,
     build_console_settings_readiness,
@@ -61,12 +60,33 @@ from tldw_chatbook.Chat.console_session_settings import (
     normalize_console_model_value,
     normalize_llamacpp_base_url,
     reasoning_effort_hint_for_model,
-    resolve_effective_chat_configuration,
     validate_console_session_settings,
 )
 from tldw_chatbook.Chat.thinking_blocks import (
     ThinkingHistoryPolicy,
     normalize_thinking_history_policy,
+)
+from tldw_chatbook.Chat.console_settings_apply import (
+    FULL_MODEL_DEFAULT_FIELDS,
+    ConsoleEndpointDraft,
+    ConsoleSettingsAction,
+    ConsoleSettingsCommittedSubmission,
+    ConsoleSettingsDraftState,
+    ConsoleSettingsFieldDraft,
+    ConsoleSettingsFieldProvenance,
+    ConsoleSettingsLiveCommit,
+    ConsoleSettingsOrigin,
+    ConsoleSettingsSurface,
+    ConsoleSettingsSubmission,
+    ConsoleSettingsTransfer,
+    remember_model_draft,
+)
+from tldw_chatbook.Chat.console_settings_defaults import (
+    ConsoleDefaultDurabilityState,
+    ConsoleDefaultRecoveryAction,
+    ConsoleDefaultRecoveryRequest,
+    ConsoleDefaultSavePhase,
+    format_console_endpoint_preview,
 )
 from tldw_chatbook.Utils.input_validation import validate_text_input
 from tldw_chatbook.Utils.input_validation import validate_url
@@ -166,39 +186,64 @@ PROVIDER_CHOICE_NO_EFFECT_SUFFIX = " (no effect on this provider)"
 STREAMING_ON_LABEL = "On"
 STREAMING_OFF_LABEL = "Off"
 CONSOLE_SETTINGS_MODEL_SCOPE_COPY = (
-    "Save applies to this conversation. Save model defaults also writes the "
-    "provider, model, generation, and streaming defaults used by new conversations."
+    "Apply affects this chat. Save as model default writes this model's shown "
+    "generation profile. Make default for new chats also selects this provider "
+    "and model for eligible new chats."
 )
 CONSOLE_SETTINGS_CONTEXT_SCOPE_COPY = (
-    "Save applies to this conversation. Global context defaults are in "
+    "Apply affects this chat. Global context defaults are in "
     "F9 Settings > Console behavior."
 )
 CONSOLE_SETTINGS_SCOPE_COPY = CONSOLE_SETTINGS_MODEL_SCOPE_COPY
-CONSOLE_SETTINGS_SAVE_DEFAULT_FAILED_COPY = (
-    "Could not write defaults to the config file; session values still apply."
-)
 #: Debounce for the custom-model-id `Input` -- mirrors the picker/filter
 #: family's 0.2 s shape (`console_prompt_picker_modal.py`). Each settle
 #: rebuilds a full `ConsoleSessionSettings` draft from every form field and
 #: re-validates it, which must not happen on every keystroke (task-15476).
 CONSOLE_SETTINGS_READINESS_DEBOUNCE_SECONDS = 0.2
 # Draft fields persisted under [api_settings.<provider>] by Save as default.
-PROVIDER_DEFAULT_PERSIST_FIELDS = (
-    "temperature",
-    "top_p",
-    "min_p",
-    "top_k",
-    "max_tokens",
-    "seed",
-    "presence_penalty",
-    "frequency_penalty",
-    "reasoning_effort",
-    "reasoning_summary",
-    "verbosity",
-    "thinking_effort",
-    "thinking_budget_tokens",
-)
-_ENDPOINT_PERSIST_KEYS = ("api_base_url", "api_base", "base_url", "api_url")
+STREAMING_INHERIT_LABEL = "Inherit"
+_GENERATION_FIELD_BY_INPUT_ID = {
+    "console-settings-temperature": "temperature",
+    "console-settings-top-p": "top_p",
+    "console-settings-min-p": "min_p",
+    "console-settings-top-k": "top_k",
+    "console-settings-max-tokens": "max_tokens",
+    "console-settings-seed": "seed",
+    "console-settings-presence-penalty": "presence_penalty",
+    "console-settings-frequency-penalty": "frequency_penalty",
+    "console-settings-reasoning-effort": "reasoning_effort",
+    "console-settings-reasoning-summary": "reasoning_summary",
+    "console-settings-verbosity": "verbosity",
+    "console-settings-thinking-effort": "thinking_effort",
+    "console-settings-thinking-budget-tokens": "thinking_budget_tokens",
+}
+
+
+class DraftRebaser(Protocol):
+    """Controller-owned provider/model rebase seam."""
+
+    def __call__(
+        self,
+        state: ConsoleSettingsDraftState,
+        *,
+        provider: str,
+        model: str | None,
+        app_config: Mapping[str, object],
+        exposed_fields: frozenset[str],
+    ) -> ConsoleSettingsDraftState: ...
+
+
+class DefaultReadinessResolver(Protocol):
+    """Configuration-owned readiness seam for future-chat defaults."""
+
+    def __call__(self, provider: str, model: str | None) -> Any: ...
+
+
+LiveCommitter = Callable[[ConsoleSettingsSubmission], ConsoleSettingsLiveCommit]
+DefaultRecoveryHandler = Callable[
+    [ConsoleDefaultRecoveryRequest],
+    Awaitable[ConsoleDefaultDurabilityState],
+]
 
 
 def _settings_screen_region(widget: Any) -> Any:
@@ -282,7 +327,10 @@ class ConsoleSettingsInput(Input):
 
 
 class ConsoleSettingsModal(
-    SafeModalDismissMixin, ModalScreen[ConsoleSettingsResult | None]
+    SafeModalDismissMixin,
+    ModalScreen[
+        ConsoleSettingsCommittedSubmission | ConsoleSettingsTransfer | None
+    ],
 ):
     """Edit a draft of the current Console session settings."""
 
@@ -336,6 +384,26 @@ class ConsoleSettingsModal(
         height: 1;
         min-height: 1;
         color: $text-muted;
+    }}
+
+    ConsoleSettingsModal #console-settings-actions Button {{
+        border: none;
+    }}
+
+    ConsoleSettingsModal #console-settings-new-chat-default-block,
+    ConsoleSettingsModal #console-settings-default-recovery,
+    ConsoleSettingsModal #console-settings-default-recovery-summary {{
+        height: auto;
+    }}
+
+    ConsoleSettingsModal #console-settings-new-chat-default-block,
+    ConsoleSettingsModal #console-settings-default-recovery {{
+        margin: 1 0 0 0;
+    }}
+
+    ConsoleSettingsModal #console-settings-default-recovery-actions {{
+        height: {MODAL_CONTROL_HEIGHT};
+        min-height: {MODAL_CONTROL_HEIGHT};
     }}
 
     ConsoleSettingsModal #console-settings-memory-review {{
@@ -394,6 +462,9 @@ class ConsoleSettingsModal(
         self,
         *,
         settings: ConsoleSessionSettings,
+        origin: ConsoleSettingsOrigin | None = None,
+        initial_draft: ConsoleSettingsDraftState | None = None,
+        transfer: ConsoleSettingsTransfer | None = None,
         user_display_name_override: str | None = None,
         global_user_display_name: str = "User",
         app_config: Mapping[str, object],
@@ -408,9 +479,22 @@ class ConsoleSettingsModal(
         reset_all_memories: AllMemoryResetter | None = None,
         compact_now: ContextCompactor | None = None,
         model_prober: ModelProber | None = None,
+        draft_rebaser: DraftRebaser | None = None,
+        live_committer: LiveCommitter | None = None,
+        default_readiness_resolver: DefaultReadinessResolver | None = None,
+        default_durability_state: ConsoleDefaultDurabilityState | None = None,
+        default_recovery_handler: DefaultRecoveryHandler | None = None,
     ) -> None:
         super().__init__()
-        self._settings = settings
+        if transfer is not None:
+            origin = transfer.origin
+            initial_draft = transfer.draft
+            settings = transfer.draft.settings
+        self._origin = origin or ConsoleSettingsOrigin(
+            "legacy-console-settings", None, 0
+        )
+        self._draft = initial_draft or self._initial_full_draft(settings)
+        self._settings = self._draft.settings
         try:
             self._user_display_name_override = normalize_chat_display_name(
                 user_display_name_override, blank_means_none=True
@@ -429,9 +513,11 @@ class ConsoleSettingsModal(
         self._app_config = app_config
         self._providers_models = providers_models
         self._context_estimate = context_estimate
-        self._context_state = context_state or build_console_context_control_state(
-            settings=settings,
+        self._context_state = self._context_state_with_draft_overrides(
+            context_state,
+            settings=self._settings,
             estimate=context_estimate,
+            overrides=self._draft.context_policy_overrides,
         )
         self._can_save = can_save
         self._focus_model = focus_model
@@ -444,24 +530,212 @@ class ConsoleSettingsModal(
         self._confirm_reset_all = False
         self._context_overrides_reset = False
         self._model_prober: ModelProber = model_prober or _default_model_prober
+        self._draft_rebaser = draft_rebaser
+        self._live_committer = live_committer
+        self._default_readiness_resolver = default_readiness_resolver
+        self._default_durability_state = (
+            default_durability_state or ConsoleDefaultDurabilityState()
+        )
+        self._default_recovery_handler = default_recovery_handler
+        self._default_recovery_pending: tuple[
+            int,
+            ConsoleDefaultSavePhase,
+        ] | None = None
+        self._default_recovery_layout_phase: ConsoleDefaultSavePhase | None = None
         self._discovered_model_ids: dict[str, tuple[str, ...]] = {}
-        self._streaming_draft = bool(settings.streaming)
-        self._active_provider = settings.provider
+        streaming_field = self._draft_field("streaming")
+        self._streaming_draft: bool | None = (
+            streaming_field.profile_override
+            if streaming_field is not None
+            and (
+                streaming_field.profile_override is None
+                or type(streaming_field.profile_override) is bool
+            )
+            else bool(self._settings.streaming)
+        )
+        self._streaming_effective_fallback = bool(self._settings.streaming)
+        # Compose-time Input/Select echoes must not convert transferred draft
+        # state into a new user edit. The guard is released after the first
+        # refresh, once every mounted control reflects the transferred state.
+        self._updating_controls = True
+        self._initial_feedback_sync = True
+        self._edited_generation_fields: set[str] = set()
+        self._submit_pending = False
+        self._rebase_event_guard = False
+        self._active_provider = self._settings.provider
         self._provider_model_drafts: dict[str, str | None] = {}
-        self._set_provider_model_draft(settings.provider, settings.model)
+        self._set_provider_model_draft(
+            self._settings.provider,
+            self._settings.model,
+        )
         self._provider_base_url_drafts: dict[str, str] = {}
         initial_base_url = self._initial_base_url_for_provider(
-            settings.provider,
-            settings.base_url,
+            self._settings.provider,
+            self._settings.base_url,
         )
         if initial_base_url:
-            self._provider_base_url_drafts[settings.provider] = initial_base_url
+            self._provider_base_url_drafts[self._settings.provider] = initial_base_url
+        self._endpoint_draft = self._draft.endpoint_draft or ConsoleEndpointDraft(
+            value=initial_base_url or "",
+            bound_provider_config_key=provider_config_key(self._settings.provider),
+            dirty=False,
+            checked=False,
+        )
         self._readiness_debounce_timer: Timer | None = None
         self._settings_close_guard_mode: str | None = None
         self._settings_close_guard_focus: Widget | None = None
         self._compaction_wait_worker: Any | None = None
         self._compaction_provider_task: asyncio.Task[tuple[bool, str]] | None = None
         self._compaction_result_definitive = False
+
+    @staticmethod
+    def _context_state_with_draft_overrides(
+        state: ConsoleContextControlState | None,
+        *,
+        settings: ConsoleSessionSettings,
+        estimate: ConsoleSettingsContextEstimate,
+        overrides: ConsoleContextPolicyOverrides,
+    ) -> ConsoleContextControlState:
+        """Apply transferred policy intent without dropping live context metadata."""
+
+        if state is None:
+            return build_console_context_control_state(
+                settings=settings,
+                estimate=estimate,
+                overrides=overrides,
+            )
+        if state.overrides == overrides:
+            return state
+        inherited = state.inherited_policy
+        inherited_overrides = ConsoleContextPolicyOverrides(
+            budget_mode=inherited.budget_mode,
+            custom_budget_tokens=inherited.custom_budget_tokens,
+            compaction_mode=inherited.compaction_mode,
+            compaction_representation=inherited.compaction_representation,
+            trigger_ratio=inherited.trigger_ratio,
+            target_ratio=inherited.target_ratio,
+            summary_max_tokens=inherited.summary_max_tokens,
+            failure_behavior=inherited.failure_behavior,
+            carry_forward_mode=inherited.carry_forward_mode,
+        )
+        reserved = (
+            state.response_max_tokens
+            + int(state.safety_margin_tokens or 0)
+            + int(state.request_overhead_tokens or 0)
+        )
+        effective_cap = (
+            state.safe_input_ceiling_tokens + reserved
+            if state.safe_input_ceiling_tokens is not None
+            else None
+        )
+        provider_cap = (
+            effective_cap
+            if effective_cap is not None
+            and effective_cap > 0
+            and (
+                state.model_window_tokens is None
+                or effective_cap < state.model_window_tokens
+            )
+            else None
+        )
+        return build_console_context_control_state(
+            settings=settings,
+            estimate=estimate,
+            overrides=overrides,
+            global_overrides=inherited_overrides,
+            active_memory=state.active_memory,
+            conversation_tokens=state.conversation_tokens,
+            request_overhead_tokens=state.request_overhead_tokens,
+            provider_input_cap_tokens=provider_cap,
+            safety_margin_tokens=state.safety_margin_tokens,
+            busy=state.busy,
+            status_message=state.status_message,
+        )
+
+    @staticmethod
+    def _initial_full_draft(
+        settings: ConsoleSessionSettings,
+    ) -> ConsoleSettingsDraftState:
+        """Build a full-field draft for transitional callers without a transfer."""
+
+        fields = tuple(
+            ConsoleSettingsFieldDraft(
+                name=name,
+                effective_value=getattr(settings, name),
+                profile_override=getattr(settings, name),
+                provenance=ConsoleSettingsFieldProvenance.INHERITED,
+                dirty=False,
+            )
+            for name in sorted(FULL_MODEL_DEFAULT_FIELDS)
+        )
+        return ConsoleSettingsDraftState(
+            settings=settings,
+            context_policy_overrides=ConsoleContextPolicyOverrides(),
+            field_drafts=fields,
+            model_drafts=(),
+            endpoint_draft=None,
+        )
+
+    def _draft_field(self, name: str) -> ConsoleSettingsFieldDraft | None:
+        return next(
+            (field for field in self._draft.field_drafts if field.name == name),
+            None,
+        )
+
+    def _updated_field_draft(
+        self,
+        name: str,
+        effective_value: object | None,
+    ) -> ConsoleSettingsFieldDraft:
+        """Merge one mounted value without erasing inherited/carried intent."""
+
+        prior = self._draft_field(name)
+        # Textual may deliver a model Select change before a previously queued
+        # Input.Changed notification. Comparing the mounted effective value to
+        # the immutable draft makes that edit observable during the snapshot,
+        # while an untouched inherited value still compares equal and remains
+        # sparse rather than becoming an explicit override.
+        direct_edit = bool(
+            name in self._edited_generation_fields
+            or (
+                prior is not None
+                and effective_value != prior.effective_value
+            )
+        )
+        profile_override = (
+            self._streaming_draft
+            if name == "streaming"
+            else effective_value
+            if direct_edit
+            else prior.profile_override
+            if prior is not None
+            else None
+        )
+        changed = bool(
+            direct_edit
+            or (
+                name == "streaming"
+                and (prior is None or prior.profile_override != profile_override)
+            )
+        )
+        dirty = bool((prior is not None and prior.dirty) or changed)
+        if changed:
+            provenance = (
+                ConsoleSettingsFieldProvenance.INHERITED
+                if profile_override is None
+                else ConsoleSettingsFieldProvenance.EXPLICIT
+            )
+        elif prior is not None:
+            provenance = prior.provenance
+        else:
+            provenance = ConsoleSettingsFieldProvenance.INHERITED
+        return ConsoleSettingsFieldDraft(
+            name=name,
+            effective_value=effective_value,
+            profile_override=profile_override,
+            provenance=provenance,
+            dirty=dirty,
+        )
 
     def compose(self) -> ComposeResult:
         provider_options = self._provider_select_options()
@@ -519,12 +793,14 @@ class ConsoleSettingsModal(
                 classes="console-settings-modal-row",
                 markup=False,
             )
-            yield Static(
+            error_summary = Static(
                 "",
                 id="console-settings-error",
                 classes="console-settings-error console-settings-error-summary",
                 markup=False,
             )
+            error_summary.display = False
+            yield error_summary
 
             body = ScrollableContainer(
                 id="console-settings-body",
@@ -637,6 +913,24 @@ class ConsoleSettingsModal(
                         )
                         base_url_input.display = uses_base_url
                         yield base_url_input
+                    with Horizontal(classes="console-settings-modal-row"):
+                        yield self._modal_label("New-chat default")
+                        endpoint_checkbox = Checkbox(
+                            self._endpoint_save_copy(),
+                            value=self._endpoint_checkbox_value(),
+                            id="console-settings-save-endpoint",
+                            disabled=not self._endpoint_can_be_checked(),
+                        )
+                        endpoint_checkbox.display = uses_base_url
+                        yield endpoint_checkbox
+                    endpoint_status = Static(
+                        self._endpoint_status_copy(),
+                        id="console-settings-endpoint-status",
+                        classes="console-settings-modal-row",
+                        markup=False,
+                    )
+                    endpoint_status.display = uses_base_url
+                    yield endpoint_status
 
                 with Vertical(
                     classes="console-settings-modal-section console-settings-model-view"
@@ -1126,6 +1420,22 @@ class ConsoleSettingsModal(
                             confirm.display = False
                             yield confirm
 
+                new_chat_block = Static(
+                    "",
+                    id="console-settings-new-chat-default-block",
+                    markup=False,
+                )
+                new_chat_block.display = False
+                yield new_chat_block
+                recovery = Vertical(id="console-settings-default-recovery")
+                recovery.display = False
+                with recovery:
+                    yield Static(
+                        "",
+                        id="console-settings-default-recovery-summary",
+                        markup=False,
+                    )
+
             fold_hint = Static(
                 "▼ more — scroll for the rest",
                 id="console-settings-fold-hint",
@@ -1133,33 +1443,63 @@ class ConsoleSettingsModal(
             )
             fold_hint.display = False
             yield fold_hint
-            with Horizontal(
+            recovery_actions = Horizontal(
+                id="console-settings-default-recovery-actions"
+            )
+            recovery_actions.display = False
+            with recovery_actions:
+                yield Button(
+                    "Retry default save",
+                    id="console-settings-default-retry",
+                )
+                yield Button(
+                    "Discard retry",
+                    id="console-settings-default-discard",
+                )
+                yield Button(
+                    "Refresh running app",
+                    id="console-settings-default-refresh",
+                )
+                yield Button(
+                    "Dismiss",
+                    id="console-settings-default-dismiss",
+                )
+            with Vertical(
                 id="console-settings-actions",
                 classes="console-settings-modal-row console-settings-modal-actions",
             ):
-                yield Button("Cancel", id="console-settings-cancel")
-                save_default = Button(
-                    "Save model defaults",
-                    id="console-settings-save-default",
-                    disabled=not self._can_save,
-                )
-                save_default.tooltip = (
-                    "Apply to this conversation and write provider, model, generation, "
-                    "and streaming defaults for new conversations."
-                )
-                # Match the 1-row Cancel/Save action styling (their sizes come
-                # from id-scoped app CSS this button's id does not inherit).
-                save_default.styles.height = 1
-                save_default.styles.min_height = 1
-                save_default.styles.width = 24
-                save_default.styles.min_width = 24
-                yield save_default
-                yield Button(
-                    "Save",
-                    id="console-settings-save",
-                    variant="primary",
-                    disabled=not self._can_save,
-                )
+                with Horizontal(classes="console-settings-action-group"):
+                    yield Button("Cancel", id="console-settings-cancel")
+                    save_default = Button(
+                        "Save as model default",
+                        id="console-settings-save-default",
+                        disabled=not self._can_save,
+                    )
+                    save_default.tooltip = (
+                        "Apply to this chat and save the shown generation profile "
+                        "for this exact provider and model."
+                    )
+                    save_default.styles.width = 24
+                    save_default.styles.min_width = 24
+                    yield save_default
+                with Horizontal(classes="console-settings-action-group"):
+                    make_default = Button(
+                        "Make default for new chats",
+                        id="console-settings-make-default",
+                        disabled=not self._can_save,
+                    )
+                    make_default.styles.width = 28
+                    make_default.styles.min_width = 28
+                    yield make_default
+                    apply = Button(
+                        "Apply to this chat",
+                        id="console-settings-save",
+                        variant="primary",
+                        disabled=not self._can_save,
+                    )
+                    apply.styles.width = 20
+                    apply.styles.min_width = 20
+                    yield apply
             guard = Vertical(
                 Static("", id="console-settings-close-message", markup=False),
                 Horizontal(
@@ -1184,27 +1524,95 @@ class ConsoleSettingsModal(
             yield guard
 
     def on_mount(self) -> None:
+        self._sync_action_layout(self.size.width)
         self._show_settings_view(self._active_view)
-        if self._focus_model:
-            self._focus_model_control()
-        elif self._active_view == "context":
-            self._sync_visual_representation_availability()
-            self.call_after_refresh(self._focus_context_control)
+        self._sync_endpoint_controls()
+        self._sync_default_recovery_region()
+        self._sync_default_readiness()
+        self.call_after_refresh(self._reveal_default_feedback)
+        self.call_after_refresh(self._finish_initial_control_sync)
+        if self._default_recovery_layout_phase is None:
+            if self._focus_model:
+                self._focus_model_control()
+            elif self._active_view == "context":
+                self._sync_visual_representation_availability()
+                self.call_after_refresh(self._focus_context_control)
         self.call_after_refresh(self._sync_fold_hint)
 
-    def on_resize(self, _event: events.Resize) -> None:
+    def _finish_initial_control_sync(self) -> None:
+        """Allow mounted control events after transferred state is projected."""
+
+        self._updating_controls = False
+        self.call_after_refresh(self._finish_initial_feedback_sync)
+
+    def _finish_initial_feedback_sync(self) -> None:
+        """Allow feedback reveals after the initial mount/resize callback batch."""
+
+        self._initial_feedback_sync = False
+
+    def on_resize(self, event: events.Resize) -> None:
         """Recompute the body fold affordance after viewport changes."""
+        self._sync_action_layout(event.size.width)
         self.call_after_refresh(self._sync_fold_hint)
+        self.call_after_refresh(self._reveal_default_feedback)
+
+    def _sync_action_layout(self, viewport_width: int) -> None:
+        """Keep every footer action reachable at supported terminal widths."""
+
+        compact = viewport_width < 100
+        recovery_active = (
+            self._default_durability_state.recovery_intent is not None
+            and self._default_durability_state.failure_phase is not None
+        )
+        view_tabs = self.query_one("#console-settings-view-tabs", Horizontal)
+        view_height = 1 if compact else MODAL_CONTROL_HEIGHT
+        view_tabs.styles.height = view_height
+        view_tabs.styles.min_height = view_height
+        for button in view_tabs.query(Button):
+            button.styles.height = view_height
+            button.styles.min_height = view_height
+        for selector in ("#console-settings-readiness", "#console-settings-scope"):
+            summary = self.query_one(selector, Static)
+            summary.styles.height = "auto"
+            summary.styles.min_height = 1 if compact else MODAL_CONTROL_HEIGHT
+        recovery_actions = self.query_one(
+            "#console-settings-default-recovery-actions", Horizontal
+        )
+        recovery_actions.styles.height = 1 if compact else MODAL_CONTROL_HEIGHT
+        recovery_actions.styles.min_height = 1 if compact else MODAL_CONTROL_HEIGHT
+        for button in recovery_actions.query(Button):
+            button.styles.height = 1 if compact else MODAL_CONTROL_HEIGHT
+            button.styles.min_height = 1 if compact else MODAL_CONTROL_HEIGHT
+        actions = self.query_one("#console-settings-actions", Vertical)
+        actions.styles.layout = "vertical" if compact else "horizontal"
+        action_height = 1 if recovery_active or not compact else 2
+        actions.styles.height = action_height
+        actions.styles.min_height = action_height
+        action_groups = list(actions.query(".console-settings-action-group"))
+        for group in action_groups:
+            group.styles.width = "100%" if compact else "auto"
+            group.styles.height = 1
+            group.styles.min_height = 1
+            group.styles.align_horizontal = "right"
+        if len(action_groups) > 1:
+            action_groups[1].display = not recovery_active
+        for button in actions.query(Button):
+            button.styles.height = 1
+            button.styles.min_height = 1
 
     def _show_settings_view(self, view: str) -> None:
         """Switch between the two stable in-modal destinations."""
         self._active_view = "context" if view == "context" else "model"
-        show_model = self._active_view == "model"
+        recovery_active = (
+            self._default_durability_state.recovery_intent is not None
+            and self._default_durability_state.failure_phase is not None
+        )
+        show_model = self._active_view == "model" and not recovery_active
         for section in self.query(".console-settings-model-view"):
             section.display = show_model
         self.query_one(
             "#console-settings-context-view", Vertical
-        ).display = not show_model
+        ).display = self._active_view == "context" and not recovery_active
         self.query_one("#console-settings-view-model", Button).variant = (
             "primary" if show_model else "default"
         )
@@ -1213,13 +1621,333 @@ class ConsoleSettingsModal(
         )
         self.query_one("#console-settings-scope", Static).update(self._scope_copy())
         self.query_one("#console-settings-save-default", Button).display = show_model
+        self.query_one("#console-settings-make-default", Button).display = show_model
+        self.query_one("#console-settings-save", Button).display = not recovery_active
+        readiness = self.query_one(
+            "#console-settings-new-chat-default-block", Static
+        )
+        readiness.display = show_model and bool(str(readiness.renderable))
         self.call_after_refresh(self._sync_fold_hint)
+        self.call_after_refresh(self._reveal_default_feedback)
 
     def _scope_copy(self) -> str:
         """Return save-scope copy for the active modal destination."""
         if self._active_view == "context":
             return CONSOLE_SETTINGS_CONTEXT_SCOPE_COPY
         return CONSOLE_SETTINGS_MODEL_SCOPE_COPY
+
+    def _sync_default_readiness(self) -> None:
+        """Gate default actions on an exact model and future-chat readiness."""
+
+        try:
+            save_button = self.query_one(
+                "#console-settings-save-default", Button
+            )
+            make_button = self.query_one(
+                "#console-settings-make-default", Button
+            )
+            block = self.query_one(
+                "#console-settings-new-chat-default-block", Static
+            )
+        except (NoMatches, QueryError):
+            return
+        settings = self._build_draft()
+        readiness = (
+            self._default_readiness_resolver(settings.provider, settings.model)
+            if self._default_readiness_resolver is not None
+            else build_console_settings_readiness(
+                settings,
+                app_config=self._app_config,
+            )
+        )
+        if not settings.model:
+            copy = "Unavailable: choose a model first."
+        elif not readiness.native_send_supported:
+            copy = f"Unavailable: {readiness.detail}"
+        else:
+            copy = ""
+        recovery_active = (
+            self._default_durability_state.recovery_intent is not None
+            and self._default_durability_state.failure_phase is not None
+        )
+        save_button.disabled = not settings.model or not self._can_save
+        make_button.disabled = bool(copy) or not self._can_save
+        block.update(copy)
+        block.display = (
+            bool(copy)
+            and self._active_view == "model"
+            and not recovery_active
+        )
+        if block.display:
+            self.call_after_refresh(self._sync_fold_hint)
+            self.call_after_refresh(self._reveal_default_feedback)
+
+    def _default_recovery_summary(self) -> str:
+        state = self._default_durability_state
+        intent = state.recovery_intent
+        phase = state.failure_phase
+        if intent is None or phase is None:
+            return ""
+        action = (
+            "Make default for new chats"
+            if intent.action is ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT
+            else "Save as model default"
+        )
+        fields = ", ".join(sorted(intent.field_mask))
+        endpoint = ""
+        if intent.endpoint_patch is not None:
+            preview = format_console_endpoint_preview(intent.endpoint_patch.value)
+            if preview is not None:
+                endpoint = f" · connection {preview}"
+        status = (
+            "Not written to disk"
+            if phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+            else "Saved on disk; running app refresh failed"
+        )
+        return (
+            f"{status}\n{action}: {intent.provider_config_key}/"
+            f"{intent.literal_model_id} · fields: {fields}{endpoint}"
+        )
+
+    def _sync_default_recovery_region(self) -> None:
+        """Render the current app-owned recovery snapshot without consuming it."""
+
+        try:
+            region = self.query_one(
+                "#console-settings-default-recovery", Vertical
+            )
+            actions = self.query_one(
+                "#console-settings-default-recovery-actions", Horizontal
+            )
+            summary = self.query_one(
+                "#console-settings-default-recovery-summary", Static
+            )
+        except (NoMatches, QueryError):
+            return
+        state = self._default_durability_state
+        phase = state.failure_phase
+        visible = state.recovery_intent is not None and phase is not None
+        region.display = visible
+        actions.display = visible
+        summary.update(self._default_recovery_summary())
+        self._sync_default_recovery_layout(visible)
+        if not visible:
+            return
+        before_replace = phase is ConsoleDefaultSavePhase.BEFORE_REPLACE
+        pending = self._default_recovery_pending is not None
+        retry = self.query_one("#console-settings-default-retry", Button)
+        discard = self.query_one("#console-settings-default-discard", Button)
+        refresh = self.query_one("#console-settings-default-refresh", Button)
+        dismiss = self.query_one("#console-settings-default-dismiss", Button)
+        retry.display = before_replace
+        discard.display = before_replace
+        refresh.display = not before_replace
+        dismiss.display = not before_replace
+        for button in (retry, discard, refresh, dismiss):
+            button.disabled = pending
+        self.call_after_refresh(self._reveal_default_feedback)
+
+    def _sync_default_recovery_layout(self, visible: bool) -> None:
+        """Give the exact recovery summary the bounded body at narrow heights."""
+
+        previous_phase = self._default_recovery_layout_phase
+        current_phase = (
+            self._default_durability_state.failure_phase if visible else None
+        )
+        self._default_recovery_layout_phase = current_phase
+        self._sync_action_layout(self.size.width)
+        for selector in (
+            "#console-settings-view-tabs",
+            "#console-settings-readiness",
+            "#console-settings-scope",
+        ):
+            self.query_one(selector).display = not visible
+        if visible:
+            self.query_one(
+                "#console-settings-new-chat-default-block", Static
+            ).display = False
+            for section in self.query(".console-settings-model-view"):
+                section.display = False
+            self.query_one(
+                "#console-settings-context-view", Vertical
+            ).display = False
+            if current_phase is not previous_phase:
+                self.call_after_refresh(self._scroll_default_recovery_summary_home)
+                self.call_after_refresh(self._focus_default_recovery_action)
+            self.call_after_refresh(self._sync_fold_hint)
+            return
+        self._show_settings_view(self._active_view)
+        if previous_phase is not None:
+            self.call_after_refresh(self._restore_focus_after_default_recovery)
+        self.call_after_refresh(self._sync_fold_hint)
+
+    def _scroll_default_recovery_summary_home(self) -> None:
+        """Start a newly visible recovery at the beginning of its exact summary."""
+
+        if not self.is_mounted or self._default_recovery_layout_phase is None:
+            return
+        try:
+            body = self.query_one("#console-settings-body", ScrollableContainer)
+        except (NoMatches, QueryError):
+            return
+        body.scroll_to(y=0, animate=False, immediate=True, force=True)
+
+    def _focus_default_recovery_action(self) -> None:
+        """Focus the first action valid for the current recovery phase."""
+
+        if not self.is_mounted:
+            return
+        selector = {
+            ConsoleDefaultSavePhase.BEFORE_REPLACE: (
+                "#console-settings-default-retry"
+            ),
+            ConsoleDefaultSavePhase.CACHE_PUBLICATION: (
+                "#console-settings-default-refresh"
+            ),
+        }.get(self._default_recovery_layout_phase)
+        if selector is None:
+            return
+        try:
+            button = self.query_one(selector, Button)
+        except (NoMatches, QueryError):
+            return
+        if button.display and not button.disabled:
+            button.focus()
+
+    def _restore_focus_after_default_recovery(self) -> None:
+        """Return focus to the visible editor after recovery succeeds."""
+
+        if not self.is_mounted or self._default_recovery_layout_phase is not None:
+            return
+        try:
+            if self._active_view == "context":
+                self._focus_context_control()
+            else:
+                self._focus_model_control()
+        except (NoMatches, QueryError):
+            return
+
+    def _reveal_default_feedback(self) -> None:
+        """Reveal the applicable dynamic status inside the bounded modal body."""
+
+        if not self.is_mounted or self._initial_feedback_sync:
+            return
+        try:
+            recovery = self.query_one(
+                "#console-settings-default-recovery", Vertical
+            )
+            block = self.query_one(
+                "#console-settings-new-chat-default-block", Static
+            )
+        except (NoMatches, QueryError):
+            return
+        if recovery.display:
+            return
+        if block.display:
+            body = self.query_one("#console-settings-body", ScrollableContainer)
+            focused = self.app.focused
+            if focused is not None and body in focused.ancestors:
+                return
+            block.scroll_visible(
+                animate=False,
+                immediate=True,
+                force=True,
+            )
+
+    async def _request_default_recovery(
+        self,
+        action: ConsoleDefaultRecoveryAction,
+    ) -> None:
+        intent = self._default_durability_state.recovery_intent
+        phase = self._default_durability_state.failure_phase
+        allowed_actions = {
+            ConsoleDefaultSavePhase.BEFORE_REPLACE: {
+                ConsoleDefaultRecoveryAction.RETRY_SAVE,
+                ConsoleDefaultRecoveryAction.DISCARD_RETRY,
+            },
+            ConsoleDefaultSavePhase.CACHE_PUBLICATION: {
+                ConsoleDefaultRecoveryAction.REFRESH_RUNNING_APP,
+                ConsoleDefaultRecoveryAction.DISMISS_REFRESH,
+            },
+        }
+        if (
+            intent is None
+            or self._default_recovery_handler is None
+            or action not in allowed_actions.get(phase, set())
+            or self._default_recovery_pending is not None
+        ):
+            return
+        assert isinstance(phase, ConsoleDefaultSavePhase)
+        request = ConsoleDefaultRecoveryRequest(action, intent.generation)
+        self._default_recovery_pending = (intent.generation, phase)
+        self._sync_default_recovery_region()
+        try:
+            state = await self._default_recovery_handler(request)
+        except Exception:
+            self._set_validation_error("Default recovery failed; try again.")
+            return
+        finally:
+            self._default_recovery_pending = None
+            self._sync_default_recovery_region()
+            self.call_after_refresh(self._focus_default_recovery_action)
+        if not isinstance(state, ConsoleDefaultDurabilityState):
+            self._set_validation_error("Default recovery returned invalid state.")
+            self._sync_default_recovery_region()
+            return
+        self._clear_validation_error_summary()
+        self._default_durability_state = state
+        self._sync_default_recovery_region()
+        self._sync_default_readiness()
+
+    def on_key(self, event: events.Key) -> None:
+        """Scroll an overflowing recovery summary while its actions keep focus."""
+
+        if self._default_recovery_layout_phase is None:
+            return
+        try:
+            body = self.query_one("#console-settings-body", ScrollableContainer)
+        except (NoMatches, QueryError):
+            return
+        if event.key == "pageup":
+            body.scroll_page_up(animate=False, force=True)
+        elif event.key == "pagedown":
+            body.scroll_page_down(animate=False, force=True)
+        elif event.key == "home":
+            body.scroll_home(animate=False, immediate=True, force=True)
+        elif event.key == "end":
+            body.scroll_end(animate=False, immediate=True, force=True)
+        else:
+            return
+        event.stop()
+        event.prevent_default()
+
+    @on(Button.Pressed, "#console-settings-default-retry")
+    async def _retry_default_save(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self._request_default_recovery(
+            ConsoleDefaultRecoveryAction.RETRY_SAVE
+        )
+
+    @on(Button.Pressed, "#console-settings-default-discard")
+    async def _discard_default_retry(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self._request_default_recovery(
+            ConsoleDefaultRecoveryAction.DISCARD_RETRY
+        )
+
+    @on(Button.Pressed, "#console-settings-default-refresh")
+    async def _refresh_running_app(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self._request_default_recovery(
+            ConsoleDefaultRecoveryAction.REFRESH_RUNNING_APP
+        )
+
+    @on(Button.Pressed, "#console-settings-default-dismiss")
+    async def _dismiss_runtime_refresh(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self._request_default_recovery(
+            ConsoleDefaultRecoveryAction.DISMISS_REFRESH
+        )
 
     def _focus_context_control(self) -> None:
         """Focus and reveal the first editable current-conversation control."""
@@ -1228,7 +1956,11 @@ class ConsoleSettingsModal(
         except NoMatches:
             return
         control.focus()
-        control.scroll_visible(animate=False)
+        control.scroll_visible(
+            animate=False,
+            immediate=True,
+            force=True,
+        )
 
     def _sync_fold_hint(self) -> None:
         """Show a persistent cue whenever the modal body has hidden content."""
@@ -1237,7 +1969,17 @@ class ConsoleSettingsModal(
             hint = self.query_one("#console-settings-fold-hint", Static)
         except NoMatches:
             return
-        hint.display = body.virtual_size.height > body.container_size.height
+        recovery_active = (
+            self._default_durability_state.recovery_intent is not None
+            and self._default_durability_state.failure_phase is not None
+        )
+        overflow = body.virtual_size.height > body.container_size.height
+        if recovery_active:
+            hint.update("▼ more — scroll recovery summary")
+            hint.display = overflow
+            return
+        hint.update("▼ more — scroll for the rest")
+        hint.display = overflow
 
     @on(Button.Pressed, "#console-settings-view-model")
     def _show_model_view(self, event: Button.Pressed) -> None:
@@ -1490,47 +2232,17 @@ class ConsoleSettingsModal(
     @on(Button.Pressed, "#console-settings-save")
     def _save(self, event: Button.Pressed) -> None:
         event.stop()
-        result = self._validated_result_or_show_errors()
-        if result is None:
-            return
-        for warning in console_settings_warnings(result.settings):
-            self.notify(warning, severity="warning", timeout=8000)
-        self.dismiss(result)
+        self._submit(ConsoleSettingsAction.APPLY_TO_CHAT)
 
     @on(Button.Pressed, "#console-settings-save-default")
-    async def _save_as_default(self, event: Button.Pressed) -> None:
-        """Apply the draft to the session and write it through to config defaults.
-
-        task-15470: the write itself now runs via ``asyncio.to_thread``
-        rather than straight on the event loop -- a full config.toml
-        read+atomic-rewrite+cache-reload could otherwise stall the UI
-        thread for the duration of the write on slow storage. The
-        success/failure contract is unchanged: this handler still awaits
-        the result before showing the error copy or dismissing, exactly as
-        the synchronous call did.
-        """
+    def _save_as_default(self, event: Button.Pressed) -> None:
         event.stop()
-        result = self._validated_result_or_show_errors()
-        if result is None:
-            return
-        try:
-            saved = await asyncio.to_thread(
-                save_settings_to_cli_config,
-                self._default_persist_sections(result.settings),
-            )
-        except Exception:
-            saved = False
-        if not saved:
-            self.query_one("#console-settings-error", Static).update(
-                CONSOLE_SETTINGS_SAVE_DEFAULT_FAILED_COPY
-            )
-            return
-        # Warnings surface only after the write succeeded, so a failed
-        # default-persist shows the error copy alone instead of warnings
-        # for values that were not actually persisted.
-        for warning in console_settings_warnings(result.settings):
-            self.notify(warning, severity="warning", timeout=8000)
-        self.dismiss(result)
+        self._submit(ConsoleSettingsAction.SAVE_MODEL_DEFAULT)
+
+    @on(Button.Pressed, "#console-settings-make-default")
+    def _make_default(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._submit(ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT)
 
     @on(Button.Pressed, "#console-context-reset-overrides")
     def _reset_policy_overrides(self, event: Button.Pressed) -> None:
@@ -1760,6 +2472,7 @@ class ConsoleSettingsModal(
             # (the review's "Save did nothing" confusion), so scroll it into view.
             error_banner = self.query_one("#console-settings-error", Static)
             error_banner.update("\n".join(errors))
+            error_banner.display = True
             error_banner.scroll_visible()
             return None
         return ConsoleSettingsResult(
@@ -1808,84 +2521,317 @@ class ConsoleSettingsModal(
         else:
             status.update("Could not save the new-conversation thinking default.")
 
-    def _default_persist_sections(
+    def _validated_submission_draft(self) -> tuple[ConsoleSettingsDraftState, str | None] | None:
+        """Return the complete full-surface draft after mounted validation."""
+
+        provider = self._select_value_text(
+            self.query_one("#console-settings-provider", Select).value
+        )
+        model = self._current_model_value()
+        if self._draft_rebaser is not None and (
+            provider,
+            model,
+        ) != (
+            self._draft.settings.provider,
+            self._draft.settings.model,
+        ):
+            picker = self.query_one(
+                "#console-settings-model-picker", ModelSearchPicker
+            )
+            if not self._rebase_to(
+                provider,
+                model,
+                preserve_custom_model_input=picker.custom_mode,
+            ):
+                return None
+        result = self._validated_result_or_show_errors()
+        if result is None:
+            return None
+        field_drafts: list[ConsoleSettingsFieldDraft] = []
+        for name in sorted(FULL_MODEL_DEFAULT_FIELDS):
+            effective = getattr(result.settings, name)
+            field_drafts.append(self._updated_field_draft(name, effective))
+        endpoint = replace(
+            self._endpoint_draft,
+            value=result.settings.base_url or "",
+            checked=self._endpoint_checkbox_value(),
+        )
+        state = ConsoleSettingsDraftState(
+            settings=result.settings,
+            context_policy_overrides=(
+                result.context_policy_overrides or ConsoleContextPolicyOverrides()
+            ),
+            field_drafts=tuple(field_drafts),
+            model_drafts=self._draft.model_drafts,
+            endpoint_draft=endpoint,
+        )
+        self._draft = remember_model_draft(state)
+        return self._draft, result.user_display_name_override
+
+    def _submission_for_action(
         self,
-        draft: ConsoleSessionSettings,
-    ) -> dict[str, dict[str, object]]:
-        """Build config sections written through by Save as default.
+        action: ConsoleSettingsAction,
+    ) -> ConsoleSettingsSubmission | None:
+        """Build one discriminated exact-origin submission for every action."""
 
-        Model and endpoint land in ``[api_settings.<provider>]`` (the sources
-        ``build_default_console_session_settings`` resolves provider/model
-        from). Sampling values land in ``[console.provider_defaults.
-        <provider>]`` — a section that only ever contains Console-saved
-        defaults, so the boot builder can rank it above ``chat_defaults``
-        without letting factory ``api_settings`` template scalars shadow
-        user-tuned globals (TASK-342; writing sampling into api_settings was
-        inert because chat_defaults deliberately outranks it, f14d22dc3).
-        Streaming lands on the canonical ``chat_defaults.streaming`` key (the
-        legacy ``enable_streaming`` bridge only applies when the canonical key
-        is absent). ``chat_defaults.provider`` is written too — the default
-        provider itself resolves ONLY from that key, so omitting it would make
-        "Save as default" keep booting into the previous provider. ``None``
-        values are skipped rather than deleting existing defaults.
-        """
-        sections: dict[str, dict[str, object]] = {}
-        resolved = resolve_effective_chat_configuration(
-            self._app_config,
-            provider=draft.provider,
-            model=draft.model,
+        validated = self._validated_submission_draft()
+        if validated is None:
+            return None
+        draft, display_name = validated
+        endpoint = draft.endpoint_draft
+        if action is ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT:
+            if not self._endpoint_is_authorized(endpoint, draft.settings.provider):
+                endpoint = None
+            draft = replace(
+                draft,
+                model_drafts=tuple(
+                    replace(remembered, endpoint_draft=None)
+                    for remembered in draft.model_drafts
+                ),
+            )
+        elif not self._endpoint_is_live_bound(endpoint, draft.settings.provider):
+            endpoint = None
+        draft = replace(draft, endpoint_draft=endpoint)
+        return ConsoleSettingsSubmission(
+            submission_id=uuid4().hex,
+            action=action,
+            surface=ConsoleSettingsSurface.FULL_SETTINGS,
+            origin=self._origin,
+            draft=draft,
+            user_display_name_override=display_name,
+            default_field_mask=(
+                frozenset()
+                if action is ConsoleSettingsAction.APPLY_TO_CHAT
+                else FULL_MODEL_DEFAULT_FIELDS
+            ),
         )
-        model = normalize_console_model_value(draft.model)
-        effective = EffectiveChatConfiguration(
-            provider=resolved.provider,
-            model=model,
-            base_url=draft.base_url,
-            model_source="session" if model else "none",
-        )
-        provider_key = effective.provider
-        provider_values: dict[str, object] = {}
-        if model:
-            provider_values["model"] = model
-        base_url = (draft.base_url or "").strip()
-        if base_url and self._provider_uses_base_url(provider_key):
-            provider_values[self._endpoint_persist_key(provider_key)] = base_url
-        saved_defaults: dict[str, object] = {}
-        for field_name in PROVIDER_DEFAULT_PERSIST_FIELDS:
-            value = getattr(draft, field_name)
-            if value is not None:
-                saved_defaults[field_name] = value
-        if provider_key and provider_values:
-            sections[f"api_settings.{provider_key}"] = provider_values
-        if provider_key and saved_defaults:
-            sections[f"console.provider_defaults.{provider_key}"] = saved_defaults
-        canonical_defaults = build_canonical_chat_defaults_mutation(effective)[
-            "chat_defaults"
-        ]
-        chat_defaults: dict[str, object] = {
-            "streaming": bool(draft.streaming),
-            **canonical_defaults,
-        }
-        sections["chat_defaults"] = chat_defaults
-        return sections
 
-    def _endpoint_persist_key(self, provider_key: str) -> str:
-        """Return the endpoint config key to write, preferring the configured one."""
-        provider_settings = self._provider_settings(provider_key)
-        for key in _ENDPOINT_PERSIST_KEYS:
-            value = provider_settings.get(key)
-            if isinstance(value, str) and value.strip():
-                return key
-        return "api_url"
+    def _submit(self, action: ConsoleSettingsAction) -> None:
+        """Live-commit one action and dismiss only after exact-origin success."""
+
+        if self._submit_pending or self._safe_dismiss_committed:
+            return
+        if action is ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT:
+            button = self.query_one("#console-settings-make-default", Button)
+            if button.disabled:
+                self._set_validation_error(
+                    str(
+                        self.query_one(
+                            "#console-settings-new-chat-default-block", Static
+                        ).renderable
+                    )
+                    or "Default is unavailable."
+                )
+                return
+        submission = self._submission_for_action(action)
+        if submission is None:
+            return
+        if action is not ConsoleSettingsAction.APPLY_TO_CHAT:
+            self._sync_default_readiness()
+            if normalize_console_model_value(
+                submission.draft.settings.model
+            ) is None:
+                self._set_validation_error(
+                    "Unavailable: choose a model first."
+                )
+                return
+        if action is ConsoleSettingsAction.MAKE_NEW_CHAT_DEFAULT:
+            button = self.query_one("#console-settings-make-default", Button)
+            if button.disabled:
+                self._set_validation_error(
+                    str(
+                        self.query_one(
+                            "#console-settings-new-chat-default-block", Static
+                        ).renderable
+                    )
+                    or "Default is unavailable."
+                )
+                return
+        captured = self.app.mouse_captured
+        if captured is not None:
+            captured.release_mouse()
+        self._submit_pending = True
+        try:
+            live_commit = (
+                self._live_committer(submission)
+                if self._live_committer is not None
+                else self._transitional_live_commit(submission)
+            )
+        except ValueError as error:
+            message = str(error).strip().rstrip(".")
+            if message == "Chat closed; nothing applied":
+                self.notify("Chat closed; nothing applied", severity="warning")
+                self.dismiss_safe_once(None)
+                return
+            self._set_validation_error(str(error) or "Settings could not be applied.")
+            self._submit_pending = False
+            return
+        except Exception:
+            self._set_validation_error("Settings could not be applied; nothing changed.")
+            self._submit_pending = False
+            return
+        if not isinstance(live_commit, ConsoleSettingsLiveCommit):
+            self._set_validation_error("Settings could not be applied; nothing changed.")
+            self._submit_pending = False
+            return
+        delivered = False
+        try:
+            for warning in console_settings_warnings(live_commit.settings):
+                self.notify(warning, severity="warning", timeout=8000)
+            delivered = self.dismiss_safe_once(
+                ConsoleSettingsCommittedSubmission(submission, live_commit)
+            )
+        finally:
+            if not delivered and live_commit.durability_admission is not None:
+                live_commit.durability_admission.release()
+
+    @staticmethod
+    def _transitional_live_commit(
+        submission: ConsoleSettingsSubmission,
+    ) -> ConsoleSettingsLiveCommit:
+        """Keep pre-Task-8 callers mountable without mutating configuration."""
+
+        return ConsoleSettingsLiveCommit(
+            submission_id=submission.submission_id,
+            session_id=submission.origin.session_id,
+            persisted_conversation_id=submission.origin.persisted_conversation_id,
+            conversation_binding_revision=(
+                submission.origin.conversation_binding_revision
+            ),
+            generation_revision=0,
+            context_policy_revision=0,
+            settings=submission.draft.settings,
+            context_policy_overrides=submission.draft.context_policy_overrides,
+            accepted_submission=submission,
+        )
+
+    def _set_validation_error(self, copy: str) -> None:
+        error = self.query_one("#console-settings-error", Static)
+        error.update(copy)
+        error.display = bool(copy)
+        if copy:
+            error.scroll_visible()
 
     @on(Button.Pressed, "#console-settings-streaming")
     def _toggle_streaming(self, event: Button.Pressed) -> None:
-        """Cycle the streaming draft between on and off."""
+        """Cycle the profile draft through Inherit, On, and Off."""
         event.stop()
-        self._streaming_draft = not self._streaming_draft
+        self._streaming_draft = {
+            None: True,
+            True: False,
+            False: None,
+        }[self._streaming_draft]
         event.button.label = self._streaming_toggle_label()
 
     def _streaming_toggle_label(self) -> str:
+        if self._streaming_draft is None:
+            return STREAMING_INHERIT_LABEL
         return STREAMING_ON_LABEL if self._streaming_draft else STREAMING_OFF_LABEL
+
+    def _effective_streaming_value(self) -> bool:
+        return (
+            self._streaming_effective_fallback
+            if self._streaming_draft is None
+            else self._streaming_draft
+        )
+
+    def _endpoint_checkbox_value(self) -> bool:
+        try:
+            checkbox = self.query_one("#console-settings-save-endpoint", Checkbox)
+        except (NoMatches, QueryError):
+            return bool(self._endpoint_draft.checked)
+        return bool(checkbox.value and not checkbox.disabled)
+
+    def _endpoint_can_be_checked(self) -> bool:
+        provider = provider_config_key(self._active_provider)
+        endpoint = self._endpoint_draft
+        return bool(
+            endpoint.dirty
+            and endpoint.bound_provider_config_key == provider
+            and format_console_endpoint_preview(endpoint.value) is not None
+        )
+
+    def _endpoint_save_copy(self) -> str:
+        preview = format_console_endpoint_preview(self._endpoint_draft.value)
+        return (
+            f"Also save connection: {preview}"
+            if preview is not None
+            else "Also save connection"
+        )
+
+    def _endpoint_status_copy(self) -> str:
+        endpoint = self._endpoint_draft
+        if not endpoint.dirty:
+            return "Edit the Base URL to enable connection saving."
+        if endpoint.bound_provider_config_key != provider_config_key(
+            self._active_provider
+        ):
+            return "Connection edit belongs to another provider."
+        if format_console_endpoint_preview(endpoint.value) is None:
+            return "Enter a valid endpoint before saving the connection."
+        return "Connection is saved only by Make default for new chats."
+
+    @staticmethod
+    def _endpoint_is_live_bound(
+        endpoint: ConsoleEndpointDraft | None,
+        provider: str,
+    ) -> bool:
+        return bool(
+            endpoint is not None
+            and endpoint.dirty
+            and endpoint.bound_provider_config_key == provider_config_key(provider)
+            and format_console_endpoint_preview(endpoint.value) is not None
+        )
+
+    @classmethod
+    def _endpoint_is_authorized(
+        cls,
+        endpoint: ConsoleEndpointDraft | None,
+        provider: str,
+    ) -> bool:
+        return bool(
+            cls._endpoint_is_live_bound(endpoint, provider)
+            and endpoint is not None
+            and endpoint.checked
+        )
+
+    def _sync_endpoint_controls(self) -> None:
+        try:
+            checkbox = self.query_one("#console-settings-save-endpoint", Checkbox)
+            status = self.query_one("#console-settings-endpoint-status", Static)
+        except (NoMatches, QueryError):
+            return
+        uses_endpoint = self._provider_uses_base_url(self._active_provider)
+        checkbox.display = uses_endpoint
+        status.display = uses_endpoint
+        checkbox.disabled = not self._endpoint_can_be_checked()
+        checkbox.label = self._endpoint_save_copy()
+        checkbox.value = bool(self._endpoint_draft.checked and not checkbox.disabled)
+        status.update(self._endpoint_status_copy())
+
+    @on(Input.Changed, "#console-settings-base-url")
+    def _base_url_changed(self, event: Input.Changed) -> None:
+        if self._updating_controls:
+            return
+        value = event.value.strip()
+        if value == self._endpoint_draft.value:
+            return
+        self._endpoint_draft = ConsoleEndpointDraft(
+            value=value,
+            bound_provider_config_key=provider_config_key(self._active_provider),
+            dirty=True,
+            checked=False,
+        )
+        self._sync_endpoint_controls()
+
+    @on(Checkbox.Changed, "#console-settings-save-endpoint")
+    def _endpoint_checked(self, event: Checkbox.Changed) -> None:
+        if self._updating_controls:
+            return
+        self._endpoint_draft = replace(
+            self._endpoint_draft,
+            checked=bool(event.value and self._endpoint_can_be_checked()),
+        )
 
     def _choice_placeholder(self, input_id: str) -> str:
         """Return the accepted-values placeholder for an enumerated choice input."""
@@ -1922,17 +2868,202 @@ class ConsoleSettingsModal(
         handlers below (it does not stop the event).
         """
         self._clear_validation_error_summary()
+        if (
+            isinstance(event, Input.Changed)
+            and not self._updating_controls
+            and event.input.id in _GENERATION_FIELD_BY_INPUT_ID
+        ):
+            self._edited_generation_fields.add(
+                _GENERATION_FIELD_BY_INPUT_ID[event.input.id]
+            )
 
     def _clear_validation_error_summary(self) -> None:
         try:
-            self.query_one("#console-settings-error", Static).update("")
+            error = self.query_one("#console-settings-error", Static)
+            error.update("")
+            error.display = False
         except (QueryError, NoMatches):
             pass
+
+    def _snapshot_before_rebase(self) -> ConsoleSettingsDraftState:
+        """Capture current mounted edits under the still-active source key."""
+
+        mounted = self._build_draft()
+        source_settings = replace(
+            mounted,
+            provider=self._active_provider,
+            # A model-change event arrives after its control already displays
+            # the target. The immutable draft still identifies the source
+            # whose mounted edits must be remembered.
+            model=self._draft.settings.model,
+            base_url=self._current_base_url_value(self._active_provider),
+        )
+        fields: list[ConsoleSettingsFieldDraft] = []
+        for name in sorted(FULL_MODEL_DEFAULT_FIELDS):
+            effective = getattr(source_settings, name)
+            fields.append(self._updated_field_draft(name, effective))
+        return remember_model_draft(
+            replace(
+                self._draft,
+                settings=source_settings,
+                field_drafts=tuple(fields),
+                endpoint_draft=self._endpoint_draft,
+            )
+        )
+
+    def _rebase_to(
+        self,
+        provider: str,
+        model: str | None,
+        *,
+        preserve_custom_model_input: bool = False,
+    ) -> bool:
+        """Delegate provider/model changes to the controller-owned rebaser."""
+
+        if self._draft_rebaser is None:
+            return False
+        source = self._snapshot_before_rebase()
+        try:
+            rebased = self._draft_rebaser(
+                source,
+                provider=provider,
+                model=model,
+                app_config=self._app_config,
+                exposed_fields=FULL_MODEL_DEFAULT_FIELDS,
+            )
+        except Exception:
+            self._set_validation_error(
+                "Provider/model settings could not be rebased."
+            )
+            return False
+        if not isinstance(rebased, ConsoleSettingsDraftState):
+            self._set_validation_error("Provider/model rebase returned invalid state.")
+            return False
+        requested_provider = provider_config_key(provider)
+        requested_model = normalize_console_model_value(model)
+        provider_changed = (
+            provider_config_key(source.settings.provider) != requested_provider
+        )
+        provider_matches = (
+            provider_config_key(rebased.settings.provider) == requested_provider
+        )
+        model_matches = (
+            normalize_console_model_value(rebased.settings.model)
+            == requested_model
+        )
+        if not provider_matches or not (
+            model_matches or (provider_changed and requested_model is None)
+        ):
+            self._set_validation_error(
+                "Rebased settings did not match the requested provider/model."
+            )
+            self._sync_default_readiness()
+            return False
+        self._apply_rebased_state(
+            rebased,
+            preserve_custom_model_input=preserve_custom_model_input,
+        )
+        return True
+
+    def _apply_rebased_state(
+        self,
+        state: ConsoleSettingsDraftState,
+        *,
+        preserve_custom_model_input: bool = False,
+    ) -> None:
+        """Project a controller-owned rebase back into mounted controls."""
+
+        self._updating_controls = True
+        self._rebase_event_guard = True
+        try:
+            self._draft = state
+            self._settings = state.settings
+            self._active_provider = state.settings.provider
+            self._endpoint_draft = state.endpoint_draft or ConsoleEndpointDraft(
+                value=state.settings.base_url or "",
+                bound_provider_config_key=provider_config_key(
+                    state.settings.provider
+                ),
+                dirty=False,
+                checked=False,
+            )
+            self.query_one("#console-settings-provider", Select).value = (
+                state.settings.provider
+            )
+            if preserve_custom_model_input:
+                self.query_one(
+                    "#console-settings-model-picker", ModelSearchPicker
+                ).set_custom_value(state.settings.model)
+                self.query_one(
+                    "#console-settings-model-custom", Button
+                ).label = "Model list"
+            else:
+                self._sync_model_controls(
+                    state.settings.provider,
+                    state.settings.model,
+                )
+            self._sync_base_url_control(
+                state.settings.provider,
+                state.settings.base_url,
+            )
+            input_fields = {
+                "temperature": "console-settings-temperature",
+                "top_p": "console-settings-top-p",
+                "min_p": "console-settings-min-p",
+                "top_k": "console-settings-top-k",
+                "max_tokens": "console-settings-max-tokens",
+                "seed": "console-settings-seed",
+                "presence_penalty": "console-settings-presence-penalty",
+                "frequency_penalty": "console-settings-frequency-penalty",
+                "reasoning_effort": "console-settings-reasoning-effort",
+                "reasoning_summary": "console-settings-reasoning-summary",
+                "verbosity": "console-settings-verbosity",
+                "thinking_effort": "console-settings-thinking-effort",
+                "thinking_budget_tokens": "console-settings-thinking-budget-tokens",
+            }
+            for name, input_id in input_fields.items():
+                self.query_one(f"#{input_id}", Input).value = self._format_value(
+                    getattr(state.settings, name)
+                )
+            streaming = self._draft_field("streaming")
+            self._streaming_effective_fallback = bool(state.settings.streaming)
+            self._streaming_draft = (
+                streaming.profile_override
+                if streaming is not None
+                and (
+                    streaming.profile_override is None
+                    or type(streaming.profile_override) is bool
+                )
+                else bool(state.settings.streaming)
+            )
+            self.query_one("#console-settings-streaming", Button).label = (
+                self._streaming_toggle_label()
+            )
+            self._edited_generation_fields.clear()
+            self._sync_model_discover_controls(state.settings.provider)
+            self._sync_provider_choice_placeholders()
+            self._sync_endpoint_controls()
+        finally:
+            self._updating_controls = False
+        self._sync_readiness_display()
+        self._sync_default_readiness()
+        self._sync_visual_representation_availability()
+        self.call_after_refresh(self._clear_rebase_event_guard)
+
+    def _clear_rebase_event_guard(self) -> None:
+        self._rebase_event_guard = False
 
     @on(Select.Changed, "#console-settings-provider")
     def _provider_changed(self, event: Select.Changed) -> None:
         provider = self._select_value_text(event.value)
-        if provider == self._active_provider:
+        if (
+            self._updating_controls
+            or self._rebase_event_guard
+            or provider == self._active_provider
+        ):
+            return
+        if self._draft_rebaser is not None:
+            self._rebase_to(provider, None)
             return
         self._store_current_model_for_provider(self._active_provider)
         self._store_current_base_url_for_provider(self._active_provider)
@@ -1945,15 +3076,36 @@ class ConsoleSettingsModal(
         self._sync_provider_choice_placeholders()
         self._sync_readiness_display()
         self._sync_visual_representation_availability()
+        self._sync_endpoint_controls()
+        self._sync_default_readiness()
 
     @on(Select.Changed, "#console-settings-model-select")
     def _model_select_changed(self, event: Select.Changed) -> None:
         model_id = normalize_console_model_value(
             self._select_value_text(event.value)
         )
+        # ``set_options`` queues a transient blank event before the concrete
+        # replacement value. By dispatch time the Select already exposes the
+        # final value, so ignore that stale adapter echo instead of rebasing a
+        # second time to a model-less target.
+        current_select_model = normalize_console_model_value(
+            self._select_value_text(
+                self.query_one("#console-settings-model-select", Select).value
+            )
+        )
+        if model_id is None and current_select_model is not None:
+            return
         self.query_one(
             "#console-settings-model-picker", ModelSearchPicker
         ).set_model_value(model_id)
+        if (
+            not self._updating_controls
+            and not self._rebase_event_guard
+            and self._draft_rebaser is not None
+            and model_id != self._draft.settings.model
+        ):
+            self._rebase_to(self._active_provider, model_id)
+            return
         self._sync_readiness_display()
         self._sync_visual_representation_availability()
 
@@ -1974,6 +3126,11 @@ class ConsoleSettingsModal(
         )
         if picker.custom_mode:
             picker.set_custom_value(event.value)
+        self._schedule_readiness_sync()
+
+    def _schedule_readiness_sync(self) -> None:
+        """Debounce validation and custom-model rebasing while text is edited."""
+
         if self._readiness_debounce_timer is not None:
             self._readiness_debounce_timer.stop()
         self._readiness_debounce_timer = self.set_timer(
@@ -1983,12 +3140,37 @@ class ConsoleSettingsModal(
 
     def _apply_readiness_sync_debounced(self) -> None:
         self._readiness_debounce_timer = None
+        model = self._current_model_value()
+        if (
+            self._draft_rebaser is not None
+            and not self._updating_controls
+            and (self._active_provider, model)
+            != (self._draft.settings.provider, self._draft.settings.model)
+        ):
+            picker = self.query_one(
+                "#console-settings-model-picker", ModelSearchPicker
+            )
+            self._rebase_to(
+                self._active_provider,
+                model,
+                preserve_custom_model_input=picker.custom_mode,
+            )
+            return
         self._sync_readiness_display()
+        self._sync_default_readiness()
         self._sync_visual_representation_availability()
 
     @on(ModelSearchPicker.ModelSelected)
     def _model_picker_selected(self, event: ModelSearchPicker.ModelSelected) -> None:
         event.stop()
+        if (
+            self._draft_rebaser is not None
+            and not self._updating_controls
+            and not self._rebase_event_guard
+            and event.model_id != self._draft.settings.model
+        ):
+            self._rebase_to(self._active_provider, event.model_id)
+            return
         self._set_provider_model_draft(self._active_provider, event.model_id)
         self._sync_model_controls(self._active_provider, event.model_id)
         self._sync_readiness_display()
@@ -1998,6 +3180,24 @@ class ConsoleSettingsModal(
     def _model_picker_value_changed(
         self, event: ModelSearchPicker.ModelValueChanged
     ) -> None:
+        event.stop()
+        if event.custom:
+            self._schedule_readiness_sync()
+            return
+        if (
+            event.model_id is None
+            and not event.custom
+            and self._draft.settings.model is not None
+        ):
+            return
+        if (
+            self._draft_rebaser is not None
+            and not self._updating_controls
+            and not self._rebase_event_guard
+            and event.model_id != self._draft.settings.model
+        ):
+            self._rebase_to(self._active_provider, event.model_id)
+            return
         self._set_provider_model_draft(self._active_provider, event.model_id)
         self._sync_readiness_display()
         self._sync_visual_representation_availability()
@@ -2201,7 +3401,7 @@ class ConsoleSettingsModal(
             thinking_budget_tokens=self._parse_optional_int_input(
                 "console-settings-thinking-budget-tokens"
             ),
-            streaming=self._streaming_draft,
+            streaming=self._effective_streaming_value(),
             character_label=self._settings.character_label,
         )
 
@@ -2290,9 +3490,15 @@ class ConsoleSettingsModal(
         self._sync_readiness_display()
 
     def _focus_model_control(self) -> None:
-        self.query_one(
+        picker = self.query_one(
             "#console-settings-model-picker", ModelSearchPicker
-        ).focus_input()
+        )
+        picker.focus_input()
+        picker.query_one("#model-search-picker-input", Input).scroll_visible(
+            animate=False,
+            immediate=True,
+            force=True,
+        )
 
     def _provider_select_options(self) -> list[tuple[str, str]]:
         """Return provider options labeled with shared catalog display names.

--- a/tldw_chatbook/Widgets/Console/trace_export_dialog.py
+++ b/tldw_chatbook/Widgets/Console/trace_export_dialog.py
@@ -185,6 +185,7 @@ class TraceExportDialog(SafeModalDismissMixin, ModalScreen[Path | None]):
                 )
 
     async def on_mount(self) -> None:
+        super().on_mount()
         await self.select_profile(self._selected_profile)
         self.query_one("#trace-export-path", Input).focus()
 

--- a/tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py
+++ b/tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py
@@ -8,6 +8,7 @@ from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal
+from textual.events import DescendantFocus
 from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Button
@@ -120,6 +121,10 @@ class LibraryAdaptiveReaderShell(Horizontal):
             extra_classes=grip_classes,
             id=f"{id_prefix}-items-grip",
         )
+        self._last_focused_descendant: dict[PaneName, Widget | None] = {
+            "library": None,
+            "items": None,
+        }
         self.effective_layout = layout
         self._applied_layout: AdaptiveReaderEffectiveLayout | None = None
 
@@ -140,14 +145,47 @@ class LibraryAdaptiveReaderShell(Horizontal):
         """Request layout resolution after the shell allocation changes."""
         self.post_message(AdaptiveReaderShellResized())
 
-    def sync_layout(self, layout: AdaptiveReaderEffectiveLayout) -> None:
+    def on_descendant_focus(self, event: DescendantFocus) -> None:
+        """Remember optional-pane focus before a grip activation moves it."""
+        target = event.widget
+        for pane_name, pane in (
+            ("library", self.library),
+            ("items", self.items),
+        ):
+            if self._is_valid_focus_target(pane, target):
+                self._last_focused_descendant[pane_name] = target
+                return
+
+    def _pane_focus_chain(self, pane: Widget) -> list[Widget]:
+        """Return currently reachable pane targets in Textual focus order."""
+        if not self.is_mounted:
+            return []
+        return [
+            target
+            for target in self.app.screen.focus_chain
+            if target is pane or pane in target.ancestors
+        ]
+
+    def _is_valid_focus_target(self, pane: Widget, target: Widget | None) -> bool:
+        """Return whether ``target`` is currently reachable within ``pane``."""
+        return target is not None and target in self._pane_focus_chain(pane)
+
+    def sync_layout(
+        self,
+        layout: AdaptiveReaderEffectiveLayout,
+        *,
+        manual_reopen: PaneName | None = None,
+    ) -> None:
         """Patch pane display and exact cell widths in place."""
         previous_layout = self._applied_layout
         self.effective_layout = layout
         focused = self.app.focused if self.is_mounted else None
-        restore_focus: Widget | None = None
-        for pane, grip, open, width, was_open in (
+        evacuation_target: Widget | None = None
+        manual_reopen_pane: Widget | None = None
+        automatic_reopen_target: Widget | None = None
+        for pane_name, pane, grip, open, width, was_open in (
             (
+                "library",
                 self.library,
                 self.library_grip,
                 layout.library_open,
@@ -159,6 +197,7 @@ class LibraryAdaptiveReaderShell(Horizontal):
                 ),
             ),
             (
+                "items",
                 self.items,
                 self.items_grip,
                 layout.items_open,
@@ -175,7 +214,9 @@ class LibraryAdaptiveReaderShell(Horizontal):
                 and focused is not None
                 and (focused is pane or pane in focused.ancestors)
             ):
-                restore_focus = grip
+                if focused is not pane and self._is_valid_focus_target(pane, focused):
+                    self._last_focused_descendant[pane_name] = focused
+                evacuation_target = grip
             if pane.display != open:
                 pane.display = open
             if pane.disabled != (not open):
@@ -189,7 +230,7 @@ class LibraryAdaptiveReaderShell(Horizontal):
             if previous_layout is None:
                 pane.styles.height = "100%"
             if open and not was_open and focused is grip:
-                restore_focus = next(
+                automatic_reopen_target = next(
                     (
                         candidate
                         for candidate in self.screen.focus_chain
@@ -200,13 +241,24 @@ class LibraryAdaptiveReaderShell(Horizontal):
                     grip,
                 )
             grip.sync_open(open)
+            if open and not was_open and manual_reopen == pane_name:
+                manual_reopen_pane = pane
         if previous_layout is None:
             self.work.display = True
             self.work.styles.width = "1fr"
             self.work.styles.min_width = 0
             self.work.styles.height = "100%"
         self._applied_layout = layout
-        if restore_focus is not None:
-            # Widget.focus() defers through app.call_later(), which could overwrite
-            # a newer user focus intent queued before the next refresh.
-            self.screen.set_focus(restore_focus, scroll_visible=False)
+        if evacuation_target is not None:
+            self.screen.set_focus(evacuation_target, scroll_visible=False)
+        elif manual_reopen_pane is not None:
+            focus_chain = self._pane_focus_chain(manual_reopen_pane)
+            target = self._last_focused_descendant[manual_reopen]
+            if target not in focus_chain:
+                target = next(iter(focus_chain), None)
+            if target is not None:
+                self.screen.set_focus(target, scroll_visible=False)
+        elif automatic_reopen_target is not None:
+            # Keep focus recovery synchronous so it cannot overwrite a newer
+            # explicit focus change queued before the next refresh.
+            self.screen.set_focus(automatic_reopen_target, scroll_visible=False)

--- a/tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py
+++ b/tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py
@@ -182,6 +182,7 @@ class LibraryAdaptiveReaderShell(Horizontal):
         focused = self.app.focused if self.is_mounted else None
         evacuation_target: Widget | None = None
         manual_reopen_pane: Widget | None = None
+        manual_reopen_name: PaneName | None = None
         automatic_reopen_target: Widget | None = None
         for pane_name, pane, grip, open, width, was_open in (
             (
@@ -243,6 +244,7 @@ class LibraryAdaptiveReaderShell(Horizontal):
             grip.sync_open(open)
             if open and not was_open and manual_reopen == pane_name:
                 manual_reopen_pane = pane
+                manual_reopen_name = pane_name
         if previous_layout is None:
             self.work.display = True
             self.work.styles.width = "1fr"
@@ -251,9 +253,9 @@ class LibraryAdaptiveReaderShell(Horizontal):
         self._applied_layout = layout
         if evacuation_target is not None:
             self.screen.set_focus(evacuation_target, scroll_visible=False)
-        elif manual_reopen_pane is not None:
+        elif manual_reopen_pane is not None and manual_reopen_name is not None:
             focus_chain = self._pane_focus_chain(manual_reopen_pane)
-            target = self._last_focused_descendant[manual_reopen]
+            target = self._last_focused_descendant[manual_reopen_name]
             if target not in focus_chain:
                 target = next(iter(focus_chain), None)
             if target is not None:

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -22,6 +22,7 @@ from textual.events import Resize
 from textual.message import Message
 from textual.screen import ModalScreen
 from textual.timer import Timer
+from textual.widget import Widget
 from textual.worker import Worker
 from textual.widgets import Button, Input, ListView, Static, TextArea, Tree
 
@@ -85,7 +86,19 @@ from tldw_chatbook.Notes.file_notes_service import (
     ScanResult,
 )
 from tldw_chatbook.Third_Party.textual_fspicker import SelectDirectory
+from tldw_chatbook.Utils.adaptive_reader_state import (
+    AdaptiveReaderEffectiveLayout,
+    AdaptiveReaderLayoutPreferences,
+    AdaptiveReaderLayoutProfile,
+    PaneName,
+    resolve_adaptive_reader_layout,
+)
 from tldw_chatbook.Utils.input_validation import validate_text_input
+from tldw_chatbook.Widgets.Library.library_adaptive_reader_shell import (
+    AdaptiveReaderShellResized,
+    LibraryAdaptiveReaderShell,
+)
+from tldw_chatbook.Widgets.Library.library_notes_canvas import NotesStatusChannels
 from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
 from tldw_chatbook.Widgets.Library.library_file_notes_git_panel import (
     CommitDraftProjection,
@@ -104,6 +117,127 @@ from tldw_chatbook.Widgets.Library.library_file_notes_git_panel import (
     _middle_elide_cells,
 )
 
+FileNotesPathTask = Literal["none", "new", "move", "save_copy"]
+FileNotesWorkMode = Literal["edit", "manage"]
+
+
+def resolve_file_note_status_channels(
+    *,
+    root: str | Path | None,
+    conflict: bool = False,
+    unavailable: bool = False,
+    read_only: bool = False,
+    exact_export_available: bool = False,
+    save_failed: bool = False,
+    saving: bool = False,
+    dirty: bool = False,
+    git_failure: str = "",
+    git_uncertain: str = "",
+    git_running: str = "",
+    git_changes: int = 0,
+    authority_failure: str = "",
+    authority_uncertain: str = "",
+    authority_running: str = "",
+) -> NotesStatusChannels:
+    """Resolve Folder content and Git status without cross-channel masking."""
+    if conflict:
+        content = "Conflict — the disk file changed; your draft is preserved."
+        safe = "Save Copy"
+    elif unavailable:
+        content = "Unavailable — the folder cannot be reached; your draft is preserved."
+        safe = "Choose folder"
+    elif read_only:
+        content = (
+            "Read-only — the file cannot be edited; the current text is preserved."
+        )
+        safe = "Export exact copy" if exact_export_available else "Open Manage"
+    elif save_failed:
+        content = "Save failed — your draft remains in the editor."
+        safe = "Save Copy"
+    elif saving:
+        content, safe = "Saving…", None
+    elif dirty:
+        content, safe = "Unsaved changes", None
+    else:
+        content, safe = "Saved", None
+
+    if git_failure:
+        failure_lower = git_failure.casefold()
+        if "commit" in failure_lower:
+            git_failure = "Commit failed"
+        elif "push" in failure_lower:
+            git_failure = "Push failed"
+        elif "status" in failure_lower:
+            git_failure = "Git status failed"
+        elif "action" in failure_lower or "stage" in failure_lower:
+            git_failure = "Git action failed"
+        elif cell_len(git_failure) > 24:
+            git_failure = "Git operation failed"
+    if git_uncertain and cell_len(git_uncertain) > 24:
+        git_uncertain = "Outcome uncertain"
+    if git_running and cell_len(git_running) > 24:
+        git_running = "Git operation running"
+
+    status_copy = authority_failure or authority_uncertain or authority_running
+    if not status_copy:
+        status_copy = (
+            (f"Git · {git_failure}" if git_failure else "")
+            or (f"Git · {git_uncertain}" if git_uncertain else "")
+            or (f"Git · {git_running}" if git_running else "")
+        )
+    if not status_copy and git_changes:
+        change_word = "change" if git_changes == 1 else "changes"
+        status_copy = f"Git · {git_changes} {change_word}"
+    if cell_len(status_copy) > 34:
+        status_copy = _middle_elide_cells(status_copy, 34)
+
+    authority_suffix = f" · {status_copy}" if status_copy else ""
+    if root is None:
+        root_copy = "No folder selected"
+    else:
+        path = Path(root)
+        folder_name = path.name or path.anchor or str(path)
+        authority_prefix = "Folder Files · Folder:"
+        available = 60 - cell_len(authority_prefix + " " + authority_suffix)
+        if available > 0:
+            root_name = _middle_elide_cells(folder_name, min(14, available))
+            root_copy = f"Folder: {root_name}"
+        else:
+            root_copy = "Folder:…"
+    authority = f"Folder Files · {root_copy}{authority_suffix}"
+    if cell_len(authority) > 60:
+        authority = _middle_elide_cells(authority, 60)
+    return NotesStatusChannels(content, authority, safe)
+
+
+class _FileNotesWorkspaceMessage(Message):
+    """Message whose control is the retained Folder Files workspace."""
+
+    @property
+    def control(self) -> "LibraryFileNotesWorkspace":
+        return cast("LibraryFileNotesWorkspace", self._sender)
+
+
+class FileNotesEditableOpened(_FileNotesWorkspaceMessage):
+    """Announce one admitted editable file identity."""
+
+    def __init__(self, identity: str) -> None:
+        super().__init__()
+        self.identity = identity
+
+
+class FileNotesIdentityCleared(_FileNotesWorkspaceMessage):
+    """Announce an explicit opened-file identity clear."""
+
+
+class FileNotesRootChanged(_FileNotesWorkspaceMessage):
+    """Announce one admitted current Folder Files root."""
+
+    def __init__(self, root: Path) -> None:
+        super().__init__()
+        self.root = root
+
+
 SaveState = Literal["idle", "dirty", "saving", "saved", "conflict", "error"]
 _SAVE_STATE_COPY: dict[SaveState, str] = {
     "idle": "Auto-save to local folder: idle",
@@ -114,9 +248,7 @@ _SAVE_STATE_COPY: dict[SaveState, str] = {
     "error": "Save failed: draft preserved in editor",
 }
 _UNSET = object()
-_SESSION_GIT_MUTATION_BUSY = (
-    "Git operation in progress; structural actions are busy."
-)
+_SESSION_GIT_MUTATION_BUSY = "Git operation in progress; structural actions are busy."
 FILE_TREE_BATCH_SIZE = 100
 
 
@@ -645,6 +777,12 @@ class LibraryFileNotesWorkspace(Vertical):
         min-height: 8;
     }
 
+    #library-file-notes-reader-shell,
+    #file-notes-work {
+        height: 100%;
+        min-width: 0;
+    }
+
     #file-notes-navigator {
         width: 3fr;
         min-width: 24;
@@ -654,8 +792,8 @@ class LibraryFileNotesWorkspace(Vertical):
     }
 
     #file-notes-editor-pane {
-        width: 7fr;
-        min-width: 32;
+        width: 100%;
+        min-width: 0;
         height: 100%;
         padding-left: 1;
         overflow-x: hidden;
@@ -672,6 +810,11 @@ class LibraryFileNotesWorkspace(Vertical):
     #file-notes-path-row {
         height: 4;
         min-height: 4;
+    }
+
+    #file-notes-path-task {
+        height: 5;
+        min-height: 5;
     }
 
     .file-notes-field-label {
@@ -717,10 +860,23 @@ class LibraryFileNotesWorkspace(Vertical):
     }
 
     #file-notes-breadcrumb {
+        width: 1fr;
+        min-width: 0;
         text-style: bold;
     }
 
+    #file-notes-work-header {
+        height: auto;
+        min-height: 1;
+    }
+
+    #file-notes-mode-controls {
+        width: auto;
+        min-width: 14;
+    }
+
     #file-notes-save-status,
+    #file-notes-save-detail,
     #file-notes-preview-status,
     #file-notes-action-status {
         color: $text-muted;
@@ -770,6 +926,18 @@ class LibraryFileNotesWorkspace(Vertical):
         min-height: 5;
     }
 
+    #file-notes-edit-region,
+    #file-notes-manage-region {
+        height: 1fr;
+        min-height: 0;
+    }
+
+    #file-notes-edit-region,
+    #file-notes-manage-region {
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
+
     .file-notes-toolbar {
         height: auto;
         min-height: 1;
@@ -791,6 +959,11 @@ class LibraryFileNotesWorkspace(Vertical):
         background: transparent;
     }
 
+    #file-notes-session-changes {
+        width: 1fr;
+        padding: 0;
+    }
+
     LibraryFileNotesWorkspace.-prepare-session-wide .file-notes-toolbar {
         display: none;
     }
@@ -800,6 +973,19 @@ class LibraryFileNotesWorkspace(Vertical):
         grid-size: 2;
         grid-columns: 1fr 1fr;
         height: auto;
+    }
+
+    LibraryFileNotesWorkspace.-stack-editor-actions #file-notes-editor-pane {
+        padding-left: 0;
+    }
+
+    LibraryFileNotesWorkspace.-stack-editor-actions #file-notes-work-header {
+        layout: vertical;
+    }
+
+    LibraryFileNotesWorkspace.-stack-editor-actions #file-notes-mode-controls {
+        width: 100%;
+        min-width: 0;
     }
 
     LibraryFileNotesWorkspace.-stack-editor-actions .file-notes-toolbar Button {
@@ -928,10 +1114,13 @@ class LibraryFileNotesWorkspace(Vertical):
         self._autosave_timer: Timer | None = None
         self._poll_worker: Worker[Any] | None = None
         self._save_worker: Worker[Any] | None = None
+        self._save_task: asyncio.Task[bool] | None = None
         self._git_status_worker: Worker[Any] | None = None
         self._git_action_worker: Worker[Any] | None = None
         self._git_status_task: asyncio.Task[SessionGitStatus] | None = None
         self._git_status_task_binding: SessionBinding | None = None
+        self._git_status_failure = ""
+        self._git_action_running = ""
         self._active = False
         self._refresh_lock = asyncio.Lock()
         self._save_lock = asyncio.Lock()
@@ -968,6 +1157,9 @@ class LibraryFileNotesWorkspace(Vertical):
         self._editor_action_layout_sync_scheduled = False
         self._editor_action_focus_target: str | None = None
         self._maintenance_expanded = False
+        self._work_mode: FileNotesWorkMode = "edit"
+        self._path_task: FileNotesPathTask = "none"
+        self._path_task_opener_id = ""
         self._git_observed_changes: tuple[SequencedSessionChange, ...] | None = None
         self._git_refresh_timer: Timer | None = None
         self._git_refresh_after_mutation = False
@@ -987,9 +1179,7 @@ class LibraryFileNotesWorkspace(Vertical):
             "needs_attention",
         ] = "idle"
         self._push_view_phase: PushPanelPhase = "list"
-        self._push_authorization_projection: (
-            PushAuthorizationProjection | None
-        ) = None
+        self._push_authorization_projection: PushAuthorizationProjection | None = None
         self._push_review_handle: PushReviewHandle | None = None
         self._push_review_projection: PushPanelReviewProjection | None = None
         self._push_result: object | None = None
@@ -1028,6 +1218,291 @@ class LibraryFileNotesWorkspace(Vertical):
             id="file-notes-editor",
             read_only=True,
         )
+        self._search_widget = Input(
+            placeholder="File contents…",
+            id="file-notes-search",
+            value=self._search_query,
+        )
+        self._tree_widget: Tree[object] = Tree("Files", id="file-notes-tree")
+        self._search_results_widget: Tree[object] = Tree(
+            "Search results",
+            id="file-notes-search-results",
+        )
+        self._search_results_widget.display = False
+        self._reader_items_widget = self._build_reader_items_pane()
+        self._reader_work_widget = self._build_reader_work_pane()
+        self._reader_shell: LibraryAdaptiveReaderShell | None = None
+        self._reader_shell_external = False
+        self._reader_layout = AdaptiveReaderEffectiveLayout(
+            library_open=False,
+            items_open=True,
+            library_width=0,
+            items_width=40,
+            reader_width=30,
+            priority_pane=None,
+        )
+        self._standalone_reader_preferences = AdaptiveReaderLayoutPreferences(
+            library_open=False,
+            items_open=True,
+        )
+
+    def _build_reader_items_pane(self) -> Widget:
+        """Build the retained Folder navigator role once."""
+        return Vertical(
+            Horizontal(
+                Static("Folder files", classes="destination-section", markup=False),
+                Button("New", id="file-notes-new", compact=True),
+                id="file-notes-tree-header",
+            ),
+            Horizontal(
+                Static(
+                    "Search",
+                    id="file-notes-search-label",
+                    classes="file-notes-field-label",
+                    markup=False,
+                ),
+                self._search_widget,
+                id="file-notes-search-row",
+            ),
+            self._tree_widget,
+            self._search_results_widget,
+            id="file-notes-navigator",
+        )
+
+    def _build_reader_work_pane(self) -> Widget:
+        """Build the retained incumbent Folder work role once."""
+        back = Button(
+            "Back to navigator",
+            id="file-notes-back",
+            compact=True,
+        )
+        back.display = False
+        preview_status = Static(
+            "",
+            id="file-notes-preview-status",
+            markup=False,
+        )
+        preview_status.display = False
+        keep = Button(
+            "Keep editing",
+            id="file-notes-resolution-keep",
+            compact=True,
+        )
+        keep.tooltip = "Close these choices and leave the conflict open"
+        save_new = Button(
+            "Save draft as new note",
+            id="file-notes-resolution-save-new",
+            compact=True,
+        )
+        save_new.tooltip = (
+            "Write the complete draft to the Target path without replacing "
+            "an existing file"
+        )
+        discard = Button(
+            "Discard draft and load disk",
+            id="file-notes-resolution-discard",
+            compact=True,
+        )
+        discard.tooltip = (
+            "Open a separate confirmation before replacing the editor with "
+            "the current disk file"
+        )
+        path_task = Vertical(
+            Static(
+                self._path_field_label_copy(),
+                id="file-notes-path-label",
+                classes="file-notes-field-label",
+                markup=False,
+            ),
+            Input(
+                placeholder="relative/path.md",
+                id="file-notes-path",
+                value="",
+            ),
+            Horizontal(
+                Button("Continue", id="file-notes-path-submit", compact=True),
+                Button("Cancel", id="file-notes-path-cancel", compact=True),
+                classes="file-notes-toolbar",
+            ),
+            id="file-notes-path-task",
+        )
+        path_task.display = False
+        editor_pane = Vertical(
+            back,
+            Horizontal(
+                Static(
+                    "No file selected",
+                    id="file-notes-breadcrumb",
+                    markup=False,
+                ),
+                Horizontal(
+                    Button("Edit", id="file-notes-edit", compact=True),
+                    Button("Manage", id="file-notes-manage", compact=True),
+                    id="file-notes-mode-controls",
+                    classes="file-notes-toolbar",
+                ),
+                id="file-notes-work-header",
+            ),
+            Static(
+                _SAVE_STATE_COPY["idle"],
+                id="file-notes-save-status",
+                markup=False,
+            ),
+            preview_status,
+            Vertical(
+                self._editor_widget,
+                Horizontal(
+                    Button("Restore", id="file-notes-restore", compact=True),
+                    Button("Compare", id="file-notes-compare", compact=True),
+                    Button(
+                        "Resolve conflict",
+                        id="file-notes-resolve-conflict",
+                        compact=True,
+                    ),
+                    Button(
+                        "Reload from disk",
+                        id="file-notes-recovery-reload",
+                        compact=True,
+                    ),
+                    Button(
+                        "Save Copy",
+                        id="file-notes-recovery-save-copy",
+                        compact=True,
+                    ),
+                    id="file-notes-contextual-actions",
+                    classes="file-notes-toolbar",
+                ),
+                Static(
+                    "Choose a safe next step. No option overwrites the disk file.",
+                    id="file-notes-resolution-copy",
+                    markup=False,
+                ),
+                Horizontal(
+                    keep,
+                    save_new,
+                    discard,
+                    id="file-notes-resolution-actions",
+                    classes="file-notes-toolbar",
+                ),
+                Static(
+                    (
+                        self._reload_confirmation_copy()
+                        if self.reload_confirmation_active
+                        else ""
+                    ),
+                    id="file-notes-reload-confirm-copy",
+                    markup=False,
+                ),
+                Horizontal(
+                    Button("Cancel", id="file-notes-reload-cancel", compact=True),
+                    Button(
+                        "Discard draft and load disk",
+                        id="file-notes-reload-confirm",
+                        compact=True,
+                    ),
+                    id="file-notes-reload-confirm-actions",
+                    classes="file-notes-toolbar",
+                ),
+                id="file-notes-edit-region",
+            ),
+            Vertical(
+                Static(
+                    "File details & path", classes="destination-section", markup=False
+                ),
+                Static("No file selected", id="file-notes-exact-path", markup=False),
+                Static("", id="file-notes-save-detail", markup=False),
+                Static("File actions", classes="destination-section", markup=False),
+                Horizontal(
+                    Button("Move", id="file-notes-move", compact=True),
+                    Button("Reload", id="file-notes-reload", compact=True),
+                    Button("Save copy", id="file-notes-save-copy", compact=True),
+                    Button(
+                        "More file actions",
+                        id="file-notes-maintenance-toggle",
+                        compact=True,
+                    ),
+                    id="file-notes-file-actions",
+                    classes="file-notes-toolbar",
+                ),
+                Horizontal(
+                    Button("Protect", id="file-notes-protect", compact=True),
+                    Button("Refresh", id="file-notes-refresh", compact=True),
+                    id="file-notes-maintenance-actions",
+                    classes="file-notes-toolbar",
+                ),
+                Static("Session Git", classes="destination-section", markup=False),
+                Button(
+                    "Review session changes (0)",
+                    id="file-notes-session-changes",
+                    compact=True,
+                ),
+                self._git_panel_widget,
+                Static("Danger", classes="destination-section", markup=False),
+                Horizontal(
+                    Static("", id="file-notes-delete-spacer"),
+                    Button("Delete", id="file-notes-delete", compact=True),
+                    classes="file-notes-toolbar",
+                ),
+                id="file-notes-manage-region",
+            ),
+            path_task,
+            Static("", id="file-notes-action-status", markup=False),
+            id="file-notes-editor-pane",
+        )
+        return Vertical(editor_pane, id="file-notes-work")
+
+    def configure_reader_shell(
+        self,
+        *,
+        library_pane: Widget,
+        layout: AdaptiveReaderEffectiveLayout,
+    ) -> None:
+        """Attach the screen-owned Library rail before this workspace mounts."""
+        if self.is_attached:
+            raise RuntimeError("configure_reader_shell requires a detached workspace")
+        self._reader_shell_external = True
+        self._reader_layout = layout
+        if self._reader_shell is None:
+            self._reader_shell = LibraryAdaptiveReaderShell(
+                library=library_pane,
+                items=self._reader_items_widget,
+                work=self._reader_work_widget,
+                layout=layout,
+                id_prefix="library-file-notes",
+                library_label="Library",
+                items_label="Folder files",
+                id="library-file-notes-reader-shell",
+            )
+        else:
+            self._reader_shell.sync_layout(layout)
+
+    def sync_reader_layout(
+        self,
+        layout: AdaptiveReaderEffectiveLayout,
+        *,
+        manual_reopen: PaneName | None = None,
+    ) -> None:
+        """Patch the mounted shared shell without recomposing its roles."""
+        self._reader_layout = layout
+        shell = self._reader_shell
+        if shell is not None:
+            shell.sync_layout(layout, manual_reopen=manual_reopen)
+        self._schedule_editor_action_layout()
+
+    def _ensure_standalone_reader_shell(self) -> LibraryAdaptiveReaderShell:
+        """Supply the shared structure for direct workspace harnesses."""
+        if self._reader_shell is None:
+            self._reader_shell = LibraryAdaptiveReaderShell(
+                library=Static(id="file-notes-standalone-library"),
+                items=self._reader_items_widget,
+                work=self._reader_work_widget,
+                layout=self._reader_layout,
+                id_prefix="library-file-notes",
+                library_label="Library",
+                items_label="Folder files",
+                id="library-file-notes-reader-shell",
+            )
+        return self._reader_shell
 
     @staticmethod
     def _configured_root(value: object) -> Path | None:
@@ -1087,6 +1562,16 @@ class LibraryFileNotesWorkspace(Vertical):
         return self._conflict_resolution_active
 
     @property
+    def work_mode(self) -> FileNotesWorkMode:
+        """Return the visible retained work presentation."""
+        return self._work_mode
+
+    @property
+    def path_task(self) -> FileNotesPathTask:
+        """Return the one active named target-path task."""
+        return self._path_task
+
+    @property
     def leave_allowed(self) -> bool:
         """Return whether the retained draft can be left without a flush."""
         binding = self._session_binding
@@ -1094,8 +1579,7 @@ class LibraryFileNotesWorkspace(Vertical):
             not self._root_transitioning
             and not self._path_transitioning
             and not (
-                binding is not None
-                and self._session_owner.mutation_active(binding)
+                binding is not None and self._session_owner.mutation_active(binding)
             )
             and self._save_state not in {"dirty", "saving", "conflict", "error"}
         )
@@ -1123,16 +1607,201 @@ class LibraryFileNotesWorkspace(Vertical):
     @property
     def navigator_visible(self) -> bool:
         """Return whether the navigator pane is currently displayed."""
-        return self.query_one("#file-notes-navigator").display
+        return not self._narrow or self._narrow_view == "navigator"
 
     @property
     def editor_visible(self) -> bool:
         """Return whether the editor pane is currently displayed."""
-        return self.query_one("#file-notes-editor-pane").display
+        return not self._narrow or self._narrow_view == "editor"
 
     def _path_field_label_copy(self) -> str:
         """Describe the action context currently represented by the path field."""
-        return "Target path · New / Move / Save copy"
+        return {
+            "new": "New file path",
+            "move": "Move file to",
+            "save_copy": "Save copy as",
+        }.get(self._path_task, "Target path · New / Move / Save copy")
+
+    def _sync_work_mode(self) -> None:
+        """Toggle retained Edit and Manage presentations without remounting."""
+        if not self._active or not self.is_mounted:
+            return
+        edit = self.query_one("#file-notes-edit-region")
+        manage = self.query_one("#file-notes-manage-region")
+        edit.display = self._work_mode == "edit"
+        manage.display = self._work_mode == "manage"
+        edit_button = self.query_one("#file-notes-edit", Button)
+        manage_button = self.query_one("#file-notes-manage", Button)
+        edit_button.set_class(self._work_mode == "edit", "is-active")
+        manage_button.set_class(self._work_mode == "manage", "is-active")
+        for button in (edit_button, manage_button):
+            # The app-wide active-state rule adds a physical border. These
+            # compact mode chips are deliberately one row tall, so keep the
+            # semantic class while preventing a selected chip from growing
+            # to two rows and clipping its label.
+            button.styles.border = ("none", "transparent")
+        exact_path = self.query_one("#file-notes-exact-path", Static)
+        relative_path = self._current_path or self._selected_deleted_path
+        if relative_path and self._root is not None:
+            exact_path.update(str(self._root / relative_path))
+        else:
+            exact_path.update(relative_path or "No file selected")
+        self._sync_editor_action_visibility()
+        self._sync_navigator_mode()
+
+    def _sync_path_task_surface(self, *, focus_target: bool = False) -> None:
+        """Project the one named path task into the retained target row."""
+        if not self._active or not self.is_mounted:
+            return
+        task = self.query_one("#file-notes-path-task")
+        active = self._path_task != "none"
+        task.display = active
+        self.query_one("#file-notes-path-label", Static).update(
+            self._path_field_label_copy()
+        )
+        submit = self.query_one("#file-notes-path-submit", Button)
+        submit.label = {
+            "new": "Create",
+            "move": "Move",
+            "save_copy": (
+                "Export exact copy"
+                if self._opened is not None and self._opened.is_excerpt
+                else "Save Copy"
+            ),
+        }.get(self._path_task, "Continue")
+        submit.disabled = (
+            not active or self._root_transitioning or self._path_transitioning
+        )
+        self.query_one("#file-notes-path-cancel", Button).disabled = not active
+        if active and focus_target:
+            self.call_after_refresh(self._focus_path_task_input)
+
+    def _focus_path_task_input(self) -> None:
+        """Reveal the complete named task before focusing its retained input."""
+        task = self.query_one("#file-notes-path-task")
+        task.scroll_visible(animate=False, top=True)
+        self.query_one("#file-notes-path", Input).focus(scroll_visible=False)
+
+    async def _open_path_task(
+        self,
+        task: FileNotesPathTask,
+        *,
+        opener_id: str,
+    ) -> bool:
+        """Open one guarded target-path task and remember its focus origin."""
+        if task == "none":
+            self._close_path_task()
+            return True
+        if task not in {"new", "move", "save_copy"}:
+            raise ValueError(f"Unsupported File Notes path task: {task}")
+        service = self._service
+        generation = self._root_generation
+        binding = self._session_binding
+        session_key = self._session_key
+        if (
+            not self._active
+            or not self.is_mounted
+            or not self.display
+            or self._root_transitioning
+            or self._path_transitioning
+            or self._shutdown
+            or service is None
+        ):
+            return False
+        if task in {"move", "save_copy"} and self._opened is None:
+            return False
+        if task in {"new", "move"} and self._opened is not None:
+            if not await self.flush_pending_work():
+                return False
+            if (
+                not self._active
+                or not self.is_mounted
+                or not self.display
+                or self._root_transitioning
+                or self._path_transitioning
+                or self._shutdown
+                or generation != self._root_generation
+                or service is not self._service
+                or binding != self._session_binding
+                or session_key != self._session_key
+                or (task == "move" and self._opened is None)
+            ):
+                return False
+        if self._path_task != "none":
+            self._close_path_task(restore_focus=False)
+        self._path_task = task
+        self._path_task_opener_id = opener_id
+        path = self.query_one("#file-notes-path", Input)
+        path.value = self._current_path if task == "move" else ""
+        self._sync_path_task_surface(focus_target=True)
+        return True
+
+    def _close_path_task(self, *, restore_focus: bool = True) -> None:
+        """Close the named task and restore its actual invoking control."""
+        closed_task = self._path_task
+        opener_id = self._path_task_opener_id
+        self._path_task = "none"
+        self._path_task_opener_id = ""
+        self._sync_path_task_surface()
+        if (
+            not restore_focus
+            or not opener_id
+            or not self._active
+            or not self.is_mounted
+        ):
+            return
+        matches = self.query(f"#{opener_id}")
+        if not matches:
+            return
+        opener = matches.first(Button)
+        opener_is_visible = opener.display and all(
+            ancestor.display for ancestor in opener.ancestors if ancestor is not self
+        )
+        if opener_is_visible and not opener.disabled:
+            self.call_after_refresh(opener.focus)
+            return
+        if self._work_mode == "manage":
+            fallback_ids = (
+                ("file-notes-save-copy", "file-notes-manage")
+                if closed_task == "save_copy"
+                else ("file-notes-manage",)
+            )
+            for fallback_id in fallback_ids:
+                fallback = self.query_one(f"#{fallback_id}", Button)
+                if fallback.display and not fallback.disabled:
+                    self.call_after_refresh(fallback.focus)
+                    return
+        editor = self.query_one("#file-notes-editor", TextArea)
+        if self._work_mode == "edit" and editor.display:
+            self.call_after_refresh(editor.focus)
+
+    def cancel_path_task(self) -> bool:
+        """Cancel a visible path task for the screen-level guarded Escape path."""
+        if self._path_task == "none":
+            return False
+        self._close_path_task(restore_focus=True)
+        return True
+
+    async def _submit_path_task(self) -> bool:
+        """Execute the active task through its incumbent validation/service seam."""
+        task = self._path_task
+        if task == "none":
+            return False
+        if task == "new":
+            succeeded = await self._execute_new_file()
+        elif task == "move":
+            succeeded = await self._execute_move_file()
+        else:
+            opened = self._opened
+            action = (
+                "Export exact copy"
+                if opened is not None and opened.is_excerpt
+                else "Save draft as copy"
+            )
+            succeeded = await self._save_editor_copy(action)
+        if succeeded:
+            self._close_path_task(restore_focus=True)
+        return succeeded
 
     @staticmethod
     def _large_file_preview_copy(opened: OpenedFileNote) -> str:
@@ -1184,244 +1853,111 @@ class LibraryFileNotesWorkspace(Vertical):
                 compact=True,
             )
         with Horizontal(id="file-notes-body"):
-            with Vertical(id="file-notes-navigator"):
-                with Horizontal(id="file-notes-search-row"):
-                    yield Static(
-                        "Search",
-                        id="file-notes-search-label",
-                        classes="file-notes-field-label",
-                        markup=False,
-                    )
-                    yield Input(
-                        placeholder="File contents…",
-                        id="file-notes-search",
-                        value=self._search_query,
-                    )
-                yield Tree[object]("Files", id="file-notes-tree")
-                search_results = Tree[object](
-                    "Search results",
-                    id="file-notes-search-results",
-                )
-                search_results.display = False
-                yield search_results
-                yield Button(
-                    "Review session changes (0)",
-                    id="file-notes-session-changes",
-                    compact=True,
-                )
-                yield self._git_panel_widget
-            with Vertical(id="file-notes-editor-pane"):
-                back = Button(
-                    "Back to navigator",
-                    id="file-notes-back",
-                    compact=True,
-                )
-                back.display = False
-                yield back
-                yield Static(
-                    "No file selected",
-                    id="file-notes-breadcrumb",
-                    markup=False,
-                )
-                yield Static(
-                    _SAVE_STATE_COPY["idle"],
-                    id="file-notes-save-status",
-                    markup=False,
-                )
-                preview_status = Static(
-                    "",
-                    id="file-notes-preview-status",
-                    markup=False,
-                )
-                preview_status.display = False
-                yield preview_status
-                with Vertical(id="file-notes-path-row"):
-                    yield Static(
-                        self._path_field_label_copy(),
-                        id="file-notes-path-label",
-                        classes="file-notes-field-label",
-                        markup=False,
-                    )
-                    yield Input(
-                        placeholder="relative/path.md",
-                        id="file-notes-path",
-                        value=self._selected_deleted_path or self._current_path,
-                    )
-                yield self._editor_widget
-                with Horizontal(
-                    id="file-notes-file-actions",
-                    classes="file-notes-toolbar",
-                ):
-                    yield Button("New", id="file-notes-new", compact=True)
-                    yield Button("Move", id="file-notes-move", compact=True)
-                    yield Button("Restore", id="file-notes-restore", compact=True)
-                    yield Button(
-                        "Compare",
-                        id="file-notes-compare",
-                        compact=True,
-                    )
-                    yield Button(
-                        "Resolve conflict",
-                        id="file-notes-resolve-conflict",
-                        compact=True,
-                    )
-                    yield Button("Reload", id="file-notes-reload", compact=True)
-                    yield Button(
-                        "Save copy",
-                        id="file-notes-save-copy",
-                        compact=True,
-                    )
-                    yield Static("", id="file-notes-delete-spacer")
-                    yield Button("Delete", id="file-notes-delete", compact=True)
-                    yield Button(
-                        "More file actions",
-                        id="file-notes-maintenance-toggle",
-                        compact=True,
-                    )
-                with Horizontal(
-                    id="file-notes-maintenance-actions",
-                    classes="file-notes-toolbar",
-                ):
-                    yield Button("Protect", id="file-notes-protect", compact=True)
-                    yield Button("Refresh", id="file-notes-refresh", compact=True)
-                yield Static(
-                    (
-                        "Choose a safe next step. No option overwrites the disk "
-                        "file."
-                    ),
-                    id="file-notes-resolution-copy",
-                    markup=False,
-                )
-                with Horizontal(
-                    id="file-notes-resolution-actions",
-                    classes="file-notes-toolbar",
-                ):
-                    keep = Button(
-                        "Keep editing",
-                        id="file-notes-resolution-keep",
-                        compact=True,
-                    )
-                    keep.tooltip = "Close these choices and leave the conflict open"
-                    yield keep
-                    save_new = Button(
-                        "Save draft as new note",
-                        id="file-notes-resolution-save-new",
-                        compact=True,
-                    )
-                    save_new.tooltip = (
-                        "Write the complete draft to the Target path without "
-                        "replacing an existing file"
-                    )
-                    yield save_new
-                    discard = Button(
-                        "Discard draft and load disk",
-                        id="file-notes-resolution-discard",
-                        compact=True,
-                    )
-                    discard.tooltip = (
-                        "Open a separate confirmation before replacing the editor "
-                        "with the current disk file"
-                    )
-                    yield discard
-                yield Static(
-                    (
-                        self._reload_confirmation_copy()
-                        if self.reload_confirmation_active
-                        else ""
-                    ),
-                    id="file-notes-reload-confirm-copy",
-                    markup=False,
-                )
-                with Horizontal(
-                    id="file-notes-reload-confirm-actions",
-                    classes="file-notes-toolbar",
-                ):
-                    yield Button(
-                        "Cancel",
-                        id="file-notes-reload-cancel",
-                        compact=True,
-                    )
-                    yield Button(
-                        "Discard draft and load disk",
-                        id="file-notes-reload-confirm",
-                        compact=True,
-                    )
-                yield Static("", id="file-notes-action-status", markup=False)
+            yield self._ensure_standalone_reader_shell()
 
     def _authority_copy(self, session_git_count: int | None = None) -> str:
-        """Describe disk authority, current work, and the next available action."""
-        if self._root is None:
-            return "Folder files · No folder selected · Next: Choose folder."
-        folder_name = self._root.name or self._root.anchor or str(self._root)
-        folder_label = Text(folder_name)
-        folder_label.truncate(5, overflow="ellipsis")
-        first_line = ["Folder files", f"Folder: {folder_label.plain}"]
-        state_copy = ""
-        next_action = ""
-        if self._root_transitioning:
-            state_copy = "Changing folder"
-            next_action = "Wait for change."
-        elif self._path_transitioning:
-            state_copy = "File operation"
-            next_action = "Wait for file."
-        elif self._root_offline is None:
-            state_copy = "Checking"
-            next_action = "Wait for check."
-        elif self._root_offline is True:
-            state_copy = "Offline+Warning" if self._runtime_warning else "Offline"
-            next_action = "Reconnect/change."
-        elif self._runtime_warning:
-            state_copy = "Warning"
-            next_action = "Open Details."
-        if state_copy:
-            first_line.append(state_copy)
-        save_copy = {
-            "dirty": "Unsaved",
-            "saving": "Saving",
-            "saved": "Saved",
-            "conflict": "Conflict",
-            "error": "Save failed",
-        }.get(self._save_state, "")
-        if save_copy:
-            first_line.append(save_copy)
-        elif not state_copy:
-            first_line.append("Ready")
+        """Return the authority/Git channel only."""
         if session_git_count is None:
             binding = self._session_binding
             changes = (
                 () if binding is None else self._session_owner.snapshot(binding).changes
             )
             session_git_count = len(coalesce_session_changes(changes))
-        git_count_copy = "99+" if session_git_count > 99 else str(session_git_count)
-        if self._push_phase == "idle":
-            change_word = "change" if session_git_count == 1 else "changes"
-            git_copy = f"Session Git: {git_count_copy} {change_word}"
-        else:
-            push_copy = {
-                "checking": "Check push",
-                "pushing": "Pushing",
-                "needs_attention": "Push attention",
-            }[self._push_phase]
-            git_copy = f"Session Git: {git_count_copy} · {push_copy}"
-        if not next_action:
-            if self._save_state == "conflict":
-                next_action = "Resolve/copy."
-            elif self._save_state == "error":
-                next_action = "Retry/copy."
-            elif self._save_state == "saving":
-                next_action = "Wait for save."
-            elif self._save_state == "dirty":
-                next_action = "Keep editing."
-            elif self._push_phase != "idle" or session_git_count:
-                next_action = "Review changes."
-            elif self._save_state == "saved":
-                next_action = "Keep editing."
-            else:
-                next_action = "Choose/new file."
-        return (
-            f"{' · '.join(first_line)}\n"
-            f"{git_copy} · Next: {next_action}"
+        return self._status_channels(session_git_count).authority_git
+
+    def _status_channels(
+        self, session_git_count: int | None = None
+    ) -> NotesStatusChannels:
+        """Project current async inputs through the pure status resolver."""
+        if session_git_count is None:
+            binding = self._session_binding
+            changes = (
+                () if binding is None else self._session_owner.snapshot(binding).changes
+            )
+            session_git_count = len(coalesce_session_changes(changes))
+        git_failure = ""
+        git_uncertain = ""
+        commit_result = self._commit_result_projection
+        if self._commit_view_phase == "result" and commit_result is not None:
+            if commit_result.outcome.state == "failed_unchanged":
+                git_failure = "Commit failed"
+            elif commit_result.outcome.state == "uncertain":
+                git_uncertain = "Commit outcome uncertain"
+        if self._git_last_action is not None and self._git_last_action.complete:
+            git_failure = git_failure or self._git_last_action.text.removeprefix(
+                "Last action: "
+            )
+        git_failure = git_failure or self._git_status_failure
+        if not git_uncertain and self._push_phase == "needs_attention":
+            git_uncertain = "Push outcome needs attention"
+        commit_running = {
+            "checking": "Checking commit…",
+            "confirming": "Checking commit…",
+            "executing": "Committing…",
+        }.get(self._commit_view_phase, "")
+        status_task = self._git_status_task
+        status_checking = bool(
+            status_task is not None
+            and not status_task.done()
+            and self._git_status_task_binding == self._session_binding
         )
+        git_running = (
+            commit_running
+            or {
+                "checking": "Checking push…",
+                "pushing": "Pushing…",
+            }.get(self._push_phase, "")
+            or self._git_action_running
+            or ("Checking Git…" if status_checking else "")
+        )
+        opened = self._opened
+        authority_failure = ""
+        authority_uncertain = ""
+        authority_running = ""
+        if self._root is not None and self._root_offline is True:
+            authority_failure = "Folder unavailable"
+        elif self._runtime_warning:
+            authority_uncertain = "Folder warning"
+        elif self._root_transitioning:
+            authority_running = "Changing folder…"
+        elif self._path_transitioning:
+            authority_running = "File operation…"
+        elif self._root is not None and self._root_offline is None:
+            authority_running = "Checking folder…"
+        return resolve_file_note_status_channels(
+            root=self._root,
+            conflict=self._save_state == "conflict",
+            unavailable=self._root is None or self._root_offline is True,
+            read_only=opened is not None and not opened.editable,
+            exact_export_available=opened is not None and opened.is_excerpt,
+            save_failed=self._save_state == "error",
+            saving=self._save_state == "saving",
+            dirty=self._save_state == "dirty",
+            git_failure=git_failure,
+            git_uncertain=git_uncertain,
+            git_running=git_running,
+            git_changes=session_git_count,
+            authority_failure=authority_failure,
+            authority_uncertain=authority_uncertain,
+            authority_running=authority_running,
+        )
+
+    def _render_status_channels(self, session_git_count: int | None = None) -> None:
+        """Render both header channels from one deterministic projection."""
+        if not self._active or not self.is_mounted:
+            return
+        channels = self._status_channels(session_git_count)
+        content = channels.content_recovery
+        if channels.safe_next_action:
+            content = f"{content} Next: {channels.safe_next_action}."
+        detail = self._save_detail.strip()
+        status = self.query_one("#file-notes-save-status", Static)
+        status.update(content)
+        status.tooltip = detail or None
+        save_detail = self.query_one("#file-notes-save-detail", Static)
+        save_detail.update(f"Content detail: {detail}" if detail else "")
+        save_detail.display = bool(detail)
+        self.query_one("#file-notes-authority", Static).update(channels.authority_git)
 
     def on_mount(self) -> None:
         """Start background initialization and polling for this mount."""
@@ -1440,8 +1976,12 @@ class LibraryFileNotesWorkspace(Vertical):
         self._set_save_state(self._save_state, self._save_detail)
         self._sync_large_file_preview()
         self._set_action_status(self._action_detail)
+        self._sync_work_mode()
+        self._sync_path_task_surface()
         self._update_root_surface()
         self._sync_navigator_mode()
+        if self._search_paths:
+            self._rebuild_search_results(self._search_paths)
         self._rehydrate_git_presentation()
         self._update_controls()
         self.run_worker(
@@ -1455,11 +1995,27 @@ class LibraryFileNotesWorkspace(Vertical):
             self._start_poll,
             pause=False,
         )
+        if self._save_task is not None and not self._save_task.done():
+            self._attach_save_observer(self._save_task)
+        elif self._save_state == "saving":
+            self._set_save_state("dirty", "save interrupted")
+            self._arm_autosave()
+        elif self._save_state == "dirty":
+            self._arm_autosave()
 
     def on_unmount(self) -> None:
         """Pause timers; Textual cancels node workers during removal."""
         self._active = False
-        if self._save_state == "saving":
+        # Source and breakpoint transitions keep this workspace mounted, but
+        # an explicit host removal still lets Textual prune the composed shell.
+        # Rebuild that disposable shell wrapper on a later remount while
+        # retaining the incumbent editor, navigator, Git, and recovery roles.
+        self._reader_shell = None
+        self._reader_items_widget = self._build_reader_items_pane()
+        self._reader_work_widget = self._build_reader_work_pane()
+        if self._save_state == "saving" and (
+            self._save_task is None or self._save_task.done()
+        ):
             self._save_state = "dirty"
             self._save_detail = "save interrupted"
         for timer in (
@@ -1497,6 +2053,12 @@ class LibraryFileNotesWorkspace(Vertical):
         self._poll_timer = None
         self._autosave_timer = None
         self._git_refresh_timer = None
+        save_task = self._save_task
+        if save_task is not None and not save_task.done():
+            try:
+                await asyncio.shield(save_task)
+            except (asyncio.CancelledError, Exception):
+                pass
         if self._owns_session_owner:
             await asyncio.to_thread(self._session_owner.shutdown)
         elif self._owns_replica:
@@ -1674,6 +2236,7 @@ class LibraryFileNotesWorkspace(Vertical):
         *,
         persist: bool,
     ) -> bool:
+        previous_root = self._root
         with self._runtime_lock:
             if (
                 self._shutdown
@@ -1732,6 +2295,8 @@ class LibraryFileNotesWorkspace(Vertical):
                     self._git_observed_changes = None
                     self._git_status_task = None
                     self._git_status_task_binding = None
+                    self._git_status_failure = ""
+                    self._git_action_running = ""
                     if self._active and self.is_mounted:
                         self._git_panel_widget.render_unavailable(
                             "Selected notes root changed. Open Review session "
@@ -1741,7 +2306,9 @@ class LibraryFileNotesWorkspace(Vertical):
                 self._root = root
                 self._session_binding = binding
                 self._service = service
-                self._clear_open_document()
+                self._clear_open_document(
+                    announce_identity_cleared=previous_root == root
+                )
                 self._initialized = True
                 self._apply_scan(
                     result,
@@ -1755,6 +2322,8 @@ class LibraryFileNotesWorkspace(Vertical):
             # this reservation.
             with self._runtime_lock:
                 reservation.commit(publish)
+            if previous_root != self._root:
+                self.post_message(FileNotesRootChanged(root).set_sender(self))
             if cancellation is not None:
                 raise cancellation
             return True
@@ -1864,7 +2433,6 @@ class LibraryFileNotesWorkspace(Vertical):
         if not self._active or not self.is_mounted or not self.children:
             return
         try:
-            authority = self.query_one("#file-notes-authority", Static)
             status = self.query_one("#file-notes-root-status", Static)
             body = self.query_one("#file-notes-body")
             details = self.query_one("#file-notes-root-details", Button)
@@ -1872,14 +2440,11 @@ class LibraryFileNotesWorkspace(Vertical):
         except NoMatches:
             return
         binding = self._session_binding
-        mutation_active = (
-            binding is not None
-            and self._session_owner.mutation_active(binding)
+        mutation_active = binding is not None and self._session_owner.mutation_active(
+            binding
         )
         choose.disabled = (
-            self._root_transitioning
-            or self._path_transitioning
-            or mutation_active
+            self._root_transitioning or self._path_transitioning or mutation_active
         )
         if self._root is None:
             self._root_status_detail = "Choose a notes folder."
@@ -1893,7 +2458,7 @@ class LibraryFileNotesWorkspace(Vertical):
             details.display = False
             choose.label = "Choose folder…"
             choose.display = True
-            authority.update(self._authority_copy())
+            self._render_status_channels()
             return
         status.set_class(False, "-empty-root")
         is_offline = self._root_offline if offline is None else offline
@@ -1914,16 +2479,14 @@ class LibraryFileNotesWorkspace(Vertical):
             if is_offline is True and self._runtime_warning
             else ("Warning" if self._runtime_warning else state)
         )
-        self._root_status_summary = (
-            f"{display_state} · Local folder: {folder_name}"
-        )
+        self._root_status_summary = f"{display_state} · Local folder: {folder_name}"
         status.tooltip = Text(detail)
         status.update(self._root_status_summary)
         body.display = True
         details.display = True
         choose.label = "Change…"
         choose.display = True
-        authority.update(self._authority_copy())
+        self._render_status_channels()
         self._apply_responsive_layout(self.size.width)
         self.call_after_refresh(self._fit_root_status)
 
@@ -1944,8 +2507,10 @@ class LibraryFileNotesWorkspace(Vertical):
             return
         was_narrow = self._narrow
         self._narrow = width < 80
-        if self._narrow and not was_narrow and (
-            self._opened is not None or self._selected_deleted_path
+        if (
+            self._narrow
+            and not was_narrow
+            and (self._opened is not None or self._selected_deleted_path)
         ):
             # task-15790 (bisected to 4202930d6's era, born-green then
             # regressed): `_narrow_view` was only ever set to "editor" when a
@@ -1957,17 +2522,24 @@ class LibraryFileNotesWorkspace(Vertical):
             # document. Transition-only on purpose: while ALREADY narrow,
             # Back's explicit navigator choice must keep winning.
             self._narrow_view = "editor"
-        navigator = self.query_one("#file-notes-navigator")
-        editor = self.query_one("#file-notes-editor-pane")
         back = self.query_one("#file-notes-back", Button)
-        if self._narrow:
-            navigator.display = self._narrow_view == "navigator"
-            editor.display = self._narrow_view == "editor"
-            back.display = self._narrow_view == "editor"
-        else:
-            navigator.display = True
-            editor.display = True
-            back.display = False
+        back.display = self._narrow and self._narrow_view == "editor"
+        if not self._reader_shell_external:
+            preferences = self._standalone_reader_preferences
+            priority: PaneName | None = None
+            if self._narrow:
+                if self._narrow_view == "navigator":
+                    priority = "items"
+                else:
+                    preferences = replace(preferences, items_open=False)
+            layout = resolve_adaptive_reader_layout(
+                max(width, 0),
+                preferences,
+                AdaptiveReaderLayoutProfile(work_min_width=30),
+                previous=self._reader_layout,
+                priority=priority,
+            )
+            self.sync_reader_layout(layout)
         self._sync_navigator_mode()
         self._schedule_editor_action_layout()
 
@@ -1983,12 +2555,17 @@ class LibraryFileNotesWorkspace(Vertical):
             "#file-notes-git-panel",
             LibraryFileNotesGitPanel,
         )
-        git_visible = self._navigator_mode == "git"
+        git_visible = self._navigator_mode == "git" and self._work_mode == "manage"
+        file_mode = (
+            self._navigator_mode_before_git
+            if self._navigator_mode == "git"
+            else self._navigator_mode
+        )
         panel.display = git_visible
-        search_row.display = not git_visible
+        search_row.display = True
         entry.display = not git_visible
-        tree.display = not git_visible and self._navigator_mode == "files"
-        results.display = not git_visible and self._navigator_mode == "search"
+        tree.display = file_mode == "files"
+        results.display = file_mode == "search"
         self.set_class(
             git_visible and not self._narrow,
             "-prepare-session-wide",
@@ -1996,14 +2573,17 @@ class LibraryFileNotesWorkspace(Vertical):
 
     def _schedule_editor_action_layout(self) -> None:
         """Coalesce editor-action measurements after Textual refreshes layout."""
-        if (
-            not self._active
-            or not self.is_mounted
-            or self._editor_action_layout_sync_scheduled
-        ):
+        if not self._active or not self.is_mounted:
+            return
+        # Label/display changes can happen while an earlier resize measurement
+        # is pending.  Fit the current settled pane synchronously so those
+        # controls never keep stale off-pane geometry.
+        self._apply_editor_action_layout()
+        if self._editor_action_layout_sync_scheduled:
             return
         self._editor_action_layout_sync_scheduled = True
-        self.call_after_refresh(self._sync_editor_action_layout)
+        self.refresh(layout=True)
+        self.call_later(self._sync_editor_action_layout)
 
     def _set_delete_confirmation(self, relative_path: str = "") -> None:
         """Project one confirmation state into its copy and narrow layout."""
@@ -2053,6 +2633,8 @@ class LibraryFileNotesWorkspace(Vertical):
         was_active = self.reload_confirmation_active
         self._reload_confirmation = confirmation
         if self._active and self.is_mounted:
+            self._work_mode = "edit"
+            self._sync_work_mode()
             self.query_one("#file-notes-reload-confirm-copy", Static).update(
                 self._reload_confirmation_copy()
             )
@@ -2077,6 +2659,9 @@ class LibraryFileNotesWorkspace(Vertical):
             return False
         self._reload_confirmation = None
         if self._active and self.is_mounted:
+            if focus_opener and confirmation.opener_id == "file-notes-reload":
+                self._work_mode = "manage"
+                self._sync_work_mode()
             self.query_one("#file-notes-reload-confirm-copy", Static).update("")
             self._update_controls()
             if focus_opener:
@@ -2093,12 +2678,22 @@ class LibraryFileNotesWorkspace(Vertical):
     def _sync_editor_action_layout(self) -> None:
         """Stack current editor actions only when their labels need the space."""
         self._editor_action_layout_sync_scheduled = False
+        self._apply_editor_action_layout()
+
+    def _apply_editor_action_layout(self) -> None:
+        """Fit actions to the currently settled retained work-pane geometry."""
         if not self._active or not self.is_mounted:
             return
         pane = self.query_one("#file-notes-editor-pane")
         if not pane.display:
             return
-        available_width = pane.content_region.width
+        settled_width = pane.content_region.width
+        projected_width = self._reader_layout.reader_width
+        available_width = (
+            min(settled_width, projected_width)
+            if settled_width > 0 and projected_width > 0
+            else max(settled_width, projected_width)
+        )
         if available_width <= 0:
             return
         single_column = available_width <= 40
@@ -2114,6 +2709,12 @@ class LibraryFileNotesWorkspace(Vertical):
         )
         self.set_class(needs_stack, "-stack-editor-actions")
         self.set_class(single_column, "-single-editor-actions")
+        for toolbar in pane.query(".file-notes-toolbar"):
+            toolbar.styles.grid_size_columns = 1 if single_column else None
+            toolbar.styles.grid_columns = "1fr" if single_column else None
+            for button in toolbar.query(Button):
+                button.styles.column_span = 1 if single_column else None
+                button.styles.width = "1fr" if single_column else None
         delete = self.query_one("#file-notes-delete", Button)
         self.query_one("#file-notes-delete-spacer", Static).display = (
             delete.display and not needs_stack
@@ -2209,7 +2810,7 @@ class LibraryFileNotesWorkspace(Vertical):
         items = self._page_items(page)
         end = min(page.offset + FILE_TREE_BATCH_SIZE, len(items))
         last_node: Any | None = None
-        for item in items[page.offset:end]:
+        for item in items[page.offset : end]:
             if item.kind == "folder":
                 last_node = parent.add(
                     Text(item.label),
@@ -2260,10 +2861,13 @@ class LibraryFileNotesWorkspace(Vertical):
         self._append_tree_page(node, page)
 
     def _rebuild_search_results(self, paths: tuple[str, ...]) -> None:
+        self._search_paths = paths
         if not self._active or not self.is_mounted:
             return
-        results = self.query_one("#file-notes-search-results", Tree)
-        self._search_paths = paths
+        matches = self.query("#file-notes-search-results")
+        if not matches:
+            return
+        results = matches.first(Tree)
         results.reset(Text("Search results"))
         self._append_tree_page(
             results.root,
@@ -2327,9 +2931,7 @@ class LibraryFileNotesWorkspace(Vertical):
         if count is None:
             binding = self._session_binding
             changes = (
-                ()
-                if binding is None
-                else self._session_owner.snapshot(binding).changes
+                () if binding is None else self._session_owner.snapshot(binding).changes
             )
             count = len(coalesce_session_changes(changes))
         suffix = {
@@ -2339,11 +2941,10 @@ class LibraryFileNotesWorkspace(Vertical):
         }.get(self._push_phase, "")
         try:
             entry = self.query_one("#file-notes-session-changes", Button)
-            authority = self.query_one("#file-notes-authority", Static)
         except NoMatches:
             return
         entry.label = f"Review session changes ({count}){suffix}"
-        authority.update(self._authority_copy(count))
+        self._render_status_channels(count)
 
     def _clear_push_presentation(self) -> None:
         """Retire visible push state without canceling service-owned work."""
@@ -2413,9 +3014,7 @@ class LibraryFileNotesWorkspace(Vertical):
         )
 
     @staticmethod
-    def _settled_push_phase(result: object) -> Literal[
-        "idle", "needs_attention"
-    ]:
+    def _settled_push_phase(result: object) -> Literal["idle", "needs_attention"]:
         """Map typed service outcomes to the persistent indicator."""
         if isinstance(result, PushDestinationPolicyResult):
             return "needs_attention" if result.state != "ready" else "idle"
@@ -2424,8 +3023,7 @@ class LibraryFileNotesWorkspace(Vertical):
         if isinstance(result, PushExecutionResult):
             return (
                 "needs_attention"
-                if result.state
-                in {"blocked", "failed_no_update_observed", "uncertain"}
+                if result.state in {"blocked", "failed_no_update_observed", "uncertain"}
                 else "idle"
             )
         if isinstance(result, PushRecoveryProjection):
@@ -2439,9 +3037,7 @@ class LibraryFileNotesWorkspace(Vertical):
         if self._push_availability is None:
             self._git_panel_widget.clear_push_availability()
         else:
-            self._git_panel_widget.render_push_availability(
-                self._push_availability
-            )
+            self._git_panel_widget.render_push_availability(self._push_availability)
 
     @staticmethod
     def _push_view_for_operation(
@@ -2474,8 +3070,7 @@ class LibraryFileNotesWorkspace(Vertical):
             "pushing",
         }:
             self._git_panel_widget.render_push_progress(
-                phase,
-                operation_id=operation_id
+                phase, operation_id=operation_id
             )
         elif phase == "review" and self._push_review_projection is not None:
             self._git_panel_widget.render_push_review(
@@ -2596,9 +3191,7 @@ class LibraryFileNotesWorkspace(Vertical):
                     "result. Inspect the configured destination externally "
                     "before taking further action."
                 ),
-                action=(
-                    "review_again" if pre_network else "back_to_session"
-                ),
+                action=("review_again" if pre_network else "back_to_session"),
             )
         )
         self._render_session_git_label()
@@ -2621,9 +3214,7 @@ class LibraryFileNotesWorkspace(Vertical):
             return
         if isinstance(result, PushDestinationPolicyResult):
             if snapshot.push_candidate != operation.candidate:
-                self._set_push_result_projection(
-                    self._expired_push_review_projection()
-                )
+                self._set_push_result_projection(self._expired_push_review_projection())
                 return
             if result.state == "ready" and result.authorization is not None:
                 self._push_authorization_projection = result.authorization
@@ -2671,9 +3262,7 @@ class LibraryFileNotesWorkspace(Vertical):
                 snapshot.push_candidate != operation.candidate
                 and result.outcome is None
             ):
-                self._set_push_result_projection(
-                    self._expired_push_review_projection()
-                )
+                self._set_push_result_projection(self._expired_push_review_projection())
                 return
             if result.outcome is not None:
                 self._set_push_result_projection(
@@ -2721,9 +3310,7 @@ class LibraryFileNotesWorkspace(Vertical):
                 )
             )
             return
-        action_enabled = (
-            snapshot.push_recovery_available and result.can_check_again
-        )
+        action_enabled = snapshot.push_recovery_available and result.can_check_again
         self._set_push_result_projection(
             PushPanelResultProjection(
                 title=result.title,
@@ -3076,11 +3663,10 @@ class LibraryFileNotesWorkspace(Vertical):
                 recovery = snapshot.push_recovery
                 if (
                     recovery is not None
-                    and snapshot.push_recovery_candidate
-                    == operation.candidate
+                    and snapshot.push_recovery_candidate == operation.candidate
                 ):
-                    self._push_authorization_projection = (
-                        PushAuthorizationProjection(recovery.destination)
+                    self._push_authorization_projection = PushAuthorizationProjection(
+                        recovery.destination
                     )
                     self._open_push_authorization(
                         operation,
@@ -3098,9 +3684,7 @@ class LibraryFileNotesWorkspace(Vertical):
                         replace(
                             projection,
                             action_enabled=False,
-                            disabled_reason=(
-                                self._push_recovery_not_ready_copy()
-                            ),
+                            disabled_reason=(self._push_recovery_not_ready_copy()),
                         )
                     )
                 return
@@ -3140,7 +3724,9 @@ class LibraryFileNotesWorkspace(Vertical):
             self._push_result = None
             self._return_push_to_list()
         retained_push = (
-            None if service is None else getattr(service, "retained_push_operation", None)
+            None
+            if service is None
+            else getattr(service, "retained_push_operation", None)
         )
         operation = None if retained_push is None else retained_push(binding)
         if operation is None:
@@ -3154,9 +3740,7 @@ class LibraryFileNotesWorkspace(Vertical):
                 self._return_push_to_list()
             self._push_key = candidate_key
             self._push_phase = (
-                "needs_attention"
-                if snapshot.push_recovery is not None
-                else "idle"
+                "needs_attention" if snapshot.push_recovery is not None else "idle"
             )
             self._render_session_git_label()
             return availability is not None or snapshot.push_recovery is not None
@@ -3166,7 +3750,10 @@ class LibraryFileNotesWorkspace(Vertical):
             current_operation is not None
             and self._push_operation_admitted
             and (
-                (candidate_key is not None and candidate_key != self._push_operation_key)
+                (
+                    candidate_key is not None
+                    and candidate_key != self._push_operation_key
+                )
                 or (
                     candidate_key is None
                     and current_operation.kind not in {"push", "recovery"}
@@ -3177,9 +3764,7 @@ class LibraryFileNotesWorkspace(Vertical):
             self._push_operation_admitted = False
             self._push_result = None
             self._push_phase = (
-                "needs_attention"
-                if snapshot.push_recovery is not None
-                else "idle"
+                "needs_attention" if snapshot.push_recovery is not None else "idle"
             )
             self._push_key = candidate_key
             self._return_push_to_list()
@@ -3187,16 +3772,11 @@ class LibraryFileNotesWorkspace(Vertical):
             if not self._push_operation_admitted:
                 self._push_key = candidate_key
                 self._push_phase = (
-                    "needs_attention"
-                    if snapshot.push_recovery is not None
-                    else "idle"
+                    "needs_attention" if snapshot.push_recovery is not None else "idle"
                 )
                 self._return_push_to_list()
                 self._render_session_git_label()
-                return (
-                    availability is not None
-                    or snapshot.push_recovery is not None
-                )
+                return availability is not None or snapshot.push_recovery is not None
             if (
                 self._push_operation_admitted
                 and self._push_operation_key == operation_key
@@ -3209,14 +3789,11 @@ class LibraryFileNotesWorkspace(Vertical):
                     if operation.kind == "push" and operation.child_started
                     else "checking"
                 )
-                self._push_view_phase = self._push_view_for_operation(
-                    operation
-                )
+                self._push_view_phase = self._push_view_for_operation(operation)
             refreshed = self._refresh_push_recovery_readiness(snapshot)
             if (
                 not refreshed
-                and self._git_panel_widget.push_phase
-                != self._push_view_phase
+                and self._git_panel_widget.push_phase != self._push_view_phase
             ):
                 self._render_current_push_view()
             if (
@@ -3235,9 +3812,7 @@ class LibraryFileNotesWorkspace(Vertical):
             if not self._push_operation_admitted:
                 self._push_key = candidate_key
                 self._push_phase = (
-                    "needs_attention"
-                    if snapshot.push_recovery is not None
-                    else "idle"
+                    "needs_attention" if snapshot.push_recovery is not None else "idle"
                 )
                 self._return_push_to_list()
             self._render_session_git_label()
@@ -3270,9 +3845,7 @@ class LibraryFileNotesWorkspace(Vertical):
             self._push_result = None
             self._return_push_to_list()
             self._push_phase = (
-                "needs_attention"
-                if snapshot.push_recovery is not None
-                else "idle"
+                "needs_attention" if snapshot.push_recovery is not None else "idle"
             )
         self._render_session_git_label()
         return True
@@ -3431,11 +4004,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self._commit_review_projection = None
         self._commit_result_projection = None
         binding = self._session_binding
-        snapshot = (
-            None
-            if binding is None
-            else self._session_owner.snapshot(binding)
-        )
+        snapshot = None if binding is None else self._session_owner.snapshot(binding)
         if binding is not None and snapshot is not None:
             self._rehydrate_push_state(
                 self._session_git_service(),
@@ -3485,9 +4054,7 @@ class LibraryFileNotesWorkspace(Vertical):
             snapshot.binding == action.binding
             and snapshot.trusted_repository == action.repository
             and snapshot.changes == action.changes
-            and self._repository_identity_is_complete(
-                snapshot.trusted_repository
-            )
+            and self._repository_identity_is_complete(snapshot.trusted_repository)
         )
 
     def _clear_git_last_action(self) -> None:
@@ -3495,6 +4062,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self._git_last_action = None
         if self._active and self.is_mounted:
             self._git_panel_widget.clear_last_action()
+            self._render_status_channels()
 
     def _sync_git_last_action(self) -> bool:
         """Validate and project the retained action against fresh owner state."""
@@ -3510,6 +4078,7 @@ class LibraryFileNotesWorkspace(Vertical):
                     action.text,
                     complete=action.complete,
                 )
+            self._render_status_channels()
         return action is not None
 
     def _git_can_retain_rows(self, binding: SessionBinding) -> bool:
@@ -3562,10 +4131,7 @@ class LibraryFileNotesWorkspace(Vertical):
             return False
         key = draft.key
         if not self._commit_key_is_current(key):
-            if (
-                self._session_owner.snapshot(binding).trusted_repository
-                is None
-            ):
+            if self._session_owner.snapshot(binding).trusted_repository is None:
                 return False
             self._invalidate_commit_binding(
                 "Repository changed; the previous commit draft was cleared."
@@ -3686,9 +4252,7 @@ class LibraryFileNotesWorkspace(Vertical):
             )
             self._git_refresh_after_mutation = True
             return True
-        retained_task = (
-            None if service is None else service.retained_status(binding)
-        )
+        retained_task = None if service is None else service.retained_status(binding)
         if retained_task is not None:
             self._git_status_task = retained_task
             self._git_status_task_binding = binding
@@ -3728,8 +4292,7 @@ class LibraryFileNotesWorkspace(Vertical):
         """Project one discovery failure to reason plus feasible recovery."""
         if discovery.state == "not_repository":
             return (
-                "This notes folder is not in a Git worktree. "
-                "Notes remain fully usable."
+                "This notes folder is not in a Git worktree. Notes remain fully usable."
             )
 
         defaults = {
@@ -3812,9 +4375,7 @@ class LibraryFileNotesWorkspace(Vertical):
                 )
             return
         snapshot = self._session_owner.snapshot(binding)
-        needs_trust = (
-            force_prompt or snapshot.trusted_repository != repository
-        )
+        needs_trust = force_prompt or snapshot.trusted_repository != repository
         if needs_trust:
             self._clear_git_last_action()
             self._git_panel_widget.render_untrusted(repository.worktree_root)
@@ -3826,9 +4387,7 @@ class LibraryFileNotesWorkspace(Vertical):
             if not await service.revalidate_repository(binding, repository):
                 if self._git_binding_is_current(binding):
                     self._clear_git_last_action()
-                    self._git_panel_widget.render_untrusted(
-                        repository.worktree_root
-                    )
+                    self._git_panel_widget.render_untrusted(repository.worktree_root)
                     self._git_panel_widget.set_current_status(
                         "Status: TRUST REQUIRED — Repository identity changed; "
                         "retry Trust and check status.",
@@ -3839,9 +4398,8 @@ class LibraryFileNotesWorkspace(Vertical):
                 self._clear_git_last_action()
                 return
             snapshot = self._session_owner.snapshot(binding)
-        if (
-            self._git_refresh_after_mutation
-            and not self._session_owner.mutation_active(binding)
+        if self._git_refresh_after_mutation and not self._session_owner.mutation_active(
+            binding
         ):
             self._git_refresh_after_mutation = False
             self._start_git_refresh()
@@ -3896,9 +4454,14 @@ class LibraryFileNotesWorkspace(Vertical):
                 f"{error}. Retry Refresh.",
                 retain_rows=self._git_can_retain_rows(binding),
             )
+            if error.reason != "mutation_active":
+                self._git_status_failure = "Git status failed"
+                self._render_status_channels()
             return
+        self._git_status_failure = ""
         self._git_status_task = task
         self._git_status_task_binding = binding
+        self._render_status_channels()
         self._ensure_git_status_waiter(task, binding, replace=True)
 
     async def _render_git_status(
@@ -3912,6 +4475,7 @@ class LibraryFileNotesWorkspace(Vertical):
             raise
         except Exception as error:
             if self._git_binding_is_current(binding):
+                self._git_status_failure = "Git status failed"
                 self._sync_git_last_action()
                 self._git_panel_widget.mark_stale(
                     f"Git status failed: {error}. Retry Refresh.",
@@ -3921,6 +4485,7 @@ class LibraryFileNotesWorkspace(Vertical):
                 if self._git_status_task is task:
                     self._git_status_task = None
                     self._git_status_task_binding = None
+                self._render_status_channels()
             return
         self._sync_git_last_action()
         if not self._git_binding_is_current(binding):
@@ -3929,6 +4494,8 @@ class LibraryFileNotesWorkspace(Vertical):
         if self._git_status_task is task:
             self._git_status_task = None
             self._git_status_task_binding = None
+        self._git_status_failure = ""
+        self._render_status_channels()
         if snapshot.trusted_repository is None:
             self._clear_git_last_action()
             self._git_panel_widget.render_unavailable(
@@ -3965,22 +4532,17 @@ class LibraryFileNotesWorkspace(Vertical):
         if state != "conflict":
             self._conflict_resolution_active = False
         if self._active and self.is_mounted:
-            label = _SAVE_STATE_COPY[state]
-            if detail:
-                label = f"{label}; {detail}"
             status = self.query_one("#file-notes-save-status", Static)
             status.set_class(state == "conflict", "-conflict")
             status.set_class(state == "error", "-error")
-            status.update(label)
-            self.query_one("#file-notes-authority", Static).update(
-                self._authority_copy()
-            )
+            self._render_status_channels()
             self._update_controls()
 
     def _set_action_status(self, text: str) -> None:
         self._action_detail = text
         if self._active and self.is_mounted:
             self.query_one("#file-notes-action-status", Static).update(text)
+            self._render_status_channels()
 
     def _acquire_editor_read_only(
         self,
@@ -4182,9 +4744,8 @@ class LibraryFileNotesWorkspace(Vertical):
         )
         transitioning = self._root_transitioning or self._path_transitioning
         binding = self._session_binding
-        mutation_active = (
-            binding is not None
-            and self._session_owner.mutation_active(binding)
+        mutation_active = binding is not None and self._session_owner.mutation_active(
+            binding
         )
         focused = self.app.focused
         if (
@@ -4204,6 +4765,8 @@ class LibraryFileNotesWorkspace(Vertical):
                 "file-notes-protect",
                 "file-notes-reload",
                 "file-notes-save-copy",
+                "file-notes-recovery-save-copy",
+                "file-notes-recovery-reload",
                 "file-notes-refresh",
                 "file-notes-maintenance-toggle",
             }
@@ -4211,31 +4774,23 @@ class LibraryFileNotesWorkspace(Vertical):
             self._editor_action_focus_target = focused.id
         structurally_available = not transitioning and not mutation_active
         has_service = (
-            self._service is not None
-            and self._initialized
-            and structurally_available
+            self._service is not None and self._initialized and structurally_available
         )
         has_document = self._opened is not None and not transitioning
         has_deleted = bool(self._selected_deleted_path) and not transitioning
         self.query_one("#file-notes-new", Button).disabled = not has_service
         for selector in ("move", "delete", "reload"):
-            self.query_one(
-                f"#file-notes-{selector}", Button
-            ).disabled = not (
+            self.query_one(f"#file-notes-{selector}", Button).disabled = not (
                 has_document and structurally_available
             )
         self.query_one("#file-notes-protect", Button).disabled = not (
             has_document and structurally_available
         )
         self.query_one("#file-notes-compare", Button).disabled = not (
-            has_document
-            and structurally_available
-            and self._save_state == "conflict"
+            has_document and structurally_available and self._save_state == "conflict"
         )
         self.query_one("#file-notes-resolve-conflict", Button).disabled = not (
-            has_document
-            and structurally_available
-            and self._save_state == "conflict"
+            has_document and structurally_available and self._save_state == "conflict"
         )
         for selector in (
             "resolution-keep",
@@ -4264,6 +4819,26 @@ class LibraryFileNotesWorkspace(Vertical):
                 and self._save_state not in {"dirty", "conflict", "error"}
             )
         )
+        copy_disabled_reason = None
+        if not has_document:
+            copy_disabled_reason = "Open a file before saving a copy."
+        elif not structurally_available:
+            copy_disabled_reason = (
+                "Wait for the current file or Git operation to finish."
+            )
+        elif not exact_export and self._save_state not in {
+            "dirty",
+            "conflict",
+            "error",
+        }:
+            copy_disabled_reason = (
+                "Save Copy becomes available when the draft differs from disk."
+            )
+        copy_button.tooltip = copy_disabled_reason
+        recovery_copy = self.query_one("#file-notes-recovery-save-copy", Button)
+        recovery_copy.label = copy_label
+        recovery_copy.disabled = copy_button.disabled
+        recovery_copy.tooltip = copy_disabled_reason
         self.query_one("#file-notes-restore", Button).disabled = (
             not has_service or not has_deleted or not structurally_available
         )
@@ -4285,13 +4860,12 @@ class LibraryFileNotesWorkspace(Vertical):
             if protect.parent is not None:
                 protect.parent.refresh(layout=True)
         reload_button = self.query_one("#file-notes-reload", Button)
+        recovery_reload = self.query_one("#file-notes-recovery-reload", Button)
         reload_label = (
             "Reload from disk"
             if self._save_state == "conflict"
             else (
-                "Discard draft and reload"
-                if self._save_state == "error"
-                else "Reload"
+                "Discard draft and reload" if self._save_state == "error" else "Reload"
             )
         )
         if str(reload_button.label) != reload_label:
@@ -4299,10 +4873,12 @@ class LibraryFileNotesWorkspace(Vertical):
             reload_button.refresh(layout=True)
             if reload_button.parent is not None:
                 reload_button.parent.refresh(layout=True)
+        recovery_reload.label = reload_label
+        recovery_reload.disabled = reload_button.disabled
         self._sync_editor_action_visibility()
-        self.query_one("#file-notes-reload-cancel", Button).disabled = (
-            not self.reload_confirmation_active
-        )
+        self.query_one(
+            "#file-notes-reload-cancel", Button
+        ).disabled = not self.reload_confirmation_active
         self.query_one("#file-notes-reload-confirm", Button).disabled = (
             not self.reload_confirmation_active or not structurally_available
         )
@@ -4326,6 +4902,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self.query_one("#file-notes-path", Input).disabled = (
             transitioning or mutation_active
         )
+        self._sync_path_task_surface()
         self.query_one("#file-notes-tree", Tree).disabled = (
             transitioning or mutation_active
         )
@@ -4338,7 +4915,11 @@ class LibraryFileNotesWorkspace(Vertical):
     def _sync_editor_action_disabled_presentation(self) -> None:
         """Keep every disabled editor action readable and visibly inert."""
         prefix = f"{LIBRARY_DISABLED_ACTION_MARKER} "
-        for button in self.query(".file-notes-toolbar Button"):
+        buttons = (
+            self.query_one("#file-notes-new", Button),
+            *self.query(".file-notes-toolbar Button"),
+        )
+        for button in buttons:
             label = str(button.label)
             base_label = label.removeprefix(prefix)
             rendered_label = library_disabled_action_label(
@@ -4366,9 +4947,7 @@ class LibraryFileNotesWorkspace(Vertical):
             "file-notes-move": has_document,
             "file-notes-delete": has_document and not resolving_conflict,
             "file-notes-restore": has_deleted,
-            "file-notes-compare": (
-                has_document and self._save_state == "conflict"
-            ),
+            "file-notes-compare": (has_document and self._save_state == "conflict"),
             "file-notes-resolve-conflict": (
                 has_document
                 and self._save_state == "conflict"
@@ -4384,6 +4963,16 @@ class LibraryFileNotesWorkspace(Vertical):
                 )
             ),
             "file-notes-refresh": has_service,
+            "file-notes-recovery-reload": (
+                has_document and self._save_state in {"conflict", "error"}
+            ),
+            "file-notes-recovery-save-copy": (
+                has_document
+                and (
+                    (self._opened is not None and self._opened.is_excerpt)
+                    or self._save_state in {"conflict", "error"}
+                )
+            ),
         }
         maintenance_ids = {
             "file-notes-protect",
@@ -4419,29 +5008,21 @@ class LibraryFileNotesWorkspace(Vertical):
             if action_id in maintenance_ids:
                 displayed = displayed and (
                     self._maintenance_expanded
-                    or (
-                        action_id == "file-notes-reload"
-                        and critical_reload
-                    )
+                    or (action_id == "file-notes-reload" and critical_reload)
                 )
             if confirming_reload:
-                displayed = action_id == "file-notes-save-copy" and displayed
+                displayed = action_id == "file-notes-recovery-save-copy" and displayed
             button = self.query_one(f"#{action_id}", Button)
             if button is focused and not displayed:
                 self._editor_action_focus_target = action_id
             button.display = displayed
-        self.query_one("#file-notes-delete-spacer", Static).display = (
-            visibility["file-notes-delete"]
-            and not self.has_class("-stack-editor-actions")
-        )
+        self.query_one("#file-notes-delete-spacer", Static).display = visibility[
+            "file-notes-delete"
+        ] and not self.has_class("-stack-editor-actions")
 
-        maintenance_toggle = self.query_one(
-            "#file-notes-maintenance-toggle", Button
-        )
+        maintenance_toggle = self.query_one("#file-notes-maintenance-toggle", Button)
         maintenance_toggle.label = (
-            "Hide file actions"
-            if self._maintenance_expanded
-            else "More file actions"
+            "Hide file actions" if self._maintenance_expanded else "More file actions"
         )
         maintenance = self.query_one("#file-notes-maintenance-actions")
         maintenance.display = (
@@ -4464,9 +5045,7 @@ class LibraryFileNotesWorkspace(Vertical):
             "#file-notes-reload-confirm-copy",
             Static,
         )
-        confirmation_actions = self.query_one(
-            "#file-notes-reload-confirm-actions"
-        )
+        confirmation_actions = self.query_one("#file-notes-reload-confirm-actions")
         confirmation_copy.display = confirming_reload
         confirmation_actions.display = confirming_reload
         for button in confirmation_actions.query(Button):
@@ -4668,10 +5247,15 @@ class LibraryFileNotesWorkspace(Vertical):
                 or service is not self._service
             ):
                 return False
-            self._apply_opened_document(opened)
+            self._apply_opened_document(opened, announce_editable=True)
             return True
 
-    def _apply_opened_document(self, opened: OpenedFileNote) -> None:
+    def _apply_opened_document(
+        self,
+        opened: OpenedFileNote,
+        *,
+        announce_editable: bool = False,
+    ) -> None:
         if not self._active:
             return
         self._dismiss_reload_confirmation(focus_opener=False)
@@ -4687,6 +5271,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self._sync_large_file_preview()
         self.query_one("#file-notes-path", Input).value = opened.relative_path
         self.query_one("#file-notes-breadcrumb", Static).update(opened.relative_path)
+        self.query_one("#file-notes-exact-path", Static).update(opened.relative_path)
         if opened.editable:
             self._set_save_state("saved")
         else:
@@ -4698,9 +5283,22 @@ class LibraryFileNotesWorkspace(Vertical):
         if self._narrow:
             self._narrow_view = "editor"
             self._apply_responsive_layout(self.size.width)
+            if self._reader_shell_external:
+                self.post_message(AdaptiveReaderShellResized())
         self._update_controls()
+        self._sync_work_mode()
+        if announce_editable and opened.editable:
+            self.post_message(
+                FileNotesEditableOpened(opened.relative_path).set_sender(self)
+            )
 
-    def _clear_open_document(self, *, keep_restore_path: bool = False) -> None:
+    def _clear_open_document(
+        self,
+        *,
+        keep_restore_path: bool = False,
+        announce_identity_cleared: bool = True,
+    ) -> None:
+        had_identity = self._opened is not None
         self._dismiss_reload_confirmation(focus_opener=False)
         self._opened = None
         self._current_path = ""
@@ -4708,6 +5306,7 @@ class LibraryFileNotesWorkspace(Vertical):
         self._delete_confirmation_path = ""
         if not keep_restore_path:
             self._selected_deleted_path = ""
+        self._close_path_task(restore_focus=False)
         if not self._active or not self.is_mounted:
             self._save_state = "idle"
             self._save_detail = ""
@@ -4720,20 +5319,26 @@ class LibraryFileNotesWorkspace(Vertical):
         if not keep_restore_path:
             self.query_one("#file-notes-path", Input).value = ""
             self.query_one("#file-notes-breadcrumb", Static).update("No file selected")
+            self.query_one("#file-notes-exact-path", Static).update("No file selected")
         self._set_delete_confirmation()
         self._set_save_state("idle")
         self._update_controls()
+        if had_identity and announce_identity_cleared:
+            self.post_message(FileNotesIdentityCleared().set_sender(self))
 
     def select_deleted(self, relative_path: str) -> bool:
         """Select one persistent tombstone for the Restore action."""
         if not self._active or relative_path not in self._deleted_paths:
             return False
+        self._work_mode = "edit"
+        self._sync_work_mode()
         self._selected_deleted_path = relative_path
         self._clear_open_document(keep_restore_path=True)
         self.query_one("#file-notes-path", Input).value = relative_path
         self.query_one("#file-notes-breadcrumb", Static).update(
             f"Recently deleted: {relative_path}"
         )
+        self.query_one("#file-notes-exact-path", Static).update(relative_path)
         self._set_action_status("Ready to restore.")
         if self._narrow:
             self._narrow_view = "editor"
@@ -4863,26 +5468,71 @@ class LibraryFileNotesWorkspace(Vertical):
 
     def _start_autosave(self) -> None:
         self._autosave_timer = None
-        if (
-            not self._active
-            or self._save_state != "dirty"
-            or (
-                self._save_worker is not None
-                and not self._save_worker.is_finished
-            )
-        ):
+        if not self._active or self._save_state != "dirty":
+            return
+        task = self._save_task
+        if task is None or task.done():
+            task = self._begin_save_task()
+        self._attach_save_observer(task)
+
+    def _begin_save_task(self) -> asyncio.Task[bool]:
+        """Start one process-owned save that survives Textual node removal."""
+        task = asyncio.create_task(
+            self._save_draft(),
+            name="file-notes-autosave-task",
+        )
+        self._save_task = task
+        task.add_done_callback(self._save_task_finished)
+        return task
+
+    def _attach_save_observer(self, task: asyncio.Task[bool]) -> None:
+        """Attach one mount-owned Worker observer without owning the save task."""
+        if not self._active or not self.is_attached or task.done():
+            return
+        if self._save_worker is not None and not self._save_worker.is_finished:
             return
         self._save_worker = self.run_worker(
-            self._save_draft(),
+            self._observe_save_task(task),
             name="file-notes-autosave",
             group="file-notes-save",
             exclusive=False,
         )
 
+    @staticmethod
+    async def _observe_save_task(task: asyncio.Task[bool]) -> bool:
+        """Observe a retained save without letting Worker cancellation own it."""
+        return await asyncio.shield(task)
+
+    def _save_task_finished(self, task: asyncio.Task[bool]) -> None:
+        """Consume one save result and schedule a newer retained draft once."""
+        if self._save_task is task:
+            self._save_task = None
+        try:
+            saved = task.result()
+        except asyncio.CancelledError:
+            if self._save_state == "saving":
+                self._set_save_state("dirty", "save interrupted")
+        except Exception as error:
+            self._set_save_state("error", str(error))
+        else:
+            if not saved and self._save_state == "saving":
+                self._set_save_state("dirty", "save authority changed")
+        if (
+            self._active
+            and self.is_attached
+            and not self._shutdown
+            and self._save_state == "dirty"
+            and self._autosave_timer is None
+        ):
+            self._arm_autosave()
+
     async def _save_draft(self) -> bool:
         async with self._save_lock:
             opened = self._opened
             service = self._service
+            generation = self._root_generation
+            binding = self._session_binding
+            session_key = self._session_key
             if opened is None or service is None:
                 return True
             if self._save_state in {"conflict", "error"}:
@@ -4895,12 +5545,18 @@ class LibraryFileNotesWorkspace(Vertical):
                     service.save_file,
                     opened,
                     body,
-                    session_key=self._session_key,
+                    session_key=session_key,
                 )
             except Exception as error:
                 self._set_save_state("error", str(error))
                 return False
-            if not self._active:
+            if (
+                service is not self._service
+                or generation != self._root_generation
+                or binding != self._session_binding
+                or session_key != self._session_key
+                or opened is not self._opened
+            ):
                 return False
             if result.status == "ok" and result.content_hash is not None:
                 self._opened = replace(
@@ -4912,7 +5568,8 @@ class LibraryFileNotesWorkspace(Vertical):
                     self._set_save_state("saved")
                 else:
                     self._set_save_state("dirty")
-                    self._arm_autosave()
+                    if self._active and self.is_attached:
+                        self._arm_autosave()
                 self._set_action_status(result.replica_warning or "")
                 self._refresh_session_changes()
                 return True
@@ -4942,16 +5599,21 @@ class LibraryFileNotesWorkspace(Vertical):
         if self._autosave_timer is not None:
             self._autosave_timer.stop()
             self._autosave_timer = None
-        worker = self._save_worker
-        if worker is not None and not worker.is_finished:
+        task = self._save_task
+        if task is not None and not task.done():
             try:
-                await worker.wait()
+                await asyncio.shield(task)
             except Exception:
                 pass
         if self._save_state in {"conflict", "error"}:
             return False
         if self._save_state == "dirty":
-            await self._save_draft()
+            task = self._begin_save_task()
+            self._attach_save_observer(task)
+            try:
+                await asyncio.shield(task)
+            except Exception:
+                pass
         binding = self._session_binding
         if self._mutation_blocks_flush(binding):
             return False
@@ -5002,27 +5664,28 @@ class LibraryFileNotesWorkspace(Vertical):
         relative_path: str,
         operation: Callable[..., OperationResult],
         *args: object,
-    ) -> None:
+    ) -> bool:
         with self._hold_path_transition() as transition:
             if transition is None:
-                return
+                return False
             service, generation = transition
             result = await asyncio.to_thread(operation, *args)
             if self._path_result_is_stale(service, generation):
-                return
+                return False
             if not result.succeeded:
                 self._operation_error(action, result)
-                return
+                return False
             if not await self._rescan_after_action():
-                return
+                return False
             try:
                 opened = await asyncio.to_thread(service.open_file, relative_path)
             except Exception as error:
                 self._set_action_status(f"Open failed: {error}")
-                return
+                return False
             if self._path_result_is_stale(service, generation):
-                return
-            self._apply_opened_document(opened)
+                return False
+            self._apply_opened_document(opened, announce_editable=True)
+            return True
 
     @on(TextArea.Changed, "#file-notes-editor")
     def _editor_changed(self, event: TextArea.Changed) -> None:
@@ -5032,6 +5695,7 @@ class LibraryFileNotesWorkspace(Vertical):
             or self._path_transitioning
             or self._opened is None
             or not self._opened.editable
+            or self._save_state == "conflict"
         ):
             return
         self._set_delete_confirmation()
@@ -5163,6 +5827,8 @@ class LibraryFileNotesWorkspace(Vertical):
         event.stop()
         self._narrow_view = "navigator"
         self._apply_responsive_layout(self.size.width)
+        if self._reader_shell_external:
+            self.post_message(AdaptiveReaderShellResized())
 
     @on(Button.Pressed, "#file-notes-session-changes")
     def _session_git_pressed(self, event: Button.Pressed) -> None:
@@ -5170,9 +5836,7 @@ class LibraryFileNotesWorkspace(Vertical):
         entry_owned_focus = event.button.has_focus
         if self._navigator_mode != "git":
             self._navigator_mode_before_git = (
-                "search"
-                if self._navigator_mode == "search"
-                else "files"
+                "search" if self._navigator_mode == "search" else "files"
             )
         self._navigator_mode = "git"
         self._sync_navigator_mode()
@@ -5422,8 +6086,7 @@ class LibraryFileNotesWorkspace(Vertical):
             operation is None
             or key is None
             or service is None
-            or self._push_view_phase
-            not in {"checking_candidate", "checking_remote"}
+            or self._push_view_phase not in {"checking_candidate", "checking_remote"}
             or operation_id != self._push_operation_id
             or not self._push_operation_is_current(
                 operation,
@@ -5754,8 +6417,7 @@ class LibraryFileNotesWorkspace(Vertical):
                 review,
                 key.repository,
                 tuple(
-                    CommitReviewNoteProjection(note)
-                    for note in review.included_notes
+                    CommitReviewNoteProjection(note) for note in review.included_notes
                 ),
             )
         except ValueError:
@@ -5941,9 +6603,7 @@ class LibraryFileNotesWorkspace(Vertical):
             self._clear_commit_draft_after_success()
             snapshot = self._session_owner.snapshot(key.binding)
             if snapshot.trusted_repository == key.repository:
-                note_label = (
-                    "note" if result.committed_note_count == 1 else "notes"
-                )
+                note_label = "note" if result.committed_note_count == 1 else "notes"
                 self._git_last_action = _GitLastAction(
                     binding=key.binding,
                     repository=key.repository,
@@ -6122,10 +6782,8 @@ class LibraryFileNotesWorkspace(Vertical):
         pending_save = (
             self._save_state in {"dirty", "saving"}
             or self._autosave_timer is not None
-            or (
-                self._save_worker is not None
-                and not self._save_worker.is_finished
-            )
+            or (self._save_task is not None and not self._save_task.done())
+            or (self._save_worker is not None and not self._save_worker.is_finished)
         )
         if (action == "stage" or pending_save) and not await self.flush_pending_work():
             gerund = "staging" if action == "stage" else "unstaging"
@@ -6135,14 +6793,9 @@ class LibraryFileNotesWorkspace(Vertical):
                     "Return to the editor."
                 )
             elif self._save_state == "error":
-                detail = (
-                    f"Fix the save error before {gerund}. "
-                    "Return to the editor."
-                )
+                detail = f"Fix the save error before {gerund}. Return to the editor."
             else:
-                detail = (
-                    f"Save the note before {gerund}. Return to the editor."
-                )
+                detail = f"Save the note before {gerund}. Return to the editor."
             self._git_panel_widget.set_current_status(
                 f"Status: CURRENT · BLOCKED — {detail}",
                 complete=True,
@@ -6187,6 +6840,8 @@ class LibraryFileNotesWorkspace(Vertical):
         action_key_after_admission = self._capture_git_action_key(binding)
         if action_key_after_admission != action_key:
             action_key = None
+        self._git_status_failure = ""
+        self._git_action_running = "Staging…" if action == "stage" else "Unstaging…"
         self._clear_git_last_action()
         self._git_status_task = None
         self._git_status_task_binding = None
@@ -6225,10 +6880,7 @@ class LibraryFileNotesWorkspace(Vertical):
                 f"Git action failed: {error}. Inspect the repository "
                 "index outside Chatbook, then Refresh."
             )
-            if (
-                action_key is not None
-                and self._git_action_key_is_current(action_key)
-            ):
+            if action_key is not None and self._git_action_key_is_current(action_key):
                 self._git_last_action = replace(
                     action_key,
                     text=f"Last action: FAILED — {detail}",
@@ -6249,21 +6901,20 @@ class LibraryFileNotesWorkspace(Vertical):
                     summary_context,
                     action_key,
                 )
-                if (
-                    summary is not None
-                    and self._git_action_key_is_current(action_key)
-                ):
+                if summary is not None and self._git_action_key_is_current(action_key):
                     self._git_last_action = replace(
                         action_key,
                         text=(
-                            f"Last action: {self._git_action_label(result)} — "
-                            f"{summary}"
+                            f"Last action: {self._git_action_label(result)} — {summary}"
                         ),
                         complete=result.state != "success",
                     )
                     if self._git_binding_is_current(binding):
                         self._sync_git_last_action()
         finally:
+            self._git_action_running = ""
+            if self._active and self.is_mounted:
+                self._render_status_channels()
             binding_changed = (
                 binding != self._session_binding
                 or binding != self._session_owner.current_binding()
@@ -6298,9 +6949,7 @@ class LibraryFileNotesWorkspace(Vertical):
             return _GitActionSummaryContext()
         requested = frozenset(group_ids)
         excluded: tuple[SessionGitRow, ...] = tuple(
-            row
-            for row in self._git_panel_widget.rows
-            if row.group_id not in requested
+            row for row in self._git_panel_widget.rows if row.group_id not in requested
         )
         clean = sum(row.state == "clean" for row in excluded)
         if action == "stage":
@@ -6335,11 +6984,7 @@ class LibraryFileNotesWorkspace(Vertical):
         )
         affected = len(tuple(dict.fromkeys(affected_group_ids)))
         counts: list[str] = []
-        if (
-            context.bulk
-            and result.action == "stage"
-            and context.already_staged
-        ):
+        if context.bulk and result.action == "stage" and context.already_staged:
             counts.append(f"already staged {context.already_staged}")
         if context.bulk and result.action == "unstage" and context.skipped:
             counts.append(f"skipped {context.skipped}")
@@ -6349,9 +6994,7 @@ class LibraryFileNotesWorkspace(Vertical):
             counts.append(f"clean {clean}")
         if blocked:
             counts.append(f"blocked {blocked}")
-        counts_text = (
-            f"Counts: {'; '.join(counts)}." if counts else ""
-        )
+        counts_text = f"Counts: {'; '.join(counts)}." if counts else ""
 
         message = (result.message or "").strip()
         if message and message[-1] not in ".!?":
@@ -6370,9 +7013,7 @@ class LibraryFileNotesWorkspace(Vertical):
                     f"{affected} {note} unstaged; Chatbook restored only its "
                     f"owned session {entry}."
                 )
-            return " ".join(
-                part for part in (core, message, counts_text) if part
-            )
+            return " ".join(part for part in (core, message, counts_text) if part)
 
         if result.state == "success":
             past = "staged" if result.action == "stage" else "unstaged"
@@ -6408,9 +7049,7 @@ class LibraryFileNotesWorkspace(Vertical):
             "blocked": (
                 "Resolve the reported Git state outside Chatbook, then Refresh."
             ),
-            "stale": (
-                "Review the changed repository or session state, then Refresh."
-            ),
+            "stale": ("Review the changed repository or session state, then Refresh."),
             "error": "Fix the reported Git error outside Chatbook, then Refresh.",
             "uncertain": (
                 "Inspect the repository index outside Chatbook, then Refresh."
@@ -6442,15 +7081,17 @@ class LibraryFileNotesWorkspace(Vertical):
     @on(Button.Pressed, "#file-notes-new")
     async def _new_file(self, event: Button.Pressed) -> None:
         event.stop()
-        if not await self.flush_pending_work():
-            return
+        await self._open_path_task("new", opener_id=event.button.id or "file-notes-new")
+
+    async def _execute_new_file(self) -> bool:
+        """Execute New through the incumbent validator and file service."""
         service = self._service
         if service is None:
-            return
+            return False
         destination = self._validated_path_input("Create")
         if destination is None:
-            return
-        await self._complete_path_action(
+            return False
+        return await self._complete_path_action(
             "Create",
             destination,
             service.create_file,
@@ -6460,22 +7101,56 @@ class LibraryFileNotesWorkspace(Vertical):
     @on(Button.Pressed, "#file-notes-move")
     async def _move_file(self, event: Button.Pressed) -> None:
         event.stop()
+        await self._open_path_task(
+            "move", opener_id=event.button.id or "file-notes-move"
+        )
+
+    async def _execute_move_file(self) -> bool:
+        """Execute Move through the incumbent validator and file service."""
         opened = self._opened
-        if opened is None or not await self.flush_pending_work():
-            return
+        if opened is None:
+            return False
         service = self._service
         if service is None:
-            return
+            return False
         destination = self._validated_path_input("Move")
         if destination is None:
-            return
-        await self._complete_path_action(
+            return False
+        return await self._complete_path_action(
             "Move",
             destination,
             service.move_file,
             opened.relative_path,
             destination,
         )
+
+    @on(Button.Pressed, "#file-notes-path-submit")
+    async def _submit_named_path_task(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self._submit_path_task()
+
+    @on(Button.Pressed, "#file-notes-path-cancel")
+    def _cancel_named_path_task(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._close_path_task(restore_focus=True)
+
+    @on(Button.Pressed, "#file-notes-edit")
+    def _show_edit_mode(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._work_mode = "edit"
+        self._sync_work_mode()
+        self.call_after_refresh(self._editor_widget.focus)
+
+    @on(Button.Pressed, "#file-notes-manage")
+    def _show_manage_mode(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._work_mode = "manage"
+        self._sync_work_mode()
+        if self._narrow:
+            self._narrow_view = "editor"
+            self._apply_responsive_layout(self.size.width)
+            if self._reader_shell_external:
+                self.post_message(AdaptiveReaderShellResized())
 
     @on(Button.Pressed, "#file-notes-maintenance-toggle")
     def _toggle_maintenance_actions(self) -> None:
@@ -6494,9 +7169,7 @@ class LibraryFileNotesWorkspace(Vertical):
     ) -> None:
         """Project the bounded conflict choices without resolving any side."""
         self._conflict_resolution_active = bool(
-            active
-            and self._opened is not None
-            and self._save_state == "conflict"
+            active and self._opened is not None and self._save_state == "conflict"
         )
         self._update_controls()
         if not self._active or not self.is_mounted:
@@ -6557,6 +7230,8 @@ class LibraryFileNotesWorkspace(Vertical):
                 return
             deleted_path = opened.relative_path
             self._selected_deleted_path = deleted_path
+            self._work_mode = "edit"
+            self._sync_work_mode()
             self._clear_open_document(keep_restore_path=True)
             self.query_one("#file-notes-path", Input).value = deleted_path
             self.query_one("#file-notes-breadcrumb", Static).update(
@@ -6594,9 +7269,7 @@ class LibraryFileNotesWorkspace(Vertical):
         if service is None or opened is None:
             return
         target = not opened.protected
-        operation = (
-            service.protect_path if target else service.unprotect_path
-        )
+        operation = service.protect_path if target else service.unprotect_path
         result = await asyncio.to_thread(operation, opened.relative_path)
         if self._path_result_is_stale(service, generation):
             return
@@ -6878,10 +7551,9 @@ class LibraryFileNotesWorkspace(Vertical):
                 return
             if self._reload_confirmation is not confirmation:
                 return
-            if (
-                self._path_result_is_stale(service, generation)
-                or not self._reload_confirmation_is_current(confirmation)
-            ):
+            if self._path_result_is_stale(
+                service, generation
+            ) or not self._reload_confirmation_is_current(confirmation):
                 self._dismiss_reload_confirmation(focus_opener=True)
                 self._set_action_status(
                     "Reload stopped: the active root, file, or editing session "
@@ -6936,22 +7608,33 @@ class LibraryFileNotesWorkspace(Vertical):
     @on(Button.Pressed, "#file-notes-save-copy")
     async def _save_copy(self, event: Button.Pressed) -> None:
         event.stop()
-        opened = self._opened
-        if opened is None:
-            return
-        action = "Export exact copy" if opened.is_excerpt else "Save draft as copy"
-        await self._save_editor_copy(action)
+        await self._open_path_task(
+            "save_copy", opener_id=event.button.id or "file-notes-save-copy"
+        )
+
+    @on(Button.Pressed, "#file-notes-recovery-save-copy")
+    async def _save_recovery_copy(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self._open_path_task(
+            "save_copy",
+            opener_id=event.button.id or "file-notes-recovery-save-copy",
+        )
+
+    @on(Button.Pressed, "#file-notes-recovery-reload")
+    async def _reload_from_recovery(self, event: Button.Pressed) -> None:
+        await self._reload_file(event)
 
     @on(Button.Pressed, "#file-notes-resolution-save-new")
     async def _save_conflict_draft_as_new_note(
         self,
         event: Button.Pressed,
     ) -> None:
-        """Save the retained draft through the existing no-clobber copy path."""
+        """Open recovery Save Copy through the same named no-clobber path."""
         event.stop()
-        if await self._save_editor_copy("Save draft as new note"):
-            editor = self.query_one("#file-notes-editor", TextArea)
-            self.call_after_refresh(editor.focus)
+        await self._open_path_task(
+            "save_copy",
+            opener_id=event.button.id or "file-notes-resolution-save-new",
+        )
 
     @on(Button.Pressed, "#file-notes-refresh")
     async def _refresh_pressed(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -50,6 +50,48 @@ _SORT_LABELS = {"newest": "Newest", "oldest": "Oldest", "title": "Title"}
 
 
 @dataclass(frozen=True)
+class NotesStatusChannels:
+    """Independent Notes header channels with one optional recovery action."""
+
+    content_recovery: str
+    authority_git: str
+    safe_next_action: str | None = None
+
+
+def resolve_database_note_status_channels(
+    *,
+    conflict: bool = False,
+    unavailable: bool = False,
+    read_only: bool = False,
+    save_failed: bool = False,
+    saving: bool = False,
+    dirty: bool = False,
+) -> NotesStatusChannels:
+    """Resolve Database Notes status in the approved deterministic order."""
+    if conflict:
+        content = "Conflict — the note changed elsewhere; your draft is preserved."
+        safe = "Review recovery"
+    elif unavailable:
+        content = (
+            "Unavailable — the database cannot be reached; your draft is preserved."
+        )
+        safe = "Retry when storage is available"
+    elif read_only:
+        content = "Read-only — this note cannot be changed; your draft is preserved."
+        safe = "Keep the draft"
+    elif save_failed:
+        content = "Save failed — your draft remains in the editor."
+        safe = "Retry Save"
+    elif saving:
+        content, safe = "Saving…", None
+    elif dirty:
+        content, safe = "Unsaved changes", None
+    else:
+        content, safe = "Saved", None
+    return NotesStatusChannels(content, "Database Notes · Library database", safe)
+
+
+@dataclass(frozen=True)
 class LibraryNotePresentationState:
     """Immutable presentation input for one mounted Database Note canvas.
 
@@ -74,6 +116,7 @@ class LibraryNotePresentationState:
     transfer_running: bool = False
     bulk_read_only: bool = False
     bulk_included: bool = False
+    status_channels: NotesStatusChannels | None = None
 
 
 class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical):
@@ -938,6 +981,10 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         keywords_text = snapshot.keywords_text
         metadata_line = presentation_state.metadata_line
         status_line = presentation_state.status_line
+        channels = presentation_state.status_channels or NotesStatusChannels(
+            status_line or "Saved",
+            "Database Notes · Library database",
+        )
 
         # File-synced notes may carry YAML front matter; consume it instead
         # of rendering the delimiter block as note content.
@@ -957,7 +1004,7 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 compact=True,
             )
             yield Static(
-                "Edit note",
+                ellipsize_note_title_cells(title, 72),
                 id="library-note-editor-title",
                 markup=False,
             )
@@ -971,6 +1018,11 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 id="library-note-context-title",
                 markup=False,
             )
+            yield Static(
+                channels.authority_git,
+                id="library-note-authority-git-status",
+                markup=False,
+            )
         yield Static(
             "Included in bulk selection"
             if presentation_state.bulk_included
@@ -979,6 +1031,58 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             classes="destination-purpose",
             markup=False,
         )
+        with Horizontal(id="library-note-header-second-row"):
+            yield Static(
+                channels.content_recovery,
+                id="library-note-status",
+                markup=False,
+            )
+            primary_actions = Horizontal(
+                id="library-note-primary-actions", classes="ds-toolbar"
+            )
+            primary_actions.styles.height = "auto"
+            with primary_actions:
+                with Horizontal(id="library-note-mode-controls", classes="ds-toolbar"):
+                    yield Button(
+                        "Edit",
+                        id="library-note-edit",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                    yield Button(
+                        "Preview",
+                        id="library-note-preview",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                    yield Button(
+                        "Info",
+                        id="library-note-context",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                with Horizontal(id="library-note-task-actions", classes="ds-toolbar"):
+                    yield Button(
+                        "Save",
+                        id="library-note-save",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                    yield Button(
+                        "Use in Console",
+                        id="library-note-use-in-console",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                    discard_new = Button(
+                        "Discard" if self.compact else "Discard new note",
+                        id="library-note-discard-new",
+                        classes="library-canvas-action library-media-action-danger",
+                        compact=True,
+                    )
+                    discard_new.display = presentation_state.discard_new_note
+                    discard_new.disabled = presentation_state.destructive_running
+                    yield discard_new
         with Vertical(id="library-note-editor-region"):
             with Horizontal(id="library-note-title-row"):
                 yield Static("Title", id="library-note-title-label", markup=False)
@@ -1012,16 +1116,18 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                     placeholder="Comma-separated keywords",
                     id="library-note-context-keywords",
                 )
-            yield Static("Metadata", classes="destination-section", markup=False)
             yield Static(metadata_line, id="library-note-context-meta", markup=False)
-            yield Static("Chatbook", classes="destination-section", markup=False)
-            yield Button(
+            yield Static("Reuse & Export", classes="destination-section", markup=False)
+            legacy_use_in_console = Button(
                 "Use in Console",
                 id="library-note-context-use-in-console",
                 classes="library-canvas-action",
                 compact=True,
             )
-            yield Static("Utilities", classes="destination-section", markup=False)
+            # Retain the incumbent selector/handler for compatibility while the
+            # single visible affordance lives in the primary task group.
+            legacy_use_in_console.display = False
+            yield legacy_use_in_console
             yield Button(
                 "Copy",
                 id="library-note-context-copy",
@@ -1047,47 +1153,13 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 id="library-note-context-transfer-status",
                 markup=False,
             )
-            yield Static("Danger zone", classes="destination-section", markup=False)
+            yield Static("Danger", classes="destination-section", markup=False)
             yield Button(
                 "Delete",
                 id="library-note-context-delete",
                 classes="library-canvas-action library-media-action-danger",
                 compact=True,
             )
-        yield Static(status_line, id="library-note-status", markup=False)
-
-        primary_actions = Horizontal(
-            id="library-note-primary-actions", classes="ds-toolbar"
-        )
-        primary_actions.styles.height = "auto"
-        with primary_actions:
-            yield Button(
-                "Save",
-                id="library-note-save",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            yield Button(
-                "Edit" if presentation_state.presentation == "preview" else "Preview",
-                id="library-note-preview",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            yield Button(
-                "Info",
-                id="library-note-context",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            discard_new = Button(
-                "Discard" if self.compact else "Discard new note",
-                id="library-note-discard-new",
-                classes="library-canvas-action library-media-action-danger",
-                compact=True,
-            )
-            discard_new.display = presentation_state.discard_new_note
-            discard_new.disabled = presentation_state.destructive_running
-            yield discard_new
         yield Static(
             presentation_state.transfer_status,
             id="library-note-transfer-status",
@@ -1105,12 +1177,6 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             wide_actions = Horizontal(classes="ds-toolbar")
             wide_actions.styles.height = "auto"
             with wide_actions:
-                yield Button(
-                    "Use in Console",
-                    id="library-note-use-in-console",
-                    classes="library-canvas-action",
-                    compact=True,
-                )
                 yield Button(
                     "Export Markdown",
                     id="library-note-export-md",
@@ -1256,6 +1322,50 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                     export_base, button.disabled
                 )
             return
+        header_rows = self.query("#library-note-header-second-row")
+        if header_rows:
+            heading = self.query_one("#library-note-heading")
+            second_row = header_rows.first(Horizontal)
+            status = self.query_one("#library-note-status", Static)
+            authority = self.query_one("#library-note-authority-git-status", Static)
+            primary = self.query_one("#library-note-primary-actions", Horizontal)
+            mode_controls = self.query_one("#library-note-mode-controls", Horizontal)
+            task_actions = self.query_one("#library-note-task-actions", Horizontal)
+            heading.styles.layout = "horizontal"
+            heading.styles.height = 1 if compact else 3
+            heading.styles.min_height = 1 if compact else 3
+            heading.styles.max_height = 1 if compact else 3
+            second_row.styles.layout = "vertical" if compact else "horizontal"
+            second_row.styles.height = "auto" if compact else 3
+            second_row.styles.min_height = 3
+            second_row.styles.max_height = 5 if compact else 3
+            status.styles.width = "1fr"
+            status.styles.height = "auto" if compact else 3
+            status.styles.min_height = 1 if compact else 3
+            status.styles.max_height = 3
+            status.styles.text_wrap = "wrap"
+            status.styles.text_overflow = "clip"
+            primary.styles.layout = "vertical" if compact else "horizontal"
+            primary.styles.width = "100%" if compact else "auto"
+            primary.styles.height = 2 if compact else 3
+            primary.styles.min_height = 2 if compact else 3
+            primary.styles.max_height = 2 if compact else 3
+            for actions in (mode_controls, task_actions):
+                actions.styles.width = "100%" if compact else "auto"
+                actions.styles.height = 1 if compact else 3
+                actions.styles.min_height = 1 if compact else 3
+                actions.styles.max_height = 1 if compact else 3
+            authority.styles.width = 18 if compact else "auto"
+            authority.styles.min_width = 12 if compact else 0
+            authority.styles.max_width = 18 if compact else None
+            authority.styles.height = 1 if compact else 3
+            authority.styles.text_wrap = "nowrap" if compact else "wrap"
+            authority.styles.text_overflow = "ellipsis" if compact else "clip"
+            for button in primary.query(Button):
+                button.styles.width = "auto"
+                button.styles.height = 1 if compact else 3
+                button.styles.min_height = 1 if compact else 3
+                button.styles.max_height = 1 if compact else 3
         discard_new = self.query("#library-note-discard-new")
         if discard_new:
             discard_new.first(Button).label = (
@@ -1289,17 +1399,16 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         confirming_delete = state.confirming_delete and not conflict
         bulk_read_only = state.bulk_read_only
         show_context = (
-            state.region == "context" and not conflict and not confirming_delete
+            state.region == "context"
+            and not conflict
+            and not confirming_delete
             and not bulk_read_only
         )
-        show_preview = (
-            bulk_read_only
-            or (
-                not show_context
-                and not conflict
-                and not confirming_delete
-                and state.presentation == "preview"
-            )
+        show_preview = bulk_read_only or (
+            not show_context
+            and not conflict
+            and not confirming_delete
+            and state.presentation == "preview"
         )
         show_editor = not show_context and not show_preview
 
@@ -1324,7 +1433,11 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
 
         title_width = 52 if state.compact else 72
         title = ellipsize_note_title_cells(snapshot.title, title_width)
-        for selector in ("#library-note-preview-title", "#library-note-context-title"):
+        for selector in (
+            "#library-note-editor-title",
+            "#library-note-preview-title",
+            "#library-note-context-title",
+        ):
             widget = self.query_one(selector, Static)
             if self._static_text(widget) != title:
                 widget.update(title)
@@ -1336,15 +1449,20 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         # unbounded hidden-render backlog.
         if show_preview and preview_body.source != snapshot.body:
             preview_body.update(snapshot.body)
-        compact_status = (
-            state.transfer_status
-            if state.compact and state.transfer_status
-            else state.status_line
+        channels = state.status_channels or NotesStatusChannels(
+            state.status_line or "Saved",
+            "Database Notes · Library database",
         )
+        content_copy = channels.content_recovery
+        if channels.safe_next_action:
+            content_copy = f"{content_copy} Next: {channels.safe_next_action}."
         for selector in ("#library-note-status", "#library-note-context-status"):
             widget = self.query_one(selector, Static)
-            if self._static_text(widget) != compact_status:
-                widget.update(compact_status)
+            if self._static_text(widget) != content_copy:
+                widget.update(content_copy)
+        authority_status = self.query_one("#library-note-authority-git-status", Static)
+        if self._static_text(authority_status) != channels.authority_git:
+            authority_status.update(channels.authority_git)
         for selector in ("#library-note-meta", "#library-note-context-meta"):
             widget = self.query_one(selector, Static)
             if self._static_text(widget) != state.metadata_line:
@@ -1364,9 +1482,7 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             not show_context and not bulk_read_only
         )
         self.query_one("#library-note-context-back").display = show_context
-        self.query_one("#library-note-editor-title").display = (
-            show_editor and state.compact
-        )
+        self.query_one("#library-note-editor-title").display = show_editor
         self.query_one("#library-note-preview-title").display = show_preview
         self.query_one("#library-note-context-title").display = show_context
         bulk_status = self.query_one("#library-note-bulk-status", Static)
@@ -1382,16 +1498,17 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         self.query_one("#library-note-preview-region").display = show_preview
         self.query_one("#library-note-context-status").display = show_context
         self.query_one("#library-note-context-region").display = show_context
-        self.query_one("#library-note-status").display = not show_context
+        self.query_one("#library-note-edit", Button).set_class(show_editor, "is-active")
+        self.query_one("#library-note-preview", Button).set_class(
+            show_preview and not bulk_read_only, "is-active"
+        )
+        self.query_one("#library-note-context", Button).set_class(
+            show_context, "is-active"
+        )
         self.query_one("#library-note-primary-actions").display = (
-            not show_context and not conflict and not confirming_delete
+            not conflict and not confirming_delete
         )
-        self.query_one("#library-note-wide-utilities").display = (
-            not state.compact
-            and not show_context
-            and not conflict
-            and not confirming_delete
-        )
+        self.query_one("#library-note-wide-utilities").display = False
         self.query_one("#library-note-conflict-region").display = conflict
         self.query_one("#library-note-delete-confirmation").display = confirming_delete
 
@@ -1404,12 +1521,8 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         self.query_one("#library-note-preview-region").can_focus = show_preview
         self.query_one("#library-note-context-region").can_focus = show_context
 
-        preview_button = self.query_one("#library-note-preview", Button)
-        preview_label = "Edit" if state.presentation == "preview" else "Preview"
-        if str(preview_button.label) != preview_label:
-            preview_button.label = preview_label
-
         for selector in (
+            "#library-note-edit",
             "#library-note-save",
             "#library-note-preview",
             "#library-note-context",

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -202,6 +202,10 @@ from tldw_chatbook.Chat.console_image_edit_operations import (
 )
 from tldw_chatbook.Chat.console_runtime import ConsoleRuntime, dispose_console_runtime
 from tldw_chatbook.Chat.console_raw_cli import RawCliRuntime
+from tldw_chatbook.Chat.console_settings_durability import (
+    ConsoleSettingsDurabilityOwner,
+)
+from tldw_chatbook.Chat.console_settings_defaults import ConsoleDefaultDurabilityState
 from tldw_chatbook.Chat.server_chat_conversation_service import (
     ServerChatConversationService,
 )
@@ -7104,6 +7108,17 @@ class TldwCli(
         self.app_config = load_settings()
         self.raw_cli_runtime = RawCliRuntime(lambda: _read_app_raw_cli_permitted(self))
         self._raw_cli_runtime_shutdown_task: asyncio.Task[Any] | None = None
+        # Default-save failures belong to the application lifetime rather
+        # than whichever Console screen happens to be mounted.  New-chat
+        # generation advances only after a Make Default intent is fully
+        # published into this running process.
+        self.console_default_durability_state = ConsoleDefaultDurabilityState()
+        self.console_new_chat_default_generation = 0
+        self.console_settings_durability_owner = ConsoleSettingsDurabilityOwner()
+        self.console_settings_durability_tasks = (
+            self.console_settings_durability_owner.tasks
+        )
+        self.console_default_recovery_inflight: set[tuple[int, str]] = set()
         self.library_new_profile_admission = first_profile_created_this_session()
         self.console_image_edit_operations = ImageEditOperationRegistry()
         self._console_image_edit_shutdown_task: asyncio.Task[None] | None = None
@@ -15191,6 +15206,21 @@ class TldwCli(
             self._raw_cli_runtime_shutdown_task = task
         await asyncio.shield(task)
 
+    async def _shutdown_console_settings_durability(self) -> None:
+        """Drain admitted settings writes without cancelling thread work.
+
+        The coordinator tasks can be awaiting ``asyncio.to_thread`` writes,
+        which cannot be recalled once admitted. Shielding preserves those
+        writes if application shutdown is cancelled; ``_shutdown`` retries
+        this lifecycle pass and does not dispose the Console runtime until the
+        registry is empty.
+        """
+
+        owner = getattr(self, "console_settings_durability_owner", None)
+        if not isinstance(owner, ConsoleSettingsDurabilityOwner):
+            return
+        await owner.close_and_drain()
+
     async def _shutdown_app_owned_lifecycles(self) -> None:
         """Drain durable app-owned work before Textual closes screen state."""
         await self._shutdown_notes_sync_runtime()
@@ -15199,6 +15229,7 @@ class TldwCli(
         # Console shutdown terminally fences every trusted Buddy producer
         # before Buddy itself closes admission and drains owned work.
         await self._shutdown_raw_cli_runtime()
+        await self._shutdown_console_settings_durability()
         await self._shutdown_console_runtime()
         change_review = getattr(self, "change_review_consent_service", None)
         if change_review is not None:

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -47,6 +47,9 @@ from tldw_chatbook.DB.Prompts_DB import PromptsDatabase
 if TYPE_CHECKING:
     from tldw_chatbook.Chat.console_exchange_capture import CaptureDetail
 from tldw_chatbook.Utils.adaptive_reader_state import (
+    ITEMS_MAX_WIDTH,
+    ITEMS_MIN_WIDTH,
+    ITEMS_TARGET_WIDTH,
     normalize_adaptive_reader_preferences,
 )
 from tldw_chatbook.Utils.console_background_effects import (
@@ -1879,6 +1882,40 @@ def _load_settings_uncached(
             "items_open": destination_preferences.items_open,
             "items_width": destination_preferences.items_width,
         }
+        if section_name == "notes_reader":
+            files_tree_width = os.getenv(
+                "TLDW_LIBRARY_NOTES_READER_FILES_TREE_WIDTH",
+                raw_destination.get("files_tree_width"),
+            )
+            try:
+                parsed_files_tree_width = (
+                    int(files_tree_width.strip())
+                    if isinstance(files_tree_width, str)
+                    else files_tree_width
+                )
+            except ValueError:
+                parsed_files_tree_width = ITEMS_TARGET_WIDTH
+            if (
+                type(parsed_files_tree_width) is not int
+                or not ITEMS_MIN_WIDTH <= parsed_files_tree_width <= ITEMS_MAX_WIDTH
+            ):
+                parsed_files_tree_width = ITEMS_TARGET_WIDTH
+            files_tree_preferences = normalize_adaptive_reader_preferences(
+                {
+                    "custom_widths_enabled": True,
+                    "items_open": os.getenv(
+                        "TLDW_LIBRARY_NOTES_READER_FILES_TREE_OPEN",
+                        raw_destination.get("files_tree_open"),
+                    ),
+                    "items_width": parsed_files_tree_width,
+                }
+            )
+            normalized_destination_readers[section_name].update(
+                {
+                    "files_tree_open": files_tree_preferences.items_open,
+                    "files_tree_width": files_tree_preferences.items_width,
+                }
+            )
     config_dict = {
         # General App
         "APP_MODE_STR": single_user_mode_str,
@@ -3288,9 +3325,12 @@ items_open = true
 items_width = 40
 
 [library.notes_reader]
-# Environment overrides use TLDW_LIBRARY_NOTES_READER_<KEY>.
+# Items environment overrides use TLDW_LIBRARY_NOTES_READER_ITEMS_<KEY>.
+# Folder-tree overrides use TLDW_LIBRARY_NOTES_READER_FILES_TREE_<KEY>.
 items_open = true
 items_width = 40
+files_tree_open = true
+files_tree_width = 40
 
 [library.prompts_reader]
 # Environment overrides use TLDW_LIBRARY_PROMPTS_READER_<KEY>.
@@ -5562,6 +5602,33 @@ class AtomicConfigSnapshot(NamedTuple):
     values: Dict[str, Any]
 
 
+@dataclass(frozen=True, slots=True)
+class LiteralSettingsMutation:
+    """Exact set/delete operations addressed by literal TOML mapping paths."""
+
+    section_values: Mapping[tuple[str, ...], Mapping[str, object]]
+    delete_keys: Mapping[tuple[str, ...], Collection[str]]
+
+
+@dataclass(frozen=True, slots=True)
+class AtomicLiteralMutationSnapshot:
+    """Authoritative raw and effective config views held under the write lock."""
+
+    generation: int
+    raw_values: Mapping[str, object]
+    effective_values: Mapping[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class LiteralConfigMutationResult:
+    """Two-phase literal mutation outcome with an optional fresh settings view."""
+
+    file_replaced: bool
+    caches_reloaded: bool
+    settings_view: Mapping[str, object] | None
+    failure_phase: str | None
+
+
 def _atomic_config_values_from_raw(
     config_data: Mapping[str, Any],
 ) -> Dict[str, Any]:
@@ -6041,22 +6108,46 @@ def _delete_config_keys(
     delete_keys: Mapping[str, Collection[str]],
 ) -> bool:
     """Delete exact keys and report whether the config changed."""
+    return _delete_literal_config_keys(
+        config_data,
+        {tuple(section.split(".")): keys for section, keys in delete_keys.items()},
+    )
+
+
+def _literal_config_section(
+    config_data: Dict[str, Any],
+    path: tuple[str, ...],
+    *,
+    create: bool,
+) -> Dict[str, Any] | None:
+    """Resolve one literal mapping path without interpreting punctuation."""
+
+    current_level: Any = config_data
+    for part in path:
+        if not isinstance(current_level, dict):
+            raise TypeError(part)
+        if part not in current_level:
+            if not create:
+                return None
+            current_level[part] = {}
+        current_level = current_level[part]
+    if not isinstance(current_level, dict):
+        raise TypeError(".".join(path))
+    return current_level
+
+
+def _delete_literal_config_keys(
+    config_data: Dict[str, Any],
+    delete_keys: Mapping[tuple[str, ...], Collection[str]],
+) -> bool:
+    """Delete exact keys beneath literal paths and report whether any existed."""
+
     changed = False
     missing = object()
-    for section, keys in delete_keys.items():
-        current_level: Any = config_data
-        section_missing = False
-        for part in section.split("."):
-            if not isinstance(current_level, dict):
-                raise TypeError(part)
-            if part not in current_level:
-                section_missing = True
-                break
-            current_level = current_level[part]
-        if section_missing:
+    for path, keys in delete_keys.items():
+        current_level = _literal_config_section(config_data, path, create=False)
+        if current_level is None:
             continue
-        if not isinstance(current_level, dict):
-            raise TypeError(section)
         for key in keys:
             if current_level.pop(key, missing) is not missing:
                 changed = True
@@ -6106,19 +6197,147 @@ def _validate_config_mutation_targets(
         raise ValueError("Configuration mutation cannot set and delete the same key")
 
 
-def apply_settings_mutation_to_cli_config(
-    section_values: Mapping[str, Mapping[Any, Any]],
+def _validate_literal_config_mutation_targets(
+    mutation: LiteralSettingsMutation,
+) -> None:
+    """Validate literal paths and reject overlapping exact set/delete targets."""
+
+    if not isinstance(mutation, LiteralSettingsMutation):
+        raise TypeError("Literal mutation builder returned an invalid result")
+    if not isinstance(mutation.section_values, Mapping) or not isinstance(
+        mutation.delete_keys,
+        Mapping,
+    ):
+        raise TypeError("Literal configuration mutations must use mappings")
+
+    set_targets: set[tuple[tuple[str, ...], str]] = set()
+    for path, values in mutation.section_values.items():
+        _validate_literal_config_path(path)
+        if not isinstance(values, Mapping):
+            raise TypeError("Literal configuration section values must be mappings")
+        for key in values:
+            if type(key) is not str or not key:
+                raise TypeError("Literal configuration keys must be non-empty strings")
+            set_targets.add((path, key))
+
+    delete_targets: set[tuple[tuple[str, ...], str]] = set()
+    for path, keys in mutation.delete_keys.items():
+        _validate_literal_config_path(path)
+        if isinstance(keys, (str, bytes)) or not isinstance(keys, Collection):
+            raise TypeError("Literal configuration delete keys must be collections")
+        for key in keys:
+            if type(key) is not str or not key:
+                raise TypeError("Literal configuration delete keys must be non-empty strings")
+            delete_targets.add((path, key))
+
+    if set_targets.intersection(delete_targets):
+        raise ValueError("Configuration mutation cannot set and delete the same key")
+
+
+def _detach_literal_settings_mutation(
+    mutation: LiteralSettingsMutation,
+) -> LiteralSettingsMutation:
+    """Copy a builder-owned mutation before validation or application."""
+
+    if not isinstance(mutation, LiteralSettingsMutation):
+        raise TypeError("Literal mutation builder returned an invalid result")
+    if not isinstance(mutation.section_values, Mapping) or not isinstance(
+        mutation.delete_keys,
+        Mapping,
+    ):
+        raise TypeError("Literal configuration mutations must use mappings")
+
+    section_values: dict[tuple[str, ...], dict[str, object]] = {}
+    for path, values in mutation.section_values.items():
+        if type(path) is not tuple:
+            raise TypeError("Literal configuration paths must be tuples")
+        if not isinstance(values, Mapping):
+            raise TypeError("Literal configuration section values must be mappings")
+        owned_path = tuple(part for part in path)
+        section_values[owned_path] = copy.deepcopy(dict(values))
+
+    delete_keys: dict[tuple[str, ...], tuple[str, ...]] = {}
+    for path, keys in mutation.delete_keys.items():
+        if type(path) is not tuple:
+            raise TypeError("Literal configuration paths must be tuples")
+        if isinstance(keys, (str, bytes)) or not isinstance(keys, Collection):
+            raise TypeError("Literal configuration delete keys must be collections")
+        owned_path = tuple(part for part in path)
+        delete_keys[owned_path] = tuple(keys)
+
+    return LiteralSettingsMutation(
+        section_values=section_values,
+        delete_keys=delete_keys,
+    )
+
+
+def _validate_literal_config_path(path: object) -> None:
+    """Validate one exact TOML mapping path."""
+
+    if (
+        type(path) is not tuple
+        or not path
+        or any(type(part) is not str or not part for part in path)
+    ):
+        raise TypeError("Literal configuration paths must be non-empty string tuples")
+    if path[0] in _REVISION_OWNED_CONFIG_SECTIONS:
+        raise ValueError("Revision-owned configuration requires its dedicated writer")
+
+
+def _literal_mutation_log_shape(
+    mutation: LiteralSettingsMutation,
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """Return value-free path/key shapes suitable for diagnostic logging."""
+
+    sets = {
+        repr(path): list(values.keys())
+        for path, values in mutation.section_values.items()
+    }
+    deletes = {repr(path): list(keys) for path, keys in mutation.delete_keys.items()}
+    return sets, deletes
+
+
+def _current_settings_view() -> Mapping[str, object]:
+    """Return a detached copy of the freshly published normalized settings."""
+
+    return copy.deepcopy(settings)
+
+
+def _apply_literal_mutation_unlocked(
+    config_data: Dict[str, Any],
+    mutation: LiteralSettingsMutation,
+) -> bool:
+    """Apply one validated literal mutation to the authoritative raw mapping."""
+
+    deleted_any = _delete_literal_config_keys(config_data, mutation.delete_keys)
+    set_any = False
+    for path, values in mutation.section_values.items():
+        if not values:
+            continue
+        current_level = _literal_config_section(config_data, path, create=True)
+        assert current_level is not None
+        for key, value in values.items():
+            current_level[key] = _maybe_encrypt_setting_value(config_data, key, value)
+            set_any = True
+    return set_any or deleted_any
+
+
+def _apply_literal_settings_transaction_locked(
+    mutation_builder: Callable[
+        [AtomicLiteralMutationSnapshot], LiteralSettingsMutation
+    ],
     *,
-    delete_keys: Mapping[str, Collection[str]] | None = None,
-    mutation_precondition: Callable[[], bool] | None = None,
+    mutation_precondition: Callable[[], bool] | None,
     locked_snapshot_precondition: Callable[[AtomicConfigSnapshot], bool] | None = None,
+    publish_noop: bool,
+    validate_literal_targets: bool,
     before_replace: Callable[[], None] | None = None,
     after_replace: Callable[[], None] | None = None,
-) -> ConfigMutationResult:
-    """Atomically apply exact config sets/deletes, then refresh caches."""
-    global _CONFIG_CACHE, _SETTINGS_CACHE, settings
-    requested_deletes = {} if delete_keys is None else delete_keys
+) -> LiteralConfigMutationResult:
+    """Run one authoritative read/build/replace/publication transaction."""
     try:
+        if not callable(mutation_builder):
+            raise TypeError("Literal configuration mutation builder must be callable")
         if mutation_precondition is not None and not callable(mutation_precondition):
             raise TypeError("Configuration mutation precondition must be callable")
         if locked_snapshot_precondition is not None and not callable(
@@ -6136,7 +6355,7 @@ def apply_settings_mutation_to_cli_config(
             "(phase=resolve_path, config_path=unresolved, error_type={}).",
             type(error).__name__,
         )
-        return ConfigMutationResult(False, False, "before_replace")
+        return LiteralConfigMutationResult(False, False, None, "before_replace")
 
     with ExitStack() as locks:
         try:
@@ -6148,101 +6367,63 @@ def apply_settings_mutation_to_cli_config(
                 config_path,
                 type(error).__name__,
             )
-            return ConfigMutationResult(False, False, "before_replace")
+            return LiteralConfigMutationResult(False, False, None, "before_replace")
         try:
-            _validate_config_mutation_targets(section_values, requested_deletes)
-            logged_keys = {
-                section: list(values.keys())
-                for section, values in section_values.items()
-            }
-            logged_deletes = {
-                section: list(keys) for section, keys in requested_deletes.items()
-            }
-            logger.info(
-                "Attempting to apply settings mutation: "
-                f"sets={logged_keys!r}, deletes={logged_deletes!r}"
-            )
             config_data = _read_raw_cli_config_unlocked(config_path)
-        except tomllib.TOMLDecodeError as error:
+        except Exception as error:
             logger.error(
                 "Configuration mutation failed "
                 "(phase=read, config_path={}, error_type={}).",
                 config_path,
                 type(error).__name__,
             )
-            return ConfigMutationResult(False, False, "before_replace")
-        except Exception as error:
-            logger.opt(exception=True).error(
-                "Configuration mutation failed "
-                "(phase=read, config_path={}, error_type={}).",
-                config_path,
-                type(error).__name__,
-            )
-            return ConfigMutationResult(False, False, "before_replace")
+            return LiteralConfigMutationResult(False, False, None, "before_replace")
 
         if mutation_precondition is not None:
             try:
-                is_current = mutation_precondition()
+                if mutation_precondition() is not True:
+                    return LiteralConfigMutationResult(
+                        False, False, None, "identity_changed"
+                    )
             except Exception as error:
                 logger.error(
                     "Configuration mutation failed "
                     "(phase=precondition, error_type={}).",
                     type(error).__name__,
                 )
-                return ConfigMutationResult(False, False, "before_replace")
-            if is_current is not True:
-                return ConfigMutationResult(
-                    False,
-                    False,
-                    None,
-                    conflict=True,
-                    conflict_reason="identity_changed",
+                return LiteralConfigMutationResult(
+                    False, False, None, "before_replace"
                 )
 
-        if locked_snapshot_precondition is not None:
-            try:
-                locked_snapshot = AtomicConfigSnapshot(
+        try:
+            effective_values = _atomic_config_values_from_raw(config_data)
+            if locked_snapshot_precondition is not None:
+                legacy_snapshot = AtomicConfigSnapshot(
                     generation=_CONFIG_GENERATION,
-                    values=_atomic_config_values_from_raw(config_data),
+                    values=copy.deepcopy(effective_values),
                 )
-                is_current = locked_snapshot_precondition(locked_snapshot)
-            except Exception as error:
-                logger.error(
-                    "Configuration mutation failed "
-                    "(phase=locked_precondition, error_type={}).",
-                    type(error).__name__,
-                )
-                return ConfigMutationResult(False, False, "before_replace")
-            if is_current is not True:
-                return ConfigMutationResult(
-                    False,
-                    False,
-                    None,
-                    conflict=True,
-                    conflict_reason="identity_changed",
-                )
-
-        if before_replace is not None:
-            try:
-                before_replace()
-            except Exception as error:
-                logger.error(
-                    "Configuration mutation failed "
-                    "(phase=before_replace_callback, error_type={}).",
-                    type(error).__name__,
-                )
-                return ConfigMutationResult(False, False, "before_replace")
-
-        try:
-            deleted_any = _delete_config_keys(config_data, requested_deletes)
-            for section, values in section_values.items():
-                if not values:
-                    continue
-                current_level = _target_config_section(config_data, section)
-                for key, value in values.items():
-                    current_level[key] = _maybe_encrypt_setting_value(
-                        config_data, key, value
+                if locked_snapshot_precondition(legacy_snapshot) is not True:
+                    return LiteralConfigMutationResult(
+                        False, False, None, "identity_changed"
                     )
+            snapshot = AtomicLiteralMutationSnapshot(
+                generation=_CONFIG_GENERATION,
+                raw_values=copy.deepcopy(config_data),
+                effective_values=copy.deepcopy(effective_values),
+            )
+            mutation = _detach_literal_settings_mutation(mutation_builder(snapshot))
+            if validate_literal_targets:
+                _validate_literal_config_mutation_targets(mutation)
+            logged_sets, logged_deletes = _literal_mutation_log_shape(mutation)
+            logger.info(
+                "Attempting to apply literal settings mutation: "
+                "sets={}, deletes={}",
+                logged_sets,
+                logged_deletes,
+            )
+            if before_replace is not None:
+                before_replace()
+            changed = _apply_literal_mutation_unlocked(config_data, mutation)
         except Exception as error:
             logger.error(
                 "Configuration mutation failed "
@@ -6250,28 +6431,52 @@ def apply_settings_mutation_to_cli_config(
                 config_path,
                 type(error).__name__,
             )
-            return ConfigMutationResult(False, False, "before_replace")
-        set_any = any(bool(values) for values in section_values.values())
-        if not set_any and not deleted_any:
-            return ConfigMutationResult(False, False, None)
+            return LiteralConfigMutationResult(False, False, None, "before_replace")
 
-        try:
-            persisted = _config_data_for_persistence(config_data)
-            raw_written = _write_raw_cli_config_unlocked(
-                config_path,
-                persisted,
-            )
-        except Exception as error:
-            logger.error(
-                "Configuration mutation failed "
-                "(phase=before_replace, config_path={}, error_type={}).",
-                config_path,
-                type(error).__name__,
-            )
-            return ConfigMutationResult(False, False, "before_replace")
+        if not changed and not publish_noop:
+            return LiteralConfigMutationResult(False, False, None, None)
 
-        file_replaced = True
-        logger.success(f"Successfully replaced settings file at {config_path}")
+        raw_written: Mapping[str, Any] | None = None
+        if changed:
+            persisted: Mapping[str, Any] | None = None
+            expected_raw: Mapping[str, Any] | None = None
+            try:
+                persisted = _config_data_for_persistence(config_data)
+                expected_raw = tomllib.loads(toml.dumps(dict(persisted)))
+                raw_written = _write_raw_cli_config_unlocked(config_path, persisted)
+            except Exception as error:
+                committed_content_visible = False
+                if expected_raw is not None:
+                    try:
+                        committed_content_visible = (
+                            _read_raw_cli_config_unlocked(config_path) == expected_raw
+                        )
+                    except Exception:
+                        committed_content_visible = False
+                if committed_content_visible:
+                    logger.error(
+                        "Configuration mutation failed after the requested "
+                        "content became visible "
+                        "(phase=cache_reload, config_path={}, error_type={}).",
+                        config_path,
+                        type(error).__name__,
+                    )
+                    return LiteralConfigMutationResult(
+                        True, False, None, "cache_reload"
+                    )
+                logger.error(
+                    "Configuration mutation failed "
+                    "(phase=before_replace, config_path={}, error_type={}).",
+                    config_path,
+                    type(error).__name__,
+                )
+                return LiteralConfigMutationResult(
+                    False, False, None, "before_replace"
+                )
+            logger.success(f"Successfully replaced settings file at {config_path}")
+        else:
+            _invalidate_config_caches()
+            raw_written = config_data
 
         if after_replace is not None:
             try:
@@ -6282,10 +6487,11 @@ def apply_settings_mutation_to_cli_config(
                     "(phase=after_replace_callback, error_type={}).",
                     type(error).__name__,
                 )
-                return ConfigMutationResult(True, False, "cache_reload")
+                return LiteralConfigMutationResult(changed, False, None, "cache_reload")
 
         try:
             _publish_runtime_config_unlocked(raw_config=raw_written)
+            settings_view = _current_settings_view()
         except Exception as error:
             logger.error(
                 "Configuration mutation failed "
@@ -6293,10 +6499,132 @@ def apply_settings_mutation_to_cli_config(
                 config_path,
                 type(error).__name__,
             )
-            return ConfigMutationResult(file_replaced, False, "cache_reload")
+            return LiteralConfigMutationResult(changed, False, None, "cache_reload")
 
         logger.info("Global configuration caches invalidated and reloaded.")
-        return ConfigMutationResult(file_replaced, True, None)
+        return LiteralConfigMutationResult(changed, True, settings_view, None)
+
+
+def apply_literal_settings_transaction_to_cli_config(
+    mutation_builder: Callable[
+        [AtomicLiteralMutationSnapshot], LiteralSettingsMutation
+    ],
+    *,
+    mutation_precondition: Callable[[], bool] | None = None,
+) -> LiteralConfigMutationResult:
+    """Apply a builder-produced mutation whose tuple paths stay fully literal."""
+
+    return _apply_literal_settings_transaction_locked(
+        mutation_builder,
+        mutation_precondition=mutation_precondition,
+        publish_noop=True,
+        validate_literal_targets=True,
+    )
+
+
+def refresh_runtime_config_from_cli_config() -> LiteralConfigMutationResult:
+    """Republish the existing on-disk config without writing the file."""
+
+    try:
+        config_path = _get_effective_config_path()
+    except Exception as error:
+        logger.error(
+            "Configuration refresh failed (phase=resolve_path, error_type={}).",
+            type(error).__name__,
+        )
+        return LiteralConfigMutationResult(False, False, None, "cache_reload")
+
+    try:
+        with _config_write_lock(config_path):
+            raw = _read_raw_cli_config_unlocked(config_path)
+            _invalidate_config_caches()
+            _publish_runtime_config_unlocked(raw_config=raw)
+            return LiteralConfigMutationResult(
+                False,
+                True,
+                _current_settings_view(),
+                None,
+            )
+    except Exception as error:
+        logger.error(
+            "Configuration refresh failed "
+            "(phase=cache_reload, config_path={}, error_type={}).",
+            config_path,
+            type(error).__name__,
+        )
+        return LiteralConfigMutationResult(False, False, None, "cache_reload")
+
+
+def apply_settings_mutation_to_cli_config(
+    section_values: Mapping[str, Mapping[Any, Any]],
+    *,
+    delete_keys: Mapping[str, Collection[str]] | None = None,
+    mutation_precondition: Callable[[], bool] | None = None,
+    locked_snapshot_precondition: Callable[[AtomicConfigSnapshot], bool] | None = None,
+    before_replace: Callable[[], None] | None = None,
+    after_replace: Callable[[], None] | None = None,
+) -> ConfigMutationResult:
+    """Atomically apply exact config sets/deletes, then refresh caches."""
+    requested_deletes = {} if delete_keys is None else delete_keys
+    try:
+        if not isinstance(section_values, Mapping) or not isinstance(
+            requested_deletes,
+            Mapping,
+        ):
+            raise TypeError("Configuration mutations must use mappings")
+        owned_section_values: dict[str, dict[Any, Any]] = {}
+        for section, values in section_values.items():
+            if not isinstance(values, Mapping):
+                raise TypeError("Configuration section values must be mappings")
+            owned_section_values[section] = copy.deepcopy(dict(values.items()))
+        owned_delete_keys: dict[str, tuple[str, ...]] = {}
+        for section, keys in requested_deletes.items():
+            if isinstance(keys, (str, bytes)) or not isinstance(keys, Collection):
+                raise TypeError("Configuration delete keys must be collections")
+            owned_delete_keys[section] = tuple(keys)
+
+        _validate_config_mutation_targets(owned_section_values, owned_delete_keys)
+        literal = _detach_literal_settings_mutation(
+            LiteralSettingsMutation(
+                section_values={
+                    tuple(section.split(".")): values
+                    for section, values in owned_section_values.items()
+                },
+                delete_keys={
+                    tuple(section.split(".")): keys
+                    for section, keys in owned_delete_keys.items()
+                },
+            )
+        )
+    except Exception as error:
+        logger.error(
+            "Configuration mutation failed "
+            "(phase=validation, config_path=unresolved, error_type={}).",
+            type(error).__name__,
+        )
+        return ConfigMutationResult(False, False, "before_replace")
+    result = _apply_literal_settings_transaction_locked(
+        lambda _snapshot: literal,
+        mutation_precondition=mutation_precondition,
+        locked_snapshot_precondition=locked_snapshot_precondition,
+        before_replace=before_replace,
+        after_replace=after_replace,
+        publish_noop=False,
+        validate_literal_targets=False,
+    )
+    if result.failure_phase == "identity_changed":
+        return ConfigMutationResult(
+            False,
+            False,
+            None,
+            conflict=True,
+            conflict_reason="identity_changed",
+        )
+    return ConfigMutationResult(
+        result.file_replaced,
+        result.caches_reloaded,
+        result.failure_phase,
+    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -1081,6 +1081,7 @@ ConsoleRunLogModal {
     border: none;
 }
 
+#library-file-notes-rail,
 #library-rail {
     border: solid $ds-column-line;
     background: $ds-surface-panel;

--- a/tldw_chatbook/css/components/_forms.tcss
+++ b/tldw_chatbook/css/components/_forms.tcss
@@ -169,6 +169,29 @@ LibraryFileNotesWorkspace TextArea:focus {
     outline: none;
 }
 
+/* Long-form Notes bodies keep their resting fill while typing. The heavy
+ * semantic perimeter is the focus cue; it costs no rows or columns and leaves
+ * compact fields and every unrelated TextArea on the shared focused fill. */
+#library-note-body:focus,
+#file-notes-editor:focus {
+    outline: heavy $ds-action-focus;
+    background: $ds-surface-raised;
+}
+
+/* Some decorative themes intentionally place `$primary` close to `$panel`
+ * (pastel_dreams measures 1.03:1). Keep the semantic outline, and make the
+ * existing TextArea border the contrast-safe second boundary without adding
+ * geometry. Textual's mode class is the reliable cross-theme lightness seam. */
+.-dark-mode #library-note-body:focus,
+.-dark-mode #file-notes-editor:focus {
+    border: solid white;
+}
+
+.-light-mode #library-note-body:focus,
+.-light-mode #file-notes-editor:focus {
+    border: solid black;
+}
+
 /* TASK-2300. `Select:focus` used to be in the rule above, and it is the one
  * member of that list that does not draw its own border.
  *

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -1167,6 +1167,29 @@ LibraryFileNotesWorkspace TextArea:focus {
     outline: none;
 }
 
+/* Long-form Notes bodies keep their resting fill while typing. The heavy
+ * semantic perimeter is the focus cue; it costs no rows or columns and leaves
+ * compact fields and every unrelated TextArea on the shared focused fill. */
+#library-note-body:focus,
+#file-notes-editor:focus {
+    outline: heavy $ds-action-focus;
+    background: $ds-surface-raised;
+}
+
+/* Some decorative themes intentionally place `$primary` close to `$panel`
+ * (pastel_dreams measures 1.03:1). Keep the semantic outline, and make the
+ * existing TextArea border the contrast-safe second boundary without adding
+ * geometry. Textual's mode class is the reliable cross-theme lightness seam. */
+.-dark-mode #library-note-body:focus,
+.-dark-mode #file-notes-editor:focus {
+    border: solid white;
+}
+
+.-light-mode #library-note-body:focus,
+.-light-mode #file-notes-editor:focus {
+    border: solid black;
+}
+
 /* TASK-2300. `Select:focus` used to be in the rule above, and it is the one
  * member of that list that does not draw its own border.
  *
@@ -3256,6 +3279,7 @@ ConsoleRunLogModal {
     border: none;
 }
 
+#library-file-notes-rail,
 #library-rail {
     border: solid $ds-column-line;
     background: $ds-surface-panel;


### PR DESCRIPTION
## Summary

This replacement PR rebases the long-lived `feat/task-3401-video-generation-foundation` branch onto current `dev` and consolidates its history into one reviewable commit. Its scope is intentionally broad and includes:

- the TASK-3401 video-generation, ephemeral video storage, playback, and streaming foundation
- Console Provider modal behavior: Apply updates only the current chat, Make Default persists the global provider/model/profile, Save as model default persists per-model sampler settings, and failures retain explicit Retry/Discard recovery
- conversation-owned generation settings, navigation-safe Console turns, and associated durability/context metadata
- retained Library Folder Files workspaces and adaptive-reader/focus behavior
- supporting ADRs, backlog records, specifications, plans, and focused regression coverage

## Rebase and review repairs

- rebased onto `dev` at `9c900b3121`
- preserved the current `dev` Notes accessibility contract (visible Save/autosave; Ctrl+S remains Skill-editor-only)
- routed retained Folder Files rail search, disclosure, and Explore focus through the visible authority instead of hidden duplicate IDs
- restored disabled settings-search hits to their enabling control and indexed Folder Files reader settings
- retained the newer adaptive-reader focus-memory and manual-reopen behavior

## Verification

- 73 branch-added Library tests passed
- 54 affected Console provider/defaults/recovery and Settings tests passed
- `py_compile` passed for the conflict-repaired modules
- Ruff undefined/redefined-name checks passed
- `git diff --check` passed

The source branch was updated with an exact force-with-lease after verifying its remote tip had not changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebases the long-lived `feat/task-3401-video-generation-foundation` branch onto current `dev` and collapses its history into one reviewable commit that delivers the TASK-3401 video generation, ephemeral storage, playback, and streaming foundation plus the Console provider and settings consolidation.

**Behavior changes**
- Console Provider modal Apply now updates only the originating conversation and persists conversation-owned generation settings across restart instead of only the live session.
- Make Default persists the global provider/model/profile; Save as model default persists per-model sampler settings, and failures keep explicit Retry/Discard recovery.
- Accepted Console turns now survive screen navigation; returning reattaches to the running turn instead of cancelling it.
- Library Folder Files workspaces are retained with independent collapse grips, boundary-only editor focus, and navigation routed through the visible authority.
- Pending settings writes drain through an application-lifetime durability owner on close instead of being cancelled mid-flight.

**Supporting material**
- Adds ADRs, design specs, implementation plans, and backlog records covering Console navigation survival, provider defaults, duplex voice, and personal context.
- Adds Library and Console provider/defaults/recovery test coverage; compile, Ruff, and diff checks pass.

<sup>Written for commit 7a13b2a623603f635809cdc4c0df218a5228011e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

