### PR TITLE
feat: own persistent terminal sessions

### DIFF
--- a/Tests/Terminal/test_io_actors.py
+++ b/Tests/Terminal/test_io_actors.py
@@ -398,6 +398,20 @@ def test_output_credit_race_never_exceeds_capacity() -> None:
     assert actor.pending_chunks == 1
 
 
+def test_output_close_atomically_refuses_future_chunks_without_dropping_pending() -> (
+    None
+):
+    actor = TerminalOutputActor(capacity_bytes=64, max_chunk_bytes=64)
+    assert actor.offer_output(b"before eof").accepted is True
+
+    pending_at_close = actor.close_output()
+    late = actor.offer_output(b"after eof")
+
+    assert pending_at_close == len(b"before eof")
+    assert late.accepted is False
+    assert actor.pending_bytes == len(b"before eof")
+
+
 def test_parser_turn_splits_a_chunk_at_the_exact_byte_budget() -> None:
     actor = TerminalOutputActor(
         capacity_bytes=64,

--- a/Tests/Terminal/test_screen_model.py
+++ b/Tests/Terminal/test_screen_model.py
@@ -413,6 +413,7 @@ def test_parser_failure_stops_projection_with_a_content_free_reason(
         model.feed(b"later")
 
     snapshot = model.snapshot()
+    assert model.failure_reason is TerminalReason.TERMINAL_PROTOCOL_FAILED
     assert snapshot.failure_reason is TerminalReason.TERMINAL_PROTOCOL_FAILED
     assert snapshot.lines[0].text == ""
     assert "SECRET" not in repr(snapshot)

--- a/Tests/Terminal/test_session_manager.py
+++ b/Tests/Terminal/test_session_manager.py
@@ -1,0 +1,1413 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from threading import Barrier, Event, Lock
+
+import pytest
+
+from tldw_chatbook.Chat.console_raw_cli import RawCliRuntime
+from tldw_chatbook.Terminal.contracts import (
+    AdmissionGate,
+    BackendIdentity,
+    CleanupAttempt,
+    CleanupProof,
+    CleanupSchedule,
+    MAX_SESSION_RECORDS,
+    TerminalLaunchRequest,
+    TerminalLifecycle,
+    TerminalReason,
+)
+from tldw_chatbook.Terminal.io_actors import InputEventKind
+from tldw_chatbook.Terminal.session_manager import (
+    ManagedProcessIdentity,
+    TerminalArmResult,
+    TerminalCleanupDeadline,
+    TerminalCreateResult,
+    TerminalSessionView,
+    TerminalSessionManager,
+    TerminalSubscriptionToken,
+    TerminalViewState,
+    TerminalViewToken,
+)
+from tldw_chatbook.Terminal.screen_model import (
+    TerminalScreenModel,
+    TerminalScreenSnapshot,
+)
+
+
+def launch_request(name: str) -> TerminalLaunchRequest:
+    """Return one already-validated launch request for manager tests."""
+    return TerminalLaunchRequest(
+        name=name,
+        shell="default",
+        start_directory=str(Path.cwd()),
+        columns=80,
+        rows=24,
+    )
+
+
+class RecordingBackend:
+    """Narrow complete backend used to observe manager coordination."""
+
+    def __init__(
+        self,
+        *,
+        on_start: Callable[[TerminalLaunchRequest, AdmissionGate], None] | None = None,
+        on_cleanup: Callable[[CleanupAttempt], CleanupProof] | None = None,
+        on_raw_cleanup_drain: Callable[[CleanupAttempt], CleanupProof] | None = None,
+        cleanup_proof: CleanupProof = CleanupProof(True, True, True),
+    ) -> None:
+        self.on_start = on_start
+        self.on_cleanup = on_cleanup
+        self.on_raw_cleanup_drain = on_raw_cleanup_drain
+        self.cleanup_proof = cleanup_proof
+        self.started: list[tuple[TerminalLaunchRequest, AdmissionGate]] = []
+        self.writes: list[bytes] = []
+        self.resizes: list[tuple[int, int]] = []
+        self.priority_close_requests = 0
+        self.cleanup_attempts: list[CleanupAttempt] = []
+        self.raw_cleanup_attempts: list[CleanupAttempt] = []
+
+    def start(
+        self, request: TerminalLaunchRequest, admission: AdmissionGate
+    ) -> BackendIdentity:
+        self.started.append((request, admission))
+        if self.on_start is not None:
+            self.on_start(request, admission)
+        if admission.admitted is not True:
+            raise RuntimeError("backend received a refused admission")
+        return BackendIdentity(session_id=admission.token)
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(data)
+
+    def resize(self, columns: int, rows: int) -> None:
+        self.resizes.append((columns, rows))
+
+    def request_priority_close(self) -> None:
+        self.priority_close_requests += 1
+
+    def cleanup(self, attempt: CleanupAttempt) -> CleanupProof:
+        self.cleanup_attempts.append(attempt)
+        if self.on_cleanup is not None:
+            return self.on_cleanup(attempt)
+        return self.cleanup_proof
+
+    def cleanup_raw_drain(self, attempt: CleanupAttempt) -> CleanupProof:
+        self.raw_cleanup_attempts.append(attempt)
+        if self.on_raw_cleanup_drain is not None:
+            return self.on_raw_cleanup_drain(attempt)
+        return self.cleanup_proof
+
+
+class ManualClock:
+    """Thread-safe manually advanced monotonic clock."""
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+        self._lock = Lock()
+
+    def __call__(self) -> float:
+        with self._lock:
+            return self._value
+
+    def set(self, value: float) -> None:
+        with self._lock:
+            self._value = value
+
+
+def create_running_session(
+    terminal: TerminalSessionManager,
+    name: str,
+) -> str:
+    """Create one running session and return its opaque ID."""
+    result = terminal.create_session(launch_request(name))
+    assert result.admitted is True
+    assert result.projection is not None
+    return result.projection.session_id
+
+
+def test_terminal_arm_is_independent_and_resets_per_manager() -> None:
+    raw = RawCliRuntime(lambda: True)
+    terminal = TerminalSessionManager(
+        read_permitted=lambda: True,
+        backend_factory=RecordingBackend,
+    )
+
+    assert terminal.discoverable is True
+    assert terminal.permitted is True
+    assert terminal.armed is False
+    assert terminal.disclosure_acknowledged is False
+    assert raw.arm().armed is True
+    assert terminal.armed is False
+
+    first_arm = terminal.arm()
+    assert first_arm == TerminalArmResult(
+        armed=False,
+        reason=None,
+        disclosure_required=True,
+    )
+    assert terminal.arm(acknowledge_disclosure=True).armed is True
+    assert terminal.disclosure_acknowledged is True
+
+    raw.disarm()
+    assert terminal.armed is True
+    terminal.disarm()
+    assert terminal.armed is False
+    assert terminal.disclosure_acknowledged is True
+    assert terminal.arm().armed is True
+
+    fresh = TerminalSessionManager(lambda: True, RecordingBackend)
+    assert fresh.armed is False
+    assert fresh.disclosure_acknowledged is False
+    assert fresh.arm().disclosure_required is True
+
+
+@pytest.mark.parametrize("saved_value", [False, None, "true", "1", 1, object()])
+def test_terminal_arm_requires_the_literal_persisted_boolean_true(
+    saved_value: object,
+) -> None:
+    terminal = TerminalSessionManager(lambda: saved_value, RecordingBackend)
+
+    result = terminal.arm(acknowledge_disclosure=True)
+
+    assert result == TerminalArmResult(
+        armed=False,
+        reason=TerminalReason.LOCKED,
+        disclosure_required=False,
+    )
+    assert terminal.discoverable is True
+    assert terminal.permitted is False
+    assert terminal.armed is False
+    assert terminal.disclosure_acknowledged is False
+
+
+def test_terminal_permission_reader_failure_is_fail_closed() -> None:
+    def broken_reader() -> bool:
+        raise RuntimeError("unreadable setting")
+
+    terminal = TerminalSessionManager(broken_reader, RecordingBackend)
+
+    assert terminal.permitted is False
+    assert terminal.arm(acknowledge_disclosure=True).reason is TerminalReason.LOCKED
+    assert terminal.armed is False
+
+
+def test_create_requires_current_unlock_and_launch_local_arm() -> None:
+    permitted = True
+    terminal = TerminalSessionManager(lambda: permitted, RecordingBackend)
+
+    unarmed = terminal.create_session(launch_request("unarmed"))
+    assert unarmed == TerminalCreateResult(reason=TerminalReason.UNARMED)
+
+    terminal.arm(acknowledge_disclosure=True)
+    permitted = False
+    locked = terminal.create_session(launch_request("locked"))
+    assert locked == TerminalCreateResult(reason=TerminalReason.LOCKED)
+    assert terminal.armed is False
+    assert terminal.projections() == ()
+
+
+def test_persisted_unlock_revocation_disarms_cleans_and_requires_rearming() -> None:
+    permitted = True
+    clock = ManualClock(25.0)
+    backends: list[RecordingBackend] = []
+
+    def backend_factory() -> RecordingBackend:
+        backend = RecordingBackend()
+        backends.append(backend)
+        return backend
+
+    terminal = TerminalSessionManager(
+        lambda: permitted,
+        backend_factory,
+        monotonic_clock=clock,
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    create_running_session(terminal, "revoked-one")
+    create_running_session(terminal, "revoked-two")
+
+    permitted = False
+    assert terminal.permitted is False
+    assert terminal.armed is False
+    assert all(
+        terminal.wait_for_cleanup(projection.session_id, timeout_seconds=1)
+        for projection in terminal.projections()
+    )
+    assert [backend.cleanup_attempts for backend in backends] == [
+        [CleanupAttempt(25.0)],
+        [CleanupAttempt(25.0)],
+    ]
+    assert terminal.projections() == ()
+
+    permitted = True
+    assert terminal.permitted is True
+    assert terminal.armed is False
+    assert terminal.create_session(launch_request("still-unarmed")) == (
+        TerminalCreateResult(reason=TerminalReason.UNARMED)
+    )
+
+
+def test_create_reserves_atomically_before_calling_the_backend() -> None:
+    worker_count = MAX_SESSION_RECORDS + 3
+    race = Barrier(worker_count + 1)
+    observation_lock = Lock()
+    backend_calls = 0
+    terminal: TerminalSessionManager
+
+    def observe_start(request: TerminalLaunchRequest, admission: AdmissionGate) -> None:
+        nonlocal backend_calls
+        with observation_lock:
+            backend_calls += 1
+        assert admission.admitted is True
+        assert any(
+            item.session_id == admission.token
+            and item.name == request.name
+            and item.lifecycle
+            in {
+                TerminalLifecycle.RESERVED,
+                TerminalLifecycle.CREATING,
+                TerminalLifecycle.ADMITTING,
+            }
+            for item in terminal.projections()
+        )
+
+    def backend_factory() -> RecordingBackend:
+        return RecordingBackend(on_start=observe_start)
+
+    terminal = TerminalSessionManager(lambda: True, backend_factory)
+    assert terminal.arm(acknowledge_disclosure=True).armed is True
+
+    def create(index: int) -> TerminalCreateResult:
+        race.wait()
+        return terminal.create_session(launch_request(f"session-{index}"))
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        futures = [executor.submit(create, index) for index in range(worker_count)]
+        race.wait()
+        results = [future.result(timeout=2) for future in futures]
+
+    admitted = [result for result in results if result.admitted]
+    refused = [result for result in results if not result.admitted]
+    assert len(admitted) == MAX_SESSION_RECORDS
+    assert len(refused) == worker_count - MAX_SESSION_RECORDS
+    assert {result.reason for result in refused} == {TerminalReason.SESSION_LIMIT}
+    assert backend_calls == MAX_SESSION_RECORDS
+    assert len(terminal.projections()) == MAX_SESSION_RECORDS
+
+
+def test_prelaunch_failure_releases_its_reservation() -> None:
+    calls = 0
+
+    def backend_factory() -> RecordingBackend:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("backend unavailable before launch")
+        return RecordingBackend()
+
+    terminal = TerminalSessionManager(lambda: True, backend_factory)
+    terminal.arm(acknowledge_disclosure=True)
+
+    failed = terminal.create_session(launch_request("reusable"))
+    succeeded = terminal.create_session(launch_request("reusable"))
+
+    assert failed == TerminalCreateResult(reason=TerminalReason.BACKEND_UNAVAILABLE)
+    assert succeeded.admitted is True
+    assert len(terminal.projections()) == 1
+
+
+def test_casefolded_unicode_names_are_unique_across_retained_records() -> None:
+    terminal = TerminalSessionManager(lambda: True, RecordingBackend)
+    terminal.arm(acknowledge_disclosure=True)
+
+    first = terminal.create_session(launch_request("  Straße  "))
+    duplicate = terminal.create_session(launch_request("STRASSE"))
+
+    assert first.admitted is True
+    assert first.projection is not None
+    assert first.projection.name == "Straße"
+    assert duplicate == TerminalCreateResult(reason=TerminalReason.INVALID_NAME)
+    assert len(terminal.projections()) == 1
+
+
+def test_public_manager_results_and_projections_are_immutable() -> None:
+    terminal = TerminalSessionManager(lambda: True, RecordingBackend)
+    arm_result = terminal.arm(acknowledge_disclosure=True)
+    create_result = terminal.create_session(launch_request("immutable"))
+
+    with pytest.raises(FrozenInstanceError):
+        arm_result.armed = False  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        create_result.reason = TerminalReason.IO_FAILED  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        create_result.projection.lifecycle = TerminalLifecycle.CLOSED  # type: ignore[misc,union-attr]
+
+
+def test_shell_exit_uses_one_absolute_attempt_and_retains_exited_record() -> None:
+    clock = ManualClock(100.0)
+    cleanup_started = Event()
+    finish_cleanup = Event()
+    backend = RecordingBackend()
+
+    def cleanup(attempt: CleanupAttempt) -> CleanupProof:
+        cleanup_started.set()
+        assert finish_cleanup.wait(1)
+        return CleanupProof(True, True, True)
+
+    backend.on_cleanup = cleanup
+    terminal = TerminalSessionManager(
+        lambda: True,
+        lambda: backend,
+        monotonic_clock=clock,
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "natural-exit")
+
+    receipt = terminal.shell_exited(session_id, exit_code=7)
+
+    assert receipt is not None
+    assert receipt.attempt == CleanupAttempt(100.0)
+    assert receipt.action == "shell_exit"
+    assert cleanup_started.wait(1)
+    draining = terminal.projection(session_id)
+    assert draining is not None
+    assert draining.lifecycle is TerminalLifecycle.DRAINING
+    assert draining.exit_code == 7
+    deadline = terminal.cleanup_deadline(session_id)
+    assert deadline == TerminalCleanupDeadline(
+        attempt=CleanupAttempt(100.0),
+        hangup_at=100.75,
+        terminate_at=102.25,
+        force_kill_at=103.75,
+        deadline_at=105.0,
+    )
+
+    clock.set(1_000.0)
+    finish_cleanup.set()
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+    exited = terminal.projection(session_id)
+    assert exited is not None
+    assert exited.lifecycle is TerminalLifecycle.EXITED
+    assert exited.exit_code == 7
+    assert exited.stream_closed is True
+    assert exited.output_complete is True
+    assert backend.cleanup_attempts == [CleanupAttempt(100.0)]
+
+
+def test_disarm_starts_one_parallel_cleanup_cohort_after_clearing_arm() -> None:
+    clock = ManualClock(200.0)
+    cleanup_started = Barrier(3)
+    finish_cleanup = Event()
+    backends: list[RecordingBackend] = []
+    terminal: TerminalSessionManager
+
+    def backend_factory() -> RecordingBackend:
+        def cleanup(attempt: CleanupAttempt) -> CleanupProof:
+            assert terminal.armed is False
+            cleanup_started.wait()
+            assert finish_cleanup.wait(1)
+            return CleanupProof(True, True, True)
+
+        backend = RecordingBackend(on_cleanup=cleanup)
+        backends.append(backend)
+        return backend
+
+    terminal = TerminalSessionManager(
+        lambda: True,
+        backend_factory,
+        monotonic_clock=clock,
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    session_ids = [
+        create_running_session(terminal, "parallel-one"),
+        create_running_session(terminal, "parallel-two"),
+    ]
+
+    terminal.disarm()
+
+    assert terminal.armed is False
+    cleanup_started.wait(timeout=1)
+    assert {
+        terminal.projection(session_id).lifecycle  # type: ignore[union-attr]
+        for session_id in session_ids
+    } == {TerminalLifecycle.CLOSING}
+    assert [backend.cleanup_attempts for backend in backends] == [
+        [CleanupAttempt(200.0)],
+        [CleanupAttempt(200.0)],
+    ]
+    finish_cleanup.set()
+    for session_id in session_ids:
+        assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+    assert terminal.projections() == ()
+
+
+def test_joined_disarm_does_not_extend_or_duplicate_an_existing_cleanup() -> None:
+    clock = ManualClock(300.0)
+    cleanup_started = Event()
+    finish_cleanup = Event()
+
+    def cleanup(attempt: CleanupAttempt) -> CleanupProof:
+        cleanup_started.set()
+        assert finish_cleanup.wait(1)
+        return CleanupProof(True, True, True)
+
+    backend = RecordingBackend(on_cleanup=cleanup)
+    terminal = TerminalSessionManager(
+        lambda: True,
+        lambda: backend,
+        monotonic_clock=clock,
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "joined")
+    terminal.shell_exited(session_id, exit_code=0)
+    assert cleanup_started.wait(1)
+
+    clock.set(301.0)
+    terminal.disarm()
+
+    receipt = terminal.cleanup_receipt(session_id)
+    assert receipt is not None
+    assert receipt.attempt == CleanupAttempt(300.0)
+    assert backend.cleanup_attempts == [CleanupAttempt(300.0)]
+    finish_cleanup.set()
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+
+
+def test_only_explicit_retry_gets_a_fresh_cleanup_attempt() -> None:
+    clock = ManualClock(400.0)
+    attempts = 0
+
+    def cleanup(attempt: CleanupAttempt) -> CleanupProof:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return CleanupProof(False, False, False)
+        return CleanupProof(True, True, True)
+
+    backend = RecordingBackend(on_cleanup=cleanup)
+    permitted = True
+    terminal = TerminalSessionManager(
+        lambda: permitted,
+        lambda: backend,
+        monotonic_clock=clock,
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "retry")
+    terminal.disarm()
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+    retained = terminal.projection(session_id)
+    assert retained is not None
+    assert retained.lifecycle is TerminalLifecycle.CLEANUP_UNPROVEN
+    assert terminal.cleanup_receipt(session_id).attempt == CleanupAttempt(400.0)  # type: ignore[union-attr]
+
+    permitted = False
+    clock.set(500.0)
+    view = terminal.attach_view()
+    retry_receipt = terminal.retry_cleanup(session_id, view=view)
+
+    assert retry_receipt is not None
+    assert retry_receipt.action == "retry"
+    assert retry_receipt.attempt == CleanupAttempt(500.0)
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+    assert terminal.projection(session_id) is None
+    assert backend.cleanup_attempts == [CleanupAttempt(400.0), CleanupAttempt(500.0)]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_unproven_is_never_retried_by_other_actions() -> None:
+    clock = ManualClock(525.0)
+    backend = RecordingBackend(cleanup_proof=CleanupProof())
+    terminal = TerminalSessionManager(
+        lambda: True,
+        lambda: backend,
+        monotonic_clock=clock,
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "explicit-retry-only")
+    terminal.disarm()
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+    original_receipt = terminal.cleanup_receipt(session_id)
+    assert original_receipt is not None
+
+    clock.set(550.0)
+    terminal.disarm()
+    view = terminal.attach_view()
+    assert terminal.close_session(session_id, view=view) == original_receipt
+    assert await terminal.shutdown(deadline_seconds=0.01) is False
+    assert terminal.shell_exited(session_id, exit_code=9) == original_receipt
+
+    retained = terminal.projection(session_id)
+    assert retained is not None
+    assert retained.lifecycle is TerminalLifecycle.CLEANUP_UNPROVEN
+    assert retained.exit_code == 9
+    assert backend.cleanup_attempts == [CleanupAttempt(525.0)]
+
+
+def test_shell_exit_joins_cleanup_already_in_progress() -> None:
+    clock = ManualClock(575.0)
+    cleanup_started = Event()
+    finish_cleanup = Event()
+
+    def cleanup(attempt: CleanupAttempt) -> CleanupProof:
+        cleanup_started.set()
+        assert finish_cleanup.wait(1)
+        return CleanupProof(True, True, True)
+
+    backend = RecordingBackend(on_cleanup=cleanup)
+    terminal = TerminalSessionManager(
+        lambda: True,
+        lambda: backend,
+        monotonic_clock=clock,
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "late-shell-exit")
+    view = terminal.attach_view()
+    close_receipt = terminal.close_session(session_id, view=view)
+    assert close_receipt is not None
+    assert cleanup_started.wait(1)
+
+    clock.set(580.0)
+    shell_receipt = terminal.shell_exited(session_id, exit_code=7)
+
+    assert shell_receipt == close_receipt
+    closing = terminal.projection(session_id)
+    assert closing is not None
+    assert closing.lifecycle is TerminalLifecycle.CLOSING
+    assert closing.exit_code == 7
+    assert backend.cleanup_attempts == [CleanupAttempt(575.0)]
+    finish_cleanup.set()
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_is_bounded_and_uses_one_global_attempt() -> None:
+    clock = ManualClock(600.0)
+    backends: list[RecordingBackend] = []
+
+    def backend_factory() -> RecordingBackend:
+        backend = RecordingBackend()
+        backends.append(backend)
+        return backend
+
+    terminal = TerminalSessionManager(
+        lambda: True,
+        backend_factory,
+        monotonic_clock=clock,
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    create_running_session(terminal, "shutdown-one")
+    create_running_session(terminal, "shutdown-two")
+
+    assert await terminal.shutdown(deadline_seconds=0.5) is True
+
+    assert terminal.armed is False
+    assert terminal.projections() == ()
+    assert [backend.cleanup_attempts for backend in backends] == [
+        [CleanupAttempt(600.0)],
+        [CleanupAttempt(600.0)],
+    ]
+
+
+def test_parser_failure_disables_input_and_raw_drains_only_after_death() -> None:
+    clock = ManualClock(700.0)
+    cleanup_started = Event()
+    finish_cleanup = Event()
+    raw_drain_process_dead: list[bool] = []
+
+    def cleanup(attempt: CleanupAttempt) -> CleanupProof:
+        cleanup_started.set()
+        assert finish_cleanup.wait(1)
+        return CleanupProof(True, False, False)
+
+    def raw_cleanup_drain(attempt: CleanupAttempt) -> CleanupProof:
+        raw_drain_process_dead.append(True)
+        return CleanupProof(True, True, False)
+
+    backend = RecordingBackend(
+        on_cleanup=cleanup,
+        on_raw_cleanup_drain=raw_cleanup_drain,
+    )
+
+    class FailingScreen:
+        def feed(self, data: bytes) -> None:
+            del data
+            raise RuntimeError("parser invariant failed")
+
+        def resize(self, *, columns: int, rows: int) -> None:
+            del columns, rows
+
+        def snapshot(self) -> object:
+            return object()
+
+    terminal = TerminalSessionManager(
+        lambda: True,
+        lambda: backend,
+        monotonic_clock=clock,
+        screen_model_factory=lambda _columns, _rows: FailingScreen(),
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "parser-failure")
+    assert terminal.accepts_input(session_id) is True
+    assert terminal.offer_output(session_id, b"not projected").accepted is True
+
+    assert terminal.process_output(session_id, visible=True) is None
+
+    failed = terminal.projection(session_id)
+    assert failed is not None
+    assert failed.lifecycle is TerminalLifecycle.CLOSING
+    assert failed.reason is TerminalReason.TERMINAL_PROTOCOL_FAILED
+    assert failed.parser_failed is True
+    assert terminal.accepts_input(session_id) is False
+    assert backend.priority_close_requests == 1
+    assert cleanup_started.wait(1)
+    assert backend.raw_cleanup_attempts == []
+
+    finish_cleanup.set()
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+    assert raw_drain_process_dead == [True]
+    assert backend.raw_cleanup_attempts == [CleanupAttempt(700.0)]
+    assert terminal.projection(session_id) is None
+
+
+def test_parser_failure_never_raw_drains_without_process_death_proof() -> None:
+    backend = RecordingBackend(cleanup_proof=CleanupProof(False, False, False))
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "no-raw-drain")
+
+    terminal.parser_failed(session_id)
+
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+    assert backend.raw_cleanup_attempts == []
+    retained = terminal.projection(session_id)
+    assert retained is not None
+    assert retained.lifecycle is TerminalLifecycle.CLEANUP_UNPROVEN
+    assert retained.reason is TerminalReason.CLEANUP_UNPROVEN
+
+
+def test_screen_model_reported_failure_closes_the_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = RecordingBackend(cleanup_proof=CleanupProof(False, False, False))
+    model = TerminalScreenModel(columns=80, rows=24)
+
+    def fail_without_exposing_output(_: str) -> None:
+        raise RuntimeError("private terminal output")
+
+    monkeypatch.setattr(model._stream, "feed", fail_without_exposing_output)
+    terminal = TerminalSessionManager(
+        lambda: True,
+        lambda: backend,
+        screen_model_factory=lambda _columns, _rows: model,
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "reported-parser-failure")
+    assert terminal.offer_output(session_id, b"private terminal output").accepted
+
+    assert terminal.process_output(session_id, visible=True) is None
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+
+    retained = terminal.projection(session_id)
+    assert retained is not None
+    assert retained.lifecycle is TerminalLifecycle.CLEANUP_UNPROVEN
+    assert retained.parser_failed is True
+    assert backend.priority_close_requests == 1
+
+
+def test_malformed_terminal_reply_fails_closed_before_input_queueing() -> None:
+    backend = RecordingBackend(cleanup_proof=CleanupProof(False, False, False))
+
+    class MalformedReplyScreen(TerminalScreenModel):
+        def take_pending_replies(self) -> tuple[object, ...]:
+            return (object(),)
+
+    terminal = TerminalSessionManager(
+        lambda: True,
+        lambda: backend,
+        screen_model_factory=lambda columns, rows: MalformedReplyScreen(
+            columns=columns,
+            rows=rows,
+        ),
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "malformed-reply")
+    assert terminal.offer_output(session_id, b"safe output").accepted
+
+    assert terminal.process_output(session_id, visible=True) is None
+    assert terminal.take_input(session_id) is None
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+
+    retained = terminal.projection(session_id)
+    assert retained is not None
+    assert retained.lifecycle is TerminalLifecycle.CLEANUP_UNPROVEN
+    assert retained.parser_failed is True
+    assert backend.priority_close_requests == 1
+
+
+def test_cleanup_schedule_defaults_are_not_mutated_by_waits() -> None:
+    assert CleanupSchedule() == CleanupSchedule(
+        deadline_seconds=5.0,
+        hangup_no_later_than=0.75,
+        terminate_no_later_than=2.25,
+        force_kill_no_later_than=3.75,
+        proof_reserve_seconds=1.25,
+    )
+
+
+def test_view_state_contains_only_immutable_safe_projections() -> None:
+    backend = RecordingBackend()
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "safe-view")
+    token = terminal.attach_view()
+    terminal.offer_output(session_id, b"safe output")
+    terminal.process_output(session_id, visible=True)
+
+    state = terminal.view_state(token)
+
+    assert isinstance(token, TerminalViewToken)
+    assert isinstance(state, TerminalViewState)
+    assert state.selected_session_id == session_id
+    assert len(state.sessions) == 1
+    session = state.sessions[0]
+    assert isinstance(session, TerminalSessionView)
+    assert session.projection.session_id == session_id
+    assert session.screen.lines[0].text.startswith("safe output")
+    assert set(TerminalSessionView.__slots__) == {
+        "projection",
+        "screen",
+        "shell",
+        "start_directory",
+        "columns",
+        "rows",
+        "cleanup_receipt",
+    }
+    assert session.shell == "default"
+    assert session.start_directory == str(Path.cwd())
+    assert (session.columns, session.rows) == (80, 24)
+    assert not hasattr(session, "backend")
+    assert not hasattr(session, "model")
+    assert not hasattr(session, "environment")
+    with pytest.raises(FrozenInstanceError):
+        state.selected_session_id = "changed"  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        session.projection.name = "changed"  # type: ignore[misc]
+
+
+def test_screen_snapshot_waits_for_the_active_parser_turn() -> None:
+    parser_entered = Event()
+    release_parser = Event()
+    concurrent_snapshot = Event()
+
+    class CoordinatedScreen:
+        def feed(self, data: bytes) -> None:
+            del data
+            parser_entered.set()
+            assert release_parser.wait(1)
+
+        def resize(self, *, columns: int, rows: int) -> None:
+            del columns, rows
+
+        def snapshot(self) -> TerminalScreenSnapshot:
+            if parser_entered.is_set() and not release_parser.is_set():
+                concurrent_snapshot.set()
+            return TerminalScreenSnapshot(lines=())
+
+        def take_pending_replies(self) -> tuple[bytes, ...]:
+            return ()
+
+    terminal = TerminalSessionManager(
+        lambda: True,
+        RecordingBackend,
+        screen_model_factory=lambda _columns, _rows: CoordinatedScreen(),
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "serialized-screen")
+    view = terminal.attach_view()
+    assert terminal.offer_output(session_id, b"one parser turn").accepted is True
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        parsing = executor.submit(terminal.process_output, session_id, visible=True)
+        assert parser_entered.wait(1)
+        snapshot = executor.submit(terminal.view_state, view)
+
+        assert concurrent_snapshot.wait(0.1) is False
+        release_parser.set()
+        assert parsing.result(timeout=1) is not None
+        assert snapshot.result(timeout=1) is not None
+
+    assert concurrent_snapshot.is_set() is False
+
+
+def test_stale_or_detached_view_tokens_cannot_mutate_or_repaint() -> None:
+    cleanup_started = Event()
+    finish_cleanup = Event()
+
+    def cleanup(attempt: CleanupAttempt) -> CleanupProof:
+        cleanup_started.set()
+        assert finish_cleanup.wait(1)
+        return CleanupProof(True, True, True)
+
+    backends = [RecordingBackend(on_cleanup=cleanup), RecordingBackend()]
+    terminal = TerminalSessionManager(lambda: True, lambda: backends.pop(0))
+    terminal.arm(acknowledge_disclosure=True)
+    first_id = create_running_session(terminal, "first")
+    second_id = create_running_session(terminal, "second")
+    stale = terminal.attach_view()
+    current = terminal.attach_view()
+
+    assert terminal.view_state(stale) is None
+    assert terminal.resize_session(first_id, columns=100, rows=30, view=stale) is False
+    assert terminal.focus_session(second_id, view=stale) is False
+    assert terminal.close_session(first_id, view=stale) is None
+    assert terminal.selected_session_id == first_id
+    assert terminal.projection(first_id).lifecycle is TerminalLifecycle.RUNNING  # type: ignore[union-attr]
+
+    assert terminal.resize_session(first_id, columns=100, rows=30, view=current)
+    assert terminal.focus_session(second_id, view=current)
+    assert terminal.selected_session_id == second_id
+    receipt = terminal.close_session(first_id, view=current)
+    assert receipt is not None
+    assert cleanup_started.wait(1)
+    assert terminal.projection(first_id).lifecycle is TerminalLifecycle.CLOSING  # type: ignore[union-attr]
+
+    terminal.detach_view(current)
+    assert terminal.view_state(current) is None
+    assert (
+        terminal.resize_session(second_id, columns=90, rows=25, view=current) is False
+    )
+    assert terminal.focus_session(first_id, view=current) is False
+    finish_cleanup.set()
+    assert terminal.wait_for_cleanup(first_id, timeout_seconds=1)
+
+
+@pytest.mark.asyncio
+async def test_resize_is_coalesced_and_applied_outside_the_view_callback() -> None:
+    backend = RecordingBackend()
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "coalesced-resize")
+    view = terminal.attach_view()
+
+    assert terminal.resize_session(session_id, columns=90, rows=25, view=view)
+    assert terminal.resize_session(session_id, columns=100, rows=30, view=view)
+    assert backend.resizes == []
+
+    assert await terminal.apply_pending_resize(session_id, view=view) is True
+    assert backend.resizes == [(100, 30)]
+    state = terminal.view_state(view)
+    assert state is not None
+    assert (state.sessions[0].columns, state.sessions[0].rows) == (100, 30)
+
+
+@pytest.mark.asyncio
+async def test_blocked_backend_resize_cannot_delay_disarm_cleanup() -> None:
+    resize_started = Event()
+    release_resize = Event()
+    cleanup_started = Event()
+
+    class BlockingResizeBackend(RecordingBackend):
+        def resize(self, columns: int, rows: int) -> None:
+            del columns, rows
+            resize_started.set()
+            assert release_resize.wait(1)
+
+        def cleanup(self, attempt: CleanupAttempt) -> CleanupProof:
+            del attempt
+            cleanup_started.set()
+            return CleanupProof(True, True, True)
+
+    terminal = TerminalSessionManager(lambda: True, BlockingResizeBackend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "blocking-resize")
+    view = terminal.attach_view()
+    assert terminal.resize_session(session_id, columns=100, rows=30, view=view)
+
+    resize_task = asyncio.create_task(
+        terminal.apply_pending_resize(session_id, view=view)
+    )
+    assert await asyncio.to_thread(resize_started.wait, 1)
+    disarm_task = asyncio.create_task(asyncio.to_thread(terminal.disarm))
+    cleanup_was_not_blocked = await asyncio.to_thread(cleanup_started.wait, 0.2)
+
+    release_resize.set()
+    await disarm_task
+    assert await resize_task is False
+    assert cleanup_was_not_blocked is True
+
+
+def test_stale_view_cannot_retry_retained_cleanup() -> None:
+    backend = RecordingBackend(cleanup_proof=CleanupProof())
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "stale-retry")
+    stale = terminal.attach_view()
+
+    assert terminal.close_session(session_id, view=stale) is not None
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+    assert (
+        terminal.projection(session_id).lifecycle is TerminalLifecycle.CLEANUP_UNPROVEN
+    )  # type: ignore[union-attr]
+    current = terminal.attach_view()
+
+    with pytest.raises(TypeError):
+        terminal.retry_cleanup(session_id)  # type: ignore[call-arg]
+    assert terminal.retry_cleanup(session_id, view=stale) is None
+    assert len(backend.cleanup_attempts) == 1
+    assert terminal.retry_cleanup(session_id, view=current) is not None
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+    assert len(backend.cleanup_attempts) == 2
+
+
+def test_destroy_and_remount_preserves_backend_identity_while_output_continues() -> (
+    None
+):
+    backend = RecordingBackend()
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "remount")
+    first_view = terminal.attach_view()
+    terminal.offer_output(session_id, b"before ")
+    terminal.process_output(session_id, visible=True)
+    first_state = terminal.view_state(first_view)
+    terminal.detach_view(first_view)
+
+    terminal.offer_output(session_id, b"after")
+    terminal.process_output(session_id, visible=False)
+    second_view = terminal.attach_view()
+    second_state = terminal.view_state(second_view)
+
+    assert first_state is not None
+    assert second_state is not None
+    assert first_state.sessions[0].projection.session_id == session_id
+    assert second_state.sessions[0].projection.session_id == session_id
+    assert second_state.sessions[0].screen.lines[0].text.startswith("before after")
+    assert len(backend.started) == 1
+    assert backend.started[0][1].token == session_id
+
+
+def test_healthy_output_drain_remains_available_during_cleanup() -> None:
+    cleanup_started = Event()
+    finish_cleanup = Event()
+
+    def cleanup(attempt: CleanupAttempt) -> CleanupProof:
+        cleanup_started.set()
+        assert finish_cleanup.wait(1)
+        return CleanupProof(True, True, True)
+
+    backend = RecordingBackend(on_cleanup=cleanup)
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "healthy-drain")
+
+    terminal.disarm()
+    assert cleanup_started.wait(1)
+    assert terminal.offer_output(session_id, b"final bytes").accepted is True
+    turn = terminal.process_output(session_id, visible=False)
+    assert turn is not None
+    assert turn.processed_bytes == len(b"final bytes")
+    finish_cleanup.set()
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_returns_at_its_wait_bound_when_cleanup_is_still_running() -> (
+    None
+):
+    cleanup_started = Event()
+    finish_cleanup = Event()
+
+    def cleanup(attempt: CleanupAttempt) -> CleanupProof:
+        cleanup_started.set()
+        assert finish_cleanup.wait(1)
+        return CleanupProof(True, True, True)
+
+    backend = RecordingBackend(on_cleanup=cleanup)
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "bounded-shutdown")
+
+    try:
+        async with asyncio.timeout(0.2):
+            assert await terminal.shutdown(deadline_seconds=0.01) is False
+        assert cleanup_started.wait(1)
+        assert terminal.armed is False
+        assert terminal.projection(session_id) is not None
+    finally:
+        finish_cleanup.set()
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+
+
+def test_managed_process_inventory_is_test_only_and_content_free() -> None:
+    class InventoryBackend(RecordingBackend):
+        def managed_process_inventory_for_tests(
+            self,
+        ) -> tuple[ManagedProcessIdentity, ...]:
+            return (
+                ManagedProcessIdentity(pid=101, birth_identity="birth-a"),
+                ManagedProcessIdentity(pid=202, birth_identity="birth-b"),
+            )
+
+    terminal = TerminalSessionManager(lambda: True, InventoryBackend)
+    terminal.arm(acknowledge_disclosure=True)
+    create_running_session(terminal, "inventory")
+    view = terminal.attach_view()
+
+    inventory = terminal.managed_process_inventory_for_tests()
+    state = terminal.view_state(view)
+
+    assert inventory == (
+        ManagedProcessIdentity(pid=101, birth_identity="birth-a"),
+        ManagedProcessIdentity(pid=202, birth_identity="birth-b"),
+    )
+    assert ManagedProcessIdentity.__slots__ == ("pid", "birth_identity")
+    assert state is not None
+    assert not hasattr(state, "managed_processes")
+    assert all(not hasattr(session, "managed_processes") for session in state.sessions)
+
+
+def test_rename_is_normalized_unique_and_generation_scoped() -> None:
+    terminal = TerminalSessionManager(lambda: True, RecordingBackend)
+    terminal.arm(acknowledge_disclosure=True)
+    first_id = create_running_session(terminal, "First")
+    second_id = create_running_session(terminal, "Second")
+    stale = terminal.attach_view()
+    current = terminal.attach_view()
+
+    assert terminal.rename_session(second_id, "Renamed", view=stale) is False
+    assert terminal.rename_session(second_id, "  FIRST  ", view=current) is False
+    assert terminal.rename_session(second_id, "  Résumé  ", view=current) is True
+
+    assert terminal.projection(first_id).name == "First"  # type: ignore[union-attr]
+    assert terminal.projection(second_id).name == "Résumé"  # type: ignore[union-attr]
+
+
+def test_view_input_uses_the_owned_bounded_actor_and_stale_calls_are_ignored() -> None:
+    terminal = TerminalSessionManager(lambda: True, RecordingBackend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "input")
+    stale = terminal.attach_view()
+    current = terminal.attach_view()
+
+    assert terminal.send_key(session_id, b"a", view=stale).accepted is False
+    assert terminal.send_key(session_id, b"a", view=current).accepted is True
+    assert (
+        terminal.send_paste(
+            session_id,
+            "line\n",
+            bracketed=False,
+            view=current,
+        ).accepted
+        is True
+    )
+
+    key = terminal.take_input(session_id)
+    paste = terminal.take_input(session_id)
+    assert key is not None
+    assert key.kind is InputEventKind.KEY
+    assert key.data == b"a"
+    assert paste is not None
+    assert paste.kind is InputEventKind.PASTE
+    assert paste.data == b"line\n"
+    assert terminal.take_input(session_id) is None
+
+    terminal.disarm()
+    assert terminal.send_key(session_id, b"b", view=current).accepted is False
+
+
+def test_change_subscriptions_are_content_free_and_unsubscribable() -> None:
+    notifications: list[str] = []
+    terminal = TerminalSessionManager(lambda: True, RecordingBackend)
+    subscription = terminal.subscribe(lambda: notifications.append("changed"))
+    assert isinstance(subscription, TerminalSubscriptionToken)
+
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "subscription")
+    terminal.offer_output(session_id, b"output")
+    terminal.process_output(session_id, visible=True)
+
+    assert notifications
+    before_unsubscribe = len(notifications)
+    assert terminal.unsubscribe(subscription) is True
+    view = terminal.attach_view()
+    assert terminal.rename_session(session_id, "renamed", view=view) is True
+    assert len(notifications) == before_unsubscribe
+
+
+def test_explicit_retry_notifies_before_cleanup_settles() -> None:
+    retry_started = Event()
+    finish_retry = Event()
+    attempts = 0
+
+    def cleanup(attempt: CleanupAttempt) -> CleanupProof:
+        nonlocal attempts
+        del attempt
+        attempts += 1
+        if attempts == 1:
+            return CleanupProof()
+        retry_started.set()
+        assert finish_retry.wait(1)
+        return CleanupProof(True, True, True)
+
+    backend = RecordingBackend(on_cleanup=cleanup)
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "retry-notification")
+    terminal.disarm()
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+    notifications: list[str] = []
+    terminal.subscribe(lambda: notifications.append("changed"))
+    view = terminal.attach_view()
+
+    receipt = terminal.retry_cleanup(session_id, view=view)
+
+    assert receipt is not None
+    assert retry_started.wait(1)
+    assert terminal.projection(session_id).lifecycle is TerminalLifecycle.CLOSING  # type: ignore[union-attr]
+    assert notifications == ["changed"]
+    finish_retry.set()
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+
+
+def test_disarm_during_backend_factory_cancels_before_backend_start() -> None:
+    factory_started = Event()
+    release_factory = Event()
+    backend = RecordingBackend()
+
+    def backend_factory() -> RecordingBackend:
+        factory_started.set()
+        assert release_factory.wait(1)
+        return backend
+
+    terminal = TerminalSessionManager(lambda: True, backend_factory)
+    terminal.arm(acknowledge_disclosure=True)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        creating = executor.submit(
+            terminal.create_session,
+            launch_request("cancel-factory"),
+        )
+        assert factory_started.wait(1)
+        terminal.disarm()
+        release_factory.set()
+        result = creating.result(timeout=1)
+
+    assert result.admitted is False
+    assert terminal.armed is False
+    assert terminal.projections() == ()
+    assert backend.started == []
+
+
+def test_disarm_during_backend_start_never_resurrects_a_running_record() -> None:
+    start_entered = Event()
+    release_start = Event()
+    cleanup_started = Event()
+    release_cleanup = Event()
+
+    def on_start(
+        request: TerminalLaunchRequest,
+        admission: AdmissionGate,
+    ) -> None:
+        del request, admission
+        start_entered.set()
+        assert release_start.wait(1)
+
+    def on_cleanup(attempt: CleanupAttempt) -> CleanupProof:
+        del attempt
+        cleanup_started.set()
+        assert release_cleanup.wait(1)
+        return CleanupProof(True, True, True)
+
+    backend = RecordingBackend(on_start=on_start, on_cleanup=on_cleanup)
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        creating = executor.submit(
+            terminal.create_session,
+            launch_request("cancel-start"),
+        )
+        assert start_entered.wait(1)
+        terminal.disarm()
+        assert cleanup_started.wait(1)
+        release_start.set()
+        result = creating.result(timeout=1)
+
+    assert result.admitted is False
+    assert all(
+        projection.lifecycle is not TerminalLifecycle.RUNNING
+        for projection in terminal.projections()
+    )
+    release_cleanup.set()
+    assert terminal.wait_for_cleanup(
+        backend.started[0][1].token,
+        timeout_seconds=1,
+    )
+    assert terminal.projections() == ()
+
+
+def test_start_failure_after_disarm_cannot_erase_cleanup_uncertainty() -> None:
+    start_entered = Event()
+    release_start = Event()
+    cleanup_finished = Event()
+
+    def on_start(
+        request: TerminalLaunchRequest,
+        admission: AdmissionGate,
+    ) -> None:
+        del request, admission
+        start_entered.set()
+        assert release_start.wait(1)
+        raise RuntimeError("launch failed after cleanup began")
+
+    def on_cleanup(attempt: CleanupAttempt) -> CleanupProof:
+        del attempt
+        cleanup_finished.set()
+        return CleanupProof()
+
+    backend = RecordingBackend(on_start=on_start, on_cleanup=on_cleanup)
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        creating = executor.submit(
+            terminal.create_session,
+            launch_request("failed-start-cleanup"),
+        )
+        assert start_entered.wait(1)
+        terminal.disarm()
+        assert cleanup_finished.wait(1)
+        release_start.set()
+        result = creating.result(timeout=1)
+
+    assert result == TerminalCreateResult(reason=TerminalReason.SPAWN_FAILED)
+    assert len(terminal.projections()) == 1
+    retained = terminal.projections()[0]
+    assert retained.lifecycle is TerminalLifecycle.CLEANUP_UNPROVEN
+    assert retained.reason is TerminalReason.CLEANUP_UNPROVEN
+
+
+def test_shell_exit_without_eof_retains_cleanup_unproven_not_exited() -> None:
+    backend = RecordingBackend(cleanup_proof=CleanupProof(True, False, False))
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "missing-eof")
+
+    terminal.shell_exited(session_id, exit_code=0)
+
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+    retained = terminal.projection(session_id)
+    assert retained is not None
+    assert retained.lifecycle is TerminalLifecycle.CLEANUP_UNPROVEN
+    assert retained.stream_closed is False
+    assert retained.output_complete is False
+
+
+def test_eof_settlement_drains_admitted_output_and_finalizes_the_screen() -> None:
+    backend = RecordingBackend(cleanup_proof=CleanupProof(True, True, True))
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "final-output")
+    view = terminal.attach_view()
+    assert terminal.offer_output(session_id, b"final output").accepted
+
+    terminal.shell_exited(session_id, exit_code=0)
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+
+    exited = terminal.projection(session_id)
+    assert exited is not None
+    assert exited.lifecycle is TerminalLifecycle.EXITED
+    assert exited.stream_closed is True
+    assert exited.output_complete is True
+    state = terminal.view_state(view)
+    assert state is not None
+    assert state.sessions[0].screen.lines[0].text.startswith("final output")
+
+
+def test_eof_finalizer_failure_fails_closed_instead_of_claiming_completeness() -> None:
+    backend = RecordingBackend(cleanup_proof=CleanupProof(True, True, True))
+
+    class FailingFinalizerScreen:
+        failure_reason = None
+
+        def feed(self, data: bytes) -> None:
+            del data
+
+        def take_pending_replies(self) -> tuple[bytes, ...]:
+            return ()
+
+        def finish(self) -> None:
+            raise RuntimeError("decoder finalization failed")
+
+        def resize(self, *, columns: int, rows: int) -> None:
+            del columns, rows
+
+    terminal = TerminalSessionManager(
+        lambda: True,
+        lambda: backend,
+        screen_model_factory=lambda _columns, _rows: FailingFinalizerScreen(),
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "failing-finalizer")
+    assert terminal.offer_output(session_id, b"partial").accepted
+
+    terminal.shell_exited(session_id, exit_code=0)
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+
+    assert terminal.projection(session_id) is None
+    assert backend.priority_close_requests == 1
+
+
+def test_output_is_refused_after_stream_closure_is_proven() -> None:
+    backend = RecordingBackend(cleanup_proof=CleanupProof(True, True, True))
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "closed-stream")
+
+    terminal.shell_exited(session_id, exit_code=0)
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+
+    exited = terminal.projection(session_id)
+    assert exited is not None
+    assert exited.stream_closed is True
+    assert terminal.offer_output(session_id, b"late bytes").accepted is False
+
+
+def test_view_snapshot_failure_is_contained_and_closes_the_session() -> None:
+    backend = RecordingBackend(cleanup_proof=CleanupProof(False, False, False))
+
+    class SnapshotFailingScreen:
+        failure_reason = None
+
+        def feed(self, data: bytes) -> None:
+            del data
+
+        def resize(self, *, columns: int, rows: int) -> None:
+            del columns, rows
+
+        def snapshot(self) -> TerminalScreenSnapshot:
+            raise RuntimeError("private screen state")
+
+        def take_pending_replies(self) -> tuple[bytes, ...]:
+            return ()
+
+    terminal = TerminalSessionManager(
+        lambda: True,
+        lambda: backend,
+        screen_model_factory=lambda _columns, _rows: SnapshotFailingScreen(),
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "snapshot-failure")
+    view = terminal.attach_view()
+
+    assert terminal.view_state(view) is None
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+
+    retained = terminal.projection(session_id)
+    assert retained is not None
+    assert retained.parser_failed is True
+    assert retained.lifecycle is TerminalLifecycle.CLEANUP_UNPROVEN
+    assert backend.priority_close_requests == 1

--- a/Tests/Terminal/test_session_manager.py
+++ b/Tests/Terminal/test_session_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import FrozenInstanceError
@@ -21,7 +22,7 @@ from tldw_chatbook.Terminal.contracts import (
     TerminalLifecycle,
     TerminalReason,
 )
-from tldw_chatbook.Terminal.io_actors import InputEventKind
+from tldw_chatbook.Terminal.io_actors import InputEventKind, TerminalOutputActor
 from tldw_chatbook.Terminal.session_manager import (
     ManagedProcessIdentity,
     TerminalArmResult,
@@ -129,6 +130,14 @@ def create_running_session(
     assert result.admitted is True
     assert result.projection is not None
     return result.projection.session_id
+
+
+def test_create_session_docstring_documents_parameter_and_result() -> None:
+    docstring = inspect.getdoc(TerminalSessionManager.create_session)
+
+    assert docstring is not None
+    assert "Args:" in docstring
+    assert "Returns:" in docstring
 
 
 def test_terminal_arm_is_independent_and_resets_per_manager() -> None:
@@ -906,6 +915,86 @@ async def test_resize_is_coalesced_and_applied_outside_the_view_callback() -> No
 
 
 @pytest.mark.asyncio
+async def test_concurrent_resize_workers_never_enter_backend_out_of_order() -> None:
+    first_resize_started = Event()
+    second_resize_started = Event()
+    release_first_resize = Event()
+    call_lock = Lock()
+
+    class OrderedResizeBackend(RecordingBackend):
+        def resize(self, columns: int, rows: int) -> None:
+            with call_lock:
+                call_number = len(self.resizes) + 1
+                self.resizes.append((columns, rows))
+            if call_number == 1:
+                first_resize_started.set()
+                assert release_first_resize.wait(1)
+            else:
+                second_resize_started.set()
+
+    backend = OrderedResizeBackend()
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "ordered-resize")
+    view = terminal.attach_view()
+    assert terminal.resize_session(session_id, columns=90, rows=25, view=view)
+
+    first = asyncio.create_task(terminal.apply_pending_resize(session_id, view=view))
+    assert await asyncio.to_thread(first_resize_started.wait, 1)
+    assert terminal.resize_session(session_id, columns=100, rows=30, view=view)
+    second = asyncio.create_task(terminal.apply_pending_resize(session_id, view=view))
+
+    second_entered_while_first_blocked = await asyncio.to_thread(
+        second_resize_started.wait,
+        0.2,
+    )
+    release_first_resize.set()
+
+    assert second_entered_while_first_blocked is False
+    assert await first is True
+    assert await second is True
+    assert backend.resizes == [(90, 25), (100, 30)]
+
+
+@pytest.mark.asyncio
+async def test_model_resize_failure_starts_cleanup_instead_of_leaving_split_state() -> (
+    None
+):
+    class ResizeFailingScreen:
+        failure_reason = None
+
+        def feed(self, data: bytes) -> None:
+            del data
+
+        def take_pending_replies(self) -> tuple[bytes, ...]:
+            return ()
+
+        def resize(self, *, columns: int, rows: int) -> None:
+            del columns, rows
+            raise RuntimeError("model resize failed")
+
+    backend = RecordingBackend(cleanup_proof=CleanupProof())
+    terminal = TerminalSessionManager(
+        lambda: True,
+        lambda: backend,
+        screen_model_factory=lambda _columns, _rows: ResizeFailingScreen(),
+    )
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "failed-model-resize")
+    view = terminal.attach_view()
+    assert terminal.resize_session(session_id, columns=100, rows=30, view=view)
+
+    assert await terminal.apply_pending_resize(session_id, view=view) is False
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+
+    retained = terminal.projection(session_id)
+    assert backend.resizes == [(100, 30)]
+    assert len(backend.cleanup_attempts) == 1
+    assert retained is not None
+    assert retained.lifecycle is TerminalLifecycle.CLEANUP_UNPROVEN
+
+
+@pytest.mark.asyncio
 async def test_blocked_backend_resize_cannot_delay_disarm_cleanup() -> None:
     resize_started = Event()
     release_resize = Event()
@@ -1232,11 +1321,12 @@ def test_disarm_during_backend_start_never_resurrects_a_running_record() -> None
         )
         assert start_entered.wait(1)
         terminal.disarm()
-        assert cleanup_started.wait(1)
+        assert cleanup_started.wait(0.2) is False
         release_start.set()
         result = creating.result(timeout=1)
 
     assert result.admitted is False
+    assert cleanup_started.wait(1)
     assert all(
         projection.lifecycle is not TerminalLifecycle.RUNNING
         for projection in terminal.projections()
@@ -1279,15 +1369,52 @@ def test_start_failure_after_disarm_cannot_erase_cleanup_uncertainty() -> None:
         )
         assert start_entered.wait(1)
         terminal.disarm()
-        assert cleanup_finished.wait(1)
+        assert cleanup_finished.wait(0.2) is False
         release_start.set()
         result = creating.result(timeout=1)
 
     assert result == TerminalCreateResult(reason=TerminalReason.SPAWN_FAILED)
+    assert cleanup_finished.wait(1)
     assert len(terminal.projections()) == 1
     retained = terminal.projections()[0]
     assert retained.lifecycle is TerminalLifecycle.CLEANUP_UNPROVEN
     assert retained.reason is TerminalReason.CLEANUP_UNPROVEN
+
+
+@pytest.mark.parametrize("mismatched_identity", [False, True])
+def test_attempted_start_failure_runs_cleanup_before_releasing_ownership(
+    mismatched_identity: bool,
+) -> None:
+    cleanup_finished = Event()
+
+    class FailedStartBackend(RecordingBackend):
+        def start(
+            self,
+            request: TerminalLaunchRequest,
+            admission: AdmissionGate,
+        ) -> BackendIdentity:
+            self.started.append((request, admission))
+            if mismatched_identity:
+                return BackendIdentity(session_id="wrong-session")
+            raise RuntimeError("failed after partial spawn")
+
+        def cleanup(self, attempt: CleanupAttempt) -> CleanupProof:
+            self.cleanup_attempts.append(attempt)
+            cleanup_finished.set()
+            return CleanupProof(True, True, True)
+
+    backend = FailedStartBackend()
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+
+    result = terminal.create_session(launch_request("failed-start"))
+
+    assert result == TerminalCreateResult(reason=TerminalReason.SPAWN_FAILED)
+    assert cleanup_finished.wait(1)
+    session_id = backend.started[0][1].token
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+    assert len(backend.cleanup_attempts) == 1
+    assert terminal.projections() == ()
 
 
 def test_shell_exit_without_eof_retains_cleanup_unproven_not_exited() -> None:
@@ -1374,6 +1501,39 @@ def test_output_is_refused_after_stream_closure_is_proven() -> None:
     assert exited is not None
     assert exited.stream_closed is True
     assert terminal.offer_output(session_id, b"late bytes").accepted is False
+
+
+def test_offer_delayed_after_manager_check_is_refused_by_actor_eof_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    offer_reached_actor = Event()
+    release_offer = Event()
+    original_offer = TerminalOutputActor.offer_output
+
+    def delayed_offer(actor: TerminalOutputActor, data: bytes):
+        offer_reached_actor.set()
+        assert release_offer.wait(1)
+        return original_offer(actor, data)
+
+    monkeypatch.setattr(TerminalOutputActor, "offer_output", delayed_offer)
+    backend = RecordingBackend(cleanup_proof=CleanupProof(True, True, True))
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    session_id = create_running_session(terminal, "eof-offer-race")
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        offering = executor.submit(terminal.offer_output, session_id, b"late bytes")
+        assert offer_reached_actor.wait(1)
+        terminal.shell_exited(session_id, exit_code=0)
+        assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
+        release_offer.set()
+        result = offering.result(timeout=1)
+
+    assert result.accepted is False
+    exited = terminal.projection(session_id)
+    assert exited is not None
+    assert exited.stream_closed is True
+    assert exited.output_complete is True
 
 
 def test_view_snapshot_failure_is_contained_and_closes_the_session() -> None:

--- a/tldw_chatbook/Terminal/io_actors.py
+++ b/tldw_chatbook/Terminal/io_actors.py
@@ -503,6 +503,7 @@ class TerminalOutputActor:
         self._queue: deque[_OutputChunk] = deque()
         self._pending_bytes = 0
         self._refresh_pending = False
+        self._output_closed = False
         self._lock = Lock()
         self._parser_lock = Lock()
 
@@ -565,14 +566,26 @@ class TerminalOutputActor:
         encoded_size = len(data)
         if encoded_size > self.max_chunk_bytes:
             return OutputOfferResult(reason=OutputRefusalReason.CHUNK_TOO_LARGE)
-        if encoded_size == 0:
-            return OutputOfferResult(accepted=True)
         with self._lock:
+            if self._output_closed:
+                return OutputOfferResult()
+            if encoded_size == 0:
+                return OutputOfferResult(accepted=True)
             if self._pending_bytes + encoded_size > self.capacity_bytes:
                 return OutputOfferResult(reason=OutputRefusalReason.BACKPRESSURE)
             self._queue.append(_OutputChunk(data=data, encoded_size=encoded_size))
             self._pending_bytes += encoded_size
             return OutputOfferResult(accepted=True)
+
+    def close_output(self) -> int:
+        """Atomically close admission and return already-admitted pending bytes.
+
+        Returns:
+            Bytes admitted before the output-close boundary that still need parsing.
+        """
+        with self._lock:
+            self._output_closed = True
+            return self._pending_bytes
 
     def process_parser_turn(
         self,

--- a/tldw_chatbook/Terminal/screen_model.py
+++ b/tldw_chatbook/Terminal/screen_model.py
@@ -506,6 +506,11 @@ class TerminalScreenModel:
         if decoded:
             self._feed_parser(decoded)
 
+    @property
+    def failure_reason(self) -> TerminalReason | None:
+        """Return the content-free terminal protocol failure category."""
+        return self._failure_reason
+
     def finish(self) -> None:
         """Finalize incremental decoding and discard incomplete controls."""
         if self._failure_reason is not None:

--- a/tldw_chatbook/Terminal/session_manager.py
+++ b/tldw_chatbook/Terminal/session_manager.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field, replace
-from threading import Lock, RLock
+from threading import Event, Lock, RLock
 from time import monotonic
 from typing import Any
 from uuid import uuid4
@@ -125,6 +125,8 @@ class _SessionRecord:
     backend: TerminalBackend | None = None
     model: Any | None = None
     model_lock: Any = field(default_factory=Lock, repr=False)
+    resize_lock: Any = field(default_factory=asyncio.Lock, repr=False)
+    startup_done: Event = field(default_factory=Event, repr=False)
     input_actor: TerminalInputActor | None = None
     output_actor: TerminalOutputActor | None = None
     receipt: TerminalReceipt | None = None
@@ -220,7 +222,14 @@ class TerminalSessionManager:
         self._notify_subscribers()
 
     def create_session(self, request: TerminalLaunchRequest) -> TerminalCreateResult:
-        """Atomically reserve and start one admitted terminal session."""
+        """Atomically reserve and start one admitted terminal session.
+
+        Args:
+            request: Validated name, shell, directory, and initial dimensions.
+
+        Returns:
+            Content-free admission result and immutable projection when admitted.
+        """
         with self._lock:
             refusal = self._creation_refusal_locked()
             if refusal is not None:
@@ -275,14 +284,33 @@ class TerminalSessionManager:
                 self._sessions.pop(session_id, None)
                 return TerminalCreateResult(reason=TerminalReason.BACKEND_UNAVAILABLE)
             self._replace_lifecycle_locked(session_id, TerminalLifecycle.ADMITTING)
+            startup_done = record.startup_done
 
         admission = AdmissionGate(admitted=True, token=session_id)
+        startup_failed = False
         try:
             identity = backend.start(admitted_request, admission)
             if identity.session_id != session_id:
                 raise RuntimeError("backend returned a mismatched session identity")
         except Exception:
-            self._release_failed_reservation(session_id)
+            startup_failed = True
+        finally:
+            startup_done.set()
+
+        if startup_failed:
+            with self._lock:
+                record = self._sessions.get(session_id)
+                if (
+                    record is not None
+                    and record.backend is backend
+                    and record.cleanup_future is None
+                ):
+                    self._begin_cleanup_locked(
+                        session_id,
+                        action="spawn_failed",
+                        t0=self._clock(),
+                    )
+            self._notify_subscribers()
             return TerminalCreateResult(reason=TerminalReason.SPAWN_FAILED)
 
         with self._lock:
@@ -639,60 +667,74 @@ class TerminalSessionManager:
             if record is None or record.input_actor is None:
                 return False
             actor = record.input_actor
+            resize_lock = record.resize_lock
 
-        resize = await actor.take_resize_debounced()
-        if resize is None:
-            return False
+        async with resize_lock:
+            with self._lock:
+                if not self._valid_view_locked(view):
+                    return False
+                record = self._sessions.get(session_id)
+                if (
+                    record is None
+                    or record.input_actor is not actor
+                    or record.resize_lock is not resize_lock
+                ):
+                    return False
 
-        with self._lock:
-            if not self._valid_view_locked(view):
+            resize = await actor.take_resize_debounced()
+            if resize is None:
                 return False
-            record = self._sessions.get(session_id)
-            if (
-                record is None
-                or record.input_actor is not actor
-                or record.backend is None
-                or record.model is None
-                or not self._armed
-                or not self.permitted
-                or record.projection.lifecycle is not TerminalLifecycle.RUNNING
-            ):
-                return False
-            backend = record.backend
-            model = record.model
-            model_lock = record.model_lock
 
-        applied = await asyncio.to_thread(
-            self._apply_resize,
-            backend,
-            model,
-            model_lock,
-            resize.columns,
-            resize.rows,
-        )
-        if not applied:
-            return False
+            with self._lock:
+                if not self._valid_view_locked(view):
+                    return False
+                record = self._sessions.get(session_id)
+                if (
+                    record is None
+                    or record.input_actor is not actor
+                    or record.resize_lock is not resize_lock
+                    or record.backend is None
+                    or record.model is None
+                    or not self._armed
+                    or not self.permitted
+                    or record.projection.lifecycle is not TerminalLifecycle.RUNNING
+                ):
+                    return False
+                backend = record.backend
+                model = record.model
+                model_lock = record.model_lock
 
-        with self._lock:
-            record = self._sessions.get(session_id)
-            if (
-                not self._valid_view_locked(view)
-                or record is None
-                or record.backend is not backend
-                or record.model is not model
-                or record.projection.lifecycle is not TerminalLifecycle.RUNNING
-            ):
+            applied = await asyncio.to_thread(
+                self._apply_resize,
+                backend,
+                model,
+                model_lock,
+                resize.columns,
+                resize.rows,
+            )
+            if not applied:
+                self._fail_resize(session_id, backend=backend, model=model)
                 return False
-            try:
+
+            with self._lock:
+                record = self._sessions.get(session_id)
+                if (
+                    record is None
+                    or record.backend is not backend
+                    or record.model is not model
+                ):
+                    return False
                 record.request = replace(
                     record.request,
                     columns=resize.columns,
                     rows=resize.rows,
                 )
-            except Exception:
-                return False
+                remains_current = (
+                    self._valid_view_locked(view)
+                    and record.projection.lifecycle is TerminalLifecycle.RUNNING
+                )
         self._notify_subscribers()
-        return True
+        return remains_current
 
     def focus_session(self, session_id: str, *, view: TerminalViewToken) -> bool:
         """Select a retained session only from the current view generation."""
@@ -966,6 +1008,7 @@ class TerminalSessionManager:
             self._run_cleanup,
             session_id,
             record.backend,
+            record.startup_done,
             attempt,
         )
         record.cleanup_future = future
@@ -975,8 +1018,10 @@ class TerminalSessionManager:
         self,
         session_id: str,
         backend: TerminalBackend,
+        startup_done: Event,
         attempt: CleanupAttempt,
     ) -> None:
+        startup_done.wait()
         try:
             proof = backend.cleanup(attempt)
             if not isinstance(proof, CleanupProof):
@@ -1021,10 +1066,22 @@ class TerminalSessionManager:
                 or record.projection.parser_failed
             ):
                 return False
-            record.projection = replace(record.projection, stream_closed=True)
             actor = record.output_actor
             model = record.model
             model_lock = record.model_lock
+
+        actor.close_output()
+
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if (
+                record is None
+                or record.output_actor is not actor
+                or record.model is not model
+                or record.projection.parser_failed
+            ):
+                return False
+            record.projection = replace(record.projection, stream_closed=True)
 
         try:
             while actor.pending_bytes:
@@ -1115,6 +1172,35 @@ class TerminalSessionManager:
         except Exception:
             return False
         return True
+
+    def _fail_resize(
+        self,
+        session_id: str,
+        *,
+        backend: TerminalBackend,
+        model: Any,
+    ) -> None:
+        """Fail and clean a session whose backend/model resize did not agree."""
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if (
+                record is None
+                or record.backend is not backend
+                or record.model is not model
+                or record.projection.lifecycle is not TerminalLifecycle.RUNNING
+            ):
+                return
+            record.projection = replace(
+                record.projection,
+                reason=TerminalReason.IO_FAILED,
+                output_complete=False,
+            )
+            self._begin_cleanup_locked(
+                session_id,
+                action="resize_failure",
+                t0=self._clock(),
+            )
+        self._notify_subscribers()
 
     def _select_after_removal_locked(self, removed_session_id: str) -> None:
         if self._selected_session_id != removed_session_id:

--- a/tldw_chatbook/Terminal/session_manager.py
+++ b/tldw_chatbook/Terminal/session_manager.py
@@ -1,0 +1,1180 @@
+"""App-global ownership boundary for persistent terminal sessions."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field, replace
+from threading import Lock, RLock
+from time import monotonic
+from typing import Any
+from uuid import uuid4
+
+from .backend import TerminalBackend
+from .contracts import (
+    AdmissionGate,
+    CleanupAttempt,
+    CleanupProof,
+    CleanupSchedule,
+    MAX_SESSION_RECORDS,
+    TerminalLaunchRequest,
+    TerminalLifecycle,
+    TerminalEvent,
+    TerminalProjection,
+    TerminalReason,
+    TerminalReceipt,
+    apply_event,
+)
+from .io_actors import (
+    InputOfferResult,
+    OutputOfferResult,
+    ParserTurnResult,
+    TerminalInputActor,
+    TerminalInputEvent,
+    TerminalOutputActor,
+)
+from .launch import normalize_session_name
+from .screen_model import TerminalScreenModel, TerminalScreenSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalArmResult:
+    """Content-free result of a launch-local arm request."""
+
+    armed: bool = False
+    reason: TerminalReason | None = None
+    disclosure_required: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalCreateResult:
+    """Immutable result of a terminal-session creation request."""
+
+    admitted: bool = False
+    reason: TerminalReason | None = None
+    projection: TerminalProjection | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalCleanupDeadline:
+    """Absolute boundaries derived from one cleanup attempt."""
+
+    attempt: CleanupAttempt
+    hangup_at: float
+    terminate_at: float
+    force_kill_at: float
+    deadline_at: float
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalViewToken:
+    """Opaque monotonically increasing mounted-view generation."""
+
+    generation: int
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalSubscriptionToken:
+    """Opaque identity for one content-free change subscription."""
+
+    value: int
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalSessionView:
+    """Immutable session and screen values safe for a mounted view."""
+
+    projection: TerminalProjection
+    screen: TerminalScreenSnapshot
+    shell: str = ""
+    start_directory: str = ""
+    columns: int = 0
+    rows: int = 0
+    cleanup_receipt: TerminalReceipt | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalViewState:
+    """Immutable manager state returned to the current view generation."""
+
+    selected_session_id: str | None = None
+    sessions: tuple[TerminalSessionView, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedProcessIdentity:
+    """Test-only process identity used for managed-RSS accounting."""
+
+    pid: int
+    birth_identity: str
+
+    def __post_init__(self) -> None:
+        if type(self.pid) is not int or self.pid <= 0:
+            raise ValueError("pid must be a positive integer")
+        if type(self.birth_identity) is not str or not self.birth_identity:
+            raise ValueError("birth_identity must be non-empty text")
+
+
+@dataclass(slots=True)
+class _SessionRecord:
+    """Manager-private mutable ownership for one retained session."""
+
+    projection: TerminalProjection
+    request: TerminalLaunchRequest = TerminalLaunchRequest()
+    backend: TerminalBackend | None = None
+    model: Any | None = None
+    model_lock: Any = field(default_factory=Lock, repr=False)
+    input_actor: TerminalInputActor | None = None
+    output_actor: TerminalOutputActor | None = None
+    receipt: TerminalReceipt | None = None
+    cleanup_future: Future[None] | None = None
+    cleanup_action: str = ""
+
+
+class TerminalSessionManager:
+    """Own terminal authority and sessions independently of mounted views."""
+
+    def __init__(
+        self,
+        read_permitted: Callable[[], object],
+        backend_factory: Callable[[], TerminalBackend],
+        *,
+        monotonic_clock: Callable[[], float] = monotonic,
+        screen_model_factory: Callable[[int, int], Any] | None = None,
+    ) -> None:
+        self._read_permitted = read_permitted
+        self._backend_factory = backend_factory
+        self._clock = monotonic_clock
+        self._screen_model_factory = screen_model_factory
+        self._lock = RLock()
+        self._armed = False
+        self._disclosure_acknowledged = False
+        self._shutting_down = False
+        self._sessions: dict[str, _SessionRecord] = {}
+        self._selected_session_id: str | None = None
+        self._view_generation = 0
+        self._current_view: TerminalViewToken | None = None
+        self._subscription_generation = 0
+        self._subscriptions: dict[TerminalSubscriptionToken, Callable[[], None]] = {}
+        self._cleanup_executor = ThreadPoolExecutor(
+            max_workers=MAX_SESSION_RECORDS,
+            thread_name_prefix="terminal-cleanup",
+        )
+
+    @property
+    def discoverable(self) -> bool:
+        """Return whether the Terminal feature is discoverable."""
+        return True
+
+    @property
+    def permitted(self) -> bool:
+        """Return the latest strict persisted unlock state."""
+        try:
+            permitted = self._read_permitted() is True
+        except Exception:
+            permitted = False
+        if not permitted:
+            self._revoke_persisted_unlock()
+        return permitted
+
+    @property
+    def armed(self) -> bool:
+        """Return the launch-local terminal arm bit."""
+        with self._lock:
+            return self._armed
+
+    @property
+    def disclosure_acknowledged(self) -> bool:
+        """Return whether this manager observed the full disclosure."""
+        with self._lock:
+            return self._disclosure_acknowledged
+
+    def arm(self, *, acknowledge_disclosure: bool = False) -> TerminalArmResult:
+        """Arm Terminal for this launch after strict unlock and disclosure."""
+        with self._lock:
+            if not self.permitted:
+                self._armed = False
+                result = TerminalArmResult(reason=TerminalReason.LOCKED)
+            elif not self._disclosure_acknowledged:
+                if acknowledge_disclosure is not True:
+                    result = TerminalArmResult(disclosure_required=True)
+                else:
+                    self._disclosure_acknowledged = True
+                    self._armed = True
+                    result = TerminalArmResult(armed=True)
+            else:
+                self._armed = True
+                result = TerminalArmResult(armed=True)
+        self._notify_subscribers()
+        return result
+
+    def disarm(self) -> None:
+        """Clear authority first, then start one concurrent cleanup cohort."""
+        with self._lock:
+            self._armed = False
+            t0 = self._clock()
+            session_ids = tuple(self._sessions)
+            for session_id in session_ids:
+                self._begin_cleanup_locked(session_id, action="disarm", t0=t0)
+        self._notify_subscribers()
+
+    def create_session(self, request: TerminalLaunchRequest) -> TerminalCreateResult:
+        """Atomically reserve and start one admitted terminal session."""
+        with self._lock:
+            refusal = self._creation_refusal_locked()
+            if refusal is not None:
+                return TerminalCreateResult(reason=refusal)
+            try:
+                name = normalize_session_name(
+                    request.name,
+                    existing_names=(
+                        record.projection.name for record in self._sessions.values()
+                    ),
+                )
+            except (TypeError, ValueError):
+                return TerminalCreateResult(reason=TerminalReason.INVALID_NAME)
+
+            session_id = uuid4().hex
+            projection = TerminalProjection(
+                session_id=session_id,
+                name=name,
+                lifecycle=TerminalLifecycle.RESERVED,
+            )
+            admitted_request = replace(request, name=name)
+            self._sessions[session_id] = _SessionRecord(
+                projection=projection,
+                request=admitted_request,
+            )
+            self._replace_lifecycle_locked(session_id, TerminalLifecycle.CREATING)
+
+        try:
+            backend = self._backend_factory()
+        except Exception:
+            self._release_failed_reservation(session_id)
+            return TerminalCreateResult(reason=TerminalReason.BACKEND_UNAVAILABLE)
+
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if record is None:
+                return TerminalCreateResult(reason=TerminalReason.ADMISSION_FAILED)
+            authority_reason = self._authority_refusal_locked()
+            if authority_reason is not None:
+                self._sessions.pop(session_id, None)
+                self._select_after_removal_locked(session_id)
+                return TerminalCreateResult(reason=authority_reason)
+            record.backend = backend
+            try:
+                record.model = self._make_screen_model(
+                    admitted_request.columns,
+                    admitted_request.rows,
+                )
+                record.input_actor = TerminalInputActor(clock=self._clock)
+                record.output_actor = TerminalOutputActor(clock=self._clock)
+            except Exception:
+                self._sessions.pop(session_id, None)
+                return TerminalCreateResult(reason=TerminalReason.BACKEND_UNAVAILABLE)
+            self._replace_lifecycle_locked(session_id, TerminalLifecycle.ADMITTING)
+
+        admission = AdmissionGate(admitted=True, token=session_id)
+        try:
+            identity = backend.start(admitted_request, admission)
+            if identity.session_id != session_id:
+                raise RuntimeError("backend returned a mismatched session identity")
+        except Exception:
+            self._release_failed_reservation(session_id)
+            return TerminalCreateResult(reason=TerminalReason.SPAWN_FAILED)
+
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if record is None:
+                return TerminalCreateResult(reason=TerminalReason.ADMISSION_FAILED)
+            authority_reason = self._authority_refusal_locked()
+            if (
+                authority_reason is not None
+                or record.projection.lifecycle is not TerminalLifecycle.ADMITTING
+            ):
+                if record.cleanup_future is None:
+                    self._begin_cleanup_locked(
+                        session_id,
+                        action="authority_revoked",
+                        t0=self._clock(),
+                    )
+                return TerminalCreateResult(
+                    reason=authority_reason or TerminalReason.ADMISSION_FAILED
+                )
+            self._replace_lifecycle_locked(session_id, TerminalLifecycle.RUNNING)
+            if self._selected_session_id is None:
+                self._selected_session_id = session_id
+            result = TerminalCreateResult(admitted=True, projection=record.projection)
+        self._notify_subscribers()
+        return result
+
+    def projections(self) -> tuple[TerminalProjection, ...]:
+        """Return immutable UI-safe projections for retained sessions."""
+        with self._lock:
+            return tuple(record.projection for record in self._sessions.values())
+
+    def projection(self, session_id: str) -> TerminalProjection | None:
+        """Return one immutable projection when retained."""
+        with self._lock:
+            record = self._sessions.get(session_id)
+            return None if record is None else record.projection
+
+    def shell_exited(
+        self, session_id: str, *, exit_code: int
+    ) -> TerminalReceipt | None:
+        """Start bounded settlement when the exact shell exits."""
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if record is None or record.projection.lifecycle not in {
+                TerminalLifecycle.RUNNING,
+                TerminalLifecycle.CLOSING,
+                TerminalLifecycle.CLEANUP_UNPROVEN,
+            }:
+                return None
+            record.projection = apply_event(
+                record.projection,
+                TerminalEvent("shell_exit", exit_code=exit_code),
+            )
+            receipt = self._begin_cleanup_locked(
+                session_id,
+                action="shell_exit",
+                t0=self._clock(),
+                transition=False,
+            )
+        self._notify_subscribers()
+        return receipt
+
+    def cleanup_receipt(self, session_id: str) -> TerminalReceipt | None:
+        """Return immutable retained cleanup metadata."""
+        with self._lock:
+            record = self._sessions.get(session_id)
+            return None if record is None else record.receipt
+
+    def cleanup_deadline(self, session_id: str) -> TerminalCleanupDeadline | None:
+        """Return absolute stage boundaries for the retained attempt."""
+        receipt = self.cleanup_receipt(session_id)
+        if receipt is None:
+            return None
+        schedule = CleanupSchedule()
+        t0 = receipt.attempt.t0
+        return TerminalCleanupDeadline(
+            attempt=receipt.attempt,
+            hangup_at=t0 + schedule.hangup_no_later_than,
+            terminate_at=t0 + schedule.terminate_no_later_than,
+            force_kill_at=t0 + schedule.force_kill_no_later_than,
+            deadline_at=t0 + schedule.deadline_seconds,
+        )
+
+    def wait_for_cleanup(self, session_id: str, *, timeout_seconds: float) -> bool:
+        """Wait only for the record's already-authoritative cleanup task."""
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if record is None or record.cleanup_future is None:
+                return True
+            future = record.cleanup_future
+        try:
+            future.result(timeout=timeout_seconds)
+        except TimeoutError:
+            return False
+        return True
+
+    def retry_cleanup(
+        self,
+        session_id: str,
+        *,
+        view: TerminalViewToken,
+    ) -> TerminalReceipt | None:
+        """Start the sole user-authorized fresh cleanup deadline."""
+        with self._lock:
+            if not self._valid_view_locked(view):
+                return None
+            record = self._sessions.get(session_id)
+            if (
+                record is None
+                or record.projection.lifecycle is not TerminalLifecycle.CLEANUP_UNPROVEN
+                or (
+                    record.cleanup_future is not None
+                    and not record.cleanup_future.done()
+                )
+            ):
+                return None
+            receipt = self._begin_cleanup_locked(
+                session_id,
+                action="retry",
+                t0=self._clock(),
+            )
+        if receipt is not None:
+            self._notify_subscribers()
+        return receipt
+
+    async def shutdown(self, *, deadline_seconds: float = 5.0) -> bool:
+        """Bound app shutdown while all retained sessions clean concurrently."""
+        if not isinstance(deadline_seconds, (int, float)) or isinstance(
+            deadline_seconds, bool
+        ):
+            raise TypeError("deadline_seconds must be a number")
+        if deadline_seconds < 0:
+            raise ValueError("deadline_seconds must not be negative")
+        with self._lock:
+            self._shutting_down = True
+            self._armed = False
+            t0 = self._clock()
+            for session_id in tuple(self._sessions):
+                self._begin_cleanup_locked(session_id, action="shutdown", t0=t0)
+            futures = tuple(
+                record.cleanup_future
+                for record in self._sessions.values()
+                if record.cleanup_future is not None
+            )
+        if futures:
+            wrapped = [asyncio.wrap_future(future) for future in futures]
+            done, pending = await asyncio.wait(wrapped, timeout=float(deadline_seconds))
+            del done
+            if pending:
+                return False
+        with self._lock:
+            return not self._sessions
+
+    def accepts_input(self, session_id: str) -> bool:
+        """Return whether a running record currently accepts input."""
+        with self._lock:
+            record = self._sessions.get(session_id)
+            return (
+                record is not None
+                and record.projection.lifecycle is TerminalLifecycle.RUNNING
+                and not record.projection.parser_failed
+                and self._armed
+                and self.permitted
+            )
+
+    def offer_output(self, session_id: str, data: bytes) -> OutputOfferResult:
+        """Offer bounded backend bytes to a healthy retained parser path."""
+        with self._lock:
+            record = self._sessions.get(session_id)
+            actor = None if record is None else record.output_actor
+            output_refused = (
+                record is None
+                or record.projection.parser_failed
+                or record.projection.stream_closed
+            )
+        if actor is None or output_refused:
+            return OutputOfferResult()
+        return actor.offer_output(data)
+
+    def process_output(
+        self, session_id: str, *, visible: bool
+    ) -> ParserTurnResult | None:
+        """Run one bounded parser turn and fail closed on parser exceptions."""
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if (
+                record is None
+                or record.output_actor is None
+                or record.model is None
+                or record.projection.parser_failed
+            ):
+                return None
+            actor = record.output_actor
+            model = record.model
+            model_lock = record.model_lock
+        try:
+            with model_lock:
+                result = actor.process_parser_turn(model.feed, visible=visible)
+                replies = self._take_model_replies(model)
+                failure_reason = getattr(model, "failure_reason", None)
+        except Exception:
+            self.parser_failed(session_id)
+            return None
+        if failure_reason is TerminalReason.TERMINAL_PROTOCOL_FAILED:
+            self.parser_failed(session_id)
+            return None
+        self._queue_model_replies(session_id, model, replies)
+        self._notify_subscribers()
+        return result
+
+    def parser_failed(self, session_id: str) -> TerminalReceipt | None:
+        """Disable input/repaint and request out-of-band cleanup immediately."""
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if record is None or record.projection.parser_failed:
+                return None if record is None else record.receipt
+            record.projection = apply_event(
+                record.projection,
+                TerminalEvent(
+                    "parser_failure",
+                    reason=TerminalReason.TERMINAL_PROTOCOL_FAILED,
+                ),
+            )
+            backend = record.backend
+            cleanup_active = (
+                record.cleanup_future is not None and not record.cleanup_future.done()
+            )
+        if backend is not None and not cleanup_active:
+            try:
+                backend.request_priority_close()
+            except Exception:
+                pass
+        with self._lock:
+            receipt = self._begin_cleanup_locked(
+                session_id,
+                action="parser_failure",
+                t0=self._clock(),
+                transition=False,
+            )
+        self._notify_subscribers()
+        return receipt
+
+    @property
+    def selected_session_id(self) -> str | None:
+        """Return the selected opaque session identity."""
+        with self._lock:
+            return self._selected_session_id
+
+    def attach_view(self) -> TerminalViewToken:
+        """Attach one new view generation, invalidating the previous one."""
+        with self._lock:
+            self._view_generation += 1
+            self._current_view = TerminalViewToken(self._view_generation)
+            return self._current_view
+
+    def detach_view(self, view: TerminalViewToken) -> bool:
+        """Detach only the current generation."""
+        with self._lock:
+            if not self._valid_view_locked(view):
+                return False
+            self._current_view = None
+            return True
+
+    def view_state(self, view: TerminalViewToken) -> TerminalViewState | None:
+        """Return immutable projections only to the current generation."""
+        with self._lock:
+            if not self._valid_view_locked(view):
+                return None
+            candidates = tuple(
+                (session_id, record, record.model, record.model_lock)
+                for session_id, record in self._sessions.items()
+                if record.model is not None
+            )
+
+        snapshots: dict[str, TerminalScreenSnapshot] = {}
+        for session_id, _record, model, model_lock in candidates:
+            try:
+                with model_lock:
+                    snapshot = model.snapshot()
+            except Exception:
+                self.parser_failed(session_id)
+                return None
+            if isinstance(snapshot, TerminalScreenSnapshot):
+                snapshots[session_id] = snapshot
+
+        with self._lock:
+            if not self._valid_view_locked(view):
+                return None
+            if any(
+                self._sessions.get(session_id) is not record
+                or record.model is not model
+                for session_id, record, model, _model_lock in candidates
+            ):
+                return None
+            sessions = tuple(
+                TerminalSessionView(
+                    projection=record.projection,
+                    screen=snapshots[session_id],
+                    shell=record.request.shell,
+                    start_directory=record.request.start_directory,
+                    columns=record.request.columns,
+                    rows=record.request.rows,
+                    cleanup_receipt=record.receipt,
+                )
+                for session_id, record, _model, _model_lock in candidates
+                if session_id in snapshots
+            )
+            return TerminalViewState(
+                selected_session_id=self._selected_session_id,
+                sessions=sessions,
+            )
+
+    def resize_session(
+        self,
+        session_id: str,
+        *,
+        columns: int,
+        rows: int,
+        view: TerminalViewToken,
+    ) -> bool:
+        """Offer a coalesced resize from the current mounted generation."""
+        with self._lock:
+            if not self._valid_view_locked(view):
+                return False
+            record = self._sessions.get(session_id)
+            if (
+                record is None
+                or record.backend is None
+                or record.model is None
+                or record.input_actor is None
+                or not self._armed
+                or not self.permitted
+                or record.projection.lifecycle is not TerminalLifecycle.RUNNING
+            ):
+                return False
+            try:
+                record.input_actor.offer_resize(columns=columns, rows=rows)
+            except (TypeError, ValueError):
+                return False
+        return True
+
+    async def apply_pending_resize(
+        self,
+        session_id: str,
+        *,
+        view: TerminalViewToken,
+    ) -> bool:
+        """Apply the latest debounced resize without holding manager authority."""
+        with self._lock:
+            if not self._valid_view_locked(view):
+                return False
+            record = self._sessions.get(session_id)
+            if record is None or record.input_actor is None:
+                return False
+            actor = record.input_actor
+
+        resize = await actor.take_resize_debounced()
+        if resize is None:
+            return False
+
+        with self._lock:
+            if not self._valid_view_locked(view):
+                return False
+            record = self._sessions.get(session_id)
+            if (
+                record is None
+                or record.input_actor is not actor
+                or record.backend is None
+                or record.model is None
+                or not self._armed
+                or not self.permitted
+                or record.projection.lifecycle is not TerminalLifecycle.RUNNING
+            ):
+                return False
+            backend = record.backend
+            model = record.model
+            model_lock = record.model_lock
+
+        applied = await asyncio.to_thread(
+            self._apply_resize,
+            backend,
+            model,
+            model_lock,
+            resize.columns,
+            resize.rows,
+        )
+        if not applied:
+            return False
+
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if (
+                not self._valid_view_locked(view)
+                or record is None
+                or record.backend is not backend
+                or record.model is not model
+                or record.projection.lifecycle is not TerminalLifecycle.RUNNING
+            ):
+                return False
+            try:
+                record.request = replace(
+                    record.request,
+                    columns=resize.columns,
+                    rows=resize.rows,
+                )
+            except Exception:
+                return False
+        self._notify_subscribers()
+        return True
+
+    def focus_session(self, session_id: str, *, view: TerminalViewToken) -> bool:
+        """Select a retained session only from the current view generation."""
+        with self._lock:
+            if not self._valid_view_locked(view) or session_id not in self._sessions:
+                return False
+            self._selected_session_id = session_id
+        self._notify_subscribers()
+        return True
+
+    def close_session(
+        self,
+        session_id: str,
+        *,
+        view: TerminalViewToken,
+    ) -> TerminalReceipt | None:
+        """Start bounded close only for the current view generation."""
+        with self._lock:
+            if not self._valid_view_locked(view):
+                return None
+            receipt = self._begin_cleanup_locked(
+                session_id,
+                action="close",
+                t0=self._clock(),
+            )
+        self._notify_subscribers()
+        return receipt
+
+    def managed_process_inventory_for_tests(
+        self,
+    ) -> tuple[ManagedProcessIdentity, ...]:
+        """Aggregate only PID/birth identities from retained backends."""
+        with self._lock:
+            backends = tuple(
+                record.backend
+                for record in self._sessions.values()
+                if record.backend is not None
+            )
+        inventory: list[ManagedProcessIdentity] = []
+        for backend in backends:
+            reader = getattr(backend, "managed_process_inventory_for_tests", None)
+            if not callable(reader):
+                continue
+            try:
+                identities = reader()
+            except Exception:
+                continue
+            if not isinstance(identities, tuple):
+                continue
+            inventory.extend(
+                identity
+                for identity in identities
+                if isinstance(identity, ManagedProcessIdentity)
+            )
+        return tuple(inventory)
+
+    def rename_session(
+        self,
+        session_id: str,
+        name: str,
+        *,
+        view: TerminalViewToken,
+    ) -> bool:
+        """Rename a retained record under normalized unique-name policy."""
+        with self._lock:
+            if not self._valid_view_locked(view):
+                return False
+            record = self._sessions.get(session_id)
+            if record is None:
+                return False
+            try:
+                normalized = normalize_session_name(
+                    name,
+                    existing_names=(
+                        other.projection.name
+                        for other_id, other in self._sessions.items()
+                        if other_id != session_id
+                    ),
+                )
+            except (TypeError, ValueError):
+                return False
+            record.projection = replace(record.projection, name=normalized)
+            record.request = replace(record.request, name=normalized)
+        self._notify_subscribers()
+        return True
+
+    def send_key(
+        self,
+        session_id: str,
+        data: bytes,
+        *,
+        view: TerminalViewToken,
+    ) -> InputOfferResult:
+        """Offer one key event through the manager-owned bounded input actor."""
+        with self._lock:
+            actor = self._input_actor_for_view_locked(session_id, view)
+            if actor is None:
+                return InputOfferResult()
+            return actor.offer_key(data)
+
+    def send_paste(
+        self,
+        session_id: str,
+        text: str,
+        *,
+        bracketed: bool,
+        view: TerminalViewToken,
+    ) -> InputOfferResult:
+        """Offer one atomic paste through the manager-owned input actor."""
+        with self._lock:
+            actor = self._input_actor_for_view_locked(session_id, view)
+            if actor is None:
+                return InputOfferResult()
+            return actor.offer_paste(text, bracketed=bracketed)
+
+    def take_input(self, session_id: str) -> TerminalInputEvent | None:
+        """Let the owned backend pull one ordered event while input is live."""
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if (
+                record is None
+                or record.input_actor is None
+                or record.projection.lifecycle is not TerminalLifecycle.RUNNING
+                or not self._armed
+                or not self.permitted
+            ):
+                return None
+            actor = record.input_actor
+        return actor.take_nowait()
+
+    def subscribe(self, callback: Callable[[], None]) -> TerminalSubscriptionToken:
+        """Register a content-free callback token."""
+        if not callable(callback):
+            raise TypeError("callback must be callable")
+        with self._lock:
+            self._subscription_generation += 1
+            token = TerminalSubscriptionToken(self._subscription_generation)
+            self._subscriptions[token] = callback
+            return token
+
+    def unsubscribe(self, subscription: TerminalSubscriptionToken) -> bool:
+        """Remove one content-free change subscription."""
+        with self._lock:
+            return self._subscriptions.pop(subscription, None) is not None
+
+    def _creation_refusal_locked(self) -> TerminalReason | None:
+        if self._shutting_down:
+            self._armed = False
+            return TerminalReason.UNARMED
+        authority_reason = self._authority_refusal_locked()
+        if authority_reason is not None:
+            return authority_reason
+        if len(self._sessions) >= MAX_SESSION_RECORDS:
+            return TerminalReason.SESSION_LIMIT
+        return None
+
+    def _revoke_persisted_unlock(self) -> None:
+        """Apply persisted-lock revocation with the same cleanup as Disarm."""
+        with self._lock:
+            self._armed = False
+            if not self._sessions:
+                return
+            t0 = self._clock()
+            for session_id in tuple(self._sessions):
+                self._begin_cleanup_locked(
+                    session_id,
+                    action="lock_revoked",
+                    t0=t0,
+                )
+
+    def _authority_refusal_locked(self) -> TerminalReason | None:
+        if not self.permitted:
+            self._armed = False
+            return TerminalReason.LOCKED
+        if not self._armed:
+            return TerminalReason.UNARMED
+        return None
+
+    def _replace_lifecycle_locked(
+        self, session_id: str, lifecycle: TerminalLifecycle
+    ) -> None:
+        record = self._sessions[session_id]
+        record.projection = replace(record.projection, lifecycle=lifecycle)
+
+    def _release_failed_reservation(self, session_id: str) -> None:
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if record is None:
+                return
+            if record.cleanup_future is not None or record.projection.lifecycle in {
+                TerminalLifecycle.CLOSING,
+                TerminalLifecycle.CLEANUP_UNPROVEN,
+            }:
+                return
+            self._sessions.pop(session_id, None)
+            self._select_after_removal_locked(session_id)
+
+    def _make_screen_model(self, columns: int, rows: int) -> Any:
+        if self._screen_model_factory is not None:
+            return self._screen_model_factory(columns, rows)
+        return TerminalScreenModel(columns=columns, rows=rows)
+
+    def _begin_cleanup_locked(
+        self,
+        session_id: str,
+        *,
+        action: str,
+        t0: float,
+        transition: bool = True,
+    ) -> TerminalReceipt | None:
+        record = self._sessions.get(session_id)
+        if record is None:
+            return None
+        if record.backend is None:
+            self._sessions.pop(session_id, None)
+            self._select_after_removal_locked(session_id)
+            return None
+        if (
+            record.projection.lifecycle is TerminalLifecycle.CLEANUP_UNPROVEN
+            and action != "retry"
+        ):
+            return record.receipt
+
+        current_future = record.cleanup_future
+        if current_future is not None and not current_future.done():
+            if action != "shell_exit":
+                if record.cleanup_action == "shell_exit":
+                    self._request_priority_close(record.backend)
+                record.cleanup_action = action
+                if record.projection.lifecycle is not TerminalLifecycle.CLOSING:
+                    record.projection = replace(
+                        record.projection,
+                        lifecycle=TerminalLifecycle.CLOSING,
+                    )
+                existing_t0 = (
+                    record.receipt.attempt.t0 if record.receipt is not None else t0
+                )
+                record.receipt = TerminalReceipt(
+                    CleanupAttempt(min(existing_t0, t0)),
+                    action,
+                )
+            return record.receipt
+
+        if transition:
+            if record.projection.lifecycle is TerminalLifecycle.CLEANUP_UNPROVEN:
+                record.projection = replace(
+                    record.projection,
+                    lifecycle=TerminalLifecycle.CLOSING,
+                )
+            elif record.projection.lifecycle in {
+                TerminalLifecycle.RESERVED,
+                TerminalLifecycle.CREATING,
+                TerminalLifecycle.ADMITTING,
+            }:
+                record.projection = replace(
+                    record.projection,
+                    lifecycle=TerminalLifecycle.CLOSING,
+                )
+            else:
+                record.projection = apply_event(
+                    record.projection,
+                    TerminalEvent("close"),
+                )
+        attempt = CleanupAttempt(t0)
+        receipt = TerminalReceipt(attempt, action)
+        record.receipt = receipt
+        record.cleanup_action = action
+        if action != "shell_exit" and action != "parser_failure":
+            self._request_priority_close(record.backend)
+        future = self._cleanup_executor.submit(
+            self._run_cleanup,
+            session_id,
+            record.backend,
+            attempt,
+        )
+        record.cleanup_future = future
+        return receipt
+
+    def _run_cleanup(
+        self,
+        session_id: str,
+        backend: TerminalBackend,
+        attempt: CleanupAttempt,
+    ) -> None:
+        try:
+            proof = backend.cleanup(attempt)
+            if not isinstance(proof, CleanupProof):
+                proof = CleanupProof()
+        except Exception:
+            proof = CleanupProof()
+
+        if proof.process_dead and proof.stream_closed:
+            parser_complete = self._finalize_output_at_eof(session_id)
+            proof = CleanupProof(
+                process_dead=True,
+                stream_closed=True,
+                output_complete=proof.output_complete and parser_complete,
+            )
+
+        with self._lock:
+            record = self._sessions.get(session_id)
+            parser_failed = record is not None and record.projection.parser_failed
+        if parser_failed and proof.process_dead and not proof.stream_closed:
+            raw_drain = getattr(backend, "cleanup_raw_drain", None)
+            if callable(raw_drain):
+                try:
+                    raw_proof = raw_drain(attempt)
+                except Exception:
+                    raw_proof = CleanupProof(process_dead=True)
+                if isinstance(raw_proof, CleanupProof):
+                    proof = CleanupProof(
+                        process_dead=proof.process_dead and raw_proof.process_dead,
+                        stream_closed=raw_proof.stream_closed,
+                        output_complete=False,
+                    )
+        self._settle_cleanup(session_id, proof)
+
+    def _finalize_output_at_eof(self, session_id: str) -> bool:
+        """Drain admitted bytes and finalize decoding before claiming completeness."""
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if (
+                record is None
+                or record.output_actor is None
+                or record.model is None
+                or record.projection.parser_failed
+            ):
+                return False
+            record.projection = replace(record.projection, stream_closed=True)
+            actor = record.output_actor
+            model = record.model
+            model_lock = record.model_lock
+
+        try:
+            while actor.pending_bytes:
+                with model_lock:
+                    actor.process_parser_turn(model.feed, visible=False)
+                    self._take_model_replies(model)
+                    if (
+                        getattr(model, "failure_reason", None)
+                        is TerminalReason.TERMINAL_PROTOCOL_FAILED
+                    ):
+                        raise RuntimeError("terminal protocol failed")
+            with model_lock:
+                finish = getattr(model, "finish", None)
+                if callable(finish):
+                    finish()
+                self._take_model_replies(model)
+                if (
+                    getattr(model, "failure_reason", None)
+                    is TerminalReason.TERMINAL_PROTOCOL_FAILED
+                ):
+                    raise RuntimeError("terminal protocol failed")
+        except Exception:
+            self.parser_failed(session_id)
+            return False
+
+        with self._lock:
+            record = self._sessions.get(session_id)
+            return (
+                record is not None
+                and record.output_actor is actor
+                and record.model is model
+                and not record.projection.parser_failed
+                and actor.pending_bytes == 0
+            )
+
+    def _settle_cleanup(self, session_id: str, proof: CleanupProof) -> None:
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if record is None:
+                return
+            action = record.cleanup_action
+            parser_failed = record.projection.parser_failed
+            if action == "shell_exit" and proof.process_dead and proof.stream_closed:
+                record.projection = replace(
+                    record.projection,
+                    lifecycle=TerminalLifecycle.EXITED,
+                    stream_closed=proof.stream_closed,
+                    output_complete=proof.output_complete and not parser_failed,
+                )
+                record.cleanup_future = None
+            elif proof.process_dead and proof.stream_closed:
+                self._sessions.pop(session_id, None)
+                self._select_after_removal_locked(session_id)
+            else:
+                record.projection = replace(
+                    record.projection,
+                    lifecycle=TerminalLifecycle.CLEANUP_UNPROVEN,
+                    reason=TerminalReason.CLEANUP_UNPROVEN,
+                    stream_closed=proof.stream_closed,
+                    output_complete=False,
+                )
+                record.cleanup_future = None
+        self._notify_subscribers()
+
+    def _valid_view_locked(self, view: TerminalViewToken) -> bool:
+        return type(view) is TerminalViewToken and view == self._current_view
+
+    @staticmethod
+    def _request_priority_close(backend: TerminalBackend) -> None:
+        try:
+            backend.request_priority_close()
+        except Exception:
+            pass
+
+    @staticmethod
+    def _apply_resize(
+        backend: TerminalBackend,
+        model: Any,
+        model_lock: Any,
+        columns: int,
+        rows: int,
+    ) -> bool:
+        """Resize backend and model without blocking manager or event-loop locks."""
+        try:
+            backend.resize(columns, rows)
+            with model_lock:
+                model.resize(columns=columns, rows=rows)
+        except Exception:
+            return False
+        return True
+
+    def _select_after_removal_locked(self, removed_session_id: str) -> None:
+        if self._selected_session_id != removed_session_id:
+            return
+        self._selected_session_id = next(iter(self._sessions), None)
+
+    def _input_actor_for_view_locked(
+        self,
+        session_id: str,
+        view: TerminalViewToken,
+    ) -> TerminalInputActor | None:
+        if not self._valid_view_locked(view):
+            return None
+        record = self._sessions.get(session_id)
+        if (
+            record is None
+            or record.input_actor is None
+            or record.projection.lifecycle is not TerminalLifecycle.RUNNING
+            or record.projection.parser_failed
+            or not self._armed
+            or not self.permitted
+        ):
+            return None
+        return record.input_actor
+
+    @staticmethod
+    def _take_model_replies(model: Any) -> tuple[bytes, ...]:
+        take_replies = getattr(model, "take_pending_replies", None)
+        if not callable(take_replies):
+            return ()
+        replies = take_replies()
+        if not isinstance(replies, tuple):
+            raise TypeError("terminal model replies must be an immutable tuple")
+        if any(type(reply) is not bytes for reply in replies):
+            raise TypeError("terminal model replies must contain only bytes")
+        return replies
+
+    def _queue_model_replies(
+        self,
+        session_id: str,
+        model: Any,
+        replies: tuple[bytes, ...],
+    ) -> None:
+        with self._lock:
+            record = self._sessions.get(session_id)
+            if (
+                record is None
+                or record.model is not model
+                or record.input_actor is None
+                or record.projection.lifecycle is not TerminalLifecycle.RUNNING
+            ):
+                return
+            for reply in replies:
+                record.input_actor.offer_reply(reply)
+
+    def _notify_subscribers(self) -> None:
+        with self._lock:
+            callbacks = tuple(self._subscriptions.values())
+        for callback in callbacks:
+            try:
+                callback()
+            except Exception:
+                continue


### PR DESCRIPTION
## Summary

- Add an app-global, process-memory terminal session manager with strict persisted unlock and launch-local arming.
- Enforce four-record atomic admission, immutable view projections and generations, actor-routed input/output/resize, and content-free subscriptions.
- Coordinate shell exit, disarm, shutdown, parser failure, cleanup uncertainty, explicit Retry, and manager-owned EOF finalization.
- Expose screen-model failure reasons and a test-only managed-process inventory.

## Review fixes

- Persisted unlock revocation immediately disarms and starts one cleanup cohort.
- Retry requires the current view generation.
- Resize is coalesced/debounced, and backend/model work runs outside manager authority and event-loop locks.
- Output completeness is derived by draining and finalizing the manager-owned parser path.
- Malformed terminal replies fail closed before queueing.

## Verification

- Focused Terminal suite: 214 passed.
- Import provenance regression: 1 passed.
- Ruff check passed for the Terminal package and tests.
- Ruff format check passed for all changed implementation and test files.
- Git diff whitespace checks passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an app-global terminal session manager that owns persistent sessions independently of UI views, with strict arm/unlock and coordinated cleanup. Previously sessions were tied to view lifecycles; now they survive remounts and follow a single authority for lifecycle, I/O, and cleanup. Also closes lifecycle races by making output close atomic.

**Behavior**
- Sessions are created under an atomic admission gate with a per-launch session limit.
- Cleanup uses one absolute attempt per action; only an explicit retry starts a fresh deadline.
- Shell exit retains the session until EOF finalization proves output completeness.
- Output close atomically refuses late chunks without dropping pending data.
- Parser failures disable input, request priority close, and leave a cleanup-unproven state until proven otherwise.
- Views are generation-scoped; stale or detached views cannot mutate sessions.
- Resize is coalesced and applied without blocking manager locks.
- `TerminalScreenModel` exposes a content-free `failure_reason`.

**Verification**
- Adds 1,413 lines of session manager tests and updates a screen model test.
- Focused terminal suite passes (214 tests).

<sup>Written for commit 9112ddfc787f3bd253f37e85d32a1dc9b9bbe3dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

