### PR TITLE
docs(lessons): record three traps from the Context rail UAT

### DIFF
--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -665,6 +665,40 @@ ancestor and review the exact commit count and branch-range diff.
 
 ---
 
+## A background merge loop must hold a lock — `pkill -f` will not find its sibling
+
+**Incident.** PR #2260, 2026-08-31. I started a background merge loop
+(`/tmp/merge3.sh`), decided it was gating wrongly, wrote a replacement
+(`/tmp/merge3b.sh`), and killed the old one with `pkill -f merge3b.sh` — the
+NEW script's name. `merge3b.sh` is not a substring of `merge3.sh`, so nothing
+matched and the original kept running, invisible, for another forty minutes.
+
+Two loops then ran concurrently against one branch, each doing
+`fetch` → `rebase` → `push --force-with-lease`. The older one rebased my branch
+out from under a commit I had just pushed, leaving local and origin diverged
+(7 commits vs 4) with no error anywhere. Nothing was lost, but only by luck:
+branch protection refused its merge attempt, and its second pass happened to
+stop on an unrelated preflight failure instead of force-pushing through.
+
+That preflight failure was itself real and load-bearing — a `TASK-25713`
+collision with a task `dev` had landed fifteen minutes earlier — so the rogue
+loop caught, by accident, a problem I would otherwise have force-pushed past.
+
+**What to do.** Any background loop that mutates git state takes a single-instance
+lock (`mkdir /tmp/<name>.lock` succeeds atomically; `trap 'rmdir' EXIT` releases
+it) so a second copy exits instead of racing. Kill by the pattern you actually
+started (`pkill -f merge3` matches both), and **verify with `ps` that nothing
+survived** rather than trusting `pkill`'s silence — it is silent both when it
+kills something and when it matches nothing. Give the loop a hard stop on
+rebase conflict or preflight failure rather than letting it push through.
+
+**Corollary for long-lived branches.** A backlog task id reserved locally is not
+reserved on `dev`. Between `backlog task create` and pushing, `dev` can land the
+same id — it did here, by fifteen minutes. Re-run `./scripts/preflight.sh`
+immediately before every push, not just before the first one.
+
+---
+
 ## Related
 
 - `lessons-testing-evidence.md`

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9839,6 +9839,29 @@ messages on both sides.
 anyway, `git diff --stat` before AND after the swap and compare the numbers —
 that is the only cheap detector for both failure modes above.
 
+**Extension — TASK-25715, 2026-08-31: pick the base commit, not `dev`.** The
+worktree method above is right, but "the base" is the commit your work branched
+from, not wherever `dev` is now. Two Console rail tests were failing on my
+branch; I ran them in a pristine `origin/dev` worktree, saw them fail there too,
+and wrote "pre-existing on dev, not from this branch" into a PR body. The
+measurement was real and the conclusion did not follow: `dev` had by then
+absorbed my own two earlier PRs, so red-on-dev could no longer separate someone
+else's regression from mine. Re-run at the pre-branch commit, both tests
+**passed** — meaning I had shipped a claim of innocence I had not tested.
+
+They did turn out to be someone else's, but only a first-parent binary search
+over the 60 merges in between could say so: the header-padding failure came
+from #2220 changing the *Inspector* side of a band the test pins to the Context
+side, and the reveal-queue failure from #2252 resolving `#console-left-rail-body`
+unguarded. The same search is what actively cleared my own merges — which is the
+part "it fails on dev too" can never do.
+
+**What to do.** Once any of your work has merged to the base branch, `dev` is no
+longer a neutral witness about your work. Verify at the commit you branched from,
+and if that is green, bisect — a binary search over first-parent merges costs
+~6 test runs and names a commit, where "pre-existing" names nobody and quietly
+includes you.
+
 ## A focusable widget can be painting nothing (TASK-23100, 2026-08-28)
 
 A UX critique drove the real Schedules create form and found that choosing "Recurring"
@@ -10238,3 +10261,38 @@ merger and to the current base revision. Enforce required checks for
 administrators, require the latest base, and verify the live protection API
 after changing it. The workflow's eventual failure proves the checker works;
 it does not prove the branch was protected at merge time.
+
+---
+
+## A strict gate slower than the base branch's merge cadence punishes eager rebasing
+
+**Incident.** PR #2260, 2026-08-31. The follow-on cost of the fix above. With
+`strict: true`, any movement on `dev` makes an open PR out-of-date, so my merge
+loop rebased and force-pushed the moment it saw itself behind. It never landed.
+
+Measured afterwards: `Derived artifacts reproduce from their sources` is
+`needs: [pr-fast-lane]`, and that lane runs a pytest suite — **~20 minutes**
+end-to-end including shared-pool queue. `dev` was merging every **~13 minutes**
+that day. Each rebase restarted a 20-minute clock that a 13-minute cadence was
+already beating, so the gate never reported for the commit that was still HEAD.
+It had in fact **passed three times** — for `6ab0cf5e`, `8493ddbf` and
+`92e325ec` — each time finishing after I had already replaced the commit it was
+green for. One run went green six minutes *after* I force-pushed past it.
+
+I spent an hour reporting this as CI queue congestion, citing an existing
+backlog task about exactly that, without once opening
+`.github/workflows/derived-artifacts.yml`. The workflow's own header comment
+documents the same pathology from the cancellation side (TASK-21250: 45
+cancelled / 14 success over 60 runs, a 23% success rate for a required check).
+
+**What to do.** Poll and merge the *instant* the gate is green; never rebase
+pre-emptively. Move HEAD only when GitHub itself reports `BEHIND`, and prefer
+`gh pr update-branch` over a rebase + force-push so the commits stay reviewable.
+Check `gh pr merge --auto` first — it removes your reaction time from the race
+entirely — but confirm it is enabled: `enablePullRequestAutoMerge` is off for
+this repository, which is why the polling loop is necessary here.
+
+**Before blaming shared CI, read the workflow file.** `gh run view <id> --json
+jobs` shows whether the job ran and what it was waiting on, and it is the
+difference between "the queue is slow" and "I keep invalidating my own green
+check".


### PR DESCRIPTION
Docs only. DoD item 10 for the Console Context rail work (#2233, #2242, #2260) — three mistakes from that run that generalise past it, each with the incident that produced it.

### 1. "Red on dev" stops proving non-authorship once your own work is in dev

Extends the existing detached-worktree entry, which is right about the *method* and silent about which commit to use as the base.

I verified two failing tests against a pristine `origin/dev`, concluded "pre-existing, not from this branch", and put that in a PR body. `dev` already contained my two earlier PRs, so that comparison could not distinguish someone else's regression from mine. Re-run at the pre-branch commit, **both passed** — I had shipped a claim of innocence I hadn't tested.

A first-parent binary search over the 60 merges between (~6 test runs) named `c2f64f690` (#2220) and `0ef6f3fd4` (#2252) — and actively cleared my own merges, which "it fails on dev too" can never do.

### 2. A strict gate slower than the base branch's cadence punishes eager rebasing

Filed next to TASK-25705, whose fix (`strict: true`) is what makes this reachable.

The required check is `needs: [pr-fast-lane]`, a pytest lane — **~20 min** end to end. `dev` was merging every **~13 min**. My loop rebased whenever it saw itself behind, restarting a clock it was already losing. The check had **passed three times**, each for a commit I'd already force-pushed past; one went green six minutes after I replaced it.

I spent an hour reporting this as CI queue congestion — citing a real backlog task about queue congestion — without opening `.github/workflows/derived-artifacts.yml`. The workflow's own header documents the same pathology from the cancellation side (TASK-21250: 23% success rate for a required check).

### 3. A background git loop needs a single-instance lock

`pkill -f merge3b.sh` does not match `merge3.sh`. The loop I thought I'd killed ran another forty minutes and rebased the branch out from under a commit I'd just pushed, leaving local and origin diverged with no error surfaced.

Nothing was lost, but only by luck — and the rogue loop accidentally caught a real `TASK-25713` id collision that `dev` had landed fifteen minutes earlier, which I'd otherwise have force-pushed past. Hence the corollary: re-run preflight before *every* push, not just the first.

---

No code, no tests, no derived artifacts touched. `preflight`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrN2mbF8byxMfPNPtVJwFb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records three traps from the Console Context rail UAT in the backlog lessons docs. Each entry pairs a concrete incident with a generalizable rule: verifying failures against `dev` no longer proves non-authorship once your own work is merged in, a strict required check slower than the base branch's merge cadence punishes eager rebasing, and background git loops need a single-instance lock. Extends `backlog/docs/lessons-testing-evidence.md` and `backlog/docs/lessons-backlog-hygiene.md`. Docs only — no code, tests, or derived artifacts touched, `preflight` is green.

<sup>Written for commit 39be0600cde182b8601932ab62d757c1c7b77f5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

