### PR TITLE
fix(ci): stop duplicate workflow fan-out

### DIFF
--- a/.github/workflows/backlog-guard.yml
+++ b/.github/workflows/backlog-guard.yml
@@ -2,6 +2,7 @@ name: Backlog Guard
 
 on:
   pull_request:
+    branches: [dev]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'backlog/tasks/**'
@@ -34,7 +35,6 @@ jobs:
   duplicate-task-ids:
     name: No duplicate backlog task IDs
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/css-bundle-guard.yml
+++ b/.github/workflows/css-bundle-guard.yml
@@ -19,6 +19,7 @@ name: CSS Bundle Guard
 
 on:
   pull_request:
+    branches: [dev]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'tldw_chatbook/css/**'
@@ -51,7 +52,6 @@ jobs:
   css-bundle-reproducible:
     name: CSS bundle reproduces from its sources
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/derived-artifacts.yml
+++ b/.github/workflows/derived-artifacts.yml
@@ -19,6 +19,7 @@ name: Derived Artifacts
 
 on:
   pull_request:
+    branches: [dev]
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [dev, main]
@@ -67,9 +68,6 @@ jobs:
     # stable.
     name: Derived artifacts reproduce from their sources
     runs-on: ubuntu-latest
-    # PR #602 is a permanent draft mirror from dev to main. Keep it visible as
-    # a skipped check, but do not spend runner capacity until it is marked ready.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -13,6 +13,7 @@ name: Perf Guard
 
 on:
   pull_request:
+    branches: [dev]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'tldw_chatbook/**.py'
@@ -49,7 +50,6 @@ jobs:
   ui-latency-guardrails:
     name: UI latency guardrails
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main", "dev" ]
+    branches: ["dev"]
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
   schedule:
@@ -12,12 +12,10 @@ on:
     # scheduled workflows execute from the default branch.
     - cron: '30 8 * * *'
 
-# One PUSH run per workflow per ref: a new push supersedes the previous run instead of
-# queueing another alongside it. Without this, every push to `dev` stacked a full
-# run - 50+ obsolete runs accumulated, all competing for the shared account pool.
-# The event name is part of the group so different trigger types (push,
-# pull_request, schedule) never cancel each other, and `main` is never cancelled
-# so its history stays complete.
+# One run per workflow per event/ref. The trigger contract below keeps the full
+# suite on PRs into `dev`, a release run on pushes to `main`, and the deep matrix
+# on schedule. The event name keeps those independent lanes from cancelling one
+# another, and `main` is never cancelled so its history stays complete.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   # TASK-22250: cancel superseded PUSH runs, never a pull_request run.
@@ -80,7 +78,7 @@ jobs:
     # control. Cross-platform breadth lives in nightly-deep.
     name: Core Tests (all but UI) - shard ${{ matrix.shard }}/${{ strategy.job-total }}
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
+    if: ${{ github.event_name != 'schedule' }}
     # Kept at 120 as headroom: the per-shard estimate is ~32 min, so this is
     # ~4x margin rather than a target. A shard that approaches it is a signal
     # to resize the matrix, not to raise the cap again.
@@ -146,17 +144,17 @@ jobs:
   artifact-lease-spike:
     name: Artifact leases - Python ${{ matrix.python-version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
+    if: ${{ github.event_name != 'schedule' }}
     strategy:
       fail-fast: false
       matrix:
-        # TASK-22250: the full OS matrix runs on MERGE (push to dev/main) and
-        # nightly; a pull_request gets ubuntu only. Measured cause: ~12
+        # TASK-22250: main pushes and manual runs use the full OS matrix; a
+        # pull_request gets ubuntu only. Measured cause: ~12
         # concurrent ubuntu slots against a 25-job fan-out per Tests run, which
         # leaves short REQUIRED checks from other workflows queued for hours
         # (PR #2129 waited ~4h on a 4.5-minute check). This spike's cross-OS
-        # question is file-locking behaviour, which the merge run and
-        # nightly-deep both still cover.
+        # question is file-locking behaviour, which the main/manual run and
+        # scheduled nightly-deep matrix both still cover.
         os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest","macos-latest","windows-latest"]') }}
         python-version: ["3.11"]
 
@@ -184,7 +182,7 @@ jobs:
   artifact-lease-shape:
     name: Artifact lease workflow shape
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
+    if: ${{ github.event_name != 'schedule' }}
 
     steps:
     - uses: actions/checkout@v4
@@ -206,7 +204,7 @@ jobs:
     name: Artifact Lease Gate
     runs-on: ubuntu-latest
     needs: [artifact-lease-spike, artifact-lease-shape]
-    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main') }}
+    if: ${{ always() && github.event_name != 'schedule' }}
 
     steps:
     - name: Require successful native lease matrix and CI shape
@@ -226,7 +224,7 @@ jobs:
     # budget, with xdist parallelism retained WITHIN each shard.
     name: UI Tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
+    if: ${{ github.event_name != 'schedule' }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -278,7 +276,7 @@ jobs:
   textual-minimum:
     name: MCP - Minimum Textual 8.2.8
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main' }}
+    if: ${{ github.event_name != 'schedule' }}
     timeout-minutes: 10
 
     steps:
@@ -450,7 +448,7 @@ jobs:
     name: Test Summary
     runs-on: ubuntu-latest
     needs: [core-tests, ui-tests, textual-minimum, artifact-lease-gate]
-    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.number != 602 || github.event.pull_request.draft == false || github.head_ref != 'dev' || github.base_ref != 'main') }}
+    if: ${{ always() && github.event_name != 'schedule' }}
     
     steps:
     - uses: actions/checkout@v4

--- a/Docs/superpowers/plans/2026-08-29-account-ci-trigger-recovery.md
+++ b/Docs/superpowers/plans/2026-08-29-account-ci-trigger-recovery.md
@@ -1,0 +1,257 @@
+# Account CI Trigger Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `tldw_chatbook` from duplicating its heavy CI workload so the shared `rmusser01` Actions queue can drain and fresh pull-request checks can reach verdicts.
+
+**Architecture:** Enforce the approved workload policy at GitHub Actions trigger boundaries, before runs enter the account queue. Keep the ordinary suite on PRs into `dev`, keep a release run on pushes to `main`, and gate ordinary jobs out of the scheduled event so only `nightly-deep` consumes scheduled runners.
+
+**Tech Stack:** GitHub Actions YAML, Python 3.12, PyYAML, pytest, Ruff, GitHub CLI
+
+---
+
+### Task 1: Pin the new trigger and schedule contract
+
+**Files:**
+- Modify: `Tests/CI/test_ci_queue_pressure_contract.py`
+- Modify: `Tests/CI/test_github_actions_test_workflow.py`
+- Read: `.github/workflows/test.yml`
+- Read: `.github/workflows/derived-artifacts.yml`
+- Read: `.github/workflows/css-bundle-guard.yml`
+- Read: `.github/workflows/perf-guard.yml`
+- Read: `.github/workflows/backlog-guard.yml`
+
+- [ ] **Step 1: Replace the obsolete PR #602 job-guard contract**
+
+In `Tests/CI/test_ci_queue_pressure_contract.py`, replace the promotion-guard constants and test with trigger-level assertions:
+
+```python
+SCHEDULE_SKIP = "${{ github.event_name != 'schedule' }}"
+ALWAYS_SCHEDULE_SKIP = "${{ always() && github.event_name != 'schedule' }}"
+ORDINARY_TEST_JOB_CONDITIONS = {
+    "core-tests": SCHEDULE_SKIP,
+    "artifact-lease-spike": SCHEDULE_SKIP,
+    "artifact-lease-shape": SCHEDULE_SKIP,
+    "artifact-lease-gate": ALWAYS_SCHEDULE_SKIP,
+    "ui-tests": SCHEDULE_SKIP,
+    "textual-minimum": SCHEDULE_SKIP,
+    "test-summary": ALWAYS_SCHEDULE_SKIP,
+}
+
+
+def test_dev_merge_creates_one_heavy_tests_run() -> None:
+    triggers = _workflow("test.yml").get("on", _workflow("test.yml").get(True))
+    assert triggers["pull_request"]["branches"] == ["dev"]
+    assert triggers["pull_request"]["types"] == PULL_REQUEST_TYPES
+    assert triggers["push"]["branches"] == ["main"]
+    assert "workflow_dispatch" in triggers
+
+
+def test_schedule_skips_the_ordinary_test_suite() -> None:
+    jobs = _workflow("test.yml")["jobs"]
+    for job_name, expected in ORDINARY_TEST_JOB_CONDITIONS.items():
+        assert jobs[job_name].get("if") == expected
+    assert jobs["nightly-deep"]["if"] == (
+        "github.event_name == 'schedule' || "
+        "github.event_name == 'workflow_dispatch'"
+    )
+    assert jobs["all-tests"]["if"] == "github.event_name == 'workflow_dispatch'"
+
+
+def test_focused_guards_ignore_the_permanent_main_promotion_pr() -> None:
+    for workflow_name in STANDALONE_JOB_GUARDS:
+        workflow = _workflow(workflow_name)
+        triggers = workflow.get("on", workflow.get(True))
+        assert triggers["pull_request"]["branches"] == ["dev"]
+        assert triggers["push"]["branches"] == ["dev", "main"]
+```
+
+Also assert that the changed workflows no longer contain `pull_request.number` or a PR #602 job-level exception.
+
+- [ ] **Step 2: Update existing shape assertions for schedule exclusions**
+
+In `Tests/CI/test_github_actions_test_workflow.py`, replace `PROMOTION_GUARD` and `ALWAYS_PROMOTION_GUARD` with `SCHEDULE_SKIP` and `ALWAYS_SCHEDULE_SKIP`. Update the artifact-lease description to state that PRs use Ubuntu, `main` pushes/manual runs use the three-OS spike, and schedules use `nightly-deep` instead of the ordinary spike.
+
+- [ ] **Step 3: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/CI/test_ci_queue_pressure_contract.py \
+  Tests/CI/test_github_actions_test_workflow.py \
+  Tests/CI/test_derived_artifacts_workflow.py \
+  -q --confcutdir=Tests/CI
+```
+
+Expected: failures show that `test.yml` still targets `dev` pushes and `main` PRs, ordinary jobs still carry PR #602 guards, schedules still admit ordinary jobs, and focused guards have no `pull_request.branches` filter.
+
+### Task 2: Apply the minimum workflow trigger fix
+
+**Files:**
+- Modify: `.github/workflows/test.yml`
+- Modify: `.github/workflows/derived-artifacts.yml`
+- Modify: `.github/workflows/css-bundle-guard.yml`
+- Modify: `.github/workflows/perf-guard.yml`
+- Modify: `.github/workflows/backlog-guard.yml`
+
+- [ ] **Step 1: Narrow the heavy workflow at the trigger boundary**
+
+Change the start of `.github/workflows/test.yml` to:
+
+```yaml
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["dev"]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+  schedule:
+    - cron: '30 8 * * *'
+```
+
+- [ ] **Step 2: Exclude ordinary jobs from the scheduled event**
+
+Set these exact conditions:
+
+```yaml
+# core-tests, artifact-lease-spike, artifact-lease-shape, ui-tests,
+# textual-minimum
+if: ${{ github.event_name != 'schedule' }}
+
+# artifact-lease-gate, test-summary
+if: ${{ always() && github.event_name != 'schedule' }}
+```
+
+Remove every PR #602-specific job condition and update nearby comments. Keep `all-tests`, `nightly-deep`, and both `max-parallel: 3` settings unchanged.
+
+- [ ] **Step 3: Narrow synchronization-capable focused guards**
+
+Add `branches: [dev]` below `pull_request:` in the four focused guard workflows. Keep their existing push branches and paths. Remove the obsolete PR #602 job conditions and comments.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run the Task 1 command again.
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit the test-first workflow change**
+
+```bash
+git add \
+  .github/workflows/test.yml \
+  .github/workflows/derived-artifacts.yml \
+  .github/workflows/css-bundle-guard.yml \
+  .github/workflows/perf-guard.yml \
+  .github/workflows/backlog-guard.yml \
+  Tests/CI/test_ci_queue_pressure_contract.py \
+  Tests/CI/test_github_actions_test_workflow.py
+git commit -m "fix(ci): stop account-wide workflow duplication"
+```
+
+### Task 3: Verify the complete local CI contract
+
+**Files:**
+- Verify: `.github/workflows/*.yml`
+- Verify: `Tests/CI/test_*.py`
+
+- [ ] **Step 1: Run all affected CI contract tests**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/CI/test_ci_queue_pressure_contract.py \
+  Tests/CI/test_github_actions_test_workflow.py \
+  Tests/CI/test_derived_artifacts_workflow.py \
+  Tests/CI/test_task2062_1_gguf_import_evidence.py \
+  Tests/CI/test_task2062_2_gguf_source_evidence.py \
+  -q --confcutdir=Tests/CI
+```
+
+Expected: all selected tests pass. Do not run the repository-wide suite; AGENTS.md requires targeted verification unless the owner requests a full sweep.
+
+- [ ] **Step 2: Run Ruff on changed Python contracts**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  Tests/CI/test_ci_queue_pressure_contract.py \
+  Tests/CI/test_github_actions_test_workflow.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check \
+  Tests/CI/test_ci_queue_pressure_contract.py \
+  Tests/CI/test_github_actions_test_workflow.py
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 3: Parse all changed YAML and inspect the diff**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c \
+  'from pathlib import Path; import yaml; [yaml.safe_load(p.read_text()) for p in map(Path, [".github/workflows/test.yml", ".github/workflows/derived-artifacts.yml", ".github/workflows/css-bundle-guard.yml", ".github/workflows/perf-guard.yml", ".github/workflows/backlog-guard.yml"])]'
+git diff --check
+git diff --stat origin/dev...HEAD
+git diff origin/dev...HEAD -- .github/workflows Tests/CI
+```
+
+Expected: YAML parsing and diff checks exit 0; the diff contains only the approved trigger/condition contract and its tests.
+
+### Task 4: Record implementation evidence without closing live criteria
+
+**Files:**
+- Modify: `backlog/tasks/task-22250 - CI runs are swept by simultaneous burst cancellations.md`
+
+- [ ] **Step 1: Add an implementation update**
+
+Record the authenticated account evidence, changed trigger contract, focused local verification, ADR decision, and the fact that the two live acceptance criteria remain open until GitHub produces a post-change PR verdict. Do not mark the task Done.
+
+- [ ] **Step 2: Commit the task evidence**
+
+```bash
+git add 'backlog/tasks/task-22250 - CI runs are swept by simultaneous burst cancellations.md'
+git diff --cached --check
+git commit -m "docs: record account CI recovery evidence"
+```
+
+### Task 5: Open the recovery PR and drain only obsolete work
+
+**Files:**
+- Remote branch: `codex/task-22250-account-ci-recovery`
+- GitHub pull request: base `dev`
+
+- [ ] **Step 1: Rebase on the latest `origin/dev` and repeat Task 3 verification**
+
+Confirm `git log --oneline origin/dev..HEAD` contains only this task's commits and `git merge-base --is-ancestor origin/dev HEAD` exits 0.
+
+- [ ] **Step 2: Push and open the PR**
+
+Push the branch and create a PR whose body includes the account usage evidence, trigger reduction, test evidence, ADR result, and explicit live-verdict requirement.
+
+- [ ] **Step 3: Audit the queue using current authority**
+
+Build the preservation set from current open-PR head SHAs plus current `dev`/`main` SHAs in both `tldw_chatbook` and `tldw_server`. Cancel only obsolete idle queued/pending runs. Preserve runs with executing jobs and record zero-job HTTP 409 ghost entries.
+
+- [ ] **Step 4: Verify post-change runner admission**
+
+Inspect the recovery PR by head SHA, not PR number alone. Success requires a newly created `Tests` run to start jobs and eventually produce a completed verdict. Queue-count reduction alone is not evidence.
+
+### Task 6: Address review and merge only after live proof
+
+**Files:**
+- GitHub PR review threads and Qodo comments
+- Potentially the same workflow/test/task files when a finding is valid
+
+- [ ] **Step 1: Inspect every review comment**
+
+Use `superpowers:receiving-code-review`. Verify each finding against GitHub event semantics and the repository contract; implement valid findings test-first and respond to or resolve every thread.
+
+- [ ] **Step 2: Rebase on the latest `dev` and repeat targeted verification**
+
+After any base movement, rerun the complete Task 3 commands and confirm the pushed head SHA is the one being observed.
+
+- [ ] **Step 3: Complete TASK-22250 only with live evidence**
+
+Check both remaining acceptance criteria only when the recovery PR's test workflows complete without a simultaneous sweep and `Tests` has a completed verdict. Add the final live run URLs and results to Implementation Notes, then set the task status to Done.
+
+- [ ] **Step 4: Merge and verify the exact head**
+
+Merge only after local verification, review resolution, and live criteria. Confirm the PR state is `MERGED`, `mergeCommit` is non-null, and `headRefOid` equals the verified SHA.

--- a/Docs/superpowers/specs/2026-08-29-account-ci-trigger-recovery-design.md
+++ b/Docs/superpowers/specs/2026-08-29-account-ci-trigger-recovery-design.md
@@ -1,0 +1,145 @@
+# Account CI Trigger Recovery Design
+
+## Problem
+
+GitHub Actions is effectively serialized across the `rmusser01` account while
+current workflows continue to create work faster than that restricted capacity
+can drain it. Authenticated account evidence collected on 2026-08-29 showed:
+
+- 442 active owned repositories audited;
+- only `tldw_chatbook` and `tldw_server` had queued or pending Actions runs;
+- no owned repository had an in-progress run at the audit instant;
+- `tldw_chatbook` had consumed 510,153 runner-minutes in August, approximately
+  93% of the account total;
+- `tldw_chatbook`'s `Tests` workflow creates 23 ordinary test jobs per run before
+  the schedule-only matrix is considered.
+
+The dominant work is duplicated at its trigger boundary. Every merge to `dev`
+currently creates a `push` run and also updates permanent promotion PR #602
+(`dev` to `main`), creating a second `pull_request` run. The workflow's nightly
+schedule also launches the ordinary PR suite because those jobs have no
+schedule exclusion. Job-level guards added for draft PR #602 do not prevent the
+workflow run from entering GitHub's queue.
+
+GitHub documents public standard runners as free, so this is not a paid-minute
+exhaustion problem. GitHub also documents that Actions may be rate-limited as
+usage scales. The repository-side recovery must therefore stop generating
+duplicate work before asking GitHub to restore or increase account capacity.
+
+## Goals
+
+1. Preserve the full ordinary test suite for every pull request targeting
+   `dev`.
+2. Preserve a full post-release test run for pushes to `main`.
+3. Make the daily schedule launch only the five-leg `nightly-deep` matrix.
+4. Stop permanent `dev` to `main` PR #602 from creating duplicate ordinary CI
+   workflow runs when `dev` advances.
+5. Preserve manual dispatch behavior.
+6. Leave short push guards on `dev` and `main` so direct pushes and merge commits
+   still receive their focused checks.
+7. Reduce account demand without changing application code, test selection, or
+   shard coverage.
+
+## Non-goals
+
+- Reducing the six core or twelve UI shard coverage.
+- Moving public-repository CI onto self-hosted runners.
+- Changing `tldw_server` before the dominant `tldw_chatbook` source is removed.
+- Upgrading the GitHub account or changing payment settings.
+- Treating queued-run cancellation as the fix; cancellation is cleanup only.
+
+## Considered Approaches
+
+### 1. Filter at workflow triggers and exclude ordinary jobs from schedules
+
+Selected. Restrict `pull_request` triggers to base branch `dev`, restrict the
+heavy `Tests` push trigger to `main`, and add a schedule exclusion to ordinary
+test jobs. This prevents duplicate work from being created while preserving the
+approved PR and release coverage.
+
+### 2. Keep broad triggers and skip jobs with `if`
+
+Rejected. This is the current PR #602 mitigation. GitHub still creates workflow
+runs and check runs before evaluating job conditions, so the account continues
+to accumulate pending/queued workflow records during every `dev` update.
+
+### 3. Split nightly tests into a separate workflow
+
+Rejected for this recovery. It would make event ownership explicit, but would
+duplicate setup and summary wiring or require a larger workflow refactor. A
+schedule predicate on the existing ordinary jobs produces the same runner
+contract with a smaller, independently testable diff.
+
+## Trigger Contract
+
+### Heavy `Tests` workflow
+
+- `pull_request`: only base branch `dev`; retain the existing activity types.
+- `push`: only branch `main`.
+- `workflow_dispatch`: unchanged.
+- `schedule`: unchanged at 08:30 UTC.
+- Ordinary jobs (`core-tests`, artifact-lease jobs, `ui-tests`,
+  `textual-minimum`, and `test-summary`) do not run for `schedule` events.
+- `nightly-deep` continues to run only for `schedule` and manual dispatch.
+- `all-tests` continues to run only for manual dispatch.
+- The existing core/UI `max-parallel: 3` limits remain.
+
+The PR #602-specific job conditions become unnecessary once `pull_request`
+targets only `dev`; removing them prevents a stale exception from obscuring the
+real trigger contract.
+
+### Focused guard workflows
+
+`Derived Artifacts`, `CSS Bundle Guard`, `Perf Guard`, and `Backlog Guard` retain
+their existing `push` branches and path behavior, but their `pull_request`
+triggers target only `dev`. Their PR #602-specific job conditions are removed.
+
+### Label-driven evidence workflows
+
+The TASK-598, TASK-601, TASK-602, and TASK-603 evidence workflows remain
+unchanged. They accept only the `labeled` pull-request activity, so a normal
+update to PR #602 does not trigger them. Narrowing their base branches would not
+reduce synchronization fan-out and would unnecessarily remove explicitly
+requested evidence from a labeled main-targeting PR. The TASK-2062 workflows
+already target `dev` and retain that contract.
+
+## Queue Recovery
+
+After the trigger fix is pushed, queue cleanup uses current open-PR head SHAs
+plus current `dev` and `main` SHAs as the authority boundary. Obsolete idle
+queued/pending runs may be cancelled. A run with executing jobs, a current open
+PR head, or a current protected-branch SHA is preserved. GitHub ghost records
+that contain no jobs and return HTTP 409 to cancellation are recorded and left
+alone.
+
+The cleanup is successful only when a fresh pull-request run created after the
+trigger change starts jobs and reaches a verdict. A reduced queue count alone
+is not completion evidence.
+
+## Verification
+
+Focused contract tests must prove:
+
+- the heavy workflow targets PRs into `dev` and pushes to `main` only;
+- scheduled events skip every ordinary runner-consuming job and run
+  `nightly-deep`;
+- manual dispatch behavior remains intact;
+- every synchronization-capable PR workflow changed by this recovery excludes
+  base branch `main`;
+- core and UI matrices remain bounded at three concurrent jobs;
+- pull-request runs are not cancelled in progress;
+- workflow YAML parses and repository diff checks pass.
+
+Live verification must then prove both remaining TASK-22250 criteria: one PR's
+test workflows complete without a simultaneous sweep, and `Tests` reports a
+verdict on at least one PR.
+
+## ADR Check
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: this changes operational GitHub Actions trigger and scheduling policy;
+it does not alter application architecture, storage, security, dependencies, or
+cross-module runtime contracts.

--- a/Tests/CI/test_ci_queue_pressure_contract.py
+++ b/Tests/CI/test_ci_queue_pressure_contract.py
@@ -11,33 +11,23 @@ yaml = pytest.importorskip("yaml")
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_ROOT = PROJECT_ROOT / ".github" / "workflows"
-PROMOTION_GUARD = (
-    "${{ github.event_name != 'pull_request' || "
-    "github.event.pull_request.number != 602 || "
-    "github.event.pull_request.draft == false || github.head_ref != 'dev' || "
-    "github.base_ref != 'main' }}"
-)
-ALWAYS_PROMOTION_GUARD = (
-    "${{ always() && (github.event_name != 'pull_request' || "
-    "github.event.pull_request.number != 602 || "
-    "github.event.pull_request.draft == false || github.head_ref != 'dev' || "
-    "github.base_ref != 'main') }}"
-)
-TEST_JOB_GUARDS = {
-    "core-tests": PROMOTION_GUARD,
-    "artifact-lease-spike": PROMOTION_GUARD,
-    "artifact-lease-shape": PROMOTION_GUARD,
-    "artifact-lease-gate": ALWAYS_PROMOTION_GUARD,
-    "ui-tests": PROMOTION_GUARD,
-    "textual-minimum": PROMOTION_GUARD,
-    "test-summary": ALWAYS_PROMOTION_GUARD,
+SCHEDULE_SKIP = "${{ github.event_name != 'schedule' }}"
+ALWAYS_SCHEDULE_SKIP = "${{ always() && github.event_name != 'schedule' }}"
+ORDINARY_TEST_JOB_CONDITIONS = {
+    "core-tests": SCHEDULE_SKIP,
+    "artifact-lease-spike": SCHEDULE_SKIP,
+    "artifact-lease-shape": SCHEDULE_SKIP,
+    "artifact-lease-gate": ALWAYS_SCHEDULE_SKIP,
+    "ui-tests": SCHEDULE_SKIP,
+    "textual-minimum": SCHEDULE_SKIP,
+    "test-summary": ALWAYS_SCHEDULE_SKIP,
 }
-STANDALONE_JOB_GUARDS = {
-    "derived-artifacts.yml": "derived-artifacts",
-    "css-bundle-guard.yml": "css-bundle-reproducible",
-    "perf-guard.yml": "ui-latency-guardrails",
-    "backlog-guard.yml": "duplicate-task-ids",
-}
+STANDALONE_WORKFLOWS = (
+    "derived-artifacts.yml",
+    "css-bundle-guard.yml",
+    "perf-guard.yml",
+    "backlog-guard.yml",
+)
 PUSH_ONLY_CANCELLATION = (
     "${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}"
 )
@@ -48,19 +38,49 @@ def _workflow(name: str) -> dict:
     return yaml.safe_load((WORKFLOW_ROOT / name).read_text(encoding="utf-8"))
 
 
-def test_draft_dev_to_main_promotion_does_not_request_runners() -> None:
-    """Only permanent promotion PR #602 may report skips without runner use."""
-    test_jobs = _workflow("test.yml")["jobs"]
-    for job_name, expected_guard in TEST_JOB_GUARDS.items():
-        assert test_jobs[job_name].get("if") == expected_guard
+def test_dev_merge_creates_one_heavy_tests_run() -> None:
+    """A dev merge is tested on its PR, not duplicated by the dev push."""
+    workflow = _workflow("test.yml")
+    triggers = workflow.get("on", workflow.get(True))
 
-    for workflow_name, job_name in STANDALONE_JOB_GUARDS.items():
-        assert _workflow(workflow_name)["jobs"][job_name].get("if") == PROMOTION_GUARD
+    assert triggers["pull_request"]["branches"] == ["dev"]
+    assert triggers["pull_request"]["types"] == PULL_REQUEST_TYPES
+    assert triggers["push"]["branches"] == ["main"]
+    assert "workflow_dispatch" in triggers
 
 
-def test_ready_for_review_retriggers_jobs_skipped_while_draft() -> None:
-    """Marking the promotion ready must replace its earlier skipped verdicts."""
-    for workflow_name in ("test.yml", *STANDALONE_JOB_GUARDS):
+def test_schedule_skips_the_ordinary_test_suite() -> None:
+    """The nightly event runs its deep matrix without duplicating the PR suite."""
+    jobs = _workflow("test.yml")["jobs"]
+
+    for job_name, expected_condition in ORDINARY_TEST_JOB_CONDITIONS.items():
+        assert jobs[job_name].get("if") == expected_condition
+    assert jobs["nightly-deep"]["if"] == (
+        "github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'"
+    )
+    assert jobs["all-tests"]["if"] == "github.event_name == 'workflow_dispatch'"
+
+
+def test_focused_guards_ignore_the_permanent_main_promotion_pr() -> None:
+    """Short guards retain dev pushes without following PR #602 into main."""
+    for workflow_name in STANDALONE_WORKFLOWS:
+        workflow = _workflow(workflow_name)
+        triggers = workflow.get("on", workflow.get(True))
+
+        assert triggers["pull_request"]["branches"] == ["dev"]
+        assert triggers["push"]["branches"] == ["dev", "main"]
+        assert "pull_request.number" not in (WORKFLOW_ROOT / workflow_name).read_text(
+            encoding="utf-8"
+        )
+
+    assert "pull_request.number" not in (WORKFLOW_ROOT / "test.yml").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_ready_for_review_remains_an_explicit_activity() -> None:
+    """Activating a dev-targeting draft must request fresh checks."""
+    for workflow_name in ("test.yml", *STANDALONE_WORKFLOWS):
         workflow = _workflow(workflow_name)
         triggers = workflow.get("on", workflow.get(True))
         assert triggers["pull_request"]["types"] == PULL_REQUEST_TYPES
@@ -75,6 +95,6 @@ def test_pull_request_shards_leave_capacity_for_required_checks() -> None:
 
 def test_tests_still_cancels_only_superseded_push_runs() -> None:
     """Queue bounding must not reintroduce pull-request cancellation sweeps."""
-    for workflow_name in ("test.yml", *STANDALONE_JOB_GUARDS):
+    for workflow_name in ("test.yml", *STANDALONE_WORKFLOWS):
         concurrency = _workflow(workflow_name)["concurrency"]
         assert concurrency["cancel-in-progress"] == PUSH_ONLY_CANCELLATION

--- a/Tests/CI/test_github_actions_test_workflow.py
+++ b/Tests/CI/test_github_actions_test_workflow.py
@@ -9,18 +9,8 @@ ARTIFACT_LEASE_TEST_TARGETS = (
     "Tests/Model_Artifacts/test_operation_leases.py",
     "Tests/Model_Artifacts/test_operation_leases_process.py",
 )
-PROMOTION_GUARD = (
-    "if: ${{ github.event_name != 'pull_request' || "
-    "github.event.pull_request.number != 602 || "
-    "github.event.pull_request.draft == false || github.head_ref != 'dev' || "
-    "github.base_ref != 'main' }}"
-)
-ALWAYS_PROMOTION_GUARD = (
-    "if: ${{ always() && (github.event_name != 'pull_request' || "
-    "github.event.pull_request.number != 602 || "
-    "github.event.pull_request.draft == false || github.head_ref != 'dev' || "
-    "github.base_ref != 'main') }}"
-)
+SCHEDULE_SKIP = "if: ${{ github.event_name != 'schedule' }}"
+ALWAYS_SCHEDULE_SKIP = "if: ${{ always() && github.event_name != 'schedule' }}"
 
 
 def _workflow_text() -> str:
@@ -184,11 +174,13 @@ def test_ci_exercises_mcp_against_minimum_textual() -> None:
     )
 
 
-def test_artifact_lease_spike_runs_three_os_on_merge_and_ubuntu_on_a_pull_request() -> (
+def test_artifact_lease_spike_runs_three_os_on_main_and_ubuntu_on_a_pull_request() -> (
     None
 ):
-    """TASK-22250: the three-OS matrix moved to MERGE (push to dev/main) and
-    nightly; a pull_request gets ubuntu only.
+    """TASK-22250: main/manual runs use three OSes; PRs use Ubuntu only.
+
+    The scheduled event uses ``nightly-deep`` for cross-platform breadth and
+    does not run this ordinary artifact spike.
 
     Measured reason: ~12 concurrent ubuntu slots against a 25-job fan-out per
     Tests run left short REQUIRED checks from other workflows queued for hours
@@ -209,7 +201,7 @@ def test_artifact_lease_spike_runs_three_os_on_merge_and_ubuntu_on_a_pull_reques
     assert "os: [ubuntu-latest, macos-latest, windows-latest]" not in block
     # pull_request arm: ubuntu only.
     assert "'[\"ubuntu-latest\"]'" in block
-    # push / schedule arm: the full matrix still runs.
+    # main push / manual arm: the full matrix still runs.
     assert '\'["ubuntu-latest","macos-latest","windows-latest"]\'' in block
     assert 'python-version: ["3.11"]' in block
     assert "pip install -e ." in block
@@ -247,7 +239,7 @@ def test_ci_shape_regression_runs_in_dedicated_pull_request_job() -> None:
     ]
 
     assert "runs-on: ubuntu-latest" in shape
-    assert PROMOTION_GUARD in shape
+    assert SCHEDULE_SKIP in shape
     assert "uses: actions/checkout@v4" in shape
     assert "uses: actions/setup-python@v5" in shape
     assert 'python-version: "3.11"' in shape
@@ -268,7 +260,7 @@ def test_artifact_lease_gate_exposes_stable_required_context() -> None:
     assert "name: Artifact Lease Gate" in gate
     assert "runs-on: ubuntu-latest" in gate
     assert "needs: [artifact-lease-spike, artifact-lease-shape]" in gate
-    assert ALWAYS_PROMOTION_GUARD in gate
+    assert ALWAYS_SCHEDULE_SKIP in gate
     assert (
         'if [ "${{ needs.artifact-lease-spike.result }}" != "success" ] || '
         '[ "${{ needs.artifact-lease-shape.result }}" != "success" ]; then' in gate

--- a/backlog/tasks/task-22250 - CI runs are swept by simultaneous burst cancellations.md
+++ b/backlog/tasks/task-22250 - CI runs are swept by simultaneous burst cancellations.md
@@ -41,16 +41,24 @@ fix it (this is why the proposed workflow edit was put on hold).
 
 ## Implementation Plan
 
-1. Add focused workflow-contract tests for the selected queue-pressure controls.
-2. Suppress runner-consuming checks only for a draft `dev` to `main` promotion PR.
-3. Cap the core and UI shard matrices at three simultaneous jobs each while
-   preserving push-only cancellation behavior.
-4. Restrict the two TASK-2062 GGUF evidence workflows to their owned code and
-   test paths while retaining manual dispatch.
-5. Run YAML/static validation and the targeted CI contract tests, then
-   self-review the workflow diff.
-6. Audit both repository queues and cancel only obsolete queued/pending runs,
-   preserving the newest useful run for each active lane.
+1. Pin the approved trigger contract with focused RED tests: full ordinary
+   coverage on PRs into `dev`, a release run on pushes to `main`, and only
+   `nightly-deep` consuming scheduled runners.
+2. Filter synchronization-capable workflows before GitHub creates duplicate
+   runs for permanent promotion PR #602, while preserving focused push guards
+   on `dev` and `main`.
+3. Remove the obsolete PR #602 job-level exceptions and retain the existing
+   core/UI `max-parallel: 3` bounds and push-only cancellation behavior.
+4. Run the targeted CI contract suite, Ruff, YAML parsing, and diff checks.
+5. Rebase on latest `dev`, open the recovery PR, and cancel only obsolete idle
+   runs using current PR heads plus `dev`/`main` SHAs as the authority boundary.
+6. Verify a fresh post-change `Tests` run starts and reaches a verdict, address
+   every Qodo/review finding, rebase and reverify, then merge the exact verified
+   head.
+
+Design: `Docs/superpowers/specs/2026-08-29-account-ci-trigger-recovery-design.md`
+
+Plan: `Docs/superpowers/plans/2026-08-29-account-ci-trigger-recovery.md`
 
 ADR required: no
 

--- a/backlog/tasks/task-22250 - CI runs are swept by simultaneous burst cancellations.md
+++ b/backlog/tasks/task-22250 - CI runs are swept by simultaneous burst cancellations.md
@@ -337,3 +337,58 @@ ADR path: N/A
 
 Reason: the change is operational CI scheduling and trigger policy, not a
 long-lived application architecture boundary.
+
+## Update 2026-08-29 — account workload source removed, live proof pending
+
+Authenticated account inspection closed the ambiguity left by the repository-
+only probes:
+
+- All 442 active repositories owned by `rmusser01` were scanned. Only
+  `tldw_chatbook` and `tldw_server` had live Actions work, and neither had an
+  in-progress run at the audit instant.
+- The account is on GitHub Free. August public-runner usage was fully discounted
+  to a net $0, ruling out private-minute exhaustion as the cause.
+- `tldw_chatbook` consumed 510,153 runner-minutes in August, approximately 93%
+  of the account total. `tldw_server` consumed 33,634 runner-minutes.
+- The live snapshot contained 96 queued plus 28 pending `tldw_chatbook` runs
+  and 20 queued `tldw_server` runs. GitHub documents that Actions may be rate-
+  limited as usage scales; the API does not expose a personal-account throttle
+  flag, so the observed effective serialization is evidence of restriction,
+  not a claim about an undisclosed GitHub enforcement reason.
+
+The dominant duplicate source was the trigger contract. Every merge to `dev`
+created the 23-job `Tests` suite once for the `dev` push and again when permanent
+promotion PR #602 (`dev` to `main`) synchronized. The daily schedule also ran
+the ordinary suite before its five-leg `nightly-deep` matrix.
+
+The recovery branch now prevents that work before GitHub queues it:
+
+- `Tests` runs the ordinary suite for PRs into `dev`, runs a release suite on
+  pushes to `main`, preserves manual dispatch, and excludes ordinary jobs from
+  the scheduled event so only `nightly-deep` consumes scheduled runners.
+- Derived Artifacts, CSS Bundle Guard, Perf Guard, and Backlog Guard accept PRs
+  into `dev` while retaining their existing `dev`/`main` push checks.
+- The obsolete PR #602 job-level conditions were removed. The label-only
+  TASK-598/601/602/603 evidence workflows were deliberately left unchanged
+  because normal PR synchronization never triggers them.
+- The existing core/UI `max-parallel: 3` bounds and push-only cancellation
+  policy remain intact.
+
+Local verification after the RED-to-GREEN contract change:
+
+- 40 targeted CI workflow-contract tests passed.
+- Ruff check and format check passed for both changed Python contract files.
+- All five changed workflows parsed as YAML, and `git diff --check` passed.
+- The full suite was not run; repository policy calls for targeted verification
+  unless the owner explicitly requests a full sweep.
+
+The two live acceptance criteria remain open. This branch is not the fix until
+a fresh PR `Tests` run starts, survives without a simultaneous sweep, and
+reports a completed verdict.
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: this remains an operational GitHub Actions trigger and scheduling
+policy change, not an application architecture boundary.


### PR DESCRIPTION
## Summary

- stop the heavy Tests workflow from running twice for every merge to dev
- make scheduled Tests runs nightly-only while preserving manual full-suite dispatch
- move focused PR workflows to the dev integration boundary and remove obsolete PR #602 job guards
- add regression contracts for trigger topology, schedule isolation, matrix throttling, and manual dispatch

## Root cause

The heavy Tests workflow created 23 ordinary jobs on direct dev pushes and again when permanent PR #602 synchronized. Scheduled runs also launched the ordinary suite plus the nightly matrix. This branch removes those duplicate trigger paths.

## Verification

- TDD red: 5 focused contract failures before the workflow edits
- TDD green: 32 focused contract tests passed after the edits
- post-rebase publication gate: 40 targeted CI contract tests passed
- Ruff check passed; Ruff format check passed
- all 5 modified workflows parsed successfully
- git diff --check passed
- branch rebased onto current origin/dev

The full suite was not run; repository guidance requires targeted verification unless a full sweep is requested.

## Scope notes

- label-only TASK-598/601/602/603 evidence workflows are intentionally unchanged because PR synchronization does not trigger them
- origin/dev currently contains duplicate task-23112 files, so the repository-wide backlog ID guard may report that unrelated baseline defect
- ADR required: no; this is a routine workflow trigger correction using existing CI boundaries
- live completion evidence remains pending until this exact PR head receives a fresh Tests verdict without a cancellation sweep

Backlog: task-22250
Design: Docs/superpowers/specs/2026-08-29-account-ci-trigger-recovery-design.md
Plan: Docs/superpowers/plans/2026-08-29-account-ci-trigger-recovery.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the duplicate CI fan-out behind task-22250: the heavy `Tests` workflow ran on every merge to `dev` and again when permanent promotion PR #602 synchronized, and scheduled runs launched the ordinary suite plus the nightly matrix. `Tests` now runs the full suite for PRs targeting `dev`, a release suite for pushes to `main`, only `nightly-deep` on the daily schedule, and preserves manual full-suite dispatch.

- Focused guard workflows (`Derived Artifacts`, `CSS Bundle Guard`, `Perf Guard`, `Backlog Guard`) now accept PRs into `dev` only, and their obsolete PR #602 job guards were removed.
- Added regression contract tests covering trigger topology, schedule isolation, matrix throttling, and manual dispatch.

<sup>Written for commit d6a95dd02faa145f235bec4389e583b75ddd7f02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

