### PR TITLE
feat: add bounded terminal screen model

### DIFF
--- a/Tests/Terminal/test_protocol_gate.py
+++ b/Tests/Terminal/test_protocol_gate.py
@@ -216,6 +216,14 @@ def test_utf8_continuation_equal_to_c1_st_does_not_end_a_string() -> None:
     assert output == b"beforeafter"
 
 
+def test_raw_st_after_incomplete_utf8_terminates_a_bounded_string() -> None:
+    gate = TerminalProtocolGate()
+
+    output = gate.feed(b"before\x1b]discard-\xe2\x9cafter")
+
+    assert output == b"beforeafter"
+
+
 def test_utf8_between_escape_and_backslash_does_not_form_string_terminator() -> None:
     gate = TerminalProtocolGate()
 
@@ -232,3 +240,24 @@ def test_discard_mode_requires_adjacent_escape_and_backslash_terminator() -> Non
 
     assert first == b""
     assert second == b"after"
+
+
+def test_raw_st_after_incomplete_utf8_at_string_cap_recovers_safe_text() -> None:
+    gate = TerminalProtocolGate()
+
+    before = gate.feed(b"\x1b]" + b"S" * 4094 + b"\xe2")
+    after = gate.feed(b"\x9csafe")
+
+    assert before == b""
+    assert after == b"safe"
+    assert gate.snapshot().discarding is False
+
+
+def test_valid_utf8_crossing_string_cap_does_not_act_as_raw_st() -> None:
+    gate = TerminalProtocolGate()
+
+    before = gate.feed(b"\x1b]" + b"S" * 4094 + "✓".encode())
+    after = gate.feed(b"still-discarded\x07safe")
+
+    assert before == b""
+    assert after == b"safe"

--- a/Tests/Terminal/test_protocol_gate.py
+++ b/Tests/Terminal/test_protocol_gate.py
@@ -1,0 +1,234 @@
+"""Behavioral tests for the bounded terminal protocol pre-parser."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from tldw_chatbook.Terminal.protocol_gate import TerminalProtocolGate
+
+
+def _feed(gate: TerminalProtocolGate, *chunks: bytes) -> bytes:
+    return b"".join(gate.feed(chunk) for chunk in chunks)
+
+
+def test_plain_text_and_admitted_csi_recover_across_chunk_boundaries() -> None:
+    gate = TerminalProtocolGate()
+
+    admitted = _feed(gate, b"before\x1b[3", b"1mafter")
+
+    assert admitted == b"before\x1b[31mafter"
+    assert gate.snapshot().buffered_bytes == 0
+
+
+@pytest.mark.parametrize(
+    ("sequence", "admitted"),
+    [
+        (b"\x1b[" + b"1;" * 31 + b"1m", True),
+        (b"\x1b[" + b"1;" * 32 + b"1m", False),
+        (b"\x1b[9999m", True),
+        (b"\x1b[10000m", False),
+        (b"\x1b[00001m", False),
+    ],
+)
+def test_csi_parameter_and_private_intermediate_caps(
+    sequence: bytes, admitted: bool
+) -> None:
+    gate = TerminalProtocolGate()
+
+    output = _feed(gate, sequence, b"tail")
+
+    assert output == (sequence if admitted else b"") + b"tail"
+    assert gate.snapshot().rejected_sequences == (0 if admitted else 1)
+
+
+@pytest.mark.parametrize(
+    ("private_bytes", "rejected"),
+    [(16, False), (17, True)],
+)
+def test_csi_private_intermediate_cap_precedes_unknown_sequence_filtering(
+    private_bytes: int, rejected: bool
+) -> None:
+    gate = TerminalProtocolGate()
+    sequence = b"\x1b[" + b"?" * private_bytes + b"h"
+
+    output = _feed(gate, sequence, b"tail")
+
+    assert output == b"tail"
+    assert gate.snapshot().rejected_sequences == int(rejected)
+    assert gate.snapshot().ignored_sequences == int(not rejected)
+
+
+def test_csi_limit_crossing_discards_until_the_late_final_byte() -> None:
+    gate = TerminalProtocolGate()
+
+    first = gate.feed(b"\x1b[" + b"1;" * 33)
+    status = gate.snapshot()
+    second = gate.feed(b"mrecovered")
+
+    assert first == b""
+    assert status.discarding is True
+    assert status.buffered_bytes == 0
+    assert second == b"recovered"
+    assert gate.snapshot().discarding is False
+
+
+@pytest.mark.parametrize(
+    ("intermediate_count", "rejected"),
+    [(14, False), (15, True)],
+)
+def test_non_csi_escape_sequence_has_a_sixteen_byte_total_cap(
+    intermediate_count: int, rejected: bool
+) -> None:
+    gate = TerminalProtocolGate()
+    sequence = b"\x1b" + b" " * intermediate_count + b"7"
+
+    output = _feed(gate, sequence, b"tail")
+
+    # The bounded sequence is unsupported and therefore ignored. The
+    # distinction under test is whether it crossed the safety cap.
+    assert output == b"tail"
+    assert gate.snapshot().rejected_sequences == int(rejected)
+
+
+@pytest.mark.parametrize("introducer", [b"\x1b]", b"\x1bP", b"\x1b^", b"\x1b_"])
+@pytest.mark.parametrize("terminator", [b"\x07", b"\x1b\\", b"\x18", b"\x1a", b"\x9c"])
+def test_string_controls_discard_payload_and_recover_on_late_terminator(
+    introducer: bytes,
+    terminator: bytes,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    gate = TerminalProtocolGate()
+    secret = b"QODO_SECRET_PAYLOAD"
+
+    with caplog.at_level(logging.DEBUG):
+        before = gate.feed(b"before" + introducer + secret)
+        during = gate.snapshot()
+        after = gate.feed(terminator + b"after")
+
+    assert before == b"before"
+    assert during.buffered_bytes <= 4096
+    assert after == b"after"
+    assert secret.decode() not in repr(during)
+    assert secret.decode() not in caplog.text
+
+
+def test_incomplete_string_retains_only_classification_state() -> None:
+    gate = TerminalProtocolGate()
+    secret = b"LIVE_OBJECT_SECRET"
+
+    gate.feed(b"\x1b]52;c;" + secret)
+
+    assert gate.snapshot().buffered_bytes == 0
+    assert secret not in bytes(gate._buffer)
+
+
+@pytest.mark.parametrize("introducer", [b"\x1b]", b"\x1bP", b"\x1b^", b"\x1b_"])
+def test_oversized_string_control_retains_no_payload_while_discarding(
+    introducer: bytes,
+) -> None:
+    gate = TerminalProtocolGate()
+
+    assert gate.feed(introducer + b"S" * 4096) == b""
+    status = gate.snapshot()
+    recovered = gate.feed(b"\x1b\\safe")
+
+    assert status.discarding is True
+    assert status.buffered_bytes == 0
+    assert "SSSS" not in repr(status)
+    assert recovered == b"safe"
+    assert gate.snapshot().rejected_sequences == 1
+
+
+def test_parser_reset_terminates_string_discard_and_is_admitted() -> None:
+    gate = TerminalProtocolGate()
+
+    output = _feed(gate, b"\x1b]discarded", b"\x1bc", b"safe")
+
+    assert output == b"\x1bcsafe"
+    assert gate.snapshot().buffered_bytes == 0
+
+
+def test_finish_discards_an_incomplete_sequence_without_exposing_it() -> None:
+    gate = TerminalProtocolGate()
+    secret = b"INCOMPLETE_SECRET"
+
+    assert gate.feed(b"\x1b]" + secret) == b""
+    status = gate.finish()
+
+    assert status.buffered_bytes == 0
+    assert status.discarding is False
+    assert status.rejected_sequences == 1
+    assert secret.decode() not in repr(status)
+
+
+def test_unknown_controls_are_ignored_without_hiding_following_text() -> None:
+    gate = TerminalProtocolGate()
+
+    output = _feed(gate, b"a\x1b[1;2z", b"b\x1b X", b"c")
+
+    assert output == b"abc"
+    assert gate.snapshot().ignored_sequences == 2
+
+
+@pytest.mark.parametrize(
+    "sequence",
+    [
+        b"\x1b[1;2A",
+        b"\x1b[?5n",
+        b"\x1b[1;2c",
+        b"\x1b[>1m",
+        b"\x1b[1 q",
+    ],
+)
+def test_unsupported_csi_argument_shapes_are_ignored(sequence: bytes) -> None:
+    gate = TerminalProtocolGate()
+
+    output = _feed(gate, b"before", sequence, b"after")
+
+    assert output == b"beforeafter"
+    assert gate.snapshot().ignored_sequences == 1
+
+
+def test_raw_c1_bytes_never_enter_the_admitted_stream() -> None:
+    gate = TerminalProtocolGate()
+
+    output = gate.feed(b"before\x9b31mafter")
+
+    assert output == b"beforeafter"
+    assert gate.snapshot().ignored_sequences == 1
+
+
+def test_raw_c1_string_and_st_are_discarded_without_exposing_payload() -> None:
+    gate = TerminalProtocolGate()
+
+    output = gate.feed(b"before\x9dsecret\x9cafter")
+
+    assert output == b"beforeafter"
+
+
+def test_utf8_continuation_equal_to_c1_st_does_not_end_a_string() -> None:
+    gate = TerminalProtocolGate()
+
+    output = gate.feed(b"before\x1b]discard-\xe2\x9c\x93\x07after")
+
+    assert output == b"beforeafter"
+
+
+def test_utf8_between_escape_and_backslash_does_not_form_string_terminator() -> None:
+    gate = TerminalProtocolGate()
+
+    output = gate.feed(b"before\x1b]discard\x1b\xe2\x9c\x93\\still-discarded\x07after")
+
+    assert output == b"beforeafter"
+
+
+def test_discard_mode_requires_adjacent_escape_and_backslash_terminator() -> None:
+    gate = TerminalProtocolGate()
+
+    first = gate.feed(b"\x1b]" + b"S" * 4096)
+    second = gate.feed(b"\x1b\xe2\x9c\x93\\still-discarded\x07after")
+
+    assert first == b""
+    assert second == b"after"

--- a/Tests/Terminal/test_screen_model.py
+++ b/Tests/Terminal/test_screen_model.py
@@ -1,0 +1,522 @@
+"""Behavioral tests for safe persistent-terminal screen projections."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import MutableMapping, MutableSequence, MutableSet
+from dataclasses import FrozenInstanceError
+import logging
+import unicodedata
+
+import pyte
+import pytest
+
+from tldw_chatbook.Terminal.contracts import TerminalReason
+from tldw_chatbook.Terminal.screen_model import TerminalScreenModel
+
+
+def _feed_in_seven_byte_chunks(model: TerminalScreenModel, value: bytes) -> None:
+    for offset in range(0, len(value), 7):
+        model.feed(value[offset : offset + 7])
+
+
+def _projected_text(model: TerminalScreenModel) -> str:
+    snapshot = model.snapshot()
+    return "\n".join(line.text for line in (*snapshot.scrollback, *snapshot.lines))
+
+
+def test_incremental_utf8_preserves_split_scalars_and_replaces_invalid_bytes() -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+
+    model.feed(b"A\xe2")
+    assert model.visible_text() == "A"
+    model.feed(b"\x82\xacB\xffC")
+
+    assert model.visible_text() == "A\u20acB\ufffdC"
+
+
+def test_finish_replaces_an_incomplete_utf8_scalar() -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+
+    model.feed(b"A\xe2\x82")
+    model.finish()
+
+    assert model.visible_text() == "A\ufffd"
+
+
+def test_ascii_wide_combining_and_joiner_graphemes_use_safe_cells() -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+
+    _feed_in_seven_byte_chunks(model, "A界e\u0301👩\u200d💻".encode())
+    snapshot = model.snapshot()
+
+    assert snapshot.lines[0].text == "A界é👩\u200d💻"
+    # Cursor coordinates are 1-based; the six occupied columns leave the
+    # insertion cursor at column seven.
+    assert snapshot.cursor_column == 7
+    assert snapshot.lines[0].column_width == 6
+
+
+def test_variation_selector_width_change_preserves_following_cell() -> None:
+    model = TerminalScreenModel(columns=10, rows=2)
+
+    model.feed("❤️X".encode())
+    line = model.snapshot().lines[0]
+
+    assert line.text == "❤️X"
+    assert line.column_width == 3
+    assert [(cell.text, cell.width) for run in line.runs for cell in run.cells] == [
+        ("❤️", 2),
+        ("X", 1),
+    ]
+
+
+def test_wide_character_at_right_edge_wraps_without_exceeding_viewport() -> None:
+    model = TerminalScreenModel(columns=10, rows=2)
+
+    model.feed("123456789界".encode())
+    snapshot = model.snapshot()
+
+    assert snapshot.lines[0].text == "123456789"
+    assert snapshot.lines[0].column_width == 9
+    assert snapshot.lines[1].text == "界"
+    assert snapshot.lines[1].column_width == 2
+    assert all(line.column_width <= 10 for line in snapshot.lines)
+
+
+def test_writing_into_wide_continuation_clears_both_original_halves() -> None:
+    model = TerminalScreenModel(columns=10, rows=2)
+
+    model.feed("界".encode() + b"\x1b[DX")
+    line = model.snapshot().lines[0]
+
+    assert line.text == " X"
+    assert line.column_width == 2
+
+
+def test_variation_selector_width_change_at_right_edge_wraps_atomically() -> None:
+    model = TerminalScreenModel(columns=10, rows=2)
+
+    model.feed("123456789❤️X".encode())
+    snapshot = model.snapshot()
+
+    assert snapshot.lines[0].text == "123456789"
+    assert snapshot.lines[1].text == "❤️X"
+    assert snapshot.lines[1].column_width == 3
+    assert all(line.column_width <= 10 for line in snapshot.lines)
+
+
+def test_cell_scalar_overflow_is_replaced_and_counted_without_content() -> None:
+    model = TerminalScreenModel(columns=10, rows=2)
+
+    model.feed(("a" + "\u0301" * 40).encode())
+    snapshot = model.snapshot()
+
+    assert snapshot.lines[0].text == "\ufffd"
+    assert snapshot.cell_overflow_count == 1
+    assert all(
+        len(cell.text) <= 32 and len(cell.text.encode()) <= 256
+        for run in snapshot.lines[0].runs
+        for cell in run.cells
+    )
+
+
+def test_cell_overflow_marker_moves_with_inserted_cells() -> None:
+    model = TerminalScreenModel(columns=10, rows=2)
+    model.feed(("Xa" + "\u0301" * 40).encode())
+
+    model.feed(b"\r\x1b[@\x1b[3G")
+    model.feed("\u0301".encode())
+
+    assert model.snapshot().lines[0].text == " X\u0301�"
+
+
+def test_cursor_savepoint_stack_evicts_the_oldest_after_sixteen() -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+
+    for column in range(17):
+        model.feed(f"\x1b[{column + 1}G\x1b7".encode())
+    snapshot = model.snapshot()
+
+    assert snapshot.cursor_savepoints == 16
+    model.feed(b"\x1b8")
+    assert model.snapshot().cursor_column == 17
+
+
+def test_style_runs_are_safe_immutable_values() -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+
+    model.feed(b"\x1b[1;3;4;31;44mX\x1b[0mY")
+    snapshot = model.snapshot()
+    first, second = snapshot.lines[0].runs
+
+    assert first.text == "X"
+    assert first.style.fg == "red"
+    assert first.style.bg == "blue"
+    assert first.style.bold is True
+    assert first.style.italics is True
+    assert first.style.underscore is True
+    assert second.text == "Y"
+    with pytest.raises(FrozenInstanceError):
+        first.style.fg = "green"  # type: ignore[misc]
+
+
+def test_trailing_styled_spaces_remain_visible_safe_cells() -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+
+    model.feed(b"\x1b[44m   \x1b[0m")
+    line = model.snapshot().lines[0]
+
+    assert line.text == "   "
+    assert line.column_width == 3
+    assert len(line.runs) == 1
+    assert line.runs[0].style.bg == "blue"
+
+
+def test_alternate_screen_never_enters_normal_scrollback() -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+    model.feed(b"primary-1\r\nprimary-2")
+    primary = model.visible_text()
+    scrollback_before = model.snapshot().scrollback
+
+    model.feed(b"\x1b[?1049halt-1\r\nalt-2\r\nalt-3")
+    assert model.snapshot().in_alternate is True
+    assert model.snapshot().scrollback == scrollback_before
+    model.feed(b"\x1b[?1049l")
+
+    assert model.snapshot().in_alternate is False
+    assert model.snapshot().scrollback == scrollback_before
+    assert model.visible_text() == primary
+
+
+def test_resize_updates_both_screens_and_preserves_each_cursor() -> None:
+    model = TerminalScreenModel(columns=10, rows=3)
+    model.feed(b"primary\x1b[2;4H\x1b[?1049halt\x1b[3;5H")
+
+    model.resize(columns=12, rows=4)
+
+    alternate = model.snapshot()
+    assert alternate.in_alternate is True
+    assert (alternate.cursor_row, alternate.cursor_column) == (3, 5)
+    assert len(alternate.lines) == 4
+    model.feed(b"\x1b[?1049l")
+    primary = model.snapshot()
+    assert (primary.cursor_row, primary.cursor_column) == (2, 4)
+    assert len(primary.lines) == 4
+
+
+def test_reset_from_alternate_screen_restores_coherent_primary_state() -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+    model.feed(b"primary\x1b[?1049halt\x1bc")
+
+    snapshot = model.snapshot()
+
+    assert snapshot.in_alternate is False
+    assert model.visible_text() == ""
+    assert (snapshot.cursor_row, snapshot.cursor_column) == (1, 1)
+
+
+def test_scrollback_accounting_is_text_plus_runs_plus_line_overhead() -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+
+    model.feed(b"\x1b[31mA\x1b[0mB\r\nline-2\r\nline-3")
+    retained = model.snapshot().scrollback[0]
+
+    assert retained.text == "AB"
+    assert len(retained.runs) == 2
+    assert retained.accounted_bytes == 2 + 2 * 32 + 16
+    assert model.snapshot().scrollback_bytes == retained.accounted_bytes
+
+
+def test_scrollback_evicts_oldest_lines_at_the_line_limit() -> None:
+    model = TerminalScreenModel(
+        columns=20,
+        rows=2,
+        scrollback_line_limit=2,
+        scrollback_byte_limit=4 * 1024 * 1024,
+    )
+
+    # Five logical lines in a two-row viewport produce three scrolled lines,
+    # so this actually crosses the two-line limit.
+    model.feed(b"A\r\nB\r\nC\r\nD\r\nE")
+
+    assert [line.text for line in model.snapshot().scrollback] == ["B", "C"]
+
+
+def test_scrollback_evicts_oldest_lines_at_the_byte_limit() -> None:
+    model = TerminalScreenModel(
+        columns=20,
+        rows=2,
+        scrollback_line_limit=5_000,
+        scrollback_byte_limit=98,
+    )
+
+    # Each one-character/default-style line accounts for 49 bytes. Three
+    # scrolled lines force oldest-first eviction at the 98-byte limit.
+    model.feed(b"A\r\nB\r\nC\r\nD\r\nE")
+    snapshot = model.snapshot()
+
+    assert [line.text for line in snapshot.scrollback] == ["B", "C"]
+    assert snapshot.scrollback_bytes == 98
+
+
+@pytest.mark.parametrize(
+    "control",
+    [
+        b"\x1b]0;HOST_TITLE\x07",
+        b"\x1b]1;HOST_ICON\x1b\\",
+        b"\x1b]8;;https://secret.invalid\x07link\x1b]8;;\x07",
+        b"\x1b]9;NOTIFICATION_SECRET\x07",
+        b"\x1b]52;c;CLIPBOARD_SECRET\x07",
+        b"\x1bPDEVICE_SECRET\x1b\\",
+    ],
+)
+def test_host_affecting_and_string_controls_never_reach_safe_cells(
+    control: bytes,
+) -> None:
+    model = TerminalScreenModel(columns=80, rows=3)
+
+    model.feed(b"before" + control + b"after")
+    projected = _projected_text(model)
+
+    expected = (
+        "beforelinkafter\n\n"
+        if b"https://secret.invalid" in control
+        else "beforeafter\n\n"
+    )
+    assert projected == expected
+    assert "SECRET" not in repr(model.snapshot())
+    assert "secret.invalid" not in repr(model.snapshot())
+    assert model.pending_replies() == ()
+
+
+def test_allowlisted_device_queries_create_only_bounded_code_owned_replies() -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+
+    model.feed(b"X\x1b[5n\x1b[6n\x1b[c")
+
+    assert model.pending_replies() == (b"\x1b[0n", b"\x1b[1;2R", b"\x1b[?6c")
+    assert all(len(reply) <= 256 for reply in model.pending_replies())
+    assert model.take_pending_replies() == (
+        b"\x1b[0n",
+        b"\x1b[1;2R",
+        b"\x1b[?6c",
+    )
+    assert model.pending_replies() == ()
+
+
+def test_unsupported_csi_shapes_do_not_fail_the_screen_model() -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+
+    model.feed(b"before\x1b[1;2A\x1b[?5n\x1b[>1mafter")
+
+    assert model.visible_text() == "beforeafter"
+    assert model.snapshot().failure_reason is None
+
+
+QUALIFICATION_CORPUS = (
+    (
+        "parser-powershell-cmd-fixtures/cmd",
+        b"Microsoft Windows [Version 10.0.17763]\r\nC:\\>dir\r\n",
+    ),
+    (
+        "parser-powershell-cmd-fixtures/powershell",
+        b"\x1b[93mPS C:\\>\x1b[0m Get-Command python\r\n",
+    ),
+    (
+        "parser-full-screen-programs/editor",
+        b"\x1b[?1049h\x1b[Heditor fixture\x1b[?1049l",
+    ),
+    (
+        "parser-full-screen-programs/pager",
+        b"\x1b[2J\x1b[H\x1b[7mpager fixture\x1b[0m\r\n:",
+    ),
+    (
+        "parser-full-screen-programs/monitor",
+        b"\x1b[H\x1b[7mprocess monitor fixture\x1b[0m",
+    ),
+    ("parser-unicode-cells", "A界e\u0301🙂".encode()),
+    ("parser-alternate-screen", b"primary\x1b[?1049halt\x1b[?1049l"),
+    ("parser-bracketed-paste", b"\x1b[?2004htext\x1b[?2004l"),
+    ("parser-terminal-queries", b"\x1b[5n\x1b[6n\x1b[c"),
+    (
+        "parser-malformed-controls",
+        b"\x1b[999999999999;::::m\xff\xfeplain\x1b]bad\x07",
+    ),
+    ("parser-incomplete-sequence-bounds/incomplete-utf8", b"\xe2\x82"),
+    ("parser-incomplete-sequence-bounds/non-csi", b"\x1b" + b"x" * 16),
+    ("parser-incomplete-sequence-bounds/csi", b"\x1b[" + b"1" * 257),
+    (
+        "parser-incomplete-sequence-bounds/parameters",
+        b"\x1b[" + b"1;" * 33 + b"m",
+    ),
+    ("parser-incomplete-sequence-bounds/value", b"\x1b[10000m"),
+    (
+        "parser-incomplete-sequence-bounds/intermediates",
+        b"\x1b[" + b" " * 17 + b"m",
+    ),
+    ("parser-incomplete-sequence-bounds/osc", b"\x1b]" + b"x" * 4096),
+    ("parser-incomplete-sequence-bounds/dcs", b"\x1bP" + b"x" * 4096),
+    ("parser-incomplete-sequence-bounds/apc", b"\x1b_" + b"x" * 4096),
+    ("parser-incomplete-sequence-bounds/pm", b"\x1b^" + b"x" * 4096),
+)
+
+
+@pytest.mark.parametrize(("row_id", "fixture"), QUALIFICATION_CORPUS)
+def test_qualification_corpus_projects_only_safe_content(
+    row_id: str, fixture: bytes
+) -> None:
+    model = TerminalScreenModel(columns=120, rows=40)
+
+    model.feed(b"before")
+    _feed_in_seven_byte_chunks(model, fixture)
+    model.feed(b"\x18after")
+    model.finish()
+    projected = _projected_text(model)
+
+    assert model.snapshot().failure_reason is None, row_id
+    # Full-screen fixtures may legitimately clear or overwrite the earlier
+    # marker. The post-CAN marker proves recovery and keeps this assertion
+    # discriminating against a neutral/no-op implementation.
+    assert "after" in projected, row_id
+    assert "\x1b" not in projected, row_id
+    assert not any(
+        unicodedata.category(character) in {"Cc", "Cs"}
+        or 0x80 <= ord(character) <= 0x9F
+        for character in projected
+        if character != "\n"
+    ), row_id
+
+
+def test_parser_failure_stops_projection_with_a_content_free_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+
+    def fail_without_exposing_payload(_: str) -> None:
+        raise RuntimeError("PARSER_SECRET")
+
+    monkeypatch.setattr(model._stream, "feed", fail_without_exposing_payload)
+    with caplog.at_level(logging.DEBUG):
+        model.feed(b"OUTPUT_SECRET")
+        model.feed(b"later")
+
+    snapshot = model.snapshot()
+    assert snapshot.failure_reason is TerminalReason.TERMINAL_PROTOCOL_FAILED
+    assert snapshot.lines[0].text == ""
+    assert "SECRET" not in repr(snapshot)
+    assert "SECRET" not in caplog.text
+
+
+def test_snapshot_is_immutable_and_contains_no_parser_owned_collections() -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+    model.feed(b"safe")
+    snapshot = model.snapshot()
+
+    assert isinstance(snapshot.lines, tuple)
+    assert isinstance(snapshot.lines[0].runs, tuple)
+    assert isinstance(snapshot.lines[0].runs[0].cells, tuple)
+    with pytest.raises(FrozenInstanceError):
+        snapshot.cursor_column = 99  # type: ignore[misc]
+
+
+def test_every_mutable_parser_and_screen_collection_is_classified_and_bounded() -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+    model.feed(b"\x1b[1;2Hsafe")
+    mutable_types = (MutableMapping, MutableSequence, MutableSet, deque, bytearray)
+
+    def mutable_attributes(value: object) -> set[str]:
+        return {
+            name
+            for name, member in vars(value).items()
+            if isinstance(member, mutable_types)
+        }
+
+    assert mutable_attributes(model) == {"_scrollback", "_pending_replies"}
+    assert mutable_attributes(model._gate) == {"_buffer"}
+    assert mutable_attributes(model._stream) == set()
+    assert mutable_attributes(model._screens) == set()
+
+    parser_locals = model._stream._parser.gi_frame.f_locals
+    parser_collections = {
+        name: member
+        for name, member in parser_locals.items()
+        if isinstance(member, mutable_types)
+    }
+    assert set(parser_collections) == {
+        "basic",
+        "OSC_TERMINATORS",
+        "basic_dispatch",
+        "sharp_dispatch",
+        "escape_dispatch",
+        "csi_dispatch",
+        "params",
+    }
+    assert parser_collections["basic"] is pyte.Stream.basic
+    assert parser_collections["OSC_TERMINATORS"] == {"\x1b\\", "\x07", "\x9c"}
+    assert set(parser_collections["basic_dispatch"]) == set(pyte.Stream.basic)
+    assert set(parser_collections["sharp_dispatch"]) == set(pyte.Stream.sharp)
+    assert set(parser_collections["escape_dispatch"]) == set(pyte.Stream.escape)
+    assert set(parser_collections["csi_dispatch"]) == set(pyte.Stream.csi)
+    assert len(parser_collections["params"]) <= 32
+
+    for screen in (model._screens.primary, model._screens.alternate):
+        assert mutable_attributes(screen) == {
+            "savepoints",
+            "buffer",
+            "dirty",
+            "mode",
+            "tabstops",
+        }
+        assert len(screen.savepoints) <= 16
+        assert len(screen.buffer) <= screen.lines
+        assert all(len(line) <= screen.columns for line in screen.buffer.values())
+        assert screen.dirty <= set(range(screen.lines))
+        assert len(screen.mode) <= 10
+        assert len(screen.tabstops) <= screen.columns
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"columns": 4, "rows": 2},
+        {"columns": 301, "rows": 2},
+        {"columns": 20, "rows": 1},
+        {"columns": 20, "rows": 121},
+        {"columns": 20, "rows": 2, "scrollback_line_limit": 5_001},
+        {
+            "columns": 20,
+            "rows": 2,
+            "scrollback_byte_limit": 4 * 1024 * 1024 + 1,
+        },
+    ],
+)
+def test_screen_model_rejects_bounds_outside_the_terminal_contract(
+    arguments: dict[str, int],
+) -> None:
+    with pytest.raises(ValueError):
+        TerminalScreenModel(**arguments)
+
+
+@pytest.mark.parametrize(
+    ("columns", "rows"),
+    [(4, 2), (301, 2), (20, 1), (20, 121)],
+)
+def test_resize_rejects_bounds_outside_the_terminal_contract(
+    columns: int, rows: int
+) -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+
+    with pytest.raises(ValueError):
+        model.resize(columns=columns, rows=rows)
+
+
+def test_pending_reply_queue_is_capped_at_the_aggregate_reply_bound() -> None:
+    model = TerminalScreenModel(columns=20, rows=2)
+
+    model.feed(b"\x1b[5n" * 1_100)
+
+    replies = model.pending_replies()
+    assert sum(map(len, replies)) == 4 * 1024
+    assert all(reply == b"\x1b[0n" for reply in replies)

--- a/Tests/Terminal/test_screen_model.py
+++ b/Tests/Terminal/test_screen_model.py
@@ -106,6 +106,16 @@ def test_variation_selector_width_change_at_right_edge_wraps_atomically() -> Non
     assert all(line.column_width <= 10 for line in snapshot.lines)
 
 
+def test_combining_mark_after_line_movement_does_not_mutate_previous_row() -> None:
+    model = TerminalScreenModel(columns=5, rows=2)
+
+    model.feed("1234❤\r\n\ufe0fsafe".encode())
+    snapshot = model.snapshot()
+
+    assert [line.text for line in snapshot.lines] == ["1234❤", "safe"]
+    assert snapshot.failure_reason is None
+
+
 def test_cell_scalar_overflow_is_replaced_and_counted_without_content() -> None:
     model = TerminalScreenModel(columns=10, rows=2)
 

--- a/tldw_chatbook/Terminal/protocol_gate.py
+++ b/tldw_chatbook/Terminal/protocol_gate.py
@@ -1,0 +1,421 @@
+"""Bounded byte-level gate in front of the persistent-terminal parser.
+
+The gate deliberately knows less than the terminal emulator. Its job is to
+bound every control sequence before a third-party parser sees it, discard host
+integration controls, and expose only content-free diagnostics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+MAX_CONTROL_BYTES = 4 * 1024
+MAX_CSI_PARAMETERS = 32
+MAX_CSI_PARAMETER_DIGITS = 4
+MAX_CSI_PARAMETER_VALUE = 9_999
+MAX_CSI_PRIVATE_INTERMEDIATE_BYTES = 16
+MAX_ESCAPE_BYTES = 16
+
+_C0_ADMITTED = frozenset(b"\a\b\t\n\v\f\r\x0e\x0f")
+_STRING_INTRODUCERS = frozenset((ord("]"), ord("P"), ord("^"), ord("_")))
+_C1_STRING_INTRODUCERS = frozenset((0x90, 0x9D, 0x9E, 0x9F))
+_CSI_ONE_PARAMETER_FINALS = frozenset(b"@ABCDEFGJKLM PXadeg".replace(b" ", b""))
+_CSI_TWO_PARAMETER_FINALS = frozenset(b"Hfr")
+_CSI_VARIADIC_FINALS = frozenset(b"hlm")
+_KNOWN_SIMPLE_ESCAPES = frozenset(
+    (
+        b"\x1b7",  # save cursor
+        b"\x1b8",  # restore cursor
+        b"\x1bD",  # index
+        b"\x1bE",  # next line
+        b"\x1bH",  # horizontal tab set
+        b"\x1bM",  # reverse index
+        b"\x1bc",  # reset
+        b"\x1b=",  # application keypad
+        b"\x1b>",  # normal keypad
+    )
+)
+_CHARSET_INTERMEDIATES = frozenset(b"#()*+-./%")
+
+
+@dataclass(frozen=True, slots=True)
+class ProtocolGateSnapshot:
+    """Content-free diagnostic state for the terminal protocol gate."""
+
+    buffered_bytes: int = 0
+    discarding: bool = False
+    rejected_sequences: int = 0
+    ignored_sequences: int = 0
+
+
+class TerminalProtocolGate:
+    """Incrementally admit bounded terminal bytes for the VT parser."""
+
+    _TEXT = "text"
+    _ESCAPE = "escape"
+    _CSI = "csi"
+    _STRING = "string"
+    _DISCARD_ESCAPE = "discard_escape"
+    _DISCARD_CSI = "discard_csi"
+    _DISCARD_STRING = "discard_string"
+
+    def __init__(self) -> None:
+        self._state = self._TEXT
+        self._buffer = bytearray()
+        self._control_bytes = 0
+        self._raw_c1 = False
+        self._utf8_remaining = 0
+        self._csi_parameters = 1
+        self._csi_parameter_digits = 0
+        self._csi_parameter_value = 0
+        self._csi_private_intermediate_bytes = 0
+        self._string_escape_pending = False
+        self._string_utf8_remaining = 0
+        self._discard_escape_pending = False
+        self._rejected_sequences = 0
+        self._ignored_sequences = 0
+
+    def feed(self, data: bytes) -> bytes:
+        """Return parser-admitted bytes from one output chunk.
+
+        Bytes belonging to a control sequence are withheld until the sequence
+        is complete and proven bounded. Once a limit is crossed, retained
+        bytes are erased immediately and input is consumed through the
+        sequence terminator.
+        """
+        admitted = bytearray()
+        for byte in data:
+            self._consume(byte, admitted)
+        return bytes(admitted)
+
+    def snapshot(self) -> ProtocolGateSnapshot:
+        """Return content-free bounded parser state."""
+        return ProtocolGateSnapshot(
+            buffered_bytes=len(self._buffer),
+            discarding=self._state.startswith("discard_"),
+            rejected_sequences=self._rejected_sequences,
+            ignored_sequences=self._ignored_sequences,
+        )
+
+    def finish(self) -> ProtocolGateSnapshot:
+        """Discard any incomplete sequence and return final state."""
+        if self._state != self._TEXT:
+            if not self._state.startswith("discard_"):
+                self._rejected_sequences += 1
+            self._reset_sequence()
+        return self.snapshot()
+
+    def _consume(self, byte: int, admitted: bytearray) -> None:
+        if self._state == self._TEXT:
+            self._consume_text(byte, admitted)
+        elif self._state == self._ESCAPE:
+            self._consume_escape(byte, admitted)
+        elif self._state == self._CSI:
+            self._consume_csi(byte, admitted)
+        elif self._state == self._STRING:
+            self._consume_string(byte, admitted)
+        elif self._state == self._DISCARD_ESCAPE:
+            self._consume_discard_escape(byte, admitted)
+        elif self._state == self._DISCARD_CSI:
+            self._consume_discard_csi(byte, admitted)
+        else:
+            self._consume_discard_string(byte, admitted)
+
+    def _consume_text(self, byte: int, admitted: bytearray) -> None:
+        # A C1-valued byte is ordinary text when it is a continuation byte in
+        # a UTF-8 sequence. Standalone C1 bytes retain their control meaning.
+        if self._utf8_remaining:
+            if 0x80 <= byte <= 0xBF:
+                admitted.append(byte)
+                self._utf8_remaining -= 1
+                return
+            self._utf8_remaining = 0
+            self._consume_text(byte, admitted)
+            return
+
+        if 0xC2 <= byte <= 0xDF:
+            self._utf8_remaining = 1
+            admitted.append(byte)
+            return
+        if 0xE0 <= byte <= 0xEF:
+            self._utf8_remaining = 2
+            admitted.append(byte)
+            return
+        if 0xF0 <= byte <= 0xF4:
+            self._utf8_remaining = 3
+            admitted.append(byte)
+            return
+
+        if byte == 0x1B:
+            self._start_escape()
+        elif byte == 0x9B:
+            self._start_csi(raw_c1=True)
+        elif byte in _C1_STRING_INTRODUCERS:
+            self._start_string(byte, raw_c1=True)
+        elif 0x80 <= byte <= 0x9F:
+            self._ignored_sequences += 1
+        elif byte < 0x20 or byte == 0x7F:
+            if byte in _C0_ADMITTED:
+                admitted.append(byte)
+        else:
+            admitted.append(byte)
+
+    def _start_escape(self) -> None:
+        self._state = self._ESCAPE
+        self._buffer = bytearray((0x1B,))
+        self._raw_c1 = False
+
+    def _start_csi(self, *, raw_c1: bool) -> None:
+        self._state = self._CSI
+        self._buffer = bytearray((0x9B,)) if raw_c1 else bytearray(b"\x1b[")
+        self._raw_c1 = raw_c1
+        self._csi_parameters = 1
+        self._csi_parameter_digits = 0
+        self._csi_parameter_value = 0
+        self._csi_private_intermediate_bytes = 0
+
+    def _start_string(self, introducer: int, *, raw_c1: bool = False) -> None:
+        self._state = self._STRING
+        self._buffer.clear()
+        self._control_bytes = 1 if raw_c1 else 2
+        self._raw_c1 = raw_c1
+        self._string_escape_pending = False
+        self._string_utf8_remaining = 0
+
+    def _consume_escape(self, byte: int, admitted: bytearray) -> None:
+        if len(self._buffer) == 1:
+            if byte == ord("["):
+                self._start_csi(raw_c1=False)
+                return
+            if byte in _STRING_INTRODUCERS:
+                self._start_string(byte)
+                return
+
+        self._buffer.append(byte)
+        is_final = 0x30 <= byte <= 0x7E
+        if len(self._buffer) > MAX_ESCAPE_BYTES:
+            self._reject_and_discard(self._TEXT if is_final else self._DISCARD_ESCAPE)
+            return
+
+        if byte in (0x18, 0x1A):
+            self._ignored_sequences += 1
+            self._reset_sequence()
+        elif is_final:
+            sequence = bytes(self._buffer)
+            if self._is_known_escape(sequence):
+                admitted.extend(sequence)
+            else:
+                self._ignored_sequences += 1
+            self._reset_sequence()
+        elif not 0x20 <= byte <= 0x2F:
+            self._ignored_sequences += 1
+            self._reset_sequence()
+
+    @staticmethod
+    def _is_known_escape(sequence: bytes) -> bool:
+        if sequence in _KNOWN_SIMPLE_ESCAPES:
+            return True
+        return (
+            len(sequence) == 3
+            and sequence[1] in _CHARSET_INTERMEDIATES
+            and 0x30 <= sequence[2] <= 0x7E
+        )
+
+    def _consume_csi(self, byte: int, admitted: bytearray) -> None:
+        self._buffer.append(byte)
+        is_final = 0x40 <= byte <= 0x7E
+
+        crossed_limit = len(self._buffer) > MAX_CONTROL_BYTES
+        if 0x30 <= byte <= 0x39:
+            self._csi_parameter_digits += 1
+            self._csi_parameter_value = self._csi_parameter_value * 10 + byte - 0x30
+            crossed_limit = crossed_limit or (
+                self._csi_parameter_digits > MAX_CSI_PARAMETER_DIGITS
+                or self._csi_parameter_value > MAX_CSI_PARAMETER_VALUE
+            )
+        elif byte in (ord(";"), ord(":")):
+            self._csi_parameters += 1
+            self._csi_parameter_digits = 0
+            self._csi_parameter_value = 0
+            crossed_limit = crossed_limit or (self._csi_parameters > MAX_CSI_PARAMETERS)
+        elif 0x20 <= byte <= 0x2F or 0x3C <= byte <= 0x3F:
+            self._csi_private_intermediate_bytes += 1
+            crossed_limit = crossed_limit or (
+                self._csi_private_intermediate_bytes
+                > MAX_CSI_PRIVATE_INTERMEDIATE_BYTES
+            )
+
+        if crossed_limit:
+            self._reject_and_discard(self._TEXT if is_final else self._DISCARD_CSI)
+            return
+
+        if byte in (0x18, 0x1A):
+            self._ignored_sequences += 1
+            self._reset_sequence()
+        elif is_final:
+            sequence = bytes(self._buffer)
+            if not self._raw_c1 and self._is_known_csi(sequence):
+                admitted.extend(sequence)
+            else:
+                self._ignored_sequences += 1
+            self._reset_sequence()
+        elif not (0x20 <= byte <= 0x3F):
+            self._ignored_sequences += 1
+            self._reset_sequence()
+
+    @staticmethod
+    def _is_known_csi(sequence: bytes) -> bool:
+        if len(sequence) < 3:
+            return False
+
+        body = sequence[2:-1]
+        # pyte 0.8.2 does not parse colon-form subparameters. Withholding the
+        # whole operation prevents the unparsed suffix becoming visible text.
+        if b":" in body:
+            return False
+        private = b""
+        if body and body[0] in b"<=>?":
+            private, body = body[:1], body[1:]
+        if any(byte not in b"0123456789;" for byte in body):
+            return False
+
+        parameters = tuple(int(value or b"0") for value in body.split(b";"))
+        final = sequence[-1]
+        if private:
+            return private == b"?" and final in b"hl"
+        if final in _CSI_ONE_PARAMETER_FINALS:
+            return len(parameters) == 1
+        if final in _CSI_TWO_PARAMETER_FINALS:
+            return len(parameters) <= 2
+        if final in _CSI_VARIADIC_FINALS:
+            return True
+        if final == ord("c"):
+            return len(parameters) == 1 and parameters[0] == 0
+        if final == ord("n"):
+            return len(parameters) == 1 and parameters[0] in (5, 6)
+        return False
+
+    def _consume_string(self, byte: int, admitted: bytearray) -> None:
+        self._control_bytes += 1
+        if self._string_utf8_remaining:
+            if 0x80 <= byte <= 0xBF:
+                self._string_utf8_remaining -= 1
+                self._discard_string_if_oversized()
+                return
+            self._string_utf8_remaining = 0
+            self._control_bytes -= 1
+            self._consume_string(byte, admitted)
+            return
+        if 0xC2 <= byte <= 0xDF:
+            self._string_escape_pending = False
+            self._string_utf8_remaining = 1
+            self._discard_string_if_oversized()
+            return
+        if 0xE0 <= byte <= 0xEF:
+            self._string_escape_pending = False
+            self._string_utf8_remaining = 2
+            self._discard_string_if_oversized()
+            return
+        if 0xF0 <= byte <= 0xF4:
+            self._string_escape_pending = False
+            self._string_utf8_remaining = 3
+            self._discard_string_if_oversized()
+            return
+
+        terminator = byte in (0x07, 0x18, 0x1A, 0x9C)
+        reset = self._string_escape_pending and byte == ord("c")
+        string_terminator = self._string_escape_pending and byte == ord("\\")
+
+        if self._control_bytes > MAX_CONTROL_BYTES:
+            if terminator or string_terminator or reset:
+                self._reject_and_discard(self._TEXT)
+                if reset:
+                    admitted.extend(b"\x1bc")
+            else:
+                self._reject_and_discard(self._DISCARD_STRING)
+                self._discard_escape_pending = byte == 0x1B
+            return
+
+        if terminator or string_terminator or reset:
+            self._reset_sequence()
+            if reset:
+                admitted.extend(b"\x1bc")
+            return
+
+        self._string_escape_pending = byte == 0x1B
+
+    def _discard_string_if_oversized(self) -> None:
+        """Cross into payload-free discard state at the string byte cap."""
+        if self._control_bytes > MAX_CONTROL_BYTES:
+            self._reject_and_discard(self._DISCARD_STRING)
+
+    def _consume_discard_escape(self, byte: int, admitted: bytearray) -> None:
+        if self._discard_reset(byte, admitted):
+            return
+        if byte in (0x18, 0x1A) or 0x30 <= byte <= 0x7E:
+            self._reset_sequence()
+
+    def _consume_discard_csi(self, byte: int, admitted: bytearray) -> None:
+        if self._discard_reset(byte, admitted):
+            return
+        if byte in (0x18, 0x1A) or 0x40 <= byte <= 0x7E:
+            self._reset_sequence()
+
+    def _consume_discard_string(self, byte: int, admitted: bytearray) -> None:
+        if self._string_utf8_remaining:
+            if 0x80 <= byte <= 0xBF:
+                self._string_utf8_remaining -= 1
+                return
+            self._string_utf8_remaining = 0
+            self._consume_discard_string(byte, admitted)
+            return
+        if 0xC2 <= byte <= 0xDF:
+            self._discard_escape_pending = False
+            self._string_utf8_remaining = 1
+            return
+        if 0xE0 <= byte <= 0xEF:
+            self._discard_escape_pending = False
+            self._string_utf8_remaining = 2
+            return
+        if 0xF0 <= byte <= 0xF4:
+            self._discard_escape_pending = False
+            self._string_utf8_remaining = 3
+            return
+        if byte in (0x07, 0x18, 0x1A, 0x9C):
+            self._reset_sequence()
+            return
+        if self._discard_escape_pending and byte == ord("\\"):
+            self._reset_sequence()
+            return
+        if self._discard_escape_pending and byte == ord("c"):
+            self._reset_sequence()
+            admitted.extend(b"\x1bc")
+            return
+        self._discard_escape_pending = byte == 0x1B
+
+    def _discard_reset(self, byte: int, admitted: bytearray) -> bool:
+        if self._discard_escape_pending and byte == ord("c"):
+            self._reset_sequence()
+            admitted.extend(b"\x1bc")
+            return True
+        self._discard_escape_pending = byte == 0x1B
+        return False
+
+    def _reject_and_discard(self, next_state: str) -> None:
+        self._rejected_sequences += 1
+        self._buffer.clear()
+        self._control_bytes = 0
+        self._state = next_state
+        self._raw_c1 = False
+        self._string_escape_pending = False
+        self._discard_escape_pending = False
+
+    def _reset_sequence(self) -> None:
+        self._state = self._TEXT
+        self._buffer.clear()
+        self._control_bytes = 0
+        self._raw_c1 = False
+        self._string_escape_pending = False
+        self._string_utf8_remaining = 0
+        self._discard_escape_pending = False

--- a/tldw_chatbook/Terminal/protocol_gate.py
+++ b/tldw_chatbook/Terminal/protocol_gate.py
@@ -72,6 +72,7 @@ class TerminalProtocolGate:
         self._csi_private_intermediate_bytes = 0
         self._string_escape_pending = False
         self._string_utf8_remaining = 0
+        self._string_utf8_saw_st = False
         self._discard_escape_pending = False
         self._rejected_sequences = 0
         self._ignored_sequences = 0
@@ -83,6 +84,12 @@ class TerminalProtocolGate:
         is complete and proven bounded. Once a limit is crossed, retained
         bytes are erased immediately and input is consumed through the
         sequence terminator.
+
+        Args:
+            data: The next terminal-output byte chunk.
+
+        Returns:
+            Bytes admitted for incremental UTF-8 decoding and VT parsing.
         """
         admitted = bytearray()
         for byte in data:
@@ -182,6 +189,7 @@ class TerminalProtocolGate:
         self._raw_c1 = raw_c1
         self._string_escape_pending = False
         self._string_utf8_remaining = 0
+        self._string_utf8_saw_st = False
 
     def _consume_escape(self, byte: int, admitted: bytearray) -> None:
         if len(self._buffer) == 1:
@@ -300,26 +308,38 @@ class TerminalProtocolGate:
         self._control_bytes += 1
         if self._string_utf8_remaining:
             if 0x80 <= byte <= 0xBF:
+                self._string_utf8_saw_st = self._string_utf8_saw_st or byte == 0x9C
                 self._string_utf8_remaining -= 1
+                if self._string_utf8_remaining == 0:
+                    self._string_utf8_saw_st = False
                 self._discard_string_if_oversized()
                 return
+            saw_st = self._string_utf8_saw_st
             self._string_utf8_remaining = 0
+            self._string_utf8_saw_st = False
             self._control_bytes -= 1
+            if saw_st:
+                self._reset_sequence()
+                self._consume_text(byte, admitted)
+                return
             self._consume_string(byte, admitted)
             return
         if 0xC2 <= byte <= 0xDF:
             self._string_escape_pending = False
             self._string_utf8_remaining = 1
+            self._string_utf8_saw_st = False
             self._discard_string_if_oversized()
             return
         if 0xE0 <= byte <= 0xEF:
             self._string_escape_pending = False
             self._string_utf8_remaining = 2
+            self._string_utf8_saw_st = False
             self._discard_string_if_oversized()
             return
         if 0xF0 <= byte <= 0xF4:
             self._string_escape_pending = False
             self._string_utf8_remaining = 3
+            self._string_utf8_saw_st = False
             self._discard_string_if_oversized()
             return
 
@@ -365,22 +385,34 @@ class TerminalProtocolGate:
     def _consume_discard_string(self, byte: int, admitted: bytearray) -> None:
         if self._string_utf8_remaining:
             if 0x80 <= byte <= 0xBF:
+                self._string_utf8_saw_st = self._string_utf8_saw_st or byte == 0x9C
                 self._string_utf8_remaining -= 1
+                if self._string_utf8_remaining == 0:
+                    self._string_utf8_saw_st = False
                 return
+            saw_st = self._string_utf8_saw_st
             self._string_utf8_remaining = 0
+            self._string_utf8_saw_st = False
+            if saw_st:
+                self._reset_sequence()
+                self._consume_text(byte, admitted)
+                return
             self._consume_discard_string(byte, admitted)
             return
         if 0xC2 <= byte <= 0xDF:
             self._discard_escape_pending = False
             self._string_utf8_remaining = 1
+            self._string_utf8_saw_st = False
             return
         if 0xE0 <= byte <= 0xEF:
             self._discard_escape_pending = False
             self._string_utf8_remaining = 2
+            self._string_utf8_saw_st = False
             return
         if 0xF0 <= byte <= 0xF4:
             self._discard_escape_pending = False
             self._string_utf8_remaining = 3
+            self._string_utf8_saw_st = False
             return
         if byte in (0x07, 0x18, 0x1A, 0x9C):
             self._reset_sequence()
@@ -418,4 +450,5 @@ class TerminalProtocolGate:
         self._raw_c1 = False
         self._string_escape_pending = False
         self._string_utf8_remaining = 0
+        self._string_utf8_saw_st = False
         self._discard_escape_pending = False

--- a/tldw_chatbook/Terminal/screen_model.py
+++ b/tldw_chatbook/Terminal/screen_model.py
@@ -1,0 +1,669 @@
+"""Safe immutable projections for persistent terminal output."""
+
+from __future__ import annotations
+
+import codecs
+from collections import deque
+from dataclasses import dataclass
+import re
+import unicodedata
+from typing import Any, Callable
+
+import pyte
+from pyte import modes as pyte_modes
+from wcwidth import wcwidth, wcswidth
+
+from tldw_chatbook.Terminal.contracts import (
+    MAX_COLUMNS,
+    MAX_ROWS,
+    MAX_SCROLLBACK_BYTES,
+    MAX_SCROLLBACK_LINES,
+    MIN_COLUMNS,
+    MIN_ROWS,
+    TerminalReason,
+)
+from tldw_chatbook.Terminal.protocol_gate import TerminalProtocolGate
+
+
+MAX_CELL_SCALARS = 32
+MAX_CELL_UTF8_BYTES = 256
+MAX_CURSOR_SAVEPOINTS = 16
+MAX_REPLY_BYTES = 256
+MAX_PENDING_REPLY_BYTES = 4 * 1024
+STYLE_RUN_ACCOUNTING_BYTES = 32
+LINE_ACCOUNTING_BYTES = 16
+_OVERFLOW_CELL = "\udfff"
+
+_ALLOWED_PRIVATE_MODES = frozenset((1, 5, 6, 7, 25, 2004))
+_ALLOWED_STANDARD_MODES = frozenset((4, 20))
+_SAFE_COLOR = re.compile(r"\A[0-9A-Za-z#_-]{1,32}\Z")
+_CURSOR_REPLY = re.compile(r"\A\x1b\[[1-9][0-9]{0,4};[1-9][0-9]{0,4}R\Z")
+
+
+@dataclass(frozen=True, slots=True)
+class SafeTerminalStyle:
+    """Renderer-safe style values for one terminal run."""
+
+    fg: str = "default"
+    bg: str = "default"
+    bold: bool = False
+    italics: bool = False
+    underscore: bool = False
+    strikethrough: bool = False
+    reverse: bool = False
+    blink: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class SafeTerminalCell:
+    """One bounded renderer-safe terminal cell."""
+
+    text: str = ""
+    width: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class SafeTerminalRun:
+    """Adjacent safe cells sharing one style."""
+
+    cells: tuple[SafeTerminalCell, ...] = ()
+    style: SafeTerminalStyle = SafeTerminalStyle()
+
+    @property
+    def text(self) -> str:
+        """Return the run's safe text."""
+        return "".join(cell.text for cell in self.cells)
+
+
+@dataclass(frozen=True, slots=True)
+class SafeTerminalLine:
+    """One run-compressed safe terminal line."""
+
+    runs: tuple[SafeTerminalRun, ...] = ()
+    accounted_bytes: int = LINE_ACCOUNTING_BYTES
+
+    @property
+    def text(self) -> str:
+        """Return the line's safe text."""
+        return "".join(run.text for run in self.runs)
+
+    @property
+    def column_width(self) -> int:
+        """Return the retained terminal-cell width."""
+        return sum(cell.width for run in self.runs for cell in run.cells)
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalScreenSnapshot:
+    """Immutable screen projection safe for Textual consumers."""
+
+    lines: tuple[SafeTerminalLine, ...]
+    scrollback: tuple[SafeTerminalLine, ...] = ()
+    cursor_row: int = 1
+    cursor_column: int = 1
+    cursor_visible: bool = True
+    cursor_savepoints: int = 0
+    in_alternate: bool = False
+    generation: int = 0
+    dirty_lines: tuple[int, ...] = ()
+    scrollback_bytes: int = 0
+    cell_overflow_count: int = 0
+    failure_reason: TerminalReason | None = None
+
+
+class _BoundedScreen(pyte.Screen):
+    """pyte screen with bounded mutable state and content-free callbacks."""
+
+    def __init__(
+        self,
+        columns: int,
+        lines: int,
+        *,
+        on_scroll: Callable[[Any], None] | None,
+        on_reply: Callable[[bytes], None],
+        on_cell_overflow: Callable[[], None],
+    ) -> None:
+        self._on_scroll = on_scroll
+        self._on_reply = on_reply
+        self._on_cell_overflow = on_cell_overflow
+        self._join_cell: tuple[int, int, int] | None = None
+        super().__init__(columns, lines)
+
+    def reset(self) -> None:
+        """Reset the screen and every code-owned mutable extension."""
+        super().reset()
+        self.savepoints.clear()
+        self._join_cell = None
+
+    def save_cursor(self) -> None:
+        """Save the cursor while retaining only the newest 16 entries."""
+        super().save_cursor()
+        if len(self.savepoints) > MAX_CURSOR_SAVEPOINTS:
+            del self.savepoints[: len(self.savepoints) - MAX_CURSOR_SAVEPOINTS]
+
+    def index(self) -> None:
+        """Capture a line only when the full normal viewport scrolls."""
+        top, bottom = self.margins or pyte.screens.Margins(0, self.lines - 1)
+        full_viewport_scroll = (
+            self.cursor.y == bottom and top == 0 and bottom == self.lines - 1
+        )
+        if full_viewport_scroll and self._on_scroll is not None:
+            self._on_scroll(self.buffer[top])
+        super().index()
+        self._join_cell = None
+
+    def set_mode(self, *modes: int, **kwargs: Any) -> None:
+        """Apply only the finite mode allowlist used by the safe adapter."""
+        allowed = (
+            _ALLOWED_PRIVATE_MODES
+            if kwargs.get("private") is True
+            else _ALLOWED_STANDARD_MODES
+        )
+        retained = tuple(mode for mode in modes if mode in allowed)
+        if retained:
+            super().set_mode(*retained, **kwargs)
+
+    def reset_mode(self, *modes: int, **kwargs: Any) -> None:
+        """Reset only modes from the same finite allowlist."""
+        allowed = (
+            _ALLOWED_PRIVATE_MODES
+            if kwargs.get("private") is True
+            else _ALLOWED_STANDARD_MODES
+        )
+        retained = tuple(mode for mode in modes if mode in allowed)
+        if retained:
+            super().reset_mode(*retained, **kwargs)
+
+    def draw(self, data: str) -> None:
+        """Draw Unicode text while bounding combining and joiner cells."""
+        data = data.translate(self.g1_charset if self.charset else self.g0_charset)
+        for character in data:
+            width = wcwidth(character)
+            if width == 0:
+                self._append_zero_width(character)
+                continue
+            if width < 0:
+                self._join_cell = None
+                continue
+            if self._append_joined_character(character):
+                continue
+            self._draw_advancing_character(character, min(width, 2))
+        self.dirty.add(self.cursor.y)
+
+    def _append_zero_width(self, character: str) -> None:
+        position = self._previous_base_cell()
+        if position is None:
+            return
+        row, column = position
+        line = self.buffer[row]
+        previous = line[column]
+        if previous.data == _OVERFLOW_CELL:
+            return
+        value = unicodedata.normalize("NFC", previous.data + character)
+        position = self._replace_cell_text(position, value)
+        if character == "\u200d":
+            self._join_cell = (*position, self.cursor.x)
+
+    def _append_joined_character(self, character: str) -> bool:
+        join = self._join_cell
+        self._join_cell = None
+        if join is None:
+            return False
+        row, column, expected_cursor = join
+        if row != self.cursor.y or expected_cursor != self.cursor.x:
+            return False
+        position = (row, column)
+        line = self.buffer[row]
+        previous = line[column]
+        if previous.data == _OVERFLOW_CELL:
+            return True
+        value = unicodedata.normalize("NFC", previous.data + character)
+        self._replace_cell_text(position, value)
+        return True
+
+    def _draw_advancing_character(self, character: str, width: int) -> None:
+        if self.cursor.x == self.columns:
+            if pyte_modes.DECAWM in self.mode:
+                self.dirty.add(self.cursor.y)
+                self.carriage_return()
+                self.linefeed()
+            else:
+                self.cursor.x = max(0, self.cursor.x - width)
+
+        if width == 2 and self.cursor.x == self.columns - 1:
+            if pyte_modes.DECAWM in self.mode:
+                self.dirty.add(self.cursor.y)
+                self.carriage_return()
+                self.linefeed()
+            else:
+                character = "\ufffd"
+                width = 1
+
+        if pyte_modes.IRM in self.mode:
+            self.insert_characters(width)
+
+        row, column = self.cursor.y, self.cursor.x
+        line = self.buffer[row]
+        self._clear_intersecting_wide_cells(line, column, width)
+        line[column] = self.cursor.attrs._replace(data=character)
+        if width == 2 and column + 1 < self.columns:
+            line[column + 1] = self.cursor.attrs._replace(data="")
+        self.cursor.x = min(self.cursor.x + width, self.columns)
+        self._join_cell = None
+
+    def _clear_intersecting_wide_cells(
+        self, line: Any, column: int, width: int
+    ) -> None:
+        """Clear both halves of every wide cell touched by a new write."""
+        clear_columns: set[int] = set()
+        for target in range(column, min(column + width, self.columns)):
+            if line[target].data == "" and target > 0:
+                clear_columns.update((target - 1, target))
+            elif target + 1 < self.columns and line[target + 1].data == "":
+                clear_columns.update((target, target + 1))
+        for target in clear_columns:
+            line[target] = self.default_char
+
+    def _previous_base_cell(self) -> tuple[int, int] | None:
+        row = self.cursor.y
+        column = self.cursor.x - 1
+        if column < 0:
+            row -= 1
+            column = self.columns - 1
+        while row >= 0:
+            line = self.buffer[row]
+            while column >= 0:
+                if line[column].data:
+                    return row, column
+                column -= 1
+            row -= 1
+            column = self.columns - 1
+        return None
+
+    def _bounded_cell(self, value: str) -> str:
+        if (
+            len(value) <= MAX_CELL_SCALARS
+            and len(value.encode("utf-8")) <= MAX_CELL_UTF8_BYTES
+        ):
+            return value
+        self._on_cell_overflow()
+        return _OVERFLOW_CELL
+
+    def _replace_cell_text(
+        self, position: tuple[int, int], value: str
+    ) -> tuple[int, int]:
+        """Replace one cell and atomically reconcile a grapheme width change."""
+        row, column = position
+        line = self.buffer[row]
+        previous = line[column]
+        old_width = (
+            2 if column + 1 < self.columns and line[column + 1].data == "" else 1
+        )
+        bounded = self._bounded_cell(value)
+        new_width = 1 if bounded == _OVERFLOW_CELL else max(1, min(wcswidth(value), 2))
+
+        if new_width == 2 and column + 1 >= self.columns:
+            if (
+                pyte_modes.DECAWM in self.mode
+                and row == self.cursor.y
+                and self.cursor.x == self.columns
+            ):
+                line[column] = previous._replace(data=" ")
+                self.dirty.add(row)
+                self.carriage_return()
+                self.linefeed()
+                row, column = self.cursor.y, self.cursor.x
+                line = self.buffer[row]
+                line[column] = previous._replace(data=bounded)
+                line[column + 1] = previous._replace(data="")
+                self.cursor.x = column + 2
+                self.dirty.add(row)
+                return row, column
+            bounded = "\ufffd"
+            new_width = 1
+
+        line[column] = previous._replace(data=bounded)
+        if old_width == 1 and new_width == 2:
+            line[column + 1] = previous._replace(data="")
+        elif old_width == 2 and new_width == 1:
+            line[column + 1] = previous._replace(data=" ")
+        if row == self.cursor.y and self.cursor.x == column + old_width:
+            self.cursor.x = min(column + new_width, self.columns)
+        self.dirty.add(row)
+        return row, column
+
+    def write_process_input(self, data: str) -> None:
+        """Queue only fixed or bounded code-owned replies."""
+        if (
+            data not in ("\x1b[0n", "\x1b[?6c")
+            and _CURSOR_REPLY.fullmatch(data) is None
+        ):
+            return
+        encoded = data.encode("ascii")
+        if len(encoded) <= MAX_REPLY_BYTES:
+            self._on_reply(encoded)
+
+    def set_title(self, _: str) -> None:
+        """Ignore host title changes."""
+
+    def set_icon_name(self, _: str) -> None:
+        """Ignore host icon changes."""
+
+    def bell(self) -> None:
+        """Ignore host bell requests."""
+
+    def debug(self, *args: Any, **kwargs: Any) -> None:
+        """Ignore unsupported operations without retaining their content."""
+
+
+class _AlternateScreenAdapter:
+    """Route DEC 1049 operations between isolated bounded screens."""
+
+    def __init__(
+        self,
+        columns: int,
+        lines: int,
+        *,
+        on_scroll: Callable[[Any], None],
+        on_reply: Callable[[bytes], None],
+        on_cell_overflow: Callable[[], None],
+    ) -> None:
+        self.primary = _BoundedScreen(
+            columns,
+            lines,
+            on_scroll=on_scroll,
+            on_reply=on_reply,
+            on_cell_overflow=on_cell_overflow,
+        )
+        self.alternate = _BoundedScreen(
+            columns,
+            lines,
+            on_scroll=None,
+            on_reply=on_reply,
+            on_cell_overflow=on_cell_overflow,
+        )
+        self.active = self.primary
+        self.in_alternate = False
+
+    def set_mode(self, *modes: int, **kwargs: Any) -> None:
+        """Enter alternate screen for private DEC mode 1049."""
+        private = kwargs.get("private") is True
+        remaining = tuple(mode for mode in modes if not (private and mode == 1049))
+        if private and 1049 in modes and not self.in_alternate:
+            self.primary.save_cursor()
+            self.alternate.reset()
+            self.active = self.alternate
+            self.in_alternate = True
+            self.active.dirty.update(range(self.active.lines))
+        if remaining:
+            self.active.set_mode(*remaining, **kwargs)
+
+    def reset_mode(self, *modes: int, **kwargs: Any) -> None:
+        """Leave alternate screen for private DEC mode 1049."""
+        private = kwargs.get("private") is True
+        remaining = tuple(mode for mode in modes if not (private and mode == 1049))
+        if remaining:
+            self.active.reset_mode(*remaining, **kwargs)
+        if private and 1049 in modes and self.in_alternate:
+            self.active = self.primary
+            self.primary.restore_cursor()
+            self.in_alternate = False
+            self.active.dirty.update(range(self.active.lines))
+
+    def reset(self) -> None:
+        """Reset both buffers and leave alternate-screen mode coherently."""
+        self.primary.reset()
+        self.alternate.reset()
+        self.active = self.primary
+        self.in_alternate = False
+
+    def resize(self, *, columns: int, rows: int) -> None:
+        """Resize both isolated buffers while preserving their cursor state."""
+        for screen in (self.primary, self.alternate):
+            screen.resize(lines=rows, columns=columns)
+            screen._join_cell = None
+            screen.dirty.update(range(rows))
+
+    def _forward(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        if name != "draw":
+            self.active._join_cell = None
+        return getattr(self.active, name)(*args, **kwargs)
+
+
+def _install_dynamic_screen_forwarders() -> None:
+    """Install forwarding methods before pyte statically binds its events."""
+
+    def make_forwarder(name: str) -> Callable[..., Any]:
+        def forward(self: _AlternateScreenAdapter, *args: Any, **kwargs: Any) -> Any:
+            return self._forward(name, *args, **kwargs)
+
+        forward.__name__ = name
+        return forward
+
+    for event in pyte.Stream.events - {"set_mode", "reset_mode"}:
+        if not hasattr(_AlternateScreenAdapter, event):
+            setattr(_AlternateScreenAdapter, event, make_forwarder(event))
+
+
+_install_dynamic_screen_forwarders()
+
+
+class TerminalScreenModel:
+    """Own bounded parser state and expose only safe immutable values."""
+
+    def __init__(
+        self,
+        *,
+        columns: int,
+        rows: int,
+        scrollback_line_limit: int = MAX_SCROLLBACK_LINES,
+        scrollback_byte_limit: int = MAX_SCROLLBACK_BYTES,
+    ) -> None:
+        if not MIN_COLUMNS <= columns <= MAX_COLUMNS:
+            raise ValueError("terminal columns outside contract")
+        if not MIN_ROWS <= rows <= MAX_ROWS:
+            raise ValueError("terminal rows outside contract")
+        if not 0 <= scrollback_line_limit <= MAX_SCROLLBACK_LINES:
+            raise ValueError("scrollback line limit outside contract")
+        if not 0 <= scrollback_byte_limit <= MAX_SCROLLBACK_BYTES:
+            raise ValueError("scrollback byte limit outside contract")
+
+        self.columns = columns
+        self.rows = rows
+        self._scrollback_line_limit = scrollback_line_limit
+        self._scrollback_byte_limit = scrollback_byte_limit
+        self._scrollback: deque[SafeTerminalLine] = deque()
+        self._scrollback_bytes = 0
+        self._pending_replies: deque[bytes] = deque()
+        self._pending_reply_bytes = 0
+        self._cell_overflow_count = 0
+        self._failure_reason: TerminalReason | None = None
+        self._generation = 0
+        self._gate = TerminalProtocolGate()
+        self._decoder = codecs.getincrementaldecoder("utf-8")("replace")
+        self._screens = _AlternateScreenAdapter(
+            columns,
+            rows,
+            on_scroll=self._retain_scrollback_line,
+            on_reply=self._queue_reply,
+            on_cell_overflow=self._count_cell_overflow,
+        )
+        self._stream = pyte.Stream(self._screens)
+
+    def feed(self, data: bytes) -> None:
+        """Feed one bounded terminal-output chunk."""
+        if self._failure_reason is not None:
+            return
+        admitted = self._gate.feed(data)
+        if not admitted:
+            return
+        decoded = self._decoder.decode(admitted, final=False)
+        if decoded:
+            self._feed_parser(decoded)
+
+    def finish(self) -> None:
+        """Finalize incremental decoding and discard incomplete controls."""
+        if self._failure_reason is not None:
+            return
+        self._gate.finish()
+        decoded = self._decoder.decode(b"", final=True)
+        if decoded:
+            self._feed_parser(decoded)
+
+    def resize(self, *, columns: int, rows: int) -> None:
+        """Resize both terminal buffers within the persistent-session bounds."""
+        if not MIN_COLUMNS <= columns <= MAX_COLUMNS:
+            raise ValueError("terminal columns outside contract")
+        if not MIN_ROWS <= rows <= MAX_ROWS:
+            raise ValueError("terminal rows outside contract")
+        self._screens.resize(columns=columns, rows=rows)
+        self.columns = columns
+        self.rows = rows
+        self._generation += 1
+
+    def snapshot(self) -> TerminalScreenSnapshot:
+        """Return an immutable renderer-safe screen projection."""
+        active = self._screens.active
+        lines = tuple(
+            self._project_line(active.buffer[row]) for row in range(self.rows)
+        )
+        return TerminalScreenSnapshot(
+            lines=lines,
+            scrollback=tuple(self._scrollback),
+            cursor_row=active.cursor.y + 1,
+            cursor_column=active.cursor.x + 1,
+            cursor_visible=not active.cursor.hidden,
+            cursor_savepoints=len(active.savepoints),
+            in_alternate=self._screens.in_alternate,
+            generation=self._generation,
+            dirty_lines=tuple(sorted(row + 1 for row in active.dirty)),
+            scrollback_bytes=self._scrollback_bytes,
+            cell_overflow_count=self._cell_overflow_count,
+            failure_reason=self._failure_reason,
+        )
+
+    def visible_text(self) -> str:
+        """Return visible safe text without trailing blank rows."""
+        lines = [line.text for line in self.snapshot().lines]
+        while lines and not lines[-1]:
+            lines.pop()
+        return "\n".join(lines)
+
+    def pending_replies(self) -> tuple[bytes, ...]:
+        """Return queued code-owned terminal replies."""
+        return tuple(self._pending_replies)
+
+    def take_pending_replies(self) -> tuple[bytes, ...]:
+        """Take queued code-owned terminal replies."""
+        replies = tuple(self._pending_replies)
+        self._pending_replies.clear()
+        self._pending_reply_bytes = 0
+        return replies
+
+    def _feed_parser(self, decoded: str) -> None:
+        try:
+            self._screens.active.dirty.clear()
+            self._stream.feed(decoded)
+        except Exception:
+            # Parser exceptions may contain terminal output. Never copy or log
+            # them; the category is the complete diagnostic contract.
+            self._failure_reason = TerminalReason.TERMINAL_PROTOCOL_FAILED
+            return
+        self._generation += 1
+
+    def _retain_scrollback_line(self, line: Any) -> None:
+        retained = self._project_line(line)
+        self._scrollback.append(retained)
+        self._scrollback_bytes += retained.accounted_bytes
+        while self._scrollback and (
+            len(self._scrollback) > self._scrollback_line_limit
+            or self._scrollback_bytes > self._scrollback_byte_limit
+        ):
+            evicted = self._scrollback.popleft()
+            self._scrollback_bytes -= evicted.accounted_bytes
+
+    def _count_cell_overflow(self) -> None:
+        self._cell_overflow_count += 1
+
+    def _queue_reply(self, reply: bytes) -> None:
+        if self._pending_reply_bytes + len(reply) > MAX_PENDING_REPLY_BYTES:
+            return
+        self._pending_replies.append(reply)
+        self._pending_reply_bytes += len(reply)
+
+    def _project_line(self, line: Any) -> SafeTerminalLine:
+        last_column = -1
+        for column in range(self.columns):
+            character = line[column]
+            if character.data != "" and (
+                character.data != " " or _safe_style(character) != SafeTerminalStyle()
+            ):
+                last_column = column
+        if last_column < 0:
+            return SafeTerminalLine()
+
+        runs: list[SafeTerminalRun] = []
+        run_cells: list[SafeTerminalCell] = []
+        run_style: SafeTerminalStyle | None = None
+        column = 0
+        while column <= last_column:
+            character = line[column]
+            if character.data == "":
+                column += 1
+                continue
+            text = _safe_cell_text(character.data)
+            width = (
+                2 if column + 1 < self.columns and line[column + 1].data == "" else 1
+            )
+            if width == 1 and wcswidth(text) > 1:
+                text = "\ufffd"
+            cell = SafeTerminalCell(text=text, width=width)
+            style = _safe_style(character)
+            if run_style is not None and style != run_style:
+                runs.append(SafeTerminalRun(cells=tuple(run_cells), style=run_style))
+                run_cells = []
+            run_style = style
+            run_cells.append(cell)
+            column += width
+
+        if run_style is not None:
+            runs.append(SafeTerminalRun(cells=tuple(run_cells), style=run_style))
+        accounted_bytes = (
+            sum(len(run.text.encode("utf-8")) for run in runs)
+            + len(runs) * STYLE_RUN_ACCOUNTING_BYTES
+            + LINE_ACCOUNTING_BYTES
+        )
+        return SafeTerminalLine(runs=tuple(runs), accounted_bytes=accounted_bytes)
+
+
+def _safe_cell_text(value: str) -> str:
+    """Strip renderer-active controls from a parser-owned cell value."""
+    safe = "".join(
+        character
+        if not (
+            unicodedata.category(character) in {"Cc", "Cs"}
+            or 0x80 <= ord(character) <= 0x9F
+        )
+        else "\ufffd"
+        for character in value
+    )
+    return unicodedata.normalize("NFC", safe)
+
+
+def _safe_style(character: Any) -> SafeTerminalStyle:
+    """Copy a pyte character style into primitive immutable values."""
+
+    def color(value: Any) -> str:
+        candidate = str(value)
+        return candidate if _SAFE_COLOR.fullmatch(candidate) is not None else "default"
+
+    return SafeTerminalStyle(
+        fg=color(character.fg),
+        bg=color(character.bg),
+        bold=bool(character.bold),
+        italics=bool(character.italics),
+        underscore=bool(character.underscore),
+        strikethrough=bool(character.strikethrough),
+        reverse=bool(character.reverse),
+        blink=bool(character.blink),
+    )

--- a/tldw_chatbook/Terminal/screen_model.py
+++ b/tldw_chatbook/Terminal/screen_model.py
@@ -36,6 +36,7 @@ _OVERFLOW_CELL = "\udfff"
 
 _ALLOWED_PRIVATE_MODES = frozenset((1, 5, 6, 7, 25, 2004))
 _ALLOWED_STANDARD_MODES = frozenset((4, 20))
+_DEC_ALTERNATE_SCREEN_MODE = 1049
 _SAFE_COLOR = re.compile(r"\A[0-9A-Za-z#_-]{1,32}\Z")
 _CURSOR_REPLY = re.compile(r"\A\x1b\[[1-9][0-9]{0,4};[1-9][0-9]{0,4}R\Z")
 
@@ -268,16 +269,12 @@ class _BoundedScreen(pyte.Screen):
         row = self.cursor.y
         column = self.cursor.x - 1
         if column < 0:
-            row -= 1
-            column = self.columns - 1
-        while row >= 0:
-            line = self.buffer[row]
-            while column >= 0:
-                if line[column].data:
-                    return row, column
-                column -= 1
-            row -= 1
-            column = self.columns - 1
+            return None
+        line = self.buffer[row]
+        while column >= 0:
+            if line[column].data:
+                return row, column
+            column -= 1
         return None
 
     def _bounded_cell(self, value: str) -> str:
@@ -388,8 +385,12 @@ class _AlternateScreenAdapter:
     def set_mode(self, *modes: int, **kwargs: Any) -> None:
         """Enter alternate screen for private DEC mode 1049."""
         private = kwargs.get("private") is True
-        remaining = tuple(mode for mode in modes if not (private and mode == 1049))
-        if private and 1049 in modes and not self.in_alternate:
+        remaining = tuple(
+            mode
+            for mode in modes
+            if not (private and mode == _DEC_ALTERNATE_SCREEN_MODE)
+        )
+        if private and _DEC_ALTERNATE_SCREEN_MODE in modes and not self.in_alternate:
             self.primary.save_cursor()
             self.alternate.reset()
             self.active = self.alternate
@@ -401,10 +402,14 @@ class _AlternateScreenAdapter:
     def reset_mode(self, *modes: int, **kwargs: Any) -> None:
         """Leave alternate screen for private DEC mode 1049."""
         private = kwargs.get("private") is True
-        remaining = tuple(mode for mode in modes if not (private and mode == 1049))
+        remaining = tuple(
+            mode
+            for mode in modes
+            if not (private and mode == _DEC_ALTERNATE_SCREEN_MODE)
+        )
         if remaining:
             self.active.reset_mode(*remaining, **kwargs)
-        if private and 1049 in modes and self.in_alternate:
+        if private and _DEC_ALTERNATE_SCREEN_MODE in modes and self.in_alternate:
             self.active = self.primary
             self.primary.restore_cursor()
             self.in_alternate = False
@@ -511,7 +516,15 @@ class TerminalScreenModel:
             self._feed_parser(decoded)
 
     def resize(self, *, columns: int, rows: int) -> None:
-        """Resize both terminal buffers within the persistent-session bounds."""
+        """Resize both terminal buffers within the persistent-session bounds.
+
+        Args:
+            columns: New viewport width in terminal cells.
+            rows: New viewport height in terminal rows.
+
+        Raises:
+            ValueError: If either dimension is outside the terminal contract.
+        """
         if not MIN_COLUMNS <= columns <= MAX_COLUMNS:
             raise ValueError("terminal columns outside contract")
         if not MIN_ROWS <= rows <= MAX_ROWS:


### PR DESCRIPTION
## Summary

- add a bounded byte-level terminal protocol gate that admits only supported screen and query operations while discarding host-affecting controls without retaining payloads
- add immutable safe terminal projections with bounded cells, replies, savepoints, scrollback, alternate-screen isolation, resize, and coherent reset behavior
- add the Task 5 parser qualification corpus, hostile cross-chunk controls, Unicode and wide-cell regressions, and explicit mutable-state inventory

## Architecture

- implements Task 5 of task-22512
- follows existing ADR-099; no new ADR is required

## Verification

- 450 targeted tests passed
- 1 expected Windows-only test skipped
- Ruff format check passed
- Ruff lint passed
- git diff check passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Task 5 of task-22512 by adding a bounded terminal screen model that safely parses terminal output and exposes immutable, renderer-safe projections.

**New Features**
- `TerminalProtocolGate` admits only supported screen and query sequences; host-affecting controls are discarded without retaining payloads.
- `TerminalScreenModel` projects safe cells, scrollback, alternate-screen isolation, resize, and reset with bounded mutable state.
- Includes a qualification corpus for cross-chunk controls, Unicode width regressions, and mutable-state inventory.

<sup>Written for commit 4232291c0515654c684a76d110d3b158b343d6be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

