### PR TITLE
feat(console): bind local path tools to admitted roots

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -1063,21 +1063,33 @@ you haven't seen"; viewing the conversation clears either.
 ### Local file authority
 
 Every live Console Chat owns an independent private temporary scratch space.
-No folder setup is required. Relative paths used by Chatbook's built-in file
-tools and local `fs_*`/Git tools resolve in that Chat's scratch space unless a
-named Workspace explicitly adds authority:
+No folder setup is required for Chatbook's built-in sandbox file tools. The
+structured local `fs_*`/Git tools and virtual CLI receive path authority only
+from valid local-folder bindings admitted from the run's owning Workspace:
 
 | Console context | Built-in file tools | Local `fs_*` / Git and virtual CLI |
 |---|---|---|
-| Chat in Default | Private scratch only | Private scratch only |
-| Named Workspace, no selected project folder | Private scratch plus live explicit folder bindings | Private scratch only |
+| Chat in Default | Private scratch only | Not advertised |
+| Named Workspace, no valid folder binding | Private scratch only | Not advertised |
+| Named Workspace with project instructions disabled | Private scratch plus live explicit folder bindings | Every valid binding captured for the run |
 | Named Workspace, selected project folder | Private scratch plus live explicit folder bindings | The selected binding only |
+
+Each captured root uses its stable folder-binding ID as an opaque `root_alias`.
+With one root the alias may be omitted; with multiple roots every path call must
+select one explicitly. The app rechecks owning-Workspace membership, locator,
+filesystem identity, and access before review and execution. Removing or
+retargeting a binding, replacing its directory, or changing `rw` to `ro`
+revokes that run's captured authority. Reads accept `ro` or `rw`; mutations
+require current `rw`.
 
 Workspace folders are optional and start read-only. Approval still applies:
 path confinement cannot turn Ask into Allow, bypass a tool kill switch, expose
-a protected credential path, or make a read-only binding writable. A denial
-outside every allowed root says that Chats do not need a folder and points to a
-named Workspace only when access to that external folder is intended.
+a protected credential path, or make a read-only binding writable. This
+upgrade changes path-tool schemas, so previously saved Allows for those tools
+are invalidated by the existing definition guard and require fresh approval.
+The legacy `[console] workspace_root` and process working directory do not grant
+path access inside the Console; the standalone MCP server retains its explicit
+configured-root behavior.
 
 Scratch belongs to the live tab, not the saved conversation. Two tabs for the
 same conversation have different scratch spaces; closing and reopening starts
@@ -1098,19 +1110,21 @@ string, parse pipes or redirection, expand environment variables, or invoke a
 host shell. Its fixed read-only commands are `ls`, `cat`, `grep`, `find`,
 `stat`, `git_status`, `git_diff`, `git_log`, `git_blame`, and `git_branches`.
 
-The tool is discoverable whenever local tools are enabled, but discoverability
-is not authorization. Before each invocation, Chatbook resolves the selected
-command under the separate **Virtual CLI (read-only)** group in MCP ▸ Tools.
+The tool is discoverable only when local tools are enabled and the run admitted
+at least one valid Workspace folder, but discoverability is not authorization.
+Before each invocation, Chatbook resolves the selected command under the
+separate **Virtual CLI (read-only)** group in MCP ▸ Tools.
 Every command has its own Allow, Ask, or Off setting, defaults to Ask when no
 decision exists, and remains independent from the equivalent `fs_*` or Git
 tool permission. Allowing `cat` does not allow `grep`, and allowing `fs_read`
 does not allow virtual `cat`.
 
 Approved commands dispatch directly to the same confined read-only filesystem
-and Git implementations used by Chatbook's local tools. The active Chat scratch
-or selected Workspace binding, protected-path checks, Git exclusions, result
-limits, global tool kill switch, and approval audit therefore remain in force.
-There is no escape hatch to arbitrary programs or shell syntax.
+and Git implementations used by Chatbook's local tools. The run-admitted
+Workspace binding, protected-path checks, Git exclusions, result limits, global
+tool kill switch, and approval audit therefore remain in force. With multiple
+roots, `root_alias` is required just as it is for `fs_*` and Git calls. There is
+no escape hatch to arbitrary programs or shell syntax.
 
 ### Raw CLI: direct user commands and model `shell_exec`
 

--- a/Docs/superpowers/plans/2026-08-30-task-19504-run-admitted-workspace-roots.md
+++ b/Docs/superpowers/plans/2026-08-30-task-19504-run-admitted-workspace-roots.md
@@ -1,0 +1,23 @@
+# TASK-19504 implementation plan
+
+ADR required: yes
+ADR path: `backlog/decisions/102-console-run-admitted-local-path-authority.md`
+Reason: the task changes the Console's security authority, tool schemas, and the
+disabled-session behavior explicitly retained by ADR-069.
+
+Approved design:
+`Docs/superpowers/specs/2026-08-30-task-19504-run-admitted-workspace-roots-design.md`
+
+1. Add failing provider tests for zero, one, mixed, and multiple admitted roots,
+   including exact alias schema and call-time revocation behavior.
+2. Add the immutable admitted-root contract and minimally extend
+   `LocalToolProvider` to route existing path specs and executors by alias.
+3. Add failing controller tests for owning-workspace admission, default/bindingless
+   schema removal, ADR-069 preservation, and active-workspace/config/CWD isolation.
+4. Wire run admission through Console composition without changing standalone MCP
+   or built-in sandbox authority.
+5. Add Virtual CLI alias/revocation tests and route it through the same admitted
+   read roots.
+6. Add definition-hash and upgrade-copy coverage, then update the Console guide.
+7. Run focused regression suites, changed-file Ruff/format/compile checks,
+   diagnostic and diff checks, and final independent review.

--- a/Docs/superpowers/specs/2026-08-30-task-19504-run-admitted-workspace-roots-design.md
+++ b/Docs/superpowers/specs/2026-08-30-task-19504-run-admitted-workspace-roots-design.md
@@ -1,0 +1,101 @@
+# TASK-19504: Console run-admitted workspace roots design
+
+## Goal
+
+Remove hidden in-app Console fallback authority for structured local path tools.
+Every published `fs_*`, read-only `git_*`, or Virtual CLI operation must select a
+folder binding admitted for the owning run, while unrelated local tools and
+built-in private-scratch tools remain available.
+
+## Authority snapshot
+
+At run admission the controller reads the owning session and its workspace ID.
+Project-instruction-enabled sessions contribute their already validated ADR-069
+selection. Disabled named workspaces contribute every currently valid
+local-filesystem binding returned for that workspace. The default workspace and a
+named workspace with no valid folder bindings contribute none.
+
+Each immutable admitted root contains:
+
+- `workspace_id` and `binding_id`;
+- `alias`, equal to the stable opaque binding ID;
+- resolved root and canonical-locator fingerprint;
+- captured root/ancestor filesystem identity;
+- admission-time `allow_write`;
+- a call-time guard that re-reads that binding ID and compares every field above.
+
+Invalid, missing, symlinked, retargeted, identity-replaced, or non-ready bindings
+are excluded at admission. The guard also rejects removal and `rw` to `ro`
+downgrades. A read accepts either current access mode. A mutation requires current
+`rw`; no admission-time state can widen later registry state.
+
+## Local provider catalog
+
+The existing `LocalToolProvider` remains the single provider and approval owner.
+It gains an immutable alias-to-authority map and routes only the existing path
+specs through the selected authority's existing `WorkspaceToolExecutor`.
+
+- Zero admitted roots: omit `_PATH_AUTHORITY_LOCAL_NAMES`; keep web, Watchlists,
+  todo, and other non-path specs.
+- One root: add optional `root_alias` with a one-value enum; omission selects the
+  sole root.
+- Multiple roots: add required `root_alias` with the admitted aliases as its enum.
+- Mutation specs appear only when at least one admitted root is writable. Selecting
+  a read-only root for a mutation fails before execution.
+
+The alias argument is retained in approval arguments but removed before invoking
+the existing root-bound handler. `path_targets`, approval preflight, and execution
+all use the same selector. The schema itself therefore participates in the
+existing definition-hash approval guard.
+
+## Virtual CLI
+
+`VirtualCliProvider` receives the same read-authority map and schema rule. It
+selects one existing `VirtualCliRegistry`/pinned executor per call. Because every
+Virtual CLI command is read-only, both `ro` and `rw` roots are eligible. With no
+roots, the provider is not composed.
+
+Raw shell is unchanged and remains under ADR-094; TASK-19504 neither grants it a
+workspace binding nor claims its process boundary.
+
+## Controller composition
+
+Provider composition receives the captured roots instead of a scratch/config/CWD
+fallback. Project-instruction state supplies exactly one selected root. Otherwise
+the controller captures the owning named workspace's valid bindings once at run
+admission. It never consults the active workspace after capture.
+
+The non-path local provider may retain private scratch only as an internal service
+construction input; no path spec or handler is registered against it. Built-in
+file tools continue to receive Chat scratch plus their existing binding policy.
+Standalone MCP construction remains unchanged.
+
+## Upgrade communication
+
+The Console tool guide will state that structured path tools now require admitted
+workspace folders and that existing persistent approvals may prompt once again
+because their schemas changed. No permission rows are manually deleted.
+
+## Error handling and privacy
+
+All authority failures are fail-closed and use bounded, path-free refusal copy.
+Diagnostics identify only codes and opaque binding IDs. Absolute locators never
+enter model schemas, approval metadata, or generic logs.
+
+## Verification
+
+Focused tests will prove:
+
+- zero/one/multiple-root catalog and alias schemas;
+- owning-workspace capture independent of active workspace;
+- read/write enforcement for mixed roots;
+- removal, retarget, identity replacement, and downgrade revocation;
+- preserved ADR-069 single-selection behavior;
+- preservation of web, Watchlists, todo, and built-in scratch tools;
+- Console config/CWD independence and unchanged standalone MCP behavior;
+- definition-hash invalidation from the schema change;
+- Virtual CLI parity and existing ADR-101 pinned execution.
+
+The task will run targeted provider/controller/workspace tests, changed-file static
+checks, diff checks, and a final independent review. A full repository sweep is
+outside the default verification scope unless explicitly requested.

--- a/Tests/Agents/test_local_tool_provider.py
+++ b/Tests/Agents/test_local_tool_provider.py
@@ -22,6 +22,7 @@ from tldw_chatbook.Agents.local_tool_provider import (
     LocalToolExposure,
     LocalToolProvider,
     LocalToolSpec,
+    RunAdmittedWorkspaceRoot,
 )
 from tldw_chatbook.Agents.run_context import use_run_id
 from tldw_chatbook.Agents.tool_catalog import ToolExecutionPolicy
@@ -32,7 +33,7 @@ from tldw_chatbook.Agents.session_todo_store import (
     TODO_STATUSES,
     SessionTodoStore,
 )
-from tldw_chatbook.MCP.permission_store import EffectiveToolState
+from tldw_chatbook.MCP.permission_store import EffectiveToolState, definition_hash
 from tldw_chatbook.Tools import (
     git_tool_impls,
     local_tool_impls,
@@ -131,17 +132,187 @@ def make_provider(state=ALLOW, kill=False, **kwargs):
     use_default_executor = kwargs.pop("use_default_executor", False)
     kwargs.setdefault("resolve_state", lambda hub: state)
     kwargs.setdefault("kill_switch", lambda: kill)
-    root = (
-        Path(kwargs.pop("root", ".")).resolve()
-        if "root" in kwargs
-        else Path(".")
-    )
+    root = Path(kwargs.pop("root", ".")).resolve() if "root" in kwargs else Path(".")
     if not use_default_executor:
         kwargs.setdefault("workspace_executor", InProcessWorkspaceExecutor(root))
     return LocalToolProvider(
         workspace_root=root,
         **kwargs,
     )
+
+
+def admitted_root(
+    *,
+    alias: str,
+    root: Path,
+    allow_write: bool,
+    executor: RecordingWorkspaceExecutor,
+    guard=lambda _write: True,
+) -> RunAdmittedWorkspaceRoot:
+    """Build one opaque run authority without registry or path leakage."""
+    return RunAdmittedWorkspaceRoot(
+        workspace_id="workspace-1",
+        binding_id=alias,
+        alias=alias,
+        root=root,
+        locator_fingerprint=f"fingerprint-{alias}",
+        root_identity=((str(root), 1, 2, 0o40755),),
+        allow_write=allow_write,
+        guard=guard,
+        workspace_executor=executor,
+    )
+
+
+def test_empty_admitted_roots_remove_only_path_tools(tmp_path):
+    provider = make_provider(
+        root=tmp_path,
+        admitted_roots=(),
+        todo_store=SessionTodoStore(),
+    )
+    names = {entry.name for entry in provider.list_catalog()}
+
+    assert local_tool_provider._PATH_AUTHORITY_LOCAL_NAMES.isdisjoint(names)
+    assert {"web_fetch", "web_search", "todo_create", "todo_list"} <= names
+
+
+def test_one_admitted_root_adds_optional_stable_alias_and_routes_without_it(
+    tmp_path,
+):
+    executor = RecordingWorkspaceExecutor()
+    root = admitted_root(
+        alias="folder-stable-a",
+        root=tmp_path,
+        allow_write=True,
+        executor=executor,
+    )
+    provider = make_provider(root=tmp_path, admitted_roots=(root,))
+
+    schema = provider.load_schema("local:fs_read").parameters
+    assert schema["properties"]["root_alias"]["enum"] == ["folder-stable-a"]
+    assert "root_alias" not in schema["required"]
+
+    result = provider.invoke("local:fs_read", {"path": "a.txt"})
+
+    assert result.ok
+    assert executor.calls == [("fs_read", {"path": "a.txt"}, "read")]
+
+
+def test_root_alias_schema_changes_permission_definition_hash(tmp_path):
+    legacy = make_provider(root=tmp_path)
+    admitted = make_provider(
+        root=tmp_path,
+        admitted_roots=(
+            admitted_root(
+                alias="folder-stable-a",
+                root=tmp_path,
+                allow_write=False,
+                executor=RecordingWorkspaceExecutor(),
+            ),
+        ),
+    )
+    legacy_tool = legacy.hub_tool_for("fs_read")
+    admitted_tool = admitted.hub_tool_for("fs_read")
+
+    assert definition_hash(
+        legacy_tool.description, legacy_tool.input_schema
+    ) != definition_hash(admitted_tool.description, admitted_tool.input_schema)
+
+
+def test_multiple_admitted_roots_require_alias_and_route_exactly_once(tmp_path):
+    first_executor = RecordingWorkspaceExecutor(result="first")
+    second_executor = RecordingWorkspaceExecutor(result="second")
+    roots = (
+        admitted_root(
+            alias="folder-stable-b",
+            root=tmp_path / "b",
+            allow_write=True,
+            executor=second_executor,
+        ),
+        admitted_root(
+            alias="folder-stable-a",
+            root=tmp_path / "a",
+            allow_write=False,
+            executor=first_executor,
+        ),
+    )
+    provider = make_provider(root=tmp_path, admitted_roots=roots)
+
+    schema = provider.load_schema("local:fs_read").parameters
+    assert schema["properties"]["root_alias"]["enum"] == [
+        "folder-stable-a",
+        "folder-stable-b",
+    ]
+    assert "root_alias" in schema["required"]
+    missing = provider.invoke("local:fs_read", {"path": "a.txt"})
+    selected = provider.invoke(
+        "local:fs_read",
+        {"root_alias": "folder-stable-b", "path": "a.txt"},
+    )
+
+    assert not missing.ok and "root_alias" in missing.error
+    assert selected.ok and selected.content == "second"
+    assert first_executor.calls == []
+    assert second_executor.calls == [("fs_read", {"path": "a.txt"}, "read")]
+
+
+def test_mixed_access_roots_refuse_mutation_on_read_only_alias(tmp_path):
+    read_executor = RecordingWorkspaceExecutor()
+    write_executor = RecordingWorkspaceExecutor()
+    provider = make_provider(
+        root=tmp_path,
+        admitted_roots=(
+            admitted_root(
+                alias="folder-ro",
+                root=tmp_path / "ro",
+                allow_write=False,
+                executor=read_executor,
+            ),
+            admitted_root(
+                alias="folder-rw",
+                root=tmp_path / "rw",
+                allow_write=True,
+                executor=write_executor,
+            ),
+        ),
+    )
+
+    refused = provider.invoke(
+        "local:fs_write",
+        {"root_alias": "folder-ro", "path": "a.txt", "content": "x"},
+    )
+    allowed = provider.invoke(
+        "local:fs_write",
+        {"root_alias": "folder-rw", "path": "a.txt", "content": "x"},
+    )
+
+    assert not refused.ok and refused.outcome == "blocked"
+    assert read_executor.calls == []
+    assert allowed.ok
+    assert write_executor.calls == [
+        ("fs_write", {"path": "a.txt", "content": "x"}, "write")
+    ]
+
+
+def test_admitted_root_guard_revokes_before_executor(tmp_path):
+    executor = RecordingWorkspaceExecutor()
+    provider = make_provider(
+        root=tmp_path,
+        admitted_roots=(
+            admitted_root(
+                alias="folder-revoked",
+                root=tmp_path,
+                allow_write=True,
+                executor=executor,
+                guard=lambda _write: False,
+            ),
+        ),
+    )
+
+    result = provider.invoke("local:fs_read", {"path": "a.txt"})
+
+    assert not result.ok and result.outcome == "blocked"
+    assert result.error == LOCAL_ROOT_CHANGED_REFUSAL
+    assert executor.calls == []
 
 
 _LOCAL_WORKSPACE_EXECUTOR_CASES = (
@@ -273,11 +444,14 @@ def test_web_todo_and_watchlists_handlers_never_launch_workspace_executor(
         provider.invoke("local:web_search", {"query": "topic"}),
         provider.invoke("local:web_crawl", {"url": "https://example.test"}),
         provider.invoke("local:todo_create", {"content": "task"}),
-        provider.invoke("local:todo_update", {
-            "id": "1",
-            "expected_version": 1,
-            "status": "completed",
-        }),
+        provider.invoke(
+            "local:todo_update",
+            {
+                "id": "1",
+                "expected_version": 1,
+                "status": "completed",
+            },
+        ),
         provider.invoke("local:todo_get", {"id": "1"}),
         provider.invoke("local:todo_list", {}),
         provider.invoke("local:watchlists_search_items", {"query": "topic"}),
@@ -419,7 +593,7 @@ def test_local_tool_spec_rejects_missing_or_unknown_exposure_and_effect():
     with pytest.raises(ValueError, match="exposure"):
         LocalToolSpec(
             **kwargs,
-            exposure="external" ,
+            exposure="external",
             approval_effects=(LocalApprovalEffect.PRIVATE_READ,),
         )
     with pytest.raises(ValueError, match="approval_effects"):
@@ -461,15 +635,15 @@ def test_catalog_exposure_and_effects_are_explicit_and_queryable(tmp_path):
     assert provider.approval_effects_for("fs_read") == (
         LocalApprovalEffect.PRIVATE_READ,
     )
-    assert provider.approval_effects_for("web_fetch") == (
-        LocalApprovalEffect.NETWORK,
-    )
+    assert provider.approval_effects_for("web_fetch") == (LocalApprovalEffect.NETWORK,)
     assert provider.approval_effects_for("fs_write") == (
         LocalApprovalEffect.MUTATES_LOCAL,
     )
 
 
-def test_operational_watchlists_commands_are_console_only_and_definitive_on_accept(tmp_path):
+def test_operational_watchlists_commands_are_console_only_and_definitive_on_accept(
+    tmp_path,
+):
     provider = make_provider(root=tmp_path)
 
     console_specs = {
@@ -673,10 +847,15 @@ class RecordingWatchlistsCommandService:
 
     @staticmethod
     def approval_source_destinations(arguments):
-        return {"source_count": len(arguments["sources"]), "destination_hosts": ["example.com"]}
+        return {
+            "source_count": len(arguments["sources"]),
+            "destination_hosts": ["example.com"],
+        }
 
 
-def test_watchlists_authoring_specs_are_console_only_mutations_with_safe_approval(tmp_path):
+def test_watchlists_authoring_specs_are_console_only_mutations_with_safe_approval(
+    tmp_path,
+):
     commands = RecordingWatchlistsCommandService()
     provider = make_provider(
         root=tmp_path,

--- a/Tests/Agents/test_local_tool_provider.py
+++ b/Tests/Agents/test_local_tool_provider.py
@@ -146,7 +146,7 @@ def admitted_root(
     alias: str,
     root: Path,
     allow_write: bool,
-    executor: RecordingWorkspaceExecutor,
+    executor: RecordingWorkspaceExecutor | None,
     guard=lambda _write: True,
 ) -> RunAdmittedWorkspaceRoot:
     """Build one opaque run authority without registry or path leakage."""
@@ -313,6 +313,128 @@ def test_admitted_root_guard_revokes_before_executor(tmp_path):
     assert not result.ok and result.outcome == "blocked"
     assert result.error == LOCAL_ROOT_CHANGED_REFUSAL
     assert executor.calls == []
+
+
+def test_unusable_admitted_root_is_omitted_without_losing_other_tools(
+    tmp_path, monkeypatch
+):
+    bad_root = tmp_path / "removed"
+    good_root = tmp_path / "good"
+    good_executor = RecordingWorkspaceExecutor(result="good")
+
+    class FailingExecutor:
+        def __init__(self, root: Path) -> None:
+            assert Path(root) == bad_root
+            raise OSError("root disappeared")
+
+    monkeypatch.setattr(local_tool_provider, "WorkspaceToolExecutor", FailingExecutor)
+    provider = make_provider(
+        root=tmp_path,
+        admitted_roots=(
+            admitted_root(
+                alias="bad",
+                root=bad_root,
+                allow_write=True,
+                executor=None,
+            ),
+            admitted_root(
+                alias="good",
+                root=good_root,
+                allow_write=True,
+                executor=good_executor,
+            ),
+        ),
+    )
+
+    names = {entry.name for entry in provider.list_catalog()}
+    schema = provider.load_schema("local:fs_read").parameters
+    bad = provider.invoke("local:fs_read", {"root_alias": "bad", "path": "a.txt"})
+    good = provider.invoke("local:fs_read", {"root_alias": "good", "path": "a.txt"})
+
+    assert "web_fetch" in names
+    assert schema["properties"]["root_alias"]["enum"] == ["good"]
+    assert not bad.ok and "root_alias" in bad.error
+    assert good.ok and good.content == "good"
+
+
+def test_custom_path_specs_are_rejected_with_admitted_roots(tmp_path):
+    custom_path_spec = LocalToolSpec(
+        name="fs_read",
+        description="custom read",
+        parameters={"type": "object", "properties": {}},
+        handler=lambda _args: "custom",
+        exposure=LocalToolExposure.CONSOLE_ONLY,
+        approval_effects=(LocalApprovalEffect.PRIVATE_READ,),
+    )
+    root = admitted_root(
+        alias="folder-a",
+        root=tmp_path,
+        allow_write=False,
+        executor=RecordingWorkspaceExecutor(),
+    )
+
+    with pytest.raises(ValueError, match="custom path specs"):
+        make_provider(root=tmp_path, specs=[custom_path_spec], admitted_roots=(root,))
+
+
+def test_custom_non_path_specs_remain_usable_with_admitted_roots(tmp_path):
+    custom_spec = LocalToolSpec(
+        name="custom_status",
+        description="custom status",
+        parameters={"type": "object", "properties": {}},
+        handler=lambda _args: "custom",
+        exposure=LocalToolExposure.CONSOLE_ONLY,
+        approval_effects=(),
+    )
+    root = admitted_root(
+        alias="folder-a",
+        root=tmp_path,
+        allow_write=False,
+        executor=RecordingWorkspaceExecutor(),
+    )
+    provider = make_provider(root=tmp_path, specs=[custom_spec], admitted_roots=(root,))
+
+    result = provider.invoke("local:custom_status", {})
+
+    assert result.ok and result.content == "custom"
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        "success",
+        "domain_error",
+        "unexpected_error",
+    ],
+)
+def test_admitted_root_locator_is_redacted_from_local_results(tmp_path, outcome):
+    private_root = tmp_path / "private-binding"
+    if outcome == "success":
+        executor = RecordingWorkspaceExecutor(result=f"{private_root}/result.txt")
+    elif outcome == "domain_error":
+        executor = RecordingWorkspaceExecutor(
+            error="tool_failure", error_message=f"failed at {private_root}/result.txt"
+        )
+    else:
+
+        class UnexpectedFailureExecutor(RecordingWorkspaceExecutor):
+            def execute(self, operation: str, arguments: dict, *, intent: str) -> str:
+                raise RuntimeError(f"failed at {private_root}/result.txt")
+
+        executor = UnexpectedFailureExecutor()
+    root = admitted_root(
+        alias="folder-a",
+        root=private_root,
+        allow_write=False,
+        executor=executor,
+    )
+    provider = make_provider(root=tmp_path, admitted_roots=(root,))
+
+    result = provider.invoke("local:fs_read", {"path": "result.txt"})
+    rendered = result.content if result.ok else result.error
+
+    assert str(private_root) not in rendered
+    assert "result.txt" in rendered
 
 
 _LOCAL_WORKSPACE_EXECUTOR_CASES = (

--- a/Tests/Agents/test_virtual_cli_provider.py
+++ b/Tests/Agents/test_virtual_cli_provider.py
@@ -85,7 +85,7 @@ def make_provider(tmp_path: Path, state=ASK, **kwargs) -> VirtualCliProvider:
 def admitted_root(
     alias: str,
     root: Path,
-    executor: RecordingWorkspaceExecutor,
+    executor: RecordingWorkspaceExecutor | None,
     *,
     guard=lambda _write: True,
 ) -> RunAdmittedWorkspaceRoot:
@@ -203,6 +203,77 @@ def test_admitted_root_revocation_blocks_virtual_cli_before_executor(tmp_path):
 
     assert not result.ok and result.error == LOCAL_ROOT_CHANGED_REFUSAL
     assert executor.calls == []
+
+
+def test_unusable_admitted_root_is_omitted_from_virtual_cli_schema(
+    tmp_path, monkeypatch
+):
+    bad_root = tmp_path / "removed"
+    good_root = tmp_path / "good"
+    good_executor = RecordingWorkspaceExecutor(result="good")
+
+    class FailingExecutor:
+        def __init__(self, root: Path) -> None:
+            assert Path(root) == bad_root
+            raise OSError("root disappeared")
+
+    monkeypatch.setattr(virtual_cli_provider, "WorkspaceToolExecutor", FailingExecutor)
+    provider = make_provider(
+        tmp_path,
+        state=ALLOW,
+        admitted_roots=(
+            admitted_root("bad", bad_root, None),
+            admitted_root("good", good_root, good_executor),
+        ),
+    )
+
+    schema = provider.load_schema("virtual_cli:virtual_cli").parameters
+    bad = provider.invoke(
+        "virtual_cli", {"root_alias": "bad", "command": "ls", "argv": ["."]}
+    )
+    good = provider.invoke(
+        "virtual_cli", {"root_alias": "good", "command": "ls", "argv": ["."]}
+    )
+
+    assert schema["properties"]["root_alias"]["enum"] == ["good"]
+    assert not bad.ok and "root_alias" in bad.error
+    assert good.ok and good.content == "good"
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        "success",
+        "domain_error",
+        "unexpected_error",
+    ],
+)
+def test_admitted_root_locator_is_redacted_from_virtual_cli_results(tmp_path, outcome):
+    private_root = tmp_path / "private-binding"
+    if outcome == "success":
+        executor = RecordingWorkspaceExecutor(result=f"{private_root}/result.txt")
+    elif outcome == "domain_error":
+        executor = RecordingWorkspaceExecutor(
+            error="tool_failure", error_message=f"failed at {private_root}/result.txt"
+        )
+    else:
+
+        class UnexpectedFailureExecutor(RecordingWorkspaceExecutor):
+            def execute(self, operation: str, arguments: dict, *, intent: str) -> str:
+                raise RuntimeError(f"failed at {private_root}/result.txt")
+
+        executor = UnexpectedFailureExecutor()
+    provider = make_provider(
+        tmp_path,
+        state=ALLOW,
+        admitted_roots=(admitted_root("folder-a", private_root, executor),),
+    )
+
+    result = provider.invoke("virtual_cli", {"command": "ls", "argv": ["."]})
+    rendered = result.content if result.ok else result.error
+
+    assert str(private_root) not in rendered
+    assert "result.txt" in rendered
 
 
 def test_provider_constructs_and_injects_real_executor_by_default(

--- a/Tests/Agents/test_virtual_cli_provider.py
+++ b/Tests/Agents/test_virtual_cli_provider.py
@@ -10,6 +10,7 @@ from tldw_chatbook.Agents.agent_models import ToolCall
 from tldw_chatbook.Agents.local_tool_provider import (
     LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL,
     LOCAL_ROOT_CHANGED_REFUSAL,
+    RunAdmittedWorkspaceRoot,
 )
 from tldw_chatbook.Agents.run_context import (
     current_tool_call_id,
@@ -81,6 +82,26 @@ def make_provider(tmp_path: Path, state=ASK, **kwargs) -> VirtualCliProvider:
     return VirtualCliProvider(workspace_root=tmp_path, **kwargs)
 
 
+def admitted_root(
+    alias: str,
+    root: Path,
+    executor: RecordingWorkspaceExecutor,
+    *,
+    guard=lambda _write: True,
+) -> RunAdmittedWorkspaceRoot:
+    return RunAdmittedWorkspaceRoot(
+        workspace_id="workspace-1",
+        binding_id=alias,
+        alias=alias,
+        root=root,
+        locator_fingerprint=f"fingerprint-{alias}",
+        root_identity=((str(root), 1, 2, 0o40755),),
+        allow_write=False,
+        guard=guard,
+        workspace_executor=executor,
+    )
+
+
 def test_provider_exposes_one_structured_model_tool(tmp_path):
     provider = make_provider(tmp_path)
 
@@ -97,6 +118,91 @@ def test_provider_exposes_one_structured_model_tool(tmp_path):
     assert schema.parameters["properties"]["argv"]["type"] == "array"
     assert "shell" not in schema.parameters["properties"]
     assert "command_line" not in schema.parameters["properties"]
+
+
+def test_one_admitted_root_adds_optional_alias_and_routes_without_it(tmp_path):
+    executor = RecordingWorkspaceExecutor(result="first")
+    provider = make_provider(
+        tmp_path,
+        state=ALLOW,
+        admitted_roots=(admitted_root("folder-a", tmp_path / "a", executor),),
+    )
+
+    schema = provider.load_schema("virtual_cli:virtual_cli").parameters
+    assert schema["properties"]["root_alias"]["enum"] == ["folder-a"]
+    assert "root_alias" not in schema["required"]
+    result = provider.invoke("virtual_cli", {"command": "ls", "argv": ["."]})
+
+    assert result.ok and result.content == "first"
+    assert executor.calls == [("fs_list", {"path": "."}, "read")]
+
+
+def test_admitted_root_alias_changes_virtual_cli_permission_definition_hash(tmp_path):
+    legacy = make_provider(tmp_path, state=ALLOW)
+    admitted = make_provider(
+        tmp_path,
+        state=ALLOW,
+        admitted_roots=(
+            admitted_root("folder-a", tmp_path / "a", RecordingWorkspaceExecutor()),
+        ),
+    )
+    legacy_tool = legacy.hub_tool_for("ls")
+    admitted_tool = admitted.hub_tool_for("ls")
+
+    assert "root_alias" not in legacy_tool.input_schema["properties"]
+    assert admitted_tool.input_schema["properties"]["root_alias"]["enum"] == [
+        "folder-a"
+    ]
+    assert definition_hash(
+        legacy_tool.description, legacy_tool.input_schema
+    ) != definition_hash(admitted_tool.description, admitted_tool.input_schema)
+
+
+def test_multiple_admitted_roots_require_alias_and_route_once(tmp_path):
+    first = RecordingWorkspaceExecutor(result="first")
+    second = RecordingWorkspaceExecutor(result="second")
+    provider = make_provider(
+        tmp_path,
+        state=ALLOW,
+        admitted_roots=(
+            admitted_root("folder-a", tmp_path / "a", first),
+            admitted_root("folder-b", tmp_path / "b", second),
+        ),
+    )
+
+    schema = provider.load_schema("virtual_cli:virtual_cli").parameters
+    assert "root_alias" in schema["required"]
+    missing = provider.invoke("virtual_cli", {"command": "ls", "argv": ["."]})
+    selected = provider.invoke(
+        "virtual_cli",
+        {"root_alias": "folder-b", "command": "ls", "argv": ["."]},
+    )
+
+    assert not missing.ok and "root_alias" in missing.error
+    assert selected.ok and selected.content == "second"
+    assert first.calls == []
+    assert second.calls == [("fs_list", {"path": "."}, "read")]
+
+
+def test_admitted_root_revocation_blocks_virtual_cli_before_executor(tmp_path):
+    executor = RecordingWorkspaceExecutor()
+    provider = make_provider(
+        tmp_path,
+        state=ALLOW,
+        admitted_roots=(
+            admitted_root(
+                "folder-a",
+                tmp_path / "a",
+                executor,
+                guard=lambda _write: False,
+            ),
+        ),
+    )
+
+    result = provider.invoke("virtual_cli", {"command": "ls", "argv": ["."]})
+
+    assert not result.ok and result.error == LOCAL_ROOT_CHANGED_REFUSAL
+    assert executor.calls == []
 
 
 def test_provider_constructs_and_injects_real_executor_by_default(
@@ -236,9 +342,7 @@ def test_virtual_cli_preserves_bounded_domain_failure_text(tmp_path):
         workspace_executor=InProcessWorkspaceExecutor(tmp_path),
     )
 
-    result = provider.invoke(
-        "virtual_cli", {"command": "cat", "argv": ["missing.txt"]}
-    )
+    result = provider.invoke("virtual_cli", {"command": "cat", "argv": ["missing.txt"]})
 
     assert not result.ok and result.outcome is None
     assert result.error == "file not found: missing.txt"

--- a/Tests/Chat/test_console_agent_project_instructions.py
+++ b/Tests/Chat/test_console_agent_project_instructions.py
@@ -34,6 +34,7 @@ from tldw_chatbook.Chat.console_chat_controller import (
     ConsoleRunStatus,
     ProjectInstructionBindingRecovery,
     build_project_instruction_dispatch_notice,
+    capture_run_admitted_workspace_roots,
     commit_project_instruction_dispatch_decision,
     project_instruction_authority_is_current,
     resolve_project_instruction_binding,
@@ -742,6 +743,154 @@ def test_sole_eligible_binding_auto_selects_and_captures_fingerprint(tmp_path):
     )
 
 
+def test_disabled_named_workspace_admits_all_valid_bindings_by_stable_id(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    session = _session(ProjectInstructionControlState.legacy_disabled())
+    roots = capture_run_admitted_workspace_roots(
+        session=session,
+        registry=_BindingRegistry(
+            [
+                _binding(first, "folder-first", access="ro"),
+                _binding(second, "folder-second", access="rw"),
+            ]
+        ),
+    )
+
+    assert [root.alias for root in roots] == ["folder-first", "folder-second"]
+    assert [root.allow_write for root in roots] == [False, True]
+    assert [root.root for root in roots] == [first.resolve(), second.resolve()]
+
+
+@pytest.mark.parametrize("workspace_id", ["global", "workspace-default"])
+def test_default_workspaces_never_consult_binding_registry(workspace_id):
+    class UnexpectedRegistry:
+        def list_runtime_bindings(self, _workspace_id):
+            raise AssertionError("default workspace must not admit folder bindings")
+
+    roots = capture_run_admitted_workspace_roots(
+        session=SimpleNamespace(workspace_id=workspace_id),
+        registry=UnexpectedRegistry(),
+    )
+
+    assert roots == ()
+
+
+def test_project_instruction_selection_admits_only_selected_binding(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    session = _session(ProjectInstructionControlState.new_session())
+    registry = _BindingRegistry(
+        [_binding(first, "folder-first"), _binding(second, "folder-second")]
+    )
+    selection = controller_mod._validate_project_instruction_binding(
+        session, registry.get_runtime_binding("folder-second")
+    )
+
+    roots = capture_run_admitted_workspace_roots(
+        session=session,
+        registry=registry,
+        project_selection=selection,
+        project_authority_guard=lambda: True,
+    )
+
+    assert [root.alias for root in roots] == ["folder-second"]
+
+
+@pytest.mark.asyncio
+async def test_agent_provider_composition_uses_owning_workspace_admission(tmp_path):
+    own = tmp_path / "own"
+    active_other = tmp_path / "active-other"
+    own.mkdir()
+    active_other.mkdir()
+    registry = _BindingRegistry(
+        [
+            _binding(own, "own-binding"),
+            WorkspaceRuntimeBinding(
+                workspace_id="other-workspace",
+                binding_id="active-binding",
+                binding_kind="local-filesystem",
+                label="active-binding",
+                locator=str(active_other),
+                status="ready",
+                metadata={"access": "rw"},
+            ),
+        ]
+    )
+    session = SimpleNamespace(
+        id="session-1",
+        workspace_id="w1",
+        project_instruction_state=ProjectInstructionControlState.legacy_disabled(),
+    )
+    captured: dict[str, object] = {}
+    controller = object.__new__(ConsoleChatController)
+    controller.app = SimpleNamespace(
+        workspace_registry_service=registry,
+        unified_mcp_service=None,
+    )
+    controller.store = SimpleNamespace(sessions=lambda: [session])
+
+    async def compose_mcp(*_args, **_kwargs):
+        return None
+
+    def compose_local(*_args, **kwargs):
+        captured.update(kwargs)
+        return None, None
+
+    controller._compose_mcp_provider = compose_mcp
+    controller._compose_local_provider = compose_local
+
+    await controller._compose_agent_request_providers(
+        session_id=session.id,
+        project_selection=None,
+        project_authority_guard=None,
+    )
+
+    assert [root.alias for root in captured["admitted_roots"]] == ["own-binding"]
+
+
+def test_run_admitted_guard_revokes_removal_retarget_and_access_downgrade(tmp_path):
+    original = tmp_path / "original"
+    replacement = tmp_path / "replacement"
+    original.mkdir()
+    replacement.mkdir()
+    binding = _binding(original, "folder-one", access="rw")
+    registry = _BindingRegistry([binding])
+    root = capture_run_admitted_workspace_roots(
+        session=_session(ProjectInstructionControlState.legacy_disabled()),
+        registry=registry,
+    )[0]
+
+    assert root.guard(False) is True
+    assert root.guard(True) is True
+
+    registry.bindings[binding.binding_id] = _binding(
+        original, binding.binding_id, access="ro"
+    )
+    assert root.guard(False) is False
+    assert root.guard(True) is False
+
+    registry.bindings[binding.binding_id] = _binding(
+        replacement, binding.binding_id, access="rw"
+    )
+    assert root.guard(False) is False
+
+    registry.bindings[binding.binding_id] = _binding(
+        original, binding.binding_id, access="rw"
+    )
+    retained = tmp_path / "retained-original"
+    original.rename(retained)
+    original.mkdir()
+    assert root.guard(False) is False
+
+    registry.bindings.pop(binding.binding_id)
+    assert root.guard(False) is False
+
+
 def test_binding_with_symlinked_ancestor_is_never_auto_selected(tmp_path):
     real_parent = tmp_path / "real"
     real_root = real_parent / "repo"
@@ -935,15 +1084,17 @@ async def test_controller_notice_uses_owning_session_and_drift_cancels_bridge_se
 
     class Gateway:
         async def resolve_for_send(self, _selection):
-            return with_destination(ConsoleProviderResolution(
-                provider="OpenAI",
-                base_url="https://user:password@api.example/v1?secret=yes",
-                model="test-model",
-                ready=True,
-                readiness_key="openai",
-                execution_key="openai",
-                max_tokens=128,
-            ))
+            return with_destination(
+                ConsoleProviderResolution(
+                    provider="OpenAI",
+                    base_url="https://user:password@api.example/v1?secret=yes",
+                    model="test-model",
+                    ready=True,
+                    readiness_key="openai",
+                    execution_key="openai",
+                    max_tokens=128,
+                )
+            )
 
     gateway = Gateway()
     controller = ConsoleChatController(
@@ -992,15 +1143,17 @@ async def test_folderless_session_skips_optional_project_instructions_and_runs(
 
     class Gateway:
         async def resolve_for_send(self, _selection):
-            return with_destination(ConsoleProviderResolution(
-                provider="DeepSeek",
-                base_url="https://api.deepseek.com",
-                model="deepseek-chat",
-                ready=True,
-                readiness_key="deepseek",
-                execution_key="deepseek",
-                max_tokens=128,
-            ))
+            return with_destination(
+                ConsoleProviderResolution(
+                    provider="DeepSeek",
+                    base_url="https://api.deepseek.com",
+                    model="deepseek-chat",
+                    ready=True,
+                    readiness_key="deepseek",
+                    execution_key="deepseek",
+                    max_tokens=128,
+                )
+            )
 
     async def select_binding(*args):
         setup_calls.append(args)
@@ -1089,15 +1242,17 @@ async def test_project_instruction_disable_terminalizes_and_allows_retry(tmp_pat
     class Gateway:
         async def resolve_for_send(self, _selection):
             provider_calls.append(True)
-            return with_destination(ConsoleProviderResolution(
-                provider="OpenAI",
-                base_url="http://127.0.0.1:18991/v1",
-                model="gpt-4o-mini",
-                ready=True,
-                readiness_key="openai",
-                execution_key="openai",
-                max_tokens=128,
-            ))
+            return with_destination(
+                ConsoleProviderResolution(
+                    provider="OpenAI",
+                    base_url="http://127.0.0.1:18991/v1",
+                    model="gpt-4o-mini",
+                    ready=True,
+                    readiness_key="openai",
+                    execution_key="openai",
+                    max_tokens=128,
+                )
+            )
 
     class Bridge:
         def run_reply(self, **_kwargs):

--- a/Tests/Chat/test_console_local_review_hook.py
+++ b/Tests/Chat/test_console_local_review_hook.py
@@ -96,9 +96,13 @@ def test_watchlists_receipt_capture_accepts_only_structured_canonical_ids():
     assert watchlists_operation_receipt_ids(
         "watchlists_generate_briefing", briefing_result
     ) == ("local:briefing:9",)
-    assert watchlists_operation_receipt_ids(
-        "watchlists_check_sources", ToolResult(ok=False, content=check_result.content)
-    ) == ()
+    assert (
+        watchlists_operation_receipt_ids(
+            "watchlists_check_sources",
+            ToolResult(ok=False, content=check_result.content),
+        )
+        == ()
+    )
     assert watchlists_operation_receipt_ids("calculator", check_result) == ()
     assert secret not in repr(
         watchlists_operation_receipt_ids("watchlists_check_sources", check_result)
@@ -130,9 +134,7 @@ def test_controller_retains_and_publishes_only_canonical_receipt_identity():
         ),
     )
 
-    assert controller._followed_watchlists_operation_ids == (
-        "local:briefing:9",
-    )
+    assert controller._followed_watchlists_operation_ids == ("local:briefing:9",)
     assert published == [("local:briefing:9",)]
     assert "never retain me" not in repr(controller._followed_watchlists_operation_ids)
 
@@ -245,13 +247,9 @@ def test_hook_keeps_same_name_watchlist_decisions_per_call(tmp_path):
     assert [row.call_id for row in seen[0]] == ["call-denied", "call-session"]
     assert verdicts == {
         "watchlists_create_collection": "proceed",
-        "call-denied": USER_DENIED_REFUSAL.format(
-            name="watchlists_create_collection"
-        ),
+        "call-denied": USER_DENIED_REFUSAL.format(name="watchlists_create_collection"),
     }
-    assert p._stamps == {
-        (RUN, "watchlists_create_collection"): "approve_session"
-    }
+    assert p._stamps == {(RUN, "watchlists_create_collection"): "approve_session"}
 
 
 @pytest.mark.parametrize(
@@ -363,9 +361,7 @@ def test_combined_hook_does_not_overwrite_a_local_refusal(tmp_path):
     # This deliberately impossible double-owner arrangement pins the merge
     # safety rule: a later refusal cannot be weakened to proceed.
     out = hook([ToolCall(name="fs_list", args={"path": "."})], RUN)
-    assert out == {
-        "fs_list": USER_DENIED_REFUSAL.format(name="fs_list")
-    }
+    assert out == {"fs_list": USER_DENIED_REFUSAL.format(name="fs_list")}
 
 
 def test_combined_hook_empty_list_is_noop():
@@ -838,7 +834,9 @@ async def test_compose_local_provider_wires_transactional_watchlists_commands(
             "source_id": "local:subscription:1",
         }
     ]
-    assert database.conn.execute("SELECT COUNT(*) FROM subscriptions").fetchone()[0] == 1
+    assert (
+        database.conn.execute("SELECT COUNT(*) FROM subscriptions").fetchone()[0] == 1
+    )
 
     created_collection = await asyncio.to_thread(
         provider.invoke,
@@ -1072,6 +1070,30 @@ def test_compose_local_provider_empty_workspace_root_uses_scratch(
         controller._test_turn_context.scratch_space.root
     )
     assert local_provider.workspace_root != tmp_path.resolve()
+
+
+def test_console_run_without_admitted_roots_keeps_non_path_local_tools(tmp_path):
+    controller = _bare_controller(SimpleNamespace(unified_mcp_service=_FakeService()))
+
+    provider, review = _compose_local_provider(controller, admitted_roots=())
+
+    names = {entry.name for entry in provider.list_catalog()}
+    assert {
+        "fs_list",
+        "fs_read",
+        "fs_write",
+        "fs_edit",
+        "fs_patch",
+        "fs_glob",
+        "fs_grep",
+        "git_status",
+        "git_diff",
+        "git_log",
+        "git_blame",
+        "git_branches",
+    }.isdisjoint(names)
+    assert {"web_search", "web_fetch", "watchlists_search_items"} <= names
+    assert callable(review)
 
 
 def test_local_provider_read_only_filters_write_specs_without_global_mutation(tmp_path):

--- a/Tests/Chat/test_console_virtual_cli_approval.py
+++ b/Tests/Chat/test_console_virtual_cli_approval.py
@@ -71,9 +71,7 @@ def test_review_hook_clears_stale_stamps_before_a_raising_round(tmp_path):
     )
     pending = provider.pending_gate_for(call)
     assert pending is not None
-    provider.apply_batch_decisions(
-        "run-1", {"call-a": "approve_once"}, [pending]
-    )
+    provider.apply_batch_decisions("run-1", {"call-a": "approve_once"}, [pending])
 
     def raise_during_review(_rows):
         raise RuntimeError("approval bridge unavailable")
@@ -96,9 +94,7 @@ def test_stamp_scope_hides_parent_verdicts_and_restores_them(tmp_path):
     )
     pending = provider.pending_gate_for(call)
     assert pending is not None
-    provider.apply_batch_decisions(
-        "run-1", {"call-a": "approve_once"}, [pending]
-    )
+    provider.apply_batch_decisions("run-1", {"call-a": "approve_once"}, [pending])
 
     with use_tool_call_id("call-a"):
         with provider.stamp_scope("run-1"):
@@ -138,6 +134,29 @@ def test_controller_composition_honors_local_master_and_kill_switch(
     assert (hook is not None) is expected
 
 
+def test_controller_does_not_compose_virtual_cli_without_admitted_roots(tmp_path):
+    service = SimpleNamespace(
+        get_kill_switch=lambda: False,
+        gate_tool_test=lambda _hub: ALLOW,
+        approve_for_session=lambda *_args: None,
+        set_tool_state=lambda *_args, **_kwargs: None,
+        record_tool_decision=lambda *_args, **_kwargs: None,
+        is_session_approved=lambda *_args: False,
+    )
+    controller = object.__new__(ConsoleChatController)
+    controller.app = SimpleNamespace(unified_mcp_service=service)
+
+    assert controller._compose_virtual_cli_provider(
+        session_id="session-1",
+        turn_context=SimpleNamespace(
+            tool_configuration={"local_tools_enabled": True},
+            scratch_space=None,
+        ),
+        project_root=tmp_path,
+        admitted_roots=(),
+    ) == (None, None)
+
+
 def test_run_registry_advertises_the_one_virtual_cli_model_tool(tmp_path):
     provider = VirtualCliProvider(
         workspace_root=tmp_path,
@@ -146,11 +165,9 @@ def test_run_registry_advertises_the_one_virtual_cli_model_tool(tmp_path):
         ),
     )
 
-    registry, allowed, _builtin_names, local_names = (
-        _compose_run_registry_and_allowed(
-            {},
-            virtual_cli_provider=provider,
-        )
+    registry, allowed, _builtin_names, local_names = _compose_run_registry_and_allowed(
+        {},
+        virtual_cli_provider=provider,
     )
 
     assert "virtual_cli" in allowed

--- a/Tests/MCP/test_local_server_tools.py
+++ b/Tests/MCP/test_local_server_tools.py
@@ -44,6 +44,31 @@ BUILTIN_TOOL_NAMES = [descriptor["name"] for descriptor in _describe_local_tools
 TASK_TOOL_NAMES = {"todo_create", "todo_update", "todo_get", "todo_list"}
 
 
+def test_standalone_workspace_root_keeps_configured_and_cwd_fallback(
+    monkeypatch, tmp_path
+):
+    import tldw_chatbook.config as config
+
+    configured = tmp_path / "configured"
+    process_cwd = tmp_path / "cwd"
+    configured.mkdir()
+    process_cwd.mkdir()
+    monkeypatch.chdir(process_cwd)
+    monkeypatch.setattr(
+        config,
+        "get_cli_setting",
+        lambda section, key, default=None: (
+            str(configured)
+            if (section, key) == ("console", "workspace_root")
+            else default
+        ),
+    )
+    assert local_server_tools.resolve_server_workspace_root() == configured.resolve()
+
+    monkeypatch.setattr(config, "get_cli_setting", lambda *_args, **_kwargs: "")
+    assert local_server_tools.resolve_server_workspace_root() == process_cwd.resolve()
+
+
 class RecordingWorkspaceExecutor:
     """Protocol-shaped executor fake for MCP admission/effect tests."""
 

--- a/Tests/test_persistent_diagnostic_boundary.py
+++ b/Tests/test_persistent_diagnostic_boundary.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import logging
 from pathlib import Path
 
@@ -14,8 +15,33 @@ from tldw_chatbook.Utils.persistent_diagnostics import (
     log_persistent_metadata,
 )
 
-
 PRIVATE_SENTINEL = "PRIVATE-PROMPT-SENTINEL-sk-not-a-real-key"
+
+_CONSTANT_DIAGNOSTIC_PREFIXES = {
+    "tldw_chatbook/Agents/mcp_tool_provider.py": (
+        "MCPToolProvider: persona_policy_provider failed",
+    ),
+    "tldw_chatbook/Agents/persona_policy.py": (
+        "Dropping non-mapping persona policy rule",
+        "Dropping malformed persona policy rule",
+    ),
+    "tldw_chatbook/Character_Chat/local_character_persona_service.py": (
+        "Dropping malformed persona policy rule",
+    ),
+    "tldw_chatbook/UI/Screens/personas_screen.py": (
+        "Error saving persona policy rules",
+    ),
+    "tldw_chatbook/Workspaces/agent_provisioning.py": (
+        "Workspace agent provisioning failed",
+        "Workspace agent backfill could not persist defaults",
+    ),
+    "tldw_chatbook/Workspaces/registry_service.py": (
+        "Workspace agent provisioning hook failed",
+        "Workspace agent provisioning returned no defaults",
+        "Workspace agent defaults could not be persisted",
+        "Ignoring malformed workspace assistant_defaults",
+    ),
+}
 
 
 def _real_private_sink(path: Path) -> PrivateRotatingFileHandler:
@@ -52,6 +78,45 @@ def _emit_owned_loguru_payload(module_name: str, message: str) -> None:
             "message": message,
         },
     )
+
+
+def _diagnostic_template(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        return "".join(
+            part.value
+            for part in node.values
+            if isinstance(part, ast.Constant) and isinstance(part.value, str)
+        )
+    return None
+
+
+def test_persona_workspace_diagnostics_do_not_interpolate_private_values() -> None:
+    """Persistent diagnostics name the failure category, never private values."""
+    root = Path(__file__).resolve().parents[1]
+    for relative_path, prefixes in _CONSTANT_DIAGNOSTIC_PREFIXES.items():
+        tree = ast.parse((root / relative_path).read_text(encoding="utf-8"))
+        matched: set[str] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not node.args:
+                continue
+            template = _diagnostic_template(node.args[0])
+            if template is None:
+                continue
+            for prefix in prefixes:
+                if not template.startswith(prefix):
+                    continue
+                matched.add(prefix)
+                assert isinstance(node.args[0], ast.Constant), (
+                    f"{relative_path}: {prefix!r} must use a constant message"
+                )
+                assert len(node.args) == 1, (
+                    f"{relative_path}: {prefix!r} must not format runtime values"
+                )
+        assert matched == set(prefixes), (
+            f"{relative_path}: expected diagnostics were renamed or removed"
+        )
 
 
 def test_real_rotating_sink_rejects_owned_standard_payloads_but_keeps_metadata(

--- a/backlog/decisions/102-console-run-admitted-local-path-authority.md
+++ b/backlog/decisions/102-console-run-admitted-local-path-authority.md
@@ -1,0 +1,85 @@
+# ADR-102: Bind Console local path tools to run-admitted workspace roots
+
+Status: Accepted
+Date: 2026-08-30
+Related Task: [TASK-19504](../tasks/task-19504%20-%20Bind-Console-local-path-tools-to-run-admitted-workspace-roots.md)
+Design: [Console run-admitted local path authority](../../Docs/superpowers/specs/2026-08-30-task-19504-run-admitted-workspace-roots-design.md)
+Supersedes: ADR-069's disabled-session local-provider fallback only
+
+## Decision
+
+The in-app Console will publish structured local filesystem, read-only Git, and
+Virtual CLI schemas only when the owning run admits one or more valid local-folder
+bindings. A run captures bindings from its own workspace ID, never from the
+currently viewed or globally active workspace. The default workspace and a named
+workspace with no valid bindings publish none of those path-taking schemas.
+Unrelated local web, Watchlists, and todo tools remain available, and built-in
+sandbox file tools retain their private Chat scratch authority.
+
+Each admitted root carries its stable binding ID as the model-facing root alias,
+canonical-locator fingerprint, captured filesystem identity, and admission-time
+access mode. With one admitted root the alias may be omitted for compatibility;
+with multiple roots every path call must provide an alias. Alias selection never
+re-reads the active workspace.
+
+Before review and again immediately before execution, the provider resolves the
+captured binding ID and verifies workspace membership, local-filesystem kind,
+ready status, locator fingerprint, filesystem identity, and sufficient current
+access. Reads accept `ro` or `rw`; mutations require `rw`. Removal, retargeting,
+identity replacement, or access downgrade refuses the call. Once admitted, the
+operation uses ADR-101's one-shot pinned executor as its pathname-race boundary.
+
+Project-instruction-enabled sessions retain ADR-069's single selected binding and
+its stronger session-state guard. The selected binding is represented through the
+same run-root shape so local providers have one authority contract.
+
+Path-tool input schemas include the admitted alias contract. That intentional
+schema change flows through the existing permission definition hash, invalidating
+stale persistent approvals without a new permission store or migration.
+
+The standalone local MCP server remains outside this in-app authority path and
+continues to use its explicit `[console] workspace_root` or standalone process-CWD
+fallback. Raw shell remains governed separately by ADR-094 and is not widened by
+this decision.
+
+## Context
+
+ADR-069 selected one workspace binding for project-instruction-enabled sessions
+but explicitly left disabled sessions on the legacy provider-root behavior.
+Subsequent Console work gave each Chat private scratch and retired configured-root
+authority in the mounted Console, yet structured `fs_*`, `git_*`, and Virtual CLI
+schemas still appear against that scratch when no workspace folder was admitted.
+Named workspaces with multiple bindings likewise have no stable per-call root
+selection contract.
+
+TASK-19637 and ADR-101 now provide the missing execution primitive: every admitted
+operation runs in a fresh worker pinned to the captured root identity. TASK-19504
+can therefore remove fallback authority without overstating pathname safety.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Generate one tool name per root | Makes catalog names workspace-specific, multiplies approval rows, and creates more schema churn than one explicit argument. |
+| Encode aliases in paths such as `@root/file` | Introduces a second path grammar and makes patch/Git argument parsing ambiguous. |
+| Keep scratch-backed structured tools when no binding exists | Preserves hidden authority and contradicts the task's bindingless behavior. Built-in sandbox tools already own private scratch access. |
+| Re-resolve the active workspace on every call | A tab or workspace switch could retarget a live run. Authority must derive from the run's captured workspace and binding IDs. |
+| Add a new permission subsystem | Existing schema definition hashes already invalidate stale grants; another store would duplicate policy. |
+
+## Consequences
+
+- Dynamic path schemas vary with the admitted alias set and intentionally require
+  renewed approval after this upgrade or a later authority-shape change.
+- Bindingless runs lose only structured local filesystem/Git and Virtual CLI
+  schemas; non-path local tools and built-in scratch tools remain intact.
+- Mixed `ro`/`rw` roots can expose mutation schemas when at least one root is
+  writable, but a call selecting a read-only alias is refused at call time.
+- Registry and filesystem authority are checked at least twice per path call.
+- The model sees opaque binding IDs and labels, never raw absolute locators.
+
+## Links
+
+- [ADR-028](028-settings-workspaces-category-and-folder-roots.md)
+- [ADR-032](032-local-agent-tool-permission-boundary.md)
+- [ADR-069](069-console-project-instruction-local-state-and-preflight.md)
+- [ADR-101](101-one-shot-pinned-workspace-tool-execution.md)

--- a/backlog/tasks/task-19504 - Bind-Console-local-path-tools-to-run-admitted-workspace-roots.md
+++ b/backlog/tasks/task-19504 - Bind-Console-local-path-tools-to-run-admitted-workspace-roots.md
@@ -72,4 +72,13 @@ Python 3.12 environment, including production subprocess-worker execution, plus
 15 built-in scratch tests and 75 documentation contract tests. Ruff, formatting,
 `py_compile`, and `git diff --check` passed. The shared development venv was not
 modified; its editable install still points at an unrelated older worktree.
+
+During PR integration, the repository-wide diagnostic-inventory gate exposed
+new persona and Workspace diagnostics inherited from the updated `dev` base that
+still interpolated private runtime values. Those messages now retain only their
+failure categories, an AST regression test enforces constant metadata-only
+templates at the affected boundaries, and the reviewed derived inventory was
+regenerated. The focused privacy/logging suite passed 121 tests, the exact
+inventory checker passed with 546 owners and eight sink files, and the original
+329-test TASK-19504 sweep remained green.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19504 - Bind-Console-local-path-tools-to-run-admitted-workspace-roots.md
+++ b/backlog/tasks/task-19504 - Bind-Console-local-path-tools-to-run-admitted-workspace-roots.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-19504
 title: Bind Console local path tools to run-admitted workspace roots
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-21'
+updated_date: '2026-08-30 16:10'
 labels:
   - console
   - tools
@@ -11,7 +12,6 @@ labels:
 dependencies:
   - TASK-17067
   - TASK-19637
-priority: critical
 ---
 
 ## Description
@@ -22,11 +22,54 @@ Remove the in-app Console's hidden configured-root and process-CWD fallback so l
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Project-instruction-enabled sessions preserve ADR-069's one selected binding and call-time membership, fingerprint, access, and filesystem-identity checks
-- [ ] #2 Disabled named workspaces capture their valid bindings at run admission and select them through stable binding-ID aliases without active-workspace retargeting
-- [ ] #3 Multiple admitted roots require an explicit root alias; reads honor ro or rw and mutations require current rw
-- [ ] #4 Binding removal, locator retargeting, identity replacement, and rw-to-ro downgrade revoke access during a run
-- [ ] #5 Default and binding-less named workspaces remove only local fs and Git schemas while preserving local web, Watchlists, and todo tools and built-in sandbox file access
-- [ ] #6 The in-app Console ignores configured workspace_root and process CWD; standalone MCP retains its explicit configured root
-- [ ] #7 The schema change invalidates stale persistent approvals through the existing definition-hash guard and the upgrade copy discloses reapproval
+- [x] #1 Project-instruction-enabled sessions preserve ADR-069's one selected binding and call-time membership, fingerprint, access, and filesystem-identity checks
+- [x] #2 Disabled named workspaces capture their valid bindings at run admission and select them through stable binding-ID aliases without active-workspace retargeting
+- [x] #3 Multiple admitted roots require an explicit root alias; reads honor ro or rw and mutations require current rw
+- [x] #4 Binding removal, locator retargeting, identity replacement, and rw-to-ro downgrade revoke access during a run
+- [x] #5 Default and binding-less named workspaces remove only local fs and Git schemas while preserving local web, Watchlists, and todo tools and built-in sandbox file access
+- [x] #6 The in-app Console ignores configured workspace_root and process CWD; standalone MCP retains its explicit configured root
+- [x] #7 The schema change invalidates stale persistent approvals through the existing definition-hash guard and the upgrade copy discloses reapproval
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: `backlog/decisions/102-console-run-admitted-local-path-authority.md`
+Reason: this task changes the Console security authority and supersedes ADR-069's
+disabled-session fallback behavior.
+
+Approved design:
+`Docs/superpowers/specs/2026-08-30-task-19504-run-admitted-workspace-roots-design.md`
+
+Detailed plan:
+`Docs/superpowers/plans/2026-08-30-task-19504-run-admitted-workspace-roots.md`
+
+1. Pin zero/one/multiple-root schemas and runtime revocation with failing tests.
+2. Add one immutable run-admitted root contract and alias-aware routing over the
+   existing local provider, Virtual CLI registry, and ADR-101 executor.
+3. Capture roots from the owning session workspace without active-workspace,
+   configured-root, process-CWD, or scratch-backed structured-tool fallback.
+4. Preserve project-instruction selection, non-path local tools, built-in scratch
+   tools, standalone MCP, definition-hash invalidation, and upgrade guidance.
+5. Run focused/static/diff/diagnostic verification and final review.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented ADR-102 with one immutable run-admitted root contract shared by the
+structured local provider and Virtual CLI. Console composition now captures the
+owning named Workspace's valid bindings once per run, uses stable binding-ID
+aliases, removes path schemas when no root is admitted, and revalidates binding
+membership, locator, identity, and access before review and execution. ADR-069's
+selected project root, non-path local tools, built-in scratch tools, and standalone
+MCP authority remain unchanged. Local and Virtual CLI permission descriptors now
+include the alias schema so the existing definition hash forces reapproval.
+
+Verification covered the complete 329-test affected-file sweep in an isolated
+Python 3.12 environment, including production subprocess-worker execution, plus
+15 built-in scratch tests and 75 documentation contract tests. Ruff, formatting,
+`py_compile`, and `git diff --check` passed. The shared development venv was not
+modified; its editable install still points at an unrelated older worktree.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-19504 - Bind-Console-local-path-tools-to-run-admitted-workspace-roots.md
+++ b/backlog/tasks/task-19504 - Bind-Console-local-path-tools-to-run-admitted-workspace-roots.md
@@ -81,4 +81,14 @@ templates at the affected boundaries, and the reviewed derived inventory was
 regenerated. The focused privacy/logging suite passed 121 tests, the exact
 inventory checker passed with 546 owners and eight sink files, and the original
 329-test TASK-19504 sweep remained green.
+
+Qodo's post-push review identified six additional integration gaps. The public
+capture helper now has complete Google-style parameter and return documentation;
+Virtual CLI request data is parsed through a typed Pydantic boundary; roots that
+become unusable between admission and provider construction are omitted without
+aborting unrelated local tools; custom path specs combined with admitted roots
+are rejected at construction; and both provider paths redact results and errors
+against the selected admitted root. Focused regressions cover the constructor
+race, custom-spec contract, and success/error locator redaction for both Local
+and Virtual CLI providers.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Agents/local_tool_provider.py
+++ b/tldw_chatbook/Agents/local_tool_provider.py
@@ -9,10 +9,11 @@ methods are sync and worker-thread safe; no Textual/event-loop imports.
 
 from __future__ import annotations
 
+import copy
 import json
 import threading
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from pathlib import Path
 from typing import (
@@ -23,6 +24,7 @@ from typing import (
     Iterator,
     Mapping,
     NotRequired,
+    Sequence,
     TypedDict,
 )
 
@@ -247,12 +249,8 @@ class LocalToolSpec:
         """Fail closed when descriptor policy is missing or not code-owned."""
         if not isinstance(self.exposure, LocalToolExposure):
             raise ValueError("LocalToolSpec exposure must be a LocalToolExposure")
-        if (
-            not isinstance(self.approval_effects, tuple)
-            or not all(
-                isinstance(effect, LocalApprovalEffect)
-                for effect in self.approval_effects
-            )
+        if not isinstance(self.approval_effects, tuple) or not all(
+            isinstance(effect, LocalApprovalEffect) for effect in self.approval_effects
         ):
             raise ValueError(
                 "LocalToolSpec approval_effects must be LocalApprovalEffect values"
@@ -265,6 +263,37 @@ class LocalToolSpec:
             raise ValueError(
                 "LocalToolSpec execution_policy must be a ToolExecutionPolicy"
             )
+
+
+@dataclass(frozen=True, slots=True)
+class RunAdmittedWorkspaceRoot:
+    """Immutable local-folder authority captured for one Console run."""
+
+    workspace_id: str
+    binding_id: str
+    alias: str
+    root: Path
+    locator_fingerprint: str
+    root_identity: tuple[tuple[str, int, int, int], ...]
+    allow_write: bool
+    guard: Callable[[bool], bool]
+    workspace_executor: WorkspaceToolExecutor | None = None
+    authority_scope: Callable[[], ContextManager[Path]] | None = None
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "workspace_id",
+            "binding_id",
+            "alias",
+            "locator_fingerprint",
+        ):
+            if not str(getattr(self, field_name)).strip():
+                raise ValueError(f"{field_name} must be non-empty")
+        object.__setattr__(self, "root", Path(self.root))
+        if not self.root_identity:
+            raise ValueError("root_identity must be non-empty")
+        if not callable(self.guard):
+            raise ValueError("guard must be callable")
 
 
 def _fit_result(text: str) -> str:
@@ -335,6 +364,9 @@ class LocalToolProvider:
             root; ordinary and explicitly bound Workspace providers omit it.
         workspace_executor: One-shot pinned workspace executor. When omitted,
             the provider constructs the production executor for ``workspace_root``.
+        admitted_roots: Immutable Console run authorities. ``None`` preserves
+            the legacy standalone provider root; an empty sequence removes path
+            tools; one or more entries route path calls by stable alias.
     """
 
     def __init__(
@@ -359,17 +391,30 @@ class LocalToolProvider:
         authority_scope: Callable[[], ContextManager[Path]] | None = None,
         result_redaction_root: Path | None = None,
         workspace_executor: WorkspaceToolExecutor | None = None,
+        admitted_roots: Sequence[RunAdmittedWorkspaceRoot] | None = None,
     ) -> None:
         self._root = workspace_root
-        selected_executor = (
-            WorkspaceToolExecutor(workspace_root)
-            if workspace_executor is None
-            else workspace_executor
+        ordered_roots = (
+            None
+            if admitted_roots is None
+            else tuple(sorted(admitted_roots, key=lambda authority: authority.alias))
         )
-        selected_specs = (
-            specs
-            if specs is not None
-            else _default_specs(
+        self._admitted_roots = (
+            None
+            if ordered_roots is None
+            else {authority.alias: authority for authority in ordered_roots}
+        )
+        if admitted_roots is not None and len(self._admitted_roots) != len(
+            admitted_roots
+        ):
+            raise ValueError("admitted root aliases must be unique")
+        self._path_specs_by_alias: dict[str, dict[str, LocalToolSpec]] = {}
+
+        selected_executor = workspace_executor or WorkspaceToolExecutor(workspace_root)
+        if specs is not None:
+            selected_specs = specs
+        elif self._admitted_roots is None:
+            selected_specs = _default_specs(
                 workspace_root,
                 workspace_executor=selected_executor,
                 todo_store=todo_store,
@@ -377,7 +422,68 @@ class LocalToolProvider:
                 watchlists_service=watchlists_service,
                 watchlists_command_service=watchlists_command_service,
             )
-        )
+        elif not self._admitted_roots:
+            selected_specs = [
+                spec
+                for spec in _default_specs(
+                    workspace_root,
+                    workspace_executor=selected_executor,
+                    todo_store=todo_store,
+                    on_todo_change=on_todo_change,
+                    watchlists_service=watchlists_service,
+                    watchlists_command_service=watchlists_command_service,
+                )
+                if spec.name not in _PATH_AUTHORITY_LOCAL_NAMES
+            ]
+        else:
+            representative_specs: list[LocalToolSpec] | None = None
+            for alias, authority in self._admitted_roots.items():
+                executor = authority.workspace_executor or WorkspaceToolExecutor(
+                    authority.root
+                )
+                authority_specs = _default_specs(
+                    authority.root,
+                    workspace_executor=executor,
+                    todo_store=todo_store,
+                    on_todo_change=on_todo_change,
+                    watchlists_service=watchlists_service,
+                    watchlists_command_service=watchlists_command_service,
+                )
+                self._path_specs_by_alias[alias] = {
+                    spec.name: spec
+                    for spec in authority_specs
+                    if spec.name in _PATH_AUTHORITY_LOCAL_NAMES
+                }
+                if representative_specs is None:
+                    representative_specs = authority_specs
+
+            assert representative_specs is not None
+            aliases = list(self._admitted_roots)
+            require_alias = len(aliases) > 1
+            any_write = any(
+                authority.allow_write for authority in self._admitted_roots.values()
+            )
+            selected_specs = []
+            for spec in representative_specs:
+                if spec.name not in _PATH_AUTHORITY_LOCAL_NAMES:
+                    selected_specs.append(spec)
+                    continue
+                if (
+                    LocalApprovalEffect.MUTATES_LOCAL in spec.approval_effects
+                    and not any_write
+                ):
+                    continue
+                parameters = copy.deepcopy(spec.parameters)
+                parameters.setdefault("properties", {})["root_alias"] = {
+                    "type": "string",
+                    "enum": aliases,
+                    "description": "Stable workspace-folder binding alias for this run.",
+                }
+                required = list(parameters.get("required", ()))
+                if require_alias and "root_alias" not in required:
+                    required.append("root_alias")
+                parameters["required"] = required
+                selected_specs.append(replace(spec, parameters=parameters))
         if not allow_write:
             selected_specs = [
                 spec
@@ -412,6 +518,48 @@ class LocalToolProvider:
         # dict; no locked method calls another, and `stamp_scope` never
         # holds it across its `yield`.
         self._stamps_lock = threading.Lock()
+
+    def _select_admitted_root(
+        self, name: str, args: Mapping[str, Any]
+    ) -> tuple[RunAdmittedWorkspaceRoot | None, Mapping[str, Any]]:
+        """Select one captured root and strip the routing-only argument."""
+        if name not in _PATH_AUTHORITY_LOCAL_NAMES or self._admitted_roots is None:
+            return None, args
+        if not self._admitted_roots:
+            raise ValueError("No workspace root was admitted for this run")
+        if type(args) is not dict:
+            raise ValueError("arguments must be an object")
+        clean_args = dict(args)
+        alias = clean_args.pop("root_alias", None)
+        if alias is None:
+            if len(self._admitted_roots) != 1:
+                raise ValueError(
+                    "root_alias is required when multiple roots are admitted"
+                )
+            return next(iter(self._admitted_roots.values())), clean_args
+        if not isinstance(alias, str) or alias not in self._admitted_roots:
+            raise ValueError("root_alias does not name a root admitted for this run")
+        return self._admitted_roots[alias], clean_args
+
+    @staticmethod
+    def _is_mutating_path_tool(spec: LocalToolSpec) -> bool:
+        return LocalApprovalEffect.MUTATES_LOCAL in spec.approval_effects
+
+    def _authority_is_valid(
+        self,
+        authority: RunAdmittedWorkspaceRoot | None,
+        *,
+        write: bool,
+    ) -> bool:
+        """Fail closed while revalidating legacy or run-admitted authority."""
+        if authority is None:
+            return self._root_is_valid()
+        if write and not authority.allow_write:
+            return False
+        try:
+            return bool(authority.guard(write))
+        except Exception:  # noqa: BLE001 - invocation must fail closed
+            return False
 
     # -- catalog ------------------------------------------------------
 
@@ -548,9 +696,7 @@ class LocalToolProvider:
         self, exposure: LocalToolExposure
     ) -> tuple[LocalToolSpec, ...]:
         """Return descriptors carrying exactly the requested exposure."""
-        return tuple(
-            spec for spec in self._specs.values() if spec.exposure is exposure
-        )
+        return tuple(spec for spec in self._specs.values() if spec.exposure is exposure)
 
     def approval_effects_for(self, tool_id: str) -> tuple[LocalApprovalEffect, ...]:
         """Return the code-owned effects for one registered local tool."""
@@ -570,13 +716,28 @@ class LocalToolProvider:
     ) -> tuple[ToolPathTarget, ...]:
         """Map path targets while holding scratch authority when required."""
         name = tool_id.split(":", 1)[-1]
-        if self._authority_scope is not None and name in _PATH_AUTHORITY_LOCAL_NAMES:
-            with self._authority_scope():
-                return self._path_targets_without_authority(tool_id, args)
-        return self._path_targets_without_authority(tool_id, args)
+        authority, clean_args = self._select_admitted_root(name, args)
+        spec = self._specs.get(name)
+        if spec is None:
+            return ()
+        write = self._is_mutating_path_tool(spec)
+        if not self._authority_is_valid(authority, write=write):
+            raise ValueError("Selected workspace root changed after dispatch started")
+        scope = (
+            authority.authority_scope
+            if authority is not None
+            else self._authority_scope
+        )
+        root = authority.root if authority is not None else self._root
+        if scope is not None and name in _PATH_AUTHORITY_LOCAL_NAMES:
+            with scope():
+                return self._path_targets_without_authority(
+                    tool_id, clean_args, root=root
+                )
+        return self._path_targets_without_authority(tool_id, clean_args, root=root)
 
     def _path_targets_without_authority(
-        self, tool_id: str, args: Mapping[str, Any]
+        self, tool_id: str, args: Mapping[str, Any], *, root: Path
     ) -> tuple[ToolPathTarget, ...]:
         """Map supported local file and git calls to validated path targets."""
         name = tool_id.split(":", 1)[-1]
@@ -588,7 +749,7 @@ class LocalToolProvider:
             resolve_workspace_path,
         )
 
-        root = Path(self._root).resolve()
+        root = Path(root).resolve()
         # `intent` only selects the refusal wording (and, for writes, the
         # new-directory-chain guard) inside the choke point; a protected
         # path raises LocalToolError here exactly as it does at execution
@@ -738,11 +899,17 @@ class LocalToolProvider:
         # Same `local:`-prefix tolerance as invoke()/load_schema(): the
         # registry invokes by catalog id ("local:fs_list") while the review
         # hook resolves by LLM-facing name ("fs_list").
-        if not self._root_is_valid():
-            return None
         name = name.split(":", 1)[1] if ":" in name else name
         spec = self._specs.get(name)
         if spec is None:
+            return None
+        try:
+            authority, _clean_args = self._select_admitted_root(name, args)
+        except ValueError:
+            return None
+        if not self._authority_is_valid(
+            authority, write=self._is_mutating_path_tool(spec)
+        ):
             return None
         gate, _resolve_failed = self._resolve_pending_gate(
             name, args, self.hub_tool_for(name), call_id=call_id
@@ -848,7 +1015,12 @@ class LocalToolProvider:
         spec = self._specs.get(name)
         if spec is None:
             return ToolResult(ok=False, error=f"Unknown local tool: {name}")
-        if not self._root_is_valid():
+        try:
+            authority, clean_args = self._select_admitted_root(name, args)
+        except ValueError as exc:
+            return ToolResult(ok=False, error=str(exc))
+        write = self._is_mutating_path_tool(spec)
+        if not self._authority_is_valid(authority, write=write):
             return ToolResult.blocked(LOCAL_ROOT_CHANGED_REFUSAL)
         if self._kill_switch_engaged():
             self._record_decision_safe(self.hub_tool_for(name), "denied")
@@ -862,14 +1034,19 @@ class LocalToolProvider:
         if verdict == "allow":
 
             def _invoke_allowed() -> ToolResult:
-                if not self._root_is_valid():
+                if not self._authority_is_valid(authority, write=write):
                     return ToolResult.blocked(LOCAL_ROOT_CHANGED_REFUSAL)
                 try:
+                    selected_spec = (
+                        self._path_specs_by_alias[authority.alias][name]
+                        if authority is not None and name in _PATH_AUTHORITY_LOCAL_NAMES
+                        else spec
+                    )
                     return ToolResult(
                         ok=True,
                         content=_fit_result(
                             redact_root_locator(
-                                spec.handler(args),
+                                selected_spec.handler(clean_args),
                                 self._result_redaction_root,
                             )
                         ),
@@ -889,12 +1066,14 @@ class LocalToolProvider:
                         error=error[:_MAX_ERROR_CHARS],
                     )
 
-            if (
-                self._authority_scope is not None
-                and name in _PATH_AUTHORITY_LOCAL_NAMES
-            ):
+            authority_scope = (
+                authority.authority_scope
+                if authority is not None
+                else self._authority_scope
+            )
+            if authority_scope is not None and name in _PATH_AUTHORITY_LOCAL_NAMES:
                 try:
-                    with self._authority_scope():
+                    with authority_scope():
                         return _invoke_allowed()
                 except Exception:  # noqa: BLE001 - lease failure is fail-closed
                     return ToolResult.blocked(LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL)
@@ -1271,6 +1450,7 @@ def _default_specs(
             runtime_source_loader=lambda: "local",
         )
     if watchlists_command_service is None:
+
         def _unavailable_command(*_args: Any, **_kwargs: Any) -> Any:
             raise RuntimeError("Watchlists command service unavailable")
 
@@ -2043,12 +2223,27 @@ def _default_specs(
                         "items": {
                             "type": "object",
                             "properties": {
-                                "url": {"type": "string", "minLength": 1, "maxLength": 2_048},
-                                "name": {"type": "string", "minLength": 1, "maxLength": 512},
-                                "type": {"type": "string", "enum": ["rss", "atom", "url"]},
+                                "url": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 2_048,
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "maxLength": 512,
+                                },
+                                "type": {
+                                    "type": "string",
+                                    "enum": ["rss", "atom", "url"],
+                                },
                                 "tags": {
                                     "type": "array",
-                                    "items": {"type": "string", "minLength": 1, "maxLength": 64},
+                                    "items": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "maxLength": 64,
+                                    },
                                     "maxItems": 20,
                                 },
                                 "active": {"type": "boolean"},

--- a/tldw_chatbook/Agents/local_tool_provider.py
+++ b/tldw_chatbook/Agents/local_tool_provider.py
@@ -412,6 +412,12 @@ class LocalToolProvider:
 
         selected_executor = workspace_executor or WorkspaceToolExecutor(workspace_root)
         if specs is not None:
+            if self._admitted_roots is not None and any(
+                spec.name in _PATH_AUTHORITY_LOCAL_NAMES for spec in specs
+            ):
+                raise ValueError(
+                    "custom path specs cannot be combined with admitted roots"
+                )
             selected_specs = specs
         elif self._admitted_roots is None:
             selected_specs = _default_specs(
@@ -437,53 +443,74 @@ class LocalToolProvider:
             ]
         else:
             representative_specs: list[LocalToolSpec] | None = None
+            usable_roots: dict[str, RunAdmittedWorkspaceRoot] = {}
             for alias, authority in self._admitted_roots.items():
-                executor = authority.workspace_executor or WorkspaceToolExecutor(
-                    authority.root
-                )
-                authority_specs = _default_specs(
-                    authority.root,
-                    workspace_executor=executor,
-                    todo_store=todo_store,
-                    on_todo_change=on_todo_change,
-                    watchlists_service=watchlists_service,
-                    watchlists_command_service=watchlists_command_service,
-                )
+                try:
+                    executor = authority.workspace_executor or WorkspaceToolExecutor(
+                        authority.root
+                    )
+                    authority_specs = _default_specs(
+                        authority.root,
+                        workspace_executor=executor,
+                        todo_store=todo_store,
+                        on_todo_change=on_todo_change,
+                        watchlists_service=watchlists_service,
+                        watchlists_command_service=watchlists_command_service,
+                    )
+                except Exception:  # noqa: BLE001 - a raced root is revoked
+                    continue
                 self._path_specs_by_alias[alias] = {
                     spec.name: spec
                     for spec in authority_specs
                     if spec.name in _PATH_AUTHORITY_LOCAL_NAMES
                 }
+                usable_roots[alias] = authority
                 if representative_specs is None:
                     representative_specs = authority_specs
 
-            assert representative_specs is not None
-            aliases = list(self._admitted_roots)
-            require_alias = len(aliases) > 1
-            any_write = any(
-                authority.allow_write for authority in self._admitted_roots.values()
-            )
-            selected_specs = []
-            for spec in representative_specs:
-                if spec.name not in _PATH_AUTHORITY_LOCAL_NAMES:
-                    selected_specs.append(spec)
-                    continue
-                if (
-                    LocalApprovalEffect.MUTATES_LOCAL in spec.approval_effects
-                    and not any_write
-                ):
-                    continue
-                parameters = copy.deepcopy(spec.parameters)
-                parameters.setdefault("properties", {})["root_alias"] = {
-                    "type": "string",
-                    "enum": aliases,
-                    "description": "Stable workspace-folder binding alias for this run.",
-                }
-                required = list(parameters.get("required", ()))
-                if require_alias and "root_alias" not in required:
-                    required.append("root_alias")
-                parameters["required"] = required
-                selected_specs.append(replace(spec, parameters=parameters))
+            self._admitted_roots = usable_roots
+            if representative_specs is None:
+                selected_specs = [
+                    spec
+                    for spec in _default_specs(
+                        workspace_root,
+                        workspace_executor=selected_executor,
+                        todo_store=todo_store,
+                        on_todo_change=on_todo_change,
+                        watchlists_service=watchlists_service,
+                        watchlists_command_service=watchlists_command_service,
+                    )
+                    if spec.name not in _PATH_AUTHORITY_LOCAL_NAMES
+                ]
+            else:
+                aliases = list(self._admitted_roots)
+                require_alias = len(aliases) > 1
+                any_write = any(
+                    authority.allow_write for authority in self._admitted_roots.values()
+                )
+                selected_specs = []
+                for spec in representative_specs:
+                    if spec.name not in _PATH_AUTHORITY_LOCAL_NAMES:
+                        selected_specs.append(spec)
+                        continue
+                    if (
+                        LocalApprovalEffect.MUTATES_LOCAL in spec.approval_effects
+                        and not any_write
+                    ):
+                        continue
+                    parameters = copy.deepcopy(spec.parameters)
+                    parameters.setdefault("properties", {})["root_alias"] = {
+                        "type": "string",
+                        "enum": aliases,
+                        "description": (
+                            "Stable workspace-folder binding alias for this run."
+                        ),
+                    }
+                    required = list(parameters.get("required", ()))
+                    if require_alias and "root_alias" not in required:
+                        required.append("root_alias")
+                    parameters["required"] = required
+                    selected_specs.append(replace(spec, parameters=parameters))
         if not allow_write:
             selected_specs = [
                 spec
@@ -1036,6 +1063,11 @@ class LocalToolProvider:
             def _invoke_allowed() -> ToolResult:
                 if not self._authority_is_valid(authority, write=write):
                     return ToolResult.blocked(LOCAL_ROOT_CHANGED_REFUSAL)
+                redaction_root = (
+                    authority.root
+                    if authority is not None
+                    else self._result_redaction_root
+                )
                 try:
                     selected_spec = (
                         self._path_specs_by_alias[authority.alias][name]
@@ -1047,19 +1079,19 @@ class LocalToolProvider:
                         content=_fit_result(
                             redact_root_locator(
                                 selected_spec.handler(clean_args),
-                                self._result_redaction_root,
+                                redaction_root,
                             )
                         ),
                     )
                 except WorkspaceToolExecutionError as exc:
                     return _workspace_execution_error_result(
                         exc,
-                        redaction_root=self._result_redaction_root,
+                        redaction_root=redaction_root,
                     )
                 except Exception as exc:  # noqa: BLE001 — protocol boundary
                     error = redact_root_locator(
                         str(exc) or repr(exc),
-                        self._result_redaction_root,
+                        redaction_root,
                     )
                     return ToolResult(
                         ok=False,

--- a/tldw_chatbook/Agents/virtual_cli_provider.py
+++ b/tldw_chatbook/Agents/virtual_cli_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import re
 import threading
 from contextlib import contextmanager, nullcontext
@@ -32,6 +33,7 @@ from .local_tool_provider import (
     LOCAL_KILL_SWITCH_REFUSAL,
     LOCAL_ROOT_CHANGED_REFUSAL,
     LOCAL_TIMEOUT_REFUSAL,
+    RunAdmittedWorkspaceRoot,
 )
 from .mcp_tool_provider import MCPPendingCall
 from .run_context import current_run_id, current_tool_call_id
@@ -93,7 +95,7 @@ def _sanitize_result(text: str) -> str:
 
 
 class VirtualCliProvider:
-    """Expose one schema while resolving authority per selected command."""
+    """Expose one schema while resolving command and admitted-root authority."""
 
     def __init__(
         self,
@@ -111,6 +113,7 @@ class VirtualCliProvider:
         authority_scope: Callable[[], ContextManager[Path]] | None = None,
         result_redaction_root: Path | None = None,
         workspace_executor: WorkspaceToolExecutor | None = None,
+        admitted_roots: Sequence[RunAdmittedWorkspaceRoot] | None = None,
     ) -> None:
         selected_executor = (
             WorkspaceToolExecutor(workspace_root)
@@ -121,6 +124,39 @@ class VirtualCliProvider:
             workspace_root,
             workspace_executor=selected_executor,
         )
+        ordered_roots = (
+            None
+            if admitted_roots is None
+            else tuple(sorted(admitted_roots, key=lambda authority: authority.alias))
+        )
+        self._admitted_roots = (
+            None
+            if ordered_roots is None
+            else {authority.alias: authority for authority in ordered_roots}
+        )
+        if admitted_roots is not None and len(self._admitted_roots) != len(
+            admitted_roots
+        ):
+            raise ValueError("admitted root aliases must be unique")
+        self._registries_by_alias: dict[str, VirtualCliRegistry] = {}
+        self._model_schema = copy.deepcopy(_MODEL_SCHEMA)
+        if self._admitted_roots:
+            aliases = list(self._admitted_roots)
+            self._model_schema["properties"]["root_alias"] = {
+                "type": "string",
+                "enum": aliases,
+                "description": "Stable workspace-folder binding alias for this run.",
+            }
+            if len(aliases) > 1:
+                self._model_schema["required"].append("root_alias")
+            for alias, authority in self._admitted_roots.items():
+                executor = authority.workspace_executor or WorkspaceToolExecutor(
+                    authority.root
+                )
+                self._registries_by_alias[alias] = VirtualCliRegistry(
+                    authority.root,
+                    workspace_executor=executor,
+                )
         self._resolve_state = resolve_state or (
             lambda _hub: EffectiveToolState(state="ask", origin="global_default")
         )
@@ -161,13 +197,26 @@ class VirtualCliProvider:
                 "Run one allowlisted read-only workspace or Git command. "
                 "argv is structured and is never parsed by a host shell."
             ),
-            parameters=_MODEL_SCHEMA,
+            parameters=self._model_schema,
         )
 
     def hub_tool_for(self, command: str) -> HubTool:
         if command not in VIRTUAL_CLI_COMMANDS:
             raise KeyError(command)
         usage = _USAGE[command]
+        properties = {
+            "argv": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": usage,
+            }
+        }
+        required = ["argv"]
+        root_alias_schema = self._model_schema["properties"].get("root_alias")
+        if root_alias_schema is not None:
+            properties["root_alias"] = copy.deepcopy(root_alias_schema)
+            if "root_alias" in self._model_schema["required"]:
+                required.append("root_alias")
         return HubTool(
             server_key=VIRTUAL_CLI_SERVER_KEY,
             server_label=VIRTUAL_CLI_SERVER_LABEL,
@@ -179,14 +228,8 @@ class VirtualCliProvider:
             ),
             input_schema={
                 "type": "object",
-                "properties": {
-                    "argv": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": usage,
-                    }
-                },
-                "required": ["argv"],
+                "properties": properties,
+                "required": required,
                 "additionalProperties": False,
             },
             tags=(),
@@ -197,11 +240,20 @@ class VirtualCliProvider:
     def hub_tools(self) -> list[HubTool]:
         return [self.hub_tool_for(command) for command in VIRTUAL_CLI_COMMANDS]
 
-    @staticmethod
-    def _validated_args(args: Mapping[str, object]) -> tuple[str, Sequence[str]]:
-        if not isinstance(args, Mapping) or set(args) != {"command", "argv"}:
+    def _validated_args(
+        self, args: Mapping[str, object]
+    ) -> tuple[str, Sequence[str], RunAdmittedWorkspaceRoot | None]:
+        required = {"command", "argv"}
+        allowed = required | (
+            {"root_alias"} if self._admitted_roots is not None else set()
+        )
+        if (
+            not isinstance(args, Mapping)
+            or not required <= set(args)
+            or not set(args) <= allowed
+        ):
             raise VirtualCliArgumentError(
-                "virtual_cli requires exactly command and argv"
+                "virtual_cli requires command and argv plus an optional root_alias"
             )
         command = args.get("command")
         argv = args.get("argv")
@@ -209,14 +261,42 @@ class VirtualCliProvider:
             raise VirtualCliArgumentError("command must be a string")
         if not isinstance(argv, Sequence) or isinstance(argv, (str, bytes)):
             raise VirtualCliArgumentError("argv must be an array of strings")
+        authority = self._select_admitted_root(args.get("root_alias"))
         request, _parsed = parse_request(command, argv)
-        return request.command, request.argv
+        return request.command, request.argv, authority
+
+    def _select_admitted_root(self, alias: object) -> RunAdmittedWorkspaceRoot | None:
+        if self._admitted_roots is None:
+            return None
+        if not self._admitted_roots:
+            raise VirtualCliArgumentError("no workspace root was admitted for this run")
+        if alias is None:
+            if len(self._admitted_roots) != 1:
+                raise VirtualCliArgumentError(
+                    "root_alias is required when multiple roots are admitted"
+                )
+            return next(iter(self._admitted_roots.values()))
+        if not isinstance(alias, str) or alias not in self._admitted_roots:
+            raise VirtualCliArgumentError(
+                "root_alias does not name a root admitted for this run"
+            )
+        return self._admitted_roots[alias]
+
+    def _authority_is_valid(self, authority: RunAdmittedWorkspaceRoot | None) -> bool:
+        if authority is None:
+            return self._root_is_valid()
+        try:
+            return bool(authority.guard(False))
+        except Exception:  # noqa: BLE001 - invocation must fail closed
+            return False
 
     def pending_gate_for(self, call: ToolCall) -> MCPPendingCall | None:
-        if call.name != VIRTUAL_CLI_TOOL_NAME or not self._root_is_valid():
+        if call.name != VIRTUAL_CLI_TOOL_NAME:
             return None
         try:
-            command, _argv = self._validated_args(call.args)
+            command, _argv, authority = self._validated_args(call.args)
+            if not self._authority_is_valid(authority):
+                return None
             state = self._resolve_state(self.hub_tool_for(command))
         except Exception:
             return None
@@ -286,11 +366,11 @@ class VirtualCliProvider:
         if name != VIRTUAL_CLI_TOOL_NAME:
             return ToolResult(ok=False, error=f"Unknown virtual CLI tool: {name}")
         try:
-            command, argv = self._validated_args(args)
+            command, argv, authority = self._validated_args(args)
         except VirtualCliArgumentError as exc:
             return ToolResult(ok=False, error=f"invalid virtual_cli request: {exc}")
         hub = self.hub_tool_for(command)
-        if not self._root_is_valid():
+        if not self._authority_is_valid(authority):
             self._record(hub, "denied")
             return ToolResult.blocked(LOCAL_ROOT_CHANGED_REFUSAL)
         if not self._local_tools_are_enabled():
@@ -319,28 +399,43 @@ class VirtualCliProvider:
             return ToolResult.blocked(refusal)
 
         def execute() -> ToolResult:
-            if not self._root_is_valid():
+            if not self._authority_is_valid(authority):
                 return ToolResult.blocked(LOCAL_ROOT_CHANGED_REFUSAL)
             if not self._local_tools_are_enabled() or self._kill_switch_engaged():
                 return ToolResult.blocked(LOCAL_KILL_SWITCH_REFUSAL)
             try:
-                content = self._registry.execute(command, argv)
-                content = redact_root_locator(content, self._result_redaction_root)
+                registry = (
+                    self._registry
+                    if authority is None
+                    else self._registries_by_alias[authority.alias]
+                )
+                content = registry.execute(command, argv)
+                redaction_root = (
+                    self._result_redaction_root if authority is None else None
+                )
+                content = redact_root_locator(content, redaction_root)
                 return ToolResult(ok=True, content=_sanitize_result(content))
             except WorkspaceToolExecutionError as exc:
                 if exc.code == "root_pin_failed":
                     return ToolResult.blocked(LOCAL_ROOT_CHANGED_REFUSAL)
                 if exc.code not in {"invalid_request", "tool_failure"}:
                     return ToolResult.blocked(LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL)
-                error = redact_root_locator(str(exc), self._result_redaction_root)
+                error = redact_root_locator(
+                    str(exc),
+                    self._result_redaction_root if authority is None else None,
+                )
                 return ToolResult(ok=False, error=error[:_MAX_ERROR_CHARS])
             except Exception as exc:  # noqa: BLE001 - provider boundary
                 error = redact_root_locator(
-                    str(exc) or repr(exc), self._result_redaction_root
+                    str(exc) or repr(exc),
+                    self._result_redaction_root if authority is None else None,
                 )
                 return ToolResult(ok=False, error=error[:_MAX_ERROR_CHARS])
 
-        scope = self._authority_scope() if self._authority_scope else nullcontext()
+        scope_factory = (
+            self._authority_scope if authority is None else authority.authority_scope
+        )
+        scope = scope_factory() if scope_factory else nullcontext()
         try:
             with scope:
                 return execute()

--- a/tldw_chatbook/Agents/virtual_cli_provider.py
+++ b/tldw_chatbook/Agents/virtual_cli_provider.py
@@ -10,12 +10,15 @@ from pathlib import Path
 from typing import Callable, ContextManager, Iterator, Mapping, Sequence
 
 from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ValidationError as PydanticValidationError
 
 from tldw_chatbook.MCP.hub_tool_catalog import HubTool
 from tldw_chatbook.MCP.permission_store import EffectiveToolState
 from tldw_chatbook.Tools.virtual_cli_impls import (
     MAX_ARGV_ITEMS,
     VIRTUAL_CLI_COMMANDS,
+    VirtualCliCommand,
     VirtualCliArgumentError,
     VirtualCliRegistry,
     parse_request,
@@ -81,6 +84,21 @@ _MODEL_SCHEMA = {
 }
 
 
+class _VirtualCliInput(BaseModel):
+    """Validated model-facing Virtual CLI arguments."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    command: VirtualCliCommand
+    argv: list[str] = Field(max_length=MAX_ARGV_ITEMS)
+
+
+class _AdmittedVirtualCliInput(_VirtualCliInput):
+    """Validated Virtual CLI arguments with run-root selection."""
+
+    root_alias: str | None = None
+
+
 def _sanitize_result(text: str) -> str:
     text = _ANSI_ESCAPE.sub("", text)
     text = "".join(
@@ -141,22 +159,32 @@ class VirtualCliProvider:
         self._registries_by_alias: dict[str, VirtualCliRegistry] = {}
         self._model_schema = copy.deepcopy(_MODEL_SCHEMA)
         if self._admitted_roots:
-            aliases = list(self._admitted_roots)
-            self._model_schema["properties"]["root_alias"] = {
-                "type": "string",
-                "enum": aliases,
-                "description": "Stable workspace-folder binding alias for this run.",
-            }
-            if len(aliases) > 1:
-                self._model_schema["required"].append("root_alias")
+            usable_roots: dict[str, RunAdmittedWorkspaceRoot] = {}
             for alias, authority in self._admitted_roots.items():
-                executor = authority.workspace_executor or WorkspaceToolExecutor(
-                    authority.root
-                )
-                self._registries_by_alias[alias] = VirtualCliRegistry(
-                    authority.root,
-                    workspace_executor=executor,
-                )
+                try:
+                    executor = authority.workspace_executor or WorkspaceToolExecutor(
+                        authority.root
+                    )
+                    registry = VirtualCliRegistry(
+                        authority.root,
+                        workspace_executor=executor,
+                    )
+                except Exception:  # noqa: BLE001 - a raced root is revoked
+                    continue
+                self._registries_by_alias[alias] = registry
+                usable_roots[alias] = authority
+            self._admitted_roots = usable_roots
+            if usable_roots:
+                aliases = list(usable_roots)
+                self._model_schema["properties"]["root_alias"] = {
+                    "type": "string",
+                    "enum": aliases,
+                    "description": (
+                        "Stable workspace-folder binding alias for this run."
+                    ),
+                }
+                if len(aliases) > 1:
+                    self._model_schema["required"].append("root_alias")
         self._resolve_state = resolve_state or (
             lambda _hub: EffectiveToolState(state="ask", origin="global_default")
         )
@@ -243,26 +271,22 @@ class VirtualCliProvider:
     def _validated_args(
         self, args: Mapping[str, object]
     ) -> tuple[str, Sequence[str], RunAdmittedWorkspaceRoot | None]:
-        required = {"command", "argv"}
-        allowed = required | (
-            {"root_alias"} if self._admitted_roots is not None else set()
-        )
-        if (
-            not isinstance(args, Mapping)
-            or not required <= set(args)
-            or not set(args) <= allowed
-        ):
+        if not isinstance(args, Mapping):
+            raise VirtualCliArgumentError("virtual_cli arguments must be an object")
+        model = _AdmittedVirtualCliInput if self._admitted_roots else _VirtualCliInput
+        try:
+            validated = model.model_validate(dict(args))
+        except PydanticValidationError as exc:
             raise VirtualCliArgumentError(
-                "virtual_cli requires command and argv plus an optional root_alias"
-            )
-        command = args.get("command")
-        argv = args.get("argv")
-        if not isinstance(command, str):
-            raise VirtualCliArgumentError("command must be a string")
-        if not isinstance(argv, Sequence) or isinstance(argv, (str, bytes)):
-            raise VirtualCliArgumentError("argv must be an array of strings")
-        authority = self._select_admitted_root(args.get("root_alias"))
-        request, _parsed = parse_request(command, argv)
+                "virtual_cli arguments do not match the tool schema"
+            ) from exc
+        alias = (
+            validated.root_alias
+            if isinstance(validated, _AdmittedVirtualCliInput)
+            else None
+        )
+        authority = self._select_admitted_root(alias)
+        request, _parsed = parse_request(validated.command, validated.argv)
         return request.command, request.argv, authority
 
     def _select_admitted_root(self, alias: object) -> RunAdmittedWorkspaceRoot | None:
@@ -411,7 +435,7 @@ class VirtualCliProvider:
                 )
                 content = registry.execute(command, argv)
                 redaction_root = (
-                    self._result_redaction_root if authority is None else None
+                    self._result_redaction_root if authority is None else authority.root
                 )
                 content = redact_root_locator(content, redaction_root)
                 return ToolResult(ok=True, content=_sanitize_result(content))
@@ -422,13 +446,17 @@ class VirtualCliProvider:
                     return ToolResult.blocked(LOCAL_AUTHORITY_UNAVAILABLE_REFUSAL)
                 error = redact_root_locator(
                     str(exc),
-                    self._result_redaction_root if authority is None else None,
+                    self._result_redaction_root
+                    if authority is None
+                    else authority.root,
                 )
                 return ToolResult(ok=False, error=error[:_MAX_ERROR_CHARS])
             except Exception as exc:  # noqa: BLE001 - provider boundary
                 error = redact_root_locator(
                     str(exc) or repr(exc),
-                    self._result_redaction_root if authority is None else None,
+                    self._result_redaction_root
+                    if authority is None
+                    else authority.root,
                 )
                 return ToolResult(ok=False, error=error[:_MAX_ERROR_CHARS])
 

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -27,6 +27,7 @@ from typing import (
     Callable,
     Literal,
     Protocol,
+    Sequence,
     TypedDict,
 )
 from uuid import uuid4
@@ -302,6 +303,7 @@ from tldw_chatbook.Agents.builtin_tool_gate import (
     build_builtin_gate,
 )
 from tldw_chatbook.Agents.human_input_wait import use_human_input_wait
+
 # task-24458: same deferral as the raw-shell/virtual-CLI providers below --
 # `LocalToolProvider` is the third entry point into the workspace
 # tool-execution cluster, and it is only needed when a run composes it.
@@ -311,6 +313,7 @@ from tldw_chatbook.Agents.project_instruction_resolver import (
     StartupInstructionCandidate,
 )
 from tldw_chatbook.Agents.mcp_tool_provider import MCPPendingCall, MCPToolProvider
+
 # NOTE (boot budget, ADR-097): `Agents.persona_policy` is imported lazily
 # (annotation-only `PersonaToolPolicy` under TYPE_CHECKING; the parsing and
 # floor helpers are imported inside their per-run use sites) so the module
@@ -321,6 +324,7 @@ from tldw_chatbook.Agents.session_todo_store import (
     TodoChangeCallback,
 )
 from tldw_chatbook.Agents.tool_catalog import BuiltinToolProvider, ToolExecutionPolicy
+
 # task-24458: these two providers pull the whole workspace tool-execution
 # cluster (`Tools.workspace_tool_executor` -> `Tools.{git,local,patch,
 # virtual_cli}_tool_impls`, `Tools.workspace_root_pin`,
@@ -882,6 +886,115 @@ def _same_project_instruction_authority(
     )
 
 
+def _workspace_binding_authority_is_current(
+    *,
+    workspace_id: str,
+    registry: Any,
+    expected_selection: ProjectInstructionBindingSelection,
+    write: bool,
+) -> bool:
+    """Revalidate one run-admitted binding without consulting active workspace."""
+    from types import SimpleNamespace
+
+    if write and not expected_selection.allow_write:
+        return False
+    try:
+        binding = registry.get_runtime_binding(
+            str(expected_selection.binding.binding_id)
+        )
+    except (KeyError, OSError, RuntimeError, ValueError, AttributeError):
+        return False
+    current = _validate_project_instruction_binding(
+        SimpleNamespace(workspace_id=workspace_id), binding
+    )
+    return current is not None and _same_project_instruction_authority(
+        current, expected_selection
+    )
+
+
+def capture_run_admitted_workspace_roots(
+    *,
+    session: ConsoleChatSession | Any,
+    registry: Any,
+    project_selection: ProjectInstructionBindingSelection | None = None,
+    project_authority_guard: Callable[[], bool] | None = None,
+) -> tuple[Any, ...]:
+    """Capture immutable local-folder authority for one owning Console run."""
+    from tldw_chatbook.Agents.local_tool_provider import RunAdmittedWorkspaceRoot
+    from tldw_chatbook.Chat.console_chat_models import CONSOLE_GLOBAL_WORKSPACE_ID
+    from tldw_chatbook.Workspaces.models import DEFAULT_WORKSPACE_ID
+
+    workspace_id = str(getattr(session, "workspace_id", ""))
+    if (
+        not workspace_id
+        or workspace_id in {CONSOLE_GLOBAL_WORKSPACE_ID, DEFAULT_WORKSPACE_ID}
+        or registry is None
+    ):
+        return ()
+
+    if project_selection is not None:
+        selections = (project_selection,)
+    else:
+        try:
+            bindings = registry.list_runtime_bindings(workspace_id)
+        except (KeyError, OSError, RuntimeError, ValueError, AttributeError):
+            return ()
+        selections = tuple(
+            sorted(
+                (
+                    selection
+                    for binding in bindings
+                    if (
+                        selection := _validate_project_instruction_binding(
+                            session, binding
+                        )
+                    )
+                    is not None
+                ),
+                key=lambda selection: str(selection.binding.binding_id),
+            )
+        )
+
+    roots = []
+    for selection in selections:
+        binding_id = str(selection.binding.binding_id)
+        if project_selection is not None and project_authority_guard is not None:
+
+            def guard(
+                write: bool,
+                selection: ProjectInstructionBindingSelection = selection,
+            ) -> bool:
+                return (not write or selection.allow_write) and bool(
+                    project_authority_guard()
+                )
+        else:
+
+            def guard(
+                write: bool,
+                selection: ProjectInstructionBindingSelection = selection,
+            ) -> bool:
+                return _workspace_binding_authority_is_current(
+                    workspace_id=workspace_id,
+                    registry=registry,
+                    expected_selection=selection,
+                    write=write,
+                )
+
+        roots.append(
+            RunAdmittedWorkspaceRoot(
+                workspace_id=workspace_id,
+                binding_id=binding_id,
+                alias=binding_id,
+                root=selection.root,
+                locator_fingerprint=selection.locator_fingerprint,
+                root_identity=selection.root_identity,
+                allow_write=selection.allow_write,
+                guard=guard,
+            )
+        )
+    return tuple(roots)
+
+
 def project_instruction_authority_is_current(
     *,
     store: Any,
@@ -1079,10 +1192,14 @@ def watchlists_operation_receipt_ids(
     result: Any,
 ) -> tuple[str, ...]:
     """Extract canonical receipt identity from a structured local result."""
-    if tool_name not in {
-        "watchlists_check_sources",
-        "watchlists_generate_briefing",
-    } or getattr(result, "ok", False) is not True:
+    if (
+        tool_name
+        not in {
+            "watchlists_check_sources",
+            "watchlists_generate_briefing",
+        }
+        or getattr(result, "ok", False) is not True
+    ):
         return ()
     content = getattr(result, "content", None)
     if not isinstance(content, str):
@@ -1772,9 +1889,7 @@ def build_local_review_hook(
             stamps.setdefault(name, "deny")
         provider.apply_batch_decisions(run_id, stamps)
 
-        verdicts: dict[str, str] = {
-            row.llm_name: "proceed" for row in pending
-        }
+        verdicts: dict[str, str] = {row.llm_name: "proceed" for row in pending}
         for row in pending:
             if _decision_for(row) != "deny":
                 continue
@@ -2583,9 +2698,9 @@ class ConsoleChatController:
         #: persisted, run about to start) so the composer can clear immediately
         #: instead of holding the sent text for the whole run.
         self.on_submission_accepted: Callable[[], None] | None = None
-        self.follow_watchlists_operations: (
-            Callable[[tuple[str, ...]], None] | None
-        ) = None
+        self.follow_watchlists_operations: Callable[[tuple[str, ...]], None] | None = (
+            None
+        )
         #: Content-free queued counterpart to ``on_submission_accepted``.
         #: It may refresh transcript/queue UI, but cannot clear a composer.
         self.on_queued_submission_accepted: (
@@ -7220,6 +7335,7 @@ class ConsoleChatController:
                 raise RuntimeError("Prepared turn changed before provider dispatch.")
 
         try:
+
             async def publish_identity_and_settings() -> None:
                 self.store.publish_durable_turn_identity(session_id, commit)
                 await self.store.reconcile_durable_turn_settings(session_id, commit)
@@ -9372,9 +9488,7 @@ class ConsoleChatController:
             # above already guarantees every name resolves, so `.get`'s
             # own "deny" fallback here is a belt-and-suspenders no-op, not
             # a second source of truth.
-            decision_snapshot = {
-                key: decisions.get(key, "deny") for key in unique_keys
-            }
+            decision_snapshot = {key: decisions.get(key, "deny") for key in unique_keys}
             approved_values = {"approve_once", "approve_session", "always_allow"}
             finishing_calls = [
                 call_payload
@@ -9935,6 +10049,7 @@ class ConsoleChatController:
         project_authority_guard: Callable[[], bool] | None,
         turn_context: ConsoleTurnExecutionContext | None = None,
         publish_mcp_counts: bool = True,
+        admitted_roots: Sequence[Any] | None = None,
     ) -> tuple[
         MCPToolProvider | None,
         "BuiltinToolGate",
@@ -9975,8 +10090,8 @@ class ConsoleChatController:
                 turn_context.persona_policy_rules
             )
             if parsed_persona_policy.kinds:
-                mcp_profile_kwargs["persona_policy_provider"] = (
-                    lambda: parsed_persona_policy
+                mcp_profile_kwargs["persona_policy_provider"] = lambda: (
+                    parsed_persona_policy
                 )
         mcp_provider = await self._compose_mcp_provider(
             session_id,
@@ -9986,6 +10101,16 @@ class ConsoleChatController:
         builtin_gate = build_builtin_gate(
             getattr(self.app, "unified_mcp_service", None)
         )
+        if admitted_roots is None:
+            session = next(
+                (item for item in self.store.sessions() if item.id == session_id), None
+            )
+            admitted_roots = capture_run_admitted_workspace_roots(
+                session=session,
+                registry=getattr(self.app, "workspace_registry_service", None),
+                project_selection=project_selection,
+                project_authority_guard=project_authority_guard,
+            )
         local_provider, local_review_hook = self._compose_local_provider(
             session_id=session_id,
             turn_context=turn_context,
@@ -9995,6 +10120,7 @@ class ConsoleChatController:
                 project_selection.root_identity if project_selection else None
             ),
             project_root_guard=project_authority_guard,
+            admitted_roots=admitted_roots,
         )
         return mcp_provider, builtin_gate, local_provider, local_review_hook
 
@@ -10007,6 +10133,7 @@ class ConsoleChatController:
         allow_write: bool = True,
         project_root_identity: tuple[tuple[str, int, int, int], ...] | None = None,
         project_root_guard: Callable[[], bool] | None = None,
+        admitted_roots: Sequence[Any] | None = None,
     ) -> tuple[
         LocalToolProvider | None, Callable[[list["ToolCall"]], dict[str, str]] | None
     ]:
@@ -10205,7 +10332,9 @@ class ConsoleChatController:
         # (2) the persona floor then lowers allow->ask for tools whose rules
         # demand confirmation. No path here can raise a state or add a tool.
         profile_id = (
-            turn_context.tool_policy_profile_id if turn_context is not None else "default"
+            turn_context.tool_policy_profile_id
+            if turn_context is not None
+            else "default"
         )
         # Lazy import (boot budget, ADR-097): per-run provider gate only.
         from tldw_chatbook.Agents.persona_policy import (
@@ -10250,6 +10379,7 @@ class ConsoleChatController:
             record_decision=_record_decision,
             watchlists_service=watchlists_service,
             watchlists_command_service=watchlists_command_service,
+            admitted_roots=admitted_roots,
             **self._todo_wiring(session_id),
         )
         return provider, build_local_review_hook(provider, bound_request_approvals)
@@ -10262,6 +10392,7 @@ class ConsoleChatController:
         project_root: Path | None = None,
         project_root_identity: tuple[tuple[str, int, int, int], ...] | None = None,
         project_root_guard: Callable[[], bool] | None = None,
+        admitted_roots: Sequence[Any] | None = None,
     ) -> tuple[
         VirtualCliProvider | None,
         Callable[[list["ToolCall"], str], dict[str, str]] | None,
@@ -10277,6 +10408,8 @@ class ConsoleChatController:
             )
         )
         if not coerce_bool_setting(configured, LOCAL_TOOLS_DEFAULT_ENABLED):
+            return None, None
+        if admitted_roots is not None and not admitted_roots:
             return None, None
         service = getattr(self.app, "unified_mcp_service", None)
         if service is None:
@@ -10342,6 +10475,7 @@ class ConsoleChatController:
             root_guard=root_guard,
             authority_scope=authority_scope,
             result_redaction_root=(root if project_root is None else None),
+            admitted_roots=admitted_roots,
         )
         return provider, build_virtual_cli_review_hook(provider, bound_request)
 
@@ -10365,9 +10499,7 @@ class ConsoleChatController:
                 "console", "local_tools_enabled", LOCAL_TOOLS_DEFAULT_ENABLED
             )
         )
-        local_enabled = coerce_bool_setting(
-            configured, LOCAL_TOOLS_DEFAULT_ENABLED
-        )
+        local_enabled = coerce_bool_setting(configured, LOCAL_TOOLS_DEFAULT_ENABLED)
         if not local_enabled or not session_id:
             return None, None
         service = getattr(self.app, "unified_mcp_service", None)
@@ -10663,9 +10795,7 @@ class ConsoleChatController:
             if operation_id not in followed:
                 return False
             self._followed_watchlists_operation_ids = tuple(
-                receipt_id
-                for receipt_id in followed
-                if receipt_id != operation_id
+                receipt_id for receipt_id in followed if receipt_id != operation_id
             )
         return True
 
@@ -12414,7 +12544,8 @@ class ConsoleChatController:
             )
         except Exception:
             return self._summarize_block(
-                session_id, "The active provider could not be prepared for summarization."
+                session_id,
+                "The active provider could not be prepared for summarization.",
             )
         if not getattr(resolution, "ready", False):
             return self._summarize_block(
@@ -12533,9 +12664,7 @@ class ConsoleChatController:
                 current_fence = self._manual_runtime_fence(
                     session_id=session_id,
                     snapshots=self._durable_context_snapshots(session_id),
-                    configuration=self.resolve_turn_configuration_snapshot(
-                        session_id
-                    ),
+                    configuration=self.resolve_turn_configuration_snapshot(session_id),
                     resolution=resolution,
                     prompt=prompt,
                     admission=admission,
@@ -12585,7 +12714,9 @@ class ConsoleChatController:
         if transaction.reason == "compaction_already_running":
             visible_copy = "Another summary is already running."
         elif transaction.terminal is CompactionTerminal.STALE:
-            visible_copy = "Conversation changed while summarizing. No memory was saved."
+            visible_copy = (
+                "Conversation changed while summarizing. No memory was saved."
+            )
         elif transaction.reason == "summary_did_not_make_progress":
             visible_copy = "The summary would not reduce this conversation's context."
         elif transaction.reason == "invalid_summary_output":
@@ -12599,7 +12730,9 @@ class ConsoleChatController:
         if reason == "no_complete_prior_unit":
             return "Nothing to summarize before that message."
         if reason == "manual_auxiliary_input_too_large":
-            return "That span is too large to summarize in one call. Choose a later start."
+            return (
+                "That span is too large to summarize in one call. Choose a later start."
+            )
         if reason == "manual_visual_input_unsupported":
             return (
                 "The active provider and model cannot safely summarize image "
@@ -13456,6 +13589,11 @@ class ConsoleChatController:
         # advertise tools the live run drops. A resolution failure degrades
         # to no turn context, matching the pre-Task-7 preview composition.
         preview_turn_context = turn_context
+        preview_admitted_roots = capture_run_admitted_workspace_roots(
+            session=session,
+            registry=registry,
+            project_selection=selection,
+        )
         (
             mcp_provider,
             builtin_gate,
@@ -13467,6 +13605,7 @@ class ConsoleChatController:
             project_authority_guard=None,
             turn_context=preview_turn_context,
             publish_mcp_counts=False,
+            admitted_roots=preview_admitted_roots,
         )
         virtual_cli_provider, _virtual_cli_review_hook = (
             self._compose_virtual_cli_provider(
@@ -13474,14 +13613,13 @@ class ConsoleChatController:
                 turn_context=preview_turn_context,
                 project_root=selection.root,
                 project_root_identity=selection.root_identity,
+                admitted_roots=preview_admitted_roots,
             )
         )
-        raw_shell_provider, _raw_shell_review_hook = (
-            self._compose_raw_shell_provider(
-                session_id=session_id,
-                turn_context=preview_turn_context,
-                project_root=selection.root,
-            )
+        raw_shell_provider, _raw_shell_review_hook = self._compose_raw_shell_provider(
+            session_id=session_id,
+            turn_context=preview_turn_context,
+            project_root=selection.root,
         )
         try:
             preview_result = await asyncio.to_thread(
@@ -15361,9 +15499,7 @@ class ConsoleChatController:
         projected: list[DurableMessageSnapshot] = []
         for row in durable:
             message = by_native.get(row.message_id)
-            checkpoint = (
-                message.provider_continuation if message is not None else None
-            )
+            checkpoint = message.provider_continuation if message is not None else None
             if checkpoint is None:
                 projected.append(row)
                 continue
@@ -15415,9 +15551,7 @@ class ConsoleChatController:
                 for call_index, call in enumerate(round_.calls):
                     if call.result is None:
                         return None
-                    tool_id = (
-                        f"{row.message_id}:tool-result:{round_index}:{call_index}"
-                    )
+                    tool_id = f"{row.message_id}:tool-result:{round_index}:{call_index}"
                     projected.append(
                         DurableMessageSnapshot(
                             message_id=tool_id,
@@ -15444,9 +15578,7 @@ class ConsoleChatController:
         return hashlib.sha256(encoded).hexdigest()
 
     @classmethod
-    def _repository_prefix_digest(
-        cls, rows: tuple[DurableMessageSnapshot, ...]
-    ) -> str:
+    def _repository_prefix_digest(cls, rows: tuple[DurableMessageSnapshot, ...]) -> str:
         return cls._manual_json_digest(
             [
                 {
@@ -15473,26 +15605,21 @@ class ConsoleChatController:
         ConsoleMemoryScopeRecord | None,
     ]:
         """Read one branch head, retaining bounded-list compatibility doubles."""
-        load_applicable = getattr(
-            repository, "load_applicable_branch_memory", None
-        )
+        load_applicable = getattr(repository, "load_applicable_branch_memory", None)
         if callable(load_applicable):
             state = load_applicable(conversation_id, lineage_message_ids)
             return state.selection, state.memory, state.scope
 
         memories = tuple(repository.list_active_memories(conversation_id))
         load_scope = getattr(repository, "load_memory_scope", None)
-        list_selections = getattr(
-            repository, "list_active_memory_selections", None
-        )
+        list_selections = getattr(repository, "list_active_memory_selections", None)
         if callable(load_scope) and callable(list_selections):
             selections = tuple(list_selections(conversation_id))
             head = next(
                 (
                     item
                     for item in selections
-                    if item.active
-                    and item.activation_message_id in lineage_message_ids
+                    if item.active and item.activation_message_id in lineage_message_ids
                 ),
                 None,
             )
@@ -15500,8 +15627,7 @@ class ConsoleChatController:
                 (
                     item
                     for item in memories
-                    if head is not None
-                    and item.memory_id == head.selected_memory_id
+                    if head is not None and item.memory_id == head.selected_memory_id
                 ),
                 None,
             )
@@ -15529,8 +15655,7 @@ class ConsoleChatController:
             (
                 item
                 for item in reversed(selections)
-                if item.active
-                and item.activation_message_id in lineage_message_ids
+                if item.active and item.activation_message_id in lineage_message_ids
             ),
             None,
         )
@@ -15560,12 +15685,15 @@ class ConsoleChatController:
         *,
         session_id: str,
         snapshots: tuple[DurableMessageSnapshot, ...],
-    ) -> tuple[
-        MemorySelectionFence,
-        MemorySelectionFence,
-        tuple[str, str | None],
-        tuple[PersistedLineageFenceRow, ...],
-    ] | None:
+    ) -> (
+        tuple[
+            MemorySelectionFence,
+            MemorySelectionFence,
+            tuple[str, str | None],
+            tuple[PersistedLineageFenceRow, ...],
+        ]
+        | None
+    ):
         repository = self._context_repository
         owner = next(
             (item for item in self.store.sessions() if item.id == session_id), None
@@ -15660,9 +15788,7 @@ class ConsoleChatController:
                 and memory.source_kind == "generated"
                 and memory.captured_leaf_message_id == head.activation_message_id
                 and boundary_index is not None
-                and self._repository_prefix_digest(
-                    snapshots[: boundary_index + 1]
-                )
+                and self._repository_prefix_digest(snapshots[: boundary_index + 1])
                 == memory.summarized_prefix_digest
             )
             if valid and scope.origin_kind is MemoryOriginKind.AUTOMATIC:
@@ -15726,9 +15852,7 @@ class ConsoleChatController:
         owner = next(
             (item for item in self.store.sessions() if item.id == session_id), None
         )
-        fences = self._manual_branch_fences(
-            session_id=session_id, snapshots=snapshots
-        )
+        fences = self._manual_branch_fences(session_id=session_id, snapshots=snapshots)
         if owner is None or owner.persisted_conversation_id is None or fences is None:
             return None
         effective, head, cursor, lineage = fences
@@ -15806,9 +15930,7 @@ class ConsoleChatController:
         owner = next(
             (item for item in self.store.sessions() if item.id == session_id), None
         )
-        fences = self._manual_branch_fences(
-            session_id=session_id, snapshots=snapshots
-        )
+        fences = self._manual_branch_fences(session_id=session_id, snapshots=snapshots)
         if owner is None or owner.persisted_conversation_id is None or fences is None:
             return None
         expected_effective, head, cursor, lineage = fences
@@ -15897,8 +16019,7 @@ class ConsoleChatController:
                 snapshots is None
                 or owner is None
                 or self.store.active_session_id != session_id
-                or owner.persisted_conversation_id
-                != admission.memory.conversation_id
+                or owner.persisted_conversation_id != admission.memory.conversation_id
             ):
                 return None
             fences = self._manual_branch_fences(
@@ -15970,7 +16091,11 @@ class ConsoleChatController:
         """Decode the compatibility pair once into the typed selector input."""
 
         summary, native_boundary = self.store.session_context_summary(session_id)
-        if not isinstance(summary, str) or not summary.strip() or native_boundary is None:
+        if (
+            not isinstance(summary, str)
+            or not summary.strip()
+            or native_boundary is None
+        ):
             return NO_LEGACY_MEMORY
         persisted_boundary = next(
             (
@@ -15999,9 +16124,7 @@ class ConsoleChatController:
         """Read candidates and make the one typed branch-memory decision."""
 
         repository = self._context_repository
-        legacy = self._validated_legacy_memory(
-            session_id, conversation_id, snapshots
-        )
+        legacy = self._validated_legacy_memory(session_id, conversation_id, snapshots)
         if repository is None:
             return select_effective_memory(
                 conversation_id,
@@ -16036,11 +16159,7 @@ class ConsoleChatController:
             (item for item in self.store.sessions() if item.id == session_id), None
         )
         snapshots = self._durable_context_snapshots(session_id)
-        if (
-            owner is None
-            or owner.persisted_conversation_id is None
-            or not snapshots
-        ):
+        if owner is None or owner.persisted_conversation_id is None or not snapshots:
             effective = EffectiveMemoryResult(EffectiveMemoryKind.RAW)
         else:
             effective = self._select_session_effective_memory(
@@ -16247,7 +16366,9 @@ class ConsoleChatController:
         _overrides, _global, after_memory = self.context_control_inputs(session_id)
         before_identity = (
             before_memory.kind,
-            before_memory.memory.memory_id if before_memory.memory is not None else None,
+            before_memory.memory.memory_id
+            if before_memory.memory is not None
+            else None,
             (
                 before_memory.legacy.boundary_message_id
                 if before_memory.legacy is not None
@@ -18707,6 +18828,15 @@ class ConsoleChatController:
         # outside this task's file scope, so keeping that function
         # byte-identical and building the run-level hook separately here
         # is the lower-blast-radius choice.
+        run_admitted_roots = capture_run_admitted_workspace_roots(
+            session=next(
+                (item for item in self.store.sessions() if item.id == session_id),
+                None,
+            ),
+            registry=getattr(self.app, "workspace_registry_service", None),
+            project_selection=project_selection,
+            project_authority_guard=project_authority_guard,
+        )
         (
             mcp_provider,
             builtin_gate,
@@ -18717,6 +18847,7 @@ class ConsoleChatController:
             project_selection=project_selection,
             project_authority_guard=project_authority_guard,
             turn_context=turn_context,
+            admitted_roots=run_admitted_roots,
         )
         virtual_cli_provider, virtual_cli_review_hook = (
             self._compose_virtual_cli_provider(
@@ -18731,16 +18862,15 @@ class ConsoleChatController:
                     else None
                 ),
                 project_root_guard=project_authority_guard,
+                admitted_roots=run_admitted_roots,
             )
         )
-        raw_shell_provider, raw_shell_review_hook = (
-            self._compose_raw_shell_provider(
-                session_id=session_id,
-                turn_context=turn_context,
-                project_root=(
-                    project_selection.root if project_selection is not None else None
-                ),
-            )
+        raw_shell_provider, raw_shell_review_hook = self._compose_raw_shell_provider(
+            session_id=session_id,
+            turn_context=turn_context,
+            project_root=(
+                project_selection.root if project_selection is not None else None
+            ),
         )
         self._mcp_provider = mcp_provider
 
@@ -18907,9 +19037,7 @@ class ConsoleChatController:
                 ),
                 change_roots=change_roots,
                 change_root_aliases=turn_context.change_review_root_aliases,
-                change_review_skipped_roots=(
-                    turn_context.change_review_skipped_roots
-                ),
+                change_review_skipped_roots=(turn_context.change_review_skipped_roots),
                 turn_skill_bindings=skill_bindings,
                 turn_bundle_block=skill_bundle_block,
                 request_skill_install_confirm=functools.partial(
@@ -20235,17 +20363,12 @@ class ConsoleChatController:
             row: dict[str, Any] = {"role": lightweight.role, "content": content}
             if annotate_ids:
                 row[NATIVE_MESSAGE_ID_KEY] = lightweight.source_message_id
-                persisted_message_id = persisted_ids.get(
-                    lightweight.source_message_id
-                )
-                if (
-                    isinstance(persisted_message_id, str)
-                    and isinstance(persisted_conversation_id, str)
+                persisted_message_id = persisted_ids.get(lightweight.source_message_id)
+                if isinstance(persisted_message_id, str) and isinstance(
+                    persisted_conversation_id, str
                 ):
                     row[PERSISTED_MESSAGE_ID_KEY] = persisted_message_id
-                    row[PERSISTED_CONVERSATION_ID_KEY] = (
-                        persisted_conversation_id
-                    )
+                    row[PERSISTED_CONVERSATION_ID_KEY] = persisted_conversation_id
             payloads.append(row)
         return payloads
 

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -919,7 +919,20 @@ def capture_run_admitted_workspace_roots(
     project_selection: ProjectInstructionBindingSelection | None = None,
     project_authority_guard: Callable[[], bool] | None = None,
 ) -> tuple[Any, ...]:
-    """Capture immutable local-folder authority for one owning Console run."""
+    """Capture immutable local-folder authority for one owning Console run.
+
+    Args:
+        session: Console session that owns the run and its Workspace binding.
+        registry: Workspace registry used to enumerate and revalidate bindings.
+        project_selection: Optional ADR-069 binding already selected for project
+            instructions; when present, it is the run's only admitted root.
+        project_authority_guard: Optional selected-project guard reused by the
+            admitted authority.
+
+    Returns:
+        Immutable run-root authorities ordered by stable binding ID, or an
+        empty tuple when the owning session has no valid local binding.
+    """
     from tldw_chatbook.Agents.local_tool_provider import RunAdmittedWorkspaceRoot
     from tldw_chatbook.Chat.console_chat_models import CONSOLE_GLOBAL_WORKSPACE_ID
     from tldw_chatbook.Workspaces.models import DEFAULT_WORKSPACE_ID


### PR DESCRIPTION
## Summary
- capture valid local-folder bindings from the owning Console workspace once per run and route structured fs/Git tools by stable binding-ID aliases
- enforce zero/one/multiple-root schemas, read/write access, and call-time revocation across LocalToolProvider and Virtual CLI
- preserve ADR-069 selected-root behavior, built-in scratch tools, non-path local tools, and standalone MCP authority
- accept ADR-102, close TASK-19504, and document the reapproval upgrade behavior

## Verification
- 329 affected provider/controller/MCP tests passed in an isolated Python 3.12 environment, including production subprocess-worker execution
- 15 built-in scratch-authority tests passed
- 75 MCP documentation contract tests passed
- Ruff check and format check passed
- py_compile passed for changed runtime modules
- git diff --check passed

## Governance
- TASK-19504: Done; all seven acceptance criteria checked
- ADR-102: Accepted

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds the Console's structured `fs_*`/Git and Virtual CLI path tools to local-folder bindings admitted from the owning run's workspace, removing the hidden configured-root and process-CWD fallback. Runs in the default workspace or in a workspace with no valid folder bindings no longer receive those path-taking schemas; non-path local tools and built-in scratch tools are unchanged. Also sanitizes persistent diagnostics so log messages no longer include tool names, workspace IDs, persona IDs, or policy rule contents.

**Migration**
- Ensure the owning workspace has at least one valid local-folder binding before a run that needs structured path tools.
- Multiple admitted roots require callers to pass the stable binding-ID alias; reads honor `ro`, mutations require `rw`.
- Removing or retargeting a binding revokes that root at call time, and a reapproval may be needed to admit new roots.
- Project-instruction-enabled sessions keep their single ADR-069 selected binding; standalone MCP authority is unaffected.

<sup>Written for commit 2ce7e0c11f601c56d96ee532137dff3d91213335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

