### PR TITLE
feat: bound terminal io actors

### DIFF
--- a/Tests/Packaging/test_app_import_diet_closure.py
+++ b/Tests/Packaging/test_app_import_diet_closure.py
@@ -115,6 +115,10 @@ forbidden = (
     "tldw_chatbook.Notes.note_import_plan_models",
     "tldw_chatbook.Notes.note_import_windows_fs",
     "tldw_chatbook.Notes.sync_paths",
+    # Shared validation is resident at boot, but terminal-only contracts are not.
+    "tldw_chatbook.Terminal",
+    "tldw_chatbook.Terminal.backend",
+    "tldw_chatbook.Terminal.contracts",
 )
 resident = sorted(m for m in forbidden if sys.modules.get(m) is not None)
 assert not resident, (

--- a/Tests/Terminal/test_io_actors.py
+++ b/Tests/Terminal/test_io_actors.py
@@ -1,0 +1,469 @@
+"""Behavioral tests for bounded persistent-terminal input/output actors."""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import FrozenInstanceError
+import os
+from statistics import quantiles
+from threading import Barrier
+
+import pytest
+
+from tldw_chatbook.Terminal.contracts import (
+    MAX_COLUMNS,
+    MAX_IO_CHUNK_BYTES,
+    MAX_PARSER_TURN_BYTES,
+    MAX_PARSER_TURN_SECONDS,
+    MAX_PASTE_BYTES,
+    MAX_PENDING_INPUT_BYTES,
+    MAX_PENDING_OUTPUT_BYTES,
+    MAX_ROWS,
+    MIN_COLUMNS,
+    MIN_ROWS,
+)
+from tldw_chatbook.Terminal.io_actors import (
+    InputEventKind,
+    InputRefusalReason,
+    OutputRefusalReason,
+    PasteRefusalReason,
+    TerminalInputActor,
+    TerminalOutputActor,
+    TerminalPriorityControl,
+)
+from tldw_chatbook.Terminal.screen_model import TerminalScreenModel
+
+
+BRACKETED_PASTE_START = b"\x1b[200~"
+BRACKETED_PASTE_END = b"\x1b[201~"
+
+
+class ManualClock:
+    """Small injected monotonic clock for rate and parser-budget behavior."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _drain_input(actor: TerminalInputActor) -> list[tuple[InputEventKind, bytes]]:
+    drained: list[tuple[InputEventKind, bytes]] = []
+    while (event := actor.take_nowait()) is not None:
+        assert event.encoded_size == len(event.data)
+        drained.append((event.kind, event.data))
+    return drained
+
+
+def test_key_paste_and_reply_share_one_ordered_byte_counted_queue() -> None:
+    actor = TerminalInputActor()
+
+    assert actor.offer_key(b"a").accepted is True
+    assert actor.offer_paste("b\n", bracketed=True).accepted is True
+    assert actor.offer_reply(b"reply").accepted is True
+
+    assert actor.pending_events == 3
+    assert actor.pending_bytes == 1 + 2 + 12 + 5
+    assert _drain_input(actor) == [
+        (InputEventKind.KEY, b"a"),
+        (
+            InputEventKind.PASTE,
+            BRACKETED_PASTE_START + b"b\n" + BRACKETED_PASTE_END,
+        ),
+        (InputEventKind.REPLY, b"reply"),
+    ]
+    assert actor.pending_bytes == 0
+
+
+def test_input_envelopes_are_frozen_and_carry_precomputed_size() -> None:
+    actor = TerminalInputActor()
+    assert actor.offer_key(b"key").accepted is True
+
+    event = actor.take_nowait()
+    assert event is not None
+    assert event.encoded_size == 3
+    assert "__dict__" not in event.__slots__
+    with pytest.raises(FrozenInstanceError):
+        event.encoded_size = 4  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "control",
+    [
+        "\x00",
+        "\x01",
+        "\x08",
+        "\x0b",
+        "\x0c",
+        "\x1b",
+        "\x1f",
+        "\x7f",
+        "\x80",
+        "\x9f",
+    ],
+)
+def test_prohibited_paste_is_refused_before_any_bytes_are_enqueued(
+    control: str,
+) -> None:
+    private_payload = f"safe{control}PRIVATE-PASTE-CONTENT"
+    actor = TerminalInputActor(capacity_bytes=MAX_PENDING_INPUT_BYTES)
+
+    result = actor.offer_paste(private_payload, bracketed=True)
+
+    assert result.accepted is False
+    assert result.reason is PasteRefusalReason.PROHIBITED_CONTROL
+    assert actor.pending_bytes == 0
+    assert actor.take_nowait() is None
+    assert "PRIVATE-PASTE-CONTENT" not in result.safe_message
+    assert "PRIVATE-PASTE-CONTENT" not in repr(result)
+
+
+def test_tab_cr_and_lf_remain_allowed_in_one_atomic_paste() -> None:
+    actor = TerminalInputActor()
+
+    result = actor.offer_paste("a\tb\rc\nd", bracketed=False)
+
+    assert result.accepted is True
+    event = actor.take_nowait()
+    assert event is not None
+    assert event.kind is InputEventKind.PASTE
+    assert event.data == b"a\tb\rc\nd"
+
+
+def test_bracketed_markers_are_added_only_after_validation_and_credit() -> None:
+    payload = "safe"
+    encoded_size = (
+        len(payload.encode()) + len(BRACKETED_PASTE_START) + len(BRACKETED_PASTE_END)
+    )
+    exact = TerminalInputActor(capacity_bytes=encoded_size)
+    short = TerminalInputActor(capacity_bytes=encoded_size - 1)
+
+    assert exact.offer_paste(payload, bracketed=True).accepted is True
+    refused = short.offer_paste(payload, bracketed=True)
+
+    assert refused.reason is PasteRefusalReason.BACKPRESSURE
+    assert short.pending_bytes == 0
+    assert short.take_nowait() is None
+
+
+def test_paste_limit_counts_replacement_encoded_payload_bytes_atomically() -> None:
+    actor = TerminalInputActor()
+
+    accepted = actor.offer_paste("a" * MAX_PASTE_BYTES, bracketed=False)
+    actor.take_nowait()
+    refused = actor.offer_paste("a" * (MAX_PASTE_BYTES + 1), bracketed=False)
+
+    assert accepted.accepted is True
+    assert refused.reason is PasteRefusalReason.TOO_LARGE
+    assert actor.pending_bytes == 0
+
+
+def test_invalid_unicode_is_replaced_before_transport_byte_accounting() -> None:
+    actor = TerminalInputActor(capacity_bytes=1)
+
+    refused = actor.offer_paste("\ud800\ud800", bracketed=False)
+
+    assert refused.reason is PasteRefusalReason.BACKPRESSURE
+    assert actor.pending_bytes == 0
+
+
+def test_key_backpressure_never_truncates_or_claims_delivery() -> None:
+    actor = TerminalInputActor(capacity_bytes=3)
+
+    assert actor.offer_key(b"abc").accepted is True
+    refused = actor.offer_key(b"d")
+
+    assert refused.reason is InputRefusalReason.BACKPRESSURE
+    assert actor.pending_bytes == 3
+    assert _drain_input(actor) == [(InputEventKind.KEY, b"abc")]
+
+
+def test_empty_input_offers_are_noops_instead_of_unbounded_envelopes() -> None:
+    actor = TerminalInputActor(capacity_bytes=1)
+
+    for _ in range(1_000):
+        assert actor.offer_key(b"").accepted is True
+        assert actor.offer_paste("", bracketed=False).accepted is True
+        assert actor.offer_reply(b"").accepted is True
+
+    assert actor.pending_bytes == 0
+    assert actor.pending_events == 0
+
+
+def test_fixed_replies_are_individually_bounded_and_rate_limited() -> None:
+    clock = ManualClock()
+    actor = TerminalInputActor(clock=clock)
+
+    oversized = actor.offer_reply(b"x" * 257)
+    assert oversized.reason is InputRefusalReason.REPLY_TOO_LARGE
+
+    for _ in range(16):
+        assert actor.offer_reply(b"x" * 256).accepted is True
+    limited = actor.offer_reply(b"y")
+    assert limited.reason is InputRefusalReason.REPLY_RATE_LIMIT
+    assert actor.pending_bytes == 4 * 1024
+
+    clock.advance(1.0)
+    assert actor.offer_reply(b"y").accepted is True
+
+
+@pytest.mark.asyncio
+async def test_resize_is_latest_only_and_debounced_at_least_one_loop_turn() -> None:
+    actor = TerminalInputActor()
+    actor.offer_resize(columns=80, rows=24)
+    actor.offer_resize(columns=120, rows=40)
+    loop_advanced = False
+
+    async def mark_next_turn() -> None:
+        nonlocal loop_advanced
+        await asyncio.sleep(0)
+        loop_advanced = True
+
+    marker = asyncio.create_task(mark_next_turn())
+    resize = await actor.take_resize_debounced()
+    await marker
+
+    assert loop_advanced is True
+    assert resize is not None
+    assert (resize.columns, resize.rows) == (120, 40)
+    assert await actor.take_resize_debounced() is None
+    assert actor.pending_bytes == 0
+
+
+@pytest.mark.parametrize(
+    ("columns", "rows"),
+    [
+        (MIN_COLUMNS - 1, MIN_ROWS),
+        (MAX_COLUMNS + 1, MIN_ROWS),
+        (MIN_COLUMNS, MIN_ROWS - 1),
+        (MIN_COLUMNS, MAX_ROWS + 1),
+    ],
+)
+def test_resize_refuses_dimensions_outside_the_terminal_contract(
+    columns: int, rows: int
+) -> None:
+    actor = TerminalInputActor()
+
+    with pytest.raises(ValueError, match="outside contract"):
+        actor.offer_resize(columns=columns, rows=rows)
+
+
+def test_input_credit_race_admits_only_complete_events() -> None:
+    workers = 16
+    payload = b"x" * 64
+    actor = TerminalInputActor(capacity_bytes=len(payload))
+    barrier = Barrier(workers)
+
+    def offer() -> bool:
+        barrier.wait()
+        return actor.offer_key(payload).accepted
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        admitted = list(pool.map(lambda _: offer(), range(workers)))
+
+    assert admitted.count(True) == 1
+    assert actor.pending_bytes == len(payload)
+    assert actor.pending_events == 1
+
+
+def test_output_chunks_and_total_credit_are_bounded_without_dropping_state() -> None:
+    actor = TerminalOutputActor()
+
+    oversized = actor.offer_output(b"x" * (MAX_IO_CHUNK_BYTES + 1))
+    assert oversized.reason is OutputRefusalReason.CHUNK_TOO_LARGE
+    assert actor.pending_bytes == 0
+
+    chunk = b"x" * MAX_IO_CHUNK_BYTES
+    for _ in range(MAX_PENDING_OUTPUT_BYTES // MAX_IO_CHUNK_BYTES):
+        assert actor.offer_output(chunk).accepted is True
+
+    assert actor.pending_bytes == MAX_PENDING_OUTPUT_BYTES
+    assert actor.read_credit_bytes == 0
+    assert actor.next_read_size == 0
+    refused = actor.offer_output(b"y")
+    assert refused.reason is OutputRefusalReason.BACKPRESSURE
+    assert actor.pending_bytes == MAX_PENDING_OUTPUT_BYTES
+
+
+def test_output_credit_race_never_exceeds_capacity() -> None:
+    workers = 16
+    payload = b"x" * 64
+    actor = TerminalOutputActor(capacity_bytes=len(payload), max_chunk_bytes=64)
+    barrier = Barrier(workers)
+
+    def offer() -> bool:
+        barrier.wait()
+        return actor.offer_output(payload).accepted
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        admitted = list(pool.map(lambda _: offer(), range(workers)))
+
+    assert admitted.count(True) == 1
+    assert actor.pending_bytes == len(payload)
+    assert actor.pending_chunks == 1
+
+
+def test_parser_turn_splits_a_chunk_at_the_exact_byte_budget() -> None:
+    actor = TerminalOutputActor(
+        capacity_bytes=64,
+        max_chunk_bytes=64,
+        max_turn_bytes=5,
+    )
+    consumed: list[bytes] = []
+    assert actor.offer_output(b"abcdefgh").accepted is True
+
+    first = actor.process_parser_turn(consumed.append, visible=True)
+    second = actor.process_parser_turn(consumed.append, visible=True)
+
+    assert consumed == [b"abcde", b"fgh"]
+    assert first.processed_bytes == 5
+    assert first.pending_bytes == 3
+    assert first.refresh_requested is True
+    assert second.processed_bytes == 3
+    assert second.pending_bytes == 0
+    assert second.refresh_requested is False
+
+
+def test_parser_turn_stops_after_injected_eight_millisecond_budget() -> None:
+    clock = ManualClock()
+    actor = TerminalOutputActor(
+        capacity_bytes=32,
+        max_chunk_bytes=8,
+        max_turn_bytes=32,
+        max_turn_seconds=MAX_PARSER_TURN_SECONDS,
+        clock=clock,
+    )
+    for value in (b"aaaaaaaa", b"bbbbbbbb", b"cccccccc"):
+        assert actor.offer_output(value).accepted is True
+    consumed: list[bytes] = []
+
+    def consume(value: bytes) -> None:
+        consumed.append(value)
+        clock.advance(MAX_PARSER_TURN_SECONDS)
+
+    result = actor.process_parser_turn(consume, visible=False)
+
+    assert consumed == [b"aaaaaaaa"]
+    assert result.processed_bytes == 8
+    assert result.pending_bytes == 16
+    assert result.refresh_requested is False
+
+
+def test_parser_turn_observes_time_budget_with_cost_proportional_to_bytes() -> None:
+    clock = ManualClock()
+    actor = TerminalOutputActor(
+        capacity_bytes=8 * 1024,
+        max_chunk_bytes=8 * 1024,
+        max_turn_bytes=8 * 1024,
+        max_turn_seconds=MAX_PARSER_TURN_SECONDS,
+        clock=clock,
+    )
+    consumed: list[bytes] = []
+    assert actor.offer_output(b"x" * (8 * 1024)).accepted is True
+
+    def consume(value: bytes) -> None:
+        consumed.append(value)
+        clock.advance((len(value) / 1024) * 0.004)
+
+    result = actor.process_parser_turn(consume, visible=False)
+
+    assert result.processed_bytes <= 2 * 1024
+    assert result.pending_bytes >= 6 * 1024
+
+
+def test_parser_turn_never_exceeds_global_byte_or_time_defaults() -> None:
+    actor = TerminalOutputActor()
+    chunk = b"x" * MAX_IO_CHUNK_BYTES
+    for _ in range(8):
+        assert actor.offer_output(chunk).accepted is True
+
+    result = actor.process_parser_turn(lambda _: None, visible=False)
+
+    assert result.processed_bytes <= MAX_PARSER_TURN_BYTES
+    assert result.pending_bytes >= MAX_PENDING_OUTPUT_BYTES - MAX_PARSER_TURN_BYTES
+
+
+def test_visible_refresh_is_coalesced_until_the_frame_is_acknowledged() -> None:
+    actor = TerminalOutputActor(capacity_bytes=8, max_chunk_bytes=8)
+    assert actor.offer_output(b"a").accepted is True
+    first = actor.process_parser_turn(lambda _: None, visible=True)
+    assert actor.offer_output(b"b").accepted is True
+    second = actor.process_parser_turn(lambda _: None, visible=True)
+
+    assert first.refresh_requested is True
+    assert second.refresh_requested is False
+    assert actor.acknowledge_visible_refresh() is True
+    assert actor.acknowledge_visible_refresh() is False
+
+    assert actor.offer_output(b"c").accepted is True
+    third = actor.process_parser_turn(lambda _: None, visible=True)
+    assert third.refresh_requested is True
+
+
+def test_hidden_output_parses_without_scheduling_a_refresh() -> None:
+    actor = TerminalOutputActor(capacity_bytes=8, max_chunk_bytes=8)
+    assert actor.offer_output(b"hidden").accepted is True
+
+    result = actor.process_parser_turn(lambda _: None, visible=False)
+
+    assert result.processed_bytes == len(b"hidden")
+    assert result.refresh_requested is False
+    assert actor.acknowledge_visible_refresh() is False
+
+
+def test_priority_close_is_independent_and_idempotent_when_both_paths_are_full() -> (
+    None
+):
+    input_actor = TerminalInputActor(capacity_bytes=1)
+    output_actor = TerminalOutputActor(capacity_bytes=1, max_chunk_bytes=1)
+    priority = TerminalPriorityControl()
+    assert input_actor.offer_key(b"x").accepted is True
+    assert output_actor.offer_output(b"y").accepted is True
+
+    assert priority.request_priority_close() is True
+    assert priority.request_priority_close() is False
+    assert priority.requested is True
+    assert priority.wait(timeout=0) is True
+    assert input_actor.pending_bytes == 1
+    assert output_actor.pending_bytes == 1
+
+
+@pytest.mark.asyncio
+async def test_ten_second_ansi_flood_keeps_actors_bounded_and_reports_latency(
+    request: pytest.FixtureRequest,
+) -> None:
+    actor = TerminalOutputActor()
+    model = TerminalScreenModel(columns=80, rows=24)
+    loop = asyncio.get_running_loop()
+    duration = 10.0
+    stop_at = loop.time() + duration
+    sentinel_lateness: list[float] = []
+    payload = (b"\x1b[32mterminal-flood\x1b[0m\r\n" * 2_048)[:MAX_IO_CHUNK_BYTES]
+    assert actor.offer_output(payload).accepted is True
+
+    async def sentinel() -> None:
+        target = loop.time() + 0.1
+        while target < stop_at:
+            await asyncio.sleep(max(0.0, target - loop.time()))
+            sentinel_lateness.append(max(0.0, loop.time() - target))
+            target += 0.1
+
+    sentinel_task = asyncio.create_task(sentinel())
+    while loop.time() < stop_at:
+        if actor.next_read_size >= len(payload):
+            assert actor.offer_output(payload).accepted is True
+        actor.process_parser_turn(model.feed, visible=False)
+        assert actor.pending_bytes <= MAX_PENDING_OUTPUT_BYTES
+        await asyncio.sleep(0)
+    await sentinel_task
+
+    assert len(sentinel_lateness) >= 90
+    p95 = quantiles(sentinel_lateness, n=100, method="inclusive")[94]
+    request.node.user_properties.append(("terminal_ansi_flood_p95_ms", p95 * 1_000))
+    if os.environ.get("TLDW_TERMINAL_QUALIFICATION_HOST") == "1":
+        assert p95 < 0.1

--- a/Tests/Terminal/test_io_actors.py
+++ b/Tests/Terminal/test_io_actors.py
@@ -8,9 +8,11 @@ from dataclasses import FrozenInstanceError
 import os
 from statistics import quantiles
 from threading import Barrier
+from types import SimpleNamespace
 
 import pytest
 
+from tldw_chatbook.Terminal import io_actors as io_actors_module
 from tldw_chatbook.Terminal.contracts import (
     MAX_COLUMNS,
     MAX_IO_CHUNK_BYTES,
@@ -58,6 +60,94 @@ def _drain_input(actor: TerminalInputActor) -> list[tuple[InputEventKind, bytes]
         assert event.encoded_size == len(event.data)
         drained.append((event.kind, event.data))
     return drained
+
+
+@pytest.mark.asyncio
+async def test_actors_consume_shared_validation_model_attributes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, object]] = []
+
+    def validate_key(data: object) -> SimpleNamespace:
+        calls.append(("key", data))
+        return SimpleNamespace(data=b"validated-key")
+
+    def validate_paste(text: object, bracketed: object) -> SimpleNamespace:
+        calls.append(("paste", (text, bracketed)))
+        return SimpleNamespace(
+            bracketed=True,
+            classify=lambda: (None, b"validated-paste"),
+        )
+
+    def validate_reply(data: object) -> SimpleNamespace:
+        calls.append(("reply", data))
+        return SimpleNamespace(data=b"validated-reply")
+
+    def validate_resize(columns: object, rows: object) -> SimpleNamespace:
+        calls.append(("resize", (columns, rows)))
+        return SimpleNamespace(columns=80, rows=24)
+
+    def validate_output(data: object) -> SimpleNamespace:
+        calls.append(("output", data))
+        return SimpleNamespace(data=b"validated-output")
+
+    monkeypatch.setattr(
+        io_actors_module, "validate_terminal_key_input", validate_key, raising=False
+    )
+    monkeypatch.setattr(
+        io_actors_module,
+        "validate_terminal_paste_input",
+        validate_paste,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        io_actors_module,
+        "validate_terminal_reply_input",
+        validate_reply,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        io_actors_module,
+        "validate_terminal_resize_input",
+        validate_resize,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        io_actors_module,
+        "validate_terminal_output_input",
+        validate_output,
+        raising=False,
+    )
+
+    input_actor = TerminalInputActor()
+    output_actor = TerminalOutputActor()
+    assert input_actor.offer_key(b"raw-key").accepted is True
+    assert input_actor.offer_paste("raw-paste", bracketed=False).accepted is True
+    assert input_actor.offer_reply(b"raw-reply").accepted is True
+    input_actor.offer_resize(columns=1, rows=1)
+    assert output_actor.offer_output(b"raw-output").accepted is True
+
+    assert _drain_input(input_actor) == [
+        (InputEventKind.KEY, b"validated-key"),
+        (
+            InputEventKind.PASTE,
+            BRACKETED_PASTE_START + b"validated-paste" + BRACKETED_PASTE_END,
+        ),
+        (InputEventKind.REPLY, b"validated-reply"),
+    ]
+    resize = await input_actor.take_resize_debounced()
+    assert resize is not None
+    assert (resize.columns, resize.rows) == (80, 24)
+    consumed: list[bytes] = []
+    output_actor.process_parser_turn(consumed.append, visible=False)
+    assert consumed == [b"validated-output"]
+    assert calls == [
+        ("key", b"raw-key"),
+        ("paste", ("raw-paste", False)),
+        ("reply", b"raw-reply"),
+        ("resize", (1, 1)),
+        ("output", b"raw-output"),
+    ]
 
 
 def test_key_paste_and_reply_share_one_ordered_byte_counted_queue() -> None:
@@ -374,6 +464,27 @@ def test_parser_turn_observes_time_budget_with_cost_proportional_to_bytes() -> N
 
     assert result.processed_bytes <= 2 * 1024
     assert result.pending_bytes >= 6 * 1024
+
+
+def test_parser_exception_retires_ambiguous_slice_without_replaying_it() -> None:
+    actor = TerminalOutputActor(
+        capacity_bytes=8,
+        max_chunk_bytes=8,
+        max_turn_bytes=3,
+    )
+    assert actor.offer_output(b"abcdef").accepted is True
+
+    with pytest.raises(RuntimeError, match="parser failed"):
+        actor.process_parser_turn(
+            lambda _value: (_ for _ in ()).throw(RuntimeError("parser failed")),
+            visible=False,
+        )
+
+    assert actor.pending_bytes == 3
+    consumed: list[bytes] = []
+    result = actor.process_parser_turn(consumed.append, visible=False)
+    assert consumed == [b"def"]
+    assert result.pending_bytes == 0
 
 
 def test_parser_turn_never_exceeds_global_byte_or_time_defaults() -> None:

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9,6 +9,27 @@ decays into folklore, and folklore is ignored. If you add one, bring the inciden
 
 ---
 
+## A turn deadline cannot preempt one oversized synchronous callback
+
+**TASK-22512 Task 6, 2026-08-30.** The persistent-terminal actor passed its
+functional parser-budget tests because the injected clock advanced only between
+backend chunks. The required ten-second ANSI flood report then measured about
+6,127 ms p95 lateness for a 100 ms event-loop sentinel. A single 64 KiB call into
+the real screen parser took roughly 275–285 ms, so checking the eight-millisecond
+deadline only after that call could neither enforce the budget nor let the
+sentinel catch up. Delivering admitted output to the parser in bounded 1 KiB
+slices made the time check observable between calls; the same qualification path
+then passed at about 34.1 ms p95.
+
+**What to do.** A deadline checked between synchronous callbacks bounds a turn
+only when each callback is independently small enough. Pair byte and time budgets
+with a bounded delivery slice, add a deterministic clock test whose cost scales
+with callback size, and run the real parser/event-loop flood with its latency
+threshold enabled. A test that advances the clock by a fixed amount per callback
+can stay green while one callback monopolizes the loop far beyond the deadline.
+
+---
+
 ## Pilot clicks can bind a widget that recomposition removes before hit-testing
 
 **TASK-24403, 2026-08-29.** The clean fast-PR lane passed all 670 selected tests,

--- a/tldw_chatbook/Terminal/io_actors.py
+++ b/tldw_chatbook/Terminal/io_actors.py
@@ -11,16 +11,18 @@ from threading import Event, Lock
 from time import monotonic
 
 from .contracts import (
-    MAX_COLUMNS,
     MAX_IO_CHUNK_BYTES,
     MAX_PARSER_TURN_BYTES,
     MAX_PARSER_TURN_SECONDS,
-    MAX_PASTE_BYTES,
     MAX_PENDING_INPUT_BYTES,
     MAX_PENDING_OUTPUT_BYTES,
-    MAX_ROWS,
-    MIN_COLUMNS,
-    MIN_ROWS,
+)
+from tldw_chatbook.Utils.input_validation import (
+    validate_terminal_key_input,
+    validate_terminal_output_input,
+    validate_terminal_paste_input,
+    validate_terminal_reply_input,
+    validate_terminal_resize_input,
 )
 
 
@@ -153,7 +155,11 @@ class TerminalPriorityControl:
 
     @property
     def requested(self) -> bool:
-        """Return whether priority close has been requested."""
+        """Return whether priority close has been requested.
+
+        Returns:
+            Whether the independent close signal is set.
+        """
         return self._event.is_set()
 
     def request_priority_close(self) -> bool:
@@ -181,7 +187,17 @@ class TerminalPriorityControl:
 
 
 class TerminalInputActor:
-    """Thread-safe bounded queue for ordered terminal input events."""
+    """Thread-safe bounded queue for ordered terminal input events.
+
+    Args:
+        capacity_bytes: Input credit in bytes, from one byte through 512 KiB.
+        clock: Injected monotonic clock used by reply-rate accounting.
+        resize_debounce_seconds: Resize debounce from zero through 50 ms.
+
+    Raises:
+        TypeError: If a configured limit has the wrong type.
+        ValueError: If a configured limit is outside its contract.
+    """
 
     def __init__(
         self,
@@ -211,13 +227,21 @@ class TerminalInputActor:
 
     @property
     def pending_bytes(self) -> int:
-        """Return bytes currently consuming input credit."""
+        """Return bytes currently consuming input credit.
+
+        Returns:
+            Number of admitted bytes waiting for transport.
+        """
         with self._lock:
             return self._pending_bytes
 
     @property
     def pending_events(self) -> int:
-        """Return complete ordered events waiting for transport."""
+        """Return complete ordered events waiting for transport.
+
+        Returns:
+            Number of queued key, paste, and reply envelopes.
+        """
         with self._lock:
             return len(self._queue)
 
@@ -229,8 +253,11 @@ class TerminalInputActor:
 
         Returns:
             Content-free admission result.
+
+        Raises:
+            TypeError: If ``data`` is not immutable bytes.
         """
-        _require_bytes("data", data)
+        data = validate_terminal_key_input(data).data
         with self._lock:
             return self._offer_locked(
                 InputEventKind.KEY,
@@ -248,30 +275,24 @@ class TerminalInputActor:
 
         Returns:
             Content-free admission result.
+
+        Raises:
+            TypeError: If ``text`` is not text or ``bracketed`` is not boolean.
         """
-        if not isinstance(text, str):
-            raise TypeError("text must be str")
-        if type(bracketed) is not bool:
-            raise TypeError("bracketed must be bool")
-        if len(text) > MAX_PASTE_BYTES:
+        validated = validate_terminal_paste_input(text, bracketed)
+        violation, payload = validated.classify()
+        if violation == "too_large":
             return InputOfferResult(
                 reason=PasteRefusalReason.TOO_LARGE,
                 safe_message=_PASTE_TOO_LARGE_MESSAGE,
             )
-        if _contains_prohibited_paste_control(text):
+        if violation == "prohibited_control":
             return InputOfferResult(
                 reason=PasteRefusalReason.PROHIBITED_CONTROL,
                 safe_message=_PASTE_CONTROL_MESSAGE,
             )
-
-        payload = text.encode("utf-8", "replace")
-        if len(payload) > MAX_PASTE_BYTES:
-            return InputOfferResult(
-                reason=PasteRefusalReason.TOO_LARGE,
-                safe_message=_PASTE_TOO_LARGE_MESSAGE,
-            )
         with self._lock:
-            return self._offer_paste_locked(payload, bracketed=bracketed)
+            return self._offer_paste_locked(payload, bracketed=validated.bracketed)
 
     def offer_reply(self, data: bytes) -> InputOfferResult:
         """Atomically offer a bounded terminal-protocol reply.
@@ -281,8 +302,11 @@ class TerminalInputActor:
 
         Returns:
             Content-free admission result.
+
+        Raises:
+            TypeError: If ``data`` is not immutable bytes.
         """
-        _require_bytes("data", data)
+        data = validate_terminal_reply_input(data).data
         if not data:
             return InputOfferResult(accepted=True)
         if len(data) > MAX_REPLY_BYTES:
@@ -324,15 +348,12 @@ class TerminalInputActor:
             ValueError: If either dimension is outside the terminal contract.
             TypeError: If either dimension is not an integer.
         """
-        if type(columns) is not int or type(rows) is not int:
-            raise TypeError("terminal dimensions must be integers")
-        if (
-            not MIN_COLUMNS <= columns <= MAX_COLUMNS
-            or not MIN_ROWS <= rows <= MAX_ROWS
-        ):
-            raise ValueError("terminal dimensions are outside contract")
+        validated = validate_terminal_resize_input(columns, rows)
         with self._lock:
-            self._latest_resize = TerminalResize(columns=columns, rows=rows)
+            self._latest_resize = TerminalResize(
+                columns=validated.columns,
+                rows=validated.rows,
+            )
 
     def take_nowait(self) -> TerminalInputEvent | None:
         """Take the oldest complete input event without waiting.
@@ -427,7 +448,19 @@ class _OutputChunk:
 
 
 class TerminalOutputActor:
-    """Thread-safe bounded output queue with parser-turn budgets."""
+    """Thread-safe bounded output queue with parser-turn budgets.
+
+    Args:
+        capacity_bytes: Output credit in bytes, from one byte through 512 KiB.
+        max_chunk_bytes: Maximum backend chunk, up to 64 KiB.
+        max_turn_bytes: Maximum parser work per turn, up to 256 KiB.
+        max_turn_seconds: Maximum parser-turn duration, up to 8 ms.
+        clock: Injected monotonic clock used by parser-turn accounting.
+
+    Raises:
+        TypeError: If a configured limit has the wrong type.
+        ValueError: If a configured limit is outside its contract.
+    """
 
     def __init__(
         self,
@@ -475,25 +508,41 @@ class TerminalOutputActor:
 
     @property
     def pending_bytes(self) -> int:
-        """Return bytes queued or currently being delivered to the parser."""
+        """Return bytes queued or currently being delivered to the parser.
+
+        Returns:
+            Number of admitted bytes still consuming output credit.
+        """
         with self._lock:
             return self._pending_bytes
 
     @property
     def pending_chunks(self) -> int:
-        """Return chunks currently waiting for parser delivery."""
+        """Return chunks currently waiting for parser delivery.
+
+        Returns:
+            Number of queued output envelopes or remainders.
+        """
         with self._lock:
             return len(self._queue)
 
     @property
     def read_credit_bytes(self) -> int:
-        """Return output bytes that may currently be admitted."""
+        """Return output bytes that may currently be admitted.
+
+        Returns:
+            Remaining byte credit for backend output.
+        """
         with self._lock:
             return self.capacity_bytes - self._pending_bytes
 
     @property
     def next_read_size(self) -> int:
-        """Return the maximum safe size for the next backend read."""
+        """Return the maximum safe size for the next backend read.
+
+        Returns:
+            Bounded next-read size, or zero when output credit is full.
+        """
         with self._lock:
             return min(
                 self.max_chunk_bytes,
@@ -508,8 +557,11 @@ class TerminalOutputActor:
 
         Returns:
             Content-free admission result.
+
+        Raises:
+            TypeError: If ``data`` is not immutable bytes.
         """
-        _require_bytes("data", data)
+        data = validate_terminal_output_input(data).data
         encoded_size = len(data)
         if encoded_size > self.max_chunk_bytes:
             return OutputOfferResult(reason=OutputRefusalReason.CHUNK_TOO_LARGE)
@@ -536,6 +588,11 @@ class TerminalOutputActor:
 
         Returns:
             Content-free accounting and refresh-coalescing result.
+
+        Raises:
+            TypeError: If ``consumer`` is not callable or ``visible`` is not boolean.
+            Exception: Re-raises consumer failures after retiring the ambiguous
+                attempted slice; failed parser callbacks must not be retried.
         """
         if not callable(consumer):
             raise TypeError("consumer must be callable")
@@ -596,23 +653,6 @@ class TerminalOutputActor:
                 return False
             self._refresh_pending = False
             return True
-
-
-def _contains_prohibited_paste_control(text: str) -> bool:
-    """Return whether text contains a disallowed C0, DEL, or C1 control."""
-    for character in text:
-        codepoint = ord(character)
-        if codepoint < 0x20 and character not in "\t\n\r":
-            return True
-        if 0x7F <= codepoint <= 0x9F:
-            return True
-    return False
-
-
-def _require_bytes(name: str, value: bytes) -> None:
-    """Require immutable bytes at an actor boundary."""
-    if type(value) is not bytes:
-        raise TypeError(f"{name} must be bytes")
 
 
 def _validate_positive_limit(name: str, value: int, maximum: int) -> None:

--- a/tldw_chatbook/Terminal/io_actors.py
+++ b/tldw_chatbook/Terminal/io_actors.py
@@ -1,0 +1,623 @@
+"""Bounded input/output actors for persistent terminal sessions."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum
+from threading import Event, Lock
+from time import monotonic
+
+from .contracts import (
+    MAX_COLUMNS,
+    MAX_IO_CHUNK_BYTES,
+    MAX_PARSER_TURN_BYTES,
+    MAX_PARSER_TURN_SECONDS,
+    MAX_PASTE_BYTES,
+    MAX_PENDING_INPUT_BYTES,
+    MAX_PENDING_OUTPUT_BYTES,
+    MAX_ROWS,
+    MIN_COLUMNS,
+    MIN_ROWS,
+)
+
+
+BRACKETED_PASTE_START = b"\x1b[200~"
+BRACKETED_PASTE_END = b"\x1b[201~"
+MAX_REPLY_BYTES = 256
+MAX_REPLY_RATE_BYTES = 4 * 1024
+REPLY_RATE_WINDOW_SECONDS = 1.0
+MAX_RESIZE_DEBOUNCE_SECONDS = 0.05
+MAX_PARSER_SLICE_BYTES = 1024
+
+_PASTE_TOO_LARGE_MESSAGE = "Paste refused because it exceeds the size limit."
+_PASTE_BACKPRESSURE_MESSAGE = "Paste refused because terminal input is full."
+_PASTE_CONTROL_MESSAGE = "Paste refused because it contains a prohibited control."
+_INPUT_BACKPRESSURE_MESSAGE = "Input refused because terminal input is full."
+_REPLY_TOO_LARGE_MESSAGE = "Terminal reply refused because it is too large."
+_REPLY_RATE_LIMIT_MESSAGE = "Terminal reply refused because its rate limit was reached."
+
+
+class InputEventKind(str, Enum):
+    """Ordered terminal-input event kinds."""
+
+    KEY = "key"
+    PASTE = "paste"
+    REPLY = "reply"
+
+
+class InputRefusalReason(str, Enum):
+    """Content-free reasons ordinary input was refused."""
+
+    BACKPRESSURE = "input_backpressure"
+    REPLY_TOO_LARGE = "reply_too_large"
+    REPLY_RATE_LIMIT = "reply_rate_limit"
+
+
+class PasteRefusalReason(str, Enum):
+    """Content-free reasons an atomic paste was refused."""
+
+    TOO_LARGE = "paste_too_large"
+    BACKPRESSURE = "input_backpressure"
+    PROHIBITED_CONTROL = "prohibited_control"
+
+
+class OutputRefusalReason(str, Enum):
+    """Content-free reasons terminal output was not admitted."""
+
+    CHUNK_TOO_LARGE = "chunk_too_large"
+    BACKPRESSURE = "output_backpressure"
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalInputEvent:
+    """One immutable ordered input envelope.
+
+    Attributes:
+        kind: Input source category.
+        data: Complete transport bytes for the event.
+        encoded_size: Precomputed byte length used for credit accounting.
+    """
+
+    kind: InputEventKind
+    data: bytes
+    encoded_size: int
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalResize:
+    """One latest-only terminal resize request.
+
+    Attributes:
+        columns: Requested terminal width.
+        rows: Requested terminal height.
+    """
+
+    columns: int
+    rows: int
+
+
+@dataclass(frozen=True, slots=True)
+class InputOfferResult:
+    """Content-free input admission result.
+
+    Attributes:
+        accepted: Whether the complete event was admitted.
+        reason: Structured refusal category when admission failed.
+        safe_message: User-facing message that never includes input content.
+    """
+
+    accepted: bool = False
+    reason: InputRefusalReason | PasteRefusalReason | None = None
+    safe_message: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class OutputOfferResult:
+    """Content-free output admission result.
+
+    Attributes:
+        accepted: Whether the complete output chunk was admitted.
+        reason: Structured refusal category when admission failed.
+    """
+
+    accepted: bool = False
+    reason: OutputRefusalReason | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ParserTurnResult:
+    """Content-free accounting for one bounded parser turn.
+
+    Attributes:
+        processed_bytes: Bytes delivered to the parser this turn.
+        processed_chunks: Parser calls made this turn.
+        pending_bytes: Bytes still held by the output actor.
+        refresh_requested: Whether this turn scheduled a visible refresh.
+    """
+
+    processed_bytes: int = 0
+    processed_chunks: int = 0
+    pending_bytes: int = 0
+    refresh_requested: bool = False
+
+
+class TerminalPriorityControl:
+    """Independent, idempotent close signal that cannot wait behind I/O queues."""
+
+    def __init__(self) -> None:
+        self._event = Event()
+        self._request_lock = Lock()
+
+    @property
+    def requested(self) -> bool:
+        """Return whether priority close has been requested."""
+        return self._event.is_set()
+
+    def request_priority_close(self) -> bool:
+        """Set the close signal and report whether this call set it first.
+
+        Returns:
+            ``True`` only for the first request.
+        """
+        with self._request_lock:
+            if self._event.is_set():
+                return False
+            self._event.set()
+            return True
+
+    def wait(self, timeout: float | None = None) -> bool:
+        """Wait for priority close without consulting either I/O queue.
+
+        Args:
+            timeout: Maximum seconds to wait, or ``None`` to wait indefinitely.
+
+        Returns:
+            Whether the close signal was set before the timeout.
+        """
+        return self._event.wait(timeout)
+
+
+class TerminalInputActor:
+    """Thread-safe bounded queue for ordered terminal input events."""
+
+    def __init__(
+        self,
+        capacity_bytes: int = MAX_PENDING_INPUT_BYTES,
+        *,
+        clock: Callable[[], float] | None = None,
+        resize_debounce_seconds: float = 0.0,
+    ) -> None:
+        _validate_positive_limit(
+            "capacity_bytes", capacity_bytes, MAX_PENDING_INPUT_BYTES
+        )
+        if not isinstance(resize_debounce_seconds, (int, float)) or isinstance(
+            resize_debounce_seconds, bool
+        ):
+            raise TypeError("resize_debounce_seconds must be a number")
+        if not 0.0 <= resize_debounce_seconds <= MAX_RESIZE_DEBOUNCE_SECONDS:
+            raise ValueError("resize_debounce_seconds is outside contract")
+        self.capacity_bytes = capacity_bytes
+        self._clock = clock or monotonic
+        self._resize_debounce_seconds = float(resize_debounce_seconds)
+        self._queue: deque[TerminalInputEvent] = deque()
+        self._pending_bytes = 0
+        self._reply_usage: deque[tuple[float, int]] = deque()
+        self._reply_usage_bytes = 0
+        self._latest_resize: TerminalResize | None = None
+        self._lock = Lock()
+
+    @property
+    def pending_bytes(self) -> int:
+        """Return bytes currently consuming input credit."""
+        with self._lock:
+            return self._pending_bytes
+
+    @property
+    def pending_events(self) -> int:
+        """Return complete ordered events waiting for transport."""
+        with self._lock:
+            return len(self._queue)
+
+    def offer_key(self, data: bytes) -> InputOfferResult:
+        """Atomically offer encoded key bytes.
+
+        Args:
+            data: Complete key encoding to enqueue.
+
+        Returns:
+            Content-free admission result.
+        """
+        _require_bytes("data", data)
+        with self._lock:
+            return self._offer_locked(
+                InputEventKind.KEY,
+                data,
+                InputRefusalReason.BACKPRESSURE,
+                _INPUT_BACKPRESSURE_MESSAGE,
+            )
+
+    def offer_paste(self, text: str, *, bracketed: bool) -> InputOfferResult:
+        """Validate and atomically offer one paste operation.
+
+        Args:
+            text: Untrusted paste text.
+            bracketed: Whether to wrap accepted bytes in bracketed-paste markers.
+
+        Returns:
+            Content-free admission result.
+        """
+        if not isinstance(text, str):
+            raise TypeError("text must be str")
+        if type(bracketed) is not bool:
+            raise TypeError("bracketed must be bool")
+        if len(text) > MAX_PASTE_BYTES:
+            return InputOfferResult(
+                reason=PasteRefusalReason.TOO_LARGE,
+                safe_message=_PASTE_TOO_LARGE_MESSAGE,
+            )
+        if _contains_prohibited_paste_control(text):
+            return InputOfferResult(
+                reason=PasteRefusalReason.PROHIBITED_CONTROL,
+                safe_message=_PASTE_CONTROL_MESSAGE,
+            )
+
+        payload = text.encode("utf-8", "replace")
+        if len(payload) > MAX_PASTE_BYTES:
+            return InputOfferResult(
+                reason=PasteRefusalReason.TOO_LARGE,
+                safe_message=_PASTE_TOO_LARGE_MESSAGE,
+            )
+        with self._lock:
+            return self._offer_paste_locked(payload, bracketed=bracketed)
+
+    def offer_reply(self, data: bytes) -> InputOfferResult:
+        """Atomically offer a bounded terminal-protocol reply.
+
+        Args:
+            data: Complete fixed reply bytes.
+
+        Returns:
+            Content-free admission result.
+        """
+        _require_bytes("data", data)
+        if not data:
+            return InputOfferResult(accepted=True)
+        if len(data) > MAX_REPLY_BYTES:
+            return InputOfferResult(
+                reason=InputRefusalReason.REPLY_TOO_LARGE,
+                safe_message=_REPLY_TOO_LARGE_MESSAGE,
+            )
+
+        with self._lock:
+            if self._pending_bytes + len(data) > self.capacity_bytes:
+                return InputOfferResult(
+                    reason=InputRefusalReason.BACKPRESSURE,
+                    safe_message=_INPUT_BACKPRESSURE_MESSAGE,
+                )
+            now = self._clock()
+            self._discard_expired_reply_usage_locked(now)
+            if self._reply_usage_bytes + len(data) > MAX_REPLY_RATE_BYTES:
+                return InputOfferResult(
+                    reason=InputRefusalReason.REPLY_RATE_LIMIT,
+                    safe_message=_REPLY_RATE_LIMIT_MESSAGE,
+                )
+            self._reply_usage.append((now, len(data)))
+            self._reply_usage_bytes += len(data)
+            return self._offer_locked(
+                InputEventKind.REPLY,
+                data,
+                InputRefusalReason.BACKPRESSURE,
+                _INPUT_BACKPRESSURE_MESSAGE,
+            )
+
+    def offer_resize(self, *, columns: int, rows: int) -> None:
+        """Replace the pending resize with the newest valid dimensions.
+
+        Args:
+            columns: Requested terminal width.
+            rows: Requested terminal height.
+
+        Raises:
+            ValueError: If either dimension is outside the terminal contract.
+            TypeError: If either dimension is not an integer.
+        """
+        if type(columns) is not int or type(rows) is not int:
+            raise TypeError("terminal dimensions must be integers")
+        if (
+            not MIN_COLUMNS <= columns <= MAX_COLUMNS
+            or not MIN_ROWS <= rows <= MAX_ROWS
+        ):
+            raise ValueError("terminal dimensions are outside contract")
+        with self._lock:
+            self._latest_resize = TerminalResize(columns=columns, rows=rows)
+
+    def take_nowait(self) -> TerminalInputEvent | None:
+        """Take the oldest complete input event without waiting.
+
+        Returns:
+            Oldest event, or ``None`` when the queue is empty.
+        """
+        with self._lock:
+            if not self._queue:
+                return None
+            event = self._queue.popleft()
+            self._pending_bytes -= event.encoded_size
+            return event
+
+    async def take_resize_debounced(self) -> TerminalResize | None:
+        """Yield once, debounce briefly if configured, then take the latest resize.
+
+        Returns:
+            Latest pending dimensions, or ``None`` when no resize is pending.
+        """
+        await asyncio.sleep(self._resize_debounce_seconds)
+        with self._lock:
+            resize = self._latest_resize
+            self._latest_resize = None
+            return resize
+
+    def _offer_locked(
+        self,
+        kind: InputEventKind,
+        data: bytes,
+        refusal_reason: InputRefusalReason | PasteRefusalReason,
+        safe_message: str,
+    ) -> InputOfferResult:
+        """Enqueue one event while the actor lock is held."""
+        encoded_size = len(data)
+        if encoded_size == 0:
+            return InputOfferResult(accepted=True)
+        if self._pending_bytes + encoded_size > self.capacity_bytes:
+            return InputOfferResult(reason=refusal_reason, safe_message=safe_message)
+        self._queue.append(
+            TerminalInputEvent(kind=kind, data=data, encoded_size=encoded_size)
+        )
+        self._pending_bytes += encoded_size
+        return InputOfferResult(accepted=True)
+
+    def _offer_paste_locked(
+        self, payload: bytes, *, bracketed: bool
+    ) -> InputOfferResult:
+        """Reserve paste credit before constructing optional transport markers."""
+        marker_size = (
+            len(BRACKETED_PASTE_START) + len(BRACKETED_PASTE_END) if bracketed else 0
+        )
+        encoded_size = len(payload) + marker_size
+        if encoded_size == 0:
+            return InputOfferResult(accepted=True)
+        if self._pending_bytes + encoded_size > self.capacity_bytes:
+            return InputOfferResult(
+                reason=PasteRefusalReason.BACKPRESSURE,
+                safe_message=_PASTE_BACKPRESSURE_MESSAGE,
+            )
+        data = (
+            BRACKETED_PASTE_START + payload + BRACKETED_PASTE_END
+            if bracketed
+            else payload
+        )
+        self._queue.append(
+            TerminalInputEvent(
+                kind=InputEventKind.PASTE,
+                data=data,
+                encoded_size=encoded_size,
+            )
+        )
+        self._pending_bytes += encoded_size
+        return InputOfferResult(accepted=True)
+
+    def _discard_expired_reply_usage_locked(self, now: float) -> None:
+        """Drop reply-rate entries outside the sliding window."""
+        while (
+            self._reply_usage
+            and now - self._reply_usage[0][0] >= REPLY_RATE_WINDOW_SECONDS
+        ):
+            _, size = self._reply_usage.popleft()
+            self._reply_usage_bytes -= size
+
+
+@dataclass(frozen=True, slots=True)
+class _OutputChunk:
+    """One immutable admitted output chunk."""
+
+    data: bytes
+    encoded_size: int
+
+
+class TerminalOutputActor:
+    """Thread-safe bounded output queue with parser-turn budgets."""
+
+    def __init__(
+        self,
+        capacity_bytes: int = MAX_PENDING_OUTPUT_BYTES,
+        *,
+        max_chunk_bytes: int | None = None,
+        max_turn_bytes: int | None = None,
+        max_turn_seconds: float | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        selected_chunk_bytes = (
+            MAX_IO_CHUNK_BYTES if max_chunk_bytes is None else max_chunk_bytes
+        )
+        selected_turn_bytes = (
+            MAX_PARSER_TURN_BYTES if max_turn_bytes is None else max_turn_bytes
+        )
+        selected_turn_seconds = (
+            MAX_PARSER_TURN_SECONDS if max_turn_seconds is None else max_turn_seconds
+        )
+        _validate_positive_limit(
+            "capacity_bytes", capacity_bytes, MAX_PENDING_OUTPUT_BYTES
+        )
+        _validate_positive_limit(
+            "max_chunk_bytes", selected_chunk_bytes, MAX_IO_CHUNK_BYTES
+        )
+        _validate_positive_limit(
+            "max_turn_bytes", selected_turn_bytes, MAX_PARSER_TURN_BYTES
+        )
+        if not isinstance(selected_turn_seconds, (int, float)) or isinstance(
+            selected_turn_seconds, bool
+        ):
+            raise TypeError("max_turn_seconds must be a number")
+        if not 0.0 < selected_turn_seconds <= MAX_PARSER_TURN_SECONDS:
+            raise ValueError("max_turn_seconds is outside contract")
+        self.capacity_bytes = capacity_bytes
+        self.max_chunk_bytes = selected_chunk_bytes
+        self.max_turn_bytes = selected_turn_bytes
+        self.max_turn_seconds = float(selected_turn_seconds)
+        self._clock = clock or monotonic
+        self._queue: deque[_OutputChunk] = deque()
+        self._pending_bytes = 0
+        self._refresh_pending = False
+        self._lock = Lock()
+        self._parser_lock = Lock()
+
+    @property
+    def pending_bytes(self) -> int:
+        """Return bytes queued or currently being delivered to the parser."""
+        with self._lock:
+            return self._pending_bytes
+
+    @property
+    def pending_chunks(self) -> int:
+        """Return chunks currently waiting for parser delivery."""
+        with self._lock:
+            return len(self._queue)
+
+    @property
+    def read_credit_bytes(self) -> int:
+        """Return output bytes that may currently be admitted."""
+        with self._lock:
+            return self.capacity_bytes - self._pending_bytes
+
+    @property
+    def next_read_size(self) -> int:
+        """Return the maximum safe size for the next backend read."""
+        with self._lock:
+            return min(
+                self.max_chunk_bytes,
+                self.capacity_bytes - self._pending_bytes,
+            )
+
+    def offer_output(self, data: bytes) -> OutputOfferResult:
+        """Atomically admit one complete backend-output chunk.
+
+        Args:
+            data: Complete bytes returned by one bounded backend read.
+
+        Returns:
+            Content-free admission result.
+        """
+        _require_bytes("data", data)
+        encoded_size = len(data)
+        if encoded_size > self.max_chunk_bytes:
+            return OutputOfferResult(reason=OutputRefusalReason.CHUNK_TOO_LARGE)
+        if encoded_size == 0:
+            return OutputOfferResult(accepted=True)
+        with self._lock:
+            if self._pending_bytes + encoded_size > self.capacity_bytes:
+                return OutputOfferResult(reason=OutputRefusalReason.BACKPRESSURE)
+            self._queue.append(_OutputChunk(data=data, encoded_size=encoded_size))
+            self._pending_bytes += encoded_size
+            return OutputOfferResult(accepted=True)
+
+    def process_parser_turn(
+        self,
+        consumer: Callable[[bytes], None],
+        *,
+        visible: bool,
+    ) -> ParserTurnResult:
+        """Deliver output under exact byte and monotonic-time budgets.
+
+        Args:
+            consumer: Parser callback receiving each admitted byte slice.
+            visible: Whether parsed output belongs to the visible terminal.
+
+        Returns:
+            Content-free accounting and refresh-coalescing result.
+        """
+        if not callable(consumer):
+            raise TypeError("consumer must be callable")
+        if type(visible) is not bool:
+            raise TypeError("visible must be bool")
+
+        processed_bytes = 0
+        processed_chunks = 0
+        with self._parser_lock:
+            started_at = self._clock()
+            while processed_bytes < self.max_turn_bytes:
+                if (
+                    processed_chunks
+                    and self._clock() - started_at >= self.max_turn_seconds
+                ):
+                    break
+                remaining_budget = self.max_turn_bytes - processed_bytes
+                delivery_size = min(remaining_budget, MAX_PARSER_SLICE_BYTES)
+                with self._lock:
+                    if not self._queue:
+                        break
+                    chunk = self._queue.popleft()
+                    delivered = chunk.data[:delivery_size]
+                    remainder = chunk.data[delivery_size:]
+                    if remainder:
+                        self._queue.appendleft(
+                            _OutputChunk(data=remainder, encoded_size=len(remainder))
+                        )
+                try:
+                    consumer(delivered)
+                finally:
+                    with self._lock:
+                        self._pending_bytes -= len(delivered)
+                processed_bytes += len(delivered)
+                processed_chunks += 1
+
+            refresh_requested = False
+            with self._lock:
+                if processed_bytes and visible and not self._refresh_pending:
+                    self._refresh_pending = True
+                    refresh_requested = True
+                pending_bytes = self._pending_bytes
+        return ParserTurnResult(
+            processed_bytes=processed_bytes,
+            processed_chunks=processed_chunks,
+            pending_bytes=pending_bytes,
+            refresh_requested=refresh_requested,
+        )
+
+    def acknowledge_visible_refresh(self) -> bool:
+        """Clear one coalesced visible-refresh request if present.
+
+        Returns:
+            Whether a pending refresh was acknowledged.
+        """
+        with self._lock:
+            if not self._refresh_pending:
+                return False
+            self._refresh_pending = False
+            return True
+
+
+def _contains_prohibited_paste_control(text: str) -> bool:
+    """Return whether text contains a disallowed C0, DEL, or C1 control."""
+    for character in text:
+        codepoint = ord(character)
+        if codepoint < 0x20 and character not in "\t\n\r":
+            return True
+        if 0x7F <= codepoint <= 0x9F:
+            return True
+    return False
+
+
+def _require_bytes(name: str, value: bytes) -> None:
+    """Require immutable bytes at an actor boundary."""
+    if type(value) is not bytes:
+        raise TypeError(f"{name} must be bytes")
+
+
+def _validate_positive_limit(name: str, value: int, maximum: int) -> None:
+    """Validate one positive integer limit against its global ceiling."""
+    if type(value) is not int:
+        raise TypeError(f"{name} must be int")
+    if not 0 < value <= maximum:
+        raise ValueError(f"{name} is outside contract")

--- a/tldw_chatbook/Utils/input_validation.py
+++ b/tldw_chatbook/Utils/input_validation.py
@@ -19,13 +19,6 @@ from pydantic import (
 )
 import regex
 
-from ..Terminal.contracts import (
-    MAX_COLUMNS,
-    MAX_PASTE_BYTES,
-    MAX_ROWS,
-    MIN_COLUMNS,
-    MIN_ROWS,
-)
 from ..Metrics.metrics_logger import log_counter, log_histogram
 
 
@@ -158,6 +151,8 @@ class TerminalPasteInput(BaseModel):
             A content-free violation category and payload bytes. The payload is
             empty when a violation is present.
         """
+        from ..Terminal.contracts import MAX_PASTE_BYTES
+
         if len(self.text) > MAX_PASTE_BYTES:
             return "too_large", b""
         for character in self.text:
@@ -201,8 +196,26 @@ class TerminalResizeInput(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
 
-    columns: int = Field(ge=MIN_COLUMNS, le=MAX_COLUMNS)
-    rows: int = Field(ge=MIN_ROWS, le=MAX_ROWS)
+    columns: int
+    rows: int
+
+    @field_validator("columns")
+    @classmethod
+    def _validate_columns(cls, value: int) -> int:
+        from ..Terminal.contracts import MAX_COLUMNS, MIN_COLUMNS
+
+        if not MIN_COLUMNS <= value <= MAX_COLUMNS:
+            raise ValueError("terminal columns are outside contract")
+        return value
+
+    @field_validator("rows")
+    @classmethod
+    def _validate_rows(cls, value: int) -> int:
+        from ..Terminal.contracts import MAX_ROWS, MIN_ROWS
+
+        if not MIN_ROWS <= value <= MAX_ROWS:
+            raise ValueError("terminal rows are outside contract")
+        return value
 
 
 _TerminalBytesInput = TypeVar(

--- a/tldw_chatbook/Utils/input_validation.py
+++ b/tldw_chatbook/Utils/input_validation.py
@@ -7,12 +7,25 @@ import ipaddress
 from itertools import islice
 import time
 import unicodedata
-from typing import Literal, Optional, Union
+from typing import Literal, Optional, TypeVar, Union
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError as PydanticValidationError,
+    field_validator,
+)
 import regex
 
+from ..Terminal.contracts import (
+    MAX_COLUMNS,
+    MAX_PASTE_BYTES,
+    MAX_ROWS,
+    MIN_COLUMNS,
+    MIN_ROWS,
+)
 from ..Metrics.metrics_logger import log_counter, log_histogram
 
 
@@ -125,6 +138,182 @@ class TerminalSessionNameInput(BaseModel):
         if "[" in normalized or "]" in normalized:
             raise ValueError("terminal session name must not contain markup")
         return normalized
+
+
+TerminalPasteViolation = Literal["too_large", "prohibited_control"]
+
+
+class TerminalPasteInput(BaseModel):
+    """Strict shared boundary for one terminal paste offer."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    text: str = Field(repr=False)
+    bracketed: bool
+
+    def classify(self) -> tuple[TerminalPasteViolation | None, bytes]:
+        """Classify paste content and return its replacement-encoded payload.
+
+        Returns:
+            A content-free violation category and payload bytes. The payload is
+            empty when a violation is present.
+        """
+        if len(self.text) > MAX_PASTE_BYTES:
+            return "too_large", b""
+        for character in self.text:
+            codepoint = ord(character)
+            if codepoint < 0x20 and character not in "\t\n\r":
+                return "prohibited_control", b""
+            if 0x7F <= codepoint <= 0x9F:
+                return "prohibited_control", b""
+        payload = self.text.encode("utf-8", "replace")
+        if len(payload) > MAX_PASTE_BYTES:
+            return "too_large", b""
+        return None, payload
+
+
+class TerminalKeyInput(BaseModel):
+    """Strict shared boundary for encoded terminal key bytes."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    data: bytes = Field(repr=False)
+
+
+class TerminalReplyInput(BaseModel):
+    """Strict shared boundary for code-owned terminal reply bytes."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    data: bytes = Field(repr=False)
+
+
+class TerminalOutputInput(BaseModel):
+    """Strict shared boundary for terminal backend output bytes."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    data: bytes = Field(repr=False)
+
+
+class TerminalResizeInput(BaseModel):
+    """Strict shared boundary for terminal resize dimensions."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    columns: int = Field(ge=MIN_COLUMNS, le=MAX_COLUMNS)
+    rows: int = Field(ge=MIN_ROWS, le=MAX_ROWS)
+
+
+_TerminalBytesInput = TypeVar(
+    "_TerminalBytesInput",
+    TerminalKeyInput,
+    TerminalReplyInput,
+    TerminalOutputInput,
+)
+
+
+def _validate_terminal_bytes_input(
+    model_type: type[_TerminalBytesInput],
+    data: object,
+    *,
+    label: str,
+) -> _TerminalBytesInput:
+    """Return one strict bytes model with a content-free type error."""
+    try:
+        return model_type.model_validate({"data": data})
+    except PydanticValidationError:
+        raise TypeError(f"terminal {label} data must be bytes") from None
+
+
+def validate_terminal_key_input(data: object) -> TerminalKeyInput:
+    """Validate encoded terminal key bytes through the shared model.
+
+    Args:
+        data: Candidate encoded key bytes.
+
+    Returns:
+        Strict validated key model.
+
+    Raises:
+        TypeError: If ``data`` is not immutable bytes.
+    """
+    return _validate_terminal_bytes_input(TerminalKeyInput, data, label="key")
+
+
+def validate_terminal_paste_input(
+    text: object, bracketed: object
+) -> TerminalPasteInput:
+    """Validate a terminal paste offer through the shared model.
+
+    Args:
+        text: Candidate paste text.
+        bracketed: Candidate bracketed-paste mode flag.
+
+    Returns:
+        Strict validated paste model.
+
+    Raises:
+        TypeError: If either value has the wrong type.
+    """
+    try:
+        return TerminalPasteInput.model_validate({"text": text, "bracketed": bracketed})
+    except PydanticValidationError:
+        raise TypeError("terminal paste values have invalid types") from None
+
+
+def validate_terminal_reply_input(data: object) -> TerminalReplyInput:
+    """Validate terminal reply bytes through the shared model.
+
+    Args:
+        data: Candidate terminal reply bytes.
+
+    Returns:
+        Strict validated reply model.
+
+    Raises:
+        TypeError: If ``data`` is not immutable bytes.
+    """
+    return _validate_terminal_bytes_input(TerminalReplyInput, data, label="reply")
+
+
+def validate_terminal_output_input(data: object) -> TerminalOutputInput:
+    """Validate terminal backend output through the shared model.
+
+    Args:
+        data: Candidate backend output bytes.
+
+    Returns:
+        Strict validated output model.
+
+    Raises:
+        TypeError: If ``data`` is not immutable bytes.
+    """
+    return _validate_terminal_bytes_input(TerminalOutputInput, data, label="output")
+
+
+def validate_terminal_resize_input(
+    columns: object, rows: object
+) -> TerminalResizeInput:
+    """Validate terminal dimensions through the shared model.
+
+    Args:
+        columns: Candidate terminal width.
+        rows: Candidate terminal height.
+
+    Returns:
+        Strict validated resize model.
+
+    Raises:
+        TypeError: If either dimension is not an integer.
+        ValueError: If either dimension is outside the terminal contract.
+    """
+    if type(columns) is not int or type(rows) is not int:
+        raise TypeError("terminal dimensions must be integers")
+    try:
+        return TerminalResizeInput.model_validate({"columns": columns, "rows": rows})
+    except PydanticValidationError:
+        raise ValueError("terminal dimensions are outside contract") from None
 
 
 class TerminalEnvironmentInput(BaseModel):


### PR DESCRIPTION
## Summary
- add byte-counted terminal input and output actors with atomic paste validation, reply throttling, latest-only resize, and independent priority close
- enforce output credit, parser byte/time budgets, 1 KiB delivery slices, and visible-refresh coalescing
- add race, backpressure, parser-budget, and ten-second ANSI flood coverage plus the resulting testing lesson

## Test plan
- [x] `../../.venv/bin/python -B -m pytest Tests/Terminal/test_io_actors.py -q` (35 passed)
- [x] `../../.venv/bin/python -B -m pytest Tests/Terminal -q` (488 passed, 1 expected native-Windows skip)
- [x] qualification-host ANSI flood threshold (34.1 ms p95, below 100 ms)
- [x] Ruff check and format check on changed Python files
- [x] `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded terminal I/O actors so persistent terminals can no longer buffer input or output without limit. Input and output now use byte-counted credit with backpressure, parser delivery is slice- and time-budgeted, and terminal-only validation contracts are lazy-imported to keep boot-time imports unchanged.

**Input actor**
- Keys, pastes, and fixed replies share one ordered byte-counted queue.
- Pastes are validated atomically for size and control characters before any bytes are enqueued.
- Replies are individually size-capped and rate-limited per second.
- Resizes are latest-only and debounced, with contract-validated dimensions.
- Priority close is an independent signal that never waits behind either I/O queue.

**Output actor**
- Admitted output is bounded by chunk size and total pending bytes.
- Parser turns honor byte and time budgets, delivering in 1 KiB slices; failed slices are retired without replay.
- Visible refreshes are coalesced until acknowledged; hidden parsing never schedules a refresh.
- Adds race, backpressure, parser-budget, and 10-second ANSI flood tests; the deadline lesson is documented in `backlog/docs/lessons-testing-evidence.md`.

<sup>Written for commit 0f8109319152924151c828b9a78dcebb0a711586. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

