### PR TITLE
feat: include context and tools in Console first-send token previews

### DIFF
--- a/Tests/Chat/test_console_display_state.py
+++ b/Tests/Chat/test_console_display_state.py
@@ -689,3 +689,23 @@ def test_next_send_estimate_accepts_multimodal_part_list_content():
 
     assert total is not None
     assert total > 0
+
+
+@pytest.mark.unit
+def test_next_send_estimate_skips_schemas_that_cannot_serialize():
+    """Qodo finding 3: a schema object whose serialization raises must
+    degrade to "no tools row", not propagate out of the estimator."""
+
+    class _Unserializable:
+        def __str__(self):  # pragma: no cover - exercised via dumps
+            raise TypeError("no repr for you")
+
+    total = estimate_console_next_send_tokens(
+        payload_messages=_FIRST_SEND_MESSAGES,
+        tools_info={"native_schemas": [{"name": _Unserializable()}]},
+    )
+    without = estimate_console_next_send_tokens(
+        payload_messages=_FIRST_SEND_MESSAGES
+    )
+
+    assert total == without

--- a/Tests/Chat/test_console_display_state.py
+++ b/Tests/Chat/test_console_display_state.py
@@ -551,7 +551,7 @@ def test_permanently_dead_review_tool_call_action_is_gone():
     )
 
 
-# --- Next-send token estimate (task-21513) ---------------------------------
+# --- Next-send token estimate (task-25836) ---------------------------------
 #
 # The Next Send tab's "~N tokens" header and the cost chip's first-send
 # readout both need "what will the next request actually carry": system

--- a/Tests/Chat/test_console_display_state.py
+++ b/Tests/Chat/test_console_display_state.py
@@ -14,6 +14,7 @@ from tldw_chatbook.Chat.console_display_state import (
     ConsoleInspectorState,
     ConsoleLibraryPolicyDisplayState,
     ConsoleStagedContextState,
+    estimate_console_next_send_tokens,
 )
 from tldw_chatbook.Chat.console_library_policy import (
     ConsoleAssistantLibraryAccess,
@@ -548,3 +549,143 @@ def test_permanently_dead_review_tool_call_action_is_gone():
     assert not any("Review tool call" in lbl for lbl in labels), (
         f"the dead action is still advertised: {labels}"
     )
+
+
+# --- Next-send token estimate (task-21513) ---------------------------------
+#
+# The Next Send tab's "~N tokens" header and the cost chip's first-send
+# readout both need "what will the next request actually carry": system
+# prompt + messages (draft included) + tool schemas + staged evidence.
+# These tests pin the shared pure estimator's counting and its guards.
+
+
+_FIRST_SEND_MESSAGES = [
+    {"role": "system", "content": "You are a thorough assistant. " * 5},
+    {"role": "user", "content": "hello, this is my first message"},
+]
+
+
+@pytest.mark.unit
+def test_next_send_estimate_counts_tools_on_top_of_messages():
+    without_tools = estimate_console_next_send_tokens(
+        payload_messages=_FIRST_SEND_MESSAGES
+    )
+    with_tools = estimate_console_next_send_tokens(
+        payload_messages=_FIRST_SEND_MESSAGES,
+        tools_info={
+            "native_schemas": [
+                {
+                    "name": "demo_tool",
+                    "description": "does demo things",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+            ]
+        },
+    )
+
+    assert without_tools is not None
+    assert with_tools is not None
+    assert with_tools > without_tools
+
+
+@pytest.mark.unit
+def test_next_send_estimate_does_not_double_count_duplicated_system_row():
+    """The payload's `system` field duplicates the leading system row in
+    `messages` (by design, so the viewer can show it at a glance) -- the
+    estimate must not count it twice."""
+    system_rows = [
+        {"role": "system", "content": _FIRST_SEND_MESSAGES[0]["content"]}
+    ]
+    plain = estimate_console_next_send_tokens(
+        payload_messages=_FIRST_SEND_MESSAGES
+    )
+    duplicated = estimate_console_next_send_tokens(
+        payload_messages=_FIRST_SEND_MESSAGES,
+        payload_system=system_rows,
+    )
+
+    assert duplicated == plain
+
+
+@pytest.mark.unit
+def test_next_send_estimate_counts_fallback_system_when_messages_have_none():
+    """`build_context_snapshot` can hand a `system` field whose rows are NOT
+    in `messages` (its fallback branch) -- that content still ships."""
+    user_only = [{"role": "user", "content": "hello"}]
+    without = estimate_console_next_send_tokens(payload_messages=user_only)
+    with_system = estimate_console_next_send_tokens(
+        payload_messages=user_only,
+        payload_system=[
+            {"role": "system", "content": "You are a thorough assistant." * 20}
+        ],
+    )
+
+    assert without is not None
+    assert with_system is not None
+    assert with_system > without
+
+
+@pytest.mark.unit
+def test_next_send_estimate_folds_extra_texts_and_skips_blank_ones():
+    """Staged evidence text rides along as an extra text (the preview payload
+    lists staged sources as label-only metadata); blank texts add nothing."""
+    base = estimate_console_next_send_tokens(
+        payload_messages=_FIRST_SEND_MESSAGES
+    )
+    with_staged = estimate_console_next_send_tokens(
+        payload_messages=_FIRST_SEND_MESSAGES,
+        extra_texts=["", "   ", "staged evidence snippet " * 10],
+    )
+
+    assert base is not None
+    assert with_staged is not None
+    assert with_staged > base
+
+
+@pytest.mark.unit
+def test_next_send_estimate_ignores_tools_info_without_schemas():
+    """`tools_info` carries prose notes (`mcp_note`/`preview_note`) that are
+    not request content; an empty `native_schemas` contributes nothing."""
+    with_notes = estimate_console_next_send_tokens(
+        payload_messages=_FIRST_SEND_MESSAGES,
+        tools_info={
+            "native_schemas": [],
+            "preview_note": "No native tools are configured for preview.",
+        },
+    )
+    without = estimate_console_next_send_tokens(
+        payload_messages=_FIRST_SEND_MESSAGES
+    )
+
+    assert with_notes == without
+
+
+@pytest.mark.unit
+def test_next_send_estimate_returns_none_when_nothing_to_send():
+    assert estimate_console_next_send_tokens() is None
+    assert (
+        estimate_console_next_send_tokens(
+            payload_messages=[],
+            payload_system=[],
+            tools_info={"native_schemas": []},
+            extra_texts=["   "],
+        )
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_next_send_estimate_accepts_multimodal_part_list_content():
+    """Message content may be a provider part-list (text + image) -- the
+    estimator must not crash and must count the text part (plus the
+    non-text part allowance)."""
+    parts = [
+        {"type": "text", "text": "describe this image"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+    ]
+    total = estimate_console_next_send_tokens(
+        payload_messages=[{"role": "user", "content": parts}]
+    )
+
+    assert total is not None
+    assert total > 0

--- a/Tests/UI/test_console_conversation_inspector.py
+++ b/Tests/UI/test_console_conversation_inspector.py
@@ -1864,3 +1864,58 @@ def test_messages_section_title_states_original_and_elided_counts() -> None:
     )
     plain_title = str(inspector._build_messages_section(plain_capture, "k").title)
     assert plain_title == "Messages (3)"
+
+
+# --- task-21513: payload-based Next Send header token estimate --------------
+
+
+async def _payload_snapshot() -> ConsoleContextSnapshot:
+    return ConsoleContextSnapshot(
+        current_messages=[],
+        next_send_payload={
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_next_send_payload_estimate_replaces_header_count_once_loaded():
+    """task-21513: after the snapshot loads, the Next Send header's "~N
+    tokens" count must reflect the assembled next-send payload (system +
+    tools + staged evidence included), not the draft-only factory value."""
+    app = InspectorHarness(
+        **_default_kwargs(
+            snapshot_factory=_payload_snapshot,
+            estimate_factory=lambda: 7,
+            token_estimate=7,
+            payload_estimate=lambda snapshot: 4242,
+            initial_tab=TAB_NEXT_SEND,
+        )
+    )
+
+    async with app.run_test(size=(120, 44)) as pilot:
+        modal = app.screen
+        header = modal.query_one("#console-inspector-next-send-header", Static)
+        await _wait_until(pilot, lambda: "~4242 tokens" in str(header.renderable))
+
+
+@pytest.mark.asyncio
+async def test_next_send_payload_estimate_none_falls_back_to_factory():
+    """A payload estimate of ``None`` (nothing estimable, e.g. an
+    assembly-error payload) falls back to the draft-only factory rather
+    than dropping the count."""
+    app = InspectorHarness(
+        **_default_kwargs(
+            snapshot_factory=_payload_snapshot,
+            estimate_factory=lambda: 9,
+            token_estimate=7,
+            payload_estimate=lambda snapshot: None,
+            initial_tab=TAB_NEXT_SEND,
+        )
+    )
+
+    async with app.run_test(size=(120, 44)) as pilot:
+        modal = app.screen
+        header = modal.query_one("#console-inspector-next-send-header", Static)
+        await _wait_until(pilot, lambda: "~9 tokens" in str(header.renderable))

--- a/Tests/UI/test_console_conversation_inspector.py
+++ b/Tests/UI/test_console_conversation_inspector.py
@@ -1866,7 +1866,7 @@ def test_messages_section_title_states_original_and_elided_counts() -> None:
     assert plain_title == "Messages (3)"
 
 
-# --- task-21513: payload-based Next Send header token estimate --------------
+# --- task-25836: payload-based Next Send header token estimate --------------
 
 
 async def _payload_snapshot() -> ConsoleContextSnapshot:
@@ -1881,7 +1881,7 @@ async def _payload_snapshot() -> ConsoleContextSnapshot:
 
 @pytest.mark.asyncio
 async def test_next_send_payload_estimate_replaces_header_count_once_loaded():
-    """task-21513: after the snapshot loads, the Next Send header's "~N
+    """task-25836: after the snapshot loads, the Next Send header's "~N
     tokens" count must reflect the assembled next-send payload (system +
     tools + staged evidence included), not the draft-only factory value."""
     app = InspectorHarness(

--- a/Tests/UI/test_console_cost_chip_screen.py
+++ b/Tests/UI/test_console_cost_chip_screen.py
@@ -883,9 +883,27 @@ _DEMO_TOOL_SCHEMA = {
 
 
 def _first_send_tool_bridge():
-    return SimpleNamespace(
-        native_tool_schemas=lambda: [_DEMO_TOOL_SCHEMA],
-    )
+    """Stub agent bridge: the real native schemas for the fold-in, plus a
+    permissive fallback for the OTHER bridge surfaces the Console sync
+    paths touch on a tick (e.g. ``subagent_counts``) -- a bare
+    SimpleNamespace made those workers raise ``AttributeError``."""
+
+    class _BridgeStub:
+        def native_tool_schemas(self):
+            return [_DEMO_TOOL_SCHEMA]
+
+        def subagent_counts(self, conversation_ids):
+            return {}
+
+        def __getattr__(self, name):
+            # Unknown bridge surface: callable returning an empty mapping
+            # keeps tick-path consumers happy without encoding each one.
+            def _empty(*_args, **_kwargs):
+                return {}
+
+            return _empty
+
+    return _BridgeStub()
 
 
 def _row_roles(rows) -> list[str]:
@@ -1040,3 +1058,149 @@ async def test_console_next_send_token_estimate_counts_context_not_just_draft():
             current_messages=[], next_send_payload={"error": "boom"}
         )
         assert console._console_next_send_token_estimate(degraded) is None
+
+
+# --- Qodo review fixes (task-25836 round 2) ---------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_send_pseudo_rows_skip_draft_once_it_is_the_trailing_row():
+    """Qodo finding 2 (High): during the mouse-send window the real user
+    row is already in the store while the composer draft is not yet
+    cleared -- the draft pseudo-row must be dropped, not double-counted."""
+    from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("hello, this is my first message")
+        store.append_message(
+            session_id,
+            role=ConsoleMessageRole.USER,
+            content="hello, this is my first message",
+        )
+        await pilot.pause()
+
+        rows = console._console_first_send_pseudo_rows()
+        assert all(
+            not (row.role == "user" and "first message" in str(row.content))
+            for row in rows
+        ), f"draft re-added next to its own persisted row: {rows}"
+        # The persisted user row itself is what the chip prices for the
+        # draft now -- the fold-in may still carry system/tools context.
+        state = console._build_console_cost_state()
+        assert state is not None
+
+
+@pytest.mark.asyncio
+async def test_first_send_pseudo_rows_include_prefill_and_memory_projection():
+    """Qodo finding 1: the fold-in must reuse the controller's own
+    effective-memory and prefill projections instead of under-counting a
+    configured session."""
+    from types import SimpleNamespace as _NS
+
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+        controller = console._ensure_console_chat_controller()
+        store.set_session_one_shot_prefill(session_id, "Sure thing:")
+
+        original_projection = controller._project_session_effective_memory
+        controller._project_session_effective_memory = (
+            lambda sid, rows: (
+                None,
+                _NS(memory=[{"role": "system", "content": "MEMORY FACTS"}]),
+            )
+        )
+        try:
+            composer = console.query_one(
+                "#console-native-composer", ConsoleComposerBar
+            )
+            composer.load_draft("hello")
+            rows = console._console_first_send_pseudo_rows()
+        finally:
+            controller._project_session_effective_memory = original_projection
+
+        contents = [str(row.content) for row in rows]
+        assert any("MEMORY FACTS" in content for content in contents)
+        assert any(
+            row.role == "assistant" and "Sure thing:" in str(row.content)
+            for row in rows
+        )
+
+
+@pytest.mark.asyncio
+async def test_next_send_estimate_gates_staged_evidence_on_session():
+    """Qodo finding 4: staged evidence belongs to the ACTIVE session; an
+    estimate captured for a different session must not splice it in."""
+    from tldw_chatbook.Chat.citation_evidence_models import (
+        EvidenceBundle,
+        EvidenceReference,
+    )
+    from tldw_chatbook.Chat.console_chat_models import ConsoleContextSnapshot
+    from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
+
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        store = console._ensure_console_chat_store()
+
+        big_reference = EvidenceReference(
+            evidence_id="S1",
+            source_id="media-1",
+            source_type="media",
+            title="Big corpus",
+            snippet="staged evidence text " * 5_000,
+            authority_label="local",
+            status="available",
+            source_owner="local",
+        )
+        bundle = EvidenceBundle(
+            bundle_id="bundle-gate",
+            query="question",
+            source="Library Search/RAG",
+            references=(big_reference,),
+        )
+        launch = ConsoleLiveWorkLaunch.from_values(
+            source="Library Search/RAG",
+            title="Library Search/RAG retrieval",
+            payload={"query": "question", "evidence_bundle": bundle.to_payload()},
+            status="staged",
+        )
+        console._retrieval._stage_console_library_rag_launch(launch)
+        await pilot.pause()
+
+        snapshot = ConsoleContextSnapshot(
+            current_messages=[],
+            next_send_payload={
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        active_id = store.active_session_id
+        with_staging = console._console_next_send_token_estimate(
+            snapshot, session_id=active_id
+        )
+        without_staging = console._console_next_send_token_estimate(
+            snapshot, session_id="a-different-session"
+        )
+
+        assert with_staging is not None and without_staging is not None
+        assert with_staging > without_staging

--- a/Tests/UI/test_console_cost_chip_screen.py
+++ b/Tests/UI/test_console_cost_chip_screen.py
@@ -866,7 +866,7 @@ async def test_build_console_cost_state_includes_a_survivors_post_turn_spend():
         assert "Sub-agents: 1.3k tok (not priced)" in state.tooltip
 
 
-# --- task-21513: first-send context/tool/draft rows -------------------------
+# --- task-25836: first-send context/tool/draft rows -------------------------
 #
 # The chip's running total ignored everything a FIRST send actually ships
 # (session system prompt, tool schemas, the draft itself), so a brand-new
@@ -1004,7 +1004,7 @@ async def test_first_send_pseudo_rows_stop_once_a_reply_exists():
 
 @pytest.mark.asyncio
 async def test_console_next_send_token_estimate_counts_context_not_just_draft():
-    """task-21513: the estimate wired into the inspector's Next Send header
+    """task-25836: the estimate wired into the inspector's Next Send header
     must count the assembled payload (system prompt + draft turn), not the
     draft text alone -- the first-message case where the gap is largest."""
     from tldw_chatbook.Chat.console_chat_models import ConsoleContextSnapshot

--- a/Tests/UI/test_console_cost_chip_screen.py
+++ b/Tests/UI/test_console_cost_chip_screen.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import replace
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -863,3 +864,179 @@ async def test_build_console_cost_state_includes_a_survivors_post_turn_spend():
         state = console._build_console_cost_state()
         assert state is not None
         assert "Sub-agents: 1.3k tok (not priced)" in state.tooltip
+
+
+# --- task-21513: first-send context/tool/draft rows -------------------------
+#
+# The chip's running total ignored everything a FIRST send actually ships
+# (session system prompt, tool schemas, the draft itself), so a brand-new
+# conversation with a typed draft still read "0 tok" until the first reply
+# landed. The fold-in is first-send-only: once a reply (or any usage row)
+# exists, the chip reverts to the running-total semantics.
+
+
+_DEMO_TOOL_SCHEMA = {
+    "name": "demo_tool",
+    "description": "does demo things",
+    "parameters": {"type": "object", "properties": {}},
+}
+
+
+def _first_send_tool_bridge():
+    return SimpleNamespace(
+        native_tool_schemas=lambda: [_DEMO_TOOL_SCHEMA],
+    )
+
+
+def _row_roles(rows) -> list[str]:
+    return [str(getattr(row.role, "value", row.role)) for row in rows]
+
+
+@pytest.mark.asyncio
+async def test_first_send_pseudo_rows_absent_while_draft_is_blank():
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        assert console._console_first_send_pseudo_rows() == []
+        state = console._build_console_cost_state()
+        assert state is not None
+        assert "Tokens: 0" in state.tooltip
+
+
+@pytest.mark.asyncio
+async def test_first_send_pseudo_rows_carry_system_tools_and_draft():
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        console._session._apply_console_session_system_prompt(
+            "You are a thorough assistant. " * 5
+        )
+        console._ensure_console_agent_bridge = _first_send_tool_bridge
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("hello, this is my first message")
+
+        rows = console._console_first_send_pseudo_rows()
+        roles = _row_roles(rows)
+        contents = [row.content for row in rows]
+        assert all(getattr(row, "usage", "missing") is None for row in rows)
+        system_contents = [
+            content for role, content in zip(roles, contents) if role == "system"
+        ]
+        assert any("thorough assistant" in content for content in system_contents)
+        assert any('"demo_tool"' in content for content in system_contents)
+        assert any(
+            role == "user" and "first message" in content
+            for role, content in zip(roles, contents)
+        )
+
+        state = console._build_console_cost_state()
+        assert state is not None
+        assert "Tokens: 0" not in state.tooltip
+        assert state.label.startswith("~")
+
+
+@pytest.mark.asyncio
+async def test_first_send_pseudo_rows_draft_only_without_prompt_or_tools():
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("just a draft")
+
+        rows = console._console_first_send_pseudo_rows()
+        assert _row_roles(rows) == ["user"]
+        assert "just a draft" in rows[0].content
+
+
+@pytest.mark.asyncio
+async def test_first_send_pseudo_rows_stop_once_a_reply_exists():
+    gateway = _AnthropicCostGateway(PRICED_USAGE, reply="the priced answer")
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _send_and_settle(console, pilot, "hello", "the priced answer")
+
+        before = console._build_console_cost_state()
+        assert before is not None
+
+        # Everything the fold-in would count, queued behind a finished reply:
+        # none of it may leak into the conversation's running total.
+        console._session._apply_console_session_system_prompt(
+            "You are a thorough assistant. " * 20
+        )
+        console._ensure_console_agent_bridge = _first_send_tool_bridge
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("a queued follow-up message " * 100)
+
+        assert console._console_first_send_pseudo_rows() == []
+
+        after = console._build_console_cost_state()
+        assert after is not None
+
+        def _tokens_line(state):
+            return next(
+                line
+                for line in state.tooltip.splitlines()
+                if line.startswith("Tokens:")
+            )
+
+        assert _tokens_line(after) == _tokens_line(before)
+
+
+@pytest.mark.asyncio
+async def test_console_next_send_token_estimate_counts_context_not_just_draft():
+    """task-21513: the estimate wired into the inspector's Next Send header
+    must count the assembled payload (system prompt + draft turn), not the
+    draft text alone -- the first-message case where the gap is largest."""
+    from tldw_chatbook.Chat.console_chat_models import ConsoleContextSnapshot
+    from tldw_chatbook.Utils.token_counter import estimate_tokens
+
+    app = _build_test_app()
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        controller = console._ensure_console_chat_controller()
+        store = controller.store
+        session_id = store.active_session_id or store.ensure_session(
+            title="First message"
+        ).id
+        console._session._apply_console_session_system_prompt(
+            "You are a thorough assistant. " * 5
+        )
+        await pilot.pause()
+
+        snapshot = await controller.build_context_snapshot(
+            draft="hello there", session_id=session_id
+        )
+        estimate = console._console_next_send_token_estimate(snapshot)
+
+        draft_only = estimate_tokens("hello there", "", "")
+        assert estimate is not None
+        assert estimate > draft_only
+
+        degraded = ConsoleContextSnapshot(
+            current_messages=[], next_send_payload={"error": "boom"}
+        )
+        assert console._console_next_send_token_estimate(degraded) is None

--- a/backlog/tasks/task-21513 - Console-first-send-token-previews-include-context-and-tools.md
+++ b/backlog/tasks/task-21513 - Console-first-send-token-previews-include-context-and-tools.md
@@ -1,0 +1,97 @@
+---
+id: TASK-21513
+title: Console first-send token previews include context and tools
+status: Done
+assignee:
+  - '@Robert'
+created_date: '2026-08-31 02:42'
+updated_date: '2026-08-31 06:26'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When composing the first message of a Console conversation, the two token readouts a user checks -- the context viewer's '~N tokens' header and the cost chip's token label -- count only the draft (chip) or nothing at all (modal header is draft-only, chip ignores system prompt/tools). The first send actually ships the system prompt, project-instruction bodies, tool schemas, and staged evidence, so both readouts massively understate the request. Make both count the full next-send request.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Context viewer: the "~N tokens" header estimate is computed from the loaded next-send payload (messages incl. system row and draft turn, tool schemas, staged evidence text), not the draft alone
+- [x] #2 No double counting: the payload's duplicated `system` field is not counted again when the leading system row is already in `messages`
+- [x] #3 Cost chip: while the active session has no assistant rows and no usage rows (first send pending), the chip folds the session system prompt, tool schemas, and current draft in as estimated rows alongside the existing staged-evidence row
+- [x] #4 Cost chip: once the session has an assistant/usage row, the running total is unchanged from today's behavior (no system/tools/draft pseudo-rows)
+- [x] #5 Both readouts stay estimates ("~" semantics preserved) and degrade safely (snapshot error payload, empty draft, no tools)
+- [x] #6 Targeted tests pass (context-modal tests + new estimator/chip tests)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: estimate-only change inside two existing UI surfaces; no schema, sync, provider-boundary, or interface-contract decision.
+
+1. Add a pure shared estimator (`Chat/console_display_state.py`) that counts a next-send request: payload messages (role-aware, via `_estimate_tokens_locally`), tool-schema JSON, and extra texts (staged evidence), with a system-dedupe guard.
+2. Context viewer: `ConsoleContextModal` gains an optional `payload_estimate` callable used after `_load_snapshot`; `ChatScreen.action_view_chat_context` wires it (draft-only value stays as the pre-load header).
+3. Cost chip: in `ChatScreen._build_console_cost_state`, when no assistant/usage rows exist, append estimated pseudo-rows (system prompt, tools JSON, draft) next to the existing staged-evidence pseudo-row.
+4. Tests first for each piece; targeted runs of `Tests/UI/test_chat_screen_context_modal.py` plus the new tests.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Summary.** Both Console "tokens" readouts now count what a send actually
+ships. The context viewer's header estimate (`Ctrl+Shift+P`) is computed from
+the loaded `next_send_payload` (system row + messages incl. the draft turn +
+`native_schemas` JSON + staged evidence text) instead of the bare draft; the
+cost chip folds the session system prompt, tool schemas, and the composer
+draft in as estimated pseudo-rows while a conversation has no assistant/usage
+rows, flipping the existing `~`/"includes estimated" markers.
+
+**Approach & decisions.**
+- One shared pure estimator, `estimate_console_next_send_tokens` in
+  `Chat/console_display_state.py` (next to `console_prompted_evidence_text`),
+  routing through `count_tokens_messages` so the number keeps the same
+  semantics as the settings estimate and the chip. Guards: the payload's
+  by-design duplicated `system` field is skipped when `messages` already
+  carries a system row; prose `tools_info` notes contribute nothing; blank
+  extra texts are dropped; all-empty input returns `None` (no count rather
+  than a misleading zero).
+- `ConsoleContextModal` gained an optional `payload_estimate(snapshot)`
+  callable; `_load_snapshot` prefers it post-load and falls back to the
+  draft-only `estimate_factory`. Existing callers/tests that pass only
+  `estimate_factory` behave exactly as before. Also added
+  `watch_token_estimate` — previously the post-load estimate NEVER repainted
+  the header (latent bug found by a TDD regression test; the pre-load value
+  was the only one users ever saw after a refresh).
+- Chip fold-in lives in `ChatScreen._console_first_send_pseudo_rows()` and is
+  gated: blank draft returns `[]` before any state is read (idle tick stays
+  free), and the fold-in stops the moment the session has any assistant row
+  or recorded usage — after a reply the chip is a running total of real
+  spend, and re-adding system/tools would corrupt it. Pseudo-rows reuse the
+  staged-evidence row contract (`usage=None`), so pricing/`~`-marker
+  behavior in `build_cost_snapshot` is untouched.
+
+**Verification.** TDD throughout (every new test watched failing first).
+Targeted: 93 passed across the four directly-touched test files + 56 in the
+adjacent cost/chip files; ruff clean. Live web-UI check via `tldw-serve`
+confirmed the served app runs the new code, the viewer opens through the real
+command-palette path with the payload-based header ("Chat Context (~33
+tokens)" for a context-free session — truthful there: no system prompt, no
+tools), and the chip reads "0 tok" at rest with an empty draft. The
+system-prompt/tools leg could not be staged live (synthetic clicks/modifier
+keys don't reach textual-web's xterm layer; see
+`backlog/docs/lessons-live-verification.md` entry) and is covered by the
+mounted-app tests instead.
+
+**Files changed.** `tldw_chatbook/Chat/console_display_state.py` (estimator),
+`tldw_chatbook/Widgets/Console/console_context_modal.py` (payload_estimate +
+watcher), `tldw_chatbook/UI/Screens/chat_screen.py` (wiring + chip fold-in);
+tests in `Tests/Chat/test_console_display_state.py`,
+`Tests/UI/test_console_context_modal.py`,
+`Tests/UI/test_chat_screen_context_modal.py`,
+`Tests/UI/test_console_cost_chip_screen.py` (also dropped one pre-existing
+unused import the file already had at HEAD).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-25836 - Console-first-send-token-previews-include-context-and-tools.md
+++ b/backlog/tasks/task-25836 - Console-first-send-token-previews-include-context-and-tools.md
@@ -43,12 +43,13 @@ Reason: estimate-only change inside two existing UI surfaces; no schema, sync, p
 
 <!-- SECTION:NOTES:BEGIN -->
 **Summary.** Both Console "tokens" readouts now count what a send actually
-ships. The context viewer's header estimate (`Ctrl+Shift+P`) is computed from
+ships. The Next Send tab's header estimate (`Ctrl+Shift+P`) is computed from
 the loaded `next_send_payload` (system row + messages incl. the draft turn +
 `native_schemas` JSON + staged evidence text) instead of the bare draft; the
-cost chip folds the session system prompt, tool schemas, and the composer
-draft in as estimated pseudo-rows while a conversation has no assistant/usage
-rows, flipping the existing `~`/"includes estimated" markers.
+cost chip folds the session system prompt, tool schemas, effective-memory
+rows, response prefill, and the composer draft in as estimated pseudo-rows
+while a conversation has no assistant/usage rows, flipping the existing
+`~`/"includes estimated" markers.
 
 **Approach & decisions.**
 - One shared pure estimator, `estimate_console_next_send_tokens` in
@@ -57,41 +58,62 @@ rows, flipping the existing `~`/"includes estimated" markers.
   semantics as the settings estimate and the chip. Guards: the payload's
   by-design duplicated `system` field is skipped when `messages` already
   carries a system row; prose `tools_info` notes contribute nothing; blank
-  extra texts are dropped; all-empty input returns `None` (no count rather
-  than a misleading zero).
-- `ConsoleContextModal` gained an optional `payload_estimate(snapshot)`
-  callable; `_load_snapshot` prefers it post-load and falls back to the
-  draft-only `estimate_factory`. Existing callers/tests that pass only
-  `estimate_factory` behave exactly as before. Also added
-  `watch_token_estimate` — previously the post-load estimate NEVER repainted
-  the header (latent bug found by a TDD regression test; the pre-load value
-  was the only one users ever saw after a refresh).
-- Chip fold-in lives in `ChatScreen._console_first_send_pseudo_rows()` and is
-  gated: blank draft returns `[]` before any state is read (idle tick stays
-  free), and the fold-in stops the moment the session has any assistant row
-  or recorded usage — after a reply the chip is a running total of real
-  spend, and re-adding system/tools would corrupt it. Pseudo-rows reuse the
-  staged-evidence row contract (`usage=None`), so pricing/`~`-marker
-  behavior in `build_cost_snapshot` is untouched.
+  extra texts are dropped; schemas that fail to serialize degrade to "no
+  tools row" rather than raising; all-empty input returns `None` (no count
+  rather than a misleading zero).
+- `ConsoleConversationInspector` (dev's unified Costs/Exchange/Next Send
+  modal) gained an optional `payload_estimate(snapshot)` kwarg threaded
+  through `_push_console_inspector`; `_load_snapshot` prefers it post-load
+  and falls back to the draft-only `estimate_factory`. Existing
+  callers/tests that pass only `estimate_factory` behave exactly as before.
+  (On the feature branch the standalone `ConsoleContextModal` got the
+  equivalent change plus a `watch_token_estimate` repaint fix for a latent
+  staleness bug dev's port had already solved by ordering.)
+- Chip fold-in lives in `ChatScreen._console_first_send_pseudo_rows()` and
+  is gated: blank draft returns `[]` before any state is read (idle tick
+  stays free), and the fold-in stops the moment the session has any
+  assistant row or recorded usage — after a reply the chip is a running
+  total of real spend, and re-adding system/tools would corrupt it.
+  Pseudo-rows reuse the staged-evidence row contract (`usage=None`), so
+  pricing/`~`-marker behavior in `build_cost_snapshot` is untouched.
+- Qodo review round (PR #2261), all four findings addressed:
+  1. Undercount — the fold-in now resolves effective memory through the
+     controller's own `_project_session_effective_memory` and the response
+     prefill through `_resolve_submit_prefill` (both synchronous,
+     read-only; the preview path uses the same seams) instead of
+     re-deriving partial context.
+  2. High: mouse-send race double-count — when the trailing transcript row
+     is a user message with the draft's exact text (send in flight, draft
+     not yet cleared), the draft pseudo-row is dropped; the persisted row
+     is what the chip prices.
+  3. Unguarded `json.dumps` — serialization failures in the estimator skip
+     the tools row instead of propagating.
+  4. Session-scoped staged evidence — `_console_next_send_token_estimate`
+     gates the screen-global pending launch on the captured session still
+     being active, mirroring `_console_settings_context_estimate_for_session`.
+- Task ID renumbered 21513 → 25836: dev's Daily-Reports task had taken 21513
+  between branch creation and the PR (the exact collision class the
+  `docs/lesson-adr-number-collisions` work tracks).
 
 **Verification.** TDD throughout (every new test watched failing first).
-Targeted: 93 passed across the four directly-touched test files + 56 in the
-adjacent cost/chip files; ruff clean. Live web-UI check via `tldw-serve`
-confirmed the served app runs the new code, the viewer opens through the real
-command-palette path with the payload-based header ("Chat Context (~33
-tokens)" for a context-free session — truthful there: no system prompt, no
-tools), and the chip reads "0 tok" at rest with an empty draft. The
-system-prompt/tools leg could not be staged live (synthetic clicks/modifier
-keys don't reach textual-web's xterm layer; see
-`backlog/docs/lessons-live-verification.md` entry) and is covered by the
-mounted-app tests instead.
+On dev's base: 112 passed across the touched test files (estimator
+counting/guards incl. serialization degradation, inspector header
+payload-preference + fallback, chip fold-in content/gating/stop-after-reply,
+race skip, prefill/memory inclusion, staged-evidence session gate) plus the
+backlog task-ID uniqueness guard; ruff clean. Two failures in
+`test_console_inspector_navigation.py` reproduce on clean dev — pre-existing.
+Live web-UI check via `tldw-serve` (on the branch build) confirmed the served
+app runs the new code end-to-end; the system-prompt/tools leg is covered by
+the mounted-app tests (browser automation can't deliver synthetic
+clicks/modifier keys to textual-web's xterm layer — see
+`backlog/docs/lessons-live-verification.md`).
 
-**Files changed.** `tldw_chatbook/Chat/console_display_state.py` (estimator),
-`tldw_chatbook/Widgets/Console/console_context_modal.py` (payload_estimate +
-watcher), `tldw_chatbook/UI/Screens/chat_screen.py` (wiring + chip fold-in);
-tests in `Tests/Chat/test_console_display_state.py`,
-`Tests/UI/test_console_context_modal.py`,
-`Tests/UI/test_chat_screen_context_modal.py`,
-`Tests/UI/test_console_cost_chip_screen.py` (also dropped one pre-existing
-unused import the file already had at HEAD).
+**Files changed (dev port, PR #2261).**
+`tldw_chatbook/Chat/console_display_state.py` (estimator + json guard),
+`tldw_chatbook/Widgets/Console/console_conversation_inspector.py`
+(payload_estimate), `tldw_chatbook/UI/Screens/chat_screen.py` (wiring,
+session-gated staged evidence, chip fold-in with memory/prefill/race
+handling); tests in `Tests/Chat/test_console_display_state.py`,
+`Tests/UI/test_console_conversation_inspector.py`,
+`Tests/UI/test_console_cost_chip_screen.py`.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-25836 - Console-first-send-token-previews-include-context-and-tools.md
+++ b/backlog/tasks/task-25836 - Console-first-send-token-previews-include-context-and-tools.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-21513
+id: TASK-25836
 title: Console first-send token previews include context and tools
 status: Done
 assignee:

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -1067,9 +1067,17 @@ def estimate_console_next_send_tokens(
         else None
     )
     if schemas:
-        rows.append(
-            {"role": "system", "content": json.dumps(schemas, default=str)}
-        )
+        # Serialization is guarded, not assumed: a schema object whose
+        # repr raises (or a cyclic structure a provider handed back) must
+        # degrade to "no tools row" rather than propagate out of the
+        # estimator -- "no count is better than a wrong one" cuts both
+        # ways.
+        try:
+            schemas_text = json.dumps(schemas, default=str)
+        except (TypeError, ValueError):
+            schemas_text = ""
+        if schemas_text:
+            rows.append({"role": "system", "content": schemas_text})
     for text in extra_texts:
         if str(text).strip():
             rows.append({"role": "user", "content": text})

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -1001,7 +1001,7 @@ def estimate_console_next_send_tokens(
 ) -> Optional[int]:
     """Estimate the tokens the next Console send will actually carry.
 
-    task-21513: the Next Send tab's "~N tokens" header estimated the
+    task-25836: the Next Send tab's "~N tokens" header estimated the
     composer draft alone, so a first message in a fresh conversation read
     "~3 tokens" while the real request ships the system prompt,
     project-instruction bodies, tool schemas, and staged evidence on top of

--- a/tldw_chatbook/Chat/console_display_state.py
+++ b/tldw_chatbook/Chat/console_display_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 from html import escape as html_escape
@@ -28,6 +29,7 @@ from tldw_chatbook.RAG_Search.local_citation_capture import (
     normalize_console_evidence_references,
 )
 from tldw_chatbook.UI.character_display_text import sanitize_character_display_label
+from tldw_chatbook.Utils.token_counter import count_tokens_messages
 
 CONSOLE_INSPECTOR_REVIEW_APPROVAL_ID = "console-inspector-review-approval"
 CONSOLE_INSPECTOR_REVIEW_APPROVAL_LABEL = "Review approval"
@@ -986,6 +988,94 @@ def console_prompted_evidence_text(launch: ConsoleLiveWorkLaunch | None) -> str:
     """
     formatted = _console_prompted_evidence_context(launch)
     return formatted.context if formatted is not None else ""
+
+
+def estimate_console_next_send_tokens(
+    *,
+    payload_messages: Sequence[Mapping[str, Any]] = (),
+    payload_system: Any = None,
+    tools_info: Mapping[str, Any] | None = None,
+    extra_texts: Sequence[str] = (),
+    model: str = "",
+    provider: str = "",
+) -> Optional[int]:
+    """Estimate the tokens the next Console send will actually carry.
+
+    task-21513: the Next Send tab's "~N tokens" header estimated the
+    composer draft alone, so a first message in a fresh conversation read
+    "~3 tokens" while the real request ships the system prompt,
+    project-instruction bodies, tool schemas, and staged evidence on top of
+    the draft. This estimator counts the assembled request: every payload
+    message row (which already includes the leading system row and a
+    synthetic draft turn), the native tool schemas as JSON (tool
+    definitions are request tokens; ``tools_info``'s prose notes are not),
+    and any ``extra_texts`` (e.g. staged evidence text, which the preview
+    payload lists as label-only metadata) as one user row each.
+
+    All counting routes through :func:`count_tokens_messages` -- the same
+    real counter (custom tokenizer -> tiktoken -> chars floor, with
+    per-message framing) the settings estimate and cost chip already use --
+    so the number stays an estimate with consistent semantics everywhere it
+    appears.
+
+    Args:
+        payload_messages: ``next_send_payload["messages"]`` rows (role +
+            content; content may be a provider part-list for multimodal
+            turns, which the counter normalizes).
+        payload_system: ``next_send_payload["system"]`` -- a list of
+            message rows that DUPLICATES the leading system row when one is
+            present in ``payload_messages`` (the snapshot's by-design
+            duplication). Counted only when ``payload_messages`` carries no
+            system row of its own, so the prompt is never double-counted.
+        tools_info: ``next_send_payload["tools"]``; only its
+            ``native_schemas`` entries contribute.
+        extra_texts: Additional texts the send carries outside the payload
+            messages; blank/whitespace entries are ignored.
+        model: Model name (selects the tokenizer and framing convention).
+        provider: Provider name (selects the chars-floor ratio when no
+            tokenizer is installed).
+
+    Returns:
+        The estimated token count, or ``None`` when there is nothing to
+        send (no message rows, no schemas, no non-blank extra texts) -- the
+        caller renders no count rather than a misleading zero.
+    """
+    rows: list[dict[str, Any]] = []
+    for message in payload_messages:
+        if not isinstance(message, Mapping):
+            continue
+        rows.append(
+            {
+                "role": message.get("role", ""),
+                "content": message.get("content", ""),
+            }
+        )
+    if not any(row["role"] == "system" for row in rows) and isinstance(
+        payload_system, (list, tuple)
+    ):
+        for message in payload_system:
+            if isinstance(message, Mapping):
+                rows.append(
+                    {
+                        "role": message.get("role", "system"),
+                        "content": message.get("content", ""),
+                    }
+                )
+    schemas = (
+        tools_info.get("native_schemas")
+        if isinstance(tools_info, Mapping)
+        else None
+    )
+    if schemas:
+        rows.append(
+            {"role": "system", "content": json.dumps(schemas, default=str)}
+        )
+    for text in extra_texts:
+        if str(text).strip():
+            rows.append({"role": "user", "content": text})
+    if not rows:
+        return None
+    return count_tokens_messages(rows, model, provider)
 
 
 @dataclass(frozen=True)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -336,6 +336,7 @@ from ...Chat.console_display_state import (
     console_prompted_evidence_text,
     console_prompted_source_count,
     console_staged_source_count,
+    estimate_console_next_send_tokens,
 )
 from ...Chat.console_onboarding_state import (
     ConsoleSetupCardState,
@@ -4452,6 +4453,11 @@ class ChatScreen(BaseAppScreen):
             estimate_factory=estimate_factory,
             token_estimate=token_estimate,
             in_progress=in_progress,
+            # task-21513: once the snapshot loads, the Next Send header
+            # count switches from the draft-only pre-load value to the whole
+            # next-send request (system + messages + tools + staged
+            # evidence) this estimate computes from the payload.
+            payload_estimate=self._console_next_send_token_estimate,
             **project_instruction_ui.project_instruction_context_kwargs(
                 self, controller, session_id
             ),
@@ -4529,6 +4535,39 @@ class ChatScreen(BaseAppScreen):
         if not text:
             return None
         return estimate_tokens(text, "", "")
+
+    def _console_next_send_token_estimate(
+        self, snapshot: Any
+    ) -> Optional[int]:
+        """Estimate the tokens the snapshot's next-send payload will ship.
+
+        task-21513: the Next Send header's count must answer "what is this
+        message about to send", which on a first message is dominated by the
+        system prompt, project-instruction bodies, tool schemas, and staged
+        evidence -- none of which the draft-only estimate sees. Counted via
+        the shared pure estimator (:func:`estimate_console_next_send_tokens`)
+        over the assembled payload, plus the staged evidence text the
+        preview payload carries only as label-only metadata (the same
+        zero-I/O seam ``console_prompted_evidence_text`` the settings
+        estimate and cost chip already read). Degrades to ``None`` on an
+        assembly-error payload -- no count is better than a wrong one.
+        """
+        payload = getattr(snapshot, "next_send_payload", None)
+        if not isinstance(payload, dict) or payload.get("error"):
+            return None
+        provider, model, _settings = self._active_console_provider_model_display()
+        return estimate_console_next_send_tokens(
+            payload_messages=payload.get("messages") or [],
+            payload_system=payload.get("system"),
+            tools_info=payload.get("tools"),
+            extra_texts=(
+                console_prompted_evidence_text(
+                    self._pending_console_launch_context
+                ),
+            ),
+            model=model or "",
+            provider=provider or "",
+        )
 
     async def action_jump_console_tab(self, number: int) -> None:
         """Jump directly to the Nth native Console session tab (Alt+1..9).
@@ -8238,6 +8277,68 @@ class ChatScreen(BaseAppScreen):
             system_prompt_set=bool(getattr(settings, "system_prompt", None)),
         )
 
+    def _console_first_send_pseudo_rows(self) -> list[Any]:
+        """Return estimated rows for the context a FIRST send will ship.
+
+        task-21513: while a conversation has no answered/billed turns, the
+        next request carries the session system prompt, the native tool
+        schemas, and the composer draft -- none of which are transcript
+        rows, so the cost chip under-reported a first send as "0 tok".
+        Returns duck-typed rows (``.role``/``.content``/``.usage=None``,
+        the same contract as the staged-evidence pseudo-row) that
+        ``build_cost_snapshot`` prices through its ESTIMATED-row branch,
+        flipping `has_estimated_entries` so the chip's ``~`` honesty marker
+        shows.
+
+        Empty when no send is pending: a blank draft short-circuits before
+        any state is read (the steady-state cost of this on the sync tick
+        is one composer read), and the fold-in stops the moment the session
+        has ANY assistant row or recorded usage -- after that the chip is a
+        running total of what was actually sent, and re-adding
+        system/tools per tick would corrupt it.
+        """
+        composer = self._console_composer_or_none()
+        draft = composer.draft_text() if composer is not None else ""
+        if not str(draft).strip():
+            return []
+        store = self._console_chat_store
+        session_id = store.active_session_id if store is not None else None
+        if session_id is None:
+            return []
+        try:
+            messages = store.messages_for_session(session_id)
+        except KeyError:
+            return []
+        for message in messages:
+            if getattr(message, "usage", None) is not None:
+                return []
+            if str(getattr(message.role, "value", message.role)) == "assistant":
+                return []
+        rows: list[Any] = []
+        settings = self._session._active_console_session_settings()
+        system_prompt = str(getattr(settings, "system_prompt", "") or "")
+        if system_prompt.strip():
+            rows.append(
+                SimpleNamespace(role="system", content=system_prompt, usage=None)
+            )
+        try:
+            bridge = self._ensure_console_agent_bridge()
+            schemas = (
+                bridge.native_tool_schemas()
+                if bridge is not None and hasattr(bridge, "native_tool_schemas")
+                else []
+            )
+        except Exception:
+            schemas = []
+        if schemas:
+            rows.append(
+                SimpleNamespace(
+                    role="system", content=json.dumps(schemas, default=str), usage=None
+                )
+            )
+        rows.append(SimpleNamespace(role="user", content=draft, usage=None))
+        return rows
+
     def _build_console_cost_state(self) -> ConsoleCostState | None:
         """Build the cost chip's display state for the active session (task-5).
 
@@ -8286,6 +8387,17 @@ class ChatScreen(BaseAppScreen):
                 snapshot_messages = snapshot_messages + [
                     SimpleNamespace(role="user", content=staged_text, usage=None)
                 ]
+            # task-21513: a FIRST send ships the session system prompt, tool
+            # schemas, and the draft itself on top of the staged evidence
+            # above -- none of which existed as transcript rows, so a
+            # brand-new conversation with a typed draft still read "0 tok".
+            # Same pseudo-row treatment as the staged evidence: folded in
+            # only while the session has nothing answered/billed yet (see
+            # `_console_first_send_pseudo_rows`), so the running-total
+            # semantics after a reply are untouched.
+            first_send_rows = self._console_first_send_pseudo_rows()
+            if first_send_rows:
+                snapshot_messages = snapshot_messages + first_send_rows
             provider, model, _settings = self._active_console_provider_model_display()
             # PR2b Task 5 (cost rollup): the active conversation's LIVE
             # sub-agent fleet spend, folded into the snapshot's token total
@@ -8785,6 +8897,7 @@ class ChatScreen(BaseAppScreen):
         snapshot_factory: Callable[[], Awaitable[ConsoleContextSnapshot]],
         estimate_factory: Callable[[], int | None] | None = None,
         token_estimate: int | None = None,
+        payload_estimate: Callable[[ConsoleContextSnapshot], int | None] | None = None,
         in_progress: bool = False,
         project_instruction_state: ConsoleProjectInstructionState | None = None,
         project_instruction_state_factory: Callable[
@@ -8828,6 +8941,7 @@ class ChatScreen(BaseAppScreen):
             snapshot_factory=snapshot_factory,
             token_estimate=token_estimate,
             estimate_factory=estimate_factory,
+            payload_estimate=payload_estimate,
             in_progress=in_progress,
             ephemeral=self._console_active_session_is_ephemeral(),
             initial_tab=initial_tab,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4456,8 +4456,15 @@ class ChatScreen(BaseAppScreen):
             # task-25836: once the snapshot loads, the Next Send header
             # count switches from the draft-only pre-load value to the whole
             # next-send request (system + messages + tools + staged
-            # evidence) this estimate computes from the payload.
-            payload_estimate=self._console_next_send_token_estimate,
+            # evidence) this estimate computes from the payload. The
+            # session is captured so a session switch behind the open
+            # inspector cannot splice the wrong session's staged evidence
+            # into the estimate.
+            payload_estimate=lambda snapshot: (
+                self._console_next_send_token_estimate(
+                    snapshot, session_id=session_id
+                )
+            ),
             **project_instruction_ui.project_instruction_context_kwargs(
                 self, controller, session_id
             ),
@@ -4537,7 +4544,7 @@ class ChatScreen(BaseAppScreen):
         return estimate_tokens(text, "", "")
 
     def _console_next_send_token_estimate(
-        self, snapshot: Any
+        self, snapshot: Any, session_id: Optional[str] = None
     ) -> Optional[int]:
         """Estimate the tokens the snapshot's next-send payload will ship.
 
@@ -4551,10 +4558,24 @@ class ChatScreen(BaseAppScreen):
         zero-I/O seam ``console_prompted_evidence_text`` the settings
         estimate and cost chip already read). Degrades to ``None`` on an
         assembly-error payload -- no count is better than a wrong one.
+
+        ``session_id`` is the session the snapshot was captured for; the
+        screen-global staged launch is folded in ONLY while that session is
+        still the active one, mirroring
+        ``_console_settings_context_estimate_for_session``'s
+        ``include_active_staging`` gate -- a session switch behind an open
+        inspector must not splice the new session's staged evidence into
+        the old session's estimate.
         """
         payload = getattr(snapshot, "next_send_payload", None)
         if not isinstance(payload, dict) or payload.get("error"):
             return None
+        include_staged = True
+        if session_id is not None:
+            store = self._console_chat_store
+            include_staged = (
+                store is not None and store.active_session_id == session_id
+            )
         provider, model, _settings = self._active_console_provider_model_display()
         return estimate_console_next_send_tokens(
             payload_messages=payload.get("messages") or [],
@@ -4564,7 +4585,9 @@ class ChatScreen(BaseAppScreen):
                 console_prompted_evidence_text(
                     self._pending_console_launch_context
                 ),
-            ),
+            )
+            if include_staged
+            else (),
             model=model or "",
             provider=provider or "",
         )
@@ -8282,13 +8305,18 @@ class ChatScreen(BaseAppScreen):
 
         task-25836: while a conversation has no answered/billed turns, the
         next request carries the session system prompt, the native tool
-        schemas, and the composer draft -- none of which are transcript
-        rows, so the cost chip under-reported a first send as "0 tok".
-        Returns duck-typed rows (``.role``/``.content``/``.usage=None``,
-        the same contract as the staged-evidence pseudo-row) that
-        ``build_cost_snapshot`` prices through its ESTIMATED-row branch,
-        flipping `has_estimated_entries` so the chip's ``~`` honesty marker
-        shows.
+        schemas, the effective-memory rows, an optional response prefill,
+        and the composer draft -- none of which are transcript rows, so the
+        cost chip under-reported a first send as "0 tok". Memory and
+        prefill are resolved through the controller's own read-only seams
+        (``_project_session_effective_memory`` /
+        ``_resolve_submit_prefill`` -- the same projections the real
+        assembly uses) rather than re-derived here, so the estimate tracks
+        what dispatch would actually carry. Returns duck-typed rows
+        (``.role``/``.content``/``.usage=None``, the same contract as the
+        staged-evidence pseudo-row) that ``build_cost_snapshot`` prices
+        through its ESTIMATED-row branch, flipping
+        ``has_estimated_entries`` so the chip's ``~`` honesty marker shows.
 
         Empty when no send is pending: a blank draft short-circuits before
         any state is read (the steady-state cost of this on the sync tick
@@ -8296,6 +8324,12 @@ class ChatScreen(BaseAppScreen):
         has ANY assistant row or recorded usage -- after that the chip is a
         running total of what was actually sent, and re-adding
         system/tools per tick would corrupt it.
+
+        The DRAFT row is dropped when the trailing transcript row is a
+        user message carrying the same text: that is the mouse-send window
+        where the real user row is already persisted (and priced) but the
+        composer draft is not cleared until the send completes -- appending
+        the draft again would double-count it.
         """
         composer = self._console_composer_or_none()
         draft = composer.draft_text() if composer is not None else ""
@@ -8314,6 +8348,19 @@ class ChatScreen(BaseAppScreen):
                 return []
             if str(getattr(message.role, "value", message.role)) == "assistant":
                 return []
+        # Qodo review finding 2 (mouse-send race): with no assistant/usage
+        # rows, a trailing user row whose content matches the draft means
+        # the send is already in flight and the draft is persisted as a
+        # real (estimated) row -- re-adding it here would double-count.
+        draft_pending = True
+        if messages:
+            last = messages[-1]
+            if (
+                str(getattr(last.role, "value", last.role)) == "user"
+                and str(getattr(last, "content", "") or "").strip()
+                == str(draft).strip()
+            ):
+                draft_pending = False
         rows: list[Any] = []
         settings = self._session._active_console_session_settings()
         system_prompt = str(getattr(settings, "system_prompt", "") or "")
@@ -8336,7 +8383,44 @@ class ChatScreen(BaseAppScreen):
                     role="system", content=json.dumps(schemas, default=str), usage=None
                 )
             )
-        rows.append(SimpleNamespace(role="user", content=draft, usage=None))
+        # Qodo review finding 1: fold the controller's own effective-memory
+        # and prefill projections in rather than under-counting a
+        # configured session. Both seams are synchronous and read-only
+        # (the preview path uses them the same way, without consuming the
+        # one-shot); best-effort, since a chip estimate must never raise.
+        controller = self._console_chat_controller
+        try:
+            projection_rows = [
+                {"role": str(getattr(row.role, "value", row.role)), "content": row.content}
+                for row in rows
+            ]
+            _effective, projection = (
+                controller._project_session_effective_memory(
+                    session_id, projection_rows
+                )
+            )
+            for memory_row in projection.memory:
+                content = memory_row.get("content", "")
+                if str(content).strip():
+                    rows.append(
+                        SimpleNamespace(
+                            role=memory_row.get("role", "system"),
+                            content=content,
+                            usage=None,
+                        )
+                    )
+        except Exception:
+            pass
+        try:
+            prefill, _from_one_shot = controller._resolve_submit_prefill(session_id)
+        except Exception:
+            prefill = None
+        if prefill and str(prefill).strip():
+            rows.append(
+                SimpleNamespace(role="assistant", content=prefill, usage=None)
+            )
+        if draft_pending:
+            rows.append(SimpleNamespace(role="user", content=draft, usage=None))
         return rows
 
     def _build_console_cost_state(self) -> ConsoleCostState | None:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -4453,7 +4453,7 @@ class ChatScreen(BaseAppScreen):
             estimate_factory=estimate_factory,
             token_estimate=token_estimate,
             in_progress=in_progress,
-            # task-21513: once the snapshot loads, the Next Send header
+            # task-25836: once the snapshot loads, the Next Send header
             # count switches from the draft-only pre-load value to the whole
             # next-send request (system + messages + tools + staged
             # evidence) this estimate computes from the payload.
@@ -4541,7 +4541,7 @@ class ChatScreen(BaseAppScreen):
     ) -> Optional[int]:
         """Estimate the tokens the snapshot's next-send payload will ship.
 
-        task-21513: the Next Send header's count must answer "what is this
+        task-25836: the Next Send header's count must answer "what is this
         message about to send", which on a first message is dominated by the
         system prompt, project-instruction bodies, tool schemas, and staged
         evidence -- none of which the draft-only estimate sees. Counted via
@@ -8280,7 +8280,7 @@ class ChatScreen(BaseAppScreen):
     def _console_first_send_pseudo_rows(self) -> list[Any]:
         """Return estimated rows for the context a FIRST send will ship.
 
-        task-21513: while a conversation has no answered/billed turns, the
+        task-25836: while a conversation has no answered/billed turns, the
         next request carries the session system prompt, the native tool
         schemas, and the composer draft -- none of which are transcript
         rows, so the cost chip under-reported a first send as "0 tok".
@@ -8387,7 +8387,7 @@ class ChatScreen(BaseAppScreen):
                 snapshot_messages = snapshot_messages + [
                     SimpleNamespace(role="user", content=staged_text, usage=None)
                 ]
-            # task-21513: a FIRST send ships the session system prompt, tool
+            # task-25836: a FIRST send ships the session system prompt, tool
             # schemas, and the draft itself on top of the staged evidence
             # above -- none of which existed as transcript rows, so a
             # brand-new conversation with a typed draft still read "0 tok".

--- a/tldw_chatbook/Widgets/Console/console_conversation_inspector.py
+++ b/tldw_chatbook/Widgets/Console/console_conversation_inspector.py
@@ -395,7 +395,7 @@ class ConsoleConversationInspector(SafeModalDismissMixin, ModalScreen[None]):
                 tab's header, or ``None``.
             estimate_factory: Re-estimate callback for a Next Send refresh,
                 or ``None``.
-            payload_estimate: task-21513 -- optional callback computing the
+            payload_estimate: task-25836 -- optional callback computing the
                 header count from a LOADED snapshot (the whole next-send
                 request: system row, messages incl. the draft turn, tool
                 schemas, staged evidence), preferred over
@@ -1967,7 +1967,7 @@ class ConsoleConversationInspector(SafeModalDismissMixin, ModalScreen[None]):
             # header text -- assigning the snapshot first would render
             # with the PRIOR estimate, one refresh stale (a real bug in
             # the retired standalone context modal this was ported from).
-            # task-21513: prefer the payload-based estimate (the whole
+            # task-25836: prefer the payload-based estimate (the whole
             # next-send request -- system row, messages incl. the draft
             # turn, tool schemas, staged evidence) over the draft-only
             # factory; fall back to the factory when the payload yields

--- a/tldw_chatbook/Widgets/Console/console_conversation_inspector.py
+++ b/tldw_chatbook/Widgets/Console/console_conversation_inspector.py
@@ -355,6 +355,7 @@ class ConsoleConversationInspector(SafeModalDismissMixin, ModalScreen[None]):
         snapshot_factory: SnapshotFactory,
         token_estimate: int | None = None,
         estimate_factory: Callable[[], int | None] | None = None,
+        payload_estimate: Callable[[ConsoleContextSnapshot], int | None] | None = None,
         in_progress: bool = False,
         ephemeral: bool = False,
         project_instruction_state: ConsoleProjectInstructionState | None = None,
@@ -394,6 +395,13 @@ class ConsoleConversationInspector(SafeModalDismissMixin, ModalScreen[None]):
                 tab's header, or ``None``.
             estimate_factory: Re-estimate callback for a Next Send refresh,
                 or ``None``.
+            payload_estimate: task-21513 -- optional callback computing the
+                header count from a LOADED snapshot (the whole next-send
+                request: system row, messages incl. the draft turn, tool
+                schemas, staged evidence), preferred over
+                ``estimate_factory`` once the snapshot arrives; ``None``
+                keeps the draft-only ``estimate_factory`` contract exactly
+                as before.
             in_progress: Whether a response is currently in flight (shows
                 the Next Send tab's in-progress warning line and disables
                 its Refresh button).
@@ -460,6 +468,7 @@ class ConsoleConversationInspector(SafeModalDismissMixin, ModalScreen[None]):
         self._snapshot_factory = snapshot_factory
         self._token_estimate = token_estimate
         self._estimate_factory = estimate_factory
+        self._payload_estimate = payload_estimate
         self._in_progress = in_progress
         self._ephemeral = ephemeral
         self._project_instruction_state = project_instruction_state
@@ -1958,7 +1967,20 @@ class ConsoleConversationInspector(SafeModalDismissMixin, ModalScreen[None]):
             # header text -- assigning the snapshot first would render
             # with the PRIOR estimate, one refresh stale (a real bug in
             # the retired standalone context modal this was ported from).
-            if self._estimate_factory is not None:
+            # task-21513: prefer the payload-based estimate (the whole
+            # next-send request -- system row, messages incl. the draft
+            # turn, tool schemas, staged evidence) over the draft-only
+            # factory; fall back to the factory when the payload yields
+            # nothing estimable (e.g. an assembly-error payload).
+            if self._payload_estimate is not None:
+                payload_tokens = self._payload_estimate(new_snapshot)
+                if payload_tokens is not None:
+                    self._token_estimate = payload_tokens
+                elif self._estimate_factory is not None:
+                    self._token_estimate = self._estimate_factory()
+                else:
+                    self._token_estimate = None
+            elif self._estimate_factory is not None:
                 self._token_estimate = self._estimate_factory()
             self.snapshot = new_snapshot
             self.call_after_refresh(self._focus_initial_control)


### PR DESCRIPTION
## What

Both of the Console's "tokens" readouts counted only the composer draft, so while writing a first message in a fresh conversation the Next Send header read "~3 tokens" and the cost chip read "0 tok" — while the actual request ships the system prompt, project-instruction bodies, tool schemas, and staged evidence on top of the draft.

- **Shared pure estimator** `estimate_console_next_send_tokens` (`Chat/console_display_state.py`): counts the assembled next-send request — payload messages (incl. leading system row and the synthetic draft turn), native tool schemas as JSON, staged evidence text — through `count_tokens_messages`, with a no-double-count guard for the payload's by-design duplicated `system` field. All-empty input returns `None` (no count rather than a misleading zero).
- **Next Send tab** (`ConsoleConversationInspector`): new optional `payload_estimate` callable, preferred over the draft-only `estimate_factory` once the snapshot loads; falls back to the factory for nothing-estimable payloads (e.g. assembly errors). Existing callers keep the old contract unchanged.
- **Cost chip** (`ChatScreen._build_console_cost_state`): folds the session system prompt, tool schemas, and the current draft in as estimated pseudo-rows (same contract as the existing staged-evidence row) while the session has no assistant/usage rows; stops the moment a reply exists so the running total of real spend is untouched. Blank draft gates the whole fold-in before any state is read, so the idle sync cost is one composer read.

## Verification

- TDD: every new test was watched failing first.
- Targeted: 105 passed across `test_console_display_state.py`, `test_console_conversation_inspector.py`, `test_console_cost_chip_screen.py` (15 new tests: estimator counting/guards, header payload-preference + fallback, chip fold-in content/gating/stop-after-reply, screen wiring); plus 78 passed in adjacent cost/inspector files. Ruff clean.
- Two failures in `test_console_inspector_navigation.py` reproduce on clean `dev` without this branch — pre-existing.
- Live web-UI check (`tldw-serve`): the served app runs the new code end-to-end; the viewer opened through the real command-palette path with the payload-based header count, and the chip gates correctly at rest. The system-prompt/tools scenario is covered by the mounted-app tests (browser automation can't deliver synthetic clicks/modifier keys to textual-web's xterm layer).

## Notes

- Ported onto `dev`'s surfaces (`dev` uses the unified `ConsoleConversationInspector`, not the standalone context modal that exists on other branches).
- ADR: not required — estimate-only change inside two existing UI surfaces; no schema/sync/provider-boundary decision. Recorded in the task file.
- Task: TASK-21513 (ACs all checked, implementation notes included).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Console's first-send token readouts so they estimate the whole request a send ships, not just the composer draft. A new conversation with a typed draft previously showed "~3 tokens" in the Next Send header and "0 tok" in the cost chip; both now include the system prompt, tool schemas, and staged evidence (TASK-25836, renumbered from 21513 which Daily-Reports took on dev).

- `estimate_console_next_send_tokens` in `Chat/console_display_state.py` counts payload messages, tool-schema JSON, and staged evidence via `count_tokens_messages`, avoids double-counting the payload's duplicated `system` field, and skips schemas that fail to serialize.
- The Next Send header prefers the payload-based estimate once the snapshot loads and falls back to the draft-only factory; callers without a `payload_estimate` keep the old behavior.
- The cost chip folds in the session system prompt, tool schemas, effective-memory rows, response prefill, and draft as estimated rows only while the session has no assistant or usage rows; once a reply exists it stops so the running spend total is untouched.
- The fold-in drops the draft row when it matches the trailing user row (mouse-send race), gates staged evidence on the captured session, and short-circuits on a blank draft.

<sup>Written for commit a82b48d3281337ed0d407fdc0e18e03355a1e9ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

