### PR TITLE
fix(console): dismiss the conversation action menu via Escape-anywhere and click-outside (TASK-25709)

### DIFF
--- a/Tests/UI/test_console_conversation_action_menu.py
+++ b/Tests/UI/test_console_conversation_action_menu.py
@@ -158,6 +158,108 @@ async def test_menu_focuses_its_first_actionable_entry_on_open() -> None:
         assert not focused.disabled
 
 
+@pytest.mark.asyncio
+async def test_click_outside_closes_the_menu_without_dispatching(monkeypatch) -> None:
+    """ADR-068 dismiss contract: a click elsewhere folds the menu, no actions.
+
+    Clicking the composer is the canonical stranding path: Textual moves
+    focus to the clicked widget before the press bubbles to the screen, so
+    the dismissal must also leave focus exactly where the click put it.
+    """
+    async with make_console_pilot(size=(160, 48), production_styles=True) as pilot:
+        screen = pilot.app.screen
+        _opener(screen).press()
+        await pilot.pause(0.3)
+        assert screen.query(ConsoleConversationActionMenu)
+
+        dispatched: list[object] = []
+        monkeypatch.setattr(
+            screen,
+            "on_conversation_action_chosen",
+            lambda event: dispatched.append(event),
+        )
+
+        assert await pilot.click("#console-native-composer")
+        await pilot.pause(0.3)
+
+        assert not screen.query(ConsoleConversationActionMenu), (
+            "a click outside the menu left it open"
+        )
+        assert dispatched == [], "an outside click dispatched a menu action"
+        assert pilot.app.focused is not None
+        assert pilot.app.focused is not _opener(screen), (
+            "outside-click dismissal pulled focus back to the opener"
+        )
+
+
+@pytest.mark.asyncio
+async def test_click_on_menu_chrome_keeps_the_menu_open() -> None:
+    """A click on the menu's border must not fold it mid-inspection.
+
+    Targets the top border row (offset y=0) -- menu chrome, not a button --
+    through the same screen-level mouse path a real terminal press takes.
+    """
+    async with make_console_pilot(size=(160, 48), production_styles=True) as pilot:
+        screen = pilot.app.screen
+        _opener(screen).press()
+        await pilot.pause(0.3)
+        menu = screen.query_one(ConsoleConversationActionMenu)
+
+        await pilot.click(ConsoleConversationActionMenu, offset=(2, 0))
+        await pilot.pause(0.3)
+
+        assert screen.query_one(ConsoleConversationActionMenu), (
+            "a click on the menu itself dismissed it"
+        )
+        assert menu.page == "root"
+
+
+@pytest.mark.asyncio
+async def test_escape_with_focus_outside_the_menu_closes_it() -> None:
+    """Escape must reach a stranded menu even after focus moved elsewhere.
+
+    Focus is moved to the composer without a mouse press (the screen seam
+    directly), which is the state a user reaches via keyboard pane cycling
+    once click-outside dismissal exists.
+    """
+    async with make_console_pilot(size=(160, 48), production_styles=True) as pilot:
+        screen = pilot.app.screen
+        _opener(screen).press()
+        await pilot.pause(0.3)
+        assert screen.query(ConsoleConversationActionMenu)
+
+        composer = screen.query_one("#console-native-composer")
+        screen.set_focus(composer)
+        await pilot.pause()
+
+        await pilot.press("escape")
+        await pilot.pause(0.3)
+
+        assert not screen.query(ConsoleConversationActionMenu), (
+            "escape from outside the menu left it stranded"
+        )
+        assert pilot.app.focused is composer, (
+            "escape-from-elsewhere moved focus instead of only closing the menu"
+        )
+
+
+@pytest.mark.asyncio
+async def test_pressing_the_asterisk_again_replaces_rather_than_stacks() -> None:
+    """The opener's press path still ends with exactly one menu mounted."""
+    async with make_console_pilot(size=(160, 48), production_styles=True) as pilot:
+        screen = pilot.app.screen
+        _opener(screen).press()
+        await pilot.pause(0.3)
+
+        await pilot.click("#console-conversation-actions-0")
+        await pilot.pause(0.3)
+
+        mounted = screen.query(ConsoleConversationActionMenu)
+        assert len(mounted) == 1, (
+            f"expected one replaced menu, found {len(mounted)}"
+        )
+
+
 @pytest.mark.unit
 def test_menu_width_constant_and_stylesheet_cannot_drift() -> None:
     """The two encodings of the menu's width must agree.

--- a/backlog/docs/lessons-textual.md
+++ b/backlog/docs/lessons-textual.md
@@ -421,3 +421,21 @@ before a probe printed `button.display`.
 Re-query after **every** await that could trigger a recompose, and take the reference
 the caller will act on *after* the last one — scrolling counts, because
 `scroll_to_widget` can itself provoke another reconciliation pass.
+
+## Textual focuses the clicked widget BEFORE the press bubbles — a click-outside dismissal must not restore the popup's opener
+
+**TASK-25709, 2026-08-30.** Wiring click-outside dismissal for the Context rail's
+conversation action menu, the obvious implementation reused the menu's existing
+`Dismissed` handler, which returns focus to the opener asterisk. In Textual 8.2.8
+`Screen._forward_event` calls `set_focus(focusable_widget)` on every `MouseDown` and
+only then dispatches the event into the widget tree (`textual/screen.py:1607-1610`) —
+so by the time a screen-level `on_mouse_down` dismissal runs, focus has ALREADY moved
+to the clicked widget. Posting an opener-restore from there yanks focus back to the
+rail after the user clicked into the composer. The same applies to an Escape issued
+while focus sits outside the menu.
+
+Thread the restore through the dismissal cause: the popup's own in-menu Escape
+restores the opener (focus was inside the popup); outside-click and stranded-Escape
+paths skip it. The pinned test is
+`test_click_outside_closes_the_menu_without_dispatching`, which asserts focus is NOT
+the opener after the click.

--- a/backlog/tasks/task-25709 - Console-conversation-action-menu-—-Escape-and-click-outside-dismissal.md
+++ b/backlog/tasks/task-25709 - Console-conversation-action-menu-—-Escape-and-click-outside-dismissal.md
@@ -1,0 +1,72 @@
+---
+id: TASK-25709
+title: Console conversation action menu — Escape and click-outside dismissal
+status: Done
+assignee:
+  - '@Robert'
+created_date: '2026-08-31 02:36'
+updated_date: '2026-08-31 02:56'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The Context rail conversation action menu (TASK-23200) can only be closed by choosing an action or pressing Escape while focus is still inside it. One click anywhere else strands it on screen. Extend the ADR-068 dismiss contract: Escape dismisses it even when focus has left the menu, and any click outside the menu folds it with no side effects.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Click outside the open menu (composer, transcript, rail) removes it without dispatching its actions
+- [x] #2 Click inside the menu (buttons, border, padding) does not dismiss it
+- [x] #3 Escape with focus outside the menu (e.g. composer) dismisses it and leaves focus where it is
+- [x] #4 Escape with focus inside the menu still steps back from a submenu before closing
+- [x] #5 Opening another row's menu still replaces the open one
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Tests first in Tests/UI/test_console_conversation_action_menu.py: click-outside dismisses, click-inside survives, stranded-Escape dismisses, regressions for submenu step-back and replace-on-second-asterisk.\n2. Menu widget (console_conversation_action_menu.py): WeakSet registry + conversation_action_menus_on_screen(); dismiss_menu(restore_focus=True) threading a flag onto ConversationActionMenuDismissed; registry-based dismiss_conversation_action_menus(screen, *, restore_focus=True).\n3. Screen (chat_screen.py): ancestor-walk guard by DOM id for in-menu clicks; outside-click path dismisses conversation menus with restore_focus=False (lazy import, ADR-097 boot ratchet); Escape actions (composer-home + collapsed-composer) gain the guard after the slash-popup check, restore_focus=False; replace-on-open passes restore_focus=False.\n4. Targeted pytest runs; self-review; task notes + AC check.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added the two missing ADR-068 dismissal paths to the Context rail's conversation
+action menu (TASK-23200), plus a latent crash fix its tests exposed.
+
+- **Click-outside**: the screen's per-press dismissal pass
+  (`_dismiss_console_selection_menus_outside_transcript`) now also folds conversation
+  menus — guarded by a DOM-id ancestor-walk entry so clicks on the menu itself
+  (buttons, border, padding) never dismiss it mid-press. The menu list comes from a
+  new `WeakSet` registry (`conversation_action_menus_on_screen`) instead of a DOM
+  query, keeping the TASK-21119 per-press rule; the module import stays lazy so the
+  ADR-097 `_ui_ready` ratchet is untouched (census re-run green).
+- **Escape with focus elsewhere**: both Escape consumers
+  (`action_focus_console_composer_home`, `action_expand_collapsed_console_composer`)
+  and the two loop-scoped Escape fallbacks (hands-free, realtime) gained the guard
+  after the existing slash-popup check, mirroring `_dismiss_console_command_popup`.
+  In-menu Escape behavior is unchanged (submenu step-back first).
+- **Focus semantics**: Textual 8.2.8 focuses the clicked widget before the press
+  bubbles (`Screen._forward_event`), so outside-click and stranded-Escape dismissals
+  skip the opener focus-restore via a `restore_focus` flag on
+  `ConversationActionMenuDismissed`; the menu's own Escape still restores the opener.
+  Recorded in `backlog/docs/lessons-textual.md`.
+- **Crash fix (pre-existing)**: re-pressing a row's asterisk while its menu was open
+  crashed the app with `DuplicateIds` — `remove()` only schedules the prune, and the
+  remount raced it. The open path is now async and awaits each open menu's detachment
+  through a memoized single-shot removal awaitable (`await_detachment`/`_detach`).
+  Same trap as the transcript selection menu's documented lesson.
+- Tests: 4 new cases in `Tests/UI/test_console_conversation_action_menu.py` (outside
+  click, chrome click, stranded Escape, replace-not-stack); 12/12 pass there, 162
+  pass across the seven seam-adjacent suites (routing, rail, actions model,
+  hands-free, composer draft, selection-dismissal perf). Ruff clean. The two
+  Architecture ratchet failures (`wave6_closeout_inventory`,
+  `review_selection_controller_boundary`) are pre-existing on clean origin/dev —
+  verified by stashing this change and re-running.
+- ADR check: no new ADR — direct application of ADR-068's dismiss contract; ADR-097
+  (boot ratchet) and ADR-068 linked here. Files: `console_conversation_action_menu.py`,
+  `chat_screen.py`, the test file, and the lessons entry.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1788,11 +1788,14 @@ class ChatScreen(BaseAppScreen):
         """Expand the hidden Console composer and return keyboard focus to it.
 
         An open slash-command popup swallows Escape first and is dismissed
-        instead, leaving the collapsed composer untouched.
+        instead, leaving the collapsed composer untouched; an open
+        conversation row menu does the same (TASK-25709).
         """
         if self._console_setup_modal_blocking():
             return
         if self._dismiss_console_command_popup():
+            return
+        if self._dismiss_console_conversation_action_menus():
             return
         self._set_console_composer_collapsed(False)
 
@@ -4288,6 +4291,8 @@ class ChatScreen(BaseAppScreen):
             return
         if self._dismiss_console_command_popup():
             return
+        if self._dismiss_console_conversation_action_menus():
+            return
         self._focus_console_composer_if_needed(force=True)
 
     def action_new_console_tab(self) -> None:
@@ -4536,7 +4541,27 @@ class ChatScreen(BaseAppScreen):
 
     # ---- Conversation action menu (TASK-23200) -------------------------
 
-    def _open_console_conversation_action_menu(self, opener: Button) -> None:
+    def _dismiss_console_conversation_action_menus(self) -> bool:
+        """Fold any open conversation row menu; True when one was open.
+
+        TASK-25709: the Escape consumers' guard, slotting in exactly where
+        ``_dismiss_console_command_popup`` already sits -- an open menu
+        swallows Escape before the action's own focus work runs. Focus is
+        NOT restored to the opener here: Escape arrived from outside the
+        menu (inside it, the menu's own ``on_key`` claims the key first),
+        so the user's focus stays where it is. Lazy import per ADR-097 --
+        this module must stay off the ``_ui_ready`` boot leg.
+
+        Returns:
+            True when a menu was open and has been dismissed.
+        """
+        from tldw_chatbook.Widgets.Console.console_conversation_action_menu import (
+            dismiss_conversation_action_menus,
+        )
+
+        return dismiss_conversation_action_menus(self, restore_focus=False) > 0
+
+    async def _open_console_conversation_action_menu(self, opener: Button) -> None:
         """Anchor the row action menu beneath the pressed asterisk.
 
         Args:
@@ -4547,12 +4572,17 @@ class ChatScreen(BaseAppScreen):
         )
         from tldw_chatbook.Widgets.Console.console_conversation_action_menu import (
             ConsoleConversationActionMenu,
-            dismiss_conversation_action_menus,
+            conversation_action_menus_on_screen,
         )
 
         # Only one menu at a time; a second asterisk replaces the first
         # rather than stacking two overlays the user must dismiss twice.
-        dismiss_conversation_action_menus(self)
+        # The awaits are load-bearing (TASK-25709): ``remove()`` only
+        # schedules the prune, so mounting the same DOM id over a
+        # still-attached menu raised Textual's app-fatal ``DuplicateIds``
+        # on consecutive opens.
+        for menu in conversation_action_menus_on_screen(self):
+            await menu.await_detachment()
 
         conversation_id = (
             str(getattr(opener, "conversation_id", "") or "").strip() or None
@@ -4640,8 +4670,15 @@ class ChatScreen(BaseAppScreen):
         breaching the module-count ratchet. Every other reference to those two
         modules is already lazy, so this keeps the whole feature off the boot
         leg until a user actually opens the menu.
+
+        TASK-25709: `restore_focus` is False for outside-click and
+        stranded-Escape dismissals -- Textual has already moved focus to the
+        clicked widget (it focuses before the press bubbles to the screen),
+        and restoring the opener there would yank focus back to the rail.
         """
         event.stop()
+        if not getattr(event, "restore_focus", True):
+            return
         if not event.opener_id:
             return
         try:
@@ -17074,7 +17111,13 @@ class ChatScreen(BaseAppScreen):
                 # before the loop exit ("make the overlay go away" must not
                 # cost the loop). The priority binding's action makes the
                 # same claim; this bubbling-order branch is the fallback.
+                # TASK-25709: an open conversation row menu claims it too,
+                # on the same overlay-before-loop rule.
                 if self._dismiss_console_command_popup():
+                    event.stop()
+                    event.prevent_default()
+                    return
+                if self._dismiss_console_conversation_action_menus():
                     event.stop()
                     event.prevent_default()
                     return
@@ -17101,15 +17144,17 @@ class ChatScreen(BaseAppScreen):
             hands_free.controller.on_composer_key()
         # TASK-24417: while a realtime loop is active, an open slash popup
         # claims Escape before the loop's key policy consumes it -- the same
-        # claim the hands-free branches make above.
-        if (
-            event.key == "escape"
-            and self._realtime.session is not None
-            and self._dismiss_console_command_popup()
-        ):
-            event.stop()
-            event.prevent_default()
-            return
+        # claim the hands-free branches make above. TASK-25709: the
+        # conversation row menu makes the same overlay-first claim.
+        if event.key == "escape" and self._realtime.session is not None:
+            if self._dismiss_console_command_popup():
+                event.stop()
+                event.prevent_default()
+                return
+            if self._dismiss_console_conversation_action_menus():
+                event.stop()
+                event.prevent_default()
+                return
         if self._realtime.handle_key(event.key):
             event.stop()
             event.prevent_default()
@@ -17785,6 +17830,9 @@ class ChatScreen(BaseAppScreen):
     ) -> None:
         """Fold selection menus when a click lands outside every transcript.
 
+        TASK-25709: conversation row action menus (Context rail asterisk)
+        fold here too, on the same contract.
+
         Console selection phase 1 (click-outside dismissal, screen half).
         Clicks that stay INSIDE a transcript are handled there (rows stop
         their own clicks; the transcript's ``on_click`` owns the in-area
@@ -17823,9 +17871,21 @@ class ChatScreen(BaseAppScreen):
                 return  # the transcript/menu own their in-area interaction
             if getattr(node, "id", None) == "console-message-more-menu":
                 return  # the transcript/menu own their in-area interaction
+            if getattr(node, "id", None) == "console-conversation-action-menu":
+                # TASK-25709: the row menu owns its in-area interaction --
+                # border and padding clicks must not fold it mid-press.
+                return
             node = getattr(node, "parent", None)
         menus = selection_menus_on_screen(self)
         more_menus = message_more_menus_on_screen(self)
+        # TASK-25709: the conversation row menu folds on the same contract.
+        # Lazy import per ADR-097; after first load this is a cached-module
+        # lookup, not a DOM walk, so the TASK-21119 per-press rule holds.
+        from tldw_chatbook.Widgets.Console.console_conversation_action_menu import (
+            conversation_action_menus_on_screen,
+        )
+
+        conversation_menus = conversation_action_menus_on_screen(self)
         # Only transcripts the cleanup would actually change; on the rest,
         # all three steps below are provable no-ops (see
         # ``ConsoleTranscript.has_pending_selection_ui``).
@@ -17834,7 +17894,7 @@ class ChatScreen(BaseAppScreen):
             for transcript in console_transcripts_on_screen(self)
             if transcript.has_pending_selection_ui
         ]
-        if not menus and not more_menus and not transcripts:
+        if not menus and not more_menus and not conversation_menus and not transcripts:
             return  # the common case: no selection UI anywhere on the screen
         # Menus mount on the screen now; route the dismissal through every
         # transcript's centralized selection-UI cleanup (clears highlight +
@@ -17848,6 +17908,11 @@ class ChatScreen(BaseAppScreen):
             if not getattr(menu, "_pruning", False):
                 menu.remove()
         dismiss_message_more_menus(more_menus)
+        # restore_focus=False: Textual has already moved focus to the clicked
+        # widget (it focuses before the press bubbles here), and the opener
+        # restore would pull focus back to the rail.
+        for menu in conversation_menus:
+            menu.dismiss_menu(restore_focus=False)
 
     def on_mouse_down(self, event: MouseDown) -> None:
         """Dismiss selection UI before descendants may consume the click."""
@@ -18671,7 +18736,7 @@ class ChatScreen(BaseAppScreen):
             # than silently toggling a favourite, so favouriting, status,
             # archive, rename and delete all reach the user from one place.
             event.stop()
-            self._open_console_conversation_action_menu(event.button)
+            await self._open_console_conversation_action_menu(event.button)
             return
         # NOTE: the `console-workspace-conversations-toggle` branch that stood
         # here was deleted in wave 4. Commit 3b0374479 removed the only button

--- a/tldw_chatbook/Widgets/Console/console_conversation_action_menu.py
+++ b/tldw_chatbook/Widgets/Console/console_conversation_action_menu.py
@@ -12,6 +12,15 @@ status" and "More" swap the menu's contents in place instead of stacking a
 second popup, which keeps one widget, one lifecycle and one focus owner in a
 27-column rail that has no room for cascading submenus.
 
+TASK-25709 extends the dismissal contract (ADR-068) to the two paths the
+original shipped without: a click outside the menu folds it from the screen's
+per-press dismissal pass, and Escape reaches a stranded menu whose focus has
+moved elsewhere. Both skip the opener focus-restore -- the dismissal cause
+already tells us where the user wants focus. Reopening a row also awaits the
+old menu's DOM detachment first, because ``remove()`` only schedules the
+prune and a same-id remount over a still-attached menu crashes the app with
+``DuplicateIds``.
+
 The menu holds no policy: what to paint comes from
 ``Chat.console_conversation_actions``, which is pure and separately tested.
 """
@@ -19,10 +28,12 @@ The menu holds no policy: what to paint comes from
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from weakref import WeakSet
 
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Vertical
+from textual.dom import NoScreen
 from textual.events import Key
 from textual.geometry import Offset
 from textual.message import Message
@@ -37,10 +48,32 @@ from tldw_chatbook.Chat.console_conversation_actions import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover
-    pass
+    from textual.app import AwaitRemove
+    from textual.screen import Screen
 
 MENU_ID = "console-conversation-action-menu"
 MENU_ITEM_PREFIX = "console-conversation-action-"
+
+#: TASK-25709: every mounted menu registers itself here so the screen's
+#: per-press dismissal checks never pay a full-DOM ``query`` walk (the
+#: TASK-21119 rule). Mirrors ``console_message_more_menu``'s registry.
+_LIVE_MENUS: "WeakSet[ConsoleConversationActionMenu]" = WeakSet()
+
+
+def conversation_action_menus_on_screen(
+    screen: "Screen[object]",
+) -> list["ConsoleConversationActionMenu"]:
+    """Return attached conversation action menus owned by ``screen``."""
+    menus: list[ConsoleConversationActionMenu] = []
+    for menu in _LIVE_MENUS:
+        if menu.parent is None:
+            continue
+        try:
+            if menu.screen is screen:
+                menus.append(menu)
+        except NoScreen:
+            continue
+    return menus
 
 
 class ConversationActionChosen(Message):
@@ -61,17 +94,27 @@ class ConversationActionChosen(Message):
 
 
 class ConversationActionMenuDismissed(Message):
-    """The menu closed without choosing a command."""
+    """The menu closed without choosing a command.
 
-    def __init__(self, opener_id: str) -> None:
+    ``restore_focus`` is False for dismissals where the user has already
+    expressed a focus intent elsewhere -- an outside click (Textual moves
+    focus to the clicked widget before the press reaches the screen) or an
+    Escape issued while focus sits outside the menu. The opener-restore is
+    only correct when the menu itself held focus (its own Escape path).
+    """
+
+    def __init__(self, opener_id: str, *, restore_focus: bool = True) -> None:
         """Create the message.
 
         Args:
             opener_id: DOM id of the asterisk that opened the menu, so focus
                 can be restored deterministically.
+            restore_focus: Whether the screen handler should return focus to
+                the opener.
         """
         super().__init__()
         self.opener_id = opener_id
+        self.restore_focus = restore_focus
 
 
 class ConsoleConversationActionMenu(Vertical):
@@ -136,6 +179,13 @@ class ConsoleConversationActionMenu(Vertical):
         self._anchor = (screen_x, screen_y)
         self._page: MenuPage = "root"
         self._claimed = False
+        #: Memoized ``remove()`` awaitable. Textual detaches a removed widget
+        #: only when its Prune message is processed, so a same-id remount
+        #: races an un-awaited removal into ``DuplicateIds``; every dismissal
+        #: path funnels through this so ``remove()`` stays single-shot and
+        #: the open path can await the detach it guards against.
+        self._removal: AwaitRemove | None = None
+        _LIVE_MENUS.add(self)
 
     @property
     def target(self) -> ConversationMenuTarget:
@@ -193,13 +243,39 @@ class ConsoleConversationActionMenu(Vertical):
         await self.recompose()
         self._focus_first_enabled()
 
-    def dismiss_menu(self) -> None:
-        """Close the menu and hand focus back to the opener."""
+    def dismiss_menu(self, *, restore_focus: bool = True) -> None:
+        """Close the menu, optionally handing focus back to the opener.
+
+        Args:
+            restore_focus: Post the opener-restore message. False when the
+                dismissal cause already expresses the user's focus intent
+                (outside click, Escape from elsewhere, replacement by a new
+                menu).
+        """
         if self._claimed:
             return
         self._claimed = True
-        self.post_message(ConversationActionMenuDismissed(self._opener_id))
-        self.remove()
+        if restore_focus:
+            self.post_message(ConversationActionMenuDismissed(self._opener_id))
+        self._detach()
+
+    async def await_detachment(self) -> None:
+        """Claim and fully detach this menu, awaiting the DOM removal.
+
+        The replace-on-reopen path calls this before mounting a new menu:
+        ``remove()`` only posts a Prune message, and mounting the same DOM
+        id while the old menu is still attached raises Textual's app-fatal
+        ``DuplicateIds``. No dismissal message is posted -- the new menu
+        takes focus anyway.
+        """
+        self._claimed = True
+        await self._detach()
+
+    def _detach(self) -> "AwaitRemove":
+        """Return the memoized single removal awaitable for this menu."""
+        if self._removal is None:
+            self._removal = self.remove()
+        return self._removal
 
     def on_key(self, event: Key) -> None:
         if event.key == "escape":
@@ -244,7 +320,7 @@ class ConsoleConversationActionMenu(Vertical):
             return
         self._claimed = True
         self.post_message(ConversationActionChosen(action_id, self._target))
-        self.remove()
+        self._detach()
 
 
 def _slug(action_id: str) -> str:
@@ -252,11 +328,21 @@ def _slug(action_id: str) -> str:
     return action_id.replace(":", "-")
 
 
-def dismiss_conversation_action_menus(screen: Widget) -> None:
+def dismiss_conversation_action_menus(
+    screen: Widget, *, restore_focus: bool = True
+) -> int:
     """Remove any open conversation action menu on ``screen``.
 
     Args:
         screen: The screen (or any widget on it) to search.
+        restore_focus: Passed through to each menu's dismissal; False for
+            outside-click and stranded-Escape dismissals, where the user
+            has already moved focus somewhere deliberate.
+
+    Returns:
+        How many menus were open and dismissed.
     """
-    for menu in screen.query(ConsoleConversationActionMenu):
-        menu.dismiss_menu()
+    menus = conversation_action_menus_on_screen(screen.screen)
+    for menu in menus:
+        menu.dismiss_menu(restore_focus=restore_focus)
+    return len(menus)

--- a/tldw_chatbook/Widgets/Console/console_conversation_action_menu.py
+++ b/tldw_chatbook/Widgets/Console/console_conversation_action_menu.py
@@ -63,7 +63,17 @@ _LIVE_MENUS: "WeakSet[ConsoleConversationActionMenu]" = WeakSet()
 def conversation_action_menus_on_screen(
     screen: "Screen[object]",
 ) -> list["ConsoleConversationActionMenu"]:
-    """Return attached conversation action menus owned by ``screen``."""
+    """Return the conversation action menus currently attached to ``screen``.
+
+    Args:
+        screen: The screen whose mounted menus are wanted (usually the
+            Console ``ChatScreen``).
+
+    Returns:
+        Every registry-registered menu still attached to that screen, in
+        registry iteration order. Detached menus (``parent is None`` or no
+        resolvable screen) are skipped.
+    """
     menus: list[ConsoleConversationActionMenu] = []
     for menu in _LIVE_MENUS:
         if menu.parent is None:


### PR DESCRIPTION
## Summary

The Context rail's row action menu (TASK-23200 — the asterisk on each conversation row) could only be closed by choosing an action or pressing Escape while focus was still inside it. One click anywhere else stranded it on screen with no dismissal path. This extends the ADR-068 dismiss contract to the two missing paths, and fixes a latent crash the new tests exposed.

- **Click-outside dismissal**: the screen's per-press dismissal pass (`_dismiss_console_selection_menus_outside_transcript`) now folds conversation menus, with a DOM-id ancestor-walk guard so clicks on the menu itself (buttons, border, padding) never dismiss it mid-press. Menu lookup uses a `WeakSet` registry (`conversation_action_menus_on_screen`) instead of a DOM query, preserving the TASK-21119 per-press rule; imports stay lazy so the ADR-097 `_ui_ready` boot ratchet is untouched (module census re-run green).
- **Escape with focus elsewhere**: both Escape consumers (`action_focus_console_composer_home`, `action_expand_collapsed_console_composer`) and the two loop-scoped Escape fallbacks (hands-free, realtime) gained the guard after the existing slash-popup check. In-menu Escape is unchanged (submenu step-back first, then close).
- **Focus semantics**: Textual 8.2.8 focuses the clicked widget before the press bubbles to the screen, so outside-click and stranded-Escape dismissals skip the opener focus-restore via a `restore_focus` flag on `ConversationActionMenuDismissed`; the menu's own Escape still restores the opener. Recorded in `backlog/docs/lessons-textual.md`.
- **Crash fix (pre-existing on dev)**: re-pressing a row's asterisk while its menu was open crashed the app with `DuplicateIds` — `remove()` only schedules the prune and the remount raced it (the same trap the transcript's selection menu documents). The open path is now async and awaits each open menu's detachment through a memoized single-shot removal awaitable.

## Testing

- 4 new cases in `Tests/UI/test_console_conversation_action_menu.py` (outside click, menu-chrome click, stranded Escape, replace-not-stack); 12/12 pass there.
- 162 passed across the seven seam-adjacent suites (button routing, workspace context rail, conversation actions model, hands-free wiring, composer draft, selection-dismissal perf).
- Ruff clean; `Tests/Performance/test_ui_ready_module_census.py` green (boot ratchet).
- The two Architecture ratchet failures (`wave6_closeout_inventory`, `review_selection_controller_boundary`) are pre-existing on clean `origin/dev` — verified by stashing this change and re-running.
- Full suite not run (repo policy: targeted runs unless opted in).

TASK-25709 · ADR-068 (dismiss contract) · ADR-097 (boot ratchet)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the console conversation action menu so it closes on click-outside and Escape with focus elsewhere, instead of stranding on screen with no dismissal path. Also fixes a latent `DuplicateIds` crash when re-pressing a row's asterisk while its menu is open.

- Click-outside now folds open menus from the screen's per-press dismissal pass; clicks on the menu's own buttons, border, or padding keep it open.
- Escape with focus outside the menu dismisses it without moving focus; Escape inside the menu still steps back from a submenu before closing.
- Outside-click and stranded-Escape dismissals skip restoring focus to the opener because Textual has already moved focus to the clicked widget.
- Reopening a row now awaits the old menu's detachment, resolving the crash from scheduling removal and remounting the same DOM id.

<sup>Written for commit c78247aa64be3a033b22566a368c1d1985526487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

