### PR TITLE
feat(console): workspace and tree-chat action menus in the Context rail (TASK-25710)

### DIFF
--- a/Tests/Architecture/test_timer_path_static_update_inventory.py
+++ b/Tests/Architecture/test_timer_path_static_update_inventory.py
@@ -365,12 +365,6 @@ CLASSIFIED_SITES: dict[tuple[str, str, str], str] = {
         "with the poster-text fallback), so the box really does resize per "
         "frame."
     ),
-    # -- tldw_chatbook/Widgets/Console/console_workspace_context.py
-    (
-        "tldw_chatbook/Widgets/Console/console_workspace_context.py",
-        "ConsoleWorkspaceContextTray._update_workspace_tree_selection_context",
-        "context",
-    ): "NEEDS-LAYOUT: the context tray line count tracks the selection.",
     # -- tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
     (
         "tldw_chatbook/Widgets/Library/library_file_notes_workspace.py",

--- a/Tests/Chat/test_console_workspace_actions.py
+++ b/Tests/Chat/test_console_workspace_actions.py
@@ -1,4 +1,4 @@
-"""Menu model for the Console workspace action menu (TASK-25710)."""
+"""Menu model for the Console workspace action menu (TASK-25712)."""
 
 from __future__ import annotations
 

--- a/Tests/Chat/test_console_workspace_actions.py
+++ b/Tests/Chat/test_console_workspace_actions.py
@@ -1,0 +1,100 @@
+"""Menu model for the Console workspace action menu (TASK-25710)."""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.Chat.console_workspace_actions import (
+    ACTION_ACTIVATE,
+    ACTION_ARCHIVE,
+    ACTION_BACK,
+    ACTION_NEW_CHAT,
+    ACTION_RAG_SCOPE,
+    ACTION_RENAME,
+    WorkspaceMenuTarget,
+    build_workspace_menu,
+    page_from_action,
+)
+
+
+def _workspace(**overrides) -> WorkspaceMenuTarget:
+    base = {"workspace_id": "ws-1", "name": "Research", "is_active": False}
+    base.update(overrides)
+    return WorkspaceMenuTarget(**base)
+
+
+@pytest.mark.unit
+def test_root_menu_offers_the_five_approved_entries():
+    labels = [item.label for item in build_workspace_menu(_workspace())]
+    assert labels == [
+        "Activate",
+        "New chat",
+        "Rename…",
+        "RAG scope…",
+        "More",
+    ]
+
+
+@pytest.mark.unit
+def test_activate_marks_and_disables_the_active_workspace():
+    active = build_workspace_menu(_workspace(is_active=True))[0]
+    assert active.is_current is True
+    assert active.enabled is False
+    assert active.disabled_reason, "the disabled Activate must state its reason"
+
+    inactive = build_workspace_menu(_workspace(is_active=False))[0]
+    assert inactive.is_current is False
+    assert inactive.enabled is True
+    assert inactive.disabled_reason == ""
+
+
+@pytest.mark.unit
+def test_rag_scope_gates_on_active_workspace_with_a_stated_reason():
+    inactive = build_workspace_menu(_workspace(is_active=False))[3]
+    assert inactive.action_id == ACTION_RAG_SCOPE
+    assert inactive.enabled is False
+    assert "Activate" in inactive.disabled_reason
+
+    active = build_workspace_menu(_workspace(is_active=True))[3]
+    assert active.enabled is True
+    assert active.disabled_reason == ""
+
+
+@pytest.mark.unit
+def test_more_page_offers_back_and_archive_only():
+    items = build_workspace_menu(_workspace(), page="more")
+    assert [(i.action_id, i.label) for i in items] == [
+        (ACTION_BACK, "‹ Back"),
+        (ACTION_ARCHIVE, "Archive"),
+    ]
+
+
+@pytest.mark.unit
+def test_every_disabled_entry_states_its_precondition():
+    for page in ("root", "more"):
+        for item in build_workspace_menu(_workspace(is_active=True), page=page):
+            if not item.enabled:
+                assert item.disabled_reason, (
+                    f"{item.action_id} on {page} is disabled with no reason"
+                )
+
+
+@pytest.mark.unit
+def test_root_commands_carry_no_page_navigation():
+    for item in build_workspace_menu(_workspace()):
+        if item.opens_page is None:
+            assert item.action_id in {
+                ACTION_ACTIVATE,
+                ACTION_NEW_CHAT,
+                ACTION_RENAME,
+                ACTION_RAG_SCOPE,
+            }
+
+
+@pytest.mark.unit
+def test_page_from_action_recognises_only_workspace_pages():
+    assert page_from_action("page:more") == "more"
+    assert page_from_action("page:root") == "root"
+    assert page_from_action(ACTION_ACTIVATE) is None
+    # Pages from the sibling conversation menu must not leak in.
+    assert page_from_action("page:status") is None

--- a/Tests/UI/test_console_rail_reconciliation.py
+++ b/Tests/UI/test_console_rail_reconciliation.py
@@ -317,7 +317,7 @@ async def test_native_tree_restores_persisted_disclosure() -> (
         assert writes == [frozenset({"workspace-1"})]
         hidden_demand = bounded.desired_content_lines
 
-        # TASK-25710: the pointer star and its action row are retired; the
+        # TASK-25712: the pointer star and its action row are retired; the
         # row menu's trailing asterisk replaces them (covered by the
         # workspace action menu suite), so a cursor move changes no demand.
         tree.move_cursor(tree.conversation_nodes["conversation-1"])
@@ -354,7 +354,7 @@ async def test_workspace_context_change_survives_transient_relabel_controls() ->
         tray = app.query_one("#console-workspaces-context")
         assert tray._workspace_tree_context_data.conversation_id == "conversation-1"
 
-        # TASK-25710: the star action controls are retired; the surviving
+        # TASK-25712: the star action controls are retired; the surviving
         # invariant is that a context change delivered inside a recompose
         # window still lands and survives the rebuild.
         workspace = tree.workspace_nodes["workspace-1"]

--- a/Tests/UI/test_console_rail_reconciliation.py
+++ b/Tests/UI/test_console_rail_reconciliation.py
@@ -293,7 +293,7 @@ def _native_workspace_tree_state() -> ConsoleWorkspaceContextState:
 
 
 @pytest.mark.asyncio
-async def test_native_tree_restores_persisted_disclosure_and_exposes_pointer_star() -> (
+async def test_native_tree_restores_persisted_disclosure() -> (
     None
 ):
     writes: list[frozenset[str]] = []
@@ -307,11 +307,9 @@ async def test_native_tree_restores_persisted_disclosure_and_exposes_pointer_sta
         await _settle(pilot)
         tree = app.query_one(ConsoleWorkspaceTree)
         workspace = tree.workspace_nodes["workspace-1"]
-        action_row = app.query_one("#console-workspace-context-action-row")
         bounded = app.query_one(
             "#console-bounded-section-workspace", ConsoleBoundedSection
         )
-        assert action_row.display is False
         assert workspace.is_collapsed
 
         workspace.expand()
@@ -319,32 +317,16 @@ async def test_native_tree_restores_persisted_disclosure_and_exposes_pointer_sta
         assert writes == [frozenset({"workspace-1"})]
         hidden_demand = bounded.desired_content_lines
 
+        # TASK-25710: the pointer star and its action row are retired; the
+        # row menu's trailing asterisk replaces them (covered by the
+        # workspace action menu suite), so a cursor move changes no demand.
         tree.move_cursor(tree.conversation_nodes["conversation-1"])
         await _settle(pilot)
-        star = app.query_one("#console-workspace-tree-star", Button)
-        assert app.query_one("#console-workspace-context-action-row").display is True
-        assert bounded.desired_content_lines == hidden_demand + 1
-        assert star.disabled is False
-        assert str(star.label) == "Star"
-
-        app.query_one(ConsoleLeftRail).activate_section("workspace")
-        star.scroll_visible(animate=False, force=True)
-        await _settle(pilot)
-        assert await pilot.click(star)
-        await pilot.pause()
-        assert len(app.star_requests) == 1
-        assert app.star_requests[0].conversation_id == "conversation-1"
-        assert app.star_requests[0].starred is False
+        assert bounded.desired_content_lines == hidden_demand
 
         tree.move_cursor(workspace)
         await _settle(pilot)
-        assert app.query_one("#console-workspace-context-action-row").display is False
-        expected_demand = sum(
-            child.virtual_region_with_margin.height
-            for child in bounded._native_content
-            if child.is_mounted and child.display
-        ) + max(0, tree.virtual_size.height)
-        assert bounded.desired_content_lines == expected_demand
+        assert bounded.desired_content_lines == hidden_demand
 
         tree.set_search_active(True, forced_workspace_ids={"workspace-1"})
         workspace.collapse()
@@ -354,92 +336,6 @@ async def test_native_tree_restores_persisted_disclosure_and_exposes_pointer_sta
         tree.set_search_active(False)
         assert workspace.is_expanded
         assert writes == [frozenset({"workspace-1"})]
-
-
-@pytest.mark.asyncio
-async def test_native_tree_hides_star_for_unmarkable_conversation() -> None:
-    state = _native_workspace_tree_state()
-    conversation = replace(
-        state.workspace_tree[0].conversations[0],
-        conversation_id="native:session-7",
-        star_enabled=False,
-    )
-    state = replace(
-        state,
-        workspace_tree=(
-            replace(state.workspace_tree[0], conversations=(conversation,)),
-        ),
-    )
-    app = _RailHarness(
-        workspace_state=state,
-        workspace_tree_expanded_ids=frozenset({"workspace-1"}),
-    )
-
-    async with app.run_test(size=(60, 30)) as pilot:
-        await _settle(pilot)
-        tree = app.query_one(ConsoleWorkspaceTree)
-        tree.move_cursor(tree.conversation_nodes["native:session-7"])
-        await _settle(pilot)
-
-        action_row = app.query_one("#console-workspace-context-action-row")
-        star = app.query_one("#console-workspace-tree-star", Button)
-        assert action_row.display is False
-        assert star.disabled is True
-
-
-@pytest.mark.asyncio
-async def test_rapid_workspace_context_show_hide_restores_exact_geometry() -> None:
-    app = _RailHarness(
-        workspace_state=_native_workspace_tree_state(),
-        workspace_tree_expanded_ids=frozenset({"workspace-1"}),
-    )
-
-    async with app.run_test(size=(60, 30)) as pilot:
-        await _settle(pilot)
-        tree = app.query_one(ConsoleWorkspaceTree)
-        workspace = tree.workspace_nodes["workspace-1"]
-        tray = app.query_one("#console-workspaces-context")
-        bounded = app.query_one(
-            "#console-bounded-section-workspace", ConsoleBoundedSection
-        )
-        initial_tray_height = int(tray.region.height)
-        initial_demand = bounded.desired_content_lines
-
-        tree.move_cursor(tree.conversation_nodes["conversation-1"])
-        tree.move_cursor(workspace)
-        await _settle(pilot)
-
-        assert app.query_one("#console-workspace-context-action-row").display is False
-        assert int(tray.region.height) == initial_tray_height
-        assert bounded.desired_content_lines == initial_demand
-
-
-@pytest.mark.asyncio
-async def test_workspace_resize_preserves_visible_contextual_star() -> None:
-    app = _RailHarness(
-        workspace_state=_native_workspace_tree_state(),
-        workspace_tree_expanded_ids=frozenset({"workspace-1"}),
-    )
-
-    async with app.run_test(size=(70, 30)) as pilot:
-        await _settle(pilot)
-        tree = app.query_one(ConsoleWorkspaceTree)
-        tree.move_cursor(tree.conversation_nodes["conversation-1"])
-        await _settle(pilot)
-
-        tray = app.query_one("#console-workspaces-context")
-        initial_content_width = tray._row_content_width
-        assert app.query_one("#console-workspace-context-action-row").display is True
-
-        app.query_one(ConsoleLeftRail).styles.width = 42
-        await _settle(pilot)
-
-        assert tray._row_content_width == initial_content_width + 2
-        action_row = app.query_one("#console-workspace-context-action-row")
-        star = app.query_one("#console-workspace-tree-star", Button)
-        assert action_row.display is True
-        assert star.disabled is False
-        assert star.conversation_id == "conversation-1"
 
 
 @pytest.mark.asyncio
@@ -458,26 +354,17 @@ async def test_workspace_context_change_survives_transient_relabel_controls() ->
         tray = app.query_one("#console-workspaces-context")
         assert tray._workspace_tree_context_data.conversation_id == "conversation-1"
 
-        # Width relabeling temporarily removes the action controls. Deliver
-        # the cursor's new workspace context in that window, then let compose
-        # rebuild from the cached truth.
-        await app.query_one("#console-workspace-context-action-row").remove()
+        # TASK-25710: the star action controls are retired; the surviving
+        # invariant is that a context change delivered inside a recompose
+        # window still lands and survives the rebuild.
         workspace = tree.workspace_nodes["workspace-1"]
         assert tray.sync_workspace_tree_context(workspace.data) is False
         tray.refresh(recompose=True)
         await _settle(pilot)
 
         assert tray._workspace_tree_context_data is workspace.data
-        selection_context = tray.query_one(
-            "#console-workspace-tree-selection-context", Static
-        )
-        assert str(selection_context.renderable) == (
-            "Selected: Workspace One · Enter open"
-        )
-        assert app.query_one("#console-workspace-context-action-row").display is False
-        star = app.query_one("#console-workspace-tree-star", Button)
-        assert star.disabled is True
-        assert star.conversation_id is None
+        assert not tray.query("#console-workspace-tree-star")
+        assert not tray.query("#console-workspace-tree-selection-context")
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_workspace_action_menu.py
+++ b/Tests/UI/test_console_workspace_action_menu.py
@@ -149,6 +149,153 @@ async def test_workspace_menu_pages_and_escapes_like_the_conversation_menu(
 
 
 @pytest.mark.asyncio
+async def test_unsaved_native_rows_get_none_and_gate_saved_only_actions() -> None:
+    """A synthetic `native:` tree identity must not reach persistence.
+
+    Review, PR #2255: unsaved rows carry ``native:<session-id>`` as their
+    tree identity; the menu must see ``conversation_id=None`` so the pure
+    model disables Favourite/status/archive/rename with the "send or save"
+    reason instead of handing the synthetic key to the database.
+    """
+    from tldw_chatbook.Widgets.Console.console_workspace_tree import (
+        WorkspaceTreeNodeData,
+        _menu_conversation_payload,
+    )
+
+    unsaved = WorkspaceTreeNodeData.conversation(
+        "ws-alpha",
+        "native:session-7",
+        "Untitled",
+        starred=False,
+        selected=True,
+        star_enabled=False,
+    )
+    conversation_id, title = _menu_conversation_payload(unsaved)
+    assert conversation_id is None, "native: identity leaked to the menu"
+    assert title == "Untitled"
+
+    saved = WorkspaceTreeNodeData.conversation(
+        "ws-alpha",
+        "conv-123",
+        "Real chat",
+        starred=False,
+        selected=False,
+        star_enabled=True,
+    )
+    conversation_id, title = _menu_conversation_payload(saved)
+    assert conversation_id == "conv-123"
+    assert title == "Real chat"
+
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        console = pilot.app.screen
+        _request_menu(
+            console, kind="conversation", conversation_id=None, title="Untitled"
+        )
+        await pilot.pause(0.4)
+        menu = console.query_one(ConsoleConversationActionMenu)
+        assert menu.target.conversation_id is None
+        # Rename carries the unsaved reason regardless of whether the marks
+        # service exists (Favourite's reason folds in availability too).
+        rename = menu.query_one("#console-conversation-action-rename", Button)
+        assert rename.disabled is True
+        assert rename.tooltip == "Send or save this chat first."
+
+
+@pytest.mark.asyncio
+async def test_tree_menu_target_carries_the_row_title() -> None:
+    """The row's title reaches the menu target (rename/delete copy)."""
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        console = pilot.app.screen
+        _request_menu(
+            console,
+            kind="conversation",
+            conversation_id="conv-a0",
+            title="Alpha conversation 0",
+        )
+        await pilot.pause(0.4)
+        menu = console.query_one(ConsoleConversationActionMenu)
+        assert menu.target.title == "Alpha conversation 0"
+
+
+@pytest.mark.asyncio
+async def test_new_chat_does_not_create_when_activation_cannot_land(
+    monkeypatch,
+) -> None:
+    """A vanished workspace or a failed switch must not create a chat.
+
+    Review, PR #2255: the activation wrapper discards the switch result, so
+    the composite verifies the registry state afterwards; a new chat must
+    only appear in the workspace the user actually picked.
+    """
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        console = pilot.app.screen
+        calls: list[str] = []
+
+        async def _fake_create():
+            calls.append("created")
+
+        monkeypatch.setattr(
+            console._session,
+            "_create_native_console_session_from_active_context",
+            _fake_create,
+        )
+        monkeypatch.setattr(
+            console._workspace,
+            "activate_workspace_id",
+            lambda ws_id: calls.append("activated"),
+        )
+
+        # Workspace vanished between open and choose: no create.
+        console.app_instance.workspace_registry_service = SimpleNamespace(
+            get_workspace=lambda ws_id: None
+        )
+        from tldw_chatbook.Chat.console_workspace_actions import (
+            ACTION_NEW_CHAT,
+            WorkspaceMenuTarget,
+        )
+        from tldw_chatbook.Widgets.Console.console_workspace_action_menu import (
+            WorkspaceActionChosen,
+        )
+
+        console.on_workspace_action_chosen(
+            WorkspaceActionChosen(
+                ACTION_NEW_CHAT,
+                WorkspaceMenuTarget(workspace_id="ws-beta", name="Beta"),
+            )
+        )
+        await pilot.pause(0.8)
+        assert calls == [], "created a chat for a vanished workspace"
+
+        # Workspace exists but the switch cannot land (still inactive): no create.
+        record = SimpleNamespace(
+            workspace_id="ws-beta", name="Beta", active=False
+        )
+        console.app_instance.workspace_registry_service = SimpleNamespace(
+            get_workspace=lambda ws_id: record
+        )
+        console.on_workspace_action_chosen(
+            WorkspaceActionChosen(
+                ACTION_NEW_CHAT,
+                WorkspaceMenuTarget(workspace_id="ws-beta", name="Beta"),
+            )
+        )
+        await pilot.pause(0.8)
+        assert "activated" in calls
+        assert "created" not in calls, "created a chat after a failed switch"
+
+        # Already active: straight to creation.
+        record.active = True
+        console.on_workspace_action_chosen(
+            WorkspaceActionChosen(
+                ACTION_NEW_CHAT,
+                WorkspaceMenuTarget(workspace_id="ws-beta", name="Beta"),
+            )
+        )
+        await pilot.pause(0.8)
+        assert calls[-1] == "created"
+
+
+@pytest.mark.asyncio
 async def test_tree_chat_row_opens_the_shared_conversation_menu() -> None:
     async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
         console = pilot.app.screen
@@ -267,6 +414,14 @@ async def test_workspace_actions_route_through_the_existing_seams(
             console._session,
             "_create_native_console_session_from_active_context",
             _fake_create,
+        )
+        # The guard verifies activation against the registry afterwards, so
+        # the stub's record must actually flip to active when "activated".
+        beta = SimpleNamespace(
+            workspace_id="ws-beta", name="Workspace Beta", active=True
+        )
+        console.app_instance.workspace_registry_service = SimpleNamespace(
+            get_workspace=lambda ws_id: beta if ws_id == "ws-beta" else None
         )
 
         from tldw_chatbook.Chat.console_workspace_actions import (

--- a/Tests/UI/test_console_workspace_action_menu.py
+++ b/Tests/UI/test_console_workspace_action_menu.py
@@ -1,6 +1,6 @@
 """The Workspaces-tree row action menus, driven through the real Console.
 
-TASK-25710. TASK-23200 gave the grouped browser's conversation rows an
+TASK-25712. TASK-23200 gave the grouped browser's conversation rows an
 asterisk menu and TASK-25709 made it dismissable everywhere; this suite pins
 the same pattern on the Workspaces tree: workspace rows open the workspace
 action menu, chat rows open the shared conversation menu, the pointer

--- a/Tests/UI/test_console_workspace_action_menu.py
+++ b/Tests/UI/test_console_workspace_action_menu.py
@@ -1,0 +1,315 @@
+"""The Workspaces-tree row action menus, driven through the real Console.
+
+TASK-25710. TASK-23200 gave the grouped browser's conversation rows an
+asterisk menu and TASK-25709 made it dismissable everywhere; this suite pins
+the same pattern on the Workspaces tree: workspace rows open the workspace
+action menu, chat rows open the shared conversation menu, the pointer
+affordance is the row's trailing asterisk, and the ``m`` binding is the
+keyboard equivalent.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.test_console_left_rail import (
+    _click_rail_toggle,
+    make_console_pilot,
+)
+from Tests.UI.test_console_workspace_tree_cursor_layout import (
+    _console_with_probe_tree,
+)
+from tldw_chatbook.Widgets.Console.console_conversation_action_menu import (
+    ConsoleConversationActionMenu,
+)
+from tldw_chatbook.Widgets.Console.console_workspace_action_menu import (
+    ConsoleWorkspaceActionMenu,
+)
+from tldw_chatbook.Widgets.Console.console_workspace_tree import (
+    WorkspaceTreeMenuRequested,
+)
+
+
+def _stub_registry():
+    """A registry resolving the two synthetic seeded workspaces."""
+
+    records = {
+        "ws-alpha": SimpleNamespace(
+            workspace_id="ws-alpha", name="Workspace Alpha", active=True
+        ),
+        "ws-beta": SimpleNamespace(
+            workspace_id="ws-beta", name="Workspace Beta", active=False
+        ),
+    }
+    return SimpleNamespace(
+        get_workspace=lambda ws_id: records.get(ws_id)
+    )
+
+
+def _request_menu(console, *, kind: str, **kwargs) -> None:
+    """Drive the screen's tree-menu seam the way the tree's message would."""
+    payload = {
+        "kind": kind,
+        "workspace_id": "ws-beta",
+        "screen_x": 4,
+        "screen_y": 8,
+    }
+    payload.update(kwargs)
+    console.on_workspace_tree_menu_requested(WorkspaceTreeMenuRequested(**payload))
+
+
+@pytest.mark.asyncio
+async def test_tree_rows_paint_a_trailing_asterisk_affordance() -> None:
+    """Workspace and chat rows carry the opener; auxiliary rows do not."""
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        host = pilot.app
+        console, _rail, tree = await _console_with_probe_tree(host, pilot)
+
+        workspace_key = tree.workspace_nodes["ws-alpha"].data.key
+        conversation_key = tree.conversation_nodes["conv-a0"].data.key
+        assert workspace_key in tree._menu_zones, "workspace row lost its asterisk"
+        assert conversation_key in tree._menu_zones, "chat row lost its asterisk"
+
+        start, end = tree._menu_zones[conversation_key]
+        assert start < end, "empty asterisk zone"
+        # The affordance press is recognized inside the zone and not outside.
+        tree._pressed_x = start
+        assert tree._pressed_menu_affordance(
+            tree.conversation_nodes["conv-a0"].data
+        )
+        tree._pressed_x = end
+        assert not tree._pressed_menu_affordance(
+            tree.conversation_nodes["conv-a0"].data
+        )
+
+
+@pytest.mark.asyncio
+async def test_workspace_menu_opens_with_the_five_approved_entries(
+    monkeypatch,
+) -> None:
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        console = pilot.app.screen
+        console.app_instance.workspace_registry_service = _stub_registry()
+
+        _request_menu(console, kind="workspace")
+        await pilot.pause(0.4)
+
+        menu = console.query_one(ConsoleWorkspaceActionMenu)
+        labels = [str(button.label).strip() for button in menu.query(Button)]
+        assert labels == [
+            "Activate",
+            "New chat",
+            "Rename…",
+            "RAG scope…",
+            "More ▸",
+        ]
+        # The stub registry reports ws-beta inactive, so Activate is live and
+        # RAG scope states its precondition instead of being silently dead.
+        actions = {
+            getattr(b, "workspace_action_id", ""): b for b in menu.query(Button)
+        }
+        assert actions["activate"].disabled is False
+        assert actions["rag-scope"].disabled is True
+        assert actions["rag-scope"].tooltip
+
+
+@pytest.mark.asyncio
+async def test_workspace_menu_pages_and_escapes_like_the_conversation_menu(
+    monkeypatch,
+) -> None:
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        console = pilot.app.screen
+        console.app_instance.workspace_registry_service = _stub_registry()
+
+        _request_menu(console, kind="workspace")
+        await pilot.pause(0.4)
+
+        more = next(
+            b
+            for b in console.query_one(ConsoleWorkspaceActionMenu).query(Button)
+            if getattr(b, "workspace_action_id", "") == "page:more"
+        )
+        more.press()
+        await pilot.pause(0.5)
+        menu = console.query_one(ConsoleWorkspaceActionMenu)
+        assert menu.page == "more"
+        assert [
+            getattr(b, "workspace_action_id", "") for b in menu.query(Button)
+        ] == ["page:root", "archive"]
+
+        await pilot.press("escape")
+        await pilot.pause(0.5)
+        assert console.query_one(ConsoleWorkspaceActionMenu).page == "root"
+        await pilot.press("escape")
+        await pilot.pause(0.5)
+        assert not console.query(ConsoleWorkspaceActionMenu)
+
+
+@pytest.mark.asyncio
+async def test_tree_chat_row_opens_the_shared_conversation_menu() -> None:
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        console = pilot.app.screen
+
+        _request_menu(
+            console, kind="conversation", conversation_id="conv-a0"
+        )
+        await pilot.pause(0.4)
+
+        menu = console.query_one(ConsoleConversationActionMenu)
+        labels = [str(button.label).strip() for button in menu.query(Button)]
+        assert labels[:2] == ["Favourite", "Change status ▸"]
+        assert menu.target.conversation_id == "conv-a0"
+
+
+@pytest.mark.asyncio
+async def test_m_binding_opens_the_menu_for_the_cursor_workspace_row(
+    monkeypatch,
+) -> None:
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        host = pilot.app
+        console, rail, tree = await _console_with_probe_tree(host, pilot)
+        console.app_instance.workspace_registry_service = _stub_registry()
+
+        # The default rail state collapses the Workspaces section, which
+        # leaves the tree a 0x0 region and the keyboard anchor meaningless
+        # (the section-header click a real user made first is what opens
+        # it); click that toggle exactly as the rail suite's helper does.
+        await _click_rail_toggle(pilot, "workspace")
+        await pilot.pause(0.4)
+        assert tree.region, "workspace section stayed collapsed"
+
+        # Walk the cursor onto a workspace row.
+        tree.focus()
+        for _ in range(12):
+            node = tree.cursor_node
+            if node is not None and node.data and node.data.kind == "workspace":
+                break
+            tree.action_cursor_up()
+        node = tree.cursor_node
+        assert node is not None and node.data.kind == "workspace"
+
+        await pilot.press("m")
+        await pilot.pause(0.5)
+        assert console.query(ConsoleWorkspaceActionMenu), (
+            "the m binding did not open the workspace menu"
+        )
+
+
+@pytest.mark.asyncio
+async def test_workspace_menu_dismisses_on_outside_click_and_stranded_escape(
+    monkeypatch,
+) -> None:
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        console = pilot.app.screen
+        console.app_instance.workspace_registry_service = _stub_registry()
+
+        _request_menu(console, kind="workspace")
+        await pilot.pause(0.4)
+        assert console.query(ConsoleWorkspaceActionMenu)
+
+        await pilot.click("#console-native-composer")
+        await pilot.pause(0.3)
+        assert not console.query(ConsoleWorkspaceActionMenu), (
+            "an outside click left the workspace menu open"
+        )
+
+        _request_menu(console, kind="workspace")
+        await pilot.pause(0.4)
+        composer = console.query_one("#console-native-composer")
+        console.set_focus(composer)
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause(0.3)
+        assert not console.query(ConsoleWorkspaceActionMenu), (
+            "stranded Escape left the workspace menu open"
+        )
+        assert pilot.app.focused is composer
+
+
+@pytest.mark.asyncio
+async def test_workspace_actions_route_through_the_existing_seams(
+    monkeypatch,
+) -> None:
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        console = pilot.app.screen
+        calls: list[tuple] = []
+        monkeypatch.setattr(
+            console._workspace,
+            "activate_workspace_id",
+            lambda ws_id: calls.append(("activate", ws_id)),
+        )
+        monkeypatch.setattr(
+            console._workspace,
+            "_open_console_workspace_rename",
+            lambda ws_id: calls.append(("rename", ws_id)),
+        )
+        monkeypatch.setattr(
+            console._workspace,
+            "_confirm_console_workspace_archive",
+            lambda ws_id: calls.append(("archive", ws_id)),
+        )
+        async def _fake_scope_picker():
+            calls.append(("rag-scope", None))
+
+        monkeypatch.setattr(
+            console._workspace,
+            "_open_console_workspace_scope_picker",
+            _fake_scope_picker,
+        )
+
+        async def _fake_create():
+            calls.append(("new-chat", None))
+
+        monkeypatch.setattr(
+            console._session,
+            "_create_native_console_session_from_active_context",
+            _fake_create,
+        )
+
+        from tldw_chatbook.Chat.console_workspace_actions import (
+            ACTION_ACTIVATE,
+            ACTION_ARCHIVE,
+            ACTION_NEW_CHAT,
+            ACTION_RAG_SCOPE,
+            ACTION_RENAME,
+            WorkspaceMenuTarget,
+        )
+        from tldw_chatbook.Widgets.Console.console_workspace_action_menu import (
+            WorkspaceActionChosen,
+        )
+
+        target = WorkspaceMenuTarget(
+            workspace_id="ws-beta", name="Workspace Beta", is_active=False
+        )
+        for action in (
+            ACTION_ACTIVATE,
+            ACTION_NEW_CHAT,
+            ACTION_RENAME,
+            ACTION_RAG_SCOPE,
+            ACTION_ARCHIVE,
+        ):
+            console.on_workspace_action_chosen(
+                WorkspaceActionChosen(action, target)
+            )
+        await pilot.pause(0.8)
+
+        routed = {name for name, _ in calls}
+        assert routed == {"activate", "new-chat", "rename", "rag-scope", "archive"}
+        assert ("activate", "ws-beta") in calls
+        assert ("rename", "ws-beta") in calls
+        assert ("archive", "ws-beta") in calls
+
+
+@pytest.mark.asyncio
+async def test_contextual_star_button_and_selection_line_are_retired() -> None:
+    """The single Star control is gone; row menus own the actions now."""
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        console = pilot.app.screen
+        await _console_with_probe_tree(pilot.app, pilot)
+
+        assert not console.query("#console-workspace-tree-star")
+        assert not console.query("#console-workspace-tree-selection-context")
+        assert not console.query("#console-workspace-context-action-row")

--- a/Tests/UI/test_console_workspace_context_rail.py
+++ b/Tests/UI/test_console_workspace_context_rail.py
@@ -8,10 +8,8 @@ from dataclasses import replace
 from pathlib import Path
 
 import pytest
-from rich.text import Text
 from textual.content import Content
 from textual.widgets import Button, Input, Static
-from textual.widgets._tooltip import Tooltip
 
 from Tests.UI.test_destination_shells import _wait_for_selector
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
@@ -36,7 +34,6 @@ from tldw_chatbook.Widgets.Console.console_workspace_context import (
 )
 from tldw_chatbook.Widgets.Console.console_workspace_tree import (
     ConsoleWorkspaceTree,
-    WorkspaceTreeNodeData,
 )
 from tldw_chatbook.Widgets.Console.console_workspace_details import (
     ConsoleWorkspaceDetailsTray,
@@ -456,144 +453,6 @@ async def test_console_workspace_context_mounts_native_tree_without_legacy_group
         assert len(console.query("#console-workspace-tree")) == 1
         assert len(console.query("#console-workspace-search")) == 1
         assert len(console.query("#console-conversation-browser-starred-title")) == 0
-
-
-@pytest.mark.asyncio
-async def test_workspace_tree_selection_context_is_one_reserved_updating_row() -> None:
-    state = replace(_base_grouped_workspace_state(), workspace_name="Research Lab")
-
-    class TestApp(ConsolidatedCSSApp):
-        CSS_PATH = str(BUNDLED_STYLESHEET)
-
-        def compose(self):
-            yield ConsoleWorkspaceContextTray(
-                state,
-                show_heading=False,
-                content="workspace",
-                id="console-workspaces-context",
-            )
-
-    app = TestApp()
-    async with app.run_test(size=(40, 20)) as pilot:
-        tray = app.query_one(ConsoleWorkspaceContextTray)
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        action_row = app.query_one("#console-workspace-context-action-row")
-
-        assert context.region.height == 1
-        assert context.styles.height.value == 1
-        assert context.styles.text_wrap == "nowrap"
-        assert context.styles.text_overflow == "ellipsis"
-        assert str(context.renderable) == "Selected: Research Lab · Enter open"
-        assert action_row.display is False
-
-        conversation = WorkspaceTreeNodeData.conversation(
-            "workspace-1",
-            "conversation-1",
-            "Planning notes",
-            starred=False,
-            selected=False,
-            star_enabled=True,
-        )
-        assert tray.sync_workspace_tree_context(conversation) is False
-        await pilot.pause()
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        action_row = app.query_one("#console-workspace-context-action-row")
-        assert str(context.renderable) == "Selected: Planning notes · Enter open"
-        assert action_row.display is False
-
-        auxiliary = WorkspaceTreeNodeData.auxiliary(
-            "load-more",
-            "workspace-1",
-            "action:workspace-1:load-more",
-            "Load more…",
-        )
-        assert tray.sync_workspace_tree_context(auxiliary) is False
-        await pilot.pause()
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        action_row = app.query_one("#console-workspace-context-action-row")
-        assert str(context.renderable) == "Selected: Load more… · Enter open"
-        assert action_row.display is False
-
-        assert tray.sync_workspace_tree_context(None) is False
-        await pilot.pause()
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        assert str(context.renderable) == "Selected: Research Lab · Enter open"
-        assert context.region.height == 1
-
-
-@pytest.mark.asyncio
-async def test_workspace_tree_selection_context_tooltip_only_when_clipped() -> None:
-    state = replace(_base_grouped_workspace_state(), workspace_name="Research Lab")
-
-    class TestApp(ConsolidatedCSSApp):
-        CSS_PATH = str(BUNDLED_STYLESHEET)
-
-        def compose(self):
-            yield ConsoleWorkspaceContextTray(
-                state,
-                show_heading=False,
-                content="workspace",
-                id="console-workspaces-context",
-            )
-
-    app = TestApp()
-    async with app.run_test(size=(90, 20)) as pilot:
-        tray = app.query_one(ConsoleWorkspaceContextTray)
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        assert context.tooltip is None
-
-        long_label = "研究🙂" * 8
-        tray.sync_workspace_tree_context(
-            WorkspaceTreeNodeData.workspace("workspace-1", long_label)
-        )
-        await pilot.resize_terminal(28, 20)
-        await pilot.pause()
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        full_copy = f"Selected: {long_label} · Enter open"
-        assert context.region.height == 1
-        assert isinstance(context.tooltip, Text)
-        assert context.tooltip.plain == full_copy
-
-        await pilot.resize_terminal(90, 20)
-        await pilot.pause()
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        assert context.tooltip is None
-
-
-@pytest.mark.asyncio
-async def test_workspace_tree_selection_context_renders_markup_label_literally() -> (
-    None
-):
-    state = replace(_base_grouped_workspace_state(), workspace_name="Research Lab")
-    raw = "[bold]abc"
-
-    class TestApp(ConsolidatedCSSApp):
-        CSS_PATH = str(BUNDLED_STYLESHEET)
-
-        def compose(self):
-            yield ConsoleWorkspaceContextTray(
-                state,
-                show_heading=False,
-                content="workspace",
-                id="console-workspaces-context",
-            )
-
-    app = TestApp()
-    app.TOOLTIP_DELAY = 0.01
-    async with app.run_test(size=(28, 20), tooltips=True) as pilot:
-        tray = app.query_one(ConsoleWorkspaceContextTray)
-        tray.sync_workspace_tree_context(
-            WorkspaceTreeNodeData.workspace("workspace-1", raw)
-        )
-        await pilot.pause()
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        assert raw in str(context.render())
-
-        assert await pilot.hover(context)
-        await pilot.pause(0.05)
-        tooltip = app.screen.get_child_by_type(Tooltip)
-        assert tooltip.display is True
-        assert raw in str(tooltip.render())
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_workspace_tree_cursor_layout.py
+++ b/Tests/UI/test_console_workspace_tree_cursor_layout.py
@@ -50,7 +50,6 @@ from tldw_chatbook.Widgets.Console import (
 )
 from tldw_chatbook.Widgets.Console.console_workspace_tree import (
     ConsoleWorkspaceTree,
-    WorkspaceTreeNodeData,
 )
 from tldw_chatbook.Workspaces.workspace_tree_state import (
     WorkspaceTreeConversation,
@@ -224,13 +223,6 @@ async def test_non_boundary_cursor_move_arms_zero_screen_layout_passes(
         console, rail, tree = await _console_with_probe_tree(host, pilot)
         tree.move_cursor(tree.conversation_nodes["conv-a0"])
         await _settle(pilot, passes=4)
-        tray = console.query_one(
-            "#console-workspaces-context", ConsoleWorkspaceContextTray
-        )
-        context = tray.query_one(
-            "#console-workspace-tree-selection-context", Static
-        )
-
         counts = _arm_counters(monkeypatch, host.screen_stack[-1], rail)
         started = time.perf_counter()
         for press in range(PRESSES):
@@ -249,8 +241,6 @@ async def test_non_boundary_cursor_move_arms_zero_screen_layout_passes(
             f"rail_query_one={counts['rail_query_one']}, "
             f"section_reconciles={counts['section_reconciles']}"
         )
-        # The context copy DID follow the cursor (the guard must not freeze it).
-        assert str(context.renderable).startswith("Selected: Alpha conversation")
         assert counts["screen_layout"] == 0, counts
         assert counts["allocation_runs"] == 0, counts
         assert counts["allocation_preps"] == 0, counts
@@ -283,19 +273,15 @@ async def test_boundary_crossing_reconciles_only_the_workspace_section(
         console, rail, tree = await _console_with_probe_tree(host, pilot)
         tree.move_cursor(tree.workspace_nodes["ws-alpha"])
         await _settle(pilot, passes=6)
-        action_row = console.query_one("#console-workspace-context-action-row")
         bounded = console.query_one(
             "#console-bounded-section-workspace", ConsoleBoundedSection
         )
-        assert action_row.display is False
 
         counts = _arm_counters(monkeypatch, host.screen_stack[-1], rail)
         started = time.perf_counter()
         for press in range(PRESSES):
             await pilot.press("down" if press % 2 == 0 else "up")
             await _settle(pilot, passes=4)
-            # Behavior preserved: the action row tracks the boundary every press.
-            assert action_row.display is (press % 2 == 0)
         elapsed = time.perf_counter() - started
 
         print(
@@ -310,9 +296,11 @@ async def test_boundary_crossing_reconciles_only_the_workspace_section(
         # The rail allocation pipeline never runs on a cursor boundary flip.
         assert counts["allocation_runs"] == 0, counts
         assert counts["allocation_preps"] == 0, counts
-        # The scoped reconcile DID run, and only for the workspace section.
-        assert counts["section_reconciles"], counts
-        assert set(counts["section_reconciles"]) == {"workspace"}, counts
+        # TASK-25710: the star seam the boundary used to drive is retired, so
+        # a crossing now runs NO reconcile at all -- the old invariant ("only
+        # the workspace section, never the rail pipeline") is preserved and
+        # strengthened: nothing fires.
+        assert counts["section_reconciles"] == [], counts
         # The whole rail cost is the per-press tray lookup, not the ~45-query
         # allocation measure.
         assert counts["rail_query_one"] <= 2 * PRESSES, counts
@@ -434,173 +422,6 @@ def _tray_harness():
             )
 
     return TrayApp()
-
-
-@pytest.mark.asyncio
-async def test_selection_copy_writes_are_equality_guarded_and_layout_free(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Unchanged copy -> no ``Static.update`` and no tooltip write; changed
-    copy -> exactly one ``layout=False`` repaint into the pinned one-row slot."""
-
-    app = _tray_harness()
-    async with app.run_test(size=(40, 20)) as pilot:
-        tray = app.query_one(ConsoleWorkspaceContextTray)
-        # Let the tray's first fit/relabel recompose settle before recording:
-        # captured child references die at a recompose, so all recording is
-        # class-level, filtered by the slot's id, and all assertions re-query.
-        for _ in range(6):
-            await pilot.pause()
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        slot_region = context.region
-        assert slot_region.height == 1
-
-        writes: list[tuple[str, object]] = []
-        original_update = Static.update
-
-        def recording_update(widget, content: object = "", **kwargs: object):
-            if getattr(widget, "id", None) == (
-                "console-workspace-tree-selection-context"
-            ):
-                writes.append((str(content), kwargs.get("layout", True)))
-            return original_update(widget, content, **kwargs)
-
-        monkeypatch.setattr(Static, "update", recording_update)
-
-        tooltip_writes: list[object] = []
-        screen = app.screen
-        original_tooltip_sync = screen._update_tooltip
-
-        def recording_tooltip_sync(widget):
-            if getattr(widget, "id", None) == (
-                "console-workspace-tree-selection-context"
-            ):
-                tooltip_writes.append(widget.tooltip)
-            return original_tooltip_sync(widget)
-
-        monkeypatch.setattr(screen, "_update_tooltip", recording_tooltip_sync)
-
-        conversation = WorkspaceTreeNodeData.conversation(
-            "workspace-1",
-            "conversation-1",
-            "Planning notes",
-            starred=False,
-            selected=False,
-            star_enabled=True,
-        )
-        tray.sync_workspace_tree_context(conversation)
-        await pilot.pause()
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        assert str(context.renderable) == "Selected: Planning notes · Enter open"
-        assert len(writes) == 1
-
-        # The same cursor context again: fully skipped, both halves.
-        tooltip_writes.clear()
-        tray.sync_workspace_tree_context(conversation)
-        await pilot.pause()
-        assert len(writes) == 1, writes
-        assert tooltip_writes == [], tooltip_writes
-
-        # A different context repaints once, without a layout pass, into the
-        # same pinned geometry.
-        other = WorkspaceTreeNodeData.conversation(
-            "workspace-1",
-            "conversation-2",
-            "Retro notes",
-            starred=False,
-            selected=False,
-            star_enabled=True,
-        )
-        tray.sync_workspace_tree_context(other)
-        await pilot.pause()
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        assert str(context.renderable) == "Selected: Retro notes · Enter open"
-        assert len(writes) == 2, writes
-        assert all(layout is False for _copy, layout in writes), writes
-        assert context.region == slot_region
-
-        # Review hardening (TASK-22203): a copy WIDER than the slot must not
-        # bank a geometry change for the next real layout pass. This is the
-        # contract that makes ``layout=False`` safe at all — the CSS pins the
-        # slot to a single ``nowrap``/``ellipsis`` row, so no copy can change
-        # its height. Asserting the region right after the write cannot detect
-        # the pin being removed: ``layout=False`` itself freezes the stale
-        # region (and even an ancestor-level layout keeps the Static's cached
-        # content height). The honest probe arms the layout pass the guarded
-        # write withheld — ``context.refresh(layout=True)``, exactly what
-        # ``update()`` would have armed, and what any later slot-level
-        # invalidation (width relabel recompose, resize) performs — and
-        # requires the one-row geometry to survive it. Unpin the CSS
-        # (``height: 1``/``text-wrap: nowrap``) and this overlong copy
-        # re-measures to several rows on that pass, and reds here.
-        overlong = WorkspaceTreeNodeData.conversation(
-            "workspace-1",
-            "conversation-3",
-            "An overlong conversation title that cannot possibly fit the "
-            "selection slot at this rail width without wrapping",
-            starred=False,
-            selected=False,
-            star_enabled=True,
-        )
-        tray.sync_workspace_tree_context(overlong)
-        await pilot.pause()
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        assert len(writes) == 3, writes
-        assert all(layout is False for _copy, layout in writes), writes
-        assert context.region == slot_region
-        context.refresh(layout=True)
-        await pilot.pause()
-        await pilot.pause()
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        assert context.region == slot_region
-
-
-@pytest.mark.asyncio
-async def test_selection_tooltip_writes_are_equality_guarded_when_clipped(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A clipped copy still exposes its tooltip once, not on every re-sync."""
-
-    app = _tray_harness()
-    async with app.run_test(size=(28, 20)) as pilot:
-        tray = app.query_one(ConsoleWorkspaceContextTray)
-        for _ in range(6):
-            await pilot.pause()
-
-        tooltip_writes: list[object] = []
-        screen = app.screen
-        original_tooltip_sync = screen._update_tooltip
-
-        def recording_tooltip_sync(widget):
-            if getattr(widget, "id", None) == (
-                "console-workspace-tree-selection-context"
-            ):
-                tooltip_writes.append(widget.tooltip)
-            return original_tooltip_sync(widget)
-
-        monkeypatch.setattr(screen, "_update_tooltip", recording_tooltip_sync)
-
-        long_label = "研究🙂" * 8
-        node = WorkspaceTreeNodeData.workspace("workspace-1", long_label)
-        tray.sync_workspace_tree_context(node)
-        await pilot.pause()
-        full_copy = f"Selected: {long_label} · Enter open"
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        assert isinstance(context.tooltip, Text)
-        assert context.tooltip.plain == full_copy
-        assert len(tooltip_writes) == 1
-
-        tray.sync_workspace_tree_context(node)
-        await pilot.pause()
-        context = app.query_one("#console-workspace-tree-selection-context", Static)
-        assert len(tooltip_writes) == 1, tooltip_writes
-        assert isinstance(context.tooltip, Text)
-        assert context.tooltip.plain == full_copy
-
-
-# ---------------------------------------------------------------------------
-# 4. The Tree tooltip memo
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -782,8 +603,6 @@ async def test_boundary_flip_coexists_with_an_in_flight_allocation_pass(
         tree.move_cursor(tree.conversation_nodes["conv-a0"])
         await _settle(pilot, passes=8)
 
-        action_row = console.query_one("#console-workspace-context-action-row")
-        assert action_row.display is True
         assert len(runs) == 1, runs
         assert rail._allocation_reconcile_scheduled is False
 

--- a/Tests/UI/test_console_workspace_tree_cursor_layout.py
+++ b/Tests/UI/test_console_workspace_tree_cursor_layout.py
@@ -296,7 +296,7 @@ async def test_boundary_crossing_reconciles_only_the_workspace_section(
         # The rail allocation pipeline never runs on a cursor boundary flip.
         assert counts["allocation_runs"] == 0, counts
         assert counts["allocation_preps"] == 0, counts
-        # TASK-25710: the star seam the boundary used to drive is retired, so
+        # TASK-25712: the star seam the boundary used to drive is retired, so
         # a crossing now runs NO reconcile at all -- the old invariant ("only
         # the workspace section, never the rail pipeline") is preserved and
         # strengthened: nothing fires.

--- a/backlog/tasks/task-25710 - Workspace-and-tree-chat-action-menus-in-the-Console-Context-rail.md
+++ b/backlog/tasks/task-25710 - Workspace-and-tree-chat-action-menus-in-the-Console-Context-rail.md
@@ -1,0 +1,87 @@
+---
+id: TASK-25710
+title: Workspace and tree-chat action menus in the Console Context rail
+status: Done
+assignee:
+  - '@Robert'
+created_date: '2026-08-31 04:34'
+updated_date: '2026-08-31 05:33'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Extend the TASK-23200/25709 asterisk-menu pattern to the Workspaces tree: workspace nodes open a workspace action menu (Activate, New chat, Rename, RAG scope, More>Archive) and chat rows reuse the conversation action menu. Retires the tree's single contextual Star button.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A workspace tree node's trailing asterisk (click) and the m binding open the workspace action menu with Activate/New chat/Rename/RAG scope/More>Archive
+- [x] #2 A tree chat row's trailing asterisk (click) and the m binding open the existing conversation action menu
+- [x] #3 Activate is bulleted and disabled for the already-active workspace; RAG scope states its active-workspace precondition when disabled
+- [x] #4 New chat on a non-active workspace activates it and creates the session there
+- [x] #5 Rename and Archive route through the existing workspace seams
+- [x] #6 The contextual Star button and its selection-context line are retired; the s star binding remains
+- [x] #7 Both new menus dismiss via Escape-anywhere and click-outside per ADR-068 (registry + TASK-25709 paths)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Tests first: pure workspace-menu model suite; widget suite for shape/paging/escape; wiring suite for tree click + m binding + routing + star retirement + dismissal parity.\n2. Chat/console_workspace_actions.py pure model (target, build menu, pages, gating).\n3. Widgets/Console/console_workspace_action_menu.py sibling widget + WeakSet registry + messages.\n4. console_workspace_tree.py: trailing asterisk labels, click hit-test on the asterisk cell, m binding, WorkspaceTreeMenuRequested messages.\n5. chat_screen.py: mount/route seams (activate, activate+new chat, rename, archive, rag scope), conversation-menu reuse for tree chats, dismissal paths extended to the workspace registry, Dismissed handler focuses any widget by id.\n6. console_workspace_context.py: retire tree star button + selection-context line.\n7. Targeted suites, lint, boot census; task notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Extended the TASK-23200/25709 row-menu pattern to the Workspaces tree, per
+the approved design (workspaces tree nodes + tree chat rows; full action set).
+
+- **Pure model** (`Chat/console_workspace_actions.py`): `WorkspaceMenuTarget`
+  + `build_workspace_menu` — root Activate/New chat/Rename…/RAG scope…/More ▸,
+  More page Archive. Activate is bulleted+disabled for the active workspace;
+  RAG scope gates on active (the scope-picker seam is active-workspace
+  scoped) with a stated reason. Separately tested (7 tests).
+- **Widget** (`Widgets/Console/console_workspace_action_menu.py`): sibling of
+  the conversation menu with its own `WeakSet` registry, `restore_focus`
+  dismissal semantics, memoized single-shot detach, and paging. The two
+  registries share one screen-level contract: the outside-click pass, the
+  Escape guards (composer-home, collapsed-composer, hands-free, realtime),
+  and the one-menu-at-a-time mount helper all fold BOTH kinds, so every
+  TASK-25709 dismissal behavior carries over (pinned by parity tests).
+- **Tree affordances** (`console_workspace_tree.py`): workspace/conversation
+  labels carry a trailing ` *` appended AFTER truncation (budget reduced by
+  the affordance width — shared `_label_budget` used by render AND the
+  tooltip fit decision, so a tooltip can't fire for a row that only looks
+  truncated); `render_label` records each row's asterisk x-zone, cleared per
+  projection pass, and a pointer press inside the zone posts
+  `WorkspaceTreeMenuRequested` instead of selecting. New `m` binding opens
+  the menu at the cursor row (guarded on a measured region — a collapsed
+  section's 0×0 tree has no anchor).
+- **Screen routing** (`chat_screen.py`): `on_workspace_tree_menu_requested`
+  mounts the right menu; `on_workspace_action_chosen` routes through existing
+  seams (activate, activate-then-create for New chat, rename modal, archive
+  confirmation, scope picker). Tree chat rows reuse
+  `ConsoleConversationActionMenu` with a target built from marks-service
+  truth. Menu-opener focus restore is now by DOM id on any widget (the tree
+  is not a Button).
+- **Retirement**: the contextual Star/Unstar button, its selection-context
+  line, the dead left_rail press branch, and the timer-inventory pin are
+  gone; `sync_workspace_tree_context` remains as the cursor recorder.
+  Tests pinning the retired chrome were rerouted (disclosure test keeps the
+  persisted-disclosure invariants; boundary perf test now pins the stronger
+  "no reconcile at all") or deleted (selection-copy/tooltip write tests,
+  star visibility/geometry tests).
+- **Verification**: 243 passed across 13 suites (model, new menu suite 8/8,
+  conversation menu, routing, context rail, rail reconciliation, cursor
+  layout, timer inventory, hands-free, composer draft, selection-dismissal
+  perf, boot census green — ADR-097 ratchet intact since all new module
+  references are lazy). The 7 failures in the sweep (4 hands-free wiring, 2
+  tree tooltips, 1 timer census) were each verified red on clean origin/dev
+  by stashing this change. Ruff clean on all task files.
+- ADR check: no new ADR — applies ADR-068's dismiss contract and the
+  TASK-23200 menu pattern to two more surfaces; ADR-097 boot-ratchet honored.
+  Files: 4 new (model, widget, 2 test files), 8 modified.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-25712 - Workspace-and-tree-chat-action-menus-in-the-Console-Context-rail.md
+++ b/backlog/tasks/task-25712 - Workspace-and-tree-chat-action-menus-in-the-Console-Context-rail.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-25710
+id: TASK-25712
 title: Workspace and tree-chat action menus in the Console Context rail
 status: Done
 assignee:
@@ -32,6 +32,15 @@ Extend the TASK-23200/25709 asterisk-menu pattern to the Workspaces tree: worksp
 <!-- SECTION:PLAN:BEGIN -->
 1. Tests first: pure workspace-menu model suite; widget suite for shape/paging/escape; wiring suite for tree click + m binding + routing + star retirement + dismissal parity.\n2. Chat/console_workspace_actions.py pure model (target, build menu, pages, gating).\n3. Widgets/Console/console_workspace_action_menu.py sibling widget + WeakSet registry + messages.\n4. console_workspace_tree.py: trailing asterisk labels, click hit-test on the asterisk cell, m binding, WorkspaceTreeMenuRequested messages.\n5. chat_screen.py: mount/route seams (activate, activate+new chat, rename, archive, rag scope), conversation-menu reuse for tree chats, dismissal paths extended to the workspace registry, Dismissed handler focuses any widget by id.\n6. console_workspace_context.py: retire tree star button + selection-context line.\n7. Targeted suites, lint, boot census; task notes.
 <!-- SECTION:PLAN:END -->
+
+## Renumbering
+
+TASK-19601 owner rule: this task originally took id 25710, which collided
+with the older arrival ``task-25710 - Home-content-recents-stream-resume-
+banner.md`` (created 2026-08-30 23:39 vs this task's 2026-08-31 04:34; the
+older id keeps). Renumbered to TASK-25712 with this provenance section; the
+task-file frontmatter, doc comments, and test references were updated with
+it. Earlier commit messages on this branch still name TASK-25710.
 
 ## Implementation Notes
 

--- a/tldw_chatbook/Chat/console_workspace_actions.py
+++ b/tldw_chatbook/Chat/console_workspace_actions.py
@@ -1,0 +1,151 @@
+"""Pure menu model for the Console workspace action menu (TASK-25710).
+
+TASK-23200 gave the Context rail's conversation rows an asterisk that opens a
+paged action menu; TASK-25709 made that menu dismissable everywhere. This
+module extends the same pattern to the Workspaces tree's workspace nodes:
+an asterisk that opens Activate / New chat / Rename… / RAG scope… / More ▸
+Archive.
+
+Everything here is pure: given what is true of one workspace, return the
+items to paint. No DOM, no database, no service lookups -- so the menu's
+shape, labelling and gating are testable without mounting an app.
+
+Every command routes through code that already exists (activate_workspace_
+id, the rename modal, the archive confirmation, the workspace scope picker,
+and activate-then-create for "New chat" in a non-active workspace). RAG
+scope is the one gated entry: the scope-picker seam is active-workspace
+scoped, so a non-active workspace states that precondition rather than
+silently editing the active workspace's scope.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+MenuPage = Literal["root", "more"]
+
+#: Action ids the menu can emit. Kept as plain strings so the widget, the
+#: screen handler and the tests all name them the same way.
+ACTION_ACTIVATE = "activate"
+ACTION_NEW_CHAT = "new-chat"
+ACTION_RENAME = "rename"
+ACTION_RAG_SCOPE = "rag-scope"
+ACTION_ARCHIVE = "archive"
+ACTION_PAGE_PREFIX = "page:"
+ACTION_BACK = "page:root"
+
+_ALREADY_ACTIVE_REASON = "This workspace is already active."
+_RAG_SCOPE_INACTIVE_REASON = "Activate this workspace to edit its RAG scope."
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceMenuItem:
+    """One painted row of the workspace action menu.
+
+    Attributes:
+        action_id: Stable identifier emitted when the item is chosen.
+        label: Text shown to the user.
+        enabled: Whether the item may be chosen.
+        disabled_reason: Why it may not be, shown as a tooltip. Only ever set
+            when ``enabled`` is False -- a disabled control with no stated
+            precondition is the defect the sibling menu exists to remove.
+        opens_page: The page this item navigates to, when it is a submenu
+            opener rather than a command.
+        is_current: Whether the item describes the workspace's present state,
+            so the menu can mark it rather than implying choosing it does
+            something.
+    """
+
+    action_id: str
+    label: str
+    enabled: bool = True
+    disabled_reason: str = ""
+    opens_page: MenuPage | None = None
+    is_current: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceMenuTarget:
+    """What the menu needs to know about the workspace it was opened from.
+
+    Attributes:
+        workspace_id: Registry id of the workspace.
+        name: Current workspace name, for notifications.
+        is_active: Whether this workspace is the active one. Drives the
+            Activate entry's current-mark/gating and the RAG scope gate.
+    """
+
+    workspace_id: str
+    name: str = ""
+    is_active: bool = False
+
+
+def build_workspace_menu(
+    target: WorkspaceMenuTarget,
+    page: MenuPage = "root",
+) -> tuple[WorkspaceMenuItem, ...]:
+    """Return the items to paint for one page of the menu.
+
+    Args:
+        target: What is true of the workspace the menu was opened from.
+        page: Which page to render.
+
+    Returns:
+        The ordered items for that page. Never empty: the non-root page
+        carries a Back item.
+    """
+    if page == "more":
+        return _more_page()
+    return _root_page(target)
+
+
+def _root_page(
+    target: WorkspaceMenuTarget,
+) -> tuple[WorkspaceMenuItem, ...]:
+    return (
+        WorkspaceMenuItem(
+            action_id=ACTION_ACTIVATE,
+            label="Activate",
+            enabled=not target.is_active,
+            disabled_reason="" if not target.is_active else _ALREADY_ACTIVE_REASON,
+            is_current=target.is_active,
+        ),
+        WorkspaceMenuItem(action_id=ACTION_NEW_CHAT, label="New chat"),
+        WorkspaceMenuItem(action_id=ACTION_RENAME, label="Rename…"),
+        WorkspaceMenuItem(
+            action_id=ACTION_RAG_SCOPE,
+            label="RAG scope…",
+            enabled=target.is_active,
+            disabled_reason="" if target.is_active else _RAG_SCOPE_INACTIVE_REASON,
+        ),
+        WorkspaceMenuItem(
+            action_id=f"{ACTION_PAGE_PREFIX}more",
+            label="More",
+            opens_page="more",
+        ),
+    )
+
+
+def _more_page() -> tuple[WorkspaceMenuItem, ...]:
+    return (
+        WorkspaceMenuItem(action_id=ACTION_BACK, label="‹ Back", opens_page="root"),
+        WorkspaceMenuItem(action_id=ACTION_ARCHIVE, label="Archive"),
+    )
+
+
+def page_from_action(action_id: str) -> MenuPage | None:
+    """Return the page an action navigates to, or None if it is a command.
+
+    Args:
+        action_id: An action id emitted by the menu.
+
+    Returns:
+        The page name, or None for commands and for page ids this menu
+        cannot navigate to (the sibling conversation menu's pages do not
+        leak in).
+    """
+    if not action_id.startswith(ACTION_PAGE_PREFIX):
+        return None
+    candidate = action_id[len(ACTION_PAGE_PREFIX) :]
+    return candidate if candidate in ("root", "more") else None

--- a/tldw_chatbook/Chat/console_workspace_actions.py
+++ b/tldw_chatbook/Chat/console_workspace_actions.py
@@ -1,4 +1,4 @@
-"""Pure menu model for the Console workspace action menu (TASK-25710).
+"""Pure menu model for the Console workspace action menu (TASK-25712).
 
 TASK-23200 gave the Context rail's conversation rows an asterisk that opens a
 paged action menu; TASK-25709 made that menu dismissable everywhere. This

--- a/tldw_chatbook/UI/Console_Modules/left_rail.py
+++ b/tldw_chatbook/UI/Console_Modules/left_rail.py
@@ -79,7 +79,6 @@ from ...Widgets.Console import (
     WorkspaceTreeContextChanged,
     WorkspaceTreeExpansionChanged,
     WorkspaceTreeFocusRecoveryRequested,
-    WorkspaceTreeStarRequested,
 )
 from ...Widgets.Console.console_agent_steering_bar import (
     STEERING_BAR_ID,
@@ -2414,19 +2413,6 @@ class ConsoleLeftRail(Vertical):
         if button_id == "console-character-reaction-open":
             event.stop()
             self.post_message(self.ReactionPickerRequested())
-            return
-        if button_id == "console-workspace-tree-star":
-            event.stop()
-            workspace_id = getattr(event.button, "workspace_id", None)
-            conversation_id = getattr(event.button, "conversation_id", None)
-            if workspace_id and conversation_id:
-                self.post_message(
-                    WorkspaceTreeStarRequested(
-                        workspace_id,
-                        conversation_id,
-                        starred=bool(getattr(event.button, "starred", False)),
-                    )
-                )
             return
         if not button_id.startswith(RAIL_SECTION_TOGGLE_PREFIX):
             return

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4559,7 +4559,7 @@ class ChatScreen(BaseAppScreen):
         so the user's focus stays where it is. Lazy import per ADR-097 --
         this module must stay off the ``_ui_ready`` boot leg.
 
-        TASK-25710: covers BOTH row menus -- the conversation menu and the
+        TASK-25712: covers BOTH row menus -- the conversation menu and the
         Workspaces-tree workspace menu -- so any open row menu claims the
         Escape regardless of kind.
 
@@ -4580,7 +4580,7 @@ class ChatScreen(BaseAppScreen):
     def _restore_console_menu_opener_focus(self, opener_id: str) -> None:
         """Return focus to whatever widget opened a row action menu.
 
-        TASK-25710: the conversation menu's openers are asterisk ``Button``s,
+        TASK-25712: the conversation menu's openers are asterisk ``Button``s,
         but the workspace menu's opener is the Workspaces tree, so the
         restore is by DOM id on any focusable widget -- not Button-typed.
         """
@@ -4701,7 +4701,7 @@ class ChatScreen(BaseAppScreen):
             return
         self._restore_console_menu_opener_focus(event.opener_id)
 
-    # ---- Workspace action menu (TASK-25710) ----------------------------
+    # ---- Workspace action menu (TASK-25712) ----------------------------
 
     def _workspace_menu_target(self, workspace_id: str):
         """Build the pure menu target from registry truth.
@@ -4911,7 +4911,7 @@ class ChatScreen(BaseAppScreen):
     async def _create_console_chat_in_workspace(self, workspace_id: str) -> None:
         """Activate a workspace, then create the new chat inside it.
 
-        TASK-25710: "New chat" on a non-active workspace composes the two
+        TASK-25712: "New chat" on a non-active workspace composes the two
         existing operations -- activation, then session creation, which
         targets the active workspace -- rather than threading a workspace
         parameter through session creation.
@@ -18220,7 +18220,7 @@ class ChatScreen(BaseAppScreen):
                 # border and padding clicks must not fold it mid-press.
                 return
             if getattr(node, "id", None) == "console-workspace-action-menu":
-                # TASK-25710: the workspace row menu owns the same contract.
+                # TASK-25712: the workspace row menu owns the same contract.
                 return
             node = getattr(node, "parent", None)
         menus = selection_menus_on_screen(self)
@@ -18267,7 +18267,7 @@ class ChatScreen(BaseAppScreen):
         dismiss_message_more_menus(more_menus)
         # restore_focus=False: Textual has already moved focus to the clicked
         # widget (it focuses before the press bubbles here), and the opener
-        # restore would pull focus back to the rail. TASK-25710: the
+        # restore would pull focus back to the rail. TASK-25712: the
         # Workspaces-tree menu folds on the same contract.
         for menu in conversation_menus:
             menu.dismiss_menu(restore_focus=False)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -610,6 +610,13 @@ NoteRequested = ConsoleSelectionNoteRequested
 
 if TYPE_CHECKING:
     from tldw_chatbook.app import TldwCli
+    from tldw_chatbook.Widgets.Console.console_workspace_action_menu import (
+        WorkspaceActionChosen,
+        WorkspaceActionMenuDismissed,
+    )
+    from tldw_chatbook.Widgets.Console.console_workspace_tree import (
+        WorkspaceTreeMenuRequested,
+    )
 
 logger = logger.bind(module="ChatScreen")
 _CONSOLE_DEFAULT_RESERVATION_ATTEMPTS = 8
@@ -4614,8 +4621,7 @@ class ChatScreen(BaseAppScreen):
         # otherwise anchor a menu that runs off the end of the screen.
         region = opener.region
         menu_width = ConsoleConversationActionMenu.MENU_WIDTH
-        # Root page is the tallest: five items plus the rounded border.
-        menu_height = 7
+        menu_height = ConsoleConversationActionMenu.ROOT_PAGE_HEIGHT
         screen_region = self.region
         await self._mount_console_row_action_menu(
             target,
@@ -4763,8 +4769,7 @@ class ChatScreen(BaseAppScreen):
         for menu in workspace_action_menus_on_screen(self):
             await menu.await_detachment()
         menu_width = ConsoleWorkspaceActionMenu.MENU_WIDTH
-        # Root page is the tallest: five items plus the rounded border.
-        menu_height = 7
+        menu_height = ConsoleWorkspaceActionMenu.ROOT_PAGE_HEIGHT
         screen_region = self.region
         self.screen.mount(
             ConsoleWorkspaceActionMenu(
@@ -4784,6 +4789,7 @@ class ChatScreen(BaseAppScreen):
         self,
         *,
         conversation_id: str | None,
+        title: str,
         screen_x: int,
         screen_y: int,
     ) -> None:
@@ -4791,7 +4797,10 @@ class ChatScreen(BaseAppScreen):
 
         Args:
             conversation_id: Persisted conversation id of the row, or None
-                when the tree row has no persisted conversation yet.
+                when the tree row has no persisted conversation yet (the
+                tree's synthetic ``native:`` identity never reaches here).
+            title: The row's display title, so rename, delete, and the
+                confirmations name the chat the user pressed.
             screen_x: Absolute anchor column.
             screen_y: Absolute anchor row.
         """
@@ -4812,13 +4821,13 @@ class ChatScreen(BaseAppScreen):
                 starred = bool(is_starred(conversation_id))
         target = ConversationMenuTarget(
             conversation_id=conversation_id,
-            title="",
+            title=title,
             state=self._console_conversation_state(conversation_id),
             starred=starred,
             favorites_available=marks_service is not None,
         )
         menu_width = ConsoleConversationActionMenu.MENU_WIDTH
-        menu_height = 7
+        menu_height = ConsoleConversationActionMenu.ROOT_PAGE_HEIGHT
         screen_region = self.region
         await self._mount_console_row_action_menu(
             target,
@@ -4869,7 +4878,9 @@ class ChatScreen(BaseAppScreen):
             )
         )
 
-    def on_workspace_tree_menu_requested(self, event) -> None:
+    def on_workspace_tree_menu_requested(
+        self, event: "WorkspaceTreeMenuRequested"
+    ) -> None:
         """Mount the row menu a Workspaces-tree asterisk asked for.
 
         Dispatched by handler-name convention (ADR-097 lazy-import rule).
@@ -4889,6 +4900,7 @@ class ChatScreen(BaseAppScreen):
         self.run_worker(
             self._open_console_tree_conversation_action_menu(
                 conversation_id=event.conversation_id,
+                title=event.title,
                 screen_x=event.screen_x,
                 screen_y=event.screen_y,
             ),
@@ -4900,14 +4912,47 @@ class ChatScreen(BaseAppScreen):
         """Activate a workspace, then create the new chat inside it.
 
         TASK-25710: "New chat" on a non-active workspace composes the two
-        existing operations -- activation is idempotent, and session
-        creation targets the active workspace -- rather than threading a
-        workspace parameter through session creation.
+        existing operations -- activation, then session creation, which
+        targets the active workspace -- rather than threading a workspace
+        parameter through session creation.
+
+        Review, PR #2255: the activation wrapper deliberately discards
+        ``_switch_console_workspace``'s failure result (its other callers
+        are fire-and-forget), so success is verified against the registry
+        afterwards. A missing workspace or a failed switch must NOT create
+        the chat in the previously active workspace -- the user asked for
+        it somewhere specific.
         """
-        self._workspace.activate_workspace_id(workspace_id)
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+
+        def _record():
+            return (
+                registry_service.get_workspace(workspace_id)
+                if registry_service is not None
+                else None
+            )
+
+        record = _record()
+        if record is None:
+            self.app_instance.notify(
+                "This workspace is no longer available.", severity="warning"
+            )
+            return
+        if not getattr(record, "active", False):
+            self._workspace.activate_workspace_id(workspace_id)
+            record = _record()
+            if record is None or not getattr(record, "active", False):
+                self.app_instance.notify(
+                    f"Could not activate {record.name if record else workspace_id}. "
+                    "New chat was not created.",
+                    severity="warning",
+                )
+                return
         await self._session._create_native_console_session_from_active_context()
 
-    def on_workspace_action_chosen(self, event) -> None:
+    def on_workspace_action_chosen(self, event: "WorkspaceActionChosen") -> None:
         """Run the chosen workspace command against the captured row.
 
         Dispatched by handler-name convention (ADR-097 lazy-import rule).
@@ -4947,7 +4992,9 @@ class ChatScreen(BaseAppScreen):
             self._workspace._confirm_console_workspace_archive(workspace_id)
             return
 
-    def on_workspace_action_menu_dismissed(self, event) -> None:
+    def on_workspace_action_menu_dismissed(
+        self, event: "WorkspaceActionMenuDismissed"
+    ) -> None:
         """Return focus to the tree that opened the workspace menu.
 
         Dispatched by handler-name convention (ADR-097 lazy-import rule);

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4542,7 +4542,7 @@ class ChatScreen(BaseAppScreen):
     # ---- Conversation action menu (TASK-23200) -------------------------
 
     def _dismiss_console_conversation_action_menus(self) -> bool:
-        """Fold any open conversation row menu; True when one was open.
+        """Fold any open row action menu; True when one was open.
 
         TASK-25709: the Escape consumers' guard, slotting in exactly where
         ``_dismiss_console_command_popup`` already sits -- an open menu
@@ -4552,14 +4552,37 @@ class ChatScreen(BaseAppScreen):
         so the user's focus stays where it is. Lazy import per ADR-097 --
         this module must stay off the ``_ui_ready`` boot leg.
 
+        TASK-25710: covers BOTH row menus -- the conversation menu and the
+        Workspaces-tree workspace menu -- so any open row menu claims the
+        Escape regardless of kind.
+
         Returns:
             True when a menu was open and has been dismissed.
         """
         from tldw_chatbook.Widgets.Console.console_conversation_action_menu import (
             dismiss_conversation_action_menus,
         )
+        from tldw_chatbook.Widgets.Console.console_workspace_action_menu import (
+            dismiss_workspace_action_menus,
+        )
 
-        return dismiss_conversation_action_menus(self, restore_focus=False) > 0
+        dismissed = dismiss_conversation_action_menus(self, restore_focus=False)
+        dismissed += dismiss_workspace_action_menus(self, restore_focus=False)
+        return dismissed > 0
+
+    def _restore_console_menu_opener_focus(self, opener_id: str) -> None:
+        """Return focus to whatever widget opened a row action menu.
+
+        TASK-25710: the conversation menu's openers are asterisk ``Button``s,
+        but the workspace menu's opener is the Workspaces tree, so the
+        restore is by DOM id on any focusable widget -- not Button-typed.
+        """
+        if not opener_id:
+            return
+        try:
+            self.query_one(f"#{opener_id}").focus()
+        except (NoMatches, QueryError):
+            pass
 
     async def _open_console_conversation_action_menu(self, opener: Button) -> None:
         """Anchor the row action menu beneath the pressed asterisk.
@@ -4572,18 +4595,10 @@ class ChatScreen(BaseAppScreen):
         )
         from tldw_chatbook.Widgets.Console.console_conversation_action_menu import (
             ConsoleConversationActionMenu,
-            conversation_action_menus_on_screen,
         )
 
-        # Only one menu at a time; a second asterisk replaces the first
-        # rather than stacking two overlays the user must dismiss twice.
-        # The awaits are load-bearing (TASK-25709): ``remove()`` only
-        # schedules the prune, so mounting the same DOM id over a
-        # still-attached menu raised Textual's app-fatal ``DuplicateIds``
-        # on consecutive opens.
-        for menu in conversation_action_menus_on_screen(self):
-            await menu.await_detachment()
-
+        # One row menu at a time (across kinds) and the DuplicateIds detach
+        # guard both live in the shared mount helper (TASK-25709/25710).
         conversation_id = (
             str(getattr(opener, "conversation_id", "") or "").strip() or None
         )
@@ -4602,8 +4617,8 @@ class ChatScreen(BaseAppScreen):
         # Root page is the tallest: five items plus the rounded border.
         menu_height = 7
         screen_region = self.region
-        menu = ConsoleConversationActionMenu(
-            target=target,
+        await self._mount_console_row_action_menu(
+            target,
             opener_id=str(opener.id or ""),
             screen_x=max(
                 screen_region.x, min(region.x, screen_region.right - menu_width)
@@ -4613,7 +4628,6 @@ class ChatScreen(BaseAppScreen):
                 min(region.bottom, screen_region.bottom - menu_height),
             ),
         )
-        self.screen.mount(menu)
 
     def _console_conversation_state(self, conversation_id: str | None) -> str:
         """Return one conversation's PERSISTED state, or the default.
@@ -4679,12 +4693,270 @@ class ChatScreen(BaseAppScreen):
         event.stop()
         if not getattr(event, "restore_focus", True):
             return
-        if not event.opener_id:
+        self._restore_console_menu_opener_focus(event.opener_id)
+
+    # ---- Workspace action menu (TASK-25710) ----------------------------
+
+    def _workspace_menu_target(self, workspace_id: str):
+        """Build the pure menu target from registry truth.
+
+        Args:
+            workspace_id: Registry id of the workspace row pressed.
+
+        Returns:
+            A ``WorkspaceMenuTarget`` (imported lazily per ADR-097) or None
+            when the workspace is no longer resolvable -- the caller then
+            just does not open a menu.
+        """
+        from tldw_chatbook.Chat.console_workspace_actions import (
+            WorkspaceMenuTarget,
+        )
+
+        registry_service = getattr(
+            self.app_instance, "workspace_registry_service", None
+        )
+        record = (
+            registry_service.get_workspace(workspace_id)
+            if registry_service is not None
+            else None
+        )
+        if record is None:
+            return None
+        return WorkspaceMenuTarget(
+            workspace_id=workspace_id,
+            name=str(getattr(record, "name", "") or ""),
+            is_active=bool(getattr(record, "active", False)),
+        )
+
+    async def _open_console_workspace_action_menu(
+        self,
+        *,
+        workspace_id: str,
+        screen_x: int,
+        screen_y: int,
+    ) -> None:
+        """Anchor the workspace action menu at the pressed tree asterisk.
+
+        Args:
+            workspace_id: Registry id of the workspace row.
+            screen_x: Absolute anchor column.
+            screen_y: Absolute anchor row.
+        """
+        target = self._workspace_menu_target(workspace_id)
+        if target is None:
+            self.app_instance.notify(
+                "This workspace is no longer available.", severity="warning"
+            )
             return
-        try:
-            self.query_one(f"#{event.opener_id}", Button).focus()
-        except (NoMatches, QueryError):
-            pass
+        from tldw_chatbook.Widgets.Console.console_conversation_action_menu import (
+            conversation_action_menus_on_screen,
+        )
+        from tldw_chatbook.Widgets.Console.console_workspace_action_menu import (
+            ConsoleWorkspaceActionMenu,
+            workspace_action_menus_on_screen,
+        )
+
+        # One row menu on screen at a time, across kinds; the awaits are
+        # the DuplicateIds guard (see the conversation open path).
+        for menu in conversation_action_menus_on_screen(self):
+            await menu.await_detachment()
+        for menu in workspace_action_menus_on_screen(self):
+            await menu.await_detachment()
+        menu_width = ConsoleWorkspaceActionMenu.MENU_WIDTH
+        # Root page is the tallest: five items plus the rounded border.
+        menu_height = 7
+        screen_region = self.region
+        self.screen.mount(
+            ConsoleWorkspaceActionMenu(
+                target=target,
+                opener_id="console-workspace-tree",
+                screen_x=max(
+                    screen_region.x, min(screen_x, screen_region.right - menu_width)
+                ),
+                screen_y=max(
+                    screen_region.y,
+                    min(screen_y, screen_region.bottom - menu_height),
+                ),
+            )
+        )
+
+    async def _open_console_tree_conversation_action_menu(
+        self,
+        *,
+        conversation_id: str | None,
+        screen_x: int,
+        screen_y: int,
+    ) -> None:
+        """Open the shared conversation menu for one Workspaces-tree chat row.
+
+        Args:
+            conversation_id: Persisted conversation id of the row, or None
+                when the tree row has no persisted conversation yet.
+            screen_x: Absolute anchor column.
+            screen_y: Absolute anchor row.
+        """
+        from tldw_chatbook.Chat.console_conversation_actions import (
+            ConversationMenuTarget,
+        )
+        from tldw_chatbook.Widgets.Console.console_conversation_action_menu import (
+            ConsoleConversationActionMenu,
+        )
+
+        marks_service = getattr(
+            self.app_instance, "conversation_local_marks_service", None
+        )
+        starred = False
+        if conversation_id and marks_service is not None:
+            is_starred = getattr(marks_service, "is_starred", None)
+            if callable(is_starred):
+                starred = bool(is_starred(conversation_id))
+        target = ConversationMenuTarget(
+            conversation_id=conversation_id,
+            title="",
+            state=self._console_conversation_state(conversation_id),
+            starred=starred,
+            favorites_available=marks_service is not None,
+        )
+        menu_width = ConsoleConversationActionMenu.MENU_WIDTH
+        menu_height = 7
+        screen_region = self.region
+        await self._mount_console_row_action_menu(
+            target,
+            opener_id="console-workspace-tree",
+            screen_x=max(
+                screen_region.x, min(screen_x, screen_region.right - menu_width)
+            ),
+            screen_y=max(
+                screen_region.y,
+                min(screen_y, screen_region.bottom - menu_height),
+            ),
+        )
+
+    async def _mount_console_row_action_menu(
+        self,
+        target,
+        *,
+        opener_id: str,
+        screen_x: int,
+        screen_y: int,
+    ) -> None:
+        """Mount one shared conversation menu with the detach guard.
+
+        Args:
+            target: The ``ConversationMenuTarget`` captured at open time.
+            opener_id: DOM id of the opener used for focus restoration.
+            screen_x: Absolute anchor column.
+            screen_y: Absolute anchor row.
+        """
+        from tldw_chatbook.Widgets.Console.console_conversation_action_menu import (
+            ConsoleConversationActionMenu,
+            conversation_action_menus_on_screen,
+        )
+        from tldw_chatbook.Widgets.Console.console_workspace_action_menu import (
+            workspace_action_menus_on_screen,
+        )
+
+        for menu in conversation_action_menus_on_screen(self):
+            await menu.await_detachment()
+        for menu in workspace_action_menus_on_screen(self):
+            await menu.await_detachment()
+        self.screen.mount(
+            ConsoleConversationActionMenu(
+                target=target,
+                opener_id=opener_id,
+                screen_x=screen_x,
+                screen_y=screen_y,
+            )
+        )
+
+    def on_workspace_tree_menu_requested(self, event) -> None:
+        """Mount the row menu a Workspaces-tree asterisk asked for.
+
+        Dispatched by handler-name convention (ADR-097 lazy-import rule).
+        """
+        event.stop()
+        if event.kind == "workspace":
+            self.run_worker(
+                self._open_console_workspace_action_menu(
+                    workspace_id=event.workspace_id,
+                    screen_x=event.screen_x,
+                    screen_y=event.screen_y,
+                ),
+                exclusive=True,
+                group="console-row-action-menu-open",
+            )
+            return
+        self.run_worker(
+            self._open_console_tree_conversation_action_menu(
+                conversation_id=event.conversation_id,
+                screen_x=event.screen_x,
+                screen_y=event.screen_y,
+            ),
+            exclusive=True,
+            group="console-row-action-menu-open",
+        )
+
+    async def _create_console_chat_in_workspace(self, workspace_id: str) -> None:
+        """Activate a workspace, then create the new chat inside it.
+
+        TASK-25710: "New chat" on a non-active workspace composes the two
+        existing operations -- activation is idempotent, and session
+        creation targets the active workspace -- rather than threading a
+        workspace parameter through session creation.
+        """
+        self._workspace.activate_workspace_id(workspace_id)
+        await self._session._create_native_console_session_from_active_context()
+
+    def on_workspace_action_chosen(self, event) -> None:
+        """Run the chosen workspace command against the captured row.
+
+        Dispatched by handler-name convention (ADR-097 lazy-import rule).
+        """
+        from tldw_chatbook.Chat.console_workspace_actions import (
+            ACTION_ACTIVATE,
+            ACTION_ARCHIVE,
+            ACTION_NEW_CHAT,
+            ACTION_RAG_SCOPE,
+            ACTION_RENAME,
+        )
+
+        event.stop()
+        target = event.target
+        workspace_id = str(target.workspace_id)
+        if event.action_id == ACTION_ACTIVATE:
+            self._workspace.activate_workspace_id(workspace_id)
+            return
+        if event.action_id == ACTION_NEW_CHAT:
+            self.run_worker(
+                self._create_console_chat_in_workspace(workspace_id),
+                exclusive=True,
+                group="console-workspace-new-chat",
+            )
+            return
+        if event.action_id == ACTION_RENAME:
+            self._workspace._open_console_workspace_rename(workspace_id)
+            return
+        if event.action_id == ACTION_RAG_SCOPE:
+            self.run_worker(
+                self._workspace._open_console_workspace_scope_picker(),
+                exclusive=True,
+                group="console-workspace-scope-open",
+            )
+            return
+        if event.action_id == ACTION_ARCHIVE:
+            self._workspace._confirm_console_workspace_archive(workspace_id)
+            return
+
+    def on_workspace_action_menu_dismissed(self, event) -> None:
+        """Return focus to the tree that opened the workspace menu.
+
+        Dispatched by handler-name convention (ADR-097 lazy-import rule);
+        ``restore_focus`` semantics mirror the conversation menu's.
+        """
+        event.stop()
+        if not getattr(event, "restore_focus", True):
+            return
+        self._restore_console_menu_opener_focus(event.opener_id)
 
     def on_conversation_action_chosen(self, event: Message) -> None:
         """Run the chosen row command against the captured conversation.
@@ -17900,6 +18172,9 @@ class ChatScreen(BaseAppScreen):
                 # TASK-25709: the row menu owns its in-area interaction --
                 # border and padding clicks must not fold it mid-press.
                 return
+            if getattr(node, "id", None) == "console-workspace-action-menu":
+                # TASK-25710: the workspace row menu owns the same contract.
+                return
             node = getattr(node, "parent", None)
         menus = selection_menus_on_screen(self)
         more_menus = message_more_menus_on_screen(self)
@@ -17909,8 +18184,12 @@ class ChatScreen(BaseAppScreen):
         from tldw_chatbook.Widgets.Console.console_conversation_action_menu import (
             conversation_action_menus_on_screen,
         )
+        from tldw_chatbook.Widgets.Console.console_workspace_action_menu import (
+            workspace_action_menus_on_screen,
+        )
 
         conversation_menus = conversation_action_menus_on_screen(self)
+        workspace_menus = workspace_action_menus_on_screen(self)
         # Only transcripts the cleanup would actually change; on the rest,
         # all three steps below are provable no-ops (see
         # ``ConsoleTranscript.has_pending_selection_ui``).
@@ -17919,7 +18198,13 @@ class ChatScreen(BaseAppScreen):
             for transcript in console_transcripts_on_screen(self)
             if transcript.has_pending_selection_ui
         ]
-        if not menus and not more_menus and not conversation_menus and not transcripts:
+        if (
+            not menus
+            and not more_menus
+            and not conversation_menus
+            and not workspace_menus
+            and not transcripts
+        ):
             return  # the common case: no selection UI anywhere on the screen
         # Menus mount on the screen now; route the dismissal through every
         # transcript's centralized selection-UI cleanup (clears highlight +
@@ -17935,8 +18220,11 @@ class ChatScreen(BaseAppScreen):
         dismiss_message_more_menus(more_menus)
         # restore_focus=False: Textual has already moved focus to the clicked
         # widget (it focuses before the press bubbles here), and the opener
-        # restore would pull focus back to the rail.
+        # restore would pull focus back to the rail. TASK-25710: the
+        # Workspaces-tree menu folds on the same contract.
         for menu in conversation_menus:
+            menu.dismiss_menu(restore_focus=False)
+        for menu in workspace_menus:
             menu.dismiss_menu(restore_focus=False)
 
     def on_mouse_down(self, event: MouseDown) -> None:

--- a/tldw_chatbook/Widgets/Console/console_conversation_action_menu.py
+++ b/tldw_chatbook/Widgets/Console/console_conversation_action_menu.py
@@ -132,6 +132,12 @@ class ConsoleConversationActionMenu(Vertical):
 
     can_focus = True
 
+    #: Painted height of the menu's tallest page (the root: five one-row
+    #: buttons plus the rounded border), used by the screen's anchor
+    #: clamping. Keep in lockstep with the root page's item count.
+    ROOT_PAGE_HEIGHT = 7
+
+
     #: Anchoring clamps against this; the stylesheet below must declare the
     #: same width or viewport clamping drifts from what is painted (Qodo
     #: review, PR #2233). It CANNOT be interpolated: `css/build_css.py`

--- a/tldw_chatbook/Widgets/Console/console_workspace_action_menu.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_action_menu.py
@@ -125,6 +125,12 @@ class ConsoleWorkspaceActionMenu(Vertical):
 
     can_focus = True
 
+    #: Painted height of the menu's tallest page (the root: five one-row
+    #: buttons plus the rounded border), used by the screen's anchor
+    #: clamping. Keep in lockstep with the root page's item count.
+    ROOT_PAGE_HEIGHT = 7
+
+
     #: Anchoring clamps against this; the stylesheet below must declare the
     #: same width or viewport clamping drifts from what is painted. Pinned
     #: together by test the same way the conversation menu's pair is.
@@ -219,10 +225,17 @@ class ConsoleWorkspaceActionMenu(Vertical):
             yield button
 
     def on_mount(self) -> None:
+        """Anchor at the captured screen cell and seat focus on row one."""
         self.absolute_offset = Offset(*self._anchor)
         self._focus_first_enabled()
 
     def _focus_first_enabled(self) -> None:
+        """Focus the first enabled entry, skipping gated ones.
+
+        Focusing a disabled button drops focus entirely, which would strand
+        keyboard navigation, so disabled entries are skipped rather than
+        visited.
+        """
         for button in self.query(Button):
             if not button.disabled:
                 button.focus(scroll_visible=False)
@@ -268,6 +281,12 @@ class ConsoleWorkspaceActionMenu(Vertical):
         return self._removal
 
     def on_key(self, event: Key) -> None:
+        """Handle the menu's keyboard contract: cycle, page, or dismiss.
+
+        Args:
+            event: The key event delivered while the menu (or one of its
+                buttons) holds focus.
+        """
         if event.key == "escape":
             event.stop()
             event.prevent_default()

--- a/tldw_chatbook/Widgets/Console/console_workspace_action_menu.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_action_menu.py
@@ -1,4 +1,4 @@
-"""Anchored action menu for one Console workspace tree node (TASK-25710).
+"""Anchored action menu for one Console workspace tree node (TASK-25712).
 
 Opened by the trailing asterisk on a workspace row in the Workspaces tree
 (pointer) or the ``m`` binding (keyboard). Mirrors
@@ -47,7 +47,7 @@ if TYPE_CHECKING:  # pragma: no cover
 MENU_ID = "console-workspace-action-menu"
 MENU_ITEM_PREFIX = "console-workspace-action-"
 
-#: TASK-25710: every mounted menu registers itself here so the screen's
+#: TASK-25712: every mounted menu registers itself here so the screen's
 #: per-press dismissal checks never pay a full-DOM ``query`` walk (the
 #: TASK-21119 rule). Mirrors the conversation menu's registry.
 _LIVE_MENUS: "WeakSet[ConsoleWorkspaceActionMenu]" = WeakSet()

--- a/tldw_chatbook/Widgets/Console/console_workspace_action_menu.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_action_menu.py
@@ -1,0 +1,337 @@
+"""Anchored action menu for one Console workspace tree node (TASK-25710).
+
+Opened by the trailing asterisk on a workspace row in the Workspaces tree
+(pointer) or the ``m`` binding (keyboard). Mirrors
+``ConsoleConversationActionMenu``: an absolutely-positioned ``Vertical``
+overlaying the screen, keyboard navigable, paged in place ("More" swaps
+contents rather than cascading -- a 27-column rail has no room for a second
+popup), dismissed with Escape and by the screen's outside-click pass.
+
+Disposal follows the TASK-25709 contract exactly: a constructor-registered
+``WeakSet`` registry backs ``workspace_action_menus_on_screen`` so the
+screen's per-press dismissal checks pay no DOM walk; ``remove()`` is
+memoized single-shot with an awaitable detach so a same-id remount can
+never race an un-awaited prune into ``DuplicateIds``; and the opener
+focus-restore is skipped for outside-click / stranded-Escape dismissals
+because those causes already express where the user wants focus.
+
+The menu holds no policy: what to paint comes from
+``Chat.console_workspace_actions``, which is pure and separately tested.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from weakref import WeakSet
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.dom import NoScreen
+from textual.events import Key
+from textual.geometry import Offset
+from textual.message import Message
+from textual.widget import Widget
+from textual.widgets import Button
+
+from tldw_chatbook.Chat.console_workspace_actions import (
+    WorkspaceMenuTarget,
+    build_workspace_menu,
+    page_from_action,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from textual.app import AwaitRemove
+    from textual.screen import Screen
+
+MENU_ID = "console-workspace-action-menu"
+MENU_ITEM_PREFIX = "console-workspace-action-"
+
+#: TASK-25710: every mounted menu registers itself here so the screen's
+#: per-press dismissal checks never pay a full-DOM ``query`` walk (the
+#: TASK-21119 rule). Mirrors the conversation menu's registry.
+_LIVE_MENUS: "WeakSet[ConsoleWorkspaceActionMenu]" = WeakSet()
+
+
+def workspace_action_menus_on_screen(
+    screen: "Screen[object]",
+) -> list["ConsoleWorkspaceActionMenu"]:
+    """Return the workspace action menus currently attached to ``screen``.
+
+    Args:
+        screen: The screen whose mounted menus are wanted (usually the
+            Console ``ChatScreen``).
+
+    Returns:
+        Every registry-registered menu still attached to that screen, in
+        registry iteration order. Detached menus (``parent is None`` or no
+        resolvable screen) are skipped.
+    """
+    menus: list[ConsoleWorkspaceActionMenu] = []
+    for menu in _LIVE_MENUS:
+        if menu.parent is None:
+            continue
+        try:
+            if menu.screen is screen:
+                menus.append(menu)
+        except NoScreen:
+            continue
+    return menus
+
+
+class WorkspaceActionChosen(Message):
+    """A command item was chosen from the workspace action menu."""
+
+    def __init__(self, action_id: str, target: WorkspaceMenuTarget) -> None:
+        """Create the message.
+
+        Args:
+            action_id: The chosen command's stable identifier. Never a
+                navigation id -- page moves are handled inside the menu.
+            target: The workspace the menu was opened from, captured at open
+                time so a later tree refresh cannot redirect the action.
+        """
+        super().__init__()
+        self.action_id = action_id
+        self.target = target
+
+
+class WorkspaceActionMenuDismissed(Message):
+    """The menu closed without choosing a command.
+
+    ``restore_focus`` is False for dismissals where the user has already
+    expressed a focus intent elsewhere -- an outside click (Textual moves
+    focus to the clicked widget before the press reaches the screen) or an
+    Escape issued while focus sits outside the menu. The opener-restore is
+    only correct when the menu itself held focus (its own Escape path).
+    """
+
+    def __init__(self, opener_id: str, *, restore_focus: bool = True) -> None:
+        """Create the message.
+
+        Args:
+            opener_id: DOM id of the opener (the tree) that opened the
+                menu, so focus can be restored deterministically.
+            restore_focus: Whether the screen handler should return focus
+                to the opener.
+        """
+        super().__init__()
+        self.opener_id = opener_id
+        self.restore_focus = restore_focus
+
+
+class ConsoleWorkspaceActionMenu(Vertical):
+    """Paged, keyboard-operable action menu bound to one workspace row."""
+
+    can_focus = True
+
+    #: Anchoring clamps against this; the stylesheet below must declare the
+    #: same width or viewport clamping drifts from what is painted. Pinned
+    #: together by test the same way the conversation menu's pair is.
+    MENU_WIDTH = 26
+
+    BUNDLED_CSS = """
+    ConsoleWorkspaceActionMenu {
+        position: absolute;
+        overlay: screen;
+        width: 26;
+        height: auto;
+        border: round $primary;
+        background: $surface;
+        padding: 0 1;
+    }
+    ConsoleWorkspaceActionMenu Button {
+        width: 100%;
+        height: 1 !important;
+        min-height: 1 !important;
+        border: none !important;
+        border-top: none !important;
+        border-bottom: none !important;
+        padding: 0 1 !important;
+        text-align: left;
+    }
+    ConsoleWorkspaceActionMenu Button:focus {
+        outline: heavy $accent;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        target: WorkspaceMenuTarget,
+        opener_id: str,
+        screen_x: int,
+        screen_y: int,
+    ) -> None:
+        """Create a menu bound immutably to one workspace.
+
+        Args:
+            target: What is true of the workspace, captured at open time.
+            opener_id: DOM id of the opener used for deterministic focus
+                restoration (the Workspaces tree).
+            screen_x: Absolute column to anchor at.
+            screen_y: Absolute row to anchor at.
+        """
+        super().__init__(id=MENU_ID)
+        self._target = target
+        self._opener_id = opener_id
+        self._anchor = (screen_x, screen_y)
+        self._page = "root"
+        self._claimed = False
+        #: Memoized ``remove()`` awaitable; see the module docstring for why
+        #: every dismissal path funnels through it.
+        self._removal: AwaitRemove | None = None
+        _LIVE_MENUS.add(self)
+
+    @property
+    def target(self) -> WorkspaceMenuTarget:
+        """Return the workspace captured when the menu opened."""
+        return self._target
+
+    @property
+    def opener_id(self) -> str:
+        """Return the opener used for deterministic focus restoration."""
+        return self._opener_id
+
+    @property
+    def page(self) -> str:
+        """Return the page currently painted."""
+        return self._page
+
+    def compose(self) -> ComposeResult:
+        """Build one ``Button`` per entry on the menu's current page."""
+        for item in build_workspace_menu(self._target, self._page):
+            label = (
+                f"{item.label} ▸"
+                if item.opens_page and item.action_id.endswith("more")
+                else item.label
+            )
+            if item.is_current:
+                label = f"• {label}"
+            button = Button(
+                label,
+                id=f"{MENU_ITEM_PREFIX}{_slug(item.action_id)}",
+                disabled=not item.enabled,
+            )
+            button.workspace_action_id = item.action_id
+            if item.disabled_reason:
+                button.tooltip = item.disabled_reason
+            yield button
+
+    def on_mount(self) -> None:
+        self.absolute_offset = Offset(*self._anchor)
+        self._focus_first_enabled()
+
+    def _focus_first_enabled(self) -> None:
+        for button in self.query(Button):
+            if not button.disabled:
+                button.focus(scroll_visible=False)
+                return
+
+    async def _show_page(self, page: str) -> None:
+        """Swap the menu's contents in place and re-seat focus."""
+        self._page = page
+        await self.recompose()
+        self._focus_first_enabled()
+
+    def dismiss_menu(self, *, restore_focus: bool = True) -> None:
+        """Close the menu, optionally handing focus back to the opener.
+
+        Args:
+            restore_focus: Post the opener-restore message. False when the
+                dismissal cause already expresses the user's focus intent
+                (outside click, Escape from elsewhere, replacement).
+        """
+        if self._claimed:
+            return
+        self._claimed = True
+        if restore_focus:
+            self.post_message(WorkspaceActionMenuDismissed(self._opener_id))
+        self._detach()
+
+    async def await_detachment(self) -> None:
+        """Claim and fully detach this menu, awaiting the DOM removal.
+
+        The replace-on-reopen path calls this before mounting a new menu:
+        ``remove()`` only posts a Prune message, and mounting the same DOM
+        id while the old menu is still attached raises Textual's app-fatal
+        ``DuplicateIds``. No dismissal message is posted -- the new menu
+        takes focus anyway.
+        """
+        self._claimed = True
+        await self._detach()
+
+    def _detach(self) -> "AwaitRemove":
+        """Return the memoized single removal awaitable for this menu."""
+        if self._removal is None:
+            self._removal = self.remove()
+        return self._removal
+
+    def on_key(self, event: Key) -> None:
+        if event.key == "escape":
+            event.stop()
+            event.prevent_default()
+            # Escape steps back out of a submenu before closing the menu,
+            # mirroring the conversation menu's contract.
+            if self._page != "root":
+                self.run_worker(
+                    self._show_page("root"),
+                    group="console-workspace-action-menu-page",
+                    exclusive=True,
+                )
+                return
+            self.dismiss_menu()
+            return
+        if event.key not in {"up", "down", "tab", "shift+tab"}:
+            return
+        event.stop()
+        event.prevent_default()
+        buttons = [button for button in self.query(Button) if not button.disabled]
+        if not buttons:
+            return
+        focused = next((button for button in buttons if button.has_focus), buttons[0])
+        step = 1 if event.key in {"down", "tab"} else -1
+        buttons[(buttons.index(focused) + step) % len(buttons)].focus()
+
+    @on(Button.Pressed)
+    def _choose(self, event: Button.Pressed) -> None:
+        event.stop()
+        action_id = getattr(event.button, "workspace_action_id", None)
+        if self._claimed or not isinstance(action_id, str):
+            return
+        page = page_from_action(action_id)
+        if page is not None:
+            self.run_worker(
+                self._show_page(page),
+                group="console-workspace-action-menu-page",
+                exclusive=True,
+            )
+            return
+        self._claimed = True
+        self.post_message(WorkspaceActionChosen(action_id, self._target))
+        self._detach()
+
+
+def _slug(action_id: str) -> str:
+    """Return a DOM-id-safe form of an action id."""
+    return action_id.replace(":", "-")
+
+
+def dismiss_workspace_action_menus(
+    screen: Widget, *, restore_focus: bool = True
+) -> int:
+    """Remove any open workspace action menu on ``screen``.
+
+    Args:
+        screen: The screen (or any widget on it) to search.
+        restore_focus: Passed through to each menu's dismissal; False for
+            outside-click and stranded-Escape dismissals, where the user
+            has already moved focus somewhere deliberate.
+
+    Returns:
+        How many menus were open and dismissed.
+    """
+    menus = workspace_action_menus_on_screen(screen.screen)
+    for menu in menus:
+        menu.dismiss_menu(restore_focus=restore_focus)
+    return len(menus)

--- a/tldw_chatbook/Widgets/Console/console_workspace_context.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_context.py
@@ -9,7 +9,6 @@ from rich.markup import escape as _escape_markup
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
-from textual.css.query import NoMatches
 from textual.message import Message
 from textual.widgets import Button, Input, Static
 
@@ -568,7 +567,6 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
         # The first measurement always relabels (to replace the pre-measure
         # fallback budget); later ones apply the hysteresis threshold.
         self._row_width_measured = False
-        self._workspace_action_fit_generation = 0
         self._workspace_tree_context_data: Any | None = None
         self.styles.height = "auto"
         self.styles.min_height = 0
@@ -581,7 +579,6 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
         """
 
         self.call_after_refresh(self._fit_height_to_content)
-        self.call_after_refresh(self._update_workspace_tree_selection_context)
 
     def on_resize(self, event: Any) -> None:
         """Refit wrapped status rows when the rail width changes.
@@ -594,7 +591,6 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
         """
 
         self.call_after_refresh(self._fit_height_to_content)
-        self.call_after_refresh(self._update_workspace_tree_selection_context)
 
     def sync_state(self, state: ConsoleWorkspaceContextState) -> None:
         """Refresh the mounted workspace context tray from new display state.
@@ -1319,49 +1315,12 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
             scope_button.styles.width = "auto"
             scope_button.tooltip = "RAG Scope: narrow retrieval to this workspace"
             yield self._record_composed_node(scope_button)
-        context_data = self._workspace_tree_context_data
-        selection_copy = self._workspace_tree_selection_copy(context_data)
-        yield self._record_composed_node(
-            Static(
-                selection_copy,
-                id="console-workspace-tree-selection-context",
-                classes="console-workspace-tree-selection-context",
-                markup=False,
-            )
-        )
-        context_is_markable = self._workspace_tree_context_is_markable(context_data)
-        context_action_row = Horizontal(
-            id="console-workspace-context-action-row",
-            classes="console-workspace-context-action-row",
-        )
-        context_action_row.display = context_is_markable
-        with self._record_composed_node(context_action_row):
-            star_button = Button(
-                (
-                    "Unstar"
-                    if context_is_markable
-                    and bool(getattr(context_data, "starred", False))
-                    else "Star"
-                ),
-                id="console-workspace-tree-star",
-                classes="console-workspace-action console-workspace-tree-star",
-                compact=True,
-                disabled=not context_is_markable,
-            )
-            star_button.workspace_id = (
-                getattr(context_data, "workspace_id", None)
-                if context_is_markable
-                else None
-            )
-            star_button.conversation_id = (
-                getattr(context_data, "conversation_id", None)
-                if context_is_markable
-                else None
-            )
-            star_button.starred = bool(
-                context_is_markable and getattr(context_data, "starred", False)
-            )
-            yield self._record_composed_node(star_button)
+        # TASK-25710: the contextual Star/Unstar button and its
+        # selection-context line are retired. The tree's chat rows now open
+        # the shared conversation action menu (Favourite lives there), and
+        # workspace rows open the workspace action menu -- the same
+        # one-asterisk-per-row pattern the grouped browser adopted in
+        # TASK-23200. The ``s`` star-toggle binding on the tree remains.
 
         yield self._record_composed_node(
             ConsoleBrowserSearchInput(
@@ -1407,106 +1366,18 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
             )
 
     def sync_workspace_tree_context(self, data: Any | None) -> bool:
-        """Update the compact Tree action and report a visibility change."""
+        """Record the Tree cursor row; the star seam is retired (TASK-25710).
 
-        is_conversation = self._workspace_tree_context_is_markable(data)
-        starred = bool(getattr(data, "starred", False)) if is_conversation else False
-        # A width relabel removes these controls before recomposing them. Keep
-        # the latest cursor truth even in that transient NoMatches window so
-        # compose cannot rebuild Star for the conversation the cursor left.
-        self._workspace_tree_context_data = data
-        self._update_workspace_tree_selection_context()
-        try:
-            button = self.query_one("#console-workspace-tree-star", Button)
-            action_row = self.query_one(
-                "#console-workspace-context-action-row", Horizontal
-            )
-        except NoMatches:
-            return False
-        visibility_changed = action_row.display != is_conversation
-        action_row.display = is_conversation
-        if visibility_changed:
-            self._workspace_action_fit_generation += 1
-            generation = self._workspace_action_fit_generation
-            self.styles.height = "auto"
-            self.refresh(layout=True)
-
-            def fit_current_action_geometry() -> None:
-                if generation != self._workspace_action_fit_generation:
-                    return
-                self._fit_height_to_content()
-
-                def reconcile_current_action_geometry() -> None:
-                    if generation != self._workspace_action_fit_generation:
-                        return
-                    self._reconcile_workspace_action_owners()
-
-                self.call_after_refresh(reconcile_current_action_geometry)
-
-            self.call_after_refresh(fit_current_action_geometry)
-        button.label = "Unstar" if starred else "Star"
-        button.disabled = not is_conversation
-        button.workspace_id = (
-            getattr(data, "workspace_id", None) if is_conversation else None
-        )
-        button.conversation_id = (
-            getattr(data, "conversation_id", None) if is_conversation else None
-        )
-        button.starred = starred
-        return visibility_changed
-
-    def _workspace_tree_selection_copy(self, data: Any | None) -> str:
-        """Return the stable one-row copy for the current Tree cursor."""
-
-        raw_label = str(getattr(data, "raw_label", "") or "")
-        rows = raw_label.splitlines()
-        label = rows[0] if rows else ""
-        if not label:
-            label = self.state.workspace_name or self._workspace_selector_label()
-        if not label:
-            label = "Workspace tree"
-        return f"Selected: {label} · Enter open"
-
-    def _update_workspace_tree_selection_context(self) -> None:
-        """Patch selected copy and expose the full value only when clipped.
-
-        TASK-22203: every Tree cursor move lands here, so both writes are
-        equality-guarded. A changed copy repaints with ``layout=False``
-        because the slot's geometry is pinned at compose time (one
-        ``nowrap``/``ellipsis`` row — ``#console-workspace-tree-selection-
-        context`` in the CSS pins ``height/min/max: 1``); the unguarded
-        ``Static.update`` default armed one screen layout pass per arrow key.
+        The contextual Star/Unstar button this used to drive is gone -- chat
+        rows open the shared conversation action menu and workspace rows the
+        workspace action menu. The cursor truth is still recorded because
+        width relabels rebuild the tray and nothing else owns it. Always
+        returns False: no visibility can change any more, and the rail's
+        reconcile decision reads that as "nothing to refit".
         """
 
-        if not self.is_mounted:
-            return
-        try:
-            context = self.query_one(
-                "#console-workspace-tree-selection-context", Static
-            )
-        except NoMatches:
-            return
-        copy = self._workspace_tree_selection_copy(self._workspace_tree_context_data)
-        if context.content != copy:
-            context.update(copy, layout=False)
-        width = max(0, context.content_region.width)
-        tooltip = Text(copy) if width and cell_len(copy) > width else None
-        current = context.tooltip
-        current_plain = current.plain if isinstance(current, Text) else current
-        if (tooltip.plain if tooltip is not None else None) != current_plain:
-            context.tooltip = tooltip
-
-    def _workspace_tree_context_is_markable(self, data: Any | None) -> bool:
-        """Return whether ``data`` may expose the contextual star action."""
-
-        return bool(
-            data is not None
-            and getattr(data, "kind", None) == "conversation"
-            and getattr(data, "workspace_id", None)
-            and getattr(data, "conversation_id", None)
-            and getattr(data, "star_enabled", False)
-            and self.state.workspace_marks_available
-        )
+        self._workspace_tree_context_data = data
+        return False
 
     def _reconcile_workspace_action_owners(self) -> None:
         """Re-fit the bounded owner's local geometry after the action-row fit.

--- a/tldw_chatbook/Widgets/Console/console_workspace_context.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_context.py
@@ -1315,7 +1315,7 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
             scope_button.styles.width = "auto"
             scope_button.tooltip = "RAG Scope: narrow retrieval to this workspace"
             yield self._record_composed_node(scope_button)
-        # TASK-25710: the contextual Star/Unstar button and its
+        # TASK-25712: the contextual Star/Unstar button and its
         # selection-context line are retired. The tree's chat rows now open
         # the shared conversation action menu (Favourite lives there), and
         # workspace rows open the workspace action menu -- the same
@@ -1366,7 +1366,7 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
             )
 
     def sync_workspace_tree_context(self, data: Any | None) -> bool:
-        """Record the Tree cursor row; the star seam is retired (TASK-25710).
+        """Record the Tree cursor row; the star seam is retired (TASK-25712).
 
         The contextual Star/Unstar button this used to drive is gone -- chat
         rows open the shared conversation action menu and workspace rows the

--- a/tldw_chatbook/Widgets/Console/console_workspace_tree.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_tree.py
@@ -22,6 +22,9 @@ from ..glyph_fallback import ascii_glyph_mode, resolve_glyph
 
 
 _TEXTUAL_PRIVATE_MOVE_VERSION = "8.2.8"
+
+#: TASK-25710: the trailing per-row menu opener glyph and its cell width.
+_MENU_AFFORDANCE = " *"
 _NodeKind = Literal["workspace", "conversation", "status", "load-more", "retry"]
 
 
@@ -166,6 +169,46 @@ class WorkspaceTreeFocusRecoveryRequested(Message):
     """The Tree became empty and focus must return to its owning section."""
 
 
+class WorkspaceTreeMenuRequested(Message):
+    """The user asked for the row action menu on one tree node (TASK-25710).
+
+    Posted by a pointer press on a row's trailing asterisk cell or the ``m``
+    binding on the cursor row. The tree stays display-only: the owning
+    ``ChatScreen`` mounts the anchored menu (the workspace action menu for a
+    workspace node, the conversation action menu for a chat node).
+    """
+
+    KIND_WORKSPACE = "workspace"
+    KIND_CONVERSATION = "conversation"
+
+    def __init__(
+        self,
+        *,
+        kind: str,
+        workspace_id: str,
+        conversation_id: str | None = None,
+        screen_x: int,
+        screen_y: int,
+    ) -> None:
+        """Create the message.
+
+        Args:
+            kind: ``KIND_WORKSPACE`` or ``KIND_CONVERSATION``.
+            workspace_id: The workspace the row belongs to.
+            conversation_id: The persisted conversation id for chat rows;
+                None for workspace rows.
+            screen_x: Absolute column to anchor the menu at.
+            screen_y: Absolute row to anchor the menu at (the screen mounts
+                the menu just below this row).
+        """
+        self.kind = kind
+        self.workspace_id = workspace_id
+        self.conversation_id = conversation_id
+        self.screen_x = screen_x
+        self.screen_y = screen_y
+        super().__init__()
+
+
 class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
     """Incrementally synchronize the Console Workspace projection into a Tree.
 
@@ -179,6 +222,7 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
         Binding("left", "workspace_left", "Collapse", show=False),
         Binding("right", "workspace_right", "Expand", show=False),
         Binding("s", "workspace_star", "Star/Unstar", show=False),
+        Binding("m", "workspace_menu", "Row menu", show=False),
     ]
 
     # TASK-22203: class-level default because ``watch_cursor_line`` (and with
@@ -247,6 +291,13 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
         self.can_focus = False
         self._pressed_node_key: str | None = None
         self._last_pointer_click_key: str | None = None
+        # TASK-25710: x-range (widget content cells, half-open) of the
+        # trailing asterisk each menu-bearing row painted in its LAST render
+        # pass, keyed by node key. Rebuilt by ``render_label``; cleared at
+        # the start of every ``sync_projection`` pass so removed rows can
+        # never keep a stale hit zone.
+        self._menu_zones: dict[str, tuple[int, int]] = {}
+        self._pressed_x: int | None = None
         # TASK-22203: identity+geometry key of the last computed tooltip, so
         # per-cursor-move and per-projection-push calls skip the cell-width
         # measurement and the tooltip write when nothing relevant changed.
@@ -362,6 +413,9 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
             self._preferred_expanded_workspace_ids = set(expanded)
             return
         self._projection_memo = None
+        # TASK-25710: a full pass rebuilds every label; drop the previous
+        # pass's asterisk hit zones so removed rows keep no stale target.
+        self._menu_zones.clear()
         hovered_node = (
             self.get_node_at_line(self.hover_line) if self.hover_line >= 0 else None
         )
@@ -521,7 +575,15 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
         base_style: Style,
         style: Style,
     ) -> Text:
-        """Render one literal row with an end ellipsis inside the Tree width."""
+        """Render one literal row with an end ellipsis inside the Tree width.
+
+        TASK-25710: workspace and conversation rows also carry a trailing
+        ``*`` that opens the row's action menu when pressed. It is appended
+        AFTER truncation (with the budget reduced by its width) so a long
+        title can never ellipsize over it, and its x-range is recorded in
+        ``_menu_zones`` for the pointer hit-test -- the painted text IS the
+        geometry source, so the two cannot drift.
+        """
 
         label = super().render_label(node, base_style, style)
         toggle = (
@@ -539,8 +601,33 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
             (marker, marker_style),
             label[toggle_length:],
         )
-        label.truncate(self._available_label_cells(node), overflow="ellipsis")
+        label.truncate(self._label_budget(node), overflow="ellipsis")
+        data = node.data
+        kind = data.kind if data is not None else None
+        if kind in {"workspace", "conversation"} and data is not None:
+            affordance = _MENU_AFFORDANCE
+            label.append(affordance, base_style)
+            end = label.cell_len
+            self._menu_zones[data.key] = (end - len(affordance), end)
+        else:
+            if data is not None:
+                self._menu_zones.pop(data.key, None)
         return label
+
+    def _label_budget(self, node: TreeNode[WorkspaceTreeNodeData]) -> int:
+        """Return the content-cell budget for one row's label.
+
+        TASK-25710: menu-bearing rows reserve the trailing ``*`` affordance,
+        so their CONTENT truncates two cells early. Render and the tooltip
+        fit decision must share this -- a tooltip that ignores the reserved
+        cells fires for rows that only look truncated.
+        """
+
+        budget = self._available_label_cells(node)
+        data = node.data
+        if data is not None and data.kind in {"workspace", "conversation"}:
+            budget -= len(_MENU_AFFORDANCE)
+        return max(1, budget)
 
     def _available_label_cells(self, node: TreeNode[WorkspaceTreeNodeData]) -> int:
         """Return the painted label budget after visible native guides."""
@@ -806,6 +893,7 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
         # Native Tree MouseDown only brokers metadata; Click remains suppressed
         # below because this widget owns selection and activation semantics.
         self._pressed_node_key = None
+        self._pressed_x = event.x
         meta = event.style.meta
         line = meta.get("line")
         node = self.get_node_at_line(line) if isinstance(line, int) else None
@@ -817,6 +905,26 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
             self._pressed_node_key = None
             self._last_pointer_click_key = None
             self._update_tooltip()
+
+    def _pressed_menu_affordance(
+        self,
+        data: WorkspaceTreeNodeData,
+    ) -> bool:
+        """Whether the pressed cell was the row's trailing asterisk.
+
+        TASK-25710: the zone comes from the row's own last ``render_label``
+        pass, so the hit-test matches what is painted without duplicating
+        the indent/guide math. A missing zone (auxiliary rows, stale
+        geometry) is simply not an affordance press.
+        """
+
+        if self._pressed_x is None:
+            return False
+        zone = self._menu_zones.get(data.key)
+        if zone is None:
+            return False
+        start, end = zone
+        return start <= self._pressed_x < end
 
     async def _on_click(self, event: events.Click) -> None:
         """Resolve the complete pointer gesture only through its pressed key."""
@@ -835,6 +943,27 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
             if data is None or not data.selectable:
                 self._last_pointer_click_key = None
                 return
+            if data.kind in {"workspace", "conversation"} and (
+                self._pressed_menu_affordance(data)
+            ):
+                # TASK-25710: the asterisk opens the row's action menu
+                # instead of selecting/activating, exactly like the grouped
+                # browser's asterisk column.
+                self._last_pointer_click_key = None
+                self.post_message(
+                    WorkspaceTreeMenuRequested(
+                        kind=(
+                            WorkspaceTreeMenuRequested.KIND_WORKSPACE
+                            if data.kind == "workspace"
+                            else WorkspaceTreeMenuRequested.KIND_CONVERSATION
+                        ),
+                        workspace_id=str(data.workspace_id or ""),
+                        conversation_id=data.conversation_id,
+                        screen_x=event.screen_x,
+                        screen_y=event.screen_y + 1,
+                    )
+                )
+                return
             selected = self.cursor_node
             selected_key = (
                 selected.data.key if selected is not None and selected.data else None
@@ -851,6 +980,40 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
             if activate_double_click:
                 self._activate_node(node)
             self._last_pointer_click_key = data.key
+
+    def action_workspace_menu(self) -> None:
+        """Open the row action menu for the cursor row (``m`` binding)."""
+
+        node = self.cursor_node
+        data = node.data if node is not None else None
+        if data is None or data.kind not in {"workspace", "conversation"}:
+            return
+        region = self.region
+        if not region:
+            return
+        line = self.cursor_line
+        zone = self._menu_zones.get(data.key)
+        anchor_x = (
+            region.x + min(zone[1], region.width - 1)
+            if zone is not None
+            else region.right - 1
+        )
+        anchor_y = region.y + max(
+            0, line - int(self.scroll_offset.y)
+        ) + 1
+        self.post_message(
+            WorkspaceTreeMenuRequested(
+                kind=(
+                    WorkspaceTreeMenuRequested.KIND_WORKSPACE
+                    if data.kind == "workspace"
+                    else WorkspaceTreeMenuRequested.KIND_CONVERSATION
+                ),
+                workspace_id=str(data.workspace_id or ""),
+                conversation_id=data.conversation_id,
+                screen_x=anchor_x,
+                screen_y=anchor_y,
+            )
+        )
 
     def action_select_cursor(self) -> None:
         """Activate the current row from the keyboard Enter binding."""
@@ -1073,7 +1236,7 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
             Text(data.raw_label)
             if data is not None
             and cell_len(self._untruncated_visible_label(node))
-            > self._available_label_cells(node)
+            > self._label_budget(node)
             else None
         )
 

--- a/tldw_chatbook/Widgets/Console/console_workspace_tree.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_tree.py
@@ -187,6 +187,7 @@ class WorkspaceTreeMenuRequested(Message):
         kind: str,
         workspace_id: str,
         conversation_id: str | None = None,
+        title: str = "",
         screen_x: int,
         screen_y: int,
     ) -> None:
@@ -195,8 +196,12 @@ class WorkspaceTreeMenuRequested(Message):
         Args:
             kind: ``KIND_WORKSPACE`` or ``KIND_CONVERSATION``.
             workspace_id: The workspace the row belongs to.
-            conversation_id: The persisted conversation id for chat rows;
-                None for workspace rows.
+            conversation_id: The PERSISTED conversation id for chat rows;
+                None for workspace rows and for unsaved native rows (whose
+                tree identity is a synthetic ``native:<session-id>`` key the
+                menu must never hand to persistence APIs).
+            title: The row's display title (first physical line), for the
+                conversation menu's target.
             screen_x: Absolute column to anchor the menu at.
             screen_y: Absolute row to anchor the menu at (the screen mounts
                 the menu just below this row).
@@ -204,9 +209,30 @@ class WorkspaceTreeMenuRequested(Message):
         self.kind = kind
         self.workspace_id = workspace_id
         self.conversation_id = conversation_id
+        self.title = title
         self.screen_x = screen_x
         self.screen_y = screen_y
         super().__init__()
+
+
+def _menu_conversation_payload(
+    data: WorkspaceTreeNodeData,
+) -> tuple[str | None, str]:
+    """Return the menu's persisted conversation id and title for one row.
+
+    TASK-25710 review (PR #2255): unsaved native rows carry a synthetic
+    ``native:<session-id>`` key as their tree identity. The action menu must
+    see ``None`` for those, so the pure model disables persistence-only
+    commands ("Send or save this chat first") instead of handing the
+    synthetic key to the database. The title is the row's first physical
+    line, so rename/delete/confirmations name the chat the user pressed.
+    """
+
+    conversation_id = data.conversation_id
+    if conversation_id is not None and conversation_id.startswith("native:"):
+        conversation_id = None
+    first_line = str(data.raw_label or "").splitlines()[:1]
+    return conversation_id, (first_line[0] if first_line else "")
 
 
 class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
@@ -950,6 +976,7 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
                 # instead of selecting/activating, exactly like the grouped
                 # browser's asterisk column.
                 self._last_pointer_click_key = None
+                conversation_id, title = _menu_conversation_payload(data)
                 self.post_message(
                     WorkspaceTreeMenuRequested(
                         kind=(
@@ -958,7 +985,8 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
                             else WorkspaceTreeMenuRequested.KIND_CONVERSATION
                         ),
                         workspace_id=str(data.workspace_id or ""),
-                        conversation_id=data.conversation_id,
+                        conversation_id=conversation_id,
+                        title=title,
                         screen_x=event.screen_x,
                         screen_y=event.screen_y + 1,
                     )
@@ -1001,6 +1029,7 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
         anchor_y = region.y + max(
             0, line - int(self.scroll_offset.y)
         ) + 1
+        conversation_id, title = _menu_conversation_payload(data)
         self.post_message(
             WorkspaceTreeMenuRequested(
                 kind=(
@@ -1009,7 +1038,8 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
                     else WorkspaceTreeMenuRequested.KIND_CONVERSATION
                 ),
                 workspace_id=str(data.workspace_id or ""),
-                conversation_id=data.conversation_id,
+                conversation_id=conversation_id,
+                title=title,
                 screen_x=anchor_x,
                 screen_y=anchor_y,
             )

--- a/tldw_chatbook/Widgets/Console/console_workspace_tree.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_tree.py
@@ -23,7 +23,7 @@ from ..glyph_fallback import ascii_glyph_mode, resolve_glyph
 
 _TEXTUAL_PRIVATE_MOVE_VERSION = "8.2.8"
 
-#: TASK-25710: the trailing per-row menu opener glyph and its cell width.
+#: TASK-25712: the trailing per-row menu opener glyph and its cell width.
 _MENU_AFFORDANCE = " *"
 _NodeKind = Literal["workspace", "conversation", "status", "load-more", "retry"]
 
@@ -170,7 +170,7 @@ class WorkspaceTreeFocusRecoveryRequested(Message):
 
 
 class WorkspaceTreeMenuRequested(Message):
-    """The user asked for the row action menu on one tree node (TASK-25710).
+    """The user asked for the row action menu on one tree node (TASK-25712).
 
     Posted by a pointer press on a row's trailing asterisk cell or the ``m``
     binding on the cursor row. The tree stays display-only: the owning
@@ -220,7 +220,7 @@ def _menu_conversation_payload(
 ) -> tuple[str | None, str]:
     """Return the menu's persisted conversation id and title for one row.
 
-    TASK-25710 review (PR #2255): unsaved native rows carry a synthetic
+    TASK-25712 review (PR #2255): unsaved native rows carry a synthetic
     ``native:<session-id>`` key as their tree identity. The action menu must
     see ``None`` for those, so the pure model disables persistence-only
     commands ("Send or save this chat first") instead of handing the
@@ -317,7 +317,7 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
         self.can_focus = False
         self._pressed_node_key: str | None = None
         self._last_pointer_click_key: str | None = None
-        # TASK-25710: x-range (widget content cells, half-open) of the
+        # TASK-25712: x-range (widget content cells, half-open) of the
         # trailing asterisk each menu-bearing row painted in its LAST render
         # pass, keyed by node key. Rebuilt by ``render_label``; cleared at
         # the start of every ``sync_projection`` pass so removed rows can
@@ -439,7 +439,7 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
             self._preferred_expanded_workspace_ids = set(expanded)
             return
         self._projection_memo = None
-        # TASK-25710: a full pass rebuilds every label; drop the previous
+        # TASK-25712: a full pass rebuilds every label; drop the previous
         # pass's asterisk hit zones so removed rows keep no stale target.
         self._menu_zones.clear()
         hovered_node = (
@@ -603,7 +603,7 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
     ) -> Text:
         """Render one literal row with an end ellipsis inside the Tree width.
 
-        TASK-25710: workspace and conversation rows also carry a trailing
+        TASK-25712: workspace and conversation rows also carry a trailing
         ``*`` that opens the row's action menu when pressed. It is appended
         AFTER truncation (with the budget reduced by its width) so a long
         title can never ellipsize over it, and its x-range is recorded in
@@ -643,7 +643,7 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
     def _label_budget(self, node: TreeNode[WorkspaceTreeNodeData]) -> int:
         """Return the content-cell budget for one row's label.
 
-        TASK-25710: menu-bearing rows reserve the trailing ``*`` affordance,
+        TASK-25712: menu-bearing rows reserve the trailing ``*`` affordance,
         so their CONTENT truncates two cells early. Render and the tooltip
         fit decision must share this -- a tooltip that ignores the reserved
         cells fires for rows that only look truncated.
@@ -938,7 +938,7 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
     ) -> bool:
         """Whether the pressed cell was the row's trailing asterisk.
 
-        TASK-25710: the zone comes from the row's own last ``render_label``
+        TASK-25712: the zone comes from the row's own last ``render_label``
         pass, so the hit-test matches what is painted without duplicating
         the indent/guide math. A missing zone (auxiliary rows, stale
         geometry) is simply not an affordance press.
@@ -972,7 +972,7 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
             if data.kind in {"workspace", "conversation"} and (
                 self._pressed_menu_affordance(data)
             ):
-                # TASK-25710: the asterisk opens the row's action menu
+                # TASK-25712: the asterisk opens the row's action menu
                 # instead of selecting/activating, exactly like the grouped
                 # browser's asterisk column.
                 self._last_pointer_click_key = None

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -2249,6 +2249,32 @@
     }
 
 
+/* ===== WIDGET: ConsoleWorkspaceActionMenu (Widgets/Console/console_workspace_action_menu.py) ===== */
+
+    ConsoleWorkspaceActionMenu {
+        position: absolute;
+        overlay: screen;
+        width: 26;
+        height: auto;
+        border: round $primary;
+        background: $surface;
+        padding: 0 1;
+    }
+    ConsoleWorkspaceActionMenu Button {
+        width: 100%;
+        height: 1 !important;
+        min-height: 1 !important;
+        border: none !important;
+        border-top: none !important;
+        border-bottom: none !important;
+        padding: 0 1 !important;
+        text-align: left;
+    }
+    ConsoleWorkspaceActionMenu Button:focus {
+        outline: heavy $accent;
+    }
+
+
 /* ===== WIDGET: LibraryEmergencyReturn (Widgets/Library/library_emergency_return.py) ===== */
 
     LibraryEmergencyReturn {


### PR DESCRIPTION
## Summary

Extends the TASK-23200/25709 asterisk-menu pattern to the Workspaces tree. Workspace nodes open a workspace action menu (Activate / New chat / Rename… / RAG scope… / More ▸ Archive); chat rows open the shared conversation menu. Every command routes through existing seams — New chat on a non-active workspace composes activate-then-create, and RAG scope gates on the active workspace with a stated reason (the scope-picker seam is active-scoped).

- **Pointer affordance**: a trailing `*` on each menu-bearing row, appended after truncation (budget reduced by the affordance width) so a long title can never ellipsize it. `render_label` records each row's asterisk x-zone (cleared per projection pass) and a press inside it posts `WorkspaceTreeMenuRequested` instead of selecting. The tooltip fit decision shares the same budget, so rows that only look truncated don't grow tooltips.
- **Keyboard**: new `m` binding opens the menu at the cursor row (guarded on a measured region — a collapsed section's 0×0 tree has no anchor).
- **Disposal**: the workspace menu widget mirrors the conversation menu — WeakSet registry, `restore_focus` dismissal semantics, memoized single-shot detach. Both kinds fold through the same outside-click and Escape paths (ADR-068), and one row menu is on screen at a time across kinds. Menu-opener focus restore is now by DOM id on any widget (the tree is not a Button).
- **Retirement**: the tree's contextual Star/Unstar button and its selection-context line are gone (`s` star binding remains); the dead left_rail press branch and timer-inventory pin removed with it.

## Testing

- New suites: `Tests/Chat/test_console_workspace_actions.py` (pure model, 7) and `Tests/UI/test_console_workspace_action_menu.py` (tree asterisk zones, click-open, `m` binding, paging/Escape, routing through the existing seams, dismissal parity, star retirement — 8).
- Retired-chrome fallout rerouted or deleted across cursor-layout / rail-reconciliation / context-rail / timer-inventory suites (disclosure and perf invariants kept; the boundary perf test now pins the stronger "no reconcile at all").
- 243 passed across 13 targeted suites. The 7 failures in the sweep (4 hands-free wiring, 2 tree tooltips, 1 timer census) were each verified red on clean `origin/dev` by stashing this change — pre-existing, not from this PR.
- Boot-module census green (all new module references lazy; ADR-097 intact). Ruff clean.
- **Live UAT** (real app in a real PTY, real mouse sequences + keys, isolated scratch profile): trailing `*` paints on workspace rows; clicking it opens the five-entry menu; in-menu Escape closes; outside-click folds it with focus preserved in the composer (typed proof); `m` opens at the cursor; clean Ctrl+Q exit; zero `DuplicateIds`/tracebacks beyond the known-benign textual_image boot probe. The tree chat-row scenario could not be exercised live — a seeded workspace-scoped conversation would not surface in the rail (listing semantics resisted seeding) — that path is covered by the mounted suite instead.

TASK-25710 · ADR-068 (dismiss contract) · ADR-097 (boot ratchet)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds action menus to the Workspaces tree in the Console Context rail. Workspace rows open a workspace action menu (Activate, New chat, Rename…, RAG scope…, Archive) and chat rows reuse the existing conversation menu, replacing the tree's contextual Star button and its selection-context line.

**Details**
- The trailing `*` on each menu-bearing row opens the menu on click; the `m` binding does the same for the cursor row.
- New chat on a non-active workspace composes activate-then-create and verifies activation before creating; RAG scope is gated on the active workspace and states why when disabled.
- Unsaved native tree rows no longer leak their synthetic `native:` identity into the conversation menu; send-or-save actions are gated with the appropriate reason.
- The conversation menu now receives the tree row's title, so rename, delete, and confirmations name the pressed chat.
- Dismissal follows the existing Escape/outside-click contract, with focus restored appropriately, and only one row menu is open at a time.

<sup>Written for commit 4a4930b56612b73dd36e14e232f137432f23e044. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

