### PR TITLE
test(console): clear both Context rail xfails, correcting one wrong diagnosis

### DIFF
--- a/Tests/UI/test_console_rail_reconciliation.py
+++ b/Tests/UI/test_console_rail_reconciliation.py
@@ -838,19 +838,6 @@ async def _open_all_production_context_sections(host, pilot) -> ConsoleLeftRail:
     return rail
 
 
-@pytest.mark.xfail(
-    reason=(
-        "TASK-25708: partially re-derived, not finished. The press-and-reflow "
-        "half now works against the post-TASK-23199 rail -- the press target "
-        "is chosen from the visible band instead of a fixed line, and the "
-        "pressed-key/active-section/scroll assertions all pass. What remains "
-        "is the TRAILING double-click phase: after the reveal the pressed row "
-        "sits exactly on the outer clip's bottom edge, and centring it in the "
-        "tree viewport does not move it off that boundary. Finishing it needs "
-        "the clip interaction understood, not another coordinate guess."
-    ),
-    strict=False,
-)
 @pytest.mark.asyncio
 async def test_production_workspace_pointer_keeps_pressed_key_across_outer_reflow(
     monkeypatch: pytest.MonkeyPatch,
@@ -917,8 +904,12 @@ async def test_production_workspace_pointer_keeps_pressed_key_across_outer_reflo
         assert bounded.native_scroll_owner is tree
         assert tree.max_scroll_y > 0
         rail.activate_section("details", deliberate_reveal=False)
-        workspace_line = int(workspace._line)
-        tree.scroll_to(y=max(0, workspace_line - 1), animate=False, immediate=True)
+        # Keep the tree at its own top. This used to pre-scroll to
+        # `workspace_line - 1` to bring a HARDCODED target into view; the
+        # search below now picks whichever workspace row satisfies the
+        # visibility bounds, and pre-scrolling only shifts the line-to-row
+        # mapping out from under it.
+        tree.scroll_to(y=0, animate=False, immediate=True)
         outer = rail.query_one("#console-left-rail-body", VerticalScroll)
 
         # TASK-25708: this used to scroll to `workspace_header_y - 3`, which
@@ -933,12 +924,21 @@ async def test_production_workspace_pointer_keeps_pressed_key_across_outer_reflo
         # band that is actually visible rather than from a fixed line -- the
         # test now reads the layout instead of assuming one.
         outer.scroll_to(
-            y=max(1, min(4, outer.max_scroll_y)), animate=False, immediate=True
+            # Two rows is enough for the reveal to be a real reflow, and
+            # keeps the usable press window wide: each workspace row is
+            # followed by four conversation rows, so a large shift can leave
+            # no workspace row satisfying both bounds below.
+            y=max(1, min(2, outer.max_scroll_y)), animate=False, immediate=True
         )
         await _settle(pilot, passes=4)
         assert rail._active_section_id == "details"
         assert outer.scroll_y > 0, "outer did not scroll; the reveal cannot move it"
 
+        # Revealing Workspaces scrolls the outer back to the top, which moves
+        # everything DOWN by exactly the current offset. Both the press and
+        # the later click must survive that shift, so budget for it here
+        # rather than discovering it as a click that silently misses.
+        reveal_shift = int(outer.scroll_y)
         visible_top = max(tree.content_region.y, outer.content_region.y)
         visible_bottom = min(tree.content_region.bottom, outer.content_region.bottom)
         assert visible_bottom - visible_top >= 2, (
@@ -953,17 +953,24 @@ async def test_production_workspace_pointer_keeps_pressed_key_across_outer_reflo
         # double-click asserts a workspace activation, so a conversation row
         # would not exercise it. Scanning from the middle outward keeps the
         # press away from the band's edges, which the reveal shifts.
-        midpoint = (visible_bottom - visible_top) // 2
-        offsets = sorted(range(visible_bottom - visible_top), key=lambda o: abs(o - midpoint))
+        # The pointer deliberately stays still through the reflow, so the
+        # chosen row must be on the tree BOTH before and after the shift:
+        #   lower bound -- at least `reveal_shift` rows into the tree, or the
+        #     stationary pointer ends up above it once content moves down;
+        #   upper bound -- `reveal_shift` rows clear of the clip's bottom, or
+        #     it moves out the other side.
         pressed_node = None
-        for offset in offsets:
-            candidate_y = visible_top + offset
+        for candidate_y in range(visible_top + reveal_shift, visible_bottom):
+            if candidate_y + reveal_shift >= outer.content_region.bottom:
+                continue
             line = int(tree.scroll_y) + (candidate_y - tree.content_region.y)
             node = tree.get_node_at_line(line)
             if node is not None and str(node.data.key).startswith("workspace:"):
                 pressed_node, press_screen_y = node, candidate_y
                 break
-        assert pressed_node is not None, "no workspace row visible to press"
+        assert pressed_node is not None, (
+            "no workspace row is visible both before and after the reveal"
+        )
         pressed_key = pressed_node.data.key
         pressed_workspace_id = pressed_key.split(":", 1)[1]
 

--- a/Tests/UI/test_console_workspace_context_rail.py
+++ b/Tests/UI/test_console_workspace_context_rail.py
@@ -1295,53 +1295,6 @@ class _StyledConsoleHarness(ConsoleHarness):
     CSS_PATH = str(BUNDLED_STYLESHEET)
 
 
-@pytest.mark.xfail(
-    reason=(
-        "TASK-23201: reads whole-screen compositor pixels through a harness "
-        "that does not reproduce the real app's layout, so it depended on "
-        "the pre-TASK-23193 default section set. The rail itself still "
-        "paints correctly -- see the 2026-08-29 UAT captures."
-    ),
-    strict=False,
-)
-@pytest.mark.asyncio
-async def test_narrow_details_rail_paints_full_private_scratch_value() -> None:
-    """The human-visible rail must not reduce the authority value to ``Priva…``."""
-    app = _build_test_app()
-    host = _StyledConsoleHarness(app)
-
-    async with host.run_test(size=(180, 55)) as pilot:
-        console = host.screen_stack[-1]
-        await _wait_for_selector(console, pilot, "#console-workspace-runtime-value")
-        if not console._current_console_rail_state().details_open:
-            console._toggle_console_rail_section("details")
-        await pilot.pause()
-
-        details_section = console.query_one(
-            "#console-bounded-section-details", ConsoleBoundedSection
-        )
-        left_rail = console.query_one("#console-left-rail")
-        runtime_value = console.query_one("#console-workspace-runtime-value")
-        left_rail.activate_section("details")
-        await _wait_for_condition(
-            pilot,
-            lambda: (
-                details_section.desired_content_lines > 0
-                and not details_section._reconcile_scheduled
-                and not left_rail._allocation_reconcile_scheduled
-            ),
-        )
-        details_section.viewport.scroll_to_widget(
-            runtime_value, animate=False, immediate=True
-        )
-        await pilot.pause(0.1)
-
-        rendered_rows = _render_screen_lines(console)
-        assert any(
-            "Local files" in row and "Private scratch" in row for row in rendered_rows
-        ), [row for row in rendered_rows if "Local" in row or "Priva" in row]
-
-
 async def _wait_for_workspace_switcher_modal(host: ConsoleHarness, pilot):
     for _ in range(40):
         if host.screen_stack and host.screen_stack[-1].query(
@@ -1408,6 +1361,83 @@ def test_console_workspace_readiness_detail_preserves_error_copy() -> None:
         )
         == "Chats stay local. Connect a server later for explicit handoff."
     )
+
+
+@pytest.mark.asyncio
+async def test_narrow_details_rail_truncates_cleanly_and_keeps_the_full_value() -> None:
+    """The authority value degrades by ELLIPSIS, never by letter-stacking.
+
+    This replaces `test_narrow_details_rail_paints_full_private_scratch_value`,
+    which demanded the whole value be painted and had been failing on `dev`
+    since before TASK-23193 -- verified by running it at 4da99a884, where it
+    also fails. TASK-23201 recorded the cause as a section-layout dependency;
+    that was wrong.
+
+    The real cause is that the guarantee never existed. `ConsoleWorkspaceStatusPair`
+    sizes the label column to the label plus one gutter cell and gives the value
+    the remainder, and its own comment states the intent: "Longer labels may
+    shrink the value to 6 cells and use the existing ellipsis + tooltip
+    behavior instead of widening the whole rail." At the rail's fixed width,
+    "Local files" (11 cells + gutter) leaves 13 for "Private scratch" (15), so
+    it truncates by design at every terminal size.
+
+    What TASK-384 actually fixed, and what is worth pinning, is the FAILURE
+    MODE: a value that does not fit must ellipsize on one line rather than
+    word-wrap into a "Priv / ate / scr" letter stack, and the full text must
+    stay reachable on hover.
+    """
+    app = _build_test_app()
+    host = _StyledConsoleHarness(app)
+
+    async with host.run_test(size=(180, 55)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-workspace-runtime-value")
+        if not console._current_console_rail_state().details_open:
+            console._toggle_console_rail_section("details")
+        await pilot.pause()
+
+        details_section = console.query_one(
+            "#console-bounded-section-details", ConsoleBoundedSection
+        )
+        left_rail = console.query_one("#console-left-rail")
+        runtime_value = console.query_one("#console-workspace-runtime-value", Static)
+        runtime_label = console.query_one("#console-workspace-runtime-label", Static)
+        left_rail.activate_section("details")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                details_section.desired_content_lines > 0
+                and not details_section._reconcile_scheduled
+                and not left_rail._allocation_reconcile_scheduled
+            ),
+        )
+
+        full_value = str(runtime_value.renderable)
+        painted = "".join(seg.text for seg in runtime_value.render_line(0))
+
+        # One line, never a letter stack (TASK-384).
+        assert runtime_value.region.height == 1, (
+            f"value occupies {runtime_value.region.height} rows; it word-wrapped"
+        )
+        assert runtime_value.styles.text_wrap == "nowrap"
+        assert runtime_value.styles.text_overflow == "ellipsis"
+
+        # The label itself must never be the thing that gets cut.
+        assert str(runtime_label.renderable) in "".join(
+            seg.text for seg in runtime_label.render_line(0)
+        )
+
+        # Either it fits, or it ends in a single ellipsis -- not a hard cut.
+        if len(painted.rstrip()) < len(full_value):
+            assert painted.rstrip().endswith("\u2026"), (
+                f"value was cut without an ellipsis: {painted!r}"
+            )
+            assert runtime_value.tooltip, (
+                "truncated value has no tooltip, so the full text is unreachable"
+            )
+            assert full_value in str(runtime_value.tooltip)
+        else:
+            assert full_value in painted
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-23201 - Console-two-Context-rail-paint-tests-depend-on-the-pre-TASK-23193-section-layout.md
+++ b/backlog/tasks/task-23201 - Console-two-Context-rail-paint-tests-depend-on-the-pre-TASK-23193-section-layout.md
@@ -3,10 +3,10 @@ id: TASK-23201
 title: >-
   Console: two Context rail paint tests depend on the pre-TASK-23193 section
   layout
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-30 01:06'
-updated_date: '2026-08-30 06:37'
+updated_date: '2026-08-31 05:39'
 labels:
   - console
   - tests
@@ -21,14 +21,31 @@ test_conversation_status_row_label_and_value_are_separate_visual_runs and test_n
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [~] #1 Both tests assert their property without reading whole-screen compositor pixels, or reproduce the real app's layout deterministically
-- [~] #2 The xfail markers are removed
+- [x] #1 Both tests assert their property without reading whole-screen compositor pixels, or reproduce the real app's layout deterministically
+- [x] #2 The xfail markers are removed
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
+--------------------------------------------------
 Half resolved by TASK-23199. test_conversation_status_row_label_and_value_are_separate_visual_runs was DELETED rather than reworked: it asserted the painted separation of the '#console-active-scope' status pair, and that pair no longer exists -- TASK-23199 retired it because it read 'Conversation  None' above the active chat's own name when unsaved and the tautology 'Conversation  This conversation' when saved. There is no longer a defect for it to guard.
 
 Still open: test_narrow_details_rail_paints_full_private_scratch_value, which remains xfail for the original reason.
+
+--- 2026-08-30: DONE, and this task's stated premise was WRONG ---
+
+I recorded these as 'test infrastructure, not a user-visible regression' caused by TASK-23193's section-layout change. That was wrong for the second test, and I only found out by probing instead of re-reading my own note.
+
+test_narrow_details_rail_paints_full_private_scratch_value was failing BEFORE any of this work: ran it at 4da99a884, the pre-branch commit, where it also fails. So TASK-23193 did not break it and the layout dependency was not the cause.
+
+The actual cause is that the guarantee it asserted never existed. ConsoleWorkspaceStatusPair sizes the label column to the label plus one gutter cell and gives the value the remainder, and its own comment states the intent: 'Longer labels may shrink the value to 6 cells and use the existing ellipsis + tooltip behavior instead of widening the whole rail.' At the rail's fixed width, 'Local files' (11 cells + gutter) leaves 13 columns for 'Private scratch' (15), so it truncates at EVERY terminal size. Probed the widget directly: it renders 'Private scra…' on dev, on my branch, and at 4da99a884 alike.
+
+So the test demanded something the design deliberately does not promise. Rewritten to pin what TASK-384 actually fixed and what is worth guarding: the failure MODE. A value that does not fit must ellipsize on one line rather than word-wrap into a letter stack, the label must never be the thing cut, and the full text must stay reachable via tooltip.
+
+The first test in this task was already resolved by TASK-23199 (it asserted painted separation of a status pair that no longer exists, and was deleted).
+
+Near-miss worth recording: my span-based edit removed the xfail block AND two helpers AND four unrelated tests along with it. Only a NameError from a surviving call site caught it. Verified afterwards by comparing test-name sets against HEAD -- 46 before, 46 after, with only the intentionally replaced name gone. Span replacements across a test file need that check, not a glance.
+
+No xfails remain in test_console_workspace_context_rail.py. preflight green.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-25708 - Console-re-derive-the-workspace-pointer-reflow-test-geometry-after-the-Sessions-merge.md
+++ b/backlog/tasks/task-25708 - Console-re-derive-the-workspace-pointer-reflow-test-geometry-after-the-Sessions-merge.md
@@ -3,10 +3,10 @@ id: TASK-25708
 title: >-
   Console: re-derive the workspace-pointer reflow test geometry after the
   Sessions merge
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-08-30 19:40'
-updated_date: '2026-08-30 22:37'
+updated_date: '2026-08-31 04:55'
 labels:
   - console
   - tests
@@ -28,13 +28,13 @@ test_production_workspace_pointer_keeps_pressed_key_across_outer_reflow scrolls 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Partially re-derived on the TASK-23199 branch; NOT finished.
+Done. Fixed by probing the live geometry rather than guessing coordinates.
 
-Done: the press target is now chosen from the band that is actually visible (intersection of the tree's content region with the outer's clip), scanning outward from the midpoint for a WORKSPACE row, with the expected activation id derived from the node rather than hardcoded to 'workspace-1'. The outer is scrolled away from the top so the reveal has somewhere to move from. With that, the first half passes against the new layout: _pressed_node_key, the active section flipping to 'workspace', outer.scroll_y changing, and tree.content_region.y changing.
+The probe showed the constraint the old fixed offsets had been satisfying by accident: revealing Workspaces scrolls the outer back to the top, moving content DOWN by exactly the current offset, while the pointer deliberately stays still through the reflow. The pressed row must therefore be on the tree BOTH before and after the shift - at least reveal_shift rows into the tree (or the stationary pointer ends up above it) and reveal_shift rows clear of the clip bottom (or it leaves the other side). Encoding both bounds is what made it deterministic.
 
-Remaining: the trailing double-click phase. After the reveal the pressed row lands on row 24 while the outer's content_region.bottom is exactly 24 -- one cell outside the clip -- and centring the row in the tree's own viewport does not move it off that boundary, which suggests the tree extends past the outer clip in a way the tree-relative offset does not account for. pilot.click then refuses the offset.
+Two supporting findings from the same probe: the offset must be small (two rows, not five) because each workspace row is followed by four conversation rows, so a large shift can leave NO workspace row satisfying both bounds; and the tree's own pre-scroll had to go - it existed to bring the hardcoded workspace-1 into view and was shifting the line-to-row mapping out from under the search.
 
-Left xfail rather than tuned to green: I had it passing at one point by hand-picking a scroll offset, then the click coordinate stopped landing, which is the signature of calibrating numbers until the bar turns green. The behaviour under test is unchanged; what is needed is understanding the tree/outer clip interaction, not another guess.
+The test now reads the layout instead of assuming one: it searches the visible band for a workspace row meeting the bounds and derives the expected activation id from that node. It should survive future changes to the rail's section set, which is what broke it in the first place.
 
-Sibling coverage note for whoever picks this up: Tests/UI/test_console_workspace_tree.py covers _pressed_node_key at the WIDGET level (54 tests). What this test uniquely covers is the press surviving a RAIL REFLOW, so the gap while xfailed is real.
+Passes three consecutive runs; test_console_rail_reconciliation.py has no xfails left (54 passed). preflight green.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-25714 - Console-Context-rail-still-overflows-below-140x40.md
+++ b/backlog/tasks/task-25714 - Console-Context-rail-still-overflows-below-140x40.md
@@ -1,0 +1,45 @@
+---
+id: TASK-25714
+title: Console Context rail still overflows below 140x40
+status: To Do
+assignee: []
+created_date: '2026-08-31 14:27'
+labels:
+  - console
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-23193 made all Context rail section headers reachable without scrolling at 160x48, and its implementation notes record that 140x40 and below still overflow as follow-up work rather than something silently dropped. This is that follow-up. The rail's fit was bought at 160x48 by merging Sessions into Conversations and trimming section content; the smaller sizes were never re-measured after those changes landed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The Context rail's section headers are reachable without scrolling at 140x40
+- [ ] #2 Behaviour below 140x40 is either made to fit or given a deliberate, documented degradation rather than an unbounded overflow
+- [ ] #3 A test pins the smallest size the rail is claimed to fit, so the claim cannot rot silently
+<!-- AC:END -->
+
+## Context
+
+Two constraints from TASK-23193 that this task inherits, so they are not
+rediscovered from scratch:
+
+- The obvious lever -- dropping the section headers' border-top rule and their
+  2-row min-height -- **was built and did make 140x40 fit (25 rows of content
+  in 25 available)**. It was reverted because
+  `test_context_section_headers_match_inspector_title_band` deliberately ties
+  Context section headers to the Inspector's title band, and on review of both
+  screenshots the reviewer chose to keep the rule. So the fit is achievable;
+  what blocked it was a visual contract, not layout.
+- That contract test is itself now red on dev for an unrelated reason
+  (TASK-25715: #2220 changed the Inspector side's padding to 0 while the
+  Context side kept 1). Whoever takes this on should settle TASK-25715 first --
+  if the shared band is no longer real, the trade TASK-23193 made to protect it
+  should be re-decided rather than inherited.
+
+Sizes worth measuring: 140x40, 120x36, and the 80x24 floor.

--- a/backlog/tasks/task-25715 - Two-Console-rail-tests-are-red-on-dev-each-bisected-to-its-cause.md
+++ b/backlog/tasks/task-25715 - Two-Console-rail-tests-are-red-on-dev-each-bisected-to-its-cause.md
@@ -1,0 +1,89 @@
+---
+id: TASK-25715
+title: 'Two Console rail tests are red on dev, each bisected to its cause'
+status: To Do
+assignee: []
+created_date: '2026-08-31 14:27'
+labels:
+  - console
+  - testing
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Two Console rail tests pass at 4da99a884 and fail on origin/dev at 46c2b0e5f0fb. Both were found while baselining the Context rail UX work (PRs #2233, #2242, #2260) against dev, and neither is caused by it -- each is bisected below to the commit that introduced it. Filed so they are not silently re-attributed to whatever change happens to run next to them, and so the two owning changes get the decision they each imply.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 test_context_section_headers_match_inspector_title_band passes, or the contract it pins is deliberately retired with the Inspector/Context divergence recorded
+- [ ] #2 test_active_reveal_queue_retains_only_identity_across_target_and_rail_removal passes, or the reveal callback is documented as not surviving rail removal
+- [ ] #3 Neither test is left red on dev without an owner
+<!-- AC:END -->
+
+## Evidence
+
+Measured with `PYTHONPATH=<worktree> <main>/.venv/bin/pytest -p no:randomly`
+in detached worktrees, so each commit's own source is what ran.
+
+Both PASS at `4da99a884` (the commit the Context rail work branched from) and
+FAIL at `origin/dev` `46c2b0e5f0fb`. A manual first-parent binary search over
+the 60 merges between them isolated one cause each.
+
+### 1. Header padding — first bad `c2f64f690` (#2220, Inspect rail UX burn-down)
+
+```
+Tests/UI/test_console_left_rail.py::test_context_section_headers_match_inspector_title_band
+E  assert Spacing(top=0, right=1, bottom=0, left=1)
+       == Spacing(top=0, right=0, bottom=0, left=0)
+```
+
+The test ties Context section headers to the Inspector's title band. #2220
+changed the **Inspector** side to zero padding; the Context side still carries
+`1`. The test is asserting a shared visual band that one of the two sides has
+since left, so it fails on the Context header while naming neither change.
+
+Worth noting for whoever picks this up: the same contract test is why
+TASK-23193's header-chrome reduction was reverted (a 140x40 fit was given up to
+keep the band). If the band is no longer real, that trade should be revisited
+rather than inherited.
+
+### 2. Reveal queue — first bad `0ef6f3fd4` (#2252, console-rail-adaptive-row-cap)
+
+```
+Tests/UI/test_console_rail_reconciliation.py::test_active_reveal_queue_retains_only_identity_across_target_and_rail_removal
+E  textual.css.query.NoMatches: No nodes match '#console-left-rail-body'
+     on ConsoleLeftRail(id='console-left-rail', ...)
+```
+
+The test removes the rail and then fires the queued reveal callback, pinning
+that a deferred reveal holds only identities and degrades quietly when its
+target is gone. After #2252 the callback resolves `#console-left-rail-body`
+unguarded, so a reveal that outlives its rail raises instead. The queue still
+carries no widget references -- the two `_contains_widget_reference` assertions
+before it still pass -- so this is the lookup at the end, not the queue design.
+
+Bisect also cleared the neighbouring Console merges: `3c081c79e` (#2233),
+`4ae04314c` (#2242), `51d3fbdbf` (#2249) and `41176579f` (#2250) are all GOOD
+for the test each is adjacent to.
+
+## Notes
+
+Filed in the same spirit as TASK-15512. `origin/dev` had by this point absorbed
+the Context rail PRs, so "red on dev" alone no longer told me the failures were
+not mine -- both had to be re-run at the pre-branch commit and then bisected
+before either could honestly be called someone else's.
+
+## Renumbering provenance
+
+This task previously held id TASK-25713, colliding with the older
+"Census-warm-boot-flakes-on-sys.modules-mutation-during-iteration" task that
+arrived on dev first (created 14:12; this one 14:27 the same day).
+Per the owner rule decided 2026-08-21 in TASK-19601 (**older id keeps it;
+the younger task renumbers with a provenance note, regardless of Done
+status**), it renumbered to TASK-25715. Citations to TASK-25713 in
+this branch's own commit messages and in PR #2260's body refer to THIS
+task; the other TASK-25713 holder is the older arrival and keeps the id.


### PR DESCRIPTION
## What this is

Test-only. It clears the two `xfail`s left behind by #2233 and #2242 — and correcting the second one turned up a finding worth reading.

## 1. The reflow test — re-derived, not tuned

`test_production_workspace_pointer_keeps_pressed_key_across_outer_reflow` scrolled to `workspace_header_y - 3` to put the Workspaces header above the fold. #2242 retired the Sessions section, so Workspaces leads the rail, that expression clamps to `0`, and the reflow the test asserts could not happen.

Fixed by probing the live geometry rather than guessing offsets. That exposed the constraint the old fixed coordinates had been satisfying **by accident**: revealing Workspaces scrolls the outer back to the top, moving content **down by exactly the current offset**, while the pointer deliberately stays still through the reflow. So the pressed row must be on the tree *both before and after* the shift:

- **lower bound** — at least `reveal_shift` rows into the tree, or the stationary pointer ends up above it
- **upper bound** — `reveal_shift` rows clear of the clip's bottom, or it leaves the other side

I'd only ever encoded the upper bound, which is why each earlier attempt moved the failure instead of removing it.

Two supporting findings from the same probe:

- The offset must be **small** (2 rows, not 5): each workspace row is followed by four conversation rows, so a large shift can leave *no* workspace row satisfying both bounds.
- The tree's own pre-scroll had to go — it existed to bring the hardcoded `workspace-1` into view and was shifting the line-to-row mapping out from under the search.

The test now searches the visible band for a workspace row meeting both bounds and takes the expected activation id from that node, so it reads the layout instead of assuming one. Passes three consecutive runs.

## 2. The details paint test — my earlier diagnosis was wrong

`test_narrow_details_rail_paints_full_private_scratch_value` demanded the whole authority value be painted. I had recorded it (TASK-23201) as test infrastructure broken by #2233's section-layout change.

**That was wrong.** Running it at `4da99a884` — before any of this work — it also fails. #2233 did not break it.

The guarantee never existed. `ConsoleWorkspaceStatusPair` sizes the label column to the label plus one gutter cell and gives the value the remainder, and its own comment states the intent:

> Longer labels may shrink the value to 6 cells and use the existing ellipsis + tooltip behavior instead of widening the whole rail.

`"Local files"` (11 cells + gutter) leaves **13** columns for `"Private scratch"` (**15**), so it truncates at *every* terminal size. Probing the widget confirms it renders `'Private scra…'` on dev, on this branch, and pre-branch alike.

So the test asserted something the design deliberately does not promise. It now pins what TASK-384 actually fixed — the **failure mode**: one line with an ellipsis rather than a `Priv / ate / scr` letter stack, the label never the thing that gets cut, and the full value reachable by tooltip.

## Notes for review

- **No xfails remain** in either file.
- **Two failures on this branch are not from it — each is bisected to its cause** (TASK-25715, filed here). I first wrote this as "pre-existing on dev", which was too weak to mean anything: `dev` had already absorbed #2233 and #2242, so red-on-dev no longer separates someone else's regression from my own. Both PASS at `4da99a884`, the commit this work branched from, so I binary-searched the 60 merges since:
  - `test_context_section_headers_match_inspector_title_band` ← `c2f64f690` (#2220) set the **Inspector** title band's padding to 0 while the Context header kept 1; the test pins the two as one shared band. Worth flagging: that same contract is why TASK-23193 reverted a header trim that *had* made 140x40 fit. If the band has diverged, that trade is now being paid for nothing — TASK-25714.
  - `test_active_reveal_queue_retains_only_identity_across_target_and_rail_removal` ← `0ef6f3fd4` (#2252): a queued reveal outliving its rail resolves `#console-left-rail-body` unguarded and raises `NoMatches`. The queue still holds no widget references — the two assertions before it pass — so this is the final lookup, not the design.
  - The search also clears the adjacent Console merges: `3c081c79e` (#2233), `4ae04314c` (#2242), `51d3fbdbf` (#2249), `41176579f` (#2250).
- Worth a second pair of eyes: my span-based edit in `test_console_workspace_context_rail.py` initially removed two helpers and **four unrelated tests** along with the xfail block. A `NameError` caught it. Test-name sets were diffed against HEAD afterwards — 46 before, 46 after, with only the intentionally replaced name gone.
- `preflight`: all derived-artifact checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrN2mbF8byxMfPNPtVJwFb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the last two `xfail`s in the console rail tests, all test-only: one test now derives its geometry from the live layout, and the other pins the truncation contract the code actually guarantees instead of what a wrong diagnosis assumed.

- TASK-25708: the reflow test scrolled to a hardcoded offset that clamped to `0` after Sessions was retired; it now probes the visible band for a workspace row that survives the reveal shift.
- TASK-23201: the details paint test was failing on `dev` before this branch. The full value was never guaranteed to fit; the test now asserts one line, ellipsis, label never cut, and the full value reachable via tooltip.

**Notes**
- Two other rail tests are red on dev, each bisected to its cause and filed as TASK-25715 (renumbered from TASK-25713 after an id collision): #2220 changed the Inspector title band's padding and broke `test_context_section_headers_match_inspector_title_band`; #2252 added an unguarded `#console-left-rail-body` lookup and broke the reveal-queue test.
- TASK-25714 files the known rail overflow below 140x40; the fix that made it fit was reverted to protect the header/Inspector band contract that TASK-25715 shows has since diverged.

<sup>Written for commit d91d8872c3129140c78f0e6717ddcd3a49e6b45b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

> **Correction (2026-08-31, post-merge).** The attribution of `test_active_reveal_queue_retains_only_identity_across_target_and_rail_removal` to `0ef6f3fd4` (#2252) above is **withdrawn**. That test is flaky (~1 in 12), failing at both ends of the range — 11 passed / 1 failed of 12 at the very commit the bisect called FIRST BAD. A bisect run once per step over a flaky test converges on the coin, not the cause. The two #2220 attributions re-measured 0/5 and stand. See PR #2269 and TASK-25715.
