### PR TITLE
ci: activate nightly deep workflow on main

### DIFF
--- a/.github/workflows/nightly-deep.yml
+++ b/.github/workflows/nightly-deep.yml
@@ -1,0 +1,119 @@
+name: Nightly Deep
+
+# Scheduled workflows are registered only from the default branch (`main`).
+# This file is kept identical on `dev` and `main`; its checkout pins the test
+# target to `dev` without promoting unrelated development changes.
+on:
+  schedule:
+    - cron: '30 8 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  PYTEST_TIMEOUT: 300
+  PYTHONDONTWRITEBYTECODE: 1
+  PYTHONUNBUFFERED: 1
+  FORCE_COLOR: 1
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  resolve-dev-sha:
+    name: Resolve nightly dev commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - name: Resolve one dev commit for every matrix leg
+        id: resolve
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  nightly-deep:
+    # task-1465: serial execution (order-regression canary), thorough
+    # Hypothesis, --run-slow, CSS parse cache off, coverage, and the OS/Python
+    # breadth intentionally excluded from the fast PR lane.
+    name: Nightly Deep - Python ${{ matrix.python-version }} - ${{ matrix.os }}
+    needs: [resolve-dev-sha]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python-version: "3.11"
+          - os: ubuntu-latest
+            python-version: "3.12"
+          - os: ubuntu-latest
+            python-version: "3.13"
+          - os: macos-latest
+            python-version: "3.12"
+          - os: windows-latest
+            python-version: "3.12"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-dev-sha.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Record tested dev commit
+        run: echo "Tested dev commit ${{ needs.resolve-dev-sha.outputs.sha }}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install all dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements.txt
+          pip install -r requirements-test.txt
+          pip install pytest-json-report pytest-cov
+          pip install -e ".[embeddings_rag,websearch,chunker]"
+          # pydub (+ its 3.13 audioop shim) only: briefings audio tests need
+          # these two, not the entire heavyweight `audio` extra.
+          pip install pydub "audioop-lts; python_version >= '3.13'"
+
+      - name: Setup test environment
+        run: |
+          python -c "import nltk; nltk.download('punkt', quiet=True)"
+          python -c "import nltk; nltk.download('punkt_tab', quiet=True)"
+
+      - name: Run deep suite (serial, thorough, slow tiers, cache-off)
+        env:
+          TLDW_HYPOTHESIS_PROFILE: thorough
+          TLDW_TEST_CSS_CACHE: "0"
+        run: |
+          pytest ./Tests/ \
+            --run-slow \
+            --timeout=600 \
+            --json-report --json-report-omit log \
+            --json-report-file=nightly-test-results-${{ matrix.os }}-${{ matrix.python-version }}.json \
+            --cov=tldw_chatbook \
+            --cov-report=xml:coverage-nightly-${{ matrix.os }}-${{ matrix.python-version }}.xml
+
+      - name: Upload nightly results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-test-results-${{ matrix.os }}-${{ matrix.python-version }}
+          path: |
+            nightly-test-results-*.json
+            coverage-nightly-*.xml


### PR DESCRIPTION
## Summary

- register the reviewed Nightly Deep workflow on the default branch so GitHub can schedule it
- keep the main copy byte-for-byte identical to the workflow merged into `dev` by #2208
- resolve one immutable `dev` SHA and use it across all five test environments without promoting unrelated `dev` changes

This is the atomic default-branch activation step for TASK-19600 and ADR-103. It changes only `.github/workflows/nightly-deep.yml`.

## Verification

- YAML parsed and workflow shape asserted locally
- activation blob `4548fb1db77a43bb46cea13cf30c1044106896d2` exactly matches `origin/dev`
- branch refreshed against latest `origin/main` before push
- `git diff --cached --check` passed before commit

After merge I will manually dispatch the workflow, verify all matrix legs record the same resolved `dev` SHA, and observe the scheduled trigger.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activate the Nightly Deep workflow on the default branch so GitHub can schedule it, without changing what tests run.

- Adds `.github/workflows/nightly-deep.yml`, identical to the version already on `dev`.
- Pins all five test environments to one resolved `dev` commit via a preliminary job, avoiding promotion of unrelated `dev` changes.

<sup>Written for commit 9294f741b52888bb341f628108807a13c8976f02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

