### PR TITLE
fix(windows): stabilize submitted-log regression coverage

### DIFF
--- a/.github/workflows/nightly-deep.yml
+++ b/.github/workflows/nightly-deep.yml
@@ -56,14 +56,21 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: "3.11"
+            io-encoding: utf-8
           - os: ubuntu-latest
             python-version: "3.12"
+            io-encoding: utf-8
           - os: ubuntu-latest
             python-version: "3.13"
+            io-encoding: utf-8
           - os: macos-latest
             python-version: "3.12"
+            io-encoding: utf-8
           - os: windows-latest
             python-version: "3.12"
+            # TASK-25706: exercise the common legacy Windows console posture,
+            # not only the UTF-8 environment supplied by hosted runners.
+            io-encoding: cp1252
 
     steps:
       - uses: actions/checkout@v4
@@ -100,6 +107,7 @@ jobs:
         env:
           TLDW_HYPOTHESIS_PROFILE: thorough
           TLDW_TEST_CSS_CACHE: "0"
+          PYTHONIOENCODING: ${{ matrix.io-encoding }}
         run: |
           pytest ./Tests/ \
             --run-slow \

--- a/Tests/Architecture/test_persistent_diagnostic_inventory.py
+++ b/Tests/Architecture/test_persistent_diagnostic_inventory.py
@@ -1139,6 +1139,24 @@ def test_build_inventory_projects_schema_v3_path_candidates(
     ]
 
 
+def test_build_inventory_uses_case_sensitive_posix_path_order(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    package_root = tmp_path / "tldw_chatbook"
+    package_root.mkdir()
+    for name in ("alpha.py", "Zeta.py"):
+        (package_root / name).write_text('logger.info("safe")\n', encoding="utf-8")
+    monkeypatch.setattr(diagnostic_inventory, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(diagnostic_inventory, "PACKAGE_ROOT", package_root)
+
+    inventory = diagnostic_inventory.build_inventory()
+
+    assert [owner["path"] for owner in inventory["owners"]] == [
+        "tldw_chatbook/Zeta.py",
+        "tldw_chatbook/alpha.py",
+    ]
+
+
 BASE_MODULE = (
     "from loguru import logger\n"
     "\n"

--- a/Tests/CI/test_ci_queue_pressure_contract.py
+++ b/Tests/CI/test_ci_queue_pressure_contract.py
@@ -133,11 +133,11 @@ def test_dedicated_nightly_owns_exact_schedule_and_full_tree_matrix() -> None:
     nightly = workflow["jobs"]["nightly-deep"]
     assert nightly["needs"] == ["resolve-dev-sha"]
     assert nightly["strategy"]["matrix"]["include"] == [
-        {"os": "ubuntu-latest", "python-version": "3.11"},
-        {"os": "ubuntu-latest", "python-version": "3.12"},
-        {"os": "ubuntu-latest", "python-version": "3.13"},
-        {"os": "macos-latest", "python-version": "3.12"},
-        {"os": "windows-latest", "python-version": "3.12"},
+        {"os": "ubuntu-latest", "python-version": "3.11", "io-encoding": "utf-8"},
+        {"os": "ubuntu-latest", "python-version": "3.12", "io-encoding": "utf-8"},
+        {"os": "ubuntu-latest", "python-version": "3.13", "io-encoding": "utf-8"},
+        {"os": "macos-latest", "python-version": "3.12", "io-encoding": "utf-8"},
+        {"os": "windows-latest", "python-version": "3.12", "io-encoding": "cp1252"},
     ]
     checkout = next(
         step

--- a/Tests/DB/test_private_sqlite.py
+++ b/Tests/DB/test_private_sqlite.py
@@ -61,6 +61,10 @@ OPEN_CONNECTION_BACKUP_OWNER_IDS = (
     "tts.profile_migration_backup",
 )
 MIGRATION_BOUNDARY_BACKUP_OWNER_IDS = ("tts.profile_migration_boundary",)
+POSIX_PROFILE_MIGRATION_BOUNDARY = pytest.mark.skipif(
+    not private_sqlite.private_paths._posix_guards_available(),
+    reason="POSIX descriptor/ACL profile-migration contract (ADR-029)",
+)
 
 
 def test_retired_settings_owner_policies_are_absent() -> None:
@@ -173,6 +177,7 @@ def test_every_backup_enabled_owner_has_a_behavioral_operation() -> None:
     }
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 def test_profile_migration_boundary_destination_is_opaque_private_and_exact(
     tmp_path: Path,
 ) -> None:
@@ -211,6 +216,7 @@ def test_profile_migration_boundary_destination_is_opaque_private_and_exact(
     assert not any(Path(f"{target}{suffix}").exists() for suffix in ("-wal", "-shm"))
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 @pytest.mark.parametrize("unsafe_kind", ["symlink", "hardlink", "permissive"])
 def test_profile_migration_boundary_destination_refuses_existing_artifact(
     tmp_path: Path,
@@ -239,6 +245,7 @@ def test_profile_migration_boundary_destination_refuses_existing_artifact(
     assert outside.read_bytes() == b"outside-private-value"
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 @pytest.mark.parametrize("suffix", ["-wal", "-shm", "-journal"])
 def test_profile_migration_boundary_refuses_preexisting_sidecar_namespace(
     tmp_path: Path,
@@ -260,6 +267,7 @@ def test_profile_migration_boundary_refuses_preexisting_sidecar_namespace(
     assert sidecar.read_bytes() == foreign
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 def test_profile_migration_boundary_destination_rejects_substitution_before_copy(
     tmp_path: Path,
 ) -> None:
@@ -296,6 +304,7 @@ def test_profile_migration_boundary_destination_rejects_substitution_before_copy
         reopened.close()
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 @pytest.mark.parametrize("unsafe_kind", ["attached", "populated", "transaction"])
 def test_profile_migration_boundary_destination_revalidates_connection_state(
     tmp_path: Path,
@@ -344,6 +353,7 @@ def test_profile_migration_boundary_destination_revalidates_connection_state(
         reopened.close()
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 def test_profile_migration_boundary_rejects_substitution_during_final_fsync(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -395,6 +405,7 @@ def test_profile_migration_boundary_rejects_substitution_during_final_fsync(
         reopened.close()
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 def test_profile_migration_boundary_revalidates_content_after_final_fsync(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -444,6 +455,7 @@ def test_profile_migration_boundary_revalidates_content_after_final_fsync(
     assert target.read_bytes().startswith(b"corrupt!")
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 @pytest.mark.parametrize("suffix", ["-wal", "-shm", "-journal"])
 def test_profile_migration_boundary_rejects_dangling_sidecar_entry(
     tmp_path: Path,
@@ -477,6 +489,7 @@ def test_profile_migration_boundary_rejects_dangling_sidecar_entry(
     assert sidecar.readlink() == missing
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 def test_canonical_migration_candidate_reuses_tombstone_and_revokes_descriptors(
     tmp_path: Path,
 ) -> None:
@@ -526,6 +539,7 @@ def test_canonical_migration_candidate_reuses_tombstone_and_revokes_descriptors(
         )
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 def test_canonical_migration_candidate_rejects_substitution_before_sqlite_open(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -568,6 +582,7 @@ def test_canonical_migration_candidate_rejects_substitution_before_sqlite_open(
     assert sqlite_opens == []
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 def test_canonical_migration_candidate_pins_exact_file_through_migration(
     tmp_path: Path,
 ) -> None:
@@ -609,6 +624,7 @@ def test_canonical_migration_candidate_pins_exact_file_through_migration(
         )
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 def test_canonical_migration_candidate_substitution_preserves_retained_exact_inode(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -670,6 +686,7 @@ def test_canonical_migration_candidate_substitution_preserves_retained_exact_ino
     )
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 def test_canonical_migration_candidate_close_error_retains_live_connection(
     tmp_path: Path,
 ) -> None:
@@ -740,6 +757,7 @@ def test_canonical_migration_candidate_close_error_retains_live_connection(
     )
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 def test_canonical_migration_candidate_late_hardlink_preserves_all_bytes(
     tmp_path: Path,
 ) -> None:
@@ -780,6 +798,7 @@ def test_canonical_migration_candidate_late_hardlink_preserves_all_bytes(
     assert alias.read_bytes() == before
 
 
+@POSIX_PROFILE_MIGRATION_BOUNDARY
 def test_discard_never_truncates_after_atomic_quarantine(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -819,6 +838,28 @@ def test_discard_never_truncates_after_atomic_quarantine(
     assert not target.exists()
     assert tombstone.read_bytes() == before
     assert alias.read_bytes() == before
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows fail-closed posture")
+def test_windows_profile_migration_destinations_fail_closed_without_residue(
+    tmp_path: Path,
+) -> None:
+    boundary = tmp_path / "boundary.sqlite3"
+    canonical = tmp_path / ".profile-migration-active.candidate.sqlite3"
+
+    with pytest.raises(private_sqlite.SQLitePrivateDestinationError):
+        private_sqlite.open_profile_migration_boundary_destination(
+            boundary,
+            schema_version=2,
+        )
+    with pytest.raises(private_sqlite.SQLitePrivateDestinationError):
+        private_sqlite.open_canonical_profile_migration_destination(
+            canonical,
+            schema_version=0,
+            tombstone_key=MigrationTombstoneKey.ACTIVE_CANDIDATE,
+        )
+
+    assert list(tmp_path.iterdir()) == []
 
 
 @pytest.mark.parametrize("owner_id", CONNECTION_BACKUP_OWNER_IDS)
@@ -2166,7 +2207,19 @@ def test_real_reopen_hardens_existing_wal_and_shm_before_use(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "name", ["space name.sqlite", "query?.sqlite", "hash#.sqlite", "雪.sqlite"]
+    "name",
+    [
+        "space name.sqlite",
+        pytest.param(
+            "query?.sqlite",
+            marks=pytest.mark.skipif(
+                os.name == "nt",
+                reason="Question marks are illegal in Windows filenames",
+            ),
+        ),
+        "hash#.sqlite",
+        "雪.sqlite",
+    ],
 )
 def test_read_only_uri_preserves_special_filename_identity_and_rejects_writes(
     tmp_path,
@@ -2315,6 +2368,10 @@ def test_read_only_rejects_unsafe_source_kinds(tmp_path, monkeypatch, unsafe_kin
         connect_private_sqlite("settings.integrity", target, read_only=True)
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Question marks are illegal in Windows filenames; builder coverage is pure",
+)
 def test_read_only_path_query_characters_are_percent_encoded(tmp_path, monkeypatch):
     target = tmp_path / "db.sqlite?immutable=1#fragment"
     target.write_bytes(b"")

--- a/Tests/DB/test_private_sqlite.py
+++ b/Tests/DB/test_private_sqlite.py
@@ -846,6 +846,7 @@ def test_windows_profile_migration_destinations_fail_closed_without_residue(
 ) -> None:
     boundary = tmp_path / "boundary.sqlite3"
     canonical = tmp_path / ".profile-migration-active.candidate.sqlite3"
+    existing_entries = set(tmp_path.iterdir())
 
     with pytest.raises(private_sqlite.SQLitePrivateDestinationError):
         private_sqlite.open_profile_migration_boundary_destination(
@@ -859,7 +860,7 @@ def test_windows_profile_migration_destinations_fail_closed_without_residue(
             tombstone_key=MigrationTombstoneKey.ACTIVE_CANDIDATE,
         )
 
-    assert list(tmp_path.iterdir()) == []
+    assert set(tmp_path.iterdir()) == existing_entries
 
 
 @pytest.mark.parametrize("owner_id", CONNECTION_BACKUP_OWNER_IDS)

--- a/Tests/Evals/test_task_loader.py
+++ b/Tests/Evals/test_task_loader.py
@@ -62,7 +62,6 @@ import tldw_chatbook.Evals.task_loader
     assert len(matching_lines) == 1
     assert matching_lines[0].startswith("INFO|")
     assert "pip install datasets" in matching_lines[0]
-    assert "WARNING|" not in result.stdout
 
 
 class TestTaskConfig:

--- a/Tests/RuntimePolicy/test_runtime_policy_private_store.py
+++ b/Tests/RuntimePolicy/test_runtime_policy_private_store.py
@@ -49,7 +49,7 @@ def test_runtime_policy_store_rejects_symlink_before_parsing(
 
 
 @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO unavailable")
-@pytest.mark.timeout(2, method="signal")
+@pytest.mark.timeout(2)
 def test_runtime_policy_store_rejects_fifo_before_parsing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/Tests/UI/test_console_selection_menu.py
+++ b/Tests/UI/test_console_selection_menu.py
@@ -41,12 +41,22 @@ from tldw_chatbook.Widgets.Console.console_transcript import (
 
 async def _wait_for_menu(app, pilot, predicate):
     deadline = asyncio.get_running_loop().time() + 30.0
+    last_observed = "no menu mounted"
     while asyncio.get_running_loop().time() < deadline:
         menus = list(app.query(ConsoleSelectionMenu))
         if menus and predicate(menus[0]):
             return menus[0]
+        if menus:
+            menu = menus[0]
+            last_observed = (
+                f"classes={sorted(menu.classes)!r}, region={menu.region!r}, "
+                f"display={menu.display!r}"
+            )
         await pilot.pause(0.02)
-    raise AssertionError("Selection menu never reached the expected geometry")
+    raise AssertionError(
+        "Selection menu never reached the expected geometry; "
+        f"last observed {last_observed}"
+    )
 
 
 class _MenuApp(ConsolidatedCSSApp):

--- a/Tests/UI/test_console_selection_transcript.py
+++ b/Tests/UI/test_console_selection_transcript.py
@@ -12,6 +12,8 @@ protected controls never arm a drag, and reconciliation cancels state whose
 row was removed/rebuilt.
 """
 
+import asyncio
+
 import pytest
 from textual.app import App, ComposeResult
 from textual.events import Click, MouseDown, MouseMove, MouseUp
@@ -69,6 +71,15 @@ async def _mounted_row(pilot, message_id: str) -> ConsoleTranscriptMessage:
     await transcript.refresh_messages()
     await pilot.pause()
     return pilot.app.query_one(f"#console-message-{message_id}", ConsoleTranscriptMessage)
+
+
+async def _wait_for_selected_event(app, pilot) -> None:
+    """Wait for the transcript's async selection handler to bubble the event."""
+    deadline = asyncio.get_running_loop().time() + 5.0
+    while not app.selected_events:
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError("Transcript selection event was not delivered")
+        await pilot.pause(0.01)
 
 
 def _body_static(row: ConsoleTranscriptMessage) -> Static:
@@ -162,6 +173,7 @@ async def test_drag_selects_text_and_posts_selection_event():
         assert selection.row_key == row.id
         assert (selection.start, selection.end) == (3, 11)
         assert row.get_selection_text() == "lo selec"
+        await _wait_for_selected_event(app, pilot)
         assert len(app.selected_events) == 1
         event = app.selected_events[0]
         assert event.selection == TextSelection(row_key=row.id, start=3, end=11)
@@ -309,6 +321,7 @@ async def test_drag_extends_while_mouse_is_captured():
         )
         await pilot.pause()
         assert transcript.selection_manager.state.active is False
+        await _wait_for_selected_event(app, pilot)
         assert len(app.selected_events) == 1
 
 
@@ -412,6 +425,7 @@ async def test_markdown_rows_start_line_selection():
         )
         await pilot.pause()
         assert transcript.selection_manager.state.active is False
+        await _wait_for_selected_event(app, pilot)
         assert len(app.selected_events) == 1
 
 
@@ -509,6 +523,7 @@ async def test_mouse_up_outside_transcript_finishes_drag():
         selection = transcript.selection_manager.state.selection
         assert selection is not None
         assert (selection.start, selection.end) == (3, 11)
+        await _wait_for_selected_event(app, pilot)
         assert len(app.selected_events) == 1
 
         # The next distinct row click works normally: its empty MouseUp commits

--- a/Tests/fixtures/summarization_diagnostic_review.json
+++ b/Tests/fixtures/summarization_diagnostic_review.json
@@ -1,8 +1,8 @@
 {
     "schema_version": 1,
     "manifest_boundary": {
-        "checked_normalized_inventory_sha256": "38e4ab444125883dfb47ae5748f8310ba9028d1322d30e58e32755aa7751439d",
-        "origin_dev_generated_normalized_inventory_sha256": "38e4ab444125883dfb47ae5748f8310ba9028d1322d30e58e32755aa7751439d",
+        "checked_normalized_inventory_sha256": "1c0fab100fbed49db6e8411372f8aa5820f0c205ae2d98f40ee05d007f286ea0",
+        "origin_dev_generated_normalized_inventory_sha256": "1c0fab100fbed49db6e8411372f8aa5820f0c205ae2d98f40ee05d007f286ea0",
         "owned_entries": [
             {
                 "path": "tldw_chatbook/LLM_Calls/Local_Summarization_Lib.py",

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -258,6 +258,22 @@ not that retry or cleanup is valid against the real library.
 
 ---
 
+## A workflow dispatched from a branch may still test a different ref
+
+**TASK-25706, 2026-08-30.** A temporary native-Windows validation workflow was
+dispatched with `--ref codex/post-merge-windows-validation`, and its run reported
+the temporary workflow's custom job and step names. That looked like branch
+evidence, but the inherited resolver explicitly checked out `dev`, exported that
+SHA, and the Windows job checked out the exported value. The run therefore tested
+`dev`, not the temporary branch or its validation commit; matching workflow UI
+labels proved only which YAML definition ran.
+
+**What to do.** For a branch-specific validation, pin checkout to the dispatched
+commit (`github.sha`) and print `git rev-parse HEAD` in the job summary. Compare
+that recorded SHA with the intended branch head before treating results as
+evidence. A workflow may legitimately load its definition from one ref and test
+another, so the workflow name, step names, and dispatch ref are not sufficient.
+
 ## A privacy assertion must inspect every default durable owner, not only the primary database
 
 **TASK-19908, 2026-08-22.** Trace capture tests proved that AgentRunsDB and the

--- a/backlog/tasks/task-25706 - Make-submitted-log-regression-coverage-truthful-on-Windows.md
+++ b/backlog/tasks/task-25706 - Make-submitted-log-regression-coverage-truthful-on-Windows.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-30 17:52'
-updated_date: '2026-08-30 18:50'
+updated_date: '2026-08-30 18:58'
 labels: []
 dependencies: []
 priority: high
@@ -57,4 +57,6 @@ The existing nightly Windows leg now runs under `PYTHONIOENCODING=cp1252`, while
 ADR required: no. Existing ADR: `backlog/decisions/029-local-private-data-boundary.md`.
 
 Updated tests and infrastructure in `.github/workflows/nightly-deep.yml`, `Tests/`, `scripts/check_persistent_diagnostic_inventory.py`, `tldw_chatbook/Widgets/Console/console_selection_menu.py`, and the testing-evidence lessons ledger.
+
+Qodo follow-up identified that the exact nightly matrix contract still expected two-key entries and that the new public resize callback lacked an `Args:` section. The contract now pins each platform's intended encoding, the callback documents its event parameter, and both focused regressions plus Ruff and diff checks pass.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-25706 - Make-submitted-log-regression-coverage-truthful-on-Windows.md
+++ b/backlog/tasks/task-25706 - Make-submitted-log-regression-coverage-truthful-on-Windows.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-25706
 title: Make submitted-log regression coverage truthful on Windows
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-30 17:52'
-updated_date: '2026-08-30 17:52'
+updated_date: '2026-08-30 18:50'
 labels: []
 dependencies: []
 priority: high
@@ -19,13 +19,13 @@ Correct Windows-only failures exposed by the native submitted-log validation so 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The submitted-log regression matrix completes on native Windows without pytest internal errors.
-- [ ] #2 POSIX-only profile-migration security tests are capability-gated and Windows retains a tested fail-closed contract.
-- [ ] #3 Windows-illegal filename fixtures do not mask SQLite URI coverage.
-- [ ] #4 The optional-datasets notice test ignores unrelated expected platform diagnostics.
-- [ ] #5 The compact selection-menu case is independently diagnosed and either fixed or proven stable on Windows.
-- [ ] #6 Durable CI coverage exercises the corrected Windows contract.
-- [ ] #7 Generated diagnostic inventories have the same deterministic path order on Windows and POSIX hosts.
+- [x] #1 The submitted-log regression matrix completes on native Windows without pytest internal errors.
+- [x] #2 POSIX-only profile-migration security tests are capability-gated and Windows retains a tested fail-closed contract.
+- [x] #3 Windows-illegal filename fixtures do not mask SQLite URI coverage.
+- [x] #4 The optional-datasets notice test ignores unrelated expected platform diagnostics.
+- [x] #5 The compact selection-menu case is independently diagnosed and either fixed or proven stable on Windows.
+- [x] #6 Durable CI coverage exercises the corrected Windows contract.
+- [x] #7 Generated diagnostic inventories have the same deterministic path order on Windows and POSIX hosts.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -44,3 +44,17 @@ ADR path: `backlog/decisions/029-local-private-data-boundary.md`
 
 Reason: ADR-029 already defines Windows privacy as unverified pending separately approved native ACL work; this task corrects test and CI portability while preserving that runtime boundary.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Made the submitted-log regression surface platform-truthful without changing ADR-029's fail-closed Windows privacy boundary. POSIX descriptor/ACL migration tests now use a capability gate, Windows directly proves both migration destinations reject without residue, illegal `?` filename cases no longer obscure pure URI-builder coverage, pytest chooses its native timeout method, and the optional-datasets notice test asserts only the notice it owns.
+
+Native follow-up exposed two additional cross-platform defects: diagnostic inventory generation inherited Windows case-folded `Path` ordering, and the floating selection menu could finish its first clamp before late CSS measurement. Inventory paths now sort by their serialized POSIX spelling with regression coverage, and menus re-clamp after resize; transcript event assertions also wait for the owning async handler to finish bubbling.
+
+The existing nightly Windows leg now runs under `PYTHONIOENCODING=cp1252`, while other legs remain UTF-8. Native Windows validation at commit `ee83b50b4c` passed the isolated compact-menu probe and the complete submitted-log matrix: 601 passed, 145 intentionally skipped, 746 total ([run 33328585489](https://github.com/rmusser01/tldw_chatbook/actions/runs/33328585489)). Local CP1252-targeted UI, SQLite/runtime, manifest-boundary, and inventory-order tests passed; Ruff, workflow YAML parsing, diagnostic inventory verification, Backlog task-ID validation, and `git diff --check` passed.
+
+ADR required: no. Existing ADR: `backlog/decisions/029-local-private-data-boundary.md`.
+
+Updated tests and infrastructure in `.github/workflows/nightly-deep.yml`, `Tests/`, `scripts/check_persistent_diagnostic_inventory.py`, `tldw_chatbook/Widgets/Console/console_selection_menu.py`, and the testing-evidence lessons ledger.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-25706 - Make-submitted-log-regression-coverage-truthful-on-Windows.md
+++ b/backlog/tasks/task-25706 - Make-submitted-log-regression-coverage-truthful-on-Windows.md
@@ -25,6 +25,7 @@ Correct Windows-only failures exposed by the native submitted-log validation so 
 - [ ] #4 The optional-datasets notice test ignores unrelated expected platform diagnostics.
 - [ ] #5 The compact selection-menu case is independently diagnosed and either fixed or proven stable on Windows.
 - [ ] #6 Durable CI coverage exercises the corrected Windows contract.
+- [ ] #7 Generated diagnostic inventories have the same deterministic path order on Windows and POSIX hosts.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -33,8 +34,9 @@ Correct Windows-only failures exposed by the native submitted-log validation so 
 1. Preserve the native Windows run as RED evidence and add focused platform-contract tests for timeout selection, filenames, optional-datasets logging, and profile-migration fail-closed behavior.
 2. Apply narrow test capability gates without changing ADR-029 or weakening production privacy checks.
 3. Run the compact selection-menu case independently on Windows with actionable geometry diagnostics and fix only a reproduced product defect.
-4. Add durable native-Windows submitted-log coverage with uploaded structured results.
-5. Run targeted local tests, the native Windows matrix, static checks, and self-review; document results and close the task.
+4. Make diagnostic inventory ordering platform-independent and keep the floating menu contained after late layout measurement.
+5. Add durable native-Windows submitted-log coverage with uploaded structured results.
+6. Run targeted local tests, the native Windows matrix, static checks, and self-review; document results and close the task.
 
 ADR required: no
 

--- a/backlog/tasks/task-25706 - Make-submitted-log-regression-coverage-truthful-on-Windows.md
+++ b/backlog/tasks/task-25706 - Make-submitted-log-regression-coverage-truthful-on-Windows.md
@@ -1,0 +1,44 @@
+---
+id: TASK-25706
+title: Make submitted-log regression coverage truthful on Windows
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-08-30 17:52'
+updated_date: '2026-08-30 17:52'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Correct Windows-only failures exposed by the native submitted-log validation so the matrix distinguishes portable behavior from intentionally POSIX-only security contracts and reports actionable evidence without weakening ADR-029.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The submitted-log regression matrix completes on native Windows without pytest internal errors.
+- [ ] #2 POSIX-only profile-migration security tests are capability-gated and Windows retains a tested fail-closed contract.
+- [ ] #3 Windows-illegal filename fixtures do not mask SQLite URI coverage.
+- [ ] #4 The optional-datasets notice test ignores unrelated expected platform diagnostics.
+- [ ] #5 The compact selection-menu case is independently diagnosed and either fixed or proven stable on Windows.
+- [ ] #6 Durable CI coverage exercises the corrected Windows contract.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Preserve the native Windows run as RED evidence and add focused platform-contract tests for timeout selection, filenames, optional-datasets logging, and profile-migration fail-closed behavior.
+2. Apply narrow test capability gates without changing ADR-029 or weakening production privacy checks.
+3. Run the compact selection-menu case independently on Windows with actionable geometry diagnostics and fix only a reproduced product defect.
+4. Add durable native-Windows submitted-log coverage with uploaded structured results.
+5. Run targeted local tests, the native Windows matrix, static checks, and self-review; document results and close the task.
+
+ADR required: no
+
+ADR path: `backlog/decisions/029-local-private-data-boundary.md`
+
+Reason: ADR-029 already defines Windows privacy as unverified pending separately approved native ACL work; this task corrects test and CI portability while preserving that runtime boundary.
+<!-- SECTION:PLAN:END -->

--- a/scripts/check_persistent_diagnostic_inventory.py
+++ b/scripts/check_persistent_diagnostic_inventory.py
@@ -1024,11 +1024,18 @@ def _scan_file(
     return _scan_parsed_source(source, tree)
 
 
+def _inventory_path_sort_key(path: Path) -> str:
+    """Return the case-sensitive POSIX spelling used by the inventory."""
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
 def build_inventory() -> dict[str, Any]:
     owners: list[dict[str, Any]] = []
     topology: list[dict[str, Any]] = []
     path_privacy_candidates: list[dict[str, Any]] = []
-    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+    # Path ordering is case-folded on Windows. Sort by the serialized POSIX
+    # spelling so every host produces the same ordered inventory lists.
+    for path in sorted(PACKAGE_ROOT.rglob("*.py"), key=_inventory_path_sort_key):
         relative = path.relative_to(REPO_ROOT).as_posix()
         diagnostics, sinks, candidates = _scan_file(path)
         if diagnostics:

--- a/tldw_chatbook/Widgets/Console/console_selection_menu.py
+++ b/tldw_chatbook/Widgets/Console/console_selection_menu.py
@@ -34,7 +34,7 @@ from textual import on
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.dom import NoScreen
-from textual.events import Click, Key
+from textual.events import Click, Key, Resize
 from textual.geometry import Offset, Region
 from textual.message import Message
 from textual.widget import Widget
@@ -373,6 +373,10 @@ class ConsoleSelectionMenu(Vertical):
             buttons[0].focus(scroll_visible=False)
         else:
             self.focus(scroll_visible=False)
+
+    def on_resize(self, _event: Resize) -> None:
+        """Re-clamp after late CSS measurement changes the menu's extent."""
+        self.call_after_refresh(self._clamp_within_owner)
 
     def _clamp_within_owner(self) -> None:
         """Shift the anchor so the measured menu fits its clamp box.

--- a/tldw_chatbook/Widgets/Console/console_selection_menu.py
+++ b/tldw_chatbook/Widgets/Console/console_selection_menu.py
@@ -375,7 +375,11 @@ class ConsoleSelectionMenu(Vertical):
             self.focus(scroll_visible=False)
 
     def on_resize(self, _event: Resize) -> None:
-        """Re-clamp after late CSS measurement changes the menu's extent."""
+        """Re-clamp after late CSS measurement changes the menu's extent.
+
+        Args:
+            _event: Textual resize notification; only the settled extent matters.
+        """
         self.call_after_refresh(self._clamp_within_owner)
 
     def _clamp_within_owner(self) -> None:


### PR DESCRIPTION
## Summary

- make the submitted-log regression surface truthful on native Windows while preserving ADR-029's fail-closed privacy boundary
- capability-gate POSIX-only migration contracts, directly test Windows rejection/no-residue behavior, and avoid Windows-illegal filename fixtures
- make diagnostic inventory ordering platform-independent and re-clamp the floating selection menu after late layout measurement
- exercise the nightly Windows leg under CP1252 while retaining UTF-8 on POSIX legs

## Verification

- Native Windows CP1252 validation: 601 passed, 145 intentional skips, 746 total; isolated compact-menu probe also passed ([run 33328585489](https://github.com/rmusser01/tldw_chatbook/actions/runs/33328585489))
- Post-rebase targeted tests: 71 UI passed; 305 SQLite/runtime/eval passed with 2 expected non-Windows skips; 9 inventory-boundary tests passed
- Ruff passed on all changed Python files
- Production diagnostic inventory verified with no drift
- Nightly workflow YAML, Backlog task IDs, and git diff checks passed

## Architecture

ADR required: no. Existing `backlog/decisions/029-local-private-data-boundary.md` remains authoritative; native Windows ACL support stays outside this task.

Backlog: TASK-25706

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes submitted-log regression coverage truthful on native Windows while preserving ADR-029's fail-closed privacy boundary. Closes TASK-25706.

- POSIX-only profile-migration tests skip on Windows, which instead directly proves both migration destinations reject without leaving residue.
- Question-mark filename fixtures skip on Windows so they no longer obscure pure SQLite URI-builder coverage.
- Transcript event assertions wait for the async selection handler to finish, and menu geometry failures report the last observed widget state.
- The optional-datasets notice test asserts only the notice it owns, ignoring unrelated platform diagnostics.
- Pytest now uses its native timeout method instead of `signal`.
- The nightly Windows leg runs under `PYTHONIOENCODING=cp1252`; other legs stay UTF-8, and the CI matrix contract pins each platform's encoding.
- Fixture manifest hashes were updated to match the new deterministic inventory order.

**Bug Fixes**
- Diagnostic inventory now sorts by serialized POSIX spelling, so Windows no longer case-folds the path order.
- The floating selection menu re-clamps after late layout measurement changes its extent.

<sup>Written for commit 5142beee6be0438675caecd795d50cc1c1a21b12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

