### PR TITLE
fix(console): restore published defaults for blank sessions

### DIFF
--- a/Tests/Chat/test_console_context_policy_lifecycle.py
+++ b/Tests/Chat/test_console_context_policy_lifecycle.py
@@ -340,9 +340,9 @@ async def test_effective_thinking_policy_uses_send_continuation_groups(
         role=ConsoleMessageRole.ASSISTANT,
         content="answer",
     )
-    store._message_or_raise(owner.id).provider_continuation = (
-        _thinking_policy_checkpoint(state=checkpoint_state)
-    )
+    store._message_or_raise(
+        owner.id
+    ).provider_continuation = _thinking_policy_checkpoint(state=checkpoint_state)
     controller = ConsoleChatController(
         store=store,
         provider_gateway=_ThinkingPolicyGateway(model=resolved_model),
@@ -377,13 +377,21 @@ async def test_new_conversation_uses_store_default_without_post_create_write() -
     )
     controller._capture_console_draft_switch_snapshot = lambda: None
     controller._refresh_console_library_policy_defaults = lambda: None
-    controller._active_console_session_settings = lambda: None
-    controller._default_console_session_settings = lambda: ConsoleSessionSettings(
+    controller._blank_console_session_settings = lambda: ConsoleSessionSettings(
         provider="llama_cpp",
         model="model-a",
     )
+    controller._console_new_chat_default_generation = lambda: 0
+    controller._workspace_default_for_new_session = lambda: None
+
+    def _new_session(**kwargs):
+        generation = kwargs.pop("new_chat_default_generation")
+        session = store.create_session(**kwargs)
+        session.new_chat_default_generation = generation
+        return session
+
     controller._ensure_console_chat_controller_fn = lambda: SimpleNamespace(
-        new_session=lambda **kwargs: store.create_session(**kwargs)
+        new_session=_new_session
     )
     controller._invalidate_persisted_rows_cache_fn = lambda: None
 
@@ -397,3 +405,7 @@ async def test_new_conversation_uses_store_default_without_post_create_write() -
     await controller._create_native_console_session_from_active_context()
 
     assert store.sessions()[0].thinking_history_policy == "exclude"
+    assert store.sessions()[0].settings == ConsoleSessionSettings(
+        provider="llama_cpp",
+        model="model-a",
+    )

--- a/Tests/Chat/test_workspace_default_session.py
+++ b/Tests/Chat/test_workspace_default_session.py
@@ -172,9 +172,7 @@ def test_helper_skips_global_default_and_missing_workspaces():
 
 
 def test_helper_skips_archived_workspaces():
-    host = _host(
-        "w-1", workspace=_workspace("w-1", archived=True)
-    )
+    host = _host("w-1", workspace=_workspace("w-1", archived=True))
     assert _resolve_workspace_default(host) is None
 
 
@@ -314,9 +312,7 @@ def test_existing_sessions_independent_of_later_default_edits():
         }
     )
 
-    reloaded = next(
-        item for item in store.sessions() if item.id == session.id
-    )
+    reloaded = next(item for item in store.sessions() if item.id == session.id)
     after = (
         reloaded.assistant_kind,
         reloaded.assistant_id,
@@ -326,11 +322,11 @@ def test_existing_sessions_independent_of_later_default_edits():
     assert before == after
 
 
-# -- Fix round 1: startup settings/identity selection ------------------------
+# -- Startup settings/identity selection ------------------------------------
 
 
 class StartupHost(StubHost):
-    """Host for `_new_session_startup_settings` (fix round 1 seam)."""
+    """Host for the unbound ``_new_session_startup_settings`` seam."""
 
     def __init__(self, app, store):
         super().__init__(app, store)
@@ -348,7 +344,19 @@ class StartupHost(StubHost):
             return None
 
     def _default_console_session_settings(self):
-        return default_console_session_settings({}, "llama_cpp")
+        return ConsoleSessionSettings(
+            provider="local_llamacpp",
+            model="active-control-model",
+            temperature=1.4,
+        )
+
+    def _blank_console_session_settings(self):
+        return ConsoleSessionSettings(
+            provider="openai",
+            model="published-model",
+            temperature=0.23,
+            streaming=False,
+        )
 
     def _workspace_default_for_new_session(self):
         return ConsoleSessionController._workspace_default_for_new_session(self)
@@ -361,19 +369,14 @@ def _startup_host(workspace_id="w-1", *, workspace=None, persona=PERSONA):
     registry = StubRegistry(
         {} if workspace is None else {workspace.workspace_id: workspace}
     )
-    return StartupHost(
-        StubApp(registry, StubPersonas(records)), _store(workspace_id)
-    )
+    return StartupHost(StubApp(registry, StubPersonas(records)), _store(workspace_id))
 
 
 def _startup(host):
     return ConsoleSessionController._new_session_startup_settings(host)
 
 
-def test_persona_carry_stamps_persona_identity_on_new_tab():
-    # Fix round 1 (Important #1): a new tab after a persona-defaulted tab
-    # must carry BOTH the persona settings and the persona identity --
-    # never a persona snapshot on a generic-identity record.
+def test_new_tab_re_resolves_workspace_persona_on_published_defaults():
     host = _startup_host()
     workspace_default = ConsoleSessionController._workspace_default_for_new_session(
         host
@@ -381,7 +384,7 @@ def test_persona_carry_stamps_persona_identity_on_new_tab():
     assert workspace_default is not None
     assistant_id, label, prompt, memory_mode = workspace_default
     stamped = replace(
-        default_console_session_settings({}, "llama_cpp"),
+        host._default_console_session_settings(),
         system_prompt=prompt,
         character_label=label,
         persona_memory_mode=memory_mode,
@@ -392,7 +395,9 @@ def test_persona_carry_stamps_persona_identity_on_new_tab():
         assistant_id=assistant_id,
     )
     settings, assistant_kwargs = _startup(host)
-    assert settings is stamped
+    assert settings is not stamped
+    assert (settings.provider, settings.model) == ("openai", "published-model")
+    assert settings.temperature == 0.23
     assert assistant_kwargs == {
         "assistant_kind": "persona",
         "assistant_id": "local-persona-1",
@@ -400,10 +405,7 @@ def test_persona_carry_stamps_persona_identity_on_new_tab():
     }
 
 
-def test_pristine_carry_falls_through_to_workspace_default():
-    # Fix round 1 (related concern): a persona-free first tab whose carried
-    # snapshot still equals its canonical baseline is not an explicit
-    # choice -- later plain tabs get the workspace default.
+def test_plain_new_tab_ignores_pristine_active_session():
     host = _startup_host()
     defaults = default_console_session_settings({}, "llama_cpp")
     host._store.create_session(
@@ -417,22 +419,24 @@ def test_pristine_carry_falls_through_to_workspace_default():
     assert "You are a literary companion." in settings.system_prompt
 
 
-def test_explicit_plain_carry_still_suppresses_workspace_default():
-    # A snapshot that DIVERGED from its baseline is a user choice; it rides
-    # forward unchanged and generic, with no workspace-default injection.
+def test_plain_new_tab_does_not_clone_active_settings():
     host = _startup_host()
-    defaults = default_console_session_settings({}, "llama_cpp")
+    defaults = host._default_console_session_settings()
     explicit = replace(defaults, temperature=0.11)
-    # No canonical baseline: the snapshot diverged from any provenance, the
-    # same shape a user-edited session has.
     host._store.create_session(settings=explicit)
     settings, assistant_kwargs = _startup(host)
-    assert settings is explicit
-    assert assistant_kwargs == {}
+    assert settings is not explicit
+    assert (settings.provider, settings.model) == ("openai", "published-model")
+    assert settings.temperature == 0.23
+    assert assistant_kwargs["assistant_kind"] == "persona"
+    assert assistant_kwargs["assistant_id"] == "local-persona-1"
 
 
 def test_no_active_session_stamps_workspace_default():
     host = _startup_host()
     settings, assistant_kwargs = _startup(host)
     assert assistant_kwargs["assistant_kind"] == "persona"
+    assert (settings.provider, settings.model) == ("openai", "published-model")
+    assert settings.temperature == 0.23
+    assert settings.streaming is False
     assert settings.persona_memory_mode == "read_only"

--- a/backlog/tasks/task-25707 - Restore-published-defaults-for-blank-Console-sessions.md
+++ b/backlog/tasks/task-25707 - Restore-published-defaults-for-blank-Console-sessions.md
@@ -1,0 +1,56 @@
+---
+id: TASK-25707
+title: Restore published defaults for blank Console sessions
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-08-30 19:48'
+updated_date: '2026-08-30 19:58'
+labels:
+  - console
+  - settings
+  - workspaces
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure every eligible blank Console creation path continues to use the app-published new-chat defaults after workspace-assistant startup selection was introduced, so live provider controls or readiness snapshots cannot leak into unrelated new chats.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Ctrl+T and temporary blank Console sessions use the app-published provider, model, model-profile values, and default generation
+- [x] #2 Workspace-created blank sessions use the same app-published settings snapshot
+- [x] #3 Workspace default personas are stamped onto the published blank snapshot without weakening explicit source-owned session behavior
+- [x] #4 Targeted Console session and workspace-default regression tests plus static checks pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm the regression and ownership contract against ADR-095 and ADR-079, and verify no duplicate in-flight fix.
+2. Change the plain new-session startup fallback to use the app-owned published blank-settings snapshot while preserving workspace-persona stamping and explicit source-owned carry behavior.
+3. Extend the focused workspace-default seam tests so published-default provenance remains explicit, then run the Console session-controller and workspace-default targeted suites plus Ruff and diff checks.
+4. Self-review the final diff, complete the acceptance criteria and implementation notes, and follow the normal dev PR/review/merge workflow.
+
+ADR required: no
+ADR path: backlog/decisions/095-conversation-owned-console-generation-settings.md and backlog/decisions/079-workspace-assistant-defaults.md
+Reason: This is a narrow regression fix restoring the already-decided blank-chat ownership and workspace-persona startup contracts; no storage, security, or interface boundary changes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Restored ADR-095 blank-chat ownership by making the plain new-session selector always start from the app-published blank settings snapshot instead of cloning active controls or active-session settings. ADR-079 workspace default personas are still resolved and stamped onto that fresh snapshot; source-owned controller, handoff, character, retry, continue, and branch paths remain separate and unchanged.
+
+Updated workspace startup regressions to distinguish published defaults from active controls, and repaired the synthetic context-policy constructor fixture to model the current controller contract explicitly. Ruff formatting was applied only to the three touched Python files.
+
+Verification: 67 targeted tests passed; Ruff lint passed; Ruff format check passed; git diff --check passed. Existing warnings are limited to third-party requests/audioop deprecations.
+
+ADR required: no. Existing ADR-095 and ADR-079 govern the repaired behavior.
+
+Modified files: tldw_chatbook/UI/Console_Modules/session.py; Tests/Chat/test_workspace_default_session.py; Tests/Chat/test_console_context_policy_lifecycle.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -244,10 +244,6 @@ from ...Widgets.Console.console_reaction_picker_modal import (
 )
 from ...Widgets.Console.console_session_switcher_modal import ConsoleSwitcherChoice
 from ...Workspaces import ConsoleConversationBrowserRow, DEFAULT_WORKSPACE_ID
-
-# NOTE (boot budget, ADR-097): `Workspaces.assistant_defaults` is imported
-# lazily at its per-turn use site (`_resolve_turn_persona_policy_rules`
-# helpers) so it stays out of the UI-ready module census.
 from ...Workspaces.display_state import (
     ConsoleWorkspaceContextState,
     ConsoleWorkspaceConversationRow,
@@ -256,6 +252,10 @@ from .reaction_preview import ConsoleReactionPreviewCoordinator
 
 if TYPE_CHECKING:
     from ..Screens.chat_screen import ChatScreen
+
+# NOTE (boot budget, ADR-097): `Workspaces.assistant_defaults` is imported
+# lazily at its per-turn use site (`_resolve_turn_persona_policy_rules`
+# helpers) so it stays out of the UI-ready module census.
 
 logger = logger.bind(module="ChatScreen")
 

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -244,6 +244,7 @@ from ...Widgets.Console.console_reaction_picker_modal import (
 )
 from ...Widgets.Console.console_session_switcher_modal import ConsoleSwitcherChoice
 from ...Workspaces import ConsoleConversationBrowserRow, DEFAULT_WORKSPACE_ID
+
 # NOTE (boot budget, ADR-097): `Workspaces.assistant_defaults` is imported
 # lazily at its per-turn use site (`_resolve_turn_persona_policy_rules`
 # helpers) so it stays out of the UI-ready module census.
@@ -2755,20 +2756,16 @@ class ConsoleSessionController:
         # to the new tab instead of clobbering it.
         self._capture_console_draft_switch_snapshot()
         self._refresh_console_library_policy_defaults()
-        defaults = self._blank_console_session_settings()
         # Task 9 (workspace assistant defaults): a plain new tab in an
         # explicit workspace starts as the workspace default persona's
-        # session. Settings/identity selection (precedence, pristine-carry
-        # fall-through, persona identity consistency) lives in
-        # `_new_session_startup_settings` below so it is testable without a
-        # live screen.
+        # session. Settings/default-persona selection lives in the helper
+        # below so published-default provenance is testable without a live
+        # screen.
         settings, assistant_kwargs = self._new_session_startup_settings()
         self._ensure_console_chat_controller().new_session(
             settings=settings,
             canonical_settings_baseline=settings,
-            new_chat_default_generation=(
-                self._console_new_chat_default_generation()
-            ),
+            new_chat_default_generation=(self._console_new_chat_default_generation()),
             ephemeral=ephemeral,
             **assistant_kwargs,
         )
@@ -2815,9 +2812,7 @@ class ConsoleSessionController:
         except KeyError:
             return None
 
-    def _resolve_turn_tool_policy_profile_id(
-        self, workspace_id: str | None
-    ) -> str:
+    def _resolve_turn_tool_policy_profile_id(self, workspace_id: str | None) -> str:
         """Resolve the workspace's named tool-permission profile id.
 
         Workspace assistant defaults (Task 7): the owning session's
@@ -2879,7 +2874,9 @@ class ConsoleSessionController:
             if service is None:
                 return ()
             profile = service.get_persona_profile(assistant_id)
-            rules = profile.get("policy_rules") if isinstance(profile, Mapping) else None
+            rules = (
+                profile.get("policy_rules") if isinstance(profile, Mapping) else None
+            )
             if isinstance(rules, (list, tuple)):
                 return tuple(rule for rule in rules if isinstance(rule, Mapping))
         except Exception as exc:  # noqa: BLE001 -- posture degrades, never blocks
@@ -2906,9 +2903,7 @@ class ConsoleSessionController:
         not consult this helper; their explicit choices outrank the default.
         """
         try:
-            registry = getattr(
-                self.app_instance, "workspace_registry_service", None
-            )
+            registry = getattr(self.app_instance, "workspace_registry_service", None)
             personas = getattr(
                 self.app_instance, "local_character_persona_service", None
             )
@@ -2962,73 +2957,15 @@ class ConsoleSessionController:
     ) -> "tuple[ConsoleSessionSettings | None, dict[str, str]]":
         """Pick the settings + assistant identity a plain new tab starts with.
 
-        Task 9 (workspace assistant defaults), precedence within the plain
-        new-tab path:
-
-        1. The active session's own settings snapshot, when it represents an
-           explicit choice (any persona provenance OR a snapshot that no
-           longer equals its pristine canonical baseline). Persona-provenance
-           carries ALSO stamp the matching ``assistant_kind``/``assistant_id``
-           on the new session record (fix round 1: settings and durable
-           identity must stay consistent, or persona-keyed consumers such as
-           `_resolve_turn_persona_policy_rules` never fire on the new tab).
-           The identity is carried from the source session record alongside
-           its settings -- no re-resolution, so a defaults edit between tabs
-           cannot swap the persona under a carried prompt.
-        2. Workspace effective default -- stamped onto fresh defaults, or
-           onto a PRISTINE carried snapshot (settings identical to the
-           session's canonical baseline, no persona provenance): a
-           persona-free first tab must not permanently suppress the
-           workspace default for later plain tabs.
-        3. Plain fallback.
-
-        Character/handoff paths never route through here and keep their
-        higher-precedence explicit choices. Never raises.
+        Per ADR-095, Ctrl+T and temporary chats are eligible blank-chat
+        creation paths: they start from the app-published new-chat defaults
+        and never clone the active session. An explicit workspace's available
+        default persona is then stamped onto that snapshot per ADR-079.
+        Duplicate, branch, continue, character, and handoff paths carry their
+        own source settings without routing through this helper. Never raises.
         """
         try:
-            active_settings = self._active_console_session_settings()
-            if active_settings is not None:
-                active_session = None
-                store = self._console_chat_store
-                if store is not None and store.active_session_id is not None:
-                    active_session = next(
-                        (
-                            item
-                            for item in store.sessions()
-                            if item.id == store.active_session_id
-                        ),
-                        None,
-                    )
-                # Persona-provenance carry: identity rides along with the
-                # settings so the new record is assistant_kind="persona".
-                if (
-                    active_settings.persona_memory_mode is not None
-                    and active_session is not None
-                    and active_session.assistant_kind == "persona"
-                    and bool(active_session.assistant_id)
-                ):
-                    return active_settings, {
-                        "assistant_kind": "persona",
-                        "assistant_id": str(active_session.assistant_id),
-                        "assistant_label": (
-                            active_settings.character_label or "Workspace Agent"
-                        ),
-                    }
-                # Pristine-default carry (fix round 1): a snapshot that still
-                # equals its canonical baseline and carries no persona
-                # provenance is NOT an explicit choice -- fall through to the
-                # workspace-default branch below instead of suppressing it.
-                is_pristine_carry = (
-                    active_session is not None
-                    and active_session.canonical_settings_baseline
-                    == active_settings
-                    and active_settings.system_prompt is None
-                    and not active_settings.character_label
-                    and active_settings.persona_memory_mode is None
-                )
-                if not is_pristine_carry:
-                    return active_settings, {}
-            settings = self._default_console_session_settings()
+            settings = self._blank_console_session_settings()
             if (
                 settings is not None
                 and settings.system_prompt is None
@@ -3064,7 +3001,7 @@ class ConsoleSessionController:
                 type(exc).__name__,
             )
             try:
-                return self._default_console_session_settings(), {}
+                return self._blank_console_session_settings(), {}
             except Exception:  # noqa: BLE001 -- last-resort plain session
                 return None, {}
 
@@ -3102,9 +3039,7 @@ class ConsoleSessionController:
             try:
                 admission = consent_service.admit_turn(workspace_id)
                 workspace_roots = tuple(admission.ready_roots)
-                ready_review_aliases = tuple(
-                    getattr(admission, "ready_aliases", ())
-                )
+                ready_review_aliases = tuple(getattr(admission, "ready_aliases", ()))
                 skipped_review_roots = tuple(admission.skipped_roots)
             except Exception:  # noqa: BLE001 -- review never blocks a send
                 workspace_roots = ()
@@ -3116,9 +3051,7 @@ class ConsoleSessionController:
         # policy rules. Every failure degrades to the identity posture
         # rather than blocking the send; posture is narrowing-only, so a
         # degraded read can never widen access.
-        tool_policy_profile_id = self._resolve_turn_tool_policy_profile_id(
-            workspace_id
-        )
+        tool_policy_profile_id = self._resolve_turn_tool_policy_profile_id(workspace_id)
         persona_policy_rules = self._resolve_turn_persona_policy_rules(session_id)
 
         return ConsoleTurnConfigurationSnapshot.capture(
@@ -3208,15 +3141,12 @@ class ConsoleSessionController:
         # async opener runs, but creating a tab here would both leave an
         # orphan bootstrap session and let a global conversation inherit the
         # registry-active workspace through hydration's context fallback.
-        if (
-            store.active_session_id is None
-            and bool(
-                getattr(
-                    self._screen,
-                    "_console_ordered_resume_pending",
-                    lambda: False,
-                )()
-            )
+        if store.active_session_id is None and bool(
+            getattr(
+                self._screen,
+                "_console_ordered_resume_pending",
+                lambda: False,
+            )()
         ):
             return defaults
         workspace_id = store.workspace_context.active_workspace_id


### PR DESCRIPTION
## Summary

- restore ADR-095 ownership for Ctrl+T, temporary, and workspace-created blank Console sessions
- prevent live controls or the active session settings from leaking into an unrelated plain new tab
- preserve ADR-079 workspace-default persona stamping on top of the app-published blank snapshot
- keep source-owned handoff, character, retry, continue, branch, and direct-controller paths unchanged

## Root cause

The workspace-assistant startup selector began consulting the active session and the live provider/model controls before its plain fallback. That contradicted the established blank-chat contract: ordinary new tabs must consume the published new-chat default snapshot, while source carryover belongs to explicit source-owned flows.

## Verification

- `67 passed` across the complete workspace-default and session-controller suites, the real Make-default publication flow, context-policy constructor seam, and draft-switch integrity suite
- Ruff lint passed for all modified Python files
- Ruff format check passed for all modified Python files
- `git diff --check` passed

Existing warnings are limited to third-party `requests` compatibility and Python `audioop` deprecation notices.

## Governance

- Backlog: TASK-25707 (Done)
- ADR required: no
- Existing contracts: ADR-095 and ADR-079

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TASK-25707 by restoring ADR-095 blank-chat ownership for Console sessions. Ctrl+T, temporary, and workspace-created blank tabs previously could inherit the active session's settings or live provider/model controls; they now always start from the app-published new-chat default snapshot.

The startup selector began consulting the active session and live controls before its plain fallback, which contradicted the blank-chat contract. ADR-079 workspace default personas are still stamped on top, and source-owned handoff, character, retry, continue, branch, and direct-controller paths keep their existing behavior.

**Verification**
- 67 targeted tests pass, plus Ruff lint, Ruff format check, and `git diff --check`.
- No migration or rollout steps are required.

<sup>Written for commit 10ebd9943bc56dee0e59d39dd33274fe04acef27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

