### PR TITLE
fix(console): voice chip no longer starves the composer draft at narrow widths (TASK-24620)

### DIFF
--- a/Tests/UI/test_console_composer_reason_width.py
+++ b/Tests/UI/test_console_composer_reason_width.py
@@ -293,3 +293,76 @@ def test_reason_cap_subtracts_a_displayed_chip(monkeypatch):
     composer._voice_chip_last_width = 90
     # 160 - 45 - 32 - 90 < 0 -> hide.
     assert _cap_with_row_width(composer, 160, monkeypatch) == 0
+
+
+# ---------------------------------------------------------------------------
+# PR #2230 review findings (qodo):
+# f2 -- a chip that hides (idle, or a below-legibility budget) must let the
+#       reason strip re-derive against a ZERO chip width in the SAME turn
+#       (the presentation sync re-derives it; the cache used to clear
+#       after, leaving the strip truncated as though the chip showed).
+# f3 -- preparing is exempt from the ordinary cap at EVERY width, not only
+#       where the budget hits zero: the busy copy must render whole in the
+#       intermediate band too.
+# ---------------------------------------------------------------------------
+
+#: Composer row landing in the intermediate band: app (120, 40) lays the
+#: row out around 117 content cells -- ordinary chip cap 117-77 = 40, in
+# the 12..52 band the zero-only exemption used to truncate.
+APP_INTERMEDIATE = (120, 40)
+
+
+@pytest.mark.asyncio
+async def test_chip_going_idle_restores_the_reason_strip_budget():
+    """f2: dictation ending (idle) frees the chip's cells for the reason
+    strip immediately -- not at some later unrelated sync."""
+    _, host = _ready_host()
+    async with host.run_test(size=(140, 40)) as pilot:
+        console = await _mounted_console(host, pilot)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        strip = composer.query_one("#console-send-disabled-reason", Static)
+        await pilot.pause()
+        await pilot.pause()
+
+        composer.set_voice_status("error", message=CHIP_MESSAGE)
+        await pilot.pause()
+        await pilot.pause()
+        # At this width the chip (53 cells) leaves the reason strip below
+        # its legibility floor: hidden while the chip has priority.
+        assert strip.display is False
+
+        composer.set_voice_status("idle")
+        await pilot.pause()
+        await pilot.pause()
+        assert composer._voice_chip_last_width == 0
+        assert strip.display is True, (
+            "the reason strip stayed hidden after the chip went idle -- "
+            "its budget still subtracted the chip that no longer shows"
+        )
+
+
+@pytest.mark.asyncio
+async def test_preparing_renders_whole_in_the_intermediate_band():
+    """f3: the busy/preparing action feedback is exempt from the ordinary
+    chip cap at every width, not only at a zero budget."""
+    _, host = _ready_host()
+    async with host.run_test(size=APP_INTERMEDIATE) as pilot:
+        console = await _mounted_console(host, pilot)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        chip = composer.query_one("#console-voice-status", Static)
+        await pilot.pause()
+        await pilot.pause()
+
+        # Sanity: this width really is in the intermediate band.
+        assert 12 <= composer._voice_chip_width_cap() <= 52
+
+        composer.set_voice_status(
+            "preparing", message="Local transcription busy — dictation will run next."
+        )
+        await pilot.pause()
+        await pilot.pause()
+        assert chip.display is True
+        assert chip.region.width >= 51 + 2, (
+            f"preparing copy truncated to {chip.region.width} cells in the "
+            "intermediate band (the busy-parakeet contract wants it whole)"
+        )

--- a/Tests/UI/test_console_composer_reason_width.py
+++ b/Tests/UI/test_console_composer_reason_width.py
@@ -126,6 +126,12 @@ def _cap_with_row_width(composer, row_width: int, monkeypatch) -> int:
     return composer._send_reason_width_cap()
 
 
+def _chip_cap_with_row_width(composer, row_width: int, monkeypatch) -> int:
+    row = SimpleNamespace(content_region=Region(0, 0, row_width, 1))
+    monkeypatch.setattr(composer, "query_one", lambda *args, **kwargs: row)
+    return composer._voice_chip_width_cap()
+
+
 def test_cap_without_a_mounted_row_falls_back_to_the_static_max():
     """An unmounted composer has no row to query: the static cap applies
     until the next resize re-derives against a real width."""
@@ -148,14 +154,14 @@ def test_cap_is_the_static_max_when_the_row_can_spare_it(monkeypatch):
 
 
 def test_cap_is_the_spare_budget_at_intermediate_widths(monkeypatch):
-    assert _cap_with_row_width(_bare_composer(), 100, monkeypatch) == 25
+    assert _cap_with_row_width(_bare_composer(), 100, monkeypatch) == 23
 
 
 def test_cap_hides_at_the_legibility_boundary(monkeypatch):
-    # 87 - 75 = 12: exactly the legibility floor -- still shown.
-    assert _cap_with_row_width(_bare_composer(), 87, monkeypatch) == 12
-    # 86 - 75 = 11: below it -- hide (0).
-    assert _cap_with_row_width(_bare_composer(), 86, monkeypatch) == 0
+    # 89 - 77 = 12: exactly the legibility floor -- still shown.
+    assert _cap_with_row_width(_bare_composer(), 89, monkeypatch) == 12
+    # 88 - 77 = 11: below it -- hide (0).
+    assert _cap_with_row_width(_bare_composer(), 88, monkeypatch) == 0
     # Far below: negative budget -- hide.
     assert _cap_with_row_width(_bare_composer(), 40, monkeypatch) == 0
 
@@ -165,4 +171,125 @@ def test_cap_accounts_for_attachment_actions_width(monkeypatch):
     shrinks by exactly that."""
     composer = _bare_composer()
     composer._pending_attachment_label = "image.png"
-    assert _cap_with_row_width(composer, 100, monkeypatch) == 21
+    assert _cap_with_row_width(composer, 100, monkeypatch) == 19
+
+
+# ---------------------------------------------------------------------------
+# TASK-24620: the dictation voice chip must not starve the draft either.
+# Same starvation class TASK-24415 fixed for the send-disabled reason strip:
+# set_voice_status sized the chip against the composer's FULL width with
+# only VOICE_CHIP_MIN_WIDTH (24) reserved, ignoring the left cluster, the
+# actions row, and the draft -- a long state message took up to 53 cells
+# and the 1fr draft (min_width 0) got the remainder.
+# ---------------------------------------------------------------------------
+
+#: A realistic long chip copy (error states and executor-wait copy run this
+#: long; the preparing copy is 51 cells).
+CHIP_MESSAGE = "Microphone unavailable — check permissions and retry"
+
+
+@pytest.mark.asyncio
+async def test_narrow_composer_keeps_draft_visible_beside_voice_chip():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_NARROW) as pilot:
+        console = await _mounted_console(host, pilot)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        draft = composer.query_one("#console-command-visible-text", Static)
+        chip = composer.query_one("#console-voice-status", Static)
+        await pilot.pause()
+        await pilot.pause()
+
+        composer.set_voice_status("error", message=CHIP_MESSAGE)
+        await pilot.pause()
+        await pilot.pause()
+        # Below the legible budget the chip hides -- the draft floor wins,
+        # and the Dictate button's own label still carries the mic state.
+        assert chip.display is False
+        assert draft.region.width >= 8, (
+            f"visible draft collapsed to {draft.region.width} columns beside "
+            "the voice chip at 80-column app width"
+        )
+
+
+@pytest.mark.asyncio
+async def test_wide_composer_keeps_voice_chip_capped_and_draft_floor():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_WIDE) as pilot:
+        console = await _mounted_console(host, pilot)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        draft = composer.query_one("#console-command-visible-text", Static)
+        chip = composer.query_one("#console-voice-status", Static)
+        await pilot.pause()
+        await pilot.pause()
+
+        composer.set_voice_status("error", message=CHIP_MESSAGE)
+        await pilot.pause()
+        await pilot.pause()
+        assert chip.display is True
+        assert chip.region.width <= ConsoleComposerBar.VOICE_CHIP_MAX_WIDTH
+        assert draft.region.width >= DRAFT_FLOOR
+
+
+@pytest.mark.asyncio
+async def test_resize_from_wide_to_narrow_retracts_the_voice_chip():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_WIDE) as pilot:
+        console = await _mounted_console(host, pilot)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        draft = composer.query_one("#console-command-visible-text", Static)
+        composer.set_voice_status("error", message=CHIP_MESSAGE)
+        await pilot.pause()
+        await pilot.pause()
+        assert draft.region.width >= DRAFT_FLOOR
+
+        await pilot.resize_terminal(APP_NARROW[0], APP_NARROW[1])
+        await pilot.pause()
+        await pilot.pause()
+
+        assert draft.region.width >= 8, (
+            "after resizing to a narrow terminal the draft collapsed to "
+            f"{draft.region.width} columns while the voice chip still held "
+            "layout space"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Direct unit coverage for _voice_chip_width_cap's branches (TASK-24620):
+# same stub-row pattern as the reason-cap tests above. Reserved = left
+# cluster (18) + actions (25) + ADVISORY_MARGIN_ALLOWANCE (2) = 45, so the
+# budget is row_width - 45 - DRAFT_MIN_RENDER_WIDTH(32) = row_width - 77.
+# ---------------------------------------------------------------------------
+
+
+def test_chip_cap_without_a_mounted_row_falls_back_to_the_ceiling():
+    assert _bare_composer()._voice_chip_width_cap() == (
+        ConsoleComposerBar.VOICE_CHIP_MAX_WIDTH
+    )
+
+
+def test_chip_cap_branches(monkeypatch):
+    composer = _bare_composer()
+    # Pre-layout row: fallback ceiling.
+    assert _chip_cap_with_row_width(composer, 0, monkeypatch) == 53
+    # Wide row: the ceiling binds, not the budget.
+    assert _chip_cap_with_row_width(composer, 200, monkeypatch) == 53
+    # Intermediate: the spare budget binds (100 - 77 = 23).
+    assert _chip_cap_with_row_width(composer, 100, monkeypatch) == 23
+    # Legibility boundary: 89 - 77 = 12 shows; 88 - 77 = 11 hides.
+    assert _chip_cap_with_row_width(composer, 89, monkeypatch) == 12
+    assert _chip_cap_with_row_width(composer, 88, monkeypatch) == 0
+    # Far below: hide.
+    assert _chip_cap_with_row_width(composer, 40, monkeypatch) == 0
+
+
+def test_reason_cap_subtracts_a_displayed_chip(monkeypatch):
+    """The chip has priority; the reason strip budgets around its cached
+    width (TASK-24620: without this the two strips jointly starved the
+    draft by each claiming the full remainder)."""
+    composer = _bare_composer()
+    composer._voice_chip_last_width = 40
+    # 160 - 45 - 32 - 40 = 43, under the 52 cap.
+    assert _cap_with_row_width(composer, 160, monkeypatch) == 43
+    composer._voice_chip_last_width = 90
+    # 160 - 45 - 32 - 90 < 0 -> hide.
+    assert _cap_with_row_width(composer, 160, monkeypatch) == 0

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -2507,3 +2507,23 @@ Retaining the same-key cached rows during refresh stopped the motion. Actual
 browser screenshots taken 23 seconds apart then had identical left-rail pixels.
 Use a populated profile and observe across refresh intervals; a single screenshot
 or an empty harness cannot establish that a layout stays still.
+## A shell cwd reset between commands split my patch across two checkouts — the wrong tree's green run looked like progress (TASK-24620, 2026-08-30)
+
+**What happened.** Mid-verification, one command ended with a `cd` into a
+throwaway `/tmp` worktree; the shell reset cwd back to the MAIN checkout.
+Every later `python3` patch and `pytest` invocation with relative paths then
+ran against the main checkout (a pre-feature branch), not the feature
+worktree: a test-file update landed in the wrong tree, and two pytest runs
+"passed"/"failed" against code that had none of the changes under test. It
+was caught only because an assertion referenced an attribute the wrong tree
+could not have (`AttributeError: _voice_chip_last_width`) — a greppable
+smell, since the feature code demonstrably defined it.
+
+**What to do.** In multi-worktree sessions, anchor EVERY patch script and
+pytest invocation with an explicit absolute `cd <worktree> && ...` in the
+same command — never rely on cwd persisting. When a test failure names a
+symbol your feature defines, grep BOTH trees for the symbol before
+believing either result: a zero count in the tree you thought you were
+testing means you are testing the wrong tree, not that the code is missing.
+After any suspicious run, `pwd` plus `git -C <tree> status` is one second
+of insurance against a split-brain patch.

--- a/backlog/tasks/task-24620 - Console-voice-chip-starves-the-composer-draft-at-narrow-widths.md
+++ b/backlog/tasks/task-24620 - Console-voice-chip-starves-the-composer-draft-at-narrow-widths.md
@@ -1,0 +1,74 @@
+---
+id: TASK-24620
+title: Console voice chip starves the composer draft at narrow widths
+status: In Progress
+assignee:
+  - @zcode
+created_date: '2026-08-30'
+updated_date: '2026-08-30'
+labels:
+  - console
+  - defect
+  - ux
+priority: high
+dependencies: []
+---
+
+## Description (the why)
+
+Follow-up to TASK-24415 (PR #2214), which flagged this exact same-class
+suspect in its Implementation Notes — now confirmed by the user having hit
+it live. The dictation voice chip (`#console-voice-status`) sizes itself
+against the composer's FULL width reserving only `VOICE_CHIP_MIN_WIDTH`
+(24 cells):
+
+```python
+total_width = self.size.width or self.VOICE_CHIP_MAX_WIDTH * 2
+available = max(0, total_width - self.VOICE_CHIP_MIN_WIDTH)
+width = min(self.VOICE_CHIP_MAX_WIDTH, available)
+```
+
+It ignores the left cluster (18), the actions row (25), and the draft
+entirely. With the chip's 51-cell executor-wait copy or any long state
+message, a ~100-cell composer row gives the chip up to 53 cells and the
+`1fr` draft (min_width 0) the remainder — a few columns, or zero. Exactly
+the starvation shape TASK-24415 fixed for `#console-send-disabled-reason`,
+in the one sibling the earlier task measured but did not reach.
+
+The mic-live state itself is not lost when the chip must yield: the Dictate
+button's label carries it ("Dictating"), so the chip is advisory detail
+(partial transcript, elapsed, wait copy) under the draft floor — the same
+priority TASK-24415 established.
+
+## Acceptance Criteria
+
+- [ ] With a dictation chip state rendered and a narrow composer (80-col
+      app), the visible draft keeps non-zero width; the chip clamps to a
+      live-row-derived budget or hides below a legible floor.
+- [ ] At wide widths the chip still renders within its 53-cell ceiling and
+      the draft keeps its 32-cell floor.
+- [ ] A resize re-derives the chip budget (a shrink retracts the chip, not
+      the draft).
+- [ ] Direct unit tests cover the budget helper's branches; a mounted
+      geometry test pins the integration (the TASK-24415 test pattern).
+- [ ] Live verification in a real terminal at 80 columns with a chip state
+      showing: the draft remains visible.
+
+## Implementation Plan
+
+ADR required: no
+ADR path: N/A
+Reason: layout bug fix inside the existing composer widget, mirroring
+TASK-24415's reviewer-approved pattern; no contract or boundary decision.
+
+1. RED: mounted geometry test at narrow width with a chip state — draft
+   region collapses (reproduce).
+2. Add `_voice_chip_width_cap` mirroring `_send_reason_width_cap`
+   (row − left cluster − actions(attachment-aware) − draft floor; hide
+   below a legibility floor); apply it in `set_voice_status`; cache the
+   last status inputs and replay from `on_resize`.
+3. Unit-test the cap branches; live-verify at 80 cols.
+
+## Implementation Notes
+
+(added after implementation)

--- a/backlog/tasks/task-24620 - Console-voice-chip-starves-the-composer-draft-at-narrow-widths.md
+++ b/backlog/tasks/task-24620 - Console-voice-chip-starves-the-composer-draft-at-narrow-widths.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-24620
 title: Console voice chip starves the composer draft at narrow widths
-status: In Progress
+status: Done
 assignee:
   - @zcode
 created_date: '2026-08-30'
@@ -42,17 +42,19 @@ priority TASK-24415 established.
 
 ## Acceptance Criteria
 
-- [ ] With a dictation chip state rendered and a narrow composer (80-col
+- [x] With a dictation chip state rendered and a narrow composer (80-col
       app), the visible draft keeps non-zero width; the chip clamps to a
       live-row-derived budget or hides below a legible floor.
-- [ ] At wide widths the chip still renders within its 53-cell ceiling and
+- [x] At wide widths the chip still renders within its 53-cell ceiling and
       the draft keeps its 32-cell floor.
-- [ ] A resize re-derives the chip budget (a shrink retracts the chip, not
+- [x] A resize re-derives the chip budget (a shrink retracts the chip, not
       the draft).
-- [ ] Direct unit tests cover the budget helper's branches; a mounted
+- [x] Direct unit tests cover the budget helper's branches; a mounted
       geometry test pins the integration (the TASK-24415 test pattern).
-- [ ] Live verification in a real terminal at 80 columns with a chip state
-      showing: the draft remains visible.
+- [x] Live verification in a real terminal at 80 columns with a chip state
+      showing: the draft remains visible (error-state chip hidden, typed
+      draft and caret visible; failure feedback arrived via the rail
+      panel, not the starved chip).
 
 ## Implementation Plan
 
@@ -71,4 +73,39 @@ TASK-24415's reviewer-approved pattern; no contract or boundary decision.
 
 ## Implementation Notes
 
-(added after implementation)
+Fixed 2026-08-30, TDD (RED reproduced the user-hit bug: draft at 2 columns
+beside a 53-cell chip; even at wide widths the draft got 28 < the 32 floor).
+88 dictation-streaming tests, 47 popup/composer/dictation tests green;
+live-verified at 80 columns.
+
+- **Approach**: `_voice_chip_width_cap` mirrors TASK-24415's
+  `_send_reason_width_cap` -- budget = row − left cluster − actions −
+  `ADVISORY_MARGIN_ALLOWANCE`(2) − draft floor; below a 12-cell legible
+  remainder the chip hides (the Dictate button's label carries the
+  mic-live state, and dictation failures surface through the rail panel).
+  `set_voice_status` applies it, caches its last inputs
+  (`_voice_status_last`, class attr for fixture safety) and its APPLIED
+  width (`_voice_chip_last_width` -- the cache, not `region`, because
+  region is stale until the next layout pass), and `on_resize` replays.
+- **Preparing is exempt**: the busy/preparing chip is action feedback for
+  a Dictate press; the 80-column busy-parakeet tests pin the WHOLE copy
+  visible, so preparing keeps its legacy full-width sizing (it already
+  collapses chrome via `_sync_full_width_voice_presentation`). Every other
+  state uses the budgeted cap.
+- **Two-strip interplay fixed**: the reason strip's cap now subtracts the
+  chip's cached width (chip has priority) and both caps subtract the 2
+  separator-margin cells measured on the laid-out row -- without these,
+  the two advisory strips each budgeted the full remainder and jointly
+  starved the draft to 30 < 32 at 160 cols.
+- **Pre-existing dev regression repaired**: TASK-24415 (PR #2214) broke
+  `test_busy_parakeet_mic_stays_reachable_and_cancels_at_80_columns` on
+  dev (verified failing on plain origin/dev) -- its final assert required
+  the reason strip displayed at a 77-cell row where the 24415 budget is
+  legitimately zero. The assert now pins the actual restore contract
+  (`_voice_full_width_preparing` cleared, chip-width cache reset); that
+  suite was not in PR #2214's verification runs.
+- Files: `tldw_chatbook/Widgets/Console/console_composer_bar.py`,
+  `Tests/UI/test_console_composer_reason_width.py` (+3 mounted, +4 unit),
+  `Tests/UI/test_console_dictation_streaming.py` (stale assert updated to
+  the post-24415 contract).
+- ADR: not required (layout fix mirroring an already-reviewed pattern).

--- a/backlog/tasks/task-24620 - Console-voice-chip-starves-the-composer-draft-at-narrow-widths.md
+++ b/backlog/tasks/task-24620 - Console-voice-chip-starves-the-composer-draft-at-narrow-widths.md
@@ -109,3 +109,15 @@ live-verified at 80 columns.
   `Tests/UI/test_console_dictation_streaming.py` (stale assert updated to
   the post-24415 contract).
 - ADR: not required (layout fix mirroring an already-reviewed pattern).
+- **PR #2230 review round (qodo, 3 findings, all addressed)**: (f1)
+  `on_resize` gained its Google-style docstring; (f2) both chip-hide paths
+  now clear `_voice_chip_last_width` BEFORE `_sync_full_width_voice_
+  presentation(False)` -- that sync re-derives the reason strip, which
+  subtracts the cache, so clearing after left the strip truncated as though
+  the chip still showed (RED-verified, then GREEN); (f3) PREPARING selects
+  its legacy sizing before the ordinary cap -- the full-width exemption
+  applies at every width, not only where the budget hits zero, so the busy
+  copy renders whole in the intermediate 12-52 band too (RED-verified).
+  Two new tests pin f2 (idle restores the reason budget) and f3
+  (intermediate-band preparing whole); 126 tests green across the affected
+  suites.

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -3689,13 +3689,21 @@ class ConsoleComposerBar(Horizontal):
             )
 
     def on_resize(self, event: Any) -> None:
-        # TASK-24415: the reason strip's width cap is a function of the live
-        # row width -- a resize must re-derive it, or a strip sized for the
-        # old width keeps starving the draft at the new one.
+        """Re-derive the advisory-strip budgets against the new row width.
+
+        TASK-24415/24620: the reason strip's and voice chip's width caps are
+        functions of the LIVE row width -- a resize must re-derive them, or
+        strips sized for the old width keep starving the draft at the new
+        one. The chip replays its cached status so the same budget rule
+        applies on the shrink.
+
+        Args:
+            event: Textual resize event (unused beyond the handler
+                signature; the layout has already settled when it fires).
+        """
         self._sync_send_disabled_reason(
             self._send_disabled_reason, muted=not self._send_blocked
         )
-        # TASK-24620: same discipline for the voice chip.
         if self._voice_status_last is not None:
             (
                 voice_state,
@@ -5957,39 +5965,47 @@ class ConsoleComposerBar(Horizontal):
         )
 
         if state in ("idle", "unavailable"):
+            # PR-2230 review f2: clear the chip-width cache BEFORE the
+            # presentation sync -- `_sync_full_width_voice_presentation`
+            # re-derives the disabled-reason strip, which subtracts the
+            # cache; clearing it after left the strip capped as though the
+            # chip were still displayed.
+            self._voice_chip_last_width = 0
             self._sync_full_width_voice_presentation(False)
             chip.styles.display = "none"
             chip.styles.width = 0
             chip.styles.min_width = 0
             chip.update(Content(""))
-            self._voice_chip_last_width = 0
             return
 
-        # TASK-24620: the chip's width is a live-row budget like the
-        # send-disabled reason strip's (see `_voice_chip_width_cap`) -- the
-        # draft floor wins, and below a legible remainder the chip hides
-        # rather than starve it.
-        width = self._voice_chip_width_cap()
-        if width == 0 and state == STATE_PREPARING:
-            # Action feedback: the user just pressed Dictate, and a hidden
-            # or truncated chip makes that press look dead at narrow widths
-            # (pinned by the 80-column busy-parakeet tests, which require
-            # the WHOLE copy). Preparing is already a full-width
-            # presentation (`_sync_full_width_voice_presentation` collapses
-            # the reason strip and presentation chrome), so it keeps the
-            # legacy sizing; every other state uses the budgeted cap.
+        # TASK-24620 / PR-2230 review f3: PREPARING selects its sizing
+        # BEFORE the ordinary cap -- it is action feedback for a Dictate
+        # press, and its full-width presentation exempts it at every width,
+        # not only where the budget hits zero (the 80-column busy-parakeet
+        # tests require the WHOLE copy, and intermediate budgets used to
+        # truncate it while the presentation collapsed space the chip could
+        # have used). The non-listening branch below still shrinks the
+        # final width to the message's own length, so short preparing copy
+        # does not balloon.
+        if state == STATE_PREPARING:
             total_width = self.size.width or self.VOICE_CHIP_MAX_WIDTH * 2
             width = min(
                 self.VOICE_CHIP_MAX_WIDTH,
                 max(0, total_width - self.VOICE_CHIP_MIN_WIDTH),
             )
-        elif width == 0:
+        else:
+            # The chip's width is a live-row budget like the send-disabled
+            # reason strip's (see `_voice_chip_width_cap`) -- the draft
+            # floor wins, and below a legible remainder the chip hides
+            # rather than starve it.
+            width = self._voice_chip_width_cap()
+        if width == 0:
+            self._voice_chip_last_width = 0
             self._sync_full_width_voice_presentation(False)
             chip.styles.display = "none"
             chip.styles.width = 0
             chip.styles.min_width = 0
             chip.update(Content(""))
-            self._voice_chip_last_width = 0
             return
 
         if state == "listening":

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -1867,7 +1867,21 @@ class ConsoleComposerBar(Horizontal):
             # next resize re-derives the cap against a real width.
             return self.SEND_REASON_MAX_WIDTH
         reserved = self.LEFT_CLUSTER_WIDTH + self._actions_row_width()
-        budget = row_width - reserved - self.DRAFT_MIN_RENDER_WIDTH
+        # TASK-24620: a displayed voice chip draws from the same spare
+        # space; the chip (live dictation state) has priority, so the
+        # reason strip budgets around whatever the chip currently holds.
+        # The CACHED chip width, deliberately -- `chip.region` is stale
+        # until the next layout pass, and this cap runs in the same turn
+        # that just resized the chip. Without this, the two advisory strips
+        # each budgeted the full remainder independently and jointly
+        # starved the draft.
+        budget = (
+            row_width
+            - reserved
+            - self.ADVISORY_MARGIN_ALLOWANCE
+            - self.DRAFT_MIN_RENDER_WIDTH
+            - self._voice_chip_last_width
+        )
         if budget < self.SEND_REASON_MIN_LEGIBLE_WIDTH:
             return 0
         return min(self.SEND_REASON_MAX_WIDTH, budget)
@@ -3681,6 +3695,22 @@ class ConsoleComposerBar(Horizontal):
         self._sync_send_disabled_reason(
             self._send_disabled_reason, muted=not self._send_blocked
         )
+        # TASK-24620: same discipline for the voice chip.
+        if self._voice_status_last is not None:
+            (
+                voice_state,
+                voice_partial,
+                voice_elapsed,
+                voice_message,
+                voice_segment_transcribing,
+            ) = self._voice_status_last
+            self.set_voice_status(
+                voice_state,
+                partial=voice_partial,
+                elapsed_seconds=voice_elapsed,
+                message=voice_message,
+                segment_transcribing=voice_segment_transcribing,
+            )
         self._refresh_visible_draft()
 
     def on_focus(self) -> None:
@@ -5812,6 +5842,63 @@ class ConsoleComposerBar(Horizontal):
         if self._voice_full_width_preparing:
             self._sync_full_width_voice_presentation(True)
 
+    #: TASK-24620: the voice chip's own legibility floor, mirroring
+    #: `SEND_REASON_MIN_LEGIBLE_WIDTH` -- below it the chip hides (the
+    #: Dictate button's label still carries the mic-live state).
+    VOICE_CHIP_MIN_LEGIBLE_WIDTH = 12
+    #: TASK-24620: cells the row spends on separator margins OUTSIDE the
+    #: widgets' own widths -- the chip's normal one-cell right margin plus
+    #: the one before the actions row (measured on the laid-out row: gaps
+    #: at draft|chip and reason|actions). Budgets that ignore these deliver
+    #: a draft two cells under its floor when both advisory strips show.
+    ADVISORY_MARGIN_ALLOWANCE = 2
+
+    #: TASK-24620: last `set_voice_status` inputs, replayed from
+    #: `on_resize` so the chip's row-width budget is re-derived on resize. A
+    #: CLASS attribute, deliberately, so hand-built `__new__` fixtures never
+    #: see an AttributeError (the `_console_popup_synced_draft` lesson).
+    _voice_status_last: tuple | None = None
+
+    #: TASK-24620: the chip width last APPLIED by `set_voice_status` (0 when
+    #: hidden). The reason strip's cap subtracts this; `region` cannot be
+    #: used for that because it is stale until the next layout pass.
+    _voice_chip_last_width: int = 0
+
+    def _voice_chip_width_cap(self) -> int:
+        """Return the max cells the voice chip may take (0 = hide it).
+
+        TASK-24620: mirrors `_send_reason_width_cap` (TASK-24415). The chip
+        sized itself against the composer's FULL width with only
+        `VOICE_CHIP_MIN_WIDTH` reserved, so a long state message took up to
+        53 cells and the ``1fr`` draft (``min_width: 0``) starved beside it
+        -- the same starvation class the reason strip had. The budget is
+        whatever the live row can spare after the fixed furniture and the
+        draft floor; below a legible remainder the chip hides rather than
+        blind the composer (the Dictate button's own label still says
+        "Dictating", so the mic-live state survives).
+
+        Returns:
+            0 when the row cannot spare a legible chip (hide it), else a
+            cap of at most ``VOICE_CHIP_MAX_WIDTH`` cells.
+        """
+        try:
+            row = self.query_one("#console-composer-expanded", Horizontal)
+        except NoMatches:
+            return self.VOICE_CHIP_MAX_WIDTH
+        row_width = int(row.content_region.width)
+        if row_width <= 0:
+            # Not laid out yet; the next resize re-derives the cap.
+            return self.VOICE_CHIP_MAX_WIDTH
+        reserved = (
+            self.LEFT_CLUSTER_WIDTH
+            + self._actions_row_width()
+            + self.ADVISORY_MARGIN_ALLOWANCE
+        )
+        budget = row_width - reserved - self.DRAFT_MIN_RENDER_WIDTH
+        if budget < self.VOICE_CHIP_MIN_LEGIBLE_WIDTH:
+            return 0
+        return min(self.VOICE_CHIP_MAX_WIDTH, budget)
+
     def set_voice_status(
         self,
         state: str,
@@ -5858,6 +5945,16 @@ class ConsoleComposerBar(Horizontal):
             chip = self.query_one("#console-voice-status", Static)
         except NoMatches:
             return
+        # TASK-24620: cache the inputs so `on_resize` can re-derive the
+        # chip against the new row width (a shrink must retract the chip,
+        # not the draft).
+        self._voice_status_last = (
+            state,
+            partial,
+            elapsed_seconds,
+            message,
+            segment_transcribing,
+        )
 
         if state in ("idle", "unavailable"):
             self._sync_full_width_voice_presentation(False)
@@ -5865,13 +5962,35 @@ class ConsoleComposerBar(Horizontal):
             chip.styles.width = 0
             chip.styles.min_width = 0
             chip.update(Content(""))
+            self._voice_chip_last_width = 0
             return
 
-        # `size` is (0, 0) before the first layout; fall back to the ceiling
-        # rather than computing a zero width and rendering an invisible chip.
-        total_width = self.size.width or self.VOICE_CHIP_MAX_WIDTH * 2
-        available = max(0, total_width - self.VOICE_CHIP_MIN_WIDTH)
-        width = min(self.VOICE_CHIP_MAX_WIDTH, available)
+        # TASK-24620: the chip's width is a live-row budget like the
+        # send-disabled reason strip's (see `_voice_chip_width_cap`) -- the
+        # draft floor wins, and below a legible remainder the chip hides
+        # rather than starve it.
+        width = self._voice_chip_width_cap()
+        if width == 0 and state == STATE_PREPARING:
+            # Action feedback: the user just pressed Dictate, and a hidden
+            # or truncated chip makes that press look dead at narrow widths
+            # (pinned by the 80-column busy-parakeet tests, which require
+            # the WHOLE copy). Preparing is already a full-width
+            # presentation (`_sync_full_width_voice_presentation` collapses
+            # the reason strip and presentation chrome), so it keeps the
+            # legacy sizing; every other state uses the budgeted cap.
+            total_width = self.size.width or self.VOICE_CHIP_MAX_WIDTH * 2
+            width = min(
+                self.VOICE_CHIP_MAX_WIDTH,
+                max(0, total_width - self.VOICE_CHIP_MIN_WIDTH),
+            )
+        elif width == 0:
+            self._sync_full_width_voice_presentation(False)
+            chip.styles.display = "none"
+            chip.styles.width = 0
+            chip.styles.min_width = 0
+            chip.update(Content(""))
+            self._voice_chip_last_width = 0
+            return
 
         if state == "listening":
             head = f"{resolve_glyph(GLYPH_VOICE_RECORDING)} {elapsed_seconds // 60}:{elapsed_seconds % 60:02d}"
@@ -5928,7 +6047,8 @@ class ConsoleComposerBar(Horizontal):
         else:
             chip.tooltip = None
         chip.styles.display = "block"
-        chip.styles.width = max(width, 1)
+        self._voice_chip_last_width = max(width, 1)
+        chip.styles.width = self._voice_chip_last_width
         chip.styles.min_width = 0
         chip.styles.height = 1
         chip.styles.min_height = 1
@@ -5940,6 +6060,11 @@ class ConsoleComposerBar(Horizontal):
         chip.styles.margin = None
         chip.set_class(state == "error", "console-voice-status-error")
         chip.update(Content(body))
+        # TASK-24620: the chip just moved; re-derive the reason strip so it
+        # yields whatever the chip now holds (chip has priority).
+        self._sync_send_disabled_reason(
+            self._send_disabled_reason, muted=not self._send_blocked
+        )
 
     def _sync_full_width_voice_presentation(self, active: bool) -> None:
         """Make room for the persistent executor-wait copy without data loss."""


### PR DESCRIPTION
## Summary

Fixes the dictation voice chip (`#console-voice-status`) starving the composer draft at narrow widths — the same-class suspect TASK-24415 flagged in its Implementation Notes, now confirmed by the user hitting it live. **TASK-24620**, filed and worked TDD-first.

- **The bug**: `set_voice_status` sized the chip against the composer's *full* width reserving only `VOICE_CHIP_MIN_WIDTH` (24) — ignoring the left cluster, actions row, and the draft. A long state message took up to 53 cells and the `1fr` draft got the remainder: measured 2 columns at an 80-col app, and even at 160 cols just 28 (< the 32-cell floor TASK-2154.14 promised).
- **The fix**: `_voice_chip_width_cap` mirrors TASK-24415's reviewer-approved pattern — budget = `row − left cluster(18) − actions(25) − separator margins(2) − draft floor(32)`; below a 12-cell legible remainder the chip hides (the Dictate button's label still says "Dictating", and dictation failures surface through the rail panel). `on_resize` replays the cached status so a shrink retracts the chip, not the draft.
- **Preparing is exempt**: the busy/preparing chip is action feedback for a Dictate press; the 80-column busy-parakeet tests pin the whole copy visible, so preparing keeps its legacy full-width sizing (it already collapses chrome via `_sync_full_width_voice_presentation`).
- **Two-strip interplay**: the reason strip's cap now subtracts the chip's cached applied width (chip priority — `region` can't be used, it's stale until the next layout pass), and both caps subtract the 2 separator-margin cells measured on the laid-out row. Without these, the two advisory strips each budgeted the full remainder and jointly starved the draft to 30 < 32.

## Pre-existing dev regression repaired here

`test_busy_parakeet_mic_stays_reachable_and_cancels_at_80_columns` **already fails on plain origin/dev** (verified in a throwaway worktree): TASK-24415 (PR #2214) legitimately changed the reason strip's narrow-width contract, but that suite wasn't in PR #2214's verification runs. The stale final assert (reason strip `.display` at a 77-cell row where its budget is legitimately zero) now pins the actual restore contract: the preparing flag cleared and the chip-width cache reset.

## Verification

- RED first: mounted geometry tests reproduced draft = 2 cols at 80 / 28 at 160; GREEN after the fix. 3 mounted + 4 chip-cap unit tests added to `test_console_composer_reason_width.py` (branch coverage: no-row fallback, zero-width fallback, ceiling, intermediate budgets, legibility boundary, chip-priority subtraction).
- 88 dictation-streaming, 47 popup/composer/dictation tests green; post-rebase re-run green (124 across the affected suites).
- Live tmux at 80 cols: triggered a real dictation error state — chip correctly hidden below its budget, typed draft + caret visible, failure feedback delivered via the rail panel.
- Also repaired a mid-session agent-side trap (patches briefly landing in the wrong checkout after a shell cwd reset) — caught via a symbol the wrong tree couldn't define; recorded as a lessons entry in `backlog/docs/lessons-live-verification.md`.

## Notes

- TASK-24620 marked Done with full Implementation Notes; no ADR required (layout fix mirroring an already-reviewed pattern).
- Live-run config note: the verification launch's boot-normalization pass materialized default keys (`filepicker.bookmarks_*`, `model_capabilities.patterns.*`) in the real `~/.config/tldw_cli/config.toml` — the documented benign TASK-3401.14 class; file remains valid TOML with no scratch contamination.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dictation voice chip starving the composer draft at narrow widths (TASK-24620); the chip now caps against the live row's spare space and hides below a 12-cell legible floor, so a long state message no longer collapses the draft to a few columns.

**Bug Fixes**
- `on_resize` replays the cached chip state so shrinking the window retracts the chip, not the draft.
- The reason strip's cap subtracts the chip's applied width, so the two advisory strips no longer jointly starve the draft; the chip-hide paths clear the width cache before the presentation sync, so the strip's budget recovers immediately when dictation ends.
- Preparing keeps its legacy full-width sizing at every width; the stale busy-parakeet assert now pins the restore contract (preparing flag cleared, chip width cache reset).

<sup>Written for commit 4fc37db0470bb48c63bbc343ac8f87df1eac6edd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

