### PR TITLE
fix(diagnostics): reconcile inventory and close dev gate bypass

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -62,14 +62,14 @@
     },
     {
       "call_count": 7,
-      "diagnostic_digest": "23ce5d7b67cdab2e284f",
+      "diagnostic_digest": "238dee71de700d2a41ba",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Agents/mcp_tool_provider.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
       "call_count": 2,
-      "diagnostic_digest": "8b25125a133902b88cdf",
+      "diagnostic_digest": "fc2e1ae1dcbe6a432f1c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Agents/persona_policy.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -188,7 +188,7 @@
     },
     {
       "call_count": 1,
-      "diagnostic_digest": "b5713d9f9935970b8cb5",
+      "diagnostic_digest": "78afce8fdfd750952f7e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Character_Chat/local_character_persona_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2400,7 +2400,7 @@
     },
     {
       "call_count": 20,
-      "diagnostic_digest": "973b163e7c2fc89517be",
+      "diagnostic_digest": "72201dad2822b095ab0c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/session.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2715,7 +2715,7 @@
     },
     {
       "call_count": 187,
-      "diagnostic_digest": "7ccd6fabff0f4501579c",
+      "diagnostic_digest": "58bc60ab3ca08acc5ec9",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/personas_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3737,7 +3737,7 @@
     },
     {
       "call_count": 4,
-      "diagnostic_digest": "c16fba6f187d2467d434",
+      "diagnostic_digest": "49e49487771f82b37dd0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Workspaces/agent_provisioning.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3786,7 +3786,7 @@
     },
     {
       "call_count": 8,
-      "diagnostic_digest": "46a7c52ebe882889ab3b",
+      "diagnostic_digest": "c2c34ef8a1a14f882436",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Workspaces/registry_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3800,7 +3800,7 @@
     },
     {
       "call_count": 365,
-      "diagnostic_digest": "570d23333726ecd3555e",
+      "diagnostic_digest": "da68a157bbf5c2e8a4a0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2715,7 +2715,7 @@
     },
     {
       "call_count": 187,
-      "diagnostic_digest": "58bc60ab3ca08acc5ec9",
+      "diagnostic_digest": "236781455c4b3ee0de45",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/personas_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Tests/Agents/test_persona_policy.py
+++ b/Tests/Agents/test_persona_policy.py
@@ -101,9 +101,8 @@ def test_floor_state_only_lowers_allow():
     assert persona_floor_state(allowed, policy, "fs_read") is allowed
 
 
-def test_non_mapping_rule_dropped_with_warning(caplog):
-    """FIX 2: a non-Mapping rules entry is dropped with a loguru warning
-    (spec: "dropped with a warning"), matching the malformed-entry path."""
+def test_invalid_rules_are_dropped_with_metadata_only_warnings():
+    """Invalid rule diagnostics must not retain user-authored rule values."""
     from loguru import logger
 
     class _Handler:
@@ -119,12 +118,19 @@ def test_non_mapping_rule_dropped_with_warning(caplog):
     )
     try:
         policy = parse_persona_policy_from_rules(
-            ["not-a-mapping", 42, {"rule_kind": "mcp_tool", "rule_name": "fs_read"}]
+            [
+                "PRIVATE_NON_MAPPING_RULE",
+                {"rule_kind": "bogus", "rule_name": "PRIVATE_MALFORMED_RULE"},
+                {"rule_kind": "mcp_tool", "rule_name": "fs_read"},
+            ]
         )
     finally:
         logger.remove(logger_id)
 
     assert policy.kinds == frozenset({"mcp_tool"})
     assert len(policy.rules) == 1
-    dropped = [r for r in handler.records if "non-mapping" in r]
+    dropped = [record for record in handler.records if "Dropping" in record]
     assert len(dropped) == 2, handler.records
+    rendered = "".join(dropped)
+    assert "PRIVATE_NON_MAPPING_RULE" not in rendered
+    assert "PRIVATE_MALFORMED_RULE" not in rendered

--- a/Tests/Architecture/test_persistent_diagnostic_inventory.py
+++ b/Tests/Architecture/test_persistent_diagnostic_inventory.py
@@ -38,6 +38,16 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
         "Local tool approval-state resolution failed": (),
         "Local tool approval callback failed": (),
     },
+    "tldw_chatbook/Agents/mcp_tool_provider.py": {
+        "MCPToolProvider: persona_policy_provider failed": (
+            "tool.name",
+            "type(exc).__name__",
+        ),
+    },
+    "tldw_chatbook/Agents/persona_policy.py": {
+        "Dropping non-mapping persona policy rule": ("type(entry).__name__",),
+        "Dropping malformed persona policy rule": ("type(exc).__name__",),
+    },
     "tldw_chatbook/Agents/run_log_eviction.py": {
         "continuation owner missing from payload": (),
         "run-log eviction failed for continuation history": ("type(exc).__name__",),
@@ -85,6 +95,9 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
     },
     "tldw_chatbook/Character_Chat/Character_Chat_Lib.py": {
         "Skipping malformed usage_json on message export": (),
+    },
+    "tldw_chatbook/Character_Chat/local_character_persona_service.py": {
+        "Dropping malformed persona policy rule": ("type(exc).__name__",),
     },
     "tldw_chatbook/Chat/console_fleet_attention.py": {
         "fleet unseen revision bump failed": ("type(exc).__name__",),
@@ -170,10 +183,6 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
         "Library snapshot shell reconciliation failed": (),
         "Library snapshot canvas replacement failed": (),
         "Library Search/RAG snapshot sync failed": (),
-        "Failed to continue the Database Notes folder navigator": (
-            "type(exc).__name__",
-        ),
-        "Failed to load the Database Notes folder navigator": ("type(exc).__name__",),
         "Database Notes move kept both placements": ("type(exc).__name__",),
         "Database Notes tree mutation": (
             "operation",
@@ -236,6 +245,18 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
     "tldw_chatbook/UI/Console_Modules/session.py": {
         "Character swap: roleplay template seed failed": ("type(exc).__name__",),
         "Start Chat: roleplay template seed/persist failed": ("type(exc).__name__",),
+        "Console turn context: tool policy profile resolution failed": (
+            "type(exc).__name__",
+        ),
+        "Console turn context: persona policy rules resolution failed": (
+            "type(exc).__name__",
+        ),
+        "Console session startup: workspace default persona resolution failed": (
+            "type(exc).__name__",
+        ),
+        "Console session startup: new-session settings selection failed": (
+            "type(exc).__name__",
+        ),
     },
     "tldw_chatbook/UI/Console_Modules/workspace.py": {
         "Star-toggle cancellation re-sync failed": (),
@@ -277,6 +298,7 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
         "Could not attach the world book": (),
         "Could not show the dictionary attach picker": (),
         "Could not show the world-book attach picker": (),
+        "Error saving persona policy rules": ("type(exc).__name__",),
     },
     "tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py": {
         "Wizard commit rejected non-owned sections": (),
@@ -344,6 +366,34 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
         ),
         "Generated CSS is stale during module entry; rebuilding": (),
         "Generated CSS is stale during CLI entry; rebuilding": (),
+        "Deferred workspace agent provisioning wiring failed": (
+            "type(exc).__name__",
+        ),
+        "Workspace agent provisioning skipped": (),
+        "Workspace agent backfill failed during app wiring": (
+            "type(exc).__name__",
+        ),
+        "Workspace agent backfill provisioned": ("provisioned",),
+    },
+    "tldw_chatbook/Workspaces/agent_provisioning.py": {
+        "Workspace agent provisioning failed": ("type(exc).__name__",),
+        "Workspace agent backfill could not persist defaults": (
+            "type(exc).__name__",
+        ),
+        "Workspace agent backfill had failures": (),
+        "Workspace agent backfill completion flag could not be stored": (
+            "type(exc).__name__",
+        ),
+    },
+    "tldw_chatbook/Workspaces/registry_service.py": {
+        "Workspace agent provisioning hook failed": ("type(exc).__name__",),
+        "Workspace agent provisioning returned no defaults": (),
+        "Workspace agent defaults could not be persisted": (
+            "type(exc).__name__",
+        ),
+        "Ignoring malformed workspace assistant_defaults": (
+            "type(exc).__name__",
+        ),
     },
     "tldw_chatbook/Event_Handlers/LLM_Management_Events/llm_management_events.py": {
         "GGUF launch lease close failed": ("provider",),
@@ -427,10 +477,6 @@ TASK_15743_FINAL_REBASE_DIAGNOSTICS = {
     },
     "tldw_chatbook/config.py": {
         "phase=precondition, error_type": (1, ("type(error).__name__",)),
-        "phase=locked_precondition, error_type": (
-            1,
-            ("type(error).__name__",),
-        ),
     },
 }
 

--- a/Tests/Architecture/test_persistent_diagnostic_inventory.py
+++ b/Tests/Architecture/test_persistent_diagnostic_inventory.py
@@ -298,7 +298,10 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
         "Could not attach the world book": (),
         "Could not show the dictionary attach picker": (),
         "Could not show the world-book attach picker": (),
-        "Error saving persona policy rules": ("type(exc).__name__",),
+        "Error saving persona policy rules": (
+            "len(rules)",
+            "type(exc).__name__",
+        ),
     },
     "tldw_chatbook/UI/Wizards/FirstRunSetupWizard.py": {
         "Wizard commit rejected non-owned sections": (),

--- a/Tests/Character_Chat/test_persona_policy_rules.py
+++ b/Tests/Character_Chat/test_persona_policy_rules.py
@@ -29,15 +29,31 @@ def test_caps_minimum_is_one():
         )
 
 
-def test_normalize_drops_malformed_rules():
+def test_normalize_drops_malformed_rules_without_logging_private_values():
+    from loguru import logger
+
     from tldw_chatbook.Character_Chat.local_character_persona_service import (
         normalize_policy_rules,
     )
 
-    cleaned = normalize_policy_rules(
-        [{"rule_kind": "mcp_tool", "rule_name": "ok"}, {"rule_kind": "bogus"}, "junk"]
-    )
+    records = []
+    sink_id = logger.add(records.append, level="WARNING", format="{message}")
+    try:
+        cleaned = normalize_policy_rules(
+            [
+                {"rule_kind": "mcp_tool", "rule_name": "ok"},
+                {"rule_kind": "bogus", "rule_name": "PRIVATE_POLICY_RULE"},
+                "PRIVATE_NON_MAPPING_RULE",
+            ]
+        )
+    finally:
+        logger.remove(sink_id)
+
     assert cleaned == [
         {"rule_kind": "mcp_tool", "rule_name": "ok", "allowed": True,
          "require_confirmation": False, "max_calls_per_turn": None}
     ]
+    rendered = "".join(str(record) for record in records)
+    assert rendered.count("Dropping malformed persona policy rule") == 2
+    assert "PRIVATE_POLICY_RULE" not in rendered
+    assert "PRIVATE_NON_MAPPING_RULE" not in rendered

--- a/Tests/UI/test_persona_policy_rules_editor.py
+++ b/Tests/UI/test_persona_policy_rules_editor.py
@@ -593,3 +593,46 @@ async def test_policy_rules_changed_persists_validated_rules_via_service(
         assert call.kwargs.get("expected_version") == 2
         assert call.kwargs.get("mode") == "local"
         assert any("policy rules saved" in item.lower() for item in notifications)
+
+
+@pytest.mark.usefixtures("stub_characters")
+async def test_policy_rule_save_failure_logs_metadata_only(
+    monkeypatch, mock_app_instance, local_scope
+):
+    """Persistent diagnostics must not retain service exception messages."""
+    from loguru import logger
+
+    monkeypatch.setattr(personas_screen_module, "PersonaVisualRepository", _Repository)
+    local_scope.update_persona_profile.side_effect = RuntimeError(
+        "PRIVATE_POLICY_SAVE_FAILURE"
+    )
+    app = PersonasTestApp(mock_app_instance)
+    app.notify = lambda *_args, **_kwargs: None
+    records = []
+    sink_id = logger.add(records.append, level="ERROR", format="{message}")
+    try:
+        async with app.run_test() as pilot:
+            screen = await _open_editor(pilot)
+            screen.post_message(
+                PersonaPolicyRulesChanged(
+                    [
+                        {
+                            "rule_kind": "mcp_tool",
+                            "rule_name": "search_notes",
+                            "allowed": True,
+                            "require_confirmation": False,
+                            "max_calls_per_turn": None,
+                        }
+                    ]
+                )
+            )
+            for _ in range(10):
+                await pilot.pause()
+                if local_scope.update_persona_profile.await_count:
+                    break
+    finally:
+        logger.remove(sink_id)
+
+    rendered = "".join(str(record) for record in records)
+    assert "Error saving persona policy rules" in rendered
+    assert "PRIVATE_POLICY_SAVE_FAILURE" not in rendered

--- a/Tests/UI/test_persona_policy_rules_editor.py
+++ b/Tests/UI/test_persona_policy_rules_editor.py
@@ -635,4 +635,6 @@ async def test_policy_rule_save_failure_logs_metadata_only(
 
     rendered = "".join(str(record) for record in records)
     assert "Error saving persona policy rules" in rendered
+    assert "rule_count=1" in rendered
+    assert "mode=local" in rendered
     assert "PRIVATE_POLICY_SAVE_FAILURE" not in rendered

--- a/Tests/Workspaces/test_workspace_assistant_defaults.py
+++ b/Tests/Workspaces/test_workspace_assistant_defaults.py
@@ -85,15 +85,26 @@ def test_read_write_requires_confirmation(tmp_path):
     registry.set_assistant_defaults("w-2", defaults, confirm_read_write=True)
 
 
-def test_malformed_stored_json_degrades_to_none(tmp_path):
+def test_malformed_stored_json_degrades_without_logging_private_values(tmp_path):
+    from loguru import logger
+
     registry = build_registry(tmp_path)
     registry.create_workspace(workspace_id="w-3", name="W3")
     with registry.db.transaction() as conn:
         conn.execute(
             "UPDATE workspace_records SET assistant_defaults = ? WHERE workspace_id = 'w-3'",
-            ("{not json",),
+            ('{"assistant_kind": "PRIVATE_UNSUPPORTED_KIND", "assistant_id": "p"}',),
         )
-    assert registry.get_workspace("w-3").assistant_defaults is None
+    records = []
+    sink_id = logger.add(records.append, level="WARNING", format="{message}")
+    try:
+        assert registry.get_workspace("w-3").assistant_defaults is None
+    finally:
+        logger.remove(sink_id)
+
+    rendered = "".join(str(record) for record in records)
+    assert "Ignoring malformed workspace assistant_defaults" in rendered
+    assert "PRIVATE_UNSUPPORTED_KIND" not in rendered
 
 
 def test_effective_resolution_reason_codes():

--- a/Tests/fixtures/summarization_diagnostic_review.json
+++ b/Tests/fixtures/summarization_diagnostic_review.json
@@ -1,8 +1,8 @@
 {
     "schema_version": 1,
     "manifest_boundary": {
-        "checked_normalized_inventory_sha256": "de223ae32d2fa1f35ef7419cfe97a8d8aaa5aef8e0b1413b864c9fc099c7fa55",
-        "origin_dev_generated_normalized_inventory_sha256": "de223ae32d2fa1f35ef7419cfe97a8d8aaa5aef8e0b1413b864c9fc099c7fa55",
+        "checked_normalized_inventory_sha256": "38e4ab444125883dfb47ae5748f8310ba9028d1322d30e58e32755aa7751439d",
+        "origin_dev_generated_normalized_inventory_sha256": "38e4ab444125883dfb47ae5748f8310ba9028d1322d30e58e32755aa7751439d",
         "owned_entries": [
             {
                 "path": "tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py",

--- a/Tests/fixtures/summarization_diagnostic_review.json
+++ b/Tests/fixtures/summarization_diagnostic_review.json
@@ -1,8 +1,8 @@
 {
     "schema_version": 1,
     "manifest_boundary": {
-        "checked_normalized_inventory_sha256": "af27c0ecde3f9000f34a7d9df1915b39e809dbc311fb40587a3cefeac3c6db79",
-        "origin_dev_generated_normalized_inventory_sha256": "af27c0ecde3f9000f34a7d9df1915b39e809dbc311fb40587a3cefeac3c6db79",
+        "checked_normalized_inventory_sha256": "de223ae32d2fa1f35ef7419cfe97a8d8aaa5aef8e0b1413b864c9fc099c7fa55",
+        "origin_dev_generated_normalized_inventory_sha256": "de223ae32d2fa1f35ef7419cfe97a8d8aaa5aef8e0b1413b864c9fc099c7fa55",
         "owned_entries": [
             {
                 "path": "tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py",

--- a/backlog/decisions/103-fast-pr-lane-and-required-gate-aggregation.md
+++ b/backlog/decisions/103-fast-pr-lane-and-required-gate-aggregation.md
@@ -1,8 +1,8 @@
 # ADR-103: Fast PR lane and required gate aggregation
 
-Status: Accepted
+Status: Accepted (amended 2026-08-30 for admin/current-base enforcement)
 Date: 2026-08-29
-Related Task: [TASK-24403](../tasks/task-24403%20-%20Fast-PR-lane-preserves-required-gate-and-full-coverage-cadence.md)
+Related Tasks: [TASK-24403](../tasks/task-24403%20-%20Fast-PR-lane-preserves-required-gate-and-full-coverage-cadence.md), [TASK-24653](../tasks/task-24653%20-%20Reconcile-diagnostic-inventory-and-enforce-the-dev-required-gate.md)
 Supersedes: N/A
 
 ## Decision
@@ -12,6 +12,35 @@ result is aggregated by the existing required `Derived artifacts reproduce from
 their sources` context; comprehensive test coverage runs on `main`, manual
 events, and a dedicated default-branch-owned nightly workflow instead of every
 pull-request update.
+
+## Amendment (2026-08-30, TASK-24653) — adopted
+
+The `dev` protection rule applies the existing required context to
+administrators and requires the result against the latest base revision:
+
+- `enforce_admins` is enabled; and
+- required status checks use strict/latest-base enforcement.
+
+The required context remains `Derived artifacts reproduce from their sources`.
+No workflow name or prerequisite relationship changes in this amendment.
+
+This closes a reproduced enforcement gap. PR #2228 merged into `dev` at
+15:40:01 UTC while its required workflow was still queued: the fast lane did
+not start until after the merge and the derived-artifact job did not start
+until approximately 15:48 UTC. The merge introduced persistent-diagnostic
+owners without regenerating their canonical inventory, leaving the checker
+and its dependent summarization privacy boundary red. The required workflow
+correctly detected the drift after merge, but branch protection had
+`enforce_admins=false` and `strict=false`, so an administrator could merge
+before that evidence existed and a result from a stale base could satisfy the
+rule.
+
+Repository-wide generated artifacts compose across pull requests. A required
+artifact check therefore protects the branch only when every merger is bound
+by it and its result describes the current base. The additional queue/rebase
+cost is accepted: administrators wait for the same gate as other contributors,
+and a base update may require a fresh result before merge. Force-push policy is
+unchanged by this amendment.
 
 ## Context
 
@@ -74,9 +103,10 @@ cron entry on `dev`.
   evidence matrices can add six jobs, and a synchronize event on a PR carrying
   the opt-in TASK-19637 label can add three more. Those exceptional evidence
   suites retain their explicit contracts.
-- Existing unchanged PR heads can retain a previously reported required result
-  until their next pull-request event. This bounded grandfathering is accepted
-  instead of rewriting branches or close/reopening unrelated PRs.
+- The original rollout allowed unchanged PR heads to retain a previously
+  reported required result until their next pull-request event. The 2026-08-30
+  amendment ends that grandfathering for merge eligibility: the required
+  result must now describe the latest `dev` base and applies to administrators.
 - The fast lane runs at the supported Python and Textual floor with only core
   application dependencies and explicit test utilities. Optional ML, document,
   and browser stacks remain outside the PR gate.
@@ -100,6 +130,7 @@ cron entry on `dev`.
 ## Links
 
 - [TASK-24403](../tasks/task-24403%20-%20Fast-PR-lane-preserves-required-gate-and-full-coverage-cadence.md)
+- [TASK-24653](../tasks/task-24653%20-%20Reconcile-diagnostic-inventory-and-enforce-the-dev-required-gate.md)
 - [TASK-19600](../tasks/task-19600%20-%20Nightly-deep-test-tier-has-never-fired-cron-registers-only-from-the-default-branch.md)
 - [Fast PR lane design](../../Docs/superpowers/specs/2026-08-29-fast-pr-lane-design.md)
 - [TASK-22250](../tasks/task-22250%20-%20CI%20runs%20are%20swept%20by%20simultaneous%20burst%20cancellations.md)

--- a/backlog/decisions/103-fast-pr-lane-and-required-gate-aggregation.md
+++ b/backlog/decisions/103-fast-pr-lane-and-required-gate-aggregation.md
@@ -2,7 +2,7 @@
 
 Status: Accepted (amended 2026-08-30 for admin/current-base enforcement)
 Date: 2026-08-29
-Related Tasks: [TASK-24403](../tasks/task-24403%20-%20Fast-PR-lane-preserves-required-gate-and-full-coverage-cadence.md), [TASK-24653](../tasks/task-24653%20-%20Reconcile-diagnostic-inventory-and-enforce-the-dev-required-gate.md)
+Related Tasks: [TASK-24403](../tasks/task-24403%20-%20Fast-PR-lane-preserves-required-gate-and-full-coverage-cadence.md), [TASK-25705](../tasks/task-25705%20-%20Reconcile-diagnostic-inventory-and-enforce-the-dev-required-gate.md)
 Supersedes: N/A
 
 ## Decision
@@ -13,7 +13,7 @@ their sources` context; comprehensive test coverage runs on `main`, manual
 events, and a dedicated default-branch-owned nightly workflow instead of every
 pull-request update.
 
-## Amendment (2026-08-30, TASK-24653) — adopted
+## Amendment (2026-08-30, TASK-25705) — adopted
 
 The `dev` protection rule applies the existing required context to
 administrators and requires the result against the latest base revision:
@@ -130,7 +130,7 @@ cron entry on `dev`.
 ## Links
 
 - [TASK-24403](../tasks/task-24403%20-%20Fast-PR-lane-preserves-required-gate-and-full-coverage-cadence.md)
-- [TASK-24653](../tasks/task-24653%20-%20Reconcile-diagnostic-inventory-and-enforce-the-dev-required-gate.md)
+- [TASK-25705](../tasks/task-25705%20-%20Reconcile-diagnostic-inventory-and-enforce-the-dev-required-gate.md)
 - [TASK-19600](../tasks/task-19600%20-%20Nightly-deep-test-tier-has-never-fired-cron-registers-only-from-the-default-branch.md)
 - [Fast PR lane design](../../Docs/superpowers/specs/2026-08-29-fast-pr-lane-design.md)
 - [TASK-22250](../tasks/task-22250%20-%20CI%20runs%20are%20swept%20by%20simultaneous%20burst%20cancellations.md)

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9996,3 +9996,21 @@ not proof that its replacement widget is current. When the next assertion or
 action depends on a recomposed child, also wait for that identifying mounted
 control, yield one compositor cycle, then re-query it immediately before use.
 Do not keep and press a control captured before a branch refresh.
+
+---
+
+## A required check that exempts admins or accepts a stale base is advisory
+
+**Incident.** TASK-24653, 2026-08-30. PR #2228 merged into `dev` before its
+required derived-artifact workflow started. The workflow later detected that
+new persistent diagnostics had not regenerated the canonical inventory, but
+the merge had already landed because branch protection used both
+`enforce_admins=false` and non-strict status checks. The result was a red
+architecture checker and two red dependent summarization-privacy tests on
+`dev`, even though the correct required context already existed.
+
+**What to do.** A repository-wide generated-artifact check must apply to every
+merger and to the current base revision. Enforce required checks for
+administrators, require the latest base, and verify the live protection API
+after changing it. The workflow's eventual failure proves the checker works;
+it does not prove the branch was protected at merge time.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -10001,7 +10001,7 @@ Do not keep and press a control captured before a branch refresh.
 
 ## A required check that exempts admins or accepts a stale base is advisory
 
-**Incident.** TASK-24653, 2026-08-30. PR #2228 merged into `dev` before its
+**Incident.** TASK-25705, 2026-08-30. PR #2228 merged into `dev` before its
 required derived-artifact workflow started. The workflow later detected that
 new persistent diagnostics had not regenerated the canonical inventory, but
 the merge had already landed because branch protection used both

--- a/backlog/tasks/task-24653 - Reconcile-diagnostic-inventory-and-enforce-the-dev-required-gate.md
+++ b/backlog/tasks/task-24653 - Reconcile-diagnostic-inventory-and-enforce-the-dev-required-gate.md
@@ -1,0 +1,64 @@
+---
+id: TASK-24653
+title: Reconcile diagnostic inventory and enforce the dev required gate
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-08-30 15:54'
+updated_date: '2026-08-30 16:18'
+labels:
+  - diagnostics
+  - ci
+  - reliability
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Restore the repository-wide persistent-diagnostic contract after merged diagnostic-bearing changes drifted from its generated inventory, and close the branch-protection bypass that allowed the drift to merge.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Every newly introduced or changed persistent diagnostic statement is reviewed against ADR-029 and contains no private user-authored content.
+- [x] #2 The canonical persistent-diagnostic inventory and its dependent summarization boundary fixture reproduce from current sources.
+- [x] #3 The focused inventory and summarization privacy tests pass without changing production behavior unless review identifies an unsafe diagnostic.
+- [x] #4 ADR-103 documents the merge incident and the stricter current-base/admin enforcement decision.
+- [x] #5 The dev branch requires the existing derived-artifacts context on the latest base and applies that requirement to administrators.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the inventory drift and inspect every changed diagnostic statement against ADR-029.
+2. Regenerate the canonical inventory and reconcile its dependent summarization fixture without changing runtime behavior unless privacy review requires it.
+3. Amend ADR-103 with the observed admin/latest-base bypass and the stricter protection decision.
+4. Run the focused inventory, privacy, and submitted-log regression matrix plus repository hygiene checks.
+5. Enable admin enforcement and strict latest-base checks for the existing dev required context, then verify the live protection state.
+6. Complete task hygiene and take the recovery branch through PR review and merge.
+
+ADR required: yes
+ADR path: backlog/decisions/103-fast-pr-lane-and-required-gate-aggregation.md
+Reason: This changes the long-lived enforcement semantics of the dev required-check boundary after a real bypass; ADR-029 remains the governing privacy contract for diagnostic review.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reviewed every diagnostic introduced by the merged workspace/persona changes against ADR-029. Replaced raw policy entries, workspace/persona identifiers, exception messages, and persisted tracebacks with fixed labels plus safe type/count metadata; control flow and user-visible error handling are unchanged.
+
+Regenerated Docs/security/production-diagnostic-inventory.json and reconciled the summarization privacy-boundary hash. Removed three stale historical diagnostic guard rows whose source statements had already been retired. Amended ADR-103 and the testing-evidence lesson with the reproduced PR #2228 admin/stale-base bypass. Live dev protection now requires the existing derived-artifacts context with strict/latest-base and admin enforcement enabled; force-push policy was not changed.
+
+Verification: canonical checker reports 546 owners / 1,278 TASK-492 calls / 7,384 TASK-494 calls / 8 sink files with no drift; 66 focused runtime/privacy tests pass; 3 focused architecture checks pass; the strict-CP1252 submitted-log matrix reports 738 passed and 7 expected skips; git diff --check passes. ADR required: yes; ADR-103 amended, with ADR-029 governing diagnostic privacy.
+<!-- SECTION:NOTES:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+- [x] #1 Canonical inventory checker and focused/submitted-log regression matrices pass.
+- [x] #2 Diff hygiene and changed-line static review complete without new issues.
+- [x] #3 ADR-103, the testing-evidence lesson, and task documentation are current.
+- [x] #4 Self-review confirms production changes are limited to metadata-only diagnostics.
+- [ ] #5 PR review feedback is addressed and the required merge gate is green.
+<!-- DOD:END -->

--- a/backlog/tasks/task-25705 - Reconcile-diagnostic-inventory-and-enforce-the-dev-required-gate.md
+++ b/backlog/tasks/task-25705 - Reconcile-diagnostic-inventory-and-enforce-the-dev-required-gate.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-25705
 title: Reconcile diagnostic inventory and enforce the dev required gate
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-30 15:54'
-updated_date: '2026-08-30 16:18'
+updated_date: '2026-08-30 17:23'
 labels:
   - diagnostics
   - ci
@@ -52,6 +52,8 @@ Reviewed every diagnostic introduced by the merged workspace/persona changes aga
 Regenerated Docs/security/production-diagnostic-inventory.json and reconciled the summarization privacy-boundary hash. Removed three stale historical diagnostic guard rows whose source statements had already been retired. Amended ADR-103 and the testing-evidence lesson with the reproduced PR #2228 admin/stale-base bypass. Live dev protection now requires the existing derived-artifacts context with strict/latest-base and admin enforcement enabled; force-push policy was not changed.
 
 Verification: after the final `dev` rebase, the canonical checker reports 547 owners / 1,278 TASK-492 calls / 7,397 TASK-494 calls / 8 sink files with no drift; 66 focused runtime/privacy tests pass; 323 inventory/privacy pin cases pass; 5 Qodo-focused review regressions pass; the strict-CP1252 submitted-log matrix reports 738 passed and 7 expected skips; git diff --check passes. ADR required: yes; ADR-103 amended, with ADR-029 governing diagnostic privacy.
+
+Qodo review raised one valid observability issue. Added only validated metadata (`mode=local`, `rule_count=len(rules)`) beside the exception type, updated the privacy regression and metadata guard, regenerated the inventory, replied in-thread, and resolved the thread. After two latest-dev rebases, the authoritative d1116bdcc4 gate passed 671 Fast Lane tests plus every derived-artifact check; all other PR checks are green. The concurrent TASK-24653 collision was resolved under TASK-19601 by renumbering this younger task to TASK-25705 and updating its references.
 <!-- SECTION:NOTES:END -->
 
 ## Renumbering provenance
@@ -70,5 +72,5 @@ lesson were updated to follow this task’s new id.
 - [x] #2 Diff hygiene and changed-line static review complete without new issues.
 - [x] #3 ADR-103, the testing-evidence lesson, and task documentation are current.
 - [x] #4 Self-review confirms production changes are limited to metadata-only diagnostics.
-- [ ] #5 PR review feedback is addressed and the required merge gate is green.
+- [x] #5 PR review feedback is addressed and the required merge gate is green.
 <!-- DOD:END -->

--- a/backlog/tasks/task-25705 - Reconcile-diagnostic-inventory-and-enforce-the-dev-required-gate.md
+++ b/backlog/tasks/task-25705 - Reconcile-diagnostic-inventory-and-enforce-the-dev-required-gate.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-24653
+id: TASK-25705
 title: Reconcile diagnostic inventory and enforce the dev required gate
 status: In Progress
 assignee:
@@ -51,8 +51,18 @@ Reviewed every diagnostic introduced by the merged workspace/persona changes aga
 
 Regenerated Docs/security/production-diagnostic-inventory.json and reconciled the summarization privacy-boundary hash. Removed three stale historical diagnostic guard rows whose source statements had already been retired. Amended ADR-103 and the testing-evidence lesson with the reproduced PR #2228 admin/stale-base bypass. Live dev protection now requires the existing derived-artifacts context with strict/latest-base and admin enforcement enabled; force-push policy was not changed.
 
-Verification: canonical checker reports 546 owners / 1,278 TASK-492 calls / 7,384 TASK-494 calls / 8 sink files with no drift; 66 focused runtime/privacy tests pass; 3 focused architecture checks pass; the strict-CP1252 submitted-log matrix reports 738 passed and 7 expected skips; git diff --check passes. ADR required: yes; ADR-103 amended, with ADR-029 governing diagnostic privacy.
+Verification: after the final `dev` rebase, the canonical checker reports 547 owners / 1,278 TASK-492 calls / 7,397 TASK-494 calls / 8 sink files with no drift; 66 focused runtime/privacy tests pass; 323 inventory/privacy pin cases pass; 5 Qodo-focused review regressions pass; the strict-CP1252 submitted-log matrix reports 738 passed and 7 expected skips; git diff --check passes. ADR required: yes; ADR-103 amended, with ADR-029 governing diagnostic privacy.
 <!-- SECTION:NOTES:END -->
+
+## Renumbering provenance
+
+This task was renumbered from `TASK-24653` to `TASK-25705` after rebasing
+exposed a concurrent collision. The older “Network TLS trust policy (corp DPI)”
+task was created at 2026-08-29 22:51 and keeps `TASK-24653` under the
+TASK-19601 owner rule; this recovery task was created at 2026-08-30 15:54 and
+therefore moved. A live sweep of every remote ref and local worktree confirmed
+`TASK-25705` was unused at renumbering time. ADR-103 and the testing-evidence
+lesson were updated to follow this task’s new id.
 
 ## Definition of Done
 <!-- DOD:BEGIN -->

--- a/tldw_chatbook/Agents/mcp_tool_provider.py
+++ b/tldw_chatbook/Agents/mcp_tool_provider.py
@@ -823,9 +823,12 @@ class MCPToolProvider:
             return state
         try:
             policy = self._persona_policy_provider()
-        except Exception:  # noqa: BLE001 -- a broken provider never blocks invoke
-            logger.opt(exception=True).warning(
-                "MCPToolProvider: persona_policy_provider failed"
+        except Exception as exc:  # noqa: BLE001 -- a broken provider never blocks invoke
+            logger.warning(
+                "MCPToolProvider: persona_policy_provider failed for {}; "
+                "error_type={}",
+                tool.name,
+                type(exc).__name__,
             )
             return state
         if policy is None:

--- a/tldw_chatbook/Agents/persona_policy.py
+++ b/tldw_chatbook/Agents/persona_policy.py
@@ -59,7 +59,10 @@ def parse_persona_policy_from_rules(
     cleaned: list[dict[str, object]] = []
     for entry in rules or ():
         if not isinstance(entry, Mapping):
-            logger.warning("Dropping non-mapping persona policy rule")
+            logger.warning(
+                "Dropping non-mapping persona policy rule; entry_type={}",
+                type(entry).__name__,
+            )
             continue
         try:
             from tldw_chatbook.tldw_api.character_persona_schemas import PersonaPolicyRule
@@ -67,8 +70,11 @@ def parse_persona_policy_from_rules(
             cleaned.append(
                 PersonaPolicyRule.model_validate(dict(entry)).model_dump(mode="json")
             )
-        except Exception:
-            logger.warning("Dropping malformed persona policy rule")
+        except Exception as exc:
+            logger.warning(
+                "Dropping malformed persona policy rule; error_type={}",
+                type(exc).__name__,
+            )
     return PersonaToolPolicy(
         rules=tuple(cleaned), kinds=frozenset(str(r["rule_kind"]) for r in cleaned)
     )

--- a/tldw_chatbook/Character_Chat/local_character_persona_service.py
+++ b/tldw_chatbook/Character_Chat/local_character_persona_service.py
@@ -69,8 +69,11 @@ def normalize_policy_rules(value: Any) -> list[dict[str, Any]]:
             rules.append(
                 PersonaPolicyRule.model_validate(entry).model_dump(mode="json")
             )
-        except Exception:
-            logger.warning("Dropping malformed persona policy rule")
+        except Exception as exc:
+            logger.warning(
+                "Dropping malformed persona policy rule; error_type={}",
+                type(exc).__name__,
+            )
     return rules
 
 

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -2838,10 +2838,11 @@ class ConsoleSessionController:
             profile_id = getattr(defaults, "tool_policy_profile_id", None)
             if isinstance(profile_id, str) and profile_id.strip():
                 return profile_id.strip()
-        except Exception:  # noqa: BLE001 -- posture degrades, never blocks
-            logger.opt(exception=True).warning(
+        except Exception as exc:  # noqa: BLE001 -- posture degrades, never blocks
+            logger.warning(
                 "Console turn context: tool policy profile resolution failed; "
-                "using the default profile"
+                "using the default profile; error_type={}",
+                type(exc).__name__,
             )
         return "default"
 
@@ -2881,10 +2882,11 @@ class ConsoleSessionController:
             rules = profile.get("policy_rules") if isinstance(profile, Mapping) else None
             if isinstance(rules, (list, tuple)):
                 return tuple(rule for rule in rules if isinstance(rule, Mapping))
-        except Exception:  # noqa: BLE001 -- posture degrades, never blocks
-            logger.opt(exception=True).warning(
+        except Exception as exc:  # noqa: BLE001 -- posture degrades, never blocks
+            logger.warning(
                 "Console turn context: persona policy rules resolution failed; "
-                "running with no persona rules"
+                "running with no persona rules; error_type={}",
+                type(exc).__name__,
             )
         return ()
 
@@ -2947,10 +2949,11 @@ class ConsoleSessionController:
                 prompt,
                 effective.persona_memory_mode or "read_only",
             )
-        except Exception:  # noqa: BLE001 -- workspace defaults degrade, never block
-            logger.opt(exception=True).warning(
+        except Exception as exc:  # noqa: BLE001 -- workspace defaults degrade, never block
+            logger.warning(
                 "Console session startup: workspace default persona "
-                "resolution failed; starting a plain session"
+                "resolution failed; starting a plain session; error_type={}",
+                type(exc).__name__,
             )
             return None
 
@@ -3054,10 +3057,11 @@ class ConsoleSessionController:
                         },
                     )
             return settings, {}
-        except Exception:  # noqa: BLE001 -- startup degrades, never blocks
-            logger.opt(exception=True).warning(
+        except Exception as exc:  # noqa: BLE001 -- startup degrades, never blocks
+            logger.warning(
                 "Console session startup: new-session settings selection "
-                "failed; falling back to plain defaults"
+                "failed; falling back to plain defaults; error_type={}",
+                type(exc).__name__,
             )
             try:
                 return self._default_console_session_settings(), {}

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -14640,7 +14640,9 @@ class PersonasScreen(BaseAppScreen):
             )
         except Exception as exc:
             logger.error(
-                "Error saving persona policy rules; error_type={}",
+                "Error saving persona policy rules; mode=local; rule_count={}; "
+                "error_type={}",
+                len(rules),
                 type(exc).__name__,
             )
             self._notify(f"Policy rules save failed: {exc}", "error")

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -14639,7 +14639,10 @@ class PersonasScreen(BaseAppScreen):
                 mode="local",
             )
         except Exception as exc:
-            logger.opt(exception=True).error("Error saving persona policy rules")
+            logger.error(
+                "Error saving persona policy rules; error_type={}",
+                type(exc).__name__,
+            )
             self._notify(f"Policy rules save failed: {exc}", "error")
             return
         if isinstance(updated, dict):

--- a/tldw_chatbook/Workspaces/agent_provisioning.py
+++ b/tldw_chatbook/Workspaces/agent_provisioning.py
@@ -63,7 +63,7 @@ class WorkspaceAgentProvisioner:
         """Provision the workspace's default agent, or ``None`` on failure.
 
         Never raises: any exception (persona service down, store unwritable,
-        malformed response) is logged with the workspace id and swallowed.
+        malformed response) is logged as metadata only and swallowed.
 
         Args:
             workspace: The workspace record to provision for.
@@ -89,8 +89,11 @@ class WorkspaceAgentProvisioner:
             return WorkspaceAssistantDefaults(
                 assistant_id=str(record["id"]), tool_policy_profile_id=profile_id
             )
-        except Exception:
-            logger.opt(exception=True).warning("Workspace agent provisioning failed")
+        except Exception as exc:
+            logger.warning(
+                "Workspace agent provisioning failed; error_type={}",
+                type(exc).__name__,
+            )
             return None
 
 
@@ -164,9 +167,10 @@ def run_workspace_agent_backfill(
             registry.set_assistant_defaults(
                 record.workspace_id, defaults, confirm_read_write=True
             )
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Workspace agent backfill could not persist defaults"
+        except Exception as exc:
+            logger.warning(
+                "Workspace agent backfill could not persist defaults; error_type={}",
+                type(exc).__name__,
             )
             failed = True
             continue
@@ -179,8 +183,10 @@ def run_workspace_agent_backfill(
         return count
     try:
         registry.db.mark_agent_backfill_complete()
-    except Exception:
-        logger.opt(exception=True).warning(
-            "Workspace agent backfill completion flag could not be stored"
+    except Exception as exc:
+        logger.warning(
+            "Workspace agent backfill completion flag could not be stored; "
+            "error_type={}",
+            type(exc).__name__,
         )
     return count

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -443,9 +443,10 @@ class LocalWorkspaceRegistryService:
             return created
         try:
             defaults = hook(created)
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Workspace agent provisioning hook failed"
+        except Exception as exc:
+            logger.warning(
+                "Workspace agent provisioning hook failed; error_type={}",
+                type(exc).__name__,
             )
             return created
         if defaults is None:
@@ -455,9 +456,10 @@ class LocalWorkspaceRegistryService:
             return self.set_assistant_defaults(
                 created.workspace_id, defaults, confirm_read_write=True
             )
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Workspace agent defaults could not be persisted"
+        except Exception as exc:
+            logger.warning(
+                "Workspace agent defaults could not be persisted; error_type={}",
+                type(exc).__name__,
             )
             return created
 
@@ -2947,8 +2949,11 @@ def _assistant_defaults_from_json(value: Any) -> WorkspaceAssistantDefaults | No
             persona_memory_mode=str(payload.get("persona_memory_mode") or "read_only"),
             tool_policy_profile_id=payload.get("tool_policy_profile_id"),
         )
-    except (json.JSONDecodeError, TypeError, ValueError):
-        logger.warning("Ignoring malformed workspace assistant_defaults")
+    except (json.JSONDecodeError, TypeError, ValueError) as exc:
+        logger.warning(
+            "Ignoring malformed workspace assistant_defaults; error_type={}",
+            type(exc).__name__,
+        )
         return None
 
 

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -8739,9 +8739,10 @@ class TldwCli(
         """Timer callback: run the (best-effort, non-fatal) provisioning wiring."""
         try:
             self._wire_workspace_agent_provisioning()
-        except Exception:
-            self.loguru_logger.opt(exception=True).warning(
-                "Deferred workspace agent provisioning wiring failed"
+        except Exception as exc:
+            self.loguru_logger.warning(
+                "Deferred workspace agent provisioning wiring failed; error_type={}",
+                type(exc).__name__,
             )
 
     def _wire_workspace_agent_provisioning(self) -> None:
@@ -8781,9 +8782,10 @@ class TldwCli(
                 registry=registry,
                 provisioner=provisioner,
             )
-        except Exception:
-            logger.opt(exception=True).warning(
-                "Workspace agent backfill failed during app wiring"
+        except Exception as exc:
+            logger.warning(
+                "Workspace agent backfill failed during app wiring; error_type={}",
+                type(exc).__name__,
             )
             return
         if provisioned:


### PR DESCRIPTION
## Summary

- audit the workspace/persona diagnostic delta against ADR-029 and replace raw policy entries, identifiers, exception messages, and persisted tracebacks with metadata-only diagnostics
- regenerate the canonical persistent-diagnostic inventory and reconcile the dependent summarization privacy boundary
- remove stale historical diagnostic guard rows and add regression coverage for user-authored values
- amend ADR-103 with the reproduced PR #2228 enforcement gap and document the testing lesson
- record the live `dev` protection amendment: existing required context, strict/latest-base enabled, admin enforcement enabled, force-push policy unchanged

## Verification

- `scripts/check_persistent_diagnostic_inventory.py --diff` — no drift; 546 owners, 1,278 TASK-492 calls, 7,384 TASK-494 calls, 8 sink files
- focused runtime/privacy matrix — 66 passed
- focused diagnostic architecture checks — 3 passed
- submitted-log regression matrix with `PYTHONIOENCODING=cp1252` — 738 passed, 7 skipped
- changed-line Ruff review — no findings
- changed production modules — `py_compile` passed
- `git diff --check` — passed

## Governance

- Backlog: TASK-24653
- Privacy contract: ADR-029
- Enforcement amendment: ADR-103

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements TASK-25705 (renumbered from TASK-24653 after a task-ID collision), reconciling persistent diagnostics with ADR-029 and closing the dev required-gate bypass that let PR #2228 merge before its required check ran.

**Changes**
- Replaces raw policy entries, workspace/persona identifiers, exception messages, and persisted tracebacks in diagnostics with fixed labels plus safe type/count metadata; the persona policy save error now retains `mode` and `rule_count` instead of the persona ID and exception text. Control flow and user-visible error handling are unchanged.
- Regenerates the canonical persistent-diagnostic inventory and dependent summarization privacy fixture, and removes three stale historical diagnostic guard rows.
- Adds regression tests confirming user-authored values never appear in logs.
- Amends ADR-103 and the testing-evidence lesson with the reproduced admin/stale-base enforcement gap.
- Enables admin enforcement and strict latest-base checks for the existing `dev` required context; force-push policy is unchanged.

<sup>Written for commit cf911a75bda268820748f8197bcb8782b5bbb6c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

