### PR TITLE
docs(console): focus mode end-to-end — phone/serve guide, keyboard rows, hands-free loop

### DIFF
--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -149,6 +149,54 @@ pointers and function keys are scarce.
 - Context usage remains available in the status line (on wide terminals)
   and via `Ctrl+Shift+P`.
 
+### Phone & remote use over `--serve`
+
+Chatbook can serve itself to a browser, which is how the Console becomes
+a phone surface: the app runs on your computer (or any box that stays
+on), and the phone opens a plain web page — no terminal app needed on
+the phone beyond the browser.
+
+**Start the server** (requires the `web` extra: `pip install -e ".[web]"`):
+
+```bash
+tldw-cli --serve --host 0.0.0.0 --port 8765
+# or equivalently:
+python -m tldw_chatbook.app --serve --host 0.0.0.0 --port 8765
+```
+
+Both entry points accept the same flags (`--host`, `--port`,
+`--web-title`, `--debug`; without `--port` the server binds the
+`[web_server]` config's port, default 8000). `--host 0.0.0.0` makes the
+server reachable from other devices on your LAN — then open
+`http://<your-computer's-LAN-IP>:8765` in the phone's browser. Keep
+`--serve` bound to `localhost` when you do not want that.
+
+**Make it phone-shaped.** Focus mode is the phone surface — press
+`Ctrl+Shift+F` from a desktop session first, or launch the server with
+`--focus` so every connection starts chrome-free (set
+`[general] focus_mode = true` to make that permanent). Below ~70 columns
+the rails yield to the transcript automatically, so the conversation is
+readable without any setup.
+
+**What works by touch.** The things a soft keyboard cannot reach all
+have on-screen routes:
+
+- Sending uses the composer's **Send** button; the composer **Menu**
+  gathers the actions desktop reaches through hotkeys.
+- Tool approvals are fully tappable (per-call buttons, Approve all /
+  Deny all / Submit).
+- The control bar's **Hands-free** switch is the touch route into (and
+  out of) the voice loop.
+- The command palette (`Ctrl+P` — on-screen keyboards can usually
+  produce this) is the universal escape hatch; on a phone without
+  Escape or function keys, reaching Settings or another screen from
+  the palette is the intended path, and any such jump also exits focus
+  mode (one `Ctrl+Shift+F` returns to the focused Console).
+
+Nothing about the desktop experience changes: `--serve` simply adds a
+second, browser-based way in. Multiple browser tabs are independent
+sessions of the same app instance.
+
 ### First run: the "Get started" card
 
 On a brand-new install, an app-level first-run wizard
@@ -431,6 +479,8 @@ Screen-level keys only — global keys live in the [guide index](index.md).
 | Alt+W | "Change Workspace" switcher |
 | Alt+V | Paste an image from the clipboard |
 | Ctrl+Shift+P | "Chat Context" viewer (what the model will see) |
+| Ctrl+Shift+F | Toggle focus mode — the chrome-free Console surface (see above) |
+| Ctrl+Shift+H | Enter/exit the hands-free voice loop (the control bar's **Hands-free** switch is the touch route) |
 | Esc | Return focus to the composer (expanding it first if collapsed) |
 
 While Console is the active screen, the command palette (**Ctrl+P**) also
@@ -451,8 +501,9 @@ are covered on the child pages, chiefly [Context & RAG](console/context-and-rag.
   credential both this screen's readiness check and Library's RAG Answer
   gate use), `[console]` and `[console.background_effects]` (paste
   collapse, ambience, and the false-by-default `raw_cli_permitted` unlock),
-  `[chat.images]` (attachments), `[general]`
-  `default_tab` (start here).
+  `[chat.images]` (attachments), `[general]` `default_tab` (start
+  here) and `focus_mode` (start the Console chrome-free every
+  launch — the config-file twin of `--focus`).
 - Child pages: [Chat basics](console/chat-basics.md) · [Sessions, tabs & workspaces](console/sessions-tabs-workspaces.md) · [Branching & rewind](console/branching-and-rewind.md) · [Attachments, images & voice](console/attachments-images-voice.md) · [Agent runs & tools](console/agent-runs-and-tools.md) · [Context & RAG](console/context-and-rag.md) · [Text selection & feedback](console/text-selection-and-feedback.md)
 - Deep dives: [Speech services](../Features/Speech-Services-Guide.md) (Mic dictation backends) · [Chat dictionaries](../Features/ChatDictionaries-Documented.md).
 

--- a/Docs/User_Guide/console/attachments-images-voice.md
+++ b/Docs/User_Guide/console/attachments-images-voice.md
@@ -136,6 +136,20 @@ is never sent automatically, so you can edit before pressing Enter.
   config.toml (defaults: faster-whisper, English). Only local providers
   are used — audio never leaves your machine.
 
+### Hands-free — the voice conversation loop
+
+Dictation's big sibling: instead of one capture at a time, **Hands-free**
+(`Ctrl+Shift+H`, or the control bar's **Hands-free** switch next to
+**Speak replies**) runs a continuous speak → transcribe → reply →
+speak-back loop. The switch is the touch route — on a phone over
+`--serve` there is no chorded keyboard, and the switch's state always
+reflects the real session (if the microphone is unavailable the loop
+won't start, and the switch says so by not engaging).
+
+`Esc` (or the switch again) exits the loop. The optional **Realtime
+engine** under Settings ▸ Speech & TTS swaps the pipeline for a
+low-latency provider session.
+
 ## Common tasks
 
 1. **Attach an image and ask about it** — click **Attach**, pick the image


### PR DESCRIPTION
## Summary

Completes the user-facing documentation for the focus-mode work stream (PRs #1829/#1834/#1909, task-18911/18812):

- **"Phone & remote use over `--serve`"** (new section, console.md): how to start the server (both `tldw-cli --serve` and `python -m tldw_chatbook.app --serve` now honor `--host/--port/--web-title/--debug` equally, defaulting to the `[web_server]` config port), LAN reachability with the localhost-bound trade-off, making the surface phone-shaped (`--focus`, `[general] focus_mode`, the automatic rail yield below ~70 columns), and the touch map — Send button, composer Menu, tappable tool approvals, the Hands-free switch, and the palette as the soft-keyboard escape hatch.
- **Keyboard & commands** table: `Ctrl+Shift+F` and `Ctrl+Shift+H` rows (the latter naming the switch as the touch route).
- **Related settings**: `[general] focus_mode` named alongside `default_tab`.
- **attachments-images-voice.md**: a "Hands-free" section beside the Mic-button dictation coverage — the loop, the switch as the touch route whose state always reflects the real session, Esc/switch exit, and the Realtime-engine pointer.

Every factual claim verified against the code: flag surface (`app.py` `_build_arg_parser`), port default (`serve.py`), rail-yield thresholds (`console_rail_state.py`), binding set and Esc-exits-hands-free (`chat_screen.py` BINDINGS).

Docs-only change; no ADR needed.

🤖 Generated with [ZCode](https://github.com/ZCode)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the user-facing documentation for the focus-mode feature set, adding a phone and remote usage guide over `--serve`, keyboard shortcut references, and a hands-free voice loop section.

- Adds a "Phone & remote use over `--serve`" section to `console.md` covering server flags (`--host`/`--port`), LAN setup, the phone-shaped surface, and touch routes.
- Adds `Ctrl+Shift+F` and `Ctrl+Shift+H` rows to the keyboard commands table and names `[general] focus_mode` in related settings.
- Adds a "Hands-free" section to `attachments-images-voice.md` describing the continuous voice loop and its touch switch.

<sup>Written for commit 666db423e1287901e8ac290d5d494478636c949c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

