### PR TITLE
docs: Console UX/HCI review findings + verified root cause for the dead core loop

### DIFF
--- a/backlog/tasks/task-25712 - Console-send-is-blocked-before-provider-dispatch-when-trace-capture-cannot-be-saved.md
+++ b/backlog/tasks/task-25712 - Console-send-is-blocked-before-provider-dispatch-when-trace-capture-cannot-be-saved.md
@@ -1,0 +1,28 @@
+---
+id: TASK-25712
+title: >-
+  Console send is blocked before provider dispatch when trace capture cannot be
+  saved
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:07'
+labels:
+  - console
+  - ux-review
+  - p0
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A Console send that cannot record a trace is refused entirely: the interrupt card states "The provider was not contacted". Reproduced on a clean first-run profile and on a repaired existing profile, against a local provider that answers the same request in 0.8s over curl. This makes the product's core loop unusable rather than degraded, and a diagnostics feature the user never enabled becomes a hard dependency of chatting.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A send whose trace capture fails still reaches the provider
+- [ ] #2 Trace-capture failure is surfaced as a non-blocking warning, not a card that halts dispatch
+- [ ] #3 A clean first-run profile with a reachable provider completes a send end to end without any interrupt card
+<!-- AC:END -->

--- a/backlog/tasks/task-25712 - Console-send-is-blocked-before-provider-dispatch-when-trace-capture-cannot-be-saved.md
+++ b/backlog/tasks/task-25712 - Console-send-is-blocked-before-provider-dispatch-when-trace-capture-cannot-be-saved.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-08-31 05:07'
+updated_date: '2026-08-31 05:22'
 labels:
   - console
   - ux-review
@@ -26,3 +27,62 @@ A Console send that cannot record a trace is refused entirely: the interrupt car
 - [ ] #2 Trace-capture failure is surfaced as a non-blocking warning, not a card that halts dispatch
 - [ ] #3 A clean first-run profile with a reachable provider completes a send end to end without any interrupt card
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+ROOT CAUSE FOUND (live instrumentation, not inference).
+
+Patched TraceCallPersistenceError.__init__ to dump a stack, ran the real app,
+sent a message. Single captured frame:
+
+  console_agent_bridge.py:2895   _consume -> gateway.stream_chat(...)
+  console_provider_gateway.py:3902  stream_chat -> self._reserve_trace_call(...)
+  console_provider_gateway.py:2224  raise TraceCallPersistenceError(reservation_status="not_established")
+
+Captured "active exc: None" -- nothing threw. Nothing failed to write. This is a
+guard firing on a permanent condition:
+
+  # console_provider_gateway.py:2223
+  if self._trace_call_boundary_factory is None:
+      raise TraceCallPersistenceError(reservation_status="not_established")
+
+The chain:
+1. ConsoleTurnPreparation.capture_mode defaults to CAPTURE_ON
+   (console_turn_preparation.py:118).
+2. stream_chat routes every CAPTURE_ON send through _reserve_trace_call
+   (console_provider_gateway.py:3900-3906).
+3. _reserve_trace_call hard-fails when _trace_call_boundary_factory is None.
+4. NO PRODUCTION CODE EVER SUPPLIES THAT FACTORY. Both callers of
+   ensure_provider_gateway omit it -- chat_screen.py:6392 and
+   console_launch_wake.py:212. Only six Tests/ files inject one, and
+   ConsoleTraceCallBoundary is constructed exclusively in tests.
+=> every production Console send raises, and the controller converts it into
+   the "Trace capture blocked" pause. The provider is never contacted.
+
+The gateway's own docstring calls this seam "Optional ... when supplied"
+(console_provider_gateway.py:2088), so the call site violates the documented
+contract of the parameter it depends on.
+
+WHY TESTS ARE GREEN: every test injects a factory, so the suite exercises only
+the wired path and never the production one.
+
+REGRESSION WINDOW: introduced by c78f641ad "feat(console): implement
+reference-backed semantic trace ledger" (2026-08-30, 30 commits before the
+reviewed tip 0ef6f3fd4) -- the commit added the consumer without wiring the
+producer. Same-day regression on dev, not long-standing.
+
+TWO FIX SHAPES, product decision required:
+(a) Wire a real ConsoleTraceCallBoundary factory at both production call sites
+    -- makes the shipped feature actually work.
+(b) Treat a missing factory as "capture unavailable" and take the existing
+    _capture_off_admission path instead of raising -- honours the documented
+    "optional" contract and guarantees a missing seam can never kill the core
+    loop.
+Recommend BOTH: (a) restores intent, (b) is the defense-in-depth that stops
+this class of half-wiring from ever being fatal again.
+
+REGRESSION TEST GAP: needs a test that builds the gateway WITHOUT a factory
+(i.e. exactly as production does) and asserts a CAPTURE_ON send still reaches
+the adapter.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-25712 - Console-send-is-blocked-before-provider-dispatch-when-trace-capture-cannot-be-saved.md
+++ b/backlog/tasks/task-25712 - Console-send-is-blocked-before-provider-dispatch-when-trace-capture-cannot-be-saved.md
@@ -6,7 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-08-31 05:07'
-updated_date: '2026-08-31 05:22'
+updated_date: '2026-08-31 05:34'
 labels:
   - console
   - ux-review
@@ -31,58 +31,67 @@ A Console send that cannot record a trace is refused entirely: the interrupt car
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-ROOT CAUSE FOUND (live instrumentation, not inference).
-
-Patched TraceCallPersistenceError.__init__ to dump a stack, ran the real app,
-sent a message. Single captured frame:
+ROOT CAUSE (verified by live instrumentation + isolated repro):
 
   console_agent_bridge.py:2895   _consume -> gateway.stream_chat(...)
   console_provider_gateway.py:3902  stream_chat -> self._reserve_trace_call(...)
   console_provider_gateway.py:2224  raise TraceCallPersistenceError(reservation_status="not_established")
 
-Captured "active exc: None" -- nothing threw. Nothing failed to write. This is a
-guard firing on a permanent condition:
+Captured "active exc: None" -- nothing threw, nothing failed to write. The guard
+fires on a permanent condition:
 
-  # console_provider_gateway.py:2223
   if self._trace_call_boundary_factory is None:
       raise TraceCallPersistenceError(reservation_status="not_established")
 
-The chain:
-1. ConsoleTurnPreparation.capture_mode defaults to CAPTURE_ON
-   (console_turn_preparation.py:118).
-2. stream_chat routes every CAPTURE_ON send through _reserve_trace_call
-   (console_provider_gateway.py:3900-3906).
-3. _reserve_trace_call hard-fails when _trace_call_boundary_factory is None.
-4. NO PRODUCTION CODE EVER SUPPLIES THAT FACTORY. Both callers of
-   ensure_provider_gateway omit it -- chat_screen.py:6392 and
-   console_launch_wake.py:212. Only six Tests/ files inject one, and
-   ConsoleTraceCallBoundary is constructed exclusively in tests.
-=> every production Console send raises, and the controller converts it into
-   the "Trace capture blocked" pause. The provider is never contacted.
+Chain: ConsoleTurnPreparation.capture_mode defaults to CAPTURE_ON
+(console_turn_preparation.py:118) -> stream_chat routes every CAPTURE_ON send
+through _reserve_trace_call -> that raises when the factory is None -> NO
+PRODUCTION CODE EVER SUPPLIES THAT FACTORY. Both callers of
+ensure_provider_gateway omit it (chat_screen.py:6392,
+console_launch_wake.py:212); ConsoleTraceCallBoundary is constructed only in
+Tests/. Introduced by c78f641ad (2026-08-30) -- consumer landed without producer.
 
-The gateway's own docstring calls this seam "Optional ... when supplied"
-(console_provider_gateway.py:2088), so the call site violates the documented
-contract of the parameter it depends on.
+WHY CI IS GREEN: every test injects a factory, and the shared helper
+_capture_on_prepared_request SILENTLY INSTALLS ONE when absent
+(Tests/Chat/test_console_provider_gateway.py:141-160). The suite therefore
+cannot observe the shipped configuration.
 
-WHY TESTS ARE GREEN: every test injects a factory, so the suite exercises only
-the wired path and never the production one.
+*** THE DEGRADE FIX (b) IS OFF THE TABLE -- DO NOT ATTEMPT IT. ***
+I implemented it TDD-first and it broke a deliberate pinning test:
+Tests/Chat/test_console_provider_gateway.py::
+test_capture_on_without_durable_boundary_cannot_enter_adapter
+That test is the exact inverse of the degrade: same setup (factory set to None,
+CAPTURE_ON), asserting `pytest.raises(TraceCallPersistenceError)` AND
+`adapter_called is False`. It passes on clean code. So refusing to dispatch a
+Capture-On turn with no durable boundary is an INTENTIONAL SAFETY INVARIANT --
+a provider call that leaves no auditable trace record must not happen. The
+guard is correct; the wiring is missing.
 
-REGRESSION WINDOW: introduced by c78f641ad "feat(console): implement
-reference-backed semantic trace ledger" (2026-08-30, 30 commits before the
-reviewed tip 0ef6f3fd4) -- the commit added the consumer without wiring the
-producer. Same-day regression on dev, not long-standing.
+Two degrade variants were tried and both are wrong:
+  1. Downgrade capture_mode to CAPTURE_OFF at the admission seam ->
+     TraceProvenanceAlignmentError "Capture Off cannot dispatch a capture-on
+     prepared request" (the PREPARED REQUEST carries capture-on provenance,
+     so dispatch-time downgrade is incoherent by construction).
+  2. Return None from _reserve_trace_call + supply the paired
+     capture_off_admission at both call sites (fresh route and
+     _authorize_llamacpp_fallback). This DOES work mechanically -- both new
+     tests passed -- but it defeats the invariant above.
 
-TWO FIX SHAPES, product decision required:
-(a) Wire a real ConsoleTraceCallBoundary factory at both production call sites
-    -- makes the shipped feature actually work.
-(b) Treat a missing factory as "capture unavailable" and take the existing
-    _capture_off_admission path instead of raising -- honours the documented
-    "optional" contract and guarantees a missing seam can never kill the core
-    loop.
-Recommend BOTH: (a) restores intent, (b) is the defense-in-depth that stops
-this class of half-wiring from ever being fatal again.
+=> THE ONLY CORRECT FIX IS (a): wire a real ConsoleTraceCallBoundary factory
+   at both production call sites. The feature was shipped half-wired.
 
-REGRESSION TEST GAP: needs a test that builds the gateway WITHOUT a factory
-(i.e. exactly as production does) and asserts a CAPTURE_ON send still reaches
-the adapter.
+NOTE for whoever does it: _trace_dispatch_admission (:5050) documents the
+pairing rule -- a null boundary is only accepted alongside a capture_off
+admission -- and BOTH _reserve_trace_call call sites need the real factory
+(:3902 fresh route, :4237 llama.cpp fallback; llama_cpp is the default local
+provider and an empty streaming response is what drives that retry).
+
+REGRESSION TEST TO ADD WITH THE FIX: assert that a gateway built the way
+production builds it -- runtime.ensure_provider_gateway() as called from
+chat_screen.py -- comes back with a non-None _trace_call_boundary_factory.
+No current test covers the production wiring path.
+
+UNRELATED PRE-EXISTING FAILURE observed at dev 0ef6f3fd4 (NOT caused by this):
+Tests/Chat/test_console_trace_settlement.py::
+test_cold_restart_recovers_open_calls_monotonically_and_idempotently
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-25713 - Console-shows-no-status-while-a-reply-is-pending.md
+++ b/backlog/tasks/task-25713 - Console-shows-no-status-while-a-reply-is-pending.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25713
+title: Console shows no status while a reply is pending
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:07'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+An assistant row mounts as an empty bordered block with no spinner, elapsed timer, or state label. Against a provider that answers in 0.8s, Console showed this blank block for over 30 seconds before any card appeared. A pending reply, a stalled run, and a silently failed run are visually identical, which is the highest-frequency moment in the product.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A pending assistant row always shows a live state label distinguishing generating, waiting on an action, and failed
+- [ ] #2 Elapsed time is visible while a reply is pending
+- [ ] #3 A run that ends without content renders an explicit outcome instead of an empty block
+<!-- AC:END -->

--- a/backlog/tasks/task-25714 - Conversation-database-failure-gives-recovery-advice-that-cannot-work.md
+++ b/backlog/tasks/task-25714 - Conversation-database-failure-gives-recovery-advice-that-cannot-work.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25714
+title: Conversation database failure gives recovery advice that cannot work
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:07'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When the conversation database cannot be opened, Console tells the user to restart and check the app log. Restarting cannot fix an on-disk fault, and the underlying exception is never written to the log, so the instruction leads nowhere. In the observed case a single corrupt index made the whole product unusable while table data and foreign keys were intact and one REINDEX restored it.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The underlying database exception is written to the app log before the user is told to consult it
+- [ ] #2 Console distinguishes a repairable integrity fault from an unrecoverable one and says which it is
+- [ ] #3 A repairable fault offers an in-app repair action rather than only a restart suggestion
+<!-- AC:END -->

--- a/backlog/tasks/task-25715 - Global-hotkeys-open-new-modals-over-an-unresolved-required-decision.md
+++ b/backlog/tasks/task-25715 - Global-hotkeys-open-new-modals-over-an-unresolved-required-decision.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25715
+title: Global hotkeys open new modals over an unresolved required decision
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:07'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+While a blocking interrupt card is mounted and asking the user to choose one action, Ctrl+K and F1 each open another modal on top of it, producing three stacked layers with the original decision still pending. Panels also render without a scrim, so a modal reads as an inline card and clicks outside it silently do nothing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Global hotkeys that open panels are suppressed while a blocking decision card is mounted
+- [ ] #2 Modal surfaces render a scrim that visually separates them from live content
+- [ ] #3 Clicks outside a modal produce a visible response rather than silently doing nothing
+<!-- AC:END -->

--- a/backlog/tasks/task-25716 - First-run-stepper-marks-steps-complete-that-were-never-configured.md
+++ b/backlog/tasks/task-25716 - First-run-stepper-marks-steps-complete-that-were-never-configured.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25716
+title: First-run stepper marks steps complete that were never configured
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:08'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The setup wizard stamps a checkmark on each step the user passes through, regardless of whether its required values were set. Its own summary screen contradicts the stepper, reporting the provider and model as not configured while every step chip above shows complete. Users read the stepper, not the summary, and believe setup succeeded.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A step chip shows complete only when that step's required values are set
+- [ ] #2 A skipped or incomplete step is visually distinct from a completed one
+- [ ] #3 The stepper and the summary screen never disagree about the same step
+<!-- AC:END -->

--- a/backlog/tasks/task-25717 - First-run-wizard-discards-the-provider-endpoint-the-user-entered-and-tested.md
+++ b/backlog/tasks/task-25717 - First-run-wizard-discards-the-provider-endpoint-the-user-entered-and-tested.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25717
+title: First-run wizard discards the provider endpoint the user entered and tested
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:08'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The provider step accepts an endpoint, confirms it with a successful connection test, and then does not persist it. The saved draft records only the provider key while the sibling voice step persists its own endpoint correctly. The one value that determines whether the product can reach a model is dropped after the interface confirmed it.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 An endpoint entered on the provider step is persisted with the rest of that step's draft
+- [ ] #2 A successful connection test does not report success for a value that will not be retained
+- [ ] #3 Completing first-run setup with a local provider leaves a configuration that can reach that provider
+<!-- AC:END -->

--- a/backlog/tasks/task-25718 - First-run-model-step-leaves-the-only-recommended-model-unselected.md
+++ b/backlog/tasks/task-25718 - First-run-model-step-leaves-the-only-recommended-model-unselected.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25718
+title: First-run model step leaves the only recommended model unselected
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:08'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The model step queries the configured provider, finds the available models, and labels one as recommended, but leaves every option unselected. Pressing Next proceeds with no model chosen and stamps the step complete. When exactly one model is offered and it is already marked recommended, requiring a separate click adds a step whose only outcome is a misconfigured install.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A sole available model marked recommended is selected by default
+- [ ] #2 Advancing without a model selected is either prevented or clearly reported
+- [ ] #3 The summary reflects the model actually chosen
+<!-- AC:END -->

--- a/backlog/tasks/task-25719 - First-run-wizards-final-step-removes-every-exit-affordance.md
+++ b/backlog/tasks/task-25719 - First-run-wizards-final-step-removes-every-exit-affordance.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25719
+title: First-run wizard's final step removes every exit affordance
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:08'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Steps one through five advertise Esc to leave setup and show it in the footer hint. The final step silently withdraws it: Esc stops working, the footer shows only Back, and no control is labelled Finish or Done. The only ways out are three body buttons whose names describe destinations rather than completion, so users cannot tell that setup is over.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Esc behaves consistently on every wizard step or its removal is explained on screen
+- [ ] #2 The final step offers a clearly labelled completion action
+- [ ] #3 The footer hint line matches the keys that actually work on the current step
+<!-- AC:END -->

--- a/backlog/tasks/task-25720 - Disabled-and-low-emphasis-actions-render-below-readable-contrast.md
+++ b/backlog/tasks/task-25720 - Disabled-and-low-emphasis-actions-render-below-readable-contrast.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25720
+title: Disabled and low-emphasis actions render below readable contrast
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:08'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A disabled primary button renders at roughly 1.4 to 1 against its background while the adjacent dismissive action renders near 14 to 1, so the dialog appears to offer only the dismissive choice. The same pattern makes the first-run final step's three exit controls render at roughly 1.65 to 1. A disabled control must still be legible enough to be understood as unavailable rather than absent.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Disabled control text meets at least 3 to 1 contrast against its background
+- [ ] #2 A primary action remains the most visually prominent control in its dialog in every state
+- [ ] #3 No interactive control renders below 3 to 1 in any state
+<!-- AC:END -->

--- a/backlog/tasks/task-25721 - Provider-continuation-card-shows-remote-handoff-copy-during-local-sends.md
+++ b/backlog/tasks/task-25721 - Provider-continuation-card-shows-remote-handoff-copy-during-local-sends.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25721
+title: Provider continuation card shows remote-handoff copy during local sends
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:08'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A plain local send surfaced a card reading that response delivery status is unknown on the source device and warning that retrying may send a duplicate request. There is no source device in a local single-machine send. The card also omits the Owner, Problem and Impact structure the sibling interrupt card uses, so the product presents two different grammars for the same class of blocking decision.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Continuation-recovery copy appears only for sends that genuinely crossed a device boundary
+- [ ] #2 All blocking interrupt cards use one consistent Owner, Problem, Impact and action structure
+- [ ] #3 Card copy names a concrete cause rather than an internal subsystem
+<!-- AC:END -->

--- a/backlog/tasks/task-25722 - Unsaved-changes-dialog-offers-Cancel-and-Discard-changes-without-distinguishing-them.md
+++ b/backlog/tasks/task-25722 - Unsaved-changes-dialog-offers-Cancel-and-Discard-changes-without-distinguishing-them.md
@@ -1,0 +1,27 @@
+---
+id: TASK-25722
+title: >-
+  Unsaved-changes dialog offers Cancel and Discard changes without
+  distinguishing them
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:08'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Dismissing a settings modal with unsaved edits silently adds a third button so the row reads Save, Cancel, Discard changes. Nothing indicates whether Cancel abandons the edits or abandons the dismissal, which is the classic ambiguous-dialog trap. Users must guess which control preserves their work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The dialog offers two unambiguous choices covering discard and continue editing
+- [ ] #2 Each button names the outcome it produces rather than a generic verb
+- [ ] #3 Controls appearing in response to unsaved edits are announced rather than added silently
+<!-- AC:END -->

--- a/backlog/tasks/task-25723 - Composer-actions-menu-spends-thirty-rows-on-six-items.md
+++ b/backlog/tasks/task-25723 - Composer-actions-menu-spends-thirty-rows-on-six-items.md
@@ -1,0 +1,26 @@
+---
+id: TASK-25723
+title: Composer actions menu spends thirty rows on six items
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:09'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The composer menu spreads six actions over roughly thirty rows with items centred rather than left aligned, anchors itself at the top left while its trigger sits at the bottom of the screen, and shows no keyboard accelerators. Reasons for disabled items are present and well written but separated from their action by blank rows, weakening the association. The result occludes the transcript to present very little.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Menu items are left aligned and vertically compact enough to scan without scrolling
+- [ ] #2 The menu is anchored adjacent to the control that opens it
+- [ ] #3 A disabled item's reason is visually bound to that item
+- [ ] #4 Keyboard accelerators are shown for actions that have them
+<!-- AC:END -->

--- a/backlog/tasks/task-25724 - Send-button-cost-estimate-is-reachable-only-by-mouse-hover.md
+++ b/backlog/tasks/task-25724 - Send-button-cost-estimate-is-reachable-only-by-mouse-hover.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25724
+title: Send button cost estimate is reachable only by mouse hover
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:09'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The Send label gains a dollar suffix when a cost estimate exists, but the estimate itself is delivered solely through a hover tooltip. In a keyboard-first terminal application hover is the one channel the primary audience does not use, so the information is unreachable. The unlabelled marker also changes the button's width on the keystroke path, shifting the composer's right edge while typing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A cost estimate is reachable without a pointer
+- [ ] #2 The cost affordance is labelled rather than represented by a bare symbol
+- [ ] #3 Send button width does not change as the draft is typed
+<!-- AC:END -->

--- a/backlog/tasks/task-25725 - Workspace-conversation-load-failure-shows-a-truncated-message-with-no-cause.md
+++ b/backlog/tasks/task-25725 - Workspace-conversation-load-failure-shows-a-truncated-message-with-no-cause.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25725
+title: Workspace conversation load failure shows a truncated message with no cause
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:09'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When the workspace conversation list fails to load, the rail shows a clipped string and a bare Retry control. Two distinct root causes are collapsed into one generic sentence, the real exception is swallowed into a debug log, and the visible text is cut off by the rail width so the user cannot read even the generic message.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The rail error is legible at the rail's actual width
+- [ ] #2 Distinct failure causes produce distinct user-facing messages
+- [ ] #3 The underlying exception is recorded at a level the user can be pointed to
+<!-- AC:END -->

--- a/backlog/tasks/task-25726 - Console-status-bar-clips-mid-label-instead-of-prioritising-its-content.md
+++ b/backlog/tasks/task-25726 - Console-status-bar-clips-mid-label-instead-of-prioritising-its-content.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25726
+title: Console status bar clips mid-label instead of prioritising its content
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:09'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The status strip renders its segments at fixed order and truncates whatever overflows. At eighty columns it ends mid-word on the model segment, so the model name, one of the most consequential facts in the strip, is the first thing lost. Segment content also changes shape between states, reflowing the whole row.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The status strip degrades by prioritising segments rather than clipping mid-label
+- [ ] #2 Provider and model remain visible at the narrowest supported width
+- [ ] #3 Segments do not reflow the row when their content changes
+<!-- AC:END -->

--- a/backlog/tasks/task-25727 - Footer-database-size-and-token-timers-stall-the-event-loop.md
+++ b/backlog/tasks/task-25727 - Footer-database-size-and-token-timers-stall-the-event-loop.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25727
+title: Footer database size and token timers stall the event loop
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:09'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The application log records event loop stalls above one second with the footer database size and token polling timers active. In a keyboard-driven terminal application a stall of that length buffers keystrokes and delivers them late, which is the same input-integrity failure class addressed in earlier Console work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Footer polling work runs off the event loop
+- [ ] #2 No footer-attributed stall exceeds the diagnostic threshold under normal use
+- [ ] #3 Typing remains responsive while footer counters refresh
+<!-- AC:END -->

--- a/backlog/tasks/task-25728 - Interrupt-card-consumes-the-entire-transcript-at-eighty-by-twenty-four.md
+++ b/backlog/tasks/task-25728 - Interrupt-card-consumes-the-entire-transcript-at-eighty-by-twenty-four.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25728
+title: Interrupt card consumes the entire transcript at eighty by twenty-four
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:10'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+At the default terminal size the Console chrome compacts correctly, but a mounted interrupt card fills the whole content area and leaves no transcript visible. The user is asked to choose between sending, retrying and cancelling without being able to see the message the decision applies to.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 An interrupt card leaves the relevant transcript context visible at the narrowest supported size
+- [ ] #2 The card scrolls within its own region rather than displacing all content
+- [ ] #3 The message under decision is identifiable from the card itself
+<!-- AC:END -->

--- a/backlog/tasks/task-25729 - Toggle-controls-use-three-different-state-encodings-across-the-app.md
+++ b/backlog/tasks/task-25729 - Toggle-controls-use-three-different-state-encodings-across-the-app.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25729
+title: Toggle controls use three different state encodings across the app
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:10'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Radio and checkbox states are drawn three different ways: filled versus hollow glyphs in the first-run wizard, a blank inner cell for checkboxes, and an identical glyph in both states distinguished only by dot colour in Console modals. In that last form the off state renders at roughly 1.4 to 1, so selection is invisible in any text-based capture and carried by colour alone, which the project's own accessibility guidance forbids.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Selected and unselected states differ by glyph shape, not colour alone
+- [ ] #2 One toggle encoding is used consistently across wizard, modal and settings surfaces
+- [ ] #3 The unselected indicator meets at least 3 to 1 contrast
+<!-- AC:END -->

--- a/backlog/tasks/task-25730 - Provider-list-renders-its-selected-row-dimmer-than-unselected-rows.md
+++ b/backlog/tasks/task-25730 - Provider-list-renders-its-selected-row-dimmer-than-unselected-rows.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25730
+title: Provider list renders its selected row dimmer than unselected rows
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:10'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+On the first-run provider step the chosen provider is marked with bold and underline, which is a sound non-colour signal, but its text renders at a lower value than its unselected siblings so the selected row reads as the least prominent one. No leading marker is used, which is the cheapest and clearest selection affordance in a terminal.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The selected row is at least as prominent as unselected rows
+- [ ] #2 Selection is carried by a leading marker in addition to text styling
+- [ ] #3 Selection state is apparent without comparing rows side by side
+<!-- AC:END -->

--- a/backlog/tasks/task-25731 - Connection-test-reports-outcomes-in-developer-language-and-withholds-what-it-learned.md
+++ b/backlog/tasks/task-25731 - Connection-test-reports-outcomes-in-developer-language-and-withholds-what-it-learned.md
@@ -1,0 +1,27 @@
+---
+id: TASK-25731
+title: >-
+  Connection test reports outcomes in developer language and withholds what it
+  learned
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:10'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A failed provider test reports that the model listing request had a connection error, naming neither the address tried, the reason, nor a next step. A partial success reports that the listing was reached but the selected model was not confirmed, without naming the models the server just returned. In both cases the product knows more than it says, and the copy is written for the implementer rather than the user.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A failed test names the address tried, the reason, and one concrete next step
+- [ ] #2 A successful listing reports the models it discovered
+- [ ] #3 Test result copy matches the plain-language standard used elsewhere in setup
+<!-- AC:END -->

--- a/backlog/tasks/task-25732 - Console-exposes-internal-vocabulary-and-unexplained-glyphs.md
+++ b/backlog/tasks/task-25732 - Console-exposes-internal-vocabulary-and-unexplained-glyphs.md
@@ -1,0 +1,25 @@
+---
+id: TASK-25732
+title: Console exposes internal vocabulary and unexplained glyphs
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:10'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Console surfaces terms and symbols with no in-context explanation, including resolved destination, library tool mode, impersonate, a bare dollar marker on the send control, and asterisk and dash markers on rail rows. The status chip reading agent blocked opens a modal titled library access, so the label the user clicks and the destination they reach do not share a name.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Terms shown in Console are either plain language or explained where they appear
+- [ ] #2 Glyph markers used in the rail are documented in an accessible legend
+- [ ] #3 A status chip and the surface it opens share a consistent name
+<!-- AC:END -->

--- a/backlog/tasks/task-25733 - Composer-collapse-hides-the-only-input-while-the-footer-still-advertises-sending.md
+++ b/backlog/tasks/task-25733 - Composer-collapse-hides-the-only-input-while-the-footer-still-advertises-sending.md
@@ -1,0 +1,27 @@
+---
+id: TASK-25733
+title: >-
+  Composer collapse hides the only input while the footer still advertises
+  sending
+status: To Do
+assignee: []
+created_date: '2026-08-31 05:10'
+labels:
+  - console
+  - ux-review
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The control that collapses the composer sits immediately beside the input it hides and is labelled only with the word composer. After collapsing, the footer continues to advertise Enter to send and queue although no input exists. Console also reports no active conversation in the rail while the tab bar and title both name one.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The collapse control names the outcome it produces
+- [ ] #2 Footer hints reflect only the keys that work in the current state
+- [ ] #3 Rail, tab bar and title agree on whether a conversation is active
+<!-- AC:END -->


### PR DESCRIPTION
## What this is

A live UX/HCI review of the Console screen at `dev` (`0ef6f3fd4`), filed as 22 atomic backlog tasks, plus a verified root cause for the one finding that makes the product unusable.

**This PR contains no production code.** It is `backlog/tasks/` only — 22 files, 629 insertions. See "Why no code fix" below; that is the substantive result, not an omission.

## The headline: Console's core loop is dead on `dev`

Every Console send is refused before the provider is contacted:

> Trace capture blocked — Owner: This Console send — Problem: Trace capture could not be saved. — **Impact: The provider was not contacted.**

Reproduced on a clean first-run profile *and* on an existing profile, against a local provider that answers the same request in **0.8s** over `curl`.

### Root cause (verified, not inferred)

I instrumented `TraceCallPersistenceError.__init__` to dump a stack and drove the real app:

```
console_agent_bridge.py:2895      _consume → gateway.stream_chat(...)
console_provider_gateway.py:3902  stream_chat → self._reserve_trace_call(...)
console_provider_gateway.py:2224  raise TraceCallPersistenceError(reservation_status="not_established")
--- active exc: None
```

`active exc: None` — nothing threw. Nothing failed to write. The guard fires on a permanent condition:

```python
if self._trace_call_boundary_factory is None:
    raise TraceCallPersistenceError(reservation_status="not_established")
```

**That factory is never wired in production.** `capture_mode` defaults to `CAPTURE_ON` (`console_turn_preparation.py:118`), `stream_chat` routes every Capture-On send through `_reserve_trace_call`, and both production callers of `ensure_provider_gateway` omit the seam — `chat_screen.py:6392` and `console_launch_wake.py:212`. `ConsoleTraceCallBoundary` is constructed **only in `Tests/`**.

Introduced by `c78f641ad` *"feat(console): implement reference-backed semantic trace ledger"* — same-day, 30 commits before the reviewed tip. The consumer landed without the producer.

### Why CI is green

Every test injects a factory, and the shared helper `_capture_on_prepared_request` (`test_console_provider_gateway.py:141`) **silently installs one when it is absent**. The suite structurally cannot observe the shipped configuration.

## Why no code fix in this PR

I implemented the obvious "degrade to capture-off" fix TDD-first. It went green, then broke this:

```
FAILED test_capture_on_without_durable_boundary_cannot_enter_adapter
```

That test is the exact inverse of the degrade — identical setup (factory `None`, `CAPTURE_ON`), asserting `pytest.raises(TraceCallPersistenceError)` **and** `adapter_called is False`. It passes on clean code.

So the refusal is an **intentional safety invariant**: a provider call that leaves no auditable trace must not happen. The guard is correct; the wiring is what is missing. **All experimental production changes were reverted.**

Two degrade variants were tried and both are recorded in TASK-25712 so nobody repeats them:
1. Downgrading `capture_mode` at the admission seam → `TraceProvenanceAlignmentError: Capture Off cannot dispatch a capture-on prepared request` (the *prepared request* carries capture-on provenance).
2. Returning `None` + supplying the paired `capture_off_admission` at both call sites → works mechanically, defeats the invariant.

**The only correct fix is to wire a real `ConsoleTraceCallBoundary` factory at both production sites** — `:3902` (fresh route) and `:4237` (llama.cpp fallback; `llama_cpp` is the default local provider and an empty streaming response is exactly what drives that retry). That needs judgment about how the trace service, database handle, identity and admission should be constructed, which belongs with the author of `c78f641ad`.

## The other 21 findings

Scored **23/40** against Nielsen's heuristics. 6 High · 11 Medium · 5 Low, `TASK-25712`–`25733`, each with outcome-shaped acceptance criteria.

Selected:
- **A pending assistant row renders as an empty block** with no spinner, timer or state label — 30+ seconds of silence against a provider answering in 0.8s.
- **Database-failure recovery advice cannot work**: Console says restart and check the app log; restarting cannot fix an on-disk fault and the exception is never written to the log. The observed instance was a single corrupt index that one `REINDEX` repaired with no data loss.
- **First-run setup stamps ✓ on steps that were never configured** — its own summary screen contradicts its stepper — and **discards the provider endpoint after confirming it with a successful test** (the sibling voice step persists its endpoint correctly).
- **Disabled primary actions render at ~1.4:1**, so dialogs appear to offer only their dismissive control.
- `Ctrl+K` and `F1` **stack new modals over an unresolved required decision**.

## Not addressed here

- IDs `25710`/`25711` already collide between two other in-flight branches (`feat/home-recents-resume-next-up` vs `.worktrees/console-conversation-menu-dismiss`). Not mine; my block was shifted +2 to land clear of it.
- `test_console_trace_settlement.py::test_cold_restart_recovers_open_calls_monotonically_and_idempotently` fails on clean `dev`. Pre-existing; verified against reverted code.

## Verification

- IDs swept across all local/remote refs and every worktree; `25712`–`25733` confirmed unique.
- Frontmatter `id:` matches filename on all 22.
- `backlog task list` renders all 22.
- Working tree clean; no production file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHdMC7n32o6Tkw7FKKve2o

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 22 backlog tasks from a UX/HCI review of the Console screen, including a verified root cause for its dead core loop: every send is refused before the provider is contacted because the trace-call boundary factory is never wired in production.

**Key finding**
- `stream_chat` routes every capture-on send through `_reserve_trace_call`, which raises `TraceCallPersistenceError` when the boundary factory is `None`.
- Neither production caller of `ensure_provider_gateway` supplies the factory; only tests do, so CI stays green.
- The capture-off degrade is ruled out — a pinning test confirms the refusal is an intentional safety invariant.
- The fix is wiring a real `ConsoleTraceCallBoundary` factory at both production call sites; this PR documents that, it doesn't implement it.

**Remaining findings**
- 21 tasks cover pending-state rendering, database-failure recovery advice, first-run wizard errors, and contrast and interaction issues.

<sup>Written for commit ab8cb921d63eeced50e456bc44ea2904d3181847. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

