### PR TITLE
feat: define persistent terminal launch boundary

### DIFF
--- a/Docs/superpowers/plans/2026-08-28-persistent-terminal-sessions-implementation.md
+++ b/Docs/superpowers/plans/2026-08-28-persistent-terminal-sessions-implementation.md
@@ -407,7 +407,7 @@ git commit -m "build: admit qualified terminal parser"
 - Create: `tldw_chatbook/Terminal/backend.py`
 - Create: `Tests/Terminal/test_contracts.py`
 
-- [ ] **Step 1: Write all contract, transition, and deadline tests before implementation**
+- [x] **Step 1: Write all contract, transition, and deadline tests before implementation**
 
 Pin the constants and prove lifecycle, terminal reason, exit code, `stream_closed`, and `output_complete` do not imply one another. In the same RED slice, cover reservation failure release, running-to-draining shell exit, nonzero ordinary exit, parser failure reason, closing-to-closed/cleanup-unproven, receipt Retry, forbidden transitions, and proof that only explicit Retry creates a new T0:
 
@@ -454,7 +454,7 @@ def test_exited_does_not_claim_stream_or_output_completion() -> None:
     assert projection.output_complete is False
 ```
 
-- [ ] **Step 2: Verify RED**
+- [x] **Step 2: Verify RED**
 
 Run:
 
@@ -464,7 +464,7 @@ Run:
 
 Expected: the test collects against the minimal contracts skeleton and reaches an assertion failure because transition validation, cleanup offsets, or immutable value semantics still return neutral placeholders. Import or collection failure does not count.
 
-- [ ] **Step 3: Implement minimal value contracts**
+- [x] **Step 3: Implement minimal value contracts**
 
 Use `str, Enum` values for `TerminalLifecycle` and `TerminalReason`, frozen slotted dataclasses for request/event/projection values, and one pure transition validator. Include the approved cleanup boundaries as absolute offsets:
 
@@ -488,7 +488,7 @@ class TerminalBackend(Protocol):
 
 Do not put subprocess handles, raw bytes, environment mappings, or mutable screen objects in UI projections.
 
-- [ ] **Step 4: Verify GREEN and commit**
+- [x] **Step 4: Verify GREEN and commit**
 
 Run:
 
@@ -517,11 +517,11 @@ git commit -m "feat: define persistent terminal contracts"
 - Reference: `tldw_chatbook/Chat/console_project_instructions.py`
 - Reference: `tldw_chatbook/UI/Console_Modules/wiring.py::_raw_cli_selected_local_root`
 
-- [ ] **Step 1: Write RED tests for names and fixed-family shell discovery**
+- [x] **Step 1: Write RED tests for names and fixed-family shell discovery**
 
 Cover NFC normalization, trim, 1-64 display characters, control/markup refusal, Unicode-casefold uniqueness, POSIX account-shell fallback to Bash then `sh`, Windows `pwsh` then Windows PowerShell then CMD, and no arbitrary executable picker entry. Assert argv contains no command string, `-NoProfile`, `-NonInteractive`, `/C`, or caller-supplied argument.
 
-- [ ] **Step 2: Write RED tests for starting-directory resolution**
+- [x] **Step 2: Write RED tests for starting-directory resolution**
 
 The existing Console wiring seam already resolves the current session's selected `working_folder_binding_id` to a still-usable local folder. Generalize `_raw_cli_selected_local_root` to a neutral `_selected_console_local_root` and keep raw CLI using it. The pure launch resolver receives that late-bound `Path | None`; it uses the selected root when present and otherwise the real OS account home. The New Session form may supply another path, but launch revalidates the final absolute existing directory immediately before backend admission.
 
@@ -536,15 +536,15 @@ def test_missing_or_nonlocal_selection_falls_back_to_account_home(fake_home) -> 
 
 Task 13 adds the wiring behavior test that proves only a selected, same-workspace, ready local-filesystem directory reaches this function. This is convenience only. Do not call workspace file-tool confinement helpers and do not retain a claim that later `cd` stays under the starting directory.
 
-- [ ] **Step 3: Write RED tests for the dedicated environment allowlist**
+- [x] **Step 3: Write RED tests for the dedicated environment allowlist**
 
 Parameterize POSIX and Windows. Seed ambient mappings with provider keys, proxy values, tracing fields, `PYTHONPATH`, `PYTHONHOME`, credential-agent sockets, and unrelated values; prove none enter the result. Prove account/OS values come from injected platform readers rather than the caller mapping. Assert `TERM=linux`, no `COLORTERM`, no inherited rows/columns, and no ambient `PSModulePath`.
 
-- [ ] **Step 4: Write fresh-profile integration RED tests**
+- [x] **Step 4: Write fresh-profile integration RED tests**
 
 Use temporary HOME/profile fixtures in fresh subprocesses to prove the standard Bash/Zsh profile path runs, the starting directory is correct, and scrubbed ambient sentinels are absent until explicitly restored by the profile. Add Windows-native PowerShell/CMD profile/module rows to the qualification probe rather than pretending to verify them on POSIX.
 
-- [ ] **Step 5: Verify the complete launch slice RED**
+- [x] **Step 5: Verify the complete launch slice RED**
 
 Run:
 
@@ -554,11 +554,11 @@ Run:
 
 Expected: the test collects against the launch skeleton and reaches assertions showing that environment stripping, starting-directory resolution, or profile launch behavior still returns the explicit refusal placeholder. Import or collection failure does not count.
 
-- [ ] **Step 6: Implement the smallest launch boundary**
+- [x] **Step 6: Implement the smallest launch boundary**
 
 Keep this module pure and dependency-injected. It may reuse audited validation/identity primitives but must not call `_build_shell_environment` or import the one-shot executor as its environment builder. Export immutable `ShellChoice` and `ResolvedLaunch` values; all argv remains code-owned.
 
-- [ ] **Step 7: Verify GREEN and commit**
+- [x] **Step 7: Verify GREEN and commit**
 
 Run:
 

--- a/Docs/superpowers/plans/2026-08-28-persistent-terminal-sessions-implementation.md
+++ b/Docs/superpowers/plans/2026-08-28-persistent-terminal-sessions-implementation.md
@@ -519,7 +519,7 @@ git commit -m "feat: define persistent terminal contracts"
 
 - [x] **Step 1: Write RED tests for names and fixed-family shell discovery**
 
-Cover NFC normalization, trim, 1-64 display characters, control/markup refusal, Unicode-casefold uniqueness, POSIX account-shell fallback to Bash then `sh`, Windows `pwsh` then Windows PowerShell then CMD, and no arbitrary executable picker entry. Assert argv contains no command string, `-NoProfile`, `-NonInteractive`, `/C`, or caller-supplied argument.
+Cover NFC normalization, trim, 1-64 UAX #29 extended grapheme clusters, the independent 1,024-code-point input ceiling, lazy rejection after the 65th cluster, control/markup refusal, Unicode-casefold uniqueness, POSIX account-shell fallback to Bash then `sh`, Windows `pwsh` then Windows PowerShell then CMD, and no arbitrary executable picker entry. Assert argv contains no command string, `-NoProfile`, `-NonInteractive`, `/C`, or caller-supplied argument.
 
 - [x] **Step 2: Write RED tests for starting-directory resolution**
 

--- a/Docs/superpowers/reviews/evidence/task-22512/dependency-qualification.md
+++ b/Docs/superpowers/reviews/evidence/task-22512/dependency-qualification.md
@@ -37,6 +37,18 @@ pyte==0.8.2
 - resolved dependency: `wcwidth==0.8.3`, wheel sha256:d5b73dba6158a595ec9370350e7f2637bcac8d6c5e4fde34f30fcffb6103a5e4, 331,669 bytes, license: MIT, embedded `LICENSE` sha256:70b98a95a2144eb70af8017fa8c6d95ce247e40867436e8bc649e137fe13d21a
 - installed wcwidth primary file: `wcwidth/__init__.py` sha256:2feead2f63ec7862737414280fe225acb61f252c18ec7a53af4d330ecec29ae0
 
+regex==2026.4.4
+- sha256:1b1ce5c81c9114f1ce2f9288a51a8fd3aeea33a0cc440c415bf02da323aa0a76
+- license: Apache-2.0 AND CNRI-Python; embedded `LICENSE.txt` sha256:bff55ef4cdcc8c14ce259f8e8ab60e264418440d6335f4dc138273fbd506144d
+- wheel: `regex-2026.4.4-cp312-cp312-macosx_11_0_arm64.whl`, 289,628 bytes, tag `cp312-cp312-macosx_11_0_arm64`
+- installed native extension: `regex/_regex.cpython-312-darwin.so` sha256:0b8e9ae442ad428e3fa5dda72054c1b369eb5035181e7cad5448e18c7431e78a
+- installed package entry point: `regex/__init__.py` sha256:039934ae6f0b9fb1cab1f1bef2c11661e85e93ccc22847bab105b94065009925
+- qualification: the pinned package requires Python 3.10 or newer, publishes
+  regular-GIL CPython 3.11-3.14 wheels for the admitted macOS ARM64, Linux
+  ARM64, and Windows AMD64 targets, and documents `\X` as conforming to UAX
+  #29. Chatbook passes immutable strings no longer than 1,024 code points,
+  does not request concurrent matching, and consumes at most 65 matches.
+
 pywinpty==3.0.5
 - sha256:af7a8720c78776ddd6259b71dd567944f766a6cd67f8d2887fbc4973967bacda
 - license: MIT; embedded `LICENSE.txt` sha256:f878d4767f9ad2e43d3083efa00201b000ce937d9ee8626e00ba5c72aac951e2
@@ -53,6 +65,7 @@ embedded-license hashes were verified before and after native installation;
 the remaining regular-GIL Windows wheel matrix below was checked against PyPI
 release metadata. Sources: [pyte 0.8.2 release JSON](https://pypi.org/pypi/pyte/0.8.2/json),
 [wcwidth 0.8.3 release JSON](https://pypi.org/pypi/wcwidth/0.8.3/json),
+[regex 2026.4.4 release JSON](https://pypi.org/pypi/regex/2026.4.4/json),
 [pywinpty 3.0.5 release JSON](https://pypi.org/pypi/pywinpty/3.0.5/json), and
 [pywinpty v3.0.5 source](https://github.com/andfoy/pywinpty/tree/v3.0.5).
 
@@ -203,6 +216,26 @@ The universal pyte and wcwidth wheels installed offline on native macOS ARM64
 CPython 3.11, 3.12, 3.13, and 3.14 and Linux ARM64 CPython 3.12. Wheel presence
 is packaging information, not native Windows qualification.
 
+The pinned regex release's official PyPI metadata was checked for each regular-
+GIL interpreter and admitted target. These compiled wheel rows establish
+artifact availability; the macOS ARM64 CPython 3.12 row was also installed and
+hashed above.
+
+| Python | Platform | Filename | Size | SHA-256 |
+| --- | --- | --- | ---: | --- |
+| 3.11 | macOS ARM64 | `regex-2026.4.4-cp311-cp311-macosx_11_0_arm64.whl` | 289,225 | `6aa809ed4dc3706cc38594d67e641601bd2f36d5555b2780ff074edfcb136cf8` |
+| 3.11 | Linux ARM64 | `regex-2026.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl` | 792,434 | `33424f5188a7db12958246a54f59a435b6cb62c5cf9c8d71f7cc49475a5fdada` |
+| 3.11 | Windows AMD64 | `regex-2026.4.4-cp311-cp311-win_amd64.whl` | 278,399 | `9542ccc1e689e752594309444081582f7be2fdb2df75acafea8a075108566735` |
+| 3.12 | macOS ARM64 | `regex-2026.4.4-cp312-cp312-macosx_11_0_arm64.whl` | 289,628 | `1b1ce5c81c9114f1ce2f9288a51a8fd3aeea33a0cc440c415bf02da323aa0a76` |
+| 3.12 | Linux ARM64 | `regex-2026.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl` | 796,651 | `760ef21c17d8e6a4fe8cf406a97cf2806a4df93416ccc82fc98d25b1c20425be` |
+| 3.12 | Windows AMD64 | `regex-2026.4.4-cp312-cp312-win_amd64.whl` | 277,768 | `db0ac18435a40a2543dbb3d21e161a6c78e33e8159bd2e009343d224bb03bb1b` |
+| 3.13 | macOS ARM64 | `regex-2026.4.4-cp313-cp313-macosx_11_0_arm64.whl` | 289,487 | `8fae3c6e795d7678963f2170152b0d892cf6aee9ee8afc8c45e6be38d5107fe7` |
+| 3.13 | Linux ARM64 | `regex-2026.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl` | 796,646 | `298c3ec2d53225b3bf91142eb9691025bab610e0c0c51592dde149db679b3d17` |
+| 3.13 | Windows AMD64 | `regex-2026.4.4-cp313-cp313-win_amd64.whl` | 277,733 | `3384df51ed52db0bea967e21458ab0a414f67cdddfd94401688274e55147bb81` |
+| 3.14 | macOS ARM64 | `regex-2026.4.4-cp314-cp314-macosx_11_0_arm64.whl` | 289,692 | `76d67d5afb1fe402d10a6403bae668d000441e2ab115191a804287d53b772951` |
+| 3.14 | Linux ARM64 | `regex-2026.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl` | 796,979 | `e7cd3e4ee8d80447a83bbc9ab0c8459781fa77087f856c3e740d7763be0df27f` |
+| 3.14 | Windows AMD64 | `regex-2026.4.4-cp314-cp314-win_amd64.whl` | 280,992 | `e0aab3ff447845049d676827d2ff714aab4f73f340e155b7de7458cf53baa5a4` |
+
 | Python | Windows architecture | Filename | Size | SHA-256 | Native status |
 | --- | --- | --- | ---: | --- | --- |
 | 3.11 | amd64 | `pywinpty-3.0.5-cp311-cp311-win_amd64.whl` | 2,092,466 | `af7a8720c78776ddd6259b71dd567944f766a6cd67f8d2887fbc4973967bacda` | FAIL_CLOSED |
@@ -306,6 +339,7 @@ discarded, and bounded cleanup reaped each real capture's process group.
 | Binding row | Requirement | Result | Content-free summary |
 | --- | --- | --- | --- |
 | package-pyte-0.8.2 | MANDATORY | PASS | version, wheel hash, and installed primary-file hash bound to manifest |
+| package-regex-2026.4.4 | MANDATORY | PASS | pin, license, supported wheel matrix, and bounded UAX #29 use recorded |
 | parser-shell-captures | MANDATORY | PASS | two unique available shells captured in every row |
 | parser-powershell-cmd-fixtures | MANDATORY | PASS | two bounded fixtures |
 | parser-full-screen-programs | MANDATORY | PASS | editor, pager, and monitor classes passed |
@@ -536,10 +570,10 @@ owned Job immediately, and retains at most the configured ceiling plus one
 fixed 8-KiB read chunk. Collection rejects any missing, extra, duplicate, or
 mixed-generation sibling before publication.
 
-- The formatter baseline remains byte-for-byte unchanged because the exact
+- The formatter baseline was regenerated after rebasing the PR. The exact
   `verify --head HEAD` command accepted its immutable base hashes, normalized
   formatter-diff hashes, debt facts, red-path set, and recorded Ruff version.
-  Its base is `99248ccad7868732f9216c06404003ee3dff094a`; verification does not
-  modify source.
-- This artifact adds no product code, dependency pin, workflow, or adapted
-  third-party terminal source.
+  Its base is `3e5e75e4aa884d4f362aa63c1e151c3855f07a36`; verification does not modify
+  source.
+- This artifact adds no product code, workflow, or adapted third-party terminal
+  source beyond the reviewed `regex==2026.4.4` validation dependency pin.

--- a/Docs/superpowers/reviews/evidence/task-22512/format-baseline.json
+++ b/Docs/superpowers/reviews/evidence/task-22512/format-baseline.json
@@ -1,6 +1,6 @@
 {
   "base_ref": "origin/dev",
-  "base_sha": "33c7707944aad939fdca75c52fc94d002de5e2fe",
+  "base_sha": "c2f64f690bf4a712b604a1a1db348398df932f36",
   "baseline_red_paths": [
     "tldw_chatbook/app.py",
     "tldw_chatbook/UI/Screens/settings_screen.py",
@@ -72,9 +72,9 @@
       "source_sha256": "d06b897324af463afa766235c13a23336e908c30bf11c2f96586ce90f52040d9"
     },
     "Tests/UI/test_console_internals_decomposition.py": {
-      "debt_units": 40,
+      "debt_units": 44,
       "formatter_required": true,
-      "normalized_diff_sha256": "6ba3a627ef4cbb164665d46ddf0d3d27c0e8545ae860f1074d0248d1ee6bb430",
+      "normalized_diff_sha256": "ee82d4289cb5495033c074e0d3685130839f1bc54f67a1617fd9333f58f7232e",
       "source_hunks": [
         [
           319,
@@ -89,34 +89,38 @@
           3612
         ],
         [
-          3748,
-          3756
+          3652,
+          3658
         ],
         [
-          3988,
-          3996
+          3751,
+          3759
         ],
         [
-          4246,
-          4254
+          3991,
+          3999
         ],
         [
-          4315,
-          4323
+          4251,
+          4259
         ],
         [
-          4774,
-          4781
+          4320,
+          4328
+        ],
+        [
+          4779,
+          4786
         ]
       ],
-      "source_sha256": "3394e8ff39b4f94ecfd03c48be43362d8a16bd23f60022e7f3bd07bd5556e85e"
+      "source_sha256": "7f98fe1c4e4682c2e7d308430e5fc790d26c6915c8bba1501f6cafc6ebf078f0"
     },
     "Tests/UI/test_console_left_rail.py": {
       "debt_units": 0,
       "formatter_required": false,
       "normalized_diff_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "source_hunks": [],
-      "source_sha256": "a743e0854bc3f22ef250e2ac2b86f17a52bb2353d31570c0d54b274618ed4761"
+      "source_sha256": "2e664a8df57823024c9a26fc434d5603b2d624feddec2e323b1ba38a489b16b7"
     },
     "Tests/UI/test_console_runtime_ownership.py": {
       "debt_units": 0,
@@ -130,7 +134,7 @@
       "formatter_required": false,
       "normalized_diff_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "source_hunks": [],
-      "source_sha256": "7367ce1216e530fa9d92d468575465a02893d18391d2a1063d33e42fc0121bd8"
+      "source_sha256": "9f3d18a74457e52e6474f60f19c5a54ca19f9ebff3e41dd7d1cd6d7125d71c73"
     },
     "Tests/UI/test_console_workbench_contract.py": {
       "debt_units": 18,
@@ -146,23 +150,23 @@
           658
         ],
         [
-          997,
-          1005
+          1000,
+          1008
         ],
         [
-          1845,
-          1851
+          1852,
+          1858
         ],
         [
-          1858,
-          1863
+          1865,
+          1870
         ],
         [
-          1888,
-          1893
+          1895,
+          1900
         ]
       ],
-      "source_sha256": "64c88e7917dc6faa94753be8a12e24f30c362dc318fcfc1cc48905da406fadf9"
+      "source_sha256": "edf71f2db8d0177dfec508be8584827fa27e0703c5a4bbe171ab4a168cc9fe60"
     },
     "Tests/UI/test_css_bundle_sync_guard.py": {
       "debt_units": 0,
@@ -179,24 +183,28 @@
       "source_sha256": "a94cbd4cb364f17442081ffdbcfefb9fc81ba99c244adfbe346104ff02ced64c"
     },
     "tldw_chatbook/UI/Console_Modules/left_rail.py": {
-      "debt_units": 12,
+      "debt_units": 17,
       "formatter_required": true,
-      "normalized_diff_sha256": "328acc27bc3a908a372b8454fe1ed6309b78fd0efbb3f731b2f6ec8712ab31fa",
+      "normalized_diff_sha256": "25703729966bd42a20714f1ae6111c4c8c9bc5a61f78afb3fea1a0d486cd021c",
       "source_hunks": [
         [
-          406,
-          414
+          278,
+          288
         ],
         [
-          575,
-          581
+          468,
+          476
         ],
         [
-          588,
-          597
+          637,
+          643
+        ],
+        [
+          651,
+          659
         ]
       ],
-      "source_sha256": "fa4131401e027be614c1eaba2db3bb4350b29903231d3e1f91d7bf129f25a9a8"
+      "source_sha256": "74939308da8eb5009d42e8f9c707e7333bc2aaf71ceb204a9632f7c049bae464"
     },
     "tldw_chatbook/UI/Console_Modules/wiring.py": {
       "debt_units": 4,
@@ -211,92 +219,136 @@
       "source_sha256": "5ef07f17c492aac108c19f6761a0cdd570e3716eacdd786596c8990ce8c77d4e"
     },
     "tldw_chatbook/UI/Screens/chat_screen.py": {
-      "debt_units": 14,
+      "debt_units": 23,
       "formatter_required": true,
-      "normalized_diff_sha256": "df244b5cc022fef4f3c7b2558d3d62402e237de6ab6e10d3b725e1354a6e5a90",
+      "normalized_diff_sha256": "4513da6a59c36cd13b4f3bfa19efb2c29af92f56aea934ce4256b3131c7405f5",
       "source_hunks": [
         [
-          17583,
-          17589
+          4728,
+          4734
         ],
         [
-          17730,
-          17745
+          10099,
+          10115
         ],
         [
-          17748,
-          17755
+          18106,
+          18112
+        ],
+        [
+          18253,
+          18268
+        ],
+        [
+          18271,
+          18278
         ]
       ],
-      "source_sha256": "e493adc153da07076aa79c437fbcae79e38f34c0722de0888448fa4364381a3d"
+      "source_sha256": "c19022cef12aa2fadcfef017fe0e3a0cf1783e12fdbad568dcb1383870af06ce"
     },
     "tldw_chatbook/UI/Screens/settings_screen.py": {
-      "debt_units": 86,
+      "debt_units": 124,
       "formatter_required": true,
-      "normalized_diff_sha256": "1311b40963bd507d6fb56ca2a315ff72a281a9523c1dcd44a047410dea29ab17",
+      "normalized_diff_sha256": "b048b837a3969464e537a00b4c93e0f82b5ba361c82c0460d44ce474bc0aa662",
       "source_hunks": [
         [
-          3125,
-          3133
+          106,
+          111
         ],
         [
-          3161,
-          3169
+          1098,
+          1106
         ],
         [
-          3199,
-          3208
+          2928,
+          2936
         ],
         [
-          3750,
-          3758
+          3195,
+          3203
         ],
         [
-          6140,
-          6146
+          3231,
+          3239
         ],
         [
-          6543,
-          6557
+          3269,
+          3278
         ],
         [
-          11278,
-          11292
+          3827,
+          3835
         ],
         [
-          11424,
-          11431
+          6238,
+          6244
         ],
         [
-          15192,
-          15198
+          6641,
+          6655
         ],
         [
-          15688,
-          15696
+          11380,
+          11394
         ],
         [
-          15706,
-          15725
+          11526,
+          11533
         ],
         [
-          15963,
-          15971
+          15294,
+          15300
         ],
         [
-          20017,
-          20023
+          15790,
+          15798
         ],
         [
-          20033,
-          20041
+          15808,
+          15827
         ],
         [
-          22118,
-          22129
+          16067,
+          16076
+        ],
+        [
+          16160,
+          16168
+        ],
+        [
+          16196,
+          16208
+        ],
+        [
+          16299,
+          16307
+        ],
+        [
+          19776,
+          19784
+        ],
+        [
+          20397,
+          20404
+        ],
+        [
+          20531,
+          20537
+        ],
+        [
+          20628,
+          20634
+        ],
+        [
+          20644,
+          20652
+        ],
+        [
+          22729,
+          22740
         ]
       ],
-      "source_sha256": "f191bc7349fc9a9fda356b00b2ebde6ab3da34b5200cbca9396e8de94df20bec"
+      "source_sha256": "5fb43034ef3c2f03419728d955ce82bdb56ea9f2fceeb0a3e7292213342049fc"
     },
     "tldw_chatbook/UI/console_command_provider.py": {
       "debt_units": 0,
@@ -313,9 +365,9 @@
       "source_sha256": "89c2309596c907f9da9f9f7e3d3af3e45e0120630cbe01b68ec1abbebbf73b13"
     },
     "tldw_chatbook/app.py": {
-      "debt_units": 106,
+      "debt_units": 108,
       "formatter_required": true,
-      "normalized_diff_sha256": "689e6b32506896729626226b1c1ffd11aac9160732bbe0787271eb68d194f8b7",
+      "normalized_diff_sha256": "4e5972fde078d1f27d964ec151080850022c943310a3a04bc94da64845ade27d",
       "source_hunks": [
         [
           360,
@@ -330,58 +382,66 @@
           449
         ],
         [
-          3453,
-          3461
+          697,
+          702
         ],
         [
-          6070,
-          6079
+          3461,
+          3469
         ],
         [
-          6128,
-          6136
+          6078,
+          6087
         ],
         [
-          6183,
-          6191
+          6136,
+          6144
         ],
         [
-          6953,
-          6983
+          6191,
+          6199
         ],
         [
-          7679,
-          7686
+          6961,
+          6991
         ],
         [
-          8059,
-          8065
+          7692,
+          7699
         ],
         [
-          8382,
-          8392
+          8072,
+          8078
         ],
         [
-          10927,
-          10935
+          8395,
+          8405
         ],
         [
-          13299,
-          13307
+          8768,
+          8773
         ],
         [
-          13322,
-          13330
+          11016,
+          11024
         ],
         [
-          13596,
-          13604
+          13388,
+          13396
+        ],
+        [
+          13411,
+          13419
+        ],
+        [
+          13685,
+          13693
         ]
       ],
-      "source_sha256": "12b87f13c88c26649f60b6ebab0f461c31fc63eddf73148f58329c160b4efa44"
+      "source_sha256": "8a43d9c54652b53f9faab79de5340bc565bc2b8d18a3c8821aa5c617c256f32c"
     }
   },
-  "generated_at_utc": "2026-08-30T06:20:30.410733+00:00",
+  "generated_at_utc": "2026-08-30T19:06:07.048107+00:00",
   "paths": [
     "tldw_chatbook/app.py",
     "tldw_chatbook/UI/Screens/settings_screen.py",

--- a/Docs/superpowers/reviews/evidence/task-22512/format-baseline.json
+++ b/Docs/superpowers/reviews/evidence/task-22512/format-baseline.json
@@ -1,6 +1,6 @@
 {
   "base_ref": "origin/dev",
-  "base_sha": "c2f64f690bf4a712b604a1a1db348398df932f36",
+  "base_sha": "3e5e75e4aa884d4f362aa63c1e151c3855f07a36",
   "baseline_red_paths": [
     "tldw_chatbook/app.py",
     "tldw_chatbook/UI/Screens/settings_screen.py",
@@ -441,7 +441,7 @@
       "source_sha256": "8a43d9c54652b53f9faab79de5340bc565bc2b8d18a3c8821aa5c617c256f32c"
     }
   },
-  "generated_at_utc": "2026-08-30T19:06:07.048107+00:00",
+  "generated_at_utc": "2026-08-30T19:47:59.472449+00:00",
   "paths": [
     "tldw_chatbook/app.py",
     "tldw_chatbook/UI/Screens/settings_screen.py",

--- a/Docs/superpowers/specs/2026-08-28-persistent-terminal-sessions-design.md
+++ b/Docs/superpowers/specs/2026-08-28-persistent-terminal-sessions-design.md
@@ -387,11 +387,12 @@ New Session collects:
 - one discovered shell choice, defaulting to `Default`;
 - starting directory, defaulting to active local workspace or real home.
 
-Names are 1-64 display characters after trimming and NFC normalization, reject
-controls and markup, and are unique by normalized Unicode casefold within live
-records. Names are never passed to a shell. Creating, renaming, focusing, and
-closing are direct user actions that bypass the provider prompt queue and remain
-available while a model turn is running.
+Names are 1-64 UAX #29 extended grapheme clusters after trimming and NFC
+normalization, with an independent 1,024-code-point input ceiling. They reject
+controls and markup and are unique by normalized Unicode casefold within live
+records. Names are never passed to a shell. Creating,
+renaming, focusing, and closing are direct user actions that bypass the provider
+prompt queue and remain available while a model turn is running.
 
 ### 6.3 Focus and navigation
 

--- a/Tests/Terminal/test_dependency_qualification.py
+++ b/Tests/Terminal/test_dependency_qualification.py
@@ -70,6 +70,7 @@ FORMAT_PATHS = (
 
 MANDATORY_ROWS = (
     "package-pyte-0.8.2",
+    "package-regex-2026.4.4",
     "package-pywinpty-3.0.5",
     "parser-shell-captures",
     "parser-powershell-cmd-fixtures",
@@ -154,6 +155,11 @@ def test_dependency_sources_admit_only_qualified_terminal_parser() -> None:
             for requirement in requirements
             if requirement.name.lower() == "pyte"
         ] == ["pyte==0.8.2"], source
+        assert [
+            str(requirement)
+            for requirement in requirements
+            if requirement.name.lower() == "regex"
+        ] == ["regex==2026.4.4"], source
         assert all(
             requirement.name.lower() != "pywinpty" for requirement in requirements
         ), source
@@ -181,6 +187,7 @@ def test_dependency_qualification_records_all_binding_rows() -> None:
     for heading in REQUIRED_HEADINGS:
         assert heading in evidence
     assert "pyte==0.8.2" in evidence
+    assert "regex==2026.4.4" in evidence
     assert "pywinpty==3.0.5" in evidence
     assert "textual-terminal source adaptation: none" in evidence
     assert "PENDING" not in evidence
@@ -196,7 +203,11 @@ def test_dependency_qualification_records_all_binding_rows() -> None:
 
 def test_package_rows_record_artifact_hash_license_and_wheel_facts() -> None:
     evidence = EVIDENCE.read_text(encoding="utf-8")
-    for requirement in ("pyte==0.8.2", "pywinpty==3.0.5"):
+    for requirement in (
+        "pyte==0.8.2",
+        "regex==2026.4.4",
+        "pywinpty==3.0.5",
+    ):
         assert requirement in evidence, f"missing package evidence: {requirement}"
         package_block = evidence.split(requirement, 1)[1].split("\n\n", 1)[0]
         assert re.search(r"sha256:[0-9a-f]{64}", package_block)

--- a/Tests/Terminal/test_launch.py
+++ b/Tests/Terminal/test_launch.py
@@ -7,16 +7,19 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import unicodedata
 
 import pytest
 
 from tldw_chatbook.Terminal import launch as launch_module
+from tldw_chatbook.Utils import input_validation as input_validation_module
 from tldw_chatbook.Terminal.launch import (
     ResolvedLaunch,
     ShellChoice,
     build_terminal_environment,
     discover_shell_choices,
     normalize_session_name,
+    resolve_launch,
     resolve_shell_choice,
     resolve_start_directory,
     session_name_key,
@@ -42,6 +45,65 @@ def test_session_name_is_trimmed_and_nfc_normalized() -> None:
 def test_session_name_refuses_blank_or_more_than_64_characters(name: str) -> None:
     with pytest.raises(ValueError, match="1 to 64"):
         normalize_session_name(name)
+
+
+def test_session_name_limit_counts_display_graphemes_after_nfc() -> None:
+    grapheme = "a\N{COMBINING ENCLOSING CIRCLE}"
+
+    assert normalize_session_name(grapheme * 64) == grapheme * 64
+    with pytest.raises(ValueError, match="1 to 64"):
+        normalize_session_name(grapheme * 65)
+
+
+def test_session_name_limit_counts_regional_indicator_pairs_as_graphemes() -> None:
+    flag = (
+        "\N{REGIONAL INDICATOR SYMBOL LETTER U}\N{REGIONAL INDICATOR SYMBOL LETTER S}"
+    )
+
+    assert normalize_session_name(flag * 64) == flag * 64
+    with pytest.raises(ValueError, match="1 to 64"):
+        normalize_session_name(flag * 65)
+
+
+def test_session_name_refuses_oversized_single_grapheme() -> None:
+    oversized_grapheme = "a" + "\N{COMBINING ENCLOSING CIRCLE}" * 1_024
+
+    with pytest.raises(ValueError, match="at most 1024 code points"):
+        normalize_session_name(oversized_grapheme)
+
+
+def test_session_name_refuses_nfc_expansion_past_raw_bound() -> None:
+    source = "\N{COMBINING GREEK DIALYTIKA TONOS}" * 513
+    assert len(source) <= 1_024
+    assert len(unicodedata.normalize("NFC", source)) > 1_024
+
+    with pytest.raises(ValueError, match="at most 1024 code points"):
+        normalize_session_name(source)
+
+
+def test_session_name_grapheme_count_stops_after_rejection_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class CountingPattern:
+        yielded = 0
+
+        def finditer(self, value: str):
+            for _character in value:
+                self.yielded += 1
+                if self.yielded > 65:
+                    raise AssertionError("grapheme validation consumed past rejection")
+                yield object()
+
+    pattern = CountingPattern()
+    monkeypatch.setattr(
+        input_validation_module,
+        "_EXTENDED_GRAPHEME_PATTERN",
+        pattern,
+    )
+
+    with pytest.raises(ValueError, match="1 to 64"):
+        normalize_session_name("x" * 200)
+    assert pattern.yielded == 65
 
 
 @pytest.mark.parametrize(
@@ -199,6 +261,15 @@ def test_shell_picker_has_no_arbitrary_executable_entry() -> None:
     assert all(choice.key != "/opt/custom/bin/fish" for choice in choices)
 
 
+def test_shell_resolver_rejects_forged_choice_objects() -> None:
+    class ForgedChoice:
+        key = "bash"
+        argv = ("/bin/bash", "-c", "caller-owned-command")
+
+    with pytest.raises(ValueError, match="shell choice"):
+        resolve_shell_choice("bash", (ForgedChoice(),))  # type: ignore[arg-type]
+
+
 def test_shell_discovery_fails_closed_when_no_default_exists() -> None:
     with pytest.raises(FileNotFoundError, match="shell"):
         discover_shell_choices(
@@ -209,20 +280,93 @@ def test_shell_discovery_fails_closed_when_no_default_exists() -> None:
         )
 
 
-def test_shell_values_are_frozen_slotted_and_deeply_immutable() -> None:
-    choice = ShellChoice(
-        key="bash",
-        label="Bash",
-        family="bash",
-        executable=Path("/bin/bash"),
-        argv=("/bin/bash", "--login", "-i"),
+def test_public_value_constructors_cannot_package_policy_bypasses() -> None:
+    with pytest.raises(TypeError, match="launch policy"):
+        ShellChoice(
+            key="arbitrary",
+            label="Arbitrary",
+            family="bash",
+            executable=Path("/bin/bash"),
+            argv=("/bin/bash", "-c", "caller-owned-command"),
+        )
+    with pytest.raises(TypeError, match="launch policy"):
+        ResolvedLaunch(
+            name="Unchecked",
+            shell=object(),  # type: ignore[arg-type]
+            start_directory=Path("relative"),
+            environment=(("OPENAI_API_KEY", "secret"),),
+        )
+
+
+def test_resolve_launch_derives_every_backend_value_from_validated_inputs(
+    tmp_path: Path,
+) -> None:
+    resolver = getattr(launch_module, "resolve_launch", None)
+    assert callable(resolver)
+    choices = discover_shell_choices(
+        platform_name="posix",
+        account_shell="/bin/bash",
+        executable_lookup=_lookup({"bash": "/bin/bash"}),
+        executable_is_file=_all_paths_are_files,
     )
-    launch = ResolvedLaunch(
+
+    launch = resolver(
+        name="  Terminal 1  ",
+        shell_selector="bash",
+        shell_choices=choices,
+        selected_local_root=tmp_path,
+        account_home=tmp_path,
+        platform_name="posix",
+        ambient={"PATH": str(tmp_path), "OPENAI_API_KEY": "secret"},
+        account_reader=lambda: {
+            "HOME": str(tmp_path),
+            "USER": "account-user",
+            "LOGNAME": "account-user",
+            "SHELL": "/bin/bash",
+        },
+        system_reader=lambda: {"TMPDIR": str(tmp_path)},
+    )
+
+    assert launch.name == "Terminal 1"
+    assert launch.shell.argv == ("/bin/bash", "--login", "-i")
+    assert launch.start_directory == tmp_path
+    assert dict(launch.environment) == {
+        "PATH": str(tmp_path),
+        "HOME": str(tmp_path),
+        "USER": "account-user",
+        "LOGNAME": "account-user",
+        "SHELL": "/bin/bash",
+        "TMPDIR": str(tmp_path),
+        "TERM": "linux",
+    }
+
+
+def test_shell_values_are_frozen_slotted_and_deeply_immutable(
+    tmp_path: Path,
+) -> None:
+    choices = discover_shell_choices(
+        platform_name="posix",
+        account_shell="/bin/bash",
+        executable_lookup=_lookup({"bash": "/bin/bash"}),
+        executable_is_file=_all_paths_are_files,
+    )
+    launch = resolve_launch(
         name="Terminal 1",
-        shell=choice,
-        start_directory=Path("/tmp"),
-        environment=(("TERM", "linux"),),
+        shell_selector="bash",
+        shell_choices=choices,
+        selected_local_root=tmp_path,
+        account_home=tmp_path,
+        platform_name="posix",
+        ambient={"PATH": str(tmp_path)},
+        account_reader=lambda: {
+            "HOME": str(tmp_path),
+            "USER": "account-user",
+            "LOGNAME": "account-user",
+            "SHELL": "/bin/bash",
+        },
+        system_reader=lambda: {"TMPDIR": str(tmp_path)},
     )
+    choice = launch.shell
 
     with pytest.raises(FrozenInstanceError):
         choice.key = "zsh"  # type: ignore[misc]
@@ -540,6 +684,59 @@ def test_environment_rejects_path_without_an_existing_absolute_directory() -> No
             system_reader=lambda: {},
             path_is_directory=lambda _path: False,
             fallback_path="",
+        )
+
+
+def test_default_path_admission_obeys_central_host_path_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    def reject_path(_path: str | Path) -> Path:
+        raise ValueError("central refusal")
+
+    monkeypatch.setattr(
+        launch_module,
+        "validate_existing_absolute_directory",
+        reject_path,
+    )
+
+    with pytest.raises(ValueError, match="PATH"):
+        build_terminal_environment(
+            platform_name="posix",
+            ambient={"PATH": str(tmp_path)},
+            account_reader=lambda: {
+                "HOME": str(tmp_path),
+                "USER": "account-user",
+                "LOGNAME": "account-user",
+                "SHELL": "/bin/bash",
+            },
+            system_reader=lambda: {"TMPDIR": str(tmp_path)},
+        )
+
+
+@pytest.mark.parametrize("source_name", ["ambient", "account", "system"])
+def test_environment_rejects_non_text_external_mapping_data(
+    tmp_path: Path,
+    source_name: str,
+) -> None:
+    sources: dict[str, dict[str, object]] = {
+        "ambient": {"PATH": str(tmp_path)},
+        "account": {
+            "HOME": str(tmp_path),
+            "USER": "account-user",
+            "LOGNAME": "account-user",
+            "SHELL": "/bin/bash",
+        },
+        "system": {"TMPDIR": str(tmp_path)},
+    }
+    sources[source_name]["UNTRUSTED"] = object()
+
+    with pytest.raises(ValueError, match="string"):
+        build_terminal_environment(
+            platform_name="posix",
+            ambient=sources["ambient"],  # type: ignore[arg-type]
+            account_reader=lambda: sources["account"],  # type: ignore[return-value]
+            system_reader=lambda: sources["system"],  # type: ignore[return-value]
         )
 
 

--- a/Tests/Terminal/test_launch.py
+++ b/Tests/Terminal/test_launch.py
@@ -1,0 +1,609 @@
+"""Focused contracts for persistent-terminal launch policy."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+from tldw_chatbook.Terminal import launch as launch_module
+from tldw_chatbook.Terminal.launch import (
+    ResolvedLaunch,
+    ShellChoice,
+    build_terminal_environment,
+    discover_shell_choices,
+    normalize_session_name,
+    resolve_shell_choice,
+    resolve_start_directory,
+    session_name_key,
+)
+
+
+def _lookup(paths: dict[str, str]):
+    return paths.get
+
+
+def _all_paths_are_files(_path: Path) -> bool:
+    return True
+
+
+def test_session_name_is_trimmed_and_nfc_normalized() -> None:
+    assert (
+        normalize_session_name("  Cafe\N{COMBINING ACUTE ACCENT}  ")
+        == "Caf\N{LATIN SMALL LETTER E WITH ACUTE}"
+    )
+
+
+@pytest.mark.parametrize("name", ["", "   ", "x" * 65])
+def test_session_name_refuses_blank_or_more_than_64_characters(name: str) -> None:
+    with pytest.raises(ValueError, match="1 to 64"):
+        normalize_session_name(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "bad\nname",
+        "bad\x00name",
+        "bad\N{RIGHT-TO-LEFT OVERRIDE}name",
+        "bad\ud800name",
+        "[bold]name[/bold]",
+    ],
+)
+def test_session_name_refuses_controls_and_rich_markup(name: str) -> None:
+    with pytest.raises(ValueError):
+        normalize_session_name(name)
+
+
+def test_session_name_key_detects_unicode_casefold_collisions() -> None:
+    assert session_name_key("Straße") == session_name_key("STRASSE")
+
+
+def test_session_name_refuses_casefold_duplicate_live_name() -> None:
+    with pytest.raises(ValueError, match="unique"):
+        normalize_session_name("STRASSE", existing_names=("Straße",))
+
+
+def test_posix_default_prefers_valid_account_shell_even_outside_picker_families() -> (
+    None
+):
+    choices = discover_shell_choices(
+        platform_name="posix",
+        account_shell="/opt/fish/bin/fish",
+        executable_lookup=_lookup(
+            {"bash": "/bin/bash", "zsh": "/bin/zsh", "sh": "/bin/sh"}
+        ),
+        executable_is_file=_all_paths_are_files,
+    )
+
+    default = resolve_shell_choice("default", choices)
+    assert default.family == "account"
+    assert default.executable == Path("/opt/fish/bin/fish")
+    assert default.argv == ("-fish",)
+    assert {choice.key for choice in choices} == {"default", "bash", "zsh"}
+
+
+def test_posix_default_reads_current_account_shell_when_not_injected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        launch_module,
+        "_read_posix_account_shell",
+        lambda: "/opt/fish/bin/fish",
+        raising=False,
+    )
+
+    choices = discover_shell_choices(
+        platform_name="posix",
+        executable_lookup=_lookup({"bash": "/bin/bash", "sh": "/bin/sh"}),
+        executable_is_file=_all_paths_are_files,
+    )
+
+    assert resolve_shell_choice("default", choices).executable == Path(
+        "/opt/fish/bin/fish"
+    )
+
+
+def test_posix_default_falls_back_to_bash_then_sh() -> None:
+    bash_choices = discover_shell_choices(
+        platform_name="posix",
+        account_shell="relative/fish",
+        executable_lookup=_lookup({"bash": "/bin/bash", "sh": "/bin/sh"}),
+        executable_is_file=_all_paths_are_files,
+    )
+    sh_choices = discover_shell_choices(
+        platform_name="posix",
+        account_shell="relative/unavailable",
+        executable_lookup=_lookup({"sh": "/bin/sh"}),
+        executable_is_file=_all_paths_are_files,
+    )
+
+    assert resolve_shell_choice("default", bash_choices).executable == Path("/bin/bash")
+    assert resolve_shell_choice("default", sh_choices).executable == Path("/bin/sh")
+
+
+def test_posix_named_shell_argv_is_login_interactive_and_code_owned() -> None:
+    choices = discover_shell_choices(
+        platform_name="posix",
+        account_shell="/bin/bash",
+        executable_lookup=_lookup({"bash": "/bin/bash", "zsh": "/bin/zsh"}),
+        executable_is_file=_all_paths_are_files,
+    )
+
+    assert resolve_shell_choice("bash", choices).argv == (
+        "/bin/bash",
+        "--login",
+        "-i",
+    )
+    assert resolve_shell_choice("zsh", choices).argv == ("/bin/zsh", "-l", "-i")
+
+
+def test_windows_default_prefers_pwsh_then_powershell_then_cmd() -> None:
+    pwsh = r"C:\Program Files\PowerShell\7\pwsh.exe"
+    powershell = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+    cmd = r"C:\Windows\System32\cmd.exe"
+
+    first = discover_shell_choices(
+        platform_name="nt",
+        executable_lookup=_lookup(
+            {"pwsh.exe": pwsh, "powershell.exe": powershell, "cmd.exe": cmd}
+        ),
+        executable_is_file=_all_paths_are_files,
+    )
+    second = discover_shell_choices(
+        platform_name="nt",
+        executable_lookup=_lookup({"powershell.exe": powershell, "cmd.exe": cmd}),
+        executable_is_file=_all_paths_are_files,
+    )
+    third = discover_shell_choices(
+        platform_name="nt",
+        executable_lookup=_lookup({"cmd.exe": cmd}),
+        executable_is_file=_all_paths_are_files,
+    )
+
+    assert resolve_shell_choice("default", first).executable == Path(pwsh)
+    assert resolve_shell_choice("default", second).executable == Path(powershell)
+    assert resolve_shell_choice("default", third).executable == Path(cmd)
+
+
+def test_windows_argv_keeps_profiles_and_interactive_input_enabled() -> None:
+    pwsh = r"C:\Program Files\PowerShell\7\pwsh.exe"
+    cmd = r"C:\Windows\System32\cmd.exe"
+    choices = discover_shell_choices(
+        platform_name="nt",
+        executable_lookup=_lookup({"pwsh.exe": pwsh, "cmd.exe": cmd}),
+        executable_is_file=_all_paths_are_files,
+    )
+
+    assert resolve_shell_choice("pwsh", choices).argv == (pwsh, "-NoLogo")
+    assert resolve_shell_choice("cmd", choices).argv == (cmd, "/Q")
+    flattened = "\n".join(argument for choice in choices for argument in choice.argv)
+    for forbidden in ("-NoProfile", "-NonInteractive", "/C", "fixture-command"):
+        assert forbidden not in flattened
+
+
+def test_shell_picker_has_no_arbitrary_executable_entry() -> None:
+    choices = discover_shell_choices(
+        platform_name="posix",
+        account_shell="/opt/custom/bin/fish",
+        executable_lookup=_lookup({"bash": "/bin/bash", "zsh": "/bin/zsh"}),
+        executable_is_file=_all_paths_are_files,
+    )
+
+    with pytest.raises(ValueError, match="shell choice"):
+        resolve_shell_choice("/tmp/model-supplied", choices)
+    assert all(choice.key != "/opt/custom/bin/fish" for choice in choices)
+
+
+def test_shell_discovery_fails_closed_when_no_default_exists() -> None:
+    with pytest.raises(FileNotFoundError, match="shell"):
+        discover_shell_choices(
+            platform_name="posix",
+            account_shell="relative/unavailable",
+            executable_lookup=_lookup({}),
+            executable_is_file=_all_paths_are_files,
+        )
+
+
+def test_shell_values_are_frozen_slotted_and_deeply_immutable() -> None:
+    choice = ShellChoice(
+        key="bash",
+        label="Bash",
+        family="bash",
+        executable=Path("/bin/bash"),
+        argv=("/bin/bash", "--login", "-i"),
+    )
+    launch = ResolvedLaunch(
+        name="Terminal 1",
+        shell=choice,
+        start_directory=Path("/tmp"),
+        environment=(("TERM", "linux"),),
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        choice.key = "zsh"  # type: ignore[misc]
+    with pytest.raises(TypeError):
+        launch.environment[0] = ("TERM", "xterm")  # type: ignore[index]
+    assert not hasattr(choice, "__dict__")
+    assert not hasattr(launch, "__dict__")
+
+
+def test_requested_start_directory_precedes_selected_root_and_real_home(
+    tmp_path: Path,
+) -> None:
+    requested = tmp_path / "requested"
+    selected = tmp_path / "selected"
+    home = tmp_path / "home"
+    requested.mkdir()
+    selected.mkdir()
+    home.mkdir()
+
+    assert (
+        resolve_start_directory(
+            selected,
+            requested_directory=requested,
+            account_home=home,
+        )
+        == requested
+    )
+
+
+def test_selected_ready_local_root_precedes_real_home(tmp_path: Path) -> None:
+    selected = tmp_path / "selected"
+    home = tmp_path / "home"
+    selected.mkdir()
+    home.mkdir()
+
+    assert resolve_start_directory(selected, account_home=home) == selected
+
+
+def test_missing_selection_falls_back_to_real_home(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    assert resolve_start_directory(None, account_home=home) == home
+
+
+@pytest.mark.parametrize("which", ["requested", "selected", "home"])
+def test_start_directory_revalidates_final_absolute_existing_directory(
+    tmp_path: Path,
+    which: str,
+) -> None:
+    existing_home = tmp_path / "home"
+    existing_home.mkdir()
+    selected = tmp_path if which != "selected" else tmp_path / "missing-selected"
+    requested = None if which != "requested" else tmp_path / "missing-requested"
+    home = existing_home if which != "home" else tmp_path / "missing-home"
+
+    with pytest.raises(ValueError, match="absolute existing directory"):
+        resolve_start_directory(
+            selected if which == "selected" else None,
+            requested_directory=requested,
+            account_home=home,
+        )
+
+
+def test_posix_environment_uses_account_reader_and_scrubs_ambient_secrets(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    home = tmp_path / "home"
+    temp = tmp_path / "tmp"
+    for path in (bin_dir, home, temp):
+        path.mkdir()
+    ambient = {
+        "PATH": f"relative{os.pathsep}{bin_dir}{os.pathsep}{bin_dir}",
+        "HOME": "/ambient/home",
+        "USER": "ambient-user",
+        "LOGNAME": "ambient-user",
+        "SHELL": "/ambient/shell",
+        "TMPDIR": "/ambient/tmp",
+        "LANG": "en_US.UTF-8",
+        "LC_CTYPE": "UTF-8",
+        "LC_PRIVATE_TOKEN": "must-not-cross-boundary",
+        "COLORTERM": "truecolor",
+        "LINES": "999",
+        "COLUMNS": "999",
+        "OPENAI_API_KEY": "secret",
+        "HTTPS_PROXY": "credential",
+        "OTEL_EXPORTER_OTLP_HEADERS": "trace-secret",
+        "PYTHONPATH": "/inject",
+        "PYTHONHOME": "/inject-home",
+        "SSH_AUTH_SOCK": "/agent.sock",
+        "UNRELATED": "drop-me",
+    }
+
+    environment = build_terminal_environment(
+        platform_name="posix",
+        ambient=ambient,
+        account_reader=lambda: {
+            "HOME": str(home),
+            "USER": "account-user",
+            "LOGNAME": "account-user",
+            "SHELL": "/bin/zsh",
+        },
+        system_reader=lambda: {"TMPDIR": str(temp)},
+    )
+
+    assert environment == {
+        "PATH": str(bin_dir),
+        "HOME": str(home),
+        "USER": "account-user",
+        "LOGNAME": "account-user",
+        "SHELL": "/bin/zsh",
+        "TMPDIR": str(temp),
+        "LANG": "en_US.UTF-8",
+        "LC_CTYPE": "UTF-8",
+        "TERM": "linux",
+    }
+
+
+def test_windows_environment_uses_account_and_system_readers_not_ambient() -> None:
+    ambient = {
+        "Path": r"C:\Tools;relative;C:\Windows\System32",
+        "USERPROFILE": r"C:\ambient-user",
+        "SYSTEMROOT": r"C:\ambient-windows",
+        "PSModulePath": r"C:\ambient-modules",
+        "OPENAI_API_KEY": "secret",
+        "HTTP_PROXY": "credential",
+        "PYTHONPATH": r"C:\inject",
+        "TEMP": r"C:\ambient-temp",
+        "LANG": "en-US",
+    }
+    existing = {r"C:\Tools", r"C:\Windows\System32"}
+
+    environment = build_terminal_environment(
+        platform_name="nt",
+        ambient=ambient,
+        account_reader=lambda: {
+            "USERPROFILE": r"C:\Users\account",
+            "HOMEDRIVE": "C:",
+            "HOMEPATH": r"\Users\account",
+            "USERNAME": "account",
+        },
+        system_reader=lambda: {
+            "APPDATA": r"C:\Users\account\AppData\Roaming",
+            "LOCALAPPDATA": r"C:\Users\account\AppData\Local",
+            "PROGRAMDATA": r"C:\ProgramData",
+            "PROGRAMFILES": r"C:\Program Files",
+            "SYSTEMROOT": r"C:\Windows",
+            "WINDIR": r"C:\Windows",
+            "COMSPEC": r"C:\Windows\System32\cmd.exe",
+            "PATHEXT": ".COM;.EXE;.BAT;.CMD",
+            "TEMP": r"C:\Users\account\AppData\Local\Temp",
+            "TMP": r"C:\Users\account\AppData\Local\Temp",
+        },
+        path_is_directory=lambda path: path in existing,
+    )
+
+    assert environment == {
+        "PATH": r"C:\Tools;C:\Windows\System32",
+        "USERPROFILE": r"C:\Users\account",
+        "HOMEDRIVE": "C:",
+        "HOMEPATH": r"\Users\account",
+        "USERNAME": "account",
+        "APPDATA": r"C:\Users\account\AppData\Roaming",
+        "LOCALAPPDATA": r"C:\Users\account\AppData\Local",
+        "PROGRAMDATA": r"C:\ProgramData",
+        "PROGRAMFILES": r"C:\Program Files",
+        "SYSTEMROOT": r"C:\Windows",
+        "WINDIR": r"C:\Windows",
+        "COMSPEC": r"C:\Windows\System32\cmd.exe",
+        "PATHEXT": ".COM;.EXE;.BAT;.CMD",
+        "TEMP": r"C:\Users\account\AppData\Local\Temp",
+        "TMP": r"C:\Users\account\AppData\Local\Temp",
+        "LANG": "en-US",
+        "TERM": "linux",
+    }
+    for forbidden in (
+        "PSMODULEPATH",
+        "COLORTERM",
+        "LINES",
+        "COLUMNS",
+        "OPENAI_API_KEY",
+        "HTTP_PROXY",
+        "PYTHONPATH",
+    ):
+        assert forbidden not in environment
+
+
+def test_default_windows_readers_use_platform_environment_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    platform_values = {
+        "USERPROFILE": r"C:\Users\platform",
+        "HOMEDRIVE": "C:",
+        "HOMEPATH": r"\Users\platform",
+        "USERNAME": "platform-user",
+        "APPDATA": r"C:\Users\platform\AppData\Roaming",
+        "LOCALAPPDATA": r"C:\Users\platform\AppData\Local",
+        "PROGRAMDATA": r"C:\ProgramData",
+        "PROGRAMFILES": r"C:\Program Files",
+        "PROGRAMFILES(X86)": r"C:\Program Files (x86)",
+        "PROGRAMW6432": r"C:\Program Files",
+        "SYSTEMROOT": r"C:\Windows",
+        "WINDIR": r"C:\Windows",
+        "COMSPEC": r"C:\Windows\System32\cmd.exe",
+        "PATHEXT": ".COM;.EXE;.BAT;.CMD",
+        "TEMP": r"C:\Users\platform\AppData\Local\Temp",
+        "TMP": r"C:\Users\platform\AppData\Local\Temp",
+        "UNRELATED": "must-not-cross-boundary",
+    }
+    monkeypatch.setenv("USERPROFILE", r"C:\Users\ambient")
+    monkeypatch.setenv("SYSTEMROOT", r"C:\ambient-windows")
+    monkeypatch.setattr(
+        launch_module,
+        "_read_windows_environment_block",
+        lambda: platform_values,
+        raising=False,
+    )
+
+    assert launch_module._read_account_values("nt") == {
+        key: platform_values[key]
+        for key in ("USERPROFILE", "HOMEDRIVE", "HOMEPATH", "USERNAME")
+    }
+    assert launch_module._read_system_values("nt") == {
+        key: value
+        for key, value in platform_values.items()
+        if key not in {"USERPROFILE", "HOMEDRIVE", "HOMEPATH", "USERNAME", "UNRELATED"}
+    }
+
+
+def test_windows_environment_block_parser_normalizes_keys_and_ignores_drive_state() -> (
+    None
+):
+    import ctypes
+
+    block = ctypes.create_unicode_buffer(
+        "Path=C:\\Tools\x00=C:=C:\\work\x00UserProfile=C:\\Users\\account\x00\x00"
+    )
+
+    assert launch_module._parse_windows_environment_block(block) == {
+        "PATH": r"C:\Tools",
+        "USERPROFILE": r"C:\Users\account",
+    }
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows profile APIs")
+def test_native_windows_environment_reader_ignores_process_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = launch_module._read_windows_environment_block()
+    monkeypatch.setenv("USERPROFILE", r"C:\ambient-override")
+    monkeypatch.setenv("SYSTEMROOT", r"C:\ambient-system-override")
+
+    observed = launch_module._read_windows_environment_block()
+
+    assert observed["USERPROFILE"] == expected["USERPROFILE"]
+    assert observed["SYSTEMROOT"] == expected["SYSTEMROOT"]
+
+
+@pytest.mark.parametrize(
+    "missing",
+    (
+        "APPDATA",
+        "LOCALAPPDATA",
+        "PROGRAMDATA",
+        "PROGRAMFILES",
+        "SYSTEMROOT",
+        "WINDIR",
+        "COMSPEC",
+        "PATHEXT",
+        "TEMP",
+        "TMP",
+    ),
+)
+def test_windows_environment_requires_qualified_platform_values(missing: str) -> None:
+    system = {
+        "APPDATA": r"C:\Users\account\AppData\Roaming",
+        "LOCALAPPDATA": r"C:\Users\account\AppData\Local",
+        "PROGRAMDATA": r"C:\ProgramData",
+        "PROGRAMFILES": r"C:\Program Files",
+        "SYSTEMROOT": r"C:\Windows",
+        "WINDIR": r"C:\Windows",
+        "COMSPEC": r"C:\Windows\System32\cmd.exe",
+        "PATHEXT": ".COM;.EXE;.BAT;.CMD",
+        "TEMP": r"C:\Users\account\AppData\Local\Temp",
+        "TMP": r"C:\Users\account\AppData\Local\Temp",
+    }
+    system.pop(missing)
+
+    with pytest.raises(ValueError, match=missing.replace("(", r"\(")):
+        build_terminal_environment(
+            platform_name="nt",
+            ambient={"PATH": r"C:\Tools"},
+            account_reader=lambda: {
+                "USERPROFILE": r"C:\Users\account",
+                "HOMEDRIVE": "C:",
+                "HOMEPATH": r"\Users\account",
+                "USERNAME": "account",
+            },
+            system_reader=lambda: system,
+            path_is_directory=lambda path: path == r"C:\Tools",
+        )
+
+
+def test_environment_rejects_path_without_an_existing_absolute_directory() -> None:
+    with pytest.raises(ValueError, match="PATH"):
+        build_terminal_environment(
+            platform_name="nt",
+            ambient={"PATH": r"relative;C:\missing"},
+            account_reader=lambda: {
+                "USERPROFILE": r"C:\Users\account",
+                "HOMEDRIVE": "C:",
+                "HOMEPATH": r"\Users\account",
+                "USERNAME": "account",
+            },
+            system_reader=lambda: {},
+            path_is_directory=lambda _path: False,
+            fallback_path="",
+        )
+
+
+@pytest.mark.parametrize(
+    ("shell_name", "profile_name"),
+    [("bash", ".bash_profile"), ("zsh", ".zprofile")],
+)
+def test_posix_login_shell_runs_fresh_profile_from_scrubbed_environment(
+    tmp_path: Path,
+    shell_name: str,
+    profile_name: str,
+) -> None:
+    executable = shutil.which(shell_name)
+    if executable is None:
+        pytest.skip(f"{shell_name} is unavailable")
+    home = tmp_path / f"{shell_name}-home"
+    start = tmp_path / f"{shell_name}-start"
+    temp = tmp_path / f"{shell_name}-tmp"
+    for path in (home, start, temp):
+        path.mkdir()
+    (home / profile_name).write_text(
+        'if [ -z "${OPENAI_API_KEY+x}" ]; then '
+        "export TLDW_INITIAL_SECRET_ABSENT=1; fi\n"
+        "export OPENAI_API_KEY=profile-restored\n",
+        encoding="utf-8",
+    )
+    choices = discover_shell_choices(
+        platform_name="posix",
+        account_shell=executable,
+        executable_lookup=shutil.which,
+    )
+    environment = build_terminal_environment(
+        platform_name="posix",
+        ambient={
+            "PATH": os.environ.get("PATH", os.defpath),
+            "LANG": os.environ.get("LANG", "C.UTF-8"),
+            "OPENAI_API_KEY": "ambient-secret",
+        },
+        account_reader=lambda: {
+            "HOME": str(home),
+            "USER": "fixture-user",
+            "LOGNAME": "fixture-user",
+            "SHELL": executable,
+        },
+        system_reader=lambda: {"TMPDIR": str(temp)},
+    )
+    shell = resolve_shell_choice("default", choices)
+    completed = subprocess.run(
+        shell.argv,
+        cwd=resolve_start_directory(start, account_home=home),
+        env=environment,
+        input=(
+            'printf "__TLDW_LAUNCH__%s|%s|%s\\n" "$PWD" '
+            '"${TLDW_INITIAL_SECRET_ABSENT-0}" "${OPENAI_API_KEY-unset}"\n'
+            "exit\n"
+        ),
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    assert (
+        f"__TLDW_LAUNCH__{start}|1|profile-restored"
+        in completed.stdout + completed.stderr
+    )

--- a/backlog/decisions/099-persistent-terminal-session-runtime-boundary.md
+++ b/backlog/decisions/099-persistent-terminal-session-runtime-boundary.md
@@ -76,6 +76,13 @@ environment values, and arbitrary behavior; the danger disclosure states this.
 The active local workspace, or real home when none is selected, is only the
 starting directory and is never described as confinement.
 
+Persistent-terminal session names use the core `regex` package's UAX #29
+extended-grapheme boundary (`\X`) after NFC normalization. This keeps the
+1-64 display-character contract correct for regional-indicator flags, combining
+sequences, and scripts whose displayed graphemes span several code points. A
+separate 1,024-code-point input ceiling bounds normalization and segmentation,
+and the grapheme iterator stops after the 65th cluster.
+
 The runtime enforces explicit bounds, including four retained session records,
 a 300x120 active viewport, 5,000 lines and 4 MiB of normal-screen scrollback per
 session, 512 KiB pending input and output per session, and a 256 KiB atomic paste
@@ -145,6 +152,7 @@ license notices.
 | Build a VT/xterm parser from scratch | Creates a large protocol and security surface unrelated to Chatbook's core value. A qualified pyte adapter is smaller and independently testable. |
 | Launch the user's external terminal application | Cannot deliver the approved Console workspace, session list, bounded scrollback, navigation survival, or Chatbook-owned cleanup. |
 | Reuse raw `RawShellExecutor` unchanged | Its one-shot `stdin=DEVNULL`, profile suppression, output sanitizer, and process-group lifecycle intentionally cannot represent an interactive controlling terminal or shell job control. |
+| Count names with Python `len()` or Rich cell spans | Code-point and terminal-cell helpers do not implement UAX #29 extended grapheme boundaries; they over-count valid displayed names such as regional-indicator flags and Indic conjuncts. |
 | Put PTY ownership in the Textual widget | Widget remount/recompose would become a process-lifecycle operation, making navigation destructive and cleanup races difficult to reason about. |
 | Persist or reconnect terminal sessions | Requires a durable authenticated supervisor or daemon, PID-reuse-safe recovery, and a new data/security boundary. Process-lifetime sessions satisfy the approved scope. |
 | Give models terminal read/input tools now | Violates the approved user-only privacy boundary and couples terminal authority to model permissions. TASK-24462 records separately governed bounded read proposals. |
@@ -168,6 +176,8 @@ license notices.
 ### Costs and accepted risks
 
 - `pyte` becomes a reviewed runtime dependency; the evaluated Windows-only `pywinpty` candidate is not admitted.
+- `regex==2026.4.4` becomes a reviewed core runtime dependency for UAX #29
+  session-name validation.
 - Their supported wheel matrix, concurrency behavior, versions, licenses, and
   required notices must be recorded in
   `Docs/superpowers/reviews/evidence/task-22512/dependency-qualification.md`
@@ -195,9 +205,10 @@ license notices.
   requires a new ADR.
 - Any terminal model tool or automatic model-context projection requires
   TASK-24462's separate design and ADR.
-- Changing the pinned pyte or pywinpty version or their parser/low-level ConPTY
-  API boundary requires rerunning the named qualification artifact and a new or
-  superseding ADR decision before lockfile change.
+- Changing the pinned pyte, pywinpty, or regex version, the parser/low-level
+  ConPTY API boundary, or the UAX #29 grapheme-boundary behavior requires
+  rerunning the named qualification artifact and a new or superseding ADR
+  decision before lockfile change.
 - Nested-program mouse reporting requires TASK-23114's ADR check and real-
   terminal event evidence.
 - Arbitrary launch commands, caller-provided environment overrides, or a claim

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "requests",
     "rich",
     "pyte==0.8.2",
+    "regex==2026.4.4",
     "wcwidth>=0.2.14,<1",
     "rich-pixels>=3.0.0",
     # TASK-18606: was pinned to ==11.2.1 for ADR-054 renderer identity. The

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ toml
 tomli
 rich
 pyte==0.8.2
+regex==2026.4.4
 wcwidth>=0.2.14,<1
 textual==8.2.8
 textual-diff-view==0.1.5

--- a/tldw_chatbook/Terminal/launch.py
+++ b/tldw_chatbook/Terminal/launch.py
@@ -1,0 +1,612 @@
+"""Pure launch-policy boundaries for persistent terminal sessions."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+import ntpath
+import os
+from pathlib import Path
+import posixpath
+import shutil
+import tempfile
+import unicodedata
+
+from tldw_chatbook.Utils.path_validation import (
+    validate_existing_absolute_directory,
+)
+
+
+_POSIX_ACCOUNT_KEYS = ("HOME", "USER", "LOGNAME", "SHELL")
+_POSIX_LOCALE_KEYS = (
+    "LANG",
+    "LC_ALL",
+    "LC_ADDRESS",
+    "LC_COLLATE",
+    "LC_CTYPE",
+    "LC_IDENTIFICATION",
+    "LC_MEASUREMENT",
+    "LC_MESSAGES",
+    "LC_MONETARY",
+    "LC_NAME",
+    "LC_NUMERIC",
+    "LC_PAPER",
+    "LC_TELEPHONE",
+    "LC_TIME",
+)
+_WINDOWS_ACCOUNT_KEYS = ("USERPROFILE", "HOMEDRIVE", "HOMEPATH", "USERNAME")
+_WINDOWS_REQUIRED_SYSTEM_KEYS = (
+    "APPDATA",
+    "LOCALAPPDATA",
+    "PROGRAMDATA",
+    "PROGRAMFILES",
+    "SYSTEMROOT",
+    "WINDIR",
+    "COMSPEC",
+    "PATHEXT",
+    "TEMP",
+    "TMP",
+)
+_WINDOWS_OPTIONAL_SYSTEM_KEYS = ("PROGRAMFILES(X86)", "PROGRAMW6432")
+
+
+@dataclass(frozen=True, slots=True)
+class ShellChoice:
+    """One discovered, code-owned shell picker choice.
+
+    Attributes:
+        key: Stable picker identity.
+        label: User-visible shell label.
+        family: Launch-policy family.
+        executable: Validated absolute executable path.
+        argv: Complete code-owned interactive launch arguments.
+    """
+
+    key: str
+    label: str
+    family: str
+    executable: Path
+    argv: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedLaunch:
+    """Immutable launch values ready for backend admission.
+
+    Attributes:
+        name: Validated display name.
+        shell: Discovered code-owned shell choice.
+        start_directory: Revalidated absolute existing directory.
+        environment: Immutable terminal-specific environment pairs.
+    """
+
+    name: str
+    shell: ShellChoice
+    start_directory: Path
+    environment: tuple[tuple[str, str], ...]
+
+
+def normalize_session_name(
+    name: str,
+    *,
+    existing_names: Iterable[str] = (),
+) -> str:
+    """Normalize and validate one terminal session display name.
+
+    Args:
+        name: Candidate user-visible name.
+        existing_names: Names held by live terminal records.
+
+    Returns:
+        Trimmed NFC-normalized name.
+
+    Raises:
+        TypeError: If the candidate is not text.
+        ValueError: If length, control, markup, or uniqueness checks fail.
+    """
+    if not isinstance(name, str):
+        raise TypeError("terminal session name must be text")
+    normalized = unicodedata.normalize("NFC", name.strip())
+    if not 1 <= len(normalized) <= 64:
+        raise ValueError("terminal session name must contain 1 to 64 characters")
+    if any(
+        unicodedata.category(character) in {"Cc", "Cf", "Cs"}
+        for character in normalized
+    ):
+        raise ValueError("terminal session name must not contain controls")
+    if "[" in normalized or "]" in normalized:
+        raise ValueError("terminal session name must not contain markup")
+    key = session_name_key(normalized)
+    if any(session_name_key(existing) == key for existing in existing_names):
+        raise ValueError("terminal session name must be unique")
+    return normalized
+
+
+def session_name_key(name: str) -> str:
+    """Return the normalized Unicode casefold uniqueness key.
+
+    Args:
+        name: Previously validated or existing display name.
+
+    Returns:
+        NFC-normalized, trimmed, casefolded key.
+    """
+    return unicodedata.normalize("NFC", name.strip()).casefold()
+
+
+def discover_shell_choices(
+    *,
+    platform_name: str | None = None,
+    account_shell: str | Path | None = None,
+    executable_lookup: Callable[[str], str | None] = shutil.which,
+    executable_is_file: Callable[[Path], bool] | None = None,
+) -> tuple[ShellChoice, ...]:
+    """Discover the fixed shell picker and resolve its Default choice.
+
+    Args:
+        platform_name: ``"posix"`` or ``"nt"``; defaults to ``os.name``.
+        account_shell: POSIX account shell path. Ignored on Windows.
+        executable_lookup: Injected executable lookup.
+        executable_is_file: Injected executable validation predicate.
+
+    Returns:
+        Default first, followed by discovered explicit family choices.
+
+    Raises:
+        ValueError: If the platform identity is unsupported.
+        FileNotFoundError: If no safe Default shell can be resolved.
+    """
+    platform_name = os.name if platform_name is None else platform_name
+    if platform_name not in {"posix", "nt"}:
+        raise ValueError(f"unsupported terminal platform: {platform_name!r}")
+    is_file = executable_is_file or _is_executable_file
+    if platform_name == "nt":
+        return _discover_windows_shells(executable_lookup, is_file)
+    if account_shell is None:
+        account_shell = _read_posix_account_shell()
+    return _discover_posix_shells(account_shell, executable_lookup, is_file)
+
+
+def resolve_shell_choice(
+    selector: str,
+    choices: Iterable[ShellChoice],
+) -> ShellChoice:
+    """Resolve an allowlisted picker key from discovered choices.
+
+    Args:
+        selector: Stable picker key.
+        choices: Result from :func:`discover_shell_choices`.
+
+    Returns:
+        Matching code-owned shell choice.
+
+    Raises:
+        ValueError: If the selector was not discovered.
+    """
+    for choice in choices:
+        if choice.key == selector:
+            return choice
+    raise ValueError(f"unsupported terminal shell choice: {selector!r}")
+
+
+def resolve_start_directory(
+    selected_local_root: Path | None,
+    *,
+    requested_directory: Path | None = None,
+    account_home: Path,
+) -> Path:
+    """Select and revalidate the terminal's initial directory.
+
+    Args:
+        selected_local_root: Late-bound selected local Console root, if any.
+        requested_directory: Optional explicit user-selected directory.
+        account_home: Real current-account home fallback.
+
+    Returns:
+        Normalized absolute existing directory.
+
+    Raises:
+        ValueError: If the final candidate is not an absolute existing directory.
+    """
+    candidate = requested_directory or selected_local_root or account_home
+    try:
+        return validate_existing_absolute_directory(candidate)
+    except ValueError:
+        raise ValueError(
+            "terminal start directory must be an absolute existing directory"
+        ) from None
+
+
+def build_terminal_environment(
+    *,
+    platform_name: str | None = None,
+    ambient: Mapping[str, str] | None = None,
+    account_reader: Callable[[], Mapping[str, str]] | None = None,
+    system_reader: Callable[[], Mapping[str, str]] | None = None,
+    path_is_directory: Callable[[str], bool] | None = None,
+    fallback_path: str | None = None,
+) -> dict[str, str]:
+    """Build the dedicated scrubbed environment for an interactive terminal.
+
+    Args:
+        platform_name: ``"posix"`` or ``"nt"``; defaults to ``os.name``.
+        ambient: Process environment used only for PATH and locale categories.
+        account_reader: Trusted current-account value reader.
+        system_reader: Trusted platform-system and temporary-value reader.
+        path_is_directory: Injected PATH component validator.
+        fallback_path: Platform fallback PATH when ambient PATH is absent.
+
+    Returns:
+        New environment mapping containing only approved values.
+
+    Raises:
+        ValueError: If the platform or a required approved value is unavailable.
+    """
+    platform_name = os.name if platform_name is None else platform_name
+    if platform_name not in {"posix", "nt"}:
+        raise ValueError(f"unsupported terminal platform: {platform_name!r}")
+    source = dict(os.environ if ambient is None else ambient)
+    if platform_name == "nt":
+        source = _uppercase_mapping(source)
+    account = _uppercase_mapping(
+        (account_reader or (lambda: _read_account_values(platform_name)))()
+    )
+    system = _uppercase_mapping(
+        (system_reader or (lambda: _read_system_values(platform_name)))()
+    )
+    path_value = source.get("PATH")
+    fallback = os.defpath if fallback_path is None else fallback_path
+    environment = {
+        "PATH": _validated_path(
+            path_value,
+            platform_name=platform_name,
+            is_directory=path_is_directory or _path_is_directory,
+            fallback=fallback,
+        )
+    }
+    if platform_name == "nt":
+        _copy_required(environment, account, _WINDOWS_ACCOUNT_KEYS, "account")
+        _copy_required(
+            environment,
+            system,
+            _WINDOWS_REQUIRED_SYSTEM_KEYS,
+            "platform",
+        )
+        _copy_optional(environment, system, _WINDOWS_OPTIONAL_SYSTEM_KEYS)
+        locale_keys = ("LANG", "LC_ALL")
+    else:
+        _copy_required(environment, account, _POSIX_ACCOUNT_KEYS, "account")
+        _copy_optional(environment, system, ("TMPDIR",))
+        locale_keys = _POSIX_LOCALE_KEYS
+    for key in locale_keys:
+        value = _safe_scalar(source.get(key), maximum=256)
+        if value is not None:
+            environment[key] = value
+    environment["TERM"] = "linux"
+    return environment
+
+
+def _discover_posix_shells(
+    account_shell: str | Path | None,
+    lookup: Callable[[str], str | None],
+    is_file: Callable[[Path], bool],
+) -> tuple[ShellChoice, ...]:
+    discovered = {
+        name: _validated_executable(
+            lookup(name), platform_name="posix", is_file=is_file
+        )
+        for name in ("bash", "zsh", "sh")
+    }
+    account = _validated_executable(
+        account_shell,
+        platform_name="posix",
+        is_file=is_file,
+    )
+    default_path = account or discovered["bash"] or discovered["sh"]
+    if default_path is None:
+        raise FileNotFoundError("persistent terminal shell is unavailable")
+    default_family = (
+        _posix_family(default_path)
+        if account is not None
+        else ("bash" if discovered["bash"] == default_path else "sh")
+    )
+    choices = [
+        _shell_choice(
+            key="default",
+            label="Default",
+            family=default_family,
+            executable=default_path,
+        )
+    ]
+    for family, label in (("bash", "Bash"), ("zsh", "Zsh")):
+        executable = discovered[family]
+        if executable is not None:
+            choices.append(
+                _shell_choice(
+                    key=family,
+                    label=label,
+                    family=family,
+                    executable=executable,
+                )
+            )
+    return tuple(choices)
+
+
+def _discover_windows_shells(
+    lookup: Callable[[str], str | None],
+    is_file: Callable[[Path], bool],
+) -> tuple[ShellChoice, ...]:
+    discovered = {
+        key: _validated_executable(name, platform_name="nt", is_file=is_file)
+        for key, name in (
+            ("pwsh", lookup("pwsh.exe")),
+            ("powershell", lookup("powershell.exe")),
+            ("cmd", lookup("cmd.exe")),
+        )
+    }
+    default_key = next(
+        (key for key in ("pwsh", "powershell", "cmd") if discovered[key]),
+        None,
+    )
+    if default_key is None:
+        raise FileNotFoundError("persistent terminal shell is unavailable")
+    family = "powershell" if default_key != "cmd" else "cmd"
+    default_path = discovered[default_key]
+    assert default_path is not None
+    choices = [
+        _shell_choice(
+            key="default",
+            label="Default",
+            family=family,
+            executable=default_path,
+        )
+    ]
+    for key, label in (
+        ("pwsh", "PowerShell 7"),
+        ("powershell", "Windows PowerShell"),
+        ("cmd", "Command Prompt"),
+    ):
+        executable = discovered[key]
+        if executable is not None:
+            choices.append(
+                _shell_choice(
+                    key=key,
+                    label=label,
+                    family="powershell" if key != "cmd" else "cmd",
+                    executable=executable,
+                )
+            )
+    return tuple(choices)
+
+
+def _shell_choice(
+    *,
+    key: str,
+    label: str,
+    family: str,
+    executable: Path,
+) -> ShellChoice:
+    text = str(executable)
+    if family == "bash":
+        argv = (text, "--login", "-i")
+    elif family in {"zsh", "sh"}:
+        argv = (text, "-l", "-i")
+    elif family == "account":
+        argv = (f"-{executable.name}",)
+    elif family == "powershell":
+        argv = (text, "-NoLogo")
+    elif family == "cmd":
+        argv = (text, "/Q")
+    else:
+        raise ValueError(f"unsupported terminal shell family: {family!r}")
+    return ShellChoice(
+        key=key,
+        label=label,
+        family=family,
+        executable=executable,
+        argv=argv,
+    )
+
+
+def _posix_family(executable: Path) -> str:
+    name = executable.name.casefold()
+    return name if name in {"bash", "zsh", "sh"} else "account"
+
+
+def _validated_executable(
+    candidate: str | Path | None,
+    *,
+    platform_name: str,
+    is_file: Callable[[Path], bool],
+) -> Path | None:
+    if candidate is None:
+        return None
+    text = str(candidate)
+    path_module = ntpath if platform_name == "nt" else posixpath
+    if "\x00" in text or not path_module.isabs(text):
+        return None
+    path = Path(text)
+    try:
+        return path if is_file(path) else None
+    except OSError:
+        return None
+
+
+def _is_executable_file(path: Path) -> bool:
+    return path.is_file() and os.access(path, os.X_OK)
+
+
+def _read_account_values(platform_name: str) -> Mapping[str, str]:
+    if platform_name == "nt":
+        values = _read_windows_environment_block()
+        return {key: values[key] for key in _WINDOWS_ACCOUNT_KEYS if key in values}
+    try:
+        import pwd
+
+        account = pwd.getpwuid(os.getuid())
+    except (ImportError, KeyError, OSError) as exc:
+        raise ValueError("POSIX account values are unavailable") from exc
+    return {
+        "HOME": account.pw_dir,
+        "USER": account.pw_name,
+        "LOGNAME": account.pw_name,
+        "SHELL": account.pw_shell,
+    }
+
+
+def _read_posix_account_shell() -> str | None:
+    try:
+        import pwd
+
+        return pwd.getpwuid(os.getuid()).pw_shell
+    except (ImportError, KeyError, OSError):
+        return None
+
+
+def _read_system_values(platform_name: str) -> Mapping[str, str]:
+    if platform_name == "nt":
+        values = _read_windows_environment_block()
+        keys = _WINDOWS_REQUIRED_SYSTEM_KEYS + _WINDOWS_OPTIONAL_SYSTEM_KEYS
+        return {key: values[key] for key in keys if key in values}
+    return {"TMPDIR": tempfile.gettempdir()}
+
+
+def _read_windows_environment_block() -> dict[str, str]:
+    """Read the current account's environment through native Windows APIs."""
+    if os.name != "nt":
+        raise ValueError("Windows platform values are unavailable")
+
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+    userenv = ctypes.WinDLL("userenv", use_last_error=True)
+    kernel32.GetCurrentProcess.argtypes = []
+    kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    advapi32.OpenProcessToken.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.HANDLE),
+    ]
+    advapi32.OpenProcessToken.restype = wintypes.BOOL
+    userenv.CreateEnvironmentBlock.argtypes = [
+        ctypes.POINTER(ctypes.c_void_p),
+        wintypes.HANDLE,
+        wintypes.BOOL,
+    ]
+    userenv.CreateEnvironmentBlock.restype = wintypes.BOOL
+    userenv.DestroyEnvironmentBlock.argtypes = [ctypes.c_void_p]
+    userenv.DestroyEnvironmentBlock.restype = wintypes.BOOL
+
+    token = wintypes.HANDLE()
+    if not advapi32.OpenProcessToken(
+        kernel32.GetCurrentProcess(),
+        0x000A,  # TOKEN_QUERY | TOKEN_DUPLICATE
+        ctypes.byref(token),
+    ):
+        raise ValueError("Windows account values are unavailable")
+    block = ctypes.c_void_p()
+    try:
+        if not userenv.CreateEnvironmentBlock(ctypes.byref(block), token, False):
+            raise ValueError("Windows platform values are unavailable")
+        return _parse_windows_environment_block(block)
+    finally:
+        if block.value:
+            userenv.DestroyEnvironmentBlock(block)
+        kernel32.CloseHandle(token)
+
+
+def _parse_windows_environment_block(block: object) -> dict[str, str]:
+    """Parse one trusted, double-NUL-terminated Windows environment block."""
+    import ctypes
+
+    characters = ctypes.cast(block, ctypes.POINTER(ctypes.c_wchar))
+    result: dict[str, str] = {}
+    offset = 0
+    maximum_characters = 131_072
+    while offset < maximum_characters:
+        start = offset
+        while offset < maximum_characters and characters[offset] != "\x00":
+            offset += 1
+        if offset == maximum_characters:
+            break
+        if offset == start:
+            return result
+        entry = "".join(characters[index] for index in range(start, offset))
+        offset += 1
+        if entry.startswith("="):
+            continue
+        key, separator, value = entry.partition("=")
+        if separator and key:
+            result[key.upper()] = value
+    raise ValueError("Windows platform environment is malformed")
+
+
+def _uppercase_mapping(source: Mapping[str, str]) -> dict[str, str]:
+    return {str(key).upper(): value for key, value in source.items()}
+
+
+def _copy_required(
+    target: dict[str, str],
+    source: Mapping[str, str],
+    keys: Iterable[str],
+    source_name: str,
+) -> None:
+    for key in keys:
+        value = _safe_scalar(source.get(key))
+        if value is None:
+            raise ValueError(f"terminal {source_name} value {key} is unavailable")
+        target[key] = value
+
+
+def _copy_optional(
+    target: dict[str, str],
+    source: Mapping[str, str],
+    keys: Iterable[str],
+) -> None:
+    for key in keys:
+        value = _safe_scalar(source.get(key))
+        if value is not None:
+            target[key] = value
+
+
+def _safe_scalar(value: object, *, maximum: int = 4096) -> str | None:
+    if not isinstance(value, str) or not value or len(value) > maximum:
+        return None
+    if any(unicodedata.category(character) == "Cc" for character in value):
+        return None
+    return value
+
+
+def _validated_path(
+    value: str | None,
+    *,
+    platform_name: str,
+    is_directory: Callable[[str], bool],
+    fallback: str,
+) -> str:
+    separator = ";" if platform_name == "nt" else os.pathsep
+    path_module = ntpath if platform_name == "nt" else posixpath
+    accepted: list[str] = []
+    seen: set[str] = set()
+    for raw in (value or fallback).split(separator):
+        if not raw or "\x00" in raw or not path_module.isabs(raw):
+            continue
+        try:
+            available = is_directory(raw)
+        except OSError:
+            available = False
+        key = raw.casefold() if platform_name == "nt" else raw
+        if available and key not in seen:
+            accepted.append(raw)
+            seen.add(key)
+    if not accepted:
+        raise ValueError("terminal PATH has no existing absolute directory")
+    return separator.join(accepted)
+
+
+def _path_is_directory(path: str) -> bool:
+    return Path(path).is_dir()

--- a/tldw_chatbook/Terminal/launch.py
+++ b/tldw_chatbook/Terminal/launch.py
@@ -12,6 +12,10 @@ import shutil
 import tempfile
 import unicodedata
 
+from tldw_chatbook.Utils.input_validation import (
+    TerminalEnvironmentInput,
+    TerminalSessionNameInput,
+)
 from tldw_chatbook.Utils.path_validation import (
     validate_existing_absolute_directory,
 )
@@ -50,7 +54,7 @@ _WINDOWS_REQUIRED_SYSTEM_KEYS = (
 _WINDOWS_OPTIONAL_SYSTEM_KEYS = ("PROGRAMFILES(X86)", "PROGRAMW6432")
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, init=False)
 class ShellChoice:
     """One discovered, code-owned shell picker choice.
 
@@ -68,8 +72,11 @@ class ShellChoice:
     executable: Path
     argv: tuple[str, ...]
 
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        raise TypeError("ShellChoice must be created by terminal launch policy")
 
-@dataclass(frozen=True, slots=True)
+
+@dataclass(frozen=True, slots=True, init=False)
 class ResolvedLaunch:
     """Immutable launch values ready for backend admission.
 
@@ -84,6 +91,9 @@ class ResolvedLaunch:
     shell: ShellChoice
     start_directory: Path
     environment: tuple[tuple[str, str], ...]
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        raise TypeError("ResolvedLaunch must be created by terminal launch policy")
 
 
 def normalize_session_name(
@@ -104,18 +114,7 @@ def normalize_session_name(
         TypeError: If the candidate is not text.
         ValueError: If length, control, markup, or uniqueness checks fail.
     """
-    if not isinstance(name, str):
-        raise TypeError("terminal session name must be text")
-    normalized = unicodedata.normalize("NFC", name.strip())
-    if not 1 <= len(normalized) <= 64:
-        raise ValueError("terminal session name must contain 1 to 64 characters")
-    if any(
-        unicodedata.category(character) in {"Cc", "Cf", "Cs"}
-        for character in normalized
-    ):
-        raise ValueError("terminal session name must not contain controls")
-    if "[" in normalized or "]" in normalized:
-        raise ValueError("terminal session name must not contain markup")
+    normalized = TerminalSessionNameInput(name=name).name
     key = session_name_key(normalized)
     if any(session_name_key(existing) == key for existing in existing_names):
         raise ValueError("terminal session name must be unique")
@@ -184,7 +183,7 @@ def resolve_shell_choice(
         ValueError: If the selector was not discovered.
     """
     for choice in choices:
-        if choice.key == selector:
+        if type(choice) is ShellChoice and choice.key == selector:
             return choice
     raise ValueError(f"unsupported terminal shell choice: {selector!r}")
 
@@ -217,6 +216,62 @@ def resolve_start_directory(
         ) from None
 
 
+def resolve_launch(
+    *,
+    name: str,
+    shell_selector: str,
+    shell_choices: Iterable[ShellChoice],
+    selected_local_root: Path | None,
+    account_home: Path,
+    existing_names: Iterable[str] = (),
+    requested_directory: Path | None = None,
+    platform_name: str | None = None,
+    ambient: Mapping[str, str] | None = None,
+    account_reader: Callable[[], Mapping[str, str]] | None = None,
+    system_reader: Callable[[], Mapping[str, str]] | None = None,
+    path_is_directory: Callable[[str], bool] | None = None,
+    fallback_path: str | None = None,
+) -> ResolvedLaunch:
+    """Resolve every backend launch value through one policy boundary.
+
+    Args:
+        name: Candidate user-visible session name.
+        shell_selector: Stable key from the discovered shell picker.
+        shell_choices: Choices returned by :func:`discover_shell_choices`.
+        selected_local_root: Late-bound selected local Console root, if any.
+        account_home: Real current-account home fallback.
+        existing_names: Names held by live terminal records.
+        requested_directory: Optional explicit user-selected directory.
+        platform_name: ``"posix"`` or ``"nt"``; defaults to ``os.name``.
+        ambient: Process environment source for approved ambient values.
+        account_reader: Trusted current-account value reader.
+        system_reader: Trusted platform-system value reader.
+        path_is_directory: Injected PATH component validator.
+        fallback_path: Platform fallback PATH when ambient PATH is absent.
+
+    Returns:
+        One immutable launch value ready for backend admission.
+    """
+    environment = build_terminal_environment(
+        platform_name=platform_name,
+        ambient=ambient,
+        account_reader=account_reader,
+        system_reader=system_reader,
+        path_is_directory=path_is_directory,
+        fallback_path=fallback_path,
+    )
+    return _new_resolved_launch(
+        name=normalize_session_name(name, existing_names=existing_names),
+        shell=resolve_shell_choice(shell_selector, shell_choices),
+        start_directory=resolve_start_directory(
+            selected_local_root,
+            requested_directory=requested_directory,
+            account_home=account_home,
+        ),
+        environment=tuple(environment.items()),
+    )
+
+
 def build_terminal_environment(
     *,
     platform_name: str | None = None,
@@ -245,15 +300,19 @@ def build_terminal_environment(
     platform_name = os.name if platform_name is None else platform_name
     if platform_name not in {"posix", "nt"}:
         raise ValueError(f"unsupported terminal platform: {platform_name!r}")
-    source = dict(os.environ if ambient is None else ambient)
+    validated = TerminalEnvironmentInput(
+        platform_name=platform_name,
+        ambient=dict(os.environ if ambient is None else ambient),
+        account=dict(
+            (account_reader or (lambda: _read_account_values(platform_name)))()
+        ),
+        system=dict((system_reader or (lambda: _read_system_values(platform_name)))()),
+    )
+    source = validated.ambient
     if platform_name == "nt":
         source = _uppercase_mapping(source)
-    account = _uppercase_mapping(
-        (account_reader or (lambda: _read_account_values(platform_name)))()
-    )
-    system = _uppercase_mapping(
-        (system_reader or (lambda: _read_system_values(platform_name)))()
-    )
+    account = _uppercase_mapping(validated.account)
+    system = _uppercase_mapping(validated.system)
     path_value = source.get("PATH")
     fallback = os.defpath if fallback_path is None else fallback_path
     environment = {
@@ -399,13 +458,45 @@ def _shell_choice(
         argv = (text, "/Q")
     else:
         raise ValueError(f"unsupported terminal shell family: {family!r}")
-    return ShellChoice(
+    return _new_shell_choice(
         key=key,
         label=label,
         family=family,
         executable=executable,
         argv=argv,
     )
+
+
+def _new_shell_choice(
+    *,
+    key: str,
+    label: str,
+    family: str,
+    executable: Path,
+    argv: tuple[str, ...],
+) -> ShellChoice:
+    choice = object.__new__(ShellChoice)
+    object.__setattr__(choice, "key", key)
+    object.__setattr__(choice, "label", label)
+    object.__setattr__(choice, "family", family)
+    object.__setattr__(choice, "executable", executable)
+    object.__setattr__(choice, "argv", argv)
+    return choice
+
+
+def _new_resolved_launch(
+    *,
+    name: str,
+    shell: ShellChoice,
+    start_directory: Path,
+    environment: tuple[tuple[str, str], ...],
+) -> ResolvedLaunch:
+    launch = object.__new__(ResolvedLaunch)
+    object.__setattr__(launch, "name", name)
+    object.__setattr__(launch, "shell", shell)
+    object.__setattr__(launch, "start_directory", start_directory)
+    object.__setattr__(launch, "environment", environment)
+    return launch
 
 
 def _posix_family(executable: Path) -> str:
@@ -609,4 +700,8 @@ def _validated_path(
 
 
 def _path_is_directory(path: str) -> bool:
-    return Path(path).is_dir()
+    try:
+        validate_existing_absolute_directory(path)
+    except ValueError:
+        return False
+    return True

--- a/tldw_chatbook/Tools/file_operation_tools.py
+++ b/tldw_chatbook/Tools/file_operation_tools.py
@@ -1338,15 +1338,12 @@ def _run_grep_subprocess(
     unconditionally, regardless of what the process is doing.
 
     Why a subprocess rather than the third-party `regex` module (which
-    supports `timeout=`): `regex` is not a direct OR declared optional
-    dependency of this project (checked against `pyproject.toml`) -- it is
-    only present at all, transitively, through unrelated optional extras
-    (`nltk`/`transformers`/`dateparser`, pulled in by the RAG/embeddings
-    extras). `grep_files` is a core built-in, reachable with no extras
-    installed; depending on `regex` here would make a currently-optional,
-    transitive package a hard requirement for the base install. A
-    subprocess adds no new dependency and works with the stdlib `re`
-    already in use.
+    supports `timeout=`): `regex` is now a direct core dependency for bounded
+    UAX #29 session-name segmentation, but `grep_files` accepts arbitrary
+    patterns and file content. Keeping that search in a child gives the OS an
+    unconditional kill boundary even if an engine timeout or worker thread
+    fails to return. The subprocess continues to use the stdlib `re` engine so
+    this safety property does not depend on a second matching implementation.
 
     This function is a BLOCKING call (`Popen.communicate(timeout=...)`);
     `GrepFiles.execute` runs it via `asyncio.to_thread` rather than

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -382,7 +382,7 @@ def _raw_cli_persist_session_if_needed(
     return screen._ensure_console_chat_store().persist_session_if_needed(session_id)
 
 
-def _raw_cli_selected_local_root(screen: Any, session_id: str) -> Path | None:
+def _selected_console_local_root(screen: Any, session_id: str) -> Path | None:
     """Resolve the session's selected local-folder binding, if still usable."""
     store = screen._ensure_console_chat_store()
     session = next(
@@ -1651,7 +1651,7 @@ def build_console_controllers(
             )
         ),
         selected_local_root=(
-            lambda session_id: _raw_cli_selected_local_root(screen, session_id)
+            lambda session_id: _selected_console_local_root(screen, session_id)
         ),
         private_scratch_root=(
             lambda session_id: (

--- a/tldw_chatbook/Utils/input_validation.py
+++ b/tldw_chatbook/Utils/input_validation.py
@@ -4,11 +4,14 @@ Input validation utilities for secure user input handling.
 
 import re
 import ipaddress
+from itertools import islice
 import time
+import unicodedata
 from typing import Literal, Optional, Union
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+import regex
 
 from ..Metrics.metrics_logger import log_counter, log_histogram
 
@@ -18,6 +21,10 @@ CONSOLE_DRAFT_MAX_LENGTH = 100_000
 CONSOLE_FORK_TITLE_MAX_LENGTH = 60
 RAW_CLI_COMMAND_MAX_BYTES = 16 * 1024
 RAW_CLI_TIMEOUT_MAX_SECONDS = 300.0
+TERMINAL_SESSION_NAME_MIN_DISPLAY_CHARACTERS = 1
+TERMINAL_SESSION_NAME_MAX_DISPLAY_CHARACTERS = 64
+TERMINAL_SESSION_NAME_MAX_CODEPOINTS = 1_024
+_EXTENDED_GRAPHEME_PATTERN = regex.compile(r"\X", regex.VERSION1)
 
 
 def derive_console_session_title(draft: str, *, max_length: int) -> str:
@@ -68,6 +75,67 @@ class ConsoleForkTitleInput(BaseModel):
     @classmethod
     def _normalize_title(cls, value: object) -> str:
         return validate_console_fork_title(value)
+
+
+class TerminalSessionNameInput(BaseModel):
+    """Strict shared boundary for a persistent-terminal display name."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    name: str
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _normalize_name(cls, value: object) -> str:
+        if not isinstance(value, str):
+            raise TypeError("terminal session name must be text")
+        if len(value) > TERMINAL_SESSION_NAME_MAX_CODEPOINTS:
+            raise ValueError(
+                "terminal session name must contain at most "
+                f"{TERMINAL_SESSION_NAME_MAX_CODEPOINTS} code points"
+            )
+        normalized = unicodedata.normalize("NFC", value.strip())
+        if len(normalized) > TERMINAL_SESSION_NAME_MAX_CODEPOINTS:
+            raise ValueError(
+                "terminal session name must contain at most "
+                f"{TERMINAL_SESSION_NAME_MAX_CODEPOINTS} code points"
+            )
+        grapheme_count = sum(
+            1
+            for _match in islice(
+                _EXTENDED_GRAPHEME_PATTERN.finditer(normalized),
+                TERMINAL_SESSION_NAME_MAX_DISPLAY_CHARACTERS + 1,
+            )
+        )
+        if not (
+            TERMINAL_SESSION_NAME_MIN_DISPLAY_CHARACTERS
+            <= grapheme_count
+            <= TERMINAL_SESSION_NAME_MAX_DISPLAY_CHARACTERS
+        ):
+            raise ValueError(
+                "terminal session name must contain "
+                f"{TERMINAL_SESSION_NAME_MIN_DISPLAY_CHARACTERS} to "
+                f"{TERMINAL_SESSION_NAME_MAX_DISPLAY_CHARACTERS} characters"
+            )
+        if any(
+            unicodedata.category(character) in {"Cc", "Cf", "Cs"}
+            for character in normalized
+        ):
+            raise ValueError("terminal session name must not contain controls")
+        if "[" in normalized or "]" in normalized:
+            raise ValueError("terminal session name must not contain markup")
+        return normalized
+
+
+class TerminalEnvironmentInput(BaseModel):
+    """Strict shared boundary for persistent-terminal environment sources."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    platform_name: Literal["posix", "nt"]
+    ambient: dict[str, str]
+    account: dict[str, str]
+    system: dict[str, str]
 
 
 class RawShellExecInput(BaseModel):
@@ -311,9 +379,13 @@ def validate_git_repo_url(url: str) -> None:
     if url != url.strip() or any(c.isspace() for c in url):
         raise ValidationError("repo_url must not contain whitespace")
     if "\\" in url or any(ord(c) < 0x20 for c in url):
-        raise ValidationError("repo_url must not contain backslashes or control characters")
+        raise ValidationError(
+            "repo_url must not contain backslashes or control characters"
+        )
     if not url.isprintable():
-        raise ValidationError("repo_url must not contain non-printable/zero-width characters")
+        raise ValidationError(
+            "repo_url must not contain non-printable/zero-width characters"
+        )
     if url.startswith("-"):
         raise ValidationError("repo_url must not start with '-' (git-option injection)")
     try:
@@ -327,8 +399,12 @@ def validate_git_repo_url(url: str) -> None:
         )
     if not parsed.hostname:
         raise ValidationError("repo_url must include a host")
-    if (parsed.hostname or "").startswith("-") or (parsed.username or "").startswith("-"):
-        raise ValidationError("repo_url host/user must not start with '-' (ssh option injection)")
+    if (parsed.hostname or "").startswith("-") or (parsed.username or "").startswith(
+        "-"
+    ):
+        raise ValidationError(
+            "repo_url host/user must not start with '-' (ssh option injection)"
+        )
 
 
 def validate_git_ref(ref: str) -> None:


### PR DESCRIPTION
## Summary

- add the pure persistent-terminal launch boundary for validated names, fixed shell discovery, code-owned argv, starting directories, and immutable launch values
- build a dedicated scrubbed interactive-shell environment with explicit POSIX/Windows allowlists and native Windows account/platform readers
- generalize the Console selected-local-root seam, record Task 3/4 plan completion, and refresh the formatter baseline against the rebased dev SHA

This slice does not start processes, add a PTY backend, or expose Terminal UI.

## Verification

- `359 passed, 1 skipped` across terminal contracts, launch, qualification, formatter-ratchet, import-provenance, and Console wiring tests
- native-Windows environment-reader test is the one expected skip on macOS
- Ruff check passed
- Ruff format check passed
- formatter ratchet passed
- `git diff --check` passed

## Governance

- TASK-22512
- ADR-099: persistent terminal session runtime boundary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the pure persistent-terminal launch boundary for TASK-22512: validated session names, fixed shell discovery, code-owned argv, starting directories, immutable launch values, and a scrubbed interactive-shell environment, without starting processes, adding a PTY backend, or exposing Terminal UI.

**What changed**
- New `tldw_chatbook/Terminal/launch.py` module with its test suite in `Tests/Terminal/test_launch.py`.
- Session names are 1-64 UAX #29 extended grapheme clusters with a 1,024-code-point ceiling, backed by the new qualified `regex==2026.4.4` dependency (ADR-099 updated).
- Shell choices are fixed families (bash/zsh/sh on POSIX; pwsh/PowerShell/CMD on Windows) with no arbitrary executable picker entry.
- Environment builder uses explicit POSIX/Windows allowlists and native account/platform readers; ambient secrets, proxies, tracing, and Python injection keys never cross.
- Renamed `_raw_cli_selected_local_root` to `_selected_console_local_root` in `Console_Modules/wiring.py` so raw CLI and terminal launch share the same selected-root seam.
- Revalidates the final absolute existing start directory, falling back to selected root then real account home.
- Refreshed the formatter baseline and checked off completed plan steps in the implementation plan.

<sup>Written for commit b8b5c8180fce848f75c0c5b0ee8e1ec91e99085b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

