### PR TITLE
fix(diagnostics): reconcile manifest-boundary baseline pins on the review fixture

### DIFF
--- a/Tests/fixtures/summarization_diagnostic_review.json
+++ b/Tests/fixtures/summarization_diagnostic_review.json
@@ -1,8 +1,8 @@
 {
     "schema_version": 1,
     "manifest_boundary": {
-        "checked_normalized_inventory_sha256": "cd7176f3e0076283595f40edf48b992067372764d9b06abc939c4a811bfed819",
-        "origin_dev_generated_normalized_inventory_sha256": "cd7176f3e0076283595f40edf48b992067372764d9b06abc939c4a811bfed819",
+        "checked_normalized_inventory_sha256": "af27c0ecde3f9000f34a7d9df1915b39e809dbc311fb40587a3cefeac3c6db79",
+        "origin_dev_generated_normalized_inventory_sha256": "af27c0ecde3f9000f34a7d9df1915b39e809dbc311fb40587a3cefeac3c6db79",
         "owned_entries": [
             {
                 "path": "tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py",


### PR DESCRIPTION
## What

Fixes the three failing `Tests/LLM_Calls/test_summarization_diagnostic_privacy.py::test_manifest_boundary_*` tests on dev (`3 failed, 254 passed` at 581ef09ac).

## Diagnosis

The fixture's `manifest_boundary` pins the normalized diagnostic-inventory projection **excluding** the two summarization owner files, asserting "nothing outside the summarization owners changed since the last reconciliation." PR #2190 set those pins; every PR since that touched other diagnostic owners (including #2223's `Utils/tls_trust` owner, +6 calls) legitimately moved the projection, so the pins went stale — the inventory itself is healthy.

Verified before touching anything:
- `check_persistent_diagnostic_inventory.py` passes on dev (543 owners, checked == fresh `build_inventory()`).
- The two owned summarization entries (`path`/`owner`/`reason`) match both the checked and generated inventories.
- The 523-site review ledger and its separate `STARTING_PROJECTION_SHA256` are untouched and passing.

## Change

Two hash strings in `Tests/fixtures/summarization_diagnostic_review.json`: `cd7176f3…` → `af27c0ec…` (both `checked_normalized_inventory_sha256` and `origin_dev_generated_normalized_inventory_sha256`, which must be equal). No review decisions, sites, or schema changed — a 2-line diff.

## Evidence

`.venv/bin/python -m pytest Tests/LLM_Calls/test_summarization_diagnostic_privacy.py -q` → **257 passed** (was 3 failed / 254 passed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the manifest-boundary baseline pins in the summarization review fixture so the three failing `test_manifest_boundary_*` tests pass again. The pins were stale because other diagnostic owners legitimately moved the normalized inventory projection.

The two owned summarization entries still match both the checked and generated inventories, and the 523-site review ledger is untouched. Only the two `manifest_boundary` SHA256 hashes change.

<sup>Written for commit 0e3e8e7524c7aa061925fd69ead264b738062fb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

