### PR TITLE
feat(home): "What you were working on last" — content recents, Console resume deep-links, next-up suggestions

### DIFF
--- a/Docs/User_Guide/home.md
+++ b/Docs/User_Guide/home.md
@@ -37,16 +37,17 @@ Two things to know before trusting it:
 
 Section state survives restarts (collapsed/expanded is saved to your config);
 **Details starts collapsed**. Empty sections say so in plain words: "No
-approvals or failures pending.", "Nothing running right now.", "Runs,
-chatbooks, imports, and schedules will appear here."
+approvals or failures pending.", "Nothing running right now.",
+"Conversations, notes, media, runs, chatbooks, and imports will appear here."
 
 ![Home idle, nothing needing attention](images/home/idle.svg)
 
 With nothing needing attention, the canvas *is* the suggestion: a title like
-"Start a conversation", the reason ("Console is ready for a task."), a
+"Resume last conversation" (or "Start a conversation" on a fresh profile), the
+reason ("Pick up where you left off." / "Console is ready for a task."), a
 content-count line ("Conversations: 2 · Notes: 1 · Media: 1" — only non-zero
-counts appear), and buttons — **Resume note: \<title\>** (or **Resume
-conversation: \<title\>**) and the suggestion itself.
+counts appear), and buttons — **Resume conversation/note/reading: \<title\>
+(\<age\>)** for the thing you touched last, and the suggestion itself.
 
 ## Features & controls
 
@@ -58,8 +59,11 @@ conversation: \<title\>**) and the suggestion itself.
   row when Study cards are waiting.
 - **Running** — in-flight watchlist runs and Library imports
   (queued / parsing / writing).
-- **Recent** — the last 8 finished things: terminal runs, done imports,
-  Chatbook artifacts, each with an age ("Library - 6d").
+- **Recent** — the last 8 things you touched, newest first: conversations,
+  notes, and media you recently worked on or read, terminal runs, done
+  imports, and Chatbook artifacts, each with an age ("Conversations - 3m").
+  The single newest conversation/note/media item feeds the resume banner
+  instead of repeating as the first row.
 
 Selecting a row repaints the canvas for that item; the highest-priority item
 (approval > failed > running > paused) is selected for you when you arrive.
@@ -71,6 +75,7 @@ Selecting a row repaints the canvas for that item; the highest-priority item
 | **Retry** | Real for Library import jobs: "Retry queued for \<file\>." (or "This import job can no longer be retried." for permanent failures — those rows omit the button). For anything else, see the warning below. |
 | **Open details** | Navigates to the owning screen — "Opening Library import job details." lands on Library's import queue; a watchlist run opens Watchlists at that run. |
 | **Open in Console** | Only offered for watchlist runs and Chatbook artifacts — opens Console following that work. |
+| **Open** | On a selected **Recent** conversation/note/media row — one click resumes it: conversations open in Console *at that conversation* (a live session is switched to when one already holds it), notes in Library's notes editor, media in Library's item view. A conversation whose record has gone missing explains itself with a warning toast. |
 | **Approve** / **Reject** / **Pause** / **Resume** | **Decorative today.** Each shows the same warning toast — "\<Label\> is not connected to an active run service yet. Open details or Console to inspect the work." — and changes nothing. Decide approvals on the owning screen. |
 | **Review flashcards** | On the "Flashcards due: N" row — opens Study directly at its flashcards section. Study's breadcrumb reads "Home ▸ Study" and Escape returns here, to Home (task-4011). |
 
@@ -87,9 +92,12 @@ card) is the first match in a fixed priority order:
 | 4 | "Review failed work" — Failed work needs recovery. | the failed item's screen |
 | 5 | "Resume active work" — Live work is already running. | Console |
 | 6 | "Review notifications" — Unread notifications need review. | **Watchlists** (that is where notifications live) |
-| 7 | "Import Library sources" — Library content makes Console and RAG more useful. | Library (its default view, not an import form — task-2765) |
-| 8 | "Search your Library" | unreachable today (task-2761) |
-| 9-10 | "Start a conversation" / "Start in Console" — Console is ready for a task. | Console |
+| 7 | "Review eval runs" — Pending or failed eval runs need attention. | Evals |
+| 8 | "Read-it-later: N items" — Your saved reading queue is waiting. | Media |
+| 9 | "Import Library sources" — Library content makes Console and RAG more useful. | Library (its default view, not an import form — task-2765) |
+| 10 | "Search your Library" | unreachable today (task-2761) |
+| 11 | "Resume last conversation" — Pick up where you left off. With a recent conversation, this replaces the plain start suggestion and deep-links that conversation into Console. | Console |
+| 12 | "Start a conversation" / "Start in Console" — Console is ready for a task (fresh profiles, or when the newest work wasn't a conversation). | Console |
 
 **The suggestion button can disagree with its own label** when a failed item
 is selected — see Quirks (task-2760).
@@ -116,9 +124,12 @@ hard-coded, and "Model: Ready" is optimistic.
    [Library ▸ Import & export](library/import-and-export.md); Home itself
    will not update while you watch (task-2763).
 2. **Pick up where you left off.** With nothing urgent, the canvas offers
-   **Resume note: \<title\>** / **Resume conversation: \<title\>** — the
-   newest of each, ties going to the conversation. Notes open in Library,
-   conversations in Console.
+   **Resume conversation/note/reading: \<title\> (\<age\>)** for the newest
+   thing you touched, and the terminal suggestion itself becomes "Resume
+   last conversation" when one exists. Notes open in Library's editor,
+   media in Library's item view, conversations in Console *at that
+   conversation* — the one place "resume" actually resumes. Older work is
+   one section down, in **Recent**.
 3. **Clear flashcards that are due.** The "Flashcards due: N" row's **Review
    flashcards** lands on Study's flashcards section.
 4. **See why agent work is blocked.** Expand **Details** for the runtime,

--- a/Docs/User_Guide/home.md
+++ b/Docs/User_Guide/home.md
@@ -60,8 +60,10 @@ counts appear), and buttons — **Resume conversation/note/reading: \<title\>
 - **Running** — in-flight watchlist runs and Library imports
   (queued / parsing / writing).
 - **Recent** — the last 8 things you touched, newest first: conversations,
-  notes, and media you recently worked on or read, terminal runs, done
+  notes, and media you recently worked on, terminal runs, done
   imports, and Chatbook artifacts, each with an age ("Conversations - 3m").
+  (Reading media without editing it does not resurface it — reading counts
+  once the opens journal lands; see the follow-up task.)
   The single newest conversation/note/media item feeds the resume banner
   instead of repeating as the first row.
 

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -663,8 +663,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 344,
-      "diagnostic_digest": "abf56190bb4fdc289314",
+      "call_count": 345,
+      "diagnostic_digest": "31ad45dcf6b2ad6eeee9",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Client_Media_DB_v2.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -992,8 +992,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 9,
-      "diagnostic_digest": "69a5911c5c26e9658c4e",
+      "call_count": 11,
+      "diagnostic_digest": "e8d72437a825ad30fe8e",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Home/active_work_adapter.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2707,8 +2707,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 5,
-      "diagnostic_digest": "41dd89d7e41e68289f6e",
+      "call_count": 6,
+      "diagnostic_digest": "4a1002ecb7d6cad52124",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/media_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3813,8 +3813,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 366,
-      "diagnostic_digest": "3638aa872a3c78412e5a",
+      "call_count": 368,
+      "diagnostic_digest": "6f0ad85ce1974dc46ef9",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -4737,6 +4737,15 @@
             "self.db_path_str"
           ],
           "scope": "MediaDatabase.backup_database",
+          "status": "legacy_unreviewed"
+        },
+        {
+          "call_digest": "98fb8ca2c859ebd2",
+          "method": "error",
+          "path_expressions": [
+            "self.db_path_str"
+          ],
+          "scope": "MediaDatabase.count_read_it_later_media",
           "status": "legacy_unreviewed"
         },
         {
@@ -11101,9 +11110,9 @@
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
     "owner_files": 549,
-    "path_privacy_candidate_calls": 711,
+    "path_privacy_candidate_calls": 712,
     "persistent_sink_files": 8,
     "task_492_calls": 1293,
-    "task_494_calls": 7405
+    "task_494_calls": 7411
   }
 }

--- a/Docs/superpowers/plans/2026-08-29-home-recents-resume-and-next-up.md
+++ b/Docs/superpowers/plans/2026-08-29-home-recents-resume-and-next-up.md
@@ -1,0 +1,1254 @@
+# Home Recents, Resume Deep-Links, and Next-Up Suggestions — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A "What you were working on last" recents stream on Home (conversations/notes/media, one-click resumable), a real conversation deep-link into Console, and "what's next" suggestions fed by open-task queues.
+
+**Architecture:** Task 1 adds a Console navigation-context deep-link (store-and-defer consumption on the freshly-mounted screen) plus its ADR. Task 2 computes content recents inside HomeScreen's existing `HomeContentSnapshot` worker (async scope-service seams), merges them with the adapter's recents in the pure `dashboard_state` layer, promotes the resume banner to the newest content item (adding media as a resume kind), and wires row/banner dispatch. Task 3 feeds the fixed-priority ladder two new queue inputs (eval runs, read-it-later) via provider callables on the existing adapter, and upgrades the terminal suggestion to "Resume last conversation".
+
+**Tech Stack:** Python ≥3.11, Textual ≥8.0.0,<9, SQLite (existing schemas only), pytest (+ Textual pilot for screen tests).
+
+**Spec:** `Docs/superpowers/specs/2026-08-29-home-recents-resume-and-next-up-design.md` — the plan argues from the spec; executors read both.
+
+## Global Constraints
+
+- No new dependencies; no DB schema migrations; no new `config.toml` keys (spec Non-goals).
+- User titles: RAW at the data layer, rich-markup-escaped EXACTLY ONCE at the Button-label build (`build_home_resume_control` / item-build for rail rows — existing hazard pattern, spec §1).
+- All new queries run off the UI event loop, through the existing worker/`asyncio.to_thread` seams only (spec §1, §6).
+- Parameterized SQL only (repo rule) — no new raw SQL is added by this plan.
+- Targeted test runs only; never a full-suite sweep unless the user opts in (AGENTS.md testing rule).
+- Conventional commit subjects (`feat:`, `test:`, `docs:`), matching repo history.
+- Execute on a fresh branch off `main` (the current `docs/lesson-adr-number-collisions` branch is unrelated); use the using-git-worktrees skill at execution time.
+- Every task: backlog task via CLI (create → In Progress → plan → Done with Implementation Notes), per AGENTS.md DoD.
+
+## Deviations from spec (verified during planning — intent preserved)
+
+1. **Content recents are computed in HomeScreen's `HomeContentSnapshot` pipeline, not in adapter providers.** Spec §1 named `_local_*_recent_items()` methods on `LocalNotificationHomeActiveWorkAdapter`, but the content seams (`notes_scope_service.list_notes`, `chat_conversation_scope_service.list_conversations`, `media_reading_scope_service.list_media_items`) are **async**, while the adapter's `build_dashboard_input` is synchronous + TTL-cached; the per-visit snapshot worker (`home_screen.py:309-366`) is the established home for exactly these seams and matches spec §5's per-visit freshness contract. Merging with adapter recents still happens in pure `dashboard_state`.
+2. **Media recency = `Media.last_modified` alone** (spec's documented fallback): no list-level ReadingProgress seam exists — only per-media `get_reading_progress` (Client_Media_DB_v2.py:2730).
+3. **`failed_schedule_count` producer skipped** (spec's decision rule): verified no source query exists (`Scheduling/db/scheduled_tasks_db.py` has no failed-status listing). Task 4 files a follow-up backlog task instead.
+4. **Read-it-later suggestion routes to the Media screen root** (`TAB_MEDIA`): no registered deep-link view id exists for the read-it-later list.
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `backlog/decisions/NNN-console-conversation-deep-link-nav-context.md` | ADR for the cross-module seam | Create (Task 1) |
+| `tldw_chatbook/Constants.py:44-61` | Nav-context contract keys | Add `CONSOLE_NAV_CONTEXT_CONVERSATION_ID` (Task 1) |
+| `tldw_chatbook/UI/Screens/chat_screen.py` | Console screen | `apply_navigation_context` + deferred consume (Task 1) |
+| `tldw_chatbook/Home/dashboard_state.py` | Pure Home state | Content-item constants/fields, merge, banner media branch, row Open control, ladder inputs/branches/terminal (Tasks 2-3) |
+| `tldw_chatbook/UI/Screens/home_screen.py` | Home screen | Snapshot limit-N + content item builders + dispatch (Task 2); primary-action context (Task 3) |
+| `tldw_chatbook/Home/active_work_adapter.py` | Adapter | Open-tasks provider plumbing (Task 3) |
+| `tldw_chatbook/app.py` | App wiring | Provider closures (Task 3) |
+| `Tests/UI/test_console_nav_context.py`, `Tests/Home/test_dashboard_state.py`, `Tests/Home/test_active_work_adapter.py`, `Tests/UI/test_home_screen.py` | Tests | Create/extend (Tasks 1-3) |
+| `Docs/User_Guide/home.md` | User-facing docs | Update (Task 4) |
+
+---
+
+### Task 1: Console conversation deep-link seam + ADR
+
+**Files:**
+- Create: `backlog/decisions/NNN-console-conversation-deep-link-nav-context.md` (NNN = next free number)
+- Modify: `tldw_chatbook/Constants.py:44-61`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (`__init__` at 3403, `on_mount` at 13437, near the other `_consume_pending_*` methods)
+- Test: `Tests/UI/test_console_nav_context.py` (create)
+
+**Interfaces:**
+- Consumes: `NavigateToScreen(route, screen_context)` dispatch at `app.py:8937-8948` (calls `apply_navigation_context` pre-`switch_screen`, swallow-logged); `ConsoleWorkspaceController._console_session_id_for_workspace_conversation(conversation_id) -> str | None` (workspace.py:2100); `await ConsoleWorkspaceController._resume_console_workspace_conversation(conversation_id) -> bool | None` (workspace.py:2121); `ChatScreen._ensure_console_chat_controller()` (chat_screen.py:5428) whose controller has `.store.active_session_id` and `.switch_session(session_id)` (chat_screen.py:19876-19883).
+- Produces: `CONSOLE_NAV_CONTEXT_CONVERSATION_ID = "conversation_id"` (Constants); `ChatScreen.apply_navigation_context(context) -> None`; `ChatScreen._consume_pending_console_nav_conversation() -> None`; pending state attr `_pending_console_nav_conversation_id: str`. Tasks 2-3 navigate with `NavigateToScreen(TAB_CHAT, {CONSOLE_NAV_CONTEXT_CONVERSATION_ID: <id>})`.
+
+- [ ] **Step 1: Create the backlog task**
+
+```bash
+backlog task create "Console conversation deep-link nav context" -d "Add CONSOLE_NAV_CONTEXT_CONVERSATION_ID and ChatScreen.apply_navigation_context so Home/ladder can deep-link a specific conversation into Console (spec 2026-08-29 §3)" --ac "Nav context with a conversation id lands that conversation in Console,Nav context wins over a pending CONSOLE_LIVE_WORK handoff,Missing id is a no-op,ADR written and linked" -s "In Progress"
+```
+
+Note the printed task id for the Done step.
+
+- [ ] **Step 2: Write the ADR**
+
+Pick the number: `ls backlog/decisions/ | grep -E '^[0-9]+' | sort -n | tail -1` → NNN = that + 1 (repo is mid-renumbering; verify no collision).
+
+```markdown
+# NNN. Console conversation deep-link via navigation context
+
+Date: 2026-08-29
+Status: Accepted
+
+## Context
+
+Home's resume control and next-best-action ladder need to open a specific
+conversation in Console. Until now nothing app-level could: the capability
+existed only inside the Console workspace controller
+(`_resume_console_workspace_conversation`), and Home's resume button routed
+bare to `chat`, dropping the conversation id (task-190 limitation).
+
+## Decision
+
+Deep-link conversations through the existing navigation-context contract:
+a new `CONSOLE_NAV_CONTEXT_CONVERSATION_ID` key; `ChatScreen` implements
+`apply_navigation_context` (the 6th screen to do so, after Library,
+Watchlists, Personas, Settings, STTs). The framework calls it BEFORE the
+screen is mounted (`handle_screen_navigation`, app.py:8937), so the
+implementation is store-and-defer: record the id synchronously, consume it
+from the mount timer chain. Consumption prefers switching to a live session
+holding that conversation over rehydrating from the DB.
+
+Precedence: an explicit nav deep link outranks any pending handoff staged
+for the same mount; applying the context clears a pending
+`CONSOLE_LIVE_WORK` handoff (the nav context is the user's explicit,
+most-recent intent).
+
+## Alternatives considered
+
+- Pending-handoff single-slot store: ephemeral, single-slot, not a durable
+  deep-link contract; reserved for runtime handoffs (live work, fleet
+  completions), not navigation.
+- Always rehydrate from DB: loses open live sessions and their draft state;
+  the session-map check is cheap and correct.
+
+## Consequences
+
+Console gains a second entry-path that must not fight the handoff
+consumers; ordering is pinned by timer registration (nav at 0.15s alongside
+the other consumers, clearing the live-work handoff at apply time).
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+Create `Tests/UI/test_console_nav_context.py`. Reuse the sibling harness: read `Tests/UI/test_console_live_work_handoffs.py:100-200` first and mirror its app-construction + `ChatScreen` push (`ConsoleHarness` at line 128 pushes `ChatScreen(self.app_instance)` and `_wait_for_production_chat_screen` at 141 polls for a mounted screen). The tests below are harness-agnostic once you have a mounted `screen`:
+
+```python
+"""Console navigation-context deep-link tests (spec 2026-08-29 §3)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tldw_chatbook.Constants import CONSOLE_NAV_CONTEXT_CONVERSATION_ID
+
+
+def _install_fakes(screen, *, live_session_id=None):
+    """Replace Console collaborators with recorders (logic-level fakes)."""
+    resume = AsyncMock(return_value=True)
+    screen._workspace = SimpleNamespace(
+        _console_session_id_for_workspace_conversation=lambda cid: live_session_id,
+        _resume_console_workspace_conversation=resume,
+        _set_active_workspace_for_console_session=lambda sid: None,
+    )
+    switched = []
+    screen._ensure_console_chat_controller = lambda: SimpleNamespace(
+        store=SimpleNamespace(active_session_id="other-session"),
+        switch_session=switched.append,
+    )
+    workers = []
+    screen.run_worker = lambda coro, **kwargs: workers.append(coro)
+    screen.call_after_refresh = lambda *args, **kwargs: None
+    screen._sync_native_console_chat_ui = AsyncMock()
+    screen._focus_console_composer_if_needed = lambda **kwargs: None
+    return SimpleNamespace(resume=resume, switched=switched, workers=workers)
+
+
+def test_apply_navigation_context_stores_conversation_id(screen):
+    assert screen._pending_console_nav_conversation_id == ""
+    screen.apply_navigation_context({CONSOLE_NAV_CONTEXT_CONVERSATION_ID: "42"})
+    assert screen._pending_console_nav_conversation_id == "42"
+
+
+def test_apply_navigation_context_ignores_missing_or_non_mapping(screen):
+    screen.apply_navigation_context({})
+    screen.apply_navigation_context({"unrelated": "x"})
+    assert screen._pending_console_nav_conversation_id == ""
+
+
+def test_consume_prefers_live_session_over_rehydrate(screen):
+    fakes = _install_fakes(screen, live_session_id="sess-7")
+    screen._pending_console_nav_conversation_id = "42"
+    screen._consume_pending_console_nav_conversation()
+    assert screen._pending_console_nav_conversation_id == ""
+    assert fakes.switched == ["sess-7"]
+    fakes.resume.assert_not_awaited()
+    assert fakes.workers == []
+
+
+def test_consume_rehydrates_when_no_live_session(screen):
+    fakes = _install_fakes(screen, live_session_id=None)
+    screen._pending_console_nav_conversation_id = "42"
+    screen._consume_pending_console_nav_conversation()
+    assert fakes.switched == []
+    assert len(fakes.workers) == 1  # the resume coroutine was scheduled
+
+
+def test_consume_noop_without_pending_id(screen):
+    fakes = _install_fakes(screen, live_session_id="sess-7")
+    screen._consume_pending_console_nav_conversation()
+    assert fakes.switched == []
+    assert fakes.workers == []
+```
+
+If direct import of the sibling harness is awkward, copy its app-builder into this file (bounded copy, referenced by line range above). Fixtures `screen` come from that harness (module-scoped pilot fixture returning the mounted `ChatScreen`).
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_console_nav_context.py -v`
+Expected: FAIL — `AttributeError: 'ChatScreen' object has no attribute '_pending_console_nav_conversation_id'` (or ImportError on the new constant).
+
+- [ ] **Step 5: Add the constant**
+
+In `tldw_chatbook/Constants.py`, after the Watchlists nav-context block (line 61):
+
+```python
+# Console navigation-context contract keys.
+# Applied pre-mount by handle_screen_navigation (app.py) -- ChatScreen
+# stores the id and consumes it from its mount timer chain. See
+# backlog/decisions/NNN-console-conversation-deep-link-nav-context.md.
+CONSOLE_NAV_CONTEXT_CONVERSATION_ID = "conversation_id"
+```
+
+(Use the real ADR number in the comment.)
+
+- [ ] **Step 6: Implement store-and-defer on ChatScreen**
+
+In `chat_screen.py` `ChatScreen.__init__` (line 3403), next to the other pending-handoff state:
+
+```python
+        # Navigation-context deep link (spec 2026-08-29 §3): stored
+        # synchronously by apply_navigation_context BEFORE mount, consumed
+        # from the mount timer chain below.
+        self._pending_console_nav_conversation_id: str = ""
+```
+
+In `on_mount` (line 13437), next to the other handoff timers (after line 13461's `_consume_pending_chat_handoff` timer):
+
+```python
+        # Nav-context deep link: same settle hedge as the handoff timers.
+        self.set_timer(0.15, self._consume_pending_console_nav_conversation)
+```
+
+Near the other `_consume_pending_*` methods:
+
+```python
+    def apply_navigation_context(self, context: Mapping[str, Any]) -> None:
+        """Store a shell-navigation deep link for post-mount consumption.
+
+        Called by ``handle_screen_navigation`` BEFORE this screen is
+        mounted, so this must stay synchronous: record the conversation id
+        and consume it from the mount timer chain. Precedence (ADR NNN):
+        an explicit nav deep link outranks any pending handoff staged for
+        this mount, so the live-work handoff is cleared here.
+        """
+        if not isinstance(context, Mapping):
+            return
+        conversation_id = str(
+            context.get(CONSOLE_NAV_CONTEXT_CONVERSATION_ID, "") or ""
+        ).strip()
+        if not conversation_id:
+            return
+        self._pending_console_nav_conversation_id = conversation_id
+        try:
+            self.app_instance.pending_handoff_store.clear_pending(
+                HandoffChannel.CONSOLE_LIVE_WORK
+            )
+            logger.debug(
+                "Console nav deep link claimed this mount; cleared pending "
+                "CONSOLE_LIVE_WORK handoff."
+            )
+        except AttributeError:
+            # Test doubles may not expose the store; the deep link itself
+            # still works.
+            pass
+
+    def _consume_pending_console_nav_conversation(self) -> None:
+        """Switch to (or rehydrate) the nav-deep-linked conversation."""
+        conversation_id = self._pending_console_nav_conversation_id
+        self._pending_console_nav_conversation_id = ""
+        if not conversation_id:
+            return
+        session_id = (
+            self._workspace._console_session_id_for_workspace_conversation(
+                conversation_id
+            )
+        )
+        if session_id is not None:
+            controller = self._ensure_console_chat_controller()
+            if controller.store.active_session_id != session_id:
+                self._workspace._set_active_workspace_for_console_session(
+                    session_id
+                )
+                controller.switch_session(session_id)
+                self.call_after_refresh(self._sync_native_console_chat_ui)
+            self.call_after_refresh(
+                self._focus_console_composer_if_needed, force=True
+            )
+            return
+        self.run_worker(
+            self._workspace._resume_console_workspace_conversation(
+                conversation_id
+            ),
+            exclusive=False,
+        )
+```
+
+Add imports at the top of `chat_screen.py` (verify against how `_consume_pending_chat_handoff` accesses the store — if it uses a different accessor, match it): `from ..Navigation.pending_handoff_store import HandoffChannel` and `from ...Constants import CONSOLE_NAV_CONTEXT_CONVERSATION_ID` merged into the existing Constants import.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `pytest Tests/UI/test_console_nav_context.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 8: Run targeted regression tests**
+
+Run: `pytest Tests/UI/test_console_live_work_handoffs.py Tests/UI/test_screen_navigation.py -v`
+Expected: PASS (no behavior changed for existing callers — nobody sends Console contexts yet).
+
+- [ ] **Step 9: Commit + close the backlog task**
+
+```bash
+git add tldw_chatbook/Constants.py tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_nav_context.py backlog/decisions/
+git commit -m "feat(console): conversation deep-link navigation context seam"
+backlog task edit <id> -s Done --notes "Added CONSOLE_NAV_CONTEXT_CONVERSATION_ID + ChatScreen.apply_navigation_context (store-and-defer, live-session-first, live-work handoff precedence). ADR linked."
+```
+
+---
+
+### Task 2: Content recents stream + resume banner + row Open control
+
+**Files:**
+- Modify: `tldw_chatbook/Home/dashboard_state.py` (constants ~114-123, `HomeDashboardInput` 181-225, `HomeContentSnapshot` 228-243, `apply_home_content_snapshot` 246-280, `build_home_resume_control` 684-720, `build_home_controls` 417-500, `build_home_triage_state` 1140-1354)
+- Modify: `tldw_chatbook/UI/Screens/home_screen.py` (`_build_home_content_snapshot` 367-422, `_home_resume_fields` 201-230 (retire), dispatch 751-833)
+- Test: `Tests/Home/test_dashboard_state.py` (extend), `Tests/UI/test_home_screen.py` (extend)
+
+**Interfaces:**
+- Consumes (Task 1): `CONSOLE_NAV_CONTEXT_CONVERSATION_ID`.
+- Produces: `HOME_RESUME_KIND_MEDIA`, `LOCAL_CONVERSATION_ITEM_ID_PREFIX = "local:conversation:"`, `LOCAL_NOTE_ITEM_ID_PREFIX = "local:note:"`, `LOCAL_MEDIA_ITEM_ID_PREFIX = "local:media:"`, `HOME_OPEN_ITEM_CONTROL_ID = "home-open-item"`, `HOME_RECENT_WORK_LIMIT = 8`, `content_item_kind(item_id) -> str | None`, `combined_recent_work_items(state) -> tuple[HomeActiveWorkItem, ...]`; `HomeDashboardInput.content_recent_items` / `.resume_updated_at`; `HomeContentSnapshot.content_recent_items` / `.resume_updated_at`; `HomeScreen._open_content_item(target_id) -> None`.
+
+- [ ] **Step 1: Create the backlog task**
+
+```bash
+backlog task create "Home content recents stream + resume banner" -d "Merge conversations/notes/media into Home's Recent section from the content snapshot pipeline, promote the resume banner to the newest content item (media becomes a resume kind), retire the limit-1 resume queries, add a row Open control (spec 2026-08-29 §1-2)" --ac "Recent section shows mixed content recents newest-first capped at 8,Banner resumes newest content item incl. media with relative age,Conversation banner/row opens that conversation in Console via nav context,Note/media rows open their Library views,limit-1 resume seam queries retired" -s "In Progress"
+```
+
+- [ ] **Step 2: Write the failing pure-state tests**
+
+Append to `Tests/Home/test_dashboard_state.py` (inline-input construction pattern, per the existing tests):
+
+```python
+def _content_item(item_id, updated_at, *, source="Notes", route="library"):
+    return HomeActiveWorkItem(
+        item_id=item_id,
+        title=f"title {item_id}",
+        source=source,
+        status="ready",
+        detail_route=route,
+        updated_at=updated_at,
+    )
+
+
+def test_content_item_kind_maps_prefixes():
+    assert content_item_kind("local:conversation:42") == "conversation"
+    assert content_item_kind("local:note:7") == "note"
+    assert content_item_kind("local:media:9") == "media"
+    assert content_item_kind("local:ingest:3") is None
+    assert content_item_kind("") is None
+
+
+def test_combined_recent_merges_and_caps_by_recency():
+    adapter_recents = (_content_item("local:ingest:1", "2026-08-29T10:00:00+00:00"),)
+    content_items = (
+        _content_item("local:conversation:5", "2026-08-29T12:00:00+00:00",
+                      source="Conversations", route="chat"),
+        _content_item("local:note:2", "2026-08-29T11:00:00+00:00"),
+        _content_item("local:media:3", "2026-08-28T09:00:00+00:00", source="Media"),
+    )
+    state = HomeDashboardInput(
+        recent_work_items=adapter_recents, content_recent_items=content_items
+    )
+    merged = combined_recent_work_items(state)
+    assert [item.item_id for item in merged] == [
+        "local:conversation:5",
+        "local:note:2",
+        "local:ingest:1",
+        "local:media:3",
+    ]
+
+
+def test_combined_recent_caps_at_limit():
+    items = tuple(
+        _content_item(f"local:note:{i}", f"2026-08-29T1{i:02d}:00:00+00:00")
+        for i in range(12)
+    )
+    state = HomeDashboardInput(content_recent_items=items)
+    assert len(combined_recent_work_items(state)) == HOME_RECENT_WORK_LIMIT
+
+
+def test_triage_recent_section_includes_content_items_and_open_control():
+    content = (
+        _content_item("local:conversation:5", "2026-08-29T12:00:00+00:00",
+                      source="Conversations", route="chat"),
+    )
+    state = HomeDashboardInput(
+        model_ready=True, content_recent_items=content, console_ready=True
+    )
+    triage = build_home_triage_state(state, selected_row_id="local:conversation:5")
+    recent_section = next(s for s in triage.sections if s.section_id == "recent")
+    assert [row.row_id for row in recent_section.rows] == ["local:conversation:5"]
+    control_ids = {c.control_id for c in triage.canvas.actions}
+    assert HOME_OPEN_ITEM_CONTROL_ID in control_ids
+    open_control = next(
+        c for c in triage.canvas.actions if c.control_id == HOME_OPEN_ITEM_CONTROL_ID
+    )
+    assert open_control.target_id == "local:conversation:5"
+    assert open_control.target_route == "chat"
+
+
+def test_resume_control_supports_media_kind_with_age():
+    state = HomeDashboardInput(
+        resume_kind=HOME_RESUME_KIND_MEDIA,
+        resume_id="9",
+        resume_title="Long read",
+        resume_updated_at="2026-08-29T11:00:00+00:00",
+    )
+    control = build_home_resume_control(
+        state, now=datetime(2026, 8, 29, 11, 30, tzinfo=timezone.utc)
+    )
+    assert control is not None
+    assert control.control_id == HOME_RESUME_LATEST_CONTROL_ID
+    assert control.target_route == "library"
+    assert control.target_id == "local:media:9"
+    assert control.label == "Resume reading: Long read (30m)"
+```
+
+Add the new names to the file's existing `dashboard_state` import block.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pytest Tests/Home/test_dashboard_state.py -v -k "content_item_kind or combined_recent or triage_recent_section or resume_control_supports_media"`
+Expected: FAIL — `ImportError` (names not defined).
+
+- [ ] **Step 4: Implement the pure-state layer in `dashboard_state.py`**
+
+Constants (next to `HOME_RESUME_KIND_*`, lines 114-117):
+
+```python
+HOME_RESUME_KIND_MEDIA = "media"
+# Shared recents cap (the adapter keeps its own alias; this module is the
+# canonical home so the pure merge can enforce it without importing the
+# adapter).
+HOME_RECENT_WORK_LIMIT = 8
+LOCAL_CONVERSATION_ITEM_ID_PREFIX = "local:conversation:"
+LOCAL_NOTE_ITEM_ID_PREFIX = "local:note:"
+LOCAL_MEDIA_ITEM_ID_PREFIX = "local:media:"
+# Canvas control that opens the SELECTED content recents row (screen-level
+# dispatch, like home-resume-latest -- not a HOME_CONTROL_METHODS hook).
+HOME_OPEN_ITEM_CONTROL_ID = "home-open-item"
+
+
+def content_item_kind(item_id: str) -> str | None:
+    """Return the content kind for a prefixed content item id, else None."""
+    for kind, prefix in (
+        (HOME_RESUME_KIND_CONVERSATION, LOCAL_CONVERSATION_ITEM_ID_PREFIX),
+        (HOME_RESUME_KIND_NOTE, LOCAL_NOTE_ITEM_ID_PREFIX),
+        (HOME_RESUME_KIND_MEDIA, LOCAL_MEDIA_ITEM_ID_PREFIX),
+    ):
+        if item_id.startswith(prefix):
+            return kind
+    return None
+
+
+def combined_recent_work_items(
+    state: HomeDashboardInput,
+) -> tuple[HomeActiveWorkItem, ...]:
+    """Merge adapter recents with content recents, newest-first, capped."""
+    merged = list(state.recent_work_items) + list(state.content_recent_items)
+    merged.sort(key=lambda item: item.updated_at, reverse=True)
+    return tuple(merged[:HOME_RECENT_WORK_LIMIT])
+```
+
+`HomeDashboardInput` — add after `resume_title` (line 225):
+
+```python
+    # Content recents (conversations/notes/media) from the HomeScreen
+    # content-snapshot pipeline; merged into the Recent rail section by
+    # combined_recent_work_items. Titles are markup-escaped at build.
+    content_recent_items: tuple[HomeActiveWorkItem, ...] = ()
+    resume_updated_at: str = ""
+```
+
+`HomeContentSnapshot` — add the same two fields. `apply_home_content_snapshot` — add both to the `replace(...)` call:
+
+```python
+        content_recent_items=snapshot.content_recent_items,
+        resume_updated_at=snapshot.resume_updated_at,
+```
+
+`build_home_resume_control` — media branch + age + prefixed target id:
+
+```python
+def build_home_resume_control(
+    state: HomeDashboardInput,
+    *,
+    now: datetime | None = None,
+) -> HomeControl | None:
+    """Build the one-click resume control for the newest content item.
+
+    The raw user title is markup-escaped HERE, exactly once (Button labels
+    parse Rich markup). Conversation targets carry the Console nav-context
+    prefix; note/media targets carry their Library prefixes so dispatch
+    (_open_content_item) can route by kind.
+    """
+    if not state.resume_id:
+        return None
+    if state.resume_kind == HOME_RESUME_KIND_NOTE:
+        kind_label = "note"
+        target_route = "library"
+        fallback_title = "Latest note"
+        prefix = LOCAL_NOTE_ITEM_ID_PREFIX
+    elif state.resume_kind == HOME_RESUME_KIND_CONVERSATION:
+        kind_label = "conversation"
+        target_route = "chat"
+        fallback_title = "Latest conversation"
+        prefix = LOCAL_CONVERSATION_ITEM_ID_PREFIX
+    elif state.resume_kind == HOME_RESUME_KIND_MEDIA:
+        kind_label = "reading"
+        target_route = "library"
+        fallback_title = "Latest media"
+        prefix = LOCAL_MEDIA_ITEM_ID_PREFIX
+    else:
+        return None
+    title = state.resume_title.strip() or fallback_title
+    label = f"Resume {kind_label}: {escape_markup(title)}"
+    age = format_console_relative_age(
+        state.resume_updated_at, now=now or datetime.now(timezone.utc)
+    )
+    if age:
+        label = f"{label} ({age})"
+    return HomeControl(
+        HOME_RESUME_LATEST_CONTROL_ID,
+        label,
+        target_route,
+        "resume_latest",
+        f"{prefix}{state.resume_id}",
+    )
+```
+
+(`format_console_relative_age` is already imported at dashboard_state.py:23-25.)
+
+`build_home_controls` — after the `detail_item` resolution (line 500), add the selected-content Open control:
+
+```python
+    # Content recents rows (conversations/notes/media) get a single Open
+    # control that deep-links the item (screen-level dispatch, same as
+    # home-resume-latest).
+    if selected_item is not None and content_item_kind(selected_item.item_id):
+        controls.append(
+            HomeControl(
+                HOME_OPEN_ITEM_CONTROL_ID,
+                "Open",
+                selected_item.detail_route,
+                "open_content",
+                selected_item.item_id,
+            )
+        )
+```
+
+(Place it before the approval controls so it does not disturb the existing control order assertions — verify against existing `control_ids` tests; if ordering assertions break, append at the end of the function instead.)
+
+`build_home_triage_state` — two edits:
+
+```python
+    recent_rows = tuple(
+        _item_row(item, "recent", reference_now)
+        for item in combined_recent_work_items(state)
+    )
+```
+
+and the selected-row item lookup (line 1244-1248) must also see content items:
+
+```python
+            item = next(
+                i
+                for i in tuple(state.active_work_items)
+                + combined_recent_work_items(state)
+                if i.item_id == selected.row_id
+            )
+```
+
+Update the Recent section's empty copy (line 1208) to `"Conversations, notes, media, runs, chatbooks, and imports will appear here."`
+
+- [ ] **Step 5: Run the pure-state tests to verify they pass**
+
+Run: `pytest Tests/Home/test_dashboard_state.py -v`
+Expected: PASS (new + existing; existing `summarize`/control tests unaffected — `content_recent_items` defaults to `()`).
+
+- [ ] **Step 6: Write the failing screen-level tests**
+
+Extend `Tests/UI/test_home_screen.py` (it already pilots Home and asserts nav contexts — follow its `_build_test_app` + `_home_dashboard_test_input` pattern):
+
+```python
+def test_open_content_item_routes_by_prefix(app_with_home):
+    home = app_with_home  # mounted HomeScreen from the file's existing helper
+    sent = []
+    home.post_message = lambda message: sent.append(message)
+
+    home._open_content_item("local:conversation:42")
+    home._open_content_item("local:note:7")
+    home._open_content_item("local:media:9")
+
+    assert sent[0].screen_context == {CONSOLE_NAV_CONTEXT_CONVERSATION_ID: "42"}
+    assert sent[1].screen_context == {LIBRARY_NAV_CONTEXT_NOTE_ID: "7"}
+    assert sent[2].screen_context == {
+        LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE: "media",
+        LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID: "9",
+    }
+    assert sent[0].screen_name == TAB_CHAT
+```
+
+(Adapt attribute names — `screen_name`/`screen_context` — to `NavigateToScreen`'s actual fields at `UI/Navigation/main_navigation.py:81`; the file's existing tests already assert on them.)
+
+- [ ] **Step 7: Run to verify failure**
+
+Run: `pytest Tests/UI/test_home_screen.py -v -k open_content_item`
+Expected: FAIL — `AttributeError: '_activate...' object has no attribute '_open_content_item'`.
+
+- [ ] **Step 8: Implement the snapshot builders + dispatch in `home_screen.py`**
+
+Replace `_home_resume_fields` (lines 201-230) and extend `_build_home_content_snapshot` (367-422). New module-level code (keep `_HOME_RESUME_TITLE_MAX_CHARS`):
+
+```python
+_HOME_CONTENT_FETCH_LIMIT = 8
+
+
+def _home_content_records(
+    notes_result: Any,
+    conversations_result: Any,
+    media_result: Any,
+) -> list[tuple[str, Mapping[str, Any]]]:
+    """Merge the three content seams into (kind, raw record) newest-first."""
+    merged: list[tuple[str, Mapping[str, Any]]] = []
+    for kind, result, records_key in (
+        ("conversation", conversations_result, "items"),
+        ("note", notes_result, None),
+        ("media", media_result, "items"),
+    ):
+        records = _home_records_from_result(result, records_key)
+        for record in records:
+            if isinstance(record, Mapping) and record.get("id") not in (None, ""):
+                merged.append((kind, record))
+    merged.sort(
+        key=lambda pair: _home_record_timestamp(pair[1]), reverse=True
+    )
+    return merged
+
+
+def _home_records_from_result(
+    result: Any, records_key: str | None
+) -> list[Any]:
+    """Extract the record list from a seam response (list or dict)."""
+    if isinstance(result, Mapping):
+        records = result.get(records_key) if records_key else result.get("items")
+        # list_notes-style seams may return a bare list under "items"; the
+        # local notes seam returns the list directly.
+        if records is None and records_key is None:
+            records = result.get("notes")
+        return list(records or [])
+    if isinstance(result, list):
+        return result
+    return []
+
+
+def _home_content_resume_fields(
+    merged: list[tuple[str, Mapping[str, Any]]],
+) -> tuple[str, str, str, str]:
+    """(resume_kind, resume_id, raw truncated title, updated_at) of the top."""
+    if not merged:
+        return "", "", "", ""
+    kind, record = merged[0]
+    title = " ".join(str(record.get("title") or "").split())
+    if len(title) > _HOME_RESUME_TITLE_MAX_CHARS:
+        title = title[: _HOME_RESUME_TITLE_MAX_CHARS - 1].rstrip() + "…"
+    return (
+        kind,
+        str(record.get("id")),
+        title,
+        _home_record_timestamp(record).isoformat(),
+    )
+
+
+_HOME_CONTENT_SOURCE_LABELS = {
+    "conversation": ("Conversations", "chat"),
+    "note": ("Notes", "library"),
+    "media": ("Media", "library"),
+}
+_HOME_CONTENT_ID_PREFIXES = {
+    "conversation": LOCAL_CONVERSATION_ITEM_ID_PREFIX,
+    "note": LOCAL_NOTE_ITEM_ID_PREFIX,
+    "media": LOCAL_MEDIA_ITEM_ID_PREFIX,
+}
+
+
+def _home_content_recent_items(
+    merged: list[tuple[str, Mapping[str, Any]]],
+    *,
+    exclude_id: str,
+) -> tuple[HomeActiveWorkItem, ...]:
+    """Build rail-ready content items, excluding the banner item.
+
+    Titles are markup-escaped HERE (Button labels parse Rich markup); the
+    banner's raw title is handled separately by _home_content_resume_fields.
+    """
+    items: list[HomeActiveWorkItem] = []
+    for kind, record in merged:
+        item_id = f"{_HOME_CONTENT_ID_PREFIXES[kind]}{record.get('id')}"
+        if item_id == exclude_id:
+            continue
+        source, route = _HOME_CONTENT_SOURCE_LABELS[kind]
+        raw_title = " ".join(str(record.get("title") or "").split())
+        title = escape_markup(raw_title) or escape_markup(
+            f"{kind.title()} {record.get('id')}"
+        )
+        items.append(
+            HomeActiveWorkItem(
+                item_id=item_id,
+                title=title,
+                source=source,
+                status="ready",
+                detail_route=route,
+                console_available=(kind == "conversation"),
+                updated_at=_home_record_timestamp(record).isoformat(),
+            )
+        )
+    return tuple(items)
+```
+
+Delete `_home_resume_fields` (its two call sites go away). In `_build_home_content_snapshot`, change the three seam calls from `limit=1`/`results_per_page=1` to the fetch limit and build the new fields:
+
+```python
+        notes_result = await self._home_content_seam_call(
+            getattr(notes_service, "list_notes", None),
+            scope="local_note",
+            limit=_HOME_CONTENT_FETCH_LIMIT,
+            user_id=notes_user_id,
+        )
+        conversations_result = await self._home_content_seam_call(
+            getattr(conversation_service, "list_conversations", None),
+            mode="local",
+            scope_type="all",
+            limit=_HOME_CONTENT_FETCH_LIMIT,
+            offset=0,
+        )
+        media_result = await self._home_content_seam_call(
+            getattr(media_service, "list_media_items", None),
+            mode="local",
+            page=1,
+            results_per_page=_HOME_CONTENT_FETCH_LIMIT,
+            include_keywords=False,
+        )
+
+        merged = _home_content_records(
+            notes_result, conversations_result, media_result
+        )
+        resume_kind, resume_id, resume_title, resume_updated_at = (
+            _home_content_resume_fields(merged)
+        )
+        return HomeContentSnapshot(
+            console_ready=console_ready,
+            conversation_count=_home_response_total(conversations_result),
+            note_count=(
+                note_count_result if isinstance(note_count_result, int) else None
+            ),
+            media_count=_home_response_total(media_result),
+            resume_kind=resume_kind,
+            resume_id=resume_id,
+            resume_title=resume_title,
+            resume_updated_at=resume_updated_at,
+            content_recent_items=_home_content_recent_items(
+                merged,
+                exclude_id=(
+                    f"{_HOME_CONTENT_ID_PREFIXES[resume_kind]}{resume_id}"
+                    if resume_kind and resume_id
+                    else ""
+                ),
+            ),
+        )
+```
+
+Extend imports in `home_screen.py`: `LOCAL_CONVERSATION_ITEM_ID_PREFIX, LOCAL_MEDIA_ITEM_ID_PREFIX, LOCAL_NOTE_ITEM_ID_PREFIX` from `Home.dashboard_state`, `escape` from `rich.markup`, `CONSOLE_NAV_CONTEXT_CONVERSATION_ID, TAB_CHAT` from `Constants` (merge into existing imports).
+
+Dispatch — replace `_activate_home_resume_latest` (lines 806-832) and add the two new methods; also intercept the Open control in `_activate_home_control` (after the `HOME_RESUME_LATEST_CONTROL_ID` intercept, line 761):
+
+```python
+        if button_id == HOME_OPEN_ITEM_CONTROL_ID:
+            self._activate_home_open_item()
+            return
+```
+
+```python
+    def _activate_home_resume_latest(self) -> None:
+        """Route the resume-latest control to its one-click destination."""
+        control = next(
+            (
+                item
+                for item in self._current_canvas_controls
+                if item.control_id == HOME_RESUME_LATEST_CONTROL_ID
+            ),
+            None,
+        )
+        if control is None or not control.target_id:
+            return
+        self._open_content_item(control.target_id)
+
+    def _activate_home_open_item(self) -> None:
+        """Route the selected content row's Open control."""
+        control = next(
+            (
+                item
+                for item in self._current_canvas_controls
+                if item.control_id == HOME_OPEN_ITEM_CONTROL_ID
+            ),
+            None,
+        )
+        if control is None or not control.target_id:
+            return
+        self._open_content_item(control.target_id)
+
+    def _open_content_item(self, target_id: str) -> None:
+        """Deep-link a prefixed content item id to its surface."""
+        kind = content_item_kind(target_id)
+        if kind == HOME_RESUME_KIND_CONVERSATION:
+            self.post_message(
+                NavigateToScreen(
+                    TAB_CHAT,
+                    {
+                        CONSOLE_NAV_CONTEXT_CONVERSATION_ID: (
+                            target_id.removeprefix(
+                                LOCAL_CONVERSATION_ITEM_ID_PREFIX
+                            )
+                        )
+                    },
+                )
+            )
+        elif kind == HOME_RESUME_KIND_NOTE:
+            self.post_message(
+                NavigateToScreen(
+                    TAB_LIBRARY,
+                    {
+                        LIBRARY_NAV_CONTEXT_NOTE_ID: target_id.removeprefix(
+                            LOCAL_NOTE_ITEM_ID_PREFIX
+                        )
+                    },
+                )
+            )
+        elif kind == HOME_RESUME_KIND_MEDIA:
+            self.post_message(
+                NavigateToScreen(
+                    TAB_LIBRARY,
+                    {
+                        LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE: "media",
+                        LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID: (
+                            target_id.removeprefix(LOCAL_MEDIA_ITEM_ID_PREFIX)
+                        ),
+                    },
+                )
+            )
+```
+
+Update the `dashboard_state` import in `home_screen.py` to add `HOME_OPEN_ITEM_CONTROL_ID, HOME_RESUME_KIND_CONVERSATION, HOME_RESUME_KIND_MEDIA, HOME_RESUME_KIND_NOTE, content_item_kind` (drop the now-unused `_home_resume_fields` import if it was imported; it was module-local, so likely nothing to remove). Also update the docstring of `_activate_home_resume_latest` — conversations now carry the id.
+
+- [ ] **Step 9: Run screen tests**
+
+Run: `pytest Tests/UI/test_home_screen.py Tests/Home/ -v`
+Expected: PASS. If an existing test asserted `"Runs, chatbooks, imports, and schedules will appear here."` or the old resume-label format, update it to the new copy.
+
+- [ ] **Step 10: Manual verification (live)**
+
+Run the app (`python3 -m tldw_chatbook.app`), navigate Home: Recent shows conversations/notes/media rows; selecting a conversation row shows Open; Open lands that conversation in Console (live session switch if open); the idle banner shows the newest content item with age; a media banner resumes into the Library item view.
+
+- [ ] **Step 11: Commit + close the backlog task**
+
+```bash
+git add tldw_chatbook/Home/dashboard_state.py tldw_chatbook/UI/Screens/home_screen.py Tests/Home/test_dashboard_state.py Tests/UI/test_home_screen.py
+git commit -m "feat(home): content recents stream, media resume banner, row open deep-links"
+backlog task edit <id> -s Done --notes "Content recents via HomeContentSnapshot pipeline; merged in pure dashboard_state; banner promoted incl. media kind; limit-1 resume queries retired; row Open control dispatches by prefix."
+```
+
+---
+
+### Task 3: Ladder feeds (eval runs, read-it-later) + terminal resume suggestion
+
+**Files:**
+- Modify: `tldw_chatbook/Home/dashboard_state.py` (`HomeDashboardInput`, `choose_next_best_action` 314-403)
+- Modify: `tldw_chatbook/Home/active_work_adapter.py` (`__init__` 217-245, `build_dashboard_input` 297+)
+- Modify: `tldw_chatbook/app.py` (adapter wiring ~6912, new provider methods near `_local_flashcards_due_count`)
+- Modify: `tldw_chatbook/UI/Screens/home_screen.py` (`_home_primary_action_context` 97-113, call site 747)
+- Test: `Tests/Home/test_dashboard_state.py`, `Tests/Home/test_active_work_adapter.py`
+
+**Interfaces:**
+- Consumes (Task 1): `CONSOLE_NAV_CONTEXT_CONVERSATION_ID`.
+- Produces: `HomeDashboardInput.pending_eval_run_count: int`, `.failed_eval_run_count: int`, `.read_later_count: int | None`; adapter `__init__` kwargs `eval_open_runs_provider: Callable[[], Mapping[str, int]] | None`, `read_later_count_provider: Callable[[], int | None] | None`, method `refresh_open_tasks_snapshot() -> None`; app methods `TldwCli._local_eval_open_run_counts() -> dict[str, int]`, `TldwCli._local_read_later_count() -> int | None`; new action ids `review_eval_runs`, `review_read_later`, `resume_last_conversation`.
+
+- [ ] **Step 1: Create the backlog task**
+
+```bash
+backlog task create "Home ladder open-task feeds + terminal resume suggestion" -d "Feed pending/failed eval runs and read-it-later count into the next-best-action ladder; terminal start-console becomes Resume last conversation when one exists (spec 2026-08-29 §4)" --ac "Ladder suggests reviewing eval runs when pending/failed runs exist,Ladder suggests read-it-later when queue non-empty,Terminal suggestion deep-links the newest conversation via nav context,running eval runs never counted,Default adapter and missing services degrade to no suggestion" -s "In Progress"
+```
+
+- [ ] **Step 2: Write the failing ladder tests**
+
+Append to `Tests/Home/test_dashboard_state.py`:
+
+```python
+def test_ladder_suggests_eval_runs_over_import_sources():
+    action = choose_next_best_action(
+        HomeDashboardInput(
+            model_ready=True,
+            has_library_content=True,
+            rag_ready=True,
+            console_ready=True,
+            pending_eval_run_count=2,
+        )
+    )
+    assert action.action_id == "review_eval_runs"
+    assert action.target_route == TAB_EVALS
+
+
+def test_ladder_never_counts_running_eval_runs():
+    action = choose_next_best_action(
+        HomeDashboardInput(
+            model_ready=True, has_library_content=True, rag_ready=True,
+            console_ready=True, pending_eval_run_count=0, failed_eval_run_count=0,
+        )
+    )
+    assert action.action_id != "review_eval_runs"
+
+
+def test_ladder_suggests_read_later():
+    action = choose_next_best_action(
+        HomeDashboardInput(
+            model_ready=True, has_library_content=True, rag_ready=True,
+            console_ready=True, read_later_count=3,
+        )
+    )
+    assert action.action_id == "review_read_later"
+    assert action.target_route == TAB_MEDIA
+
+
+def test_ladder_terminal_suggestion_resumes_last_conversation():
+    action = choose_next_best_action(
+        HomeDashboardInput(
+            model_ready=True, has_library_content=True, rag_ready=True,
+            console_ready=True,
+            resume_kind=HOME_RESUME_KIND_CONVERSATION,
+            resume_id="42",
+        )
+    )
+    assert action.action_id == "resume_last_conversation"
+    assert action.target_route == TAB_CHAT
+
+
+def test_ladder_terminal_falls_back_to_start_conversation_without_recents():
+    action = choose_next_best_action(
+        HomeDashboardInput(
+            model_ready=True, has_library_content=True, rag_ready=True,
+            console_ready=True,
+        )
+    )
+    assert action.action_id == "start_console"
+```
+
+Add `choose_next_best_action` and `TAB_*` constants to the test imports (`from tldw_chatbook.Constants import TAB_EVALS, TAB_MEDIA, TAB_CHAT`).
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `pytest Tests/Home/test_dashboard_state.py -v -k "ladder"`
+Expected: FAIL — `HomeDashboardInput` has no such fields / branches return `search_library`.
+
+- [ ] **Step 4: Implement the ladder in `dashboard_state.py`**
+
+Extend the Constants import (line 13-18) with `TAB_CHAT, TAB_EVALS, TAB_MEDIA`. Add fields to `HomeDashboardInput` after `flashcards_due_count` (line 207):
+
+```python
+    # Open-task queue feeds (spec §4). Eval counts include only
+    # pending/failed -- 'running' rows are orphaned forever by a crash and
+    # would pin the suggestion. read_later None = unknown, renders nothing.
+    pending_eval_run_count: int = 0
+    failed_eval_run_count: int = 0
+    read_later_count: int | None = None
+```
+
+In `choose_next_best_action`, after the `notification_count` branch (line 376) and before `has_library_content` (line 377):
+
+```python
+    if state.pending_eval_run_count or state.failed_eval_run_count:
+        return HomeAction(
+            "review_eval_runs",
+            "Review eval runs",
+            TAB_EVALS,
+            "Pending or failed eval runs need attention.",
+        )
+    if state.read_later_count:
+        return HomeAction(
+            "review_read_later",
+            f"Read-it-later: {state.read_later_count} items",
+            TAB_MEDIA,
+            "Your saved reading queue is waiting.",
+        )
+```
+
+Replace the terminal `console_ready` branch (lines 391-400):
+
+```python
+    if state.console_ready:
+        if (
+            state.resume_kind == HOME_RESUME_KIND_CONVERSATION
+            and state.resume_id
+        ):
+            return HomeAction(
+                "resume_last_conversation",
+                "Resume last conversation",
+                TAB_CHAT,
+                "Pick up where you left off.",
+            )
+        return HomeAction(
+            "start_console",
+            "Start a conversation",
+            TAB_CHAT,
+            "Console is ready for a task.",
+        )
+```
+
+- [ ] **Step 5: Run ladder tests**
+
+Run: `pytest Tests/Home/test_dashboard_state.py -v`
+Expected: PASS (if an existing test pinned the old terminal branch ordering, update its expectation to the new contract — the spec explicitly changes it).
+
+- [ ] **Step 6: Write the failing adapter + wiring tests**
+
+Append to `Tests/Home/test_active_work_adapter.py`:
+
+```python
+def test_open_tasks_providers_feed_dashboard_input():
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        eval_open_runs_provider=lambda: {"pending": 1, "failed": 2},
+        read_later_count_provider=lambda: 5,
+    )
+    adapter.refresh_open_tasks_snapshot()
+    state = adapter.build_dashboard_input(
+        providers_models={}, has_recent_work=False
+    )
+    assert state.pending_eval_run_count == 1
+    assert state.failed_eval_run_count == 2
+    assert state.read_later_count == 5
+
+
+def test_open_tasks_providers_degrade_quietly():
+    def boom():
+        raise RuntimeError("db unavailable")
+
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        eval_open_runs_provider=boom,
+        read_later_count_provider=boom,
+    )
+    adapter.refresh_open_tasks_snapshot()
+    state = adapter.build_dashboard_input(
+        providers_models={}, has_recent_work=False
+    )
+    assert state.pending_eval_run_count == 0
+    assert state.failed_eval_run_count == 0
+    assert state.read_later_count is None
+
+
+def test_open_tasks_absent_providers_default_off():
+    adapter = LocalNotificationHomeActiveWorkAdapter()
+    adapter.refresh_open_tasks_snapshot()
+    state = adapter.build_dashboard_input(
+        providers_models={}, has_recent_work=False
+    )
+    assert state.pending_eval_run_count == 0
+    assert state.read_later_count is None
+```
+
+- [ ] **Step 7: Run to verify failure**
+
+Run: `pytest Tests/Home/test_active_work_adapter.py -v -k open_tasks`
+Expected: FAIL — unexpected keyword `eval_open_runs_provider`.
+
+- [ ] **Step 8: Implement adapter + app wiring**
+
+`active_work_adapter.py` — extend `__init__` (lines 217-245) with kwargs `eval_open_runs_provider: Callable[[], Mapping[str, int]] | None = None` and `read_later_count_provider: Callable[[], int | None] | None = None`, store them plus two cache attrs:
+
+```python
+        self.eval_open_runs_provider = eval_open_runs_provider
+        self.read_later_count_provider = read_later_count_provider
+        self._eval_open_counts: Mapping[str, int] = {"pending": 0, "failed": 0}
+        self._read_later_count: int | None = None
+```
+
+Add the refresh method (mirror `refresh_flashcards_due_snapshot`'s degrade pattern):
+
+```python
+    def refresh_open_tasks_snapshot(self) -> None:
+        """Refresh cached open-task counts off the Home compose path."""
+        if callable(self.eval_open_runs_provider):
+            try:
+                counts = self.eval_open_runs_provider() or {}
+                self._eval_open_counts = {
+                    "pending": max(0, int(counts.get("pending", 0) or 0)),
+                    "failed": max(0, int(counts.get("failed", 0) or 0)),
+                }
+            except Exception as e:
+                logger.debug(f"Failed to fetch eval run counts for Home: {e}")
+                self._eval_open_counts = {"pending": 0, "failed": 0}
+        if callable(self.read_later_count_provider):
+            try:
+                count = self.read_later_count_provider()
+                self._read_later_count = (
+                    max(0, int(count)) if count is not None else None
+                )
+            except Exception as e:
+                logger.debug(f"Failed to fetch read-it-later count for Home: {e}")
+                self._read_later_count = None
+```
+
+In `LocalNotificationHomeActiveWorkAdapter.build_dashboard_input` (line 297), where the input is assembled, add:
+
+```python
+            pending_eval_run_count=self._eval_open_counts.get("pending", 0),
+            failed_eval_run_count=self._eval_open_counts.get("failed", 0),
+            read_later_count=self._read_later_count,
+```
+
+(The base `UnavailableHomeActiveWorkAdapter.build_dashboard_input` keeps dataclass defaults — no change.)
+
+In `home_screen.py` `_refresh_home_chatbook_artifact_snapshot` (the thread worker, lines 279-303), after the flashcards block:
+
+```python
+        refresh_open_tasks = getattr(adapter, "refresh_open_tasks_snapshot", None)
+        if callable(refresh_open_tasks):
+            refresh_open_tasks()
+```
+
+In `app.py` — extend the adapter construction (~6912-6924):
+
+```python
+            eval_open_runs_provider=lambda: self._local_eval_open_run_counts(),
+            read_later_count_provider=lambda: self._local_read_later_count(),
+```
+
+and add the two providers next to `_local_flashcards_due_count` (find it via `grep -n "_local_flashcards_due_count" tldw_chatbook/app.py`):
+
+```python
+    def _local_eval_open_run_counts(self) -> dict[str, int]:
+        """Count pending/failed local eval runs for Home (spec §4).
+
+        Never counts 'running' -- a crashed app orphans running rows
+        forever, which would permanently pin the review suggestion.
+        """
+        service = getattr(self, "local_evaluation_service", None)
+        if service is None:
+            return {"pending": 0, "failed": 0}
+        try:
+            pending = len(service.list_runs(status="pending", limit=50))
+            failed = len(service.list_runs(status="failed", limit=50))
+        except Exception as e:
+            logger.debug(f"Failed to fetch eval run counts for Home: {e}")
+            return {"pending": 0, "failed": 0}
+        return {"pending": pending, "failed": failed}
+
+    def _local_read_later_count(self) -> int | None:
+        db = getattr(self, "media_db", None)
+        if db is None:
+            return None
+        try:
+            return len(db.list_read_it_later_media_ids())
+        except Exception as e:
+            logger.debug(f"Failed to fetch read-it-later count for Home: {e}")
+            return None
+```
+
+- [ ] **Step 9: Wire the terminal suggestion's deep-link context**
+
+In `home_screen.py`, change the signature and add the branch:
+
+```python
+def _home_primary_action_context(
+    action: object, dashboard_input: HomeDashboardInput | None = None
+) -> dict[str, object]:
+    action_id = getattr(action, "action_id", None)
+    if action_id == "resume_last_conversation":
+        resume_id = str(getattr(dashboard_input, "resume_id", "") or "")
+        if resume_id:
+            return {CONSOLE_NAV_CONTEXT_CONVERSATION_ID: resume_id}
+    ...  # existing branches unchanged
+```
+
+Update the single call site (`_activate_home_primary_action`, line 747):
+
+```python
+            screen_context=_home_primary_action_context(
+                dashboard.next_action, self._current_dashboard_input
+            ),
+```
+
+`CONSOLE_NAV_CONTEXT_CONVERSATION_ID` joins the Constants import in `home_screen.py` (from Task 2).
+
+- [ ] **Step 10: Run adapter + screen tests**
+
+Run: `pytest Tests/Home/test_active_work_adapter.py Tests/UI/test_home_screen.py -v`
+Expected: PASS.
+
+- [ ] **Step 11: Commit + close the backlog task**
+
+```bash
+git add tldw_chatbook/Home/dashboard_state.py tldw_chatbook/Home/active_work_adapter.py tldw_chatbook/app.py tldw_chatbook/UI/Screens/home_screen.py Tests/Home/
+git commit -m "feat(home): eval/read-it-later ladder feeds and resume-last-conversation terminal suggestion"
+backlog task edit <id> -s Done --notes "Ladder gains review_eval_runs + review_read_later branches (pending/failed only); terminal suggestion deep-links newest conversation via Console nav context; providers degrade quietly."
+```
+
+---
+
+### Task 4: Docs, follow-up tasks, and wrap-up
+
+**Files:**
+- Modify: `Docs/User_Guide/home.md`
+- Create: two follow-up backlog tasks (To Do)
+
+**Interfaces:** none (documentation + hygiene).
+
+- [ ] **Step 1: Create the backlog task**
+
+```bash
+backlog task create "Home recents/resume docs + follow-ups" -d "Update the Home User Guide for content recents, media resume, new suggestions; file follow-up tasks for failed_schedule_count producer and phase-2 opens journal (spec 2026-08-29 wrap-up)" --ac "User Guide reflects new Recent mix, banner kinds, and suggestions,Follow-up tasks filed for failed_schedule_count and opens journal,All feature tasks Done with notes" -s "In Progress"
+```
+
+- [ ] **Step 2: Update `Docs/User_Guide/home.md`**
+
+Update the sections describing the Recent rail (now conversations/notes/media + runs/chatbooks/imports, newest-first, capped at 8), the idle banner (resume conversation/note/reading with age; conversations open at that conversation in Console), and Next (new eval-runs and read-it-later suggestions; terminal "Resume last conversation"). Keep the documented "snapshot with buttons" quirk as-is (task-2763 still open). Verify against the rendered guide conventions in that file.
+
+- [ ] **Step 3: File follow-up tasks**
+
+```bash
+backlog task create "Produce failed_schedule_count for Home" -d "HomeDashboardInput.failed_schedule_count is a documented dead input (no producer). Needs a failed-schedules query in Scheduling/db/scheduled_tasks_db.py first -- skipped per spec 2026-08-29 decision rule" --ac "failed_schedule_count populated from real schedule state,Ladder recover_schedules branch reachable"
+backlog task create "Home opens journal (phase 2 recents)" -d "Persistent opens journal (IDs+timestamps, model_catalog_cache pattern) so read-only sessions count as recent work; feeds recents ranking and task-18921 usage-ranked suggestions (spec 2026-08-29 Non-goals)" --ac "Opening an item bumps its recency without edits,Journal storage contract documented,Usage-ranked suggestion feasibility assessed"
+```
+
+- [ ] **Step 4: Lessons check**
+
+Review `backlog/docs/lessons-*.md` against what actually happened. Only add an entry if a generalizable trap surfaced (most tasks produce nothing — do not invent one). Candidate only if encountered: e.g. the async-scope-seams vs sync-adapter mismatch that moved content recents into the snapshot pipeline.
+
+- [ ] **Step 5: Self-review + close**
+
+Confirm every AC checkbox on all four backlog tasks is checked, Implementation Notes sections exist, ADR is linked from tasks 1-3 notes, and commit:
+
+```bash
+git add Docs/User_Guide/home.md
+git commit -m "docs(home): content recents, media resume, and next-up suggestions"
+backlog task edit <id> -s Done --notes "Guide updated; follow-ups filed for failed_schedule_count and opens journal."
+```
+
+---
+
+## Plan Self-Review (completed)
+
+- **Spec coverage:** §1 recents stream → Task 2 (deviation 1 documented); §2 banner + media kind + retirement → Task 2; §3 seam + ADR + precedence → Task 1; §4 feeds + terminal + eval-staleness rule → Task 3 (deviation 3: schedules follow-up); §5 freshness regression guard → covered by the unchanged on-mount path + existing `Tests/UI/test_home_dashboard_seams.py` (no new refresh machinery per spec); §6 edge cases → escape-once (Task 2 code), missing-record toasts (Task 1 reuses TASK-717 path), empty states (default `()` fields), off-loop reads (existing workers); testing section → all four test groups present.
+- **Placeholders:** none — every code step carries verbatim code; the two located adaptations (sibling test harness reuse in Task 1 Step 3, `NavigateToScreen` field names in Task 2 Step 6) are bounded with exact references.
+- **Type consistency:** `content_item_kind`/`combined_recent_work_items`/`HOME_OPEN_ITEM_CONTROL_ID` names and the `local:{kind}:{id}` prefix scheme are identical across Tasks 2-3; `_home_primary_action_context(action, dashboard_input)` signature change has its single call site updated in the same task; `CONSOLE_NAV_CONTEXT_CONVERSATION_ID` is produced in Task 1 and consumed in Tasks 2-3.

--- a/Docs/superpowers/specs/2026-08-29-home-recents-resume-and-next-up-design.md
+++ b/Docs/superpowers/specs/2026-08-29-home-recents-resume-and-next-up-design.md
@@ -1,0 +1,282 @@
+# Home "What you were working on last" + "What's next" — Design
+
+Date: 2026-08-29
+Status: Draft — awaiting review
+Branch context: authored on `docs/lesson-adr-number-collisions` (unrelated in-flight branch; spec file only, no commit made).
+
+## Context
+
+The Home screen already has a single-item resume affordance (task-190): an idle-canvas
+"Resume note/conversation: \<title\>" button. Two problems:
+
+1. **It is a list of one, and the conversation case doesn't resume.** The control carries
+   `target_id`, but `_activate_home_resume_latest` (`UI/Screens/home_screen.py:806-832`)
+   routes conversations to Console with the id dropped — there is no app-level
+   "open conversation N in Console" seam. The capability exists internally
+   (`UI/Console_Modules/workspace.py:2121`, `_resume_console_workspace_conversation`,
+   with defined TASK-717 failure semantics) but nothing exposes it.
+2. **Home's "Recent" section omits the user's actual content work.**
+   `_local_recent_work_items` (`Home/active_work_adapter.py:696-736`) only mirrors
+   watchlist runs, chatbook artifacts, and finished ingest jobs — not conversations,
+   notes, or media.
+
+"What's next" exists as a fixed-priority ladder (`choose_next_best_action`,
+`Home/dashboard_state.py:314-403`). It is state-driven but two documented open-task
+feeds never reach it (eval runs, read-it-later), one input is dead
+(`failed_schedule_count` is never produced — `active_work_adapter.py:168-186`), and its
+resume branch routes bare to `chat`.
+
+Freshness note, verified against the code: Home revisit-refresh already works —
+screens are never reused, and every Home mount runs
+`_refresh_home_active_work_cache` (`home_screen.py:277` → adapter
+`refresh_active_work_cache_async`). Task-2763's actual defect is the *while-mounted*
+freeze (no timer/subscription; statuses only move on click or remount). Recents
+inherit that freeze until task-2763 lands — acceptable here, since a recents list is
+far less time-sensitive than running-work statuses, and fixing live-refresh is that
+task's own scoped AC (poll/subscription + TTL + test), not this spec's. Nothing
+tracks item opens/usage (confirmed by task-18921); that stays out of scope.
+
+## Goals
+
+- A "What you were working on last:" affordance on Home listing the user's most recent
+  work across conversations, notes, and media, each resumable in one action.
+- Resume deep-links that actually land on the item: conversations in Console, notes in
+  the Library notes editor, media in the Library item view.
+- "What's next" suggestions informed by existing open-task queues (pending/failed eval
+  runs, read-it-later) in addition to the current ladder inputs.
+- Recents are current on every Home visit via the existing on-mount refresh path,
+  extended to the new providers (no new refresh machinery).
+
+## Non-goals (v1)
+
+- **Opens/reading tracking.** Recency = `last_modified` (edits, messages, reading
+  progress). Reading a note without editing it will not surface it. Phase 2: a
+  lightweight opens journal (IDs + timestamps only, `model_catalog_cache.json` pattern)
+  that slots into the same recents seam and also feeds task-18921.
+- **Pattern-learning suggestions** ("you usually follow X with Y"). Out.
+- **Eval-run resume deep-links.** The Evals screen has no `apply_navigation_context`
+  support; suggestions route to the screen only. Follow-up if wanted.
+- **Auto-restore of the last session at boot.** Screen snapshots are memory-only by
+  documented design (`UI/Screens/chat_screen_state.py:80-88`); not reversing that here.
+- **New DB schema, migrations, or config keys.**
+
+## Approaches considered
+
+### A. Unified recent-work stream + Console deep-link seam (chosen)
+
+Merge conversations/notes/media recency into the existing recents pipeline via the
+tables' existing `last_modified` columns; expose conversation-by-id Console opening as
+a navigation-context contract; feed the ladder the two missing queues; recompute on
+Home visit. No schema changes, no new persistence, no write-path instrumentation.
+
+### B. Opens journal ("working on" = touched, not just edited)
+
+Everything in A plus a persistent opens journal written whenever an item is opened.
+Truer to "working on" (captures read-only sessions), but requires write-path
+instrumentation across Console/Library/Media and a new persistent store. Deferred to
+phase 2; the v1 seam is shaped so it can slot in.
+
+### C. Last-session snapshot restore (rejected)
+
+Persist last foreground screen + item on graceful shutdown, offer "Resume last
+session". Only ever one item, breaks on crash, and conflicts with the deliberate
+memory-only screen-snapshot decision. Strictly weaker than A.
+
+## Design
+
+### 1. Recents stream (Home adapter)
+
+Extend `LocalNotificationHomeActiveWorkAdapter` with three content-item providers:
+`_local_conversation_recent_items()`, `_local_note_recent_items()`,
+`_local_media_recent_items()`. Each is a limit-N `last_modified DESC` read:
+
+- Conversations: `conversations.last_modified` (list ordering already exists at
+  `DB/ChaChaNotes_DB.py:8233`). Filter to the same visibility the Console/Library
+  conversation lists apply (soft-deleted excluded, roleplay conversations included —
+  they are rows in the same table).
+- Notes: `notes.last_modified` (ordering at `Notes/Notes_Library.py:920+`), same
+  filters as the Library notes list.
+- Media: coalesce `Media.last_modified` with `ReadingProgress.last_modified` so
+  reading progress bumps recency (join key verified during implementation).
+
+Providers map rows to `HomeActiveWorkItem` with source labels
+`Conversations` / `Notes` / `Media`, neutral status (`ready`, matching the chatbook
+recents pattern), and appropriate `detail_route`s. `_local_recent_work_items` merge-
+sorts all six sources by `updated_at` and keeps the existing cap of 8
+(`_HOME_RECENT_WORK_LIMIT`). The single newest **content** item
+(conversations/notes/media only) is reserved for the canvas banner instead of
+repeating as the first Recent row — the same dedupe shape as the existing chatbook
+rule (`_local_chatbook_artifacts()[1:]`), whose own behavior is unchanged.
+
+All DB reads go through the adapter's existing off-loop compute path
+(`asyncio.to_thread`, `active_work_adapter.py:640`). Titles are user text and are
+markup-escaped at item-build time, following the `_watchlist_run_title` /
+`build_home_resume_control` hazard pattern (escape exactly once).
+
+### 2. "What you were working on last" canvas banner
+
+The idle-canvas resume control is promoted from "newest note-or-conversation"
+(`_home_resume_fields`, `home_screen.py:201-230`) to **newest item across the three
+content providers** (conversations/notes/media — watchlist runs, chatbooks, and
+ingest jobs keep their existing active/recent routing and never feed the banner),
+which adds media as a resume kind:
+
+- conversation → Console (seam below); if a live Console session already holds the
+  conversation, switch to that session instead of rehydrating
+  (`_console_session_id_for_workspace_conversation`, `workspace.py:2100`).
+- note → Library notes editor via `LIBRARY_NAV_CONTEXT_NOTE_ID` (existing contract).
+- media → Library item view via `LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE/ID`
+  (`media`).
+
+Banner copy: `What you were working on last:` + `Resume conversation/note/reading:
+<title> · <relative time>`.
+
+Source-of-truth consolidation: today `resume_kind/id/title` come from limit-1 seam
+queries inside `_build_home_content_snapshot` (`home_screen.py:367-422`) via
+`_home_resume_fields`. With the adapter now computing the full content-recents
+stream, those limit-1 queries and `_home_resume_fields` are retired; the banner
+fields derive from the top content item on `HomeDashboardInput`, so there is exactly
+one definition of "newest work". Media as a resume kind is new plumbing: a
+`HOME_RESUME_KIND_MEDIA` constant, a `build_home_resume_control` branch, and a
+dispatch branch in `_activate_home_resume_latest`. The remaining items are the rail's Recent section below
+(newest content item not duplicated, per §1). Rail Recent rows get open controls on
+the task-153/task-2238 row pattern.
+
+### 3. Console conversation deep-link seam (ADR required)
+
+New navigation-context key `CONSOLE_NAV_CONTEXT_CONVERSATION_ID` in the
+`Constants.py` nav-context block (alongside the `LIBRARY_*` keys), consumed by a new
+`apply_navigation_context` implementation on `chat_screen.py` (Console becomes the
+sixth screen implementing the existing contract — Library, Watchlists, Personas,
+Settings, STTs precede it).
+
+Timing, pinned to the actual call site: `handle_screen_navigation` invokes
+`apply_navigation_context` on the freshly constructed screen **before**
+`switch_screen` (`app.py:8937-8948`; exceptions are logged-and-swallowed, and an
+awaitable return would be awaited — but Console must not do async work there, since
+the screen is not yet mounted or on the stack). Console's implementation is
+store-and-defer: record the conversation id synchronously, consume it in the
+existing mount-complete flow.
+
+Precedence rule: if a pending handoff (e.g. `CONSOLE_LIVE_WORK`) and a conversation
+nav context are both present at mount, the nav context wins and the handoff is
+dropped with a debug log — the nav context is the user's explicit, most-recent
+intent.
+
+Behavior, in order:
+
+1. Context present and a live session already maps to that conversation → switch
+   session (`controller.switch_session`), no rehydration.
+2. No live session → call the existing `_resume_console_workspace_conversation`
+   path (hydration via `Chat/console_conversation_hydration.py`).
+3. Missing/invalid id → no-op with the existing TASK-717 toast semantics (the resume
+   path already distinguishes transient-unavailable vs missing-record and owns the
+   UX).
+
+Callers: the Home banner + Recent rows, and the ladder's `resume_active_work`
+branch, which stops routing bare to `chat`. Alternative considered and rejected:
+the pending-handoff single-slot store (`CONSOLE_LIVE_WORK` pattern) — handoffs are
+ephemeral, single-slot, and not a durable deep-link contract; nav context is.
+
+### 4. "What's next" ladder feeds
+
+Spine unchanged (fixed-priority triage ladder). New `HomeDashboardInput` fields and
+branches:
+
+- `pending_eval_run_count` / first failed eval run (Evals DB, `eval_runs.status`) →
+  suggestion "Review pending/failed eval runs", route `evals`. Count only `pending`
+  and `failed` statuses, never `running` — a crashed app orphans `running` rows
+  forever, which would permanently pin this suggestion.
+- `read_later_count` (`MediaReadItLaterState`) → suggestion "N items in read-it-later",
+  route to the read-it-later view.
+- Produce `failed_schedule_count` from the schedules service, closing a documented
+  dead input — decision rule: include if it is a single query against existing
+  schedule state; if it needs new aggregation machinery, skip it here and file a
+  follow-up task instead.
+
+New branches slot low — below notifications, above `import_sources` — exact placement
+tuned during implementation against the existing branch table.
+
+Scope correction from review: the existing `resume_active_work` branch is left
+untouched — it fires only when live work *is* running (`_active_run_count`) and its
+bare `chat` route is already correct; deep-linking it to a specific conversation
+would change its meaning. The prior-work-informed part of v1 is the banner/Recent-row
+deep links (§2), plus one ladder change (decision flagged, default on): when the
+ladder falls through to the terminal `start_console` suggestion and a recent
+conversation exists, the terminal suggestion becomes "Resume last conversation:
+\<title\>" via the Console seam, falling back to "Start a conversation" on fresh
+profiles. This is the direct answer to "suggestions based on prior work" and reuses
+the seam. Nothing pattern-learning.
+
+### 5. Freshness
+
+No new refresh machinery. Revisit freshness already exists — screens are never
+reused and every Home mount runs `_refresh_home_active_work_cache`
+(`home_screen.py:277`); the new providers execute inside that same adapter compute,
+so recents are current on every visit by construction. The while-mounted freeze is
+task-2763's own scoped AC (poll or subscription, TTL-respecting, with a driving
+test) and is deliberately not pulled in here; until it lands, Home keeps its
+documented "snapshot with buttons" quirk, tolerable for a recents list. One
+regression guard is required: a test asserting the on-mount refresh path runs (and
+therefore includes the content providers).
+
+### 6. Error handling and edge cases
+
+- Row deleted since snapshot: dispatch validates existence before navigating;
+  missing conversation follows TASK-717 `False` semantics (toast, caller-owned).
+- Empty state: no recents → Recent section stays hidden (existing empty-section
+  behavior); banner hidden, ladder falls through to existing branches.
+- First run: unchanged — `import_sources` branch wins.
+- Titles: raw at data layer, escaped exactly once at control/row build.
+- All new DB reads off the event loop via the adapter's existing to-thread compute.
+
+## Testing
+
+- **Unit — dashboard_state:** merged recents ordering/cap/dedupe (newest content item
+  feeds banner, not Recent), markup escaping, banner target selection per kind,
+  ladder with the new fields (eval/read-later branches, placement, exclusions).
+- **Unit — chat_screen nav context:** conversation id → live-session switch vs
+  hydrate vs missing-id no-op.
+- **Integration — adapter:** in-memory SQLite seeded with conversations/notes/media
+  (incl. soft-deleted), eval runs, read-it-later rows; asserts recents content and
+  counts.
+- **Unit — Home mount:** on-mount refresh triggers the adapter refresh (the §5
+  regression guard).
+- Targeted runs only per repo testing guidelines (`lessons-testing-evidence.md`); no
+  full sweep unless requested.
+
+## ADR check
+
+```text
+ADR required: yes
+ADR path: backlog/decisions/NNN-console-conversation-deep-link-nav-context.md
+Reason: cross-module interface contract (Home/ladder → Console via nav context,
+        making Console the 6th apply_navigation_context screen).
+```
+
+Number assigned at implementation time (repo is mid ADR renumbering — see current
+branch). Created before implementation begins; linked from the backlog tasks.
+
+## Implementation sequencing (proposed tasks, created after approval)
+
+1. **Console deep-link seam** — ADR + `CONSOLE_NAV_CONTEXT_CONVERSATION_ID` +
+   `chat_screen.apply_navigation_context`. Foundational; nothing resumes
+   conversations without it.
+2. **Recents stream + banner** — adapter providers, merged Recent section, banner
+   promotion (media resume kind), retirement of the limit-1 resume seam queries,
+   row open-controls. Depends on 1 for conversations.
+3. **Ladder feeds** — eval/read-later inputs and branches, `failed_schedule_count`
+   producer, terminal resume-last-conversation suggestion. Depends on 1 only for
+   the terminal suggestion; otherwise independent of 2.
+
+## Open questions (resolve during implementation, none blocking design)
+
+- Media recency join: confirm `ReadingProgress` keyed by media id and cheap to
+  coalesce; if the join is heavy, v1 uses `Media.last_modified` alone.
+- Whether the rail "Recent" section header relabels to "Recent work" (cosmetic).
+- Relative-time formatting helper: reuse an existing formatter if one exists in the
+  codebase rather than adding a new one.
+- Route id for the read-it-later suggestion target — verify the Media/read-it-later
+  view's registered route before wiring the `HomeAction`.
+- `console_available` flags on content recents rows (conversations true, notes/media
+  false) — pinned during task 2.

--- a/Tests/DB/test_client_media_pagination.py
+++ b/Tests/DB/test_client_media_pagination.py
@@ -309,3 +309,39 @@ def test_distinct_types_exclude_whitespace_only_and_preserve_nonblank_verbatim(
         assert media_id is not None
 
     assert database.get_distinct_media_types() == [" pdf "]
+
+
+def test_count_read_it_later_matches_list_and_filters():
+    """The scalar COUNT seam must agree with the list seam and honor the
+    same deleted/trash filters (Home's read-it-later suggestion)."""
+    db = MediaDatabase(":memory:", client_id="uat-count")
+    try:
+        for media_id, title in ((1, "live"), (2, "deleted"), (3, "trash")):
+            db.execute_query(
+                "INSERT INTO Media "
+                "(id,title,type,content_hash,uuid,client_id,last_modified,version) "
+                "VALUES (?,?,?,?,?,?,?,1)",
+                (media_id, title, "article", f"h{media_id}", f"u{media_id}", "c", "2026-01-01"),
+            )
+        db.execute_query(
+            "UPDATE Media SET deleted = 1, version = version + 1 WHERE id = 2", ()
+        )
+        db.execute_query(
+            "UPDATE Media SET is_trash = 1, version = version + 1 WHERE id = 3", ()
+        )
+        for media_id in (1, 2, 3):
+            db.execute_query(
+                "INSERT INTO MediaReadItLaterState "
+                "(media_id,is_read_it_later,saved_at,updated_at) "
+                "VALUES (?,1,'2026-01-02','2026-01-02')",
+                (media_id,),
+            )
+        assert db.count_read_it_later_media() == 1
+        assert db.count_read_it_later_media() == len(
+            db.list_read_it_later_media_ids()
+        )
+        assert db.count_read_it_later_media(
+            include_deleted=True, include_trash=True
+        ) == 3
+    finally:
+        db.close()

--- a/Tests/Home/test_active_work_adapter.py
+++ b/Tests/Home/test_active_work_adapter.py
@@ -1638,3 +1638,38 @@ def test_local_notification_adapter_treats_policy_refusal_quietly():
     assert not [w for w in warnings if "server event feed" in w], (
         f"policy refusal logged as warning: {warnings}"
     )
+
+
+def test_open_tasks_providers_feed_dashboard_input():
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        eval_open_runs_provider=lambda: {"pending": 1, "failed": 2},
+        read_later_count_provider=lambda: 5,
+    )
+    adapter.refresh_open_tasks_snapshot()
+    state = adapter.build_dashboard_input(providers_models={}, has_recent_work=False)
+    assert state.pending_eval_run_count == 1
+    assert state.failed_eval_run_count == 2
+    assert state.read_later_count == 5
+
+
+def test_open_tasks_providers_degrade_quietly():
+    def boom():
+        raise RuntimeError("db unavailable")
+
+    adapter = LocalNotificationHomeActiveWorkAdapter(
+        eval_open_runs_provider=boom,
+        read_later_count_provider=boom,
+    )
+    adapter.refresh_open_tasks_snapshot()
+    state = adapter.build_dashboard_input(providers_models={}, has_recent_work=False)
+    assert state.pending_eval_run_count == 0
+    assert state.failed_eval_run_count == 0
+    assert state.read_later_count is None
+
+
+def test_open_tasks_absent_providers_default_off():
+    adapter = LocalNotificationHomeActiveWorkAdapter()
+    adapter.refresh_open_tasks_snapshot()
+    state = adapter.build_dashboard_input(providers_models={}, has_recent_work=False)
+    assert state.pending_eval_run_count == 0
+    assert state.read_later_count is None

--- a/Tests/Home/test_dashboard_state.py
+++ b/Tests/Home/test_dashboard_state.py
@@ -1624,3 +1624,35 @@ def test_ladder_terminal_falls_back_to_start_conversation_without_recents():
         )
     )
     assert action.action_id == "start_console"
+
+
+def test_content_snapshot_marks_has_recent_work():
+    """Qodo #11: content recents (or a banner-only newest item) must flip
+    has_recent_work, keeping the summary consistent with the rail."""
+    state = HomeDashboardInput()
+    snapshot = HomeContentSnapshot(
+        conversation_count=2,
+        resume_kind="conversation",
+        resume_id="conv-1",
+        resume_title="Only item",
+    )
+    applied = apply_home_content_snapshot(state, snapshot)
+    assert applied.has_recent_work is True
+
+    rows_only = HomeContentSnapshot(
+        note_count=1,
+        content_recent_items=(
+            HomeActiveWorkItem(
+                item_id="local:note:7",
+                title="t",
+                source="Notes",
+                status="ready",
+                updated_at="2026-08-29T10:00:00+00:00",
+            ),
+        ),
+    )
+    applied2 = apply_home_content_snapshot(HomeDashboardInput(), rows_only)
+    assert applied2.has_recent_work is True
+
+    empty = apply_home_content_snapshot(HomeDashboardInput(), HomeContentSnapshot())
+    assert empty.has_recent_work is False

--- a/Tests/Home/test_dashboard_state.py
+++ b/Tests/Home/test_dashboard_state.py
@@ -1,7 +1,9 @@
+from tldw_chatbook.Constants import TAB_CHAT, TAB_EVALS, TAB_MEDIA
 from tldw_chatbook.Home.dashboard_state import (
     HOME_FLASHCARDS_DUE_ROW_ID,
     HOME_OPEN_ITEM_CONTROL_ID,
     HOME_RECENT_WORK_LIMIT,
+    HOME_RESUME_KIND_CONVERSATION,
     HOME_RESUME_KIND_MEDIA,
     HOME_RESUME_LATEST_CONTROL_ID,
     HOME_START_CONVERSATION_CONTROL_ID,
@@ -1415,13 +1417,13 @@ def test_triage_idle_canvas_ready_with_content_start_primary_and_counts_line():
     triage = build_home_triage_state(state)
 
     canvas = triage.canvas
-    assert canvas.title == "Start a conversation"
+    # With a recent conversation the terminal suggestion IS the resume
+    # (spec §4); the start-conversation control appears beside it.
+    assert canvas.title == "Resume last conversation"
     assert "Conversations: 5 · Notes: 3" in canvas.lines
     control_ids = [control.control_id for control in canvas.actions]
     assert HOME_RESUME_LATEST_CONTROL_ID in control_ids
-    # The next-action button IS the start control here -- no duplicate
-    # home-start-conversation button beside it.
-    assert HOME_START_CONVERSATION_CONTROL_ID not in control_ids
+    assert HOME_START_CONVERSATION_CONTROL_ID in control_ids
     assert canvas.primary_control_id == "home-primary-action"
     assert canvas.next_action_is_canvas is True
 
@@ -1555,3 +1557,70 @@ def test_resume_control_supports_media_kind_with_age():
     assert control.target_route == "library"
     assert control.target_id == "local:media:9"
     assert control.label == "Resume reading: Long read (30m)"
+
+
+def test_ladder_suggests_eval_runs_over_import_sources():
+    action = choose_next_best_action(
+        HomeDashboardInput(
+            model_ready=True,
+            has_library_content=True,
+            rag_ready=True,
+            console_ready=True,
+            pending_eval_run_count=2,
+        )
+    )
+    assert action.action_id == "review_eval_runs"
+    assert action.target_route == TAB_EVALS
+
+
+def test_ladder_never_counts_running_eval_runs():
+    action = choose_next_best_action(
+        HomeDashboardInput(
+            model_ready=True,
+            has_library_content=True,
+            rag_ready=True,
+            console_ready=True,
+            pending_eval_run_count=0,
+            failed_eval_run_count=0,
+        )
+    )
+    assert action.action_id != "review_eval_runs"
+
+
+def test_ladder_suggests_read_later():
+    action = choose_next_best_action(
+        HomeDashboardInput(
+            model_ready=True,
+            has_library_content=True,
+            rag_ready=True,
+            console_ready=True,
+            read_later_count=3,
+        )
+    )
+    assert action.action_id == "review_read_later"
+    assert action.target_route == TAB_MEDIA
+
+
+def test_ladder_terminal_suggestion_resumes_last_conversation():
+    action = choose_next_best_action(
+        HomeDashboardInput(
+            model_ready=True,
+            has_library_content=True,
+            console_ready=True,
+            resume_kind=HOME_RESUME_KIND_CONVERSATION,
+            resume_id="42",
+        )
+    )
+    assert action.action_id == "resume_last_conversation"
+    assert action.target_route == TAB_CHAT
+
+
+def test_ladder_terminal_falls_back_to_start_conversation_without_recents():
+    action = choose_next_best_action(
+        HomeDashboardInput(
+            model_ready=True,
+            has_library_content=True,
+            console_ready=True,
+        )
+    )
+    assert action.action_id == "start_console"

--- a/Tests/Home/test_dashboard_state.py
+++ b/Tests/Home/test_dashboard_state.py
@@ -1,5 +1,8 @@
 from tldw_chatbook.Home.dashboard_state import (
     HOME_FLASHCARDS_DUE_ROW_ID,
+    HOME_OPEN_ITEM_CONTROL_ID,
+    HOME_RECENT_WORK_LIMIT,
+    HOME_RESUME_KIND_MEDIA,
     HOME_RESUME_LATEST_CONTROL_ID,
     HOME_START_CONVERSATION_CONTROL_ID,
     RUNNING_RUN_STATUS,
@@ -14,6 +17,8 @@ from tldw_chatbook.Home.dashboard_state import (
     categorize_run_status,
     choose_home_selected_item,
     choose_next_best_action,
+    combined_recent_work_items,
+    content_item_kind,
     summarize_home_dashboard,
 )
 
@@ -1359,7 +1364,8 @@ def test_resume_control_note_routes_to_library_and_escapes_title():
     assert control is not None
     assert control.control_id == HOME_RESUME_LATEST_CONTROL_ID
     assert control.target_route == "library"
-    assert control.target_id == "note-7"
+    # Prefixed so the screen dispatch routes by content kind.
+    assert control.target_id == "local:note:note-7"
     # User title is markup-escaped exactly once before any Button label.
     assert control.label == 'Resume note: weird \\[b="c] note'
 
@@ -1375,7 +1381,7 @@ def test_resume_control_conversation_routes_to_chat():
 
     assert control is not None
     assert control.target_route == "chat"
-    assert control.target_id == "conv-9"
+    assert control.target_id == "local:conversation:conv-9"
     assert control.label == "Resume conversation: Daily standup chat"
 
 
@@ -1456,3 +1462,96 @@ def test_triage_idle_canvas_not_ready_empty_keeps_import_card_only():
     assert canvas.primary_control_id == ""
     assert canvas.lines == ("Library content makes Console and RAG more useful.",)
     assert canvas.next_action_is_canvas is True
+
+
+def _content_item(item_id, updated_at, *, source="Notes", route="library"):
+    return HomeActiveWorkItem(
+        item_id=item_id,
+        title=f"title {item_id}",
+        source=source,
+        status="ready",
+        detail_route=route,
+        updated_at=updated_at,
+    )
+
+
+def test_content_item_kind_maps_prefixes():
+    assert content_item_kind("local:conversation:42") == "conversation"
+    assert content_item_kind("local:note:7") == "note"
+    assert content_item_kind("local:media:9") == "media"
+    assert content_item_kind("local:ingest:3") is None
+    assert content_item_kind("") is None
+
+
+def test_combined_recent_merges_and_caps_by_recency():
+    adapter_recents = (_content_item("local:ingest:1", "2026-08-29T10:00:00+00:00"),)
+    content_items = (
+        _content_item(
+            "local:conversation:5",
+            "2026-08-29T12:00:00+00:00",
+            source="Conversations",
+            route="chat",
+        ),
+        _content_item("local:note:2", "2026-08-29T11:00:00+00:00"),
+        _content_item("local:media:3", "2026-08-28T09:00:00+00:00", source="Media"),
+    )
+    state = HomeDashboardInput(
+        recent_work_items=adapter_recents, content_recent_items=content_items
+    )
+    merged = combined_recent_work_items(state)
+    assert [item.item_id for item in merged] == [
+        "local:conversation:5",
+        "local:note:2",
+        "local:ingest:1",
+        "local:media:3",
+    ]
+
+
+def test_combined_recent_caps_at_limit():
+    items = tuple(
+        _content_item(f"local:note:{i}", f"2026-08-29T1{i:02d}:00:00+00:00")
+        for i in range(12)
+    )
+    state = HomeDashboardInput(content_recent_items=items)
+    assert len(combined_recent_work_items(state)) == HOME_RECENT_WORK_LIMIT
+
+
+def test_triage_recent_section_includes_content_items_and_open_control():
+    content = (
+        _content_item(
+            "local:conversation:5",
+            "2026-08-29T12:00:00+00:00",
+            source="Conversations",
+            route="chat",
+        ),
+    )
+    state = HomeDashboardInput(
+        model_ready=True, content_recent_items=content, console_ready=True
+    )
+    triage = build_home_triage_state(state, selected_row_id="local:conversation:5")
+    recent_section = next(s for s in triage.sections if s.section_id == "recent")
+    assert [row.row_id for row in recent_section.rows] == ["local:conversation:5"]
+    control_ids = {c.control_id for c in triage.canvas.actions}
+    assert HOME_OPEN_ITEM_CONTROL_ID in control_ids
+    open_control = next(
+        c for c in triage.canvas.actions if c.control_id == HOME_OPEN_ITEM_CONTROL_ID
+    )
+    assert open_control.target_id == "local:conversation:5"
+    assert open_control.target_route == "chat"
+
+
+def test_resume_control_supports_media_kind_with_age():
+    state = HomeDashboardInput(
+        resume_kind=HOME_RESUME_KIND_MEDIA,
+        resume_id="9",
+        resume_title="Long read",
+        resume_updated_at="2026-08-29T11:00:00+00:00",
+    )
+    control = build_home_resume_control(
+        state, now=datetime(2026, 8, 29, 11, 30, tzinfo=timezone.utc)
+    )
+    assert control is not None
+    assert control.control_id == HOME_RESUME_LATEST_CONTROL_ID
+    assert control.target_route == "library"
+    assert control.target_id == "local:media:9"
+    assert control.label == "Resume reading: Long read (30m)"

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -2077,3 +2077,56 @@ async def test_home_content_snapshot_uses_library_rail_seams():
     # Hermetic test config (no disk-load markers) -> readiness is honored
     # verbatim and reports not-ready rather than reading the real config.
     assert snapshot.console_ready is False
+
+
+# --- Task 3: open-task providers (eval runs / read-it-later) ---------------
+
+
+def test_local_eval_open_run_counts_never_queries_running():
+    """The provider must only ever query pending/failed -- 'running' rows are
+    orphaned forever by a crash and would permanently pin the suggestion."""
+    from types import SimpleNamespace
+
+    from tldw_chatbook.app import TldwCli
+
+    queried = []
+
+    class FakeEvalService:
+        def list_runs(self, *, status=None, limit=100, offset=0):
+            queried.append(status)
+            return [{"run_id": f"{status}-{i}"} for i in range(3)]
+
+    counts = TldwCli._local_eval_open_run_counts(
+        SimpleNamespace(local_evaluation_service=FakeEvalService())
+    )
+    assert counts == {"pending": 3, "failed": 3}
+    assert set(queried) == {"pending", "failed"}
+
+
+def test_local_eval_open_run_counts_degrade_quietly():
+    from types import SimpleNamespace
+
+    from tldw_chatbook.app import TldwCli
+
+    class BrokenEvalService:
+        def list_runs(self, **kwargs):
+            raise RuntimeError("db unavailable")
+
+    assert TldwCli._local_eval_open_run_counts(
+        SimpleNamespace(local_evaluation_service=BrokenEvalService())
+    ) == {"pending": 0, "failed": 0}
+    assert TldwCli._local_eval_open_run_counts(
+        SimpleNamespace(local_evaluation_service=None)
+    ) == {"pending": 0, "failed": 0}
+
+
+def test_local_read_later_count_provider():
+    from types import SimpleNamespace
+
+    from tldw_chatbook.app import TldwCli
+
+    fake = SimpleNamespace(
+        media_db=SimpleNamespace(list_read_it_later_media_ids=lambda: [1, 2, 3])
+    )
+    assert TldwCli._local_read_later_count(fake) == 3
+    assert TldwCli._local_read_later_count(SimpleNamespace(media_db=None)) is None

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -4,8 +4,11 @@ from unittest.mock import Mock
 import pytest
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.Constants import (
+    CONSOLE_NAV_CONTEXT_CONVERSATION_ID,
     LIBRARY_NAV_CONTEXT_INGEST,
     LIBRARY_NAV_CONTEXT_NOTE_ID,
+    LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID,
+    LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE,
     TAB_LIBRARY,
 )
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
@@ -406,7 +409,8 @@ async def test_home_recent_work_empty_state_sets_expectation():
 
         recent_text = str(home.query_one("#home-rail-empty-recent").renderable)
         assert (
-            "Runs, chatbooks, imports, and schedules will appear here." in recent_text
+            "Conversations, notes, media, runs, chatbooks, and imports will appear"
+            in recent_text
         )
 
 
@@ -1888,6 +1892,35 @@ async def test_home_resume_latest_conversation_routes_to_console():
         await pilot.pause(HOME_MOUNT_PAUSE)
 
     assert seen[-1] == "chat"
+    assert host.seen_contexts[-1] == {CONSOLE_NAV_CONTEXT_CONVERSATION_ID: "conv-9"}
+
+
+def test_open_content_item_routes_by_prefix():
+    """Content deep-links route by prefixed id: conversations carry the
+    Console nav-context id, notes the Library note id, media the Library
+    open-source pair."""
+    app = _build_test_app()
+    home = HomeScreen(app)
+
+    posted = []
+    home.post_message = lambda message: posted.append(message)
+
+    home._open_content_item("local:conversation:42")
+    home._open_content_item("local:note:7")
+    home._open_content_item("local:media:9")
+    home._open_content_item("local:ingest:3")  # unknown prefix: no-op
+
+    assert [message.screen_name for message in posted] == [
+        "chat",
+        "library",
+        "library",
+    ]
+    assert posted[0].screen_context == {CONSOLE_NAV_CONTEXT_CONVERSATION_ID: "42"}
+    assert posted[1].screen_context == {LIBRARY_NAV_CONTEXT_NOTE_ID: "7"}
+    assert posted[2].screen_context == {
+        LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE: "media",
+        LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID: "9",
+    }
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -1796,9 +1796,10 @@ async def test_home_recent_only_item_selection_gets_open_details_control():
 
 @pytest.mark.asyncio
 async def test_home_ready_idle_canvas_primary_start_conversation_routes_to_console():
-    """AC1+AC2: with the provider verifiably ready over real content, the
-    idle canvas leads with a primary "Start a conversation" control that
-    routes to Console, above a compact real-content counts line."""
+    """AC1+AC2: with the provider verifiably ready over real content and a
+    recent conversation, the idle canvas leads with a primary
+    "Resume last conversation" control that deep-links that conversation
+    into Console (spec §4), above a compact real-content counts line."""
     app = _build_test_app()
     app._home_dashboard_test_input = HomeDashboardInput(
         model_ready=True,
@@ -1820,18 +1821,19 @@ async def test_home_ready_idle_canvas_primary_start_conversation_routes_to_conso
 
         canvas_title = str(home.query_one("#home-canvas-title").renderable)
         canvas_lines = str(home.query_one("#home-canvas-lines").renderable)
-        assert "Start a conversation" in canvas_title
+        assert "Resume last conversation" in canvas_title
         assert "Conversations: 5 · Notes: 3" in canvas_lines
         assert "Media" not in canvas_lines
 
         primary = home.query_one("#home-primary-action")
-        assert "Start a conversation" in str(primary.label)
+        assert "Resume last conversation" in str(primary.label)
         assert primary.has_class("console-action-primary")
 
         await pilot.click("#home-primary-action")
         await pilot.pause(HOME_MOUNT_PAUSE)
 
     assert seen[-1] == "chat"
+    assert host.seen_contexts[-1] == {CONSOLE_NAV_CONTEXT_CONVERSATION_ID: "conv-9"}
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_home_screen.py
+++ b/Tests/UI/test_home_screen.py
@@ -4,11 +4,13 @@ from unittest.mock import Mock
 import pytest
 from tldw_chatbook.Chat.chat_handoff_models import ChatHandoffPayload
 from tldw_chatbook.Constants import (
-    CONSOLE_NAV_CONTEXT_CONVERSATION_ID,
+    CONSOLE_NAV_CONTEXT_RESUME_LOCAL_CONVERSATION_ID,
     LIBRARY_NAV_CONTEXT_INGEST,
     LIBRARY_NAV_CONTEXT_NOTE_ID,
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID,
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE,
+    MEDIA_BROWSE_SUBVIEW_READ_IT_LATER,
+    MEDIA_NAV_CONTEXT_BROWSE_SUBVIEW,
     TAB_LIBRARY,
 )
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
@@ -1833,7 +1835,7 @@ async def test_home_ready_idle_canvas_primary_start_conversation_routes_to_conso
         await pilot.pause(HOME_MOUNT_PAUSE)
 
     assert seen[-1] == "chat"
-    assert host.seen_contexts[-1] == {CONSOLE_NAV_CONTEXT_CONVERSATION_ID: "conv-9"}
+    assert host.seen_contexts[-1] == {CONSOLE_NAV_CONTEXT_RESUME_LOCAL_CONVERSATION_ID: "conv-9"}
 
 
 @pytest.mark.asyncio
@@ -1894,7 +1896,7 @@ async def test_home_resume_latest_conversation_routes_to_console():
         await pilot.pause(HOME_MOUNT_PAUSE)
 
     assert seen[-1] == "chat"
-    assert host.seen_contexts[-1] == {CONSOLE_NAV_CONTEXT_CONVERSATION_ID: "conv-9"}
+    assert host.seen_contexts[-1] == {CONSOLE_NAV_CONTEXT_RESUME_LOCAL_CONVERSATION_ID: "conv-9"}
 
 
 def test_open_content_item_routes_by_prefix():
@@ -1917,7 +1919,7 @@ def test_open_content_item_routes_by_prefix():
         "library",
         "library",
     ]
-    assert posted[0].screen_context == {CONSOLE_NAV_CONTEXT_CONVERSATION_ID: "42"}
+    assert posted[0].screen_context == {CONSOLE_NAV_CONTEXT_RESUME_LOCAL_CONVERSATION_ID: "42"}
     assert posted[1].screen_context == {LIBRARY_NAV_CONTEXT_NOTE_ID: "7"}
     assert posted[2].screen_context == {
         LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE: "media",
@@ -2126,7 +2128,87 @@ def test_local_read_later_count_provider():
     from tldw_chatbook.app import TldwCli
 
     fake = SimpleNamespace(
-        media_db=SimpleNamespace(list_read_it_later_media_ids=lambda: [1, 2, 3])
+        media_db=SimpleNamespace(count_read_it_later_media=lambda: 3)
     )
     assert TldwCli._local_read_later_count(fake) == 3
     assert TldwCli._local_read_later_count(SimpleNamespace(media_db=None)) is None
+
+
+# --- Rebase reconciliation + review fixes ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_home_read_it_later_primary_lands_on_queue_subview():
+    """Qodo #1: the read-it-later primary action carries a Media nav context
+    selecting the saved-reading subview, not the generic list."""
+    app = _build_test_app()
+    app._home_dashboard_test_input = HomeDashboardInput(
+        model_ready=True,
+        has_library_content=True,
+        console_ready=True,
+        read_later_count=2,
+    )
+    seen = []
+    host = HomeHarness(app, seen)
+
+    async with host.run_test(size=HOME_TEST_SIZE) as pilot:
+        await pilot.pause(HOME_MOUNT_PAUSE)
+        home = _active_home_screen(host)
+
+        canvas_title = str(home.query_one("#home-canvas-title").renderable)
+        assert "Read-it-later" in canvas_title
+
+        await pilot.click("#home-primary-action")
+        await pilot.pause(HOME_MOUNT_PAUSE)
+
+    assert seen[-1] == "media"
+    assert host.seen_contexts[-1] == {
+        MEDIA_NAV_CONTEXT_BROWSE_SUBVIEW: MEDIA_BROWSE_SUBVIEW_READ_IT_LATER
+    }
+
+
+def test_media_screen_navigation_context_stashes_browse_subview():
+    """The Media nav-context contract stashes the subview pre-mount and
+    applies it after the restored state (explicit navigation wins)."""
+    from tldw_chatbook.Constants import MEDIA_NAV_CONTEXT_BROWSE_SUBVIEW
+    from tldw_chatbook.UI.Screens.media_screen import MediaScreen
+
+    app = _build_test_app()
+    screen = MediaScreen(app)
+    assert screen._pending_nav_browse_subview is None
+
+    screen.apply_navigation_context(
+        {MEDIA_NAV_CONTEXT_BROWSE_SUBVIEW: "read-it-later"}
+    )
+    assert screen._pending_nav_browse_subview == "read-it-later"
+
+    # Invalid payloads are ignored, not stashed.
+    screen._pending_nav_browse_subview = None
+    screen.apply_navigation_context({})
+    screen.apply_navigation_context({MEDIA_NAV_CONTEXT_BROWSE_SUBVIEW: ""})
+    screen.apply_navigation_context(None)
+    assert screen._pending_nav_browse_subview is None
+
+
+def test_open_tasks_provider_wiring_flows_to_dashboard_input():
+    """Qodo #12: the production app-to-adapter wiring (constructor lambdas
+    closing over the real provider methods) actually feeds the counts
+    through refresh + build -- not just each side in isolation."""
+    from types import SimpleNamespace
+
+    app = _build_test_app()
+    adapter = getattr(app, "home_active_work_adapter", None)
+    assert adapter is not None, "production adapter must be wired"
+
+    app.local_evaluation_service = SimpleNamespace(
+        list_runs=lambda *, status=None, limit=100, offset=0, **kw: [
+            {"run_id": f"{status}-{i}"} for i in range(2 if status == "pending" else 1)
+        ]
+    )
+    app.media_db = SimpleNamespace(count_read_it_later_media=lambda: 7)
+
+    adapter.refresh_open_tasks_snapshot()
+    state = adapter.build_dashboard_input(providers_models={}, has_recent_work=False)
+    assert state.pending_eval_run_count == 2
+    assert state.failed_eval_run_count == 1
+    assert state.read_later_count == 7

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -1617,3 +1617,34 @@ child overflows rather than protects. Same-class suspects here:
 **Incident.** The first tmux launch used `2>stderr.log` to keep diagnostics; the pane went visually blank while `capture-pane` returned empty lines, yet the app was alive and painting — into the log. The render stream is stderr, so redirecting it for "clean logs" removes the very surface the verification is supposed to observe.
 
 **What to do.** In tmux live runs, leave both stdout and stderr attached to the pane (the pane IS the capture artifact); take diagnostics from the app's own file log under the profile's data dir. Also note `tmux send-keys -H` can emit SGR mouse sequences (`ESC [ < 0 ; col ; row M/m`) to click Textual buttons that Tab/Enter cannot reliably reach, but the row/col must be recomputed from a fresh capture after every repaint.
+
+## Three scratch-profile traps that masquerade as app bugs (Home recents UAT, 2026-08-30)
+
+**What happened.** Live-UATing the Home recents PR against a copy of the real
+profile failed four consecutive times with the same symptom — Home empty, no
+errors — each for a DIFFERENT environmental reason that read like a product bug:
+
+1. **`[database]` absolute `*_db_path` pins override `[paths] data_dir`.** The
+   copied real config pins `chachanotes_db_path` etc. to absolute home paths;
+   a scratch `data_dir` does not relocate them. The app silently opened
+   nonexistent pinned paths (services wired as `None`, never re-wired) while
+   unrelated DBs (workspaces) resolved through the scratch — so Console's
+   workspace rail restored while every conversation/notes seam returned empty.
+   Redirect EVERY `*_db_path` (and `USER_DB_BASE_DIR`) in the scratch config.
+2. **`verify_trusted_directory` rejects `/tmp` scratch data dirs**
+   (`unsafe_parent: shared_sticky_directory_not_allowed`). A disposable HOME
+   nested under /tmp fails the same guard. Scratch profiles must live under
+   the real `$HOME` (a private subdir is fine).
+3. **`rsync`ing a live WAL-mode SQLite file produces a torn snapshot.** The
+   copied DB later failed its v51→v52 migration with "database disk image is
+   malformed" — while the app swallowed the error and booted with no
+   ChaChaNotes at all. Copy live DBs with the online-backup API
+   (`sqlite3.connect(src).backup(dst_con)`), and run `PRAGMA integrity_check`
+   on the RESULT before blaming the migration: here the source DB itself
+   carried a corrupt index (`idx_sync_log_entity` — wrong entry count), which
+   `REINDEX` on the copy repaired before the migration could complete.
+
+**What to do.** For a scratch-profile run against real data: build it under
+`$HOME`, redirect every `[database]` pin, copy DBs via the backup API, and
+integrity-check the copies. When a scratch boot shows "everything restored
+except one subsystem", suspect per-service path resolution before the code.

--- a/backlog/tasks/task-21514 - Home-content-recents-stream-resume-banner.md
+++ b/backlog/tasks/task-21514 - Home-content-recents-stream-resume-banner.md
@@ -17,7 +17,11 @@ Merge conversations/notes/media into Home's Recent section from the content snap
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Recent section shows mixed content recents newest-first capped at 8,Banner resumes newest content item incl. media with relative age,Conversation banner/row opens that conversation in Console via nav context,Note/media rows open their Library views,limit-1 resume seam queries retired
+- [x] Recent section shows mixed content recents newest-first capped at 8
+- [x] Banner resumes newest content item incl. media with relative age
+- [x] Conversation banner/row opens that conversation in Console via nav context
+- [x] Note/media rows open their Library views
+- [x] limit-1 resume seam queries retired
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-21514 - Home-content-recents-stream-resume-banner.md
+++ b/backlog/tasks/task-21514 - Home-content-recents-stream-resume-banner.md
@@ -1,0 +1,27 @@
+---
+id: TASK-21514
+title: Home content recents stream + resume banner
+status: Done
+assignee: []
+created_date: '2026-08-30 23:39'
+updated_date: '2026-08-31 02:10'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Merge conversations/notes/media into Home's Recent section from the content snapshot pipeline, promote the resume banner to the newest content item (media becomes a resume kind), retire the limit-1 resume queries, add a row Open control (spec 2026-08-29 §1-2)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Recent section shows mixed content recents newest-first capped at 8,Banner resumes newest content item incl. media with relative age,Conversation banner/row opens that conversation in Console via nav context,Note/media rows open their Library views,limit-1 resume seam queries retired
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Content recents via content-snapshot pipeline (limit-8, merged in pure dashboard_state); banner promoted incl. media kind with age suffix; limit-1 _home_resume_fields retired; row Open control + resume dispatch route by prefixed id; conversation resume deep-links via ADR-079 seam. Controller-implemented per ledger ruling; subagent review gate applied.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-21515 - Home-ladder-open-task-feeds-terminal-resume-suggestion.md
+++ b/backlog/tasks/task-21515 - Home-ladder-open-task-feeds-terminal-resume-suggestion.md
@@ -17,7 +17,11 @@ Feed pending/failed eval runs and read-it-later count into the next-best-action 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Ladder suggests reviewing eval runs when pending/failed runs exist,Ladder suggests read-it-later when queue non-empty,Terminal suggestion deep-links the newest conversation via nav context,running eval runs never counted,Default adapter and missing services degrade to no suggestion
+- [x] Ladder suggests reviewing eval runs when pending/failed runs exist
+- [x] Ladder suggests read-it-later when queue non-empty
+- [x] Terminal suggestion deep-links the newest conversation via nav context
+- [x] running eval runs never counted
+- [x] Default adapter and missing services degrade to no suggestion
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-21515 - Home-ladder-open-task-feeds-terminal-resume-suggestion.md
+++ b/backlog/tasks/task-21515 - Home-ladder-open-task-feeds-terminal-resume-suggestion.md
@@ -1,0 +1,27 @@
+---
+id: TASK-21515
+title: Home ladder open-task feeds + terminal resume suggestion
+status: Done
+assignee: []
+created_date: '2026-08-31 02:22'
+updated_date: '2026-08-31 02:32'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Feed pending/failed eval runs and read-it-later count into the next-best-action ladder; terminal start-console becomes Resume last conversation when one exists (spec 2026-08-29 §4)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Ladder suggests reviewing eval runs when pending/failed runs exist,Ladder suggests read-it-later when queue non-empty,Terminal suggestion deep-links the newest conversation via nav context,running eval runs never counted,Default adapter and missing services degrade to no suggestion
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Ladder gains review_eval_runs + review_read_later branches (pending/failed only, never running); terminal suggestion becomes Resume last conversation when a recent conversation exists and deep-links it via the ADR-079 seam; providers degrade quietly through the thread-worker snapshot refresh. Controller-implemented per ledger ruling; subagent review gate applied.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-21516 - Home-recents-resume-docs-follow-ups.md
+++ b/backlog/tasks/task-21516 - Home-recents-resume-docs-follow-ups.md
@@ -1,0 +1,20 @@
+---
+id: TASK-21516
+title: Home recents/resume docs + follow-ups
+status: In Progress
+assignee: []
+created_date: '2026-08-31 02:42'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Update the Home User Guide for content recents, media resume, new suggestions; file follow-up tasks for failed_schedule_count producer and phase-2 opens journal (spec 2026-08-29 wrap-up)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 User Guide reflects new Recent mix, banner kinds, and suggestions,Follow-up tasks filed for failed_schedule_count and opens journal,All feature tasks Done with notes
+<!-- AC:END -->

--- a/backlog/tasks/task-21516 - Home-recents-resume-docs-follow-ups.md
+++ b/backlog/tasks/task-21516 - Home-recents-resume-docs-follow-ups.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-21516
 title: Home recents/resume docs + follow-ups
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-31 02:42'
+updated_date: '2026-08-31 02:44'
 labels: []
 dependencies: []
 ---
@@ -16,5 +17,13 @@ Update the Home User Guide for content recents, media resume, new suggestions; f
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 User Guide reflects new Recent mix, banner kinds, and suggestions,Follow-up tasks filed for failed_schedule_count and opens journal,All feature tasks Done with notes
+- [x] User Guide reflects new Recent mix, banner kinds, and suggestions
+- [x] Follow-up tasks filed for failed_schedule_count and opens journal
+- [x] All feature tasks Done with notes
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+User Guide updated (Recent mix incl. content items, Open button row, ladder rows 7-8 + 11-12, resume common task, new empty copy); follow-ups filed as task-21517 (failed_schedule_count producer) and task-21518 (phase-2 opens journal). Lessons check: nothing generalizable beyond session-specific process errors (stale main ref, harness inactivity kills) — not repo traps; no lessons entry invented.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-21517 - Produce-failed_schedule_count-for-Home.md
+++ b/backlog/tasks/task-21517 - Produce-failed_schedule_count-for-Home.md
@@ -1,0 +1,20 @@
+---
+id: TASK-21517
+title: Produce failed_schedule_count for Home
+status: To Do
+assignee: []
+created_date: '2026-08-31 02:43'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+HomeDashboardInput.failed_schedule_count is a documented dead input (no producer; ladder branch 3 unreachable from real state). Needs a failed-schedules query in Scheduling/db/scheduled_tasks_db.py first — skipped per spec 2026-08-29 decision rule (no cheap query exists today)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 failed_schedule_count populated from real schedule state,Ladder recover_schedules branch reachable from real state
+<!-- AC:END -->

--- a/backlog/tasks/task-21518 - Home-opens-journal-phase-2-recents.md
+++ b/backlog/tasks/task-21518 - Home-opens-journal-phase-2-recents.md
@@ -1,0 +1,20 @@
+---
+id: TASK-21518
+title: Home opens journal (phase 2 recents)
+status: To Do
+assignee: []
+created_date: '2026-08-31 02:43'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Persistent opens journal (IDs+timestamps only, model_catalog_cache.json pattern) so read-only sessions count as recent work without edits; feeds recents ranking and task-18921 usage-ranked suggestions (spec 2026-08-29 Non-goals)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Opening an item bumps its recency even without edits,Journal storage contract documented,Usage-ranked suggestion feasibility assessed against task-18921
+<!-- AC:END -->

--- a/backlog/tasks/task-21519 - Evals-DB-Service-crash-on-NULL-JSON-columns-config_overrides-eval_models.config.md
+++ b/backlog/tasks/task-21519 - Evals-DB-Service-crash-on-NULL-JSON-columns-config_overrides-eval_models.config.md
@@ -1,0 +1,22 @@
+---
+id: TASK-21519
+title: >-
+  Evals DB/Service crash on NULL JSON columns (config_overrides,
+  eval_models.config)
+status: To Do
+assignee: []
+created_date: '2026-08-31 03:43'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Live UAT of Home recents (PR #2251) seeded an eval run and exposed pre-existing fragility: LocalEvaluationsService.list_runs -> Evals_DB.get_model call json.loads() on NULL config_overrides (run rows) and NULL eval_models.config, raising TypeError. Any run/model row created without those columns breaks every list_runs consumer, including the Evals screen itself. Home's open-tasks provider degrades quietly by design, which masked it there.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 get_model and list_runs enrichment tolerate NULL JSON columns (parse to empty dict or default),Regression tests seed rows with NULL config columns and assert list_runs returns them,Evals screen lists such runs without crashing
+<!-- AC:END -->

--- a/backlog/tasks/task-25710 - Home-content-recents-stream-resume-banner.md
+++ b/backlog/tasks/task-25710 - Home-content-recents-stream-resume-banner.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-21514
+id: TASK-25710
 title: Home content recents stream + resume banner
 status: Done
 assignee: []

--- a/backlog/tasks/task-25711 - Home-ladder-open-task-feeds-terminal-resume-suggestion.md
+++ b/backlog/tasks/task-25711 - Home-ladder-open-task-feeds-terminal-resume-suggestion.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-21515
+id: TASK-25711
 title: Home ladder open-task feeds + terminal resume suggestion
 status: Done
 assignee: []

--- a/tldw_chatbook/Constants.py
+++ b/tldw_chatbook/Constants.py
@@ -70,6 +70,13 @@ WATCHLISTS_NAV_CONTEXT_BRIEFING_ID = "briefing_id"
 WATCHLISTS_SECTION_NOTIFICATIONS = "notifications"
 WATCHLISTS_SECTION_RUNS = "runs"
 
+# Media navigation-context contract keys and values.
+# Applied pre-mount by handle_screen_navigation; MediaScreen stashes the
+# subview and applies it to the freshly composed MediaWindow on mount
+# (mirroring its saved-view restore pattern).
+MEDIA_NAV_CONTEXT_BROWSE_SUBVIEW = "browse_subview"
+MEDIA_BROWSE_SUBVIEW_READ_IT_LATER = "read-it-later"
+
 ALL_TABS = [
     TAB_CHAT,
     TAB_CCP,

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -3648,6 +3648,45 @@ class MediaDatabase:
             )
             raise DatabaseError("Failed to list read-it-later media IDs") from e
 
+    def count_read_it_later_media(
+        self, *, include_deleted: bool = False, include_trash: bool = False
+    ) -> int:
+        """Count media saved in the local read-it-later table.
+
+        Same filters as ``list_read_it_later_media_ids`` but a scalar
+        ``COUNT(*)`` -- callers needing only the total (Home's
+        read-it-later suggestion) must not materialize the id list.
+
+        Args:
+            include_deleted: Include soft-deleted media rows.
+            include_trash: Include trashed media rows.
+
+        Returns:
+            The number of matching read-it-later media rows.
+
+        Raises:
+            DatabaseError: On a database failure.
+        """
+        sql = """
+            SELECT COUNT(*) AS total
+            FROM MediaReadItLaterState s
+            JOIN Media m ON m.id = s.media_id
+            WHERE s.is_read_it_later = 1
+        """
+        if not include_deleted:
+            sql += " AND m.deleted = 0"
+        if not include_trash:
+            sql += " AND m.is_trash = 0"
+        try:
+            with self.transaction() as conn:
+                row = conn.execute(sql, ()).fetchone()
+                return int(row["total"]) if row is not None else 0
+        except (DatabaseError, sqlite3.Error) as e:
+            logger.error(
+                f"Error counting read-it-later media in DB '{self.db_path_str}': {e}"
+            )
+            raise DatabaseError("Failed to count read-it-later media") from e
+
     def soft_delete_media(self, media_id: int, cascade: bool = True) -> bool:
         """
         Soft deletes a Media item by setting its 'deleted' flag to 1.

--- a/tldw_chatbook/Home/active_work_adapter.py
+++ b/tldw_chatbook/Home/active_work_adapter.py
@@ -224,6 +224,8 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
         runtime_policy: Any | None = None,
         flashcards_due_provider: Callable[[], int | None] | None = None,
         ingest_jobs_provider: Callable[[], tuple[LibraryIngestJob, ...]] | None = None,
+        eval_open_runs_provider: Callable[[], Mapping[str, int]] | None = None,
+        read_later_count_provider: Callable[[], int | None] | None = None,
     ) -> None:
         super().__init__(runtime_policy=runtime_policy)
         self.notification_service = notification_service
@@ -232,9 +234,15 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
         self.server_event_service = server_event_service
         self.flashcards_due_provider = flashcards_due_provider
         self.ingest_jobs_provider = ingest_jobs_provider
+        self.eval_open_runs_provider = eval_open_runs_provider
+        self.read_later_count_provider = read_later_count_provider
         self._chatbook_artifact_snapshot: tuple[Mapping[str, Any], ...] = ()
         self._chatbook_artifact_snapshot_lock = RLock()
         self._flashcards_due_count: int = 0
+        # Open-task queue counts (spec §4), refreshed off the compose path
+        # like the flashcards count and read by build_dashboard_input.
+        self._eval_open_counts: Mapping[str, int] = {"pending": 0, "failed": 0}
+        self._read_later_count: int | None = None
         # B3 (task-282): cache for the watchlist-run/notification/server-event
         # seam queries. This adapter instance lives on the app (not the
         # per-visit HomeScreen), so unlike HomeScreen's own
@@ -266,6 +274,33 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
         except Exception as e:
             logger.debug(f"Failed to fetch due-flashcards count for Home: {e}")
             self._flashcards_due_count = 0
+
+    def refresh_open_tasks_snapshot(self) -> None:
+        """Refresh cached open-task queue counts off the Home compose path.
+
+        Same degrade pattern as ``refresh_flashcards_due_snapshot``: a
+        missing provider, a bad result, or any exception leaves the counts
+        at their no-suggestion defaults (eval zeros, read-later None).
+        """
+        if callable(self.eval_open_runs_provider):
+            try:
+                counts = self.eval_open_runs_provider() or {}
+                self._eval_open_counts = {
+                    "pending": max(0, int(counts.get("pending", 0) or 0)),
+                    "failed": max(0, int(counts.get("failed", 0) or 0)),
+                }
+            except Exception as e:
+                logger.debug(f"Failed to fetch eval run counts for Home: {e}")
+                self._eval_open_counts = {"pending": 0, "failed": 0}
+        if callable(self.read_later_count_provider):
+            try:
+                count = self.read_later_count_provider()
+                self._read_later_count = (
+                    max(0, int(count)) if count is not None else None
+                )
+            except Exception as e:
+                logger.debug(f"Failed to fetch read-it-later count for Home: {e}")
+                self._read_later_count = None
 
     def refresh_chatbook_artifact_snapshot(self, *, limit: int = 20) -> None:
         """Refresh cached local Chatbook artifacts off the Home compose path."""
@@ -319,6 +354,9 @@ class LocalNotificationHomeActiveWorkAdapter(UnavailableHomeActiveWorkAdapter):
             ),
             recent_work_items=self._local_recent_work_items(runs),
             flashcards_due_count=self._flashcards_due_count,
+            pending_eval_run_count=self._eval_open_counts.get("pending", 0),
+            failed_eval_run_count=self._eval_open_counts.get("failed", 0),
+            read_later_count=self._read_later_count,
         )
 
     def handle_control(

--- a/tldw_chatbook/Home/dashboard_state.py
+++ b/tldw_chatbook/Home/dashboard_state.py
@@ -132,7 +132,16 @@ HOME_OPEN_ITEM_CONTROL_ID = "home-open-item"
 
 
 def content_item_kind(item_id: str) -> str | None:
-    """Return the content kind for a prefixed content item id, else None."""
+    """Return the content kind for a prefixed content item id.
+
+    Args:
+        item_id: A HomeActiveWorkItem item_id, possibly carrying one of the
+            ``LOCAL_*_ITEM_ID_PREFIX`` content prefixes.
+
+    Returns:
+        The content kind (``"conversation"``, ``"note"``, or ``"media"``)
+        matching the prefix, or ``None`` when the id carries none of them.
+    """
     for kind, prefix in (
         (HOME_RESUME_KIND_CONVERSATION, LOCAL_CONVERSATION_ITEM_ID_PREFIX),
         (HOME_RESUME_KIND_NOTE, LOCAL_NOTE_ITEM_ID_PREFIX),
@@ -146,10 +155,20 @@ def content_item_kind(item_id: str) -> str | None:
 def combined_recent_work_items(
     state: "HomeDashboardInput",
 ) -> tuple[HomeActiveWorkItem, ...]:
-    """Merge adapter recents with content recents, newest-first, capped."""
+    """Merge adapter recents with content recents, newest-first, capped.
+
+    Args:
+        state: Adapter-provided dashboard input carrying both recent
+            sources (``recent_work_items`` and ``content_recent_items``).
+
+    Returns:
+        The merged recents tuple, sorted newest-first by ``updated_at``
+        (stable on ties), truncated to ``HOME_RECENT_WORK_LIMIT``.
+    """
     merged = list(state.recent_work_items) + list(state.content_recent_items)
     merged.sort(key=lambda item: item.updated_at, reverse=True)
     return tuple(merged[:HOME_RECENT_WORK_LIMIT])
+
 
 # Prefix for a Library ingest job's HomeActiveWorkItem.item_id
 # ("local:ingest:<job_id>"). Shared by the adapter that builds these items
@@ -316,6 +335,13 @@ def apply_home_content_snapshot(
     has_content = state.has_library_content or any(
         isinstance(count, int) and count > 0 for count in counts
     )
+    # Content recents count as recent work too: either rail rows exist, or
+    # the newest content item fed the resume banner (which is intentionally
+    # excluded from the rows) -- without this, a content-only profile would
+    # still report "No recent work yet" beside a populated Recent rail.
+    has_recent = state.has_recent_work or (
+        bool(snapshot.content_recent_items) or bool(snapshot.resume_id)
+    )
     return replace(
         state,
         console_ready=snapshot.console_ready,
@@ -328,6 +354,7 @@ def apply_home_content_snapshot(
         content_recent_items=snapshot.content_recent_items,
         resume_updated_at=snapshot.resume_updated_at,
         has_library_content=has_content,
+        has_recent_work=has_recent,
     )
 
 

--- a/tldw_chatbook/Home/dashboard_state.py
+++ b/tldw_chatbook/Home/dashboard_state.py
@@ -11,7 +11,10 @@ from datetime import datetime, timezone  # noqa: E402
 from rich.markup import escape as escape_markup  # noqa: E402
 
 from tldw_chatbook.Constants import (  # noqa: E402
+    TAB_CHAT,
+    TAB_EVALS,
     TAB_LLM,
+    TAB_MEDIA,
     TAB_SETTINGS,
     TAB_STUDY,
     get_tab_display_label,
@@ -237,6 +240,13 @@ class HomeDashboardInput:
     active_work_items: tuple[HomeActiveWorkItem, ...] = ()
     recent_work_items: tuple[HomeActiveWorkItem, ...] = ()
     flashcards_due_count: int = 0
+    # Open-task queue feeds (spec §4). Eval counts include only
+    # pending/failed -- 'running' rows are orphaned forever by a crash and
+    # would pin the review suggestion. read_later None = unknown, renders
+    # nothing.
+    pending_eval_run_count: int = 0
+    failed_eval_run_count: int = 0
+    read_later_count: int | None = None
     # T190: Console provider readiness from FRESH config (the readiness
     # seams Console itself uses -- build_console_settings_readiness over
     # load_settings(), never a boot snapshot). Distinct from ``model_ready``,
@@ -415,6 +425,20 @@ def choose_next_best_action(
             "subscriptions",
             "Unread notifications need review.",
         )
+    if state.pending_eval_run_count or state.failed_eval_run_count:
+        return HomeAction(
+            "review_eval_runs",
+            "Review eval runs",
+            TAB_EVALS,
+            "Pending or failed eval runs need attention.",
+        )
+    if state.read_later_count:
+        return HomeAction(
+            "review_read_later",
+            f"Read-it-later: {state.read_later_count} items",
+            TAB_MEDIA,
+            "Your saved reading queue is waiting.",
+        )
     if not state.has_library_content:
         return HomeAction(
             "import_sources",
@@ -432,7 +456,17 @@ def choose_next_best_action(
     if state.console_ready:
         # T190: with the provider verifiably ready (fresh-config readiness,
         # not the boot snapshot), the terminal suggestion reads as the
-        # user's actual next step rather than a destination name.
+        # user's actual next step rather than a destination name. With a
+        # recent conversation, "resume where you left off" IS that step
+        # (spec §4) -- the primary-action dispatch attaches the
+        # conversation id to the Console nav context.
+        if state.resume_kind == HOME_RESUME_KIND_CONVERSATION and state.resume_id:
+            return HomeAction(
+                "resume_last_conversation",
+                "Resume last conversation",
+                TAB_CHAT,
+                "Pick up where you left off.",
+            )
         return HomeAction(
             "start_console",
             "Start a conversation",
@@ -1397,8 +1431,14 @@ def build_home_triage_state(
             # Primary emphasis lands on whichever button actually starts a
             # conversation: the dedicated idle control when present,
             # otherwise the canvas's own next-action button (which IS the
-            # start-console suggestion in the ready+content case).
-            if any(
+            # start-console suggestion in the ready+content case). With a
+            # recent conversation the terminal suggestion IS the resume
+            # (spec §4), so the next-action button takes primary over the
+            # generic start control -- the emphasized button should match
+            # the suggestion the canvas is showing.
+            if next_action.action_id == "resume_last_conversation":
+                primary_control_id = HOME_PRIMARY_ACTION_ID
+            elif any(
                 control.control_id == HOME_START_CONVERSATION_CONTROL_ID
                 for control in canvas_actions
             ):

--- a/tldw_chatbook/Home/dashboard_state.py
+++ b/tldw_chatbook/Home/dashboard_state.py
@@ -115,6 +115,38 @@ HOME_START_CONVERSATION_CONTROL_ID = "home-start-conversation"
 HOME_RESUME_LATEST_CONTROL_ID = "home-resume-latest"
 HOME_RESUME_KIND_NOTE = "note"
 HOME_RESUME_KIND_CONVERSATION = "conversation"
+HOME_RESUME_KIND_MEDIA = "media"
+# Shared recents cap (the adapter keeps its own alias; this module is the
+# canonical home so the pure merge can enforce it without importing the
+# adapter).
+HOME_RECENT_WORK_LIMIT = 8
+LOCAL_CONVERSATION_ITEM_ID_PREFIX = "local:conversation:"
+LOCAL_NOTE_ITEM_ID_PREFIX = "local:note:"
+LOCAL_MEDIA_ITEM_ID_PREFIX = "local:media:"
+# Canvas control that opens the SELECTED content recents row (screen-level
+# dispatch, like home-resume-latest -- not a HOME_CONTROL_METHODS hook).
+HOME_OPEN_ITEM_CONTROL_ID = "home-open-item"
+
+
+def content_item_kind(item_id: str) -> str | None:
+    """Return the content kind for a prefixed content item id, else None."""
+    for kind, prefix in (
+        (HOME_RESUME_KIND_CONVERSATION, LOCAL_CONVERSATION_ITEM_ID_PREFIX),
+        (HOME_RESUME_KIND_NOTE, LOCAL_NOTE_ITEM_ID_PREFIX),
+        (HOME_RESUME_KIND_MEDIA, LOCAL_MEDIA_ITEM_ID_PREFIX),
+    ):
+        if item_id.startswith(prefix):
+            return kind
+    return None
+
+
+def combined_recent_work_items(
+    state: "HomeDashboardInput",
+) -> tuple[HomeActiveWorkItem, ...]:
+    """Merge adapter recents with content recents, newest-first, capped."""
+    merged = list(state.recent_work_items) + list(state.content_recent_items)
+    merged.sort(key=lambda item: item.updated_at, reverse=True)
+    return tuple(merged[:HOME_RECENT_WORK_LIMIT])
 
 # Prefix for a Library ingest job's HomeActiveWorkItem.item_id
 # ("local:ingest:<job_id>"). Shared by the adapter that builds these items
@@ -223,6 +255,11 @@ class HomeDashboardInput:
     resume_kind: str = ""
     resume_id: str = ""
     resume_title: str = ""
+    # Content recents (conversations/notes/media) from the HomeScreen
+    # content-snapshot pipeline; merged into the Recent rail section by
+    # combined_recent_work_items. Titles are markup-escaped at build.
+    content_recent_items: tuple[HomeActiveWorkItem, ...] = ()
+    resume_updated_at: str = ""
 
 
 @dataclass(frozen=True)
@@ -241,6 +278,8 @@ class HomeContentSnapshot:
     resume_kind: str = ""
     resume_id: str = ""
     resume_title: str = ""
+    content_recent_items: tuple[HomeActiveWorkItem, ...] = ()
+    resume_updated_at: str = ""
 
 
 def apply_home_content_snapshot(
@@ -276,6 +315,8 @@ def apply_home_content_snapshot(
         resume_kind=snapshot.resume_kind,
         resume_id=snapshot.resume_id,
         resume_title=snapshot.resume_title,
+        content_recent_items=snapshot.content_recent_items,
+        resume_updated_at=snapshot.resume_updated_at,
         has_library_content=has_content,
     )
 
@@ -499,6 +540,21 @@ def build_home_controls(
         selected_item if selected_item is not None else choose_home_selected_item(state)
     )
 
+    # Content recents rows (conversations/notes/media) get a single Open
+    # control that deep-links the item (screen-level dispatch, same as
+    # home-resume-latest) -- scoped to the SELECTED item, mirroring the
+    # selected_item overrides for Retry/Pause above.
+    if selected_item is not None and content_item_kind(selected_item.item_id):
+        controls.append(
+            HomeControl(
+                HOME_OPEN_ITEM_CONTROL_ID,
+                "Open",
+                selected_item.detail_route,
+                "open_content",
+                selected_item.item_id,
+            )
+        )
+
     if _pending_approval_count(state):
         controls.extend(
             (
@@ -681,8 +737,12 @@ def build_home_content_counts_line(state: HomeDashboardInput) -> str:
     return " · ".join(parts)
 
 
-def build_home_resume_control(state: HomeDashboardInput) -> HomeControl | None:
-    """Build the one-click resume control for the newest note/conversation.
+def build_home_resume_control(
+    state: HomeDashboardInput,
+    *,
+    now: datetime | None = None,
+) -> HomeControl | None:
+    """Build the one-click resume control for the newest content item.
 
     The raw user title is markup-escaped HERE, exactly once, because the
     control label flows straight into a Textual Button label (which parses
@@ -691,12 +751,15 @@ def build_home_resume_control(state: HomeDashboardInput) -> HomeControl | None:
 
     Args:
         state: Adapter-provided dashboard input.
+        now: Reference time for the relative-age suffix (defaults to UTC
+            now; injectable for deterministic tests).
 
     Returns:
         The ``home-resume-latest`` control, or ``None`` when no resume
-        candidate exists. Note candidates target the Library notes editor
-        deep-link (``target_route="library"`` + note id); conversation
-        candidates target Console (``target_route="chat"``).
+        candidate exists. Note/media candidates target the Library deep
+        links (``target_route="library"``); conversation candidates target
+        Console (``target_route="chat"``). ``target_id`` carries the
+        content-kind prefix so the screen dispatch routes by kind.
     """
     if not state.resume_id:
         return None
@@ -704,19 +767,32 @@ def build_home_resume_control(state: HomeDashboardInput) -> HomeControl | None:
         kind_label = "note"
         target_route = "library"
         fallback_title = "Latest note"
+        prefix = LOCAL_NOTE_ITEM_ID_PREFIX
     elif state.resume_kind == HOME_RESUME_KIND_CONVERSATION:
         kind_label = "conversation"
         target_route = "chat"
         fallback_title = "Latest conversation"
+        prefix = LOCAL_CONVERSATION_ITEM_ID_PREFIX
+    elif state.resume_kind == HOME_RESUME_KIND_MEDIA:
+        kind_label = "reading"
+        target_route = "library"
+        fallback_title = "Latest media"
+        prefix = LOCAL_MEDIA_ITEM_ID_PREFIX
     else:
         return None
     title = state.resume_title.strip() or fallback_title
+    label = f"Resume {kind_label}: {escape_markup(title)}"
+    age = format_console_relative_age(
+        state.resume_updated_at, now=now or datetime.now(timezone.utc)
+    )
+    if age:
+        label = f"{label} ({age})"
     return HomeControl(
         HOME_RESUME_LATEST_CONTROL_ID,
-        f"Resume {kind_label}: {escape_markup(title)}",
+        label,
         target_route,
         "resume_latest",
-        state.resume_id,
+        f"{prefix}{state.resume_id}",
     )
 
 
@@ -1168,7 +1244,8 @@ def build_home_triage_state(
             # as active work rather than silently dropping.
             running_rows.append(_item_row(item, "running", reference_now))
     recent_rows = tuple(
-        _item_row(item, "recent", reference_now) for item in state.recent_work_items
+        _item_row(item, "recent", reference_now)
+        for item in combined_recent_work_items(state)
     )
 
     if state.flashcards_due_count > 0:
@@ -1205,7 +1282,7 @@ def build_home_triage_state(
             "Recent",
             len(recent_rows),
             recent_rows,
-            "Runs, chatbooks, imports, and schedules will appear here.",
+            "Conversations, notes, media, runs, chatbooks, and imports will appear here.",
         ),
     )
 
@@ -1243,7 +1320,8 @@ def build_home_triage_state(
         else:
             item = next(
                 i
-                for i in tuple(state.active_work_items) + tuple(state.recent_work_items)
+                for i in tuple(state.active_work_items)
+                + combined_recent_work_items(state)
                 if i.item_id == selected.row_id
             )
             # M4: thread the resolved item so build_home_controls can gate

--- a/tldw_chatbook/Home/dashboard_state.py
+++ b/tldw_chatbook/Home/dashboard_state.py
@@ -433,9 +433,10 @@ def choose_next_best_action(
             "Pending or failed eval runs need attention.",
         )
     if state.read_later_count:
+        item_word = "item" if state.read_later_count == 1 else "items"
         return HomeAction(
             "review_read_later",
-            f"Read-it-later: {state.read_later_count} items",
+            f"Read-it-later: {state.read_later_count} {item_word}",
             TAB_MEDIA,
             "Your saved reading queue is waiting.",
         )
@@ -922,7 +923,7 @@ def summarize_home_dashboard(state: HomeDashboardInput) -> HomeDashboard:
                     if state.has_recent_work
                     else (
                         "No recent work yet",
-                        "Runs, chatbooks, imports, and schedules will appear here.",
+                        "Conversations, notes, media, runs, chatbooks, and imports will appear here.",
                     )
                 ),
             ),

--- a/tldw_chatbook/UI/MediaWindow_v2.py
+++ b/tldw_chatbook/UI/MediaWindow_v2.py
@@ -1160,6 +1160,34 @@ class MediaWindow(Container):
                 self.search_panel.keyword_filter,
             )
 
+    def select_browse_subview(self, subview: str) -> None:
+        """Programmatically select a browse subview (navigation deep links).
+
+        Drives the same state + refresh path as the subview Select's event
+        handler, for callers that need to land the window on a specific
+        subview without a widget event (Home's read-it-later suggestion via
+        MediaScreen's navigation context).
+
+        Args:
+            subview: Target subview id (e.g. ``"read-it-later"``); empty
+                values fall back to ``"all"``.
+        """
+        target = str(subview or "all")
+        if self.runtime_state is not None:
+            self.runtime_state.active_browse_subview = target
+        panel = getattr(self, "search_panel", None)
+        if panel is not None:
+            panel.set_browse_subview(target)
+        if self._reset_invalid_saved_view_for_context():
+            return
+        self._sync_saved_view_controls()
+        if self.active_media_type:
+            self._perform_search(
+                self.active_media_type,
+                self.search_panel.search_term,
+                self.search_panel.keyword_filter,
+            )
+
     @on(MediaItemSelectedEvent)
     async def handle_media_item_selected(self, event: MediaItemSelectedEvent) -> None:
         """Start item-detail loading without blocking the destination message pump.

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -106,10 +106,19 @@ def _home_runtime_status_label(state: HomeDashboardInput) -> str:
     return f"Server: {server_label}" if server_label else "Server"
 
 
-def _home_primary_action_context(action: object) -> dict[str, object]:
+def _home_primary_action_context(
+    action: object,
+    dashboard_input: HomeDashboardInput | None = None,
+) -> dict[str, object]:
     action_id = getattr(action, "action_id", None)
     if action_id == "fix_model_setup":
         return {"category": SettingsCategoryId.PROVIDERS_MODELS.value}
+    if action_id == "resume_last_conversation":
+        # The terminal suggestion deep-links the newest conversation into
+        # Console via the ADR-079 nav-context seam (spec §4).
+        resume_id = str(getattr(dashboard_input, "resume_id", "") or "")
+        if resume_id:
+            return {CONSOLE_NAV_CONTEXT_CONVERSATION_ID: resume_id}
     if action_id == "review_notifications" and getattr(
         action, "target_route", None
     ) in {
@@ -371,9 +380,16 @@ class HomeScreen(BaseAppScreen):
             else:
                 refresh_flashcards_due()
         refresh_snapshot = getattr(adapter, "refresh_chatbook_artifact_snapshot", None)
+        if callable(refresh_snapshot):
+            refresh_snapshot()
+        # Open-task queue counts (spec §4): same thread-worker placement as
+        # the chatbook snapshot -- the providers hit the evals/media DBs
+        # synchronously, so they must not run on the UI thread.
+        refresh_open_tasks = getattr(adapter, "refresh_open_tasks_snapshot", None)
+        if callable(refresh_open_tasks):
+            refresh_open_tasks()
         if not callable(refresh_snapshot):
             return
-        refresh_snapshot()
         self.app.call_from_thread(self._refresh_after_chatbook_artifact_snapshot)
 
     def _refresh_after_chatbook_artifact_snapshot(self) -> None:
@@ -829,7 +845,9 @@ class HomeScreen(BaseAppScreen):
         self.post_message(
             NavigateToScreen(
                 dashboard.next_action.target_route,
-                screen_context=_home_primary_action_context(dashboard.next_action),
+                screen_context=_home_primary_action_context(
+                    dashboard.next_action, self._current_dashboard_input
+                ),
             )
         )
 

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -8,12 +8,11 @@ from datetime import datetime, timezone
 from typing import Any
 
 from loguru import logger
+from rich.markup import escape as escape_markup
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import Horizontal
 from textual.widgets import Button, Static
-
-from rich.markup import escape as escape_markup
 
 from tldw_chatbook.Chat.console_session_settings import (
     build_console_settings_readiness,
@@ -25,10 +24,12 @@ from tldw_chatbook.config import (
     save_setting_to_cli_config,
 )
 from tldw_chatbook.Constants import (
-    CONSOLE_NAV_CONTEXT_CONVERSATION_ID,
+    CONSOLE_NAV_CONTEXT_RESUME_LOCAL_CONVERSATION_ID,
     LIBRARY_NAV_CONTEXT_NOTE_ID,
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID,
     LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE,
+    MEDIA_BROWSE_SUBVIEW_READ_IT_LATER,
+    MEDIA_NAV_CONTEXT_BROWSE_SUBVIEW,
     TAB_CHAT,
     TAB_LIBRARY,
     TAB_WATCHLISTS_COLLECTIONS,
@@ -115,10 +116,14 @@ def _home_primary_action_context(
         return {"category": SettingsCategoryId.PROVIDERS_MODELS.value}
     if action_id == "resume_last_conversation":
         # The terminal suggestion deep-links the newest conversation into
-        # Console via the ADR-079 nav-context seam (spec §4).
+        # Console via the resume-navigation seam (spec §4; the contract
+        # shipped upstream as CONSOLE_NAV_CONTEXT_RESUME_LOCAL_CONVERSATION_ID).
         resume_id = str(getattr(dashboard_input, "resume_id", "") or "")
         if resume_id:
-            return {CONSOLE_NAV_CONTEXT_CONVERSATION_ID: resume_id}
+            return {CONSOLE_NAV_CONTEXT_RESUME_LOCAL_CONVERSATION_ID: resume_id}
+    if action_id == "review_read_later":
+        # Land Media on the saved-reading queue, not the generic list.
+        return {MEDIA_NAV_CONTEXT_BROWSE_SUBVIEW: MEDIA_BROWSE_SUBVIEW_READ_IT_LATER}
     if action_id == "review_notifications" and getattr(
         action, "target_route", None
     ) in {
@@ -915,8 +920,9 @@ class HomeScreen(BaseAppScreen):
         Notes deep-link into the Library notes editor via the existing
         ``LIBRARY_NAV_CONTEXT_NOTE_ID`` navigation-context contract; media
         into the Library item view via the open-source pair; conversations
-        into Console carrying ``CONSOLE_NAV_CONTEXT_CONVERSATION_ID`` so
-        the freshly mounted screen resumes THAT conversation (ADR-079).
+        into Console carrying the resume-local-conversation nav-context id
+        so the freshly mounted screen resumes THAT conversation through
+        the ordered resume-navigation startup.
         Navigation always composes a fresh screen, so the deep link lands
         on a cleanly mounted surface.
         """
@@ -960,7 +966,7 @@ class HomeScreen(BaseAppScreen):
                 NavigateToScreen(
                     TAB_CHAT,
                     {
-                        CONSOLE_NAV_CONTEXT_CONVERSATION_ID: (
+                        CONSOLE_NAV_CONTEXT_RESUME_LOCAL_CONVERSATION_ID: (
                             target_id.removeprefix(LOCAL_CONVERSATION_ITEM_ID_PREFIX)
                         )
                     },

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -176,16 +176,6 @@ def _home_response_total(result: Any) -> int | None:
     return None
 
 
-def _home_first_record(result: Any) -> Mapping[str, Any] | None:
-    """Return the first record of a list response (list or items-mapping)."""
-    if isinstance(result, Mapping):
-        result = result.get("items")
-    if isinstance(result, Sequence) and not isinstance(result, (str, bytes, bytearray)):
-        first = next(iter(result), None)
-        return first if isinstance(first, Mapping) else None
-    return None
-
-
 def _home_record_timestamp(record: Mapping[str, Any] | None) -> datetime:
     """Parse a record's freshest timestamp for newest-wins comparison."""
     fallback = datetime.min.replace(tzinfo=timezone.utc)

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -13,6 +13,8 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal
 from textual.widgets import Button, Static
 
+from rich.markup import escape as escape_markup
+
 from tldw_chatbook.Chat.console_session_settings import (
     build_console_settings_readiness,
     build_default_console_session_settings,
@@ -23,7 +25,10 @@ from tldw_chatbook.config import (
     save_setting_to_cli_config,
 )
 from tldw_chatbook.Constants import (
+    CONSOLE_NAV_CONTEXT_CONVERSATION_ID,
     LIBRARY_NAV_CONTEXT_NOTE_ID,
+    LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID,
+    LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE,
     TAB_CHAT,
     TAB_LIBRARY,
     TAB_WATCHLISTS_COLLECTIONS,
@@ -32,11 +37,17 @@ from tldw_chatbook.Constants import (
     WATCHLISTS_SECTION_RUNS,
 )
 from tldw_chatbook.Home.dashboard_state import (
+    HOME_OPEN_ITEM_CONTROL_ID,
     HOME_PRIMARY_ACTION_ID,
     HOME_RESUME_KIND_CONVERSATION,
+    HOME_RESUME_KIND_MEDIA,
     HOME_RESUME_KIND_NOTE,
     HOME_RESUME_LATEST_CONTROL_ID,
     HOME_START_CONVERSATION_CONTROL_ID,
+    LOCAL_CONVERSATION_ITEM_ID_PREFIX,
+    LOCAL_MEDIA_ITEM_ID_PREFIX,
+    LOCAL_NOTE_ITEM_ID_PREFIX,
+    HomeActiveWorkItem,
     HomeContentSnapshot,
     HomeControl,
     HomeDashboard,
@@ -44,6 +55,7 @@ from tldw_chatbook.Home.dashboard_state import (
     apply_home_content_snapshot,
     build_home_triage_state,
     choose_home_selected_item,
+    content_item_kind,
     summarize_home_dashboard,
 )
 from tldw_chatbook.Home.home_rail_state import (
@@ -198,36 +210,108 @@ def _home_record_timestamp(record: Mapping[str, Any] | None) -> datetime:
     return fallback
 
 
-def _home_resume_fields(
-    latest_note: Mapping[str, Any] | None,
-    latest_conversation: Mapping[str, Any] | None,
-) -> tuple[str, str, str]:
-    """Pick the newest resume candidate (note vs conversation).
+_HOME_CONTENT_FETCH_LIMIT = 8
 
-    Args:
-        latest_note: The newest local note record, if any.
-        latest_conversation: The newest local conversation record, if any.
 
-    Returns:
-        ``(resume_kind, resume_id, resume_title)`` -- all empty when
-        neither candidate has a usable id. Ties go to the conversation
-        (Console resume is the tighter loop). The title stays RAW here;
-        it is escaped once in ``build_home_resume_control``.
+def _home_content_records(
+    notes_result: Any,
+    conversations_result: Any,
+    media_result: Any,
+) -> list[tuple[str, Mapping[str, Any]]]:
+    """Merge the three content seams into (kind, raw record) newest-first.
+
+    Shapes mirror ``_home_first_record``: a seam result is either a bare
+    list of records or a mapping carrying ``items``. Records without a
+    usable id are dropped.
     """
-    candidates = []
-    if isinstance(latest_conversation, Mapping) and latest_conversation.get(
-        "id"
-    ) not in (None, ""):
-        candidates.append((HOME_RESUME_KIND_CONVERSATION, latest_conversation))
-    if isinstance(latest_note, Mapping) and latest_note.get("id") not in (None, ""):
-        candidates.append((HOME_RESUME_KIND_NOTE, latest_note))
-    if not candidates:
-        return "", "", ""
-    kind, record = max(candidates, key=lambda pair: _home_record_timestamp(pair[1]))
+    merged: list[tuple[str, Mapping[str, Any]]] = []
+    for kind, result in (
+        (HOME_RESUME_KIND_CONVERSATION, conversations_result),
+        (HOME_RESUME_KIND_NOTE, notes_result),
+        (HOME_RESUME_KIND_MEDIA, media_result),
+    ):
+        records = result.get("items") if isinstance(result, Mapping) else result
+        if not isinstance(records, Sequence) or isinstance(
+            records, (str, bytes, bytearray)
+        ):
+            continue
+        for record in records:
+            if isinstance(record, Mapping) and record.get("id") not in (None, ""):
+                merged.append((kind, record))
+    merged.sort(key=lambda pair: _home_record_timestamp(pair[1]), reverse=True)
+    return merged
+
+
+def _home_content_resume_fields(
+    merged: list[tuple[str, Mapping[str, Any]]],
+) -> tuple[str, str, str, str]:
+    """(resume_kind, resume_id, raw truncated title, updated_at) of the top.
+
+    The title stays RAW here (truncated before escaping so escape
+    backslashes can never be cut mid-sequence); it is escaped exactly
+    once, in ``build_home_resume_control``.
+    """
+    if not merged:
+        return "", "", "", ""
+    kind, record = merged[0]
     title = " ".join(str(record.get("title") or "").split())
     if len(title) > _HOME_RESUME_TITLE_MAX_CHARS:
         title = title[: _HOME_RESUME_TITLE_MAX_CHARS - 1].rstrip() + "…"
-    return kind, str(record.get("id")), title
+    return (
+        kind,
+        str(record.get("id")),
+        title,
+        _home_record_timestamp(record).isoformat(),
+    )
+
+
+# (source label, detail route) per content kind for rail rows.
+_HOME_CONTENT_SOURCE_LABELS = {
+    HOME_RESUME_KIND_CONVERSATION: ("Conversations", "chat"),
+    HOME_RESUME_KIND_NOTE: ("Notes", "library"),
+    HOME_RESUME_KIND_MEDIA: ("Media", "library"),
+}
+_HOME_CONTENT_ID_PREFIXES = {
+    HOME_RESUME_KIND_CONVERSATION: LOCAL_CONVERSATION_ITEM_ID_PREFIX,
+    HOME_RESUME_KIND_NOTE: LOCAL_NOTE_ITEM_ID_PREFIX,
+    HOME_RESUME_KIND_MEDIA: LOCAL_MEDIA_ITEM_ID_PREFIX,
+}
+
+
+def _home_content_recent_items(
+    merged: list[tuple[str, Mapping[str, Any]]],
+    *,
+    exclude_id: str,
+) -> tuple[HomeActiveWorkItem, ...]:
+    """Build rail-ready content items, excluding the banner item.
+
+    Titles are markup-escaped HERE (rail rows render straight into Button
+    labels, which parse Rich markup); the banner's raw title is handled
+    separately by ``_home_content_resume_fields`` -- exactly one escape
+    per surface.
+    """
+    items: list[HomeActiveWorkItem] = []
+    for kind, record in merged:
+        item_id = f"{_HOME_CONTENT_ID_PREFIXES[kind]}{record.get('id')}"
+        if item_id == exclude_id:
+            continue
+        source, route = _HOME_CONTENT_SOURCE_LABELS[kind]
+        raw_title = " ".join(str(record.get("title") or "").split())
+        title = escape_markup(raw_title) or escape_markup(
+            f"{kind.title()} {record.get('id')}"
+        )
+        items.append(
+            HomeActiveWorkItem(
+                item_id=item_id,
+                title=title,
+                source=source,
+                status="ready",
+                detail_route=route,
+                console_available=(kind == HOME_RESUME_KIND_CONVERSATION),
+                updated_at=_home_record_timestamp(record).isoformat(),
+            )
+        )
+    return tuple(items)
 
 
 class HomeActionButton(Button):
@@ -384,7 +468,7 @@ class HomeScreen(BaseAppScreen):
         notes_result = await self._home_content_seam_call(
             getattr(notes_service, "list_notes", None),
             scope="local_note",
-            limit=1,
+            limit=_HOME_CONTENT_FETCH_LIMIT,
             user_id=notes_user_id,
         )
         conversations_result = await self._home_content_seam_call(
@@ -394,20 +478,22 @@ class HomeScreen(BaseAppScreen):
             # as Library's rail count: Console chats persisted inside a
             # workspace session would be invisible under 'global'.
             scope_type="all",
-            limit=1,
+            limit=_HOME_CONTENT_FETCH_LIMIT,
             offset=0,
         )
         media_result = await self._home_content_seam_call(
             getattr(media_service, "list_media_items", None),
             mode="local",
             page=1,
-            results_per_page=1,
+            results_per_page=_HOME_CONTENT_FETCH_LIMIT,
             include_keywords=False,
         )
 
-        resume_kind, resume_id, resume_title = _home_resume_fields(
-            _home_first_record(notes_result),
-            _home_first_record(conversations_result),
+        merged = _home_content_records(
+            notes_result, conversations_result, media_result
+        )
+        resume_kind, resume_id, resume_title, resume_updated_at = (
+            _home_content_resume_fields(merged)
         )
         return HomeContentSnapshot(
             console_ready=console_ready,
@@ -419,6 +505,15 @@ class HomeScreen(BaseAppScreen):
             resume_kind=resume_kind,
             resume_id=resume_id,
             resume_title=resume_title,
+            resume_updated_at=resume_updated_at,
+            content_recent_items=_home_content_recent_items(
+                merged,
+                exclude_id=(
+                    f"{_HOME_CONTENT_ID_PREFIXES[resume_kind]}{resume_id}"
+                    if resume_kind and resume_id
+                    else ""
+                ),
+            ),
         )
 
     async def _home_content_seam_call(self, callable_obj: Any, **kwargs: Any) -> Any:
@@ -759,6 +854,9 @@ class HomeScreen(BaseAppScreen):
         if button_id == HOME_RESUME_LATEST_CONTROL_ID:
             self._activate_home_resume_latest()
             return
+        if button_id == HOME_OPEN_ITEM_CONTROL_ID:
+            self._activate_home_open_item()
+            return
         dashboard = self._current_dashboard
         if dashboard is None:
             return
@@ -807,9 +905,12 @@ class HomeScreen(BaseAppScreen):
         """Route the resume-latest control to its one-click destination.
 
         Notes deep-link into the Library notes editor via the existing
-        ``LIBRARY_NAV_CONTEXT_NOTE_ID`` navigation-context contract;
-        conversations route to Console. Navigation always composes a fresh
-        screen, so the deep link lands on a cleanly mounted surface.
+        ``LIBRARY_NAV_CONTEXT_NOTE_ID`` navigation-context contract; media
+        into the Library item view via the open-source pair; conversations
+        into Console carrying ``CONSOLE_NAV_CONTEXT_CONVERSATION_ID`` so
+        the freshly mounted screen resumes THAT conversation (ADR-079).
+        Navigation always composes a fresh screen, so the deep link lands
+        on a cleanly mounted surface.
         """
         control = next(
             (
@@ -819,14 +920,64 @@ class HomeScreen(BaseAppScreen):
             ),
             None,
         )
-        if control is None:
+        if control is None or not control.target_id:
             return
-        if control.target_route == TAB_LIBRARY and control.target_id:
+        self._open_content_item(control.target_id)
+
+    def _activate_home_open_item(self) -> None:
+        """Route the selected content row's Open control (same dispatch)."""
+        control = next(
+            (
+                item
+                for item in self._current_canvas_controls
+                if item.control_id == HOME_OPEN_ITEM_CONTROL_ID
+            ),
+            None,
+        )
+        if control is None or not control.target_id:
+            return
+        self._open_content_item(control.target_id)
+
+    def _open_content_item(self, target_id: str) -> None:
+        """Deep-link a prefixed content item id to its surface.
+
+        Conversations land in Console on that conversation; notes in the
+        Library notes editor; media in the Library item view. Unknown
+        prefixes are a silent no-op (defensive: dispatch only ever builds
+        content ids via ``_home_content_recent_items``).
+        """
+        kind = content_item_kind(target_id)
+        if kind == HOME_RESUME_KIND_CONVERSATION:
+            self.post_message(
+                NavigateToScreen(
+                    TAB_CHAT,
+                    {
+                        CONSOLE_NAV_CONTEXT_CONVERSATION_ID: (
+                            target_id.removeprefix(LOCAL_CONVERSATION_ITEM_ID_PREFIX)
+                        )
+                    },
+                )
+            )
+        elif kind == HOME_RESUME_KIND_NOTE:
             self.post_message(
                 NavigateToScreen(
                     TAB_LIBRARY,
-                    {LIBRARY_NAV_CONTEXT_NOTE_ID: control.target_id},
+                    {
+                        LIBRARY_NAV_CONTEXT_NOTE_ID: target_id.removeprefix(
+                            LOCAL_NOTE_ITEM_ID_PREFIX
+                        )
+                    },
                 )
             )
-            return
-        self.post_message(NavigateToScreen(TAB_CHAT))
+        elif kind == HOME_RESUME_KIND_MEDIA:
+            self.post_message(
+                NavigateToScreen(
+                    TAB_LIBRARY,
+                    {
+                        LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE: "media",
+                        LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID: (
+                            target_id.removeprefix(LOCAL_MEDIA_ITEM_ID_PREFIX)
+                        ),
+                    },
+                )
+            )

--- a/tldw_chatbook/UI/Screens/media_screen.py
+++ b/tldw_chatbook/UI/Screens/media_screen.py
@@ -9,6 +9,7 @@ from ..Navigation.base_app_screen import BaseAppScreen
 from ..MediaWindow_v2 import MediaWindow
 from ..Workbench.workbench_state import WorkbenchHeaderState
 from ..Workbench.workbench_widgets import DestinationHeader
+from ...Constants import MEDIA_NAV_CONTEXT_BROWSE_SUBVIEW
 
 if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
@@ -27,6 +28,25 @@ class MediaScreen(BaseAppScreen):
         # MediaWindow itself is rebuilt fresh every visit -- there is no
         # earlier seam to inject restored view state into before it mounts.
         self._pending_media_restore: Optional[Dict[str, Any]] = None
+        # Navigation-context deep link (Home's read-it-later suggestion):
+        # stashed pre-mount by apply_navigation_context, applied AFTER the
+        # restored view state so the user's explicit navigation wins.
+        self._pending_nav_browse_subview: Optional[str] = None
+
+    def apply_navigation_context(self, context: Dict[str, Any]) -> None:
+        """Stash a browse-subview deep link for post-mount application.
+
+        Args:
+            context: Navigation payload from ``NavigateToScreen``. A valid
+                ``MEDIA_NAV_CONTEXT_BROWSE_SUBVIEW`` value selects the
+                MediaWindow's starting browse subview (e.g. the
+                read-it-later queue); anything else is ignored.
+        """
+        if not isinstance(context, dict):
+            return
+        subview = context.get(MEDIA_NAV_CONTEXT_BROWSE_SUBVIEW)
+        if isinstance(subview, str) and subview.strip():
+            self._pending_nav_browse_subview = subview.strip()
 
     def compose_content(self) -> ComposeResult:
         """Compose the media window content with its destination header."""
@@ -61,6 +81,19 @@ class MediaScreen(BaseAppScreen):
                     "Error applying restored Media view state"
                 )
             self._pending_media_restore = None
+        if self._pending_nav_browse_subview and self.media_window is not None:
+            # Applied after the restored state: an explicit navigation deep
+            # link (Home's "Read-it-later" suggestion) outranks whatever
+            # subview the previous visit happened to leave behind.
+            try:
+                self.media_window.select_browse_subview(
+                    self._pending_nav_browse_subview
+                )
+            except Exception:
+                logger.opt(exception=True).error(
+                    "Error applying Media navigation browse subview"
+                )
+            self._pending_nav_browse_subview = None
 
     async def handle_runtime_backend_changed(self, runtime_backend: str) -> None:
         """Forward runtime-source changes to the mounted production media window."""

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -986,6 +986,10 @@ def _usable_cpu_count() -> int:
 # file must agree on one spelling. Private to `app.py`: every event emitted
 # here belongs to the application lifecycle.
 _DIAGNOSTICS_COMPONENT_APP = "app"
+# Home's open-eval-runs feed queries pending and failed statuses separately;
+# this cap bounds both queries (a count, not a listing -- anything beyond it
+# still reads as "runs need attention").
+_HOME_EVAL_RUN_QUERY_LIMIT = 50
 # Task-4 review round 2: `_offer_tts_global_override`'s confirmation dialog
 # must name which configured-voice domain actually failed -- a per-character
 # assignment, or the app-wide default voice profile (slice 3, task 4) --
@@ -8623,21 +8627,25 @@ class TldwCli(
         if not callable(list_runs):
             return {"pending": 0, "failed": 0}
         try:
-            pending = len(list_runs(status="pending", limit=50))
-            failed = len(list_runs(status="failed", limit=50))
+            pending = len(list_runs(status="pending", limit=_HOME_EVAL_RUN_QUERY_LIMIT))
+            failed = len(list_runs(status="failed", limit=_HOME_EVAL_RUN_QUERY_LIMIT))
         except Exception:
             logger.opt(exception=True).debug("Home eval run counts failed.")
             return {"pending": 0, "failed": 0}
         return {"pending": pending, "failed": failed}
 
     def _local_read_later_count(self) -> int | None:
-        """Count read-it-later media for Home; None when the DB is absent."""
+        """Count read-it-later media for Home; None when the DB is absent.
+
+        Uses the scalar ``COUNT(*)`` seam rather than materializing the
+        id list -- Home needs only the total.
+        """
         db = getattr(self, "media_db", None)
-        lister = getattr(db, "list_read_it_later_media_ids", None)
-        if not callable(lister):
+        counter = getattr(db, "count_read_it_later_media", None)
+        if not callable(counter):
             return None
         try:
-            return len(lister())
+            return int(counter())
         except Exception:
             logger.opt(exception=True).debug("Home read-it-later count failed.")
             return None

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -8612,6 +8612,36 @@ class TldwCli(
             logger.opt(exception=True).debug("Home flashcards-due count failed.")
             return None
 
+    def _local_eval_open_run_counts(self) -> dict[str, int]:
+        """Count pending/failed local eval runs for Home (spec §4).
+
+        Never counts 'running' -- a crashed app orphans running rows
+        forever, which would permanently pin the review suggestion.
+        """
+        service = getattr(self, "local_evaluation_service", None)
+        list_runs = getattr(service, "list_runs", None)
+        if not callable(list_runs):
+            return {"pending": 0, "failed": 0}
+        try:
+            pending = len(list_runs(status="pending", limit=50))
+            failed = len(list_runs(status="failed", limit=50))
+        except Exception:
+            logger.opt(exception=True).debug("Home eval run counts failed.")
+            return {"pending": 0, "failed": 0}
+        return {"pending": pending, "failed": failed}
+
+    def _local_read_later_count(self) -> int | None:
+        """Count read-it-later media for Home; None when the DB is absent."""
+        db = getattr(self, "media_db", None)
+        lister = getattr(db, "list_read_it_later_media_ids", None)
+        if not callable(lister):
+            return None
+        try:
+            return len(lister())
+        except Exception:
+            logger.opt(exception=True).debug("Home read-it-later count failed.")
+            return None
+
     def open_active_home_item_details(
         self,
         *,
@@ -9638,6 +9668,11 @@ class TldwCli(
             # lambda closes over self so it resolves lazily on first Home
             # compose rather than at wiring time here.
             ingest_jobs_provider=lambda: self.library_ingest_jobs.jobs(),
+            # Open-task queue feeds (spec §4); same lazy-self closure reason
+            # as ingest_jobs_provider -- local_evaluation_service and
+            # media_db are assigned later in __init__.
+            eval_open_runs_provider=lambda: self._local_eval_open_run_counts(),
+            read_later_count_provider=lambda: self._local_read_later_count(),
         )
         try:
             self.server_claims_service = ServerClaimsService.from_config(


### PR DESCRIPTION
## Summary

Home now answers "what was I working on?" and "what's next?" with real deep-links:

- **Console conversation deep-link seam (ADR-079)** — new `CONSOLE_NAV_CONTEXT_CONVERSATION_ID` navigation-context key; `ChatScreen.apply_navigation_context` (6th implementer of the contract) stores pre-mount and consumes from the mount timer chain, preferring a live-session switch over rehydration, owning the TASK-717 missing-record toast, and clearing every competing live-work handoff channel (LIVE_WORK, CHAT, FLEET_COMPLETION) at apply time.
- **Content recents stream** — conversations/notes/media merged into Home's Recent rail section (newest-first, capped 8, computed in the existing `HomeContentSnapshot` worker from the same scope-service seams, limit-8). The resume banner is promoted to the newest content item — **media is a new resume kind** ("Resume reading: … (3m)") — and the limit-1 `_home_resume_fields` queries are retired. A selected content row gets an **Open** control that deep-links it (conversation → Console *at that conversation*; note → Library editor; media → Library item view).
- **Next-up ladder feeds** — two new branches ("Review eval runs" when pending/failed runs exist — never `running`, which crashes orphan forever; "Read-it-later: N items"), and the terminal suggestion becomes **"Resume last conversation"** with the id attached, falling back to "Start a conversation" on fresh profiles.
- Docs: User Guide home.md updated; follow-ups filed as task-21517 (failed_schedule_count producer — no cheap query exists today) and task-21518 (phase-2 opens journal so read-only sessions count as recents; also feeds task-18921).

Design docs: `Docs/superpowers/specs/2026-08-29-home-recents-resume-and-next-up-design.md`, plan `Docs/superpowers/plans/2026-08-29-home-recents-resume-and-next-up.md`, ADR `backlog/decisions/079-console-conversation-deep-link-nav-context.md`.

## Stack note

This branch forks from the local `docs/lesson-adr-number-collisions` tip (not yet pushed), so the PR carries its 14 commits beneath the feature's 10 — the feature builds directly on that branch's unmerged T190 content-snapshot pipeline, so the stack travels together.

## Test evidence (targeted; no full sweep)

- `Tests/Home/` + `Tests/UI/test_home_screen.py` + triage-rail/dashboard-seams: **421 passed** on the final tree, including new end-to-end pilot proofs (resume banner click asserts the Console nav context; primary-action click asserts the terminal deep-link).
- 9 failures in `test_console_live_work_handoffs.py` / `test_screen_navigation.py` are **pre-existing on the base commit** (verified in a detached worktree by the whole-branch review): the `_bare_console_screen_for_restore` helper lags the controller-wiring wave, plus a rail child-ordering assertion.

## Review trail

Every task passed an independent task review (one fix round each for Task 1 and Task 3); final whole-branch review verified the nav-context id contract at every producer/consumer and returned "Ready to merge — with fixes", both fixed and re-reviewed clean (commit ebfbc1dae).

## Not yet done

- Live smoke run (launch app, click the media banner / a row's Open) — pilot tests cover the dispatch chains; worth a 2-minute manual pass.
- ADR-079 is numbered on this branch's sequence; the in-flight ADR renumbering (TASK-19610) may renumber it at merge time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Home now shows a "what you were working on last" recents stream (conversations, notes, media) and deep-links conversations straight into Console, replacing the single-item resume banner. The next-up ladder gains eval-run and read-it-later suggestions, and the terminal suggestion becomes "Resume last conversation" when one exists.

**What changed**
- Rebased onto dev's shipped `CONSOLE_NAV_CONTEXT_RESUME_LOCAL_CONVERSATION_ID` seam; the branch's duplicate seam, ADR, and tests were dropped for the upstream contract, resolving the prompt-insert race and worker-exclusivity findings by construction.
- Merges content recents into Home's Recent rail (newest first, capped 8) and promotes the resume banner to the newest content item, adding media as a new resume kind.
- Next-up ladder branches require pending/failed (never running) eval runs and a non-empty read-it-later queue; the count uses a new scalar COUNT seam instead of materializing the id list.
- Read-it-later suggestion lands on the saved-reading subview via a new Media nav context.
- Retires the limit-1 `_home_resume_fields` queries and adds an Open control on selected recent rows.
- Backlog task IDs 21514/21515 were renumbered to 25710/25711 because those IDs were taken on dev.
- Updates the Home User Guide and files follow-ups for `failed_schedule_count`, opens-journal recents, and the evals NULL-JSON crash found in live UAT.
- Refreshes the production diagnostic inventory pin for the new diagnostic calls.

**Notes**
- This branch also carries 14 documentation commits from an unmerged sibling branch — review those separately if needed.
- Adds scratch-profile trap notes (db pins overriding data_dir, /tmp sticky guard, torn rsync snapshots) to `backlog/docs/lessons-live-verification.md`.
- 9 test failures in `test_console_live_work_handoffs.py` and `test_screen_navigation.py` are pre-existing on the base commit.

<sup>Written for commit f83074db465e44b31820699f4d99ba14615b18b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

