### PR TITLE
fix(perf): snapshot sys.modules before the ui_ready census iteration (TASK-25713)

### DIFF
--- a/Tests/Performance/test_ui_ready_module_census.py
+++ b/Tests/Performance/test_ui_ready_module_census.py
@@ -177,9 +177,16 @@ async def main() -> None:
     async with app.run_test(size=(120, 40)):
         while not getattr(app, "_ui_ready", False):
             await asyncio.sleep(0.005)
+        # Snapshot BEFORE iterating: background threads (tick syncs, catalog
+        # refresh) keep importing after _ui_ready, and iterating the live
+        # dict raised "dictionary changed size during iteration" -- an
+        # intermittent guardrails failure on PR #2255 and a sibling branch,
+        # 2026-08-31. A point-in-time copy is also the honest census: every
+        # module in it existed at the same instant.
+        modules_now = list(sys.modules)
         mods = sorted(
             m
-            for m in sys.modules
+            for m in modules_now
             if m.startswith("tldw_chatbook") and sys.modules[m] is not None
         )
         for m in mods:

--- a/backlog/tasks/task-25713 - Census-warm-boot-flakes-on-sys.modules-mutation-during-iteration.md
+++ b/backlog/tasks/task-25713 - Census-warm-boot-flakes-on-sys.modules-mutation-during-iteration.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-25713
 title: Census warm-boot flakes on sys.modules mutation during iteration
-status: In Progress
+status: Done
 assignee:
   - '@Robert'
 created_date: '2026-08-31 14:12'
-updated_date: '2026-08-31 14:12'
+updated_date: '2026-08-31 14:25'
 labels: []
 dependencies: []
 ---
@@ -26,3 +26,15 @@ The ui_ready module census script iterates sys.modules live while background thr
 <!-- SECTION:PLAN:BEGIN -->
 1. Snapshot sys.modules before the census genexpr in _CENSUS_SCRIPT.\n2. Verify: three consecutive census runs green; grep for other live iterations in the file.\n3. PR, review, merge.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`_CENSUS_SCRIPT` now takes `list(sys.modules)` once at census time and the
+genexpr iterates that snapshot; the in-dict `sys.modules[m]` lookups are
+plain gets and safe. A point-in-time copy is also the honest census: every
+counted module existed at the same instant instead of straddling whatever a
+background thread imported mid-walk. Verified: three consecutive local
+runs green; grep confirms no other live iterations in the file; Qodo review
+clean (0 findings). ADR: none -- test-harness bug fix.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-25713 - Census-warm-boot-flakes-on-sys.modules-mutation-during-iteration.md
+++ b/backlog/tasks/task-25713 - Census-warm-boot-flakes-on-sys.modules-mutation-during-iteration.md
@@ -1,0 +1,28 @@
+---
+id: TASK-25713
+title: Census warm-boot flakes on sys.modules mutation during iteration
+status: In Progress
+assignee:
+  - '@Robert'
+created_date: '2026-08-31 14:12'
+updated_date: '2026-08-31 14:12'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The ui_ready module census script iterates sys.modules live while background threads import modules, raising RuntimeError: dictionary changed size during iteration and failing the UI latency guardrails job intermittently (observed on PR #2255 and another branch, 2026-08-31). Snapshot the dict before iterating.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The census script iterates a point-in-time snapshot of sys.modules, no live-dict iteration remains in the script,Census test passes repeatedly (3+ consecutive local runs),No other live sys.modules iterations in the test file
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Snapshot sys.modules before the census genexpr in _CENSUS_SCRIPT.\n2. Verify: three consecutive census runs green; grep for other live iterations in the file.\n3. PR, review, merge.
+<!-- SECTION:PLAN:END -->


### PR DESCRIPTION
## Summary

The `_ui_ready` module census script iterated the **live** `sys.modules` dict. Background threads that keep importing after `\_ui_ready` (tick syncs, catalog refresh — the ones that survive the `TLDW_SCREEN_PREIMPORT` pin) mutate the dict mid-iteration, raising `RuntimeError: dictionary changed size during iteration` and intermittently failing the **UI latency guardrails** job. Observed 2026-08-31 on PR #2255 (which had passed the same job on three earlier pushes) and on a sibling branch's run — a pure flake in the harness, not in the measured code.

Fix: `list(sys.modules)` before the genexpr. A point-in-time copy is also the semantically correct census — every counted module existed at the same instant, rather than straddling whatever a background thread imported mid-walk.

## Testing

- Census suite green on three consecutive local runs.
- No other live `sys.modules` iterations remain in the file (grep-pinned by the task's AC).

TASK-25713

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `ui_ready` module census flakiness by snapshotting `sys.modules` before iteration. Previously iterated the live dict, which raised `RuntimeError: dictionary changed size during iteration` when background threads kept importing after `_ui_ready`, intermittently failing the UI latency guardrails job. The point-in-time copy also makes the census more accurate.

- Covers TASK-25713.
- Adds the TASK-25713 tracking doc with acceptance criteria and implementation notes.
- Verified with three consecutive green census runs.

<sup>Written for commit 2e6dd816c8fd3c63fff2404b2ac2c9af824230bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

