### PR TITLE
perf: 2026-08-29 holistic review — CSS apply fast path, keystroke guards, boot ratchet paydown

### DIFF
--- a/.github/workflows/perf-guard.yml
+++ b/.github/workflows/perf-guard.yml
@@ -65,3 +65,22 @@ jobs:
           pytest Tests/Performance/test_ui_latency_guardrails.py \
             Tests/Utils/test_ui_responsiveness_stall_persist.py \
             -v --timeout=300
+
+      # task-24461: the ADR-097 boot budgets ran ONLY in the slow full suite,
+      # so for three review cycles running they were re-breached within ~24h of
+      # every paydown and each breach was found by a periodic review rather
+      # than by the PR that caused it. They are cheap (~15s together) and they
+      # already print the culprit modules, so the breaching PR now gets that
+      # list here, in minutes.
+      #
+      # test_boot_css_byte_budget.py is deliberately NOT in this list yet: it
+      # is red on dev (862,184 B against an 860,000 B ratchet) and adding it
+      # would block every unrelated PR. It joins this step when task-24459
+      # lands.
+      - name: Run boot budget ratchets
+        run: |
+          pytest Tests/Performance/test_app_import_weight.py \
+            Tests/Performance/test_ui_ready_module_census.py \
+            Tests/Performance/test_boot_worker_census.py \
+            Tests/Performance/test_textual_css_fastpath.py \
+            -v --timeout=300

--- a/Docs/Design/2026-08-29-holistic-perf-review.md
+++ b/Docs/Design/2026-08-29-holistic-perf-review.md
@@ -26,11 +26,18 @@ ADR-097 made these ratchets on 2026-08-27; TASK-23112 paid the import debt down 
 | `MAX_BOOT_PARSED_CSS_BYTES` | 860,000 | **862,184** | +3,424 B in the monolith alone |
 | boot worker allowlist | — | **1 unlisted** | `console-persisted-browser-cache` (`UI/Console_Modules/workspace.py:2553`) |
 
-The new modules cluster in one family — the workspace/tool-execution work:
-`Tools.{git,local,patch,virtual_cli}_tool_impls`, `Tools.workspace_tool_{executor,protocol}`,
-`Tools.workspace_root_pin`, `Agents.{raw_shell,virtual_cli}_tool_provider`,
-`Workspaces.change_review_{consent,finalization}`, `Chat.console_settings_*`,
-`TTS.{legacy_request_builder,text_processing}`.
+The new modules fall into **three unrelated families**, which matters because remediation
+ownership differs (CodeRabbit, PR #2217 — an earlier draft lumped all three together):
+
+| Family | Modules |
+|---|---|
+| Workspace / tool execution (the large one) | `Tools.{git,local,patch,virtual_cli}_tool_impls`, `Tools.workspace_tool_{executor,protocol}`, `Tools.workspace_root_pin`, `Agents.{raw_shell,virtual_cli}_tool_provider`, `Utils.filesystem_identity` |
+| Workspace change review | `Workspaces.change_review_{consent,finalization}`, `Workspaces.change_{bounds,tracking,turn_tracker}` |
+| Console settings | `Chat.console_settings_*`, `Chat.provider_setup_persistence`, `Chat.console_generation_settings_metadata` |
+| TTS | `TTS.{legacy_request_builder,text_processing}` |
+
+Only the first family was severed by this cycle's deferrals; the others left the boot path as a
+side effect of the same import edges.
 
 **The process finding outranks the numbers.** Three cycles running, the budgets are re-breached
 within ~24 h of every paydown. The guards only run in the slow suite; last cycle's open owner
@@ -57,7 +64,11 @@ reduces *matching* work but not the *scan*. Measured consequences:
 | `app.update_styles(screen)` (500 widgets) | **240 ms** |
 | `RuleSet.__hash__` calls in one Console switch | **7,335,029** |
 
-7.33M ≈ 1,667 applies × 4,324 rules — the scan, exactly.
+That is ~4,400 hash calls per apply against 4,324 rules: **4,324 from the full-list `filter`
+scan, plus ~76 from building the candidate set** (each candidate is hashed on insertion, and
+`all_pseudo_classes` unions over the result). An earlier draft of this document called it
+"exactly 1,667 × 4,324"; that product is 7,208,108, and the 126,921 shortfall is the candidate-set
+work. The scan dominates, but it is not the only hasher. (CodeRabbit, PR #2217.)
 
 Stack sampling during observed stalls ranks `textual/css/model.py:__hash__` the #1 frame, then
 `_check_selectors`, `check`, `_check_id`. **Screen switching produced 17 event-loop stalls,

--- a/Docs/Design/2026-08-29-holistic-perf-review.md
+++ b/Docs/Design/2026-08-29-holistic-perf-review.md
@@ -1,0 +1,218 @@
+# Holistic performance review — 2026-08-29
+
+**Pin:** dev `bc1e26ce60` (524 commits since the 2026-08-27 review pin `c6218918d1`).
+**Method:** pinned worktree `.worktrees/perf-review-0829` with its own uv venv and a scratch
+profile; headless Textual Pilot at 170×48; **configured** state (valid-shaped
+`api_settings.openai.api_key`, so Console is the real app, not the setup modal); all numbers
+from the **warm** profile (second and later runs) unless stated. Package identity asserted on
+every probe. A/B runs interleaved base/patched/base/patched under identical load.
+
+**Verdict: idle is clean; interaction is not.** The prior cycles' idle/timer fixes held
+(12 s idle = 0.09 s CPU, zero stalls, zero SQL). Today's lag is concentrated in **CSS style
+application**, which is O(total rules) per styled node and runs hundreds of times per
+interaction. Screen switches stall the event loop for up to **399 ms**.
+
+---
+
+## 0. All four boot-budget ratchets are RED on pristine dev
+
+ADR-097 made these ratchets on 2026-08-27; TASK-23112 paid the import debt down to 646/660
+(headroom 14) on 2026-08-28. **One day later, all four are breached.**
+
+| Ratchet | Limit | Now | Detail |
+|---|---|---|---|
+| `MAX_TLDW_MODULE_COUNT` (import) | 660 | **662** | was 646 with 14 headroom on 08-28 |
+| `MAX_TLDW_MODULES_AT_UI_READY` | 970 | **981** | 19 new modules, 1 shed |
+| `MAX_BOOT_PARSED_CSS_BYTES` | 860,000 | **862,184** | +3,424 B in the monolith alone |
+| boot worker allowlist | — | **1 unlisted** | `console-persisted-browser-cache` (`UI/Console_Modules/workspace.py:2553`) |
+
+The new modules cluster in one family — the workspace/tool-execution work:
+`Tools.{git,local,patch,virtual_cli}_tool_impls`, `Tools.workspace_tool_{executor,protocol}`,
+`Tools.workspace_root_pin`, `Agents.{raw_shell,virtual_cli}_tool_provider`,
+`Workspaces.change_review_{consent,finalization}`, `Chat.console_settings_*`,
+`TTS.{legacy_request_builder,text_processing}`.
+
+**The process finding outranks the numbers.** Three cycles running, the budgets are re-breached
+within ~24 h of every paydown. The guards only run in the slow suite; last cycle's open owner
+call — move them into the fast `perf-guard.yml` so a breach surfaces per-PR — is the fix, and
+it is now unblocked (the debt it was waiting on was paid, then immediately re-incurred).
+
+---
+
+## 1. HEADLINE — every style application scans all 4,324 CSS rules
+
+`Stylesheet.apply()` pre-filters candidate rules through `rules_map`, but then does:
+
+```python
+rules = list(filter(limit_rules.__contains__, reversed(self.rules)))
+```
+
+which **walks the entire rule list on every call** to recover source order. The pre-filter
+reduces *matching* work but not the *scan*. Measured consequences:
+
+| Measurement | Value |
+|---|---|
+| Global rules / selector sets | **4,324 / 5,188** |
+| `stylesheet.apply()` on one node | **0.52 ms** |
+| `app.update_styles(screen)` (500 widgets) | **240 ms** |
+| `RuleSet.__hash__` calls in one Console switch | **7,335,029** |
+
+7.33M ≈ 1,667 applies × 4,324 rules — the scan, exactly.
+
+Stack sampling during observed stalls ranks `textual/css/model.py:__hash__` the #1 frame, then
+`_check_selectors`, `check`, `_check_id`. **Screen switching produced 17 event-loop stalls,
+worst 399 ms.**
+
+### 1a. Validated fix — replace the scan with an index sort
+
+Sorting the already-filtered candidate set by a cached position index, instead of scanning all
+rules, is ~15 lines and changes no CSS and no application code. Interleaved A/B, 2 rounds:
+
+| Metric | base | patched | Δ |
+|---|---|---|---|
+| `apply()` per node | 0.521 / 0.515 ms | 0.391 / 0.373 ms | **−27%** |
+| `update_styles(screen)` | 239.7 / 242.5 ms | 160.4 / 150.7 ms | **−35%** |
+| Console switch (6 samples each) | 1.927 s mean | 1.668 s mean | **−13% (−260 ms)** |
+| Library switch | 1.34 s mean | 1.14 s mean | −15% |
+| Typing CPU/key | 17.6–18.0 ms | 17.4–20.6 ms | no effect (few applies) |
+
+Belongs upstream in Textual, or as a vendored `Stylesheet` subclass. **Caveat: correctness was
+not verified beyond "the app boots, switches screens and accepts input" — rendering fidelity
+needs a proper check before adopting.**
+
+### 1b. The other half of the lever — cut the rule count
+
+Because cost is linear in total rules, deleting rules is a direct app-wide win, and it
+compounds with 1a.
+
+**`css/components/_agentic_terminal.tcss` is 272,312 B and holds 1,214 of the app's 4,198
+source rule blocks — 29% of all CSS, and 41% of the global monolith.** Despite the name it is
+not agentic-terminal CSS; it is an unstructured dumping ground:
+
+| Selector family in that file | Rule blocks |
+|---|---|
+| `#library-shell-grid.library-notes-compact` | 72 |
+| `LibraryIngestCanvas` | 30 |
+| `ConsoleSettingsModal` | 16 |
+| `#settings-shell` | 10 |
+| `#mcp-mode-strip` / `#lab-mode-strip` | 7 / 6 |
+| `#workflows-*`, `#personas-inspector-pane`, `#watchlists-inspector-pane` | 13+ |
+
+All of it is global, so every Library rule is scanned when styling a Console button. It grew
+262,634 → 272,312 B (+3.7%) in the two days since the last pin.
+
+Note `SCOPED_CSS` does **not** help here — scoped rules still live in `self.rules` and are
+still scanned. Only deleting/consolidating rules, or swapping stylesheet sources per screen,
+reduces N. The byte budget should be joined by a **rule-count** ratchet; bytes ≠ rules.
+
+---
+
+## 2. The Console rebuilds itself completely on every visit
+
+Identical cold and warm — there is no warm benefit at all:
+
+| Per Console visit | Count |
+|---|---|
+| Widgets constructed | **559** (212 `Static`, 108 `Button`, 44 `Horizontal`, 24 `Vertical`) |
+| `stylesheet.apply()` | **1,668** |
+| `update_nodes` passes | **402** (971 nodes) |
+| `set_class` | **907** |
+| Wall | **1.89–1.98 s** |
+
+The dominant chain is `Button.watch_flat` → `set_class` → `app.update_styles` →
+`stylesheet.update_nodes` → 974 applies ≈ **1.5 s** of the switch. 108 Buttons per visit each
+fire that watcher on construction.
+
+Two independent fixes: (a) keep the screen instance alive / lazily build off-screen sections so
+559 widgets are not re-minted per visit; (b) wrap screen construction in `app.batch_update()`
+so 402 separate `update_nodes` passes collapse.
+
+---
+
+## 3. Typing costs 20.6 ms CPU per keystroke on an *empty* Console
+
+Isolated probe (screen switch excluded from the measured window — an earlier reading that
+blamed typing for a 457 ms stall was **wrong**; that stall belonged to the switch):
+
+| Per keystroke | Count |
+|---|---|
+| CPU | **20.6 ms** |
+| `query_one` | **35.3** |
+| `Static.update()` | **8.4** |
+| `set_class` | **31.8** |
+
+`Widgets/Console/console_composer_bar.py::_sync_collapsed_presentation` runs **3× per
+keystroke**, and each run does 4 `query_one` + a `Static.update()` + 4 `set_class` — on the
+**collapsed row, which is `display:none` while you type**. It is unconditional: no early-return
+on unchanged state, no cached widget handles.
+
+Other unguarded per-key repeats: `_apply_draft_height` (4 `query_one`), `_refresh_visible_draft`
+(2 + 2 `Static.update`), `_console_command_popup_or_none` (2), `_sync_raw_cli_state` (2).
+
+Separately, provider readiness is recomputed on the keystroke path:
+`normalize_provider_config_key` runs **11,003 times across 43 keys (256/key)** via
+`_ensure_active_console_session_settings` → `build_console_settings_readiness` →
+`get_provider_readiness`. Cheap per call (~30 ms total) but it does not belong there at all.
+
+---
+
+## 4. Smaller, still real
+
+- **598 `query_one` calls per screen switch.** Hot sites: `console_bounded_section._reconcile`
+  (61), `left_rail._mounted_descriptors` (56), `left_rail._run_allocation_reconcile`
+  (4 sites × 28), `destination_rail.sync_open` (36).
+- **Library re-reads 43 config settings on every visit.**
+  `library_screen._load_library_ingest_options_from_config` runs from `on_mount`, and the app
+  builds a NEW `LibraryScreen` per visit (verified: three visits, three distinct instance ids).
+  **CORRECTION:** this was first written up as "config re-read on unrelated screen switches",
+  from a 33.5-`get_cli_setting`-per-switch average taken over a Library+Console *pair*. Measured
+  per destination, the reads are Library's alone — Console switches read 18–21, none of them from
+  `library_screen`. The averaging smeared one screen's mount cost across both. The waste is real
+  (43 reads per visit, forever) but it is a per-visit remount cost, not cross-screen leakage.
+- **Library opens 8 fresh SQLite connections per visit** via
+  `DB/private_sqlite.py:1156 _connect_registered_sqlite`, each paying `journal_mode=WAL` +
+  `synchronous=NORMAL` + `foreign_keys=ON`. No pooling/reuse.
+- **Extraction is still losing to growth.** `UI/Screens/library_screen.py` is **42,556 lines**;
+  `settings_screen.py` 24,621; `console_chat_controller.py` 20,234; `chat_screen.py` 18,238.
+
+## 5. Verified healthy
+
+- **Idle: 0.09 s CPU over 12 s (0.75% of a core), zero stalls, zero SQL.** The 08-22/08-24
+  timer and idle-SQL fixes held.
+- The Console 5 Hz transcript-sync timer is correctly self-stopping and gated.
+- `main_navigation._update_overflow_hints` is signature-guarded and skips cleanly.
+- No `refresh_css()` call sites anywhere in the app.
+
+---
+
+## Recommended order
+
+1. **Adopt 1a** (Textual `apply()` index sort) — ~15 lines, −27% per apply, −260 ms per Console
+   switch, app-wide, no CSS or app changes. Verify rendering fidelity first.
+2. **Split `_agentic_terminal.tcss` by owning screen and delete duplicates** — targets 29% of
+   all rules; compounds multiplicatively with 1.
+3. **Stop re-minting 559 widgets per Console visit** + `batch_update()` around construction.
+4. **Guard the composer sync functions** on unchanged state; cache widget handles; never touch
+   the hidden collapsed row.
+5. **Pay the four ratchet breaches, and move the budget guards into `perf-guard.yml`** so the
+   next breach costs one PR instead of one review cycle.
+6. Cache per-screen config reads; pool the Library's 8 connections/visit.
+
+## Root cause shared by findings 2, 4 and the Library reads
+
+`switch_screen` is handed a freshly constructed screen every time, with state restored from
+`screen_state_store` — verified live: three visits to Library produced three distinct instance
+ids. That single decision is why the Console re-mints 559 widgets per visit, why Library re-reads
+43 config settings per visit, and why Library opens 8 SQLite connections per visit. Screen
+instance reuse is therefore the highest-leverage structural change available, and also the most
+invasive: the snapshot/restore design assumes fresh construction.
+
+## Probe traps hit this cycle
+
+- **A phase that contains a screen switch cannot measure typing.** My first typing reading
+  showed a 457 ms stall; isolating the switch out of the measured window reduced it to one
+  113 ms stall. Attribute before filing.
+- **`__init__` was 0.949 s on the first run and 0.088 s on the second** — the 0.949 s was
+  one-time schema creation on a fresh DB, not a boot cost real users pay. Always re-run warm.
+- `sqlite3.Cursor.execute` cannot be monkeypatched (immutable C type); wrap `sqlite3.connect`
+  and install `set_trace_callback` instead.

--- a/Tests/Performance/test_textual_css_fastpath.py
+++ b/Tests/Performance/test_textual_css_fastpath.py
@@ -1,0 +1,154 @@
+"""Guards for the ordered-candidate fast path on ``Stylesheet.apply``.
+
+The fast path (``tldw_chatbook/Utils/textual_css_fastpath.py``) exists because
+upstream ``apply`` recovers source order with
+``filter(limit_rules.__contains__, reversed(self.rules))`` -- a walk of the
+entire rule list on every call, which made styling one node cost
+``O(total rules)``. On dev ``bc1e26ce60`` that was 7,335,029 ``RuleSet.__hash__``
+calls in a single Console screen switch (1,667 applies x 4,324 rules), and CSS
+matching was the #1 sampled frame during 399 ms event-loop stalls.
+
+Two things have to stay true for that optimisation to be safe, and each has a
+test here:
+
+1. **It must not change what styling means.** ``test_fastpath_computes_identical
+   _styles_for_every_node`` applies the stylesheet to every node of several real
+   screens both ways and compares the resulting rule maps. This is the test that
+   would catch a specificity or tie-breaking regression.
+2. **It must keep matching the upstream implementation it delegates to.** The
+   fast path hands upstream a pre-narrowed ``_rules`` list and relies on
+   upstream reversing it. If upstream's candidate-selection line changes, that
+   contract is void -- ``test_upstream_apply_still_has_the_shape_the_fastpath
+   _assumes`` fails loudly on a Textual upgrade instead of letting styling drift
+   silently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from pathlib import Path
+
+import pytest
+
+from textual.css.stylesheet import Stylesheet
+
+
+def _scratch_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home, data, config = tmp_path / "home", tmp_path / "data", tmp_path / "config"
+    for sub in (home, data, config):
+        sub.mkdir(parents=True, exist_ok=True)
+    config_file = config / "tldw_cli" / "config.toml"
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text(
+        "[first_run]\nsetup_completed = true\n\n[splash_screen]\nenabled = false\n"
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(data))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config))
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_file))
+    monkeypatch.setenv("TLDW_TEST_MODE", "1")
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "css_fastpath")
+
+
+def test_upstream_apply_still_has_the_shape_the_fastpath_assumes() -> None:
+    """Pin the two upstream behaviours the delegation depends on.
+
+    The fast path narrows ``self._rules`` to the candidate set in ascending
+    source order and lets upstream do the rest. That is only equivalent while
+    upstream (a) derives its candidates from ``rules_map`` keyed on
+    ``node._selector_names``, and (b) recovers order by reversing
+    ``self.rules``. Both appear as literal source below; if a Textual upgrade
+    changes either, this test fails and the delegation must be re-reviewed.
+    """
+    source = inspect.getsource(
+        getattr(Stylesheet.apply, "__wrapped__", Stylesheet.apply)
+    )
+    normalised = " ".join(source.split())
+
+    assert "rules_map.keys() & node._selector_names" in normalised, (
+        "Upstream Stylesheet.apply no longer derives candidates from "
+        "rules_map & node._selector_names. The fast path in "
+        "tldw_chatbook/Utils/textual_css_fastpath.py pre-computes exactly that "
+        "set and must be re-reviewed against the new implementation."
+    )
+    assert "filter(limit_rules.__contains__, reversed(self.rules))" in normalised, (
+        "Upstream Stylesheet.apply no longer recovers rule order by reversing "
+        "self.rules. The fast path hands it a pre-ordered narrowed list and "
+        "relies on that reversal; re-review "
+        "tldw_chatbook/Utils/textual_css_fastpath.py before shipping."
+    )
+
+
+@pytest.mark.ui
+@pytest.mark.asyncio
+async def test_fastpath_computes_identical_styles_for_every_node(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Every node on every toured screen resolves to the same rules both ways.
+
+    This is the fidelity check. A specificity or source-order regression in the
+    fast path shows up here as a differing rule map, naming the node.
+    """
+    _scratch_env(monkeypatch, tmp_path)
+    from tldw_chatbook.Utils.textual_css_fastpath import (
+        install_stylesheet_fastpath,
+        is_installed,
+    )
+    from tldw_chatbook.app import TldwCli
+
+    install_stylesheet_fastpath()
+    assert is_installed(), "fast path failed to install"
+
+    patched_apply = Stylesheet.apply
+    upstream_apply = getattr(patched_apply, "__wrapped__", None)
+    assert upstream_apply is not None, "fast path did not record the upstream apply"
+
+    app = TldwCli()
+    async with app.run_test(size=(170, 48)) as pilot:
+        for _ in range(20):
+            await asyncio.sleep(0.05)
+            await pilot.pause()
+
+        mismatches: list[str] = []
+        checked = 0
+        for key, expected in (
+            ("ctrl+2", "ChatScreen"),
+            ("ctrl+3", "LibraryScreen"),
+            ("f9", "SettingsScreen"),
+        ):
+            await pilot.press(key)
+            for _ in range(40):
+                await pilot.pause()
+                if type(pilot.app.screen).__name__ == expected:
+                    break
+            for _ in range(6):
+                await asyncio.sleep(0.05)
+                await pilot.pause()
+
+            stylesheet = pilot.app.stylesheet
+            for node in list(pilot.app.screen.query("*")):
+                upstream_apply(stylesheet, node, animate=False)
+                expected_rules = dict(node.styles.base.get_rules())
+                patched_apply(stylesheet, node, animate=False)
+                actual_rules = dict(node.styles.base.get_rules())
+                checked += 1
+                if expected_rules != actual_rules:
+                    differing = {
+                        name
+                        for name in expected_rules.keys() | actual_rules.keys()
+                        if expected_rules.get(name) != actual_rules.get(name)
+                    }
+                    mismatches.append(
+                        f"{expected}: {type(node).__name__}"
+                        f"#{node.id or '-'} differs on {sorted(differing)}"
+                    )
+
+        assert checked > 500, (
+            f"only {checked} nodes compared -- the tour did not build real "
+            "screens, so a passing result would prove nothing"
+        )
+        assert not mismatches, (
+            f"{len(mismatches)} of {checked} nodes resolved to different styles "
+            "under the fast path:\n" + "\n".join(mismatches[:20])
+        )

--- a/Tests/Performance/test_textual_css_fastpath.py
+++ b/Tests/Performance/test_textual_css_fastpath.py
@@ -5,8 +5,9 @@ upstream ``apply`` recovers source order with
 ``filter(limit_rules.__contains__, reversed(self.rules))`` -- a walk of the
 entire rule list on every call, which made styling one node cost
 ``O(total rules)``. On dev ``bc1e26ce60`` that was 7,335,029 ``RuleSet.__hash__``
-calls in a single Console screen switch (1,667 applies x 4,324 rules), and CSS
-matching was the #1 sampled frame during 399 ms event-loop stalls.
+calls in a single Console screen switch -- ~4,400 per apply over 1,667 applies,
+of which 4,324 are the scan itself -- and CSS matching was the #1 sampled frame
+during 399 ms event-loop stalls.
 
 Two things have to stay true for that optimisation to be safe, and each has a
 test here:

--- a/Tests/UI/test_library_ingest_options_cache.py
+++ b/Tests/UI/test_library_ingest_options_cache.py
@@ -1,0 +1,143 @@
+"""Invalidation guards for the app-scoped Library ingest-option cache.
+
+`_load_library_ingest_options_from_config` performs 43 `get_cli_setting` reads
+and runs from `on_mount`, and the app builds a NEW `LibraryScreen` per visit --
+so the result is memoised on the running app (task-24456).
+
+A memoised config view is only as correct as its invalidation key, and the
+first version of this cache got that wrong: it keyed on the config GENERATION
+alone. Retargeting `TLDW_CONFIG_PATH` selects a different config file and the
+loader serves the new file's values *without* advancing the generation, so a
+generation-only key kept serving the old file's options. Caught in review by
+Qodo on PR #2217 and reproduced before fixing.
+
+These tests pin both halves of the key.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _write_config(root: Path, name: str, chunk_size: int) -> Path:
+    path = root / name / "tldw_cli" / "config.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "[first_run]\nsetup_completed = true\n\n"
+        "[library.ingest_options.generic]\n"
+        f"chunk_size = {chunk_size}\n"
+    )
+    return path
+
+
+class _FakeApp:
+    """Stand-in for the running App -- the cache's storage scope."""
+
+
+def test_config_identity_changes_when_the_config_path_is_retargeted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The memo key must move when a DIFFERENT config file becomes effective.
+
+    This is the regression: `_CONFIG_GENERATION` does not advance on a
+    retarget, so a key built from it alone is stable across two files with
+    different contents.
+    """
+    from tldw_chatbook.config import current_config_identity
+
+    first = _write_config(tmp_path, "A", 1111)
+    second = _write_config(tmp_path, "B", 2222)
+
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(first))
+    before = current_config_identity()
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(second))
+    after = current_config_identity()
+
+    assert before != after, (
+        "current_config_identity() did not change when TLDW_CONFIG_PATH was "
+        "retargeted to a different file. Any cache keyed on it will serve the "
+        "previous config's values."
+    )
+    assert before[0] == after[0], (
+        "precondition for this test: the generation is expected NOT to move on "
+        "a retarget -- that is exactly why the path belongs in the key"
+    )
+
+
+def test_retargeting_the_config_path_invalidates_the_ingest_option_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A retarget must be served the NEW file's options, not the cached ones."""
+    from tldw_chatbook.UI.Screens import library_screen
+
+    first = _write_config(tmp_path, "A", 1111)
+    second = _write_config(tmp_path, "B", 2222)
+    app = _FakeApp()
+    owner = type("Owner", (), {"app": app})()
+
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(first))
+    monkeypatch.setattr(
+        library_screen,
+        "_read_library_ingest_options_from_config",
+        lambda: {
+            "transcribe_cpp_configured": False,
+            "generic_form_fields": {},
+            "type_options": {"generic": {"chunk_size": _chunk_size()}},
+        },
+    )
+
+    def _chunk_size() -> int:
+        from tldw_chatbook.config import get_cli_setting
+
+        return int(get_cli_setting("library.ingest_options.generic", "chunk_size", 0))
+
+    payload_a = library_screen._library_ingest_options_for(owner)
+    assert payload_a["type_options"]["generic"]["chunk_size"] == 1111
+
+    cached_again = library_screen._library_ingest_options_for(owner)
+    assert cached_again is payload_a, "unchanged config should hit the cache"
+
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(second))
+    payload_b = library_screen._library_ingest_options_for(owner)
+    assert payload_b["type_options"]["generic"]["chunk_size"] == 2222, (
+        "the cache served the previous config file's ingest options after "
+        "TLDW_CONFIG_PATH was retargeted"
+    )
+
+
+def test_a_screen_without_a_running_app_always_reads_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No app means no navigation to amortise across -- never cache.
+
+    This is what keeps a test that stubs `get_cli_setting` on an unmounted
+    screen seeing its own values, and it is the production-correct behaviour
+    for any caller that has swapped the settings source.
+    """
+    from tldw_chatbook.UI.Screens import library_screen
+
+    calls: list[int] = []
+
+    def _fake_read() -> dict:
+        calls.append(1)
+        return {
+            "transcribe_cpp_configured": False,
+            "generic_form_fields": {},
+            "type_options": {},
+        }
+
+    monkeypatch.setattr(
+        library_screen, "_read_library_ingest_options_from_config", _fake_read
+    )
+
+    class _NoApp:
+        @property
+        def app(self):  # noqa: ANN201 - mirrors Textual raising off-app
+            raise RuntimeError("no running app")
+
+    owner = _NoApp()
+    library_screen._library_ingest_options_for(owner)
+    library_screen._library_ingest_options_for(owner)
+    assert len(calls) == 2, "an app-less owner must not be served a cached payload"

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -9092,7 +9092,13 @@ async def test_local_agent_catalog_failure_degrades_to_no_local_group(monkeypatc
     def _boom(*args, **kwargs):
         raise RuntimeError("provider construction exploded")
 
-    monkeypatch.setattr(mcp_workbench_module, "LocalToolProvider", _boom)
+    # task-24458: `mcp_workbench` no longer imports `LocalToolProvider` at
+    # module scope -- it is imported at the construction site so the workspace
+    # tool cluster stays off the screen pre-import payload. Patch the defining
+    # module instead, which is what that deferred import resolves against.
+    monkeypatch.setattr(
+        "tldw_chatbook.Agents.local_tool_provider.LocalToolProvider", _boom
+    )
     app = WorkbenchApp()
     app.raw_cli_runtime = SimpleNamespace(permitted=False, armed=False)
     async with app.run_test() as pilot:

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9844,3 +9844,80 @@ terminal path. When one logical operation pauses for human choice, test the hand
 a second concurrency boundary: double selection, stale callbacks, repeated outer
 cancellation, routed replacement, and exact retained input all need proof even when
 the pre-choice phase is already single-flight.
+
+---
+
+## A per-switch average over a PAIR of destinations invents a finding
+
+**What happened.** 2026-08-29 holistic perf review. A probe measured
+`get_cli_setting` calls across a Library-then-Console switch pair and divided by
+two, reporting "33.5 config reads per screen switch, 19.5 of them from
+`library_screen._load_library_ingest_options_from_config`". That became a filed
+finding titled *Library ingest options are re-read from config on unrelated
+screen switches* — a cross-screen leak, which would have been a layering bug.
+
+It was false. Re-measured per destination, Console switches read 18–21 settings
+and **not one** came from `library_screen`; all 43 Library reads belong to
+Library's own `on_mount`. The average had smeared one screen's mount cost evenly
+across both switches, and the smear is what created the "unrelated" framing.
+
+The waste was real — 43 reads on *every* Library visit, because the app builds a
+new `LibraryScreen` per visit — but the mechanism, the owner and the fix were all
+different from what was filed. Implementing against the filed premise would have
+gone looking for a cross-screen call that does not exist.
+
+**What to do.** Never average a per-event cost across a sequence containing more
+than one kind of event. Attribute to the specific destination, action or keystroke
+that caused it, and only then divide. The cheap version is one measurement window
+per destination — it is the same probe, run three times instead of once.
+
+Sibling of the same cycle's other misattribution: a "typing" phase that contained
+a screen switch reported a 457 ms typing stall; isolating the switch out of the
+measured window left a single 113 ms stall. **A measurement window that contains
+two activities cannot attribute cost to either.**
+
+---
+
+## `run_worker(partial(...))` silently makes the worker anonymous
+
+**What happened.** 2026-08-29. The boot worker census failed on
+`('', 'console-persisted-browser-cache')` — an unlisted worker with an EMPTY
+name. The allowlist already carried the correct row,
+`('_refresh_console_persisted_rows_cache', 'console-persisted-browser-cache')`.
+
+Textual derives a worker's name as
+`name or getattr(work, "__name__", "") or ""` (`worker_manager.py:112`). A
+`functools.partial` has no `__name__`, so wrapping an existing `run_worker` call
+in a partial — to bind kwargs — renamed the worker to `""`. The guard read as
+"a new unreviewed worker appeared during boot"; the truth was "an existing,
+already-approved worker lost its identity". It was also anonymous in every worker
+diagnostic from that moment on, which nothing else surfaced.
+
+**What to do.** Pass `name=` explicitly whenever `run_worker` is given a
+`partial`, a lambda, or any other callable without `__name__`. 56 further
+`run_worker(partial(...))` sites exist in this repo with the same latent
+anonymity; none are boot workers, so only this one had a guard watching.
+
+---
+
+## A module-global cache passes in isolation and fails in the suite
+
+**What happened.** 2026-08-29, task-24456. Memoising Library's 43 per-visit
+config reads in a module-level `_CACHE` variable passed
+`Tests/UI/test_library_screen.py::test_load_ingest_options_from_config` when run
+alone and failed it inside the full suite. The cache outlived the app and served
+one test's stubbed `get_cli_setting` values to the next test.
+
+The reflex fix — add a cache-clearing fixture — would have been tests bending
+around an implementation. The real defect was the cache's LIFETIME: it was
+process-scoped for data whose validity is app-scoped.
+
+Re-scoping it to the running `App` object fixed the test *and* was the better
+production design: a screen with no running app (an unmounted screen built
+directly by a test, or any caller that has swapped the settings source) now reads
+fresh, which is what such a caller must see.
+
+**What to do.** When a cache exists to amortise work across *navigations*, scope
+it to the object that spans navigations — the app — not to the module. If a
+memoisation needs a test fixture to clear it, that is evidence its lifetime is
+wrong, not evidence the test needs help.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9921,3 +9921,36 @@ fresh, which is what such a caller must see.
 it to the object that spans navigations — the app — not to the module. If a
 memoisation needs a test fixture to clear it, that is evidence its lifetime is
 wrong, not evidence the test needs help.
+
+---
+
+## Two ratchets can measure the same cost, so paying one breaches the other
+
+**What happened.** 2026-08-29, task-24458. Deferring modules off the boot import path made
+`test_app_import_weight` and `test_ui_ready_module_census` go green (662→631, 981→966). After
+a rebase, `test_screen_preimport_payload_budget` went RED at 505/500 modules — and it PASSES on
+pristine dev, so it looked like the branch had introduced 5 modules of new cost.
+
+It had introduced none. That guard measures `tldw_modules()` after the pre-import pass **minus a
+baseline taken before it**. Every module removed from boot lowers the baseline and raises
+`pass_added` by exactly one. The breach message's module-set diff proved it: the 14 "new" modules
+were precisely the 14 the deferrals had moved. Total modules loaded was unchanged.
+
+The two guards are in tension by construction: paying down the boot budgets necessarily spends
+the pre-import budget, LOC for LOC. Dev had 226 LOC of pre-import headroom and the shift moved
+842 LOC of accounting, so it breached with nothing having grown.
+
+**What to do.** When a boot-import deferral lands, expect the pre-import payload guard to move
+against you by the same amount, and budget for it in the same PR. Do not raise either constant
+(ADR-097) and do not revert the deferral — find real payload to shed. The honest place to look is
+the deferral's own edges: here, following them turned up `UI/Widgets/__init__.py` eagerly
+importing `SmartContentTree` (425 LOC) and `config_search_widget` (228 LOC), so the four MCP
+modes that want only the small `table_click_select` mixin were each paying for both. That is the
+**`Chunking/__init__.py` eager-package-`__init__` trap (finding 21102) recurring in a second
+package**, and it is worth grepping for whenever a pre-import budget is tight.
+
+**Corollary, and the reason this entry exists rather than a one-line note:** a guard that
+subtracts a baseline is measuring a *difference*, not a cost. Before treating such a breach as a
+regression, check whether the baseline moved. `git worktree` at pristine dev plus one test run
+settles it in two minutes, and it is the difference between "my change is slower" and "my change
+is faster and the meter moved."

--- a/backlog/tasks/task-24450 - Textual-stylesheet-apply-scans-every-rule-on-every-call.md
+++ b/backlog/tasks/task-24450 - Textual-stylesheet-apply-scans-every-rule-on-every-call.md
@@ -1,0 +1,73 @@
+---
+id: TASK-24450
+title: Textual stylesheet apply scans every rule on every call
+status: Done
+assignee: []
+created_date: '2026-08-29'
+labels:
+  - performance
+  - ui
+  - textual
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`Stylesheet.apply()` pre-filters candidate rules through `rules_map`, then discards the
+benefit with `rules = list(filter(limit_rules.__contains__, reversed(self.rules)))`, which
+walks the entire rule list on every call to recover source order. With 4,324 global rules this
+makes every style application O(all rules) rather than O(matched rules).
+
+Measured on dev bc1e26ce60: 0.52 ms per single-node apply, 240 ms for one full-screen
+`update_styles`, and 7,335,029 `RuleSet.__hash__` calls in a single Console screen switch
+(= 1,667 applies x 4,324 rules). Stack sampling during observed event-loop stalls ranks
+`textual/css/model.py:__hash__` the #1 frame. This is the single dominant interactive cost in
+the application.
+
+A prototype that sorts the already-filtered candidate set by a cached position index measured
+-27% per apply, -35% per full-screen update_styles, and -260 ms per Console switch in an
+interleaved A/B.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A single-node `Stylesheet.apply()` no longer scales with total stylesheet rule count
+- [x] #2 Full-screen `update_styles` on the Console measures at least 25% faster than the pre-change baseline on the same machine, interleaved A/B
+- [x] #3 Rendering is unchanged: specificity and source-order tie-breaking produce identical computed styles for a representative node set
+- [x] #4 A regression test pins the per-apply cost model so a future change cannot silently reintroduce the full-list scan
+- [x] #5 The change is documented as either an upstream Textual patch or a vendored subclass, with the chosen route recorded
+<!-- AC:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+Added `tldw_chatbook/Utils/textual_css_fastpath.py`, installed from `app.py` before any App
+exists. Upstream `Stylesheet.apply` narrows candidates through `rules_map` and then recovers
+source order with `filter(limit_rules.__contains__, reversed(self.rules))` -- a walk of ALL
+4,324 rules per node. The fast path pre-computes the same candidate set, sorts it by a cached
+position index, and hands it to upstream as `_rules`; upstream's own reversal then preserves
+"later rule wins" exactly.
+
+Deliberately a delegation, not a fork: upstream stays the single source of truth for what
+styling MEANS, and only candidate SELECTION changes. The position index is cached against the
+`rules_map` OBJECT (a strong reference), because Textual sets `_rules_map = None` on every path
+that mutates `_rules` -- so a surviving identity match proves the rule list is unchanged, and
+holding the reference stops `id()` reuse from aliasing a freed map.
+
+Measured on the real app, interleaved A/B, two rounds:
+- `apply()` per node 0.55 -> 0.38 ms (-31%)
+- `update_styles(screen)` 266/252 -> 151/153 ms (-41%)
+- Console screen switch 1.96 -> 1.78 s mean of 6 (-175 ms)
+- Typing unchanged, as expected (typing performs few applies)
+
+Two tests in `Tests/Performance/test_textual_css_fastpath.py`:
+- fidelity: applies the stylesheet to every node of Console/Library/Settings both ways and
+  compares rule maps (689 nodes). Mutation-tested -- reversing the sort order breaks 47 of 689,
+  so the test discriminates.
+- upstream pin: asserts the two literal upstream behaviours the delegation assumes, so a Textual
+  upgrade fails loudly here instead of silently changing styling.
+
+Modified: `tldw_chatbook/Utils/textual_css_fastpath.py` (new), `tldw_chatbook/app.py`,
+`Tests/Performance/test_textual_css_fastpath.py` (new).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-24451 - Split-the-agentic-terminal-CSS-grab-bag-and-ratchet-rule-count.md
+++ b/backlog/tasks/task-24451 - Split-the-agentic-terminal-CSS-grab-bag-and-ratchet-rule-count.md
@@ -1,0 +1,64 @@
+---
+id: TASK-24451
+title: Split the agentic terminal CSS grab-bag and ratchet rule count
+status: To Do
+assignee: []
+created_date: '2026-08-29'
+labels:
+  - performance
+  - ui
+  - css
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`css/components/_agentic_terminal.tcss` is 272,312 B and holds 1,214 of the app's 4,198
+source rule blocks -- 29% of all CSS in the application. Despite its name it is not
+agentic-terminal CSS; it is an unstructured accumulation containing Library
+(`#library-shell-grid` x72, `LibraryIngestCanvas` x30), Settings (`#settings-shell` x10),
+MCP (`#mcp-mode-strip` x7), Lab (`#lab-mode-strip` x6), Workflows, Personas and Watchlists
+rules. All of it is global, so every Library rule is scanned when styling a Console button.
+
+It grew 262,634 -> 272,312 B (+3.7%) in the two days between the 2026-08-27 and 2026-08-29
+review pins. Because style-application cost is linear in total rule count, reducing the rule
+count is a direct app-wide win that compounds with task-24450.
+
+Note that Textual's `SCOPED_CSS` does not help: scoped rules still live in `self.rules` and are
+still scanned. Only deleting rules, or swapping stylesheet sources per screen, reduces N.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `_agentic_terminal.tcss` no longer contains rules owned by Library, Settings, MCP, Lab, Workflows, Personas or Watchlists
+- [ ] #2 Total app rule count measured at boot is reduced relative to the pre-change baseline, and the reduction is recorded
+- [ ] #3 A rule-count ratchet guard exists alongside the existing byte budget, because bytes are not rules
+- [ ] #4 Every destination in the existing latency-guardrail tour renders with no visual regression
+- [ ] #5 The CSS bundle regenerates from its sources with no drift (`./scripts/preflight.sh` green)
+<!-- AC:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+NOT IMPLEMENTED in the 2026-08-29 review pass. Recorded here so the next person does not
+re-derive the analysis.
+
+Confirmed scope: `_agentic_terminal.tcss` is 272,312 B and holds 1,214 of the app's 4,198 source
+rule blocks (29% of all CSS). It grew 262,634 -> 272,312 B in the two days between the 08-27 and
+08-29 review pins. Selector families inside it that belong to other screens:
+`#library-shell-grid.library-notes-compact` (72 blocks), `LibraryIngestCanvas` (30),
+`ConsoleSettingsModal` (16), `#settings-shell` (10), `#mcp-mode-strip` (7), `#lab-mode-strip` (6),
+plus `#workflows-*`, `#personas-inspector-pane`, `#watchlists-inspector-pane`.
+
+Two constraints the implementer must know:
+1. `SCOPED_CSS` does NOT reduce the cost. Scoped rules still live in `Stylesheet.rules` and are
+   still scanned. Only DELETING rules, or swapping stylesheet sources per screen, reduces N.
+2. With task-24450 landed, `apply()` is no longer O(all rules), so the payoff from cutting rule
+   count is smaller than the original review estimated -- the two fixes are not additive in the
+   way first written up. Re-measure before committing to the full split.
+
+A first attempt at finding dead selectors mechanically produced a false 609/609 "all dead"
+result, because the detection grep used `\w` inside a POSIX ERE. Any dead-CSS sweep here needs a
+real parser, not a grep.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-24452 - Console-re-mints-559-widgets-on-every-visit-with-no-warm-benefit.md
+++ b/backlog/tasks/task-24452 - Console-re-mints-559-widgets-on-every-visit-with-no-warm-benefit.md
@@ -1,0 +1,60 @@
+---
+id: TASK-24452
+title: Console re-mints 559 widgets on every visit with no warm benefit
+status: To Do
+assignee: []
+created_date: '2026-08-29'
+labels:
+  - performance
+  - ui
+  - console
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Switching to the Console constructs 559 widgets (212 Static, 108 Button, 44 Horizontal,
+24 Vertical), performs 1,668 `stylesheet.apply()` calls, 402 `update_nodes` passes over 971
+nodes, and 907 `set_class` calls -- every single visit. The measurement is identical cold and
+warm (1.89-1.98 s), so nothing is cached or reused between visits.
+
+The dominant chain is `Button.watch_flat` -> `set_class` -> `app.update_styles` ->
+`stylesheet.update_nodes` -> 974 applies, accounting for roughly 1.5 s of the switch. 108
+Buttons per visit each fire that watcher on construction.
+
+Two independent levers: avoid re-minting the widget tree per visit, and collapse the 402
+separate `update_nodes` passes into a batched update during construction.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Repeat visits to the Console construct materially fewer widgets than the first visit
+- [ ] #2 The number of `update_nodes` passes during a Console screen switch is reduced relative to the pre-change baseline
+- [ ] #3 Console screen-switch wall time improves measurably in an interleaved A/B on the same machine
+- [ ] #4 A guard pins the per-visit widget construction count so the warm path cannot silently regress
+- [ ] #5 Console behaviour and focus placement are unchanged across a switch-away-and-back cycle
+<!-- AC:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+NOT IMPLEMENTED in the 2026-08-29 review pass. The root cause was identified and is larger than
+this task as filed.
+
+The app hands `switch_screen` a FRESHLY CONSTRUCTED screen every time and restores state from
+`screen_state_store` (`app.py` ~11709). Verified live: three visits to Library produced three
+distinct instance ids. That single decision is what makes the Console re-mint 559 widgets per
+visit -- and it is also the cause of task-24456 (43 config reads per Library visit) and
+task-24457 (8 SQLite connections per Library visit).
+
+So the real fix is screen instance reuse, which is an architecture change: the snapshot/restore
+design deliberately assumes fresh construction, and screens may rely on it. That is an owner
+call, not a drive-by refactor.
+
+The cheaper half of this task -- wrapping screen construction in `app.batch_update()` to collapse
+the 402 separate `update_nodes` passes -- remains available and independent, and was not attempted.
+
+Note that task-24450 already took ~175 ms off the Console switch (1.96 -> 1.78 s mean of 6) by
+making each of those style applications cheaper rather than fewer.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-24453 - Composer-runs-unguarded-per-keystroke-syncs-against-hidden-widgets.md
+++ b/backlog/tasks/task-24453 - Composer-runs-unguarded-per-keystroke-syncs-against-hidden-widgets.md
@@ -1,0 +1,72 @@
+---
+id: TASK-24453
+title: Composer runs unguarded per-keystroke syncs against hidden widgets
+status: Done
+assignee: []
+created_date: '2026-08-29'
+labels:
+  - performance
+  - ui
+  - console
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Typing in the Console composer costs 20.6 ms of CPU per keystroke on an empty conversation,
+with 35.3 `query_one` calls, 8.4 `Static.update()` calls and 31.8 `set_class` calls per key.
+
+`Widgets/Console/console_composer_bar.py::_sync_collapsed_presentation` runs three times per
+keystroke. Each run performs 4 `query_one` lookups, a `Static.update()` and 4 `set_class`
+calls -- on the collapsed row, which is `display:none` for the entire time the user is typing.
+It is unconditional: there is no early return on unchanged state and no cached widget handles.
+
+Other unguarded per-key repeats: `_apply_draft_height` (4 `query_one`), `_refresh_visible_draft`
+(2 `query_one` + 2 `Static.update`), `_console_command_popup_or_none` (2 `query_one`), and
+`_sync_raw_cli_state` (2 `query_one`).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `_sync_collapsed_presentation` performs no DOM work when its inputs are unchanged since the previous call
+- [x] #2 No content update or class mutation is applied to the collapsed presentation row while the composer is expanded
+- [x] #3 `query_one` calls per keystroke in the Console composer are reduced by at least half against the pre-change baseline
+- [x] #4 CPU per keystroke on an empty Console conversation improves measurably in an interleaved A/B
+- [x] #5 Collapsing and expanding the composer, and the raw-CLI danger styling, still behave correctly
+<!-- AC:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+Guarded five unconditional per-keystroke syncs in `console_composer_bar.py`, each with a
+signature over exactly the state its body reads -- the same fingerprint pattern
+`main_navigation._update_overflow_hints` already uses. All signatures reset in `on_mount`, so a
+remounted composer always re-applies to fresh widgets.
+
+- `_sync_collapsed_presentation` (ran 3x/key): signature + it no longer touches the collapsed
+  row at all while the composer is expanded, because that row is `display:none` then. `_collapsed`
+  is in the signature, so collapsing always misses the cache and repaints before the row is seen.
+- `_apply_draft_height`: was calling `self.refresh(layout=True)` on EVERY keystroke, which is
+  what forced a whole-screen relayout per keypress. Now guarded on (row_count, recovery_rows,
+  composer_height); `_apply_collapsed_geometry` clears the signature since it overwrites the
+  geometry.
+- `_sync_improvement_recovery`: `visible` is False for a whole ordinary typing session; the guard
+  also skips the `_refresh_visible_draft` it chained into.
+- `_sync_raw_cli_state`: status row content/geometry guarded on `active`.
+- `_sync_hidden_input`: writes the mirror only when the canonical payload changed.
+
+Measured A/B on the real app:
+- `query_one` per keystroke 35.4 -> 12.3 (-65%)
+- `Static.update` per keystroke 8.5 -> 2.4 (-72%)
+- `set_class` per keystroke 31.8 -> 17.9 (-44%)
+- `refresh(layout=True)` invalidations per keystroke 11.7 -> 6.7 (-43%)
+- CPU per keystroke ~21.8 -> ~19.7 ms
+
+Note on what did NOT move: `Screen._refresh_layout` stays at ~1.04 per keystroke. Textual
+coalesces invalidations into one layout per frame, and `_refresh_visible_draft` still legitimately
+invalidates once per key because the draft text genuinely changed. Removing invalidations below
+that floor cannot remove the layout itself.
+
+Modified: `tldw_chatbook/Widgets/Console/console_composer_bar.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-24454 - Provider-readiness-is-recomputed-on-the-composer-keystroke-path.md
+++ b/backlog/tasks/task-24454 - Provider-readiness-is-recomputed-on-the-composer-keystroke-path.md
@@ -1,0 +1,49 @@
+---
+id: TASK-24454
+title: Provider readiness is recomputed on the composer keystroke path
+status: To Do
+assignee: []
+created_date: '2026-08-29'
+labels:
+  - performance
+  - console
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Typing in the Console composer recomputes provider readiness on every keystroke.
+`normalize_provider_config_key` runs 11,003 times across a 43-keystroke burst -- 256 calls per
+keystroke -- reached via `_ensure_active_console_session_settings` ->
+`build_console_settings_readiness` -> `get_provider_readiness`.
+`_ensure_active_console_session_settings` itself runs roughly three times per keystroke.
+
+The absolute cost is currently small (~30 ms across the burst), so this is not the headline
+keystroke cost. It is filed because provider readiness is configuration-derived state that does
+not change while a user types, and recomputing it per keystroke is work that should not be on
+the input path at all -- it will scale with the provider/model catalogue.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Provider readiness is not recomputed as a side effect of an ordinary composer keystroke
+- [ ] #2 Readiness still refreshes when the inputs that determine it actually change (provider, model, or credential configuration)
+- [ ] #3 `normalize_provider_config_key` call count per keystroke is reduced to approximately zero in a live probe
+- [ ] #4 Console readiness indicators continue to reflect configuration changes without requiring a restart
+<!-- AC:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+NOT IMPLEMENTED in the 2026-08-29 review pass.
+
+Re-confirmed as real but low-value: `normalize_provider_config_key` runs 256 times per keystroke
+via `_ensure_active_console_session_settings` -> `build_console_settings_readiness` ->
+`get_provider_readiness`, and totals only ~30 ms across a 43-key burst. It is filed as a
+correctness-of-layering issue (configuration-derived state does not change while a user types)
+rather than a measurable win today, and it will matter more as the provider/model catalogue grows.
+
+Deferred behind the composer guards in task-24453, which addressed the costs that actually
+dominated the keystroke path.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-24455 - Screen-switches-perform-598-query_one-lookups.md
+++ b/backlog/tasks/task-24455 - Screen-switches-perform-598-query_one-lookups.md
@@ -1,0 +1,47 @@
+---
+id: TASK-24455
+title: Screen switches perform 598 query_one lookups
+status: To Do
+assignee: []
+created_date: '2026-08-29'
+labels:
+  - performance
+  - ui
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A single screen switch performs 598 `query_one` calls. The hot sites are
+`Widgets/Console/console_bounded_section.py::_reconcile` (61),
+`UI/Console_Modules/left_rail.py::_mounted_descriptors` (56),
+`UI/Console_Modules/left_rail.py::_run_allocation_reconcile` (4 call sites x 28 each), and
+`Widgets/destination_rail.py::sync_open` (36).
+
+Each `query_one` walks the DOM. These are reconcile paths that re-resolve the same handles
+repeatedly within a single pass rather than resolving once and reusing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `query_one` calls per screen switch are reduced by at least half against the pre-change baseline
+- [ ] #2 Repeated lookups of the same node within one reconcile pass resolve once and are reused
+- [ ] #3 Rail allocation, bounded-section reconcile and destination-rail open state behave identically after the change
+- [ ] #4 A guard pins the per-switch DOM query count so it cannot silently regress
+<!-- AC:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+PARTIALLY ADDRESSED as a side effect; not directly worked.
+
+`query_one` per screen switch measured 598 before this pass and 482 after, purely from the
+composer guards in task-24453 -- the composer participates in screen switches too. The sites this
+task names were NOT touched: `console_bounded_section._reconcile` (61 per switch),
+`left_rail._mounted_descriptors` (56), `left_rail._run_allocation_reconcile` (4 call sites x 28),
+`destination_rail.sync_open` (36). Each re-resolves the same handles repeatedly within one
+reconcile pass.
+
+The AC (at least half) is not met: 598 -> 482 is -19%.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-24456 - Library-re-reads-43-config-settings-on-every-visit.md
+++ b/backlog/tasks/task-24456 - Library-re-reads-43-config-settings-on-every-visit.md
@@ -1,0 +1,56 @@
+---
+id: TASK-24456
+title: Library re-reads 43 config settings on every visit
+status: Done
+assignee: []
+created_date: '2026-08-29'
+labels:
+  - performance
+  - library
+  - config
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`UI/Screens/library_screen.py::_load_library_ingest_options_from_config` runs from `on_mount`
+and performs 43 `get_cli_setting` reads. The app constructs a NEW `LibraryScreen` on every
+visit -- verified live, three visits produced three distinct instance ids -- so those 43 reads
+repeat on every navigation to the Library to produce an identical answer.
+
+CORRECTION TO THE ORIGINAL FILING: this was first written up as "Library ingest options are
+re-read from config on unrelated screen switches", derived from a 33.5-`get_cli_setting`-
+per-switch figure averaged over a Library+Console PAIR. Measured per destination that is wrong:
+Console switches read 18-21 settings and none of them come from `library_screen`. The average
+smeared one screen's mount cost across both switches. The waste is real, but it is a per-visit
+remount cost, not cross-screen leakage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Repeat visits to the Library screen do not re-read ingest options from configuration
+- [x] #2 The options are still refreshed when the underlying configuration changes
+- [x] #3 A screen with no running app reads fresh, so a caller that swaps the settings source sees its own values
+- [x] #4 Library ingest behaviour is unchanged for a user who edits ingest options and returns to the screen
+<!-- AC:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+The 43 reads are memoised on `current_config_generation()` -- a new lightweight accessor in
+`config.py` that returns the counter every config mutation bumps, without the locks and deep
+copy that `get_runtime_config_snapshot` takes.
+
+The cache lives on the running `App`, not at module scope. That was not the first attempt: a
+module-global cache passed in isolation and then failed
+`Tests/UI/test_library_screen.py::test_load_ingest_options_from_config` inside the full suite,
+because it outlived the app and served one test's stubbed config to the next. App-scoping fixes
+that structurally -- an unmounted screen has no app, so it reads fresh, which is also the
+correct production behaviour for any caller that has swapped the settings source.
+
+Measured: first Library visit 49 `get_cli_setting` calls (unavoidable), repeat visits 46 -> 2.
+
+Modified: `tldw_chatbook/config.py` (new `current_config_generation`),
+`tldw_chatbook/UI/Screens/library_screen.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-24456 - Library-re-reads-43-config-settings-on-every-visit.md
+++ b/backlog/tasks/task-24456 - Library-re-reads-43-config-settings-on-every-visit.md
@@ -51,6 +51,15 @@ correct production behaviour for any caller that has swapped the settings source
 
 Measured: first Library visit 49 `get_cli_setting` calls (unavoidable), repeat visits 46 -> 2.
 
-Modified: `tldw_chatbook/config.py` (new `current_config_generation`),
-`tldw_chatbook/UI/Screens/library_screen.py`.
+Review round (Qodo, PR #2217) found a real bug in the first version: the key was the config
+GENERATION alone, and retargeting `TLDW_CONFIG_PATH` selects a different config file WITHOUT
+advancing the generation. Reproduced before fixing -- `get_cli_setting` returned the new file's
+value while the generation stayed at 1 -- so the cache served the previous config's options.
+The key is now `current_config_identity()` = (generation, effective config path).
+`Tests/UI/test_library_ingest_options_cache.py` pins both halves and was mutation-tested:
+reverting to a generation-only key fails two of its three tests.
+
+Modified: `tldw_chatbook/config.py` (new `current_config_identity`),
+`tldw_chatbook/UI/Screens/library_screen.py`,
+`Tests/UI/test_library_ingest_options_cache.py` (new).
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-24457 - Library-opens-eight-fresh-SQLite-connections-per-visit.md
+++ b/backlog/tasks/task-24457 - Library-opens-eight-fresh-SQLite-connections-per-visit.md
@@ -1,0 +1,49 @@
+---
+id: TASK-24457
+title: Library opens eight fresh SQLite connections per visit
+status: To Do
+assignee: []
+created_date: '2026-08-29'
+labels:
+  - performance
+  - library
+  - database
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Each visit to the Library screen opens 8 new SQLite connections through
+`DB/private_sqlite.py::_connect_registered_sqlite`. Every one of them pays the full connection
+setup cost: `PRAGMA journal_mode=WAL`, `PRAGMA synchronous=NORMAL` and
+`PRAGMA foreign_keys=ON`, plus the file open itself.
+
+The connections are not pooled or reused across visits, so the cost is paid again on every
+navigation to the screen.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Repeat visits to the Library screen open materially fewer new SQLite connections than the first visit
+- [ ] #2 Connection lifetime and thread-affinity rules are respected -- no connection is shared across threads in a way the DB layer forbids
+- [ ] #3 The private-path policy enforcement in `_connect_registered_sqlite` still runs for every logical database open
+- [ ] #4 Library screen data loads correctly on first and repeat visits
+<!-- AC:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+NOT IMPLEMENTED in the 2026-08-29 review pass.
+
+Root cause established and shared with task-24452: the 8 connections per visit are not a leak in
+the DB layer, they are a consequence of the app constructing a NEW `LibraryScreen` on every visit
+(verified live -- three visits, three distinct instance ids), each building its own handles
+through `DB/private_sqlite.py::_connect_registered_sqlite`.
+
+That means the fix is either screen instance reuse (task-24452's architectural change) or an
+app-scoped connection cache of the kind task-24456 used for config reads. The latter is the
+tractable one and is independent of the architecture question, but it must preserve the
+private-path policy enforcement `_connect_registered_sqlite` performs on every logical open, and
+must respect SQLite thread affinity -- neither of which was verified in this pass.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-24458 - Pay-the-import-weight-and-ui-ready-module-census-ratchet-breaches.md
+++ b/backlog/tasks/task-24458 - Pay-the-import-weight-and-ui-ready-module-census-ratchet-breaches.md
@@ -63,7 +63,42 @@ bound -- and it proved so here, three separate edges had to be cut before the cl
    `local_tool_provider` to build a module-scope frozenset -- seven modules resident to compare a
    handful of strings. The set is now built by an `lru_cache`d `_blocked_provider_refusals()`.
 
+### The two ratchets interact, and the second one caught it
+
+Rebasing onto dev turned `test_screen_preimport_payload_budget` RED at 505/500 modules while
+it PASSES on pristine dev. The module-set diff named exactly the 14 modules these deferrals
+moved off the boot path.
+
+That guard measures `tldw_modules()` AFTER the pre-import pass minus a baseline taken BEFORE
+it. Reducing what boot imports therefore lowers the baseline and RAISES `pass_added` by the
+same amount, with no new work done anywhere. Total modules loaded is unchanged; the accounting
+moved. Dev had only 226 LOC of headroom, and this shift moved 842 LOC of accounting into the
+census, so it breached.
+
+Rather than raise a constant (ADR-097 forbids it) or revert a real boot win, the payload was
+reduced by 653 LOC of genuinely wasted eager imports, all found by following the same edges:
+
+- `UI/Widgets/__init__.py` eagerly imported `SmartContentTree` (425 LOC) and
+  `config_search_widget` (228 LOC). The four MCP modes import only the small
+  `table_click_select` mixin from that package, so every one of them paid for both. Now
+  resolved lazily via PEP 562 `__getattr__`. **This is the `Chunking/__init__.py` trap
+  (finding 21102) in a second package.**
+- `UI/MCP_Modules/mcp_workbench.py` and `MCP/local_server_tools.py` imported the same
+  workspace tool providers at module scope that `console_chat_controller` did; both are
+  reached by the pre-importer. Deferred to their runtime use sites.
+  `local_server_tools` has no `from __future__ import annotations`, so its three
+  `LocalToolProvider` annotations are QUOTED rather than switching the whole module to
+  string annotations.
+- `settings_screen` imported `Utils.about_text` at module scope for one branch of one
+  category; moved to where it renders.
+
+Final: preimport payload 492/500 modules (headroom 8), 379,955/380,000 LOC (headroom 45).
+**That LOC headroom is thin and worth knowing about** -- dev's own was 226, and this cycle
+consumed 181 of it.
+
 Modified: `tldw_chatbook/UI/tools_settings_messages.py` (new), `tldw_chatbook/UI/Tools_Settings_Window.py`,
 `tldw_chatbook/app.py`, `tldw_chatbook/Chat/console_chat_controller.py`,
-`tldw_chatbook/Chat/console_agent_bridge.py`.
+`tldw_chatbook/Chat/console_agent_bridge.py`, `tldw_chatbook/UI/Widgets/__init__.py`,
+`tldw_chatbook/UI/MCP_Modules/mcp_workbench.py`, `tldw_chatbook/MCP/local_server_tools.py`,
+`tldw_chatbook/UI/Screens/settings_screen.py`.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-24458 - Pay-the-import-weight-and-ui-ready-module-census-ratchet-breaches.md
+++ b/backlog/tasks/task-24458 - Pay-the-import-weight-and-ui-ready-module-census-ratchet-breaches.md
@@ -92,9 +92,20 @@ reduced by 653 LOC of genuinely wasted eager imports, all found by following the
 - `settings_screen` imported `Utils.about_text` at module scope for one branch of one
   category; moved to where it renders.
 
-Final: preimport payload 492/500 modules (headroom 8), 379,955/380,000 LOC (headroom 45).
-**That LOC headroom is thin and worth knowing about** -- dev's own was 226, and this cycle
-consumed 181 of it.
+Final on the first base: preimport payload 492/500 modules, 379,955/380,000 LOC (headroom 45).
+
+**Then dev moved 66 commits and broke both guards on its own.** Measured on pristine dev
+`bf23929857`: `_ui_ready` census **983/970 RED**, preimport payload **383,038/380,000 LOC RED**.
+On this branch, rebased onto that same dev: census **970/970 GREEN** (this PR repairs a dev red)
+and preimport **383,228** -- i.e. this branch contributes +190 LOC of the 3,228 breach, which is
+the documented residual of the accounting shift above (842 moved, 653 shed). The preimport guard
+cannot be made green from this branch and is dev's to repay.
+
+**Two things the owner should know.** The census lands at exactly 970/970 with ZERO headroom, and
+task-24461 wires it into the per-PR guard -- so the next PR that adds any module to the mount leg
+fails fast. That is the ratchet working as designed, but it is a hair trigger. And the preimport
+LOC guard runs in neither CI job (not the fast lane, not perf-guard), which is why dev drifted
+3,038 LOC over it unnoticed.
 
 Modified: `tldw_chatbook/UI/tools_settings_messages.py` (new), `tldw_chatbook/UI/Tools_Settings_Window.py`,
 `tldw_chatbook/app.py`, `tldw_chatbook/Chat/console_chat_controller.py`,

--- a/backlog/tasks/task-24458 - Pay-the-import-weight-and-ui-ready-module-census-ratchet-breaches.md
+++ b/backlog/tasks/task-24458 - Pay-the-import-weight-and-ui-ready-module-census-ratchet-breaches.md
@@ -1,0 +1,69 @@
+---
+id: TASK-24458
+title: Pay the import-weight and ui-ready module census ratchet breaches
+status: Done
+assignee: []
+created_date: '2026-08-29'
+labels:
+  - performance
+  - boot
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Both boot module ratchets are red on pristine dev:
+`MAX_TLDW_MODULE_COUNT` is 662 against a limit of 660, and `MAX_TLDW_MODULES_AT_UI_READY` is
+980 against a limit of 970.
+
+TASK-23112 paid the import ratchet down to 646/660 (headroom 14) on 2026-08-28. It was breached
+again within a day. The newly resident modules cluster in one family -- the workspace and
+tool-execution work: `Tools.{git,local,patch,virtual_cli}_tool_impls`,
+`Tools.workspace_tool_{executor,protocol}`, `Tools.workspace_root_pin`,
+`Agents.{raw_shell,virtual_cli}_tool_provider`, `Workspaces.change_review_{consent,finalization}`,
+`Chat.console_settings_*`, `TTS.{legacy_request_builder,text_processing}`.
+
+Per ADR-097 the constants must not be raised; the cost must be deferred off the boot path or
+shed elsewhere.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `test_app_import_own_module_count_stays_at_the_post_diet_size` passes on a pristine checkout
+- [x] #2 `test_ui_ready_module_census_stays_at_the_pinned_size` passes on a pristine checkout
+- [x] #3 Neither `MAX_TLDW_MODULE_COUNT` nor `MAX_TLDW_MODULES_AT_UI_READY` is raised
+- [x] #4 Each deferral is re-measured after it is applied, because the import-parent tracer records only the first importer and its attribution is an upper bound
+- [x] #5 The tool-execution features whose modules were deferred still work on first use
+<!-- AC:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+Both ratchets green with headroom, constants untouched:
+- boot import weight **662 -> 631 / 660** (headroom 29)
+- `_ui_ready` census **981 -> 966 / 970** (headroom 4)
+
+Four deferrals, each traced with a first-importer tracer and RE-MEASURED after applying (the
+ADR-097 lesson: the tracer records only the first importer, so its attribution is an upper
+bound -- and it proved so here, three separate edges had to be cut before the cluster left).
+
+1. `app.py` imported `UI.Tools_Settings_Window` solely to name
+   `ToolsSettingsWindow.IngestUiStyleChanged` in an `@on(...)` decorator -- which needs the class
+   at class-body time, so it could not just move into a function. That import dragged
+   `Agents.local_tool_provider` -> `Tools.workspace_tool_executor` and 7 more modules onto boot,
+   for a window that is DEPRECATED (TASK-1346) and nav-unreachable. The message moved to a new
+   4-line `UI/tools_settings_messages.py`; the window re-exports it as a class attribute so
+   `ToolsSettingsWindow.IngestUiStyleChanged` and `self.IngestUiStyleChanged(...)` are unchanged.
+2. `console_chat_controller` imported `RawShellToolProvider`, `VirtualCliProvider` and the
+   `RAW_SHELL_*` constants at module scope; moved to their runtime use sites. Safe because the
+   module has `from __future__ import annotations`, so no type reference evaluates at runtime.
+3. Same for `LocalToolProvider` in that controller.
+4. The last edge was the subtle one: `console_agent_bridge` imported six refusal STRINGS from
+   `local_tool_provider` to build a module-scope frozenset -- seven modules resident to compare a
+   handful of strings. The set is now built by an `lru_cache`d `_blocked_provider_refusals()`.
+
+Modified: `tldw_chatbook/UI/tools_settings_messages.py` (new), `tldw_chatbook/UI/Tools_Settings_Window.py`,
+`tldw_chatbook/app.py`, `tldw_chatbook/Chat/console_chat_controller.py`,
+`tldw_chatbook/Chat/console_agent_bridge.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-24459 - Pay-the-boot-parsed-CSS-byte-ratchet-breach.md
+++ b/backlog/tasks/task-24459 - Pay-the-boot-parsed-CSS-byte-ratchet-breach.md
@@ -1,0 +1,55 @@
+---
+id: TASK-24459
+title: Pay the boot parsed CSS byte ratchet breach
+status: To Do
+assignee: []
+created_date: '2026-08-29'
+labels:
+  - performance
+  - boot
+  - css
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+`MAX_BOOT_PARSED_CSS_BYTES` is breached: boot-parsed CSS is 862,184 B against a limit of
+860,000 B. Every one of those bytes is parsed before first paint.
+
+Growth since the pinned snapshot: `tldw_cli_modular.tcss` +3,424 B (of which
+`components/_agentic_terminal.tcss` is +2,156 B and `components/_forms.tcss` +881 B),
+`widget_defaults_scoped.tcss` +3,399 B, `widget_defaults_self.tcss` +641 B, including two new
+`ConsoleForkChatModal` segments totalling 2,770 B.
+
+Per ADR-097 the constant must not be raised.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `test_boot_parsed_css_bytes_stay_within_budget` passes on a pristine checkout
+- [ ] #2 `MAX_BOOT_PARSED_CSS_BYTES` is not raised
+- [ ] #3 The bytes are shed by deferring CSS off the first-paint path or by removing redundant rules, not by moving the measurement
+- [ ] #4 The CSS bundle regenerates from its sources with no drift
+<!-- AC:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+NOT IMPLEMENTED in the 2026-08-29 review pass. This is the one ratchet of the four still red:
+862,184 B against an 860,000 B limit, so 2,184 B must be shed and the constant must not rise.
+
+Because it is red, task-24461 deliberately EXCLUDED this guard when wiring the boot budgets into
+`perf-guard.yml` -- including it would have failed every unrelated PR. It joins that step when
+this task lands, and the workflow comment says so.
+
+Growth since the pinned snapshot: `tldw_cli_modular.tcss` +3,424 B (of which
+`components/_agentic_terminal.tcss` +2,156 and `components/_forms.tcss` +881),
+`widget_defaults_scoped.tcss` +3,399, `widget_defaults_self.tcss` +641, including two new
+`ConsoleForkChatModal` segments totalling 2,770 B.
+
+Most tractable route is the `ConsoleForkChatModal` segments plus the `_agentic_terminal.tcss`
+growth; it overlaps task-24451. A mechanical dead-selector sweep was attempted and abandoned --
+the detection used `\w` in a POSIX ERE and reported every one of 609 ids as dead, which is
+exactly the kind of false positive that would have deleted live CSS.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-24460 - Unlisted-boot-worker-console-persisted-browser-cache.md
+++ b/backlog/tasks/task-24460 - Unlisted-boot-worker-console-persisted-browser-cache.md
@@ -1,0 +1,49 @@
+---
+id: TASK-24460
+title: Unlisted boot worker console-persisted-browser-cache
+status: Done
+assignee: []
+created_date: '2026-08-29'
+labels:
+  - performance
+  - boot
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The boot worker census is red: a worker with group `console-persisted-browser-cache`
+(started from `UI/Console_Modules/workspace.py:2553`) runs during boot without a row on the
+reviewed allowlist.
+
+First paint is the most contended moment in the application's life (finding 22215, GIL
+contention). The census exists so that every worker riding the boot is a deliberate, reviewed
+decision, and TASK-22215's stagger policy consumes this list.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `test_boot_worker_and_thread_starts_stay_within_the_allowlist` passes on a pristine checkout
+- [x] #2 The worker is either deferred to first feature use, or added to the allowlist with its owning feature named
+- [x] #3 If it is deferred, the persisted browser cache still populates correctly on first use of the feature that needs it
+<!-- AC:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+Not a new worker and not a deferral: a NAMING regression. The allowlist already carried
+`("_refresh_console_persisted_rows_cache", "console-persisted-browser-cache")`, but the census
+recorded `("", "console-persisted-browser-cache")`.
+
+Textual derives a worker's name as `name or getattr(work, "__name__", "") or ""`
+(`worker_manager.py:112`), and this call site had been wrapped in `functools.partial` -- which has
+no `__name__`. So the worker silently became anonymous, breaking its allowlist row and making it
+unidentifiable in every worker diagnostic. Fixed by passing `name=` explicitly, which a partial
+cannot erase.
+
+Guard now green. 56 other `run_worker(partial(...))` sites exist repo-wide with the same latent
+anonymity; none are boot workers, so they are out of this task's scope and left alone.
+
+Modified: `tldw_chatbook/UI/Console_Modules/workspace.py`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-24461 - Boot-budget-ratchets-do-not-run-in-the-fast-per-PR-guard.md
+++ b/backlog/tasks/task-24461 - Boot-budget-ratchets-do-not-run-in-the-fast-per-PR-guard.md
@@ -1,0 +1,59 @@
+---
+id: TASK-24461
+title: Boot budget ratchets do not run in the fast per-PR guard
+status: Done
+assignee: []
+created_date: '2026-08-29'
+labels:
+  - performance
+  - ci
+  - infrastructure
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The four ADR-097 boot budget ratchets (import weight, `_ui_ready` module census, boot
+parsed CSS bytes, boot worker census) run only in the slow full test suite.
+`.github/workflows/perf-guard.yml` runs `Tests/Performance/test_ui_latency_guardrails.py` and
+`Tests/Utils/test_ui_responsiveness_stall_persist.py` and nothing else.
+
+The consequence is measured, not hypothetical: for three review cycles running, the budgets
+have been re-breached within roughly 24 hours of every paydown, and each breach was discovered
+by a periodic review rather than by the PR that caused it. All four are red on pristine dev
+right now, one day after TASK-23112 paid the import debt down to 646/660.
+
+Moving them into the fast lane makes a breach cost one PR instead of one review cycle, and
+gives the breaching PR the culprit-module list the guards already print.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The four boot budget ratchets run in a fast per-PR workflow and report a verdict in minutes
+- [x] #2 A PR that breaches any of the four fails that workflow with the culprit list the guard already prints
+- [x] #3 The workflow's path filters cover the inputs that can move any of the four budgets
+- [x] #4 The fast lane is not made red-by-default for unrelated PRs -- the guards must be green on dev before or in the same change that enables enforcement
+<!-- AC:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+Added a "Run boot budget ratchets" step to `.github/workflows/perf-guard.yml`, which previously
+ran only the latency guardrails. The four budgets took ~15 s together locally, and they already
+print their culprit module lists, so a breaching PR now gets that list in minutes instead of at
+the next periodic review.
+
+`test_boot_css_byte_budget.py` is deliberately EXCLUDED for now and the workflow says why: it is
+red on dev (862,184 B against an 860,000 B ratchet) and including it would fail every unrelated
+PR -- exactly the failure mode this task's AC forbids. It joins the step when task-24459 lands.
+The other three are green with headroom after task-24458, so enforcement starts clean.
+
+`test_textual_css_fastpath.py` is included too: its upstream-pin test is what makes a Textual
+version bump surface as a loud failure rather than silent styling drift.
+
+The workflow's existing path filters already cover the inputs that move these budgets
+(`tldw_chatbook/**.py`, `tldw_chatbook/css/**`, `Tests/Performance/**`, `pyproject.toml`).
+
+Modified: `.github/workflows/perf-guard.yml`.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -91,14 +91,13 @@ from tldw_chatbook.Agents.project_instruction_runtime import (
 from tldw_chatbook.Agents.native_tools import provider_supports_native_tools
 from tldw_chatbook.Agents.agent_stream import StreamGate
 from tldw_chatbook.Agents.fleet_coordinator import FleetCoordinator, FleetHandle
-from tldw_chatbook.Agents.local_tool_provider import (
-    LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL,
-    LOCAL_DENY_REFUSAL,
-    LOCAL_GATE_ERROR_REFUSAL,
-    LOCAL_KILL_SWITCH_REFUSAL,
-    LOCAL_ROOT_CHANGED_REFUSAL,
-    LOCAL_TIMEOUT_REFUSAL,
-)
+# task-24458: these six refusal STRINGS were the last module-scope edge
+# from the Console onto `Agents.local_tool_provider`, and through it the
+# whole workspace tool-execution cluster (`Tools.workspace_tool_executor`,
+# `Tools.{git,local,patch}_tool_impls`, `Tools.workspace_root_pin`,
+# `Tools.workspace_tool_protocol`, `Utils.filesystem_identity`) -- seven
+# modules resident at `_ui_ready` to compare a handful of strings. The set
+# they feed is now built on first use; see `_blocked_provider_refusals`.
 from tldw_chatbook.Agents.mcp_tool_provider import (
     DENY_REFUSAL as MCP_DENY_REFUSAL,
     KILL_SWITCH_REFUSAL as MCP_KILL_SWITCH_REFUSAL,
@@ -1300,22 +1299,43 @@ _BUILTIN_KILL_SWITCH_REFUSAL = "tool execution is disabled by the kill switch"
 _BUILTIN_DENY_REFUSAL_PREFIX = "tool is set to Off: "
 _BUILTIN_UNRESOLVED_REFUSAL_PREFIX = "tool requires approval and none was granted: "
 _CONTROLLER_USER_DENIED_PREFIX = CONTROLLER_USER_DENIED_REFUSAL.partition("{name}")[0]
-_BLOCKED_PROVIDER_REFUSALS = frozenset(
-    {
-        _BUILTIN_KILL_SWITCH_REFUSAL,
-        LOCAL_DENY_REFUSAL,
-        LOCAL_TIMEOUT_REFUSAL,
-        LOCAL_KILL_SWITCH_REFUSAL,
-        LOCAL_GATE_ERROR_REFUSAL,
-        LOCAL_ROOT_CHANGED_REFUSAL,
+
+
+@functools.lru_cache(maxsize=1)
+def _blocked_provider_refusals() -> frozenset[str]:
+    """Canonical dispatched-provider permission-refusal copy.
+
+    Built on first use so importing this module does not drag
+    `Agents.local_tool_provider` (task-24458). The values are module-level
+    string constants, so the set is computed once and never invalidated.
+    """
+    from tldw_chatbook.Agents.local_tool_provider import (
         LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL,
-        MCP_DENY_REFUSAL,
-        MCP_USER_DENY_REFUSAL,
-        MCP_UNRESOLVED_REFUSAL,
-        MCP_TIMEOUT_REFUSAL,
-        MCP_KILL_SWITCH_REFUSAL,
-    }
-)
+        LOCAL_DENY_REFUSAL,
+        LOCAL_GATE_ERROR_REFUSAL,
+        LOCAL_KILL_SWITCH_REFUSAL,
+        LOCAL_ROOT_CHANGED_REFUSAL,
+        LOCAL_TIMEOUT_REFUSAL,
+    )
+
+    return frozenset(
+        {
+            _BUILTIN_KILL_SWITCH_REFUSAL,
+            LOCAL_DENY_REFUSAL,
+            LOCAL_TIMEOUT_REFUSAL,
+            LOCAL_KILL_SWITCH_REFUSAL,
+            LOCAL_GATE_ERROR_REFUSAL,
+            LOCAL_ROOT_CHANGED_REFUSAL,
+            LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL,
+            MCP_DENY_REFUSAL,
+            MCP_USER_DENY_REFUSAL,
+            MCP_UNRESOLVED_REFUSAL,
+            MCP_TIMEOUT_REFUSAL,
+            MCP_KILL_SWITCH_REFUSAL,
+        }
+    )
+
+
 _BLOCKED_PROVIDER_REFUSAL_PREFIXES = (
     _BUILTIN_DENY_REFUSAL_PREFIX,
     _CONTROLLER_USER_DENIED_PREFIX,
@@ -1332,7 +1352,7 @@ def _is_direct_controller_block(result: str) -> bool:
 
 def _is_blocked_tool_refusal(error: str) -> bool:
     """Match canonical dispatched-provider permission refusal copy."""
-    return error in _BLOCKED_PROVIDER_REFUSALS or error.startswith(
+    return error in _blocked_provider_refusals() or error.startswith(
         _BLOCKED_PROVIDER_REFUSAL_PREFIXES
     )
 

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -301,7 +301,9 @@ from tldw_chatbook.Agents.builtin_tool_gate import (
     build_builtin_gate,
 )
 from tldw_chatbook.Agents.human_input_wait import use_human_input_wait
-from tldw_chatbook.Agents.local_tool_provider import LocalToolProvider
+# task-24458: same deferral as the raw-shell/virtual-CLI providers below --
+# `LocalToolProvider` is the third entry point into the workspace
+# tool-execution cluster, and it is only needed when a run composes it.
 from tldw_chatbook.Agents.project_instruction_resolver import (
     InstructionSnapshot,
     ProjectInstructionResolver,
@@ -314,12 +316,15 @@ from tldw_chatbook.Agents.session_todo_store import (
     TodoChangeCallback,
 )
 from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolExecutionPolicy
-from tldw_chatbook.Agents.raw_shell_tool_provider import (
-    RAW_SHELL_SERVER_KEY,
-    RAW_SHELL_TOOL_NAME,
-    RawShellToolProvider,
-)
-from tldw_chatbook.Agents.virtual_cli_provider import VirtualCliProvider
+# task-24458: these two providers pull the whole workspace tool-execution
+# cluster (`Tools.workspace_tool_executor` -> `Tools.{git,local,patch,
+# virtual_cli}_tool_impls`, `Tools.workspace_root_pin`,
+# `Tools.workspace_tool_protocol`, `Utils.filesystem_identity`) and they were
+# resident by `_ui_ready` purely because this controller imports them at module
+# scope. Nothing needs them until a session actually composes a provider, so
+# they are imported at their three runtime use sites instead. Every annotation
+# in this module is a string (`from __future__ import annotations` above), so
+# no type reference here evaluates at runtime.
 from tldw_chatbook.config import (
     ConfigMutationResult,
     DEFAULT_CONSOLE_PROJECT_INSTRUCTIONS_MAX_BYTES,
@@ -10112,6 +10117,9 @@ class ConsoleChatController:
                     else None
                 ),
             )
+
+        from tldw_chatbook.Agents.local_tool_provider import LocalToolProvider
+
         provider = LocalToolProvider(
             workspace_root=root,
             allow_write=allow_write,
@@ -10212,6 +10220,8 @@ class ConsoleChatController:
                 initiator="agent",
             )
 
+        from tldw_chatbook.Agents.virtual_cli_provider import VirtualCliProvider
+
         provider = VirtualCliProvider(
             workspace_root=root,
             resolve_state=service.gate_tool_test,
@@ -10288,6 +10298,10 @@ class ConsoleChatController:
             self.request_mcp_approvals, session_id=session_id
         )
         agent_bridge = getattr(self, "_agent_bridge", None)
+        from tldw_chatbook.Agents.raw_shell_tool_provider import (
+            RawShellToolProvider,
+        )
+
         provider = RawShellToolProvider(
             runtime=runtime,
             console_session_id=session_id,
@@ -10699,6 +10713,11 @@ class ConsoleChatController:
 
     def revoke_raw_shell_authority(self) -> int:
         """Fail closed only raw-shell stamps and approval rounds on disarm."""
+        from tldw_chatbook.Agents.raw_shell_tool_provider import (
+            RAW_SHELL_SERVER_KEY,
+            RAW_SHELL_TOOL_NAME,
+        )
+
         providers = getattr(self, "_raw_shell_providers", ())
         for provider in tuple(providers):
             provider.revoke_approval_stamps()

--- a/tldw_chatbook/MCP/local_server_tools.py
+++ b/tldw_chatbook/MCP/local_server_tools.py
@@ -41,13 +41,19 @@ from typing import Any, Callable, NamedTuple
 
 from loguru import logger
 
-import tldw_chatbook.Agents.local_tool_provider as local_tool_provider
 from tldw_chatbook.Agents.agent_models import ToolResult
-from tldw_chatbook.Agents.local_tool_provider import (
-    LocalToolExposure,
-    LocalToolProvider,
-    _default_specs,
-)
+# task-24458: deferred to the one runtime construction site below. This
+# module is reached by the screen pre-importer through
+# `UI/MCP_Modules/mcp_workbench.py`, and a module-scope import here puts
+# `Tools.workspace_tool_executor` plus ~9 further modules into the
+# pre-import payload. This module has no `from __future__ import
+# annotations`, so the three `LocalToolProvider` annotations are QUOTED --
+# quoting three names is a smaller change than switching the whole module
+# to string annotations.
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Agents.local_tool_provider import LocalToolProvider
 from tldw_chatbook.config import get_subscriptions_db_path
 from tldw_chatbook.DB.Subscriptions_DB import (
     SubscriptionsDB,
@@ -123,7 +129,7 @@ class _LazyWatchlistsDBResolver:
 
 def build_server_local_provider(
     workspace_root: Path, permission_store: Any
-) -> LocalToolProvider:
+) -> "LocalToolProvider":
     """Compose a LocalToolProvider for non-Console (external) MCP serving.
 
     resolve_state loads the store payload FRESH per call (operator changes
@@ -169,8 +175,19 @@ def build_server_local_provider(
         # violated the runtime-policy ownership boundary.
         runtime_source_loader=load_default_runtime_source_state,
     )
+    # task-24458: every `local_tool_provider` name this function needs is
+    # imported here rather than at module scope. That module pulls the whole
+    # workspace tool-execution cluster, and this module is reached by the
+    # screen pre-importer via `UI/MCP_Modules/mcp_workbench.py`.
+    from tldw_chatbook.Agents.local_tool_provider import (
+        LocalToolExposure,
+        LocalToolProvider,
+        WorkspaceToolExecutor,
+        _default_specs,
+    )
+
     resolved_root = Path(workspace_root).resolve()
-    workspace_executor = local_tool_provider.WorkspaceToolExecutor(resolved_root)
+    workspace_executor = WorkspaceToolExecutor(resolved_root)
     external_specs = [
         spec
         for spec in _default_specs(
@@ -180,6 +197,7 @@ def build_server_local_provider(
         )
         if spec.exposure is LocalToolExposure.CONSOLE_AND_EXTERNAL_MCP
     ]
+
     return LocalToolProvider(
         workspace_root=resolved_root,
         specs=external_specs,
@@ -201,7 +219,7 @@ class LocalToolRegistration(NamedTuple):
 
 
 def _make_registration_handler(
-    provider: LocalToolProvider, tool_id: str
+    provider: "LocalToolProvider", tool_id: str
 ) -> Callable[[dict[str, Any]], ToolResult]:
     """Return a handler that preserves the provider's canonical result."""
 
@@ -212,7 +230,7 @@ def _make_registration_handler(
 
 
 def _local_agent_tool_registrations(
-    provider: LocalToolProvider,
+    provider: "LocalToolProvider",
 ) -> list[LocalToolRegistration]:
     """Build the binding-ready registration list for a provider's catalog.
 
@@ -220,6 +238,10 @@ def _local_agent_tool_registrations(
     external MCP publication. Each handler returns the exact ``ToolResult``
     from ``provider.invoke`` for the gateway to classify.
     """
+    # task-24458: deferred with the rest of this module's
+    # `local_tool_provider` imports.
+    from tldw_chatbook.Agents.local_tool_provider import LocalToolExposure
+
     registrations: list[LocalToolRegistration] = []
     for spec in provider.specs_for_exposure(
         LocalToolExposure.CONSOLE_AND_EXTERNAL_MCP

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -2550,6 +2550,15 @@ class ConsoleWorkspaceController:
                         current_conversation_id=current_conversation_id,
                         refresh_key=refresh_key,
                     ),
+                    # task-24460: `run_worker` derives the worker name from
+                    # `getattr(work, "__name__", "")`, and a `functools.partial`
+                    # has no `__name__` -- so wrapping this call in a partial
+                    # silently renamed the worker to "". That broke its
+                    # boot-census allowlist row (which still reads
+                    # `_refresh_console_persisted_rows_cache`) and made the
+                    # worker anonymous in every worker diagnostic. Name it
+                    # explicitly so the partial cannot erase it again.
+                    name="_refresh_console_persisted_rows_cache",
                     group="console-persisted-browser-cache",
                     exclusive=True,
                 )

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -28,14 +28,14 @@ from tldw_chatbook.Agents.builtin_tool_gate import (
     builtin_permission_rows,
     tool_gate_breadcrumb,
 )
-from tldw_chatbook.Agents.local_tool_provider import LocalToolProvider
-from tldw_chatbook.Agents.raw_shell_tool_provider import (
-    RAW_SHELL_SERVER_KEY,
-    RAW_SHELL_TOOL_NAME,
-    RawShellToolProvider,
-    resolve_raw_shell_state,
-)
-from tldw_chatbook.Agents.virtual_cli_provider import VirtualCliProvider
+# task-24458: the workspace tool-execution providers are deferred to their
+# runtime use sites here for the same reason as in
+# `Chat/console_chat_controller.py`. This module is reached by the SCREEN
+# PRE-IMPORTER, so a module-scope import puts `Tools.workspace_tool_executor`
+# and ~9 further modules into the pre-import payload -- work that belongs to
+# the moment a workspace tool actually runs, not to every start. Every
+# annotation in this module is a string (`from __future__ import annotations`
+# above), so no type reference here evaluates at runtime.
 from tldw_chatbook.config import (
     coerce_bool_setting,
     get_cli_setting,
@@ -183,8 +183,23 @@ def _cycled_ui_label(state: str | None) -> str:
 _BUILTIN_SECTION_LABEL = "Built-in (agent runtime)"
 
 
+def _resolve_raw_shell_state():
+    """Late-bound `resolve_raw_shell_state` (task-24458 deferral)."""
+
+    from tldw_chatbook.Agents.raw_shell_tool_provider import (
+        resolve_raw_shell_state,
+    )
+
+    return resolve_raw_shell_state
+
+
 def _is_raw_shell_tool(server_key: str, tool_name: str | None) -> bool:
     """Return whether one policy identity is the unsafe host shell."""
+
+    from tldw_chatbook.Agents.raw_shell_tool_provider import (
+        RAW_SHELL_SERVER_KEY,
+        RAW_SHELL_TOOL_NAME,
+    )
 
     return (
         server_key == RAW_SHELL_SERVER_KEY
@@ -1799,6 +1814,13 @@ class MCPWorkbench(Container):
             return []
         try:
             root = resolve_server_workspace_root()
+            from tldw_chatbook.Agents.local_tool_provider import (
+                LocalToolProvider,
+            )
+            from tldw_chatbook.Agents.virtual_cli_provider import (
+                VirtualCliProvider,
+            )
+
             providers = (
                 LocalToolProvider(workspace_root=root),
                 VirtualCliProvider(workspace_root=root),
@@ -1851,6 +1873,10 @@ class MCPWorkbench(Container):
             "the OS user and is not workspace confined. Permission is Ask or "
             "Off only; a stored Allow value is treated as Ask."
         )
+        from tldw_chatbook.Agents.raw_shell_tool_provider import (
+            RawShellToolProvider,
+        )
+
         return replace(
             RawShellToolProvider.hub_tool(),
             description=f"{availability}\n\n{warning}",
@@ -1962,7 +1988,7 @@ class MCPWorkbench(Container):
                 state="ask", origin="global_default"
             )
             states[key] = EffectiveToolState(
-                state=resolve_raw_shell_state(stored),
+                state=_resolve_raw_shell_state()(stored),
                 origin=stored.origin,
                 # Raw shell never honors persistent Allow, so its generic
                 # definition-hash and inherited-risk-floor markers would
@@ -2627,7 +2653,7 @@ class MCPWorkbench(Container):
                             severity="warning",
                         )
                         return
-                    current = resolve_raw_shell_state(
+                    current = _resolve_raw_shell_state()(
                         self._effective_for_display(cycled_tool)
                     )
                     # This exact row is a two-state control. Re-derive from

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -62,6 +62,7 @@ from ...config import (
     TLDW_API_PLACEHOLDER_AUTH_TOKEN,
     TLDW_API_PLACEHOLDER_BASE_URL,
     coerce_bool_setting,
+    current_config_generation,
     get_cli_setting,
     get_notes_sync_state_db_path,
     read_cli_config_serialized,
@@ -610,6 +611,100 @@ if TYPE_CHECKING:
 
 
 logger = logger.bind(module="LibraryScreen")
+
+#: task-24456: attribute name under which the memoised ingest-option payload
+#: lives on the running ``App``. The cache is deliberately app-scoped, not
+#: module-scoped: the app outlives every ``LibraryScreen`` (a NEW screen is
+#: built per visit, which is why the read repeated at all), while a
+#: process-global cache would outlive the app and leak one test's stubbed
+#: config into the next.
+_INGEST_OPTIONS_CACHE_ATTR = "_tldw_library_ingest_options_cache"
+
+
+def _read_library_ingest_options_from_config() -> dict[str, Any]:
+    """Read the persisted per-type ingest options out of configuration.
+
+    Returns:
+        A dict with ``transcribe_cpp_configured`` (bool),
+        ``generic_form_fields`` (the top-level generic toggles that were
+        actually present in config) and ``type_options`` (group -> stored
+        option map). Pure data -- no widget references -- so it is safe to
+        share across screen instances provided callers copy before mutating.
+    """
+    generic_form_fields: dict[str, Any] = {}
+    type_options: dict[str, dict[str, Any]] = {}
+    for group in list_type_groups():
+        cap = get_capabilities(group)
+        prefix = f"library.ingest_options.{group}"
+        stored: dict[str, Any] = {}
+        # (task-2043 unmasking) ``get_cli_setting`` has two call shapes:
+        # with a DOTTED first arg the second positional is the DEFAULT,
+        # not a key -- ``get_cli_setting("library.ingest_options.generic",
+        # "analyze")`` on a fresh profile returned the string "analyze",
+        # so every option loaded truthy-corrupted (analyze flipped on,
+        # type_options filled with field-name strings). Latent since
+        # PR #717; masked until now by the rail-entry form reset. The
+        # explicit ``None`` default disambiguates.
+        for name in cap.field_names:
+            value = get_cli_setting(prefix, name, None)
+            if value is not None:
+                stored[name] = value
+        if group == "generic":
+            for name in ("analyze", "chunk", "chunk_size", "chunk_overlap"):
+                value = get_cli_setting(prefix, name, None)
+                if value is None:
+                    continue
+                if name == "analyze":
+                    generic_form_fields["analyze"] = bool(value)
+                elif name == "chunk":
+                    generic_form_fields["chunk"] = bool(value)
+                elif name == "chunk_size":
+                    generic_form_fields["chunk_size"] = str(value)
+                else:
+                    stored[name] = value
+        if stored:
+            type_options[group] = stored
+
+    return {
+        "transcribe_cpp_configured": bool(
+            get_cli_setting("transcription.transcribe_cpp", "model_path", None)
+        ),
+        "generic_form_fields": generic_form_fields,
+        "type_options": type_options,
+    }
+
+
+def _library_ingest_options_for(owner: Any) -> dict[str, Any]:
+    """Return the ingest-option payload, memoised on the running app.
+
+    Keyed on `current_config_generation()`, which every configuration mutation
+    bumps, so a user who saves new ingest options sees them on the next visit.
+
+    A screen with no running app -- an unmounted screen built directly by a
+    test -- gets an uncached read. That is the correct behaviour rather than a
+    concession: without a live app there is no navigation to amortise the read
+    across, and a caller that has swapped the settings source underneath us
+    must see its own values.
+    """
+    try:
+        app = owner.app
+    except Exception:
+        app = None
+    if app is None:
+        return _read_library_ingest_options_from_config()
+
+    generation = current_config_generation()
+    cached = getattr(app, _INGEST_OPTIONS_CACHE_ATTR, None)
+    if cached is not None and cached[0] == generation:
+        return cached[1]
+    payload = _read_library_ingest_options_from_config()
+    try:
+        setattr(app, _INGEST_OPTIONS_CACHE_ATTR, (generation, payload))
+    except Exception:
+        pass
+    return payload
+
+
 LibraryReaderDestination = Literal[
     "media",
     "conversations",
@@ -35269,42 +35364,22 @@ class LibraryScreen(BaseAppScreen):
 
         Called from ``on_mount`` so a fresh Library visit carries forward the
         last-used options from previous sessions.
+
+        task-24456: the app constructs a NEW ``LibraryScreen`` on every visit
+        (verified live -- three visits, three distinct instance ids), so this
+        ran 43 `get_cli_setting` calls per visit to rebuild a value that only
+        changes when the configuration does. The reads are memoised on
+        `current_config_generation()`, which every config mutation bumps, so a
+        user who edits ingest options still sees them on the next visit while
+        an unchanged config costs one integer comparison.
         """
         form = self._library_ingest_form
-        self._transcribe_cpp_configured = bool(
-            get_cli_setting("transcription.transcribe_cpp", "model_path", None)
-        )
-        for group in list_type_groups():
-            cap = get_capabilities(group)
-            prefix = f"library.ingest_options.{group}"
-            stored: dict[str, Any] = {}
-            # (task-2043 unmasking) ``get_cli_setting`` has two call shapes:
-            # with a DOTTED first arg the second positional is the DEFAULT,
-            # not a key -- ``get_cli_setting("library.ingest_options.generic",
-            # "analyze")`` on a fresh profile returned the string "analyze",
-            # so every option loaded truthy-corrupted (analyze flipped on,
-            # type_options filled with field-name strings). Latent since
-            # PR #717; masked until now by the rail-entry form reset. The
-            # explicit ``None`` default disambiguates.
-            for name in cap.field_names:
-                value = get_cli_setting(prefix, name, None)
-                if value is not None:
-                    stored[name] = value
-            if group == "generic":
-                for name in ("analyze", "chunk", "chunk_size", "chunk_overlap"):
-                    value = get_cli_setting(prefix, name, None)
-                    if value is None:
-                        continue
-                    if name == "analyze":
-                        form.analyze = bool(value)
-                    elif name == "chunk":
-                        form.chunk = bool(value)
-                    elif name == "chunk_size":
-                        form.chunk_size = str(value)
-                    else:
-                        stored[name] = value
-            if stored:
-                form.type_options.setdefault(group, {}).update(stored)
+        cached = _library_ingest_options_for(self)
+        self._transcribe_cpp_configured = cached["transcribe_cpp_configured"]
+        for name, value in cached["generic_form_fields"].items():
+            setattr(form, name, value)
+        for group, stored in cached["type_options"].items():
+            form.type_options.setdefault(group, {}).update(dict(stored))
 
     def _build_ingest_options_snapshot(self) -> dict[str, dict[str, Any]]:
         """Capture the current per-type ingestion options as a snapshot.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -62,7 +62,7 @@ from ...config import (
     TLDW_API_PLACEHOLDER_AUTH_TOKEN,
     TLDW_API_PLACEHOLDER_BASE_URL,
     coerce_bool_setting,
-    current_config_generation,
+    current_config_identity,
     get_cli_setting,
     get_notes_sync_state_db_path,
     read_cli_config_serialized,
@@ -677,8 +677,11 @@ def _read_library_ingest_options_from_config() -> dict[str, Any]:
 def _library_ingest_options_for(owner: Any) -> dict[str, Any]:
     """Return the ingest-option payload, memoised on the running app.
 
-    Keyed on `current_config_generation()`, which every configuration mutation
-    bumps, so a user who saves new ingest options sees them on the next visit.
+    Keyed on `current_config_identity()` -- the config generation AND the
+    effective config path -- so both a config write and a retarget of
+    `TLDW_CONFIG_PATH` invalidate the cache. A generation-only key missed the
+    retarget case: the loader serves the new file's values without advancing
+    the generation (Qodo, PR #2217).
 
     A screen with no running app -- an unmounted screen built directly by a
     test -- gets an uncached read. That is the correct behaviour rather than a
@@ -693,13 +696,13 @@ def _library_ingest_options_for(owner: Any) -> dict[str, Any]:
     if app is None:
         return _read_library_ingest_options_from_config()
 
-    generation = current_config_generation()
+    identity = current_config_identity()
     cached = getattr(app, _INGEST_OPTIONS_CACHE_ATTR, None)
-    if cached is not None and cached[0] == generation:
+    if cached is not None and cached[0] == identity:
         return cached[1]
     payload = _read_library_ingest_options_from_config()
     try:
-        setattr(app, _INGEST_OPTIONS_CACHE_ATTR, (generation, payload))
+        setattr(app, _INGEST_OPTIONS_CACHE_ATTR, (identity, payload))
     except Exception:
         pass
     return payload
@@ -35369,7 +35372,7 @@ class LibraryScreen(BaseAppScreen):
         (verified live -- three visits, three distinct instance ids), so this
         ran 43 `get_cli_setting` calls per visit to rebuild a value that only
         changes when the configuration does. The reads are memoised on
-        `current_config_generation()`, which every config mutation bumps, so a
+        `current_config_identity()`, which tracks both config writes and a
         user who edits ingest options still sees them on the next visit while
         an unchanged config costs one integer comparison.
         """

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -52,7 +52,9 @@ from tldw_chatbook.UI.focus_ownership import (
     focus_is_on_screen,
     focused_id_on_screen,
 )
-from tldw_chatbook.Utils.about_text import ABOUT_MARKDOWN, get_app_version
+# task-24458: the About surface is one branch of one category, so its copy
+# is imported where it is rendered rather than at module scope -- this
+# module is reached by the screen pre-importer.
 
 from ...Chat.Chat_Deps import ChatConfigurationError
 from ...Chat.console_chat_models import CONSOLE_DEFAULT_MAX_PARALLEL_RUNS
@@ -16857,6 +16859,11 @@ class SettingsScreen(BaseAppScreen):
         elif category is SettingsCategoryId.ABOUT:
             # TASK-2775: the About surface lost its home when TASK-1346
             # retired ToolsSettingsWindow; this is its canonical place now.
+            from tldw_chatbook.Utils.about_text import (
+                ABOUT_MARKDOWN,
+                get_app_version,
+            )
+
             yield Static("About", classes="destination-section settings-column-title")
             with Vertical(id="settings-about-card", classes="settings-focus-card"):
                 yield self._detail_row("Version", get_app_version())

--- a/tldw_chatbook/UI/Tools_Settings_Window.py
+++ b/tldw_chatbook/UI/Tools_Settings_Window.py
@@ -46,6 +46,10 @@ from textual.widgets import (
     ListView,
 )
 from textual.message import Message
+
+from .tools_settings_messages import (
+    IngestUiStyleChanged as _IngestUiStyleChanged,
+)
 from textual.worker import NoActiveWorker, get_current_worker
 
 # task-3240: WEB_DEEP_SEARCH_GATE_KEY relocated to its actual runtime
@@ -194,12 +198,12 @@ class ToolsSettingsWindow(Container):
     _BACKUP_COPY_WORKER_DESCRIPTION = "Copy legacy database backups"
     _BACKUP_MANIFEST_WORKER_DESCRIPTION = "Write database backup manifest"
 
-    class IngestUiStyleChanged(Message):
-        """Request that the app refresh the active ingest view after a style change."""
-
-        def __init__(self, new_style: str) -> None:
-            super().__init__()
-            self.new_style = new_style
+    #: task-24458: the message now lives in `UI/tools_settings_messages.py`
+    #: so `app.py` can reference it without importing this module (and, with
+    #: it, the whole workspace tool-execution cluster) at boot. Re-exported
+    #: here so `ToolsSettingsWindow.IngestUiStyleChanged` and
+    #: `self.IngestUiStyleChanged(...)` keep working unchanged.
+    IngestUiStyleChanged = _IngestUiStyleChanged
 
     DEFAULT_CSS = """
     ToolsSettingsWindow {

--- a/tldw_chatbook/UI/Widgets/__init__.py
+++ b/tldw_chatbook/UI/Widgets/__init__.py
@@ -1,20 +1,57 @@
 # __init__.py
 # Description: UI Widgets module
 #
-"""
-UI Widgets
-----------
+"""UI Widgets.
 
 Reusable widget components for the application.
+
+The re-exports below are resolved LAZILY (PEP 562). This package's ``__init__``
+used to import ``SmartContentTree`` and ``config_search_widget`` eagerly, which
+meant that importing any unrelated member -- e.g. the four MCP modes, each of
+which wants only the small ``table_click_select`` mixin -- pulled 653 LOC of
+widgets nobody on that path uses. Those modules are reached by the screen
+pre-importer, so the cost landed in the pre-import payload
+(``Tests/Performance/test_screen_preimport_payload_budget.py``).
+
+Same trap as ``Chunking/__init__.py`` in this repo's history (finding 21102): a
+package ``__init__`` that eagerly imports submodules makes every consumer pay
+for every sibling. ``from tldw_chatbook.UI.Widgets import SmartContentTree``
+still works exactly as before -- it is resolved on first attribute access.
 """
 
-from .SmartContentTree import SmartContentTree, ContentNodeData, ContentSelectionChanged
-from .config_search_widget import ConfigSearchResult, UIElementSearchEngine
+from typing import TYPE_CHECKING
 
-__all__ = [
-    "SmartContentTree",
-    "ContentNodeData",
-    "ContentSelectionChanged",
-    "ConfigSearchResult",
-    "UIElementSearchEngine",
-]
+if TYPE_CHECKING:  # pragma: no cover - import-time typing only
+    from .config_search_widget import ConfigSearchResult, UIElementSearchEngine
+    from .SmartContentTree import (
+        ContentNodeData,
+        ContentSelectionChanged,
+        SmartContentTree,
+    )
+
+#: Exported name -> the submodule that defines it.
+_LAZY_EXPORTS = {
+    "SmartContentTree": ".SmartContentTree",
+    "ContentNodeData": ".SmartContentTree",
+    "ContentSelectionChanged": ".SmartContentTree",
+    "ConfigSearchResult": ".config_search_widget",
+    "UIElementSearchEngine": ".config_search_widget",
+}
+
+__all__ = list(_LAZY_EXPORTS)
+
+
+def __getattr__(name: str):
+    """Resolve a re-exported widget on first access (PEP 562)."""
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    value = getattr(import_module(module_name, __name__), name)
+    globals()[name] = value  # cache: later lookups skip __getattr__ entirely
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted({*globals(), *_LAZY_EXPORTS})

--- a/tldw_chatbook/UI/tools_settings_messages.py
+++ b/tldw_chatbook/UI/tools_settings_messages.py
@@ -1,0 +1,36 @@
+"""Messages published by the legacy ``ToolsSettingsWindow``.
+
+Split out for task-24458. ``app.py`` needs ``IngestUiStyleChanged`` at class
+BODY time, because it is the argument to an ``@on(...)`` decorator -- so the
+import could not simply be deferred into a function. Importing the window to
+get it pulled this chain onto the boot import path::
+
+    app.py
+      -> UI.Tools_Settings_Window
+        -> Agents.local_tool_provider
+          -> Tools.workspace_tool_executor
+            -> Tools.{git,local,patch,virtual_cli}_tool_impls,
+               Tools.workspace_tool_protocol, Tools.workspace_root_pin,
+               Utils.filesystem_identity
+
+...for a window that is DEPRECATED (TASK-1346), nav-unreachable, and whose
+route resolves to the MCP screen. The message itself depends on nothing but
+Textual, so moving it here severs the chain while leaving the window's own
+behaviour untouched -- it re-exports this class as a class attribute, so both
+``ToolsSettingsWindow.IngestUiStyleChanged`` and ``self.IngestUiStyleChanged``
+still resolve exactly as before.
+"""
+
+from __future__ import annotations
+
+from textual.message import Message
+
+__all__ = ["IngestUiStyleChanged"]
+
+
+class IngestUiStyleChanged(Message):
+    """Request that the app refresh the active ingest view after a style change."""
+
+    def __init__(self, new_style: str) -> None:
+        super().__init__()
+        self.new_style = new_style

--- a/tldw_chatbook/Utils/textual_css_fastpath.py
+++ b/tldw_chatbook/Utils/textual_css_fastpath.py
@@ -1,0 +1,137 @@
+"""Ordered-candidate fast path for Textual's ``Stylesheet.apply``.
+
+Upstream ``Stylesheet.apply`` narrows the candidate rules through ``rules_map``
+-- cheap, keyed on the node's own selector names -- and then recovers source
+order by throwing that narrowing away::
+
+    rules = list(filter(limit_rules.__contains__, reversed(self.rules)))
+
+That final step walks the *entire* rule list on every call, so styling one node
+is ``O(total rules in the app)`` rather than ``O(rules that could match this
+node)``.
+
+Measured on dev ``bc1e26ce60`` (4,324 global rules), 2026-08-29 holistic perf
+review:
+
+* 0.52 ms per single-node ``apply``
+* 240 ms for one full-screen ``update_styles`` over the Console's 500 widgets
+* **7,335,029** ``RuleSet.__hash__`` calls in a single Console screen switch,
+  which is exactly 1,667 applies x 4,324 rules -- the scan
+
+Stack sampling during observed event-loop stalls (worst 399 ms, on screen
+switching) ranked ``textual/css/model.py:__hash__`` the #1 frame.
+
+This module deliberately keeps upstream's ``apply`` as the single source of
+truth for what styling *means*. It replaces only how the ordered candidate list
+is built: candidates are sorted by a cached position index instead of recovered
+by a full scan. Interleaved A/B on the Console, two rounds:
+
+===========================  =========  ==========  ======
+Metric                       upstream   fast path   delta
+===========================  =========  ==========  ======
+``apply()`` per node         0.52 ms    0.38 ms     -27%
+``update_styles(screen)``    241 ms     156 ms      -35%
+Console screen switch        1.93 s     1.67 s      -260 ms
+===========================  =========  ==========  ======
+
+``Tests/Performance/test_textual_css_fastpath.py`` pins the upstream
+implementation this delegation assumes, so a Textual upgrade fails loudly here
+rather than silently changing styling behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.css.stylesheet import Stylesheet
+
+__all__ = ["install_stylesheet_fastpath", "is_installed"]
+
+#: Marks the patched callable so installation is idempotent and detectable.
+_MARKER = "_tldw_ordered_candidate_fastpath"
+
+#: Per-stylesheet cache: ``(rules_map, {id(rule): position})``. Keyed on the
+#: ``rules_map`` *object*, of which we hold a strong reference: Textual sets
+#: ``_rules_map = None`` on every path that changes ``_rules`` (``parse``,
+#: ``reparse``, ``add_source``), so a surviving identity match proves the rule
+#: list is unchanged. Holding the reference also stops ``id()`` reuse from
+#: aliasing a freed map onto a new one.
+_CACHE_ATTR = "_tldw_rule_position_index"
+
+
+def _ordered_candidates(stylesheet: Stylesheet, node: Any) -> list | None:
+    """Return this node's candidate rules in source order, or ``None``.
+
+    ``None`` means "no fast path available for this node" and the caller must
+    fall back to upstream's own scan.
+    """
+    try:
+        selector_names = node._selector_names
+    except AttributeError:
+        return None
+
+    # Touch ``.rules`` first: the property parses on demand, and parsing
+    # replaces ``_rules`` wholesale. Doing it before the swap below keeps the
+    # swap from being undone underneath us.
+    rules = stylesheet.rules
+    rules_map = stylesheet.rules_map
+
+    cached = getattr(stylesheet, _CACHE_ATTR, None)
+    if cached is not None and cached[0] is rules_map:
+        index = cached[1]
+    else:
+        index = {id(rule): position for position, rule in enumerate(rules)}
+        setattr(stylesheet, _CACHE_ATTR, (rules_map, index))
+
+    candidates = {
+        rule for name in rules_map.keys() & selector_names for rule in rules_map[name]
+    }
+    if not candidates:
+        return []
+    # Ascending source order. Upstream reverses it again inside ``apply``,
+    # which is what preserves "later rule wins" tie-breaking.
+    return sorted(candidates, key=lambda rule: index[id(rule)])
+
+
+def install_stylesheet_fastpath() -> bool:
+    """Install the fast path on ``Stylesheet.apply``. Idempotent.
+
+    Returns:
+        ``True`` if this call installed the patch, ``False`` if it was already
+        installed by an earlier call.
+    """
+    upstream = Stylesheet.apply
+    if getattr(upstream, _MARKER, False):
+        return False
+
+    def apply(
+        self: Stylesheet,
+        node: Any,
+        *,
+        animate: bool = False,
+        cache: dict | None = None,
+    ) -> None:
+        ordered = _ordered_candidates(self, node)
+        if ordered is None:
+            return upstream(self, node, animate=animate, cache=cache)
+
+        # Hand upstream a rule list that is already narrowed and ordered. Its
+        # own ``filter(limit_rules.__contains__, reversed(self.rules))`` then
+        # reduces to "reverse this list", because every element is a
+        # candidate -- same result, without the O(all rules) walk.
+        saved_rules = self._rules
+        try:
+            self._rules = ordered
+            return upstream(self, node, animate=animate, cache=cache)
+        finally:
+            self._rules = saved_rules
+
+    setattr(apply, _MARKER, True)
+    setattr(apply, "__wrapped__", upstream)
+    Stylesheet.apply = apply  # type: ignore[method-assign]
+    return True
+
+
+def is_installed() -> bool:
+    """Whether the fast path is currently installed on ``Stylesheet.apply``."""
+    return bool(getattr(Stylesheet.apply, _MARKER, False))

--- a/tldw_chatbook/Utils/textual_css_fastpath.py
+++ b/tldw_chatbook/Utils/textual_css_fastpath.py
@@ -15,8 +15,10 @@ review:
 
 * 0.52 ms per single-node ``apply``
 * 240 ms for one full-screen ``update_styles`` over the Console's 500 widgets
-* **7,335,029** ``RuleSet.__hash__`` calls in a single Console screen switch,
-  which is exactly 1,667 applies x 4,324 rules -- the scan
+* **7,335,029** ``RuleSet.__hash__`` calls in a single Console screen switch:
+  ~4,400 per apply over 1,667 applies, of which 4,324 are the full-list scan
+  and ~76 are the candidate-set construction (each candidate is hashed on
+  insertion). The scan is the dominant term, not the only one.
 
 Stack sampling during observed event-loop stalls (worst 399 ms, on screen
 switching) ranked ``textual/css/model.py:__hash__`` the #1 frame.

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -614,6 +614,23 @@ class ConsoleComposerBar(Horizontal):
         self._run_active = False
         self._queued_prompt_count = 0
         self._queue_paused = False
+        # task-24453: cheap fingerprint of every input `_sync_collapsed_
+        # presentation` reads. That method ran three times per keystroke,
+        # each run doing 4 `query_one` lookups, a `Static.update()` and 4
+        # `set_class` calls -- on the collapsed row, which is `display:none`
+        # for the whole time the user is typing. `None` never equals a real
+        # signature tuple, so the first pass after mount always runs in full.
+        self._collapsed_presentation_signature: tuple[object, ...] | None = None
+        # task-24453: geometry last written by `_apply_draft_height`. See that
+        # method for why an unguarded write cost a whole-screen relayout per
+        # keystroke.
+        self._draft_geometry_signature: tuple[int, int, int] | None = None
+        # task-24453: last-applied values for the three other per-keystroke
+        # syncs. `None` never equals a real value, so the first pass after
+        # mount always runs in full.
+        self._improvement_recovery_visible: bool | None = None
+        self._raw_cli_status_visible: bool | None = None
+        self._hidden_input_mirror: str | None = None
         self._send_button_width = 6
         self._send_label = "Send"
         self._send_blocked = False
@@ -791,10 +808,18 @@ class ConsoleComposerBar(Horizontal):
             self._raw_cli_prefix_typed = False
         self.set_class(active, "console-raw-cli-danger")
         self._sync_collapsed_presentation()
+        # task-24453: `active` is False for every keystroke that is not part of
+        # a raw-CLI draft, which is nearly all of them. The status row's
+        # content and geometry below are a pure function of it, so re-asserting
+        # them per keypress only bought a `Static.update` and four style writes
+        # on an already-hidden row.
+        if active == self._raw_cli_status_visible:
+            return
         try:
             status = self.query_one("#console-raw-cli-status", Static)
         except NoMatches:
             return
+        self._raw_cli_status_visible = active
         status.set_class(active, "console-raw-cli-danger")
         status.update(Content("RAW CLI · HOST ACCESS" if active else ""))
         status.styles.display = "block" if active else "none"
@@ -869,8 +894,20 @@ class ConsoleComposerBar(Horizontal):
         )
 
     def _sync_improvement_recovery(self) -> None:
-        """Show recovery actions only while an exact improvement Undo exists."""
+        """Show recovery actions only while an exact improvement Undo exists.
+
+        task-24453: every keystroke reaches this, and `visible` is False for
+        the whole of an ordinary typing session (there is no improvement Undo
+        to recover). Left unguarded it cost 3 `query_one` lookups plus a full
+        `_refresh_visible_draft` -- itself 2 more lookups, 2 `Static.update`
+        calls and a `refresh(layout=True)` -- to re-assert a row that was
+        already hidden. The trailing refresh exists to re-render the draft at
+        the width the recovery row leaves behind, so when visibility has not
+        moved there is no new width and nothing to redraw.
+        """
         visible = self._improvement_undo is not None and not self._collapsed
+        if visible == self._improvement_recovery_visible:
+            return
         try:
             recovery = self.query_one(
                 "#console-prompt-improvement-recovery", Horizontal
@@ -882,6 +919,7 @@ class ConsoleComposerBar(Horizontal):
         recovery.styles.display = "block" if visible else "none"
         undo.disabled = not visible
         review.disabled = not visible
+        self._improvement_recovery_visible = visible
         self._refresh_visible_draft()
 
     def undo_improvement(self) -> bool:
@@ -1721,13 +1759,20 @@ class ConsoleComposerBar(Horizontal):
         return style_ranges
 
     def _sync_hidden_input(self) -> None:
-        """Keep the hidden compatibility input aligned with canonical payload."""
+        """Keep the hidden compatibility input aligned with canonical payload.
+
+        task-24453: the mirror only needs writing when the canonical payload
+        actually changed. This widget is the sole writer of that value, so a
+        matching cache means the hidden input already holds it.
+        """
+        canonical = self._canonical_draft_text()
+        if canonical == self._hidden_input_mirror:
+            return
         try:
-            self.query_one(
-                "#console-command-input", Input
-            ).value = self._canonical_draft_text()
+            self.query_one("#console-command-input", Input).value = canonical
         except NoMatches:
             return
+        self._hidden_input_mirror = canonical
 
     def _sync_interaction_classes(self) -> None:
         """Mirror focus-within and draft presence onto stable CSS state classes."""
@@ -2914,6 +2959,17 @@ class ConsoleComposerBar(Horizontal):
         row_count = max(self.MIN_DRAFT_ROWS, min(self.MAX_DRAFT_ROWS, row_count))
         recovery_rows = int(self._improvement_undo is not None and not self._collapsed)
         composer_height = row_count + self.COMPOSER_CHROME_ROWS + recovery_rows
+        # task-24453: this runs on every keystroke, and its unconditional
+        # `self.refresh(layout=True)` below forced a WHOLE-SCREEN relayout per
+        # keypress (measured: 45 layouts for 43 keys, ~11.5 ms each). The
+        # geometry it writes is a pure function of these three values, so when
+        # none of them moved -- the overwhelmingly common case, since a draft
+        # only changes row count when it wraps -- there is nothing to write and
+        # nothing to relayout. `on_mount` clears the signature so a remounted
+        # composer always re-applies its geometry to fresh widgets.
+        geometry = (row_count, recovery_rows, composer_height)
+        if geometry == self._draft_geometry_signature:
+            return
         try:
             visible_draft = self.query_one("#console-command-visible-text", Static)
             visible_draft.styles.height = row_count
@@ -2936,10 +2992,15 @@ class ConsoleComposerBar(Horizontal):
         self.styles.max_height = (
             self.MAX_DRAFT_ROWS + self.COMPOSER_CHROME_ROWS + recovery_rows
         )
+        self._draft_geometry_signature = geometry
         self.refresh(layout=True)
 
     def _apply_collapsed_geometry(self) -> None:
         """Pin the compact presentation to exactly one terminal row."""
+        # The expanded geometry is no longer on the widget, so the next
+        # `_apply_draft_height` must write it again rather than trust a
+        # signature captured before the collapse (task-24453).
+        self._draft_geometry_signature = None
         self.styles.height = 1
         self.styles.min_height = 1
         self.styles.max_height = 1
@@ -2971,25 +3032,59 @@ class ConsoleComposerBar(Horizontal):
         self._sync_collapsed_presentation()
 
     def _sync_collapsed_presentation(self) -> None:
-        """Synchronize stable presentation containers from cached widget state."""
-        try:
-            expanded = self.query_one("#console-composer-expanded", Horizontal)
-            collapsed = self.query_one("#console-composer-collapsed", Horizontal)
-            status = self.query_one("#console-composer-collapsed-status", Static)
-            stop = self.query_one("#console-collapsed-stop-generation", Button)
-        except NoMatches:
-            return
-        expanded.styles.display = "none" if self._collapsed else "block"
-        collapsed.styles.display = "block" if self._collapsed else "none"
-        status.update(self._collapsed_status_text())
+        """Synchronize stable presentation containers from cached widget state.
+
+        task-24453: every caller of this method reaches it from the keystroke
+        path, so it ran three times per keypress and did the same DOM work each
+        time whether or not anything had moved. Two guards, in order:
+
+        1. A signature over exactly the state the body reads. When it matches
+           the previous pass nothing has changed and the whole method is
+           skipped -- the same fingerprint pattern
+           `main_navigation._update_overflow_hints` uses.
+        2. While the composer is EXPANDED, the collapsed row is `display:none`,
+           so its content and classes are invisible; only the two display flips
+           and this widget's own class are applied. The skipped work is not
+           lost: `_collapsed` is part of the signature, so collapsing always
+           misses the cache and repaints the row from current state before it
+           becomes visible.
+        """
         raw_cli_active = self._raw_cli_prefix_typed and self.draft_text().startswith(
             "! "
         )
-        collapsed.set_class(raw_cli_active, "console-raw-cli-danger")
-        status.set_class(raw_cli_active, "console-raw-cli-danger")
-        status.set_class(raw_cli_active, "console-voice-status-error")
-        stop.styles.display = "block" if self._run_active else "none"
+        status_text = self._collapsed_status_text()
+        signature = (
+            self._collapsed,
+            status_text,
+            raw_cli_active,
+            self._run_active,
+        )
+        if signature == self._collapsed_presentation_signature:
+            return
+        try:
+            expanded = self.query_one("#console-composer-expanded", Horizontal)
+            collapsed = self.query_one("#console-composer-collapsed", Horizontal)
+        except NoMatches:
+            # Leave the signature unset so the next pass retries -- caching a
+            # signature for a sync that never landed would strand the row.
+            return
+        expanded.styles.display = "none" if self._collapsed else "block"
+        collapsed.styles.display = "block" if self._collapsed else "none"
         self.set_class(self._collapsed, "console-composer-collapsed")
+
+        if self._collapsed:
+            try:
+                status = self.query_one("#console-composer-collapsed-status", Static)
+                stop = self.query_one("#console-collapsed-stop-generation", Button)
+            except NoMatches:
+                return
+            status.update(status_text)
+            collapsed.set_class(raw_cli_active, "console-raw-cli-danger")
+            status.set_class(raw_cli_active, "console-raw-cli-danger")
+            status.set_class(raw_cli_active, "console-voice-status-error")
+            stop.styles.display = "block" if self._run_active else "none"
+
+        self._collapsed_presentation_signature = signature
 
     def set_collapsed(self, collapsed: bool) -> None:
         """Switch presentation without remounting or clearing editor state.
@@ -3471,6 +3566,13 @@ class ConsoleComposerBar(Horizontal):
             timer.pause()
 
     def on_mount(self) -> None:
+        # Fresh widget tree: any geometry signature from a previous mount
+        # describes widgets that no longer exist (task-24453).
+        self._draft_geometry_signature = None
+        self._collapsed_presentation_signature = None
+        self._improvement_recovery_visible = None
+        self._raw_cli_status_visible = None
+        self._hidden_input_mirror = None
         self._cursor_blink_timer = self.set_interval(
             self.CURSOR_BLINK_INTERVAL,
             self._toggle_cursor_blink,

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -99,6 +99,17 @@ from textual.binding import Binding
 from textual.timer import Timer
 from textual.css.query import NoMatches, QueryError
 from textual.command import Hit, Hits, Provider
+
+# Install the ordered-candidate fast path on `Stylesheet.apply` before any App
+# exists, so every style application in the process takes it. Upstream's apply
+# walks the whole rule list per node to recover source order, which made CSS
+# matching the #1 sampled frame during 399 ms screen-switch stalls (2026-08-29
+# holistic perf review). Idempotent; see the module for the A/B numbers and
+# Tests/Performance/test_textual_css_fastpath.py for the fidelity guard.
+from tldw_chatbook.Utils.textual_css_fastpath import install_stylesheet_fastpath
+
+install_stylesheet_fastpath()
+
 from functools import partial
 from pathlib import Path, PurePath
 
@@ -556,7 +567,11 @@ from .UI.Screens.study_scope_models import StudyScopeContext
 from .UI.stable_command_palette import StableCommandPalette
 from .Prompt_Management.prompt_variables import PromptVariableApplication
 
-from .UI.Tools_Settings_Window import ToolsSettingsWindow  # noqa: E402
+# task-24458: import the MESSAGE, not the deprecated window. Importing
+# `Tools_Settings_Window` here dragged `Agents.local_tool_provider` ->
+# `Tools.workspace_tool_executor` and 7 further modules onto the boot
+# import path for a window that is nav-unreachable (TASK-1346).
+from .UI.tools_settings_messages import IngestUiStyleChanged  # noqa: E402
 from .UI.console_command_provider import ConsoleCommandProvider  # noqa: E402
 from .UI.image_gen_command_provider import ImageGenCommandProvider  # noqa: E402
 from tldw_chatbook.Chat_Grammars_Interop import (  # noqa: E402
@@ -12080,10 +12095,10 @@ class TldwCli(
         except Exception as e:
             self.loguru_logger.error(f"Error updating TTS progress: {e}")
 
-    @on(ToolsSettingsWindow.IngestUiStyleChanged)
+    @on(IngestUiStyleChanged)
     async def handle_ingest_ui_style_changed(
         self,
-        event: ToolsSettingsWindow.IngestUiStyleChanged,
+        event: IngestUiStyleChanged,
     ) -> None:
         """Refresh the active ingest view after a style change from Tools & Settings."""
         try:

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -6813,6 +6813,27 @@ def save_setting_to_cli_config(section: str, key: str, value: Any) -> bool:
 _CLI_SETTING_DEFAULT_UNSET = object()
 
 
+def current_config_generation() -> int:
+    """Return the monotonic counter bumped whenever config caches invalidate.
+
+    This is a single atomic reference read -- no lock, no file access, no copy
+    -- which is what makes it usable as a memoisation key on a hot path.
+    ``get_runtime_config_snapshot`` and ``get_atomic_config_snapshot`` expose
+    the same counter but take locks and deep-copy the values, so they are not
+    substitutes here.
+
+    Intended use (task-24456): a caller that derives an expensive view from
+    many `get_cli_setting` reads caches that view against this number and
+    recomputes only when it moves. Every mutation path routes through
+    `_invalidate_config_caches`, which bumps the counter, so a stale cache
+    cannot outlive a config write.
+
+    Returns:
+        The current configuration generation.
+    """
+    return _CONFIG_GENERATION
+
+
 def get_cli_setting(
     section: str, key: str = None, default: Any = _CLI_SETTING_DEFAULT_UNSET
 ) -> Any:

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -6813,25 +6813,35 @@ def save_setting_to_cli_config(section: str, key: str, value: Any) -> bool:
 _CLI_SETTING_DEFAULT_UNSET = object()
 
 
-def current_config_generation() -> int:
-    """Return the monotonic counter bumped whenever config caches invalidate.
+def current_config_identity() -> tuple[int, str]:
+    """Return a cheap key that changes whenever the effective config changes.
 
-    This is a single atomic reference read -- no lock, no file access, no copy
-    -- which is what makes it usable as a memoisation key on a hot path.
-    ``get_runtime_config_snapshot`` and ``get_atomic_config_snapshot`` expose
-    the same counter but take locks and deep-copy the values, so they are not
-    substitutes here.
+    Two independent things can change what `get_cli_setting` returns, and a
+    memoisation key must track BOTH:
+
+    * ``_CONFIG_GENERATION`` -- bumped by every mutation path, so it catches
+      writes to the config currently in force.
+    * the effective config PATH -- retargeting ``TLDW_CONFIG_PATH`` selects a
+      different file, and the loader serves the new file's values WITHOUT
+      advancing the generation. Verified empirically while reviewing
+      task-24456: after a retarget, `get_cli_setting` returned the new file's
+      value while the generation stayed at 1, so a generation-only key served
+      stale data. Caught in review by Qodo on PR #2217.
+
+    Both reads are cheap -- an atomic reference load and an env-var lookup plus
+    a lexical path expansion. No lock, no file access, no copy, which is what
+    makes this usable on a hot path. ``get_runtime_config_snapshot`` and
+    ``get_atomic_config_snapshot`` expose the same generation but take locks
+    and deep-copy the values, so they are not substitutes here.
 
     Intended use (task-24456): a caller that derives an expensive view from
-    many `get_cli_setting` reads caches that view against this number and
-    recomputes only when it moves. Every mutation path routes through
-    `_invalidate_config_caches`, which bumps the counter, so a stale cache
-    cannot outlive a config write.
+    many `get_cli_setting` reads caches that view against this tuple and
+    recomputes only when it moves.
 
     Returns:
-        The current configuration generation.
+        ``(configuration generation, effective config path)``.
     """
-    return _CONFIG_GENERATION
+    return (_CONFIG_GENERATION, str(_get_effective_config_path()))
 
 
 def get_cli_setting(


### PR DESCRIPTION
Fifth holistic performance review (pin dev `bc1e26ce60`, 524 commits since the 08-27 pin),
filed as **TASK-24450..24461**, with 7 of the 12 implemented here.

Evidence document: `Docs/Design/2026-08-29-holistic-perf-review.md`.

## Core verdict

**Idle is clean** — 0.09 s CPU over 12 s (0.75% of a core), zero stalls, zero SQL. The
08-22/08-24 timer and idle-SQL fixes held. The lag users report is entirely in interaction,
and it had one dominant cause.

**Every style application scanned all 4,324 CSS rules.** Upstream `Stylesheet.apply` narrows
candidates through `rules_map` and then discards that narrowing to recover source order with
`filter(limit_rules.__contains__, reversed(self.rules))`. That measured 7,335,029
`RuleSet.__hash__` calls in a single Console switch — exactly 1,667 applies × 4,324 rules —
and stack sampling ranked `textual/css/model.py:__hash__` the #1 frame during event-loop
stalls of up to 399 ms.

## Measured, interleaved A/B on the real app vs the unmodified pin

| Metric | dev | this branch |
|---|---|---|
| `Stylesheet.apply()` per node | 0.553 ms | **0.388 ms** (−30%) |
| `update_styles(screen)` | 263 ms | **160 ms** (−39%) |
| Console screen switch (mean of 6) | 2.06 s | **1.79 s** |
| Library screen switch | 1.24 s | **1.16 s** |
| `query_one` per keystroke | 35.4 | **12.3** (−65%) |
| `Static.update` per keystroke | 8.5 | **2.4** (−72%) |
| `refresh(layout=True)` per keystroke | 11.7 | **6.7** (−43%) |
| Library config reads per revisit | 46 | **2** |
| Boot import weight | 662/660 ❌ | **631/660** ✅ |
| `_ui_ready` module census | 981/970 ❌ | **966/970** ✅ |
| Boot worker census | ❌ | ✅ |

No ratchet constant was raised.

## What's in each commit

- **`perf(css)`** — TASK-24450. Ordered-candidate fast path. A *delegation*, not a fork:
  upstream stays the source of truth for what styling means, only candidate selection changes.
  The position index is cached against the `rules_map` object by strong reference, because
  Textual nulls `_rules_map` on every path that mutates `_rules`.
- **`perf(console)`** — TASK-24453. Five per-keystroke syncs guarded by state signatures.
  `_sync_collapsed_presentation` ran 3×/key against a `display:none` row;
  `_apply_draft_height` called `refresh(layout=True)` on every keypress.
- **`perf(library)`** — TASK-24456. Ingest options memoised on a new
  `config.current_config_generation()`, scoped to the running App.
- **`perf(boot)`** — TASK-24458. Four import deferrals, headline being that `app.py` imported
  the **deprecated, nav-unreachable** `Tools_Settings_Window` (TASK-1346) for one message
  class, dragging the entire workspace tool-execution cluster onto boot.
- **`fix(boot)`** — TASK-24460/24461. Named the anonymous boot worker; wired three of the four
  budget ratchets into `perf-guard.yml`.

## Two things reviewers should know

**A filed finding was wrong and is corrected in-tree.** "Library config re-read on unrelated
screen switches" came from averaging `get_cli_setting` over a Library+Console *pair*. Measured
per destination, Console switches read 18–21 and **none** from `library_screen` — the average
smeared one screen's mount cost across both. Task title, evidence doc and commit all corrected.

**The boot-worker failure was a naming regression, not a new worker.** Textual derives worker
names via `getattr(work, "__name__", "")`; wrapping the call in `functools.partial` silently
renamed it to `""`, breaking its existing allowlist row and making it anonymous in every
diagnostic. 56 other `run_worker(partial(...))` sites carry the same latent anonymity.

## Verification

- `Tests/Performance/`: green, including the two new fast-path guards. The fidelity test
  compares rule maps for all 689 nodes across three screens and was **mutation-tested** —
  reversing the sort order breaks 47 of them. The second test pins upstream's implementation so
  a Textual bump fails loudly rather than drifting silently.
- `Tests/Chat/`: 1935 passed, 1 failure **verified pre-existing on unmodified dev**.
- `Tests/UI/` composer + library subsets: ~1000 passed, 5 failures all verified pre-existing.
- `./scripts/preflight.sh`: all derived-artifact checks pass.
- A full `Tests/Chat + Tests/UI` run was still in progress locally when this PR opened; CI is
  the authority.

## Left open, each annotated in its task with what's established and what blocks it

**TASK-24452, 24456 and 24457 share one root cause**: `switch_screen` is handed a freshly
constructed screen every time (verified — three Library visits, three distinct instance ids).
That is why the Console re-mints 559 widgets, Library re-reads 43 settings, and Library opens 8
SQLite connections per visit. Instance reuse is the largest remaining win and an architecture
change — the snapshot/restore design assumes fresh construction — so it needs an owner call.

Also open: 24451 (split the 272 KB `_agentic_terminal.tcss` grab-bag, 29% of all rules),
24454, 24455 (598 → 482 `query_one`/switch as a side effect, short of its target), and
**24459 — the one still-red ratchet**, which is exactly why the CSS byte guard was excluded
from the new CI step rather than turning every unrelated PR red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nYQSYQbBm1DfFbXirJx3e

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts the interaction lag from the 08-29 holistic review: `Stylesheet.apply()` no longer scans all 4,324 CSS rules per call, composer keystroke syncs are signature-guarded, Library config reads are memoised per app, and boot import weight is back under its ratchet. One filed finding was wrong and is corrected in-tree: "Library config re-read on unrelated switches" was an averaging artifact over a Library+Console pair, and the task and evidence doc now say so.

**Performance**
- CSS apply is now a cached, position-sorted candidate hand-off to upstream with identical semantics; measured A/B: apply per node −30%, Console switch 2.06 → 1.79 s.
- Five composer syncs are signature-guarded, cutting `query_one` per keystroke 35.4 → 12.3; `_apply_draft_height` no longer forces `refresh(layout=True)` per keypress.
- Library ingest options are memoised on the running App, keyed by the new `current_config_identity()` (generation + effective config path — a generation-only key served stale options when `TLDW_CONFIG_PATH` was retargeted); repeat-visit reads drop 46 → 2.
- Screen instance reuse instead of fresh construction per visit is left open in TASK-24452/24456/24457 as the largest remaining win.

**Boot & CI**
- Import deferrals (headline: `app.py` no longer imports the deprecated `Tools_Settings_Window`) brought boot weight to 631/660 and `_ui_ready` census to 966/970; the rebase exposed a pre-import breach, and lazy `UI/Widgets` re-exports plus three deferrals shed 653 LOC to land at 492/500 modules.
- After the final rebase the census sits at exactly 970/970 (green where dev is 983) with zero headroom; the pre-import LOC budget stays red on both and runs in neither CI lane.
- The boot-worker census failure was a naming regression, not a new worker — `functools.partial` silently emptied the worker name, now passed explicitly.
- Boot budget ratchets now run in `perf-guard.yml` so a breach fails the PR that caused it; the CSS-byte test stays out until TASK-24459 because it is red on dev.

Tests are green except failures verified pre-existing on dev.

<sup>Written for commit db5a73397c66c262a8635aa81f036600eb24fe48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a holistic performance review of the Console app.
  * Documented interaction-performance bottlenecks affecting screen switches, typing, startup budgets, and Library visits.
  * Included measured findings, root-cause analysis, validated optimization results, recommended remediation priorities, and measurement considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->