### PR TITLE
Add paged recovery viewing to Library Media Trash

### DIFF
--- a/.impeccable/critique/2026-08-30T15-57-07Z__30-task-18918-library-media-trash-paging-design-md.md
+++ b/.impeccable/critique/2026-08-30T15-57-07Z__30-task-18918-library-media-trash-paging-design-md.md
@@ -1,0 +1,112 @@
+---
+target: TASK-18918 Library Media Trash paging design specification
+total_score: 30
+max_score: 40
+na_heuristics:
+p0_count: 0
+p1_count: 4
+timestamp: 2026-08-30T15-57-07Z
+slug: 30-task-18918-library-media-trash-paging-design-md
+---
+# Design Health
+
+| # | Heuristic | Score | Key issue |
+|---|---|---:|---|
+| 1 | Visibility of system status | 3 | Requested versus applied filter state needs fixed visible copy. |
+| 2 | Match system / real world | 3 | Filtered total and local-only authority need explicit labels. |
+| 3 | User control and freedom | 3 | Escape precedence is ambiguous while confirmation is open. |
+| 4 | Consistency and standards | 3 | Pager-originated focus behavior is not pinned to the shipped convention. |
+| 5 | Error prevention | 3 | Permanent-delete confirmation needs explicit mount/focus/activation fencing. |
+| 6 | Recognition rather than recall | 3 | Users need to see which scope the retained rows represent. |
+| 7 | Flexibility and efficiency | 3 | Page/filter completion focus outcomes are underspecified. |
+| 8 | Aesthetic and minimalist design | 3 | 80x24 allocation priorities are outcomes rather than rules. |
+| 9 | Error recovery | 4 | Committed mutation truthfulness and authoritative Retry are strong. |
+| 10 | Help and documentation | 2 | Disabled reasons and filter-validation copy are not yet specified. |
+| **Total** | | **30/40** | **Good, with P1 interaction/contract gaps** |
+
+## Design Specificity Verdict
+
+The design is authored for Chatbook's terminal-native Library: it preserves the
+three-column reader, source-owned paging, dense keyboard workflow, local authority,
+and truthful stale recovery. It is not a generic web Trash screen. The deterministic
+detector returned zero findings, which is expected for a Markdown specification and
+does not validate the runtime contracts.
+
+## Overall Impression
+
+The recovery model is unusually strong: exact pages, fail-closed envelopes, and
+committed-but-unrefreshed mutation states are treated honestly. The main opportunity
+is to make the interaction and service boundaries as exact as the data principles.
+
+## What's Working
+
+- Coherent count, rows, and complete facets prevent unreachable or falsely counted
+  records.
+- Restore and permanent delete cannot be retroactively reported as failed because a
+  follow-up read failed.
+- Trash remains an independent nested source, preserving normal Media scope and
+  avoiding a generic controller.
+
+## Priority Issues
+
+### P1 — Keyboard and focus precedence is ambiguous
+
+Escape is described as both confirmation Cancel and Trash Back, while page completion
+may select/focus the first row even when the pager or filter should retain authority.
+Add a precedence table for confirmation, page, filter, Retry, empty, mutation, and
+Back outcomes.
+
+### P1 — The exact local service and envelope are unnamed
+
+The current legacy Trash seam returns raw IDs and separately read pagination. Name a
+local-only exact scope seam and its payload keys, canonical `local:media:<id>` identity,
+cardinality rules, and explicit prohibition on extending the server API.
+
+### P1 — The immediate post-commit state is not formally stale
+
+Removing one item locally makes a full page contain 19 rows, which cannot satisfy the
+fresh-page invariant. Require the reducer to withdraw exact totals/boundaries and
+enter stale/loading immediately after commit; only the authoritative reload returns
+it to fresh.
+
+### P1 — Permanent deletion needs stronger activation safety
+
+A duplicate or truncated title is insufficient confirmation identity, and a repeated
+Enter could leak from opener to confirm. Show the wrapped full title plus type/deleted
+time, focus Cancel initially, consume opener activation, and require a later explicit
+confirm activation. Pin the call to
+`permanently_delete_media_item(mode="local", media_id=...)`, preserving its existing
+physical cascade/FTS/no-sync behavior.
+
+### P2 — Scope, return, and narrow-layout contracts need exact rules
+
+Define fixed failed-filter copy and Retry target, a distinct stable-row/scroll Trash
+return receipt, SQLite-safe page bounds, stored-type equality/facet sorting, explicit
+NULL-last SQL order, and the 80x24 vertical priority/minimum list viewport. Clarify
+that normal Media keeps scope/selection/focus but becomes stale after Restore rather
+than receiving an unranked row insertion.
+
+## Persona Red Flags
+
+- **Keyboard power user:** Page changes may leave focus or selection on an unexpected
+  target; disabled-action reasons are not yet guaranteed visible.
+- **First-time recovery user:** `Trash (N)` can look like all records rather than
+  matching records, and local authority is not visible.
+- **Failure-recovery user:** Retry does not yet say whether it repeats the failed
+  filter, reloads the prior applied page, or performs a clamp.
+
+## Minor Observations
+
+- State NULL ordering as SQL rather than merely requiring deterministic tests.
+- Label counts as `N matching` under filters and consider a quiet `Local Trash`
+  authority label.
+- Reuse the shipped visible pager-disabled reason convention.
+
+## Questions to Consider
+
+- Should a restored record appear immediately in normal Media without an
+  authoritative ranked read, or should that page become stale until refreshed?
+- At 80x24, which information can collapse without hiding the irreversible
+  consequence or recovery action?
+- When a filter request fails, what exact line proves the rows still belong to the
+  previous applied scope?

--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -242,6 +242,27 @@ until you choose the reset action. Loading and failed refreshes do not use this
 empty presentation: they keep their status, pager authority, and **Retry** so a
 previously empty page cannot hide an in-progress or recoverable request.
 
+#### Media Trash
+
+Open **Trash** from Browse › Media to recover local deleted items. Trash shows
+at most 20 items per page in a stable newest-first order. **Previous** and
+**Next** reach every page; the range and total are exact while the page is
+fresh. A submitted title search and the exact type chooser filter the complete
+Trash collection before paging. During loading or after a failed refresh, the
+last good page can remain visible, but paging and destructive actions stay
+disabled until **Retry** restores authoritative results. Selection belongs only
+to the current page and filter.
+
+**Restore** removes the item from Trash and marks the retained normal Media page
+stale; it does not insert or reorder the restored item without a fresh Media
+read. **Delete permanently** requires inline confirmation and cannot be undone.
+Back returns to the exact normal Media page, selected item, list scroll, and
+control that opened Trash. Returning from the Media viewer likewise restores
+the exact list scroll and finishes focus on the item row. These returns settle
+after the current Items layout is measured, including when the Library rail or
+Items pane is independently collapsed; collapsing the Library rail gives the
+Items title and detail area the reclaimed width.
+
 | Row | Opens | Details on |
 |---|---|---|
 | **Media** | The media list and viewer. | [Media & conversations](library/media-and-conversations.md) |

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -663,8 +663,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 345,
-      "diagnostic_digest": "31ad45dcf6b2ad6eeee9",
+      "call_count": 346,
+      "diagnostic_digest": "7952556b38e4ae0d0022",
       "owner": "TASK-494",
       "path": "tldw_chatbook/DB/Client_Media_DB_v2.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2505,6 +2505,13 @@
     },
     {
       "call_count": 1,
+      "diagnostic_digest": "5000857844237580bf71",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Library_Modules/library_media_trash_browse_controller.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
       "diagnostic_digest": "738ee5f3783f1528d3c2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Library_Modules/library_prompt_browse_controller.py",
@@ -2687,7 +2694,7 @@
     },
     {
       "call_count": 120,
-      "diagnostic_digest": "13a94b37b3c401c7e842",
+      "diagnostic_digest": "bf6d797a14fe17e73c33",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -5287,15 +5294,6 @@
             "db_instance.db_path_str"
           ],
           "scope": "mark_media_as_processed",
-          "status": "legacy_unreviewed"
-        },
-        {
-          "call_digest": "e1d3cb2a299db7ff",
-          "method": "warning",
-          "path_expressions": [
-            "db_instance.db_path_str"
-          ],
-          "scope": "permanently_delete_item",
           "status": "legacy_unreviewed"
         }
       ],
@@ -11109,10 +11107,10 @@
   "schema_version": 3,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 549,
-    "path_privacy_candidate_calls": 712,
+    "owner_files": 550,
+    "path_privacy_candidate_calls": 711,
     "persistent_sink_files": 8,
     "task_492_calls": 1295,
-    "task_494_calls": 7412
+    "task_494_calls": 7414
   }
 }

--- a/Docs/superpowers/plans/2026-08-30-library-media-return-settlement.md
+++ b/Docs/superpowers/plans/2026-08-30-library-media-return-settlement.md
@@ -265,7 +265,7 @@ Retain the existing consumer assertion in `test_library_media_side_by_side.py`; 
 
 /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
   Tests/UI/test_library_media_side_by_side.py \
-  -k 'media_recompose_restores_exact_row_and_scroll_after_other_reader_round_trip'
+  -k 'compact_media_viewer_back_survives_authoritative_recompose'
 ```
 
 Expected: the new protocol tests fail because it does not exist, and the established consumer can reproduce `(0, 33) != (0, 42)` in a fresh process.
@@ -297,7 +297,7 @@ Run the exact consumer five times with isolated pytest temp roots:
 for run in 1 2 3 4 5; do
   /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
     Tests/UI/test_library_media_side_by_side.py \
-    -k 'media_recompose_restores_exact_row_and_scroll_after_other_reader_round_trip' \
+    -k 'compact_media_viewer_back_survives_authoritative_recompose' \
     --basetemp="/tmp/task18918-media-return-${run}"
 done
 ```

--- a/Docs/superpowers/plans/2026-08-30-library-media-return-settlement.md
+++ b/Docs/superpowers/plans/2026-08-30-library-media-return-settlement.md
@@ -1,0 +1,555 @@
+# Library Media Return Settlement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Apply `superpowers:test-driven-development` to every behavior change and `superpowers:verification-before-completion` before each completion claim.
+
+**Goal:** Make normal-Media returns deterministically restore the retained page, semantic row, final focus identity, and exact list scroll after a Trash round trip or authoritative same-scope recompose.
+
+**Architecture:** Correct the Media presentation producer first so replacement stages use the adaptive Media class contract from their first frame. Add one Media-owned row-scroll geometry message derived from the owner's public Textual `Resize`, then let `LibraryScreen` settle an immutable, generation-fenced return request only when current-owner geometry proves the retained offset. Scroll is applied and verified before final focus; bounded failure is honest and non-recursive.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, immutable dataclasses, pytest/pytest-asyncio, Ruff, existing Library live harnesses.
+
+**Spec:** `Docs/superpowers/specs/2026-08-30-library-media-return-settlement-design.md`
+
+**ADR required:** yes
+
+**ADR path:** `backlog/decisions/104-library-media-return-settlement-boundary.md`
+
+**Reason:** The repair establishes a durable cross-module boundary between a Media widget's public geometry event and `LibraryScreen` navigation/focus authority, and amends the adaptive reader lifecycle.
+
+## Global constraints
+
+- `LibraryScreen` owns receipts, request identity, presentation epoch, authority fences, timeout, final-focus policy, and settlement outcomes. The Media scroll widget reports geometry only.
+- Compose must project the correct Media stage classes before yielding the replacement shell. Post-mount reconciliation is equality-based and does not create work when unchanged.
+- Textual `Resize` is the sole geometry-readiness producer after the application presentation gate. Sleeps, callback counts, recursive scheduling, geometry polling, and framework-private layout signals are prohibited.
+- A presentation-changing projection records the current owner's latest geometry revision as an exclusive floor. A queued pre-change message cannot settle the new epoch.
+- The content signature is applied scope plus ordered stable Media IDs. The logical layout signature excludes replacement widget identity, compose generation, presentation epoch, and transient geometry.
+- An unchanged revision must restore the exact retained offset. A proven content/layout revision may clamp once and record a non-exact outcome. Timeout never proves shrink.
+- Apply and verify scroll before final focus. Viewer/list returns finish on the semantic row; Trash round trips finish on the captured normal-Media control when it remains valid.
+- After exact settlement, the retained receipt and existing two-second outer arm remain available for a later authoritative recompose in that window. User input, foreign focus, route change, or deadline disarms immediately.
+- Restore retains the normal-Media page and marks it stale pending refresh; it never inserts or reranks a restored record.
+- Do not add a dependency, schema change, shared cross-reader coordinator, Notes behavior change, or TCSS change without new evidence and an updated approved design.
+- The existing uncommitted `Tests/UI/test_library_media_trash.py` repair and `Tests/Live/test_library_media_trash_paging_closeout.py` harness are Task 7 closeout work. Do not edit them in Tasks 1–3.
+- Do not run repository-wide pytest without fresh user approval. Use only the focused and production-shaped gates below.
+
+## File and ownership map
+
+**Production owners**
+
+- `tldw_chatbook/UI/Screens/library_screen.py` — Media presentation projection, presentation epoch, immutable request, authority fences, deadline, scroll/focus commit, and settlement outcomes.
+- `tldw_chatbook/Widgets/Library/library_media_canvas.py` — Media-specific row-scroll owner and Resize-derived geometry message.
+
+**Focused verification owners**
+
+- Create `Tests/UI/test_library_media_return_settlement.py` — presentation, geometry protocol, authority, focus order, and bounded-failure tests isolated from Task 7's dirty files.
+- Verify `Tests/UI/test_library_media_side_by_side.py` unchanged — production-shaped cross-reader exact-return consumer.
+- Close out the existing `Tests/UI/test_library_media_trash.py` repair and existing `Tests/Live/test_library_media_trash_paging_closeout.py` harness only in Task 4.
+
+## Approved-design coverage map
+
+| Design obligation | Production owner | Primary proof |
+| --- | --- | --- |
+| Correct first-frame and same-size-recompose presentation | Task 1, `LibraryScreen` projection | First-frame and same-size-recompose focused tests |
+| Public producer-owned geometry; no timing readiness | Task 2, `LibraryMediaRowScroll` | Resize payload/revision and no-premature-focus tests |
+| Epoch floor rejects queued pre-change proof | Tasks 2–3, `LibraryScreen` | Exclusive-floor and queued-message inverse tests |
+| Unchanged revision restores exact scroll before final focus | Tasks 2–3, settlement commit | `(0, 42)` consumer, focus-order, and five fresh runs |
+| Viewer row policy and Trash captured-control policy | Task 3, final-focus resolver | Viewer/Trash/fallback focused tests |
+| Content/layout revision and bounded failure stay honest | Task 3, authority/deadline paths | Revision, one-shot clamp, warning, and no-requeue tests |
+| Existing paging/mutation contract and four sizes remain intact | Task 4 closeout | 108-test pure gate, cross-reader gate, four-size live harness |
+
+---
+
+### Task 1: Project the correct Media presentation before layout
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Create: `Tests/UI/test_library_media_return_settlement.py`
+
+**Interfaces:**
+
+Add one idempotent projection shared by compose and the Media adaptive-shell lifecycle path:
+
+```python
+def _project_library_media_stage_classes(self, shell_grid: Widget) -> bool:
+    """Project effective Media stage classes; return whether they changed."""
+
+def _reconcile_library_media_stage_presentation(self) -> bool:
+    """Equality-reconcile the mounted Media stage; return whether it changed."""
+```
+
+- [ ] **Step 1: Write RED first-frame and same-size-recompose tests.**
+
+In `Tests/UI/test_library_media_return_settlement.py`, mount the production `LibraryScreen` through the same lightweight app/host seam used by nearby Library tests. Assert both:
+
+1. the first composed Media `#library-shell-grid` has `library-adaptive-compact` according to `_library_notes_compact` and does not have `library-notes-compact`; and
+2. after forcing the wrong legacy class and performing a same-terminal-size authoritative recompose, the replacement Media stage is correct without waiting for a screen resize.
+
+Keep the app context open inside each test; do not return mounted widgets from a helper after its `run_test()` context has exited.
+
+- [ ] **Step 2: Run the new nodes and confirm the intended RED.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_return_settlement.py \
+  -k 'first_frame or same_size_recompose'
+```
+
+Expected: assertions fail because the Media replacement stage can retain the Notes compact contract. No unrelated import or fixture failure is acceptable evidence.
+
+- [ ] **Step 3: Implement the smallest shared projection.**
+
+In `library_screen.py`:
+
+1. remove `library-notes-compact` for the Media stage;
+2. set `library-adaptive-compact` to the current effective compact projection represented by `_library_notes_compact`;
+3. return whether either class actually changed;
+4. call the projection directly in the Media compose branch before yielding the outer shell; and
+5. call the mounted reconciliation from the existing Media adaptive-shell lifecycle handler before its current shell-width synchronization.
+
+When mounted reconciliation changes classes, request one public layout refresh. Task 2
+adds presentation-epoch advancement around this already-tested seam when the settlement
+state exists. Do not reload data, write preferences, or recompose solely because
+equality already holds.
+
+- [ ] **Step 4: Verify Task 1.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_return_settlement.py \
+  -k 'first_frame or same_size_recompose'
+
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/ruff check \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  Tests/UI/test_library_media_return_settlement.py
+
+git diff --check
+```
+
+Expected: focused tests and Ruff pass; no Task 7 protected file changed during this task.
+
+- [ ] **Step 5: Commit Task 1.**
+
+```bash
+git add tldw_chatbook/UI/Screens/library_screen.py \
+  Tests/UI/test_library_media_return_settlement.py
+git commit -m "fix: project Media adaptive presentation"
+```
+
+---
+
+### Task 2: Settle viewer returns from current-owner geometry
+
+**Files:**
+
+- Modify: `tldw_chatbook/Widgets/Library/library_media_canvas.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `Tests/UI/test_library_media_return_settlement.py`
+- Verify unchanged: `Tests/UI/test_library_media_side_by_side.py`
+
+**Interfaces:**
+
+In `library_screen.py`, replace the existing viewer tuple and
+`_LibraryMediaTrashReturn` with one frozen, transient receipt captured while the normal
+Media list and its physical coordinate system still own the screen:
+
+```python
+_LibraryMediaFinalFocusPolicy: TypeAlias = Literal["row", "control"]
+
+
+@dataclass(frozen=True)
+class _LibraryMediaReturnReceipt:
+    stable_id: str
+    scroll_offset: tuple[int, int] | None
+    content_signature: tuple[object, ...]
+    layout_signature: tuple[object, ...]
+    final_focus_policy: _LibraryMediaFinalFocusPolicy
+    final_focus_identity: str | None
+```
+
+This is an in-memory normalization of the two existing return shapes, not a persisted
+or cross-reader contract. Viewer capture uses row policy; Trash capture uses control
+policy and its current normal-Media control ID.
+
+Add exact signature producers in `LibraryScreen`:
+
+```python
+def _library_media_content_signature(self) -> tuple[object, ...]:
+    """Return applied normal-Media scope plus ordered stable row IDs."""
+
+def _library_media_layout_signature(self) -> tuple[object, ...]:
+    """Return terminal allocation plus pure effective Media pane layout."""
+```
+
+The layout signature must not contain mounted object IDs, compose/lifecycle generation,
+presentation epoch, or live `size`/`virtual_size`/`container_size` payloads.
+
+In `library_media_canvas.py`, add immutable geometry data, an owner-identifying application message, and one Media-specific scroll owner:
+
+```python
+@dataclass(frozen=True)
+class LibraryMediaRowGeometry:
+    revision: int
+    size: Size
+    virtual_size: Size
+    container_size: Size | None
+
+
+class LibraryMediaRowGeometryChanged(Message):
+    def __init__(
+        self,
+        owner: "LibraryMediaRowScroll",
+        geometry: LibraryMediaRowGeometry,
+    ) -> None:
+        super().__init__()
+        self.owner = owner
+        self.geometry = geometry
+
+
+class LibraryMediaRowScroll(VerticalScroll):
+    latest_geometry: LibraryMediaRowGeometry | None
+
+    def on_resize(self, event: events.Resize) -> None:
+        """Publish distinct, monotonically revised owner geometry after reflow."""
+```
+
+Import `events` and `Message` from Textual and `Size` from
+`textual.geometry`; do not mirror Textual geometry in a second application type.
+
+In `library_screen.py`, add one frozen request value rather than parallel mutable flags:
+
+```python
+@dataclass(frozen=True)
+class _LibraryMediaReturnSettlement:
+    request_id: int
+    receipt: _LibraryMediaReturnReceipt
+    final_focus_policy: _LibraryMediaFinalFocusPolicy
+    final_focus_identity: str | None
+    focus_intent_generation: int
+    compose_generation: int
+    media_lifecycle_generation: int
+    presentation_epoch: int
+    content_signature: tuple[object, ...]
+    layout_signature: tuple[object, ...]
+    route_identity: str
+    media_view_identity: str
+    shell_identity: int | None
+    items_host_identity: int | None
+    owner_identity: int | None
+    exclusive_geometry_floor: int
+```
+
+Use the repository's actual route types when they are more specific than the
+illustrative route strings above. The receipt's signatures remain the authority for
+physical-coordinate validity; the request also captures current signatures so every
+attempt can distinguish unchanged, proven revision, and stale authority.
+
+- [ ] **Step 1: Write RED geometry and focus-order tests.**
+
+Add tests proving:
+
+- viewer and Trash capture normalize into frozen receipts with signatures taken before
+  leaving the normal Media list;
+- `LibraryMediaRowScroll` increments a revision and posts its concrete owner plus `size`, `virtual_size`, and `container_size` for distinct Resize geometry;
+- a viewer/list return request does not publish final row focus before eligible geometry;
+- geometry from the current owner at a revision above the exclusive floor applies `(0, 42)` exactly and only then focuses the semantic row; and
+- duplicate delivery of the same revision is idempotent.
+
+Retain the existing consumer assertion in `test_library_media_side_by_side.py`; do not weaken `(0, 42)` to the observed transient clamp.
+
+- [ ] **Step 2: Confirm RED, including the established consumer failure.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_return_settlement.py \
+  -k 'geometry or viewer_return or duplicate_revision'
+
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_side_by_side.py \
+  -k 'media_recompose_restores_exact_row_and_scroll_after_other_reader_round_trip'
+```
+
+Expected: the new protocol tests fail because it does not exist, and the established consumer can reproduce `(0, 33) != (0, 42)` in a fresh process.
+
+- [ ] **Step 3: Implement the Media geometry producer.**
+
+Subclass only the Media row `VerticalScroll`. On public `events.Resize`, compare all three geometry fields with the last payload. For a distinct payload, increment an owner-local integer revision, retain the frozen value, and post `LibraryMediaRowGeometryChanged(self, geometry)`. Handle that message in `LibraryScreen` with `@on(LibraryMediaRowGeometryChanged)` and stop it after resolving the current owner. The widget must not inspect route, page, receipt, focus, or screen epoch and must not schedule follow-up callbacks.
+
+- [ ] **Step 4: Implement exact viewer settlement in `LibraryScreen`.**
+
+1. Normalize viewer and Trash captures into `_LibraryMediaReturnReceipt` while the normal list is current; preserve the same semantic row, offset, and captured control behavior.
+2. Give `LibraryScreen` a monotonic presentation epoch and request ID.
+3. When presentation changes, advance the epoch and record the current owner's latest revision as an exclusive floor.
+4. Arm an immutable row-policy request from the retained viewer receipt instead of immediately declaring focus/scroll success. Keep the existing Trash final-focus continuation until Task 3 replaces it, so Task 2 does not silently change that policy before its RED coverage exists.
+5. After recompose, rebuild the current request from the still-authoritative retained receipt with fresh compose/lifecycle/owner identities.
+6. On the owner geometry message, reject unless request object identity, all captured generations, route/sub-view, Items-open state, current ancestry, receipt, applied content signature, logical layout signature, owner identity, live payload equality, and `revision > exclusive_geometry_floor` all hold.
+7. If geometry was already published before the request armed, evaluate `owner.latest_geometry` immediately only when its revision remains above the current epoch floor and every authority fence holds.
+8. Resolve the semantic row and prove the exact retained offset is within the current horizontal/vertical maxima.
+9. In one synchronous commit, set the unanimated integer scroll offset, verify equality, apply programmatic row focus with `scroll_visible=False` when supported, then verify focus did not change the offset.
+10. Record `exact-settled` for that request/revision. Consume only the ephemeral request; retain the receipt and existing outer focus arm for any later authoritative recompose inside its window.
+
+Do not use `call_later()`, `call_after_refresh()`, sleeps, polling, or a fixed event count as readiness proof.
+
+- [ ] **Step 5: Prove fresh-process determinism.**
+
+Run the exact consumer five times with isolated pytest temp roots:
+
+```bash
+for run in 1 2 3 4 5; do
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+    Tests/UI/test_library_media_side_by_side.py \
+    -k 'media_recompose_restores_exact_row_and_scroll_after_other_reader_round_trip' \
+    --basetemp="/tmp/task18918-media-return-${run}"
+done
+```
+
+Expected: five independent passes, each preserving `(0, 42)`.
+
+- [ ] **Step 6: Verify Task 2 and commit.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_return_settlement.py \
+  Tests/UI/test_library_media_side_by_side.py \
+  -k 'media and (presentation or geometry or return or recompose)'
+
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/ruff check \
+  tldw_chatbook/Widgets/Library/library_media_canvas.py \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  Tests/UI/test_library_media_return_settlement.py
+
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile \
+  tldw_chatbook/Widgets/Library/library_media_canvas.py \
+  tldw_chatbook/UI/Screens/library_screen.py
+
+git diff --check
+git add tldw_chatbook/Widgets/Library/library_media_canvas.py \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  Tests/UI/test_library_media_return_settlement.py
+git commit -m "fix: settle Media returns on owner geometry"
+```
+
+---
+
+### Task 3: Preserve Trash focus policy and fail stale work closed
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `Tests/UI/test_library_media_return_settlement.py`
+- Verify unchanged: `Tests/UI/test_library_media_side_by_side.py`
+
+**Required outcomes:**
+
+- `exact-settled` — exact scroll and requested final focus committed.
+- `exact-scroll-focus-fallback` — exact scroll committed, captured control unavailable under a proven layout, documented fallback focused.
+- `clamped-after-revision` — content/layout signature authoritatively changed, so one explicit clamp and final-focus policy committed.
+- `clamped-after-settlement-failure` — unchanged request reached its deadline with all non-geometry fences valid, then one honest geometry-based clamp/focus fallback committed.
+- `layout-settlement-failed` — unchanged request reached its deadline but no truthful commit was possible.
+
+Represent these as one transient, request-ID-keyed last outcome for assertions and
+metadata-only diagnostics, for example:
+
+```python
+_LibraryMediaSettlementOutcome: TypeAlias = Literal[
+    "exact-settled",
+    "exact-scroll-focus-fallback",
+    "clamped-after-revision",
+    "clamped-after-settlement-failure",
+    "layout-settlement-failed",
+]
+
+_library_media_last_settlement_outcome: (
+    tuple[int, _LibraryMediaSettlementOutcome, int | None] | None
+)
+```
+
+The tuple is `(request_id, outcome, owner_geometry_revision)`. It is not persisted,
+shown as user content, or used as readiness authority.
+
+- [ ] **Step 1: Write the stale-authority and Trash-policy RED matrix.**
+
+Add tests for:
+
+1. a presentation revision at or below the exclusive floor cannot settle, including a custom message queued before the class change;
+2. a Trash Back return applies exact list scroll before focusing the captured normal-Media control and retains the selected row;
+3. an unavailable captured control falls back to the semantic row or existing safe Media-list target and records `exact-scroll-focus-fallback`;
+4. a proven content-signature or logical-layout-signature change clamps once and records `clamped-after-revision`;
+5. an unchanged request with no eligible geometry reaches one deadline fallback/failure with no re-enqueued attempt;
+6. duplicate message, old owner, detached owner, replaced shell/Items host, stale request ID, stale compose/lifecycle/focus generation, foreign route, Trash still active, Items collapsed, user input, foreign focus, and unmount cannot settle; and
+7. a later authoritative recompose inside the two-second outer arm may create a new request after a prior exact settlement, while user takeover cancels that ability.
+
+Use direct event/message delivery where possible. The tests must assert state/outcome and absence of queued follow-up behavior, not sleep for layout.
+
+- [ ] **Step 2: Confirm the new matrix is RED.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_return_settlement.py \
+  -k 'exclusive_floor or trash_focus or fallback or revision or deadline or stale or takeover or unmount'
+```
+
+Expected: each new behavior fails for the missing policy/authority path rather than fixture setup.
+
+- [ ] **Step 3: Complete the final-focus policy.**
+
+Arm normal viewer/list returns with `final_focus_policy="row"`. Arm Trash Back with `final_focus_policy="control"` and the captured normal-Media control identity. Remove any independent scheduled `_restore_library_media_trash_return_focus` path; the settlement commit becomes the single ordering owner.
+
+For a current exact request, resolve both the semantic row and requested final target before mutation, apply and verify exact scroll, then set and verify final focus under the programmatic-focus guard. If the captured control is invalid only because a proven responsive layout removed it, use the documented fallback without claiming full exact settlement.
+
+- [ ] **Step 4: Implement revision and deadline outcomes.**
+
+For an authoritative content/layout signature change, use current-owner geometry to clamp once, apply the request's final-focus policy, and record `clamped-after-revision`. Do not classify widget replacement or compose/presentation generation alone as a logical revision.
+
+Bind the existing two-second deadline to the ABA-safe request ID. At expiry:
+
+- if any non-geometry fence fails, clear silently;
+- otherwise attempt at most one current-geometry clamped scroll plus final-focus fallback;
+- record `clamped-after-settlement-failure` only if that commit succeeds, else `layout-settlement-failed`;
+- emit one metadata-only warning for the current request; and
+- clear the ephemeral request, retained arm, and timer without re-enqueueing work.
+
+Route change, user input/foreign focus, another Back request, or unmount synchronously invalidates the obsolete request.
+
+- [ ] **Step 5: Run focused and cross-reader verification.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_return_settlement.py \
+  Tests/UI/test_library_media_side_by_side.py
+
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/ruff check \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  Tests/UI/test_library_media_return_settlement.py
+
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile \
+  tldw_chatbook/UI/Screens/library_screen.py
+
+git diff --check
+```
+
+Expected: all focused settlement and existing cross-reader nodes pass; the protected Task 7 files remain untouched by this task.
+
+- [ ] **Step 6: Commit Task 3.**
+
+```bash
+git add tldw_chatbook/UI/Screens/library_screen.py \
+  Tests/UI/test_library_media_return_settlement.py
+git commit -m "fix: preserve Media return authority"
+```
+
+---
+
+### Task 4: Run production-shaped closeout and finish TASK-18918
+
+**Files:**
+
+- Include existing modification: `Tests/UI/test_library_media_trash.py`
+- Include existing file: `Tests/Live/test_library_media_trash_paging_closeout.py`
+- Modify: `Docs/User_Guide/library.md`
+- Modify: `backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md`
+- Modify if incident-backed: `backlog/docs/lessons-testing-evidence.md`
+
+- [ ] **Step 1: Review and preserve the existing Task 7 closeout changes.**
+
+Confirm `Tests/UI/test_library_media_trash.py` contains only the one-line test-fake compatibility repair already made, and review the existing live harness rather than recreating it. Check that the live harness exercises more than 40 records and the exact 160×50, 120×35, 100×30, and 80×24 sizes.
+
+- [ ] **Step 2: Run the pure TASK-18918 gate.**
+
+Run the established pure gate unchanged and expect 108 passing tests:
+
+```bash
+/usr/bin/env \
+  PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-18918-media-trash-paging \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/DB/test_client_media_trash_pagination.py \
+  Tests/Media/test_local_media_reading_service.py \
+  Tests/Media/test_media_reading_scope_service.py \
+  Tests/Library/test_library_media_trash_state.py \
+  Tests/UI/test_library_media_trash_browse_controller.py \
+  Tests/UI/test_library_media_browse_controller.py \
+  -k 'media_trash or library_media_trash or permanently_delete_media_item or mark_stale_after_trash_restore'
+```
+
+Expected: `108 passed, 191 deselected`. Record the actual warning count and duration.
+If the count changes, investigate and record the reason in Implementation Notes rather
+than silently replacing the established evidence.
+
+- [ ] **Step 3: Run the mounted production-shaped cross-reader gate.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_return_settlement.py \
+  Tests/UI/test_library_media_side_by_side.py \
+  Tests/UI/test_library_media_trash.py \
+  Tests/UI/test_library_adaptive_reader_shell.py \
+  Tests/UI/test_library_adaptive_reader_closeout.py
+```
+
+Expected: all pass, including exact Media return scroll, Trash focus policy, and unchanged Notes/other-reader behavior.
+
+- [ ] **Step 4: Run the live four-size walkthrough.**
+
+```bash
+/usr/bin/env \
+  PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-18918-media-trash-paging \
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/Live/test_library_media_trash_paging_closeout.py -s
+```
+
+At 160×50, 120×35, 100×30, and 80×24 verify: all Trash pages are reachable; filters/pager/Retry and both confirmations remain operable; Library and Items collapse independently; collapsing Library expands Items so full titles/details gain width; Restore retains normal Media's page but marks it stale; Back restores selected row, exact list scroll, and captured normal-Media control; viewer returns finish on the row.
+
+- [ ] **Step 5: Run inverse-matrix and static checks.**
+
+Exercise the existing mutation/request-generation inverse matrix plus the new queued-pre-epoch geometry, old-owner, detached-owner, focus-before-scroll, duplicate-revision, user-takeover, route-change, and deadline inverses.
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/ruff check \
+  tldw_chatbook/Widgets/Library/library_media_canvas.py \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  Tests/UI/test_library_media_return_settlement.py \
+  Tests/UI/test_library_media_trash.py \
+  Tests/Live/test_library_media_trash_paging_closeout.py
+
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile \
+  tldw_chatbook/Widgets/Library/library_media_canvas.py \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  Tests/Live/test_library_media_trash_paging_closeout.py
+
+git diff --check
+```
+
+- [ ] **Step 6: Update documentation and task evidence.**
+
+Update the Library guide with the shipped Trash paging/recovery behavior and deterministic return semantics. If the failed callback-turn approaches produced a reusable lesson not already captured, add the concrete incident to `backlog/docs/lessons-testing-evidence.md`: same-size Media recompose kept the wrong presentation and four scheduler-based remedies remained nondeterministic; only producer-owned Resize evidence closed the gate.
+
+In TASK-18918:
+
+- check every acceptance criterion;
+- record the original paging work plus the ADR-104 settlement amendment;
+- list targeted test commands and exact results, five fresh exact-return passes, and all four live sizes;
+- document the Task 7 baseline test-fake repair;
+- link the spec, both plans, ADR-067, and ADR-104; and
+- set status to Done only after all evidence is green.
+
+- [ ] **Step 7: Commit closeout.**
+
+```bash
+git add Tests/UI/test_library_media_trash.py \
+  Tests/Live/test_library_media_trash_paging_closeout.py \
+  Docs/User_Guide/library.md \
+  backlog/docs/lessons-testing-evidence.md \
+  "backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md"
+git commit -m "docs: close Media Trash paging task"
+```
+
+If the lessons file did not require an incident-backed change, omit it from `git add`.
+
+## Completion criteria
+
+- The first Media frame and same-size recomposes use the adaptive Media presentation contract.
+- Exact unchanged-revision returns settle only from current-owner Resize-derived geometry above the presentation epoch's exclusive floor.
+- Scroll is exact and observable before final focus; viewer returns focus the row and Trash returns focus the captured valid control.
+- Stale authority cannot settle, proven revisions and deadline failures are labelled honestly, and no readiness polling or callback-count contract exists.
+- The established exact-return consumer passes five fresh isolated runs.
+- Focused pure/mounted gates and live 160×50, 120×35, 100×30, and 80×24 walkthroughs pass.
+- TASK-18918, ADR-104, user documentation, and any incident-backed lesson are complete.

--- a/Docs/superpowers/plans/2026-08-30-task-18918-library-media-trash-paging.md
+++ b/Docs/superpowers/plans/2026-08-30-task-18918-library-media-trash-paging.md
@@ -10,9 +10,11 @@
 
 **Spec:** `Docs/superpowers/specs/2026-08-30-task-18918-library-media-trash-paging-design.md`
 
+**Settlement amendment:** `Docs/superpowers/plans/2026-08-30-library-media-return-settlement.md` implements the approved return-settlement design and ADR-104 after Task 7 exposed a production-shaped cross-reader closeout failure.
+
 ## Global Constraints
 
-- ADR required: no; ADR path: `backlog/decisions/067-library-top-level-pagination-contracts.md`.
+- ADR required: yes; ADR paths: `backlog/decisions/067-library-top-level-pagination-contracts.md`, `backlog/decisions/104-library-media-return-settlement-boundary.md`.
 - Trash is local-only; `mode="local"` is required and no server API or server service changes are permitted.
 - Page size is exactly 20; page and coordinate validation rejects booleans/non-integers and offsets above `2**63 - 1`.
 - Search matches title metadata only, trims input, rejects embedded NUL, and is limited to 200 characters.
@@ -103,9 +105,9 @@ Add this exact plan summary to the task file:
 6. Reconcile Restore and permanent deletion through the shared Media mutation owner.
 7. Run focused automated/live verification, review, documentation, and closeout.
 
-ADR required: no
-ADR path: backlog/decisions/067-library-top-level-pagination-contracts.md
-Reason: ADR-067 already governs exact source-owned pages and stale mutation recovery.
+ADR required: yes
+ADR paths: backlog/decisions/067-library-top-level-pagination-contracts.md, backlog/decisions/104-library-media-return-settlement-boundary.md
+Reason: ADR-067 governs exact source-owned pages and stale mutation recovery; ADR-104 records the event-driven Media return-settlement boundary required by the production-shaped cross-reader gate.
 ```
 
 - [ ] **Step 4: Run the planning checkpoint checks.**

--- a/Docs/superpowers/plans/2026-08-30-task-18918-library-media-trash-paging.md
+++ b/Docs/superpowers/plans/2026-08-30-task-18918-library-media-trash-paging.md
@@ -1,0 +1,1058 @@
+# TASK-18918 Library Media Trash Paging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every deleted local Media item reachable through exact 20-item Trash pages with independent title/type filters, safe Restore and permanent deletion, truthful stale recovery, deterministic focus, and compact-terminal reachability.
+
+**Architecture:** Add a local-only coherent Trash page read beside the legacy compatibility seam, normalize it into a fail-closed canonical envelope, and give Trash its own scope/result/reducer/controller. `LibraryScreen` remains the navigation, shared-mutation, and focus owner; `LibraryMediaTrashCanvas` remains the renderer. Normal Media keeps its existing controller and page context: Restore only marks that retained page stale, and neither Trash reads nor permanent deletion overwrite it.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, SQLite/FTS5, immutable dataclasses and mappings, pytest/pytest-asyncio, Ruff, existing TCSS bundle tooling.
+
+**Spec:** `Docs/superpowers/specs/2026-08-30-task-18918-library-media-trash-paging-design.md`
+
+## Global Constraints
+
+- ADR required: no; ADR path: `backlog/decisions/067-library-top-level-pagination-contracts.md`.
+- Trash is local-only; `mode="local"` is required and no server API or server service changes are permitted.
+- Page size is exactly 20; page and coordinate validation rejects booleans/non-integers and offsets above `2**63 - 1`.
+- Search matches title metadata only, trims input, rejects embedded NUL, and is limited to 200 characters.
+- Type filtering uses trimmed values and exact case-sensitive equality; facets are complete-source, unique, sorted, and non-empty.
+- Page order is NULL-last `trash_date DESC`, then NULL-last `last_modified DESC`, then `id DESC`.
+- Exact totals/ranges are visible only for a validated fresh page; committed mutations become stale immediately and cannot be reclassified as failures by a refresh error.
+- Restore preserves normal Media scope/page/records/selection/focus/scroll but marks that page stale; it never inserts an unranked row.
+- Permanent deletion is per-item only, uses `MediaReadingScopeService.permanently_delete_media_item(mode="local", media_id=...)`, and preserves the existing physical cascade, FTS cleanup, and no-sync-log behavior.
+- Library and Items panes retain their shipped collapse behavior; Trash must work at 160×50, 120×35, 100×30, and 80×24.
+- Diagnostics are metadata-only: never log query text, titles, raw records, paths, content, credentials, stable private IDs, or permanent-delete targets.
+- Do not run the repository-wide pytest suite without fresh user approval. Verification is limited to changed owners and their direct cross-reader regressions.
+
+---
+
+## File and ownership map
+
+**Production owners**
+
+- `tldw_chatbook/DB/Client_Media_DB_v2.py` — one coherent local Trash count/page/facet transaction and deterministic SQL ordering.
+- `tldw_chatbook/Media/local_media_reading_service.py` — thin raw local Trash envelope adapter; legacy `list_media_trash` remains unchanged.
+- `tldw_chatbook/Media/media_reading_scope_service.py` — local-only policy/off-loop boundary and canonical five-key Trash summaries.
+- `tldw_chatbook/Library/library_media_state.py` — immutable Trash scope/result/state, pure transition helpers, exact envelope validation, and row projection.
+- `tldw_chatbook/UI/Library_Modules/library_media_trash_browse_controller.py` — new Trash-only generation, clamp, request-origin, Retry, and worker owner.
+- `tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py` — one small normal-Media stale-marking method used after Restore; no Trash records or workers.
+- `tldw_chatbook/UI/Screens/library_screen.py` — entry/Back return receipt, focus authority, screen event wiring, shared Media mutation interlock, Restore, and permanent-delete dispatch.
+- `tldw_chatbook/Widgets/Library/library_media_trash_canvas.py` — filters, exact pager, rows, status, Retry, and safe inline confirmation.
+- `tldw_chatbook/css/components/_agentic_terminal.tcss` plus generated `tldw_chatbook/css/tldw_cli_modular.tcss` — only if production-shaped geometry proves an inline/layout change is insufficient.
+
+**Focused test owners**
+
+- New `Tests/DB/test_client_media_trash_pagination.py`.
+- Existing `Tests/Media/test_local_media_reading_service.py` and `Tests/Media/test_media_reading_scope_service.py`.
+- Existing `Tests/Library/test_library_media_trash_state.py`.
+- New `Tests/UI/test_library_media_trash_browse_controller.py`.
+- Existing `Tests/UI/test_library_media_trash.py`, `Tests/UI/test_library_media_side_by_side.py`, `Tests/UI/test_library_adaptive_reader_shell.py`, and `Tests/UI/test_library_adaptive_reader_closeout.py`.
+
+---
+
+### Task 0: Freeze the boundary and focused baseline
+
+**Files:**
+
+- Create: `Docs/superpowers/plans/2026-08-30-task-18918-library-media-trash-paging.md`
+- Modify: `backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md`
+
+**Interfaces:**
+
+- Consumes: approved design spec and ADR-067.
+- Produces: committed implementation plan, exact baseline node list, and task metadata used by Tasks 1–7.
+
+- [ ] **Step 1: Record the exact branch base and plan-only worktree state.**
+
+```bash
+git merge-base HEAD origin/dev
+git log --oneline origin/dev..HEAD
+git status --short
+```
+
+Expected: only the two approved design commits plus this plan/task edit are ahead of the base; no unrelated files are modified.
+
+- [ ] **Step 2: Run the current Trash-focused baseline.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/Library/test_library_media_trash_state.py \
+  Tests/UI/test_library_media_trash.py
+
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/Media/test_local_media_reading_service.py \
+  Tests/Media/test_media_reading_scope_service.py \
+  -k 'media_trash or permanently_delete_media_item or restore_media_item'
+```
+
+Expected: existing tests pass. Record exact failing node IDs instead of changing production if the moved base has a baseline defect.
+
+- [ ] **Step 3: Attach the plan and ADR check to TASK-18918.**
+
+Add this exact plan summary to the task file:
+
+```markdown
+## Implementation Plan
+
+1. Add a coherent local-only database page/count/facet contract.
+2. Propagate and canonically validate the exact envelope through Media services.
+3. Add immutable Trash paging state plus a Trash-specific request controller.
+4. Wire screen entry, paging/filter generations, Back receipt, and lifecycle fencing.
+5. Render the bounded pager/filter/confirmation surface at all supported sizes.
+6. Reconcile Restore and permanent deletion through the shared Media mutation owner.
+7. Run focused automated/live verification, review, documentation, and closeout.
+
+ADR required: no
+ADR path: backlog/decisions/067-library-top-level-pagination-contracts.md
+Reason: ADR-067 already governs exact source-owned pages and stale mutation recovery.
+```
+
+- [ ] **Step 4: Run the planning checkpoint checks.**
+
+```bash
+git diff --check
+rg -n 'T[B]D|TO[D]O|implement[ ]later|similar[ ]to Task' \
+  Docs/superpowers/plans/2026-08-30-task-18918-library-media-trash-paging.md
+```
+
+Expected: `git diff --check` passes and the placeholder scan prints nothing.
+
+- [ ] **Step 5: Commit the plan checkpoint.**
+
+```bash
+git add Docs/superpowers/plans/2026-08-30-task-18918-library-media-trash-paging.md \
+  "backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md"
+git commit -m "docs: plan Media Trash paging"
+```
+
+---
+
+### Task 1: Read exact Trash pages coherently at the database boundary
+
+**Files:**
+
+- Modify: `tldw_chatbook/DB/Client_Media_DB_v2.py`
+- Create: `Tests/DB/test_client_media_trash_pagination.py`
+
+**Interfaces:**
+
+- Consumes: `MediaDatabase.transaction()` and the existing `Media` table; no schema change.
+- Produces:
+
+```python
+def list_library_media_trash_page(
+    self,
+    *,
+    query: str = "",
+    media_type: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Return raw local Trash rows plus coherent total and complete facets."""
+```
+
+The raw DB envelope is:
+
+```python
+{
+    "items": [
+        {"id": 41, "title": "Doc", "type": "pdf", "trash_date": "..."}
+    ],
+    "total": 45,
+    "limit": 20,
+    "offset": 40,
+    "types": ["audio", "pdf", "video"],
+}
+```
+
+- [ ] **Step 1: Write RED coordinate, filter, ordering, and projection tests.**
+
+Seed at least 45 trashed rows plus active and soft-deleted decoys. Include repeated/null timestamps, literal `%`, `_`, and `\\` titles, blank/padded/mixed-case types, and privacy sentinels. The first focused test should resemble:
+
+```python
+def _seed_trash(database: MediaDatabase, *, count: int) -> None:
+    for index in range(count):
+        media_id, _uuid, _message = database.add_media_with_keywords(
+            title=f"Trash {index:02d}",
+            media_type="pdf" if index % 2 else "audio",
+            content=f"private-content-{index}",
+            keywords=[],
+        )
+        assert media_id is not None
+        assert database.mark_as_trash(media_id)
+
+
+def test_library_trash_pages_filter_before_slicing_and_echo_coordinates(media_db):
+    _seed_trash(media_db, count=45)
+
+    page = media_db.list_library_media_trash_page(limit=20, offset=20)
+
+    assert page["total"] == 45
+    assert page["limit"] == 20
+    assert page["offset"] == 20
+    assert len(page["items"]) == 20
+    assert set(page["items"][0]) == {"id", "title", "type", "trash_date"}
+```
+
+Add tests proving:
+
+- offsets `0`, `20`, and `40` return 20, 20, and 5 rows;
+- booleans, non-integers, negative coordinates, zero/non-20 limit, and values above `2**63 - 1` fail before SQL;
+- literal title search escapes `%`, `_`, and `\\` rather than broadening scope;
+- `TRIM(type) = ? COLLATE BINARY` is exact and case-sensitive;
+- facets ignore query/active type/page, trim values, omit blanks, and sort uniquely;
+- NULL `trash_date` and `last_modified` sort last, with `id DESC` as final tie-break;
+- rows, count, and facets share one transaction under a coordinated WAL mutation;
+- raw rows never contain content, paths, blobs, credentials, client IDs, or other detail fields.
+
+- [ ] **Step 2: Run the new file to verify RED.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/DB/test_client_media_trash_pagination.py
+```
+
+Expected RED: `MediaDatabase` has no `list_library_media_trash_page` method.
+
+- [ ] **Step 3: Implement strict request validation and one shared predicate.**
+
+Use explicit checks rather than `int(...)` repair:
+
+```python
+if type(limit) is not int or limit != 20:
+    raise ValueError("Library Media Trash limit must equal 20.")
+if type(offset) is not int or not 0 <= offset <= 2**63 - 1:
+    raise ValueError("Library Media Trash offset is invalid.")
+query = query.strip()
+if "\x00" in query or len(query) > 200:
+    raise ValueError("Library Media Trash query is invalid.")
+media_type = media_type.strip() if media_type is not None else None
+media_type = media_type or None
+```
+
+Build the row/count predicate once. Escape LIKE metacharacters with a small private helper and bind every value:
+
+```python
+escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+conditions.append("title LIKE ? ESCAPE '\\'")
+params.append(f"%{escaped}%")
+```
+
+- [ ] **Step 4: Implement the coherent transaction and exact order.**
+
+Inside one `with self.transaction() as conn:` execute count, bounded rows, and source-wide facets. Use this exact order:
+
+```sql
+ORDER BY trash_date IS NULL ASC,
+         trash_date DESC,
+         last_modified IS NULL ASC,
+         last_modified DESC,
+         id DESC
+LIMIT ? OFFSET ?
+```
+
+The facet query must use only `deleted = 0 AND is_trash = 1`; it must not inherit title/type filters.
+
+- [ ] **Step 5: Run GREEN and two inverse checks.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/DB/test_client_media_trash_pagination.py
+```
+
+Then temporarily split count/rows into separate transactions and remove `id DESC`; require the coherent-snapshot and tie-break tests to fail, restoring production after each inverse.
+
+- [ ] **Step 6: Commit the database slice.**
+
+```bash
+git add tldw_chatbook/DB/Client_Media_DB_v2.py \
+  Tests/DB/test_client_media_trash_pagination.py
+git commit -m "feat: page Media Trash at the database"
+```
+
+---
+
+### Task 2: Propagate the local-only canonical Trash envelope
+
+**Files:**
+
+- Modify: `tldw_chatbook/Media/local_media_reading_service.py`
+- Modify: `tldw_chatbook/Media/media_reading_scope_service.py`
+- Modify: `Tests/Media/test_local_media_reading_service.py`
+- Modify: `Tests/Media/test_media_reading_scope_service.py`
+
+**Interfaces:**
+
+- Consumes: `MediaDatabase.list_library_media_trash_page(...)` from Task 1.
+- Produces:
+
+```python
+# LocalMediaReadingService
+def list_library_media_trash(
+    self,
+    *,
+    query: str = "",
+    media_type: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]: ...
+
+# MediaReadingScopeService
+async def list_library_media_trash(
+    self,
+    *,
+    mode: MediaReadingBackend | str | None = None,
+    query: str = "",
+    media_type: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict[str, Any]: ...
+```
+
+The scope envelope contains exactly `items`, `total`, `limit`, `offset`, and `types`; each item contains exactly `id`, `backing_media_id`, `title`, `media_type`, and `trash_date`.
+
+- [ ] **Step 1: Write RED local/scope service tests.**
+
+Use spies that reject unexpected keys and a raw DB item with blank title/type:
+
+```python
+@pytest.mark.asyncio
+async def test_scope_library_trash_is_local_only_and_canonical(scope_service):
+    payload = await scope_service.list_library_media_trash(
+        mode="local", query="doc", media_type="pdf", limit=20, offset=40
+    )
+
+    assert set(payload) == {"items", "total", "limit", "offset", "types"}
+    assert set(payload["items"][0]) == {
+        "id", "backing_media_id", "title", "media_type", "trash_date"
+    }
+    assert payload["items"][0]["id"] == "local:media:41"
+```
+
+Prove the exact arguments reach the DB, the legacy `list_media_trash` call shape stays unchanged, missing/malformed response keys remain observable for Task 3 to reject, local sync DB work uses `_call_local_leaf`, policy is enforced, non-local mode raises before touching the server service, and diagnostics contain no sentinels.
+
+- [ ] **Step 2: Run RED.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/Media/test_local_media_reading_service.py \
+  Tests/Media/test_media_reading_scope_service.py \
+  -k 'library_media_trash'
+```
+
+Expected RED: neither service exposes `list_library_media_trash`.
+
+- [ ] **Step 3: Add the thin local adapter.**
+
+Forward exact validated arguments without pagination repair:
+
+```python
+def list_library_media_trash(self, **kwargs: Any) -> dict[str, Any]:
+    return self._require_db().list_library_media_trash_page(**kwargs)
+```
+
+Do not change, call through, or delete the legacy `list_media_trash` method.
+
+- [ ] **Step 4: Add the scope method and canonical normalization.**
+
+Reject non-local mode, reuse the existing Trash-list policy action, call `_call_local_leaf`, preserve envelope keys without defaults, and normalize rows once:
+
+```python
+def _normalize_local_library_trash_summary(item: Mapping[str, Any]) -> dict[str, Any]:
+    backing_id = item["id"]
+    return {
+        "id": f"local:media:{backing_id}",
+        "backing_media_id": backing_id,
+        "title": str(item.get("title") or "Untitled"),
+        "media_type": str(item["type"]).strip() if item.get("type") else None,
+        "trash_date": str(item["trash_date"]) if item.get("trash_date") else None,
+    }
+```
+
+Do not coerce IDs, totals, coordinates, types, or item sequences into validity; Task 3's fail-closed validator owns response correctness.
+
+- [ ] **Step 5: Run GREEN and the server-isolation inverse.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/Media/test_local_media_reading_service.py \
+  Tests/Media/test_media_reading_scope_service.py \
+  -k 'library_media_trash or list_media_trash'
+```
+
+Temporarily allow `mode="server"`; require the server-isolation test to fail, then restore.
+
+- [ ] **Step 6: Commit the service slice.**
+
+```bash
+git add tldw_chatbook/Media/local_media_reading_service.py \
+  tldw_chatbook/Media/media_reading_scope_service.py \
+  Tests/Media/test_local_media_reading_service.py \
+  Tests/Media/test_media_reading_scope_service.py
+git commit -m "feat: expose exact local Media Trash pages"
+```
+
+---
+
+
+### Task 3: Add immutable Trash paging state and a source-owned controller
+
+**Files:**
+
+- Modify: `tldw_chatbook/Library/library_media_state.py`
+- Create: `tldw_chatbook/UI/Library_Modules/library_media_trash_browse_controller.py`
+- Modify: `Tests/Library/test_library_media_trash_state.py`
+- Create: `Tests/UI/test_library_media_trash_browse_controller.py`
+
+**Interfaces:**
+
+- Consumes: canonical scope envelope from Task 2 and shared `build_library_pager_display`.
+- Produces these source-specific types:
+
+```python
+@dataclass(frozen=True)
+class MediaTrashScope:
+    query: str = ""
+    media_type: str | None = None
+    page: int = 1
+
+    @property
+    def page_size(self) -> int: return 20
+
+    @property
+    def offset(self) -> int: return (self.page - 1) * 20
+
+
+@dataclass(frozen=True)
+class MediaTrashResult:
+    scope: MediaTrashScope
+    items: tuple[Mapping[str, Any], ...]
+    total: int
+    limit: int
+    offset: int
+    types: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MediaTrashMutationTarget:
+    stable_id: str
+    backing_media_id: int
+    title: str
+    media_type: str | None
+    trash_date: str | None
+    page_index: int
+```
+
+Request origins use one closed vocabulary:
+
+```python
+MediaTrashRequestOrigin = Literal[
+    "entry", "search", "type", "previous", "next", "retry", "mutation"
+]
+```
+
+`MediaTrashBrowseState` owns requested/applied scope, retained rows, facets, `uninitialized`/`fresh`/`stale`, loading/error/stale copy, selected ID, confirmation target, mutation-pending flag, request origin, failed target, and committed notice. Pure helpers return new state; the controller owns only generation/worker handles and assigns those returned states.
+
+The pure transition surface is:
+
+```python
+def begin_media_trash_request(state, scope, *, origin): ...
+def apply_media_trash_result(state, result): ...
+def fail_media_trash_request(state, failed_scope, *, copy): ...
+def select_media_trash_item(state, stable_id): ...
+def open_media_trash_delete_confirmation(state): ...
+def cancel_media_trash_delete_confirmation(state): ...
+def begin_media_trash_mutation(state): ...
+def fail_media_trash_mutation(state, target, *, copy): ...
+def commit_media_trash_mutation(state, target, *, notice): ...
+```
+
+The controller surface is:
+
+```python
+class LibraryMediaTrashBrowseController:
+    state: MediaTrashBrowseState
+
+    @property
+    def pager(self) -> LibraryPagerDisplay: ...
+    def request(self, scope: MediaTrashScope, *, origin: MediaTrashRequestOrigin, focus_identity: str | None): ...
+    def retry(self, *, focus_identity: str | None): ...
+    def select(self, stable_id: str) -> None: ...
+    def open_delete_confirmation(self) -> MediaTrashMutationTarget | None: ...
+    def cancel_delete_confirmation(self) -> None: ...
+    def claim_mutation(self) -> MediaTrashMutationTarget | None: ...
+    def finish_mutation_failure(self, target: MediaTrashMutationTarget, copy: str) -> None: ...
+    def finish_mutation_commit(self, target: MediaTrashMutationTarget, notice: str) -> None: ...
+    def request_after_mutation(self, *, focus_identity: str | None): ...
+    def invalidate(self) -> int: ...
+```
+
+- [ ] **Step 1: Write RED scope/result validation tests.**
+
+```python
+def test_media_trash_scope_normalizes_and_bounds_coordinates():
+    scope = MediaTrashScope(query="  doc  ", media_type=" pdf ", page=2)
+    assert scope == MediaTrashScope(query="doc", media_type="pdf", page=2)
+    assert scope.offset == 20
+
+
+def test_media_trash_result_rejects_duplicate_or_noncanonical_ids():
+    payload = {
+        "items": [
+            {"id": "local:media:1", "media_id": 1, "title": "A", "type": "pdf", "trash_date": None},
+            {"id": "local:media:2", "media_id": 2, "title": "B", "type": "pdf", "trash_date": None},
+        ],
+        "total": 2,
+        "limit": 20,
+        "offset": 0,
+        "types": ["pdf"],
+    }
+    payload["items"][1]["id"] = payload["items"][0]["id"]
+    with pytest.raises(ValueError, match="unique"):
+        build_media_trash_result(MediaTrashScope(), payload)
+```
+
+Cover bool/non-integer/overflow page inputs, NUL/201-character queries, exact five envelope keys, exact five item keys, positive non-bool backing IDs, canonical stable IDs, unique IDs, strict ISO-or-None `trash_date`, exact cardinality, sorted unique nonblank facets, and out-of-range detection.
+
+- [ ] **Step 2: Write RED pure transition tests.**
+
+Prove entry success selects the first row only while entry authority owns focus; page/search/type success leaves selection empty; selection cannot survive scope/page change; failed filter/page retains the prior fresh applied page with exact fixed copy and Retry target; initial failure has no rows; one clamp is allowed; a second shrink becomes stale; confirmation captures full immutable identity; pre-commit failure keeps row/selection; committed mutation removes the target and becomes stale/loading before refresh.
+
+- [ ] **Step 3: Write RED controller generation and request-shape tests.**
+
+```python
+@pytest.mark.asyncio
+async def test_controller_sends_exact_local_trash_scope_and_rejects_late_result():
+    controller, screen, service = _controller(_page(2, total=21), _page(1, total=1))
+    controller.request(MediaTrashScope(page=2), origin="next", focus_identity="#library-media-trash-next")
+    old = screen.pending.pop()
+    controller.request(MediaTrashScope(query="new"), origin="search", focus_identity="#library-media-trash-search")
+    new = screen.pending.pop()
+    await new
+    await old
+    assert controller.state.applied_result.scope == MediaTrashScope(query="new")
+```
+
+Also prove Retry repeats the failed target, clamp occurs once, Back/unmount invalidation fences late local thread completion, metadata-only logging excludes sentinels, and worker group is Trash-specific.
+
+- [ ] **Step 4: Run RED.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/Library/test_library_media_trash_state.py \
+  Tests/UI/test_library_media_trash_browse_controller.py
+```
+
+Expected RED: paging types/controller do not exist and legacy state silently drops malformed rows.
+
+- [ ] **Step 5: Implement exact immutable contracts and pure reducers.**
+
+Reuse `PageFreshness` and `build_library_pager_display`; do not copy range/page/button arithmetic. Freeze item mappings with `MappingProxyType`. Keep requested scope separate from `applied_result.scope`. Represent failed filter/page requests with the prior applied result still fresh; represent committed mutation/shrink as stale with `total=None` at pager derivation.
+
+- [ ] **Step 6: Implement the controller's one-generation/one-clamp loop.**
+
+Call only:
+
+```python
+payload = await run_service_call(
+    service.list_library_media_trash,
+    mode="local",
+    query=scope.query,
+    media_type=scope.media_type,
+    limit=scope.page_size,
+    offset=scope.offset,
+    isolate_in_worker=True,
+)
+result = build_media_trash_result(scope, payload)
+```
+
+The apply gate must check controller generation plus `request_is_active()` before every state/focus sync.
+
+- [ ] **Step 7: Run GREEN and required inverses.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/Library/test_library_media_trash_state.py \
+  Tests/UI/test_library_media_trash_browse_controller.py
+```
+
+Temporarily remove duplicate-ID validation and allow a second clamp/read; require their focused tests to fail, restoring each change immediately.
+
+- [ ] **Step 8: Commit the state/controller slice.**
+
+```bash
+git add tldw_chatbook/Library/library_media_state.py \
+  tldw_chatbook/UI/Library_Modules/library_media_trash_browse_controller.py \
+  Tests/Library/test_library_media_trash_state.py \
+  Tests/UI/test_library_media_trash_browse_controller.py
+git commit -m "feat: own Media Trash page state"
+```
+
+---
+
+### Task 4: Wire Trash lifecycle, filters, pager, and Back receipt
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `Tests/UI/test_library_media_trash.py`
+- Modify: `Tests/UI/test_library_shell.py` only for direct lifecycle/return integration coverage.
+
+**Interfaces:**
+
+- Consumes: `LibraryMediaTrashBrowseController` from Task 3 and existing guarded `_apply_library_media_list_return(...)` path.
+- Produces one screen-owned, Viewer-independent receipt:
+
+```python
+@dataclass(frozen=True)
+class _LibraryMediaTrashReturn:
+    stable_id: str
+    scroll_offset: tuple[int, int] | None
+    focus_identity: str
+```
+
+The screen constructs the Trash controller with `request_is_active` requiring both the Media route and `_library_media_view == "trash"`.
+
+- [ ] **Step 1: Write RED mounted lifecycle tests.**
+
+Cover initial entry unfiltered page 1, no inheritance from normal Media query/type, one request only, loading without fabricated counts, generation rejection after newer search/page intent, Back/unmount fencing, and initial failure focusing Retry. Use real keyboard input for focus-driven behavior, not programmatic `.focus()` alone.
+
+- [ ] **Step 2: Write RED search/type/page/Retry tests.**
+
+Drive `Input.Submitted`, the bounded type chooser, Previous, Next, and Retry. Assert exact requested/applied separation and fixed copies:
+
+```python
+assert status.plain == "Filter not applied — showing All Trash · Retry"
+assert controller.state.applied_result.scope == MediaTrashScope()
+assert controller.state.requested_scope == MediaTrashScope(query="failed")
+```
+
+Prove page/filter intent clears selection before dispatch, a failed ordinary page keeps old range/page fresh, Retry repeats the failed target, and pager actions after failure operate on the visible applied scope.
+
+Submitting 201 characters must leave the prior applied page visible and show exactly `Search is limited to 200 characters.` without dispatching a service request.
+
+- [ ] **Step 3: Write RED Back-receipt tests.**
+
+Enter Trash from normal Media page 2 with a selected stable row, nonzero list scroll, and toolbar focus. After independent Trash paging/filtering, Back and Escape must restore the original Media scope/page/row/scroll/focus. Assert `_library_media_viewer_return` remains untouched and a late Trash completion cannot change normal Media.
+
+- [ ] **Step 4: Run RED.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_trash.py \
+  Tests/UI/test_library_shell.py \
+  -k 'media_trash and (entry or page or filter or type or retry or generation or back or escape or return or unmount)'
+```
+
+- [ ] **Step 5: Replace ad-hoc Trash fields/load worker with the controller.**
+
+Remove `_library_media_trash_records`, `_library_media_trash_total`, and `_library_media_trash_error` as page authority. Keep only the screen-owned controller, return receipt, UI draft, and semantic focus intent. `handle_library_media_trash_open` captures the receipt before switching views, resets Trash-only draft/confirmation state, and calls:
+
+```python
+self._library_media_trash_browse_controller.request(
+    MediaTrashScope(), origin="entry", focus_identity="#library-media-trash-row-0"
+)
+```
+
+- [ ] **Step 6: Add filter/pager/Retry handlers and guarded exit.**
+
+Every handler stops its event, checks the shared mutation interlock, then delegates one intent to the controller. Back invalidates the controller before changing `_library_media_view`, clears Trash drafts/confirmation, and schedules the existing guarded Media list-return application with the distinct receipt.
+
+- [ ] **Step 7: Run GREEN and the generation inverse.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_trash.py \
+  Tests/UI/test_library_shell.py \
+  -k 'media_trash and (entry or page or filter or type or retry or generation or back or escape or return or unmount)'
+```
+
+Temporarily omit `controller.invalidate()` from Back; require the late-result test to fail, then restore.
+
+- [ ] **Step 8: Commit the screen lifecycle slice.**
+
+```bash
+git add tldw_chatbook/UI/Screens/library_screen.py \
+  Tests/UI/test_library_media_trash.py \
+  Tests/UI/test_library_shell.py
+git commit -m "feat: navigate exact Media Trash pages"
+```
+
+---
+
+### Task 5: Render bounded filters, rows, pager, and deterministic focus
+
+**Files:**
+
+- Modify: `tldw_chatbook/Widgets/Library/library_media_trash_canvas.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `Tests/UI/test_library_media_trash.py`
+- Modify: `Tests/UI/test_library_media_side_by_side.py` for production hierarchy/collapse regression coverage.
+- Modify: `tldw_chatbook/css/components/_agentic_terminal.tcss` only if measured geometry requires it.
+- Regenerate: `tldw_chatbook/css/tldw_cli_modular.tcss` only if component CSS changes.
+
+**Interfaces:**
+
+- Consumes: `LibraryMediaTrashState`, controller `pager`, complete `types`, loading/error/stale/notice copy, applied scope label, and semantic focus identity.
+- Produces stable control IDs:
+
+```text
+#library-media-trash-back
+#library-media-trash-search
+#library-media-trash-type-filter
+#library-media-trash-type-choices
+#library-media-trash-status
+#library-media-trash-list
+#library-media-trash-previous
+#library-media-trash-page
+#library-media-trash-range
+#library-media-trash-next
+#library-media-trash-retry
+#library-media-trash-restore
+#library-media-trash-delete
+```
+
+- [ ] **Step 1: Write RED semantic rendering tests.**
+
+Mount the production `LibraryScreen` hierarchy and require:
+
+- `Local Trash · N items` unfiltered and `Local Trash · N matching` filtered only while fresh;
+- the applied query/type label remains the previous scope during a failed/draft filter;
+- exact `1-20 of 45`, `Page 1 of 3`, Previous/Next reasons, and unique Retry;
+- initial/loading/stale/error states never show a fabricated count/range/page;
+- disabled Restore/Delete reasons are `Trash is refreshing.`, `Refresh Trash before changing this item.`, or `Select a Trash item first.` as appropriate;
+- only 20 two-line row buttons mount, with no horizontal scrolling;
+- a 60-type fixture mounts one bounded chooser rather than 60 Buttons, and its final option is keyboard reachable.
+- the chooser always includes `All types`, marks the applied type with `✓`, and Escape closes it without changing requested/applied scope.
+
+- [ ] **Step 2: Write RED focus-precedence tests with user inputs.**
+
+Drive actual `Tab`, arrow keys, `Enter`, `Escape`, and submitted input. Assert:
+
+```python
+assert app.focused.id == "library-media-trash-search"          # search success
+assert app.focused.id == "library-media-trash-type-filter"     # type success
+assert app.focused.id in {"library-media-trash-next", "library-media-trash-previous", "library-media-trash-back"}
+```
+
+Cover initial success/initial error, type chooser Escape, failed request Retry, page completion fallback when Next disappears, empty-state Back focus, background completion not stealing newer focus, and opener key consumption.
+
+- [ ] **Step 3: Write RED four-size compositor/geometry tests.**
+
+Parametrize exactly `(160, 50)`, `(120, 35)`, `(100, 30)`, and `(80, 24)`. For ordinary, initial-error, stale, and confirmation-ready states assert:
+
+- vertical order is header, filters, status, `1fr` list, pager, action row;
+- at 80×24 the list's painted region is at least four rows;
+- pager/actions are inside the Items pane and painted;
+- status paints no more than two rows plus its fold indicator;
+- opening/closing Library and Items panes survives a page/filter refresh;
+- compositor `get_widget_at`/rendered strips confirm reachability, not merely non-empty widget `region` values.
+
+- [ ] **Step 4: Run RED.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_trash.py \
+  Tests/UI/test_library_media_side_by_side.py \
+  -k 'media_trash and (render or pager or filter or type or focus or geometry or compact or collapse or disabled)'
+```
+
+- [ ] **Step 5: Implement declarative canvas rendering.**
+
+Pass controller-owned presentation into both constructor and `sync_state`. Keep the list as the only `1fr` child with `min_height = 0` and independent vertical scroll. Put the pager and actions after it, outside that scroll. Replace the type row with a bounded chooser while open; do not add another vertical row.
+
+Use `library_disabled_action_label(...)` and tooltips for non-colour disabled reasons. The canvas renders state only; it must not compute filters, mutate controller state, or infer focus ownership.
+
+- [ ] **Step 6: Implement focus restoration through current mounted identities.**
+
+After every recompose, reacquire the semantic target by selector, yield one compositor cycle, and reacquire immediately before focusing. Never retain and press a control captured before a request-driven recompose.
+
+- [ ] **Step 7: Change CSS only if the real hierarchy proves it necessary.**
+
+If component TCSS changes, regenerate rather than hand-edit the bundle:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python \
+  tldw_chatbook/css/build_css.py
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python \
+  tldw_chatbook/css/check_bundle_sync.py
+```
+
+- [ ] **Step 8: Run GREEN plus two layout inverses.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_trash.py \
+  Tests/UI/test_library_media_side_by_side.py \
+  -k 'media_trash and (render or pager or filter or type or focus or geometry or compact or collapse or disabled)'
+```
+
+Temporarily derive facets from visible rows and remove the list's `1fr/min-height:0` containment; require the final-facet and 80×24 paint tests to fail, restoring each immediately.
+
+- [ ] **Step 9: Commit the renderer slice.**
+
+```bash
+git add tldw_chatbook/Widgets/Library/library_media_trash_canvas.py \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  Tests/UI/test_library_media_trash.py \
+  Tests/UI/test_library_media_side_by_side.py
+# Stage component and generated TCSS only if both changed and bundle parity passed.
+git commit -m "feat: render resilient Media Trash pages"
+```
+
+---
+
+### Task 6: Reconcile Restore and permanent deletion truthfully
+
+**Files:**
+
+- Modify: `tldw_chatbook/UI/Library_Modules/library_media_trash_browse_controller.py`
+- Modify: `tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py`
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py`
+- Modify: `tldw_chatbook/Widgets/Library/library_media_trash_canvas.py`
+- Modify: `Tests/UI/test_library_media_trash_browse_controller.py`
+- Modify: `Tests/UI/test_library_media_trash.py`
+- Modify: `Tests/UI/test_library_media_browse_controller.py`
+- Modify: `Tests/Media/test_local_media_reading_service.py` to pin the existing permanent-delete physical cascade, FTS cleanup, and no-sync behavior.
+
+**Interfaces:**
+
+- Consumes: shared `_library_media_bulk_delete_in_flight` flag and `library_media_bulk_delete` worker group; existing Restore/permanent-delete scope-service methods.
+- Produces one normal-Media method:
+
+```python
+def mark_stale_after_trash_restore(self) -> None:
+    """Retain the current exact Media page but withdraw its authority."""
+```
+
+- Extends `_complete_library_media_mutation(...)` with explicit Trash behavior while preserving defaults for every existing delete/Undo/edit caller:
+
+```python
+def _complete_library_media_mutation(
+    self,
+    *,
+    committed: bool = False,
+    remove_ids: tuple[str, ...] = (),
+    upsert_items: tuple[Mapping[str, Any], ...] = (),
+    refresh_normal_media: bool = True,
+    stale_normal_media: bool = False,
+) -> None: ...
+```
+
+- [ ] **Step 1: Write RED safe-confirmation tests.**
+
+Use duplicate truncated titles and one very long title. Require the confirmation to show the full title in a bounded scrollable detail region plus type and Trash timestamp; missing values render exactly `Unknown type` and `Unknown deletion time`. Authorize by captured stable ID, focus Cancel initially, consume the opener activation, and commit only after a later explicit confirmation. Escape/Cancel returns opener focus without calling a service.
+
+- [ ] **Step 2: Write RED commit-interlock and service-seam tests.**
+
+Prove Back/Escape are disabled with `Finishing this action…` only while commit status is unknown, double press schedules one worker, and post-commit refresh can be abandoned. Assert permanent deletion calls exactly:
+
+```python
+await scope_service.permanently_delete_media_item(
+    mode="local", media_id=target.backing_media_id
+)
+```
+
+The test must fail if `empty_media_trash`, the backing lifecycle path, a canonical stable ID, or any second delete seam is used.
+
+- [ ] **Step 3: Write RED Restore reconciliation tests.**
+
+After a committed Restore require:
+
+- the Trash target disappears immediately;
+- Trash becomes stale/loading and hides exact count/range/page claims;
+- normal Media keeps exactly the same applied scope/page/records/selection/focus/scroll;
+- normal Media becomes stale and exposes its own Retry;
+- no restored summary is inserted/repositioned;
+- a successful Trash refresh does not clear normal Media stale;
+- a failed Trash refresh shows `Restored '<bounded title>'. List may be out of date · Retry` and never reports Restore as failed.
+- authoritative Trash refresh restores focus to the target's prior page-local position, then the previous row, then Back, only while mutation focus authority is current.
+
+- [ ] **Step 4: Write RED permanent-delete and pre-commit failure tests.**
+
+Committed deletion uses the same Trash stale/refresh flow but leaves normal Media freshness unchanged. Not-found/not-in-Trash/policy/service failures keep the row, selection, total, and fresh boundary while showing recoverable action copy. Extend the local service test to prove existing cascade/FTS cleanup and absence of a sync-log insert if that behavior is not already directly pinned.
+
+- [ ] **Step 5: Run RED.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_trash_browse_controller.py \
+  Tests/UI/test_library_media_trash.py \
+  Tests/UI/test_library_media_browse_controller.py \
+  Tests/Media/test_local_media_reading_service.py \
+  -k 'media_trash and (restore or permanent or confirm or mutation or stale or refresh or back or escape)'
+```
+
+- [ ] **Step 6: Implement confirmation and mutation claims through immutable targets.**
+
+`claim_mutation()` validates the selected fresh stable ID, captures the backing ID/full identity/page index, sets `mutation_pending=True`, and closes confirmation only for the captured target. Screen handlers claim the shared flag synchronously before scheduling the existing exclusive worker group.
+
+- [ ] **Step 7: Implement truthful completion paths.**
+
+For pre-commit failure call `finish_mutation_failure(...)`, release the shared interlock, retain the row/selection, and do not refresh. For commit:
+
+```python
+controller.finish_mutation_commit(target, notice)
+controller.request_after_mutation(focus_identity=target_focus_fallback)
+```
+
+Restore calls `_complete_library_media_mutation(committed=True, refresh_normal_media=False, stale_normal_media=True)` with no upsert. Permanent deletion calls the same helper with both flags false. All other existing Media mutations keep default behavior.
+
+- [ ] **Step 8: Run GREEN and three safety inverses.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_trash_browse_controller.py \
+  Tests/UI/test_library_media_trash.py \
+  Tests/UI/test_library_media_browse_controller.py \
+  Tests/Media/test_local_media_reading_service.py \
+  -k 'media_trash and (restore or permanent or confirm or mutation or stale or refresh or back or escape)'
+```
+
+One at a time, focus Confirm initially, let opener Enter fall through, and upsert the restored row into normal Media. Each corresponding safety test must turn RED; restore the approved implementation after each inverse.
+
+- [ ] **Step 9: Commit the mutation slice.**
+
+```bash
+git add tldw_chatbook/UI/Library_Modules/library_media_trash_browse_controller.py \
+  tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  tldw_chatbook/Widgets/Library/library_media_trash_canvas.py \
+  Tests/UI/test_library_media_trash_browse_controller.py \
+  Tests/UI/test_library_media_trash.py \
+  Tests/UI/test_library_media_browse_controller.py \
+  Tests/Media/test_local_media_reading_service.py
+git commit -m "feat: safely recover and purge Media Trash"
+```
+
+---
+
+### Task 7: Run focused production-shaped verification and close out TASK-18918
+
+**Files:**
+
+- Create: `Tests/Live/test_library_media_trash_paging_closeout.py` for the isolated real-database, four-size walkthrough.
+- Modify: `Docs/User_Guide/library/media-and-conversations.md`
+- Modify: `backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md`
+- Modify: `backlog/docs/lessons-testing-evidence.md` or `backlog/docs/lessons-live-verification.md` only if implementation produces a genuinely reusable incident-backed lesson.
+
+**Interfaces:**
+
+- Consumes: all Tasks 1–6 plus the production `TldwCli`/Library reader shell.
+- Produces: focused automated evidence, four-size live evidence, updated user docs, checked acceptance criteria, implementation notes, and task status Done.
+
+- [ ] **Step 1: Run the pure/database/service/controller gate.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/DB/test_client_media_trash_pagination.py \
+  Tests/Media/test_local_media_reading_service.py \
+  Tests/Media/test_media_reading_scope_service.py \
+  Tests/Library/test_library_media_trash_state.py \
+  Tests/UI/test_library_media_trash_browse_controller.py \
+  Tests/UI/test_library_media_browse_controller.py \
+  -k 'media_trash or library_media_trash or permanently_delete_media_item or mark_stale_after_trash_restore'
+```
+
+- [ ] **Step 2: Run the mounted owner and production-shaped cross-reader gate.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/UI/test_library_media_trash.py \
+  Tests/UI/test_library_media_side_by_side.py \
+  Tests/UI/test_library_adaptive_reader_shell.py \
+  Tests/UI/test_library_adaptive_reader_closeout.py \
+  -k 'media_trash or (media and (reader or collapse or compact or geometry or return))'
+```
+
+Do not replace this with `pytest` over the repository. If a surprising failure appears, reproduce it in a detached pristine-base worktree before labeling it baseline.
+
+- [ ] **Step 3: Run Ruff and structural checks only on changed files.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  tldw_chatbook/DB/Client_Media_DB_v2.py \
+  tldw_chatbook/Media/local_media_reading_service.py \
+  tldw_chatbook/Media/media_reading_scope_service.py \
+  tldw_chatbook/Library/library_media_state.py \
+  tldw_chatbook/UI/Library_Modules/library_media_trash_browse_controller.py \
+  tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py \
+  tldw_chatbook/UI/Screens/library_screen.py \
+  tldw_chatbook/Widgets/Library/library_media_trash_canvas.py \
+  Tests/DB/test_client_media_trash_pagination.py \
+  Tests/Media/test_local_media_reading_service.py \
+  Tests/Media/test_media_reading_scope_service.py \
+  Tests/Library/test_library_media_trash_state.py \
+  Tests/UI/test_library_media_trash_browse_controller.py \
+  Tests/UI/test_library_media_trash.py \
+  Tests/UI/test_library_media_browse_controller.py \
+  Tests/UI/test_library_media_side_by_side.py \
+  Tests/UI/test_library_adaptive_reader_shell.py \
+  Tests/UI/test_library_adaptive_reader_closeout.py \
+  Tests/Live/test_library_media_trash_paging_closeout.py
+git diff --check
+```
+
+If TCSS changed, rerun the bundle build/parity commands from Task 5 and require a clean diff on a second build.
+
+- [ ] **Step 4: Run the isolated live walkthrough at all four exact sizes.**
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q \
+  Tests/Live/test_library_media_trash_paging_closeout.py
+```
+
+Use `mktemp -d`, a scratch `TLDW_CONFIG_PATH`, `PYTHONPATH` pointing at this worktree, the real `MediaDatabase`, `LocalMediaReadingService`, `MediaReadingScopeService`, and production `TldwCli`. Seed more than 40 Trash rows with multiple/padded/case-distinct types, long/duplicate titles, equal/null timestamps, and active decoys. For each of 160×50, 120×35, 100×30, and 80×24 verify:
+
+1. initial unfiltered page, middle/final page, and exact Local Trash totals;
+2. title/type filtering, failed filter/page copy, Retry, and one concurrent-shrink clamp;
+3. Library and Items collapse/expand, followed by a refresh-producing action that must preserve the pane choice;
+4. full-title permanent-delete confirmation, Cancel, explicit confirm, and committed-refresh failure;
+5. Restore makes normal Media stale without inserting a row; Back restores page/selection/focus/scroll;
+6. all relevant controls are freshly mounted, displayed, painted, and keyboard reachable.
+
+Wait separately for authoritative state, current DOM identity, and compositor paint after every recompose. Re-query controls immediately before use. Capture compositor-visible evidence; do not rely on terminal capture or widget regions alone.
+
+- [ ] **Step 5: Verify privacy and real-profile isolation.**
+
+Assert the scratch run's logs omit unique query/title/ID/path/credential/delete-target sentinels. Confirm the real profile and Media database are byte-identical before/after and all workers/processes/handles drain.
+
+- [ ] **Step 6: Re-run the required inverse matrix.**
+
+One at a time and restoring immediately: split the DB snapshot, remove the stable order tie-break, allow server mode, remove duplicate-ID validation, allow a second clamp, omit Back invalidation, derive facets from the page, enable stale mutations, focus Confirm first, allow opener fallthrough, and upsert the restored row into normal Media. Every inverse must make its named focused test fail.
+
+- [ ] **Step 7: Request independent code/spec review and resolve findings.**
+
+Use `superpowers:requesting-code-review`. Treat comments through `superpowers:receiving-code-review`: verify each claim against current code/tests before changing anything. Resolve every Critical/Important finding with focused RED/GREEN evidence.
+
+- [ ] **Step 8: Update documentation and task completion metadata.**
+
+Revise the Media Trash guide from the old capped `showing X of N`/Restore-only contract to exact pages, local title/type filters, permanent-delete confirmation, Retry/stale behavior, and Back context restoration. In the task file:
+
+- check all six acceptance criteria;
+- add concise `## Implementation Notes` naming the DB/service/state/controller/canvas changes and automated/live evidence;
+- retain the ADR-067/no-new-ADR record;
+- set status to Done by direct file edit because the Backlog CLI is unsafe for five-digit task IDs.
+
+- [ ] **Step 9: Run closeout checks and commit.**
+
+```bash
+git diff --check
+git status --short
+git log --oneline origin/dev..HEAD
+```
+
+```bash
+git add Docs/User_Guide/library/media-and-conversations.md \
+  Tests/Live/test_library_media_trash_paging_closeout.py \
+  "backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md"
+# Also stage a new incident-backed lesson only when implementation produced one.
+git commit -m "docs: close Media Trash paging task"
+```
+
+---
+
+## Completion criteria
+
+TASK-18918 is complete only when every acceptance criterion is checked, exact local pages and complete filters are reachable, Restore/permanent deletion remain truthful through failed refreshes, stale and malformed states fail closed, all four terminal sizes pass production-shaped keyboard/compositor walkthroughs, the focused owner and cross-reader suites plus Ruff/diff/bundle checks are green, every required inverse has turned its focused test RED, independent review has no unresolved Critical/Important findings, user documentation is current, and the Backlog task is Done. A repository-wide pytest run remains excluded unless the user explicitly opts in.

--- a/Docs/superpowers/specs/2026-08-30-library-media-return-settlement-design.md
+++ b/Docs/superpowers/specs/2026-08-30-library-media-return-settlement-design.md
@@ -1,0 +1,208 @@
+# Library Media Return Settlement Design
+
+**Date:** 2026-08-30
+**Status:** Approved in chat; written-spec review pending
+**Related task:** TASK-18918
+**Decision:** [ADR-104](../../../backlog/decisions/104-library-media-return-settlement-boundary.md)
+
+## Purpose
+
+Normal Media must restore the retained page, semantic row, focus identity, and exact
+list scroll after a Trash round trip or authoritative same-scope recompose. The current
+flow carries the correct receipt but can apply it against a replacement scroll owner
+before that owner has the Media adaptive presentation and final geometry. Textual then
+truthfully clamps the desired `(0, 42)` to a transient or wrong-contract maximum such as
+`(0, 33)`.
+
+The repair must make restoration event-driven and deterministic. Scheduler turn counts,
+arbitrary sleeps, framework-private layout signals, and recursive polling are not
+readiness contracts.
+
+## Evidence and corrected root cause
+
+The established cross-reader test restores the correct Media row but intermittently
+observes `(0, 33)` instead of the retained `(0, 42)`. The receipt remains intact through
+capture, Trash Back, recompose, and focus arming.
+
+Diagnostic runs established two separate prerequisites:
+
+1. A newly composed `#library-shell-grid` can retain the legacy
+   `library-notes-compact` class because the existing Media shell mount handler only
+   synchronizes width. A same-size whole-screen recompose need not produce another
+   screen resize, so the replacement Media owner can remain at virtual height 40 and
+   `max_scroll_y == 33` for longer than the existing two-second focus arm.
+2. Even with a corrected presentation, `call_after_refresh()` and `call_later()` are
+   queue boundaries, not descendant-layout completion signals. One or two later turns
+   sometimes pass and sometimes reproduce the same clamp.
+
+Textual 8.2.8 posts a widget's non-bubbling `Resize` only after compositor reflow calls
+`_size_updated(size, virtual_size, container_size)`, which installs all three geometry
+values, updates scrollbars, and clamps current scroll. The current owner's own Resize is
+therefore the public geometry boundary, but only after the application has projected the
+correct Media presentation.
+
+## Decision
+
+Use a two-gate, event-driven return-settlement protocol owned by `LibraryScreen`:
+
+1. **Presentation gate:** after the current Media adaptive shell mounts or reports its
+   shell lifecycle message, reconcile the outer Library stage to the current adaptive
+   Media presentation. The stage must have `library-adaptive-compact` and must not retain
+   `library-notes-compact` when the Media adaptive reader is current. Reconciliation
+   advances an application-owned presentation epoch and requests layout only when the
+   projected class contract changes.
+2. **Geometry gate:** the current Media row-scroll owner translates its own Textual
+   `Resize` into an owner-identified application message carrying a monotonic geometry
+   revision plus `size`, `virtual_size`, and `container_size`. `LibraryScreen` settles a
+   retained return only from current-owner geometry for the required presentation epoch
+   and only when the exact retained offset is representable.
+
+No timer or callback count proves readiness. Real producer changes advance epochs; real
+owner geometry events trigger attempts. Duplicate events are coalesced and idempotent.
+
+## Components
+
+### Media row-scroll owner
+
+A small Media-owned `VerticalScroll` subclass remains a presentation widget. It:
+
+- records its latest Resize-derived geometry and increments an owner-local revision;
+- posts one owner-specific geometry message per distinct revision;
+- does not own return receipts, focus policy, route state, timers, or page data; and
+- emits no polling work.
+
+The message must identify the concrete sender. A message from an old or detached owner
+cannot settle a current request.
+
+### Presentation reconciliation
+
+The existing Media adaptive-shell lifecycle handler must run the same stage projection
+that screen resize already uses before synchronizing shell width. Projection remains
+equality-guarded: unchanged classes and geometry do not recompose, reload data, write
+preferences, or create work.
+
+Presentation epoch changes whenever an action can change the effective outer compact
+contract or current Media owner, including adaptive-shell replacement and relevant
+viewport/layout projection. The epoch is transient and screen-owned.
+
+### Return-settlement request
+
+An immutable request records:
+
+- ABA-safe request identity;
+- retained `(media_id, scroll_offset)` receipt;
+- focus-intent, compose, Media lifecycle, and presentation generations;
+- applied Media content/page revision and ordered stable IDs;
+- route and Media sub-view identity;
+- viewport/layout signature; and
+- current shell, Items host, and row-scroll owner identities once attached.
+
+The existing retained return receipt remains authoritative. Transient framework clamping
+must never overwrite it.
+
+## Settlement flow
+
+1. Back or authoritative recompose arms one immutable settlement request from the
+   retained receipt. A newer request invalidates the older object.
+2. Mounting the replacement Media adaptive shell reconciles the presentation contract
+   and advances or confirms the required presentation epoch.
+3. The current row-scroll owner emits geometry after Textual reflow. If it emitted before
+   the request was armed, its latest recorded revision may be evaluated immediately.
+4. `LibraryScreen` verifies every authority fence and the live geometry payload.
+5. For an unchanged content and layout revision, settlement is eligible only when the
+   exact desired offset lies within the owner's current maxima.
+6. In one synchronous commit, resolve the semantic row, focus it with
+   `scroll_visible=False`, apply the unanimated exact offset, verify the resulting
+   integer offset equals the receipt, and record `exact-settled` for that request and
+   geometry revision.
+7. Focus must not become the observable success boundary before exact scroll succeeds.
+   Repeated current-owner messages after success are no-ops.
+
+## Authority fences
+
+Every attempt must reject when any of these differ from the request:
+
+- request object identity;
+- focus-intent, compose, Media lifecycle, or presentation generation;
+- route, Media sub-view, Items-open state, or semantic target;
+- current shell, Items host, row-scroll owner, attachment, or ancestry;
+- retained receipt, applied scope, content revision, or ordered stable IDs;
+- viewport/layout signature for an exact return; or
+- live geometry versus the message payload.
+
+User keyboard/mouse takeover, foreign focus, another Back request, route change,
+content change, recompose, adaptive layout change, and unmount synchronously invalidate
+the obsolete request. `is_mounted` alone is insufficient; current ancestry and owner
+identity are required.
+
+## Content or layout changes
+
+Exact physical scroll is authoritative only while the content and viewport/layout
+revision captured with the receipt remain unchanged.
+
+If a controller/content revision proves that the list changed, or a viewport/layout
+revision proves that the physical coordinate system changed, the new epoch may perform
+one explicit semantic-row focus with an honest clamp from current geometry. It records
+`clamped-after-revision`, never `exact-settled`. A timeout cannot be used to infer that
+content shrank.
+
+This preserves the TASK-18918 contract: Trash navigation and Restore do not replace or
+rerank the retained normal-Media page. Restore only marks it stale pending an
+authoritative normal-Media refresh.
+
+## Bounded failure
+
+Reuse the existing two-second list-entry focus deadline as a liveness bound, not as
+readiness evidence.
+
+If an unchanged request has no representable current-owner geometry by the deadline:
+
+- record `layout-settlement-failed`;
+- clear the ephemeral settlement request and timer;
+- emit one metadata-only, privacy-safe warning; and
+- perform at most one honest semantic-focus fallback against current geometry without
+  reporting exact success.
+
+No callback is re-enqueued after failure. Route change, cancellation, or unmount clears
+the request without warning.
+
+## Alternatives rejected
+
+| Alternative | Reason rejected |
+| --- | --- |
+| Immediate focus and scroll after recompose | Applies the receipt against transient or wrong-contract geometry and clamps silently. |
+| Presentation reconciliation alone | Removes one deterministic defect but does not make scheduler timing a layout boundary. |
+| One, two, or N `call_later()` / `call_after_refresh()` turns | Repeated fresh-process trials proved these remain nondeterministic. |
+| Poll until `max_scroll_y` grows | Creates a timing loop, confuses legitimate shrink with lateness, and has no producer authority. |
+| Watch `virtual_size` only | Scroll maxima also depend on container size and current owner identity. |
+| Use `screen_layout_refresh_signal` | It is private/semi-private and describes one screen reflow, not completion of the current application presentation epoch. |
+| Change the expected scroll to `(0, 33)` | Hides the failure and violates the retained exact-return contract. |
+
+## Testing
+
+TDD retains the existing consumer-visible `(0, 42)` RED unchanged. New focused tests
+must establish:
+
+- same-size recompose reconciles adaptive Media presentation before settlement;
+- focus is withheld until current-owner Resize-derived geometry is eligible;
+- current geometry makes semantic focus and exact scroll observable together;
+- duplicate geometry is idempotent;
+- old owner, stale epoch, stale request, user takeover, route change, and unmount cannot
+  settle;
+- a proven content/layout revision clamps once and is labelled honestly;
+- no geometry reaches one bounded failure with no further queued attempt; and
+- no scheduler-turn count appears in production or tests.
+
+The established exact test must pass in five consecutive fresh processes. Then run the
+focused normal-Media Back/recompose/adaptive-layout tests, the production-shaped
+cross-reader gate, TASK-18918 Trash renderer/lifecycle/mutation gates, and the live
+160×50, 120×35, 100×30, and 80×24 walkthrough. A repository-wide test sweep remains
+out of scope without explicit approval.
+
+## Non-goals
+
+- Generalizing settlement across all Library readers in this change.
+- Altering Notes' existing restoration scheduler.
+- Persisting presentation epochs or settlement outcomes.
+- Changing Media pagination, filtering, selection, or stale-page ownership.
+- Adding sleeps, polling workers, or new dependencies.

--- a/Docs/superpowers/specs/2026-08-30-library-media-return-settlement-design.md
+++ b/Docs/superpowers/specs/2026-08-30-library-media-return-settlement-design.md
@@ -1,7 +1,7 @@
 # Library Media Return Settlement Design
 
 **Date:** 2026-08-30
-**Status:** Revised after architecture review; written-spec approval pending
+**Status:** Approved
 **Related task:** TASK-18918
 **Decision:** [ADR-104](../../../backlog/decisions/104-library-media-return-settlement-boundary.md)
 

--- a/Docs/superpowers/specs/2026-08-30-library-media-return-settlement-design.md
+++ b/Docs/superpowers/specs/2026-08-30-library-media-return-settlement-design.md
@@ -1,7 +1,7 @@
 # Library Media Return Settlement Design
 
 **Date:** 2026-08-30
-**Status:** Approved in chat; written-spec review pending
+**Status:** Revised after architecture review; written-spec approval pending
 **Related task:** TASK-18918
 **Decision:** [ADR-104](../../../backlog/decisions/104-library-media-return-settlement-boundary.md)
 
@@ -45,9 +45,10 @@ correct Media presentation.
 
 Use a two-gate, event-driven return-settlement protocol owned by `LibraryScreen`:
 
-1. **Presentation gate:** after the current Media adaptive shell mounts or reports its
-   shell lifecycle message, reconcile the outer Library stage to the current adaptive
-   Media presentation. The stage must have `library-adaptive-compact` and must not retain
+1. **Presentation gate:** compose the Media outer Library stage with the correct adaptive
+   presentation from its first frame, then equality-reconcile that same projection after
+   the current Media adaptive shell mounts or reports its shell lifecycle message. The
+   stage must have `library-adaptive-compact` and must not retain
    `library-notes-compact` when the Media adaptive reader is current. Reconciliation
    advances an application-owned presentation epoch and requests layout only when the
    projected class contract changes.
@@ -71,19 +72,29 @@ A small Media-owned `VerticalScroll` subclass remains a presentation widget. It:
 - does not own return receipts, focus policy, route state, timers, or page data; and
 - emits no polling work.
 
-The message must identify the concrete sender. A message from an old or detached owner
-cannot settle a current request.
+The message must identify the concrete sender. It does not carry or interpret the
+screen's presentation epoch. On receipt, `LibraryScreen` associates the owner revision
+with the current epoch; a message from an old or detached owner cannot settle a current
+request.
 
 ### Presentation reconciliation
 
-The existing Media adaptive-shell lifecycle handler must run the same stage projection
-that screen resize already uses before synchronizing shell width. Projection remains
-equality-guarded: unchanged classes and geometry do not recompose, reload data, write
-preferences, or create work.
+The Media compose branch and existing adaptive-shell lifecycle handler must use one
+Media-specific presentation projection. Compose applies it directly to the new outer
+grid so the first owner cannot lay out under a knowingly wrong class. The mounted
+handler equality-reconciles it before the existing shell-width synchronization, with a
+later shell event responsible for any width measurement invalidated by the class change.
+Unchanged classes and geometry do not recompose, reload data, write preferences, or
+create work.
 
 Presentation epoch changes whenever an action can change the effective outer compact
 contract or current Media owner, including adaptive-shell replacement and relevant
-viewport/layout projection. The epoch is transient and screen-owned.
+viewport/layout projection. The epoch is transient and screen-owned. When projection
+changes classes, the screen records the current owner's latest geometry revision as an
+exclusive floor; only a later owner revision can prove geometry for the new epoch. This
+also rejects a pre-change Resize whose custom message was still queued when the epoch
+advanced. If the class change produces no later Resize because geometry is identical,
+the request takes the bounded failure path rather than promoting stale proof.
 
 ### Return-settlement request
 
@@ -91,11 +102,14 @@ An immutable request records:
 
 - ABA-safe request identity;
 - retained `(media_id, scroll_offset)` receipt;
+- final focus policy and identity: semantic Media row for viewer/list returns, or the
+  captured normal-Media control for a Trash round trip;
 - focus-intent, compose, Media lifecycle, and presentation generations;
-- applied Media content/page revision and ordered stable IDs;
+- applied Media content signature: applied scope plus ordered stable IDs;
 - route and Media sub-view identity;
 - viewport/layout signature; and
-- current shell, Items host, and row-scroll owner identities once attached.
+- current shell, Items host, and row-scroll owner identities once attached, plus the
+  exclusive geometry-revision floor required by the presentation epoch.
 
 The existing retained return receipt remains authoritative. Transient framework clamping
 must never overwrite it.
@@ -106,17 +120,35 @@ must never overwrite it.
    retained receipt. A newer request invalidates the older object.
 2. Mounting the replacement Media adaptive shell reconciles the presentation contract
    and advances or confirms the required presentation epoch.
-3. The current row-scroll owner emits geometry after Textual reflow. If it emitted before
-   the request was armed, its latest recorded revision may be evaluated immediately.
+3. The current row-scroll owner emits geometry after Textual reflow. If geometry arrived
+   before the request was armed, it may be evaluated immediately only when the screen's
+   presentation epoch did not invalidate that revision. A class-changing projection
+   captures the owner's already-incremented latest revision as an exclusive floor, so a
+   custom message queued before the change cannot be accepted after it. Geometry from
+   before a presentation-class change is never promoted merely because the live values
+   still match.
 4. `LibraryScreen` verifies every authority fence and the live geometry payload.
 5. For an unchanged content and layout revision, settlement is eligible only when the
    exact desired offset lies within the owner's current maxima.
-6. In one synchronous commit, resolve the semantic row, focus it with
-   `scroll_visible=False`, apply the unanimated exact offset, verify the resulting
-   integer offset equals the receipt, and record `exact-settled` for that request and
-   geometry revision.
-7. Focus must not become the observable success boundary before exact scroll succeeds.
-   Repeated current-owner messages after success are no-ops.
+6. In one synchronous commit, resolve the semantic row and final focus target, apply the
+   unanimated exact offset, verify the resulting integer offset equals the receipt, then
+   apply the final focus programmatically with `scroll_visible=False` where supported.
+   Verify focus did not alter the exact offset and record `exact-settled` for that request
+   and geometry revision.
+7. Viewer/list returns finish on the semantic Media row. Trash round trips finish on the
+   captured normal-Media toolbar/control identity while retaining the selected row and
+   exact list scroll. Programmatic-focus guards prevent either final focus from being
+   mistaken for user takeover.
+   If a captured control is no longer mounted, reachable, or enabled under a proven
+   responsive layout revision, use the semantic row or existing safe Media-list fallback
+   and record `exact-scroll-focus-fallback`, not full exact settlement.
+8. Final focus must not become the observable success boundary before exact scroll
+   succeeds. Repeated current-owner messages after success are no-ops.
+9. Exact settlement marks only the current request/owner revision complete. The existing
+   outer two-second arm and retained receipt remain available so a later authoritative
+   recompose inside that window can create a new generation-fenced request. Any user
+   input, foreign focus, route change, or the existing deadline still disarms it
+   immediately.
 
 ## Authority fences
 
@@ -126,9 +158,11 @@ Every attempt must reject when any of these differ from the request:
 - focus-intent, compose, Media lifecycle, or presentation generation;
 - route, Media sub-view, Items-open state, or semantic target;
 - current shell, Items host, row-scroll owner, attachment, or ancestry;
-- retained receipt, applied scope, content revision, or ordered stable IDs;
-- viewport/layout signature for an exact return; or
-- live geometry versus the message payload.
+- retained receipt or applied content signature;
+- logical viewport/layout signature for an exact return; or
+- live geometry versus the message payload;
+- owner geometry revision at or below the epoch's exclusive floor; or
+- final focus identity versus the request's row-or-captured-control policy.
 
 User keyboard/mouse takeover, foreign focus, another Back request, route change,
 content change, recompose, adaptive layout change, and unmount synchronously invalidate
@@ -137,14 +171,19 @@ identity are required.
 
 ## Content or layout changes
 
-Exact physical scroll is authoritative only while the content and viewport/layout
-revision captured with the receipt remain unchanged.
+Exact physical scroll is authoritative only while the content and logical
+viewport/layout revision captured with the receipt remain unchanged. The content
+signature is the applied scope plus ordered stable IDs. The layout signature is derived
+from the terminal allocation and pure effective Media pane layout. Neither signature
+includes replacement widget identity, compose generation, presentation epoch, or
+transient framework geometry; those facts fence stale work but must not misclassify an
+equivalent recompose as a user-visible layout change.
 
-If a controller/content revision proves that the list changed, or a viewport/layout
+If the applied content signature proves that the list changed, or a viewport/layout
 revision proves that the physical coordinate system changed, the new epoch may perform
-one explicit semantic-row focus with an honest clamp from current geometry. It records
-`clamped-after-revision`, never `exact-settled`. A timeout cannot be used to infer that
-content shrank.
+one explicit honest clamp from current geometry followed by the request's final-focus
+policy. It records `clamped-after-revision`, never `exact-settled`. A timeout cannot be
+used to infer that content shrank.
 
 This preserves the TASK-18918 contract: Trash navigation and Restore do not replace or
 rerank the retained normal-Media page. Restore only marks it stale pending an
@@ -157,14 +196,17 @@ readiness evidence.
 
 If an unchanged request has no representable current-owner geometry by the deadline:
 
-- record `layout-settlement-failed`;
-- clear the ephemeral settlement request and timer;
-- emit one metadata-only, privacy-safe warning; and
-- perform at most one honest semantic-focus fallback against current geometry without
-  reporting exact success.
+- if every non-geometry authority fence still holds, attempt at most one honest
+  clamped-scroll plus final-focus fallback using the request's
+  row-or-captured-control policy;
+- record `clamped-after-settlement-failure` if that fallback commits, otherwise record
+  `layout-settlement-failed` without claiming focus or scroll success;
+- emit one metadata-only, privacy-safe warning for that current-request failure; and
+- then clear the ephemeral settlement request, retained arm, and timer.
 
-No callback is re-enqueued after failure. Route change, cancellation, or unmount clears
-the request without warning.
+No callback is re-enqueued after failure. If the non-geometry authority fences no longer
+hold at the deadline, clear the request silently. Route change, cancellation, or unmount
+also clears it without warning.
 
 ## Alternatives rejected
 
@@ -184,14 +226,20 @@ TDD retains the existing consumer-visible `(0, 42)` RED unchanged. New focused t
 must establish:
 
 - same-size recompose reconciles adaptive Media presentation before settlement;
+- the first composed Media stage never advertises the legacy compact class;
 - focus is withheld until current-owner Resize-derived geometry is eligible;
 - current geometry makes semantic focus and exact scroll observable together;
+- viewer returns finish on their Media row, while Trash returns restore the captured
+  normal-Media control without losing selected row or list scroll;
 - duplicate geometry is idempotent;
+- geometry emitted or queued before a presentation epoch cannot settle that epoch;
 - old owner, stale epoch, stale request, user takeover, route change, and unmount cannot
   settle;
+- an unavailable captured control uses the documented focus fallback without claiming
+  full exact settlement;
 - a proven content/layout revision clamps once and is labelled honestly;
 - no geometry reaches one bounded failure with no further queued attempt; and
-- no scheduler-turn count appears in production or tests.
+- no scheduler-turn count is used as readiness evidence in production or tests.
 
 The established exact test must pass in five consecutive fresh processes. Then run the
 focused normal-Media Back/recompose/adaptive-layout tests, the production-shaped

--- a/Docs/superpowers/specs/2026-08-30-task-18918-library-media-trash-paging-design.md
+++ b/Docs/superpowers/specs/2026-08-30-task-18918-library-media-trash-paging-design.md
@@ -1,0 +1,331 @@
+# TASK-18918 Library Media Trash Paging Design
+
+**Date:** 2026-08-30
+
+**Status:** Approved in conversation; self-review passed; pending user written-spec review
+
+**Task:** TASK-18918
+
+**Programme design:**
+`Docs/superpowers/specs/2026-08-14-library-top-level-source-pagination-design.md`
+
+**Governing ADR:**
+`backlog/decisions/067-library-top-level-pagination-contracts.md`
+
+## Summary
+
+Library Media Trash will become a local-only, independently filtered, exact-page
+recovery surface. It will expose at most 20 deleted Media summaries at once while
+keeping every matching item reachable. Search, type, page, selection, loading,
+staleness, and recovery remain owned by Trash rather than borrowing the active Media
+browse controller.
+
+Restore and per-item permanent deletion will share the existing Media mutation
+interlock. A committed mutation updates local presentation before any follow-up read,
+so a refresh failure cannot recast success as failure. Exact range and total copy is
+shown only for a validated authoritative page.
+
+## Context and Current Gap
+
+The current nested Trash view already provides:
+
+- entry from Library Browse › Media and Back/Escape return;
+- a local policy-checked `list_media_trash` service seam;
+- deterministic `trash_date DESC, last_modified DESC, id DESC` ordering;
+- one scrollable list, stable record IDs, single-row selection, and Restore;
+- shared Media mutation exclusion with delete and Undo;
+- honest loading, empty, error, and transient restore feedback;
+- narrow-height reachability for a large fetched page.
+
+It always requests page 1, mounts up to 200 rows, displays truncation as
+`showing X of N`, and has no way to reach later records. Its local service reads the
+count and rows separately, so the total and page are not one coherent snapshot. Trash
+also lacks complete-source filtering, generation-owned page requests, stale retained
+rows, authoritative Retry, page clamping, and per-item permanent deletion.
+
+## Approved Decisions
+
+1. Trash owns an independent filter scope. Entering Trash starts unfiltered rather
+   than inheriting Media browse search or type state.
+2. The page size is fixed at 20, following ADR-067 and the shipped Library sources.
+3. Search matches title metadata only; type is an exact complete-source facet.
+   Active-content FTS is not used for deleted records.
+4. The surface remains local-only. This task does not change server API behavior or
+   expose a source-mode selector.
+5. Permanent deletion is per-item, irreversible, and requires inline confirmation.
+   Bulk Empty Trash is not added.
+6. Back returns to the untouched Media browse scope and restores the focus/scroll
+   receipt captured on entry.
+7. Existing Library pager display derivation is reused, but Trash retains its own
+   records, workers, selection, mutations, and recovery state.
+
+## Goals
+
+1. Make every matching local Trash item reachable through exact bounded pages.
+2. Apply search and type filtering to the complete Trash source before count and
+   slicing.
+3. Keep exact totals, ranges, page boundaries, selection, and action availability
+   truthful through mutations and concurrent source changes.
+4. Preserve deterministic keyboard focus, scroll, Back, Retry, and confirmation
+   behavior at all supported terminal sizes.
+5. Fail closed on malformed service envelopes and fence late requests after newer
+   intent or unmount.
+6. Keep diagnostics metadata-only and preserve the existing Media mutation owner.
+
+## Non-goals
+
+- Changing Media Trash storage, schema, retention, or restore semantics.
+- Adding server-backed Trash paging or changing the `/api/v1/media/trash` contract.
+- Sharing page records or selection with normal Media browse.
+- Searching deleted content, chunks, keywords, or FTS indexes.
+- Adding bulk Restore, bulk permanent delete, or Empty Trash.
+- Persisting Trash records, errors, loading state, drafts, or selection across
+  Library-screen instances.
+- Introducing a generic Library pager widget or data controller.
+- Redesigning the Media reader or the shared three-column Library shell.
+
+## Interaction Design
+
+### Entry, hierarchy, and filters
+
+Trash remains a nested Media canvas reached from the normal Media toolbar. Opening it
+captures the current Media list's semantic focus and scroll receipt, clears any Media
+delete receipt or select-mode confirmation, and requests unfiltered page 1.
+
+The compact Trash header contains:
+
+- `‹ Media` Back;
+- `Trash` plus the exact total only while the page is fresh;
+- a title-search field;
+- a bounded type chooser populated from all Trash types, never the current page;
+- exact range and page copy derived by the shared Library pager function.
+
+Submitting search or choosing a type requests page 1 for that independent scope and
+clears Trash selection immediately. Search input is a draft until submitted. Failed
+or abandoned drafts are not treated as applied scope. Clearing either filter returns
+to page 1 of the remaining applied scope.
+
+The type chooser follows the existing Media type-choice interaction instead of
+mounting an unbounded row of type buttons. An `All types` choice is always available.
+
+### Rows and paging
+
+The page contains at most 20 two-line rows. Titles and secondaries wrap or truncate
+according to the existing Media row grammar without horizontal scrolling. The row
+list owns remaining vertical height and scrolls independently, keeping the action and
+pager bars reachable.
+
+The pager exposes Previous, `Page X of Y`, exact `A–B of N`, Next, and Retry as
+appropriate. A page request retains the last good rows but disables row mutation and
+pager actions until the request settles. Only an applied fresh scope exposes exact
+totals and boundaries.
+
+Selection is current-page and current-scope only. It clears before page or filter
+intent begins, so an off-page row can never remain invisibly actionable. A successful
+page selects its first row only when Trash still owns entry/list focus; background
+completion never steals newer focus.
+
+### Restore
+
+Restore acts on the visibly selected fresh row. It has no Undo receipt because it is
+a recovery action. On commit:
+
+1. remove the stable ID from the Trash page immediately;
+2. decrement the known Trash total;
+3. reconcile the restored summary through the existing Media mutation completion
+   path so normal Media browse becomes fresh or stale according to its applied scope;
+4. show `Restored '<title>'.`;
+5. request the authoritative current or clamped Trash page.
+
+If the follow-up read fails, the restore remains successful. Retained rows become
+stale, exact total/range copy is withdrawn, actions are disabled, and the status says
+that the item was restored but Trash could not refresh, with Retry.
+
+### Delete permanently
+
+`Delete permanently` is available only for a visibly selected fresh row. Activating it
+replaces the action bar with inline confirmation that names the bounded display title
+and states that the action cannot be undone. `Delete permanently` confirms; Cancel or
+Escape returns to the list and restores the opener focus without mutation.
+
+On commit, Trash removes the stable ID locally, decrements the known total, shows
+`Deleted '<title>' permanently.`, and requests the authoritative current or clamped
+page. A failed follow-up read cannot report the deletion as failed; it uses the same
+stale recovery contract as Restore. A service failure before commit keeps the row and
+selection visible and reports a recoverable action error without changing totals.
+
+Restore and permanent deletion share the existing Media mutation flag and worker
+group with Media delete/Undo. Confirmation is invalidated when scope, selection,
+generation, lifecycle, or mounted ownership changes.
+
+### Back and focus
+
+Back and Escape leave Trash through one exit seam. They invalidate Trash request
+generations, dismiss confirmation, drop Trash-only records and drafts, and restore
+the exact Media browse semantic focus and scroll receipt captured on entry. An empty
+Trash remains on its honest empty state until the user leaves; a mutation never
+navigates away implicitly. The applied Media query, type, page, selection, and rows
+are never overwritten by Trash.
+
+Within Trash, recomposition restores focus by semantic identity: Back, search, type,
+stable Media ID, Previous, Next, Retry, Restore, Delete permanently, or Cancel. If the
+identity disappears after mutation, focus moves to the row at the same page-local
+position, then the previous row, then Back. Deferred focus checks the same generation
+and lifecycle authority as the request that scheduled it.
+
+### Narrow terminals
+
+At 160×50, 120×35, 100×30, and 80×24:
+
+- the shared Library and Items panes retain their existing collapsible behavior;
+- Trash uses the same canvas allocation as normal Media;
+- search/type controls wrap into compact rows rather than forcing horizontal scroll;
+- the list, pager, confirmation, and recovery actions remain reachable;
+- long titles cannot push pager or destructive confirmation outside the viewport.
+
+## State and Authority
+
+Trash uses a source-owned immutable state/reducer separate from normal Media browse.
+Its scope contains normalized submitted query, optional media type, page, and fixed
+page size. Runtime state contains:
+
+- requested and applied scope;
+- last-good immutable page summaries;
+- fresh exact total and complete type facets;
+- `uninitialized`, `fresh`, or `stale` freshness;
+- loading direction and recoverable error/stale copy;
+- current-page selected stable ID;
+- confirmation stable ID and captured title;
+- request generation and one-clamp recovery ownership;
+- transient committed-mutation notice.
+
+The pure reducer validates every transition. UI-only focus/scroll receipts and Textual
+worker handles remain on `LibraryScreen`; service and storage layers never own them.
+
+The existing shared `build_library_pager_display` function derives copy and disabled
+state. No generic controller, widget, message type, or application store is added.
+
+## Page Contract
+
+The local Trash page request contains:
+
+- normalized title query;
+- exact optional media type;
+- page number of at least 1;
+- page size exactly 20.
+
+The response contains:
+
+- exact immutable summary items for the requested page;
+- exact total after filters;
+- echoed page size and offset, or equivalent validated page coordinates;
+- complete distinct non-empty Trash types from the same read snapshot.
+
+The facet list covers all local Trash rows independent of the submitted title query,
+active type, and current page. This keeps every type discoverable and ensures the
+user can always broaden the scope without first clearing hidden state.
+
+Each summary carries canonical stable ID, positive backing Media ID, title, media type,
+and Trash timestamp required by the existing relative-age secondary. IDs must be
+unique within the page. Page cardinality must equal
+`min(page_size, max(total - offset, 0))`; undersized non-final pages and oversized
+pages fail closed.
+
+The title query is trimmed, rejects embedded NUL, and is bounded to 200 characters at
+the service boundary. An empty normalized query means no title filter. The UI may
+prevent longer input, but service validation remains authoritative.
+
+Ordering is exactly:
+
+```text
+trash_date DESC, last_modified DESC, id DESC
+```
+
+Null timestamp behavior must be deterministic and identical between count/page tests
+and production queries. Search uses parameterized title matching with explicit
+wildcard escaping. Type matching is exact after existing Media type normalization.
+Filters apply before `COUNT`, ordering, and `LIMIT/OFFSET`.
+
+For the local backend, count, rows, and complete facets execute in one read
+transaction. The normal `list_media_trash` compatibility seam may remain for other
+callers, but Library uses the new exact contract. Scope policy enforcement and
+off-event-loop execution remain in `MediaReadingScopeService`; `LibraryScreen` never
+executes raw SQL.
+
+## Validation, Drift, and Recovery
+
+Only the latest Trash generation may apply. The apply gate checks:
+
+- mounted screen and active `media-trash` view;
+- unchanged lifecycle and Trash request generation;
+- exact requested scope fingerprint;
+- valid page envelope and unique stable IDs;
+- unchanged mutation/focus authority where the completion may move focus.
+
+A fresh response proving the requested page is beyond the last valid page triggers
+one generation-guarded request for `max(1, last_page)`. The out-of-range response is
+never displayed. If the clamp response is also out of range, malformed, or fails,
+last-good rows become stale and Retry is offered with unknown boundaries.
+
+Initial failure displays no rows and `Could not load Trash · Retry`. A failed page or
+filter request retains the last-good applied page but removes exact boundary claims
+when its authority may no longer be current. Malformed payloads are handled as
+recoverable read failures and never partially normalized into a page.
+
+Unmount, Back, new filter/page intent, and mutation each invalidate older reads before
+starting work. Cancelled Textual workers may finish their local thread reads, but late
+results cannot apply to a former or remounted screen.
+
+## Diagnostics and Privacy
+
+Diagnostics may record operation name, page size, requested page, filter-presence
+booleans, item count, total, freshness, generation outcome, and exception type. They
+must not record search text, titles, raw records, paths, content, credentials, stable
+private IDs, or permanent-delete targets.
+
+User-facing failures use bounded fixed copy and never expose raw exception text.
+
+## Verification
+
+### Pure and service tests
+
+- scope normalization and immutable page validation;
+- exact cardinality, duplicate-ID, malformed-coordinate, and out-of-range rejection;
+- title/type filtering before slicing;
+- complete facets independent of current page;
+- coherent count/rows/facets under one read transaction;
+- pure selection, loading, failure, stale, Retry, and one-clamp transitions;
+- restore and permanent-delete success/failure truthfulness.
+
+### Mounted Textual tests
+
+- open, independent filter submit/clear, type selection, Previous/Next, and Retry;
+- selection cleared before page/scope changes;
+- loading and stale states disable Restore and permanent deletion;
+- inline irreversible confirmation, Escape/Cancel, double-press exclusion, and focus;
+- late reads after new intent, Back, mutation, and unmount cannot apply;
+- committed mutation plus failed refresh remains successful and recoverable;
+- Media browse page/filter/selection/focus/scroll survives a Trash round trip;
+- semantic focus restoration across recomposition and row removal;
+- 160×50, 120×35, 100×30, and 80×24 containment and keyboard reachability.
+
+### Isolated live walkthrough
+
+Use a temporary real `MediaDatabase` with more than 40 Trash records spanning
+multiple types, long titles, equal/null timestamps, and active non-Trash controls.
+Walk through page 1, middle/final pages, title search, type filtering, Restore,
+permanent-delete confirmation, concurrent shrink, forced refresh failure/Retry, Back,
+and all four supported terminal sizes. Record compositor-visible evidence and confirm
+active Media/RAG reads still exclude Trash until restoration.
+
+## ADR Check
+
+ADR required: no
+
+ADR path: `backlog/decisions/067-library-top-level-pagination-contracts.md`
+
+Reason: ADR-067 already selects source-owned exact bounded pages, coherent totals,
+complete filtering/facets, generation fencing, clamp-on-shrink, truthful committed
+mutation recovery, privacy-safe diagnostics, and a separate Media Trash follow-up.
+This design does not change schema, storage ownership, sync/conflict policy, security,
+dependencies, runtime boundaries, or the long-lived Library topology.

--- a/Docs/superpowers/specs/2026-08-30-task-18918-library-media-trash-paging-design.md
+++ b/Docs/superpowers/specs/2026-08-30-task-18918-library-media-trash-paging-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-30
 
-**Status:** Approved in conversation; self-review passed; pending user written-spec review
+**Status:** Approved; independent critique findings incorporated
 
 **Task:** TASK-18918
 
@@ -54,10 +54,12 @@ rows, authoritative Retry, page clamping, and per-item permanent deletion.
    expose a source-mode selector.
 5. Permanent deletion is per-item, irreversible, and requires inline confirmation.
    Bulk Empty Trash is not added.
-6. Back returns to the untouched Media browse scope and restores the focus/scroll
-   receipt captured on entry.
+6. Back preserves normal Media's applied scope, page, selection, focus, and scroll.
+   Restore marks that retained Media page stale; it never inserts an unranked row.
 7. Existing Library pager display derivation is reused, but Trash retains its own
    records, workers, selection, mutations, and recovery state.
+8. Keyboard authority follows the explicit precedence table below. Deferred page,
+   filter, mutation, and focus completions cannot infer a new owner after newer intent.
 
 ## Goals
 
@@ -95,7 +97,8 @@ delete receipt or select-mode confirmation, and requests unfiltered page 1.
 The compact Trash header contains:
 
 - `‹ Media` Back;
-- `Trash` plus the exact total only while the page is fresh;
+- `Local Trash` plus `N items` when unfiltered or `N matching` when filtered, only
+  while the page is fresh;
 - a title-search field;
 - a bounded type chooser populated from all Trash types, never the current page;
 - exact range and page copy derived by the shared Library pager function.
@@ -107,6 +110,8 @@ to page 1 of the remaining applied scope.
 
 The type chooser follows the existing Media type-choice interaction instead of
 mounting an unbounded row of type buttons. An `All types` choice is always available.
+The applied query/type is visible beside the range whenever filters are active. A
+draft is never reflected in that applied-scope label until its request succeeds.
 
 ### Rows and paging
 
@@ -120,10 +125,44 @@ appropriate. A page request retains the last good rows but disables row mutation
 pager actions until the request settles. Only an applied fresh scope exposes exact
 totals and boundaries.
 
+Disabled controls remain mounted and explain their state. Loading uses
+`Trash is refreshing.`; stale mutation actions use
+`Refresh Trash before changing this item.`; and an absent selection uses
+`Select a Trash item first.` These reasons are exposed through visible status copy or
+the shipped tooltip convention as appropriate.
+
 Selection is current-page and current-scope only. It clears before page or filter
-intent begins, so an off-page row can never remain invisibly actionable. A successful
-page selects its first row only when Trash still owns entry/list focus; background
-completion never steals newer focus.
+intent begins, so an off-page row can never remain invisibly actionable. Page and
+filter completion follow the focus table below rather than always selecting the first
+row. Background completion never steals newer focus.
+
+### Keyboard and focus precedence
+
+Higher rows in this table win over lower rows:
+
+| State or origin | Escape | Successful completion | Selection/focus outcome |
+| --- | --- | --- | --- |
+| Permanent-delete confirmation | Cancel confirmation | N/A | Cancel has initial focus; opener focus returns after Cancel |
+| Restore/permanent-delete call in flight | Do not leave; status explains that the mutation is finishing | Commit or recoverable pre-commit failure | Mutation action retains authority until the service reports whether it committed |
+| Type chooser open | Close chooser | N/A until explicit activation | Type control retains focus; selection is unchanged |
+| Type-filter submission | Return to Media and invalidate the request | Page 1 applied | Type control retains focus; selection stays empty |
+| Search submission | Return to Media and invalidate the request | Page 1 applied | Search retains focus; selection stays empty |
+| Previous/Next pager | Return to Media and invalidate the request | Requested page applied | Invoking pager retains focus when it remains enabled; otherwise its nearest pager/Back fallback receives focus; selection stays empty |
+| Retry | Return to Media and invalidate the request | Failed target applies or clamps once | Retry retains focus while visible; success uses the original request-origin rule |
+| Initial entry | Return to Media and invalidate the request | Page 1 applied | First row is selected/focused only if entry authority is still current; an initial failure focuses Retry; otherwise Back |
+| Post-commit Trash refresh | Return to Media and invalidate only the follow-up read | Authoritative current/clamped page applied | Same page-local row position, then previous row, then Back, only if mutation authority is still current |
+| Empty fresh page | Return to Media | N/A | Back receives focus; selection stays empty |
+| Idle Trash list | Return to Media | N/A | Row activation selects that visible row; Up/Down follows DOM order |
+| Back activation | Already leaving | N/A | Apply the guarded normal-Media return receipt; late Trash completions are fenced |
+
+While confirmation is open, Escape always means Cancel and never Back. Otherwise
+Escape exits Trash through the shared Back seam. A keypress that opened or submitted
+a control is consumed; it cannot activate a newly mounted successor control. The only
+temporary exception is the short mutation-call phase where commit status is unknown:
+Back and Escape remain mounted but disabled with `Finishing this action…`. Once the
+service reports pre-commit failure or committed success, leaving is available again;
+a post-commit authoritative Trash refresh may be abandoned without changing the
+mutation result.
 
 ### Restore
 
@@ -131,28 +170,47 @@ Restore acts on the visibly selected fresh row. It has no Undo receipt because i
 a recovery action. On commit:
 
 1. remove the stable ID from the Trash page immediately;
-2. decrement the known Trash total;
-3. reconcile the restored summary through the existing Media mutation completion
-   path so normal Media browse becomes fresh or stale according to its applied scope;
-4. show `Restored '<title>'.`;
-5. request the authoritative current or clamped Trash page.
+2. decrement the known Trash total as internal reconciliation knowledge only;
+3. transition Trash immediately to stale/loading, withdraw exact header count, range,
+   and page claims, and disable row mutations;
+4. preserve normal Media's applied scope, page, records, selection, focus, and scroll,
+   while marking that retained page stale through the existing Media mutation
+   completion path;
+5. never insert or reposition the restored row without an authoritative ranked Media
+   read;
+6. show `Restored '<title>'.` and request the authoritative current or once-clamped
+   Trash page.
 
 If the follow-up read fails, the restore remains successful. Retained rows become
 stale, exact total/range copy is withdrawn, actions are disabled, and the status says
-that the item was restored but Trash could not refresh, with Retry.
+`Restored '<bounded title>'. List may be out of date · Retry`.
 
 ### Delete permanently
 
 `Delete permanently` is available only for a visibly selected fresh row. Activating it
-replaces the action bar with inline confirmation that names the bounded display title
-and states that the action cannot be undone. `Delete permanently` confirms; Cancel or
-Escape returns to the list and restores the opener focus without mutation.
+replaces the action bar with inline confirmation that states the irreversible
+consequence and identifies the target by its full title, media type, and Trash
+timestamp. The full title is shown in a bounded vertically scrollable detail region,
+not shortened into an ambiguous confirmation. Missing type or timestamp is rendered
+as `Unknown type` or `Unknown deletion time`, never silently omitted. The captured
+stable ID authorizes the mutation; visible text never does. Cancel receives initial
+focus. The opener keypress is consumed, so only a later explicit activation of
+`Delete permanently` can commit. Cancel or Escape returns to the list and restores
+the opener focus without mutation.
 
-On commit, Trash removes the stable ID locally, decrements the known total, shows
-`Deleted '<title>' permanently.`, and requests the authoritative current or clamped
-page. A failed follow-up read cannot report the deletion as failed; it uses the same
-stale recovery contract as Restore. A service failure before commit keeps the row and
-selection visible and reports a recoverable action error without changing totals.
+The commit calls only
+`MediaReadingScopeService.permanently_delete_media_item(mode="local", media_id=...)`.
+That seam preserves the existing physical cascade, FTS cleanup, and no-sync-log
+semantics; this task does not add a second delete path. A pre-commit not-found,
+not-in-Trash, policy, or service failure keeps the row and selection visible and
+reports a recoverable action error without changing totals.
+
+On commit, Trash removes the stable ID locally, treats the decremented known total as
+internal reconciliation knowledge only, transitions immediately to stale/loading,
+withdraws exact header/range/page claims, disables row mutations, shows
+`Deleted '<title>' permanently.`, and requests the authoritative current or
+once-clamped page. A failed follow-up read cannot report the deletion as failed; it
+uses `Deleted '<bounded title>' permanently. List may be out of date · Retry`.
 
 Restore and permanent deletion share the existing Media mutation flag and worker
 group with Media delete/Undo. Confirmation is invalidated when scope, selection,
@@ -160,12 +218,20 @@ generation, lifecycle, or mounted ownership changes.
 
 ### Back and focus
 
-Back and Escape leave Trash through one exit seam. They invalidate Trash request
-generations, dismiss confirmation, drop Trash-only records and drafts, and restore
-the exact Media browse semantic focus and scroll receipt captured on entry. An empty
-Trash remains on its honest empty state until the user leaves; a mutation never
-navigates away implicitly. The applied Media query, type, page, selection, and rows
-are never overwritten by Trash.
+Back and Escape leave Trash through one exit seam. Before entry, Trash captures a
+distinct return receipt containing the normal Media stable row identity, list scroll,
+and semantic opener/focus identity. It does not reuse the Media Viewer receipt field.
+Exit invalidates Trash request generations, dismisses confirmation, drops Trash-only
+records and drafts, and applies the receipt through the guarded Media list-return
+path. An empty Trash remains on its honest empty state until the user leaves; a
+mutation never navigates away implicitly.
+
+The applied Media query, type, page, records, selection, focus, and scroll are never
+overwritten by Trash. Restore marks that retained Media page stale and exposes its
+source-owned Retry because the restored item's ranked position is unknown. Permanent
+deletion does not independently stale normal Media because a trashed item was not in
+its active result set. A successful Trash refresh never clears normal Media's stale
+flag; only an authoritative normal-Media refresh does.
 
 Within Trash, recomposition restores focus by semantic identity: Back, search, type,
 stable Media ID, Previous, Next, Retry, Restore, Delete permanently, or Cancel. If the
@@ -179,9 +245,19 @@ At 160×50, 120×35, 100×30, and 80×24:
 
 - the shared Library and Items panes retain their existing collapsible behavior;
 - Trash uses the same canvas allocation as normal Media;
-- search/type controls wrap into compact rows rather than forcing horizontal scroll;
-- the list, pager, confirmation, and recovery actions remain reachable;
-- long titles cannot push pager or destructive confirmation outside the viewport.
+- the fixed vertical order is Back/title/authority, filters, status, the `1fr` list,
+  pager, then action or confirmation;
+- at 80×24 the list retains at least four terminal rows, enough for two complete
+  two-line entries;
+- status copy uses at most two visible lines plus a fold indicator;
+- the bounded type chooser temporarily replaces the filter row with a scrollable
+  choice strip instead of adding height;
+- search/type controls never force horizontal scrolling;
+- destructive consequence and confirmation buttons remain fixed while only the full
+  target-title detail region scrolls;
+- disabled pager and mutation controls remain visible with textual reasons or
+  tooltips, never color alone;
+- the list, pager, confirmation, and recovery actions remain keyboard reachable.
 
 ## State and Authority
 
@@ -195,12 +271,17 @@ page size. Runtime state contains:
 - `uninitialized`, `fresh`, or `stale` freshness;
 - loading direction and recoverable error/stale copy;
 - current-page selected stable ID;
-- confirmation stable ID and captured title;
+- confirmation stable ID and captured full title, type, and Trash timestamp;
 - request generation and one-clamp recovery ownership;
 - transient committed-mutation notice.
 
 The pure reducer validates every transition. UI-only focus/scroll receipts and Textual
 worker handles remain on `LibraryScreen`; service and storage layers never own them.
+After a committed mutation, the reducer may remove the captured stable ID immediately,
+but it must transition to stale/loading before scheduling the authoritative read. A
+locally decremented count is reconciliation knowledge, not display authority. Only a
+validated service result may restore fresh totals, range/page copy, selection, and
+enabled row actions.
 
 The existing shared `build_library_pager_display` function derives copy and disabled
 state. No generic controller, widget, message type, or application store is added.
@@ -214,20 +295,28 @@ The local Trash page request contains:
 - page number of at least 1;
 - page size exactly 20.
 
-The response contains:
+Page and page-size inputs reject booleans and non-integers. The derived offset must
+equal `(page - 1) * 20`, remain at most SQLite's signed 64-bit maximum
+`2**63 - 1`, and match the coordinates echoed by the response.
 
-- exact immutable summary items for the requested page;
-- exact total after filters;
-- echoed page size and offset, or equivalent validated page coordinates;
-- complete distinct non-empty Trash types from the same read snapshot.
+The response envelope contains exactly:
+
+- `items`: exact immutable summaries for the requested page;
+- `total`: exact total after filters;
+- `limit`: echoed page size;
+- `offset`: echoed derived offset;
+- `types`: complete distinct non-empty Trash types from the same read snapshot.
 
 The facet list covers all local Trash rows independent of the submitted title query,
 active type, and current page. This keeps every type discoverable and ensures the
 user can always broaden the scope without first clearing hidden state.
 
-Each summary carries canonical stable ID, positive backing Media ID, title, media type,
-and Trash timestamp required by the existing relative-age secondary. IDs must be
-unique within the page. Page cardinality must equal
+Each summary contains exactly `id`, `backing_media_id`, `title`, `media_type`, and
+`trash_date`. `backing_media_id` is a positive integer and `id` is its canonical
+`local:media:<backing_media_id>` stable ID. `title` is a non-empty display string with
+the established `Untitled` fallback, `media_type` is a trimmed string or `None`, and
+`trash_date` is an ISO timestamp string or `None`. Both stable IDs and backing IDs
+must be unique within the page. Page cardinality must equal
 `min(page_size, max(total - offset, 0))`; undersized non-final pages and oversized
 pages fail closed.
 
@@ -237,20 +326,31 @@ prevent longer input, but service validation remains authoritative.
 
 Ordering is exactly:
 
-```text
-trash_date DESC, last_modified DESC, id DESC
+```sql
+ORDER BY trash_date IS NULL ASC,
+         trash_date DESC,
+         last_modified IS NULL ASC,
+         last_modified DESC,
+         id DESC
 ```
 
-Null timestamp behavior must be deterministic and identical between count/page tests
-and production queries. Search uses parameterized title matching with explicit
-wildcard escaping. Type matching is exact after existing Media type normalization.
-Filters apply before `COUNT`, ordering, and `LIMIT/OFFSET`.
+Null timestamps therefore sort last deterministically. Search uses parameterized title
+matching with explicit wildcard escaping. Submitted and stored type values use
+`TRIM(type)` at the contract boundary; an empty trimmed value means no facet. Facets
+are unique sorted non-empty strings, and filtering compares trimmed values by exact
+case-sensitive equality. There is no case folding or alias mapping. Filters apply
+before `COUNT`, ordering, and `LIMIT/OFFSET`.
+
+The exact contract is implemented through
+`MediaDatabase.list_library_media_trash_page`,
+`LocalMediaReadingService.list_library_media_trash`, and
+`MediaReadingScopeService.list_library_media_trash`. The scope method requires
+`mode="local"`; non-local modes fail closed and no server endpoint changes. The
+legacy `list_media_trash` compatibility seam remains for other callers.
 
 For the local backend, count, rows, and complete facets execute in one read
-transaction. The normal `list_media_trash` compatibility seam may remain for other
-callers, but Library uses the new exact contract. Scope policy enforcement and
-off-event-loop execution remain in `MediaReadingScopeService`; `LibraryScreen` never
-executes raw SQL.
+transaction. Scope policy enforcement and off-event-loop execution remain in
+`MediaReadingScopeService`; `LibraryScreen` never executes raw SQL.
 
 ## Validation, Drift, and Recovery
 
@@ -267,10 +367,21 @@ one generation-guarded request for `max(1, last_page)`. The out-of-range respons
 never displayed. If the clamp response is also out of range, malformed, or fails,
 last-good rows become stale and Retry is offered with unknown boundaries.
 
-Initial failure displays no rows and `Could not load Trash · Retry`. A failed page or
-filter request retains the last-good applied page but removes exact boundary claims
-when its authority may no longer be current. Malformed payloads are handled as
-recoverable read failures and never partially normalized into a page.
+Initial failure displays no rows and `Could not load Trash · Retry`; Retry repeats the
+unfiltered page-1 request. A failed filter submission keeps the prior applied page
+fresh and shows `Filter not applied — showing <previous applied scope> · Retry`;
+Retry repeats the failed submitted scope. A failed ordinary page request keeps the
+prior applied page fresh and shows
+`Page <N> not loaded — showing page <M> · Retry`; Retry repeats page N. In both cases
+selection stays empty until the user explicitly selects a retained row, and pager
+actions operate on the visible applied scope.
+
+A committed mutation or externally detected shrink makes retained rows stale and
+shows `List may be out of date · Retry`. Stale state exposes no exact total, range, or
+page-boundary claims and disables row mutations. Retry requests the current target or
+its single guarded clamp. Query validation uses the fixed copy
+`Search is limited to 200 characters.` Malformed payloads are handled as recoverable
+read failures and never partially normalized into a page.
 
 Unmount, Back, new filter/page intent, and mutation each invalidate older reads before
 starting work. Cancelled Textual workers may finish their local thread reads, but late
@@ -290,10 +401,15 @@ User-facing failures use bounded fixed copy and never expose raw exception text.
 ### Pure and service tests
 
 - scope normalization and immutable page validation;
-- exact cardinality, duplicate-ID, malformed-coordinate, and out-of-range rejection;
-- title/type filtering before slicing;
-- complete facets independent of current page;
+- exact cardinality, duplicate stable/backing ID, malformed-coordinate, and
+  out-of-range rejection;
+- boolean/non-integer coordinate rejection and the SQLite signed-offset bound;
+- title/type filtering before slicing, including exact stored-type equality;
+- complete unique sorted facets independent of current page;
+- explicit NULL-last timestamp ordering;
 - coherent count/rows/facets under one read transaction;
+- exact local database/service/scope seam and non-local rejection, with the server
+  contract untouched;
 - pure selection, loading, failure, stale, Retry, and one-clamp transitions;
 - restore and permanent-delete success/failure truthfulness.
 
@@ -302,12 +418,21 @@ User-facing failures use bounded fixed copy and never expose raw exception text.
 - open, independent filter submit/clear, type selection, Previous/Next, and Retry;
 - selection cleared before page/scope changes;
 - loading and stale states disable Restore and permanent deletion;
-- inline irreversible confirmation, Escape/Cancel, double-press exclusion, and focus;
+- inline irreversible confirmation with duplicate/truncated/long titles, full target
+  identity, Escape/Cancel, consumed opener activation, double-press exclusion, and
+  focus;
+- every keyboard-precedence row, including initial-error Retry focus and pager
+  fallback focus;
+- Back/Escape exclusion while mutation commit status is unknown and immediate return
+  availability during the post-commit refresh;
 - late reads after new intent, Back, mutation, and unmount cannot apply;
 - committed mutation plus failed refresh remains successful and recoverable;
 - Media browse page/filter/selection/focus/scroll survives a Trash round trip;
+- Restore marks retained Media stale without inserting an unranked row, while
+  permanent deletion does not independently stale Media;
 - semantic focus restoration across recomposition and row removal;
-- 160×50, 120×35, 100×30, and 80×24 containment and keyboard reachability.
+- 160×50, 120×35, 100×30, and 80×24 containment and keyboard reachability in
+  ordinary, initial-error, stale, and destructive-confirmation states.
 
 ### Isolated live walkthrough
 
@@ -315,8 +440,10 @@ Use a temporary real `MediaDatabase` with more than 40 Trash records spanning
 multiple types, long titles, equal/null timestamps, and active non-Trash controls.
 Walk through page 1, middle/final pages, title search, type filtering, Restore,
 permanent-delete confirmation, concurrent shrink, forced refresh failure/Retry, Back,
-and all four supported terminal sizes. Record compositor-visible evidence and confirm
-active Media/RAG reads still exclude Trash until restoration.
+and all four supported terminal sizes. Confirm the Local Trash authority label,
+filtered total copy, distinct return receipt, stale normal-Media result after Restore,
+and unchanged normal-Media result after permanent deletion. Record compositor-visible
+evidence and confirm active Media/RAG reads still exclude Trash until restoration.
 
 ## ADR Check
 

--- a/Tests/DB/test_client_media_trash_pagination.py
+++ b/Tests/DB/test_client_media_trash_pagination.py
@@ -7,7 +7,10 @@ import threading
 
 import pytest
 
-from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+from tldw_chatbook.DB.Client_Media_DB_v2 import (
+    MediaDatabase,
+    permanently_delete_item,
+)
 
 
 @pytest.fixture
@@ -46,6 +49,37 @@ def _seed_trash(database: MediaDatabase, *, count: int) -> list[int]:
         )
         for index in range(count)
     ]
+
+
+def test_permanent_delete_rejects_active_media_before_fts_or_cascade_cleanup(
+    media_db, monkeypatch
+):
+    database, _path = media_db
+    media_id, _uuid, _message = database.add_media_with_keywords(
+        title="Active target",
+        media_type="document",
+        content="must remain active",
+        keywords=["must-remain"],
+    )
+    reached_fts_cleanup: list[int] = []
+    original_delete_fts = database._delete_fts_media
+
+    def record_fts_cleanup(connection, target_id):
+        reached_fts_cleanup.append(target_id)
+        return original_delete_fts(connection, target_id)
+
+    monkeypatch.setattr(database, "_delete_fts_media", record_fts_cleanup)
+
+    assert permanently_delete_item(database, media_id) is False
+    assert database.get_media_by_id(media_id) is not None
+    assert reached_fts_cleanup == []
+    connection = database.get_connection()
+    assert connection.execute(
+        "SELECT COUNT(*) FROM media_fts WHERE rowid = ?", (media_id,)
+    ).fetchone()[0] == 1
+    assert connection.execute(
+        "SELECT COUNT(*) FROM MediaKeywords WHERE media_id = ?", (media_id,)
+    ).fetchone()[0] == 1
 
 
 def test_library_trash_pages_filter_before_slicing_and_echo_coordinates(media_db):

--- a/Tests/DB/test_client_media_trash_pagination.py
+++ b/Tests/DB/test_client_media_trash_pagination.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import io
 import sqlite3
 import threading
 
 import pytest
+from loguru import logger
 
 from tldw_chatbook.DB.Client_Media_DB_v2 import (
+    DatabaseError,
     MediaDatabase,
     permanently_delete_item,
 )
@@ -133,6 +136,45 @@ def test_library_trash_rejects_invalid_coordinates_before_sql(media_db, kwargs):
         connection.set_trace_callback(None)
 
     assert statements == []
+
+
+def test_library_trash_read_failure_logs_safe_request_context(
+    media_db, monkeypatch
+):
+    database, _path = media_db
+    private_query = "private-query-sentinel"
+    private_error = "private-sqlite-sentinel"
+
+    class FailingTransaction:
+        def __enter__(self):
+            raise sqlite3.OperationalError(private_error)
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(database, "transaction", FailingTransaction)
+    output = io.StringIO()
+    sink = logger.add(output, format="{message}", level="ERROR")
+    try:
+        with pytest.raises(DatabaseError):
+            database.list_library_media_trash_page(
+                query=private_query,
+                media_type="pdf",
+                limit=20,
+                offset=40,
+            )
+    finally:
+        logger.remove(sink)
+
+    rendered = output.getvalue()
+    assert "operation=list_library_media_trash" in rendered
+    assert "limit=20" in rendered
+    assert "offset=40" in rendered
+    assert "has_query=True" in rendered
+    assert "has_type=True" in rendered
+    assert "exception_type=OperationalError" in rendered
+    assert private_query not in rendered
+    assert private_error not in rendered
 
 
 def test_library_trash_title_query_matches_like_metacharacters_literally(media_db):

--- a/Tests/DB/test_client_media_trash_pagination.py
+++ b/Tests/DB/test_client_media_trash_pagination.py
@@ -1,0 +1,267 @@
+"""Focused database-contract tests for Library Media Trash pagination."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+
+import pytest
+
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+
+
+@pytest.fixture
+def media_db(tmp_path):
+    database_path = tmp_path / "media.db"
+    database = MediaDatabase(db_path=database_path, client_id="trash-pagination-test")
+    yield database, database_path
+    database.close_connection()
+
+
+def _add_trashed_media(
+    database: MediaDatabase,
+    *,
+    title: str,
+    media_type: str,
+    content: str = "private-content",
+) -> int:
+    media_id, _uuid, _message = database.add_media_with_keywords(
+        title=title,
+        media_type=media_type,
+        content=f"{content}-{title}",
+        keywords=[],
+    )
+    assert media_id is not None
+    assert database.mark_as_trash(media_id)
+    return media_id
+
+
+def _seed_trash(database: MediaDatabase, *, count: int) -> list[int]:
+    return [
+        _add_trashed_media(
+            database,
+            title=f"Trash {index:02d}",
+            media_type="pdf" if index % 2 else "audio",
+            content=f"private-content-{index}",
+        )
+        for index in range(count)
+    ]
+
+
+def test_library_trash_pages_filter_before_slicing_and_echo_coordinates(media_db):
+    database, _path = media_db
+    media_ids = _seed_trash(database, count=45)
+
+    pages = [
+        database.list_library_media_trash_page(limit=20, offset=offset)
+        for offset in (0, 20, 40)
+    ]
+
+    assert [page["total"] for page in pages] == [45, 45, 45]
+    assert [page["limit"] for page in pages] == [20, 20, 20]
+    assert [page["offset"] for page in pages] == [0, 20, 40]
+    assert [len(page["items"]) for page in pages] == [20, 20, 5]
+    assert all(
+        set(item) == {"id", "title", "type", "trash_date"}
+        for page in pages
+        for item in page["items"]
+    )
+    assert [item["id"] for page in pages for item in page["items"]] == list(
+        reversed(media_ids)
+    )
+    assert all("private-content" not in repr(item) for page in pages for item in page["items"])
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"limit": True},
+        {"limit": 0},
+        {"limit": 19},
+        {"limit": 21},
+        {"limit": "20"},
+        {"limit": 2**63},
+        {"offset": True},
+        {"offset": "0"},
+        {"offset": -1},
+        {"offset": 2**63},
+    ],
+)
+def test_library_trash_rejects_invalid_coordinates_before_sql(media_db, kwargs):
+    database, _path = media_db
+    statements: list[str] = []
+    connection = database.get_connection()
+    connection.set_trace_callback(statements.append)
+    try:
+        with pytest.raises(ValueError):
+            database.list_library_media_trash_page(**kwargs)
+    finally:
+        connection.set_trace_callback(None)
+
+    assert statements == []
+
+
+def test_library_trash_title_query_matches_like_metacharacters_literally(media_db):
+    database, _path = media_db
+    percent_id = _add_trashed_media(database, title="budget 100%", media_type="pdf")
+    underscore_id = _add_trashed_media(database, title="under_score", media_type="pdf")
+    slash_id = _add_trashed_media(database, title=r"slash\\title", media_type="pdf")
+    _add_trashed_media(database, title="ordinary title", media_type="pdf")
+
+    assert [item["id"] for item in database.list_library_media_trash_page(query="%")["items"]] == [percent_id]
+    assert [item["id"] for item in database.list_library_media_trash_page(query="_")["items"]] == [underscore_id]
+    assert [item["id"] for item in database.list_library_media_trash_page(query=r"\\")["items"]] == [slash_id]
+
+
+def test_library_trash_filter_is_trimmed_exact_and_case_sensitive(media_db):
+    database, _path = media_db
+    pdf_id = _add_trashed_media(database, title="Padded PDF", media_type=" pdf ")
+    _add_trashed_media(database, title="Upper PDF", media_type="PDF")
+    _add_trashed_media(database, title="Audio", media_type="audio")
+
+    page = database.list_library_media_trash_page(media_type="  pdf  ")
+
+    assert page["total"] == 1
+    assert [item["id"] for item in page["items"]] == [pdf_id]
+    assert database.list_library_media_trash_page(media_type="PDF")["total"] == 1
+    assert database.list_library_media_trash_page(media_type="Pdf")["total"] == 0
+
+
+def test_library_trash_facets_are_complete_trimmed_unique_and_independent(media_db):
+    database, _path = media_db
+    _add_trashed_media(database, title="One", media_type=" pdf ")
+    _add_trashed_media(database, title="Two", media_type="audio")
+    _add_trashed_media(database, title="Three", media_type="audio")
+    _add_trashed_media(database, title="Blank", media_type=" \t ")
+    active_id, _uuid, _message = database.add_media_with_keywords(
+        title="Active only", media_type="active-private", content="active", keywords=[]
+    )
+    deleted_id = _add_trashed_media(
+        database, title="Deleted only", media_type="deleted-private"
+    )
+    assert active_id is not None
+    connection = database.get_connection()
+    connection.execute(
+        "UPDATE Media SET deleted = 1, version = version + 1 WHERE id = ?",
+        (deleted_id,),
+    )
+    connection.commit()
+
+    page = database.list_library_media_trash_page(
+        query="One", media_type="pdf", offset=0
+    )
+
+    assert page["total"] == 1
+    assert page["types"] == ["audio", "pdf"]
+
+
+def test_library_trash_order_is_null_last_and_uses_id_tie_breaker(media_db):
+    database, _path = media_db
+    older_id = _add_trashed_media(database, title="Older", media_type="pdf")
+    first_tie_id = _add_trashed_media(database, title="First tie", media_type="pdf")
+    second_tie_id = _add_trashed_media(database, title="Second tie", media_type="pdf")
+    no_trash_date_id = _add_trashed_media(database, title="No trash date", media_type="pdf")
+    connection = database.get_connection()
+    connection.executemany(
+        "UPDATE Media SET trash_date = ?, last_modified = ?, version = version + 1 WHERE id = ?",
+        [
+            ("2026-08-01T00:00:00+00:00", "2026-08-01T00:00:00+00:00", older_id),
+            ("2026-08-02T00:00:00+00:00", "2026-08-03T00:00:00+00:00", first_tie_id),
+            ("2026-08-02T00:00:00+00:00", "2026-08-03T00:00:00+00:00", second_tie_id),
+            (None, "2026-08-04T00:00:00+00:00", no_trash_date_id),
+        ],
+    )
+    connection.commit()
+    statements: list[str] = []
+    connection.set_trace_callback(statements.append)
+    try:
+        page = database.list_library_media_trash_page()
+    finally:
+        connection.set_trace_callback(None)
+
+    assert [item["id"] for item in page["items"]] == [
+        second_tie_id,
+        first_tie_id,
+        older_id,
+        no_trash_date_id,
+    ]
+    row_select = next(sql for sql in statements if "FROM Media" in sql and "LIMIT 20" in sql)
+    assert "trash_date IS NULL ASC" in row_select
+    assert "last_modified IS NULL ASC" in row_select
+    assert "id DESC" in row_select
+
+
+@pytest.mark.parametrize(
+    "query",
+    ["\x00", "x" * 201],
+)
+def test_library_trash_rejects_invalid_query(media_db, query):
+    database, _path = media_db
+
+    with pytest.raises(ValueError, match="Library Media Trash query is invalid"):
+        database.list_library_media_trash_page(query=query)
+
+
+def test_library_trash_count_rows_and_facets_share_wal_read_snapshot(media_db):
+    database, database_path = media_db
+    media_ids = _seed_trash(database, count=45)
+    connection = database.get_connection()
+    connection.execute(
+        "UPDATE Media SET type = ?, version = version + 1 WHERE id = ?",
+        ("writer-only", media_ids[-1]),
+    )
+    connection.commit()
+    writer_started = threading.Event()
+    writer_done = threading.Event()
+    writer_errors: list[Exception] = []
+
+    def writer() -> None:
+        try:
+            with sqlite3.connect(database_path, timeout=5) as writer_connection:
+                assert writer_started.wait(5)
+                writer_connection.execute(
+                    "UPDATE Media SET deleted = 1, version = version + 1 WHERE id = ?",
+                    (media_ids[-1],),
+                )
+        except Exception as error:  # surfaced in the test thread below
+            writer_errors.append(error)
+        finally:
+            writer_done.set()
+
+    worker = threading.Thread(target=writer)
+    worker.start()
+    count_started = False
+    progress_calls = 0
+    write_completed_during_read = False
+
+    def trace(sql: str) -> None:
+        nonlocal count_started
+        if "SELECT COUNT(*) AS count FROM Media" in sql:
+            count_started = True
+
+    def coordinate_write() -> int:
+        nonlocal progress_calls, write_completed_during_read
+        if count_started and not writer_started.is_set():
+            progress_calls += 1
+            if progress_calls >= 20:
+                writer_started.set()
+                assert writer_done.wait(5)
+                write_completed_during_read = True
+        return 0
+
+    connection.set_trace_callback(trace)
+    connection.set_progress_handler(coordinate_write, 1)
+    try:
+        page = database.list_library_media_trash_page(offset=40)
+    finally:
+        connection.set_progress_handler(None, 0)
+        connection.set_trace_callback(None)
+        writer_started.set()
+        worker.join(5)
+
+    assert not worker.is_alive()
+    assert writer_errors == []
+    assert write_completed_during_read
+    assert page["total"] == 45
+    assert len(page["items"]) == 5
+    assert "writer-only" in page["types"]

--- a/Tests/DB/test_client_media_trash_pagination.py
+++ b/Tests/DB/test_client_media_trash_pagination.py
@@ -191,6 +191,42 @@ def test_library_trash_order_is_null_last_and_uses_id_tie_breaker(media_db):
     assert "id DESC" in row_select
 
 
+def test_library_trash_order_sorts_null_last_modified_last_in_real_rows(media_db):
+    database, _path = media_db
+    connection = database.get_connection()
+    connection.execute("PRAGMA foreign_keys = OFF")
+    connection.execute("DROP TABLE Media")
+    connection.execute(
+        """
+        CREATE TABLE Media (
+            id INTEGER PRIMARY KEY,
+            title TEXT NOT NULL,
+            type TEXT NOT NULL,
+            trash_date DATETIME,
+            last_modified DATETIME,
+            deleted BOOLEAN NOT NULL DEFAULT 0,
+            is_trash BOOLEAN NOT NULL DEFAULT 0
+        )
+        """
+    )
+    connection.executemany(
+        """
+        INSERT INTO Media (id, title, type, trash_date, last_modified, deleted, is_trash)
+        VALUES (?, ?, ?, ?, ?, 0, 1)
+        """,
+        [
+            (1, "Older modification", "pdf", "2026-08-02T00:00:00+00:00", "2026-08-01T00:00:00+00:00"),
+            (2, "Newest modification", "pdf", "2026-08-02T00:00:00+00:00", "2026-08-03T00:00:00+00:00"),
+            (3, "Missing modification", "pdf", "2026-08-02T00:00:00+00:00", None),
+        ],
+    )
+    connection.commit()
+
+    page = database.list_library_media_trash_page()
+
+    assert [item["id"] for item in page["items"]] == [2, 1, 3]
+
+
 @pytest.mark.parametrize(
     "query",
     ["\x00", "x" * 201],

--- a/Tests/Library/test_library_media_trash_state.py
+++ b/Tests/Library/test_library_media_trash_state.py
@@ -173,6 +173,14 @@ def test_media_trash_result_rejects_malformed_summary_values(
         build_media_trash_result(MediaTrashScope(), _trash_page(items=[item]))
 
 
+def test_media_trash_result_rejects_iso_date_without_time():
+    item = _trash_item(1)
+    item["trash_date"] = "2026-08-30"
+
+    with pytest.raises(ValueError, match="trash_date"):
+        build_media_trash_result(MediaTrashScope(), _trash_page(items=[item]))
+
+
 @pytest.mark.parametrize(
     "trash_date", [None, "2026-08-11T00:00:00", "2026-08-11T00:00:00Z"]
 )
@@ -336,6 +344,28 @@ def test_failed_filter_or_page_retains_prior_fresh_page_and_retry_target(
     assert failed.failed_scope == scope
     assert failed.failed_origin == origin
     assert failed.selected_id == ""
+
+
+def test_selection_preserves_failed_request_copy_and_retry_target():
+    entered = apply_media_trash_result(
+        begin_media_trash_request(
+            MediaTrashBrowseState(), MediaTrashScope(), origin="entry"
+        ),
+        _trash_result(),
+    )
+    failed_scope = MediaTrashScope(page=2)
+    failed = fail_media_trash_request(
+        begin_media_trash_request(entered, failed_scope, origin="next"),
+        failed_scope,
+        copy="Page 2 not loaded — showing page 1.",
+    )
+
+    selected = select_media_trash_item(failed, "local:media:2")
+
+    assert selected.selected_id == "local:media:2"
+    assert selected.error_copy == "Page 2 not loaded — showing page 1."
+    assert selected.failed_scope == failed_scope
+    assert selected.failed_origin == "next"
 
 
 def test_initial_failure_has_no_rows_or_fabricated_freshness():

--- a/Tests/Library/test_library_media_trash_state.py
+++ b/Tests/Library/test_library_media_trash_state.py
@@ -181,6 +181,15 @@ def test_media_trash_result_rejects_iso_date_without_time():
         build_media_trash_result(MediaTrashScope(), _trash_page(items=[item]))
 
 
+def test_media_trash_result_accepts_sqlite_space_separated_datetime():
+    item = _trash_item(1)
+    item["trash_date"] = "2026-08-30 11:09:40.560640"
+
+    result = build_media_trash_result(MediaTrashScope(), _trash_page(items=[item]))
+
+    assert result.items[0]["trash_date"] == "2026-08-30 11:09:40.560640"
+
+
 @pytest.mark.parametrize(
     "trash_date", [None, "2026-08-11T00:00:00", "2026-08-11T00:00:00Z"]
 )

--- a/Tests/Library/test_library_media_trash_state.py
+++ b/Tests/Library/test_library_media_trash_state.py
@@ -8,15 +8,422 @@ builder the same way ``test_library_media_state.py`` pins the list's.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from types import MappingProxyType
+
+import pytest
 
 from tldw_chatbook.Library.library_media_state import (
     LIBRARY_MEDIA_TRASH_EMPTY_COPY,
     LibraryMediaTrashRow,
     LibraryMediaTrashState,
+    MediaTrashBrowseState,
+    MediaTrashMutationTarget,
+    MediaTrashScope,
+    apply_media_trash_result,
+    begin_media_trash_mutation,
+    begin_media_trash_request,
+    build_media_trash_result,
     build_library_media_trash_state,
+    cancel_media_trash_delete_confirmation,
+    commit_media_trash_mutation,
+    fail_media_trash_mutation,
+    fail_media_trash_request,
+    open_media_trash_delete_confirmation,
+    select_media_trash_item,
 )
 
 NOW = datetime(2026, 8, 11, 12, 0, tzinfo=timezone.utc)
+
+
+def _trash_item(media_id: int) -> dict[str, object]:
+    return {
+        "id": f"local:media:{media_id}",
+        "backing_media_id": media_id,
+        "title": f"Trash {media_id}",
+        "media_type": "pdf",
+        "trash_date": "2026-08-11T11:57:00+00:00",
+    }
+
+
+def _trash_page(
+    *,
+    scope: MediaTrashScope = MediaTrashScope(),
+    total: int = 1,
+    items: list[dict[str, object]] | None = None,
+    types: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "items": [_trash_item(1)] if items is None else items,
+        "total": total,
+        "limit": 20,
+        "offset": scope.offset,
+        "types": ["pdf"] if types is None else types,
+    }
+
+
+def test_media_trash_scope_normalizes_and_bounds_coordinates():
+    scope = MediaTrashScope(query="  doc  ", media_type=" pdf ", page=2)
+
+    assert scope == MediaTrashScope(query="doc", media_type="pdf", page=2)
+    assert scope.page_size == 20
+    assert scope.offset == 20
+
+
+@pytest.mark.parametrize("page", [True, False, 1.0, "1", None, 0, -1])
+def test_media_trash_scope_rejects_invalid_pages(page: object):
+    with pytest.raises((TypeError, ValueError), match="page"):
+        MediaTrashScope(page=page)  # type: ignore[arg-type]
+
+
+def test_media_trash_scope_rejects_offset_overflow_and_invalid_queries():
+    with pytest.raises(ValueError, match="offset"):
+        MediaTrashScope(page=(2**63 - 1) // 20 + 2)
+    with pytest.raises(ValueError, match="query"):
+        MediaTrashScope(query="nul\x00query")
+    with pytest.raises(ValueError, match="200"):
+        MediaTrashScope(query="x" * 201)
+
+
+@pytest.mark.parametrize("media_type", ["", "   "])
+def test_media_trash_scope_normalizes_blank_type_to_none(media_type: str):
+    assert MediaTrashScope(media_type=media_type).media_type is None
+
+
+def test_media_trash_result_is_exact_and_immutable():
+    raw_item = _trash_item(1)
+    payload = _trash_page(items=[raw_item])
+
+    result = build_media_trash_result(MediaTrashScope(), payload)
+    raw_item["title"] = "mutated"
+    payload["types"].append("video")  # type: ignore[union-attr]
+
+    assert isinstance(result.items[0], MappingProxyType)
+    assert result.items[0]["title"] == "Trash 1"
+    assert result.types == ("pdf",)
+    with pytest.raises(TypeError):
+        result.items[0]["title"] = "blocked"  # type: ignore[index]
+
+
+@pytest.mark.parametrize("key", ["items", "total", "limit", "offset", "types"])
+def test_media_trash_result_requires_exact_five_key_envelope(key: str):
+    missing = _trash_page()
+    del missing[key]
+    with pytest.raises(ValueError, match="exactly five"):
+        build_media_trash_result(MediaTrashScope(), missing)
+
+    extra = _trash_page()
+    extra["private"] = "sentinel"
+    with pytest.raises(ValueError, match="exactly five"):
+        build_media_trash_result(MediaTrashScope(), extra)
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        {"id": "local:media:1"},
+        {**_trash_item(1), "private": "sentinel"},
+    ],
+)
+def test_media_trash_result_requires_exact_five_item_keys(item: dict[str, object]):
+    with pytest.raises(ValueError, match="exactly five"):
+        build_media_trash_result(MediaTrashScope(), _trash_page(items=[item]))
+
+
+@pytest.mark.parametrize("backing_id", [True, False, 0, -1, 1.0, "1"])
+def test_media_trash_result_requires_positive_non_bool_backing_ids(
+    backing_id: object,
+):
+    item = _trash_item(1)
+    item["backing_media_id"] = backing_id
+    with pytest.raises(ValueError, match="backing_media_id"):
+        build_media_trash_result(MediaTrashScope(), _trash_page(items=[item]))
+
+
+def test_media_trash_result_rejects_duplicate_or_noncanonical_ids():
+    items = [_trash_item(1), _trash_item(2)]
+    items[1]["id"] = items[0]["id"]
+    items[1]["backing_media_id"] = items[0]["backing_media_id"]
+    with pytest.raises(ValueError, match="unique"):
+        build_media_trash_result(MediaTrashScope(), _trash_page(total=2, items=items))
+
+    item = _trash_item(1)
+    item["id"] = "media:1"
+    with pytest.raises(ValueError, match="canonical"):
+        build_media_trash_result(MediaTrashScope(), _trash_page(items=[item]))
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "copy"),
+    [
+        ("title", "", "title"),
+        ("title", "   ", "title"),
+        ("media_type", " pdf ", "media_type"),
+        ("media_type", "", "media_type"),
+        ("trash_date", "not-a-date", "trash_date"),
+        ("trash_date", " 2026-08-11T00:00:00+00:00 ", "trash_date"),
+        ("trash_date", 1, "trash_date"),
+    ],
+)
+def test_media_trash_result_rejects_malformed_summary_values(
+    field: str, value: object, copy: str
+):
+    item = _trash_item(1)
+    item[field] = value
+    with pytest.raises((TypeError, ValueError), match=copy):
+        build_media_trash_result(MediaTrashScope(), _trash_page(items=[item]))
+
+
+@pytest.mark.parametrize(
+    "trash_date", [None, "2026-08-11T00:00:00", "2026-08-11T00:00:00Z"]
+)
+def test_media_trash_result_accepts_iso_or_none_trash_date(
+    trash_date: str | None,
+):
+    item = _trash_item(1)
+    item["trash_date"] = trash_date
+
+    result = build_media_trash_result(MediaTrashScope(), _trash_page(items=[item]))
+
+    assert result.items[0]["trash_date"] == trash_date
+
+
+def test_media_trash_result_requires_exact_page_cardinality_and_coordinates():
+    with pytest.raises(ValueError, match="count"):
+        build_media_trash_result(MediaTrashScope(), _trash_page(total=2))
+
+    wrong_limit = _trash_page()
+    wrong_limit["limit"] = 19
+    with pytest.raises(ValueError, match="limit"):
+        build_media_trash_result(MediaTrashScope(), wrong_limit)
+
+    wrong_offset = _trash_page()
+    wrong_offset["offset"] = 20
+    with pytest.raises(ValueError, match="offset"):
+        build_media_trash_result(MediaTrashScope(), wrong_offset)
+
+
+@pytest.mark.parametrize(
+    "types",
+    [["video", "pdf"], ["pdf", "pdf"], ["pdf", ""], [" pdf"]],
+)
+def test_media_trash_result_requires_sorted_unique_nonblank_facets(types: list[str]):
+    with pytest.raises(ValueError, match="types"):
+        build_media_trash_result(MediaTrashScope(), _trash_page(types=types))
+
+
+def test_media_trash_result_detects_out_of_range_scope():
+    scope = MediaTrashScope(page=3)
+    result = build_media_trash_result(
+        scope,
+        _trash_page(scope=scope, total=21, items=[]),
+    )
+
+    assert result.last_page == 2
+    assert result.out_of_range is True
+
+
+def _trash_result(
+    scope: MediaTrashScope = MediaTrashScope(),
+    *,
+    total: int = 2,
+) -> object:
+    offset = scope.offset
+    count = min(20, max(total - offset, 0))
+    items = [_trash_item(offset + index + 1) for index in range(count)]
+    return build_media_trash_result(
+        scope,
+        _trash_page(scope=scope, total=total, items=items),
+    )
+
+
+def test_entry_result_selects_first_row_only_for_entry_authority():
+    state = begin_media_trash_request(
+        MediaTrashBrowseState(), MediaTrashScope(), origin="entry"
+    )
+    applied = apply_media_trash_result(state, _trash_result())
+
+    assert applied.selected_id == "local:media:1"
+    assert applied.applied_result is not None
+    assert applied.applied_result.scope == MediaTrashScope()
+    assert applied.retained_items == applied.applied_result.items
+    assert applied.types == ("pdf",)
+    assert applied.freshness == "fresh"
+    assert applied.loading is False
+
+    superseded = begin_media_trash_request(
+        applied, MediaTrashScope(query="new"), origin="search"
+    )
+    searched = apply_media_trash_result(
+        superseded, _trash_result(MediaTrashScope(query="new"))
+    )
+    assert searched.selected_id == ""
+
+
+@pytest.mark.parametrize("origin", ["search", "type", "previous", "next", "mutation"])
+def test_non_entry_result_leaves_selection_empty(origin: str):
+    state = begin_media_trash_request(
+        MediaTrashBrowseState(),
+        MediaTrashScope(),
+        origin=origin,  # type: ignore[arg-type]
+    )
+
+    applied = apply_media_trash_result(state, _trash_result())
+
+    assert applied.selected_id == ""
+
+
+def test_new_scope_clears_selection_before_request_applies():
+    entered = apply_media_trash_result(
+        begin_media_trash_request(
+            MediaTrashBrowseState(), MediaTrashScope(), origin="entry"
+        ),
+        _trash_result(),
+    )
+    selected = select_media_trash_item(entered, "local:media:2")
+
+    requested = begin_media_trash_request(
+        selected, MediaTrashScope(page=2), origin="next"
+    )
+
+    assert requested.selected_id == ""
+    assert requested.confirmation_target is None
+    assert requested.loading is True
+    assert requested.applied_result is entered.applied_result
+    assert requested.retained_items is entered.retained_items
+
+
+@pytest.mark.parametrize(
+    ("scope", "origin", "copy"),
+    [
+        (
+            MediaTrashScope(query="failed"),
+            "search",
+            "Filter not applied — showing All Trash.",
+        ),
+        (
+            MediaTrashScope(page=2),
+            "next",
+            "Page 2 not loaded — showing page 1.",
+        ),
+    ],
+)
+def test_failed_filter_or_page_retains_prior_fresh_page_and_retry_target(
+    scope: MediaTrashScope,
+    origin: str,
+    copy: str,
+):
+    entered = apply_media_trash_result(
+        begin_media_trash_request(
+            MediaTrashBrowseState(), MediaTrashScope(), origin="entry"
+        ),
+        _trash_result(),
+    )
+    retained = entered.retained_items
+    requested = begin_media_trash_request(
+        entered,
+        scope,
+        origin=origin,  # type: ignore[arg-type]
+    )
+
+    failed = fail_media_trash_request(requested, scope, copy=copy)
+
+    assert failed.requested_scope == scope
+    assert failed.applied_result is entered.applied_result
+    assert failed.retained_items is retained
+    assert failed.freshness == "fresh"
+    assert failed.loading is False
+    assert failed.error_copy == copy
+    assert failed.failed_scope == scope
+    assert failed.failed_origin == origin
+    assert failed.selected_id == ""
+
+
+def test_initial_failure_has_no_rows_or_fabricated_freshness():
+    scope = MediaTrashScope()
+    requested = begin_media_trash_request(
+        MediaTrashBrowseState(), scope, origin="entry"
+    )
+
+    failed = fail_media_trash_request(requested, scope, copy="Could not load Trash.")
+
+    assert failed.applied_result is None
+    assert failed.retained_items == ()
+    assert failed.types == ()
+    assert failed.freshness == "uninitialized"
+    assert failed.error_copy == "Could not load Trash."
+
+
+def test_confirmation_captures_full_immutable_selected_identity():
+    entered = apply_media_trash_result(
+        begin_media_trash_request(
+            MediaTrashBrowseState(), MediaTrashScope(), origin="entry"
+        ),
+        _trash_result(),
+    )
+    selected = select_media_trash_item(entered, "local:media:2")
+
+    confirming = open_media_trash_delete_confirmation(selected)
+
+    assert confirming.confirmation_target == MediaTrashMutationTarget(
+        stable_id="local:media:2",
+        backing_media_id=2,
+        title="Trash 2",
+        media_type="pdf",
+        trash_date="2026-08-11T11:57:00+00:00",
+        page_index=1,
+    )
+    assert (
+        cancel_media_trash_delete_confirmation(confirming).confirmation_target is None
+    )
+
+
+def test_precommit_mutation_failure_keeps_row_selection_and_fresh_boundary():
+    entered = apply_media_trash_result(
+        begin_media_trash_request(
+            MediaTrashBrowseState(), MediaTrashScope(), origin="entry"
+        ),
+        _trash_result(),
+    )
+    confirming = open_media_trash_delete_confirmation(entered)
+    target = confirming.confirmation_target
+    assert target is not None
+
+    pending = begin_media_trash_mutation(confirming)
+    failed = fail_media_trash_mutation(
+        pending, target, copy="Could not delete this item."
+    )
+
+    assert failed.retained_items is entered.retained_items
+    assert failed.selected_id == target.stable_id
+    assert failed.freshness == "fresh"
+    assert failed.mutation_pending is False
+    assert failed.error_copy == "Could not delete this item."
+
+
+def test_committed_mutation_removes_target_and_becomes_stale_loading():
+    entered = apply_media_trash_result(
+        begin_media_trash_request(
+            MediaTrashBrowseState(), MediaTrashScope(), origin="entry"
+        ),
+        _trash_result(),
+    )
+    confirming = open_media_trash_delete_confirmation(entered)
+    target = confirming.confirmation_target
+    assert target is not None
+    pending = begin_media_trash_mutation(confirming)
+
+    committed = commit_media_trash_mutation(
+        pending, target, notice="Deleted 'Trash 1' permanently."
+    )
+
+    assert [item["id"] for item in committed.retained_items] == ["local:media:2"]
+    assert committed.applied_result is entered.applied_result
+    assert committed.freshness == "stale"
+    assert committed.loading is True
+    assert committed.stale_copy == "List may be out of date."
+    assert committed.selected_id == ""
+    assert committed.mutation_pending is False
+    assert committed.committed_notice == "Deleted 'Trash 1' permanently."
 
 
 def test_rows_preserve_seam_order_with_trashed_age_secondary():
@@ -84,9 +491,7 @@ def test_selected_id_honored_when_present():
         {"id": "6", "title": "B", "type": "pdf"},
     ]
 
-    state = build_library_media_trash_state(
-        records, total=2, selected_id="6", now=NOW
-    )
+    state = build_library_media_trash_state(records, total=2, selected_id="6", now=NOW)
 
     assert state.selected_id == "6"
     assert [row.selected for row in state.rows] == [False, True]

--- a/Tests/Live/test_library_media_trash_paging_closeout.py
+++ b/Tests/Live/test_library_media_trash_paging_closeout.py
@@ -3,19 +3,26 @@
 from __future__ import annotations
 
 import asyncio
+import gc
+import io
 import logging
 import multiprocessing
 import os
-import pwd
+import re
+import sqlite3
 import types
+from concurrent.futures import ThreadPoolExecutor
+from html import unescape
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote, urlsplit
 
+import psutil
 import pytest
 from loguru import logger
 from textual.widgets import Button, Input, OptionList, Static
 
-from Tests.UI.app_factory import _build_test_app
+from Tests.UI import app_factory as app_factory_module
 from Tests.UI.test_library_shell import (
     _seed_conversations,
     _wait_for_condition,
@@ -30,7 +37,9 @@ from tldw_chatbook.Library.library_media_state import (
 )
 from tldw_chatbook.Media import LocalMediaReadingService, MediaReadingScopeService
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.Utils.adaptive_reader_state import PANE_GRIP_WIDTH
 from tldw_chatbook.app import TldwCli
+from tldw_chatbook.config import get_cli_config_path, get_cli_log_file_path, get_user_data_dir
 
 
 SIZES = ((160, 50), (120, 35), (100, 30), (80, 24))
@@ -51,23 +60,45 @@ PRIVACY_SENTINELS = (
 )
 
 
-def _real_profile_snapshot() -> dict[Path, tuple[bool, bytes]]:
-    """Capture real config/Media bytes without trusting the test HOME."""
-    home = Path(pwd.getpwuid(os.getuid()).pw_dir)
-    config = home / ".config" / "tldw_cli" / "config.toml"
-    media = (
-        home
-        / ".local"
-        / "share"
-        / "tldw_cli"
-        / "default_user"
-        / "tldw_chatbook_media_v2.db"
+class _SQLitePathAuthority:
+    """Fail before SQLite opens any target outside explicit harness roots."""
+
+    def __init__(self, opener, roots: tuple[Path, ...]) -> None:
+        self._opener = opener
+        self.roots = tuple(root.resolve() for root in roots)
+        self.observed: list[Path | str] = []
+
+    @staticmethod
+    def _filesystem_target(database: object) -> Path | None:
+        raw = os.fspath(database)
+        if raw == ":memory:":
+            return None
+        if raw.startswith("file:"):
+            raw = unquote(urlsplit(raw).path)
+        return Path(raw).expanduser().resolve()
+
+    def assert_allowed(self, database: object) -> Path | None:
+        target = self._filesystem_target(database)
+        if target is None:
+            self.observed.append(":memory:")
+            return None
+        assert any(target == root or root in target.parents for root in self.roots), (
+            f"SQLite target escaped live-test authority: {target}"
+        )
+        self.observed.append(target)
+        return target
+
+    def connect(self, database: object, *args: Any, **kwargs: Any):
+        self.assert_allowed(database)
+        return self._opener(database, *args, **kwargs)
+
+
+def _assert_path_allowed(path: Path, roots: tuple[Path, ...]) -> Path:
+    resolved = path.resolve()
+    assert any(resolved == root or root in resolved.parents for root in roots), (
+        f"Path escaped live-test authority: {resolved}"
     )
-    paths = (config, media, Path(f"{media}-wal"), Path(f"{media}-shm"))
-    return {
-        path: (path.exists(), path.read_bytes() if path.exists() else b"")
-        for path in paths
-    }
+    return resolved
 
 
 def _trash_timestamp(media_id: int) -> str | None:
@@ -205,8 +236,157 @@ def _stable_ids(result: Any) -> tuple[str, ...]:
 
 
 def _painted_text(screen: LibraryScreen) -> str:
-    """Read Textual's current compositor strips, never detached renderables."""
-    return "\n".join(strip.text for strip in screen._compositor.render_strips())
+    """Extract current painted text through Textual's public screenshot API."""
+    svg = screen.app.export_screenshot(simplify=True)
+    joined = "".join(re.findall(r"<text[^>]*>([^<]*)</text>", svg))
+    return unescape(joined).replace("\xa0", " ")
+
+
+def _assert_reader_width_contract(
+    *,
+    shell_content_width: int,
+    layout: Any,
+    library_region_width: int,
+    items_region_width: int,
+    reader_region_width: int,
+) -> None:
+    """Assert the effective allocation and mounted pane regions are identical."""
+    assert (
+        layout.library_width
+        + layout.items_width
+        + layout.reader_width
+        + (2 * PANE_GRIP_WIDTH)
+        == shell_content_width
+    )
+    assert library_region_width == layout.library_width
+    assert items_region_width == layout.items_width
+    assert reader_region_width == layout.reader_width
+
+
+def _assert_media_reader_geometry(screen: LibraryScreen) -> dict[str, int]:
+    """Prove layout allocations, hidden panes, chrome, and row fill structurally."""
+    shell = screen.query_one("#library-media-reader-shell")
+    layout = shell.effective_layout
+    _assert_reader_width_contract(
+        shell_content_width=shell.content_region.width,
+        layout=layout,
+        library_region_width=shell.library.region.width,
+        items_region_width=shell.items.region.width,
+        reader_region_width=shell.reader.region.width,
+    )
+    for open_state, pane in (
+        (layout.library_open, shell.library),
+        (layout.items_open, shell.items),
+    ):
+        if open_state:
+            assert pane.display is True
+            assert pane.region.area > 0
+        else:
+            assert pane.display is False
+            assert pane.region.area == 0
+    assert shell.reader.display is True
+    assert shell.reader.region.area > 0
+
+    row_width = 0
+    items_chrome = 0
+    scroll_chrome = 0
+    if layout.items_open:
+        items = screen.query_one("#library-canvas")
+        scroll = screen.query_one("#library-media-trash-list")
+        row = screen.query_one("#library-media-trash-row-0", Button)
+        items_chrome = items.region.width - items.content_region.width
+        scroll_chrome = (
+            scroll.content_region.width - scroll.scrollable_content_region.width
+        )
+        expected_scrollbar = 1 if int(scroll.max_scroll_y) > 0 else 0
+        assert scroll_chrome == expected_scrollbar
+        assert row.region.width == scroll.scrollable_content_region.width
+        assert row.region.width == (
+            layout.items_width - items_chrome - scroll_chrome
+        )
+        row_width = row.region.width
+    return {
+        "library": layout.library_width,
+        "items": layout.items_width,
+        "reader": layout.reader_width,
+        "row": row_width,
+        "items_chrome": items_chrome,
+        "scroll_chrome": scroll_chrome,
+    }
+
+
+def test_sqlite_path_authority_rejects_escape_before_open(tmp_path: Path) -> None:
+    """Mutation proof: an out-of-authority SQLite target never reaches open."""
+    opened: list[object] = []
+
+    def opener(database: object, *_args: Any, **_kwargs: Any) -> object:
+        opened.append(database)
+        return object()
+
+    authority = _SQLitePathAuthority(opener, (tmp_path / "allowed",))
+    with pytest.raises(AssertionError, match="escaped live-test authority"):
+        authority.connect(tmp_path.parent / "outside-authority.sqlite")
+    assert opened == []
+
+
+def test_reader_width_contract_rejects_one_column_mutation() -> None:
+    """Mutation proof: one misallocated column invalidates geometry evidence."""
+    layout = types.SimpleNamespace(
+        library_width=0,
+        items_width=56,
+        reader_width=50,
+    )
+    with pytest.raises(AssertionError):
+        _assert_reader_width_contract(
+            shell_content_width=116,
+            layout=layout,
+            library_region_width=0,
+            items_region_width=55,
+            reader_region_width=50,
+        )
+
+
+def _assert_viewer_target(
+    screen: Any,
+    *,
+    target_id: str,
+    scroll_offset: tuple[int, int],
+) -> None:
+    """Prove the pressed row owns selection, detail, and return coordinates."""
+    session = screen._library_media_reader_session
+    receipt = screen._library_media_viewer_return
+    assert screen._selected_media_id == target_id
+    assert session.selected_id == target_id
+    assert session.loaded_id == target_id
+    assert session.pending_request is None
+    assert receipt is not None
+    assert receipt.stable_id == target_id
+    assert receipt.scroll_offset == scroll_offset
+    assert int(screen._library_media_detail["id"]) == int(target_id.rsplit(":", 1)[1])
+    assert screen.query_one("#library-media-viewer").viewer.canonical_id == target_id
+
+
+def test_viewer_target_contract_rejects_cleared_row_selection() -> None:
+    """Mutation proof: clearing the row-produced selection breaks the evidence."""
+    target = "local:media:65"
+    screen = types.SimpleNamespace(
+        _selected_media_id="",
+        _library_media_reader_session=types.SimpleNamespace(
+            selected_id=target,
+            loaded_id=target,
+            pending_request=None,
+        ),
+        _library_media_viewer_return=types.SimpleNamespace(
+            stable_id=target,
+            scroll_offset=(0, 5),
+        ),
+        _library_media_detail={"id": 65},
+        query_one=lambda _selector: types.SimpleNamespace(
+            viewer=types.SimpleNamespace(canonical_id=target)
+        ),
+    )
+    with pytest.raises(AssertionError):
+        _assert_viewer_target(screen, target_id=target, scroll_offset=(0, 5))
 
 
 async def _current_widget(screen, pilot, selector: str, widget_type=None):
@@ -382,6 +562,30 @@ def _normal_media_row(screen: LibraryScreen, stable_id: str) -> Button:
     )
 
 
+def _target_sqlite_handles(db_path: Path) -> tuple[Path, ...]:
+    targets = {
+        db_path.resolve(),
+        Path(f"{db_path.resolve()}-wal"),
+        Path(f"{db_path.resolve()}-shm"),
+    }
+    return tuple(
+        Path(handle.path).resolve()
+        for handle in psutil.Process().open_files()
+        if Path(handle.path).resolve() in targets
+    )
+
+
+async def _walk_size_on_owned_loop(
+    *, db: MediaDatabase, size: tuple[int, int]
+) -> dict[str, Any]:
+    """Run one size with one known default-executor connection owner."""
+    loop = asyncio.get_running_loop()
+    loop.set_default_executor(
+        ThreadPoolExecutor(max_workers=1, thread_name_prefix=f"trash-{size[0]}")
+    )
+    return await _walk_size(db=db, size=size)
+
+
 async def _walk_size(
     *,
     db: MediaDatabase,
@@ -426,7 +630,7 @@ async def _walk_size(
             mode="server", query="", media_type=None, limit=20, offset=0
         )
 
-    app = _build_test_app(configured_default="library")
+    app = app_factory_module._build_test_app(configured_default="library")
     assert type(app) is TldwCli
     app.library_new_profile_admission = False
     _seed_conversations(app, [], media=[])
@@ -434,6 +638,9 @@ async def _walk_size(
     app.media_reading_scope_service = scope_service
     probe = _LiveTrashProbe(scope_service, local_service)
     probe.install()
+    delete_log = io.StringIO()
+    delete_loguru_sink: int | None = None
+    delete_stdlib_handler: logging.Handler | None = None
 
     try:
         async with app.run_test(size=size) as pilot:
@@ -483,8 +690,7 @@ async def _walk_size(
             )
             saved_scroll = (int(normal_scroll.scroll_x), int(normal_scroll.scroll_y))
             assert saved_scroll[1] > 0
-            screen._selected_media_id = selected_normal_id
-            assert screen._selected_media_id == selected_normal_id
+            assert screen._selected_media_id != selected_normal_id
 
             # Prove the normal viewer's retained-return policy while the
             # page is fresh. Restore later marks this retained page stale,
@@ -493,8 +699,18 @@ async def _walk_size(
             viewer_row.press()
             await _wait_for_condition(
                 pilot,
-                lambda: screen._library_media_view == "viewer",
-                message="Normal Media row never opened the viewer.",
+                lambda: (
+                    screen._library_media_view == "viewer"
+                    and screen._library_media_reader_session.pending_request is None
+                    and screen._library_media_reader_session.loaded_id
+                    == selected_normal_id
+                ),
+                message="Normal Media row never loaded its exact viewer target.",
+            )
+            _assert_viewer_target(
+                screen,
+                target_id=selected_normal_id,
+                scroll_offset=saved_scroll,
             )
             viewer_back = await _current_widget(
                 screen, pilot, "#library-media-back", Button
@@ -753,13 +969,15 @@ async def _walk_size(
             wide_posture = bool(
                 initial_layout.library_open and initial_layout.items_open
             )
-            items_width_contract = "exclusive-full-width"
+            layout_contract = "items-priority"
+            initial_geometry = _assert_media_reader_geometry(screen)
             if not wide_posture:
                 assert screen._library_media_reader_layout.items_open is True
                 await _toggle_pane(
                     screen, pilot, pane="library", expected_open=True
                 )
                 assert screen._library_media_reader_layout.items_open is False
+                _assert_media_reader_geometry(screen)
                 screen._request_library_media_trash_page(
                     2, focus_identity="#library-media-trash-next"
                 )
@@ -786,18 +1004,14 @@ async def _walk_size(
                 )
                 assert screen._library_media_reader_layout.items_open is True
                 assert screen._library_media_reader_layout.library_open is False
-                compact_items = screen.query_one("#library-canvas")
-                compact_row = screen.query_one("#library-media-trash-row-0", Button)
-                assert compact_items.region.width > 0
-                assert compact_row.region.width > 0
+                compact_geometry = _assert_media_reader_geometry(screen)
+                assert compact_geometry["items"] == initial_geometry["items"]
                 await _submit_search(screen, pilot, "")
             else:
+                layout_contract = "exclusive-optional-pane"
                 assert screen._library_media_reader_layout.library_open is True
                 assert screen._library_media_reader_layout.items_open is True
-                split_items_width = screen.query_one("#library-canvas").region.width
-                split_row_width = screen.query_one(
-                    "#library-media-trash-row-0", Button
-                ).region.width
+                split_geometry = _assert_media_reader_geometry(screen)
                 await _toggle_pane(
                     screen, pilot, pane="library", expected_open=False
                 )
@@ -805,15 +1019,19 @@ async def _walk_size(
                     pilot,
                     lambda: (
                         screen.query_one("#library-canvas").region.width
-                        > split_items_width
+                        > split_geometry["items"]
                         and screen.query_one(
                             "#library-media-trash-row-0", Button
                         ).region.width
-                        > split_row_width
+                        > split_geometry["row"]
                     ),
                     message="Collapsing Library did not widen Trash Items rows.",
                 )
-                items_width_contract = "expanded-title-and-detail"
+                expanded_geometry = _assert_media_reader_geometry(screen)
+                items_delta = expanded_geometry["items"] - split_geometry["items"]
+                row_delta = expanded_geometry["row"] - split_geometry["row"]
+                assert items_delta == row_delta
+                assert items_delta > 0
                 screen._request_library_media_trash_page(
                     2, focus_identity="#library-media-trash-next"
                 )
@@ -841,6 +1059,7 @@ async def _walk_size(
                     message="Wide Items-collapsed refresh never settled.",
                 )
                 assert screen._library_media_reader_layout.items_open is False
+                _assert_media_reader_geometry(screen)
                 await _toggle_pane(screen, pilot, pane="items", expected_open=True)
 
             await _wait_for_trash_page(
@@ -850,6 +1069,7 @@ async def _walk_size(
                 total=47,
                 expected_ids=first_ids,
             )
+            _assert_media_reader_geometry(screen)
             await _assert_fixed_controls_painted(screen, pilot, width=width)
 
             # Permanent deletion: the full captured title is visible, Cancel
@@ -908,6 +1128,12 @@ async def _walk_size(
             assert screen.focused is screen.query_one(
                 "#library-media-trash-delete-confirm", Button
             )
+            delete_loguru_sink = logger.add(
+                delete_log, format="{message}", level="DEBUG"
+            )
+            delete_stdlib_handler = logging.StreamHandler(delete_log)
+            delete_stdlib_handler.setLevel(logging.DEBUG)
+            logging.getLogger().addHandler(delete_stdlib_handler)
             await pilot.press("enter")
             await _wait_for_condition(
                 pilot,
@@ -943,6 +1169,36 @@ async def _walk_size(
                 scope=MediaTrashScope(),
                 total=46,
                 expected_ids=after_delete_ids,
+            )
+            logging.getLogger().removeHandler(delete_stdlib_handler)
+            delete_stdlib_handler.flush()
+            delete_stdlib_handler.close()
+            delete_stdlib_handler = None
+            logger.remove(delete_loguru_sink)
+            delete_loguru_sink = None
+            delete_log_text = delete_log.getvalue()
+            db_path = Path(db.db_path).resolve()
+            delete_private_values = (
+                str(db_path),
+                str(Path(f"{db_path}-wal")),
+                str(Path(f"{db_path}-shm")),
+                "Media ID: 45",
+                "Media 45",
+                "media 45",
+                "media_id=45",
+                "media_id: 45",
+                *PRIVACY_SENTINELS,
+            )
+            for private_value in delete_private_values:
+                assert private_value not in delete_log_text
+            permanent_lines = tuple(
+                line
+                for line in delete_log_text.splitlines()
+                if "operation=permanent_delete" in line
+            )
+            assert permanent_lines == (
+                "Media mutation operation=permanent_delete status=started count=1",
+                "Media mutation operation=permanent_delete status=committed count=1",
             )
 
             # Restore mutates the real DB, stales but does not splice the
@@ -1053,12 +1309,15 @@ async def _walk_size(
         await asyncio.sleep(0)
         assert all(worker.is_finished for worker in app.workers)
     finally:
-        # Close the main connection and any sequential default-executor
-        # connection used by the real service calls before byte/isolation checks.
-        await asyncio.gather(
-            *(asyncio.to_thread(db.close_connection) for _ in range(8))
-        )
-        db.close_connection()
+        if delete_stdlib_handler is not None:
+            logging.getLogger().removeHandler(delete_stdlib_handler)
+            delete_stdlib_handler.flush()
+            delete_stdlib_handler.close()
+        if delete_loguru_sink is not None:
+            logger.remove(delete_loguru_sink)
+        # The live runner gives this loop one default-executor worker, so
+        # this closes the service connection on the same thread that owns it.
+        await asyncio.to_thread(db.close_connection)
 
     return {
         "size": size,
@@ -1071,42 +1330,62 @@ async def _walk_size(
         "keyboard": True,
         "back": True,
         "viewer_row_return": True,
-        "items_width_contract": items_width_contract,
+        "layout_contract": layout_contract,
+        "delete_log_privacy": True,
     }
 
 
-@pytest.mark.asyncio
-async def test_live_real_database_media_trash_walkthrough(
+def test_live_real_database_media_trash_walkthrough(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Walk real local Trash through every supported terminal posture."""
-    profile_before = _real_profile_snapshot()
     child_pids_before = {child.pid for child in multiprocessing.active_children()}
     scratch_config = tmp_path / "profile" / "config.toml"
+    isolated_home = Path(os.environ["HOME"]).resolve()
+    authority_roots = (tmp_path.resolve(), isolated_home)
+    _assert_path_allowed(scratch_config, authority_roots)
     scratch_config.parent.mkdir(parents=True)
     monkeypatch.setenv("TLDW_CONFIG_PATH", str(scratch_config))
     monkeypatch.setenv("TASK_18918_LIVE_CREDENTIAL", CREDENTIAL_SENTINEL)
-    assert Path(os.environ["TLDW_CONFIG_PATH"]).resolve().is_relative_to(
-        tmp_path.resolve()
+    assert _assert_path_allowed(get_cli_config_path(), authority_roots) == (
+        scratch_config.resolve()
     )
+    _assert_path_allowed(get_user_data_dir(), authority_roots)
+    _assert_path_allowed(get_cli_log_file_path(), authority_roots)
     package_path = Path(__import__("tldw_chatbook").__file__).resolve()
     assert Path(__file__).resolve().parents[2] in package_path.parents
+
+    sqlite_authority = _SQLitePathAuthority(sqlite3.connect, authority_roots)
+    monkeypatch.setattr(sqlite3, "connect", sqlite_authority.connect)
 
     observations: list[dict[str, Any]] = []
     for size in SIZES:
         width, _height = size
-        db = _seed_real_media_database(
-            tmp_path / f"media-trash-live-{width}.db", width=width
+        app_scratch_root = tmp_path / f"app-factory-{width}"
+        _assert_path_allowed(app_scratch_root, authority_roots)
+        app_scratch_root.mkdir(mode=0o700)
+        monkeypatch.setattr(
+            app_factory_module,
+            "tempfile",
+            types.SimpleNamespace(
+                mkdtemp=lambda **_kwargs: str(app_scratch_root)
+            ),
         )
-        assert Path(db.db_path).resolve().is_relative_to(tmp_path.resolve())
+        db_path = tmp_path / f"media-trash-live-{width}.db"
+        _assert_path_allowed(db_path, authority_roots)
+        db = _seed_real_media_database(
+            db_path, width=width
+        )
+        assert db_path.resolve() in sqlite_authority.observed
         log_path = tmp_path / "logs" / f"media-trash-live-{width}.log"
+        _assert_path_allowed(log_path, authority_roots)
         log_path.parent.mkdir(parents=True, exist_ok=True)
         loguru_sink = logger.add(log_path, format="{message}", level="DEBUG")
         root_handler = logging.FileHandler(log_path, encoding="utf-8")
         root_handler.setLevel(logging.DEBUG)
         logging.getLogger().addHandler(root_handler)
         try:
-            observation = await _walk_size(db=db, size=size)
+            observation = asyncio.run(_walk_size_on_owned_loop(db=db, size=size))
         finally:
             logging.getLogger().removeHandler(root_handler)
             root_handler.flush()
@@ -1115,17 +1394,24 @@ async def test_live_real_database_media_trash_walkthrough(
         size_log_text = log_path.read_text(encoding="utf-8", errors="replace")
         for sentinel in PRIVACY_SENTINELS:
             assert sentinel not in size_log_text
-        assert _real_profile_snapshot() == profile_before
+        db.close_connection()
+        del db
+        # `_run_library_service_call(isolate_in_worker=True)` creates nested
+        # event-loop cycles whose thread-local connections become collectible
+        # only after the owning outer loop and executor have shut down.
+        gc.collect()
+        assert _target_sqlite_handles(db_path) == ()
         observation["privacy"] = True
-        observation["real_profile_unchanged"] = True
+        observation["path_authority"] = True
+        observation["zero_db_handles"] = True
         observations.append(observation)
         print(
             "TASK-18918 LIVE "
             f"{width}x{size[1]}: pages=47/3 query=5 clamp=32 "
             "delete=46 restore=45 exact-trash-back=true "
             "viewer-row-return=true "
-            f"items-width={observation['items_width_contract']} "
-            "privacy=true real-profile-unchanged=true"
+            f"layout={observation['layout_contract']} "
+            "privacy=true path-authority=true zero-db-handles=true"
         )
 
     assert tuple(observation["size"] for observation in observations) == SIZES
@@ -1142,9 +1428,11 @@ async def test_live_real_database_media_trash_walkthrough(
             "keyboard": True,
             "back": True,
             "viewer_row_return": True,
-            "items_width_contract": observation["items_width_contract"],
+            "layout_contract": observation["layout_contract"],
+            "delete_log_privacy": True,
             "privacy": True,
-            "real_profile_unchanged": True,
+            "path_authority": True,
+            "zero_db_handles": True,
         }
         for observation in observations
     )
@@ -1157,6 +1445,11 @@ async def test_live_real_database_media_trash_walkthrough(
     for sentinel in PRIVACY_SENTINELS:
         assert sentinel not in log_text
 
-    await asyncio.sleep(0)
     assert {child.pid for child in multiprocessing.active_children()} == child_pids_before
-    assert _real_profile_snapshot() == profile_before
+    assert sqlite_authority.observed
+    assert any(target == ":memory:" for target in sqlite_authority.observed)
+    assert all(
+        target == ":memory:"
+        or any(target == root or root in target.parents for root in authority_roots)
+        for target in sqlite_authority.observed
+    )

--- a/Tests/Live/test_library_media_trash_paging_closeout.py
+++ b/Tests/Live/test_library_media_trash_paging_closeout.py
@@ -42,7 +42,15 @@ from tldw_chatbook.app import TldwCli
 from tldw_chatbook.config import get_cli_config_path, get_cli_log_file_path, get_user_data_dir
 
 
-SIZES = ((160, 50), (120, 35), (100, 30), (80, 24))
+EXPECTED_LAYOUT_BY_SIZE = types.MappingProxyType(
+    {
+        (160, 50): (True, "split-then-library-collapse-delta"),
+        (120, 35): (False, "items-priority-exclusive-optional-pane"),
+        (100, 30): (False, "items-priority-exclusive-optional-pane"),
+        (80, 24): (False, "items-priority-exclusive-optional-pane"),
+    }
+)
+SIZES = tuple(EXPECTED_LAYOUT_BY_SIZE)
 QUERY_SENTINEL = "quartzneedle18918"
 TITLE_SENTINEL = "PRIVATE TITLE 18918 SHOULD NEVER REACH LOGS"
 ID_SENTINEL = "local:media:45"
@@ -344,6 +352,25 @@ def test_reader_width_contract_rejects_one_column_mutation() -> None:
             items_region_width=55,
             reader_region_width=50,
         )
+
+
+def _assert_expected_layout_posture(
+    size: tuple[int, int], actual_wide_posture: bool
+) -> tuple[bool, str]:
+    """Reject a product posture that disagrees with the exact-size oracle."""
+    expected_wide_posture, layout_contract = EXPECTED_LAYOUT_BY_SIZE[size]
+    assert actual_wide_posture is expected_wide_posture, (
+        "layout posture mismatch: "
+        f"size={size!r} expected_wide={expected_wide_posture!r} "
+        f"actual_wide={actual_wide_posture!r}"
+    )
+    return expected_wide_posture, layout_contract
+
+
+def test_layout_posture_oracle_rejects_160_compact_before_branch() -> None:
+    """Mutation proof: 160x50 may not relabel a compact regression as valid."""
+    with pytest.raises(AssertionError, match="layout posture mismatch"):
+        _assert_expected_layout_posture((160, 50), False)
 
 
 def _assert_viewer_target(
@@ -966,12 +993,14 @@ async def _walk_size(
             # two panes mutually exclusive; wide posture proves independent
             # collapse and re-expansion of both.
             initial_layout = screen._library_media_reader_layout
-            wide_posture = bool(
+            actual_wide_posture = bool(
                 initial_layout.library_open and initial_layout.items_open
             )
-            layout_contract = "items-priority"
+            expected_wide_posture, layout_contract = (
+                _assert_expected_layout_posture(size, actual_wide_posture)
+            )
             initial_geometry = _assert_media_reader_geometry(screen)
-            if not wide_posture:
+            if not expected_wide_posture:
                 assert screen._library_media_reader_layout.items_open is True
                 await _toggle_pane(
                     screen, pilot, pane="library", expected_open=True
@@ -1008,7 +1037,6 @@ async def _walk_size(
                 assert compact_geometry["items"] == initial_geometry["items"]
                 await _submit_search(screen, pilot, "")
             else:
-                layout_contract = "exclusive-optional-pane"
                 assert screen._library_media_reader_layout.library_open is True
                 assert screen._library_media_reader_layout.items_open is True
                 split_geometry = _assert_media_reader_geometry(screen)
@@ -1414,7 +1442,13 @@ def test_live_real_database_media_trash_walkthrough(
             "privacy=true path-authority=true zero-db-handles=true"
         )
 
-    assert tuple(observation["size"] for observation in observations) == SIZES
+    assert tuple(
+        (observation["size"], observation["layout_contract"])
+        for observation in observations
+    ) == tuple(
+        (size, layout_contract)
+        for size, (_wide_posture, layout_contract) in EXPECTED_LAYOUT_BY_SIZE.items()
+    )
     assert all(
         observation
         == {

--- a/Tests/Live/test_library_media_trash_paging_closeout.py
+++ b/Tests/Live/test_library_media_trash_paging_closeout.py
@@ -783,7 +783,10 @@ async def _walk_size(
                 total=47,
                 expected_ids=first_ids,
             )
-            await _assert_fixed_controls_painted(screen, pilot, width=width)
+            initial_painted = await _assert_fixed_controls_painted(
+                screen, pilot, width=width
+            )
+            assert f"Trash 46 {QUERY_SENTINEL}" in initial_painted
 
             # Every ordinary action is a real current focus target. Pager keys
             # are exercised on page 2 where both directions are enabled.
@@ -1210,6 +1213,7 @@ async def _walk_size(
                 str(db_path),
                 str(Path(f"{db_path}-wal")),
                 str(Path(f"{db_path}-shm")),
+                "Media ID 45",
                 "Media ID: 45",
                 "Media 45",
                 "media 45",

--- a/Tests/Live/test_library_media_trash_paging_closeout.py
+++ b/Tests/Live/test_library_media_trash_paging_closeout.py
@@ -1,0 +1,1162 @@
+"""Production-shaped closeout walkthrough for local Media Trash paging."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import multiprocessing
+import os
+import pwd
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+from loguru import logger
+from textual.widgets import Button, Input, OptionList, Static
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_library_shell import (
+    _seed_conversations,
+    _wait_for_condition,
+    _wait_for_library_shell,
+    _wait_for_selector,
+)
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+from tldw_chatbook.Library.library_media_state import (
+    MediaBrowseScope,
+    MediaTrashScope,
+    build_media_trash_result,
+)
+from tldw_chatbook.Media import LocalMediaReadingService, MediaReadingScopeService
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.app import TldwCli
+
+
+SIZES = ((160, 50), (120, 35), (100, 30), (80, 24))
+QUERY_SENTINEL = "quartzneedle18918"
+TITLE_SENTINEL = "PRIVATE TITLE 18918 SHOULD NEVER REACH LOGS"
+ID_SENTINEL = "local:media:45"
+PATH_SENTINEL = "private-path-18918://never-log-this"
+CREDENTIAL_SENTINEL = "credential-18918-never-log-this"
+DELETE_TARGET_TITLE = "DELETE TARGET 18918 exact permanent record title"
+RESTORE_TARGET_TITLE = "RESTORE TARGET 18918 retained-page proof"
+PRIVACY_SENTINELS = (
+    QUERY_SENTINEL,
+    TITLE_SENTINEL,
+    ID_SENTINEL,
+    PATH_SENTINEL,
+    CREDENTIAL_SENTINEL,
+    DELETE_TARGET_TITLE,
+)
+
+
+def _real_profile_snapshot() -> dict[Path, tuple[bool, bytes]]:
+    """Capture real config/Media bytes without trusting the test HOME."""
+    home = Path(pwd.getpwuid(os.getuid()).pw_dir)
+    config = home / ".config" / "tldw_cli" / "config.toml"
+    media = (
+        home
+        / ".local"
+        / "share"
+        / "tldw_cli"
+        / "default_user"
+        / "tldw_chatbook_media_v2.db"
+    )
+    paths = (config, media, Path(f"{media}-wal"), Path(f"{media}-shm"))
+    return {
+        path: (path.exists(), path.read_bytes() if path.exists() else b"")
+        for path in paths
+    }
+
+
+def _trash_timestamp(media_id: int) -> str | None:
+    if media_id == 1:
+        return None
+    minute = 10 if media_id in {10, 11} else media_id
+    return f"2026-08-30T12:{minute:02d}:00+00:00"
+
+
+def _trash_type(media_id: int) -> str:
+    return {0: "pdf", 1: " pdf ", 2: "PDF", 3: "audio", 4: "video"}[
+        media_id % 5
+    ]
+
+
+def _trash_title(media_id: int) -> str:
+    if media_id == 45:
+        return DELETE_TARGET_TITLE
+    if media_id == 44:
+        return RESTORE_TARGET_TITLE
+    if media_id == 43:
+        return TITLE_SENTINEL
+    if media_id in {41, 42}:
+        return "Duplicate visible title " + ("with bounded detail " * 4).rstrip()
+    if media_id in {6, 16, 26, 36, 46}:
+        return f"Trash {media_id:02d} {QUERY_SENTINEL}"
+    return f"Trash {media_id:02d} " + ("long recovery detail " * 3).rstrip()
+
+
+def _seed_real_media_database(path: Path, *, width: int) -> MediaDatabase:
+    """Seed deterministic Trash pages plus active same-source decoys."""
+    db = MediaDatabase(path, client_id=f"task-18918-live-{width}")
+    for media_id in range(1, 48):
+        url = PATH_SENTINEL if media_id == 43 else f"live://trash/{width}/{media_id}"
+        inserted_id, _uuid, _message = db.add_media_with_keywords(
+            url=url,
+            title=_trash_title(media_id),
+            media_type=_trash_type(media_id),
+            content=f"unique trash content {width} {media_id}",
+            keywords=["trash-live"],
+        )
+        assert inserted_id == media_id
+        assert db.mark_as_trash(media_id)
+
+    # Active decoys include the same query/type vocabulary and make normal
+    # Media genuinely paged; neither their rows nor facets may leak into Trash.
+    for active_index in range(1, 46):
+        media_id = 47 + active_index
+        title = (
+            f"Active decoy {active_index:02d} {QUERY_SENTINEL}"
+            if active_index <= 3
+            else f"Active decoy {active_index:02d}"
+        )
+        inserted_id, _uuid, _message = db.add_media_with_keywords(
+            url=f"live://active/{width}/{active_index}",
+            title=title,
+            media_type=" pdf " if active_index <= 3 else "video",
+            content=f"unique active content {width} {active_index}",
+            keywords=["active-live"],
+        )
+        assert inserted_id == media_id
+
+    with db.transaction() as conn:
+        for media_id in range(1, 48):
+            timestamp = _trash_timestamp(media_id)
+            last_modified = timestamp or "2026-08-01T00:00:00+00:00"
+            conn.execute(
+                "UPDATE Media SET trash_date = ?, last_modified = ?, "
+                "version = version + 1 WHERE id = ?",
+                (timestamp, last_modified, media_id),
+            )
+        for media_id in range(48, 93):
+            conn.execute(
+                "UPDATE Media SET last_modified = ?, version = version + 1 "
+                "WHERE id = ?",
+                (f"2026-08-31T12:{media_id - 47:02d}:00+00:00", media_id),
+            )
+    return db
+
+
+def _restore_shrunk_rows(db: MediaDatabase) -> None:
+    """Return the one-shot concurrent-shrink fixture to its original 47 rows."""
+    for media_id in range(2, 17):
+        assert db.mark_as_trash(media_id)
+    with db.transaction() as conn:
+        for media_id in range(2, 17):
+            timestamp = _trash_timestamp(media_id)
+            last_modified = timestamp or "2026-08-01T00:00:00+00:00"
+            conn.execute(
+                "UPDATE Media SET trash_date = ?, last_modified = ?, "
+                "version = version + 1 WHERE id = ?",
+                (timestamp, last_modified, media_id),
+            )
+
+
+class _LiveTrashProbe:
+    """One-shot failure/shrink controls around the real scope service."""
+
+    def __init__(
+        self,
+        scope_service: MediaReadingScopeService,
+        local_service: LocalMediaReadingService,
+    ) -> None:
+        self.scope_service = scope_service
+        self.local_service = local_service
+        self.original = local_service.list_library_media_trash
+        self.calls: list[dict[str, Any]] = []
+        self.fail_scope: MediaTrashScope | None = None
+        self.shrink_on_page_three = False
+
+    def install(self) -> None:
+        def list_with_controls(_service: object, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append(dict(kwargs))
+            scope = MediaTrashScope(
+                query=str(kwargs.get("query") or ""),
+                media_type=kwargs.get("media_type"),
+                page=(int(kwargs["offset"]) // 20) + 1,
+            )
+            if self.fail_scope == scope:
+                self.fail_scope = None
+                raise RuntimeError(" | ".join(PRIVACY_SENTINELS))
+            if self.shrink_on_page_three and scope == MediaTrashScope(page=3):
+                self.shrink_on_page_three = False
+                for media_id in range(2, 17):
+                    assert self.local_service.restore_media_item(media_id)
+            return self.original(**kwargs)
+
+        self.local_service.list_library_media_trash = types.MethodType(
+            list_with_controls, self.local_service
+        )
+
+
+def _stable_ids(result: Any) -> tuple[str, ...]:
+    return tuple(str(item["id"]) for item in result.items)
+
+
+def _painted_text(screen: LibraryScreen) -> str:
+    """Read Textual's current compositor strips, never detached renderables."""
+    return "\n".join(strip.text for strip in screen._compositor.render_strips())
+
+
+async def _current_widget(screen, pilot, selector: str, widget_type=None):
+    """Wait for and prove current mounted, displayed, laid-out DOM identity."""
+    widget = await _wait_for_selector(screen, pilot, selector)
+    await pilot.pause()
+    current = (
+        screen.query_one(selector, widget_type)
+        if widget_type
+        else screen.query_one(selector)
+    )
+    assert widget is current
+    assert current.is_mounted
+    assert current.screen is screen
+    assert current.display is True
+    assert current.region.area > 0
+    return current
+
+
+async def _wait_for_trash_page(
+    screen: LibraryScreen,
+    pilot,
+    *,
+    scope: MediaTrashScope,
+    total: int,
+    expected_ids: tuple[str, ...],
+) -> Any:
+    controller = screen._library_media_trash_browse_controller
+    await _wait_for_condition(
+        pilot,
+        lambda: (
+            controller.state.applied_result is not None
+            and controller.state.applied_result.scope == scope
+            and controller.state.applied_result.total == total
+            and not controller.state.loading
+        ),
+        message=f"Trash scope {scope!r} never became authoritative.",
+    )
+    result = controller.state.applied_result
+    assert result is not None
+    assert _stable_ids(result) == expected_ids
+    await _wait_for_condition(
+        pilot,
+        lambda: (
+            len(screen.query(".library-media-trash-row")) == len(expected_ids)
+            and (
+                not expected_ids
+                or getattr(
+                    screen.query_one("#library-media-trash-row-0"), "media_id", None
+                )
+                == expected_ids[0]
+            )
+        ),
+        message="Authoritative Trash rows never reached the current canvas.",
+    )
+    await pilot.pause()
+    await pilot.pause()
+    if expected_ids:
+        await _current_widget(screen, pilot, "#library-media-trash-row-0", Button)
+    return result
+
+
+async def _ensure_items_open(screen: LibraryScreen, pilot) -> None:
+    if screen._library_media_reader_layout.items_open:
+        return
+    grip = screen.query_one("#library-media-items-grip", Button)
+    grip.focus()
+    await pilot.press("enter")
+    await _wait_for_condition(
+        pilot,
+        lambda: (
+            screen._library_media_reader_layout.items_open
+            and screen.query_one("#library-canvas").region.area > 0
+        ),
+        message="Items pane never opened.",
+    )
+
+
+async def _toggle_pane(
+    screen: LibraryScreen, pilot, *, pane: str, expected_open: bool
+) -> None:
+    grip = screen.query_one(f"#library-media-{pane}-grip", Button)
+    grip.focus()
+    await pilot.press("enter")
+    await _wait_for_condition(
+        pilot,
+        lambda: getattr(screen._library_media_reader_layout, f"{pane}_open")
+        is expected_open,
+        message=f"{pane} pane never reached open={expected_open}.",
+    )
+
+
+async def _submit_search(screen: LibraryScreen, pilot, value: str) -> None:
+    search = await _current_widget(
+        screen, pilot, "#library-media-trash-search", Input
+    )
+    search.value = value
+    # A completed page request may still own one after-paint focus callback.
+    # Yield it, then reacquire the current Input before the keyboard submit.
+    await pilot.pause()
+    search = await _current_widget(
+        screen, pilot, "#library-media-trash-search", Input
+    )
+    search.focus()
+    await pilot.pause()
+    search = screen.query_one("#library-media-trash-search", Input)
+    search.focus()
+    assert screen.focused is search
+    await pilot.press("enter")
+
+
+async def _choose_type(screen: LibraryScreen, pilot, value: str | None) -> None:
+    chooser_button = await _current_widget(
+        screen, pilot, "#library-media-trash-type-filter", Button
+    )
+    chooser_button.focus()
+    await pilot.press("enter")
+    chooser = await _current_widget(
+        screen, pilot, "#library-media-trash-type-choices", OptionList
+    )
+    target_prompt = "All types" if value is None else value
+    target_index = next(
+        index
+        for index in range(chooser.option_count)
+        if target_prompt in str(chooser.get_option_at_index(index).prompt)
+    )
+    chooser.highlighted = target_index
+    chooser.focus()
+    assert screen.focused is chooser
+    await pilot.press("enter")
+
+
+async def _assert_fixed_controls_painted(
+    screen: LibraryScreen, pilot, *, width: int
+) -> str:
+    selectors = (
+        "#library-media-trash-back",
+        "#library-media-trash-search",
+        "#library-media-trash-type-filter",
+        "#library-media-trash-previous",
+        "#library-media-trash-next",
+        "#library-media-trash-restore",
+        "#library-media-trash-delete",
+    )
+    items = screen.query_one("#library-canvas")
+    for selector in selectors:
+        control = await _current_widget(screen, pilot, selector)
+        assert items.region.contains_region(control.region), (
+            width,
+            selector,
+            control.region,
+        )
+    painted = _painted_text(screen)
+    for copy in ("Local Trash", "Type: All", "Previous", "Next", "Restore"):
+        assert copy in painted, (width, copy, painted)
+    assert "Delete permanently" in painted
+    return painted
+
+
+def _row_for_media(screen: LibraryScreen, stable_id: str) -> Button:
+    return next(
+        row
+        for row in screen.query(".library-media-trash-row")
+        if getattr(row, "media_id", None) == stable_id
+    )
+
+
+def _normal_media_row(screen: LibraryScreen, stable_id: str) -> Button:
+    return next(
+        row
+        for row in screen.query(".library-media-row")
+        if getattr(row, "media_id", None) == stable_id
+    )
+
+
+async def _walk_size(
+    *,
+    db: MediaDatabase,
+    size: tuple[int, int],
+) -> dict[str, Any]:
+    width, _height = size
+    local_service = LocalMediaReadingService(db)
+    scope_service = MediaReadingScopeService(local_service, None)
+
+    # Real DB + both real service layers independently prove the exact
+    # snapshot, stable tie-break, complete facets, padding, and local-only gate.
+    first = await scope_service.list_library_media_trash(
+        mode="local", query="", media_type=None, limit=20, offset=0
+    )
+    middle = await scope_service.list_library_media_trash(
+        mode="local", query="", media_type=None, limit=20, offset=20
+    )
+    final = await scope_service.list_library_media_trash(
+        mode="local", query="", media_type=None, limit=20, offset=40
+    )
+    assert tuple(item["id"] for item in first["items"]) == tuple(
+        f"local:media:{media_id}" for media_id in range(47, 27, -1)
+    )
+    assert tuple(item["id"] for item in middle["items"]) == tuple(
+        f"local:media:{media_id}" for media_id in range(27, 7, -1)
+    )
+    assert tuple(item["id"] for item in final["items"]) == tuple(
+        f"local:media:{media_id}" for media_id in range(7, 0, -1)
+    )
+    assert {first["total"], middle["total"], final["total"]} == {47}
+    assert build_media_trash_result(MediaTrashScope(), first).total == 47
+    assert build_media_trash_result(MediaTrashScope(page=2), middle).total == 47
+    assert build_media_trash_result(MediaTrashScope(page=3), final).total == 47
+    assert first["types"] == ["PDF", "audio", "pdf", "video"]
+    assert [
+        item["id"]
+        for item in middle["items"]
+        if item["backing_media_id"] in {10, 11}
+    ] == ["local:media:11", "local:media:10"]
+    with pytest.raises(ValueError, match="requires local mode"):
+        await scope_service.list_library_media_trash(
+            mode="server", query="", media_type=None, limit=20, offset=0
+        )
+
+    app = _build_test_app(configured_default="library")
+    assert type(app) is TldwCli
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=[])
+    app.media_db = db
+    app.media_reading_scope_service = scope_service
+    probe = _LiveTrashProbe(scope_service, local_service)
+    probe.install()
+
+    try:
+        async with app.run_test(size=size) as pilot:
+            await _wait_for_condition(
+                pilot,
+                lambda: isinstance(app.screen, LibraryScreen),
+                message="Production TldwCli did not mount LibraryScreen.",
+            )
+            screen = app.screen
+            assert isinstance(screen, LibraryScreen)
+            await _wait_for_library_shell(screen, pilot)
+            screen.query_one("#library-row-browse-media", Button).focus()
+            await pilot.press("enter")
+            normal = screen._library_media_browse_controller
+            await _wait_for_condition(
+                pilot,
+                lambda: normal.applied_scope == MediaBrowseScope(),
+                message="Initial real normal-Media page never settled.",
+            )
+            await _ensure_items_open(screen, pilot)
+            screen._request_library_media_page(2, focus_identity=None)
+            await _wait_for_condition(
+                pilot,
+                lambda: normal.applied_scope == MediaBrowseScope(page=2),
+                message="Normal Media page 2 never settled.",
+            )
+            normal_retained = normal.retained_items
+            assert len(normal_retained) == 20
+            selected_normal_id = str(normal_retained[7]["id"])
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    len(screen.query(".library-media-row")) == 20
+                    and int(
+                        screen.query_one("#library-media-row-scroll").max_scroll_y
+                    )
+                    >= 5
+                ),
+                message="Normal Media page 2 never reached scrollable mounted rows.",
+            )
+            normal_scroll = screen.query_one("#library-media-row-scroll")
+            normal_scroll.scroll_to(y=5, animate=False, force=True, immediate=True)
+            await _wait_for_condition(
+                pilot,
+                lambda: int(normal_scroll.scroll_y) == 5,
+                message="Normal Media scroll did not settle at row offset 5.",
+            )
+            saved_scroll = (int(normal_scroll.scroll_x), int(normal_scroll.scroll_y))
+            assert saved_scroll[1] > 0
+            screen._selected_media_id = selected_normal_id
+            assert screen._selected_media_id == selected_normal_id
+
+            # Prove the normal viewer's retained-return policy while the
+            # page is fresh. Restore later marks this retained page stale,
+            # and stale rows intentionally reject viewer actions.
+            viewer_row = _normal_media_row(screen, selected_normal_id)
+            viewer_row.press()
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_media_view == "viewer",
+                message="Normal Media row never opened the viewer.",
+            )
+            viewer_back = await _current_widget(
+                screen, pilot, "#library-media-back", Button
+            )
+            viewer_back.focus()
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    screen._library_media_view == "list"
+                    and getattr(screen.focused, "media_id", None)
+                    == selected_normal_id
+                ),
+                message="Viewer Back did not finish on its semantic Media row.",
+            )
+            viewer_return_row = _normal_media_row(screen, selected_normal_id)
+            assert screen.focused is viewer_return_row
+            viewer_return_scroll = screen.query_one("#library-media-row-scroll")
+            assert (
+                int(viewer_return_scroll.scroll_x),
+                int(viewer_return_scroll.scroll_y),
+            ) == saved_scroll
+
+            opener = await _current_widget(
+                screen, pilot, "#library-media-trash-open", Button
+            )
+            opener.focus()
+            await pilot.press("enter")
+            controller = screen._library_media_trash_browse_controller
+            first_ids = tuple(
+                f"local:media:{media_id}" for media_id in range(47, 27, -1)
+            )
+            middle_ids = tuple(
+                f"local:media:{media_id}" for media_id in range(27, 7, -1)
+            )
+            final_ids = tuple(
+                f"local:media:{media_id}" for media_id in range(7, 0, -1)
+            )
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(),
+                total=47,
+                expected_ids=first_ids,
+            )
+            await _assert_fixed_controls_painted(screen, pilot, width=width)
+
+            # Every ordinary action is a real current focus target. Pager keys
+            # are exercised on page 2 where both directions are enabled.
+            for selector in (
+                "#library-media-trash-search",
+                "#library-media-trash-type-filter",
+                "#library-media-trash-row-0",
+                "#library-media-trash-restore",
+                "#library-media-trash-delete",
+                "#library-media-trash-back",
+            ):
+                control = await _current_widget(screen, pilot, selector)
+                control.focus()
+                await pilot.pause()
+                assert screen.focused is control
+
+            next_button = screen.query_one("#library-media-trash-next", Button)
+            next_button.focus()
+            await pilot.press("enter")
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(page=2),
+                total=47,
+                expected_ids=middle_ids,
+            )
+            for selector in (
+                "#library-media-trash-previous",
+                "#library-media-trash-next",
+            ):
+                control = await _current_widget(screen, pilot, selector, Button)
+                assert control.disabled is False
+                control.focus()
+                await pilot.pause()
+                assert screen.focused is control
+            screen.query_one("#library-media-trash-next", Button).focus()
+            await pilot.press("enter")
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(page=3),
+                total=47,
+                expected_ids=final_ids,
+            )
+            assert (
+                screen.query_one("#library-media-trash-range", Static).renderable
+                == "41-47 of 47"
+            )
+            assert (
+                screen.query_one("#library-media-trash-page", Static).renderable
+                == "Page 3 of 3"
+            )
+            screen.query_one("#library-media-trash-previous", Button).focus()
+            await pilot.press("enter")
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(page=2),
+                total=47,
+                expected_ids=middle_ids,
+            )
+            screen.query_one("#library-media-trash-previous", Button).focus()
+            await pilot.press("enter")
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(),
+                total=47,
+                expected_ids=first_ids,
+            )
+
+            # Failed query retains honest applied copy; current keyboard Retry
+            # repeats exactly that failed target and applies five real DB rows.
+            probe.fail_scope = MediaTrashScope(query=QUERY_SENTINEL)
+            await _submit_search(screen, pilot, QUERY_SENTINEL)
+            await _wait_for_condition(
+                pilot,
+                lambda: controller.state.failed_scope
+                == MediaTrashScope(query=QUERY_SENTINEL),
+                message="Failed real query never exposed its Retry target.",
+            )
+            assert controller.state.applied_result is not None
+            assert controller.state.applied_result.scope == MediaTrashScope()
+            assert screen.query_one(
+                "#library-media-trash-status", Static
+            ).renderable == "Filter not applied — showing All Trash · Retry"
+            retry = await _current_widget(
+                screen, pilot, "#library-media-trash-retry", Button
+            )
+            retry.focus()
+            assert screen.focused is retry
+            assert "Retry" in _painted_text(screen)
+            await pilot.press("enter")
+            query_ids = tuple(
+                f"local:media:{media_id}" for media_id in (46, 36, 26, 16, 6)
+            )
+            query_result = await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(query=QUERY_SENTINEL),
+                total=5,
+                expected_ids=query_ids,
+            )
+            assert query_result.types == ("PDF", "audio", "pdf", "video")
+
+            await _choose_type(screen, pilot, "pdf")
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(query=QUERY_SENTINEL, media_type="pdf"),
+                total=5,
+                expected_ids=query_ids,
+            )
+            await _submit_search(screen, pilot, "")
+            pdf_ids = tuple(
+                f"local:media:{media_id}"
+                for media_id in range(46, 0, -1)
+                if media_id % 5 in {0, 1}
+            )
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(media_type="pdf"),
+                total=19,
+                expected_ids=pdf_ids,
+            )
+            await _choose_type(screen, pilot, "PDF")
+            upper_ids = tuple(
+                f"local:media:{media_id}"
+                for media_id in range(47, 1, -1)
+                if media_id % 5 == 2
+            )
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(media_type="PDF"),
+                total=10,
+                expected_ids=upper_ids,
+            )
+            await _choose_type(screen, pilot, None)
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(),
+                total=47,
+                expected_ids=first_ids,
+            )
+
+            # A failed page request names both pages, retains page 1, then
+            # keyboard Retry installs the exact real middle page.
+            probe.fail_scope = MediaTrashScope(page=2)
+            screen.query_one("#library-media-trash-next", Button).focus()
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                lambda: controller.state.failed_scope == MediaTrashScope(page=2),
+                message="Failed real page never exposed its Retry target.",
+            )
+            assert screen.query_one(
+                "#library-media-trash-status", Static
+                ).renderable == "Page 2 not loaded — showing page 1 · Retry"
+            retry = await _current_widget(
+                screen, pilot, "#library-media-trash-retry", Button
+            )
+            retry.focus()
+            await pilot.press("enter")
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(page=2),
+                total=47,
+                expected_ids=middle_ids,
+            )
+
+            # The service shrinks underneath an attempted page 3. Production
+            # may clamp exactly once, to the now-valid page 2 with 32 rows.
+            calls_before_shrink = len(probe.calls)
+            probe.shrink_on_page_three = True
+            screen.query_one("#library-media-trash-next", Button).focus()
+            await pilot.press("enter")
+            shrunk_ids = tuple(
+                f"local:media:{media_id}" for media_id in range(27, 16, -1)
+            ) + ("local:media:1",)
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(page=2),
+                total=32,
+                expected_ids=shrunk_ids,
+            )
+            assert [
+                call["offset"] for call in probe.calls[calls_before_shrink:]
+            ] == [40, 20]
+            await asyncio.to_thread(_restore_shrunk_rows, db)
+            screen._request_library_media_trash_page(
+                1, focus_identity="#library-media-trash-previous"
+            )
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(),
+                total=47,
+                expected_ids=first_ids,
+            )
+
+            # Pane choices survive real refreshes. Compact posture makes the
+            # two panes mutually exclusive; wide posture proves independent
+            # collapse and re-expansion of both.
+            initial_layout = screen._library_media_reader_layout
+            wide_posture = bool(
+                initial_layout.library_open and initial_layout.items_open
+            )
+            items_width_contract = "exclusive-full-width"
+            if not wide_posture:
+                assert screen._library_media_reader_layout.items_open is True
+                await _toggle_pane(
+                    screen, pilot, pane="library", expected_open=True
+                )
+                assert screen._library_media_reader_layout.items_open is False
+                screen._request_library_media_trash_page(
+                    2, focus_identity="#library-media-trash-next"
+                )
+                await _wait_for_condition(
+                    pilot,
+                    lambda: (
+                        controller.state.applied_result is not None
+                        and controller.state.applied_result.scope
+                        == MediaTrashScope(page=2)
+                    ),
+                    message="Hidden compact Items refresh never settled.",
+                )
+                assert screen._library_media_reader_layout.library_open is True
+                assert screen._library_media_reader_layout.items_open is False
+                await _toggle_pane(screen, pilot, pane="items", expected_open=True)
+                assert screen._library_media_reader_layout.library_open is False
+                await _submit_search(screen, pilot, QUERY_SENTINEL)
+                await _wait_for_trash_page(
+                    screen,
+                    pilot,
+                    scope=MediaTrashScope(query=QUERY_SENTINEL),
+                    total=5,
+                    expected_ids=query_ids,
+                )
+                assert screen._library_media_reader_layout.items_open is True
+                assert screen._library_media_reader_layout.library_open is False
+                compact_items = screen.query_one("#library-canvas")
+                compact_row = screen.query_one("#library-media-trash-row-0", Button)
+                assert compact_items.region.width > 0
+                assert compact_row.region.width > 0
+                await _submit_search(screen, pilot, "")
+            else:
+                assert screen._library_media_reader_layout.library_open is True
+                assert screen._library_media_reader_layout.items_open is True
+                split_items_width = screen.query_one("#library-canvas").region.width
+                split_row_width = screen.query_one(
+                    "#library-media-trash-row-0", Button
+                ).region.width
+                await _toggle_pane(
+                    screen, pilot, pane="library", expected_open=False
+                )
+                await _wait_for_condition(
+                    pilot,
+                    lambda: (
+                        screen.query_one("#library-canvas").region.width
+                        > split_items_width
+                        and screen.query_one(
+                            "#library-media-trash-row-0", Button
+                        ).region.width
+                        > split_row_width
+                    ),
+                    message="Collapsing Library did not widen Trash Items rows.",
+                )
+                items_width_contract = "expanded-title-and-detail"
+                screen._request_library_media_trash_page(
+                    2, focus_identity="#library-media-trash-next"
+                )
+                await _wait_for_condition(
+                    pilot,
+                    lambda: (
+                        controller.state.applied_result is not None
+                        and controller.state.applied_result.scope
+                        == MediaTrashScope(page=2)
+                    ),
+                    message="Wide Library-collapsed refresh never settled.",
+                )
+                assert screen._library_media_reader_layout.library_open is False
+                await _toggle_pane(screen, pilot, pane="library", expected_open=True)
+                await _toggle_pane(screen, pilot, pane="items", expected_open=False)
+                screen._request_library_media_trash_page(
+                    1, focus_identity="#library-media-trash-previous"
+                )
+                await _wait_for_condition(
+                    pilot,
+                    lambda: (
+                        controller.state.applied_result is not None
+                        and controller.state.applied_result.scope == MediaTrashScope()
+                    ),
+                    message="Wide Items-collapsed refresh never settled.",
+                )
+                assert screen._library_media_reader_layout.items_open is False
+                await _toggle_pane(screen, pilot, pane="items", expected_open=True)
+
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(),
+                total=47,
+                expected_ids=first_ids,
+            )
+            await _assert_fixed_controls_painted(screen, pilot, width=width)
+
+            # Permanent deletion: the full captured title is visible, Cancel
+            # owns initial focus, Enter is safe, and only a later explicit
+            # Confirm commits. Its follow-up read fails truthfully as stale.
+            delete_row = _row_for_media(screen, ID_SENTINEL)
+            delete_row.focus()
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                lambda: controller.state.selected_id == ID_SENTINEL,
+                message="Delete target selection never settled.",
+            )
+            delete = await _current_widget(
+                screen, pilot, "#library-media-trash-delete", Button
+            )
+            delete.focus()
+            await pilot.press("enter")
+            await _current_widget(
+                screen, pilot, "#library-media-trash-delete-cancel", Button
+            )
+            await _wait_for_condition(
+                pilot,
+                lambda: screen.focused
+                is screen.query_one("#library-media-trash-delete-cancel", Button),
+                message="Cancel did not own initial destructive focus.",
+            )
+            title = screen.query_one(
+                "#library-media-trash-delete-confirm-title", Static
+            )
+            assert title.renderable == DELETE_TARGET_TITLE
+            assert "permanent" in _painted_text(screen).lower()
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                lambda: not screen.query(
+                    "#library-media-trash-delete-confirmation"
+                ),
+                message="Keyboard Cancel did not close confirmation.",
+            )
+            assert db.get_media_by_id(45, include_trash=True) is not None
+
+            delete = await _current_widget(
+                screen, pilot, "#library-media-trash-delete", Button
+            )
+            delete.focus()
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                lambda: getattr(screen.focused, "id", None)
+                == "library-media-trash-delete-cancel",
+                message="Reopened confirmation did not focus Cancel.",
+            )
+            probe.fail_scope = MediaTrashScope()
+            await pilot.press("tab")
+            assert screen.focused is screen.query_one(
+                "#library-media-trash-delete-confirm", Button
+            )
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    controller.state.freshness == "stale"
+                    and controller.state.failed_scope == MediaTrashScope()
+                    and controller.state.committed_notice
+                    == f"Deleted '{DELETE_TARGET_TITLE}' permanently."
+                ),
+                message="Committed delete refresh failure never became stale Retry.",
+            )
+            assert db.get_media_by_id(45, include_trash=True) is None
+            stale_status = screen.query_one(
+                "#library-media-trash-status", Static
+            ).renderable
+            assert stale_status == (
+                f"Deleted '{DELETE_TARGET_TITLE}' permanently. "
+                "List may be out of date · Retry"
+            )
+            retry = await _current_widget(
+                screen, pilot, "#library-media-trash-retry", Button
+            )
+            retry.focus()
+            await pilot.press("enter")
+            after_delete_ids = tuple(
+                f"local:media:{media_id}"
+                for media_id in range(47, 26, -1)
+                if media_id != 45
+            )
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(),
+                total=46,
+                expected_ids=after_delete_ids,
+            )
+
+            # Restore mutates the real DB, stales but does not splice the
+            # retained normal-Media page, and keeps Back's captured context.
+            restore_id = "local:media:44"
+            restore_row = _row_for_media(screen, restore_id)
+            restore_row.focus()
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                lambda: controller.state.selected_id == restore_id,
+                message="Restore target selection never settled.",
+            )
+            restore = await _current_widget(
+                screen, pilot, "#library-media-trash-restore", Button
+            )
+            restore.focus()
+            await pilot.press("enter")
+            after_restore_ids = tuple(
+                f"local:media:{media_id}"
+                for media_id in range(47, 25, -1)
+                if media_id not in {44, 45}
+            )
+            await _wait_for_trash_page(
+                screen,
+                pilot,
+                scope=MediaTrashScope(),
+                total=45,
+                expected_ids=after_restore_ids,
+            )
+            assert db.get_media_by_id(44, include_trash=False) is not None
+            assert normal.freshness == "stale"
+            assert normal.retained_items is normal_retained
+            assert all(
+                str(item["id"]) != restore_id for item in normal.retained_items
+            )
+            trash_return = screen._library_media_trash_return
+            assert trash_return is not None
+            assert trash_return.stable_id == selected_normal_id
+            assert trash_return.scroll_offset == saved_scroll
+            assert trash_return.final_focus_identity == "library-media-trash-open"
+
+            back = await _current_widget(
+                screen, pilot, "#library-media-trash-back", Button
+            )
+            back.focus()
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_media_view == "list",
+                message="Back never restored normal Media.",
+            )
+            await _wait_for_selector(screen, pilot, "#library-media-canvas")
+            await _wait_for_condition(
+                pilot,
+                lambda: getattr(screen.focused, "id", None)
+                == "library-media-trash-open",
+                message="Back never restored opener focus.",
+            )
+            assert normal.applied_scope == MediaBrowseScope(page=2)
+            assert screen._selected_media_id == selected_normal_id
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    int(
+                        screen.query_one("#library-media-row-scroll").scroll_x
+                    ),
+                    int(
+                        screen.query_one("#library-media-row-scroll").scroll_y
+                    ),
+                )
+                == saved_scroll,
+                message=lambda: (
+                    "Back did not restore normal Media scroll: "
+                    f"expected={saved_scroll!r}, "
+                    "actual="
+                    f"{(int(screen.query_one('#library-media-row-scroll').scroll_x), int(screen.query_one('#library-media-row-scroll').scroll_y))!r}, "
+                    "max="
+                    f"{(int(screen.query_one('#library-media-row-scroll').max_scroll_x), int(screen.query_one('#library-media-row-scroll').max_scroll_y))!r}"
+                ),
+            )
+            restored_scroll = screen.query_one("#library-media-row-scroll")
+            assert (
+                int(restored_scroll.scroll_x),
+                int(restored_scroll.scroll_y),
+            ) == saved_scroll
+            opener = screen.query_one("#library-media-trash-open", Button)
+            assert screen.focused is opener
+            assert opener.is_mounted and opener.region.area > 0
+
+            unfinished_trash_workers = tuple(
+                worker
+                for worker in screen.workers
+                if worker.group
+                in {"library-media-trash-browse", "library_media_bulk_delete"}
+            )
+            if unfinished_trash_workers:
+                await asyncio.wait_for(
+                    screen.workers.wait_for_complete(unfinished_trash_workers),
+                    timeout=10.0,
+                )
+            assert not tuple(
+                worker
+                for worker in screen.workers
+                if worker.group
+                in {"library-media-trash-browse", "library_media_bulk_delete"}
+            )
+        await asyncio.sleep(0)
+        assert all(worker.is_finished for worker in app.workers)
+    finally:
+        # Close the main connection and any sequential default-executor
+        # connection used by the real service calls before byte/isolation checks.
+        await asyncio.gather(
+            *(asyncio.to_thread(db.close_connection) for _ in range(8))
+        )
+        db.close_connection()
+
+    return {
+        "size": size,
+        "initial_total": 47,
+        "query_total": 5,
+        "clamped_total": 32,
+        "post_delete_total": 46,
+        "post_restore_total": 45,
+        "painted": True,
+        "keyboard": True,
+        "back": True,
+        "viewer_row_return": True,
+        "items_width_contract": items_width_contract,
+    }
+
+
+@pytest.mark.asyncio
+async def test_live_real_database_media_trash_walkthrough(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Walk real local Trash through every supported terminal posture."""
+    profile_before = _real_profile_snapshot()
+    child_pids_before = {child.pid for child in multiprocessing.active_children()}
+    scratch_config = tmp_path / "profile" / "config.toml"
+    scratch_config.parent.mkdir(parents=True)
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(scratch_config))
+    monkeypatch.setenv("TASK_18918_LIVE_CREDENTIAL", CREDENTIAL_SENTINEL)
+    assert Path(os.environ["TLDW_CONFIG_PATH"]).resolve().is_relative_to(
+        tmp_path.resolve()
+    )
+    package_path = Path(__import__("tldw_chatbook").__file__).resolve()
+    assert Path(__file__).resolve().parents[2] in package_path.parents
+
+    observations: list[dict[str, Any]] = []
+    for size in SIZES:
+        width, _height = size
+        db = _seed_real_media_database(
+            tmp_path / f"media-trash-live-{width}.db", width=width
+        )
+        assert Path(db.db_path).resolve().is_relative_to(tmp_path.resolve())
+        log_path = tmp_path / "logs" / f"media-trash-live-{width}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        loguru_sink = logger.add(log_path, format="{message}", level="DEBUG")
+        root_handler = logging.FileHandler(log_path, encoding="utf-8")
+        root_handler.setLevel(logging.DEBUG)
+        logging.getLogger().addHandler(root_handler)
+        try:
+            observation = await _walk_size(db=db, size=size)
+        finally:
+            logging.getLogger().removeHandler(root_handler)
+            root_handler.flush()
+            root_handler.close()
+            logger.remove(loguru_sink)
+        size_log_text = log_path.read_text(encoding="utf-8", errors="replace")
+        for sentinel in PRIVACY_SENTINELS:
+            assert sentinel not in size_log_text
+        assert _real_profile_snapshot() == profile_before
+        observation["privacy"] = True
+        observation["real_profile_unchanged"] = True
+        observations.append(observation)
+        print(
+            "TASK-18918 LIVE "
+            f"{width}x{size[1]}: pages=47/3 query=5 clamp=32 "
+            "delete=46 restore=45 exact-trash-back=true "
+            "viewer-row-return=true "
+            f"items-width={observation['items_width_contract']} "
+            "privacy=true real-profile-unchanged=true"
+        )
+
+    assert tuple(observation["size"] for observation in observations) == SIZES
+    assert all(
+        observation
+        == {
+            "size": observation["size"],
+            "initial_total": 47,
+            "query_total": 5,
+            "clamped_total": 32,
+            "post_delete_total": 46,
+            "post_restore_total": 45,
+            "painted": True,
+            "keyboard": True,
+            "back": True,
+            "viewer_row_return": True,
+            "items_width_contract": observation["items_width_contract"],
+            "privacy": True,
+            "real_profile_unchanged": True,
+        }
+        for observation in observations
+    )
+
+    log_text = "\n".join(
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in tmp_path.rglob("*.log*")
+        if path.is_file()
+    )
+    for sentinel in PRIVACY_SENTINELS:
+        assert sentinel not in log_text
+
+    await asyncio.sleep(0)
+    assert {child.pid for child in multiprocessing.active_children()} == child_pids_before
+    assert _real_profile_snapshot() == profile_before

--- a/Tests/Media/test_local_media_reading_service.py
+++ b/Tests/Media/test_local_media_reading_service.py
@@ -166,6 +166,63 @@ class LibrarySummaryRecordingDb:
         return [f"private-type-{index:02}" for index in range(61)]
 
 
+class LibraryTrashRecordingDb:
+    def __init__(self):
+        self.calls = []
+
+    def list_library_media_trash_page(
+        self, *, query="", media_type=None, limit=20, offset=0
+    ):
+        self.calls.append(
+            {
+                "query": query,
+                "media_type": media_type,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+        return {
+            "items": [
+                {
+                    "id": 41,
+                    "title": "",
+                    "type": "",
+                    "trash_date": "2026-08-30T12:00:00Z",
+                }
+            ],
+            "total": 45,
+            "limit": limit,
+            "offset": offset,
+            "types": ["pdf", "article"],
+        }
+
+
+def test_local_service_forwards_library_media_trash_page_without_repair():
+    db = LibraryTrashRecordingDb()
+
+    payload = LocalMediaReadingService(db).list_library_media_trash(
+        query="doc", media_type="pdf", limit=20, offset=40
+    )
+
+    assert db.calls == [
+        {"query": "doc", "media_type": "pdf", "limit": 20, "offset": 40}
+    ]
+    assert payload == {
+        "items": [
+            {
+                "id": 41,
+                "title": "",
+                "type": "",
+                "trash_date": "2026-08-30T12:00:00Z",
+            }
+        ],
+        "total": 45,
+        "limit": 20,
+        "offset": 40,
+        "types": ["pdf", "article"],
+    }
+
+
 def test_local_service_library_media_summary_uses_exact_db_offset_and_projection():
     db = LibrarySummaryRecordingDb()
 

--- a/Tests/Media/test_local_media_reading_service.py
+++ b/Tests/Media/test_local_media_reading_service.py
@@ -3,6 +3,7 @@ from importlib.util import module_from_spec, spec_from_file_location
 import io
 import json
 from pathlib import Path
+import threading
 import zipfile
 
 import pytest
@@ -550,6 +551,72 @@ def test_media_trash_permanent_delete_cascades_fts_without_sync_log(
         connection.execute("SELECT COUNT(*) FROM sync_log").fetchone()[0]
         == sync_count_before
     )
+
+
+def test_media_trash_permanent_delete_rechecks_trash_in_delete_transaction(
+    tmp_path, monkeypatch
+):
+    """A concurrent restore must win before the irreversible delete begins."""
+    from tldw_chatbook.DB import Client_Media_DB_v2 as media_db_module
+
+    db_path = tmp_path / "trash-delete-race.sqlite"
+    deleting_db = Database(db_path=db_path, client_id="delete-race")
+    restoring_db = Database(db_path=db_path, client_id="restore-race")
+    entered_delete = threading.Event()
+    resume_delete = threading.Event()
+    outcome: dict[str, object] = {}
+    worker: threading.Thread | None = None
+    try:
+        media_id, _, _ = deleting_db.add_media_with_keywords(
+            title="Concurrent restore target",
+            content="private race content",
+            media_type="document",
+            keywords=[],
+        )
+        assert deleting_db.mark_as_trash(media_id)
+        original_delete = media_db_module.permanently_delete_item
+
+        def coordinated_delete(db_instance, target_id):
+            entered_delete.set()
+            assert resume_delete.wait(5)
+            return original_delete(db_instance, target_id)
+
+        monkeypatch.setattr(
+            media_db_module, "permanently_delete_item", coordinated_delete
+        )
+
+        def delete_in_worker() -> None:
+            try:
+                outcome["result"] = LocalMediaReadingService(
+                    deleting_db
+                ).permanently_delete_media_item(media_id)
+            except Exception as exc:  # surfaced in the test thread below
+                outcome["error"] = exc
+
+        worker = threading.Thread(target=delete_in_worker)
+        worker.start()
+        assert entered_delete.wait(5)
+
+        assert restoring_db.restore_from_trash(media_id)
+        restored = restoring_db.get_media_by_id(media_id)
+        assert restored is not None
+        assert restored["is_trash"] in {0, False}
+
+        resume_delete.set()
+        worker.join(5)
+
+        assert not worker.is_alive()
+        assert "result" not in outcome
+        assert isinstance(outcome.get("error"), ValueError)
+        still_active = restoring_db.get_media_by_id(media_id)
+        assert still_active is not None
+        assert still_active["is_trash"] in {0, False}
+    finally:
+        resume_delete.set()
+        if worker is not None:
+            worker.join(5)
+        restoring_db.close_connection()
+        deleting_db.close_connection()
 
 
 def test_local_service_list_media_items_carries_last_modified_for_list_card_age(

--- a/Tests/Media/test_local_media_reading_service.py
+++ b/Tests/Media/test_local_media_reading_service.py
@@ -484,6 +484,74 @@ def test_local_service_direct_media_management_round_trips(memory_db_factory):
     assert after_permanent["items"] == []
 
 
+def test_media_trash_permanent_delete_cascades_fts_without_sync_log(
+    memory_db_factory,
+):
+    """The one-item Trash seam preserves the existing irreversible DB contract."""
+    db = memory_db_factory()
+    media_id, _, _ = db.add_media_with_keywords(
+        title="Cascade target",
+        content="unique permanent deletion sentinel",
+        media_type="document",
+        keywords=["cascade-keyword"],
+        chunks=[
+            {"text": "first child chunk", "chunk_type": "text"},
+            {"text": "second child chunk", "chunk_type": "text"},
+        ],
+    )
+    db.save_media_to_read_it_later(media_id)
+    assert db.mark_as_trash(media_id) is True
+    connection = db.get_connection()
+    child_tables = (
+        "MediaKeywords",
+        "UnvectorizedMediaChunks",
+        "MediaReadItLaterState",
+    )
+    assert all(
+        connection.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE media_id = ?", (media_id,)
+        ).fetchone()[0]
+        > 0
+        for table in child_tables
+    )
+    assert (
+        connection.execute(
+            "SELECT COUNT(*) FROM media_fts WHERE rowid = ?", (media_id,)
+        ).fetchone()[0]
+        == 1
+    )
+    sync_count_before = connection.execute("SELECT COUNT(*) FROM sync_log").fetchone()[
+        0
+    ]
+
+    result = LocalMediaReadingService(db).permanently_delete_media_item(media_id)
+
+    assert result == {"ok": True, "media_id": media_id}
+    assert (
+        connection.execute(
+            "SELECT COUNT(*) FROM Media WHERE id = ?", (media_id,)
+        ).fetchone()[0]
+        == 0
+    )
+    assert all(
+        connection.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE media_id = ?", (media_id,)
+        ).fetchone()[0]
+        == 0
+        for table in child_tables
+    )
+    assert (
+        connection.execute(
+            "SELECT COUNT(*) FROM media_fts WHERE rowid = ?", (media_id,)
+        ).fetchone()[0]
+        == 0
+    )
+    assert (
+        connection.execute("SELECT COUNT(*) FROM sync_log").fetchone()[0]
+        == sync_count_before
+    )
+
+
 def test_local_service_list_media_items_carries_last_modified_for_list_card_age(
     memory_db_factory,
 ):

--- a/Tests/Media/test_media_reading_scope_service.py
+++ b/Tests/Media/test_media_reading_scope_service.py
@@ -2751,6 +2751,130 @@ class LibrarySummaryLocalService:
         return [f"type-{index:02}" for index in range(61)]
 
 
+class LibraryTrashLocalService:
+    def __init__(self, payload=None):
+        self.calls = []
+        self.payload = payload or {
+            "items": [
+                {
+                    "id": 41,
+                    "title": "",
+                    "type": "",
+                    "trash_date": "2026-08-30T12:00:00Z",
+                }
+            ],
+            "total": 45,
+            "limit": 20,
+            "offset": 40,
+            "types": ["pdf", "article"],
+            "private_envelope": "PRIVATE_ENVELOPE_SENTINEL",
+        }
+
+    def list_library_media_trash(
+        self, *, query="", media_type=None, limit=20, offset=0
+    ):
+        self.calls.append(
+            {
+                "query": query,
+                "media_type": media_type,
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+        return self.payload
+
+
+@pytest.mark.asyncio
+async def test_scope_library_media_trash_is_local_only_and_canonical(monkeypatch, caplog):
+    local = LibraryTrashLocalService()
+    server = FakeServerMediaService()
+    scope_service = MediaReadingScopeService(local_service=local, server_service=server)
+    thread_calls = []
+
+    async def recording_to_thread(fn, *args, **kwargs):
+        thread_calls.append((fn.__name__, args, kwargs))
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "tldw_chatbook.Media.media_reading_scope_service.asyncio.to_thread",
+        recording_to_thread,
+    )
+
+    payload = await scope_service.list_library_media_trash(
+        mode="local", query="doc", media_type="pdf", limit=20, offset=40
+    )
+
+    assert set(payload) == {"items", "total", "limit", "offset", "types"}
+    assert set(payload["items"][0]) == {
+        "id",
+        "backing_media_id",
+        "title",
+        "media_type",
+        "trash_date",
+    }
+    assert payload["items"][0] == {
+        "id": "local:media:41",
+        "backing_media_id": 41,
+        "title": "Untitled",
+        "media_type": None,
+        "trash_date": "2026-08-30T12:00:00Z",
+    }
+    assert local.calls == [
+        {"query": "doc", "media_type": "pdf", "limit": 20, "offset": 40}
+    ]
+    assert thread_calls == [
+        (
+            "list_library_media_trash",
+            (),
+            {"query": "doc", "media_type": "pdf", "limit": 20, "offset": 40},
+        )
+    ]
+    assert server.calls == []
+    assert "PRIVATE_ENVELOPE_SENTINEL" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_scope_library_media_trash_preserves_missing_and_malformed_envelope_values():
+    payload = {"items": None, "total": "45", "limit": 21, "types": ("pdf",)}
+    local = LibraryTrashLocalService(payload)
+    scope_service = MediaReadingScopeService(local_service=local, server_service=None)
+
+    result = await scope_service.list_library_media_trash(
+        mode="local", limit=20, offset=40
+    )
+
+    assert result == payload
+    assert "offset" not in result
+
+
+@pytest.mark.asyncio
+async def test_scope_library_media_trash_enforces_existing_list_policy_before_local_call():
+    local = LibraryTrashLocalService()
+    policy_enforcer = FakePolicyEnforcer(denied_reason="policy_denied")
+    scope_service = MediaReadingScopeService(
+        local_service=local,
+        server_service=None,
+        policy_enforcer=policy_enforcer,
+    )
+
+    with pytest.raises(PolicyDeniedError):
+        await scope_service.list_library_media_trash(mode="local")
+
+    assert policy_enforcer.calls == ["media.items.trash.list.local"]
+    assert local.calls == []
+
+
+@pytest.mark.asyncio
+async def test_scope_library_media_trash_rejects_server_before_touching_server_service():
+    server = FakeServerMediaService()
+    scope_service = MediaReadingScopeService(local_service=None, server_service=server)
+
+    with pytest.raises(ValueError, match="local"):
+        await scope_service.list_library_media_trash(mode="server")
+
+    assert server.calls == []
+
+
 @pytest.mark.asyncio
 async def test_scope_service_library_media_summary_preserves_envelope_and_five_keys():
     local = LibrarySummaryLocalService()

--- a/Tests/Media_DB/test_media_db_v2.py
+++ b/Tests/Media_DB/test_media_db_v2.py
@@ -231,6 +231,7 @@ def test_permanent_delete_success_logs_only_fixed_metadata(tmp_path, caplog):
             content="private delete content",
             keywords=[],
         )
+        assert db.mark_as_trash(target_id)
 
         rendered_logs = _capture_permanent_delete_logs(
             caplog,
@@ -278,6 +279,7 @@ def test_permanent_delete_sqlite_failure_logs_category_without_private_values(
             content="private failed delete content",
             keywords=[],
         )
+        assert db.mark_as_trash(target_id)
         with db.transaction() as conn:
             conn.execute(
                 "CREATE TRIGGER block_private_media_delete "
@@ -336,6 +338,7 @@ def test_permanent_delete_fts_failure_logs_categories_without_private_values(
             content="private FTS failure content",
             keywords=[],
         )
+        assert db.mark_as_trash(target_id)
         original_delete_fts = db._delete_fts_media
         reached_fts_sink: list[int] = []
 

--- a/Tests/Media_DB/test_media_db_v2.py
+++ b/Tests/Media_DB/test_media_db_v2.py
@@ -98,7 +98,9 @@ def _assert_permanent_delete_log_privacy(
     private_values: tuple[str, ...],
 ) -> None:
     identifier_fragments = (
+        f"Media ID {target_id}",
         f"Media ID: {target_id}",
+        f"local:media:{target_id}",
         f"Media {target_id}",
         f"media {target_id}",
         f"media_id={target_id}",
@@ -109,8 +111,24 @@ def _assert_permanent_delete_log_privacy(
         str(Path(f"{db_path.resolve()}-wal")),
         str(Path(f"{db_path.resolve()}-shm")),
     )
+    assert "Traceback (most recent call last)" not in rendered_logs
     for private_value in (*identifier_fragments, *path_fragments, *private_values):
         assert private_value not in rendered_logs
+
+
+def test_permanent_delete_privacy_guard_rejects_former_fts_success_line(
+    tmp_path: Path,
+) -> None:
+    """Mutation proof: the former identifier-bearing FTS line is forbidden."""
+    target_id = 7
+    rendered_logs = f"Deleted FTS entry for Media ID {target_id}"
+    with pytest.raises(AssertionError):
+        _assert_permanent_delete_log_privacy(
+            rendered_logs,
+            target_id=target_id,
+            db_path=tmp_path / "private.sqlite",
+            private_values=(),
+        )
 
 
 def get_schema_version(db: Database) -> int:
@@ -235,6 +253,10 @@ def test_permanent_delete_success_logs_only_fixed_metadata(tmp_path, caplog):
             "Media mutation operation=permanent_delete status=started count=1",
             "Media mutation operation=permanent_delete status=committed count=1",
         )
+        assert (
+            "Media FTS mutation operation=delete status=committed count=1"
+            in tuple(record.getMessage() for record in caplog.records)
+        )
     finally:
         db.close_connection()
 
@@ -293,6 +315,103 @@ def test_permanent_delete_sqlite_failure_logs_category_without_private_values(
         )
     finally:
         db.close_connection()
+
+
+def test_permanent_delete_fts_failure_logs_categories_without_private_values(
+    tmp_path, caplog
+):
+    """Exercise the real FTS sink after Media deletion starts, then roll back."""
+    db_path = tmp_path / "private-media-fts-failure.sqlite"
+    private_title = "PRIVATE FTS FAILED DELETE TITLE"
+    private_url = "private-delete://fts-failure-url"
+    private_client = "private-delete-fts-failure-client"
+    private_exception = "PRIVATE FTS DELETE FAILURE"
+    private_sql = "DELETE FROM media_fts WHERE rowid = PRIVATE TARGET"
+    db = Database(db_path, private_client)
+    try:
+        target_id, _uuid, _message = db.add_media_with_keywords(
+            url=private_url,
+            title=private_title,
+            media_type="article",
+            content="private FTS failure content",
+            keywords=[],
+        )
+        original_delete_fts = db._delete_fts_media
+        reached_fts_sink: list[int] = []
+
+        class _FailingFTSConnection:
+            def execute(self, sql, params):
+                assert sql == "DELETE FROM media_fts WHERE rowid = ?"
+                assert params == (target_id,)
+                reached_fts_sink.append(target_id)
+                raise sqlite3.OperationalError(
+                    f"{private_exception} | {private_sql}"
+                )
+
+        def fail_after_media_delete(conn, media_id):
+            assert conn.execute(
+                "SELECT 1 FROM Media WHERE id = ?", (media_id,)
+            ).fetchone() is None
+            return original_delete_fts(_FailingFTSConnection(), media_id)
+
+        db._delete_fts_media = fail_after_media_delete
+
+        def fail_delete() -> None:
+            with pytest.raises(DatabaseError):
+                permanently_delete_item(db, target_id)
+
+        rendered_logs = _capture_permanent_delete_logs(caplog, fail_delete)
+
+        assert reached_fts_sink == [target_id]
+        assert db.get_media_by_id(target_id, include_trash=True) is not None
+        _assert_permanent_delete_log_privacy(
+            rendered_logs,
+            target_id=target_id,
+            db_path=db_path,
+            private_values=(
+                private_title,
+                private_url,
+                private_client,
+                private_exception,
+                private_sql,
+            ),
+        )
+        assert (
+            "Media FTS mutation operation=delete status=failed count=0 "
+            "category=OperationalError"
+            in tuple(record.getMessage() for record in caplog.records)
+        )
+        permanent_lines = tuple(
+            line
+            for line in rendered_logs.splitlines()
+            if "operation=permanent_delete" in line
+        )
+        assert permanent_lines == (
+            "Media mutation operation=permanent_delete status=started count=1",
+            "Media mutation operation=permanent_delete status=failed count=0 "
+            "category=DatabaseError",
+        )
+    finally:
+        db.close_connection()
+
+
+def test_permanent_delete_privacy_guard_rejects_raw_fts_failure_detail(
+    tmp_path: Path,
+) -> None:
+    """Mutation proof: category metadata may not carry raw FTS failure text."""
+    target_id = 9
+    private_exception = "PRIVATE RAW FTS FAILURE"
+    rendered_logs = (
+        "Media FTS mutation operation=delete status=failed count=0 "
+        f"category=OperationalError detail={private_exception}"
+    )
+    with pytest.raises(AssertionError):
+        _assert_permanent_delete_log_privacy(
+            rendered_logs,
+            target_id=target_id,
+            db_path=tmp_path / "private.sqlite",
+            private_values=(private_exception,),
+        )
 
 
 #######################################################################################################################

--- a/Tests/Media_DB/test_media_db_v2.py
+++ b/Tests/Media_DB/test_media_db_v2.py
@@ -3,13 +3,17 @@
 # This version is self-contained and does not require a conftest.py file.
 #
 # Standard Library Imports:
+import io
 import json
+import logging
 import os
 import pytest
 import sys
 import time
 import sqlite3
 from pathlib import Path
+
+from loguru import logger
 
 #
 # --- Path Setup (Replaces conftest.py logic) ---
@@ -28,6 +32,7 @@ except (NameError, IndexError):
 from tldw_chatbook.DB.Client_Media_DB_v2 import (
     DatabaseError,
     MediaDatabase as Database,
+    permanently_delete_item,
 )
 from Tests.DB.historical_bootstrap_v6 import media_db_at_version
 #
@@ -70,6 +75,42 @@ def get_document_version_count(db: Database, media_id: int) -> int:
         "SELECT COUNT(*) FROM DocumentVersions WHERE media_id = ?", (media_id,)
     )
     return cursor.fetchone()[0]
+
+
+def _capture_permanent_delete_logs(caplog, operation):
+    """Capture both logging stacks for one already-initialized DB operation."""
+    caplog.clear()
+    caplog.set_level(logging.DEBUG)
+    loguru_output = io.StringIO()
+    sink_id = logger.add(loguru_output, format="{message}", level="DEBUG")
+    try:
+        operation()
+    finally:
+        logger.remove(sink_id)
+    return f"{loguru_output.getvalue()}\n{caplog.text}"
+
+
+def _assert_permanent_delete_log_privacy(
+    rendered_logs: str,
+    *,
+    target_id: int,
+    db_path: Path,
+    private_values: tuple[str, ...],
+) -> None:
+    identifier_fragments = (
+        f"Media ID: {target_id}",
+        f"Media {target_id}",
+        f"media {target_id}",
+        f"media_id={target_id}",
+        f"media_id: {target_id}",
+    )
+    path_fragments = (
+        str(db_path.resolve()),
+        str(Path(f"{db_path.resolve()}-wal")),
+        str(Path(f"{db_path.resolve()}-shm")),
+    )
+    for private_value in (*identifier_fragments, *path_fragments, *private_values):
+        assert private_value not in rendered_logs
 
 
 def get_schema_version(db: Database) -> int:
@@ -156,6 +197,102 @@ def search_db(tmp_path_factory):
 
     yield db
     db.close_connection()
+
+
+def test_permanent_delete_success_logs_only_fixed_metadata(tmp_path, caplog):
+    db_path = tmp_path / "private-media-success.sqlite"
+    private_title = "PRIVATE PERMANENT DELETE TITLE"
+    private_url = "private-delete://success-url"
+    private_client = "private-delete-success-client"
+    db = Database(db_path, private_client)
+    try:
+        target_id, _uuid, _message = db.add_media_with_keywords(
+            url=private_url,
+            title=private_title,
+            media_type="article",
+            content="private delete content",
+            keywords=[],
+        )
+
+        rendered_logs = _capture_permanent_delete_logs(
+            caplog,
+            lambda: permanently_delete_item(db, target_id),
+        )
+
+        assert db.get_media_by_id(target_id, include_trash=True) is None
+        _assert_permanent_delete_log_privacy(
+            rendered_logs,
+            target_id=target_id,
+            db_path=db_path,
+            private_values=(private_title, private_url, private_client),
+        )
+        permanent_lines = tuple(
+            line
+            for line in rendered_logs.splitlines()
+            if "operation=permanent_delete" in line
+        )
+        assert permanent_lines == (
+            "Media mutation operation=permanent_delete status=started count=1",
+            "Media mutation operation=permanent_delete status=committed count=1",
+        )
+    finally:
+        db.close_connection()
+
+
+def test_permanent_delete_sqlite_failure_logs_category_without_private_values(
+    tmp_path, caplog
+):
+    db_path = tmp_path / "private-media-failure.sqlite"
+    private_title = "PRIVATE FAILED DELETE TITLE"
+    private_url = "private-delete://failure-url"
+    private_client = "private-delete-failure-client"
+    private_exception = "PRIVATE SQLITE DELETE FAILURE"
+    db = Database(db_path, private_client)
+    try:
+        target_id, _uuid, _message = db.add_media_with_keywords(
+            url=private_url,
+            title=private_title,
+            media_type="article",
+            content="private failed delete content",
+            keywords=[],
+        )
+        with db.transaction() as conn:
+            conn.execute(
+                "CREATE TRIGGER block_private_media_delete "
+                "BEFORE DELETE ON Media BEGIN "
+                f"SELECT RAISE(ABORT, '{private_exception}'); END"
+            )
+
+        def fail_delete() -> None:
+            with pytest.raises(DatabaseError):
+                permanently_delete_item(db, target_id)
+
+        rendered_logs = _capture_permanent_delete_logs(caplog, fail_delete)
+
+        assert db.get_media_by_id(target_id, include_trash=True) is not None
+        _assert_permanent_delete_log_privacy(
+            rendered_logs,
+            target_id=target_id,
+            db_path=db_path,
+            private_values=(
+                private_title,
+                private_url,
+                private_client,
+                private_exception,
+            ),
+        )
+        permanent_lines = tuple(
+            line
+            for line in rendered_logs.splitlines()
+            if "operation=permanent_delete" in line
+        )
+        assert permanent_lines == (
+            "Media mutation operation=permanent_delete status=started count=1",
+            "Media mutation operation=permanent_delete status=failed count=0 "
+            "category=IntegrityError",
+        )
+    finally:
+        db.close_connection()
 
 
 #######################################################################################################################

--- a/Tests/UI/test_library_media_browse_controller.py
+++ b/Tests/UI/test_library_media_browse_controller.py
@@ -349,6 +349,44 @@ def test_retain_stale_items_does_not_forge_exact_metadata() -> None:
 
 
 @pytest.mark.asyncio
+async def test_media_trash_restore_marks_normal_media_stale_without_changing_page() -> (
+    None
+):
+    """A Trash restore withdraws authority without guessing ranked placement."""
+    screen = _Screen()
+    service = _Service(_page(2, 40), types=("audio", "video"))
+    controller = _controller(screen, service)
+    scope = MediaBrowseScope(
+        query="retained", media_type="video", sort_by="title_asc", page=2
+    )
+    controller.request(scope, focus_identity=None)
+    await screen.pending.pop()
+    controller.request_facets(fingerprint=scope.fingerprint)
+    await screen.pending.pop()
+
+    applied = controller.applied_result
+    retained = controller.retained_items
+    requested = controller.requested_scope
+    type_options = controller.type_options
+    facet_fingerprint = controller.facet_fingerprint
+
+    controller.mark_stale_after_trash_restore()
+
+    assert controller.applied_result is applied
+    assert controller.retained_items is retained
+    assert controller.requested_scope == requested == scope
+    assert controller.type_options == type_options == ("audio", "video")
+    assert controller.facet_fingerprint == facet_fingerprint == scope.fingerprint
+    assert controller.freshness == "stale"
+    assert controller.loading is False
+    assert controller.error_copy == ""
+    assert controller.stale_copy == "Media changed; retry to load a current page."
+    assert controller.pager.title_count is None
+    assert controller.pager.page_copy == ""
+    assert controller.pager.retry_visible is True
+
+
+@pytest.mark.asyncio
 async def test_committed_mutation_reconciles_retained_without_forging_envelope() -> (
     None
 ):

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -10,6 +10,7 @@ from textual import events, on
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.geometry import Size
+from textual.widget import Widget
 from textual.widgets import Button
 
 from Tests.UI.test_library_media_side_by_side import (
@@ -589,6 +590,25 @@ def _hold_next_owner_geometry(
     assert len(held) == 1
     assert owner.latest_geometry is held[0].geometry
     return held[0]
+
+
+async def _mount_media_canvas_with_retained_owner(
+    parent: Widget,
+    canvas: Widget,
+    owner: Widget,
+    retained_rows: tuple[Widget, ...],
+    row_scroll_type,
+) -> None:
+    """Remount a canvas but reparent its original row-scroll owner."""
+    await parent.mount(canvas)
+    generated_owner = canvas.query_one("#library-media-row-scroll", row_scroll_type)
+    assert generated_owner is not owner
+    generated_parent = generated_owner.parent
+    assert generated_parent is not None
+    await generated_owner.remove()
+    await generated_parent.mount(owner)
+    for row in retained_rows:
+        await owner.mount(row)
 
 
 @pytest.mark.asyncio
@@ -1608,7 +1628,7 @@ async def test_stale_request_generation_and_subview_fences_cannot_settle(
 async def test_mounted_media_shell_replacement_rejects_delayed_old_owner_geometry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A real shell recompose mints authority only for its replacement tree."""
+    """Changing only the mounted shell identity rejects same-owner geometry."""
     _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
     app = _build_media_test_app()
     _seed_conversations(app, _two_conversations(), media=_many_media_items())
@@ -1629,7 +1649,72 @@ async def test_mounted_media_shell_replacement_rejects_delayed_old_owner_geometr
             "#library-media-reader-shell", LibraryMediaReaderShell
         )
         old_items = screen.query_one("#library-canvas", Vertical)
-        delayed_geometry = _hold_next_owner_geometry(
+        active_child = old_items.children[0]
+        monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
+        stage = screen.query_one("#library-shell-grid", Horizontal)
+        retained_rail = old_shell.library
+        retained_rows = tuple(old_owner.children)
+        for row in retained_rows:
+            await row.remove()
+        await old_owner.remove()
+        await active_child.remove()
+        await old_items.remove()
+        await retained_rail.remove()
+        await old_shell.remove()
+        replacement_shell = LibraryMediaReaderShell(
+            retained_rail,
+            old_items,
+            screen._build_library_media_reader(),
+            screen._library_media_reader_layout,
+            id="library-media-reader-shell",
+        )
+        held_shell_resizes: list[MediaShellResized] = []
+        real_shell_post_message = replacement_shell.post_message
+
+        def hold_shell_resize(message) -> bool:
+            if type(message) is MediaShellResized:
+                held_shell_resizes.append(message)
+                return True
+            return real_shell_post_message(message)
+
+        monkeypatch.setattr(replacement_shell, "post_message", hold_shell_resize)
+        await stage.mount(replacement_shell)
+        await _mount_media_canvas_with_retained_owner(
+            old_items,
+            active_child,
+            old_owner,
+            retained_rows,
+            row_scroll_type,
+        )
+        replacement_shell.sync_layout(screen._library_media_reader_layout)
+        await pilot.pause()
+        assert real_shell_post_message(
+            events.Resize(
+                replacement_shell.size,
+                replacement_shell.virtual_size,
+                replacement_shell.container_size,
+            )
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: bool(held_shell_resizes),
+            message="Replacement shell did not queue its real resize lifecycle.",
+        )
+        replacement_owner = screen.query_one(
+            "#library-media-row-scroll", row_scroll_type
+        )
+        assert screen.query_one(
+            "#library-media-reader-shell", LibraryMediaReaderShell
+        ) is replacement_shell
+        assert screen.query_one("#library-canvas", Vertical) is old_items
+        assert replacement_shell is not old_shell
+        assert replacement_owner is old_owner
+        assert old_items.children[0] is active_child
+        assert old_request.items_host_identity == id(old_items)
+        assert old_request.owner_identity == id(old_owner)
+        assert old_request.shell_identity == id(old_shell)
+
+        current_geometry = _hold_next_owner_geometry(
             monkeypatch,
             old_owner,
             row_scroll_type,
@@ -1637,79 +1722,41 @@ async def test_mounted_media_shell_replacement_rejects_delayed_old_owner_geometr
             real_on_resize,
         )
         monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
-        stage = screen.query_one("#library-shell-grid", Horizontal)
-        retained_rail = old_shell.library
-        await retained_rail.remove()
-        await old_shell.remove()
-        replacement_items = Vertical(
-            screen._build_library_media_active_child(),
-            id="library-canvas",
-            classes="destination-workbench-pane",
-        )
-        replacement_shell = LibraryMediaReaderShell(
-            retained_rail,
-            replacement_items,
-            screen._build_library_media_reader(),
-            screen._library_media_reader_layout,
-            id="library-media-reader-shell",
-        )
-        await stage.mount(replacement_shell)
-        await _wait_for_condition(
-            pilot,
-            lambda: replacement_shell.is_attached
-            and screen._library_media_return_settlement is not None
-            and screen._library_media_return_settlement.request_id
-            > old_request.request_id,
-            message="Replacement shell never received fresh lifecycle authority.",
-        )
-        replacement_owner = screen.query_one(
-            "#library-media-row-scroll", row_scroll_type
-        )
-        replacement_request = screen._library_media_return_settlement
-        assert replacement_request is not None
-        assert screen.query_one(
-            "#library-media-reader-shell", LibraryMediaReaderShell
-        ) is replacement_shell
-        assert screen.query_one("#library-canvas", Vertical) is replacement_items
-        assert replacement_shell is not old_shell
-        assert replacement_items is not old_items
-        assert replacement_owner is not old_owner
-        assert replacement_request.shell_identity == id(replacement_shell)
-        assert replacement_request.items_host_identity == id(replacement_items)
-        assert replacement_request.owner_identity == id(replacement_owner)
-
-        assert screen.post_message(delayed_geometry)
+        assert screen.post_message(current_geometry)
         await pilot.pause()
 
-        assert screen._library_media_return_settlement is replacement_request
+        assert screen._library_media_return_settlement is None
         assert screen._library_media_last_settlement_outcome is None
+        assert screen._library_media_last_successful_settlement is None
 
-        monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
-        assert replacement_owner.post_message(
-            events.Resize(
-                replacement_owner.size,
-                replacement_owner.virtual_size,
-                replacement_owner.container_size,
-            )
-        )
+        assert real_shell_post_message(held_shell_resizes.pop(0))
         await _wait_for_condition(
             pilot,
             lambda: screen._library_media_last_successful_settlement is not None
             and screen._library_media_last_successful_settlement[0].request_id
-            == replacement_request.request_id,
-            message="Replacement shell owner geometry did not settle fresh authority.",
+            > old_request.request_id,
+            message=lambda: (
+                "Replacement shell lifecycle did not mint fresh authority: "
+                f"pending={screen._library_pending_list_entry_focus!r}, "
+                f"receipt={screen._library_pending_list_entry_media_return!r}, "
+                f"request={screen._library_media_return_settlement!r}, "
+                f"latest={old_owner.latest_geometry!r}, "
+                f"actual={(old_owner.size, old_owner.virtual_size, old_owner.container_size)!r}, "
+                f"success={screen._library_media_last_successful_settlement!r}, "
+                f"outcome={screen._library_media_last_settlement_outcome!r}"
+            ),
         )
         successful_request = screen._library_media_last_successful_settlement[0]
         assert successful_request.shell_identity == id(replacement_shell)
-        assert successful_request.items_host_identity == id(replacement_items)
-        assert successful_request.owner_identity == id(replacement_owner)
+        assert successful_request.items_host_identity == old_request.items_host_identity
+        assert successful_request.owner_identity == old_request.owner_identity
 
 
 @pytest.mark.asyncio
 async def test_mounted_items_host_replacement_rejects_delayed_old_owner_geometry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A retained shell gives fresh authority only to its recomposed Items tree."""
+    """Changing only the mounted Items identity rejects same-owner geometry."""
     _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
     app = _build_media_test_app()
     _seed_conversations(app, _two_conversations(), media=_many_media_items())
@@ -1730,29 +1777,47 @@ async def test_mounted_items_host_replacement_rejects_delayed_old_owner_geometry
             "#library-media-reader-shell", LibraryMediaReaderShell
         )
         old_items = screen.query_one("#library-canvas", Vertical)
-        delayed_geometry = _hold_next_owner_geometry(
-            monkeypatch,
-            old_owner,
-            row_scroll_type,
-            geometry_message_type,
-            real_on_resize,
-        )
+        active_child = old_items.children[0]
         monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
+        retained_rows = tuple(old_owner.children)
+        for row in retained_rows:
+            await row.remove()
+        await old_owner.remove()
+        await active_child.remove()
+        await old_items.remove()
         replacement_items = Vertical(
-            screen._build_library_media_active_child(),
             id="library-canvas",
             classes="destination-workbench-pane library-adaptive-reader-items",
         )
         shell.items = replacement_items
+        held_shell_resizes: list[MediaShellResized] = []
+        real_shell_post_message = shell.post_message
 
-        await shell.recompose()
+        def hold_shell_resize(message) -> bool:
+            if type(message) is MediaShellResized:
+                held_shell_resizes.append(message)
+                return True
+            return real_shell_post_message(message)
+
+        monkeypatch.setattr(shell, "post_message", hold_shell_resize)
+
+        await shell.mount(replacement_items, before=shell.items_grip)
+        await _mount_media_canvas_with_retained_owner(
+            replacement_items,
+            active_child,
+            old_owner,
+            retained_rows,
+            row_scroll_type,
+        )
         shell.sync_layout(screen._library_media_reader_layout)
+        await pilot.pause()
+        assert real_shell_post_message(
+            events.Resize(shell.size, shell.virtual_size, shell.container_size)
+        )
         await _wait_for_condition(
             pilot,
-            lambda: bool(screen.query("#library-media-row-scroll"))
-            and screen.query_one("#library-media-row-scroll", row_scroll_type)
-            is not old_owner,
-            message="Retained shell did not mount the replacement Items tree.",
+            lambda: bool(held_shell_resizes),
+            message="Retained shell did not queue its real resize lifecycle.",
         )
         replacement_shell = screen.query_one(
             "#library-media-reader-shell", LibraryMediaReaderShell
@@ -1763,31 +1828,40 @@ async def test_mounted_items_host_replacement_rejects_delayed_old_owner_geometry
         assert replacement_shell is shell
         assert screen.query_one("#library-canvas", Vertical) is replacement_items
         assert replacement_items is not old_items
+        assert replacement_items.children[0] is active_child
+        assert replacement_owner is old_owner
+        assert old_request.shell_identity == id(shell)
+        assert old_request.items_host_identity == id(old_items)
+        assert old_request.owner_identity == id(old_owner)
 
-        assert screen.post_message(delayed_geometry)
+        current_geometry = _hold_next_owner_geometry(
+            monkeypatch,
+            old_owner,
+            row_scroll_type,
+            geometry_message_type,
+            real_on_resize,
+        )
+        monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
+        assert screen.post_message(current_geometry)
         await pilot.pause()
 
+        assert screen._library_media_return_settlement is None
         assert screen._library_media_last_settlement_outcome is None
         assert screen._library_media_last_successful_settlement is None
 
-        monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
-        assert replacement_owner.post_message(
-            events.Resize(
-                replacement_owner.size,
-                replacement_owner.virtual_size,
-                replacement_owner.container_size,
-            )
-        )
+        assert real_shell_post_message(held_shell_resizes.pop(0))
         await _wait_for_condition(
             pilot,
-            lambda: screen._library_media_last_successful_settlement is not None,
-            message="Replacement Items owner never received fresh authority.",
+            lambda: screen._library_media_last_successful_settlement is not None
+            and screen._library_media_last_successful_settlement[0].request_id
+            > old_request.request_id,
+            message="Replacement Items lifecycle did not mint fresh authority.",
         )
         successful_request = screen._library_media_last_successful_settlement[0]
         assert successful_request.request_id > old_request.request_id
-        assert successful_request.shell_identity == id(shell)
+        assert successful_request.shell_identity == old_request.shell_identity
         assert successful_request.items_host_identity == id(replacement_items)
-        assert successful_request.owner_identity == id(replacement_owner)
+        assert successful_request.owner_identity == old_request.owner_identity
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -619,7 +619,7 @@ async def test_real_compact_transition_floors_prechange_owner_geometry(
 
 
 @pytest.mark.asyncio
-async def test_current_user_media_row_focus_cancels_pending_return(
+async def test_live_user_row_focus_fences_earlier_queued_geometry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _, _, row_scroll_type, _, _ = _require_return_protocol()
@@ -641,20 +641,32 @@ async def test_current_user_media_row_focus_cancels_pending_return(
             for row in screen.query(".library-media-row")
             if str(getattr(row, "media_id", "")) != media_id
         )
-        screen.set_focus(other, scroll_visible=False)
-        screen.on_descendant_focus(events.DescendantFocus(other))
+        geometry_arm_focuses: list[object | None] = []
+        real_arm = screen._arm_library_media_return_settlement
 
-        assert screen._library_pending_list_entry_focus is False
-        assert screen._library_pending_list_entry_media_return is None
-        assert screen._library_media_return_settlement is None
+        def observe_geometry_arm_focus(*args, **kwargs):
+            geometry_arm_focuses.append(screen.focused)
+            return real_arm(*args, **kwargs)
 
+        monkeypatch.setattr(
+            screen,
+            "_arm_library_media_return_settlement",
+            observe_geometry_arm_focus,
+        )
+        other.focus(scroll_visible=False)
         monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
         owner.on_resize(
             events.Resize(owner.size, owner.virtual_size, owner.container_size)
         )
+        assert owner.latest_geometry is not None
+
         await pilot.pause()
+        assert geometry_arm_focuses == [other]
         assert screen._library_media_last_exact_settlement is None
         assert screen.focused is other
+        assert screen._library_pending_list_entry_focus is False
+        assert screen._library_pending_list_entry_media_return is None
+        assert screen._library_media_return_settlement is None
 
 
 @pytest.mark.asyncio
@@ -755,6 +767,46 @@ async def test_detached_current_owner_rejects_later_geometry_settlement(
 
         assert screen.post_message(queued)
         await pilot.pause()
+        assert screen._library_media_last_exact_settlement is None
+
+
+@pytest.mark.asyncio
+async def test_screen_unmount_revokes_complete_pending_return_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, owner, _, _, real_on_resize = await _open_pending_viewer_return(
+            host,
+            pilot,
+            monkeypatch,
+            row_scroll_type,
+        )
+        queued = _hold_next_owner_geometry(
+            monkeypatch,
+            owner,
+            row_scroll_type,
+            geometry_message_type,
+            real_on_resize,
+        )
+        assert screen._library_pending_list_entry_focus is True
+        assert screen._library_pending_list_entry_media_return is not None
+        assert screen._library_media_return_settlement is not None
+        assert screen._library_list_entry_focus_timer is not None
+
+        await host.pop_screen()
+
+        assert host.screen is not screen
+        assert screen.is_attached is False
+        assert screen._library_pending_list_entry_focus is False
+        assert screen._library_pending_list_entry_media_return is None
+        assert screen._library_media_return_settlement is None
+        assert screen._library_list_entry_focus_timer is None
+        screen._handle_library_media_row_geometry_changed(queued)
         assert screen._library_media_last_exact_settlement is None
 
 

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -757,6 +757,40 @@ async def test_real_compact_transition_floors_prechange_owner_geometry(
 
 
 @pytest.mark.asyncio
+async def test_stale_programmatic_focus_releases_guard_before_user_refocus() -> None:
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        screen._library_notes_restoring_focus = False
+        screen._mark_library_notes_user_interaction()
+        target = screen.query_one("#library-media-type-filter", Button)
+        live_focus = screen.query_one("#library-media-trash-open", Button)
+
+        screen._library_notes_programmatic_focus_target = target
+        screen.set_focus(target, scroll_visible=False)
+        assert screen.focused is target
+        screen.set_focus(live_focus, scroll_visible=False)
+        assert screen.focused is live_focus
+
+        await pilot.pause()
+
+        assert screen.focused is live_focus
+        assert screen._library_notes_programmatic_focus_target is None
+        assert screen._library_media_view == "list"
+
+        before_user_focus = screen._library_notes_focus_intent_generation
+        screen.set_focus(target, scroll_visible=False)
+        await pilot.pause()
+
+        assert screen.focused is target
+        assert target.has_focus
+        assert screen._library_notes_focus_intent_generation == before_user_focus + 1
+
+
+@pytest.mark.asyncio
 async def test_live_user_row_focus_fences_earlier_queued_geometry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -8,7 +8,7 @@ from typing import get_type_hints
 import pytest
 from textual import events, on
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal
+from textual.containers import Horizontal, Vertical
 from textual.geometry import Size
 from textual.widgets import Button
 
@@ -1605,19 +1605,17 @@ async def test_stale_request_generation_and_subview_fences_cannot_settle(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("identity_field", ("shell_identity", "items_host_identity"))
-async def test_replaced_shell_and_items_identities_reject_current_geometry(
+async def test_mounted_media_shell_replacement_rejects_delayed_old_owner_geometry(
     monkeypatch: pytest.MonkeyPatch,
-    identity_field: str,
 ) -> None:
-    """Each replaced tree identity independently fences an otherwise-live request."""
+    """A real shell recompose mints authority only for its replacement tree."""
     _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
     app = _build_media_test_app()
     _seed_conversations(app, _two_conversations(), media=_many_media_items())
     host = LibraryProductionCSSHarness(app)
 
     async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
-        screen, owner, _media_id, _scroll_offset, real_on_resize = (
+        screen, old_owner, _media_id, _scroll_offset, real_on_resize = (
             await _open_pending_viewer_return(
                 host,
                 pilot,
@@ -1625,28 +1623,171 @@ async def test_replaced_shell_and_items_identities_reject_current_geometry(
                 row_scroll_type,
             )
         )
-        request = screen._library_media_return_settlement
-        assert request is not None
-        geometry = _hold_next_owner_geometry(
+        old_request = screen._library_media_return_settlement
+        assert old_request is not None
+        old_shell = screen.query_one(
+            "#library-media-reader-shell", LibraryMediaReaderShell
+        )
+        old_items = screen.query_one("#library-canvas", Vertical)
+        delayed_geometry = _hold_next_owner_geometry(
             monkeypatch,
-            owner,
+            old_owner,
             row_scroll_type,
             geometry_message_type,
             real_on_resize,
         )
-        replacement_request = dataclasses.replace(
-            request,
-            **{identity_field: getattr(request, identity_field) + 1},
+        monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
+        stage = screen.query_one("#library-shell-grid", Horizontal)
+        retained_rail = old_shell.library
+        await retained_rail.remove()
+        await old_shell.remove()
+        replacement_items = Vertical(
+            screen._build_library_media_active_child(),
+            id="library-canvas",
+            classes="destination-workbench-pane",
         )
-        screen._library_media_return_settlement = replacement_request
+        replacement_shell = LibraryMediaReaderShell(
+            retained_rail,
+            replacement_items,
+            screen._build_library_media_reader(),
+            screen._library_media_reader_layout,
+            id="library-media-reader-shell",
+        )
+        await stage.mount(replacement_shell)
+        await _wait_for_condition(
+            pilot,
+            lambda: replacement_shell.is_attached
+            and screen._library_media_return_settlement is not None
+            and screen._library_media_return_settlement.request_id
+            > old_request.request_id,
+            message="Replacement shell never received fresh lifecycle authority.",
+        )
+        replacement_owner = screen.query_one(
+            "#library-media-row-scroll", row_scroll_type
+        )
+        replacement_request = screen._library_media_return_settlement
+        assert replacement_request is not None
+        assert screen.query_one(
+            "#library-media-reader-shell", LibraryMediaReaderShell
+        ) is replacement_shell
+        assert screen.query_one("#library-canvas", Vertical) is replacement_items
+        assert replacement_shell is not old_shell
+        assert replacement_items is not old_items
+        assert replacement_owner is not old_owner
+        assert replacement_request.shell_identity == id(replacement_shell)
+        assert replacement_request.items_host_identity == id(replacement_items)
+        assert replacement_request.owner_identity == id(replacement_owner)
 
-        assert not screen._settle_library_media_return_from_geometry(
-            replacement_request,
-            owner,
-            geometry.geometry,
+        assert screen.post_message(delayed_geometry)
+        await pilot.pause()
+
+        assert screen._library_media_return_settlement is replacement_request
+        assert screen._library_media_last_settlement_outcome is None
+
+        monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
+        assert replacement_owner.post_message(
+            events.Resize(
+                replacement_owner.size,
+                replacement_owner.virtual_size,
+                replacement_owner.container_size,
+            )
         )
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_successful_settlement is not None
+            and screen._library_media_last_successful_settlement[0].request_id
+            == replacement_request.request_id,
+            message="Replacement shell owner geometry did not settle fresh authority.",
+        )
+        successful_request = screen._library_media_last_successful_settlement[0]
+        assert successful_request.shell_identity == id(replacement_shell)
+        assert successful_request.items_host_identity == id(replacement_items)
+        assert successful_request.owner_identity == id(replacement_owner)
+
+
+@pytest.mark.asyncio
+async def test_mounted_items_host_replacement_rejects_delayed_old_owner_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retained shell gives fresh authority only to its recomposed Items tree."""
+    _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, old_owner, _media_id, _scroll_offset, real_on_resize = (
+            await _open_pending_viewer_return(
+                host,
+                pilot,
+                monkeypatch,
+                row_scroll_type,
+            )
+        )
+        old_request = screen._library_media_return_settlement
+        assert old_request is not None
+        shell = screen.query_one(
+            "#library-media-reader-shell", LibraryMediaReaderShell
+        )
+        old_items = screen.query_one("#library-canvas", Vertical)
+        delayed_geometry = _hold_next_owner_geometry(
+            monkeypatch,
+            old_owner,
+            row_scroll_type,
+            geometry_message_type,
+            real_on_resize,
+        )
+        monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
+        replacement_items = Vertical(
+            screen._build_library_media_active_child(),
+            id="library-canvas",
+            classes="destination-workbench-pane library-adaptive-reader-items",
+        )
+        shell.items = replacement_items
+
+        await shell.recompose()
+        shell.sync_layout(screen._library_media_reader_layout)
+        await _wait_for_condition(
+            pilot,
+            lambda: bool(screen.query("#library-media-row-scroll"))
+            and screen.query_one("#library-media-row-scroll", row_scroll_type)
+            is not old_owner,
+            message="Retained shell did not mount the replacement Items tree.",
+        )
+        replacement_shell = screen.query_one(
+            "#library-media-reader-shell", LibraryMediaReaderShell
+        )
+        replacement_owner = screen.query_one(
+            "#library-media-row-scroll", row_scroll_type
+        )
+        assert replacement_shell is shell
+        assert screen.query_one("#library-canvas", Vertical) is replacement_items
+        assert replacement_items is not old_items
+
+        assert screen.post_message(delayed_geometry)
+        await pilot.pause()
+
         assert screen._library_media_last_settlement_outcome is None
         assert screen._library_media_last_successful_settlement is None
+
+        monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
+        assert replacement_owner.post_message(
+            events.Resize(
+                replacement_owner.size,
+                replacement_owner.virtual_size,
+                replacement_owner.container_size,
+            )
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_successful_settlement is not None,
+            message="Replacement Items owner never received fresh authority.",
+        )
+        successful_request = screen._library_media_last_successful_settlement[0]
+        assert successful_request.request_id > old_request.request_id
+        assert successful_request.shell_identity == id(shell)
+        assert successful_request.items_host_identity == id(replacement_items)
+        assert successful_request.owner_identity == id(replacement_owner)
 
 
 @pytest.mark.asyncio
@@ -1660,7 +1801,7 @@ async def test_deadline_with_failed_nongeometry_fence_clears_silently(
     host = LibraryProductionCSSHarness(app)
 
     async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
-        screen, _owner, _media_id, _scroll_offset, _real_on_resize = (
+        screen, owner, _media_id, _scroll_offset, _real_on_resize = (
             await _open_pending_viewer_return(
                 host,
                 pilot,
@@ -1670,21 +1811,47 @@ async def test_deadline_with_failed_nongeometry_fence_clears_silently(
         )
         request = screen._library_media_return_settlement
         assert request is not None
+        timer = screen._library_list_entry_focus_timer
+        assert timer is not None
+        stale_deadline_callback = timer._callback
+        assert callable(stale_deadline_callback)
         notices: list[tuple[str, str | None]] = []
 
         def capture_notice(message: str, *, severity: str | None = None, **_kwargs):
             notices.append((message, severity))
 
         monkeypatch.setattr(app, "notify", capture_notice)
-        screen._library_notes_focus_intent_generation += 1
-        screen._expire_library_media_return_settlement(request.request_id)
+        control = screen.query_one("#library-media-type-filter", Button)
+        control.focus(scroll_visible=False)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen.focused is control
+            and not screen._library_pending_list_entry_focus,
+            message="Foreign focus did not revoke the pending return authority.",
+        )
+        request_counter = screen._library_media_return_request_id
+        scroll_after_takeover = (int(owner.scroll_x), int(owner.scroll_y))
+
+        stale_deadline_callback()
+        await pilot.pause()
 
         assert notices == []
         assert screen._library_media_last_settlement_outcome is None
+        assert (int(owner.scroll_x), int(owner.scroll_y)) == scroll_after_takeover
+        assert screen.focused is control
         assert screen._library_pending_list_entry_focus is False
         assert screen._library_pending_list_entry_media_return is None
         assert screen._library_media_return_settlement is None
         assert screen._library_list_entry_focus_timer is None
+        assert screen._library_media_return_request_id == request_counter
+
+        await screen.recompose()
+        await pilot.pause()
+
+        assert screen._library_media_return_request_id == request_counter
+        assert screen._library_media_return_settlement is None
+        assert screen._library_pending_list_entry_focus is False
+        assert notices == []
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -1,0 +1,61 @@
+"""Media adaptive-stage presentation regressions for return settlement."""
+
+from __future__ import annotations
+
+import pytest
+from textual.containers import Horizontal
+
+from Tests.UI.test_library_media_side_by_side import _build_media_test_app
+from Tests.UI.test_library_shell import (
+    LibraryProductionCSSHarness,
+    _active_library_screen,
+    _seed_conversations,
+    _two_conversations,
+    _two_media_items,
+    _wait_for_library_shell,
+    _wait_for_selector,
+)
+
+
+async def _open_compact_media(host, pilot):
+    """Enter Media after selecting the compact presentation contract."""
+    screen = _active_library_screen(host)
+    await _wait_for_library_shell(screen, pilot)
+    screen._library_notes_compact = True
+    screen.query_one("#library-row-browse-media").press()
+    await _wait_for_selector(screen, pilot, "#library-media-reader-shell")
+    return screen
+
+
+@pytest.mark.asyncio
+async def test_first_frame_media_stage_projects_adaptive_compact_without_legacy_class():
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = await _open_compact_media(host, pilot)
+        stage = screen.query_one("#library-shell-grid", Horizontal)
+
+        assert stage.has_class("library-adaptive-compact")
+        assert not stage.has_class("library-notes-compact")
+
+
+@pytest.mark.asyncio
+async def test_same_size_recompose_replaces_wrong_media_stage_presentation():
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = await _open_compact_media(host, pilot)
+        previous_stage = screen.query_one("#library-shell-grid", Horizontal)
+        previous_stage.set_class(True, "library-notes-compact")
+        previous_stage.set_class(False, "library-adaptive-compact")
+
+        await screen.recompose()
+        replacement_stage = screen.query_one("#library-shell-grid", Horizontal)
+
+        assert replacement_stage is not previous_stage
+        assert replacement_stage.has_class("library-adaptive-compact")
+        assert not replacement_stage.has_class("library-notes-compact")

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -1037,6 +1037,133 @@ async def test_route_change_rejects_later_geometry_settlement(
 
 
 @pytest.mark.asyncio
+async def test_post_exact_direct_ingest_route_synchronously_disarms_lifecycle() -> None:
+    """An admitted route change clears exact-return state without focus help."""
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, _media_id, _scroll_offset = await _open_scrolled_compact_media_viewer(
+            host,
+            pilot,
+        )
+        screen.query_one("#library-media-back", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_settlement_outcome is not None
+            and screen._library_media_last_settlement_outcome[1] == "exact-settled",
+            message="Initial exact Media return never settled.",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_notes_programmatic_focus_target is None,
+            message="Queued exact-return focus guard did not drain.",
+        )
+        assert screen._library_media_successful_focus_ownership is not None
+        assert screen._library_media_last_exact_settlement is not None
+        assert screen._library_media_last_successful_settlement is not None
+        assert screen._library_media_last_settlement_attempt is not None
+        timer = screen._library_list_entry_focus_timer
+        assert timer is not None
+        stale_deadline_callback = timer._callback
+        assert callable(stale_deadline_callback)
+        request_counter = screen._library_media_return_request_id
+
+        await screen._select_library_rail_row(
+            library_screen_module.LIBRARY_ROW_INGEST_MEDIA
+        )
+
+        assert (
+            screen._library_selected_row_id
+            == library_screen_module.LIBRARY_ROW_INGEST_MEDIA
+        )
+        assert screen.query("#library-ingest-canvas")
+        assert screen._library_pending_list_entry_focus is False
+        assert screen._library_pending_list_entry_media_return is None
+        assert screen._library_pending_list_entry_focus_anchor is None
+        assert screen._library_media_return_settlement is None
+        assert screen._library_list_entry_focus_deadline is None
+        assert screen._library_list_entry_focus_timer is None
+        assert screen._library_media_successful_focus_ownership is None
+        assert screen._library_media_last_exact_settlement is None
+        assert screen._library_media_last_successful_settlement is None
+        assert screen._library_media_last_settlement_attempt is None
+        assert screen._library_media_last_settlement_outcome is None
+        assert screen._library_notes_programmatic_focus_target is None
+
+        stale_deadline_callback()
+        await pilot.pause()
+
+        assert screen._library_media_return_request_id == request_counter
+        assert screen._library_pending_list_entry_focus is False
+        assert screen._library_pending_list_entry_media_return is None
+        assert screen._library_media_return_settlement is None
+        assert screen._library_media_last_settlement_outcome is None
+
+        await screen.recompose()
+        await pilot.pause()
+
+        assert (
+            screen._library_selected_row_id
+            == library_screen_module.LIBRARY_ROW_INGEST_MEDIA
+        )
+        assert screen._library_media_return_request_id == request_counter
+        assert screen._library_pending_list_entry_focus is False
+        assert screen._library_media_return_settlement is None
+        assert screen._library_media_successful_focus_ownership is None
+        assert screen._library_media_last_settlement_outcome is None
+
+
+@pytest.mark.asyncio
+async def test_post_exact_trash_entry_preserves_only_trash_return_receipt() -> None:
+    """Trash captures its return before clearing old exact-settlement state."""
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, media_id, scroll_offset = await _open_scrolled_compact_media_viewer(
+            host,
+            pilot,
+        )
+        screen.query_one("#library-media-back", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_settlement_outcome is not None
+            and screen._library_media_last_settlement_outcome[1] == "exact-settled",
+            message="Initial exact Media return never settled.",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_notes_programmatic_focus_target is None,
+            message="Queued exact-return focus guard did not drain.",
+        )
+        assert screen._library_media_successful_focus_ownership is not None
+
+        screen.query_one("#library-media-trash-open", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-canvas")
+
+        trash_return = screen._library_media_trash_return
+        assert trash_return is not None
+        assert trash_return.stable_id == media_id
+        assert trash_return.scroll_offset == scroll_offset
+        assert trash_return.final_focus_policy == "control"
+        assert trash_return.final_focus_identity == "library-media-trash-open"
+        assert screen._library_media_view == "trash"
+        assert screen._library_pending_list_entry_focus is False
+        assert screen._library_pending_list_entry_media_return is None
+        assert screen._library_media_return_settlement is None
+        assert screen._library_list_entry_focus_timer is None
+        assert screen._library_media_successful_focus_ownership is None
+        assert screen._library_media_last_exact_settlement is None
+        assert screen._library_media_last_successful_settlement is None
+        assert screen._library_media_last_settlement_attempt is None
+        assert screen._library_media_last_settlement_outcome is None
+        assert screen._library_notes_programmatic_focus_target is None
+
+
+@pytest.mark.asyncio
 async def test_detached_current_owner_rejects_later_geometry_settlement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -2,20 +2,37 @@
 
 from __future__ import annotations
 
-import pytest
-from textual.containers import Horizontal
+import dataclasses
 
-from Tests.UI.test_library_media_side_by_side import _build_media_test_app
+import pytest
+from textual import events, on
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal
+from textual.geometry import Size
+from textual.widgets import Button
+
+from Tests.UI.test_library_media_side_by_side import (
+    COMPACT_SCROLL_SIZE,
+    _build_media_test_app,
+    _many_media_items,
+    _open_media_list,
+    _open_scrolled_compact_media_viewer,
+)
 from Tests.UI.test_library_shell import (
     LibraryProductionCSSHarness,
     _active_library_screen,
     _seed_conversations,
     _two_conversations,
     _two_media_items,
+    _wait_for_condition,
     _wait_for_library_shell,
     _wait_for_selector,
 )
+from tldw_chatbook.UI.Screens import library_screen as library_screen_module
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.Widgets.Library import (
+    library_media_canvas as library_media_canvas_module,
+)
 from tldw_chatbook.Widgets.Library.library_media_reader_shell import (
     LibraryMediaReaderShell,
     MediaShellResized,
@@ -118,3 +135,457 @@ async def test_media_shell_lifecycle_reconciles_current_stage_once(
         await pilot.pause()
 
         assert layout_refreshes == [True]
+
+
+def _require_return_protocol():
+    """Return the wished-for Task 2 protocol or fail as an intentional RED."""
+    receipt_type = getattr(
+        library_screen_module,
+        "_LibraryMediaReturnReceipt",
+        None,
+    )
+    settlement_type = getattr(
+        library_screen_module,
+        "_LibraryMediaReturnSettlement",
+        None,
+    )
+    row_scroll_type = getattr(
+        library_media_canvas_module,
+        "LibraryMediaRowScroll",
+        None,
+    )
+    geometry_type = getattr(
+        library_media_canvas_module,
+        "LibraryMediaRowGeometry",
+        None,
+    )
+    geometry_message_type = getattr(
+        library_media_canvas_module,
+        "LibraryMediaRowGeometryChanged",
+        None,
+    )
+    assert receipt_type is not None, "Task 2 return receipt is not implemented"
+    assert settlement_type is not None, "Task 2 settlement request is not implemented"
+    assert row_scroll_type is not None, "Task 2 row-scroll owner is not implemented"
+    assert geometry_type is not None, "Task 2 geometry value is not implemented"
+    assert geometry_message_type is not None, "Task 2 geometry message is not implemented"
+    return (
+        receipt_type,
+        settlement_type,
+        row_scroll_type,
+        geometry_type,
+        geometry_message_type,
+    )
+
+
+@pytest.mark.asyncio
+async def test_viewer_return_capture_is_frozen_receipt_from_normal_media(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_type, *_ = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _wait_for_selector(screen, pilot, "#library-media-row-15")
+        content_signature = screen._library_media_content_signature()
+        layout_signature = screen._library_media_layout_signature()
+        assert content_signature == (
+            screen._library_media_browse_controller.applied_scope,
+            tuple(
+                str(item["id"])
+                for item in screen._library_media_browse_controller.retained_items
+            ),
+        )
+        assert layout_signature == (
+            int(screen.size.width),
+            int(screen.size.height),
+            screen._library_notes_compact,
+            screen._library_media_reader_preferences,
+            screen._library_media_reader_layout,
+        )
+
+        capture_views: list[tuple[str, str]] = []
+        real_content_signature = screen._library_media_content_signature
+        real_layout_signature = screen._library_media_layout_signature
+
+        def capture_content_signature() -> tuple[object, ...]:
+            capture_views.append(("content", screen._library_media_view))
+            return real_content_signature()
+
+        def capture_layout_signature() -> tuple[object, ...]:
+            capture_views.append(("layout", screen._library_media_view))
+            return real_layout_signature()
+
+        monkeypatch.setattr(
+            screen,
+            "_library_media_content_signature",
+            capture_content_signature,
+        )
+        monkeypatch.setattr(
+            screen,
+            "_library_media_layout_signature",
+            capture_layout_signature,
+        )
+        row = screen.query_one("#library-media-row-15", Button)
+        screen._open_library_media_viewer(str(row.media_id))
+
+        receipt = screen._library_media_viewer_return
+        assert type(receipt) is receipt_type
+        assert receipt.stable_id == row.media_id
+        assert receipt.content_signature == content_signature
+        assert receipt.layout_signature == layout_signature
+        assert receipt.final_focus_policy == "row"
+        assert receipt.final_focus_identity is None
+        assert capture_views == [("content", "list"), ("layout", "list")]
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            receipt.stable_id = "replacement"
+
+
+@pytest.mark.asyncio
+async def test_trash_return_capture_is_frozen_control_receipt_from_normal_media(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt_type, *_ = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        trash_button = screen.query_one("#library-media-trash-open", Button)
+        trash_button.focus()
+        content_signature = screen._library_media_content_signature()
+        layout_signature = screen._library_media_layout_signature()
+        capture_views: list[str] = []
+        real_content_signature = screen._library_media_content_signature
+        real_layout_signature = screen._library_media_layout_signature
+
+        def capture_content_signature() -> tuple[object, ...]:
+            capture_views.append(screen._library_media_view)
+            return real_content_signature()
+
+        def capture_layout_signature() -> tuple[object, ...]:
+            capture_views.append(screen._library_media_view)
+            return real_layout_signature()
+
+        monkeypatch.setattr(
+            screen,
+            "_library_media_content_signature",
+            capture_content_signature,
+        )
+        monkeypatch.setattr(
+            screen,
+            "_library_media_layout_signature",
+            capture_layout_signature,
+        )
+        trash_button.press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-canvas")
+
+        receipt = screen._library_media_trash_return
+        assert type(receipt) is receipt_type
+        assert receipt.content_signature == content_signature
+        assert receipt.layout_signature == layout_signature
+        assert receipt.final_focus_policy == "control"
+        assert receipt.final_focus_identity == "library-media-trash-open"
+        assert capture_views == ["list", "list"]
+
+
+@pytest.mark.asyncio
+async def test_media_row_geometry_publishes_distinct_resize_payloads() -> None:
+    (
+        _,
+        _,
+        row_scroll_type,
+        geometry_type,
+        geometry_message_type,
+    ) = _require_return_protocol()
+
+    class GeometryHarness(App[None]):
+        messages: list[object]
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.messages = []
+
+        def compose(self) -> ComposeResult:
+            yield row_scroll_type(id="geometry-owner")
+
+        @on(geometry_message_type)
+        def capture_geometry(self, message) -> None:
+            message.stop()
+            self.messages.append(message)
+
+    app = GeometryHarness()
+    async with app.run_test(size=(40, 12)) as pilot:
+        owner = app.query_one("#geometry-owner", row_scroll_type)
+        app.messages.clear()
+        initial_revision = (
+            owner.latest_geometry.revision
+            if owner.latest_geometry is not None
+            else 0
+        )
+        first_event = events.Resize(
+            Size(17, 5),
+            Size(17, 11),
+            Size(19, 7),
+        )
+        owner.on_resize(first_event)
+        owner.on_resize(first_event)
+        owner.on_resize(
+            events.Resize(
+                Size(18, 5),
+                Size(18, 13),
+                Size(20, 7),
+            )
+        )
+        await pilot.pause()
+
+        assert len(app.messages) == 2
+        first, second = app.messages
+        assert type(first) is geometry_message_type
+        assert first.owner is owner
+        assert first.geometry == geometry_type(
+            revision=initial_revision + 1,
+            size=Size(17, 5),
+            virtual_size=Size(17, 11),
+            container_size=Size(19, 7),
+        )
+        assert type(second) is geometry_message_type
+        assert second.owner is owner
+        assert second.geometry.revision == initial_revision + 2
+        assert second.geometry.size == Size(18, 5)
+        assert second.geometry.virtual_size == Size(18, 13)
+        assert second.geometry.container_size == Size(20, 7)
+        assert owner.latest_geometry is second.geometry
+
+
+@pytest.mark.asyncio
+async def test_viewer_return_waits_for_geometry_then_scrolls_before_row_focus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (
+        _,
+        settlement_type,
+        row_scroll_type,
+        _,
+        geometry_message_type,
+    ) = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, media_id, scroll_offset = await _open_scrolled_compact_media_viewer(
+            host,
+            pilot,
+        )
+        assert scroll_offset == (0, 42)
+        real_on_resize = row_scroll_type.on_resize
+        monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
+
+        screen.query_one("#library-media-back", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-row-scroll")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_return_settlement is not None,
+            message="Viewer return never armed an immutable settlement request.",
+        )
+        owner = screen.query_one("#library-media-row-scroll", row_scroll_type)
+        request = screen._library_media_return_settlement
+        assert type(request) is settlement_type
+        assert request.owner_identity == id(owner)
+        assert getattr(screen.focused, "media_id", None) != media_id
+        assert screen._library_media_last_exact_settlement is None
+
+        focus_observations: list[tuple[int, int]] = []
+        real_set_focus = screen.set_focus
+
+        def observe_final_focus(widget, *args, **kwargs):
+            if getattr(widget, "media_id", None) == media_id:
+                focus_observations.append(
+                    (int(owner.scroll_x), int(owner.scroll_y))
+                )
+            return real_set_focus(widget, *args, **kwargs)
+
+        monkeypatch.setattr(screen, "set_focus", observe_final_focus)
+        monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
+        owner.on_resize(
+            events.Resize(owner.size, owner.virtual_size, owner.container_size)
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_exact_settlement is not None,
+            message="Current-owner geometry did not settle the viewer return.",
+        )
+
+        assert (int(owner.scroll_x), int(owner.scroll_y)) == (0, 42)
+        assert getattr(screen.focused, "media_id", None) == media_id
+        assert focus_observations == [(0, 42)]
+        settled_request, settled_revision = (
+            screen._library_media_last_exact_settlement
+        )
+        assert settled_request.request_id == request.request_id
+        assert settled_request.owner_identity == id(owner)
+        assert settled_revision == owner.latest_geometry.revision
+        assert screen._library_media_return_settlement is None
+
+        duplicate = geometry_message_type(owner, owner.latest_geometry)
+        assert screen.post_message(duplicate)
+        await pilot.pause()
+        assert screen._library_media_last_exact_settlement == (
+            settled_request,
+            settled_revision,
+        )
+        assert focus_observations == [(0, 42)]
+        assert (int(owner.scroll_x), int(owner.scroll_y)) == (0, 42)
+
+
+@pytest.mark.asyncio
+async def test_authoritative_recompose_rearms_before_replacement_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, settlement_type, row_scroll_type, _, _ = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, media_id, scroll_offset = await _open_scrolled_compact_media_viewer(
+            host,
+            pilot,
+        )
+        screen.query_one("#library-media-back", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_exact_settlement is not None,
+            message="Initial viewer return did not settle from owner geometry.",
+        )
+        initial_owner = screen.query_one(
+            "#library-media-row-scroll",
+            row_scroll_type,
+        )
+        initial_request = screen._library_media_last_exact_settlement[0]
+
+        real_on_resize = row_scroll_type.on_resize
+        monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
+        screen.refresh(recompose=True)
+        await _wait_for_condition(
+            pilot,
+            lambda: bool(screen.query("#library-media-row-scroll"))
+            and screen.query_one("#library-media-row-scroll", row_scroll_type)
+            is not initial_owner,
+            message="Authoritative recompose did not replace the Media owner.",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_return_settlement is not None,
+            message="Replacement owner never received fresh settlement authority.",
+        )
+        owner = screen.query_one("#library-media-row-scroll", row_scroll_type)
+        request = screen._library_media_return_settlement
+        assert type(request) is settlement_type
+        assert request.request_id > initial_request.request_id
+        assert request.owner_identity == id(owner)
+        assert owner.latest_geometry is None
+        assert getattr(screen.focused, "media_id", None) != media_id
+
+        monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
+        owner.on_resize(
+            events.Resize(owner.size, owner.virtual_size, owner.container_size)
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_exact_settlement is not None
+            and screen._library_media_last_exact_settlement[0].request_id
+            == request.request_id,
+            message="Replacement-owner geometry did not settle the return.",
+        )
+
+        assert (int(owner.scroll_x), int(owner.scroll_y)) == scroll_offset == (0, 42)
+        assert getattr(screen.focused, "media_id", None) == media_id
+
+
+@pytest.mark.asyncio
+async def test_old_owner_and_below_floor_geometry_cannot_settle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (
+        _,
+        settlement_type,
+        row_scroll_type,
+        _,
+        geometry_message_type,
+    ) = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _wait_for_selector(screen, pilot, "#library-media-row-15")
+        old_owner = screen.query_one("#library-media-row-scroll", row_scroll_type)
+        await _wait_for_condition(
+            pilot,
+            lambda: old_owner.latest_geometry is not None,
+            message="Original Media owner never published concrete geometry.",
+        )
+        old_geometry = old_owner.latest_geometry
+        row = screen.query_one("#library-media-row-15", Button)
+        row.focus()
+        row.scroll_visible(animate=False, force=True, immediate=True)
+        media_id = str(row.media_id)
+        row.press()
+        await _wait_for_selector(screen, pilot, "#library-media-back")
+
+        real_on_resize = row_scroll_type.on_resize
+        monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
+        screen.query_one("#library-media-back", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-row-scroll")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_return_settlement is not None,
+            message="Viewer return never armed its replacement-owner request.",
+        )
+        owner = screen.query_one("#library-media-row-scroll", row_scroll_type)
+        assert owner is not old_owner
+        assert getattr(screen.focused, "media_id", None) != media_id
+
+        assert screen.post_message(geometry_message_type(old_owner, old_geometry))
+        await pilot.pause()
+        assert screen._library_media_last_exact_settlement is None
+        assert getattr(screen.focused, "media_id", None) != media_id
+
+        held: list[object] = []
+        real_post_message = owner.post_message
+
+        def hold_geometry(message) -> bool:
+            if type(message) is geometry_message_type:
+                held.append(message)
+                return True
+            return real_post_message(message)
+
+        monkeypatch.setattr(owner, "post_message", hold_geometry)
+        real_on_resize(
+            owner,
+            events.Resize(owner.size, owner.virtual_size, owner.container_size),
+        )
+        assert len(held) == 1
+        geometry = owner.latest_geometry
+        stage = screen.query_one("#library-shell-grid", Horizontal)
+        stage.set_class(True, "library-notes-compact")
+        assert screen._project_library_media_stage_classes(stage)
+        current_request = screen._library_media_return_settlement
+        assert type(current_request) is settlement_type
+        assert current_request.presentation_epoch == (
+            screen._library_media_presentation_epoch
+        )
+        assert current_request.exclusive_geometry_floor == geometry.revision
+
+        assert screen.post_message(held[0])
+        await pilot.pause()
+        assert screen._library_media_last_exact_settlement is None
+        assert getattr(screen.focused, "media_id", None) != media_id

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+from typing import get_type_hints
 
 import pytest
 from textual import events, on
@@ -176,6 +177,17 @@ def _require_return_protocol():
         geometry_type,
         geometry_message_type,
     )
+
+
+def test_settlement_request_uses_concrete_current_tree_types() -> None:
+    _, settlement_type, *_ = _require_return_protocol()
+
+    annotations = get_type_hints(settlement_type)
+
+    assert annotations["route_identity"] == tuple[object, ...]
+    assert annotations["shell_identity"] is int
+    assert annotations["items_host_identity"] is int
+    assert annotations["owner_identity"] is int
 
 
 @pytest.mark.asyncio
@@ -443,6 +455,9 @@ async def test_viewer_return_waits_for_geometry_then_scrolls_before_row_focus(
         assert focus_observations == [(0, 42)]
         assert (int(owner.scroll_x), int(owner.scroll_y)) == (0, 42)
 
+        screen._disarm_library_list_entry_focus()
+        assert screen._library_media_last_exact_settlement is None
+
 
 @pytest.mark.asyncio
 async def test_authoritative_recompose_rearms_before_replacement_geometry(
@@ -560,6 +575,80 @@ def _hold_next_owner_geometry(
     assert len(held) == 1
     assert owner.latest_geometry is held[0].geometry
     return held[0]
+
+
+@pytest.mark.asyncio
+async def test_failed_geometry_commit_rolls_back_and_same_revision_is_one_shot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, owner, media_id, scroll_offset, real_on_resize = (
+            await _open_pending_viewer_return(
+                host,
+                pilot,
+                monkeypatch,
+                row_scroll_type,
+            )
+        )
+        geometry = _hold_next_owner_geometry(
+            monkeypatch,
+            owner,
+            row_scroll_type,
+            geometry_message_type,
+            real_on_resize,
+        )
+        target = next(
+            row
+            for row in screen.query(".library-media-row")
+            if str(getattr(row, "media_id", "") or "") == media_id
+        )
+        pre_scroll = (int(owner.scroll_x), int(owner.scroll_y))
+        pre_focus = screen.focused
+        desired_scroll_commits = 0
+        target_focus_attempts = 0
+        real_scroll_to = owner.scroll_to
+        real_set_focus = screen.set_focus
+
+        def observe_scroll_to(*args, **kwargs):
+            nonlocal desired_scroll_commits
+            if (kwargs.get("x"), kwargs.get("y")) == scroll_offset:
+                desired_scroll_commits += 1
+            return real_scroll_to(*args, **kwargs)
+
+        def perturb_first_target_focus(widget, *args, **kwargs):
+            nonlocal target_focus_attempts
+            result = real_set_focus(widget, *args, **kwargs)
+            if widget is target:
+                target_focus_attempts += 1
+                if target_focus_attempts == 1:
+                    real_scroll_to(
+                        x=scroll_offset[0],
+                        y=scroll_offset[1] - 1,
+                        animate=False,
+                        force=True,
+                        immediate=True,
+                    )
+            return result
+
+        monkeypatch.setattr(owner, "scroll_to", observe_scroll_to)
+        monkeypatch.setattr(screen, "set_focus", perturb_first_target_focus)
+
+        screen._handle_library_media_row_geometry_changed(geometry)
+        duplicate = geometry_message_type(owner, owner.latest_geometry)
+        screen._handle_library_media_row_geometry_changed(duplicate)
+
+        assert desired_scroll_commits == 1
+        assert target_focus_attempts == 1
+        assert screen._library_media_last_exact_settlement is None
+        assert getattr(screen.focused, "media_id", None) != media_id
+        assert screen.focused is pre_focus
+        assert screen._library_notes_programmatic_focus_target is None
+        assert (int(owner.scroll_x), int(owner.scroll_y)) == pre_scroll
 
 
 @pytest.mark.asyncio
@@ -808,6 +897,32 @@ async def test_screen_unmount_revokes_complete_pending_return_authority(
         assert screen._library_list_entry_focus_timer is None
         screen._handle_library_media_row_geometry_changed(queued)
         assert screen._library_media_last_exact_settlement is None
+
+
+@pytest.mark.asyncio
+async def test_screen_unmount_clears_retained_exact_settlement_proof() -> None:
+    _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, _, _ = await _open_scrolled_compact_media_viewer(host, pilot)
+        screen.query_one("#library-media-back", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_exact_settlement is not None,
+            message="Viewer return did not retain exact proof before unmount.",
+        )
+        assert screen._library_pending_list_entry_focus is True
+        assert screen._library_list_entry_focus_timer is not None
+
+        await host.pop_screen()
+
+        assert screen._library_media_last_exact_settlement is None
+        assert screen._library_pending_list_entry_focus is False
+        assert screen._library_pending_list_entry_media_return is None
+        assert screen._library_list_entry_focus_timer is None
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -20,6 +20,7 @@ from Tests.UI.test_library_media_side_by_side import (
     _open_media_list,
     _open_scrolled_compact_media_viewer,
 )
+from Tests.UI.test_library_prompts_canvas import _FakePromptScopeServiceWithList
 from Tests.UI.test_library_shell import (
     LibraryProductionCSSHarness,
     _active_library_screen,
@@ -1116,6 +1117,108 @@ async def test_post_exact_direct_ingest_route_synchronously_disarms_lifecycle() 
 
 
 @pytest.mark.asyncio
+async def test_old_media_deadline_cannot_cancel_new_prompts_list_focus_arm() -> None:
+    """A stale Media timer cannot disarm a newer destination's focus arm."""
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    app.prompt_scope_service = _FakePromptScopeServiceWithList(
+        [
+            {
+                "id": 1,
+                "name": "Settlement prompt",
+                "last_modified": "2026-08-30T12:00:00+00:00",
+                "version": 1,
+            }
+        ]
+    )
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        row = screen.query_one("#library-media-row-19", Button)
+        scroll = screen.query_one("#library-media-row-scroll")
+        row.focus()
+        row.scroll_visible(animate=False, force=True, immediate=True)
+        await _wait_for_condition(
+            pilot,
+            lambda: scroll.scroll_y > 0,
+            message="Wide Media Items never reached a nonzero scroll offset.",
+        )
+        row.press()
+        await _wait_for_selector(screen, pilot, "#library-media-back")
+        screen.query_one("#library-media-back", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_settlement_outcome is not None
+            and screen._library_media_last_settlement_outcome[1] == "exact-settled",
+            message="Initial exact Media return never settled.",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_notes_programmatic_focus_target is None,
+            message="Queued exact-return focus guard did not drain.",
+        )
+        old_media_timer = screen._library_list_entry_focus_timer
+        assert old_media_timer is not None
+        old_media_deadline_callback = old_media_timer._callback
+        assert callable(old_media_deadline_callback)
+
+        await screen._select_library_rail_row(
+            library_screen_module.LIBRARY_ROW_BROWSE_PROMPTS
+        )
+
+        destination_timer = screen._library_list_entry_focus_timer
+        assert destination_timer is not None
+        assert destination_timer is not old_media_timer
+        assert screen._library_pending_list_entry_focus is True
+        assert screen._library_pending_list_entry_media_return is None
+        destination_state = (
+            screen._library_pending_list_entry_focus,
+            screen._library_pending_list_entry_media_return,
+            screen._library_pending_list_entry_focus_anchor,
+            screen._library_list_entry_focus_timer,
+            screen._library_list_entry_focus_deadline,
+            screen._library_list_entry_focus_generation,
+            screen._library_media_return_settlement,
+            screen._library_media_last_exact_settlement,
+            screen._library_media_last_successful_settlement,
+            screen._library_media_last_settlement_attempt,
+            screen._library_media_last_settlement_outcome,
+            screen._library_media_successful_focus_ownership,
+            screen._library_notes_programmatic_focus_target,
+        )
+
+        old_media_deadline_callback()
+        await pilot.pause()
+
+        assert (
+            screen._library_pending_list_entry_focus,
+            screen._library_pending_list_entry_media_return,
+            screen._library_pending_list_entry_focus_anchor,
+            screen._library_list_entry_focus_timer,
+            screen._library_list_entry_focus_deadline,
+            screen._library_list_entry_focus_generation,
+            screen._library_media_return_settlement,
+            screen._library_media_last_exact_settlement,
+            screen._library_media_last_successful_settlement,
+            screen._library_media_last_settlement_attempt,
+            screen._library_media_last_settlement_outcome,
+            screen._library_media_successful_focus_ownership,
+            screen._library_notes_programmatic_focus_target,
+        ) == destination_state
+        await _wait_for_selector(screen, pilot, ".library-prompt-row")
+        await screen.recompose()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen.focused is not None
+            and screen.focused.has_class("library-prompt-row"),
+            message="Prompt list focus did not settle after the stale Media deadline.",
+        )
+        assert screen._library_pending_list_entry_focus is True
+        assert screen._library_list_entry_focus_timer is destination_timer
+
+
+@pytest.mark.asyncio
 async def test_post_exact_trash_entry_preserves_only_trash_return_receipt() -> None:
     """Trash captures its return before clearing old exact-settlement state."""
     app = _build_media_test_app()
@@ -1714,8 +1817,15 @@ async def test_deadline_uses_one_current_geometry_fallback_and_never_requeues(
             return real_set_focus(widget, *args, **kwargs)
 
         monkeypatch.setattr(screen, "set_focus", observe_focus)
-        screen._expire_library_media_return_settlement(request.request_id)
-        screen._expire_library_media_return_settlement(request.request_id)
+        outer_generation = screen._library_list_entry_focus_generation
+        screen._expire_library_media_return_settlement(
+            request.request_id,
+            outer_generation,
+        )
+        screen._expire_library_media_return_settlement(
+            request.request_id,
+            outer_generation,
+        )
 
         assert screen._library_media_last_settlement_outcome == (
             request.request_id,
@@ -1758,8 +1868,15 @@ async def test_deadline_without_geometry_fails_once_with_metadata_only_warning(
             notices.append((message, severity))
 
         monkeypatch.setattr(app, "notify", capture_notice)
-        screen._expire_library_media_return_settlement(request.request_id)
-        screen._expire_library_media_return_settlement(request.request_id)
+        outer_generation = screen._library_list_entry_focus_generation
+        screen._expire_library_media_return_settlement(
+            request.request_id,
+            outer_generation,
+        )
+        screen._expire_library_media_return_settlement(
+            request.request_id,
+            outer_generation,
+        )
 
         assert screen._library_media_last_settlement_outcome == (
             request.request_id,

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -15,9 +15,14 @@ from Tests.UI.test_library_shell import (
     _wait_for_library_shell,
     _wait_for_selector,
 )
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.Widgets.Library.library_media_reader_shell import (
+    LibraryMediaReaderShell,
+    MediaShellResized,
+)
 
 
-async def _open_compact_media(host, pilot):
+async def _open_compact_media(host, pilot) -> LibraryScreen:
     """Enter Media after selecting the compact presentation contract."""
     screen = _active_library_screen(host)
     await _wait_for_library_shell(screen, pilot)
@@ -28,10 +33,19 @@ async def _open_compact_media(host, pilot):
 
 
 @pytest.mark.asyncio
-async def test_first_frame_media_stage_projects_adaptive_compact_without_legacy_class():
+async def test_first_frame_media_stage_projects_adaptive_compact_without_legacy_class(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     app = _build_media_test_app()
     _seed_conversations(app, _two_conversations(), media=_two_media_items())
-    host = LibraryProductionCSSHarness(app)
+    screen = LibraryScreen(app)
+    monkeypatch.setattr(
+        screen,
+        "_reconcile_library_media_stage_presentation",
+        lambda: False,
+    )
+    monkeypatch.setattr(screen, "_apply_library_notes_stage_visibility", lambda: None)
+    host = LibraryProductionCSSHarness(app, screen=screen)
 
     async with host.run_test(size=(170, 48)) as pilot:
         screen = await _open_compact_media(host, pilot)
@@ -42,16 +56,23 @@ async def test_first_frame_media_stage_projects_adaptive_compact_without_legacy_
 
 
 @pytest.mark.asyncio
-async def test_same_size_recompose_replaces_wrong_media_stage_presentation():
+async def test_same_size_recompose_projects_media_stage_without_reconciliation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     app = _build_media_test_app()
     _seed_conversations(app, _two_conversations(), media=_two_media_items())
-    host = LibraryProductionCSSHarness(app)
+    screen = LibraryScreen(app)
+    monkeypatch.setattr(
+        screen,
+        "_reconcile_library_media_stage_presentation",
+        lambda: False,
+    )
+    monkeypatch.setattr(screen, "_apply_library_notes_stage_visibility", lambda: None)
+    host = LibraryProductionCSSHarness(app, screen=screen)
 
     async with host.run_test(size=(170, 48)) as pilot:
         screen = await _open_compact_media(host, pilot)
         previous_stage = screen.query_one("#library-shell-grid", Horizontal)
-        previous_stage.set_class(True, "library-notes-compact")
-        previous_stage.set_class(False, "library-adaptive-compact")
 
         await screen.recompose()
         replacement_stage = screen.query_one("#library-shell-grid", Horizontal)
@@ -59,3 +80,41 @@ async def test_same_size_recompose_replaces_wrong_media_stage_presentation():
         assert replacement_stage is not previous_stage
         assert replacement_stage.has_class("library-adaptive-compact")
         assert not replacement_stage.has_class("library-notes-compact")
+
+
+@pytest.mark.asyncio
+async def test_media_shell_lifecycle_reconciles_current_stage_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = await _open_compact_media(host, pilot)
+        stage = screen.query_one("#library-shell-grid", Horizontal)
+        shell = screen.query_one("#library-media-reader-shell", LibraryMediaReaderShell)
+        stage.set_class(True, "library-notes-compact")
+        stage.set_class(False, "library-adaptive-compact")
+
+        layout_refreshes: list[bool] = []
+        refresh = screen.refresh
+
+        def count_layout_refresh(*args, **kwargs):
+            layout_refreshes.append(bool(kwargs.get("layout", False)))
+            return refresh(*args, **kwargs)
+
+        monkeypatch.setattr(screen, "refresh", count_layout_refresh)
+
+        assert shell.post_message(MediaShellResized())
+        await pilot.pause()
+
+        assert screen.query_one("#library-shell-grid", Horizontal) is stage
+        assert stage.has_class("library-adaptive-compact")
+        assert not stage.has_class("library-notes-compact")
+        assert layout_refreshes == [True]
+
+        assert shell.post_message(MediaShellResized())
+        await pilot.pause()
+
+        assert layout_refreshes == [True]

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -509,6 +509,255 @@ async def test_authoritative_recompose_rearms_before_replacement_geometry(
         assert getattr(screen.focused, "media_id", None) == media_id
 
 
+async def _open_pending_viewer_return(
+    host,
+    pilot,
+    monkeypatch: pytest.MonkeyPatch,
+    row_scroll_type,
+):
+    """Return a viewer Back request whose replacement owner has no geometry."""
+    screen, media_id, scroll_offset = await _open_scrolled_compact_media_viewer(
+        host,
+        pilot,
+    )
+    real_on_resize = row_scroll_type.on_resize
+    monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
+    screen.query_one("#library-media-back", Button).press()
+    await _wait_for_selector(screen, pilot, "#library-media-row-scroll")
+    await _wait_for_condition(
+        pilot,
+        lambda: screen._library_media_return_settlement is not None,
+        message="Viewer return never armed without geometry.",
+    )
+    owner = screen.query_one("#library-media-row-scroll", row_scroll_type)
+    assert owner.latest_geometry is None
+    return screen, owner, media_id, scroll_offset, real_on_resize
+
+
+def _hold_next_owner_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+    owner,
+    row_scroll_type,
+    geometry_message_type,
+    real_on_resize,
+):
+    """Produce concrete owner geometry without delivering its custom message."""
+    held: list[object] = []
+    real_post_message = owner.post_message
+
+    def hold_geometry(message) -> bool:
+        if type(message) is geometry_message_type:
+            held.append(message)
+            return True
+        return real_post_message(message)
+
+    monkeypatch.setattr(owner, "post_message", hold_geometry)
+    monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
+    real_on_resize(
+        owner,
+        events.Resize(owner.size, owner.virtual_size, owner.container_size),
+    )
+    assert len(held) == 1
+    assert owner.latest_geometry is held[0].geometry
+    return held[0]
+
+
+@pytest.mark.asyncio
+async def test_real_compact_transition_floors_prechange_owner_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, owner, _, _, real_on_resize = await _open_pending_viewer_return(
+            host,
+            pilot,
+            monkeypatch,
+            row_scroll_type,
+        )
+        queued = _hold_next_owner_geometry(
+            monkeypatch,
+            owner,
+            row_scroll_type,
+            geometry_message_type,
+            real_on_resize,
+        )
+        before_epoch = screen._library_media_presentation_epoch
+        assert screen._library_notes_compact is True
+        identity = screen._capture_library_notes_focus_identity(stage_from_focus=True)
+
+        screen._transition_library_notes_presentation(False, identity)
+
+        stage = screen.query_one("#library-shell-grid", Horizontal)
+        assert not stage.has_class("library-adaptive-compact")
+        assert screen._library_media_presentation_epoch == before_epoch + 1
+        assert screen._library_media_geometry_floor_owner_identity == id(owner)
+        assert screen._library_media_geometry_floor == queued.geometry.revision
+        equality_epoch = screen._library_media_presentation_epoch
+        real_settlement_tree = screen._library_media_settlement_tree
+        monkeypatch.setattr(
+            screen,
+            "_library_media_settlement_tree",
+            lambda: pytest.fail("Equality projection queried settlement authority."),
+        )
+        screen._apply_library_notes_stage_visibility()
+        assert screen._library_media_presentation_epoch == equality_epoch
+        assert screen._reconcile_library_media_stage_presentation() is False
+        assert screen._library_media_presentation_epoch == equality_epoch
+        monkeypatch.setattr(
+            screen,
+            "_library_media_settlement_tree",
+            real_settlement_tree,
+        )
+
+        assert screen.post_message(queued)
+        await pilot.pause()
+        assert screen._library_media_last_exact_settlement is None
+
+
+@pytest.mark.asyncio
+async def test_current_user_media_row_focus_cancels_pending_return(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, row_scroll_type, _, _ = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, owner, media_id, _, real_on_resize = (
+            await _open_pending_viewer_return(
+                host,
+                pilot,
+                monkeypatch,
+                row_scroll_type,
+            )
+        )
+        other = next(
+            row
+            for row in screen.query(".library-media-row")
+            if str(getattr(row, "media_id", "")) != media_id
+        )
+        screen.set_focus(other, scroll_visible=False)
+        screen.on_descendant_focus(events.DescendantFocus(other))
+
+        assert screen._library_pending_list_entry_focus is False
+        assert screen._library_pending_list_entry_media_return is None
+        assert screen._library_media_return_settlement is None
+
+        monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
+        owner.on_resize(
+            events.Resize(owner.size, owner.virtual_size, owner.container_size)
+        )
+        await pilot.pause()
+        assert screen._library_media_last_exact_settlement is None
+        assert screen.focused is other
+
+
+@pytest.mark.asyncio
+async def test_foreign_control_focus_cancels_pending_return(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, row_scroll_type, _, _ = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, owner, _, _, real_on_resize = await _open_pending_viewer_return(
+            host,
+            pilot,
+            monkeypatch,
+            row_scroll_type,
+        )
+        control = screen.query_one("#library-media-type-filter", Button)
+        screen.set_focus(control, scroll_visible=False)
+        screen.on_descendant_focus(events.DescendantFocus(control))
+
+        assert screen._library_pending_list_entry_focus is False
+        assert screen._library_pending_list_entry_media_return is None
+        assert screen._library_media_return_settlement is None
+
+        monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
+        owner.on_resize(
+            events.Resize(owner.size, owner.virtual_size, owner.container_size)
+        )
+        await pilot.pause()
+        assert screen._library_media_last_exact_settlement is None
+        assert screen.focused is control
+
+
+@pytest.mark.asyncio
+async def test_route_change_rejects_later_geometry_settlement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, owner, _, _, real_on_resize = await _open_pending_viewer_return(
+            host,
+            pilot,
+            monkeypatch,
+            row_scroll_type,
+        )
+        screen.query_one("#library-row-browse-notes", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_selected_row_id != "library-row-browse-media",
+            message="Route did not leave Media.",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: not owner.is_attached,
+            message="Departed route did not detach its Media owner.",
+        )
+        monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
+        owner.on_resize(
+            events.Resize(owner.size, owner.virtual_size, owner.container_size)
+        )
+        queued = geometry_message_type(owner, owner.latest_geometry)
+
+        assert screen.post_message(queued)
+        await pilot.pause()
+        assert screen._library_media_last_exact_settlement is None
+        assert getattr(screen.focused, "media_id", None) is None
+
+
+@pytest.mark.asyncio
+async def test_detached_current_owner_rejects_later_geometry_settlement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, owner, _, _, real_on_resize = await _open_pending_viewer_return(
+            host,
+            pilot,
+            monkeypatch,
+            row_scroll_type,
+        )
+        await owner.remove()
+        assert owner.is_attached is False
+        monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
+        owner.on_resize(
+            events.Resize(owner.size, owner.virtual_size, owner.container_size)
+        )
+        queued = geometry_message_type(owner, owner.latest_geometry)
+
+        assert screen.post_message(queued)
+        await pilot.pause()
+        assert screen._library_media_last_exact_settlement is None
+
+
 @pytest.mark.asyncio
 async def test_old_owner_and_below_floor_geometry_cannot_settle(
     monkeypatch: pytest.MonkeyPatch,

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -1204,18 +1204,25 @@ async def test_unavailable_trash_control_uses_exact_scroll_row_fallback(
             lambda: screen._library_media_return_settlement is not None,
             message="Trash Back did not arm control-policy settlement authority.",
         )
+        old_request = screen._library_media_return_settlement
+        assert old_request is not None
+        await pilot.resize_terminal(80, 24)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_return_settlement is not None
+            and screen._library_media_return_settlement.request_id
+            > old_request.request_id,
+            message="Responsive layout did not arm fresh control-policy authority.",
+        )
+        request = screen._library_media_return_settlement
+        assert request is not None
         replacement_owner = screen.query_one(
             "#library-media-row-scroll",
             row_scroll_type,
         )
         target_control = screen.query_one("#library-media-trash-open", Button)
         target_control.disabled = True
-        pre_revision_layout = screen._library_media_layout_signature()
-        monkeypatch.setattr(
-            screen,
-            "_library_media_layout_signature",
-            lambda: pre_revision_layout + (("responsive-control-hidden",),),
-        )
+        assert screen._library_media_last_settlement_outcome is None
         monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
         real_on_resize(
             replacement_owner,
@@ -1234,6 +1241,7 @@ async def test_unavailable_trash_control_uses_exact_scroll_row_fallback(
         assert screen._library_media_last_settlement_outcome[1] == (
             "exact-scroll-focus-fallback"
         )
+        assert screen._library_media_last_settlement_outcome[0] == request.request_id
         assert getattr(screen.focused, "media_id", None) == selected_id
         assert (int(replacement_owner.scroll_x), int(replacement_owner.scroll_y)) == (
             scroll_offset
@@ -1245,7 +1253,7 @@ async def test_unavailable_trash_control_uses_exact_scroll_row_fallback(
 async def test_authoritative_content_revision_clamps_once_and_labels_outcome(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A proven logical revision gets one current-geometry clamped commit."""
+    """Applied revision rejects old authority, then fresh geometry clamps once."""
     _require_terminal_outcome_type()
     _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
     app = _build_media_test_app()
@@ -1253,7 +1261,7 @@ async def test_authoritative_content_revision_clamps_once_and_labels_outcome(
     host = LibraryProductionCSSHarness(app)
 
     async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
-        screen, owner, media_id, _scroll_offset, real_on_resize = (
+        screen, old_owner, media_id, _scroll_offset, real_on_resize = (
             await _open_pending_viewer_return(
                 host,
                 pilot,
@@ -1261,22 +1269,60 @@ async def test_authoritative_content_revision_clamps_once_and_labels_outcome(
                 row_scroll_type,
             )
         )
-        request = screen._library_media_return_settlement
-        assert request is not None
-        original_content_signature = screen._library_media_content_signature
-        revised_signature = original_content_signature() + (("revision",),)
-        monkeypatch.setattr(
-            screen,
-            "_library_media_content_signature",
-            lambda: revised_signature,
-        )
-        geometry = _hold_next_owner_geometry(
+        old_request = screen._library_media_return_settlement
+        assert old_request is not None
+        old_geometry = _hold_next_owner_geometry(
             monkeypatch,
-            owner,
+            old_owner,
             row_scroll_type,
             geometry_message_type,
             real_on_resize,
         )
+        monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
+
+        controller = screen._library_media_browse_controller
+        service = app.media_reading_scope_service
+        removed_id = next(
+            str(item["id"])
+            for item in controller.retained_items
+            if str(item["id"]) != media_id
+        )
+        removed_backing = int(removed_id.rsplit(":", 1)[1])
+        service.media_items = [
+            item
+            for index, item in enumerate(service.media_items)
+            if service._backing_id(item, index) != removed_backing
+        ]
+        screen._request_library_media_browse(
+            controller.mutation_refresh_scope,
+            focus_identity=None,
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: not controller.loading
+            and screen._library_media_content_signature()
+            != old_request.content_signature,
+            message="Authoritative reordered Media content never applied.",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_return_settlement is not None
+            and screen._library_media_return_settlement.request_id
+            > old_request.request_id,
+            message="Revised current tree never received fresh immutable authority.",
+        )
+        request = screen._library_media_return_settlement
+        assert request is not None
+        owner = screen.query_one("#library-media-row-scroll", row_scroll_type)
+        assert request.content_signature == screen._library_media_content_signature()
+        assert request.layout_signature == screen._library_media_layout_signature()
+        assert not screen._settle_library_media_return_from_geometry(
+            old_request,
+            old_owner,
+            old_geometry.geometry,
+        )
+        assert screen._library_media_last_settlement_outcome is None
+
         clamped_commits = 0
         real_scroll_to = owner.scroll_to
 
@@ -1287,19 +1333,98 @@ async def test_authoritative_content_revision_clamps_once_and_labels_outcome(
             return real_scroll_to(*args, **kwargs)
 
         monkeypatch.setattr(owner, "scroll_to", observe_clamped_scroll)
-        screen._handle_library_media_row_geometry_changed(geometry)
-        screen._handle_library_media_row_geometry_changed(
-            geometry_message_type(owner, owner.latest_geometry)
+        monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
+        owner.on_resize(
+            events.Resize(owner.size, owner.virtual_size, owner.container_size)
         )
-        await pilot.pause()
-
-        assert screen._library_media_last_settlement_outcome == (
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_settlement_outcome is not None,
+            message="Fresh revised request did not reach its clamped commit.",
+        )
+        outcome = screen._library_media_last_settlement_outcome
+        assert outcome == (
             request.request_id,
             "clamped-after-revision",
-            geometry.geometry.revision,
+            owner.latest_geometry.revision,
         )
         assert clamped_commits == 1
         assert getattr(screen.focused, "media_id", None) == media_id
+        assert screen._library_pending_list_entry_focus is False
+        assert screen._library_media_return_settlement is None
+
+        request_counter = screen._library_media_return_request_id
+        owner_before_recompose = owner
+        screen.refresh(recompose=True)
+        await _wait_for_condition(
+            pilot,
+            lambda: bool(screen.query("#library-media-row-scroll"))
+            and screen.query_one("#library-media-row-scroll", row_scroll_type)
+            is not owner_before_recompose,
+            message="Terminal revision proof did not cross a mounted recompose.",
+        )
+        await pilot.pause()
+
+        assert screen._library_media_return_request_id == request_counter
+        assert screen._library_media_return_settlement is None
+        assert screen._library_media_last_settlement_outcome == outcome
+        assert clamped_commits == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signature_kind", ("content", "layout"))
+async def test_existing_request_rejects_live_signature_drift(
+    monkeypatch: pytest.MonkeyPatch,
+    signature_kind: str,
+) -> None:
+    """An immutable request cannot consume geometry after either signature drifts."""
+    _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, owner, _media_id, _scroll_offset, real_on_resize = (
+            await _open_pending_viewer_return(
+                host,
+                pilot,
+                monkeypatch,
+                row_scroll_type,
+            )
+        )
+        request = screen._library_media_return_settlement
+        assert request is not None
+        geometry = _hold_next_owner_geometry(
+            monkeypatch,
+            owner,
+            row_scroll_type,
+            geometry_message_type,
+            real_on_resize,
+        )
+        signature_method = f"_library_media_{signature_kind}_signature"
+        original_signature = getattr(screen, signature_method)
+        monkeypatch.setattr(
+            screen,
+            signature_method,
+            lambda: original_signature() + (("drift", signature_kind),),
+        )
+        scroll_commits = 0
+        real_scroll_to = owner.scroll_to
+
+        def observe_scroll(*args, **kwargs):
+            nonlocal scroll_commits
+            if kwargs.get("immediate"):
+                scroll_commits += 1
+            return real_scroll_to(*args, **kwargs)
+
+        monkeypatch.setattr(owner, "scroll_to", observe_scroll)
+        screen._handle_library_media_row_geometry_changed(geometry)
+        await pilot.pause()
+
+        assert screen._library_media_return_settlement is None
+        assert screen._library_media_last_settlement_outcome is None
+        assert screen._library_media_last_successful_settlement is None
+        assert scroll_commits == 0
 
 
 @pytest.mark.asyncio
@@ -1477,3 +1602,279 @@ async def test_stale_request_generation_and_subview_fences_cannot_settle(
         assert screen._library_media_last_settlement_outcome is None
         assert screen._library_media_last_exact_settlement is None
         assert getattr(screen.focused, "media_id", None) != media_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("identity_field", ("shell_identity", "items_host_identity"))
+async def test_replaced_shell_and_items_identities_reject_current_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+    identity_field: str,
+) -> None:
+    """Each replaced tree identity independently fences an otherwise-live request."""
+    _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, owner, _media_id, _scroll_offset, real_on_resize = (
+            await _open_pending_viewer_return(
+                host,
+                pilot,
+                monkeypatch,
+                row_scroll_type,
+            )
+        )
+        request = screen._library_media_return_settlement
+        assert request is not None
+        geometry = _hold_next_owner_geometry(
+            monkeypatch,
+            owner,
+            row_scroll_type,
+            geometry_message_type,
+            real_on_resize,
+        )
+        replacement_request = dataclasses.replace(
+            request,
+            **{identity_field: getattr(request, identity_field) + 1},
+        )
+        screen._library_media_return_settlement = replacement_request
+
+        assert not screen._settle_library_media_return_from_geometry(
+            replacement_request,
+            owner,
+            geometry.geometry,
+        )
+        assert screen._library_media_last_settlement_outcome is None
+        assert screen._library_media_last_successful_settlement is None
+
+
+@pytest.mark.asyncio
+async def test_deadline_with_failed_nongeometry_fence_clears_silently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Expiry after authority loss emits neither fallback outcome nor warning."""
+    _, _, row_scroll_type, _, _ = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, _owner, _media_id, _scroll_offset, _real_on_resize = (
+            await _open_pending_viewer_return(
+                host,
+                pilot,
+                monkeypatch,
+                row_scroll_type,
+            )
+        )
+        request = screen._library_media_return_settlement
+        assert request is not None
+        notices: list[tuple[str, str | None]] = []
+
+        def capture_notice(message: str, *, severity: str | None = None, **_kwargs):
+            notices.append((message, severity))
+
+        monkeypatch.setattr(app, "notify", capture_notice)
+        screen._library_notes_focus_intent_generation += 1
+        screen._expire_library_media_return_settlement(request.request_id)
+
+        assert notices == []
+        assert screen._library_media_last_settlement_outcome is None
+        assert screen._library_pending_list_entry_focus is False
+        assert screen._library_pending_list_entry_media_return is None
+        assert screen._library_media_return_settlement is None
+        assert screen._library_list_entry_focus_timer is None
+
+
+@pytest.mark.asyncio
+async def test_another_viewer_back_request_invalidates_prior_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second mounted viewer round trip supersedes the first request."""
+    _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, old_owner, media_id, _scroll_offset, real_on_resize = (
+            await _open_pending_viewer_return(
+                host,
+                pilot,
+                monkeypatch,
+                row_scroll_type,
+            )
+        )
+        old_request = screen._library_media_return_settlement
+        assert old_request is not None
+        old_geometry = _hold_next_owner_geometry(
+            monkeypatch,
+            old_owner,
+            row_scroll_type,
+            geometry_message_type,
+            real_on_resize,
+        )
+        monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
+        row = next(
+            row
+            for row in screen.query(".library-media-row")
+            if str(getattr(row, "media_id", "") or "") == media_id
+        )
+        row.press()
+        await _wait_for_selector(screen, pilot, "#library-media-back")
+        screen.query_one("#library-media-back", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_return_settlement is not None
+            and screen._library_media_return_settlement.request_id
+            > old_request.request_id,
+            message="Second Back did not supersede the earlier settlement request.",
+        )
+        new_request = screen._library_media_return_settlement
+        assert new_request is not None
+
+        assert not screen._settle_library_media_return_from_geometry(
+            old_request,
+            old_owner,
+            old_geometry.geometry,
+        )
+        assert screen._library_media_return_settlement is new_request
+        assert screen._library_media_last_settlement_outcome is None
+
+
+@pytest.mark.asyncio
+async def test_post_exact_user_takeover_prevents_recompose_renewal() -> None:
+    """After exact success, real user focus ends the outer recompose authority."""
+    _, _, row_scroll_type, _, _ = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, _media_id, _scroll_offset = await _open_scrolled_compact_media_viewer(
+            host,
+            pilot,
+        )
+        screen.query_one("#library-media-back", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_settlement_outcome is not None,
+            message="Initial exact return never settled.",
+        )
+        assert screen._library_media_last_settlement_outcome[1] == "exact-settled"
+        await pilot.pause()
+        control = screen.query_one("#library-media-type-filter", Button)
+        control.focus(scroll_visible=False)
+        await pilot.pause()
+        assert screen.focused is control
+        assert screen._library_pending_list_entry_focus is False
+        request_counter = screen._library_media_return_request_id
+        owner = screen.query_one("#library-media-row-scroll", row_scroll_type)
+
+        screen.refresh(recompose=True)
+        await _wait_for_condition(
+            pilot,
+            lambda: bool(screen.query("#library-media-row-scroll"))
+            and screen.query_one("#library-media-row-scroll", row_scroll_type) is not owner,
+            message="User-takeover inverse did not cross a real recompose.",
+        )
+        await pilot.pause()
+
+        assert screen._library_media_return_request_id == request_counter
+        assert screen._library_media_return_settlement is None
+        assert screen._library_pending_list_entry_focus is False
+
+
+@pytest.mark.asyncio
+async def test_trash_capture_uses_opener_identity_without_prefocus() -> None:
+    """Trash captures its semantic opener, never arbitrary current focus."""
+    receipt_type, *_ = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        unrelated = screen.query_one("#library-media-type-filter", Button)
+        unrelated.focus(scroll_visible=False)
+        await pilot.pause()
+        assert screen.focused is unrelated
+
+        screen.query_one("#library-media-trash-open", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-canvas")
+
+        receipt = screen._library_media_trash_return
+        assert type(receipt) is receipt_type
+        assert receipt.final_focus_policy == "control"
+        assert receipt.final_focus_identity == "library-media-trash-open"
+        assert receipt.final_focus_identity != unrelated.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("semantic_row_state", ("absent", "mismatched"))
+async def test_control_exact_return_requires_matching_semantic_row(
+    monkeypatch: pytest.MonkeyPatch,
+    semantic_row_state: str,
+) -> None:
+    """A valid captured control cannot bypass exact semantic-row authority."""
+    _, _, row_scroll_type, _, _ = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _wait_for_selector(screen, pilot, "#library-media-row-15")
+        semantic_row = screen.query_one("#library-media-row-15", Button)
+        selected_id = str(semantic_row.media_id)
+        screen._selected_media_id = selected_id
+        original_owner = screen.query_one("#library-media-row-scroll", row_scroll_type)
+        original_owner.scroll_to(y=42, animate=False, force=True, immediate=True)
+        opener = screen.query_one("#library-media-trash-open", Button)
+        opener.focus()
+        opener.press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-back")
+
+        real_on_resize = row_scroll_type.on_resize
+        monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
+        screen.query_one("#library-media-trash-back", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_return_settlement is not None,
+            message="Trash return did not arm control-policy authority.",
+        )
+        owner = screen.query_one("#library-media-row-scroll", row_scroll_type)
+        current_row = next(
+            row
+            for row in screen.query(".library-media-row")
+            if str(getattr(row, "media_id", "") or "") == selected_id
+        )
+        if semantic_row_state == "absent":
+            await current_row.remove()
+        else:
+            current_row.media_id = f"mismatched:{selected_id}"
+        assert not any(
+            str(getattr(row, "media_id", "") or "") == selected_id
+            for row in screen.query(".library-media-row")
+        )
+        scroll_commits = 0
+        real_scroll_to = owner.scroll_to
+
+        def observe_scroll(*args, **kwargs):
+            nonlocal scroll_commits
+            if kwargs.get("immediate"):
+                scroll_commits += 1
+            return real_scroll_to(*args, **kwargs)
+
+        monkeypatch.setattr(owner, "scroll_to", observe_scroll)
+        monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
+        owner.on_resize(
+            events.Resize(owner.size, owner.virtual_size, owner.container_size)
+        )
+        await pilot.pause()
+
+        assert screen._library_media_last_settlement_outcome is None
+        assert screen._library_media_last_successful_settlement is None
+        assert getattr(screen.focused, "id", None) != "library-media-trash-open"
+        assert scroll_commits == 0

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -179,6 +179,17 @@ def _require_return_protocol():
     )
 
 
+def _require_terminal_outcome_type():
+    """Return Task 3's transient terminal-outcome alias or fail RED."""
+    outcome_type = getattr(
+        library_screen_module,
+        "_LibraryMediaSettlementOutcome",
+        None,
+    )
+    assert outcome_type is not None, "Task 3 settlement outcomes are not implemented"
+    return outcome_type
+
+
 def test_settlement_request_uses_concrete_current_tree_types() -> None:
     _, settlement_type, *_ = _require_return_protocol()
 
@@ -216,7 +227,10 @@ async def test_viewer_return_capture_is_frozen_receipt_from_normal_media(
             int(screen.size.height),
             screen._library_notes_compact,
             screen._library_media_reader_preferences,
-            screen._library_media_reader_layout,
+            library_screen_module.resolve_media_reader_layout(
+                screen._library_media_reader_layout.reader_width,
+                screen._library_media_reader_preferences,
+            ),
         )
 
         capture_views: list[tuple[str, str]] = []
@@ -1086,5 +1100,380 @@ async def test_old_owner_and_below_floor_geometry_cannot_settle(
 
         assert screen.post_message(held[0])
         await pilot.pause()
+        assert screen._library_media_last_exact_settlement is None
+        assert getattr(screen.focused, "media_id", None) != media_id
+
+
+@pytest.mark.asyncio
+async def test_trash_back_exact_scroll_precedes_captured_control_focus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Trash Back has one scroll-then-control commit and retains selection."""
+    _require_terminal_outcome_type()
+    _, _, row_scroll_type, _, _ = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _wait_for_selector(screen, pilot, "#library-media-row-15")
+        selected = screen.query_one("#library-media-row-15", Button)
+        selected_id = str(selected.media_id)
+        screen._selected_media_id = selected_id
+        owner = screen.query_one("#library-media-row-scroll", row_scroll_type)
+        owner.scroll_to(y=42, animate=False, force=True, immediate=True)
+        scroll_offset = (int(owner.scroll_x), int(owner.scroll_y))
+        assert scroll_offset == (0, 42)
+        opener = screen.query_one("#library-media-trash-open", Button)
+        opener.focus()
+        opener.press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-back")
+
+        captured_control_scrolls: list[tuple[int, int]] = []
+        real_set_focus = screen.set_focus
+
+        def observe_control_focus(widget, *args, **kwargs):
+            if getattr(widget, "id", None) == "library-media-trash-open":
+                current_owner = screen.query_one(
+                    "#library-media-row-scroll",
+                    row_scroll_type,
+                )
+                captured_control_scrolls.append(
+                    (int(current_owner.scroll_x), int(current_owner.scroll_y))
+                )
+            return real_set_focus(widget, *args, **kwargs)
+
+        monkeypatch.setattr(screen, "set_focus", observe_control_focus)
+        screen.query_one("#library-media-trash-back", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_settlement_outcome is not None,
+            message="Trash Back never published its terminal settlement outcome.",
+        )
+
+        replacement_owner = screen.query_one(
+            "#library-media-row-scroll",
+            row_scroll_type,
+        )
+        request_id, outcome, geometry_revision = (
+            screen._library_media_last_settlement_outcome
+        )
+        assert request_id > 0
+        assert outcome == "exact-settled"
+        assert geometry_revision == replacement_owner.latest_geometry.revision
+        assert captured_control_scrolls == [scroll_offset]
+        assert screen.focused.id == "library-media-trash-open"
+        assert screen._selected_media_id == selected_id
+        assert (int(replacement_owner.scroll_x), int(replacement_owner.scroll_y)) == (
+            scroll_offset
+        )
+        assert not hasattr(screen, "_restore_library_media_trash_return_focus")
+
+
+@pytest.mark.asyncio
+async def test_unavailable_trash_control_uses_exact_scroll_row_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A layout-proven unavailable control cannot report full exact success."""
+    _require_terminal_outcome_type()
+    _, _, row_scroll_type, _, _ = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _wait_for_selector(screen, pilot, "#library-media-row-15")
+        selected = screen.query_one("#library-media-row-15", Button)
+        selected_id = str(selected.media_id)
+        screen._selected_media_id = selected_id
+        owner = screen.query_one("#library-media-row-scroll", row_scroll_type)
+        owner.scroll_to(y=42, animate=False, force=True, immediate=True)
+        scroll_offset = (int(owner.scroll_x), int(owner.scroll_y))
+        opener = screen.query_one("#library-media-trash-open", Button)
+        opener.focus()
+        opener.press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-back")
+
+        real_on_resize = row_scroll_type.on_resize
+        monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
+        screen.query_one("#library-media-trash-back", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_return_settlement is not None,
+            message="Trash Back did not arm control-policy settlement authority.",
+        )
+        replacement_owner = screen.query_one(
+            "#library-media-row-scroll",
+            row_scroll_type,
+        )
+        target_control = screen.query_one("#library-media-trash-open", Button)
+        target_control.disabled = True
+        pre_revision_layout = screen._library_media_layout_signature()
+        monkeypatch.setattr(
+            screen,
+            "_library_media_layout_signature",
+            lambda: pre_revision_layout + (("responsive-control-hidden",),),
+        )
+        monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
+        real_on_resize(
+            replacement_owner,
+            events.Resize(
+                replacement_owner.size,
+                replacement_owner.virtual_size,
+                replacement_owner.container_size,
+            ),
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_settlement_outcome is not None,
+            message="Disabled captured control never reached its row fallback.",
+        )
+
+        assert screen._library_media_last_settlement_outcome[1] == (
+            "exact-scroll-focus-fallback"
+        )
+        assert getattr(screen.focused, "media_id", None) == selected_id
+        assert (int(replacement_owner.scroll_x), int(replacement_owner.scroll_y)) == (
+            scroll_offset
+        )
+        assert screen._selected_media_id == selected_id
+
+
+@pytest.mark.asyncio
+async def test_authoritative_content_revision_clamps_once_and_labels_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A proven logical revision gets one current-geometry clamped commit."""
+    _require_terminal_outcome_type()
+    _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, owner, media_id, _scroll_offset, real_on_resize = (
+            await _open_pending_viewer_return(
+                host,
+                pilot,
+                monkeypatch,
+                row_scroll_type,
+            )
+        )
+        request = screen._library_media_return_settlement
+        assert request is not None
+        original_content_signature = screen._library_media_content_signature
+        revised_signature = original_content_signature() + (("revision",),)
+        monkeypatch.setattr(
+            screen,
+            "_library_media_content_signature",
+            lambda: revised_signature,
+        )
+        geometry = _hold_next_owner_geometry(
+            monkeypatch,
+            owner,
+            row_scroll_type,
+            geometry_message_type,
+            real_on_resize,
+        )
+        clamped_commits = 0
+        real_scroll_to = owner.scroll_to
+
+        def observe_clamped_scroll(*args, **kwargs):
+            nonlocal clamped_commits
+            if kwargs.get("immediate"):
+                clamped_commits += 1
+            return real_scroll_to(*args, **kwargs)
+
+        monkeypatch.setattr(owner, "scroll_to", observe_clamped_scroll)
+        screen._handle_library_media_row_geometry_changed(geometry)
+        screen._handle_library_media_row_geometry_changed(
+            geometry_message_type(owner, owner.latest_geometry)
+        )
+        await pilot.pause()
+
+        assert screen._library_media_last_settlement_outcome == (
+            request.request_id,
+            "clamped-after-revision",
+            geometry.geometry.revision,
+        )
+        assert clamped_commits == 1
+        assert getattr(screen.focused, "media_id", None) == media_id
+
+
+@pytest.mark.asyncio
+async def test_deadline_uses_one_current_geometry_fallback_and_never_requeues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ABA-bound deadline is one terminal liveness action, not readiness."""
+    _require_terminal_outcome_type()
+    _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, owner, media_id, _scroll_offset, real_on_resize = (
+            await _open_pending_viewer_return(
+                host,
+                pilot,
+                monkeypatch,
+                row_scroll_type,
+            )
+        )
+        geometry = _hold_next_owner_geometry(
+            monkeypatch,
+            owner,
+            row_scroll_type,
+            geometry_message_type,
+            real_on_resize,
+        )
+        request = screen._library_media_return_settlement
+        assert request is not None
+        rearms: list[int] = []
+        real_arm = screen._arm_library_media_return_settlement
+
+        def observe_rearm(*args, **kwargs):
+            rearms.append(request.request_id)
+            return real_arm(*args, **kwargs)
+
+        monkeypatch.setattr(
+            screen,
+            "_arm_library_media_return_settlement",
+            observe_rearm,
+        )
+        focus_attempts = 0
+        real_set_focus = screen.set_focus
+
+        def observe_focus(widget, *args, **kwargs):
+            nonlocal focus_attempts
+            if getattr(widget, "media_id", None) == media_id:
+                focus_attempts += 1
+            return real_set_focus(widget, *args, **kwargs)
+
+        monkeypatch.setattr(screen, "set_focus", observe_focus)
+        screen._expire_library_media_return_settlement(request.request_id)
+        screen._expire_library_media_return_settlement(request.request_id)
+
+        assert screen._library_media_last_settlement_outcome == (
+            request.request_id,
+            "clamped-after-settlement-failure",
+            geometry.geometry.revision,
+        )
+        assert focus_attempts == 1
+        assert rearms == []
+        assert screen._library_media_return_settlement is None
+        assert screen._library_pending_list_entry_focus is False
+        assert screen._library_pending_list_entry_media_return is None
+        assert screen._library_list_entry_focus_timer is None
+
+
+@pytest.mark.asyncio
+async def test_deadline_without_geometry_fails_once_with_metadata_only_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No eligible geometry yields one warning and no semantic content leak."""
+    _require_terminal_outcome_type()
+    _, _, row_scroll_type, _, _ = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, _owner, media_id, _scroll_offset, _real_on_resize = (
+            await _open_pending_viewer_return(
+                host,
+                pilot,
+                monkeypatch,
+                row_scroll_type,
+            )
+        )
+        request = screen._library_media_return_settlement
+        assert request is not None
+        notices: list[tuple[str, str | None]] = []
+
+        def capture_notice(message: str, *, severity: str | None = None, **_kwargs):
+            notices.append((message, severity))
+
+        monkeypatch.setattr(app, "notify", capture_notice)
+        screen._expire_library_media_return_settlement(request.request_id)
+        screen._expire_library_media_return_settlement(request.request_id)
+
+        assert screen._library_media_last_settlement_outcome == (
+            request.request_id,
+            "layout-settlement-failed",
+            None,
+        )
+        assert len(notices) == 1
+        assert notices[0][1] == "warning"
+        assert media_id not in notices[0][0]
+        assert screen._library_media_return_settlement is None
+        assert screen._library_pending_list_entry_focus is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "stale_fence",
+    ("request", "compose", "lifecycle", "focus", "trash", "items"),
+)
+async def test_stale_request_generation_and_subview_fences_cannot_settle(
+    monkeypatch: pytest.MonkeyPatch,
+    stale_fence: str,
+) -> None:
+    """Each mutable authority fence rejects a real current-owner geometry."""
+    _require_terminal_outcome_type()
+    _, _, row_scroll_type, _, geometry_message_type = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, owner, media_id, _scroll_offset, real_on_resize = (
+            await _open_pending_viewer_return(
+                host,
+                pilot,
+                monkeypatch,
+                row_scroll_type,
+            )
+        )
+        request = screen._library_media_return_settlement
+        assert request is not None
+        geometry = _hold_next_owner_geometry(
+            monkeypatch,
+            owner,
+            row_scroll_type,
+            geometry_message_type,
+            real_on_resize,
+        )
+
+        if stale_fence == "request":
+            screen._library_media_return_settlement = dataclasses.replace(
+                request,
+                request_id=request.request_id + 1,
+            )
+            screen._settle_library_media_return_from_geometry(
+                request,
+                owner,
+                geometry.geometry,
+            )
+        else:
+            if stale_fence == "compose":
+                screen._library_compose_generation += 1
+            elif stale_fence == "lifecycle":
+                screen._library_media_lifecycle_generation += 1
+            elif stale_fence == "focus":
+                screen._library_notes_focus_intent_generation += 1
+            elif stale_fence == "trash":
+                screen._library_media_view = "trash"
+            elif stale_fence == "items":
+                screen._library_media_reader_layout = dataclasses.replace(
+                    screen._library_media_reader_layout,
+                    items_open=False,
+                )
+            screen._handle_library_media_row_geometry_changed(geometry)
+        await pilot.pause()
+
+        assert screen._library_media_last_settlement_outcome is None
         assert screen._library_media_last_exact_settlement is None
         assert getattr(screen.focused, "media_id", None) != media_id

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -539,6 +539,95 @@ async def test_authoritative_recompose_rearms_before_replacement_geometry(
         assert getattr(screen.focused, "media_id", None) == media_id
 
 
+@pytest.mark.asyncio
+async def test_post_exact_responsive_revision_renews_after_focus_guard_drains(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The settled focus target owns one real breakpoint-crossing renewal."""
+    _, settlement_type, row_scroll_type, _, _ = _require_return_protocol()
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=COMPACT_SCROLL_SIZE) as pilot:
+        screen, media_id, _scroll_offset = await _open_scrolled_compact_media_viewer(
+            host,
+            pilot,
+        )
+        screen.query_one("#library-media-back", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_settlement_outcome is not None
+            and screen._library_media_last_settlement_outcome[1] == "exact-settled",
+            message="Initial exact Media return never settled.",
+        )
+        initial_request = screen._library_media_last_exact_settlement
+        assert initial_request is not None
+        initial_request_id = initial_request[0].request_id
+        settled_target = screen.focused
+        assert getattr(settled_target, "media_id", None) == media_id
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_notes_programmatic_focus_target is None,
+            message="Queued programmatic focus guard did not drain.",
+        )
+        assert screen.focused is settled_target
+
+        owner = screen.query_one("#library-media-row-scroll", row_scroll_type)
+        real_on_resize = row_scroll_type.on_resize
+        monkeypatch.setattr(row_scroll_type, "on_resize", lambda _owner, _event: None)
+        await pilot.resize_terminal(170, 48)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_return_settlement is not None
+            and screen._library_media_return_settlement.request_id
+            > initial_request_id,
+            message=lambda: (
+                "Responsive revision did not renew exact settlement authority: "
+                f"focus={screen.focused!r}, "
+                f"guard={screen._library_notes_programmatic_focus_target!r}, "
+                f"request={screen._library_media_return_settlement!r}, "
+                f"outcome={screen._library_media_last_settlement_outcome!r}"
+            ),
+        )
+        request = screen._library_media_return_settlement
+        assert type(request) is settlement_type
+        assert request.request_id > initial_request_id
+        assert request.content_signature == screen._library_media_content_signature()
+        assert request.layout_signature == screen._library_media_layout_signature()
+        assert screen._library_media_last_exact_settlement is None
+        assert screen._library_media_last_settlement_attempt is None
+        assert screen._library_media_last_settlement_outcome is None
+        assert screen.focused is settled_target
+
+        current_owner = screen.query_one("#library-media-row-scroll", row_scroll_type)
+        assert current_owner is owner
+        monkeypatch.setattr(row_scroll_type, "on_resize", real_on_resize)
+        real_on_resize(
+            current_owner,
+            events.Resize(
+                current_owner.size,
+                current_owner.virtual_size,
+                current_owner.container_size,
+            ),
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_last_settlement_outcome is not None,
+            message="Current responsive geometry did not settle fresh authority.",
+        )
+
+        assert screen._library_media_last_settlement_outcome == (
+            request.request_id,
+            "clamped-after-revision",
+            current_owner.latest_geometry.revision,
+        )
+        assert screen._library_media_last_exact_settlement is None
+        assert screen._library_media_return_settlement is None
+        assert screen._library_pending_list_entry_focus is False
+        assert getattr(screen.focused, "media_id", None) == media_id
+
+
 async def _open_pending_viewer_return(
     host,
     pilot,
@@ -2005,11 +2094,15 @@ async def test_post_exact_user_takeover_prevents_recompose_renewal() -> None:
         )
         assert screen._library_media_last_settlement_outcome[1] == "exact-settled"
         await pilot.pause()
+        ownership = screen._library_media_successful_focus_ownership
+        assert ownership is not None
+        assert ownership.target is screen.focused
         control = screen.query_one("#library-media-type-filter", Button)
         control.focus(scroll_visible=False)
         await pilot.pause()
         assert screen.focused is control
         assert screen._library_pending_list_entry_focus is False
+        assert screen._library_media_successful_focus_ownership is None
         request_counter = screen._library_media_return_request_id
         owner = screen.query_one("#library-media-row-scroll", row_scroll_type)
 

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -638,6 +638,10 @@ async def test_failed_geometry_commit_rolls_back_and_same_revision_is_one_shot(
         monkeypatch.setattr(owner, "scroll_to", observe_scroll_to)
         monkeypatch.setattr(screen, "set_focus", perturb_first_target_focus)
 
+        receipt = screen._library_pending_list_entry_media_return
+        request = screen._library_media_return_settlement
+        assert receipt is not None
+        assert request is not None
         screen._handle_library_media_row_geometry_changed(geometry)
         duplicate = geometry_message_type(owner, owner.latest_geometry)
         screen._handle_library_media_row_geometry_changed(duplicate)
@@ -649,6 +653,51 @@ async def test_failed_geometry_commit_rolls_back_and_same_revision_is_one_shot(
         assert screen.focused is pre_focus
         assert screen._library_notes_programmatic_focus_target is None
         assert (int(owner.scroll_x), int(owner.scroll_y)) == pre_scroll
+
+        await pilot.pause()
+
+        assert screen._library_pending_list_entry_focus is True
+        assert screen._library_pending_list_entry_media_return is receipt
+        assert screen._library_media_return_settlement is request
+        assert screen._library_media_last_exact_settlement is None
+        assert screen.focused is pre_focus
+        assert (int(owner.scroll_x), int(owner.scroll_y)) == pre_scroll
+
+        newer_messages: list[object] = []
+
+        def capture_newer_geometry(message) -> bool:
+            if type(message) is geometry_message_type:
+                newer_messages.append(message)
+                return True
+            return row_scroll_type.post_message(owner, message)
+
+        monkeypatch.setattr(owner, "post_message", capture_newer_geometry)
+        owner.virtual_size = Size(
+            owner.virtual_size.width,
+            owner.virtual_size.height + 1,
+        )
+        real_on_resize(
+            owner,
+            events.Resize(owner.size, owner.virtual_size, owner.container_size),
+        )
+        assert len(newer_messages) == 1
+        newer = newer_messages[-1]
+        assert newer.geometry.revision == geometry.geometry.revision + 1
+
+        screen._handle_library_media_row_geometry_changed(newer)
+        screen._handle_library_media_row_geometry_changed(
+            geometry_message_type(owner, owner.latest_geometry)
+        )
+        await pilot.pause()
+
+        assert desired_scroll_commits == 2
+        assert target_focus_attempts == 2
+        assert screen._library_media_last_exact_settlement == (
+            request,
+            newer.geometry.revision,
+        )
+        assert getattr(screen.focused, "media_id", None) == media_id
+        assert (int(owner.scroll_x), int(owner.scroll_y)) == scroll_offset
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_media_side_by_side.py
+++ b/Tests/UI/test_library_media_side_by_side.py
@@ -731,6 +731,188 @@ async def test_trash_view_stays_single_column_at_wide_width() -> None:
         assert trash_list.region.width >= int(canvas.region.width * 0.9)
 
 
+@pytest.mark.asyncio
+async def test_media_trash_collapse_choices_survive_filter_and_page_refresh() -> None:
+    """Real pane-grip activation remains durable across Trash recomposes."""
+    from textual.widgets import Input
+
+    from Tests.UI.test_library_media_trash import (
+        _MountedTrashFeed,
+        _canonical_trash_items,
+    )
+    from tldw_chatbook.Library.library_media_state import MediaTrashScope
+
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items())
+    feed.install(app.media_reading_scope_service)
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=(160, 50)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        screen.query_one("#library-media-trash-open", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-row-0")
+        controller = screen._library_media_trash_browse_controller
+
+        items = screen.query_one("#library-canvas")
+        initial_width = items.region.width
+        library_grip = screen.query_one("#library-media-library-grip", Button)
+        library_grip.focus()
+        await pilot.press("enter")
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen._library_media_reader_layout.library_open,
+            message="Library grip did not collapse the Library pane.",
+        )
+        assert items.region.width > initial_width
+
+        search = screen.query_one("#library-media-trash-search", Input)
+        search.focus()
+        await pilot.press("t", "r", "a", "s", "h", "enter")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                controller.state.applied_result is not None
+                and controller.state.applied_result.scope.query == "trash"
+            ),
+            message="Trash filter refresh never settled.",
+        )
+        assert screen._library_media_reader_layout.library_open is False
+
+        library_grip = screen.query_one("#library-media-library-grip", Button)
+        library_grip.focus()
+        await pilot.press("enter")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_reader_layout.library_open,
+            message="Library grip did not reopen the Library pane.",
+        )
+
+        items_grip = screen.query_one("#library-media-items-grip", Button)
+        items_grip.focus()
+        await pilot.press("enter")
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen._library_media_reader_layout.items_open,
+            message="Items grip did not collapse the Items pane.",
+        )
+        screen._request_library_media_trash_page(
+            2, focus_identity="#library-media-trash-next"
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                controller.state.applied_result is not None
+                and controller.state.applied_result.scope
+                == MediaTrashScope(query="trash", page=2)
+            ),
+            message="Hidden Items page refresh never settled.",
+        )
+        assert screen._library_media_reader_layout.items_open is False
+
+
+@pytest.mark.asyncio
+async def test_media_trash_compact_pane_priority_survives_page_and_filter_refresh() -> (
+    None
+):
+    """Compact recomposes retain whichever mutually exclusive pane was opened."""
+    from textual.widgets import Input
+
+    from Tests.UI.test_library_media_trash import (
+        _MountedTrashFeed,
+        _canonical_trash_items,
+    )
+    from tldw_chatbook.Library.library_media_state import MediaTrashScope
+
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items())
+    feed.install(app.media_reading_scope_service)
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=(80, 24)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_reader_layout.reader_width > 0,
+            message="Compact Media layout never settled.",
+        )
+        if not screen._library_media_reader_layout.items_open:
+            items_grip = screen.query_one("#library-media-items-grip", Button)
+            items_grip.focus()
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_media_reader_layout.items_open,
+                message="Compact Items pane never opened.",
+            )
+        await pilot.pause()
+        opener = screen.query_one("#library-media-trash-open", Button)
+        opener.focus()
+        await pilot.press("enter")
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.applied_result is not None,
+            message="Compact Trash page never applied.",
+        )
+
+        library_grip = screen.query_one("#library-media-library-grip", Button)
+        library_grip.focus()
+        await pilot.press("enter")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_media_reader_layout.library_open
+                and not screen._library_media_reader_layout.items_open
+            ),
+            message="Compact Library pane did not become the explicit priority.",
+        )
+        screen._sync_library_media_reader_layout_from_shell()
+        await pilot.pause()
+        assert screen._library_media_reader_layout.library_open is True
+        assert screen._library_media_reader_layout.items_open is False
+        screen._request_library_media_trash_page(
+            2, focus_identity="#library-media-trash-next"
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                controller.state.applied_result is not None
+                and controller.state.applied_result.scope == MediaTrashScope(page=2)
+            ),
+            message="Compact page refresh never settled.",
+        )
+        assert screen._library_media_reader_layout.library_open is True
+        assert screen._library_media_reader_layout.items_open is False
+
+        items_grip = screen.query_one("#library-media-items-grip", Button)
+        items_grip.focus()
+        await pilot.press("enter")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_media_reader_layout.items_open
+                and not screen._library_media_reader_layout.library_open
+            ),
+            message="Compact Items pane did not become the explicit priority.",
+        )
+        search = screen.query_one("#library-media-trash-search", Input)
+        search.focus()
+        await pilot.press("t", "r", "a", "s", "h", "enter")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                controller.state.applied_result is not None
+                and controller.state.applied_result.scope
+                == MediaTrashScope(query="trash")
+            ),
+            message="Compact filter refresh never settled.",
+        )
+        assert screen._library_media_reader_layout.items_open is True
+        assert screen._library_media_reader_layout.library_open is False
+
+
 # ---------------------------------------------------------------------------
 # AC#2: keyboard traversal (rows, preview actions, viewer entry) + footer.
 # ---------------------------------------------------------------------------

--- a/Tests/UI/test_library_media_trash.py
+++ b/Tests/UI/test_library_media_trash.py
@@ -1185,6 +1185,393 @@ async def test_media_trash_focus_completion_does_not_steal_newer_tab_intent():
 
 
 @pytest.mark.asyncio
+async def test_media_trash_render_retry_matches_recoverable_browse_authority():
+    """Retry copy, control, and focus exist only for a retryable browse."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items())
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        screen.query_one("#library-media-trash-open", Button).press()
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.applied_result is not None,
+            message="Initial Trash page never applied.",
+        )
+        ordinary = controller.state
+        first = ordinary.retained_items[0]
+        target = MediaTrashMutationTarget(
+            stable_id=str(first["id"]),
+            backing_media_id=int(first["backing_media_id"]),
+            title=str(first["title"]),
+            media_type=str(first["media_type"]),
+            trash_date=str(first["trash_date"]),
+            page_index=0,
+        )
+
+        mutation_error = fail_media_trash_mutation(
+            begin_media_trash_mutation(ordinary),
+            target,
+            copy="Could not restore this media item.",
+        )
+        controller.state = mutation_error
+        screen._library_media_trash_focus_identity = "#library-media-trash-restore"
+        screen._sync_library_media_trash_state(None)
+        await pilot.pause()
+        assert (
+            screen.query_one("#library-media-trash-status", Static).renderable
+            == "Could not restore this media item."
+        )
+        assert not screen.query("#library-media-trash-retry")
+        assert (
+            screen._library_media_trash_focus_identity == "#library-media-trash-restore"
+        )
+
+        stale_loading = dataclasses.replace(
+            ordinary,
+            freshness="stale",
+            loading=True,
+            stale_copy="List may be out of date.",
+            selected_id="",
+            request_origin="mutation",
+            failed_scope=None,
+            failed_origin=None,
+        )
+        controller.state = stale_loading
+        screen._library_media_trash_focus_identity = "#library-media-trash-row-0"
+        screen._sync_library_media_trash_state(None)
+        await pilot.pause()
+        loading_status = str(
+            screen.query_one("#library-media-trash-status", Static).renderable
+        )
+        assert "Retry" not in loading_status
+        assert not screen.query("#library-media-trash-retry")
+        assert (
+            screen._library_media_trash_focus_identity != "#library-media-trash-retry"
+        )
+
+        stale_failure = fail_media_trash_request(
+            stale_loading,
+            stale_loading.requested_scope,
+            copy="List may be out of date.",
+        )
+        controller.state = stale_failure
+        screen._sync_library_media_trash_state(None)
+        await pilot.pause()
+        assert (
+            screen.query_one("#library-media-trash-status", Static).renderable
+            == "List may be out of date · Retry"
+        )
+        assert len(list(screen.query("#library-media-trash-retry"))) == 1
+        assert (
+            screen._library_media_trash_focus_identity == "#library-media-trash-retry"
+        )
+
+
+@pytest.mark.asyncio
+async def test_media_trash_filter_draft_survives_background_recompose():
+    """A typed, unsubmitted draft survives an unrelated request completion."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items(), gate_first=True)
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+
+    try:
+        async with host.run_test(size=(100, 30)) as pilot:
+            screen = _active_library_screen(host)
+            await _wait_for_library_shell(screen, pilot)
+            screen.query_one("#library-row-browse-media", Button).press()
+            await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+            opener = screen.query_one("#library-media-trash-open", Button)
+            opener.focus()
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                feed.entered.is_set,
+                message="Initial Trash request never reached its gate.",
+            )
+
+            search_before = screen.query_one("#library-media-trash-search", Input)
+            search_before.focus()
+            await pilot.press("d", "r", "a", "f", "t")
+            await pilot.pause()
+            assert search_before.value == "draft"
+
+            feed.release.set()
+            controller = screen._library_media_trash_browse_controller
+            await _wait_for_condition(
+                pilot,
+                lambda: controller.state.applied_result is not None,
+                message="Background Trash completion never applied.",
+            )
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    screen.query_one("#library-media-trash-search", Input)
+                    is not search_before
+                ),
+                message="Trash completion did not mount a current Search input.",
+            )
+            search_after = screen.query_one("#library-media-trash-search", Input)
+            assert search_after.value == "draft"
+            assert screen._library_media_trash_query_draft == "draft"
+            assert controller.state.applied_result.scope == MediaTrashScope()
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    screen.focused
+                    is screen.query_one("#library-media-trash-search", Input)
+                ),
+                message="Draft-preserving completion did not restore current Search.",
+            )
+    finally:
+        feed.release.set()
+
+
+@pytest.mark.asyncio
+async def test_media_trash_compact_status_folds_after_two_readable_rows():
+    """An overflowing compact status paints two rows plus a clear fold."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryProductionCSSHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items())
+    feed.install(app.media_reading_scope_service)
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=(80, 24)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_reader_layout.reader_width > 0,
+            message="Compact Media layout never settled.",
+        )
+        if not screen._library_media_reader_layout.items_open:
+            grip = screen.query_one("#library-media-items-grip", Button)
+            grip.focus()
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_media_reader_layout.items_open,
+                message="Compact Items pane never opened.",
+            )
+        opener = screen.query_one("#library-media-trash-open", Button)
+        opener.focus()
+        await pilot.press("enter")
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.applied_result is not None,
+            message="Initial Trash page never applied.",
+        )
+        assert "▼ more status" not in _compositor_text(
+            host.export_screenshot(simplify=True)
+        )
+
+        long_copy = (
+            "Could not load this Trash page. The local source stayed available "
+            "but its full recovery detail does not fit in the compact status area."
+        )
+        controller.state = fail_media_trash_request(
+            begin_media_trash_request(
+                MediaTrashBrowseState(), MediaTrashScope(), origin="entry"
+            ),
+            MediaTrashScope(),
+            copy=long_copy,
+        )
+        screen._sync_library_media_trash_state(None)
+        await pilot.pause()
+        await pilot.pause()
+
+        status = screen.query_one("#library-media-trash-status", Static)
+        fold = screen.query_one("#library-media-trash-status-fold", Static)
+        trash_list = screen.query_one("#library-media-trash-list")
+        pager = screen.query_one("#library-media-trash-pager")
+        actions = screen.query_one("#library-media-trash-actions")
+        items = screen.query_one("#library-canvas")
+        assert status.region.height == 2
+        assert fold.region.height == 1
+        assert fold.region.y == status.region.bottom
+        assert fold.tooltip == f"{long_copy.rstrip('.')} · Retry"
+        assert trash_list.region.height >= 4
+        assert items.region.contains_region(pager.region)
+        assert items.region.contains_region(actions.region)
+        painted = _compositor_text(host.export_screenshot(simplify=True))
+        assert "▼ more status" in painted
+
+
+@pytest.mark.asyncio
+async def test_media_trash_focus_recovers_after_suppressed_canvas_sync(monkeypatch):
+    """A suppressed sync releases focus authority to a later real Tab."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items())
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        screen.query_one("#library-media-trash-open", Button).press()
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.applied_result is not None,
+            message="Initial Trash page never applied.",
+        )
+        await _wait_for_selector(screen, pilot, "#library-media-trash-search")
+        search = screen.query_one("#library-media-trash-search", Input)
+        search.focus()
+        await pilot.pause()
+        screen._library_notes_programmatic_focus_target = search
+        older_generation = screen._library_notes_focus_intent_generation
+
+        with monkeypatch.context() as patch:
+            patch.setattr(
+                "tldw_chatbook.UI.Screens.library_screen._sync_library_canvas",
+                lambda *args, **kwargs: False,
+            )
+            screen._sync_library_media_trash_state("#library-media-trash-search")
+
+        assert screen._library_notes_restoring_focus is False
+        assert screen._library_notes_programmatic_focus_target is None
+        await pilot.press("tab")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                getattr(screen.focused, "id", None) == "library-media-trash-type-filter"
+            ),
+            message="Real Tab did not leave Search after a suppressed sync.",
+        )
+        assert screen._library_notes_focus_intent_generation > older_generation
+        screen._focus_library_media_trash_after_paint(
+            "#library-media-trash-search", older_generation
+        )
+        await pilot.pause()
+        assert getattr(screen.focused, "id", None) == "library-media-trash-type-filter"
+
+
+@pytest.mark.asyncio
+async def test_media_trash_disabled_browse_controls_name_mutation_interlock():
+    """Every conflicting browse control is visibly disabled during mutation."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items())
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        screen.query_one("#library-media-trash-open", Button).press()
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.applied_result is not None,
+            message="Initial Trash page never applied.",
+        )
+        failed_scope = MediaTrashScope(query="failed")
+        controller.state = fail_media_trash_request(
+            begin_media_trash_request(controller.state, failed_scope, origin="search"),
+            failed_scope,
+            copy="Filter not applied — showing All Trash.",
+        )
+        screen._library_media_bulk_delete_in_flight = True
+        screen._sync_library_media_trash_state(None)
+        await pilot.pause()
+
+        reason = "Trash is refreshing."
+        search = screen.query_one("#library-media-trash-search", Input)
+        assert search.disabled is True
+        assert search.tooltip == reason
+        expected_labels = {
+            "#library-media-trash-type-filter": "○ Type: All",
+            "#library-media-trash-previous": "○ Previous",
+            "#library-media-trash-next": "○ Next",
+            "#library-media-trash-retry": "○ Retry",
+        }
+        for selector, label in expected_labels.items():
+            control = screen.query_one(selector, Button)
+            assert control.disabled is True
+            assert str(control.label) == label
+            assert control.tooltip == reason
+        screen._library_media_bulk_delete_in_flight = False
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("size", ((160, 50), (120, 35), (100, 30), (80, 24)))
 async def test_media_trash_geometry_four_sizes_paints_all_fixed_controls(size):
     """All four postures keep the bounded vertical grammar in the Items pane."""
@@ -1865,7 +2252,7 @@ def _failed_trash_restore_screen_fake():
         target,
         copy="Could not restore this media item.",
     )
-    return SimpleNamespace(
+    fake = SimpleNamespace(
         _library_selected_row_id=LIBRARY_ROW_BROWSE_MEDIA,
         _library_media_view="trash",
         _library_media_trash_browse_controller=SimpleNamespace(state=state),
@@ -1873,6 +2260,10 @@ def _failed_trash_restore_screen_fake():
         _library_media_trash_focus_identity="#library-media-trash-restore",
         _focus_library_media_trash_intent=lambda: None,
     )
+    fake._library_media_trash_retry_visible = types.MethodType(
+        LibraryScreen._library_media_trash_retry_visible, fake
+    )
+    return fake
 
 
 def test_media_trash_restore_failure_does_not_offer_browse_retry():

--- a/Tests/UI/test_library_media_trash.py
+++ b/Tests/UI/test_library_media_trash.py
@@ -2773,6 +2773,7 @@ def _trash_view_fake(
         _library_media_trash_input_error="",
         _library_media_trash_type_choices_visible=False,
         _library_media_trash_focus_identity="#library-media-trash-row-0",
+        _library_notes_focus_intent_generation=0,
         _library_media_trash_return=None,
         _trash_controller_calls=trash_controller_calls,
         app_instance=SimpleNamespace(notify=lambda msg, **k: notified.append((msg, k))),
@@ -2787,6 +2788,7 @@ def _trash_view_fake(
         _focus_library_media_trash_entry=lambda: None,
         _arm_library_list_entry_focus=lambda: None,
         _capture_library_media_trash_return=lambda: None,
+        _disarm_library_media_return_for_route_change=lambda: None,
     )
     fake._exit_library_media_select_mode = types.MethodType(
         LibraryScreen._exit_library_media_select_mode, fake
@@ -3010,6 +3012,9 @@ def test_trash_back_returns_to_list_and_drops_session_state():
     )
     fake._exit_library_media_trash = types.MethodType(
         LibraryScreen._exit_library_media_trash, fake
+    )
+    fake._library_media_return_candidate = types.MethodType(
+        LibraryScreen._library_media_return_candidate, fake
     )
     event = SimpleNamespace(stop=lambda: None)
 

--- a/Tests/UI/test_library_media_trash.py
+++ b/Tests/UI/test_library_media_trash.py
@@ -2009,7 +2009,7 @@ async def test_media_trash_precommit_failure_releases_mounted_controls_without_r
     feed.install(app.media_reading_scope_service)
     service_calls = []
 
-    async def fail_mutation(_service, *, mode, media_id):
+    async def fail_mutation(_service, *, mode, media_id, **_kwargs):
         service_calls.append({"mode": mode, "media_id": media_id})
         raise PermissionError("private policy detail")
 

--- a/Tests/UI/test_library_media_trash.py
+++ b/Tests/UI/test_library_media_trash.py
@@ -8,6 +8,8 @@ tests over a SimpleNamespace fake, and real-DB tests (file-backed
 ``isolate_in_worker=True``) for the restore path, including a chunked item.
 """
 
+import asyncio
+import threading
 import types
 from types import SimpleNamespace
 
@@ -16,7 +18,8 @@ import pytest
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
-from textual.widgets import Button, Static
+from textual.widgets import Button, Input, OptionList, Static
+from textual.widgets.option_list import Option
 
 from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 from tldw_chatbook.Media import LocalMediaReadingService, MediaReadingScopeService
@@ -28,12 +31,93 @@ from tldw_chatbook.Library.library_media_state import (
     LIBRARY_MEDIA_TRASH_RESTORE_DISABLED_LOADING_TOOLTIP,
     LIBRARY_MEDIA_TRASH_RESTORE_TOOLTIP,
     MediaBrowseScope,
+    MediaTrashBrowseState,
+    MediaTrashMutationTarget,
+    MediaTrashScope,
     build_library_media_trash_state,
 )
 from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_MEDIA
 from tldw_chatbook.Widgets.Library.library_media_trash_canvas import (
     LibraryMediaTrashCanvas,
 )
+from tldw_chatbook.UI.Library_Modules.library_media_trash_browse_controller import (
+    LibraryMediaTrashBrowseController,
+)
+
+
+def _canonical_trash_items(count: int = 45) -> list[dict[str, object]]:
+    return [
+        {
+            "id": f"local:media:{index}",
+            "backing_media_id": index,
+            "title": f"Trash {index:02d}",
+            "media_type": "audio" if index % 2 else "video",
+            "trash_date": f"2026-08-{(index % 28) + 1:02d}T00:00:00+00:00",
+        }
+        for index in range(1, count + 1)
+    ]
+
+
+class _MountedTrashFeed:
+    """Production-shaped exact Trash source with deterministic gates/failures."""
+
+    def __init__(
+        self,
+        items: list[dict[str, object]],
+        *,
+        fail_counts: dict[tuple[str, int], int] | None = None,
+        gate_first: bool = False,
+    ) -> None:
+        self.items = items
+        self.calls: list[dict[str, object]] = []
+        self.fail_counts = dict(fail_counts or {})
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        if not gate_first:
+            self.release.set()
+
+    async def list_library_media_trash(self, **kwargs: object) -> dict[str, object]:
+        self.calls.append(dict(kwargs))
+        if len(self.calls) == 1:
+            self.entered.set()
+            await asyncio.to_thread(self.release.wait, 10.0)
+        query = str(kwargs.get("query") or "")
+        offset = int(kwargs["offset"])
+        key = (query, offset)
+        remaining_failures = self.fail_counts.get(key, 0)
+        if remaining_failures:
+            self.fail_counts[key] = remaining_failures - 1
+            raise RuntimeError("private-mounted-trash-failure")
+        media_type = kwargs.get("media_type")
+        rows = [
+            item
+            for item in self.items
+            if query.casefold() in str(item["title"]).casefold()
+            and (media_type is None or item["media_type"] == media_type)
+        ]
+        limit = int(kwargs["limit"])
+        return {
+            "items": [dict(item) for item in rows[offset : offset + limit]],
+            "total": len(rows),
+            "limit": limit,
+            "offset": offset,
+            "types": sorted(
+                {
+                    str(item["media_type"])
+                    for item in self.items
+                    if item["media_type"] is not None
+                }
+            ),
+        }
+
+    def install(self, service: object) -> None:
+        async def _list_library_media_trash(_service: object, **kwargs: object):
+            return await self.list_library_media_trash(**kwargs)
+
+        service.list_library_media_trash = types.MethodType(  # type: ignore[attr-defined]
+            _list_library_media_trash,
+            service,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -113,16 +197,12 @@ async def test_trash_canvas_loading_state_never_claims_empty():
         assert LIBRARY_MEDIA_TRASH_EMPTY_COPY not in rendered
         restore = app.query_one("#library-media-trash-restore", Button)
         assert restore.disabled is True
-        assert (
-            restore.tooltip == LIBRARY_MEDIA_TRASH_RESTORE_DISABLED_LOADING_TOOLTIP
-        )
+        assert restore.tooltip == LIBRARY_MEDIA_TRASH_RESTORE_DISABLED_LOADING_TOOLTIP
 
 
 @pytest.mark.asyncio
 async def test_trash_canvas_truncation_status_and_notice_render():
-    records = [
-        {"id": str(i), "title": f"T{i}", "type": "pdf"} for i in range(3)
-    ]
+    records = [{"id": str(i), "title": f"T{i}", "type": "pdf"} for i in range(3)]
     app = _TrashCanvasApp(
         _trash_state(records=records, total=9, notice="Restored 'A doc'.")
     )
@@ -181,12 +261,13 @@ async def test_trash_canvas_error_state_restore_tooltip_names_the_failure():
 def _forty_trash_items():
     return [
         {
-            "id": f"trash-{index}",
+            "id": f"local:media:{index}",
+            "backing_media_id": index,
             "title": f"Trashed item {index:02d}",
-            "type": "document",
+            "media_type": "document",
             "trash_date": "2026-08-10T12:00:00+00:00",
         }
-        for index in range(1, 41)
+        for index in range(1, 21)
     ]
 
 
@@ -216,18 +297,8 @@ async def _open_media_trash_with_items(host, pilot, trash_items):
     screen = _active_library_screen(host)
     await _wait_for_library_shell(screen, pilot)
 
-    async def _list_media_trash(**kwargs):
-        return {
-            "items": [dict(item) for item in trash_items],
-            "pagination": {"total_items": len(trash_items)},
-        }
-
-    # The shared StaticLibraryMediaScopeService fake predates the trash
-    # seam; give this instance the same async surface the real scope
-    # service exposes.
-    host.app_instance.media_reading_scope_service.list_media_trash = (
-        _list_media_trash
-    )
+    feed = _MountedTrashFeed(list(trash_items))
+    feed.install(host.app_instance.media_reading_scope_service)
 
     await _wait_for_selector(screen, pilot, "#library-row-browse-media")
     screen.query_one("#library-row-browse-media").press()
@@ -241,15 +312,13 @@ async def _open_media_trash_with_items(host, pilot, trash_items):
 
 
 async def _assert_trash_rows_and_restore_reachable(host, pilot):
-    screen = await _open_media_trash_with_items(
-        host, pilot, _forty_trash_items()
-    )
+    screen = await _open_media_trash_with_items(host, pilot, _forty_trash_items())
     trash_list = screen.query_one("#library-media-trash-list")
     restore = screen.query_one("#library-media-trash-restore", Button)
-    last_row = screen.query_one("#library-media-trash-row-39", Button)
+    last_row = screen.query_one("#library-media-trash-row-19", Button)
     screen_height = host.size.height
 
-    # The Restore toolbar stays inside the terminal: 40 auto-height rows
+    # The Restore toolbar stays inside the terminal: 20 two-line rows
     # must not push it below the fold.
     assert restore.region.height > 0
     assert restore.region.y + restore.region.height <= screen_height
@@ -264,24 +333,24 @@ async def _assert_trash_rows_and_restore_reachable(host, pilot):
     await pilot.pause()
     await pilot.pause()
     painted = _compositor_text(host.export_screenshot(simplify=True))
-    assert "Trashed item 40" in painted
+    assert "Trashed item 20" in painted
 
     # Keyboard reachability: from the top, focusing the last row
     # auto-scrolls it into view (Screen.set_focus -> scroll_visible).
     trash_list.scroll_home(animate=False)
     await pilot.pause()
     painted_top = _compositor_text(host.export_screenshot(simplify=True))
-    assert "Trashed item 40" not in painted_top
+    assert "Trashed item 20" not in painted_top
     last_row.focus()
     await pilot.pause()
     await pilot.pause()
     painted = _compositor_text(host.export_screenshot(simplify=True))
-    assert "Trashed item 40" in painted
+    assert "Trashed item 20" in painted
 
 
 @pytest.mark.asyncio
 async def test_trash_page_past_fold_reachable_wide_split_layout():
-    """Wide (>= the compact breakpoint) on a 24-row terminal: the 40-row
+    """Wide (>= the compact breakpoint) on a 24-row terminal: the full page
     trash page scrolls; the last row and Restore both stay reachable."""
     from Tests.UI.app_factory import _build_test_app
     from Tests.UI.test_library_shell import (
@@ -320,6 +389,396 @@ async def test_trash_page_past_fold_reachable_stacked_layout():
 
 
 # ---------------------------------------------------------------------------
+# Exact-page screen lifecycle (task-18918 Task 4). The canvas gains its
+# visible filter/pager controls in Task 5; these tests pin the mounted Screen
+# authority and real event handlers that those controls consume.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_media_trash_entry_requests_one_independent_initial_page():
+    """Entry ignores normal Media filters and exposes no fabricated result."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items(), gate_first=True)
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+
+    try:
+        async with host.run_test(size=(100, 30)) as pilot:
+            screen = _active_library_screen(host)
+            await _wait_for_library_shell(screen, pilot)
+            media_row = await _wait_for_selector(
+                screen, pilot, "#library-row-browse-media"
+            )
+            media_row.focus()
+            await pilot.press("enter")
+            await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+            # These are genuine normal-Media scope values. Trash must never
+            # inherit them when its independent page owner begins.
+            screen._request_library_media_type("audio", focus_identity=None)
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    screen._library_media_browse_controller.applied_scope
+                    == MediaBrowseScope(media_type="audio")
+                ),
+                message="Normal Media type scope never applied.",
+            )
+            screen._request_library_media_filter("Interview")
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    screen._library_media_browse_controller.applied_scope
+                    == MediaBrowseScope(query="Interview", media_type="audio")
+                ),
+                message="Normal Media query scope never applied.",
+            )
+
+            opener = screen.query_one("#library-media-trash-open", Button)
+            opener.focus()
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                feed.entered.is_set,
+                message="Trash entry request never reached the service.",
+            )
+
+            controller = screen._library_media_trash_browse_controller
+            assert len(feed.calls) == 1
+            assert feed.calls[0] == {
+                "mode": "local",
+                "query": "",
+                "media_type": None,
+                "limit": 20,
+                "offset": 0,
+            }
+            assert controller.state.requested_scope == MediaTrashScope()
+            assert controller.state.applied_result is None
+            assert controller.state.loading is True
+            assert (
+                screen.query_one("#library-media-trash-status", Static).renderable
+                == "Loading Trash…"
+            )
+
+            feed.release.set()
+            await _wait_for_condition(
+                pilot,
+                lambda: controller.state.applied_result is not None,
+                message="Trash entry page never applied.",
+            )
+            assert len(feed.calls) == 1
+            assert controller.state.applied_result.scope == MediaTrashScope()
+    finally:
+        feed.release.set()
+
+
+@pytest.mark.asyncio
+async def test_media_trash_filter_retry_page_and_type_use_applied_scope():
+    """Real submitted/chooser events preserve requested/applied separation."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(
+        _canonical_trash_items(),
+        fail_counts={("failed", 0): 2},
+    )
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        screen.query_one("#library-media-trash-open", Button).press()
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.applied_result is not None,
+            message="Initial Trash page never applied.",
+        )
+        await _wait_for_selector(screen, pilot, "#library-media-trash-row-1")
+
+        screen.query_one("#library-media-trash-row-1", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.selected_id == "local:media:2",
+            message="Trash row selection never settled.",
+        )
+
+        calls_before_bound = len(feed.calls)
+        long_input = Input(id="library-media-trash-search")
+        long_event = Input.Submitted(long_input, "x" * 201)
+        screen.handle_library_media_trash_search_submitted(long_event)
+        await pilot.pause()
+        assert len(feed.calls) == calls_before_bound
+        assert controller.state.applied_result.scope == MediaTrashScope()
+        assert (
+            screen.query_one("#library-media-trash-status", Static).renderable
+            == "Search is limited to 200 characters."
+        )
+
+        failed_input = Input(id="library-media-trash-search")
+        screen.handle_library_media_trash_search_submitted(
+            Input.Submitted(failed_input, "failed")
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: bool(controller.state.error_copy),
+            message="Failed Trash filter never exposed Retry state.",
+        )
+        assert controller.state.selected_id == ""
+        assert controller.state.applied_result.scope == MediaTrashScope()
+        assert controller.state.requested_scope == MediaTrashScope(query="failed")
+        assert (
+            screen.query_one("#library-media-trash-status", Static).renderable
+            == "Filter not applied — showing All Trash · Retry"
+        )
+
+        retry = Button("Retry", id="library-media-trash-retry")
+        screen.handle_library_media_trash_retry(Button.Pressed(retry))
+        await _wait_for_condition(
+            pilot,
+            lambda: len(feed.calls) == calls_before_bound + 2,
+            message="Trash Retry did not repeat the failed target.",
+        )
+        assert feed.calls[-1]["query"] == "failed"
+        assert controller.state.applied_result.scope == MediaTrashScope()
+
+        # After that second failure, Next derives from the visible applied
+        # All-Trash page, never the failed query draft.
+        next_button = Button("Next", id="library-media-trash-next")
+        screen.handle_library_media_trash_next(Button.Pressed(next_button))
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                controller.state.applied_result is not None
+                and controller.state.applied_result.scope == MediaTrashScope(page=2)
+            ),
+            message="Trash Next did not use the visible applied scope.",
+        )
+        assert feed.calls[-1]["query"] == ""
+        assert feed.calls[-1]["offset"] == 20
+
+        # The bounded chooser event changes only the visible applied scope
+        # and clears the current-page selection before dispatch.
+        controller.select("local:media:22")
+        option_list = OptionList(id="library-media-trash-type-choices")
+        option = Option("audio")
+        option.choice_value = "audio"
+        screen.handle_library_media_trash_type_choice(
+            OptionList.OptionSelected(option_list, option, 0)
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                controller.state.applied_result is not None
+                and controller.state.applied_result.scope
+                == MediaTrashScope(media_type="audio")
+            ),
+            message="Trash type choice never applied page 1.",
+        )
+        assert controller.state.selected_id == ""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exit_key", ("button", "escape"))
+async def test_media_trash_back_and_escape_restore_distinct_media_return(exit_key):
+    """A Trash round-trip restores Media without consuming Viewer receipt."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    media = [
+        {
+            "id": f"media-{index}",
+            "title": f"Media {index:02d}",
+            "type": "video",
+            "last_modified": f"2026-08-{(index % 28) + 1:02d}T00:00:00Z",
+        }
+        for index in range(1, 46)
+    ]
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=media)
+    feed = _MountedTrashFeed(_canonical_trash_items())
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        controller = screen._library_media_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.applied_scope == MediaBrowseScope(),
+            message="Initial Media page never applied.",
+        )
+        screen._request_library_media_page(2, focus_identity=None)
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.applied_scope == MediaBrowseScope(page=2),
+            message="Media page 2 never applied.",
+        )
+        selected_id = str(controller.retained_items[4]["id"])
+        screen._selected_media_id = selected_id
+        row_scroll = screen.query_one("#library-media-row-scroll")
+        row_scroll.scroll_to(y=4, animate=False, force=True, immediate=True)
+        await pilot.pause()
+        scroll_offset = (int(row_scroll.scroll_x), int(row_scroll.scroll_y))
+        assert scroll_offset[1] > 0
+
+        viewer_receipt = ("viewer-sentinel", (0, 1))
+        screen._library_media_viewer_return = viewer_receipt
+        opener = screen.query_one("#library-media-trash-open", Button)
+        opener.focus()
+        await pilot.press("enter")
+        trash_controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: trash_controller.state.applied_result is not None,
+            message="Trash page never applied.",
+        )
+        screen._request_library_media_trash_page(
+            2, focus_identity="#library-media-trash-next"
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                trash_controller.state.applied_result is not None
+                and trash_controller.state.applied_result.scope
+                == MediaTrashScope(page=2)
+            ),
+            message="Independent Trash page 2 never applied.",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                list(screen.query("#library-media-trash-row-0"))
+                and getattr(
+                    screen.query_one("#library-media-trash-row-0"),
+                    "media_id",
+                    "",
+                )
+                == "local:media:21"
+            ),
+            message="Independent Trash page 2 never reached the mounted canvas.",
+        )
+        await pilot.pause()
+
+        if exit_key == "escape":
+            assert screen.check_action("library_media_trash_back", ()) is True
+            await pilot.press("escape")
+        else:
+            back = screen.query_one("#library-media-trash-back", Button)
+            back.focus()
+            await pilot.pause()
+            back.press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_view == "list",
+            message=f"Trash {exit_key} exit never reached normal Media.",
+        )
+        await _wait_for_selector(screen, pilot, "#library-media-canvas")
+        await _wait_for_condition(
+            pilot,
+            lambda: getattr(screen.focused, "id", None) == "library-media-trash-open",
+            message="Trash return did not restore toolbar focus.",
+        )
+
+        assert controller.applied_scope == MediaBrowseScope(page=2)
+        assert screen._selected_media_id == selected_id
+        assert screen._library_media_viewer_return == viewer_receipt
+        restored_scroll = screen.query_one("#library-media-row-scroll")
+        assert (int(restored_scroll.scroll_x), int(restored_scroll.scroll_y)) == (
+            scroll_offset
+        )
+
+
+@pytest.mark.asyncio
+async def test_media_trash_back_generation_fences_late_reactivated_completion():
+    """Back invalidation survives a later reactivation of the same subview."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items(), gate_first=True)
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+
+    try:
+        async with host.run_test(size=(100, 30)) as pilot:
+            screen = _active_library_screen(host)
+            await _wait_for_library_shell(screen, pilot)
+            screen.query_one("#library-row-browse-media", Button).press()
+            await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+            screen.query_one("#library-media-trash-open", Button).press()
+            await _wait_for_condition(
+                pilot,
+                feed.entered.is_set,
+                message="Late Trash request never reached its gate.",
+            )
+            trash_controller = screen._library_media_trash_browse_controller
+            screen._exit_library_media_trash()
+            await _wait_for_selector(screen, pilot, "#library-media-canvas")
+
+            # Model the same retained Screen becoming Trash-active again before
+            # any new request generation starts. Only Back's explicit
+            # invalidation can fence the first session in this interval.
+            screen._library_media_view = "trash"
+            feed.release.set()
+            await pilot.pause()
+            await pilot.pause()
+            screen._library_media_view = "list"
+
+            assert trash_controller.state.applied_result is None
+            assert screen.query("#library-media-canvas")
+    finally:
+        feed.release.set()
+
+
+# ---------------------------------------------------------------------------
 # The media list toolbar's "Trash" entry point (AC#1 reachability)
 # ---------------------------------------------------------------------------
 
@@ -336,9 +795,7 @@ async def test_media_list_toolbar_offers_trash_outside_select_mode():
     )
     from tldw_chatbook.Library.library_media_state import build_library_media_state
 
-    list_state = build_library_media_state(
-        [{"id": "1", "title": "One", "type": "pdf"}]
-    )
+    list_state = build_library_media_state([{"id": "1", "title": "One", "type": "pdf"}])
 
     class _ListApp(ConsolidatedCSSApp):
         def __init__(self, state):
@@ -406,9 +863,7 @@ async def test_confirm_copies_and_receipt_point_at_trash():
     async with app.run_test() as pilot:
         await pilot.pause()
         copy = str(
-            app.query_one(
-                "#library-media-bulk-delete-confirm-copy", Static
-            ).renderable
+            app.query_one("#library-media-bulk-delete-confirm-copy", Static).renderable
         )
         assert "restore later from Trash" in copy
         assert "no Trash view" not in copy
@@ -417,9 +872,7 @@ async def test_confirm_copies_and_receipt_point_at_trash():
     async with app.run_test() as pilot:
         await pilot.pause()
         receipt = str(
-            app.query_one(
-                "#library-media-bulk-delete-receipt-copy", Static
-            ).renderable
+            app.query_one("#library-media-bulk-delete-receipt-copy", Static).renderable
         )
         assert receipt == "✓ deleted · 2 items · in Trash"
 
@@ -505,6 +958,29 @@ def _trash_view_fake(
     refresh_calls = []
     worker_calls = []
     after_refresh = []
+    trash_controller_calls = []
+    first_record = next(iter(records or ()), None)
+    target_id = selected_id or (
+        LibraryScreen._source_record_id(first_record)
+        if isinstance(first_record, dict)
+        else ""
+    )
+    mutation_target = (
+        _trash_mutation_target(target_id, str(first_record.get("title") or "Untitled"))
+        if target_id and isinstance(first_record, dict)
+        else None
+    )
+    trash_controller = SimpleNamespace(
+        state=MediaTrashBrowseState(
+            retained_items=tuple(records or ()), selected_id=selected_id
+        ),
+        invalidate=lambda: trash_controller_calls.append(("invalidate",)),
+        request=lambda scope, **kwargs: trash_controller_calls.append(
+            ("request", scope, kwargs)
+        ),
+        select=lambda stable_id: trash_controller_calls.append(("select", stable_id)),
+        claim_mutation=lambda: mutation_target,
+    )
     fake = SimpleNamespace(
         _library_media_select_mode=False,
         _library_media_row_selection=RowSelection("media"),
@@ -512,14 +988,14 @@ def _trash_view_fake(
         _library_media_bulk_delete_in_flight=in_flight,
         _library_media_delete_receipt_ids=("stale-receipt-id",),
         _library_media_view=view,
-        _library_media_trash_records=records,
-        _library_media_trash_total=total,
-        _library_media_trash_error="",
-        _library_media_trash_notice="",
-        _selected_media_trash_id=selected_id,
-        app_instance=SimpleNamespace(
-            notify=lambda msg, **k: notified.append((msg, k))
-        ),
+        _library_media_trash_browse_controller=trash_controller,
+        _library_media_trash_query_draft="",
+        _library_media_trash_input_error="",
+        _library_media_trash_type_choices_visible=False,
+        _library_media_trash_focus_identity="#library-media-trash-row-0",
+        _library_media_trash_return=None,
+        _trash_controller_calls=trash_controller_calls,
+        app_instance=SimpleNamespace(notify=lambda msg, **k: notified.append((msg, k))),
         _notified=notified,
         _refresh_calls=refresh_calls,
         _worker_calls=worker_calls,
@@ -530,6 +1006,7 @@ def _trash_view_fake(
         call_after_refresh=lambda fn, *a: after_refresh.append(fn),
         _focus_library_media_trash_entry=lambda: None,
         _arm_library_list_entry_focus=lambda: None,
+        _capture_library_media_trash_return=lambda: None,
     )
     fake._exit_library_media_select_mode = types.MethodType(
         LibraryScreen._exit_library_media_select_mode, fake
@@ -551,27 +1028,28 @@ def test_trash_open_enters_view_resets_state_and_kicks_fetch():
     durable path the receipt points at), resets the fetch/session state,
     recomposes, and schedules exactly one fetch worker."""
     fake = _trash_view_fake(view="list", records=("stale",), total=7)
-    fake._library_media_trash_notice = "stale notice"
 
-    async def _load():
-        return None
-
-    fake._load_library_media_trash = _load
     event = SimpleNamespace(stop=lambda: None)
 
     LibraryScreen.handle_library_media_trash_open(fake, event)
 
     assert fake._library_media_view == "trash"
     assert fake._library_media_delete_receipt_ids == ()
-    assert fake._library_media_trash_records is None
-    assert fake._library_media_trash_total == 0
-    assert fake._library_media_trash_notice == ""
+    assert fake._library_media_trash_browse_controller.state == MediaTrashBrowseState()
+    assert fake._library_media_trash_query_draft == ""
+    assert fake._library_media_trash_input_error == ""
     assert fake._refresh_calls == [{"recompose": True}]
-    assert len(fake._worker_calls) == 1
-    _coro, kwargs = fake._worker_calls[0]
-    assert kwargs.get("exclusive") is True
-    assert kwargs.get("group") == "library_media_trash_load"
-    _coro.close()
+    assert fake._trash_controller_calls == [
+        ("invalidate",),
+        (
+            "request",
+            MediaTrashScope(),
+            {
+                "origin": "entry",
+                "focus_identity": "#library-media-trash-row-0",
+            },
+        ),
+    ]
 
 
 def test_trash_row_press_updates_selection():
@@ -582,35 +1060,48 @@ def test_trash_row_press_updates_selection():
         ),
         total=2,
     )
-    event = SimpleNamespace(
-        button=SimpleNamespace(media_id="2"), stop=lambda: None
-    )
+    event = SimpleNamespace(button=SimpleNamespace(media_id="2"), stop=lambda: None)
 
     LibraryScreen.handle_library_media_trash_row(fake, event)
 
-    assert fake._selected_media_trash_id == "2"
-    # ``_sync_library_canvas`` falls back to a full recompose on a fake
-    # without a mounted canvas -- either way the view re-renders.
-    assert fake._refresh_calls == [{"recompose": True}]
+    assert fake._trash_controller_calls == [("select", "2")]
 
 
 def test_trash_back_returns_to_list_and_drops_session_state():
-    fake = _trash_view_fake(
-        records=({"id": "1", "title": "A", "type": "pdf"},),
-        total=1,
-        selected_id="1",
+    events = []
+    controller = SimpleNamespace(
+        state=SimpleNamespace(retained_items=({"id": "local:media:1"},)),
+        invalidate=lambda: events.append("invalidate"),
     )
-    fake._library_media_trash_notice = "Restored 'A'."
+    fake = SimpleNamespace(
+        _library_media_bulk_delete_in_flight=False,
+        _library_media_trash_browse_controller=controller,
+        _library_media_view="trash",
+        _library_media_trash_query_draft="old",
+        _library_media_trash_input_error="old error",
+        _library_media_trash_type_choices_visible=True,
+        _library_media_trash_focus_identity="#old-focus",
+        _library_media_trash_return=None,
+        _apply_library_media_list_return=LibraryScreen._apply_library_media_list_return,
+        call_next=lambda callback, receipt: events.append(
+            ("return", callback, receipt)
+        ),
+    )
+    fake._exit_library_media_trash = types.MethodType(
+        LibraryScreen._exit_library_media_trash, fake
+    )
     event = SimpleNamespace(stop=lambda: None)
 
     LibraryScreen.handle_library_media_trash_back(fake, event)
 
     assert fake._library_media_view == "list"
-    assert fake._library_media_trash_records is None
-    assert fake._library_media_trash_total == 0
-    assert fake._library_media_trash_notice == ""
-    assert fake._selected_media_trash_id == ""
-    assert fake._refresh_calls == [{"recompose": True}]
+    assert controller.state.requested_scope == MediaTrashScope()
+    assert fake._library_media_trash_query_draft == ""
+    assert fake._library_media_trash_input_error == ""
+    assert fake._library_media_trash_type_choices_visible is False
+    assert events[0] == "invalidate"
+    assert events[1][0] == "return"
+    assert events[1][1] == LibraryScreen._apply_library_media_list_return
 
 
 def test_trash_restore_reads_resolved_selection_and_claims_shared_flag():
@@ -644,7 +1135,9 @@ def test_trash_restore_reads_resolved_selection_and_claims_shared_flag():
     asyncio.run(coro)
     # No explicit selection -> the state builder's first-row fallback,
     # exactly what the "▸" marker shows.
-    assert restore_calls == ["5"]
+    assert len(restore_calls) == 1
+    assert restore_calls[0].stable_id == "5"
+    assert restore_calls[0].backing_media_id == 5
 
 
 def test_trash_restore_refused_while_delete_or_undo_in_flight():
@@ -684,31 +1177,23 @@ def test_escape_gate_only_passes_in_trash_view():
         _library_media_view="trash",
         _library_media_bulk_delete_in_flight=False,
     )
+    assert LibraryScreen.check_action(in_trash, "library_media_trash_back", ()) is True
     assert (
-        LibraryScreen.check_action(in_trash, "library_media_trash_back", ())
-        is True
-    )
-    assert (
-        LibraryScreen.check_action(in_trash, "library_media_viewer_back", ())
-        is False
+        LibraryScreen.check_action(in_trash, "library_media_viewer_back", ()) is False
     )
 
     in_list = SimpleNamespace(
         _library_selected_row_id=LIBRARY_ROW_BROWSE_MEDIA,
         _library_media_view="list",
     )
-    assert (
-        LibraryScreen.check_action(in_list, "library_media_trash_back", ())
-        is False
-    )
+    assert LibraryScreen.check_action(in_list, "library_media_trash_back", ()) is False
 
     other_row = SimpleNamespace(
         _library_selected_row_id="browse-notes",
         _library_media_view="trash",
     )
     assert (
-        LibraryScreen.check_action(other_row, "library_media_trash_back", ())
-        is False
+        LibraryScreen.check_action(other_row, "library_media_trash_back", ()) is False
     )
 
 
@@ -725,6 +1210,18 @@ def _restore_fake(*, db, trash_records, media_records, media_count):
     notified = []
     refresh_calls = []
     after_refresh = []
+    trash_controller_events = []
+    trash_controller = SimpleNamespace(
+        finish_mutation_failure=lambda target, copy: trash_controller_events.append(
+            ("failure", target, copy)
+        ),
+        finish_mutation_commit=lambda target, notice: trash_controller_events.append(
+            ("commit", target, notice)
+        ),
+        request_after_mutation=lambda **kwargs: trash_controller_events.append(
+            ("request", kwargs)
+        ),
+    )
     fake = SimpleNamespace(
         app_instance=SimpleNamespace(
             media_reading_scope_service=scope_service,
@@ -733,13 +1230,10 @@ def _restore_fake(*, db, trash_records, media_records, media_count):
         _notified=notified,
         _refresh_calls=refresh_calls,
         _after_refresh=after_refresh,
+        _trash_controller_events=trash_controller_events,
+        _library_media_trash_browse_controller=trash_controller,
         _local_source_records={"media": tuple(media_records)},
         _local_source_counts={"media": media_count},
-        _library_media_trash_records=tuple(trash_records),
-        _library_media_trash_total=len(trash_records),
-        _library_media_trash_error="",
-        _library_media_trash_notice="",
-        _selected_media_trash_id="",
         # The real caller (``handle_library_media_trash_restore``) claims
         # the shared flag BEFORE scheduling this coroutine.
         _library_media_bulk_delete_in_flight=True,
@@ -754,6 +1248,17 @@ def _restore_fake(*, db, trash_records, media_records, media_count):
         LibraryScreen._notify_library_media_delete_warning, fake
     )
     return _bind_trash_mutation_seams(fake)
+
+
+def _trash_mutation_target(media_id: int | str, title: str) -> MediaTrashMutationTarget:
+    return MediaTrashMutationTarget(
+        stable_id=str(media_id),
+        backing_media_id=int(media_id),
+        title=title,
+        media_type="document",
+        trash_date=None,
+        page_index=0,
+    )
 
 
 @pytest.mark.asyncio
@@ -783,21 +1288,22 @@ async def test_restore_via_real_db_moves_item_back_and_updates_counts(tmp_path):
         media_count=1,
     )
 
-    await LibraryScreen._restore_library_media_from_trash(fake, str(trashed_id))
+    target = _trash_mutation_target(trashed_id, "Trashed Doc")
+    await LibraryScreen._restore_library_media_from_trash(fake, target)
 
     row = db.get_media_by_id(trashed_id)
     assert row is not None
     assert not row["is_trash"]
 
-    assert fake._library_media_trash_records == ()
-    assert fake._library_media_trash_total == 0
     restored_ids = {
-        LibraryScreen._source_record_id(r)
-        for r in fake._local_source_records["media"]
+        LibraryScreen._source_record_id(r) for r in fake._local_source_records["media"]
     }
     assert str(trashed_id) in restored_ids
     assert fake._local_source_counts["media"] == 2
-    assert fake._library_media_trash_notice == "Restored 'Trashed Doc'."
+    assert ("commit", target, "Restored 'Trashed Doc'.") in (
+        fake._trash_controller_events
+    )
+    assert any(event[0] == "request" for event in fake._trash_controller_events)
     assert fake._notified == []
     assert fake._refresh_calls == [{"recompose": True}]
     assert fake._library_media_bulk_delete_in_flight is False
@@ -855,7 +1361,9 @@ async def test_restore_via_real_db_chunked_item_keeps_chunks_and_url(tmp_path):
         media_count=0,
     )
 
-    await LibraryScreen._restore_library_media_from_trash(fake, str(media_id))
+    await LibraryScreen._restore_library_media_from_trash(
+        fake, _trash_mutation_target(media_id, "Chunked Doc")
+    )
 
     row = db.get_media_by_id(media_id)
     assert row is not None
@@ -881,28 +1389,28 @@ async def test_restore_failure_warns_keeps_row_and_clears_flag(tmp_path):
         media_count=0,
     )
 
-    await LibraryScreen._restore_library_media_from_trash(fake, "999999")
+    target = _trash_mutation_target(999999, "Ghost")
+    await LibraryScreen._restore_library_media_from_trash(fake, target)
 
-    assert fake._library_media_trash_records == trash_records
     assert fake._local_source_records["media"] == ()
     assert fake._local_source_counts["media"] == 0
-    assert fake._library_media_trash_notice == ""
     assert len(fake._notified) == 1
     assert "Could not restore" in fake._notified[0][0]
+    assert ("failure", target, "Could not restore this media item.") in (
+        fake._trash_controller_events
+    )
     assert fake._library_media_bulk_delete_in_flight is False
 
     db.close_connection()
 
 
 @pytest.mark.asyncio
-async def test_load_trash_fetches_page_through_real_seam(tmp_path):
+async def test_trash_controller_fetches_page_through_real_seam(tmp_path):
     """AC#1: the fetch worker lists every ``is_trash=1`` item through the
     existing ``list_media_trash`` seam and maps items + total into the
     view's session state (trash_date included, for the "trashed <age>"
     secondary)."""
-    db = MediaDatabase(
-        db_path=str(tmp_path / "media.db"), client_id="task-4025-load"
-    )
+    db = MediaDatabase(db_path=str(tmp_path / "media.db"), client_id="task-4025-load")
     active_id, _, _ = db.add_media_with_keywords(
         title="Active", content="a", media_type="article", keywords=[]
     )
@@ -915,23 +1423,21 @@ async def test_load_trash_fetches_page_through_real_seam(tmp_path):
     assert db.mark_as_trash(trashed_a) is True
     assert db.mark_as_trash(trashed_b) is True
 
-    fake = _restore_fake(
-        db=db, trash_records=(), media_records=(), media_count=1
+    scope_service = MediaReadingScopeService(LocalMediaReadingService(db), None)
+    controller = LibraryMediaTrashBrowseController(
+        screen=SimpleNamespace(run_worker=lambda *_args, **_kwargs: None),
+        run_service_call=lambda: LibraryScreen._run_library_service_call,
+        media_service=lambda: scope_service,
+        sync_view=lambda: lambda _focus: None,
+        request_is_active=lambda: True,
     )
-    fake._library_media_trash_records = None
-    fake._library_media_view = "trash"
-    # ``_load_library_media_trash``'s completion path calls the module's
-    # ``_sync_library_canvas``, which falls back to ``refresh`` on a fake.
-    await LibraryScreen._load_library_media_trash(fake)
+    result = await controller._list(MediaTrashScope())
 
-    records = fake._library_media_trash_records
-    assert records is not None
-    listed_ids = {LibraryScreen._source_record_id(r) for r in records}
-    assert listed_ids == {str(trashed_a), str(trashed_b)}
-    assert str(active_id) not in listed_ids
-    assert fake._library_media_trash_total == 2
-    assert all(r.get("trash_date") for r in records)
-    assert fake._library_media_trash_error == ""
+    listed_ids = {int(r["backing_media_id"]) for r in result.items}
+    assert listed_ids == {trashed_a, trashed_b}
+    assert active_id not in listed_ids
+    assert result.total == 2
+    assert all(r.get("trash_date") for r in result.items)
 
     db.close_connection()
 
@@ -952,9 +1458,7 @@ async def test_load_trash_fetches_page_through_real_seam(tmp_path):
 
 @pytest.mark.asyncio
 async def test_trashed_item_excluded_from_search_until_restored(tmp_path):
-    db = MediaDatabase(
-        db_path=str(tmp_path / "media.db"), client_id="task-4025-fts"
-    )
+    db = MediaDatabase(db_path=str(tmp_path / "media.db"), client_id="task-4025-fts")
     active_id, _, _ = db.add_media_with_keywords(
         title="Active zebra notes",
         content="the zebra grazes quietly",

--- a/Tests/UI/test_library_media_trash.py
+++ b/Tests/UI/test_library_media_trash.py
@@ -1799,6 +1799,8 @@ async def test_media_trash_restore_preserves_normal_page_and_marks_only_it_stale
             "id": media_id,
             "title": restored["title"],
             "type": restored["media_type"],
+            "deleted": 0,
+            "is_trash": 0,
             "last_modified": "2026-08-30T00:00:00+00:00",
         }
 
@@ -2103,6 +2105,255 @@ async def test_media_trash_precommit_failure_releases_mounted_controls_without_r
         assert (
             screen.query_one("#library-media-trash-previous", Button).disabled is True
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("operation", "outcome"),
+    (
+        ("permanent-delete", {"ok": True, "media_id": 999}),
+        ("permanent-delete", {"ok": False, "media_id": 1}),
+        ("permanent-delete", {"ok": True}),
+        ("permanent-delete", {"ok": True, "media_id": True}),
+        ("permanent-delete", ["malformed"]),
+        (
+            "restore",
+            {
+                "id": 999,
+                "title": "Wrong identity",
+                "type": "audio",
+                "deleted": 0,
+                "is_trash": 0,
+            },
+        ),
+        ("restore", {"ok": False, "media_id": 999}),
+        (
+            "restore",
+            {"id": 1, "title": "Missing state", "type": "audio"},
+        ),
+        (
+            "restore",
+            {
+                "id": True,
+                "title": "Wrong type",
+                "type": "audio",
+                "deleted": 0,
+                "is_trash": 0,
+            },
+        ),
+        ("restore", ["malformed"]),
+    ),
+)
+async def test_media_trash_malformed_mutation_results_fail_closed(
+    operation, outcome
+):
+    """Malformed acknowledgements retain truthful fresh action authority."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items(1))
+    feed.install(app.media_reading_scope_service)
+    mutation_calls: list[dict[str, object]] = []
+
+    async def mutate(_service, **kwargs):
+        mutation_calls.append(dict(kwargs))
+        return outcome
+
+    service = app.media_reading_scope_service
+    method_name = (
+        "restore_media_item"
+        if operation == "restore"
+        else "permanently_delete_media_item"
+    )
+    setattr(service, method_name, types.MethodType(mutate, service))
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        screen.query_one("#library-media-trash-open", Button).press()
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.applied_result is not None,
+            message="Initial Trash page never applied.",
+        )
+        await _wait_for_selector(
+            screen, pilot, "#library-media-trash-restore"
+        )
+        retained_applied = controller.state.applied_result
+        retained_items = controller.state.retained_items
+        retained_selected_id = controller.state.selected_id
+        records_before = screen._local_source_records.get("media", ())
+
+        if operation == "restore":
+            action = screen.query_one("#library-media-trash-restore", Button)
+            expected_error = "Could not restore this media item."
+        else:
+            action = screen.query_one("#library-media-trash-delete", Button)
+            expected_error = "Could not delete this media item permanently."
+        action.focus()
+        await pilot.press("enter")
+        if operation == "permanent-delete":
+            await _wait_for_selector(
+                screen, pilot, "#library-media-trash-delete-confirm"
+            )
+            await pilot.press("tab", "enter")
+
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                not controller.state.mutation_pending
+                and not screen._library_media_bulk_delete_in_flight
+            ),
+            message="Malformed mutation response did not settle.",
+        )
+
+        assert mutation_calls
+        if operation == "restore":
+            assert mutation_calls == [
+                {
+                    "mode": "local",
+                    "media_id": 1,
+                    "include_content": False,
+                    "include_versions": False,
+                }
+            ]
+        else:
+            assert mutation_calls == [{"mode": "local", "media_id": 1}]
+        assert controller.state.applied_result is retained_applied
+        assert controller.state.retained_items is retained_items
+        assert controller.state.selected_id == retained_selected_id
+        assert controller.state.freshness == "fresh"
+        assert controller.state.error_copy == expected_error
+        assert controller.state.committed_notice == ""
+        assert screen._local_source_records.get("media", ()) is records_before
+        assert len(feed.calls) == 1
+        assert not action.disabled
+
+
+@pytest.mark.asyncio
+async def test_media_trash_restore_bounds_request_and_retained_summary():
+    """A successful restore never requests or retains unbounded detail."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    restored_id = 41
+    trash_item = {
+        "id": f"local:media:{restored_id}",
+        "backing_media_id": restored_id,
+        "title": "Large restored item",
+        "media_type": "document",
+        "trash_date": "2026-08-30T00:00:00+00:00",
+    }
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed([trash_item])
+    feed.install(app.media_reading_scope_service)
+    restore_calls: list[dict[str, object]] = []
+
+    async def restore(_service, **kwargs):
+        restore_calls.append(dict(kwargs))
+        feed.items.clear()
+        return {
+            "id": restored_id,
+            "title": "Large restored item",
+            "type": "document",
+            "deleted": 0,
+            "is_trash": 0,
+            "content": "private-large-content" * 10_000,
+            "versions": [{"content": "private-version-content" * 10_000}],
+            "documents": [{"body": "private-document-body" * 10_000}],
+        }
+
+    app.media_reading_scope_service.restore_media_item = types.MethodType(
+        restore,
+        app.media_reading_scope_service,
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        normal = screen._library_media_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: normal.applied_result is not None,
+            message="Normal Media page never applied.",
+        )
+        retained_normal_result = normal.applied_result
+        retained_normal_items = normal.retained_items
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        screen.query_one("#library-media-trash-open", Button).press()
+        trash = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: trash.state.applied_result is not None,
+            message="Initial Trash page never applied.",
+        )
+        await _wait_for_selector(
+            screen, pilot, "#library-media-trash-restore"
+        )
+        screen.query_one("#library-media-trash-restore", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                trash.state.applied_result is not None
+                and trash.state.applied_result.total == 0
+                and trash.state.freshness == "fresh"
+            ),
+            message="Post-restore Trash page never settled empty.",
+        )
+
+        assert restore_calls == [
+            {
+                "mode": "local",
+                "media_id": restored_id,
+                "include_content": False,
+                "include_versions": False,
+            }
+        ]
+        restored_summaries = tuple(
+            record
+            for record in screen._local_source_records.get("media", ())
+            if screen._source_record_id(record) == str(restored_id)
+        )
+        assert restored_summaries == (
+            {
+                "id": restored_id,
+                "title": "Large restored item",
+                "type": "document",
+                "deleted": 0,
+                "is_trash": 0,
+            },
+        )
+        assert "private-" not in repr(restored_summaries)
+        assert normal.applied_result is retained_normal_result
+        assert normal.retained_items is retained_normal_items
+        assert normal.freshness == "stale"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_media_trash.py
+++ b/Tests/UI/test_library_media_trash.py
@@ -19,6 +19,7 @@ import pytest
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from textual.containers import VerticalScroll
 from textual.widgets import Button, Input, OptionList, Static
 from textual.widgets.option_list import Option
 
@@ -40,6 +41,7 @@ from tldw_chatbook.Library.library_media_state import (
     begin_media_trash_request,
     build_media_trash_result,
     build_library_media_trash_state,
+    commit_media_trash_mutation,
     fail_media_trash_mutation,
     fail_media_trash_request,
 )
@@ -181,6 +183,104 @@ async def test_trash_canvas_renders_heading_rows_and_enabled_restore():
         assert restore.disabled is False
         assert str(restore.label) == "Restore"
         assert restore.tooltip == LIBRARY_MEDIA_TRASH_RESTORE_TOOLTIP
+
+
+@pytest.mark.asyncio
+async def test_media_trash_permanent_confirmation_disambiguates_full_long_title():
+    """Duplicate truncated rows still expose one complete captured identity."""
+    shared_prefix = "A" * 140
+    full_title = f"{shared_prefix} selected tail"
+    other_title = f"{shared_prefix} other tail"
+    records = [
+        {
+            "id": "local:media:11",
+            "title": full_title,
+            "type": "video",
+            "trash_date": "2026-08-11T11:00:00+00:00",
+        },
+        {
+            "id": "local:media:12",
+            "title": other_title,
+            "type": "video",
+            "trash_date": "2026-08-12T12:00:00+00:00",
+        },
+    ]
+    state = _trash_state(records=records, selected_id="local:media:11")
+    target = MediaTrashMutationTarget(
+        stable_id="local:media:11",
+        backing_media_id=11,
+        title=full_title,
+        media_type="video",
+        trash_date="2026-08-11T11:00:00+00:00",
+        page_index=0,
+    )
+    app = _TrashCanvasApp(state, confirmation_target=target)
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        row_labels = [str(row.label) for row in app.query(".library-media-trash-row")]
+        assert full_title not in row_labels[0]
+        assert other_title not in row_labels[1]
+        assert row_labels[0].splitlines()[0].endswith("...")
+        assert row_labels[1].splitlines()[0].endswith("...")
+
+        details = app.query_one(
+            "#library-media-trash-delete-confirm-details", VerticalScroll
+        )
+        assert 0 < details.region.height <= 2
+        assert (
+            app.query_one(
+                "#library-media-trash-delete-confirm-title", Static
+            ).renderable
+            == full_title
+        )
+        assert (
+            app.query_one("#library-media-trash-delete-confirm-type", Static).renderable
+            == "video"
+        )
+        assert (
+            app.query_one("#library-media-trash-delete-confirm-time", Static).renderable
+            == "2026-08-11T11:00:00+00:00"
+        )
+        assert not app.query("#library-media-trash-restore")
+        assert not app.query("#library-media-trash-delete")
+        assert app.query_one("#library-media-trash-delete-cancel", Button)
+        assert app.query_one("#library-media-trash-delete-confirm", Button)
+
+
+@pytest.mark.asyncio
+async def test_media_trash_permanent_confirmation_names_missing_identity_fields():
+    state = _trash_state(
+        records=[
+            {
+                "id": "local:media:11",
+                "title": "Untyped",
+                "type": None,
+                "trash_date": None,
+            }
+        ],
+        selected_id="local:media:11",
+    )
+    target = MediaTrashMutationTarget(
+        stable_id="local:media:11",
+        backing_media_id=11,
+        title="Untyped",
+        media_type=None,
+        trash_date=None,
+        page_index=0,
+    )
+    app = _TrashCanvasApp(state, confirmation_target=target)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert (
+            app.query_one("#library-media-trash-delete-confirm-type", Static).renderable
+            == "Unknown type"
+        )
+        assert (
+            app.query_one("#library-media-trash-delete-confirm-time", Static).renderable
+            == "Unknown deletion time"
+        )
 
 
 @pytest.mark.asyncio
@@ -1572,6 +1672,302 @@ async def test_media_trash_disabled_browse_controls_name_mutation_interlock():
 
 
 @pytest.mark.asyncio
+async def test_media_trash_confirmation_focus_cancel_escape_and_explicit_commit():
+    """Cancel owns initial focus and the opener Enter never commits deletion."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items(3))
+    feed.install(app.media_reading_scope_service)
+    permanent_calls = []
+
+    async def permanently_delete(_service, *, mode, media_id):
+        permanent_calls.append({"mode": mode, "media_id": media_id})
+        feed.items[:] = [
+            item for item in feed.items if item["backing_media_id"] != media_id
+        ]
+        return {"ok": True, "media_id": media_id}
+
+    app.media_reading_scope_service.permanently_delete_media_item = types.MethodType(
+        permanently_delete,
+        app.media_reading_scope_service,
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        screen.query_one("#library-media-trash-open", Button).press()
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.applied_result is not None,
+            message="Initial Trash page never applied.",
+        )
+        await _wait_for_selector(screen, pilot, "#library-media-trash-delete")
+
+        delete = screen.query_one("#library-media-trash-delete", Button)
+        delete.focus()
+        await pilot.press("enter")
+        await _wait_for_selector(screen, pilot, "#library-media-trash-delete-cancel")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                getattr(screen.focused, "id", None)
+                == "library-media-trash-delete-cancel"
+            ),
+            message="Cancel did not receive initial confirmation focus.",
+        )
+        assert permanent_calls == []
+
+        await pilot.press("escape")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                not screen.query("#library-media-trash-delete-confirmation")
+                and getattr(screen.focused, "id", None) == "library-media-trash-delete"
+            ),
+            message="Escape did not safely cancel and restore opener focus.",
+        )
+        assert permanent_calls == []
+
+        await pilot.press("enter")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                getattr(screen.focused, "id", None)
+                == "library-media-trash-delete-cancel"
+            ),
+            message="Reopened confirmation did not focus Cancel.",
+        )
+        await pilot.press("tab")
+        assert getattr(screen.focused, "id", None) == (
+            "library-media-trash-delete-confirm"
+        )
+        await pilot.press("enter")
+        await _wait_for_condition(
+            pilot,
+            lambda: len(permanent_calls) == 1,
+            message="Later explicit confirmation did not commit.",
+        )
+        assert permanent_calls == [{"mode": "local", "media_id": 1}]
+
+
+@pytest.mark.asyncio
+async def test_media_trash_restore_preserves_normal_page_and_marks_only_it_stale():
+    """A ranked normal-Media page is retained byte-for-byte after Restore."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items(3))
+    feed.install(app.media_reading_scope_service)
+
+    async def restore_item(_service, *, mode, media_id, **_kwargs):
+        assert mode == "local"
+        restored = next(
+            item for item in feed.items if item["backing_media_id"] == media_id
+        )
+        feed.items[:] = [
+            item for item in feed.items if item["backing_media_id"] != media_id
+        ]
+        return {
+            "id": media_id,
+            "title": restored["title"],
+            "type": restored["media_type"],
+            "last_modified": "2026-08-30T00:00:00+00:00",
+        }
+
+    app.media_reading_scope_service.restore_media_item = types.MethodType(
+        restore_item,
+        app.media_reading_scope_service,
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        normal = screen._library_media_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: normal.applied_result is not None,
+            message="Normal Media page never applied.",
+        )
+        retained_applied = normal.applied_result
+        retained_items = normal.retained_items
+        retained_requested_scope = normal.requested_scope
+        retained_selected_id = screen._selected_media_id
+
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        screen.query_one("#library-media-trash-open", Button).press()
+        trash = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: trash.state.applied_result is not None,
+            message="Initial Trash page never applied.",
+        )
+        await _wait_for_selector(screen, pilot, "#library-media-trash-restore")
+        screen.query_one("#library-media-trash-restore", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                trash.state.applied_result is not None
+                and trash.state.applied_result.total == 2
+                and trash.state.freshness == "fresh"
+            ),
+            message="Authoritative post-Restore Trash page never applied.",
+        )
+
+        assert normal.applied_result is retained_applied
+        assert normal.retained_items is retained_items
+        assert normal.requested_scope == retained_requested_scope
+        assert screen._selected_media_id == retained_selected_id
+        assert normal.freshness == "stale"
+        assert normal.pager.title_count is None
+        assert normal.pager.retry_visible is True
+        # The successful Trash read owns only Trash and cannot clear Media stale.
+        assert trash.state.freshness == "fresh"
+        assert normal.freshness == "stale"
+
+
+@pytest.mark.asyncio
+async def test_media_trash_commit_unknown_blocks_back_but_refresh_can_be_abandoned():
+    """Only the irreversible-call phase owns the temporary Back exclusion."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items(3))
+    commit_entered = threading.Event()
+    release_commit = threading.Event()
+    refresh_entered = threading.Event()
+    release_refresh = threading.Event()
+    list_calls = 0
+
+    async def list_trash(_service, **kwargs):
+        nonlocal list_calls
+        list_calls += 1
+        if list_calls > 1:
+            refresh_entered.set()
+            await asyncio.to_thread(release_refresh.wait, 10.0)
+        return await feed.list_library_media_trash(**kwargs)
+
+    async def permanently_delete(_service, *, mode, media_id):
+        assert mode == "local"
+        commit_entered.set()
+        await asyncio.to_thread(release_commit.wait, 10.0)
+        feed.items[:] = [
+            item for item in feed.items if item["backing_media_id"] != media_id
+        ]
+        return {"ok": True, "media_id": media_id}
+
+    scope_service = app.media_reading_scope_service
+    scope_service.list_library_media_trash = types.MethodType(list_trash, scope_service)
+    scope_service.permanently_delete_media_item = types.MethodType(
+        permanently_delete, scope_service
+    )
+    host = LibraryHarness(app)
+
+    try:
+        async with host.run_test(size=(100, 30)) as pilot:
+            screen = _active_library_screen(host)
+            await _wait_for_library_shell(screen, pilot)
+            screen.query_one("#library-row-browse-media", Button).press()
+            await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+            screen.query_one("#library-media-trash-open", Button).press()
+            controller = screen._library_media_trash_browse_controller
+            await _wait_for_condition(
+                pilot,
+                lambda: controller.state.applied_result is not None,
+                message="Initial Trash page never applied.",
+            )
+            await _wait_for_selector(screen, pilot, "#library-media-trash-delete")
+            screen.query_one("#library-media-trash-delete", Button).press()
+            await _wait_for_selector(
+                screen, pilot, "#library-media-trash-delete-confirm"
+            )
+            screen.query_one("#library-media-trash-delete-confirm", Button).press()
+            await _wait_for_condition(
+                pilot,
+                commit_entered.is_set,
+                message="Permanent delete did not reach its commit gate.",
+            )
+
+            assert controller.state.mutation_pending is True
+            assert screen._library_media_bulk_delete_in_flight is True
+            back = screen.query_one("#library-media-trash-back", Button)
+            assert back.disabled is True
+            assert back.tooltip == "Finishing this action…"
+            assert (
+                screen.query_one("#library-media-trash-status", Static).renderable
+                == "Finishing this action…"
+            )
+            assert screen.check_action("library_media_trash_back", ()) is False
+            screen.action_library_media_trash_back()
+            assert screen._library_media_view == "trash"
+
+            release_commit.set()
+            await _wait_for_condition(
+                pilot,
+                refresh_entered.is_set,
+                message="Committed delete did not begin its Trash refresh.",
+            )
+            assert controller.state.mutation_pending is False
+            assert controller.state.loading is True
+            assert screen._library_media_bulk_delete_in_flight is False
+            back = screen.query_one("#library-media-trash-back", Button)
+            assert back.disabled is False
+            assert screen.check_action("library_media_trash_back", ()) is True
+
+            await pilot.press("escape")
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_media_view == "list",
+                message="Post-commit refresh could not be abandoned.",
+            )
+            release_refresh.set()
+            await pilot.pause()
+            assert screen._library_media_view == "list"
+    finally:
+        release_commit.set()
+        release_refresh.set()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("size", ((160, 50), (120, 35), (100, 30), (80, 24)))
 async def test_media_trash_geometry_four_sizes_paints_all_fixed_controls(size):
     """All four postures keep the bounded vertical grammar in the Items pane."""
@@ -1629,10 +2025,21 @@ async def test_media_trash_geometry_four_sizes_paints_all_fixed_controls(size):
         )
 
         ordinary = controller.state
+        first_item = ordinary.retained_items[0]
+        confirmation_target = MediaTrashMutationTarget(
+            stable_id=str(first_item["id"]),
+            backing_media_id=int(first_item["backing_media_id"]),
+            title=str(first_item["title"]),
+            media_type=str(first_item["media_type"]),
+            trash_date=str(first_item["trash_date"]),
+            page_index=0,
+        )
         postures = {
             "ordinary": ordinary,
-            "confirmation-ready": dataclasses.replace(
-                ordinary, selected_id=str(ordinary.retained_items[0]["id"])
+            "confirmation": dataclasses.replace(
+                ordinary,
+                selected_id=confirmation_target.stable_id,
+                confirmation_target=confirmation_target,
             ),
             "stale": dataclasses.replace(
                 ordinary,
@@ -1661,7 +2068,11 @@ async def test_media_trash_geometry_four_sizes_paints_all_fixed_controls(size):
             status = screen.query_one("#library-media-trash-status")
             trash_list = screen.query_one("#library-media-trash-list")
             pager = screen.query_one("#library-media-trash-pager")
-            actions = screen.query_one("#library-media-trash-actions")
+            action_region = screen.query_one(
+                "#library-media-trash-delete-confirmation"
+                if posture == "confirmation"
+                else "#library-media-trash-actions"
+            )
             items_pane = screen.query_one("#library-canvas")
             assert (
                 heading.region.y
@@ -1669,12 +2080,12 @@ async def test_media_trash_geometry_four_sizes_paints_all_fixed_controls(size):
                 <= status.region.y
                 <= trash_list.region.y
                 < pager.region.y
-                < actions.region.y
+                < action_region.region.y
             ), (
                 f"{posture}: heading={heading.region!r}, "
                 f"filters={filters.region!r}, status={status.region!r}, "
                 f"list={trash_list.region!r}, pager={pager.region!r}, "
-                f"actions={actions.region!r}, "
+                f"actions={action_region.region!r}, "
                 f"layout={screen._library_media_reader_layout!r}, "
                 f"items_display={items_pane.display!r}, "
                 f"items={items_pane.region!r}, "
@@ -1683,18 +2094,24 @@ async def test_media_trash_geometry_four_sizes_paints_all_fixed_controls(size):
             )
             assert status.region.height <= 3
             assert trash_list.region.height >= (4 if size == (80, 24) else 1)
-            restore = screen.query_one("#library-media-trash-restore", Button)
-            delete = screen.query_one("#library-media-trash-delete", Button)
             previous = screen.query_one("#library-media-trash-previous", Button)
             next_button = screen.query_one("#library-media-trash-next", Button)
             checked_controls = [
                 pager,
-                actions,
+                action_region,
                 previous,
                 next_button,
-                restore,
-                delete,
             ]
+            if posture == "confirmation":
+                cancel = screen.query_one("#library-media-trash-delete-cancel", Button)
+                confirm = screen.query_one(
+                    "#library-media-trash-delete-confirm", Button
+                )
+                checked_controls.extend((cancel, confirm))
+            else:
+                restore = screen.query_one("#library-media-trash-restore", Button)
+                delete = screen.query_one("#library-media-trash-delete", Button)
+                checked_controls.extend((restore, delete))
             if screen.query("#library-media-trash-retry"):
                 checked_controls.append(
                     screen.query_one("#library-media-trash-retry", Button)
@@ -1714,12 +2131,17 @@ async def test_media_trash_geometry_four_sizes_paints_all_fixed_controls(size):
             assert "Next" in painted
             if screen.query("#library-media-trash-retry"):
                 assert "Retry" in painted
-            assert "Restore" in painted
-            assert "Delete permanently" in painted, (
-                f"{posture}: items={items_pane.region!r}, "
-                f"actions={actions.region!r}, delete={delete.region!r}, "
-                f"label={str(delete.label)!r}"
-            )
+            if posture == "confirmation":
+                assert "cannot be undone" in painted
+                assert "Cancel" in painted
+                assert "Delete permanently" in painted
+            else:
+                assert "Restore" in painted
+                assert "Delete permanently" in painted, (
+                    f"{posture}: items={items_pane.region!r}, "
+                    f"actions={action_region.region!r}, "
+                    f"delete={delete.region!r}, label={str(delete.label)!r}"
+                )
             assert trash_list.styles.height.is_fraction
             assert trash_list.styles.min_height.value == 0
             if posture == "initial-error":
@@ -2108,6 +2530,7 @@ def _bind_trash_mutation_seams(fake):
     fake._library_media_browse_controller = SimpleNamespace(
         mutation_refresh_scope=scope,
         begin_mutation=lambda: events.append(("begin",)) or scope,
+        mark_stale_after_trash_restore=lambda: events.append(("mark-stale",)),
         reconcile_committed_mutation=lambda **kwargs: events.append(
             ("reconcile", kwargs)
         ),
@@ -2294,6 +2717,75 @@ def test_media_trash_restore_failure_preserves_restore_focus_not_retry(monkeypat
     assert len(sync_calls) == 1
 
 
+def test_media_trash_committed_refresh_failure_keeps_success_notice_and_retry():
+    """A follow-up read failure cannot recast a committed Restore as failed."""
+    scope = MediaTrashScope()
+    applied = apply_media_trash_result(
+        begin_media_trash_request(MediaTrashBrowseState(), scope, origin="entry"),
+        build_media_trash_result(
+            scope,
+            {
+                "items": _canonical_trash_items(2),
+                "total": 2,
+                "limit": 20,
+                "offset": 0,
+                "types": ["audio", "video"],
+            },
+        ),
+    )
+    target = MediaTrashMutationTarget(
+        stable_id="local:media:1",
+        backing_media_id=1,
+        title="Trash 01",
+        media_type="audio",
+        trash_date="2026-08-02T00:00:00+00:00",
+        page_index=0,
+    )
+    committed = commit_media_trash_mutation(
+        begin_media_trash_mutation(applied),
+        target,
+        notice="Restored 'Trash 01'.",
+    )
+    failed = fail_media_trash_request(
+        committed,
+        committed.requested_scope,
+        copy="List may be out of date.",
+    )
+    fake = SimpleNamespace(
+        _library_media_trash_browse_controller=SimpleNamespace(state=failed),
+        _library_media_trash_input_error="",
+    )
+    fake._library_media_trash_retry_visible = types.MethodType(
+        LibraryScreen._library_media_trash_retry_visible, fake
+    )
+
+    presentation = LibraryScreen._build_library_media_trash_state(fake)
+
+    assert presentation.error == (
+        "Restored 'Trash 01'. List may be out of date · Retry"
+    )
+    assert "Could not restore" not in presentation.error
+    assert presentation.notice == "Restored 'Trash 01'."
+
+
+def test_media_trash_mutation_focus_falls_to_same_position_then_previous_then_back():
+    fake = SimpleNamespace()
+
+    assert LibraryScreen._library_media_trash_focus_selectors(
+        fake, "#library-media-trash-row-3"
+    ) == (
+        "#library-media-trash-row-3",
+        "#library-media-trash-row-2",
+        "#library-media-trash-back",
+    )
+    assert LibraryScreen._library_media_trash_focus_selectors(
+        fake, "#library-media-trash-row-0"
+    ) == (
+        "#library-media-trash-row-0",
+        "#library-media-trash-back",
+    )
+
+
 def test_trash_open_enters_view_resets_state_and_kicks_fetch():
     """Entering Trash clears the stale receipt (the Trash view IS the
     durable path the receipt points at), resets the fetch/session state,
@@ -2435,6 +2927,299 @@ def test_trash_restore_noop_when_trash_empty():
     assert fake._library_media_bulk_delete_in_flight is False
 
 
+def test_media_trash_completion_flags_preserve_normal_media_presentation():
+    """Trash-only completion never reorders or refreshes the retained Media page."""
+    restore = _trash_view_fake(
+        records=({"id": "5", "title": "A", "type": "pdf"},),
+        total=1,
+        in_flight=True,
+    )
+    restore._selected_media_id = "local:media:22"
+    restore._library_media_focus_identity = "#library-media-row-1"
+    restore._library_media_scroll_offset = (0, 7)
+    retained_presentation = (
+        restore._selected_media_id,
+        restore._library_media_focus_identity,
+        restore._library_media_scroll_offset,
+    )
+
+    LibraryScreen._complete_library_media_mutation(
+        restore,
+        committed=True,
+        refresh_normal_media=False,
+        stale_normal_media=True,
+    )
+
+    assert (
+        restore._selected_media_id,
+        restore._library_media_focus_identity,
+        restore._library_media_scroll_offset,
+    ) == retained_presentation
+    assert restore._library_media_bulk_delete_in_flight is False
+    assert ("mark-stale",) in restore._mutation_events
+    assert not any(
+        event[0] in {"reconcile", "request", "facets"}
+        for event in restore._mutation_events
+    )
+
+    permanent = _trash_view_fake(
+        records=({"id": "5", "title": "A", "type": "pdf"},),
+        total=1,
+        in_flight=True,
+    )
+    LibraryScreen._complete_library_media_mutation(
+        permanent,
+        committed=True,
+        refresh_normal_media=False,
+        stale_normal_media=False,
+    )
+
+    assert permanent._library_media_bulk_delete_in_flight is False
+    assert not any(
+        event[0] in {"mark-stale", "reconcile", "request", "facets"}
+        for event in permanent._mutation_events
+    )
+
+
+def test_media_trash_delete_opener_is_consumed_and_only_opens_confirmation():
+    fake = _trash_view_fake(
+        records=({"id": "5", "title": "Same visible title", "type": "pdf"},),
+        total=1,
+        selected_id="5",
+    )
+    target = _trash_mutation_target(5, "Same visible title")
+    calls = []
+    fake._library_media_trash_browse_controller.open_delete_confirmation = lambda: (
+        calls.append(("open", target.stable_id)) or target
+    )
+    stopped = []
+    event = SimpleNamespace(stop=lambda: stopped.append(True))
+
+    LibraryScreen.handle_library_media_trash_delete(fake, event)
+
+    assert stopped == [True]
+    assert calls == [("open", "5")]
+    assert fake._worker_calls == []
+    assert fake._library_media_bulk_delete_in_flight is False
+    assert fake._library_media_trash_focus_identity == (
+        "#library-media-trash-delete-cancel"
+    )
+
+
+def test_media_trash_permanent_confirm_double_press_schedules_one_shared_worker():
+    fake = _trash_view_fake(
+        records=({"id": "5", "title": "Captured", "type": "pdf"},),
+        total=1,
+        selected_id="5",
+    )
+    target = _trash_mutation_target(5, "Captured")
+    fake._library_media_trash_browse_controller.state = dataclasses.replace(
+        fake._library_media_trash_browse_controller.state,
+        confirmation_target=target,
+    )
+    claims = []
+    fake._library_media_trash_browse_controller.claim_mutation = lambda: (
+        claims.append(target.stable_id) or target
+    )
+
+    async def delete_permanently(_target):
+        return None
+
+    fake._permanently_delete_library_media_from_trash = delete_permanently
+    event = SimpleNamespace(stop=lambda: None)
+
+    LibraryScreen.handle_library_media_trash_delete_confirm(fake, event)
+    LibraryScreen.handle_library_media_trash_delete_confirm(fake, event)
+
+    assert claims == ["5"]
+    assert fake._library_media_bulk_delete_in_flight is True
+    assert len(fake._worker_calls) == 1
+    coroutine, worker_kwargs = fake._worker_calls[0]
+    assert worker_kwargs == {
+        "exclusive": True,
+        "group": "library_media_bulk_delete",
+    }
+    coroutine.close()
+
+
+@pytest.mark.asyncio
+async def test_media_trash_permanent_delete_uses_only_scope_service_target_seam():
+    target = MediaTrashMutationTarget(
+        stable_id="local:media:41",
+        backing_media_id=41,
+        title="Duplicate visible title",
+        media_type="document",
+        trash_date="2026-08-30T00:00:00+00:00",
+        page_index=3,
+    )
+    service_calls = []
+
+    class ScopeService:
+        async def permanently_delete_media_item(self, **kwargs):
+            service_calls.append(("permanently_delete_media_item", kwargs))
+            return {"ok": True, "media_id": kwargs["media_id"]}
+
+        def __getattr__(self, name):
+            if name in {
+                "empty_media_trash",
+                "permanently_delete_backing_media_item",
+                "delete_media_item",
+            }:
+                pytest.fail(f"unexpected delete seam: {name}")
+            raise AttributeError(name)
+
+    events = []
+    fake = SimpleNamespace(
+        app_instance=SimpleNamespace(
+            media_reading_scope_service=ScopeService(),
+            notify=lambda *_args, **_kwargs: None,
+        ),
+        _library_media_trash_browse_controller=SimpleNamespace(
+            finish_mutation_failure=lambda *args: events.append(("failure", args)),
+            finish_mutation_commit=lambda *args: events.append(("commit", args)),
+            request_after_mutation=lambda **kwargs: events.append(
+                ("trash-request", kwargs)
+            ),
+        ),
+        _library_media_bulk_delete_in_flight=True,
+        _library_media_mutation_scope=MediaBrowseScope(page=2),
+        _library_media_mutation_authority=7,
+        _library_media_lifecycle_generation=7,
+        _library_selected_row_id=LIBRARY_ROW_BROWSE_MEDIA,
+        _library_media_browse_controller=SimpleNamespace(
+            mutation_refresh_scope=MediaBrowseScope(page=2),
+            mark_stale_after_trash_restore=lambda: events.append(("mark-stale",)),
+            reconcile_committed_mutation=lambda **kwargs: events.append(
+                ("reconcile", kwargs)
+            ),
+            request=lambda *args, **kwargs: events.append(
+                ("media-request", args, kwargs)
+            ),
+            request_facets=lambda **kwargs: events.append(("facets", kwargs)),
+        ),
+        _sync_library_media_browse_state=lambda *_args: events.append(("sync",)),
+        _run_library_service_call=LibraryScreen._run_library_service_call,
+    )
+    fake._complete_library_media_mutation = types.MethodType(
+        LibraryScreen._complete_library_media_mutation, fake
+    )
+
+    await LibraryScreen._permanently_delete_library_media_from_trash(fake, target)
+
+    assert service_calls == [
+        (
+            "permanently_delete_media_item",
+            {"mode": "local", "media_id": 41},
+        )
+    ]
+    assert (
+        "commit",
+        (target, "Deleted 'Duplicate visible title' permanently."),
+    ) in events
+    assert ("trash-request", {"focus_identity": "#library-media-trash-row-3"}) in events
+    assert not any(
+        event[0] in {"mark-stale", "reconcile", "media-request", "facets"}
+        for event in events
+    )
+    assert fake._library_media_bulk_delete_in_flight is False
+
+
+@pytest.mark.asyncio
+async def test_media_trash_permanent_failure_keeps_fresh_row_and_skips_refresh():
+    scope = MediaTrashScope()
+    item = _canonical_trash_items(1)[0]
+
+    # Use the real controller reducer boundary so row/selection/total authority
+    # is exercised rather than represented by a permissive callback fake.
+    class ControllerScreen:
+        pending = []
+
+        def run_worker(self, work, **_kwargs):
+            self.pending.append(work)
+            return work
+
+    class ListService:
+        async def list_library_media_trash(self, **_kwargs):
+            return {
+                "items": [item],
+                "total": 1,
+                "limit": 20,
+                "offset": 0,
+                "types": [str(item["media_type"])],
+            }
+
+    async def call_service(fn, **kwargs):
+        assert kwargs.pop("isolate_in_worker") is True
+        return await fn(**kwargs)
+
+    controller_screen = ControllerScreen()
+    controller = LibraryMediaTrashBrowseController(
+        screen=controller_screen,
+        run_service_call=lambda: call_service,
+        media_service=lambda: ListService(),
+        sync_view=lambda: lambda _focus: None,
+        request_is_active=lambda: True,
+    )
+    controller.request(scope, origin="entry", focus_identity=None)
+    await controller_screen.pending.pop()
+    target = controller.claim_mutation()
+    assert target is not None
+
+    class FailingScopeService:
+        async def permanently_delete_media_item(self, **_kwargs):
+            raise PermissionError("private policy detail")
+
+    events = []
+    fake = SimpleNamespace(
+        app_instance=SimpleNamespace(
+            media_reading_scope_service=FailingScopeService(),
+            notify=lambda message, **_kwargs: events.append(("notify", message)),
+        ),
+        _library_media_trash_browse_controller=controller,
+        _library_media_bulk_delete_in_flight=True,
+        _library_media_mutation_scope=MediaBrowseScope(),
+        _library_media_mutation_authority=2,
+        _library_media_lifecycle_generation=2,
+        _library_selected_row_id=LIBRARY_ROW_BROWSE_MEDIA,
+        _library_media_browse_controller=SimpleNamespace(
+            mutation_refresh_scope=MediaBrowseScope(),
+            mark_stale_after_trash_restore=lambda: events.append(("mark-stale",)),
+            reconcile_committed_mutation=lambda **kwargs: events.append(
+                ("reconcile", kwargs)
+            ),
+            request=lambda *args, **kwargs: events.append(
+                ("media-request", args, kwargs)
+            ),
+            request_facets=lambda **kwargs: events.append(("facets", kwargs)),
+        ),
+        _sync_library_media_browse_state=lambda *_args: events.append(("sync",)),
+        _run_library_service_call=LibraryScreen._run_library_service_call,
+        _notify_library_media_delete_warning=lambda message: events.append(
+            ("warning", message)
+        ),
+    )
+    fake._complete_library_media_mutation = types.MethodType(
+        LibraryScreen._complete_library_media_mutation, fake
+    )
+
+    await LibraryScreen._permanently_delete_library_media_from_trash(fake, target)
+
+    assert controller.state.retained_items == (item,)
+    assert controller.state.selected_id == target.stable_id
+    assert controller.state.freshness == "fresh"
+    assert controller.state.applied_result is not None
+    assert controller.state.applied_result.total == 1
+    assert (
+        controller.state.error_copy == "Could not delete this media item permanently."
+    )
+    assert not any(
+        event[0]
+        in {"trash-request", "media-request", "facets", "reconcile", "mark-stale"}
+        for event in events
+    )
+    assert fake._library_media_bulk_delete_in_flight is False
+
+
 def test_escape_gate_only_passes_in_trash_view():
     """check_action: ``library_media_trash_back`` fires only while the
     media canvas genuinely shows its Trash view; the viewer's own gate is
@@ -2535,10 +3320,9 @@ def _trash_mutation_target(media_id: int | str, title: str) -> MediaTrashMutatio
 @pytest.mark.asyncio
 async def test_restore_via_real_db_moves_item_back_and_updates_counts(tmp_path):
     """AC#2: restore flips ``is_trash`` back through the existing seam
-    (``restore_media_item`` -> ``restore_from_trash``, never raw SQL), the
-    trash list loses the row, the media records/rail count gain it back in
-    place, a notice (never a receipt) names it, and the shared interlock
-    clears in the ``finally``."""
+    (``restore_media_item`` -> ``restore_from_trash``, never raw SQL). The
+    broad rail snapshot may update, but the exact normal-Media page is retained
+    in place and marked stale rather than receiving an unranked row."""
     db = MediaDatabase(
         db_path=str(tmp_path / "media.db"), client_id="task-4025-restore"
     )
@@ -2579,9 +3363,10 @@ async def test_restore_via_real_db_moves_item_back_and_updates_counts(tmp_path):
     assert fake._refresh_calls == [{"recompose": True}]
     assert fake._library_media_bulk_delete_in_flight is False
     assert fake._mutation_events[0] == ("begin",)
-    assert any(event[0] == "reconcile" for event in fake._mutation_events)
-    assert any(event[0] == "request" for event in fake._mutation_events)
-    assert any(event[0] == "facets" for event in fake._mutation_events)
+    assert ("mark-stale",) in fake._mutation_events
+    assert not any(event[0] == "reconcile" for event in fake._mutation_events)
+    assert not any(event[0] == "request" for event in fake._mutation_events)
+    assert not any(event[0] == "facets" for event in fake._mutation_events)
 
     db.close_connection()
 

--- a/Tests/UI/test_library_media_trash.py
+++ b/Tests/UI/test_library_media_trash.py
@@ -52,6 +52,7 @@ from tldw_chatbook.Widgets.Library.library_media_trash_canvas import (
 )
 from tldw_chatbook.UI.Library_Modules.library_media_trash_browse_controller import (
     LibraryMediaTrashBrowseController,
+    MediaTrashMutationClaim,
 )
 
 
@@ -2557,6 +2558,112 @@ async def test_media_trash_unmount_generation_fences_late_completion():
             release_after_unmount.cancel()
 
 
+@pytest.mark.asyncio
+async def test_media_trash_unmount_fences_inflight_restore_completion():
+    """A detached Trash route releases its interlock without projecting success."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    class RestoreGate:
+        def __init__(self) -> None:
+            self.entered = threading.Event()
+            self.release = threading.Event()
+            self.calls: list[dict[str, object]] = []
+
+        async def restore(self, **kwargs: object) -> dict[str, object]:
+            self.calls.append(dict(kwargs))
+            self.entered.set()
+            await asyncio.to_thread(self.release.wait, 10.0)
+            media_id = int(kwargs["media_id"])
+            return {
+                "id": media_id,
+                "title": "Trash 01",
+                "type": "audio",
+                "deleted": 0,
+                "is_trash": 0,
+            }
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items(1))
+    feed.install(app.media_reading_scope_service)
+    restore_gate = RestoreGate()
+
+    async def restore_media_item(_service: object, **kwargs: object):
+        return await restore_gate.restore(**kwargs)
+
+    app.media_reading_scope_service.restore_media_item = types.MethodType(
+        restore_media_item,
+        app.media_reading_scope_service,
+    )
+    host = LibraryHarness(app)
+
+    try:
+        async with host.run_test(size=(100, 30)) as pilot:
+            screen = _active_library_screen(host)
+            await _wait_for_library_shell(screen, pilot)
+            screen.query_one("#library-row-browse-media", Button).press()
+            await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+            screen.query_one("#library-media-trash-open", Button).press()
+            await _wait_for_selector(screen, pilot, "#library-media-trash-row-0")
+            await _wait_for_condition(
+                pilot,
+                lambda: screen._library_media_trash_browse_controller.state.freshness
+                == "fresh",
+                message="Trash page did not settle before restore.",
+            )
+            screen.query_one("#library-media-trash-restore", Button).press()
+            await _wait_for_condition(
+                pilot,
+                restore_gate.entered.is_set,
+                message="Restore mutation never reached its gate.",
+            )
+            controller = screen._library_media_trash_browse_controller
+            records_before = screen._local_source_records.get("media", ())
+            count_before = screen._local_source_counts.get("media", 0)
+            list_calls_before = len(feed.calls)
+
+            await screen.on_unmount()
+            invalidated_state = controller.state
+            sync_calls: list[str | None] = []
+            refresh_calls: list[dict[str, object]] = []
+            screen._sync_library_media_trash_state = sync_calls.append
+            original_refresh = screen.refresh
+
+            def record_refresh(*args, **kwargs):
+                refresh_calls.append(dict(kwargs))
+                return original_refresh(*args, **kwargs)
+
+            screen.refresh = record_refresh
+            screen._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
+            screen._library_media_view = "trash"
+            restore_gate.release.set()
+            await _wait_for_condition(
+                pilot,
+                lambda: not screen._library_media_bulk_delete_in_flight,
+                message="Stale restore did not release the shared interlock.",
+            )
+
+            assert controller.state is invalidated_state
+            assert controller.state.committed_notice == ""
+            assert screen._local_source_records.get("media", ()) is records_before
+            assert screen._local_source_counts.get("media", 0) == count_before
+            assert len(feed.calls) == list_calls_before
+            assert sync_calls == []
+            assert not any(call.get("recompose") is True for call in refresh_calls)
+    finally:
+        restore_gate.release.set()
+
+
 # ---------------------------------------------------------------------------
 # The media list toolbar's "Trash" entry point (AC#1 reachability)
 # ---------------------------------------------------------------------------
@@ -2759,7 +2866,11 @@ def _trash_view_fake(
             ("request", scope, kwargs)
         ),
         select=lambda stable_id: trash_controller_calls.append(("select", stable_id)),
-        claim_mutation=lambda: mutation_target,
+        claim_mutation=lambda: (
+            _trash_mutation_claim(mutation_target)
+            if mutation_target is not None
+            else None
+        ),
     )
     fake = SimpleNamespace(
         _library_media_select_mode=False,
@@ -3062,8 +3173,8 @@ def test_trash_restore_reads_resolved_selection_and_claims_shared_flag():
     # No explicit selection -> the state builder's first-row fallback,
     # exactly what the "▸" marker shows.
     assert len(restore_calls) == 1
-    assert restore_calls[0].stable_id == "5"
-    assert restore_calls[0].backing_media_id == 5
+    assert restore_calls[0].target.stable_id == "5"
+    assert restore_calls[0].target.backing_media_id == 5
 
 
 def test_trash_restore_refused_while_delete_or_undo_in_flight():
@@ -3182,7 +3293,7 @@ def test_media_trash_permanent_confirm_double_press_schedules_one_shared_worker(
     )
     claims = []
     fake._library_media_trash_browse_controller.claim_mutation = lambda: (
-        claims.append(target.stable_id) or target
+        claims.append(target.stable_id) or _trash_mutation_claim(target)
     )
 
     async def delete_permanently(_target):
@@ -3238,9 +3349,11 @@ async def test_media_trash_permanent_delete_uses_only_scope_service_target_seam(
             notify=lambda *_args, **_kwargs: None,
         ),
         _library_media_trash_browse_controller=SimpleNamespace(
-            finish_mutation_failure=lambda *args: events.append(("failure", args)),
-            finish_mutation_commit=lambda *args: events.append(("commit", args)),
-            request_after_mutation=lambda **kwargs: events.append(
+            finish_mutation_failure=lambda *args: events.append(("failure", args))
+            or True,
+            finish_mutation_commit=lambda *args: events.append(("commit", args))
+            or True,
+            request_after_mutation=lambda *_args, **kwargs: events.append(
                 ("trash-request", kwargs)
             ),
         ),
@@ -3267,7 +3380,8 @@ async def test_media_trash_permanent_delete_uses_only_scope_service_target_seam(
         LibraryScreen._complete_library_media_mutation, fake
     )
 
-    await LibraryScreen._permanently_delete_library_media_from_trash(fake, target)
+    claim = _trash_mutation_claim(target)
+    await LibraryScreen._permanently_delete_library_media_from_trash(fake, claim)
 
     assert service_calls == [
         (
@@ -3277,7 +3391,7 @@ async def test_media_trash_permanent_delete_uses_only_scope_service_target_seam(
     ]
     assert (
         "commit",
-        (target, "Deleted 'Duplicate visible title' permanently."),
+        (claim, "Deleted 'Duplicate visible title' permanently."),
     ) in events
     assert ("trash-request", {"focus_identity": "#library-media-trash-row-3"}) in events
     assert not any(
@@ -3325,8 +3439,9 @@ async def test_media_trash_permanent_failure_keeps_fresh_row_and_skips_refresh()
     )
     controller.request(scope, origin="entry", focus_identity=None)
     await controller_screen.pending.pop()
-    target = controller.claim_mutation()
-    assert target is not None
+    claim = controller.claim_mutation()
+    assert claim is not None
+    target = claim.target
 
     class FailingScopeService:
         async def permanently_delete_media_item(self, **_kwargs):
@@ -3365,7 +3480,7 @@ async def test_media_trash_permanent_failure_keeps_fresh_row_and_skips_refresh()
         LibraryScreen._complete_library_media_mutation, fake
     )
 
-    await LibraryScreen._permanently_delete_library_media_from_trash(fake, target)
+    await LibraryScreen._permanently_delete_library_media_from_trash(fake, claim)
 
     assert controller.state.retained_items == (item,)
     assert controller.state.selected_id == target.stable_id
@@ -3431,13 +3546,15 @@ def _restore_fake(*, db, trash_records, media_records, media_count):
     after_refresh = []
     trash_controller_events = []
     trash_controller = SimpleNamespace(
-        finish_mutation_failure=lambda target, copy: trash_controller_events.append(
-            ("failure", target, copy)
-        ),
-        finish_mutation_commit=lambda target, notice: trash_controller_events.append(
-            ("commit", target, notice)
-        ),
-        request_after_mutation=lambda **kwargs: trash_controller_events.append(
+        finish_mutation_failure=lambda claim, copy: trash_controller_events.append(
+            ("failure", claim.target, copy)
+        )
+        or True,
+        finish_mutation_commit=lambda claim, notice: trash_controller_events.append(
+            ("commit", claim.target, notice)
+        )
+        or True,
+        request_after_mutation=lambda *_args, **kwargs: trash_controller_events.append(
             ("request", kwargs)
         ),
     )
@@ -3480,6 +3597,12 @@ def _trash_mutation_target(media_id: int | str, title: str) -> MediaTrashMutatio
     )
 
 
+def _trash_mutation_claim(
+    target: MediaTrashMutationTarget, generation: int = 1
+) -> MediaTrashMutationClaim:
+    return MediaTrashMutationClaim(target=target, generation=generation)
+
+
 @pytest.mark.asyncio
 async def test_restore_via_real_db_moves_item_back_and_updates_counts(tmp_path):
     """AC#2: restore flips ``is_trash`` back through the existing seam
@@ -3507,7 +3630,9 @@ async def test_restore_via_real_db_moves_item_back_and_updates_counts(tmp_path):
     )
 
     target = _trash_mutation_target(trashed_id, "Trashed Doc")
-    await LibraryScreen._restore_library_media_from_trash(fake, target)
+    await LibraryScreen._restore_library_media_from_trash(
+        fake, _trash_mutation_claim(target)
+    )
 
     row = db.get_media_by_id(trashed_id)
     assert row is not None
@@ -3581,7 +3706,7 @@ async def test_restore_via_real_db_chunked_item_keeps_chunks_and_url(tmp_path):
     )
 
     await LibraryScreen._restore_library_media_from_trash(
-        fake, _trash_mutation_target(media_id, "Chunked Doc")
+        fake, _trash_mutation_claim(_trash_mutation_target(media_id, "Chunked Doc"))
     )
 
     row = db.get_media_by_id(media_id)
@@ -3609,7 +3734,9 @@ async def test_restore_failure_warns_keeps_row_and_clears_flag(tmp_path):
     )
 
     target = _trash_mutation_target(999999, "Ghost")
-    await LibraryScreen._restore_library_media_from_trash(fake, target)
+    await LibraryScreen._restore_library_media_from_trash(
+        fake, _trash_mutation_claim(target)
+    )
 
     assert fake._local_source_records["media"] == ()
     assert fake._local_source_counts["media"] == 0

--- a/Tests/UI/test_library_media_trash.py
+++ b/Tests/UI/test_library_media_trash.py
@@ -9,6 +9,7 @@ tests over a SimpleNamespace fake, and real-DB tests (file-backed
 """
 
 import asyncio
+import dataclasses
 import threading
 import types
 from types import SimpleNamespace
@@ -40,7 +41,9 @@ from tldw_chatbook.Library.library_media_state import (
     build_media_trash_result,
     build_library_media_trash_state,
     fail_media_trash_mutation,
+    fail_media_trash_request,
 )
+from tldw_chatbook.Library.library_pager_state import build_library_pager_display
 from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_MEDIA
 from tldw_chatbook.Widgets.Library.library_media_trash_canvas import (
     LibraryMediaTrashCanvas,
@@ -148,13 +151,16 @@ def _trash_state(**kwargs):
 
 
 class _TrashCanvasApp(ConsolidatedCSSApp):
-    def __init__(self, state):
+    def __init__(self, state, **presentation):
         super().__init__()
         self._state = state
+        self._presentation = presentation
 
     def compose(self):
         yield LibraryMediaTrashCanvas(
-            canvas=self._state, id="library-media-trash-canvas"
+            canvas=self._state,
+            **self._presentation,
+            id="library-media-trash-canvas",
         )
 
 
@@ -250,6 +256,110 @@ async def test_trash_canvas_error_state_restore_tooltip_names_the_failure():
         assert str(restore.label) == "○ Restore"
         assert restore.tooltip != LIBRARY_MEDIA_TRASH_RESTORE_DISABLED_EMPTY_TOOLTIP
         assert restore.tooltip == LIBRARY_MEDIA_TRASH_RESTORE_DISABLED_ERROR_TOOLTIP
+
+
+def _fresh_trash_pager(*, page: int = 1, total: int = 45, rows: int = 20):
+    return build_library_pager_display(
+        applied_page=page,
+        requested_page=page,
+        page_size=20,
+        row_count=rows,
+        total=total,
+        freshness="fresh",
+    )
+
+
+@pytest.mark.asyncio
+async def test_media_trash_render_pager_filter_and_disabled_action_semantics():
+    """The bounded canvas names only applied fresh authority and true blockers."""
+    records = [
+        {
+            "id": str(index),
+            "title": f"Trashed item {index:02d}",
+            "type": "audio",
+            "trash_date": "2026-08-10T12:00:00+00:00",
+        }
+        for index in range(1, 21)
+    ]
+    app = _TrashCanvasApp(
+        _trash_state(records=records, total=45, selected_id=""),
+        pager=_fresh_trash_pager(),
+        types=("audio", "video"),
+        query_draft="unapplied draft",
+        applied_scope_label="",
+        applied_type=None,
+        type_choices_visible=False,
+        action_disabled_reason="Select a Trash item first.",
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        title = app.query_one("#library-media-trash-title", Static)
+        assert str(title.renderable) == "Local Trash · 45 items"
+        assert app.query_one("#library-media-trash-search", Input).value == (
+            "unapplied draft"
+        )
+        assert (
+            str(app.query_one("#library-media-trash-range", Static).renderable)
+            == "1-20 of 45"
+        )
+        assert (
+            str(app.query_one("#library-media-trash-page", Static).renderable)
+            == "Page 1 of 3"
+        )
+        previous = app.query_one("#library-media-trash-previous", Button)
+        next_button = app.query_one("#library-media-trash-next", Button)
+        assert previous.disabled is True
+        assert previous.tooltip == "Already on the first page."
+        assert next_button.disabled is False
+        assert list(app.query(".library-media-trash-row"))[0].region.height == 2
+        assert len(list(app.query(".library-media-trash-row"))) == 20
+        trash_list = app.query_one("#library-media-trash-list")
+        assert str(trash_list.styles.overflow_x) == "hidden"
+
+        for selector in (
+            "#library-media-trash-restore",
+            "#library-media-trash-delete",
+        ):
+            action = app.query_one(selector, Button)
+            assert action.disabled is True
+            assert str(action.label).startswith("○ ")
+            assert action.tooltip == "Select a Trash item first."
+
+
+@pytest.mark.asyncio
+async def test_media_trash_type_filter_uses_one_bounded_complete_facet_chooser():
+    """Sixty complete-source facets stay in one scrollable keyboard chooser."""
+    types = tuple(f"type-{index:02d}" for index in range(60))
+    app = _TrashCanvasApp(
+        _trash_state(),
+        pager=build_library_pager_display(
+            applied_page=1,
+            requested_page=1,
+            page_size=20,
+            row_count=2,
+            total=2,
+            freshness="fresh",
+        ),
+        types=types,
+        query_draft="",
+        applied_scope_label="Type: type-59",
+        applied_type="type-59",
+        type_choices_visible=True,
+        action_disabled_reason="",
+    )
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        assert not app.query("#library-media-trash-type-filter")
+        chooser = app.query_one("#library-media-trash-type-choices", OptionList)
+        assert chooser.option_count == 61
+        assert not app.query("#library-media-trash-type-choices Button")
+        assert str(chooser.get_option_at_index(0).prompt) == "All types"
+        assert str(chooser.get_option_at_index(60).prompt).startswith("✓ type-59")
+        chooser.focus()
+        await pilot.press("end")
+        await pilot.pause()
+        assert chooser.highlighted == 60
+        assert "type-59" in _compositor_text(app.export_screenshot(simplify=True))
 
 
 # ---------------------------------------------------------------------------
@@ -491,8 +601,68 @@ async def test_media_trash_entry_requests_one_independent_initial_page():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("trash_items", "expected_focus"),
+    (
+        (_canonical_trash_items(2), "library-media-trash-row-0"),
+        ([], "library-media-trash-back"),
+    ),
+)
+async def test_media_trash_focus_initial_success_and_empty_fallback(
+    trash_items, expected_focus
+):
+    """The opening Enter lands on one mounted success/empty recovery target."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(trash_items)
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        media_row = screen.query_one("#library-row-browse-media", Button)
+        media_row.focus()
+        await pilot.press("enter")
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        await pilot.pause()
+        opener = screen.query_one("#library-media-trash-open", Button)
+        opener.focus()
+        await pilot.press("enter")
+
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.applied_result is not None,
+            message="Initial Trash success never settled.",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                getattr(screen.focused, "id", None) == expected_focus
+                and screen.focused is screen.query_one(f"#{expected_focus}", Button)
+            ),
+            message="Initial Trash focus did not settle on its mounted fallback.",
+        )
+        assert screen._library_media_view == "trash"
+        assert len(feed.calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_media_trash_initial_entry_failure_sets_retry_focus_intent():
-    """An initial read failure owns Retry semantics before Task 5 renders it."""
+    """An initial read failure mounts one Retry and gives it real DOM focus."""
     from Tests.UI.app_factory import _build_test_app
     from Tests.UI.test_library_shell import (
         LibraryHarness,
@@ -516,7 +686,10 @@ async def test_media_trash_initial_entry_failure_sets_retry_focus_intent():
         await _wait_for_library_shell(screen, pilot)
         screen.query_one("#library-row-browse-media", Button).press()
         await _wait_for_selector(screen, pilot, "#library-media-trash-open")
-        screen.query_one("#library-media-trash-open", Button).press()
+        await pilot.pause()
+        opener = screen.query_one("#library-media-trash-open", Button)
+        opener.focus()
+        await pilot.press("enter")
         controller = screen._library_media_trash_browse_controller
         await _wait_for_condition(
             pilot,
@@ -532,6 +705,93 @@ async def test_media_trash_initial_entry_failure_sets_retry_focus_intent():
         )
         status = await _wait_for_selector(screen, pilot, "#library-media-trash-status")
         assert status.renderable == "Could not load Trash · Retry"
+        await _wait_for_selector(screen, pilot, "#library-media-trash-retry")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen.focused is screen.query_one("#library-media-trash-retry", Button)
+            ),
+            message="Initial Trash failure did not focus mounted Retry.",
+        )
+        assert len(list(screen.query("#library-media-trash-retry"))) == 1
+        retry = screen.query_one("#library-media-trash-retry", Button)
+        assert screen.focused is retry
+        await pilot.press("enter")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                controller.state.applied_result is not None
+                and controller.state.applied_result.scope == MediaTrashScope()
+            ),
+            message="Keyboard Retry did not apply the initial page.",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: getattr(screen.focused, "id", None) == "library-media-trash-row-0",
+            message="Retry success did not settle focus on the mounted first row.",
+        )
+
+
+@pytest.mark.asyncio
+async def test_media_trash_focus_falls_back_when_next_becomes_disabled():
+    """A real Next Enter lands on Previous when the last page removes Next."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items(21))
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        await pilot.pause()
+        opener = screen.query_one("#library-media-trash-open", Button)
+        opener.focus()
+        await pilot.press("enter")
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.applied_result is not None,
+            message="Initial Trash page never applied.",
+        )
+
+        await _wait_for_selector(screen, pilot, "#library-media-trash-next")
+        await pilot.pause()
+        next_button = screen.query_one("#library-media-trash-next", Button)
+        assert next_button.disabled is False
+        next_button.focus()
+        await pilot.press("enter")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                controller.state.applied_result is not None
+                and controller.state.applied_result.scope == MediaTrashScope(page=2)
+            ),
+            message="Last Trash page never became authoritative.",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen.focused
+                is screen.query_one("#library-media-trash-previous", Button)
+            ),
+            message="Disabled Next did not fall back to mounted Previous.",
+        )
+        assert screen.query_one("#library-media-trash-next", Button).disabled is True
 
 
 @pytest.mark.asyncio
@@ -673,6 +933,418 @@ async def test_media_trash_filter_retry_page_and_type_use_applied_scope():
             message="Trash type choice never applied page 1.",
         )
         assert controller.state.selected_id == ""
+
+
+@pytest.mark.asyncio
+async def test_media_trash_filter_type_focus_and_escape_use_real_keyboard_inputs():
+    """Search/type intents reacquire current controls; chooser Escape is inert."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items())
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        await pilot.pause()
+        opener = screen.query_one("#library-media-trash-open", Button)
+        opener.focus()
+        await pilot.press("enter")
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.applied_result is not None,
+            message="Initial Trash page never applied.",
+        )
+
+        await _wait_for_selector(screen, pilot, "#library-media-trash-search")
+        await pilot.pause()
+        search = screen.query_one("#library-media-trash-search", Input)
+        search.focus()
+        await pilot.press("t", "r", "a", "s", "h", "enter")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                controller.state.applied_result is not None
+                and controller.state.applied_result.scope.query == "trash"
+                and not controller.state.loading
+            ),
+            message="Submitted Trash query never became applied authority.",
+        )
+        assert getattr(screen.focused, "id", None) == "library-media-trash-search"
+        assert (
+            screen.query_one("#library-media-trash-scope", Static).renderable
+            == "Query: trash"
+        )
+
+        calls_before_open = len(feed.calls)
+        await pilot.press("tab")
+        assert getattr(screen.focused, "id", None) == "library-media-trash-type-filter"
+        await pilot.press("enter")
+        chooser = await _wait_for_selector(
+            screen, pilot, "#library-media-trash-type-choices"
+        )
+        assert isinstance(chooser, OptionList)
+        assert len(feed.calls) == calls_before_open
+        assert chooser.highlighted == 0
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen.focused
+                is screen.query_one("#library-media-trash-type-choices", OptionList)
+            ),
+            message="Type chooser did not receive mounted focus after paint.",
+        )
+        chooser = screen.query_one("#library-media-trash-type-choices", OptionList)
+        await pilot.press("down", "enter")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                controller.state.applied_result is not None
+                and controller.state.applied_result.scope.media_type == "audio"
+            ),
+            message="Keyboard type choice never became applied authority.",
+        )
+        assert getattr(screen.focused, "id", None) == (
+            "library-media-trash-type-filter"
+        )
+
+        applied_before_escape = controller.state.applied_result.scope
+        requested_before_escape = controller.state.requested_scope
+        type_filter = screen.query_one("#library-media-trash-type-filter", Button)
+        assert screen.focused is type_filter
+        await pilot.press("enter")
+        await _wait_for_selector(screen, pilot, "#library-media-trash-type-choices")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen.focused
+                is screen.query_one("#library-media-trash-type-choices", OptionList)
+            ),
+            message="Reopened type chooser did not receive mounted focus.",
+        )
+        await pilot.press("escape")
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen.focused
+                is screen.query_one("#library-media-trash-type-filter", Button)
+            ),
+            message="Escape did not restore mounted type-filter focus.",
+        )
+        assert controller.state.applied_result.scope == applied_before_escape
+        assert controller.state.requested_scope == requested_before_escape
+        assert getattr(screen.focused, "id", None) == (
+            "library-media-trash-type-filter"
+        )
+
+
+@pytest.mark.asyncio
+async def test_media_trash_type_filter_uses_complete_production_facets():
+    """The mounted chooser includes facets absent from the visible page."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    items = [
+        {
+            "id": f"local:media:{index}",
+            "backing_media_id": index,
+            "title": f"Facet source {index:02d}",
+            "media_type": f"type-{(index - 1) % 60:02d}",
+            "trash_date": "2026-08-10T12:00:00+00:00",
+        }
+        for index in range(1, 81)
+    ]
+    feed = _MountedTrashFeed(items)
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        await pilot.pause()
+        opener = screen.query_one("#library-media-trash-open", Button)
+        opener.focus()
+        await pilot.press("enter")
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.applied_result is not None,
+            message=lambda: (
+                "Complete-facet Trash page never applied: "
+                f"calls={feed.calls!r}, state={controller.state!r}."
+            ),
+        )
+        assert len(list(screen.query(".library-media-trash-row"))) == 20
+        type_filter = await _wait_for_selector(
+            screen, pilot, "#library-media-trash-type-filter"
+        )
+        type_filter.focus()
+        await pilot.press("enter")
+        chooser = await _wait_for_selector(
+            screen, pilot, "#library-media-trash-type-choices"
+        )
+        assert isinstance(chooser, OptionList)
+        assert chooser.option_count == 61
+        assert str(chooser.get_option_at_index(60).prompt) == "type-59"
+        chooser = screen.query_one("#library-media-trash-type-choices", OptionList)
+        chooser.focus()
+        await pilot.pause()
+        assert screen.focused is chooser
+        await pilot.press("end")
+        assert chooser.highlighted == 60
+
+
+@pytest.mark.asyncio
+async def test_media_trash_focus_completion_does_not_steal_newer_tab_intent():
+    """A gated page completion yields to a later real keyboard focus choice."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items(), gate_first=True)
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+
+    try:
+        async with host.run_test(size=(100, 30)) as pilot:
+            screen = _active_library_screen(host)
+            await _wait_for_library_shell(screen, pilot)
+            screen.query_one("#library-row-browse-media", Button).press()
+            await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+            screen.query_one("#library-media-trash-open", Button).focus()
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                feed.entered.is_set,
+                message="Initial Trash request never reached its gate.",
+            )
+            await _wait_for_selector(screen, pilot, "#library-media-trash-search")
+            screen.query_one("#library-media-trash-search", Input).focus()
+            await pilot.press("tab")
+            newer_focus = screen.focused
+            assert getattr(newer_focus, "id", None) == (
+                "library-media-trash-type-filter"
+            )
+
+            feed.release.set()
+            controller = screen._library_media_trash_browse_controller
+            await _wait_for_condition(
+                pilot,
+                lambda: controller.state.applied_result is not None,
+                message="Gated Trash page never applied.",
+            )
+            await pilot.pause()
+            assert getattr(screen.focused, "id", None) == (
+                "library-media-trash-type-filter"
+            )
+            assert screen.focused is screen.query_one(
+                "#library-media-trash-type-filter", Button
+            )
+            assert screen.focused is not newer_focus
+    finally:
+        feed.release.set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", ((160, 50), (120, 35), (100, 30), (80, 24)))
+async def test_media_trash_geometry_four_sizes_paints_all_fixed_controls(size):
+    """All four postures keep the bounded vertical grammar in the Items pane."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryProductionCSSHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items())
+    feed.install(app.media_reading_scope_service)
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=size) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        media_row = screen.query_one("#library-row-browse-media", Button)
+        media_row.focus()
+        await pilot.press("enter")
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_reader_layout.reader_width > 0,
+            message="Media reader allocation never settled for geometry inspection.",
+        )
+        if not screen._library_media_reader_layout.items_open:
+            items_grip = screen.query_one("#library-media-items-grip", Button)
+            items_grip.focus()
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    screen._library_media_reader_layout.items_open
+                    and screen.query_one("#library-canvas").region.area > 0
+                ),
+                message="Items pane never opened for compact Trash inspection.",
+            )
+        await pilot.pause()
+        opener = screen.query_one("#library-media-trash-open", Button)
+        opener.focus()
+        await pilot.press("enter")
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.applied_result is not None,
+            message="Trash page never applied for geometry inspection.",
+        )
+
+        ordinary = controller.state
+        postures = {
+            "ordinary": ordinary,
+            "confirmation-ready": dataclasses.replace(
+                ordinary, selected_id=str(ordinary.retained_items[0]["id"])
+            ),
+            "stale": dataclasses.replace(
+                ordinary,
+                freshness="stale",
+                stale_copy="List may be out of date.",
+                selected_id="",
+                failed_scope=MediaTrashScope(page=2),
+                failed_origin="next",
+            ),
+            "initial-error": fail_media_trash_request(
+                begin_media_trash_request(
+                    MediaTrashBrowseState(), MediaTrashScope(), origin="entry"
+                ),
+                MediaTrashScope(),
+                copy="Could not load Trash.",
+            ),
+        }
+        for posture, state in postures.items():
+            controller.state = state
+            screen._sync_library_media_trash_state(None)
+            await pilot.pause()
+            await pilot.pause()
+
+            heading = screen.query_one("#library-media-trash-heading")
+            filters = screen.query_one("#library-media-trash-filters")
+            status = screen.query_one("#library-media-trash-status")
+            trash_list = screen.query_one("#library-media-trash-list")
+            pager = screen.query_one("#library-media-trash-pager")
+            actions = screen.query_one("#library-media-trash-actions")
+            items_pane = screen.query_one("#library-canvas")
+            assert (
+                heading.region.y
+                <= filters.region.y
+                <= status.region.y
+                <= trash_list.region.y
+                < pager.region.y
+                < actions.region.y
+            ), (
+                f"{posture}: heading={heading.region!r}, "
+                f"filters={filters.region!r}, status={status.region!r}, "
+                f"list={trash_list.region!r}, pager={pager.region!r}, "
+                f"actions={actions.region!r}, "
+                f"layout={screen._library_media_reader_layout!r}, "
+                f"items_display={items_pane.display!r}, "
+                f"items={items_pane.region!r}, "
+                "canvas="
+                f"{screen.query_one('#library-media-trash-canvas').region!r}"
+            )
+            assert status.region.height <= 3
+            assert trash_list.region.height >= (4 if size == (80, 24) else 1)
+            restore = screen.query_one("#library-media-trash-restore", Button)
+            delete = screen.query_one("#library-media-trash-delete", Button)
+            previous = screen.query_one("#library-media-trash-previous", Button)
+            next_button = screen.query_one("#library-media-trash-next", Button)
+            checked_controls = [
+                pager,
+                actions,
+                previous,
+                next_button,
+                restore,
+                delete,
+            ]
+            if screen.query("#library-media-trash-retry"):
+                checked_controls.append(
+                    screen.query_one("#library-media-trash-retry", Button)
+                )
+            for widget in checked_controls:
+                assert items_pane.region.contains_region(widget.region), (
+                    f"{posture}: {widget.id}={widget.region!r}, "
+                    f"items={items_pane.region!r}"
+                )
+                hit, _ = screen.get_widget_at(*widget.region.center)
+                assert (
+                    hit is widget or widget in hit.ancestors or hit in widget.ancestors
+                )
+
+            painted = _compositor_text(host.export_screenshot(simplify=True))
+            assert "Previous" in painted
+            assert "Next" in painted
+            if screen.query("#library-media-trash-retry"):
+                assert "Retry" in painted
+            assert "Restore" in painted
+            assert "Delete permanently" in painted, (
+                f"{posture}: items={items_pane.region!r}, "
+                f"actions={actions.region!r}, delete={delete.region!r}, "
+                f"label={str(delete.label)!r}"
+            )
+            assert trash_list.styles.height.is_fraction
+            assert trash_list.styles.min_height.value == 0
+            if posture == "initial-error":
+                assert (
+                    screen.query_one("#library-media-trash-title", Static).renderable
+                    == "Local Trash"
+                )
+                assert not screen.query_one(
+                    "#library-media-trash-page", Static
+                ).renderable
+            elif posture == "stale":
+                assert "List may be out of date" in painted
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_media_trash.py
+++ b/Tests/UI/test_library_media_trash.py
@@ -2245,6 +2245,28 @@ async def test_media_trash_malformed_mutation_results_fail_closed(
         assert not action.disabled
 
 
+def test_media_trash_restore_summary_accepts_blank_persisted_type():
+    """A committed restore normalizes the schema-valid blank type to None."""
+    summary = LibraryScreen._validated_library_media_trash_restore_summary(
+        {
+            "id": 7,
+            "title": "Restored",
+            "type": "   ",
+            "deleted": 0,
+            "is_trash": 0,
+        },
+        media_id=7,
+    )
+
+    assert summary == {
+        "id": 7,
+        "title": "Restored",
+        "type": None,
+        "deleted": 0,
+        "is_trash": 0,
+    }
+
+
 @pytest.mark.asyncio
 async def test_media_trash_restore_bounds_request_and_retained_summary():
     """A successful restore never requests or retains unbounded detail."""

--- a/Tests/UI/test_library_media_trash.py
+++ b/Tests/UI/test_library_media_trash.py
@@ -34,7 +34,12 @@ from tldw_chatbook.Library.library_media_state import (
     MediaTrashBrowseState,
     MediaTrashMutationTarget,
     MediaTrashScope,
+    apply_media_trash_result,
+    begin_media_trash_mutation,
+    begin_media_trash_request,
+    build_media_trash_result,
     build_library_media_trash_state,
+    fail_media_trash_mutation,
 )
 from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_MEDIA
 from tldw_chatbook.Widgets.Library.library_media_trash_canvas import (
@@ -486,6 +491,50 @@ async def test_media_trash_entry_requests_one_independent_initial_page():
 
 
 @pytest.mark.asyncio
+async def test_media_trash_initial_entry_failure_sets_retry_focus_intent():
+    """An initial read failure owns Retry semantics before Task 5 renders it."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items(), fail_counts={("", 0): 1})
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        screen.query_one("#library-media-trash-open", Button).press()
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.error_copy == "Could not load Trash.",
+            message="Initial Trash failure never settled.",
+        )
+
+        assert len(feed.calls) == 1
+        assert controller.state.applied_result is None
+        assert controller.state.failed_scope == MediaTrashScope()
+        assert (
+            screen._library_media_trash_focus_identity == "#library-media-trash-retry"
+        )
+        status = await _wait_for_selector(screen, pilot, "#library-media-trash-status")
+        assert status.renderable == "Could not load Trash · Retry"
+
+
+@pytest.mark.asyncio
 async def test_media_trash_filter_retry_page_and_type_use_applied_scope():
     """Real submitted/chooser events preserve requested/applied separation."""
     from Tests.UI.app_factory import _build_test_app
@@ -537,6 +586,10 @@ async def test_media_trash_filter_retry_page_and_type_use_applied_scope():
         await pilot.pause()
         assert len(feed.calls) == calls_before_bound
         assert controller.state.applied_result.scope == MediaTrashScope()
+        assert controller.state.failed_scope is None
+        assert (
+            screen._library_media_trash_focus_identity == "#library-media-trash-search"
+        )
         assert (
             screen.query_one("#library-media-trash-status", Static).renderable
             == "Search is limited to 200 characters."
@@ -557,6 +610,23 @@ async def test_media_trash_filter_retry_page_and_type_use_applied_scope():
         assert (
             screen.query_one("#library-media-trash-status", Static).renderable
             == "Filter not applied — showing All Trash · Retry"
+        )
+
+        # Validation remains a Search-owned concern even when a prior
+        # failed browse target is still retained for a later Retry.
+        calls_before_failed_bound = len(feed.calls)
+        screen.handle_library_media_trash_search_submitted(
+            Input.Submitted(long_input, "y" * 201)
+        )
+        await pilot.pause()
+        assert len(feed.calls) == calls_before_failed_bound
+        assert controller.state.failed_scope == MediaTrashScope(query="failed")
+        assert (
+            screen._library_media_trash_focus_identity == "#library-media-trash-search"
+        )
+        assert (
+            screen.query_one("#library-media-trash-status", Static).renderable
+            == "Search is limited to 200 characters."
         )
 
         retry = Button("Retry", id="library-media-trash-retry")
@@ -776,6 +846,76 @@ async def test_media_trash_back_generation_fences_late_reactivated_completion():
             assert screen.query("#library-media-canvas")
     finally:
         feed.release.set()
+
+
+@pytest.mark.asyncio
+async def test_media_trash_unmount_generation_fences_late_completion():
+    """Unmount invalidation rejects a local read even if its route reactivates."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items(), gate_first=True)
+    feed.install(app.media_reading_scope_service)
+    host = LibraryHarness(app)
+    invalidated = asyncio.Event()
+    release_after_unmount = None
+
+    try:
+        async with host.run_test(size=(100, 30)) as pilot:
+            screen = _active_library_screen(host)
+            await _wait_for_library_shell(screen, pilot)
+            screen.query_one("#library-row-browse-media", Button).press()
+            await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+            screen.query_one("#library-media-trash-open", Button).press()
+            await _wait_for_condition(
+                pilot,
+                feed.entered.is_set,
+                message="Late Trash request never reached its gate.",
+            )
+            controller = screen._library_media_trash_browse_controller
+            original_invalidate = controller.invalidate
+
+            def invalidate_and_signal():
+                generation = original_invalidate()
+                invalidated.set()
+                return generation
+
+            controller.invalidate = invalidate_and_signal
+
+            async def reactivate_and_release_after_unmount():
+                await invalidated.wait()
+                # Match the Back inverse: make the retained predicates active
+                # again so only the explicit generation fence can reject the
+                # first session's completion.
+                screen._library_media_view = "trash"
+                feed.release.set()
+                await asyncio.sleep(0)
+
+            release_after_unmount = asyncio.create_task(
+                reactivate_and_release_after_unmount()
+            )
+
+        await asyncio.wait_for(release_after_unmount, timeout=2.0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert invalidated.is_set()
+        assert controller.state.applied_result is None
+    finally:
+        feed.release.set()
+        if release_after_unmount is not None and not release_after_unmount.done():
+            release_after_unmount.cancel()
 
 
 # ---------------------------------------------------------------------------
@@ -1021,6 +1161,74 @@ def _trash_view_fake(
         LibraryScreen._exit_library_media_trash, fake
     )
     return _bind_trash_mutation_seams(fake)
+
+
+def _failed_trash_restore_screen_fake():
+    record = _canonical_trash_items(1)[0]
+    scope = MediaTrashScope()
+    loading = begin_media_trash_request(MediaTrashBrowseState(), scope, origin="entry")
+    applied = apply_media_trash_result(
+        loading,
+        build_media_trash_result(
+            scope,
+            {
+                "items": [record],
+                "total": 1,
+                "limit": 20,
+                "offset": 0,
+                "types": ["audio"],
+            },
+        ),
+    )
+    target = MediaTrashMutationTarget(
+        stable_id="local:media:1",
+        backing_media_id=1,
+        title="Trash 01",
+        media_type="audio",
+        trash_date=str(record["trash_date"]),
+        page_index=0,
+    )
+    state = fail_media_trash_mutation(
+        begin_media_trash_mutation(applied),
+        target,
+        copy="Could not restore this media item.",
+    )
+    return SimpleNamespace(
+        _library_selected_row_id=LIBRARY_ROW_BROWSE_MEDIA,
+        _library_media_view="trash",
+        _library_media_trash_browse_controller=SimpleNamespace(state=state),
+        _library_media_trash_input_error="",
+        _library_media_trash_focus_identity="#library-media-trash-restore",
+        _focus_library_media_trash_intent=lambda: None,
+    )
+
+
+def test_media_trash_restore_failure_does_not_offer_browse_retry():
+    """A failed mutation keeps its selected row and has no list-read action."""
+    fake = _failed_trash_restore_screen_fake()
+
+    presentation = LibraryScreen._build_library_media_trash_state(fake)
+
+    assert presentation.error == "Could not restore this media item."
+    assert "Retry" not in presentation.error
+    assert presentation.selected_id == "local:media:1"
+    assert len(presentation.rows) == 1
+    assert presentation.rows[0].selected is True
+
+
+def test_media_trash_restore_failure_preserves_restore_focus_not_retry(monkeypatch):
+    """Mutation errors keep Restore authority rather than targeting read Retry."""
+    fake = _failed_trash_restore_screen_fake()
+    sync_calls = []
+    monkeypatch.setattr(
+        "tldw_chatbook.UI.Screens.library_screen._sync_library_canvas",
+        lambda *args, **kwargs: sync_calls.append((args, kwargs)),
+    )
+
+    LibraryScreen._sync_library_media_trash_state(fake, None)
+
+    assert fake._library_media_trash_focus_identity == "#library-media-trash-restore"
+    assert len(sync_calls) == 1
 
 
 def test_trash_open_enters_view_resets_state_and_kicks_fetch():

--- a/Tests/UI/test_library_media_trash.py
+++ b/Tests/UI/test_library_media_trash.py
@@ -1968,6 +1968,143 @@ async def test_media_trash_commit_unknown_blocks_back_but_refresh_can_be_abandon
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("operation", "error_copy", "expected_focus_id"),
+    (
+        (
+            "restore",
+            "Could not restore this media item.",
+            "library-media-trash-restore",
+        ),
+        (
+            "permanent-delete",
+            "Could not delete this media item permanently.",
+            "library-media-trash-delete",
+        ),
+    ),
+    ids=("restore", "permanent-delete"),
+)
+async def test_media_trash_precommit_failure_releases_mounted_controls_without_refresh(
+    operation, error_copy, expected_focus_id
+):
+    """A settled pre-commit failure republishes Trash after releasing its lease."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_media_items,
+        _wait_for_condition,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, [], media=_two_media_items())
+    feed = _MountedTrashFeed(_canonical_trash_items())
+    feed.install(app.media_reading_scope_service)
+    service_calls = []
+
+    async def fail_mutation(_service, *, mode, media_id):
+        service_calls.append({"mode": mode, "media_id": media_id})
+        raise PermissionError("private policy detail")
+
+    service = app.media_reading_scope_service
+    if operation == "restore":
+        service.restore_media_item = types.MethodType(fail_mutation, service)
+    else:
+        service.permanently_delete_media_item = types.MethodType(fail_mutation, service)
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(100, 30)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-trash-open")
+        screen.query_one("#library-media-trash-open", Button).press()
+        controller = screen._library_media_trash_browse_controller
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.state.applied_result is not None,
+            message="Initial Trash page never applied.",
+        )
+        await _wait_for_selector(screen, pilot, "#library-media-trash-restore")
+
+        retained_applied = controller.state.applied_result
+        retained_items = controller.state.retained_items
+        retained_selected_id = controller.state.selected_id
+        assert retained_applied is not None
+        assert retained_applied.total == 45
+        assert len(feed.calls) == 1
+
+        if operation == "restore":
+            action = screen.query_one("#library-media-trash-restore", Button)
+            action.focus()
+            await pilot.press("enter")
+        else:
+            action = screen.query_one("#library-media-trash-delete", Button)
+            action.focus()
+            await pilot.press("enter")
+            await _wait_for_selector(
+                screen, pilot, "#library-media-trash-delete-confirm"
+            )
+            await _wait_for_condition(
+                pilot,
+                lambda: (
+                    getattr(screen.focused, "id", None)
+                    == "library-media-trash-delete-cancel"
+                ),
+                message="Permanent-delete confirmation never focused Cancel.",
+            )
+            await pilot.press("tab", "enter")
+
+        def settled_with_enabled_controls() -> bool:
+            if (
+                controller.state.mutation_pending
+                or screen._library_media_bulk_delete_in_flight
+                or controller.state.error_copy != error_copy
+            ):
+                return False
+            selectors = (
+                "#library-media-trash-restore",
+                "#library-media-trash-delete",
+                "#library-media-trash-search",
+                "#library-media-trash-type-filter",
+                "#library-media-trash-next",
+            )
+            controls = [screen.query_one(selector) for selector in selectors]
+            return all(not control.disabled for control in controls) and (
+                getattr(screen.focused, "id", None) == expected_focus_id
+            )
+
+        await _wait_for_condition(
+            pilot,
+            settled_with_enabled_controls,
+            message=(
+                f"{operation} failure never republished enabled Trash controls "
+                "with recoverable action focus."
+            ),
+        )
+
+        assert service_calls == [{"mode": "local", "media_id": 1}]
+        assert len(feed.calls) == 1
+        assert controller.state.applied_result is retained_applied
+        assert controller.state.retained_items is retained_items
+        assert controller.state.selected_id == retained_selected_id
+        assert controller.state.freshness == "fresh"
+        assert controller.state.loading is False
+        assert controller.state.applied_result.total == 45
+        assert (
+            screen.query_one("#library-media-trash-status", Static).renderable
+            == error_copy
+        )
+        assert (
+            screen.query_one("#library-media-trash-previous", Button).disabled is True
+        )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("size", ((160, 50), (120, 35), (100, 30), (80, 24)))
 async def test_media_trash_geometry_four_sizes_paints_all_fixed_controls(size):
     """All four postures keep the bounded vertical grammar in the Items pane."""
@@ -2026,10 +2163,11 @@ async def test_media_trash_geometry_four_sizes_paints_all_fixed_controls(size):
 
         ordinary = controller.state
         first_item = ordinary.retained_items[0]
+        full_confirmation_title = f"{'A' * 140} selected tail"
         confirmation_target = MediaTrashMutationTarget(
             stable_id=str(first_item["id"]),
             backing_media_id=int(first_item["backing_media_id"]),
-            title=str(first_item["title"]),
+            title=full_confirmation_title,
             media_type=str(first_item["media_type"]),
             trash_date=str(first_item["trash_date"]),
             page_index=0,
@@ -2103,11 +2241,27 @@ async def test_media_trash_geometry_four_sizes_paints_all_fixed_controls(size):
                 next_button,
             ]
             if posture == "confirmation":
+                details = screen.query_one(
+                    "#library-media-trash-delete-confirm-details", VerticalScroll
+                )
+                title = screen.query_one(
+                    "#library-media-trash-delete-confirm-title", Static
+                )
+                media_type = screen.query_one(
+                    "#library-media-trash-delete-confirm-type", Static
+                )
+                deletion_time = screen.query_one(
+                    "#library-media-trash-delete-confirm-time", Static
+                )
                 cancel = screen.query_one("#library-media-trash-delete-cancel", Button)
                 confirm = screen.query_one(
                     "#library-media-trash-delete-confirm", Button
                 )
-                checked_controls.extend((cancel, confirm))
+                assert 0 < details.region.height <= 2
+                assert title.renderable == full_confirmation_title
+                checked_controls.extend(
+                    (details, media_type, deletion_time, cancel, confirm)
+                )
             else:
                 restore = screen.query_one("#library-media-trash-restore", Button)
                 delete = screen.query_one("#library-media-trash-delete", Button)
@@ -2127,12 +2281,16 @@ async def test_media_trash_geometry_four_sizes_paints_all_fixed_controls(size):
                 )
 
             painted = _compositor_text(host.export_screenshot(simplify=True))
+            if size == (80, 24):
+                assert items_pane.region.width == 32
             assert "Previous" in painted
             assert "Next" in painted
             if screen.query("#library-media-trash-retry"):
                 assert "Retry" in painted
             if posture == "confirmation":
                 assert "cannot be undone" in painted
+                assert confirmation_target.media_type in painted
+                assert confirmation_target.trash_date in painted
                 assert "Cancel" in painted
                 assert "Delete permanently" in painted
             else:

--- a/Tests/UI/test_library_media_trash_browse_controller.py
+++ b/Tests/UI/test_library_media_trash_browse_controller.py
@@ -310,3 +310,77 @@ async def test_controller_mutation_surface_preserves_failure_and_refreshes_commi
     assert service.calls[-1]["offset"] == 0
     assert controller.state.freshness == "fresh"
     assert controller.state.committed_notice == "Deleted 'Trash 2' permanently."
+
+
+@pytest.mark.asyncio
+async def test_mutation_claim_keeps_captured_stable_identity_for_duplicate_titles():
+    """Visible duplicate text cannot redirect an already captured mutation."""
+    scope = MediaTrashScope()
+    payload = _page(scope, total=2)
+    payload["items"][0]["title"] = "Duplicate title"
+    payload["items"][1]["title"] = "Duplicate title"
+    controller, screen, _service = _controller(payload)
+    controller.request(scope, origin="entry", focus_identity=None)
+    await screen.pending.pop()
+
+    controller.select("local:media:2")
+    captured = controller.open_delete_confirmation()
+    assert captured is not None
+    assert captured.stable_id == "local:media:2"
+    assert captured.backing_media_id == 2
+
+    claimed = controller.claim_mutation()
+
+    assert claimed == captured
+    assert claimed.stable_id != "local:media:1"
+    assert controller.state.mutation_pending is True
+    assert controller.state.confirmation_target is None
+
+
+@pytest.mark.asyncio
+async def test_precommit_failure_retains_exact_fresh_page_and_action_authority():
+    scope = MediaTrashScope(page=2)
+    controller, screen, _service = _controller(_page(scope, total=40))
+    controller.request(scope, origin="entry", focus_identity=None)
+    await screen.pending.pop()
+    controller.select("local:media:22")
+    target = controller.claim_mutation()
+    assert target is not None
+    applied = controller.state.applied_result
+    retained = controller.state.retained_items
+
+    controller.finish_mutation_failure(target, "Could not delete this item.")
+
+    assert controller.state.applied_result is applied
+    assert controller.state.retained_items is retained
+    assert controller.state.selected_id == "local:media:22"
+    assert controller.state.freshness == "fresh"
+    assert controller.state.loading is False
+    assert controller.state.mutation_pending is False
+    assert controller.state.error_copy == "Could not delete this item."
+    assert controller.pager.title_count == 40
+    assert controller.pager.range_copy == "21-40 of 40"
+    assert controller.pager.page_copy == "Page 2 of 2"
+
+
+@pytest.mark.asyncio
+async def test_committed_mutation_withdraws_exact_claims_before_refresh():
+    scope = MediaTrashScope(page=2)
+    controller, screen, _service = _controller(_page(scope, total=40))
+    controller.request(scope, origin="entry", focus_identity=None)
+    await screen.pending.pop()
+    controller.select("local:media:22")
+    target = controller.claim_mutation()
+    assert target is not None
+
+    controller.finish_mutation_commit(target, "Restored 'Trash 22'.")
+
+    assert controller.state.freshness == "stale"
+    assert controller.state.loading is True
+    assert controller.state.selected_id == ""
+    assert "local:media:22" not in {
+        str(item["id"]) for item in controller.state.retained_items
+    }
+    assert controller.pager.title_count is None
+    assert controller.pager.range_copy == "List may be out of date"
+    assert controller.pager.page_copy == ""

--- a/Tests/UI/test_library_media_trash_browse_controller.py
+++ b/Tests/UI/test_library_media_trash_browse_controller.py
@@ -438,7 +438,6 @@ async def test_precommit_failure_retains_exact_fresh_page_and_action_authority()
     controller.select("local:media:22")
     claim = controller.claim_mutation()
     assert claim is not None
-    target = claim.target
     applied = controller.state.applied_result
     retained = controller.state.retained_items
 
@@ -465,7 +464,6 @@ async def test_committed_mutation_withdraws_exact_claims_before_refresh():
     controller.select("local:media:22")
     claim = controller.claim_mutation()
     assert claim is not None
-    target = claim.target
 
     controller.finish_mutation_commit(claim, "Restored 'Trash 22'.")
 

--- a/Tests/UI/test_library_media_trash_browse_controller.py
+++ b/Tests/UI/test_library_media_trash_browse_controller.py
@@ -7,7 +7,10 @@ from typing import Any
 
 import pytest
 
+from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 from tldw_chatbook.Library.library_media_state import MediaTrashScope
+from tldw_chatbook.Media.local_media_reading_service import LocalMediaReadingService
+from tldw_chatbook.Media.media_reading_scope_service import MediaReadingScopeService
 from tldw_chatbook.UI.Library_Modules import (
     library_media_trash_browse_controller as controller_module,
 )
@@ -90,6 +93,57 @@ def _controller(
         request_is_active=active,
     )
     return controller, screen, service
+
+
+@pytest.mark.asyncio
+async def test_controller_canonicalizes_real_database_trash_titles(tmp_path):
+    database = MediaDatabase(
+        db_path=tmp_path / "canonical-trash-titles.sqlite",
+        client_id="canonical-trash-titles",
+    )
+    try:
+        padded_id, _uuid, _message = database.add_media_with_keywords(
+            title="  padded title  ",
+            content="padded",
+            media_type="document",
+            keywords=[],
+        )
+        blank_id, _uuid, _message = database.add_media_with_keywords(
+            title="   ",
+            content="blank",
+            media_type="document",
+            keywords=[],
+        )
+        assert database.mark_as_trash(padded_id)
+        assert database.mark_as_trash(blank_id)
+        service = MediaReadingScopeService(
+            local_service=LocalMediaReadingService(database), server_service=None
+        )
+        screen = _Screen()
+        controller = LibraryMediaTrashBrowseController(
+            screen=screen,
+            run_service_call=lambda: _call,
+            media_service=lambda: service,
+            sync_view=lambda: (lambda _focus: None),
+            request_is_active=lambda: True,
+        )
+
+        controller.request(MediaTrashScope(), origin="entry", focus_identity=None)
+        await screen.pending.pop()
+
+        assert controller.state.error_copy == ""
+        assert {
+            item["backing_media_id"]: item["title"]
+            for item in controller.state.retained_items
+        } == {
+            padded_id: "padded title",
+            blank_id: "Untitled",
+        }
+        assert controller.retry(focus_identity=None) is not None
+        await screen.pending.pop()
+        assert controller.state.freshness == "fresh"
+    finally:
+        database.close_connection()
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_media_trash_browse_controller.py
+++ b/Tests/UI/test_library_media_trash_browse_controller.py
@@ -1,0 +1,312 @@
+"""Non-visual source-owner contracts for exact Media Trash pages."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.Library.library_media_state import MediaTrashScope
+from tldw_chatbook.UI.Library_Modules import (
+    library_media_trash_browse_controller as controller_module,
+)
+from tldw_chatbook.UI.Library_Modules.library_media_trash_browse_controller import (
+    LibraryMediaTrashBrowseController,
+)
+
+
+def _item(media_id: int) -> dict[str, object]:
+    return {
+        "id": f"local:media:{media_id}",
+        "backing_media_id": media_id,
+        "title": f"Trash {media_id}",
+        "media_type": "pdf",
+        "trash_date": "2026-08-30T00:00:00+00:00",
+    }
+
+
+def _page(scope: MediaTrashScope, *, total: int) -> dict[str, object]:
+    count = min(scope.page_size, max(total - scope.offset, 0))
+    return {
+        "items": [_item(scope.offset + index + 1) for index in range(count)],
+        "total": total,
+        "limit": scope.page_size,
+        "offset": scope.offset,
+        "types": ["pdf"],
+    }
+
+
+class _Screen:
+    def __init__(self) -> None:
+        self.pending: list[Awaitable[None]] = []
+        self.worker_calls: list[dict[str, Any]] = []
+
+    def run_worker(self, work: Awaitable[None], **kwargs: Any) -> Awaitable[None]:
+        self.pending.append(work)
+        self.worker_calls.append(kwargs)
+        return work
+
+
+class _Service:
+    def __init__(
+        self,
+        *outcomes: object,
+        by_query: dict[str, object] | None = None,
+    ) -> None:
+        self.outcomes = list(outcomes)
+        self.by_query = dict(by_query or {})
+        self.calls: list[dict[str, Any]] = []
+
+    async def list_library_media_trash(self, **kwargs: Any) -> object:
+        self.calls.append(kwargs)
+        query = str(kwargs["query"])
+        outcome = (
+            self.by_query[query] if query in self.by_query else self.outcomes.pop(0)
+        )
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+async def _call(fn: Callable[..., Awaitable[Any]], **kwargs: Any) -> Any:
+    assert kwargs.pop("isolate_in_worker") is True
+    return await fn(**kwargs)
+
+
+def _controller(
+    *outcomes: object,
+    by_query: dict[str, object] | None = None,
+    active: Callable[[], bool] = lambda: True,
+    sync: Callable[[str | None], None] = lambda _focus: None,
+) -> tuple[LibraryMediaTrashBrowseController, _Screen, _Service]:
+    screen = _Screen()
+    service = _Service(*outcomes, by_query=by_query)
+    controller = LibraryMediaTrashBrowseController(
+        screen=screen,
+        run_service_call=lambda: _call,
+        media_service=lambda: service,
+        sync_view=lambda: sync,
+        request_is_active=active,
+    )
+    return controller, screen, service
+
+
+@pytest.mark.asyncio
+async def test_controller_sends_exact_local_trash_scope_and_rejects_late_result():
+    old_scope = MediaTrashScope(page=2)
+    new_scope = MediaTrashScope(query="new")
+    synced: list[str | None] = []
+    controller, screen, service = _controller(
+        by_query={
+            "": _page(old_scope, total=21),
+            "new": _page(new_scope, total=1),
+        },
+        sync=synced.append,
+    )
+
+    controller.request(
+        old_scope,
+        origin="next",
+        focus_identity="#library-media-trash-next",
+    )
+    old = screen.pending.pop()
+    controller.request(
+        new_scope,
+        origin="search",
+        focus_identity="#library-media-trash-search",
+    )
+    new = screen.pending.pop()
+    await new
+    await old
+
+    assert service.calls == [
+        {
+            "mode": "local",
+            "query": "new",
+            "media_type": None,
+            "limit": 20,
+            "offset": 0,
+        },
+        {
+            "mode": "local",
+            "query": "",
+            "media_type": None,
+            "limit": 20,
+            "offset": 20,
+        },
+    ]
+    assert controller.state.applied_result is not None
+    assert controller.state.applied_result.scope == new_scope
+    assert controller.state.selected_id == ""
+    assert synced == [
+        "#library-media-trash-next",
+        "#library-media-trash-search",
+        "#library-media-trash-search",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retry_repeats_failed_filter_target_and_original_focus_origin():
+    base = MediaTrashScope()
+    failed = MediaTrashScope(query="failed")
+    controller, screen, service = _controller(
+        _page(base, total=1),
+        RuntimeError("private-query-sentinel"),
+        _page(failed, total=1),
+    )
+    controller.request(base, origin="entry", focus_identity=None)
+    await screen.pending.pop()
+
+    controller.request(failed, origin="search", focus_identity="search")
+    await screen.pending.pop()
+    assert controller.state.error_copy == "Filter not applied — showing All Trash."
+    assert controller.state.failed_scope == failed
+    assert controller.state.applied_result is not None
+    assert controller.state.applied_result.scope == base
+
+    controller.retry(focus_identity="retry")
+    await screen.pending.pop()
+
+    assert service.calls[-1]["query"] == "failed"
+    assert service.calls[-1]["offset"] == 0
+    assert controller.state.applied_result is not None
+    assert controller.state.applied_result.scope == failed
+    assert controller.state.selected_id == ""
+
+
+@pytest.mark.asyncio
+async def test_controller_clamps_once_to_authoritative_final_page():
+    requested = MediaTrashScope(page=99)
+    clamped = MediaTrashScope(page=3)
+    controller, screen, service = _controller(
+        _page(requested, total=45),
+        _page(clamped, total=45),
+    )
+
+    controller.request(requested, origin="next", focus_identity="next")
+    await screen.pending.pop()
+
+    assert [call["offset"] for call in service.calls] == [1960, 40]
+    assert controller.state.requested_scope == requested
+    assert controller.state.applied_result is not None
+    assert controller.state.applied_result.scope == clamped
+    assert controller.pager.page_copy == "Page 3 of 3"
+
+
+@pytest.mark.asyncio
+async def test_second_shrink_marks_retained_page_stale_without_third_read():
+    initial = MediaTrashScope(page=2)
+    requested = MediaTrashScope(page=99)
+    second_clamp = MediaTrashScope(page=3)
+    controller, screen, service = _controller(
+        _page(initial, total=40),
+        _page(requested, total=45),
+        _page(second_clamp, total=20),
+    )
+    controller.request(initial, origin="entry", focus_identity=None)
+    await screen.pending.pop()
+    retained = controller.state.retained_items
+
+    controller.request(requested, origin="next", focus_identity="next")
+    await screen.pending.pop()
+
+    assert [call["offset"] for call in service.calls] == [20, 1960, 40]
+    assert controller.state.retained_items is retained
+    assert controller.state.freshness == "stale"
+    assert controller.state.stale_copy == "Source changed again; try again."
+    assert controller.pager.title_count is None
+    assert controller.pager.range_copy == "List may be out of date"
+    assert controller.pager.retry_visible is True
+
+
+@pytest.mark.asyncio
+async def test_invalidation_and_inactive_route_fence_late_local_completion():
+    active = True
+    synced: list[str | None] = []
+    scope = MediaTrashScope()
+    controller, screen, _service = _controller(
+        _page(scope, total=1),
+        active=lambda: active,
+        sync=synced.append,
+    )
+    controller.request(scope, origin="entry", focus_identity="entry")
+    late = screen.pending.pop()
+
+    controller.invalidate()
+    active = False
+    await late
+
+    assert controller.state.applied_result is None
+    assert synced == ["entry"]
+    assert controller.request(scope, origin="entry", focus_identity="entry") is None
+    assert screen.pending == []
+
+
+@pytest.mark.asyncio
+async def test_failure_logging_is_metadata_only(monkeypatch: pytest.MonkeyPatch):
+    sentinel = "private-query-sentinel"
+    logged: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        controller_module.logger,
+        "warning",
+        lambda *args: logged.append(args),
+    )
+    controller, screen, _service = _controller(RuntimeError(sentinel))
+
+    controller.request(
+        MediaTrashScope(query=sentinel),
+        origin="search",
+        focus_identity=None,
+    )
+    await screen.pending.pop()
+
+    rendered = " ".join(str(value) for call in logged for value in call)
+    assert logged
+    assert sentinel not in rendered
+    assert "list_library_media_trash" in rendered
+    assert "RuntimeError" in rendered
+
+
+def test_controller_uses_trash_specific_exclusive_worker_group():
+    controller, screen, _service = _controller(_page(MediaTrashScope(), total=1))
+
+    controller.request(MediaTrashScope(), origin="entry", focus_identity=None)
+
+    assert screen.worker_calls == [
+        {"exclusive": True, "group": "library-media-trash-browse"}
+    ]
+    screen.pending.pop().close()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_controller_mutation_surface_preserves_failure_and_refreshes_commit():
+    scope = MediaTrashScope()
+    controller, screen, service = _controller(
+        _page(scope, total=2),
+        _page(scope, total=1),
+    )
+    controller.request(scope, origin="entry", focus_identity=None)
+    await screen.pending.pop()
+    controller.select("local:media:2")
+
+    target = controller.open_delete_confirmation()
+    assert target is not None
+    assert controller.claim_mutation() == target
+    controller.finish_mutation_failure(target, "Could not delete this item.")
+    assert controller.state.selected_id == target.stable_id
+    assert controller.state.freshness == "fresh"
+
+    assert controller.open_delete_confirmation() == target
+    assert controller.claim_mutation() == target
+    controller.finish_mutation_commit(target, "Deleted 'Trash 2' permanently.")
+    assert controller.state.freshness == "stale"
+    assert controller.state.loading is True
+    assert [item["id"] for item in controller.state.retained_items] == ["local:media:1"]
+
+    controller.request_after_mutation(focus_identity="fallback")
+    await screen.pending.pop()
+
+    assert service.calls[-1]["offset"] == 0
+    assert controller.state.freshness == "fresh"
+    assert controller.state.committed_notice == "Deleted 'Trash 2' permanently."

--- a/Tests/UI/test_library_media_trash_browse_controller.py
+++ b/Tests/UI/test_library_media_trash_browse_controller.py
@@ -95,6 +95,29 @@ def _controller(
     return controller, screen, service
 
 
+def test_pager_fallback_uses_requested_scope_page_size(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An uninitialized pager derives its limit from the scope authority."""
+    controller, _screen, _service = _controller()
+    observed: dict[str, object] = {}
+    pager = object()
+
+    def capture_pager(**kwargs: object) -> object:
+        observed.update(kwargs)
+        return pager
+
+    monkeypatch.setattr(MediaTrashScope, "page_size", property(lambda _self: 7))
+    monkeypatch.setattr(
+        controller_module,
+        "build_library_pager_display",
+        capture_pager,
+    )
+
+    assert controller.pager is pager
+    assert observed["page_size"] == controller.state.requested_scope.page_size == 7
+
+
 @pytest.mark.asyncio
 async def test_controller_canonicalizes_real_database_trash_titles(tmp_path):
     database = MediaDatabase(

--- a/Tests/UI/test_library_media_trash_browse_controller.py
+++ b/Tests/UI/test_library_media_trash_browse_controller.py
@@ -346,24 +346,61 @@ async def test_controller_mutation_surface_preserves_failure_and_refreshes_commi
 
     target = controller.open_delete_confirmation()
     assert target is not None
-    assert controller.claim_mutation() == target
-    controller.finish_mutation_failure(target, "Could not delete this item.")
+    failure_claim = controller.claim_mutation()
+    assert failure_claim is not None
+    assert failure_claim.target == target
+    controller.finish_mutation_failure(failure_claim, "Could not delete this item.")
     assert controller.state.selected_id == target.stable_id
     assert controller.state.freshness == "fresh"
 
     assert controller.open_delete_confirmation() == target
-    assert controller.claim_mutation() == target
-    controller.finish_mutation_commit(target, "Deleted 'Trash 2' permanently.")
+    commit_claim = controller.claim_mutation()
+    assert commit_claim is not None
+    assert commit_claim.target == target
+    controller.finish_mutation_commit(commit_claim, "Deleted 'Trash 2' permanently.")
     assert controller.state.freshness == "stale"
     assert controller.state.loading is True
     assert [item["id"] for item in controller.state.retained_items] == ["local:media:1"]
 
-    controller.request_after_mutation(focus_identity="fallback")
+    controller.request_after_mutation(commit_claim, focus_identity="fallback")
     await screen.pending.pop()
 
     assert service.calls[-1]["offset"] == 0
     assert controller.state.freshness == "fresh"
     assert controller.state.committed_notice == "Deleted 'Trash 2' permanently."
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["commit", "failure"])
+async def test_invalidated_mutation_completion_cannot_publish_or_refresh(outcome):
+    scope = MediaTrashScope()
+    synced: list[str | None] = []
+    controller, screen, _service = _controller(
+        _page(scope, total=1),
+        _page(scope, total=0),
+        sync=synced.append,
+    )
+    controller.request(scope, origin="entry", focus_identity=None)
+    await screen.pending.pop()
+    claim = controller.claim_mutation()
+    assert claim is not None
+    controller.invalidate()
+    invalidated_state = controller.state
+    synced.clear()
+
+    if outcome == "commit":
+        controller.finish_mutation_commit(claim, "Restored 'Trash 1'.")
+    else:
+        controller.finish_mutation_failure(claim, "Could not restore this item.")
+    pending = controller.request_after_mutation(focus_identity="fallback")
+    if pending is not None:
+        pending.close()
+        screen.pending.remove(pending)
+
+    assert controller.state is invalidated_state
+    assert synced == []
+    assert pending is None
+    assert screen.pending == []
 
 
 @pytest.mark.asyncio
@@ -385,8 +422,9 @@ async def test_mutation_claim_keeps_captured_stable_identity_for_duplicate_title
 
     claimed = controller.claim_mutation()
 
-    assert claimed == captured
-    assert claimed.stable_id != "local:media:1"
+    assert claimed is not None
+    assert claimed.target == captured
+    assert claimed.target.stable_id != "local:media:1"
     assert controller.state.mutation_pending is True
     assert controller.state.confirmation_target is None
 
@@ -398,12 +436,13 @@ async def test_precommit_failure_retains_exact_fresh_page_and_action_authority()
     controller.request(scope, origin="entry", focus_identity=None)
     await screen.pending.pop()
     controller.select("local:media:22")
-    target = controller.claim_mutation()
-    assert target is not None
+    claim = controller.claim_mutation()
+    assert claim is not None
+    target = claim.target
     applied = controller.state.applied_result
     retained = controller.state.retained_items
 
-    controller.finish_mutation_failure(target, "Could not delete this item.")
+    controller.finish_mutation_failure(claim, "Could not delete this item.")
 
     assert controller.state.applied_result is applied
     assert controller.state.retained_items is retained
@@ -424,10 +463,11 @@ async def test_committed_mutation_withdraws_exact_claims_before_refresh():
     controller.request(scope, origin="entry", focus_identity=None)
     await screen.pending.pop()
     controller.select("local:media:22")
-    target = controller.claim_mutation()
-    assert target is not None
+    claim = controller.claim_mutation()
+    assert claim is not None
+    target = claim.target
 
-    controller.finish_mutation_commit(target, "Restored 'Trash 22'.")
+    controller.finish_mutation_commit(claim, "Restored 'Trash 22'.")
 
     assert controller.state.freshness == "stale"
     assert controller.state.loading is True

--- a/backlog/decisions/104-library-media-return-settlement-boundary.md
+++ b/backlog/decisions/104-library-media-return-settlement-boundary.md
@@ -1,6 +1,6 @@
 # ADR-104: Settle Library Media returns at current-owner geometry
 
-Status: Proposed
+Status: Accepted
 Date: 2026-08-30
 Related Task: TASK-18918
 Amends: [ADR-084](084-library-media-reader-ia.md), [ADR-086](086-library-adaptive-reader-shell.md)

--- a/backlog/decisions/104-library-media-return-settlement-boundary.md
+++ b/backlog/decisions/104-library-media-return-settlement-boundary.md
@@ -1,0 +1,83 @@
+# ADR-104: Settle Library Media returns at current-owner geometry
+
+Status: Proposed
+Date: 2026-08-30
+Related Task: TASK-18918
+Amends: [ADR-084](084-library-media-reader-ia.md), [ADR-086](086-library-adaptive-reader-shell.md)
+
+## Decision
+
+Library Media will restore retained semantic focus and physical list scroll through a
+two-gate, event-driven settlement boundary. The current Media adaptive shell must first
+project the current adaptive presentation contract after mount. The current Media
+row-scroll owner must then report its own Resize-derived geometry after Textual reflow.
+Only an authority-fenced request whose exact offset is representable may publish exact
+settlement.
+
+`LibraryScreen` owns request, route, generation, content/layout revision, timeout, and
+focus policy. A small Media-owned scroll widget reports owner identity and public
+Resize-derived geometry but owns no navigation or domain state. Real presentation
+changes advance an application epoch; real owner geometry events trigger settlement.
+Fixed scheduler-turn counts, arbitrary sleeps, recursive polling, and framework-private
+layout signals are not readiness contracts.
+
+Exact physical scroll remains valid only while the captured content and viewport/layout
+revisions remain unchanged. A proven revision may produce one honest semantic return
+with clamping and a distinct outcome. Missing eligible geometry reaches one bounded,
+privacy-safe failure at the existing two-second focus deadline and does not requeue.
+
+This decision is Media-specific. It does not generalize the protocol across Notes,
+Conversations, Prompts, Skills, Watchlists, or application-wide split panes without new
+evidence and a later decision.
+
+## Context
+
+TASK-18918's cross-reader gate showed that a correct normal-Media return receipt could
+restore `(0, 33)` instead of `(0, 42)` after authoritative recompose. Investigation
+proved that replacement shells could retain the legacy Notes compact class after a
+same-size recompose, leaving the owner under the wrong layout contract. It also proved
+that one or more later callbacks are not descendant-layout completion signals in
+Textual 8.2.8.
+
+Textual's public widget Resize boundary is emitted after it installs size, virtual size,
+and container size, updates scrollbars, and clamps scroll. That event is sufficient only
+after the application has reconciled the current Media presentation. This creates a
+durable cross-module interface and amends the adaptive shell lifecycle, so an ADR is
+required rather than treating the work as routine UI polish.
+
+## Alternatives considered
+
+| Option | Why rejected |
+| --- | --- |
+| Restore immediately after compose | Silently clamps against transient or wrong-contract geometry. |
+| Reconcile presentation and retain immediate restore | Corrects one producer defect but leaves the Textual layout race. |
+| Delay by N scheduler turns | Four progressively broader trials remained nondeterministic in fresh processes. |
+| Poll scroll maxima | Uses elapsed execution as authority, can loop, and cannot distinguish legitimate content shrink. |
+| Subscribe to private screen layout signals | Couples application behavior to non-public Textual internals without solving application-epoch authority. |
+| Generalize a shared Library settlement framework now | Only Media has complete failure evidence and an approved exact-return contract; broader extraction would be speculative. |
+
+## Consequences
+
+- Same-size Media recomposes must reconcile their adaptive presentation after mount.
+- Exact return success becomes an explicit event-driven state instead of an incidental
+  result of callback order.
+- Media gains a small owner-geometry message seam and transient settlement state.
+- Stale owners, epochs, requests, routes, content, layouts, and unmounted trees fail
+  closed.
+- A rare missing-geometry path may report one bounded fallback rather than falsely
+  claiming exact restoration.
+- Tests must prove deterministic fresh-process behavior and cross-reader isolation.
+- Other Library destinations remain unchanged.
+
+## Rollback plan
+
+Remove the Media settlement request/message seam and post-mount projection hook while
+leaving the retained receipt format unchanged. The previous immediate focus/scroll path
+can be restored mechanically, accepting its documented nondeterministic clamp. No
+stored data or migration is involved.
+
+## Links
+
+- [Library Media return settlement design](../../Docs/superpowers/specs/2026-08-30-library-media-return-settlement-design.md)
+- [ADR-084: Library Media reader information architecture](084-library-media-reader-ia.md)
+- [ADR-086: Shared adaptive Library reader shell](086-library-adaptive-reader-shell.md)

--- a/backlog/decisions/104-library-media-return-settlement-boundary.md
+++ b/backlog/decisions/104-library-media-return-settlement-boundary.md
@@ -7,17 +7,21 @@ Amends: [ADR-084](084-library-media-reader-ia.md), [ADR-086](086-library-adaptiv
 
 ## Decision
 
-Library Media will restore retained semantic focus and physical list scroll through a
-two-gate, event-driven settlement boundary. The current Media adaptive shell must first
-project the current adaptive presentation contract after mount. The current Media
-row-scroll owner must then report its own Resize-derived geometry after Textual reflow.
-Only an authority-fenced request whose exact offset is representable may publish exact
-settlement.
+Library Media will restore retained focus and physical list scroll through a two-gate,
+event-driven settlement boundary. The Media compose branch projects the correct adaptive
+presentation from its first frame, and the current Media adaptive shell equality-
+reconciles that projection after mount. The current Media row-scroll owner then reports
+its own Resize-derived geometry after Textual reflow. Only an authority-fenced request
+whose exact offset is representable may publish exact settlement.
 
-`LibraryScreen` owns request, route, generation, content/layout revision, timeout, and
-focus policy. A small Media-owned scroll widget reports owner identity and public
-Resize-derived geometry but owns no navigation or domain state. Real presentation
-changes advance an application epoch; real owner geometry events trigger settlement.
+`LibraryScreen` owns request, route, generation, content/layout revision, timeout, final
+focus policy, and the association between geometry revision and presentation epoch. A
+small Media-owned scroll widget reports owner identity and public Resize-derived
+geometry but owns no navigation, epoch, or domain state. Real presentation changes
+advance an application epoch and establish an exclusive floor over already-emitted
+owner geometry; real later owner geometry events trigger settlement. Viewer
+returns finish on the Media row, while Trash round trips finish on their captured normal-
+Media control after the retained list scroll is exact.
 Fixed scheduler-turn counts, arbitrary sleeps, recursive polling, and framework-private
 layout signals are not readiness contracts.
 
@@ -58,7 +62,8 @@ required rather than treating the work as routine UI polish.
 
 ## Consequences
 
-- Same-size Media recomposes must reconcile their adaptive presentation after mount.
+- Same-size Media recomposes must compose the correct adaptive presentation initially
+  and reconcile it after mount.
 - Exact return success becomes an explicit event-driven state instead of an incidental
   result of callback order.
 - Media gains a small owner-geometry message seam and transient settlement state.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -10264,6 +10264,25 @@ Do not keep and press a control captured before a branch refresh.
 
 ---
 
+## Callback turns are not layout evidence after same-size recomposition
+
+**TASK-18918, 2026-08-30.** Media Back retained the correct semantic row and
+requested scroll `(0, 42)`, but a same-size cross-reader recompose could keep the
+previous Notes presentation long enough for the replacement Media list to clamp
+at `(0, 33)`. Four remedies based on adding callback turns sometimes passed and
+sometimes failed in fresh processes because none proved that the current scroll
+owner had received its final geometry.
+
+The gate became deterministic only when `LibraryMediaRowScroll`, the producer
+that owns the relevant geometry, emitted Resize-derived evidence for its current
+owner and presentation epoch. Five fresh-process exact-return runs and the
+four-size live walkthrough then passed. When correctness depends on layout after
+recomposition, fixed callback counts or sleeps are not readiness signals; wait
+for a public event from the current geometry owner and fence it by identity and
+epoch.
+
+---
+
 ## A required check that exempts admins or accepts a stale base is advisory
 
 **Incident.** TASK-25705, 2026-08-30. PR #2228 merged into `dev` before its

--- a/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
+++ b/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
@@ -21,6 +21,8 @@ references:
     Docs/superpowers/specs/2026-08-14-library-top-level-source-pagination-design.md
   - >-
     Docs/superpowers/specs/2026-08-30-task-18918-library-media-trash-paging-design.md
+  - >-
+    Docs/superpowers/plans/2026-08-30-task-18918-library-media-trash-paging.md
   - backlog/decisions/067-library-top-level-pagination-contracts.md
 priority: medium
 ---
@@ -40,3 +42,19 @@ Make every deleted Media item reachable in the nested Trash recovery surface thr
 - [ ] #5 Request generations, unmount fencing, malformed envelopes, concurrent shrink, and privacy-safe diagnostics have regression coverage.
 - [ ] #6 Automated database/service/state and mounted Textual tests plus isolated live verification with more than 40 synthetic Trash records pass.
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Add a coherent local-only database page/count/facet contract.
+2. Propagate and canonically validate the exact envelope through Media services.
+3. Add immutable Trash paging state plus a Trash-specific request controller.
+4. Wire screen entry, paging/filter generations, Back receipt, and lifecycle fencing.
+5. Render the bounded pager/filter/confirmation surface at all supported sizes.
+6. Reconcile Restore and permanent deletion through the shared Media mutation owner.
+7. Run focused automated/live verification, review, documentation, and closeout.
+
+ADR required: no
+
+ADR path: `backlog/decisions/067-library-top-level-pagination-contracts.md`
+
+Reason: ADR-067 already governs exact source-owned pages and stale mutation recovery.

--- a/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
+++ b/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-18918
 title: Add paged recovery viewing to Library Media Trash
-status: Done
+status: In Progress
 assignee: []
 created_date: '2026-08-15 02:51'
-updated_date: '2026-08-31 15:41'
+updated_date: '2026-08-31 16:17'
 labels:
   - library
   - pagination
@@ -239,6 +239,78 @@ amendment:
   Tests/Live/test_library_media_trash_paging_closeout.py`, and `git diff
   --check` all passed. The repository virtualenv had to be prepended to `PATH`
   because bare `ruff` and `python` are not exposed by the login shell.
+
+### Final whole-branch review repairs
+
+The final cumulative review found five additional correctness gaps. They were
+reproduced independently and repaired in commits `7972a2e752`, `efbdd171fa`,
+`8a5c31de98`, `c17b64e4ce`, and the test-fixture cleanup `ce3a720fbb`:
+
+- Permanent deletion now owns its Trash eligibility and destructive predicate
+  in one immediate write transaction. The conditional Media delete must match
+  `id`, `deleted=0`, and `is_trash=1` before any FTS or child cleanup; a failed
+  predicate cannot partially clean up or delete a concurrently restored row.
+- The scope boundary canonicalizes every Trash title with
+  `str(raw or "").strip() or "Untitled"` before immutable state validation.
+- Mutation claims carry an immutable lifecycle generation through commit,
+  failure, and post-mutation reads. Invalidated or detached claims publish no
+  state, notices, source changes, canvas work, or refresh, while the shared
+  mutation interlock still releases.
+- Delete acknowledgements require `ok is True` plus the exact captured non-bool
+  integer media ID. Restore acknowledgements require the captured non-bool
+  integer ID, `deleted == 0`, `is_trash == 0`, and valid title/type metadata.
+  Malformed, incomplete, false, and wrong-identity responses fail closed.
+- Trash Restore explicitly requests `include_content=False` and
+  `include_versions=False`. Only a newly built bounded
+  `id/title/type/deleted/is_trash` summary enters the retained Media rail
+  snapshot; response content, documents, and versions are discarded.
+
+Review-repair RED/GREEN evidence:
+
+- Atomic deletion: the focused active-row cleanup regression and the
+  deterministic two-connection restore/delete barrier both failed before the
+  fix because the active row was hard-deleted. After the database transaction
+  became the sole eligibility owner, the atomic race, normal Trash cascade,
+  non-Trash refusal, and privacy cases passed **8**, with **56 deselected** and
+  **1 warning**.
+- Title canonicalization: the real file-backed
+  DB→local-service→scope-service→controller test failed before the fix with
+  `Could not load Trash` for padded/blank titles; after canonicalization its
+  padded and whitespace-only cases passed **2**.
+- Lifecycle fencing: the controller's invalidated commit/failure cases failed
+  **2** before the fix by mutating retained state and scheduling a refresh.
+  After immutable claim propagation, the focused controller plus mounted
+  unmount matrix passed **31**, with **46 deselected** and **2 warnings**.
+- Response validation and bounded restore: the mounted malformed/wrong-ID and
+  large-payload command failed **9**, passed **2**, deselected **63**, and
+  reported **2 warnings** before the fix. After strict validation and bounded
+  reconciliation, the same **11 passed**; the related existing mutation and
+  real-database restore selection passed **8**, with **66 deselected** and
+  **2 warnings**.
+
+Fresh final verification after all five repairs:
+
+- The established pure filter passed **113**, deselected **191**, and reported
+  **1 warning in 4.68s**. The prior **108** remain green; the five added
+  in-filter nodes are the atomic DB guard, controlled service race, real-chain
+  title regression, and two lifecycle terminal outcomes.
+- Every changed DB/service/state/controller/privacy-owner test file passed
+  **341 with 6 warnings in 7.69s**.
+- `Tests/UI/test_library_media_trash.py` first exposed one stale test-double
+  signature that rejected the new bounded Restore flags before call entry.
+  The signature-only repair passed its exact node, then the complete mounted
+  file passed **74 with 2 warnings in 76.33s**.
+- The settlement and side-by-side cross-reader files passed **73 with 2
+  warnings in 104.60s**.
+- The live privacy/hardening closeout file passed **5 with 6 warnings in
+  71.12s**, including its four-size real-database walkthrough.
+- Ruff passed for all ten production/test files changed since `70605f1608`;
+  `py_compile` passed for all five changed production files; both the cumulative
+  committed diff and working-tree `git diff --check` passed.
+
+TASK-18918 remains **In Progress** until the repaired cumulative branch receives
+fresh green spec and quality reviews. The executable evidence is complete; no
+task status claim is made ahead of those review gates.
 
 ### ADR check
 

--- a/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
+++ b/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
@@ -334,6 +334,16 @@ at **160×50**, **120×35**, **100×30**, and **80×24** with exact paging, clam
 restore/delete, return settlement, privacy, path-authority, and zero-handle
 evidence.
 
+The required derived-artifact workflow then correctly rejected the stale
+production-diagnostic inventory. Statement-level review confirmed the new Trash
+controller warning, the database paging error, the permanent-delete/FTS privacy
+repairs, and the screen deletion warning contain only fixed copy, bounded
+coordinates or booleans, counts/status, and exception categories. None include
+user text, secrets, filesystem paths, URLs, raw exception text, or tracebacks.
+`Docs/security/production-diagnostic-inventory.json` was regenerated only after
+that review; its path-privacy candidate count drops from **712** to **711**
+because the former permanent-delete database-path warning was removed.
+
 ### ADR check
 
 Existing ADR-067 governs the coherent exact-page and stale-recovery contract;

--- a/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
+++ b/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-18918
 title: Add paged recovery viewing to Library Media Trash
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-15 02:51'
-updated_date: '2026-08-30 15:43'
+updated_date: '2026-08-31 05:44'
 labels:
   - library
   - pagination
@@ -21,12 +21,9 @@ references:
     Docs/superpowers/specs/2026-08-14-library-top-level-source-pagination-design.md
   - >-
     Docs/superpowers/specs/2026-08-30-task-18918-library-media-trash-paging-design.md
-  - >-
-    Docs/superpowers/plans/2026-08-30-task-18918-library-media-trash-paging.md
-  - >-
-    Docs/superpowers/specs/2026-08-30-library-media-return-settlement-design.md
-  - >-
-    Docs/superpowers/plans/2026-08-30-library-media-return-settlement.md
+  - Docs/superpowers/plans/2026-08-30-task-18918-library-media-trash-paging.md
+  - Docs/superpowers/specs/2026-08-30-library-media-return-settlement-design.md
+  - Docs/superpowers/plans/2026-08-30-library-media-return-settlement.md
   - backlog/decisions/067-library-top-level-pagination-contracts.md
   - backlog/decisions/104-library-media-return-settlement-boundary.md
 priority: medium
@@ -40,16 +37,17 @@ Make every deleted Media item reachable in the nested Trash recovery surface thr
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Media Trash exposes coherent exact-total bounded pages with deterministic ordering and complete-source filtering before slicing.
-- [ ] #2 Restore and permanent delete reconcile or relocate the affected stable ID truthfully, clamp emptied pages, and never misreport a committed mutation as failed.
-- [ ] #3 Trash selection cannot remain invisibly active across page or scope changes, and stale refresh failures disable destructive actions until authoritative recovery.
-- [ ] #4 Loading, empty, failure, Retry, focus, back navigation, and narrow-terminal pager behavior match the established Library pagination convention.
-- [ ] #5 Request generations, unmount fencing, malformed envelopes, concurrent shrink, and privacy-safe diagnostics have regression coverage.
-- [ ] #6 Automated database/service/state and mounted Textual tests plus isolated live verification with more than 40 synthetic Trash records pass.
+- [x] #1 Media Trash exposes coherent exact-total bounded pages with deterministic ordering and complete-source filtering before slicing.
+- [x] #2 Restore and permanent delete reconcile or relocate the affected stable ID truthfully, clamp emptied pages, and never misreport a committed mutation as failed.
+- [x] #3 Trash selection cannot remain invisibly active across page or scope changes, and stale refresh failures disable destructive actions until authoritative recovery.
+- [x] #4 Loading, empty, failure, Retry, focus, back navigation, and narrow-terminal pager behavior match the established Library pagination convention.
+- [x] #5 Request generations, unmount fencing, malformed envelopes, concurrent shrink, and privacy-safe diagnostics have regression coverage.
+- [x] #6 Automated database/service/state and mounted Textual tests plus isolated live verification with more than 40 synthetic Trash records pass.
 <!-- AC:END -->
 
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 1. Add a coherent local-only database page/count/facet contract.
 2. Propagate and canonically validate the exact envelope through Media services.
 3. Add immutable Trash paging state plus a Trash-specific request controller.
@@ -63,3 +61,117 @@ ADR required: yes
 ADR paths: `backlog/decisions/067-library-top-level-pagination-contracts.md`, `backlog/decisions/104-library-media-return-settlement-boundary.md`
 
 Reason: ADR-067 governs exact source-owned pages and stale mutation recovery; ADR-104 records the cross-module, event-driven Media return-settlement boundary required by the production-shaped cross-reader gate.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented local Media Trash as an independent, exact-total recovery surface:
+the database owns one coherent count/page/facet snapshot; the local and scoped
+services preserve and validate the canonical envelope; immutable state and a
+Trash-only controller own filtering, generations, Retry, clamping, selection,
+and request fencing; and the mounted Library surface renders 20-row pages with
+Restore and confirmed permanent deletion through the existing Media mutation
+interlock. A committed Restore removes the Trash row immediately and marks the
+retained normal-Media page stale instead of inserting an unranked item.
+
+The production-shaped Task 7 gate exposed a separate cross-reader return race:
+same-size recomposition could retain the wrong reader presentation and clamp an
+otherwise correct Media return receipt. The ADR-104 amendment projects the
+Media presentation before layout, waits for producer-owned Resize evidence from
+the current `LibraryMediaRowScroll`, and fences settlement by route, owner,
+presentation epoch, content/layout revision, focus authority, and deadline.
+Viewer returns finish on the semantic row; Trash returns finish on the captured
+normal-Media control. Fixed callback-turn retries were rejected because they
+remained nondeterministic in fresh processes.
+
+Closeout preserved the original one-line Task 7 fake compatibility repair
+(`_library_notes_focus_intent_generation=0`). The mounted gate then revealed two
+additional stale test-fake seams, so the fake now supplies the production route-
+change disarm callback and binds the return-candidate method. The live harness
+was reviewed rather than recreated, then tightened to assert independent
+Library/Items collapse width, viewer row return, and per-size privacy/profile
+integrity. Two harness corrections were necessary: use the receipt's shipped
+`final_focus_identity` field, and exercise viewer return before Restore because
+the retained page is intentionally stale and action-gated afterward. No
+production code changed during closeout.
+
+Production and focused owners modified across the original work and ADR-104
+amendment:
+
+- `tldw_chatbook/DB/Client_Media_DB_v2.py`
+- `tldw_chatbook/Media/local_media_reading_service.py`
+- `tldw_chatbook/Media/media_reading_scope_service.py`
+- `tldw_chatbook/Library/library_media_state.py`
+- `tldw_chatbook/UI/Library_Modules/library_media_trash_browse_controller.py`
+- `tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py`
+- `tldw_chatbook/UI/Screens/library_screen.py`
+- `tldw_chatbook/Widgets/Library/library_media_trash_canvas.py`
+- `tldw_chatbook/Widgets/Library/library_media_canvas.py`
+- `Tests/DB/test_client_media_trash_pagination.py`, the focused Media/Library
+  state and controller suites, `Tests/UI/test_library_media_trash.py`,
+  `Tests/UI/test_library_media_return_settlement.py`, the existing cross-reader
+  suites, and `Tests/Live/test_library_media_trash_paging_closeout.py`
+- `Docs/User_Guide/library.md` and
+  `backlog/docs/lessons-testing-evidence.md`
+
+### Verification evidence
+
+- Pure paging/mutation gate:
+
+  ```bash
+  PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-18918-media-trash-paging /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/DB/test_client_media_trash_pagination.py Tests/Media/test_local_media_reading_service.py Tests/Media/test_media_reading_scope_service.py Tests/Library/test_library_media_trash_state.py Tests/UI/test_library_media_trash_browse_controller.py Tests/UI/test_library_media_browse_controller.py -k 'media_trash or library_media_trash or permanently_delete_media_item or mark_stale_after_trash_restore'
+  ```
+
+  Passed **108**, deselected **191**, and reported **1 warning in 4.81s**;
+  the historical count is unchanged.
+- Mounted cross-reader gate:
+
+  ```bash
+  /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_library_media_return_settlement.py Tests/UI/test_library_media_side_by_side.py Tests/UI/test_library_media_trash.py Tests/UI/test_library_adaptive_reader_shell.py Tests/UI/test_library_adaptive_reader_closeout.py --disable-warnings
+  ```
+
+  Passed **171 with 2 warnings in 233.24s**. The first run was **169 passed,
+  2 failed, 3 warnings in 239.71s** and identified only the two stale test-fake
+  seams documented above; the focused repair check passed **2 with 1 warning in
+  1.46s** before the full green rerun.
+- Five fresh exact-return runs of
+  `test_compact_media_viewer_back_survives_authoritative_recompose`:
+
+  ```bash
+  for run in 1 2 3 4 5; do PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-18918-media-trash-paging /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_library_media_side_by_side.py -k 'compact_media_viewer_back_survives_authoritative_recompose' --basetemp="/tmp/task18918-media-return-${run}"; done
+  ```
+
+  Each passed **1 / deselected 28 / 2 warnings** in **3.57s, 3.62s, 3.59s,
+  3.53s, and 3.34s**.
+- Live four-size command:
+
+  ```bash
+  PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-18918-media-trash-paging /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Live/test_library_media_trash_paging_closeout.py -s --disable-warnings
+  ```
+
+  Passed **1 with 6 warnings in 71.48s**. At **160×50, 120×35, 100×30, and
+  80×24**, every observation reported `pages=47/3`, `query=5`, `clamp=32`,
+  `delete=46`, `restore=45`, exact Trash Back, viewer row return, privacy
+  sentinels absent, and real profile/config/database bytes unchanged. The
+  160×50 layout reported expanded title/detail width after Library collapse;
+  the three compact layouts reported exclusive full width.
+- Static/inverse gate: the mounted suite included the inverse matrix. `ruff
+  check tldw_chatbook/Widgets/Library/library_media_canvas.py
+  tldw_chatbook/UI/Screens/library_screen.py
+  Tests/UI/test_library_media_return_settlement.py
+  Tests/UI/test_library_media_trash.py
+  Tests/Live/test_library_media_trash_paging_closeout.py`, `python -m
+  py_compile tldw_chatbook/Widgets/Library/library_media_canvas.py
+  tldw_chatbook/UI/Screens/library_screen.py
+  Tests/Live/test_library_media_trash_paging_closeout.py`, and `git diff
+  --check` all passed. The repository virtualenv had to be prepended to `PATH`
+  because bare `ruff` and `python` are not exposed by the login shell.
+
+### ADR check
+
+Existing ADR-067 governs the coherent exact-page and stale-recovery contract;
+existing ADR-104 governs event-driven Media return settlement. Both approved
+specs and both implementation plans remain linked in task references. No new
+ADR is required for this verification, documentation, and test-harness closeout.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
+++ b/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
@@ -23,7 +23,12 @@ references:
     Docs/superpowers/specs/2026-08-30-task-18918-library-media-trash-paging-design.md
   - >-
     Docs/superpowers/plans/2026-08-30-task-18918-library-media-trash-paging.md
+  - >-
+    Docs/superpowers/specs/2026-08-30-library-media-return-settlement-design.md
+  - >-
+    Docs/superpowers/plans/2026-08-30-library-media-return-settlement.md
   - backlog/decisions/067-library-top-level-pagination-contracts.md
+  - backlog/decisions/104-library-media-return-settlement-boundary.md
 priority: medium
 ---
 
@@ -53,8 +58,8 @@ Make every deleted Media item reachable in the nested Trash recovery surface thr
 6. Reconcile Restore and permanent deletion through the shared Media mutation owner.
 7. Run focused automated/live verification, review, documentation, and closeout.
 
-ADR required: no
+ADR required: yes
 
-ADR path: `backlog/decisions/067-library-top-level-pagination-contracts.md`
+ADR paths: `backlog/decisions/067-library-top-level-pagination-contracts.md`, `backlog/decisions/104-library-media-return-settlement-boundary.md`
 
-Reason: ADR-067 already governs exact source-owned pages and stale mutation recovery.
+Reason: ADR-067 governs exact source-owned pages and stale mutation recovery; ADR-104 records the cross-module, event-driven Media return-settlement boundary required by the production-shaped cross-reader gate.

--- a/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
+++ b/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
@@ -4,7 +4,7 @@ title: Add paged recovery viewing to Library Media Trash
 status: Done
 assignee: []
 created_date: '2026-08-15 02:51'
-updated_date: '2026-08-31 05:44'
+updated_date: '2026-08-31 14:47'
 labels:
   - library
   - pagination
@@ -89,12 +89,23 @@ Closeout preserved the original one-line Task 7 fake compatibility repair
 (`_library_notes_focus_intent_generation=0`). The mounted gate then revealed two
 additional stale test-fake seams, so the fake now supplies the production route-
 change disarm callback and binds the return-candidate method. The live harness
-was reviewed rather than recreated, then tightened to assert independent
-Library/Items collapse width, viewer row return, and per-size privacy/profile
-integrity. Two harness corrections were necessary: use the receipt's shipped
-`final_focus_identity` field, and exercise viewer return before Restore because
-the retained page is intentionally stale and action-gated afterward. No
-production code changed during closeout.
+was reviewed rather than recreated. Two initial harness corrections were
+necessary: use the receipt's shipped `final_focus_identity` field, and exercise
+viewer return before Restore because the retained page is intentionally stale
+and action-gated afterward.
+
+Quality review found five false-proof seams in that first closeout. Permanent-
+delete start/success/failure logs now emit fixed operation/status/count metadata
+and exception category only; they omit backing IDs, database paths, raw
+exceptions, and tracebacks. A real file-backed success test and a trigger-
+injected SQLite failure test cover both Loguru and stdlib logging. The live gate
+now proves every SQLite target against explicit pytest/HOME/app-scratch roots
+before open instead of reading real-profile bytes, asserts exact pane/content/
+scrollbar/row geometry rather than positive widths, starts viewer evidence from
+a distinct auto-selected row with no private pre-seed, and gives every size a
+fresh event loop with a one-worker connection owner followed by zero-handle
+DB/WAL/SHM verification. Painted-copy evidence uses Textual's public SVG
+screenshot exporter rather than the private compositor.
 
 Production and focused owners modified across the original work and ADR-104
 amendment:
@@ -109,7 +120,8 @@ amendment:
 - `tldw_chatbook/Widgets/Library/library_media_trash_canvas.py`
 - `tldw_chatbook/Widgets/Library/library_media_canvas.py`
 - `Tests/DB/test_client_media_trash_pagination.py`, the focused Media/Library
-  state and controller suites, `Tests/UI/test_library_media_trash.py`,
+  state and controller suites, `Tests/Media_DB/test_media_db_v2.py`,
+  `Tests/UI/test_library_media_trash.py`,
   `Tests/UI/test_library_media_return_settlement.py`, the existing cross-reader
   suites, and `Tests/Live/test_library_media_trash_paging_closeout.py`
 - `Docs/User_Guide/library.md` and
@@ -123,15 +135,26 @@ amendment:
   PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-18918-media-trash-paging /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/DB/test_client_media_trash_pagination.py Tests/Media/test_local_media_reading_service.py Tests/Media/test_media_reading_scope_service.py Tests/Library/test_library_media_trash_state.py Tests/UI/test_library_media_trash_browse_controller.py Tests/UI/test_library_media_browse_controller.py -k 'media_trash or library_media_trash or permanently_delete_media_item or mark_stale_after_trash_restore'
   ```
 
-  Passed **108**, deselected **191**, and reported **1 warning in 4.81s**;
+  Passed **108**, deselected **191**, and reported **1 warning in 4.84s**;
   the historical count is unchanged.
+- Focused privacy and live-evidence mutations:
+
+  ```bash
+  PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-18918-media-trash-paging /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Live/test_library_media_trash_paging_closeout.py::test_sqlite_path_authority_rejects_escape_before_open Tests/Live/test_library_media_trash_paging_closeout.py::test_reader_width_contract_rejects_one_column_mutation Tests/Live/test_library_media_trash_paging_closeout.py::test_viewer_target_contract_rejects_cleared_row_selection Tests/Media_DB/test_media_db_v2.py::test_permanent_delete_success_logs_only_fixed_metadata Tests/Media_DB/test_media_db_v2.py::test_permanent_delete_sqlite_failure_logs_category_without_private_values --disable-warnings --basetemp=/private/tmp/task18918-fast-green
+  ```
+
+  The two privacy nodes first failed against identifier/path/raw-exception
+  logging, then passed after the production fix. The combined final gate passed
+  **5 with 2 warnings in 1.93s**. Its path mutation proves rejection before the
+  fake opener runs; its geometry mutation changes one allocated column; and its
+  viewer mutation clears the row-produced selection.
 - Mounted cross-reader gate:
 
   ```bash
   /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_library_media_return_settlement.py Tests/UI/test_library_media_side_by_side.py Tests/UI/test_library_media_trash.py Tests/UI/test_library_adaptive_reader_shell.py Tests/UI/test_library_adaptive_reader_closeout.py --disable-warnings
   ```
 
-  Passed **171 with 2 warnings in 233.24s**. The first run was **169 passed,
+  Passed **171 with 2 warnings in 236.73s**. The first run was **169 passed,
   2 failed, 3 warnings in 239.71s** and identified only the two stale test-fake
   seams documented above; the focused repair check passed **2 with 1 warning in
   1.46s** before the full green rerun.
@@ -139,23 +162,28 @@ amendment:
   `test_compact_media_viewer_back_survives_authoritative_recompose`:
 
   ```bash
-  for run in 1 2 3 4 5; do PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-18918-media-trash-paging /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_library_media_side_by_side.py -k 'compact_media_viewer_back_survives_authoritative_recompose' --basetemp="/tmp/task18918-media-return-${run}"; done
+  for run in 1 2 3 4 5; do PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-18918-media-trash-paging /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/UI/test_library_media_side_by_side.py -k 'compact_media_viewer_back_survives_authoritative_recompose' --basetemp="/private/tmp/task18918-media-return-final-${run}"; done
   ```
 
-  Each passed **1 / deselected 28 / 2 warnings** in **3.57s, 3.62s, 3.59s,
-  3.53s, and 3.34s**.
+  Each passed **1 / deselected 28 / 2 warnings** in **3.52s, 3.57s, 3.56s,
+  3.53s, and 3.43s**.
 - Live four-size command:
 
   ```bash
   PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-18918-media-trash-paging /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Live/test_library_media_trash_paging_closeout.py -s --disable-warnings
   ```
 
-  Passed **1 with 6 warnings in 71.48s**. At **160×50, 120×35, 100×30, and
+  The exact command exited successfully; a concise same-file recording passed
+  **4 with 6 warnings in 71.85s** (the walkthrough plus three mutation proofs).
+  At **160×50, 120×35, 100×30, and
   80×24**, every observation reported `pages=47/3`, `query=5`, `clamp=32`,
   `delete=46`, `restore=45`, exact Trash Back, viewer row return, privacy
-  sentinels absent, and real profile/config/database bytes unchanged. The
-  160×50 layout reported expanded title/detail width after Library collapse;
-  the three compact layouts reported exclusive full width.
+  sentinels absent from the live-delete segment, all effective paths inside an
+  explicit allowed root, and zero process handles for the target DB/WAL/SHM
+  after each size. The **160×50** layout proved both optional panes plus equal
+  Items/row expansion after Library collapse (`exclusive-optional-pane`); the
+  three compact layouts proved the Items-priority allocation and independently
+  hidden Library pane (`items-priority`).
 - Static/inverse gate: the mounted suite included the inverse matrix. `ruff
   check tldw_chatbook/Widgets/Library/library_media_canvas.py
   tldw_chatbook/UI/Screens/library_screen.py

--- a/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
+++ b/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-18918
 title: Add paged recovery viewing to Library Media Trash
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-15 02:51'
+updated_date: '2026-08-30 15:43'
 labels:
   - library
   - pagination
@@ -18,6 +19,8 @@ dependencies:
 references:
   - >-
     Docs/superpowers/specs/2026-08-14-library-top-level-source-pagination-design.md
+  - >-
+    Docs/superpowers/specs/2026-08-30-task-18918-library-media-trash-paging-design.md
   - backlog/decisions/067-library-top-level-pagination-contracts.md
 priority: medium
 ---

--- a/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
+++ b/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
@@ -4,7 +4,7 @@ title: Add paged recovery viewing to Library Media Trash
 status: Done
 assignee: []
 created_date: '2026-08-15 02:51'
-updated_date: '2026-08-31 14:47'
+updated_date: '2026-08-31 15:11'
 labels:
   - library
   - pagination
@@ -107,6 +107,14 @@ fresh event loop with a one-worker connection owner followed by zero-handle
 DB/WAL/SHM verification. Painted-copy evidence uses Textual's public SVG
 screenshot exporter rather than the private compositor.
 
+The final geometry review also removed an observed-state oracle: exact sizes
+now have immutable expected postures before the app mounts. The walkthrough
+asserts **160×50** is wide before running its split/collapse-delta branch and
+asserts **120×35**, **100×30**, and **80×24** are compact before running their
+Items-priority/exclusive-optional-pane branch. Branch selection, labels, and the
+final ordered `(size, layout_contract)` aggregate all come from that fixed
+oracle, so a posture regression cannot relabel itself and pass.
+
 Production and focused owners modified across the original work and ADR-104
 amendment:
 
@@ -148,6 +156,16 @@ amendment:
   **5 with 2 warnings in 1.93s**. Its path mutation proves rejection before the
   fake opener runs; its geometry mutation changes one allocated column; and its
   viewer mutation clears the row-produced selection.
+- Fixed layout-posture oracle mutation:
+
+  ```bash
+  PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-18918-media-trash-paging /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Live/test_library_media_trash_paging_closeout.py::test_layout_posture_oracle_rejects_160_compact_before_branch --disable-warnings --basetemp=/private/tmp/task18918-layout-oracle-green
+  ```
+
+  RED failed **1 with 2 warnings in 2.05s** because a forced compact
+  observation at **160×50** did not raise and instead projected the compact
+  label. GREEN passed **1 with 2 warnings in 2.00s** after the helper asserted
+  the immutable size oracle before returning its branch contract.
 - Mounted cross-reader gate:
 
   ```bash
@@ -174,16 +192,18 @@ amendment:
   ```
 
   The exact command exited successfully; a concise same-file recording passed
-  **4 with 6 warnings in 71.85s** (the walkthrough plus three mutation proofs).
+  **5 with 6 warnings in 73.98s** (the walkthrough plus four mutation proofs).
   At **160×50, 120×35, 100×30, and
   80×24**, every observation reported `pages=47/3`, `query=5`, `clamp=32`,
   `delete=46`, `restore=45`, exact Trash Back, viewer row return, privacy
   sentinels absent from the live-delete segment, all effective paths inside an
   explicit allowed root, and zero process handles for the target DB/WAL/SHM
   after each size. The **160×50** layout proved both optional panes plus equal
-  Items/row expansion after Library collapse (`exclusive-optional-pane`); the
-  three compact layouts proved the Items-priority allocation and independently
-  hidden Library pane (`items-priority`).
+  Items/row expansion after Library collapse
+  (`split-then-library-collapse-delta`); the three compact layouts proved the
+  Items-priority allocation and independently hidden Library pane
+  (`items-priority-exclusive-optional-pane`). The final aggregate pins those
+  four `(size, layout_contract)` pairs in exact order.
 - Static/inverse gate: the mounted suite included the inverse matrix. `ruff
   check tldw_chatbook/Widgets/Library/library_media_canvas.py
   tldw_chatbook/UI/Screens/library_screen.py

--- a/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
+++ b/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
@@ -308,9 +308,31 @@ Fresh final verification after all five repairs:
   `py_compile` passed for all five changed production files; both the cumulative
   committed diff and working-tree `git diff --check` passed.
 
-TASK-18918 remains **In Progress** until the repaired cumulative branch receives
-fresh green spec and quality reviews. The executable evidence is complete; no
-task status claim is made ahead of those review gates.
+TASK-18918 subsequently received fresh green cumulative spec and quality reviews
+and was moved to **Done** after the required evidence and documentation gates.
+
+### PR #2268 review follow-up
+
+After rebasing all branch commits onto the latest `origin/dev`, the one shared
+lessons-ledger conflict was reconciled by retaining both the newer `dev` lessons
+and this task's current-owner geometry lesson. Qodo then reported three findings,
+each reproduced with a dedicated failing test before repair:
+
+- the uninitialized Trash pager now derives its fallback page size from the
+  requested `MediaTrashScope` instead of duplicating the behavioral literal;
+- database read failures log safe request coordinates, filter-presence booleans,
+  and exception category without raw query text, exception text, or traceback;
+- a schema-valid blank persisted media type no longer turns an already-committed
+  Restore into a false UI failure; the bounded retained summary normalizes it to
+  `None`, while non-string responses remain rejected.
+
+The three exact RED nodes failed for the reported reasons and passed after the
+minimal fixes. Fresh affected verification then passed **115** focused paging
+and mutation tests with **191 deselected**, **367** owner tests, **75** mounted
+Trash tests, and the **5-test** live closeout. The live walkthrough again passed
+at **160×50**, **120×35**, **100×30**, and **80×24** with exact paging, clamping,
+restore/delete, return settlement, privacy, path-authority, and zero-handle
+evidence.
 
 ### ADR check
 

--- a/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
+++ b/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
@@ -4,7 +4,7 @@ title: Add paged recovery viewing to Library Media Trash
 status: Done
 assignee: []
 created_date: '2026-08-15 02:51'
-updated_date: '2026-08-31 15:11'
+updated_date: '2026-08-31 15:41'
 labels:
   - library
   - pagination
@@ -97,8 +97,9 @@ and action-gated afterward.
 Quality review found five false-proof seams in that first closeout. Permanent-
 delete start/success/failure logs now emit fixed operation/status/count metadata
 and exception category only; they omit backing IDs, database paths, raw
-exceptions, and tracebacks. A real file-backed success test and a trigger-
-injected SQLite failure test cover both Loguru and stdlib logging. The live gate
+exceptions, and tracebacks. A real file-backed success test, a trigger-injected
+pre-FTS SQLite failure test, and a deterministic post-Media-delete FTS sink
+failure test cover both Loguru and stdlib logging. The live gate
 now proves every SQLite target against explicit pytest/HOME/app-scratch roots
 before open instead of reading real-profile bytes, asserts exact pane/content/
 scrollbar/row geometry rather than positive widths, starts viewer evidence from
@@ -114,6 +115,13 @@ asserts **120×35**, **100×30**, and **80×24** are compact before running thei
 Items-priority/exclusive-optional-pane branch. Branch selection, labels, and the
 final ordered `(size, layout_contract)` aggregate all come from that fixed
 oracle, so a posture regression cannot relabel itself and pass.
+
+The final privacy review pins both identifier-bearing historical FTS message
+forms (`Media ID 45` and `Media ID: 45`) as forbidden, positively requires the
+fixed committed/failed FTS metadata, and mutation-checks the former success line
+plus raw failure detail. The mounted walkthrough also proves a seeded first-page
+Trash row is present in Textual's public exported SVG, so painted-row evidence
+cannot be satisfied by a detached DOM node.
 
 Production and focused owners modified across the original work and ADR-104
 amendment:
@@ -156,6 +164,20 @@ amendment:
   **5 with 2 warnings in 1.93s**. Its path mutation proves rejection before the
   fake opener runs; its geometry mutation changes one allocated column; and its
   viewer mutation clears the row-produced selection.
+- Final Media FTS privacy proofs:
+
+  ```bash
+  PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-18918-media-trash-paging /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Media_DB/test_media_db_v2.py::test_permanent_delete_privacy_guard_rejects_former_fts_success_line Tests/Media_DB/test_media_db_v2.py::test_permanent_delete_success_logs_only_fixed_metadata Tests/Media_DB/test_media_db_v2.py::test_permanent_delete_sqlite_failure_logs_category_without_private_values Tests/Media_DB/test_media_db_v2.py::test_permanent_delete_fts_failure_logs_categories_without_private_values Tests/Media_DB/test_media_db_v2.py::test_permanent_delete_privacy_guard_rejects_raw_fts_failure_detail --disable-warnings --basetemp=/private/tmp/task18918-fts-privacy-final
+  ```
+
+  The former-line mutation first failed **1 with 1 warning in 0.53s** because
+  `Deleted FTS entry for Media ID 7` was not rejected. GREEN passed **5 with 1
+  warning in 0.59s** after the privacy guard pinned the no-colon form; the
+  success node requires the exact committed FTS metadata, and the injected FTS
+  node proves Media deletion has begun before the real `_delete_fts_media` sink
+  emits category-only failure metadata and the transaction rolls back. The
+  relevant `-k 'permanent_delete'` suite passed **5**, deselected **56**, and
+  reported **1 warning in 0.52s**.
 - Fixed layout-posture oracle mutation:
 
   ```bash
@@ -192,13 +214,15 @@ amendment:
   ```
 
   The exact command exited successfully; a concise same-file recording passed
-  **5 with 6 warnings in 73.98s** (the walkthrough plus four mutation proofs).
+  **5 with 6 warnings in 73.02s** (the walkthrough plus four mutation proofs).
   At **160×50, 120×35, 100×30, and
   80×24**, every observation reported `pages=47/3`, `query=5`, `clamp=32`,
   `delete=46`, `restore=45`, exact Trash Back, viewer row return, privacy
   sentinels absent from the live-delete segment, all effective paths inside an
   explicit allowed root, and zero process handles for the target DB/WAL/SHM
-  after each size. The **160×50** layout proved both optional panes plus equal
+  after each size. Textual's public SVG export also contained the visible
+  first-page `Trash 46` query sentinel at every size. The **160×50** layout
+  proved both optional panes plus equal
   Items/row expansion after Library collapse
   (`split-then-library-collapse-delta`); the three compact layouts proved the
   Items-priority allocation and independently hidden Library pane

--- a/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
+++ b/backlog/tasks/task-18918 - Add-paged-recovery-viewing-to-Library-Media-Trash.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-18918
 title: Add paged recovery viewing to Library Media Trash
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-08-15 02:51'
-updated_date: '2026-08-31 16:17'
+updated_date: '2026-08-31 17:22'
 labels:
   - library
   - pagination

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -2369,11 +2369,14 @@ class MediaDatabase:
         try:
             # Delete based on rowid, ignore if not found
             conn.execute("DELETE FROM media_fts WHERE rowid = ?", (media_id,))
-            logging.debug(f"Deleted FTS entry for Media ID {media_id}")
+            logging.debug(
+                "Media FTS mutation operation=delete status=committed count=1"
+            )
         except sqlite3.Error as e:
             logging.error(
-                f"Failed to delete from media_fts for Media ID {media_id}: {e}",
-                exc_info=True,
+                "Media FTS mutation operation=delete status=failed count=0 "
+                "category=%s",
+                type(e).__name__,
             )
             raise DatabaseError(
                 f"Failed to delete FTS for Media ID {media_id}: {e}"
@@ -9907,14 +9910,17 @@ def permanently_delete_item(db_instance: MediaDatabase, media_id: int) -> bool:
     if not isinstance(db_instance, MediaDatabase):
         raise TypeError("db_instance required.")
     logger.warning(
-        f"!!! PERMANENT DELETE initiated Media ID: {media_id} DB {db_instance.db_path_str}. NOT SYNCED !!!"
+        "Media mutation operation=permanent_delete status=started count=1"
     )
     try:
         with db_instance.transaction() as conn:
             cursor = conn.cursor()
             cursor.execute("SELECT 1 FROM Media WHERE id = ?", (media_id,))
             if not cursor.fetchone():
-                logger.warning(f"Permanent delete failed: Media {media_id} not found.")
+                logger.warning(
+                    "Media mutation operation=permanent_delete "
+                    "status=not_found count=0"
+                )
                 return False
             # Hard delete - Cascades should handle children via FKs
             cursor.execute("DELETE FROM Media WHERE id = ?", (media_id,))
@@ -9923,22 +9929,28 @@ def permanently_delete_item(db_instance: MediaDatabase, media_id: int) -> bool:
             db_instance._delete_fts_media(conn, media_id)
         if deleted_count > 0:
             logger.info(
-                f"Permanently deleted Media ID: {media_id}. NO sync log generated."
+                "Media mutation operation=permanent_delete "
+                "status=committed count=1"
             )
             return True
         else:
-            logger.error(f"Permanent delete failed unexpectedly Media {media_id}.")
+            logger.error(
+                "Media mutation operation=permanent_delete "
+                "status=no_rows count=0"
+            )
             return False
     except sqlite3.Error as e:
-        logger.opt(exception=True).error(
-            f"Error permanently deleting Media {media_id}: {e}"
+        logger.error(
+            "Media mutation operation=permanent_delete status=failed count=0 "
+            "category={}",
+            type(e).__name__,
         )
         raise DatabaseError(f"Failed permanently delete item: {e}") from e
     except Exception as e:
-        (
-            logger.opt(exception=True).error(
-                f"Unexpected error permanently deleting Media {media_id}: {e}"
-            )
+        logger.error(
+            "Media mutation operation=permanent_delete status=failed count=0 "
+            "category={}",
+            type(e).__name__,
         )
         raise DatabaseError(f"Unexpected permanent delete error: {e}") from e
 

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -9886,7 +9886,7 @@ def get_all_content_from_database(db_instance: MediaDatabase) -> List[Dict[str, 
 
 def permanently_delete_item(db_instance: MediaDatabase, media_id: int) -> bool:
     """
-    Performs a HARD delete of a media item and its related data via cascades.
+    Permanently deletes one active Trash item and its related data via cascades.
 
     **DANGER:** This operation bypasses the soft delete mechanism and the sync log.
     It physically removes the row from the `Media` table. Foreign key constraints
@@ -9901,7 +9901,7 @@ def permanently_delete_item(db_instance: MediaDatabase, media_id: int) -> bool:
         media_id (int): The ID of the Media item to permanently delete.
 
     Returns:
-        bool: True if the item was found and deleted, False otherwise.
+        bool: True if the item was in Trash and deleted, False otherwise.
 
     Raises:
         TypeError: If `db_instance` is not a Database object.
@@ -9913,18 +9913,23 @@ def permanently_delete_item(db_instance: MediaDatabase, media_id: int) -> bool:
         "Media mutation operation=permanent_delete status=started count=1"
     )
     try:
-        with db_instance.transaction() as conn:
+        with db_instance.transaction(immediate=True) as conn:
             cursor = conn.cursor()
-            cursor.execute("SELECT 1 FROM Media WHERE id = ?", (media_id,))
-            if not cursor.fetchone():
+            cursor.execute(
+                "DELETE FROM Media "
+                "WHERE id = ? AND deleted = 0 AND is_trash = 1",
+                (media_id,),
+            )
+            deleted_count = cursor.rowcount
+            if deleted_count == 0:
+                cursor.execute("SELECT 1 FROM Media WHERE id = ?", (media_id,))
+                status = "not_in_trash" if cursor.fetchone() else "not_found"
                 logger.warning(
                     "Media mutation operation=permanent_delete "
-                    "status=not_found count=0"
+                    "status={} count=0",
+                    status,
                 )
                 return False
-            # Hard delete - Cascades should handle children via FKs
-            cursor.execute("DELETE FROM Media WHERE id = ?", (media_id,))
-            deleted_count = cursor.rowcount
             # Manually delete from FTS (cascade should work, but belt-and-suspenders)
             db_instance._delete_fts_media(conn, media_id)
         if deleted_count > 0:

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -8604,7 +8604,15 @@ class MediaDatabase:
                 "types": normalized_types,
             }
         except sqlite3.Error as e:
-            logger.opt(exception=True).error("Error listing library media Trash page")
+            logger.error(
+                "Media operation failed; operation=list_library_media_trash "
+                "limit={} offset={} has_query={} has_type={} exception_type={}",
+                limit,
+                offset,
+                bool(query),
+                media_type is not None,
+                type(e).__name__,
+            )
             raise DatabaseError("Failed to list library media Trash page.") from e
 
     def search_library_media_page(

--- a/tldw_chatbook/DB/Client_Media_DB_v2.py
+++ b/tldw_chatbook/DB/Client_Media_DB_v2.py
@@ -8504,6 +8504,106 @@ class MediaDatabase:
             )
             raise DatabaseError(f"Failed to list library media page: {e}") from e
 
+    def list_library_media_trash_page(
+        self,
+        *,
+        query: str = "",
+        media_type: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> Dict[str, Any]:
+        """Return raw local Trash rows plus coherent total and complete facets.
+
+        The filtered rows and count include only active Trash records. Facets
+        instead describe every active Trash record, regardless of the current
+        query, type filter, or page. All three reads share one transaction.
+
+        Args:
+            query: Optional title substring matched literally.
+            media_type: Optional trimmed, exact case-sensitive type filter.
+            limit: Required page size, exactly 20.
+            offset: Number of matching records to skip.
+
+        Returns:
+            Dict containing narrow raw Trash ``items``, ``total``, request
+            coordinates, and complete-source ``types`` facets.
+
+        Raises:
+            ValueError: If request coordinates or filters are invalid.
+            DatabaseError: If the read cannot be completed.
+        """
+        if type(limit) is not int or limit != 20:
+            raise ValueError("Library Media Trash limit must equal 20.")
+        if type(offset) is not int or not 0 <= offset <= 2**63 - 1:
+            raise ValueError("Library Media Trash offset is invalid.")
+        if not isinstance(query, str):
+            raise ValueError("Library Media Trash query is invalid.")
+        query = query.strip()
+        if "\x00" in query or len(query) > 200:
+            raise ValueError("Library Media Trash query is invalid.")
+        if media_type is not None and not isinstance(media_type, str):
+            raise ValueError("Library Media Trash media type is invalid.")
+        media_type = media_type.strip() if media_type is not None else None
+        media_type = media_type or None
+
+        conditions = ["deleted = 0", "is_trash = 1"]
+        params: List[Any] = []
+        if query:
+            conditions.append("title LIKE ? ESCAPE '\\'")
+            params.append(f"%{self._escape_library_like(query)}%")
+        if media_type is not None:
+            conditions.append("TRIM(type) = ? COLLATE BINARY")
+            params.append(media_type)
+        where_clause = " AND ".join(conditions)
+
+        try:
+            with self.transaction() as conn:
+                total = conn.execute(
+                    f"SELECT COUNT(*) AS count FROM Media WHERE {where_clause}",
+                    tuple(params),
+                ).fetchone()["count"]
+                rows = conn.execute(
+                    f"""
+                    SELECT id, title, type, trash_date
+                    FROM Media
+                    WHERE {where_clause}
+                    ORDER BY trash_date IS NULL ASC,
+                             trash_date DESC,
+                             last_modified IS NULL ASC,
+                             last_modified DESC,
+                             id DESC
+                    LIMIT ? OFFSET ?
+                    """,
+                    tuple(params + [limit, offset]),
+                ).fetchall()
+                types = conn.execute(
+                    """
+                    SELECT DISTINCT TRIM(type) AS type
+                    FROM Media
+                    WHERE deleted = 0
+                      AND is_trash = 1
+                      AND TRIM(type) <> ''
+                    ORDER BY type COLLATE BINARY
+                    """
+                ).fetchall()
+            normalized_types = sorted(
+                {
+                    media_type_value.strip()
+                    for row in types
+                    if (media_type_value := row["type"]).strip()
+                }
+            )
+            return {
+                "items": [dict(row) for row in rows],
+                "total": total,
+                "limit": limit,
+                "offset": offset,
+                "types": normalized_types,
+            }
+        except sqlite3.Error as e:
+            logger.opt(exception=True).error("Error listing library media Trash page")
+            raise DatabaseError("Failed to list library media Trash page.") from e
+
     def search_library_media_page(
         self, *, query: str, limit: int, offset: int
     ) -> Dict[str, Any]:

--- a/tldw_chatbook/Library/library_media_state.py
+++ b/tldw_chatbook/Library/library_media_state.py
@@ -318,7 +318,7 @@ def _validate_media_trash_items(
         if trash_date is not None:
             if type(trash_date) is not str or trash_date != trash_date.strip():
                 raise TypeError("trash_date must be an ISO timestamp or None.")
-            if "T" not in trash_date:
+            if len(trash_date) <= 10 or trash_date[10] not in {"T", " "}:
                 raise ValueError("trash_date must be an ISO timestamp or None.")
             try:
                 datetime.fromisoformat(trash_date.replace("Z", "+00:00"))

--- a/tldw_chatbook/Library/library_media_state.py
+++ b/tldw_chatbook/Library/library_media_state.py
@@ -318,6 +318,8 @@ def _validate_media_trash_items(
         if trash_date is not None:
             if type(trash_date) is not str or trash_date != trash_date.strip():
                 raise TypeError("trash_date must be an ISO timestamp or None.")
+            if "T" not in trash_date:
+                raise ValueError("trash_date must be an ISO timestamp or None.")
             try:
                 datetime.fromisoformat(trash_date.replace("Z", "+00:00"))
             except ValueError as exc:
@@ -580,7 +582,7 @@ def select_media_trash_item(
         state,
         selected_id=selected_id,
         confirmation_target=None,
-        error_copy="",
+        error_copy=state.error_copy if state.failed_scope is not None else "",
     )
 
 

--- a/tldw_chatbook/Library/library_media_state.py
+++ b/tldw_chatbook/Library/library_media_state.py
@@ -7,11 +7,12 @@ import json
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from types import MappingProxyType
-from typing import Any, Mapping, Sequence
+from typing import Any, Literal, Mapping, Sequence
 
 from tldw_chatbook.Workspaces.conversation_browser_state import (
     format_console_relative_age,
 )
+from tldw_chatbook.Library.library_pager_state import PageFreshness
 
 LIBRARY_MEDIA_EMPTY_COPY = (
     "No media in your Library yet. Import something to see it here."
@@ -52,6 +53,10 @@ _MEDIA_BROWSE_SORTS = frozenset(
 _MEDIA_SUMMARY_KEYS = frozenset(
     {"id", "backing_media_id", "title", "media_type", "updated_at"}
 )
+_MEDIA_TRASH_SUMMARY_KEYS = frozenset(
+    {"id", "backing_media_id", "title", "media_type", "trash_date"}
+)
+_MEDIA_TRASH_ENVELOPE_KEYS = frozenset({"items", "total", "limit", "offset", "types"})
 
 _ID_KEYS = ("id", "media_id", "uuid")
 _TYPE_KEYS = ("type", "media_type")
@@ -229,6 +234,483 @@ def build_media_browse_result(
         total=payload["total"],
         limit=payload["limit"],
         offset=payload["offset"],
+    )
+
+
+@dataclass(frozen=True)
+class MediaTrashScope:
+    """One immutable exact-page request for the local Media Trash source."""
+
+    query: str = ""
+    media_type: str | None = None
+    page: int = 1
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.query, str):
+            raise TypeError("query must be a string.")
+        if self.media_type is not None and not isinstance(self.media_type, str):
+            raise TypeError("media_type must be a string or None.")
+        if type(self.page) is not int or self.page < 1:
+            raise ValueError("page must be a positive integer.")
+        if (self.page - 1) * LIBRARY_MEDIA_BROWSE_PAGE_SIZE > _SQLITE_INTEGER_MAX:
+            raise ValueError("page offset exceeds SQLite's integer range.")
+
+        query = self.query.strip()
+        if "\x00" in query:
+            raise ValueError("query cannot contain NUL.")
+        if len(query) > 200:
+            raise ValueError("query is limited to 200 characters.")
+        media_type = self.media_type.strip() if self.media_type is not None else None
+        object.__setattr__(self, "query", query)
+        object.__setattr__(self, "media_type", media_type or None)
+
+    @property
+    def page_size(self) -> int:
+        return LIBRARY_MEDIA_BROWSE_PAGE_SIZE
+
+    @property
+    def offset(self) -> int:
+        return (self.page - 1) * self.page_size
+
+    def with_page(self, page: int) -> "MediaTrashScope":
+        return replace(self, page=page)
+
+    def same_except_page(self, other: "MediaTrashScope") -> bool:
+        return isinstance(other, MediaTrashScope) and self.with_page(
+            1
+        ) == other.with_page(1)
+
+
+def _validate_media_trash_items(
+    items: Sequence[Mapping[str, Any]],
+) -> tuple[Mapping[str, Any], ...]:
+    if not isinstance(items, Sequence) or isinstance(items, (str, bytes, bytearray)):
+        raise TypeError("Media Trash items must be a sequence.")
+    stable_ids: set[str] = set()
+    backing_ids: set[int] = set()
+    frozen: list[Mapping[str, Any]] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            raise TypeError("Media Trash items must be mappings.")
+        if set(item) != _MEDIA_TRASH_SUMMARY_KEYS:
+            raise ValueError("Media Trash items must contain exactly five keys.")
+
+        backing_id = item["backing_media_id"]
+        if type(backing_id) is not int or backing_id < 1:
+            raise ValueError("backing_media_id must be a positive integer.")
+        stable_id = item["id"]
+        if type(stable_id) is not str or stable_id != f"local:media:{backing_id}":
+            raise ValueError("id must be the canonical backing_media_id identity.")
+        if stable_id in stable_ids or backing_id in backing_ids:
+            raise ValueError("Media Trash identities must be page-unique.")
+
+        title = item["title"]
+        if type(title) is not str or not title.strip() or title != title.strip():
+            raise ValueError("title must be non-empty trimmed text.")
+        media_type = item["media_type"]
+        if media_type is not None and (
+            type(media_type) is not str
+            or not media_type
+            or media_type != media_type.strip()
+        ):
+            raise ValueError("media_type must be trimmed non-empty text or None.")
+        trash_date = item["trash_date"]
+        if trash_date is not None:
+            if type(trash_date) is not str or trash_date != trash_date.strip():
+                raise TypeError("trash_date must be an ISO timestamp or None.")
+            try:
+                datetime.fromisoformat(trash_date.replace("Z", "+00:00"))
+            except ValueError as exc:
+                raise ValueError(
+                    "trash_date must be an ISO timestamp or None."
+                ) from exc
+
+        stable_ids.add(stable_id)
+        backing_ids.add(backing_id)
+        frozen.append(MappingProxyType(dict(item)))
+    return tuple(frozen)
+
+
+@dataclass(frozen=True)
+class MediaTrashResult:
+    """One exact immutable page returned by the local Media Trash service."""
+
+    scope: MediaTrashScope
+    items: tuple[Mapping[str, Any], ...]
+    total: int
+    limit: int
+    offset: int
+    types: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.scope, MediaTrashScope):
+            raise TypeError("scope must be a MediaTrashScope.")
+        for field_name, value, minimum in (
+            ("total", self.total, 0),
+            ("limit", self.limit, 1),
+            ("offset", self.offset, 0),
+        ):
+            if type(value) is not int or value < minimum:
+                raise ValueError(
+                    f"{field_name} must be an integer of at least {minimum}."
+                )
+        if self.limit != self.scope.page_size:
+            raise ValueError("limit must match the requested page size.")
+        if self.offset != self.scope.offset:
+            raise ValueError("offset must match the requested page offset.")
+
+        frozen_items = _validate_media_trash_items(self.items)
+        expected_count = min(self.limit, max(self.total - self.offset, 0))
+        if len(frozen_items) != expected_count:
+            raise ValueError("Media Trash item count is invalid for this page.")
+        if type(self.types) is not tuple or any(
+            type(value) is not str or not value or value != value.strip()
+            for value in self.types
+        ):
+            raise ValueError("types must be nonblank trimmed strings.")
+        if self.types != tuple(sorted(set(self.types))):
+            raise ValueError("types must be sorted and unique.")
+        object.__setattr__(self, "items", frozen_items)
+
+    @property
+    def last_page(self) -> int:
+        return max(1, (self.total + self.limit - 1) // self.limit)
+
+    @property
+    def out_of_range(self) -> bool:
+        return self.scope.page > self.last_page
+
+
+def build_media_trash_result(
+    scope: MediaTrashScope, payload: Mapping[str, Any]
+) -> MediaTrashResult:
+    """Build a fail-closed exact Trash page from the canonical envelope."""
+    if not isinstance(scope, MediaTrashScope):
+        raise TypeError("scope must be a MediaTrashScope.")
+    if not isinstance(payload, Mapping):
+        raise TypeError("Media Trash result must be a mapping.")
+    if set(payload) != _MEDIA_TRASH_ENVELOPE_KEYS:
+        raise ValueError("Media Trash result must contain exactly five keys.")
+    raw_items = payload["items"]
+    if not isinstance(raw_items, Sequence) or isinstance(
+        raw_items, (str, bytes, bytearray)
+    ):
+        raise TypeError("Media Trash items must be a sequence.")
+    raw_types = payload["types"]
+    if not isinstance(raw_types, Sequence) or isinstance(
+        raw_types, (str, bytes, bytearray)
+    ):
+        raise TypeError("Media Trash types must be a sequence.")
+    return MediaTrashResult(
+        scope=scope,
+        items=tuple(raw_items),
+        total=payload["total"],
+        limit=payload["limit"],
+        offset=payload["offset"],
+        types=tuple(raw_types),
+    )
+
+
+MediaTrashRequestOrigin = Literal[
+    "entry", "search", "type", "previous", "next", "retry", "mutation"
+]
+_MEDIA_TRASH_REQUEST_ORIGINS = frozenset(
+    {"entry", "search", "type", "previous", "next", "retry", "mutation"}
+)
+_MEDIA_TRASH_MUTATION_STALE_COPY = "List may be out of date."
+
+
+@dataclass(frozen=True)
+class MediaTrashMutationTarget:
+    """Full immutable identity captured before a Trash mutation."""
+
+    stable_id: str
+    backing_media_id: int
+    title: str
+    media_type: str | None
+    trash_date: str | None
+    page_index: int
+
+
+@dataclass(frozen=True)
+class MediaTrashBrowseState:
+    """Complete immutable state owned by the Media Trash page source."""
+
+    requested_scope: MediaTrashScope = MediaTrashScope()
+    applied_result: MediaTrashResult | None = None
+    retained_items: tuple[Mapping[str, Any], ...] = ()
+    types: tuple[str, ...] = ()
+    freshness: PageFreshness = "uninitialized"
+    loading: bool = False
+    error_copy: str = ""
+    stale_copy: str = ""
+    selected_id: str = ""
+    confirmation_target: MediaTrashMutationTarget | None = None
+    mutation_pending: bool = False
+    request_origin: MediaTrashRequestOrigin = "entry"
+    failed_scope: MediaTrashScope | None = None
+    failed_origin: MediaTrashRequestOrigin | None = None
+    committed_notice: str = ""
+
+
+def _require_media_trash_state(state: MediaTrashBrowseState) -> None:
+    if not isinstance(state, MediaTrashBrowseState):
+        raise TypeError("state must be a MediaTrashBrowseState.")
+
+
+def _require_media_trash_origin(origin: str) -> None:
+    if origin not in _MEDIA_TRASH_REQUEST_ORIGINS:
+        raise ValueError("origin is not a supported Media Trash request origin.")
+
+
+def begin_media_trash_request(
+    state: MediaTrashBrowseState,
+    scope: MediaTrashScope,
+    *,
+    origin: MediaTrashRequestOrigin,
+) -> MediaTrashBrowseState:
+    """Begin one immutable exact-page request and clear page-local selection."""
+    _require_media_trash_state(state)
+    if not isinstance(scope, MediaTrashScope):
+        raise TypeError("scope must be a MediaTrashScope.")
+    _require_media_trash_origin(origin)
+    if state.mutation_pending:
+        raise ValueError("a Media Trash mutation is still pending.")
+    return replace(
+        state,
+        requested_scope=scope,
+        loading=True,
+        error_copy="",
+        selected_id="",
+        confirmation_target=None,
+        request_origin=origin,
+        failed_scope=None,
+        failed_origin=None,
+    )
+
+
+def apply_media_trash_result(
+    state: MediaTrashBrowseState, result: MediaTrashResult
+) -> MediaTrashBrowseState:
+    """Apply one validated result for the state's current requested scope."""
+    _require_media_trash_state(state)
+    if not isinstance(result, MediaTrashResult):
+        raise TypeError("result must be a MediaTrashResult.")
+    if result.scope != state.requested_scope and not (
+        result.scope.same_except_page(state.requested_scope)
+        and result.scope.page < state.requested_scope.page
+    ):
+        raise ValueError("result scope must match the requested scope.")
+    if result.out_of_range:
+        raise ValueError("an out-of-range result cannot be applied.")
+    selected_id = (
+        str(result.items[0]["id"])
+        if state.request_origin == "entry" and result.items
+        else ""
+    )
+    return replace(
+        state,
+        applied_result=result,
+        retained_items=result.items,
+        types=result.types,
+        freshness="fresh",
+        loading=False,
+        error_copy="",
+        stale_copy="",
+        selected_id=selected_id,
+        confirmation_target=None,
+        mutation_pending=False,
+        failed_scope=None,
+        failed_origin=None,
+    )
+
+
+def fail_media_trash_request(
+    state: MediaTrashBrowseState,
+    failed_scope: MediaTrashScope,
+    *,
+    copy: str,
+) -> MediaTrashBrowseState:
+    """Record a recoverable read failure without replacing retained authority."""
+    _require_media_trash_state(state)
+    if not isinstance(failed_scope, MediaTrashScope):
+        raise TypeError("failed_scope must be a MediaTrashScope.")
+    if not isinstance(copy, str) or not copy.strip():
+        raise ValueError("copy must be non-empty text.")
+    if state.freshness == "stale" or (
+        state.applied_result is not None and failed_scope != state.requested_scope
+    ):
+        return replace(
+            state,
+            freshness="stale",
+            loading=False,
+            error_copy="",
+            stale_copy=copy.strip(),
+            confirmation_target=None,
+            failed_scope=failed_scope,
+            failed_origin=state.request_origin,
+        )
+    return replace(
+        state,
+        loading=False,
+        error_copy=copy.strip(),
+        confirmation_target=None,
+        failed_scope=failed_scope,
+        failed_origin=state.request_origin,
+    )
+
+
+def select_media_trash_item(
+    state: MediaTrashBrowseState, stable_id: str
+) -> MediaTrashBrowseState:
+    """Select one visible item only while its page metadata is authoritative."""
+    _require_media_trash_state(state)
+    if not isinstance(stable_id, str):
+        raise TypeError("stable_id must be a string.")
+    visible_ids = {str(item["id"]) for item in state.retained_items}
+    selected_id = (
+        stable_id
+        if state.freshness == "fresh"
+        and not state.loading
+        and not state.mutation_pending
+        and stable_id in visible_ids
+        else ""
+    )
+    return replace(
+        state,
+        selected_id=selected_id,
+        confirmation_target=None,
+        error_copy="",
+    )
+
+
+def _media_trash_target_for_selected(
+    state: MediaTrashBrowseState,
+) -> MediaTrashMutationTarget | None:
+    for page_index, item in enumerate(state.retained_items):
+        if item["id"] == state.selected_id:
+            return MediaTrashMutationTarget(
+                stable_id=str(item["id"]),
+                backing_media_id=int(item["backing_media_id"]),
+                title=str(item["title"]),
+                media_type=item["media_type"],
+                trash_date=item["trash_date"],
+                page_index=page_index,
+            )
+    return None
+
+
+def open_media_trash_delete_confirmation(
+    state: MediaTrashBrowseState,
+) -> MediaTrashBrowseState:
+    """Capture the full selected identity for irreversible confirmation."""
+    _require_media_trash_state(state)
+    target = (
+        _media_trash_target_for_selected(state)
+        if state.freshness == "fresh"
+        and not state.loading
+        and not state.mutation_pending
+        else None
+    )
+    return replace(state, confirmation_target=target, error_copy="")
+
+
+def cancel_media_trash_delete_confirmation(
+    state: MediaTrashBrowseState,
+) -> MediaTrashBrowseState:
+    """Close permanent-delete confirmation without changing selection."""
+    _require_media_trash_state(state)
+    return replace(state, confirmation_target=None)
+
+
+def begin_media_trash_mutation(
+    state: MediaTrashBrowseState,
+) -> MediaTrashBrowseState:
+    """Claim the currently selected fresh identity for one mutation."""
+    _require_media_trash_state(state)
+    target = _media_trash_target_for_selected(state)
+    if (
+        target is None
+        or state.freshness != "fresh"
+        or state.loading
+        or state.mutation_pending
+        or (
+            state.confirmation_target is not None
+            and state.confirmation_target != target
+        )
+    ):
+        return state
+    return replace(
+        state,
+        mutation_pending=True,
+        confirmation_target=None,
+        error_copy="",
+        failed_scope=None,
+        failed_origin=None,
+    )
+
+
+def _require_pending_media_trash_target(
+    state: MediaTrashBrowseState, target: MediaTrashMutationTarget
+) -> None:
+    if not isinstance(target, MediaTrashMutationTarget):
+        raise TypeError("target must be a MediaTrashMutationTarget.")
+    if not state.mutation_pending or _media_trash_target_for_selected(state) != target:
+        raise ValueError("target does not own the pending Media Trash mutation.")
+
+
+def fail_media_trash_mutation(
+    state: MediaTrashBrowseState,
+    target: MediaTrashMutationTarget,
+    *,
+    copy: str,
+) -> MediaTrashBrowseState:
+    """Release a pre-commit failure while retaining the authoritative row."""
+    _require_media_trash_state(state)
+    _require_pending_media_trash_target(state, target)
+    if not isinstance(copy, str) or not copy.strip():
+        raise ValueError("copy must be non-empty text.")
+    return replace(
+        state,
+        mutation_pending=False,
+        error_copy=copy.strip(),
+        confirmation_target=None,
+    )
+
+
+def commit_media_trash_mutation(
+    state: MediaTrashBrowseState,
+    target: MediaTrashMutationTarget,
+    *,
+    notice: str,
+) -> MediaTrashBrowseState:
+    """Reconcile a committed removal and withdraw exact page authority."""
+    _require_media_trash_state(state)
+    _require_pending_media_trash_target(state, target)
+    if not isinstance(notice, str) or not notice.strip():
+        raise ValueError("notice must be non-empty text.")
+    refresh_scope = (
+        state.applied_result.scope
+        if state.applied_result is not None
+        else state.requested_scope
+    )
+    return replace(
+        state,
+        requested_scope=refresh_scope,
+        retained_items=tuple(
+            item for item in state.retained_items if item["id"] != target.stable_id
+        ),
+        freshness="stale",
+        loading=True,
+        error_copy="",
+        stale_copy=_MEDIA_TRASH_MUTATION_STALE_COPY,
+        selected_id="",
+        confirmation_target=None,
+        mutation_pending=False,
+        request_origin="mutation",
+        failed_scope=None,
+        failed_origin=None,
+        committed_notice=notice.strip(),
     )
 
 

--- a/tldw_chatbook/Media/local_media_reading_service.py
+++ b/tldw_chatbook/Media/local_media_reading_service.py
@@ -683,17 +683,10 @@ class LocalMediaReadingService:
 
         db = self._require_db()
         normalized_media_id = self._coerce_media_id(media_id)
-        current = db.get_media_by_id(normalized_media_id, include_trash=True)
-        if current is None:
-            raise KeyError(f"Local media item not found: {media_id}")
-        if not current.get("is_trash"):
-            raise ValueError(
-                "Local media item must be in trash before permanent deletion."
-            )
         deleted = permanently_delete_item(db, normalized_media_id)
         if not deleted:
             raise ValueError(
-                f"Local media item could not be permanently deleted: {media_id}"
+                "Local media item must exist in trash before permanent deletion."
             )
         return {"ok": True, "media_id": normalized_media_id}
 

--- a/tldw_chatbook/Media/local_media_reading_service.py
+++ b/tldw_chatbook/Media/local_media_reading_service.py
@@ -171,6 +171,22 @@ class LocalMediaReadingService:
             "limit": limit,
         }
 
+    def list_library_media_trash(
+        self,
+        *,
+        query: str = "",
+        media_type: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Page local trashed media using the canonical library envelope."""
+        return self._require_db().list_library_media_trash_page(
+            query=query,
+            media_type=media_type,
+            limit=limit,
+            offset=offset,
+        )
+
     def get_library_media_text(
         self, media_uuid: str, *, start: int = 0, max_chars: int = 8000
     ) -> Optional[dict[str, Any]]:

--- a/tldw_chatbook/Media/media_reading_scope_service.py
+++ b/tldw_chatbook/Media/media_reading_scope_service.py
@@ -508,6 +508,19 @@ class MediaReadingScopeService:
             "updated_at": record.get("last_modified"),
         }
 
+    @staticmethod
+    def _normalize_local_library_trash_summary(
+        item: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        backing_id = item["id"]
+        return {
+            "id": f"local:media:{backing_id}",
+            "backing_media_id": backing_id,
+            "title": str(item.get("title") or "Untitled"),
+            "media_type": str(item["type"]).strip() if item.get("type") else None,
+            "trash_date": str(item["trash_date"]) if item.get("trash_date") else None,
+        }
+
     def _resolve_backing_media_id(
         self,
         *,
@@ -2416,6 +2429,49 @@ class MediaReadingScopeService:
                 )
             )
         )
+
+    async def list_library_media_trash(
+        self,
+        *,
+        mode: MediaReadingBackend | str | None = None,
+        query: str = "",
+        media_type: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """List local trashed media using the canonical library envelope."""
+        normalized_mode = self._normalize_mode(mode)
+        if normalized_mode != MediaReadingBackend.LOCAL:
+            raise ValueError("Library Media Trash requires local mode.")
+        self._enforce_policy(
+            self._media_item_subresource_action_id(normalized_mode, "trash", "list")
+        )
+        service = self._service_for_mode(normalized_mode)
+        payload = await self._call_local_leaf(
+            normalized_mode,
+            service,
+            "list_library_media_trash",
+            query=query,
+            media_type=media_type,
+            limit=limit,
+            offset=offset,
+        )
+        if not isinstance(payload, Mapping):
+            return payload
+        result = {
+            key: payload[key]
+            for key in ("items", "total", "limit", "offset", "types")
+            if key in payload
+        }
+        raw_items = result.get("items")
+        if isinstance(raw_items, list):
+            result["items"] = [
+                self._normalize_local_library_trash_summary(item)
+                if isinstance(item, Mapping)
+                else item
+                for item in raw_items
+            ]
+        return result
 
     async def empty_media_trash(
         self, *, mode: MediaReadingBackend | str | None = None

--- a/tldw_chatbook/Media/media_reading_scope_service.py
+++ b/tldw_chatbook/Media/media_reading_scope_service.py
@@ -516,7 +516,7 @@ class MediaReadingScopeService:
         return {
             "id": f"local:media:{backing_id}",
             "backing_media_id": backing_id,
-            "title": str(item.get("title") or "Untitled"),
+            "title": str(item.get("title") or "").strip() or "Untitled",
             "media_type": str(item["type"]).strip() if item.get("type") else None,
             "trash_date": str(item["trash_date"]) if item.get("trash_date") else None,
         }

--- a/tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py
@@ -253,6 +253,16 @@ class LibraryMediaBrowseController:
         self.invalidate(scope)
         return scope
 
+    def mark_stale_after_trash_restore(self) -> None:
+        """Retain the current exact Media page but withdraw its authority."""
+        if self.applied_result is None:
+            return
+        self.freshness = "stale"
+        self.loading = False
+        self.inflight_scope = None
+        self.error_copy = ""
+        self.stale_copy = _MUTATION_COPY
+
     def reconcile_committed_mutation(
         self,
         *,

--- a/tldw_chatbook/UI/Library_Modules/library_media_trash_browse_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_media_trash_browse_controller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any
 
 from loguru import logger
@@ -34,6 +35,14 @@ _WORKER_GROUP = "library-media-trash-browse"
 _SERVICE_ERROR = "Could not load Trash."
 _SHRINK_COPY = "Source changed again; try again."
 _STALE_COPY = "List may be out of date."
+
+
+@dataclass(frozen=True)
+class MediaTrashMutationClaim:
+    """One immutable mutation target bound to its claiming lifecycle."""
+
+    target: MediaTrashMutationTarget
+    generation: int
 
 
 class LibraryMediaTrashBrowseController:
@@ -240,7 +249,7 @@ class LibraryMediaTrashBrowseController:
         self.state = cancel_media_trash_delete_confirmation(self.state)
         self._publish(generation, None)
 
-    def claim_mutation(self) -> MediaTrashMutationTarget | None:
+    def claim_mutation(self) -> MediaTrashMutationClaim | None:
         """Fence reads and claim the currently selected fresh target."""
         if not self._request_is_active():
             return None
@@ -255,30 +264,44 @@ class LibraryMediaTrashBrowseController:
         generation = self._generation
         self.state = next_state
         self._publish(generation, None)
-        return target
+        return MediaTrashMutationClaim(target=target, generation=generation)
+
+    def _claim_is_current(self, claim: MediaTrashMutationClaim) -> bool:
+        return (
+            isinstance(claim, MediaTrashMutationClaim)
+            and claim.generation == self._generation
+            and self._current(claim.generation)
+        )
 
     def finish_mutation_failure(
-        self, target: MediaTrashMutationTarget, copy: str
-    ) -> None:
+        self, claim: MediaTrashMutationClaim, copy: str
+    ) -> bool:
         """Publish a recoverable pre-commit mutation failure."""
-        generation = self._generation
-        if not self._current(generation):
-            return
-        self.state = fail_media_trash_mutation(self.state, target, copy=copy)
-        self._publish(generation, None)
+        if not self._claim_is_current(claim):
+            return False
+        self.state = fail_media_trash_mutation(self.state, claim.target, copy=copy)
+        return self._publish(claim.generation, None)
 
     def finish_mutation_commit(
-        self, target: MediaTrashMutationTarget, notice: str
-    ) -> None:
+        self, claim: MediaTrashMutationClaim, notice: str
+    ) -> bool:
         """Publish a committed removal as stale before authoritative refresh."""
-        generation = self._generation
-        if not self._current(generation):
-            return
-        self.state = commit_media_trash_mutation(self.state, target, notice=notice)
-        self._publish(generation, None)
+        if not self._claim_is_current(claim):
+            return False
+        self.state = commit_media_trash_mutation(
+            self.state, claim.target, notice=notice
+        )
+        return self._publish(claim.generation, None)
 
-    def request_after_mutation(self, *, focus_identity: str | None) -> Any | None:
+    def request_after_mutation(
+        self,
+        claim: MediaTrashMutationClaim | None = None,
+        *,
+        focus_identity: str | None,
+    ) -> Any | None:
         """Refresh the applied page after a committed mutation."""
+        if claim is None or not self._claim_is_current(claim):
+            return None
         scope = (
             self.state.applied_result.scope
             if self.state.applied_result is not None

--- a/tldw_chatbook/UI/Library_Modules/library_media_trash_browse_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_media_trash_browse_controller.py
@@ -81,7 +81,11 @@ class LibraryMediaTrashBrowseController:
         return build_library_pager_display(
             applied_page=applied.scope.page if applied is not None else None,
             requested_page=requested_page,
-            page_size=applied.limit if applied is not None else 20,
+            page_size=(
+                applied.limit
+                if applied is not None
+                else self.state.requested_scope.page_size
+            ),
             row_count=len(self.state.retained_items),
             total=(
                 applied.total

--- a/tldw_chatbook/UI/Library_Modules/library_media_trash_browse_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_media_trash_browse_controller.py
@@ -1,0 +1,292 @@
+"""Source-owned orchestration for exact local Media Trash pages."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from loguru import logger
+
+from ...Library.library_media_state import (
+    MediaTrashBrowseState,
+    MediaTrashMutationTarget,
+    MediaTrashRequestOrigin,
+    MediaTrashResult,
+    MediaTrashScope,
+    apply_media_trash_result,
+    begin_media_trash_mutation,
+    begin_media_trash_request,
+    build_media_trash_result,
+    cancel_media_trash_delete_confirmation,
+    commit_media_trash_mutation,
+    fail_media_trash_mutation,
+    fail_media_trash_request,
+    open_media_trash_delete_confirmation,
+    select_media_trash_item,
+)
+from ...Library.library_pager_state import (
+    LibraryPagerDisplay,
+    build_library_pager_display,
+)
+
+_WORKER_GROUP = "library-media-trash-browse"
+_SERVICE_ERROR = "Could not load Trash."
+_SHRINK_COPY = "Source changed again; try again."
+_STALE_COPY = "List may be out of date."
+
+
+class LibraryMediaTrashBrowseController:
+    """Own one immutable Trash state plus request-generation worker handles."""
+
+    def __init__(
+        self,
+        *,
+        screen: Any,
+        run_service_call: Callable[[], Callable[..., Awaitable[Any]]],
+        media_service: Callable[[], Any],
+        sync_view: Callable[[], Callable[[str | None], None]],
+        request_is_active: Callable[[], bool],
+    ) -> None:
+        self._screen = screen
+        self._run_service_call = run_service_call
+        self._media_service = media_service
+        self._sync_view = sync_view
+        self._request_is_active = request_is_active
+        self._generation = 0
+        self.state = MediaTrashBrowseState()
+
+    @property
+    def _run_worker(self) -> Callable[..., Any]:
+        return self._screen.run_worker
+
+    @property
+    def pager(self) -> LibraryPagerDisplay:
+        """Derive the complete pager display from immutable source state."""
+        applied = self.state.applied_result
+        requested_page = (
+            self.state.requested_scope.page
+            if self.state.loading or self.state.error_copy or applied is None
+            else applied.scope.page
+        )
+        return build_library_pager_display(
+            applied_page=applied.scope.page if applied is not None else None,
+            requested_page=requested_page,
+            page_size=applied.limit if applied is not None else 20,
+            row_count=len(self.state.retained_items),
+            total=(
+                applied.total
+                if applied is not None and self.state.freshness == "fresh"
+                else None
+            ),
+            freshness=self.state.freshness,
+            loading=self.state.loading,
+            error_copy=self.state.error_copy,
+            stale_copy=self.state.stale_copy,
+        )
+
+    def _current(self, generation: int) -> bool:
+        return generation == self._generation and self._request_is_active()
+
+    def _publish(self, generation: int, focus_identity: str | None) -> bool:
+        if not self._current(generation):
+            return False
+        self._sync_view()(focus_identity)
+        return True
+
+    def request(
+        self,
+        scope: MediaTrashScope,
+        *,
+        origin: MediaTrashRequestOrigin,
+        focus_identity: str | None,
+    ) -> Any | None:
+        """Dispatch one exact local Trash request for the active route."""
+        next_state = begin_media_trash_request(self.state, scope, origin=origin)
+        if not self._request_is_active():
+            return None
+        self._generation += 1
+        generation = self._generation
+        self.state = next_state
+        if not self._publish(generation, focus_identity):
+            return None
+        return self._run_worker(
+            self._load(
+                scope,
+                generation=generation,
+                focus_identity=focus_identity,
+            ),
+            exclusive=True,
+            group=_WORKER_GROUP,
+        )
+
+    def retry(self, *, focus_identity: str | None) -> Any | None:
+        """Repeat the exact failed target with its original focus authority."""
+        scope = self.state.failed_scope or self.state.requested_scope
+        origin = self.state.failed_origin or "retry"
+        return self.request(scope, origin=origin, focus_identity=focus_identity)
+
+    async def _list(self, scope: MediaTrashScope) -> MediaTrashResult:
+        service = self._media_service()
+        list_trash = getattr(service, "list_library_media_trash", None)
+        if not callable(list_trash):
+            raise RuntimeError("Media Trash service unavailable")
+        payload = await self._run_service_call()(
+            list_trash,
+            mode="local",
+            query=scope.query,
+            media_type=scope.media_type,
+            limit=scope.page_size,
+            offset=scope.offset,
+            isolate_in_worker=True,
+        )
+        return build_media_trash_result(scope, payload)
+
+    async def _load(
+        self,
+        scope: MediaTrashScope,
+        *,
+        generation: int,
+        focus_identity: str | None,
+    ) -> None:
+        fetched_scope = scope
+        clamped = False
+        try:
+            while True:
+                result = await self._list(fetched_scope)
+                if not self._current(generation):
+                    return
+                if not result.out_of_range:
+                    self.state = apply_media_trash_result(self.state, result)
+                    self._publish(generation, focus_identity)
+                    return
+                if clamped:
+                    self.state = fail_media_trash_request(
+                        self.state,
+                        fetched_scope,
+                        copy=_SHRINK_COPY,
+                    )
+                    self._publish(generation, focus_identity)
+                    return
+                clamped = True
+                fetched_scope = scope.with_page(result.last_page)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            if not self._current(generation):
+                return
+            logger.warning(
+                "Library Media Trash browse failed; "
+                "operation=list_library_media_trash page={} page_size={} "
+                "has_query={} has_type={} exception_type={}",
+                fetched_scope.page,
+                fetched_scope.page_size,
+                bool(fetched_scope.query),
+                fetched_scope.media_type is not None,
+                type(exc).__name__,
+            )
+            copy = (
+                _SHRINK_COPY
+                if clamped
+                else _STALE_COPY
+                if self.state.freshness == "stale"
+                else self._failure_copy(scope)
+            )
+            self.state = fail_media_trash_request(
+                self.state,
+                fetched_scope if clamped else scope,
+                copy=copy,
+            )
+            self._publish(generation, focus_identity)
+
+    def _failure_copy(self, failed_scope: MediaTrashScope) -> str:
+        applied = self.state.applied_result
+        if applied is None:
+            return _SERVICE_ERROR
+        if failed_scope.same_except_page(applied.scope):
+            return (
+                f"Page {failed_scope.page} not loaded — "
+                f"showing page {applied.scope.page}."
+            )
+        previous = (
+            "All Trash"
+            if not applied.scope.query and applied.scope.media_type is None
+            else "previous results"
+        )
+        return f"Filter not applied — showing {previous}."
+
+    def select(self, stable_id: str) -> None:
+        """Select one visible fresh Trash identity."""
+        generation = self._generation
+        if not self._current(generation):
+            return
+        self.state = select_media_trash_item(self.state, stable_id)
+        self._publish(generation, None)
+
+    def open_delete_confirmation(self) -> MediaTrashMutationTarget | None:
+        """Capture and expose the selected permanent-delete target."""
+        generation = self._generation
+        if not self._current(generation):
+            return None
+        self.state = open_media_trash_delete_confirmation(self.state)
+        self._publish(generation, None)
+        return self.state.confirmation_target
+
+    def cancel_delete_confirmation(self) -> None:
+        """Dismiss permanent-delete confirmation without changing selection."""
+        generation = self._generation
+        if not self._current(generation):
+            return
+        self.state = cancel_media_trash_delete_confirmation(self.state)
+        self._publish(generation, None)
+
+    def claim_mutation(self) -> MediaTrashMutationTarget | None:
+        """Fence reads and claim the currently selected fresh target."""
+        if not self._request_is_active():
+            return None
+        target = self.state.confirmation_target
+        if target is None:
+            candidate = open_media_trash_delete_confirmation(self.state)
+            target = candidate.confirmation_target
+        next_state = begin_media_trash_mutation(self.state)
+        if target is None or next_state is self.state:
+            return None
+        self._generation += 1
+        generation = self._generation
+        self.state = next_state
+        self._publish(generation, None)
+        return target
+
+    def finish_mutation_failure(
+        self, target: MediaTrashMutationTarget, copy: str
+    ) -> None:
+        """Publish a recoverable pre-commit mutation failure."""
+        generation = self._generation
+        if not self._current(generation):
+            return
+        self.state = fail_media_trash_mutation(self.state, target, copy=copy)
+        self._publish(generation, None)
+
+    def finish_mutation_commit(
+        self, target: MediaTrashMutationTarget, notice: str
+    ) -> None:
+        """Publish a committed removal as stale before authoritative refresh."""
+        generation = self._generation
+        if not self._current(generation):
+            return
+        self.state = commit_media_trash_mutation(self.state, target, notice=notice)
+        self._publish(generation, None)
+
+    def request_after_mutation(self, *, focus_identity: str | None) -> Any | None:
+        """Refresh the applied page after a committed mutation."""
+        scope = (
+            self.state.applied_result.scope
+            if self.state.applied_result is not None
+            else self.state.requested_scope
+        )
+        return self.request(scope, origin="mutation", focus_identity=focus_identity)
+
+    def invalidate(self) -> int:
+        """Fence every outstanding local read without publishing route state."""
+        self._generation += 1
+        return self._generation

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -191,6 +191,9 @@ from ...Library.library_media_state import (
     LibraryMediaCanvasState,
     LibraryMediaTrashState,
     MediaBrowseScope,
+    MediaTrashBrowseState,
+    MediaTrashMutationTarget,
+    MediaTrashScope,
     build_library_media_browse_state,
     build_library_media_state,
     build_library_media_trash_state,
@@ -585,6 +588,9 @@ from ..Library_Modules import (
 from ..Library_Modules.library_media_browse_controller import (
     LibraryMediaBrowseController,
 )
+from ..Library_Modules.library_media_trash_browse_controller import (
+    LibraryMediaTrashBrowseController,
+)
 from ..Library_Modules.library_collections_browse_controller import (
     LibraryCollectionsBrowseController,
 )
@@ -753,12 +759,6 @@ LIBRARY_SOURCE_PAGE_SIZES = {
     "media": 50,
     "conversations": LIBRARY_CONVERSATION_PAGE_SIZE,
 }
-# task-4025: one fetch page for the media Trash view. Deliberately larger
-# than the media list's snapshot page (trash is browsed rarely and only to
-# recover something); when the trash genuinely exceeds it, the view says so
-# honestly ("showing X of N") rather than pretending the page is the whole
-# trash.
-LIBRARY_MEDIA_TRASH_PAGE_SIZE = 200
 LIBRARY_MEDIA_PREVIEW_CACHE_LIMIT = 20
 _LIBRARY_PROMPTS_SEARCH_DEBOUNCE_SECONDS = 0.25
 # Skills sort modes (Task 3 of the Skills sub-project): "name" (pure
@@ -1029,6 +1029,15 @@ class _LibraryEntryFocusCapture:
     outgoing_focus: Widget
     route_key: tuple[object, ...]
     notes_identity: LibraryNotesFocusIdentity | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class _LibraryMediaTrashReturn:
+    """Normal-Media list identity preserved across an independent Trash visit."""
+
+    stable_id: str
+    scroll_offset: tuple[int, int] | None
+    focus_identity: str
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1919,7 +1928,6 @@ def _sync_library_canvas(
                 "#library-media-trash-canvas", LibraryMediaTrashCanvas
             )
             new_state = screen._build_library_media_trash_state()
-            screen._selected_media_trash_id = new_state.selected_id
             sync_args = (new_state,)
         elif kind == "notes":
             canvas = screen.query_one("#library-notes-canvas", LibraryNotesCanvas)
@@ -3748,19 +3756,13 @@ class LibraryScreen(BaseAppScreen):
         # task-14902: True while the media type chooser's direct-pick strip
         # replaces the browse toolbar row (the Notes Sort strip pattern).
         self._library_media_type_choices_visible: bool = False
-        # task-4025: the Trash view's own fetch/session state. ``None``
-        # records mean the fetch has not landed yet (the view renders
-        # "Loading Trash…"); the tuple is the ``list_media_trash`` page in
-        # the seam's own trash_date-DESC order. All of it is reset on
-        # every entry/exit so a stale page can never masquerade as fresh.
-        self._library_media_trash_records: tuple[Mapping[str, Any], ...] | None = None
-        self._library_media_trash_total: int = 0
-        self._library_media_trash_error: str = ""
-        # Restore feedback line ("Restored 'Title'.") -- feedback, never a
-        # receipt: ADR-055's receipts accompany destruction, and restore
-        # is recovery, so it gets no Undo affordance.
-        self._library_media_trash_notice: str = ""
-        self._selected_media_trash_id: str = ""
+        # Trash owns an independent source scope. Draft and semantic focus
+        # remain screen concerns because Task 5 renders their controls; page
+        # authority lives exclusively in ``_library_media_trash_browse_controller``.
+        self._library_media_trash_query_draft: str = ""
+        self._library_media_trash_input_error: str = ""
+        self._library_media_trash_type_choices_visible: bool = False
+        self._library_media_trash_focus_identity: str = "#library-media-trash-row-0"
         self._library_media_detail: Mapping[str, Any] | None = None
         # task-15458: the exact detail object the last viewer compose rendered,
         # compared by IDENTITY. ``_refresh_library_media_detail``'s arrival
@@ -3980,6 +3982,18 @@ class LibraryScreen(BaseAppScreen):
             sync_view=lambda: self._sync_library_media_browse_state,
             request_is_active=lambda: (
                 self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
+            ),
+        )
+        self._library_media_trash_browse_controller = LibraryMediaTrashBrowseController(
+            screen=self,
+            run_service_call=lambda: self._run_library_service_call,
+            media_service=lambda: getattr(
+                self.app_instance, "media_reading_scope_service", None
+            ),
+            sync_view=lambda: self._sync_library_media_trash_state,
+            request_is_active=lambda: (
+                self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
+                and self._library_media_view == "trash"
             ),
         )
         self._library_collections_browse_controller = (
@@ -4537,6 +4551,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_viewer_return: tuple[str, tuple[int, int] | None] | None = (
             None
         )
+        self._library_media_trash_return: _LibraryMediaTrashReturn | None = None
         # task-2856 review (PR #1410, Qodo): the settle-window timer
         # ``_arm_library_list_entry_focus`` schedules used to be fire-and-
         # forget -- the ``Timer`` ``set_timer`` returns was never kept, so
@@ -5187,7 +5202,9 @@ class LibraryScreen(BaseAppScreen):
         """Resolve one retained Notes authority's mounted subtree."""
         if authority == "files":
             workspace = self._library_file_notes_workspace
-            return workspace if workspace is not None and workspace.is_attached else None
+            return (
+                workspace if workspace is not None and workspace.is_attached else None
+            )
         try:
             return self.query_one(
                 "#library-notes-reader-shell", LibraryAdaptiveReaderShell
@@ -5229,7 +5246,9 @@ class LibraryScreen(BaseAppScreen):
         """Restore the destination's reachable focus or its honest first target."""
         target = self._library_notes_authority_focus[authority]
         if target is not None and (
-            not target.is_attached or not target.visible or target not in self.focus_chain
+            not target.is_attached
+            or not target.visible
+            or target not in self.focus_chain
         ):
             target = None
         if target is None:
@@ -7459,7 +7478,11 @@ class LibraryScreen(BaseAppScreen):
     ) -> str:
         if pane == "library":
             return "library"
-        return "notes_file_items" if destination == "notes_files" else f"{destination}_items"
+        return (
+            "notes_file_items"
+            if destination == "notes_files"
+            else f"{destination}_items"
+        )
 
     def _claim_library_reader_persistence(
         self,
@@ -7580,10 +7603,14 @@ class LibraryScreen(BaseAppScreen):
             "prompts": self._library_prompts_reader_persistence_locks,
             "skills": self._library_skills_reader_persistence_locks,
         }[destination]
-        section = "library.reader" if pane == "library" else (
-            "library.notes_reader"
-            if destination == "notes_files"
-            else f"library.{destination}_reader"
+        section = (
+            "library.reader"
+            if pane == "library"
+            else (
+                "library.notes_reader"
+                if destination == "notes_files"
+                else f"library.{destination}_reader"
+            )
         )
         config_key = (
             "library_open"
@@ -9528,9 +9555,7 @@ class LibraryScreen(BaseAppScreen):
         self._register_footer_shortcuts()
         self.call_after_refresh(self._sync_library_media_reader_layout_from_shell)
         self.call_after_refresh(self._sync_library_ordinary_rail_width_contract)
-        self.call_after_refresh(
-            self._present_library_skills_import_choice_if_needed
-        )
+        self.call_after_refresh(self._present_library_skills_import_choice_if_needed)
         if (
             self._library_new_profile_admission
             and not self._library_lifecycle_was_stored
@@ -9563,6 +9588,21 @@ class LibraryScreen(BaseAppScreen):
                 focus_identity=None,
             )
             self._request_library_media_facets()
+        if (
+            self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
+            and self._library_media_view == "trash"
+            and self._pending_library_source_open is None
+        ):
+            self._library_media_trash_query_draft = ""
+            self._library_media_trash_input_error = ""
+            self._library_media_trash_type_choices_visible = False
+            self._library_media_trash_browse_controller.invalidate()
+            self._library_media_trash_browse_controller.state = MediaTrashBrowseState()
+            self._library_media_trash_browse_controller.request(
+                MediaTrashScope(),
+                origin="entry",
+                focus_identity="#library-media-trash-row-0",
+            )
         self._refresh_local_source_snapshot()
         if (
             self._library_selected_row_id == LIBRARY_ROW_BROWSE_NOTES
@@ -9723,6 +9763,7 @@ class LibraryScreen(BaseAppScreen):
         self._invalidate_library_prompt_detail_generation()
         self._library_media_lifecycle_generation += 1
         self._library_media_browse_controller.invalidate()
+        self._library_media_trash_browse_controller.invalidate()
         self._library_collections_browse_controller.invalidate()
         lifecycle_worker = self._library_lifecycle_persist_worker
         if lifecycle_worker is not None and not lifecycle_worker.is_finished:
@@ -12478,7 +12519,9 @@ class LibraryScreen(BaseAppScreen):
 
     async def _apply_library_media_list_return(
         self,
-        media_return: tuple[str, tuple[int, int] | None] | None,
+        media_return: (
+            tuple[str, tuple[int, int] | None] | _LibraryMediaTrashReturn | None
+        ),
     ) -> None:
         """Project the viewer-to-list return and arm the list entry focus.
 
@@ -12494,12 +12537,58 @@ class LibraryScreen(BaseAppScreen):
             or self._library_media_view == "trash"
         ):
             return
-        # Items remain mounted in the Reader shell, so the arm can run in
-        # this continuation; its own after-refresh focus attempt observes
-        # the already-laid-out list without an extra scheduling race.
+        await self._apply_library_open_item_surface(
+            self._build_library_media_active_child,
+            then=partial(self._finish_library_media_list_return, media_return),
+        )
+
+    def _finish_library_media_list_return(
+        self,
+        media_return: (
+            tuple[str, tuple[int, int] | None] | _LibraryMediaTrashReturn | None
+        ),
+    ) -> None:
+        """Arm row/scroll/focus only after the normal Media child is mounted."""
+        if (
+            self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
+            or self._library_media_view != "list"
+        ):
+            return
         self._register_footer_shortcuts()
-        self._sync_library_media_viewer_or_recompose()
-        self._arm_library_list_entry_focus(media_return=media_return)
+        viewer = self._mounted_library_media_viewer()
+        if viewer is not None:
+            self._sync_library_media_viewer_state(viewer)
+        trash_return = (
+            media_return if isinstance(media_return, _LibraryMediaTrashReturn) else None
+        )
+        row_return = (
+            (trash_return.stable_id, trash_return.scroll_offset)
+            if trash_return is not None
+            else media_return
+        )
+        self._arm_library_list_entry_focus(media_return=row_return)
+        if trash_return is not None:
+            self.call_after_refresh(
+                self._restore_library_media_trash_return_focus,
+                trash_return,
+                self._library_list_entry_focus_generation,
+            )
+
+    def _restore_library_media_trash_return_focus(
+        self,
+        receipt: _LibraryMediaTrashReturn,
+        generation: int,
+    ) -> None:
+        """Restore toolbar focus after the guarded row/scroll return lands."""
+        if (
+            self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
+            or self._library_media_view != "list"
+            or generation != self._library_list_entry_focus_generation
+        ):
+            return
+        self._focus_library_list_entry_if_current(generation)
+        self._disarm_library_list_entry_focus()
+        self._focus_library_control(f"#{receipt.focus_identity}")
 
     async def _reconcile_library_entry_state(
         self, generation: int, route_key: tuple[object, ...]
@@ -15049,7 +15138,6 @@ class LibraryScreen(BaseAppScreen):
                         # compose branch and the updater own the same
                         # conditionals via the one shared state builder).
                         trash_state = self._build_library_media_trash_state()
-                        self._selected_media_trash_id = trash_state.selected_id
                         yield LibraryMediaTrashCanvas(
                             trash_state,
                             id="library-media-trash-canvas",
@@ -16901,14 +16989,88 @@ class LibraryScreen(BaseAppScreen):
         )
 
     def _build_library_media_trash_state(self) -> LibraryMediaTrashState:
-        """Build the media Trash view display state (task-4025)."""
-        return build_library_media_trash_state(
-            self._library_media_trash_records,
-            total=self._library_media_trash_total,
-            selected_id=self._selected_media_trash_id,
-            error=self._library_media_trash_error,
-            notice=self._library_media_trash_notice,
+        """Adapt the controller-owned exact page to the pre-Task-5 canvas."""
+        state = self._library_media_trash_browse_controller.state
+        applied = state.applied_result
+        records: tuple[Mapping[str, Any], ...] | None = state.retained_items
+        if applied is None and state.loading:
+            records = None
+        total = (
+            applied.total
+            if applied is not None and state.freshness == "fresh"
+            else len(state.retained_items)
         )
+        error = self._library_media_trash_input_error
+        if not error:
+            error = state.error_copy or state.stale_copy
+            if error:
+                error = f"{error.rstrip('.')} · Retry"
+        presentation = build_library_media_trash_state(
+            records,
+            total=total,
+            selected_id=state.selected_id,
+            loading=state.loading,
+            error=error,
+            notice=state.committed_notice,
+        )
+        if not state.selected_id and presentation.selected_id:
+            presentation = dataclasses.replace(
+                presentation,
+                rows=tuple(
+                    dataclasses.replace(row, selected=False)
+                    for row in presentation.rows
+                ),
+                selected_id="",
+            )
+        return presentation
+
+    def _sync_library_media_trash_state(self, focus_identity: str | None) -> None:
+        """Publish one current Trash state without remounting another route."""
+        if (
+            self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
+            or self._library_media_view != "trash"
+        ):
+            return
+        if focus_identity is not None:
+            self._library_media_trash_focus_identity = focus_identity
+        if (
+            self._library_media_trash_input_error
+            or self._library_media_trash_browse_controller.state.error_copy
+            or self._library_media_trash_browse_controller.state.stale_copy
+        ):
+            self._library_media_trash_focus_identity = "#library-media-trash-retry"
+        _sync_library_canvas(
+            self,
+            "media-trash",
+            then=self._focus_library_media_trash_intent,
+        )
+
+    def _focus_library_media_trash_intent(self) -> None:
+        """Resolve the current semantic Trash focus against mounted controls."""
+        if (
+            self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
+            or self._library_media_view != "trash"
+        ):
+            return
+        selectors = [self._library_media_trash_focus_identity]
+        if self._library_media_trash_focus_identity.startswith(
+            "#library-media-trash-row-"
+        ):
+            selectors.extend((".library-media-trash-row", "#library-media-trash-back"))
+        elif self._library_media_trash_focus_identity.endswith(("previous", "next")):
+            selectors.extend(
+                ("#library-media-trash-retry", "#library-media-trash-back")
+            )
+        else:
+            selectors.append("#library-media-trash-back")
+        for selector in selectors:
+            try:
+                target = self.query_one(selector, Widget)
+            except (NoMatches, QueryError):
+                continue
+            if not getattr(target, "disabled", False):
+                target.focus()
+                return
 
     def _build_library_notes_state(self) -> LibraryNotesListState:
         """Build the notes canvas's list-view display state from local records."""
@@ -25743,88 +25905,191 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#library-media-trash-open")
     def handle_library_media_trash_open(self, event: Button.Pressed) -> None:
-        """Enter the media canvas's Trash view and kick its fetch (task-4025).
-
-        Entering also clears any delete receipt still showing: the receipt
-        is the at-point Undo convenience, and the Trash view IS the durable
-        path it points at -- a receipt surviving a Trash round trip could
-        name items the user just restored there. Select mode cannot
-        genuinely be active here (the button is hidden in select mode,
-        mirroring "Export…"), but the shared exit helper is called
-        defensively so a stale confirmation could never survive into the
-        Trash view either.
-
-        Args:
-            event: Button press event emitted by the list toolbar's "Trash".
-        """
+        """Capture normal Media identity and enter independent Trash page 1."""
         event.stop()
+        if self._library_media_bulk_delete_in_flight:
+            return
+        self._library_media_trash_return = self._capture_library_media_trash_return()
         self._exit_library_media_select_mode(announce_discard=True)
         self._library_media_delete_receipt_ids = ()
-        # task-14902: same staleness rule as the viewer transition.
         self._library_media_type_choices_visible = False
+        self._library_media_trash_query_draft = ""
+        self._library_media_trash_input_error = ""
+        self._library_media_trash_type_choices_visible = False
+        self._library_media_trash_focus_identity = "#library-media-trash-row-0"
+        controller = self._library_media_trash_browse_controller
+        controller.invalidate()
+        controller.state = MediaTrashBrowseState()
         self._library_media_view = "trash"
-        self._library_media_trash_records = None
-        self._library_media_trash_total = 0
-        self._library_media_trash_error = ""
-        self._library_media_trash_notice = ""
-        self._selected_media_trash_id = ""
         self.refresh(recompose=True)
-        self.run_worker(
-            self._load_library_media_trash(),
-            exclusive=True,
-            group="library_media_trash_load",
+        controller.request(
+            MediaTrashScope(),
+            origin="entry",
+            focus_identity="#library-media-trash-row-0",
         )
-        self.call_after_refresh(self._focus_library_media_trash_entry)
 
-    async def _load_library_media_trash(self) -> None:
-        """Fetch one page of trashed media through the existing seam.
-
-        ``media_reading_scope_service.list_media_trash(mode="local")`` is
-        the same policy-gated seam every other media read on this screen
-        uses -- never raw SQL. Read-only: it touches none of the shared
-        delete/undo state, so it does NOT claim the bulk-delete interlock;
-        its own exclusive worker group only prevents duplicate fetches.
-        """
-        records: tuple[Mapping[str, Any], ...] = ()
-        total = 0
-        error = ""
+    def _capture_library_media_trash_return(self) -> _LibraryMediaTrashReturn:
+        """Capture the normal-Media row, scroll, and semantic toolbar focus."""
+        scroll_offset: tuple[int, int] | None = None
         try:
-            service = getattr(self.app_instance, "media_reading_scope_service", None)
-            list_media_trash = getattr(service, "list_media_trash", None)
-            if callable(list_media_trash):
-                payload = await self._run_library_service_call(
-                    list_media_trash,
-                    mode="local",
-                    page=1,
-                    results_per_page=LIBRARY_MEDIA_TRASH_PAGE_SIZE,
-                    isolate_in_worker=True,
-                )
-                items = payload.get("items", ()) if isinstance(payload, Mapping) else ()
-                records = tuple(item for item in items if isinstance(item, Mapping))
-                pagination = (
-                    payload.get("pagination", {})
-                    if isinstance(payload, Mapping)
-                    else {}
-                )
-                try:
-                    total = int(pagination.get("total_items", len(records)))
-                except (TypeError, ValueError):
-                    total = len(records)
-            else:
-                error = "Trash is unavailable."
-        except Exception:
-            # TASK-15103: raw logger — the ledgered contract for these events
-            # carries no bound fields, including the file-level module bind.
-            loguru_logger.warning("Failed to load the Library media trash page.")
-            error = "Could not load Trash."
+            scroll = self.query_one("#library-media-row-scroll", Widget)
+        except (NoMatches, QueryError):
+            pass
+        else:
+            scroll_offset = (int(scroll.scroll_x), int(scroll.scroll_y))
+        focused = self.focused
+        focus_identity = (
+            str(focused.id)
+            if focused is not None and focused.id
+            else "library-media-trash-open"
+        )
+        return _LibraryMediaTrashReturn(
+            stable_id=self._selected_media_id,
+            scroll_offset=scroll_offset,
+            focus_identity=focus_identity,
+        )
 
-        self._library_media_trash_records = records
-        self._library_media_trash_total = total
-        self._library_media_trash_error = error
-        if self.is_mounted and self._library_media_view == "trash":
-            _sync_library_canvas(
-                self, "media-trash", then=self._focus_library_media_trash_entry
+    @on(Input.Submitted, "#library-media-trash-search")
+    def handle_library_media_trash_search_submitted(
+        self, event: Input.Submitted
+    ) -> None:
+        """Request page one for a bounded Trash query draft."""
+        event.stop()
+        if self._library_media_bulk_delete_in_flight:
+            return
+        query = event.value.strip()
+        self._library_media_trash_query_draft = event.value
+        if len(query) > 200:
+            self._library_media_trash_input_error = (
+                "Search is limited to 200 characters."
             )
+            self._library_media_trash_focus_identity = "#library-media-trash-search"
+            self._sync_library_media_trash_state("#library-media-trash-search")
+            return
+        try:
+            applied = self._library_media_trash_applied_scope()
+            scope = MediaTrashScope(
+                query=query,
+                media_type=applied.media_type,
+                page=1,
+            )
+        except ValueError:
+            self._library_media_trash_input_error = "Search contains invalid text."
+            self._sync_library_media_trash_state("#library-media-trash-search")
+            return
+        self._library_media_trash_input_error = ""
+        self._library_media_trash_browse_controller.request(
+            scope,
+            origin="search",
+            focus_identity="#library-media-trash-search",
+        )
+
+    @on(Button.Pressed, "#library-media-trash-type-filter")
+    def handle_library_media_trash_type_filter(self, event: Button.Pressed) -> None:
+        """Toggle the bounded Trash type chooser owned by Task 5."""
+        event.stop()
+        if self._library_media_bulk_delete_in_flight:
+            return
+        self._library_media_trash_type_choices_visible = (
+            not self._library_media_trash_type_choices_visible
+        )
+        target = (
+            "#library-media-trash-type-choices"
+            if self._library_media_trash_type_choices_visible
+            else "#library-media-trash-type-filter"
+        )
+        self._library_media_trash_focus_identity = target
+        self._sync_library_media_trash_state(target)
+
+    @on(OptionList.OptionSelected, "#library-media-trash-type-choices")
+    def handle_library_media_trash_type_choice(
+        self, event: OptionList.OptionSelected
+    ) -> None:
+        """Request page one for one source-provided Trash type."""
+        event.stop()
+        if self._library_media_bulk_delete_in_flight:
+            return
+        requested = getattr(event.option, "choice_value", None)
+        if requested is not None and type(requested) is not str:
+            return
+        controller = self._library_media_trash_browse_controller
+        if requested not in (None, *controller.state.types):
+            return
+        self._library_media_trash_type_choices_visible = False
+        self._library_media_trash_input_error = ""
+        applied = self._library_media_trash_applied_scope()
+        controller.request(
+            MediaTrashScope(
+                query=applied.query,
+                media_type=requested,
+                page=1,
+            ),
+            origin="type",
+            focus_identity="#library-media-trash-type-filter",
+        )
+
+    def _library_media_trash_applied_scope(self) -> MediaTrashScope:
+        """Return only the scope that owns the currently visible Trash page."""
+        applied = self._library_media_trash_browse_controller.state.applied_result
+        return applied.scope if applied is not None else MediaTrashScope()
+
+    def _request_library_media_trash_page(
+        self, page: int, *, focus_identity: str
+    ) -> Any | None:
+        """Request one page from the complete visible applied Trash scope."""
+        if self._library_media_bulk_delete_in_flight:
+            return None
+        applied = self._library_media_trash_browse_controller.state.applied_result
+        if applied is None:
+            return None
+        self._library_media_trash_input_error = ""
+        origin = "previous" if page < applied.scope.page else "next"
+        return self._library_media_trash_browse_controller.request(
+            applied.scope.with_page(page),
+            origin=origin,
+            focus_identity=focus_identity,
+        )
+
+    @on(Button.Pressed, "#library-media-trash-previous")
+    def handle_library_media_trash_previous(self, event: Button.Pressed) -> None:
+        """Request the previous page from the visible applied Trash scope."""
+        event.stop()
+        if self._library_media_bulk_delete_in_flight:
+            return
+        controller = self._library_media_trash_browse_controller
+        applied = controller.state.applied_result
+        if applied is None or controller.pager.previous_disabled:
+            return
+        self._request_library_media_trash_page(
+            applied.scope.page - 1,
+            focus_identity="#library-media-trash-previous",
+        )
+
+    @on(Button.Pressed, "#library-media-trash-next")
+    def handle_library_media_trash_next(self, event: Button.Pressed) -> None:
+        """Request the next page from the visible applied Trash scope."""
+        event.stop()
+        if self._library_media_bulk_delete_in_flight:
+            return
+        controller = self._library_media_trash_browse_controller
+        applied = controller.state.applied_result
+        if applied is None or controller.pager.next_disabled:
+            return
+        self._request_library_media_trash_page(
+            applied.scope.page + 1,
+            focus_identity="#library-media-trash-next",
+        )
+
+    @on(Button.Pressed, "#library-media-trash-retry")
+    def handle_library_media_trash_retry(self, event: Button.Pressed) -> None:
+        """Repeat the controller's retained failed Trash target."""
+        event.stop()
+        if self._library_media_bulk_delete_in_flight:
+            return
+        self._library_media_trash_input_error = ""
+        self._library_media_trash_browse_controller.retry(
+            focus_identity="#library-media-trash-retry"
+        )
 
     @on(Button.Pressed, ".library-media-trash-row")
     def handle_library_media_trash_row(self, event: Button.Pressed) -> None:
@@ -25837,8 +26102,7 @@ class LibraryScreen(BaseAppScreen):
         media_id = str(getattr(event.button, "media_id", "") or "")
         if not media_id:
             return
-        self._selected_media_trash_id = media_id
-        _sync_library_canvas(self, "media-trash")
+        self._library_media_trash_browse_controller.select(media_id)
 
     @on(Button.Pressed, "#library-media-trash-back")
     def handle_library_media_trash_back(self, event: Button.Pressed) -> None:
@@ -25851,23 +26115,20 @@ class LibraryScreen(BaseAppScreen):
         self._exit_library_media_trash()
 
     def _exit_library_media_trash(self) -> None:
-        """Shared Back exit: return the media canvas from Trash to its list.
-
-        Shared by the "‹ Media" button and the Trash view's Escape binding
-        (``action_library_media_trash_back``) -- one seam, mirroring
-        ``_exit_library_media_viewer``. The fetched page and notice are
-        dropped so a re-entry always fetches fresh.
-        """
+        """Fence Trash work, leave it, and reuse guarded Media list return."""
+        if self._library_media_bulk_delete_in_flight:
+            return
+        controller = self._library_media_trash_browse_controller
+        controller.invalidate()
         self._library_media_view = "list"
-        self._library_media_trash_records = None
-        self._library_media_trash_total = 0
-        self._library_media_trash_error = ""
-        self._library_media_trash_notice = ""
-        self._selected_media_trash_id = ""
-        self.refresh(recompose=True)
-        # task-2856 AC1's convention: every "back to a list canvas" exit
-        # re-focuses the list's first row.
-        self._arm_library_list_entry_focus()
+        controller.state = MediaTrashBrowseState()
+        self._library_media_trash_query_draft = ""
+        self._library_media_trash_input_error = ""
+        self._library_media_trash_type_choices_visible = False
+        self._library_media_trash_focus_identity = "#library-media-trash-row-0"
+        media_return = self._library_media_trash_return
+        self._library_media_trash_return = None
+        self.call_next(self._apply_library_media_list_return, media_return)
 
     def action_library_media_trash_back(self) -> None:
         """Escape: leave the Trash view for the media list (task-4025).
@@ -25879,29 +26140,8 @@ class LibraryScreen(BaseAppScreen):
             self._exit_library_media_trash()
 
     def _focus_library_media_trash_entry(self) -> None:
-        """Focus the Trash view's first row, or its back action when empty.
-
-        The list canvases' armed entry-focus mechanism
-        (``_focus_library_list_entry``) deliberately targets only
-        ``.library-media-row`` etc., so the Trash view does its own direct
-        focus -- first row for immediate Up/Down/Enter, the always-present
-        "‹ Media" back button when there are no rows (loading/empty/error),
-        so a keyboard-only user is never left with nothing focused.
-        """
-        if self._library_media_view != "trash":
-            return
-        try:
-            rows = self.query(".library-media-trash-row")
-            first_row = rows.first()
-        except NoMatches:
-            first_row = None
-        if first_row is not None:
-            first_row.focus()
-            return
-        try:
-            self.query_one("#library-media-trash-back", Button).focus()
-        except (NoMatches, QueryError):
-            pass
+        """Compatibility callback for restore paths; resolve semantic intent."""
+        self._focus_library_media_trash_intent()
 
     @on(Button.Pressed, "#library-media-trash-restore")
     def handle_library_media_trash_restore(self, event: Button.Pressed) -> None:
@@ -25923,18 +26163,20 @@ class LibraryScreen(BaseAppScreen):
         event.stop()
         if self._library_media_bulk_delete_in_flight:
             return
-        media_id = self._build_library_media_trash_state().selected_id
-        if not media_id:
+        target = self._library_media_trash_browse_controller.claim_mutation()
+        if target is None:
             return
         self._library_media_bulk_delete_in_flight = True
         self._begin_library_media_mutation()
         self.run_worker(
-            self._restore_library_media_from_trash(media_id),
+            self._restore_library_media_from_trash(target),
             exclusive=True,
             group="library_media_bulk_delete",
         )
 
-    async def _restore_library_media_from_trash(self, media_id: str) -> None:
+    async def _restore_library_media_from_trash(
+        self, target: MediaTrashMutationTarget
+    ) -> None:
         """Restore one trashed item via the existing seam (task-4025).
 
         ``media_reading_scope_service.restore_media_item(mode="local")``
@@ -25953,10 +26195,11 @@ class LibraryScreen(BaseAppScreen):
         list, both counts moving, and the transient notice line.
 
         Args:
-            media_id: The trashed item's id, read by the caller before any
-                recompose could change the selection.
+            target: Immutable row identity captured by the Trash controller
+                before it fences outstanding reads.
         """
         restored_item: Mapping[str, Any] | None = None
+        committed = False
         try:
             service = getattr(self.app_instance, "media_reading_scope_service", None)
             restore_media_item = getattr(service, "restore_media_item", None)
@@ -25966,13 +26209,13 @@ class LibraryScreen(BaseAppScreen):
                     result = await self._run_library_service_call(
                         restore_media_item,
                         mode="local",
-                        media_id=self._required_library_media_backing_id(media_id),
+                        media_id=target.backing_media_id,
                         isolate_in_worker=True,
                     )
                     if isinstance(result, Mapping):
                         restored_record = result
                         restored_item = self._library_media_mutation_summary(
-                            media_id, result
+                            target.stable_id, result
                         )
                 except Exception as exc:
                     logger.warning(
@@ -25981,22 +26224,13 @@ class LibraryScreen(BaseAppScreen):
                         type(exc).__name__,
                     )
             if restored_record is None:
+                self._library_media_trash_browse_controller.finish_mutation_failure(
+                    target, "Could not restore this media item."
+                )
                 self._notify_library_media_delete_warning(
                     "Could not restore this media item."
                 )
                 return
-
-            remaining = tuple(
-                record
-                for record in (self._library_media_trash_records or ())
-                if self._source_record_id(record) != media_id
-            )
-            removed = len(self._library_media_trash_records or ()) - len(remaining)
-            self._library_media_trash_records = remaining
-            self._library_media_trash_total = max(
-                0, self._library_media_trash_total - removed
-            )
-            self._selected_media_trash_id = ""
 
             existing_ids = {
                 self._source_record_id(record)
@@ -26011,9 +26245,11 @@ class LibraryScreen(BaseAppScreen):
                 )
 
             title = str(restored_record.get("title") or "").strip()
-            self._library_media_trash_notice = (
-                f"Restored '{title}'." if title else "Restored 1 item."
+            notice = f"Restored '{title}'." if title else "Restored 1 item."
+            self._library_media_trash_browse_controller.finish_mutation_commit(
+                target, notice
             )
+            committed = True
 
             if self.is_mounted:
                 # Full recompose, mirroring ``_undo_library_media_bulk_
@@ -26026,6 +26262,12 @@ class LibraryScreen(BaseAppScreen):
             self._complete_library_media_mutation(
                 upsert_items=(restored_item,) if restored_item is not None else (),
             )
+            if committed:
+                self._library_media_trash_browse_controller.request_after_mutation(
+                    focus_identity=(
+                        f"#library-media-trash-row-{max(0, target.page_index - 1)}"
+                    )
+                )
 
     @on(Button.Pressed, "#library-media-open-viewer")
     def handle_library_media_open_viewer(self, event: Button.Pressed) -> None:
@@ -26948,9 +27190,7 @@ class LibraryScreen(BaseAppScreen):
             ):
                 return
             self._library_skills_import_generation += 1
-            self._library_skill_import_coordinator.update_draft_path(
-                str(selected_path)
-            )
+            self._library_skill_import_coordinator.update_draft_path(str(selected_path))
             _sync_library_canvas(self, "skills")
 
         self.app.push_screen(
@@ -26997,9 +27237,7 @@ class LibraryScreen(BaseAppScreen):
             ):
                 return
             self._library_skills_import_generation += 1
-            self._library_skill_import_coordinator.update_draft_path(
-                str(selected_path)
-            )
+            self._library_skill_import_coordinator.update_draft_path(str(selected_path))
             _sync_library_canvas(self, "skills")
 
         self.app.push_screen(
@@ -27073,9 +27311,7 @@ class LibraryScreen(BaseAppScreen):
         changed_input = getattr(event, "input", None)
         if changed_input is not None:
             try:
-                current_input = self.query_one(
-                    "#library-skills-import-path", Input
-                )
+                current_input = self.query_one("#library-skills-import-path", Input)
             except (NoMatches, QueryError):
                 return
             if changed_input is not current_input:
@@ -27119,9 +27355,7 @@ class LibraryScreen(BaseAppScreen):
             return
         _sync_library_canvas(self, "skills")
         self.app.run_worker(
-            self._library_skill_import_coordinator.run(
-                raw_path, runtime_app=self.app
-            ),
+            self._library_skill_import_coordinator.run(raw_path, runtime_app=self.app),
             group=LIBRARY_SKILLS_IMPORT_WORKER_GROUP,
         )
 
@@ -27175,9 +27409,7 @@ class LibraryScreen(BaseAppScreen):
         except (NoMatches, QueryError):
             _sync_library_canvas(self, "skills")
 
-    def _present_library_skills_import_snapshot(
-        self, *, refresh_sources: bool
-    ) -> None:
+    def _present_library_skills_import_snapshot(self, *, refresh_sources: bool) -> None:
         """Project the app-owned receipt onto only the current Library row."""
         if refresh_sources:
             self._refresh_local_source_snapshot()
@@ -27190,9 +27422,7 @@ class LibraryScreen(BaseAppScreen):
             _sync_library_canvas(
                 self,
                 "skills",
-                then=lambda: self._apply_library_skills_import_status(
-                    terminal_status
-                ),
+                then=lambda: self._apply_library_skills_import_status(terminal_status),
             )
             self.call_after_refresh(
                 self._present_library_skills_import_choice_if_needed
@@ -27208,8 +27438,7 @@ class LibraryScreen(BaseAppScreen):
             or self.app.screen is not self
             or self._library_selected_row_id != LIBRARY_ROW_BROWSE_SKILLS
             or not snapshot.candidates
-            or self._library_skill_choice_presented_generation
-            == snapshot.generation
+            or self._library_skill_choice_presented_generation == snapshot.generation
         ):
             return
         choice_generation = snapshot.generation
@@ -27232,9 +27461,7 @@ class LibraryScreen(BaseAppScreen):
                     ),
                 )
                 return
-            if not self._library_skill_import_coordinator.claim_candidate(
-                candidate
-            ):
+            if not self._library_skill_import_coordinator.claim_candidate(candidate):
                 return
             _sync_library_canvas(self, "skills")
             self.app.run_worker(
@@ -40092,7 +40319,6 @@ class LibraryScreen(BaseAppScreen):
         """
         if self._library_media_view == "trash":
             trash_state = self._build_library_media_trash_state()
-            self._selected_media_trash_id = trash_state.selected_id
             return LibraryMediaTrashCanvas(
                 trash_state,
                 id="library-media-trash-canvas",

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -19,7 +19,7 @@ from enum import Enum
 from functools import partial
 import hashlib
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 from loguru import logger
 from loguru import logger as loguru_logger
@@ -554,6 +554,11 @@ from ...Widgets.Library.library_file_notes_events import (
     FileNotesRootChanged,
 )
 from ...Widgets.Library.library_media_content import LibraryMediaContentBody
+from ...Widgets.Library.library_media_canvas import (
+    LibraryMediaRowGeometry,
+    LibraryMediaRowGeometryChanged,
+    LibraryMediaRowScroll,
+)
 from ...Widgets.Library.library_note_folder_dialog import (
     LibraryNoteFolderNameDialog,
     LibraryNoteFolderTargetDialog,
@@ -1031,13 +1036,41 @@ class _LibraryEntryFocusCapture:
     notes_identity: LibraryNotesFocusIdentity | None = None
 
 
+_LibraryMediaFinalFocusPolicy: TypeAlias = Literal["row", "control"]
+
+
 @dataclasses.dataclass(frozen=True)
-class _LibraryMediaTrashReturn:
-    """Normal-Media list identity preserved across an independent Trash visit."""
+class _LibraryMediaReturnReceipt:
+    """Transient normal-Media coordinates captured before leaving its list."""
 
     stable_id: str
     scroll_offset: tuple[int, int] | None
-    focus_identity: str
+    content_signature: tuple[object, ...]
+    layout_signature: tuple[object, ...]
+    final_focus_policy: _LibraryMediaFinalFocusPolicy
+    final_focus_identity: str | None
+
+
+@dataclasses.dataclass(frozen=True)
+class _LibraryMediaReturnSettlement:
+    """Immutable authority for one current-owner Media return attempt."""
+
+    request_id: int
+    receipt: _LibraryMediaReturnReceipt
+    final_focus_policy: _LibraryMediaFinalFocusPolicy
+    final_focus_identity: str | None
+    focus_intent_generation: int
+    compose_generation: int
+    media_lifecycle_generation: int
+    presentation_epoch: int
+    content_signature: tuple[object, ...]
+    layout_signature: tuple[object, ...]
+    route_identity: object
+    media_view_identity: str
+    shell_identity: int | None
+    items_host_identity: int | None
+    owner_identity: int | None
+    exclusive_geometry_floor: int
 
 
 @dataclasses.dataclass(frozen=True)
@@ -3713,6 +3746,17 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_mutation_scope: MediaBrowseScope | None = None
         self._library_media_mutation_authority: int | None = None
         self._library_media_lifecycle_generation: int = 0
+        self._library_media_presentation_epoch: int = 0
+        self._library_media_current_owner: LibraryMediaRowScroll | None = None
+        self._library_media_geometry_floor_owner_identity: int | None = None
+        self._library_media_geometry_floor: int = 0
+        self._library_media_return_request_id: int = 0
+        self._library_media_return_settlement: (
+            _LibraryMediaReturnSettlement | None
+        ) = None
+        self._library_media_last_exact_settlement: (
+            tuple[_LibraryMediaReturnSettlement, int] | None
+        ) = None
         # task-4022 AC2: the ids from the most recently completed media
         # delete (bulk OR, since task-14901, the single-item viewer
         # delete), rendered as a "✓ deleted · N items" receipt (with
@@ -4551,12 +4595,10 @@ class LibraryScreen(BaseAppScreen):
         self._library_pending_list_entry_focus: bool = False
         self._library_list_entry_focus_generation: int = 0
         self._library_pending_list_entry_media_return: (
-            tuple[str, tuple[int, int] | None] | None
+            _LibraryMediaReturnReceipt | None
         ) = None
-        self._library_media_viewer_return: tuple[str, tuple[int, int] | None] | None = (
-            None
-        )
-        self._library_media_trash_return: _LibraryMediaTrashReturn | None = None
+        self._library_media_viewer_return: _LibraryMediaReturnReceipt | None = None
+        self._library_media_trash_return: _LibraryMediaReturnReceipt | None = None
         # task-2856 review (PR #1410, Qodo): the settle-window timer
         # ``_arm_library_list_entry_focus`` schedules used to be fire-and-
         # forget -- the ``Timer`` ``set_timer`` returns was never kept, so
@@ -6655,6 +6697,11 @@ class LibraryScreen(BaseAppScreen):
 
     def _project_library_media_stage_classes(self, shell_grid: Widget) -> bool:
         """Project effective Media stage classes; return whether they changed."""
+        current_owner: LibraryMediaRowScroll | None = None
+        if shell_grid.is_attached:
+            tree = self._library_media_settlement_tree()
+            if tree is not None and shell_grid in tree[0].ancestors:
+                current_owner = tree[2]
         changed = False
         if shell_grid.has_class("library-notes-compact"):
             shell_grid.remove_class("library-notes-compact")
@@ -6665,7 +6712,294 @@ class LibraryScreen(BaseAppScreen):
                 "library-adaptive-compact",
             )
             changed = True
+        if changed:
+            self._advance_library_media_presentation_epoch(current_owner)
         return changed
+
+    def _library_media_settlement_tree(
+        self,
+    ) -> tuple[LibraryMediaReaderShell, Vertical, LibraryMediaRowScroll] | None:
+        """Return the current attached Media shell, Items host, and row owner."""
+        try:
+            shell = self.query_one(
+                "#library-media-reader-shell",
+                LibraryMediaReaderShell,
+            )
+            items_host = self.query_one("#library-canvas", Vertical)
+            owner = self.query_one(
+                "#library-media-row-scroll",
+                LibraryMediaRowScroll,
+            )
+        except (NoMatches, QueryError):
+            return None
+        if not (shell.is_attached and items_host.is_attached and owner.is_attached):
+            return None
+        if items_host not in owner.ancestors or shell not in items_host.ancestors:
+            return None
+        if self not in shell.ancestors:
+            return None
+        return shell, items_host, owner
+
+    def _adopt_library_media_row_owner(self, owner: LibraryMediaRowScroll) -> bool:
+        """Advance presentation authority when the row owner is replaced."""
+        owner_identity = id(owner)
+        if self._library_media_current_owner is owner:
+            return False
+        self._library_media_current_owner = owner
+        self._library_media_presentation_epoch += 1
+        self._library_media_geometry_floor_owner_identity = owner_identity
+        self._library_media_geometry_floor = 0
+        self._library_media_return_settlement = None
+        return True
+
+    def _advance_library_media_presentation_epoch(
+        self,
+        owner: LibraryMediaRowScroll | None,
+    ) -> None:
+        """Fence geometry already emitted before a Media presentation change."""
+        self._library_media_presentation_epoch += 1
+        if owner is None:
+            self._library_media_current_owner = None
+            self._library_media_geometry_floor_owner_identity = None
+            self._library_media_geometry_floor = 0
+        else:
+            self._library_media_current_owner = owner
+            self._library_media_geometry_floor_owner_identity = id(owner)
+            latest = owner.latest_geometry
+            self._library_media_geometry_floor = (
+                latest.revision if latest is not None else 0
+            )
+        self._library_media_return_settlement = None
+        receipt = self._library_pending_list_entry_media_return
+        if (
+            owner is not None
+            and receipt is not None
+            and receipt.final_focus_policy == "row"
+        ):
+            self._arm_library_media_return_settlement(receipt)
+
+    def _library_media_exact_return_candidate(
+        self,
+        receipt: _LibraryMediaReturnReceipt | None,
+    ) -> bool:
+        """Return whether Task 2 may attempt an unchanged exact row return."""
+        return bool(
+            receipt is not None
+            and receipt.final_focus_policy == "row"
+            and receipt.scroll_offset is not None
+            and receipt.content_signature == self._library_media_content_signature()
+            and receipt.layout_signature == self._library_media_layout_signature()
+        )
+
+    def _library_media_request_matches_current_authority(
+        self,
+        request: _LibraryMediaReturnSettlement,
+        receipt: _LibraryMediaReturnReceipt,
+        tree: tuple[LibraryMediaReaderShell, Vertical, LibraryMediaRowScroll],
+    ) -> bool:
+        """Compare one immutable request with every non-geometry fence."""
+        shell, items_host, owner = tree
+        return bool(
+            request.receipt is receipt
+            and request.final_focus_policy == receipt.final_focus_policy
+            and request.final_focus_identity == receipt.final_focus_identity
+            and request.focus_intent_generation
+            == self._library_notes_focus_intent_generation
+            and request.compose_generation == self._library_compose_generation
+            and request.media_lifecycle_generation
+            == self._library_media_lifecycle_generation
+            and request.presentation_epoch == self._library_media_presentation_epoch
+            and request.content_signature == self._library_media_content_signature()
+            and request.layout_signature == self._library_media_layout_signature()
+            and request.route_identity == self._library_entry_route_key()
+            and request.media_view_identity == self._library_media_view == "list"
+            and request.shell_identity == id(shell)
+            and request.items_host_identity == id(items_host)
+            and request.owner_identity == id(owner)
+            and self._library_media_current_owner is owner
+            and self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
+            and self._library_media_reader_layout.items_open
+            and items_host.display
+        )
+
+    def _arm_library_media_return_settlement(
+        self,
+        receipt: _LibraryMediaReturnReceipt,
+    ) -> _LibraryMediaReturnSettlement | None:
+        """Create current-owner exact authority and consume ready geometry."""
+        if (
+            not self._library_pending_list_entry_focus
+            or self._library_pending_list_entry_media_return is not receipt
+            or not self._library_media_exact_return_candidate(receipt)
+            or self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
+            or self._library_media_view != "list"
+        ):
+            self._library_media_return_settlement = None
+            return None
+        tree = self._library_media_settlement_tree()
+        if tree is None:
+            self._library_media_return_settlement = None
+            return None
+        shell, items_host, owner = tree
+        self._adopt_library_media_row_owner(owner)
+
+        current = self._library_media_return_settlement
+        if current is not None and self._library_media_request_matches_current_authority(
+            current,
+            receipt,
+            tree,
+        ):
+            latest = owner.latest_geometry
+            if latest is not None:
+                self._settle_library_media_return_from_geometry(
+                    current,
+                    owner,
+                    latest,
+                )
+            return self._library_media_return_settlement
+
+        last_exact = self._library_media_last_exact_settlement
+        if last_exact is not None and self._library_media_request_matches_current_authority(
+            last_exact[0],
+            receipt,
+            tree,
+        ):
+            return None
+
+        self._library_media_return_request_id += 1
+        owner_identity = id(owner)
+        floor = (
+            self._library_media_geometry_floor
+            if self._library_media_geometry_floor_owner_identity == owner_identity
+            else 0
+        )
+        request = _LibraryMediaReturnSettlement(
+            request_id=self._library_media_return_request_id,
+            receipt=receipt,
+            final_focus_policy=receipt.final_focus_policy,
+            final_focus_identity=receipt.final_focus_identity,
+            focus_intent_generation=self._library_notes_focus_intent_generation,
+            compose_generation=self._library_compose_generation,
+            media_lifecycle_generation=self._library_media_lifecycle_generation,
+            presentation_epoch=self._library_media_presentation_epoch,
+            content_signature=self._library_media_content_signature(),
+            layout_signature=self._library_media_layout_signature(),
+            route_identity=self._library_entry_route_key(),
+            media_view_identity=self._library_media_view,
+            shell_identity=id(shell),
+            items_host_identity=id(items_host),
+            owner_identity=owner_identity,
+            exclusive_geometry_floor=floor,
+        )
+        self._library_media_return_settlement = request
+        latest = owner.latest_geometry
+        if latest is not None and latest.revision > floor:
+            self._settle_library_media_return_from_geometry(request, owner, latest)
+        return self._library_media_return_settlement
+
+    def _settle_library_media_return_from_geometry(
+        self,
+        request: _LibraryMediaReturnSettlement,
+        owner: LibraryMediaRowScroll,
+        geometry: LibraryMediaRowGeometry,
+    ) -> bool:
+        """Commit exact scroll and then row focus from current-owner geometry."""
+        if (
+            self._library_media_return_settlement is not request
+            or self._library_media_return_settlement.request_id != request.request_id
+        ):
+            return False
+        tree = self._library_media_settlement_tree()
+        receipt = self._library_pending_list_entry_media_return
+        if (
+            tree is None
+            or receipt is None
+            or tree[2] is not owner
+            or not self._library_media_request_matches_current_authority(
+                request,
+                receipt,
+                tree,
+            )
+            or request.content_signature != request.receipt.content_signature
+            or request.layout_signature != request.receipt.layout_signature
+            or request.receipt.stable_id != self._selected_media_id
+            or geometry.revision <= request.exclusive_geometry_floor
+            or owner.latest_geometry != geometry
+            or (owner.size, owner.virtual_size, owner.container_size)
+            != (geometry.size, geometry.virtual_size, geometry.container_size)
+        ):
+            return False
+        last_exact = self._library_media_last_exact_settlement
+        if (
+            last_exact is not None
+            and last_exact[0].request_id == request.request_id
+            and last_exact[1] >= geometry.revision
+        ):
+            return True
+
+        desired = request.receipt.scroll_offset
+        if desired is None or desired[0] < 0 or desired[1] < 0:
+            return False
+        if (
+            desired[0] > int(owner.max_scroll_x)
+            or desired[1] > int(owner.max_scroll_y)
+        ):
+            return False
+        items_host = tree[1]
+        target = next(
+            (
+                row
+                for row in self.query(".library-media-row")
+                if str(getattr(row, "media_id", "") or "")
+                == request.receipt.stable_id
+                and items_host in row.ancestors
+            ),
+            None,
+        )
+        if target is None:
+            return False
+
+        owner.scroll_to(
+            x=desired[0],
+            y=desired[1],
+            animate=False,
+            force=True,
+            immediate=True,
+        )
+        if (int(owner.scroll_x), int(owner.scroll_y)) != desired:
+            return False
+        self._library_notes_programmatic_focus_target = target
+        self.set_focus(target, scroll_visible=False)
+        if self.focused is not target:
+            return False
+        if (int(owner.scroll_x), int(owner.scroll_y)) != desired:
+            return False
+
+        self._library_media_last_exact_settlement = (request, geometry.revision)
+        self._library_media_return_settlement = None
+        return True
+
+    @on(LibraryMediaRowGeometryChanged)
+    def _handle_library_media_row_geometry_changed(
+        self,
+        event: LibraryMediaRowGeometryChanged,
+    ) -> None:
+        """Settle only from the current attached Media row-scroll owner."""
+        event.stop()
+        tree = self._library_media_settlement_tree()
+        if tree is None or tree[2] is not event.owner:
+            return
+        self._adopt_library_media_row_owner(event.owner)
+        receipt = self._library_pending_list_entry_media_return
+        if receipt is None or receipt.final_focus_policy != "row":
+            return
+        request = self._arm_library_media_return_settlement(receipt)
+        if request is not None:
+            self._settle_library_media_return_from_geometry(
+                request,
+                event.owner,
+                event.geometry,
+            )
 
     def _reconcile_library_media_stage_presentation(self) -> bool:
         """Equality-reconcile the mounted Media stage; return whether it changed."""
@@ -7842,6 +8176,7 @@ class LibraryScreen(BaseAppScreen):
             previous=previous,
             priority=priority,
         )
+        layout_changed = layout != self._library_media_reader_layout
         focused = self.focused
         if focus_intent is not None and (
             focus_intent[1] == self._library_notes_focus_intent_generation
@@ -7869,6 +8204,11 @@ class LibraryScreen(BaseAppScreen):
                 hidden_focus_target = (focused, grip)
                 break
         generation = self._library_notes_focus_intent_generation
+        if layout_changed:
+            tree = self._library_media_settlement_tree()
+            self._advance_library_media_presentation_epoch(
+                tree[2] if tree is not None else None
+            )
         shell.sync_layout(layout)
         self._library_media_reader_layout = layout
         if hidden_focus_target is not None:
@@ -7879,6 +8219,9 @@ class LibraryScreen(BaseAppScreen):
         elif (
             layout.items_open
             and self._library_pending_list_entry_focus
+            and not self._library_media_exact_return_candidate(
+                self._library_pending_list_entry_media_return
+            )
             and (
                 self._library_pending_list_entry_media_return is not None
                 or focused is None
@@ -8277,6 +8620,11 @@ class LibraryScreen(BaseAppScreen):
         else:
             self._reconcile_library_media_stage_presentation()
             self._sync_library_media_reader_layout_from_shell()
+            receipt = self._library_pending_list_entry_media_return
+            if receipt is not None and receipt.final_focus_policy == "row":
+                # Shell lifecycle establishes the replacement identity fences;
+                # only owner Resize geometry may complete the request.
+                self._arm_library_media_return_settlement(receipt)
 
     def _sync_library_ingest_rail_for_width(self, width: int) -> None:
         """Auto-collapse the rail only while narrow Ingest needs the space."""
@@ -9811,6 +10159,10 @@ class LibraryScreen(BaseAppScreen):
         self._library_skills_browse_controller.invalidate()
         self._invalidate_library_prompt_detail_generation()
         self._library_media_lifecycle_generation += 1
+        self._library_media_return_settlement = None
+        self._library_media_current_owner = None
+        self._library_media_geometry_floor_owner_identity = None
+        self._library_media_geometry_floor = 0
         self._library_media_browse_controller.invalidate()
         self._library_media_trash_browse_controller.invalidate()
         self._library_collections_browse_controller.invalidate()
@@ -10705,7 +11057,7 @@ class LibraryScreen(BaseAppScreen):
     def _arm_library_list_entry_focus(
         self,
         *,
-        media_return: tuple[str, tuple[int, int] | None] | None = None,
+        media_return: _LibraryMediaReturnReceipt | None = None,
     ) -> None:
         """Request the primary list's first row be focused (task-2856 AC1).
 
@@ -10742,7 +11094,10 @@ class LibraryScreen(BaseAppScreen):
         self._library_list_entry_focus_generation += 1
         self._library_pending_list_entry_focus = True
         self._library_pending_list_entry_media_return = media_return
-        if media_return is None:
+        exact_media_return = self._library_media_exact_return_candidate(media_return)
+        if exact_media_return:
+            self._arm_library_media_return_settlement(media_return)
+        elif media_return is None:
             self.call_after_refresh(self._focus_library_list_entry)
         else:
             self.call_after_refresh(
@@ -10773,6 +11128,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_list_entry_focus_generation += 1
         self._library_pending_list_entry_focus = False
         self._library_pending_list_entry_media_return = None
+        self._library_media_return_settlement = None
         if self._library_list_entry_focus_timer is not None:
             self._library_list_entry_focus_timer.stop()
             self._library_list_entry_focus_timer = None
@@ -10866,6 +11222,10 @@ class LibraryScreen(BaseAppScreen):
             self._library_pending_list_entry_focus
             and generation == self._library_list_entry_focus_generation
         ):
+            receipt = self._library_pending_list_entry_media_return
+            if self._library_media_exact_return_candidate(receipt):
+                self._arm_library_media_return_settlement(receipt)
+                return
             self._focus_library_list_entry()
 
     def _focus_library_list_entry(self) -> None:
@@ -10938,12 +11298,12 @@ class LibraryScreen(BaseAppScreen):
         target = rows[0]
         media_return = self._library_pending_list_entry_media_return
         if row_class == "library-media-row" and media_return is not None:
-            media_id, _scroll_offset = media_return
             target = next(
                 (
                     row
                     for row in rows
-                    if str(getattr(row, "media_id", "") or "") == media_id
+                    if str(getattr(row, "media_id", "") or "")
+                    == media_return.stable_id
                 ),
                 target,
             )
@@ -10954,7 +11314,7 @@ class LibraryScreen(BaseAppScreen):
             self._library_notes_programmatic_focus_target = target
         self.set_focus(target, scroll_visible=False)
         if row_class == "library-media-row" and media_return is not None:
-            _media_id, scroll_offset = media_return
+            scroll_offset = media_return.scroll_offset
             if scroll_offset is not None:
                 try:
                     scroll = self.query_one("#library-media-row-scroll", Widget)
@@ -12568,9 +12928,7 @@ class LibraryScreen(BaseAppScreen):
 
     async def _apply_library_media_list_return(
         self,
-        media_return: (
-            tuple[str, tuple[int, int] | None] | _LibraryMediaTrashReturn | None
-        ),
+        media_return: _LibraryMediaReturnReceipt | None,
     ) -> None:
         """Project the viewer-to-list return and arm the list entry focus.
 
@@ -12593,9 +12951,7 @@ class LibraryScreen(BaseAppScreen):
 
     def _finish_library_media_list_return(
         self,
-        media_return: (
-            tuple[str, tuple[int, int] | None] | _LibraryMediaTrashReturn | None
-        ),
+        media_return: _LibraryMediaReturnReceipt | None,
     ) -> None:
         """Arm row/scroll/focus only after the normal Media child is mounted."""
         if (
@@ -12607,25 +12963,20 @@ class LibraryScreen(BaseAppScreen):
         viewer = self._mounted_library_media_viewer()
         if viewer is not None:
             self._sync_library_media_viewer_state(viewer)
-        trash_return = (
-            media_return if isinstance(media_return, _LibraryMediaTrashReturn) else None
-        )
-        row_return = (
-            (trash_return.stable_id, trash_return.scroll_offset)
-            if trash_return is not None
-            else media_return
-        )
-        self._arm_library_list_entry_focus(media_return=row_return)
-        if trash_return is not None:
+        self._arm_library_list_entry_focus(media_return=media_return)
+        if (
+            media_return is not None
+            and media_return.final_focus_policy == "control"
+        ):
             self.call_after_refresh(
                 self._restore_library_media_trash_return_focus,
-                trash_return,
+                media_return,
                 self._library_list_entry_focus_generation,
             )
 
     def _restore_library_media_trash_return_focus(
         self,
-        receipt: _LibraryMediaTrashReturn,
+        receipt: _LibraryMediaReturnReceipt,
         generation: int,
     ) -> None:
         """Restore toolbar focus after the guarded row/scroll return lands."""
@@ -12637,7 +12988,8 @@ class LibraryScreen(BaseAppScreen):
             return
         self._focus_library_list_entry_if_current(generation)
         self._disarm_library_list_entry_focus()
-        self._focus_library_control(f"#{receipt.focus_identity}")
+        if receipt.final_focus_identity:
+            self._focus_library_control(f"#{receipt.final_focus_identity}")
 
     async def _reconcile_library_entry_state(
         self, generation: int, route_key: tuple[object, ...]
@@ -14679,7 +15031,16 @@ class LibraryScreen(BaseAppScreen):
         # covers an arbitrary-length chain of these workers instead of
         # exactly one.
         if self._library_pending_list_entry_focus:
-            if self._library_pending_list_entry_media_return is None:
+            pending_media_return = self._library_pending_list_entry_media_return
+            if self._library_media_exact_return_candidate(pending_media_return):
+                focused = self.focused
+                if focused is not None and focused.has_class("library-media-row"):
+                    # The focused row is about to be replaced. Prevent Textual
+                    # from implicitly selecting its semantic successor before
+                    # replacement-owner geometry can settle exact scroll.
+                    self.set_focus(None)
+                self._library_media_return_settlement = None
+            elif pending_media_return is None:
                 self.call_after_refresh(self._focus_library_list_entry)
             else:
                 self.call_after_refresh(
@@ -16566,6 +16927,24 @@ class LibraryScreen(BaseAppScreen):
             self._library_media_row_selection.reconcile(r.media_id for r in state.rows)
         return state
 
+    def _library_media_content_signature(self) -> tuple[object, ...]:
+        """Return applied normal-Media scope plus ordered stable row IDs."""
+        controller = self._library_media_browse_controller
+        return (
+            controller.applied_scope,
+            tuple(str(item["id"]) for item in controller.retained_items),
+        )
+
+    def _library_media_layout_signature(self) -> tuple[object, ...]:
+        """Return terminal allocation plus pure effective Media pane layout."""
+        return (
+            int(self.size.width),
+            int(self.size.height),
+            self._library_notes_compact,
+            self._library_media_reader_preferences,
+            self._library_media_reader_layout,
+        )
+
     def _library_media_canvas_presentation(self) -> dict[str, Any]:
         """Return controller-owned inputs shared by every Media canvas path."""
         controller = self._library_media_browse_controller
@@ -16764,13 +17143,36 @@ class LibraryScreen(BaseAppScreen):
             "library-media-retry",
             "library-media-type-filter",
         }
+        pending_receipt = self._library_pending_list_entry_media_return
+        exact_pending_return = bool(
+            self._library_pending_list_entry_focus
+            and focus_identity is None
+            and self._library_media_exact_return_candidate(pending_receipt)
+        )
+        if exact_pending_return:
+            self._library_media_return_settlement = None
+            if (
+                focused is not None
+                and any(
+                    widget.id == "library-media-canvas"
+                    for widget in focused.ancestors
+                )
+            ):
+                self.set_focus(None)
+                focused = None
+                focused_id = None
         pending_entry_focus_generation = (
             self._library_list_entry_focus_generation
-            if self._library_pending_list_entry_focus and focus_identity is None
+            if (
+                self._library_pending_list_entry_focus
+                and focus_identity is None
+                and not exact_pending_return
+            )
             else None
         )
         if (
-            pending_entry_focus_generation is None
+            not exact_pending_return
+            and pending_entry_focus_generation is None
             and isinstance(focused_id, str)
             and focused_id
             and any(widget.id == "library-media-canvas" for widget in focused.ancestors)
@@ -16785,7 +17187,21 @@ class LibraryScreen(BaseAppScreen):
             )
         ):
             focus_identity = f"#{focused_id}"
-        if pending_entry_focus_generation is not None:
+        if exact_pending_return:
+            exact_generation = self._library_list_entry_focus_generation
+
+            def arm_exact_return() -> None:
+                if (
+                    self._library_pending_list_entry_focus
+                    and exact_generation == self._library_list_entry_focus_generation
+                    and self._library_pending_list_entry_media_return
+                    is pending_receipt
+                    and pending_receipt is not None
+                ):
+                    self._arm_library_media_return_settlement(pending_receipt)
+
+            then = arm_exact_return
+        elif pending_entry_focus_generation is not None:
 
             def focus_pending_entry() -> None:
                 try:
@@ -26159,7 +26575,7 @@ class LibraryScreen(BaseAppScreen):
             focus_identity="#library-media-trash-row-0",
         )
 
-    def _capture_library_media_trash_return(self) -> _LibraryMediaTrashReturn:
+    def _capture_library_media_trash_return(self) -> _LibraryMediaReturnReceipt:
         """Capture the normal-Media row, scroll, and semantic toolbar focus."""
         scroll_offset: tuple[int, int] | None = None
         try:
@@ -26174,10 +26590,13 @@ class LibraryScreen(BaseAppScreen):
             if focused is not None and focused.id
             else "library-media-trash-open"
         )
-        return _LibraryMediaTrashReturn(
+        return _LibraryMediaReturnReceipt(
             stable_id=self._selected_media_id,
             scroll_offset=scroll_offset,
-            focus_identity=focus_identity,
+            content_signature=self._library_media_content_signature(),
+            layout_signature=self._library_media_layout_signature(),
+            final_focus_policy="control",
+            final_focus_identity=focus_identity,
         )
 
     @on(Input.Changed, "#library-media-trash-search")
@@ -26688,7 +27107,14 @@ class LibraryScreen(BaseAppScreen):
                 scroll_offset = None
             else:
                 scroll_offset = (int(scroll.scroll_x), int(scroll.scroll_y))
-            self._library_media_viewer_return = (media_id, scroll_offset)
+            self._library_media_viewer_return = _LibraryMediaReturnReceipt(
+                stable_id=media_id,
+                scroll_offset=scroll_offset,
+                content_signature=self._library_media_content_signature(),
+                layout_signature=self._library_media_layout_signature(),
+                final_focus_policy="row",
+                final_focus_identity=None,
+            )
         if media_id:
             self._acknowledge_library_destination_change()
             title = next(
@@ -39940,6 +40366,11 @@ class LibraryScreen(BaseAppScreen):
         # attempt runs against the MOUNTED list rows.
         media_return = self._library_media_viewer_return
         self._library_media_viewer_return = None
+        if media_return is not None and media_return.final_focus_policy == "row":
+            # The focused Back control is about to be removed. Clear it before
+            # the child swap so Textual cannot choose the replacement semantic
+            # row as an implicit successor ahead of exact scroll settlement.
+            self.set_focus(None)
         self.call_next(self._apply_library_media_list_return, media_return)
 
     def action_library_media_viewer_back(self) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -17011,6 +17011,15 @@ class LibraryScreen(BaseAppScreen):
             focus_identity=focus_identity
         )
 
+    def _library_media_trash_retry_visible(self) -> bool:
+        """Return whether the displayed status owns a browse retry target."""
+        state = self._library_media_trash_browse_controller.state
+        if self._library_media_trash_input_error or state.loading:
+            return False
+        if state.failed_scope is not None:
+            return bool(state.error_copy or state.stale_copy)
+        return state.freshness == "stale" and bool(state.stale_copy)
+
     def _build_library_media_trash_state(self) -> LibraryMediaTrashState:
         """Adapt the controller-owned exact page to the pre-Task-5 canvas."""
         state = self._library_media_trash_browse_controller.state
@@ -17026,7 +17035,7 @@ class LibraryScreen(BaseAppScreen):
         error = self._library_media_trash_input_error
         if not error:
             error = state.error_copy or state.stale_copy
-            if error and (state.failed_scope is not None or state.stale_copy):
+            if error and self._library_media_trash_retry_visible():
                 error = f"{error.rstrip('.')} · Retry"
         presentation = build_library_media_trash_state(
             records,
@@ -17059,7 +17068,10 @@ class LibraryScreen(BaseAppScreen):
         if applied_scope.media_type is not None:
             scope_parts.append(f"Type: {applied_scope.media_type}")
 
-        if state.loading or state.mutation_pending:
+        mutation_in_flight = bool(
+            state.mutation_pending or self._library_media_bulk_delete_in_flight
+        )
+        if state.loading or mutation_in_flight:
             action_disabled_reason = "Trash is refreshing."
         elif state.freshness != "fresh":
             action_disabled_reason = "Refresh Trash before changing this item."
@@ -17075,6 +17087,10 @@ class LibraryScreen(BaseAppScreen):
             "applied_type": applied_scope.media_type,
             "type_choices_visible": self._library_media_trash_type_choices_visible,
             "action_disabled_reason": action_disabled_reason,
+            "retry_visible": self._library_media_trash_retry_visible(),
+            "controls_disabled_reason": (
+                "Trash is refreshing." if mutation_in_flight else ""
+            ),
         }
 
     def _sync_library_media_trash_state(self, focus_identity: str | None) -> None:
@@ -17120,9 +17136,7 @@ class LibraryScreen(BaseAppScreen):
                 self._library_media_trash_focus_authority_generation = focus_generation
                 self._library_media_trash_focus_request_key = request_key
             self._library_media_trash_focus_identity = focus_identity
-        if not self._library_media_trash_input_error and (
-            state.failed_scope is not None or state.stale_copy
-        ):
+        if self._library_media_trash_retry_visible():
             self._library_media_trash_focus_identity = "#library-media-trash-retry"
         elif (
             not state.loading
@@ -17150,11 +17164,17 @@ class LibraryScreen(BaseAppScreen):
         # callback clears it before yielding through paint, so a real Tab in
         # the request interval still supersedes this semantic intent.
         self._library_notes_restoring_focus = True
-        _sync_library_canvas(
+        synced = _sync_library_canvas(
             self,
             "media-trash",
             then=self._focus_library_media_trash_intent,
         )
+        if not synced:
+            # Projection-suppressed and failed targeted syncs do not run the
+            # queued callback. Release both one-shot focus guards immediately
+            # so the next real Tab/click advances user authority.
+            self._library_notes_restoring_focus = False
+            self._library_notes_programmatic_focus_target = None
 
     def _focus_library_media_trash_intent(self) -> None:
         """Validate the mounted target, then defer through one paint cycle."""
@@ -26106,6 +26126,12 @@ class LibraryScreen(BaseAppScreen):
             scroll_offset=scroll_offset,
             focus_identity=focus_identity,
         )
+
+    @on(Input.Changed, "#library-media-trash-search")
+    def handle_library_media_trash_search_changed(self, event: Input.Changed) -> None:
+        """Own the visible draft without applying it to the browse scope."""
+        event.stop()
+        self._library_media_trash_query_draft = event.value
 
     @on(Input.Submitted, "#library-media-trash-search")
     def handle_library_media_trash_search_submitted(

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -11266,6 +11266,11 @@ class LibraryScreen(BaseAppScreen):
         never reach ``on_key`` at all.
         """
         focused = event.widget
+        if focused is not self.focused:
+            # Focus bubbles are queued. A transactional Media rollback may
+            # restore its prior live focus before the abandoned target's
+            # earlier bubble arrives; that stale event owns no authority.
+            return
         self._remember_library_notes_authority_focus(focused)
         target_restore = self._library_notes_programmatic_focus_target is focused
         programmatic = bool(

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1929,6 +1929,7 @@ def _sync_library_canvas(
             )
             new_state = screen._build_library_media_trash_state()
             sync_args = (new_state,)
+            sync_kwargs = screen._library_media_trash_canvas_presentation()
         elif kind == "notes":
             canvas = screen.query_one("#library-notes-canvas", LibraryNotesCanvas)
             sync_kwargs = screen._library_notes_list_canvas_kwargs()
@@ -3763,6 +3764,10 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_trash_input_error: str = ""
         self._library_media_trash_type_choices_visible: bool = False
         self._library_media_trash_focus_identity: str = "#library-media-trash-row-0"
+        self._library_media_trash_focus_authority_generation: int = 0
+        self._library_media_trash_focus_request_key: (
+            tuple[MediaTrashScope, str] | None
+        ) = None
         self._library_media_detail: Mapping[str, Any] | None = None
         # task-15458: the exact detail object the last viewer compose rendered,
         # compared by IDENTITY. ``_refresh_library_media_detail``'s arrival
@@ -7774,6 +7779,23 @@ class LibraryScreen(BaseAppScreen):
         width = shell.region.width
         if not self._library_adaptive_reader_allocation_is_current(shell):
             return
+        if (
+            priority is None
+            and self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
+            and self._library_media_view == "trash"
+            and self._library_media_reader_preferences.items_open
+            and not (
+                self._library_media_reader_layout.priority_pane == "library"
+                and self._library_media_reader_preferences.library_open
+            )
+        ):
+            # Trash is an Items surface. At the compact allocation the reader
+            # otherwise consumes every cell after a screen recompose, even
+            # though the user's Items preference remains open. Reassert that
+            # existing preference as layout priority. A still-requested,
+            # explicitly prioritized Library pane wins until it is collapsed;
+            # an explicit Items close flips that preference first too.
+            priority = "items"
         previous = self._library_media_reader_layout
         # ``__init__`` resolves a zero-width sentinel before Textual has
         # assigned the mounted shell its first real region. Treating that
@@ -10774,7 +10796,7 @@ class LibraryScreen(BaseAppScreen):
                 or stage == "rail"
                 or (
                     self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
-                    and self._library_media_view == "list"
+                    and self._library_media_view in {"list", "trash"}
                 )
                 or self._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
             )
@@ -15140,6 +15162,7 @@ class LibraryScreen(BaseAppScreen):
                         trash_state = self._build_library_media_trash_state()
                         yield LibraryMediaTrashCanvas(
                             trash_state,
+                            **self._library_media_trash_canvas_presentation(),
                             id="library-media-trash-canvas",
                         )
                     elif shell.canvas_kind == "media":
@@ -17024,6 +17047,36 @@ class LibraryScreen(BaseAppScreen):
             )
         return presentation
 
+    def _library_media_trash_canvas_presentation(self) -> dict[str, Any]:
+        """Return screen-owned Trash controls without re-deriving page authority."""
+        controller = self._library_media_trash_browse_controller
+        state = controller.state
+        applied = state.applied_result
+        applied_scope = applied.scope if applied is not None else MediaTrashScope()
+        scope_parts: list[str] = []
+        if applied_scope.query:
+            scope_parts.append(f"Query: {applied_scope.query}")
+        if applied_scope.media_type is not None:
+            scope_parts.append(f"Type: {applied_scope.media_type}")
+
+        if state.loading or state.mutation_pending:
+            action_disabled_reason = "Trash is refreshing."
+        elif state.freshness != "fresh":
+            action_disabled_reason = "Refresh Trash before changing this item."
+        elif not state.selected_id:
+            action_disabled_reason = "Select a Trash item first."
+        else:
+            action_disabled_reason = ""
+        return {
+            "pager": controller.pager,
+            "types": state.types,
+            "query_draft": self._library_media_trash_query_draft,
+            "applied_scope_label": " · ".join(scope_parts),
+            "applied_type": applied_scope.media_type,
+            "type_choices_visible": self._library_media_trash_type_choices_visible,
+            "action_disabled_reason": action_disabled_reason,
+        }
+
     def _sync_library_media_trash_state(self, focus_identity: str | None) -> None:
         """Publish one current Trash state without remounting another route."""
         if (
@@ -17031,13 +17084,72 @@ class LibraryScreen(BaseAppScreen):
             or self._library_media_view != "trash"
         ):
             return
-        if focus_identity is not None:
-            self._library_media_trash_focus_identity = focus_identity
         state = self._library_media_trash_browse_controller.state
+        focus_generation = getattr(self, "_library_notes_focus_intent_generation", 0)
+        authority_generation = getattr(
+            self,
+            "_library_media_trash_focus_authority_generation",
+            focus_generation,
+        )
+        focused = getattr(self, "focused", None)
+        focused_id = getattr(focused, "id", None)
+        focused_in_trash = bool(
+            focused_id
+            and any(
+                isinstance(ancestor, LibraryMediaTrashCanvas)
+                for ancestor in getattr(focused, "ancestors_with_self", ())
+            )
+        )
+        newer_focus_identity = (
+            f"#{focused_id}"
+            if (
+                not state.loading
+                and focus_generation != authority_generation
+                and focused_in_trash
+            )
+            else None
+        )
+        if focus_identity is not None:
+            request_key = (state.requested_scope, state.request_origin)
+            if (
+                state.loading
+                or focus_identity != self._library_media_trash_focus_identity
+                or request_key
+                != getattr(self, "_library_media_trash_focus_request_key", None)
+            ):
+                self._library_media_trash_focus_authority_generation = focus_generation
+                self._library_media_trash_focus_request_key = request_key
+            self._library_media_trash_focus_identity = focus_identity
         if not self._library_media_trash_input_error and (
             state.failed_scope is not None or state.stale_copy
         ):
             self._library_media_trash_focus_identity = "#library-media-trash-retry"
+        elif (
+            not state.loading
+            and state.freshness == "fresh"
+            and not state.error_copy
+            and self._library_media_trash_focus_identity == "#library-media-trash-retry"
+        ):
+            self._library_media_trash_focus_identity = {
+                "entry": "#library-media-trash-row-0",
+                "search": "#library-media-trash-search",
+                "type": "#library-media-trash-type-filter",
+                "previous": "#library-media-trash-previous",
+                "next": "#library-media-trash-next",
+                "retry": "#library-media-trash-back",
+                "mutation": "#library-media-trash-row-0",
+            }[state.request_origin]
+        if newer_focus_identity is not None:
+            # A real Tab/click during the request supersedes its older landing
+            # intent. Preserve that semantic control through this recompose and
+            # reacquire the newly mounted instance after paint.
+            self._library_media_trash_focus_identity = newer_focus_identity
+            self._library_media_trash_focus_authority_generation = focus_generation
+        # Child teardown may temporarily move focus to a retained pane grip.
+        # Mark only that recompose interval as programmatic; the queued
+        # callback clears it before yielding through paint, so a real Tab in
+        # the request interval still supersedes this semantic intent.
+        self._library_notes_restoring_focus = True
         _sync_library_canvas(
             self,
             "media-trash",
@@ -17045,31 +17157,74 @@ class LibraryScreen(BaseAppScreen):
         )
 
     def _focus_library_media_trash_intent(self) -> None:
-        """Resolve the current semantic Trash focus against mounted controls."""
+        """Validate the mounted target, then defer through one paint cycle."""
+        self._library_notes_restoring_focus = False
         if (
             self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
             or self._library_media_view != "trash"
+            or self._library_media_trash_focus_authority_generation
+            != self._library_notes_focus_intent_generation
         ):
             return
-        selectors = [self._library_media_trash_focus_identity]
-        if self._library_media_trash_focus_identity.startswith(
-            "#library-media-trash-row-"
-        ):
+        identity = self._library_media_trash_focus_identity
+        generation = self._library_media_trash_focus_authority_generation
+        if self._resolve_library_media_trash_focus_target(identity) is None:
+            return
+        self.call_after_refresh(
+            self._focus_library_media_trash_after_paint,
+            identity,
+            generation,
+        )
+
+    def _library_media_trash_focus_selectors(self, identity: str) -> tuple[str, ...]:
+        """Return deterministic fallbacks for one semantic Trash identity."""
+        selectors = [identity]
+        if identity.startswith("#library-media-trash-row-"):
             selectors.extend((".library-media-trash-row", "#library-media-trash-back"))
-        elif self._library_media_trash_focus_identity.endswith(("previous", "next")):
+        elif identity == "#library-media-trash-next":
             selectors.extend(
-                ("#library-media-trash-retry", "#library-media-trash-back")
+                ("#library-media-trash-previous", "#library-media-trash-back")
+            )
+        elif identity == "#library-media-trash-previous":
+            selectors.extend(("#library-media-trash-next", "#library-media-trash-back"))
+        elif identity == "#library-media-trash-retry":
+            selectors.append("#library-media-trash-back")
+        elif identity == "#library-media-trash-type-choices":
+            selectors.extend(
+                ("#library-media-trash-type-filter", "#library-media-trash-back")
             )
         else:
             selectors.append("#library-media-trash-back")
-        for selector in selectors:
+        return tuple(dict.fromkeys(selectors))
+
+    def _resolve_library_media_trash_focus_target(self, identity: str) -> Widget | None:
+        """Reacquire the first current, enabled control for an identity."""
+        for selector in self._library_media_trash_focus_selectors(identity):
             try:
                 target = self.query_one(selector, Widget)
             except (NoMatches, QueryError):
                 continue
-            if not getattr(target, "disabled", False):
-                target.focus()
-                return
+            if not getattr(target, "disabled", False) and target.can_focus:
+                return target
+        return None
+
+    def _focus_library_media_trash_after_paint(
+        self, identity: str, generation: int
+    ) -> None:
+        """Reacquire immediately before focusing after compositor paint."""
+        if (
+            self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
+            or self._library_media_view != "trash"
+            or identity != self._library_media_trash_focus_identity
+            or generation != self._library_media_trash_focus_authority_generation
+            or generation != self._library_notes_focus_intent_generation
+        ):
+            return
+        target = self._resolve_library_media_trash_focus_target(identity)
+        if target is None:
+            return
+        self._library_notes_programmatic_focus_target = target
+        target.focus()
 
     def _build_library_notes_state(self) -> LibraryNotesListState:
         """Build the notes canvas's list-view display state from local records."""
@@ -25916,6 +26071,10 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_trash_input_error = ""
         self._library_media_trash_type_choices_visible = False
         self._library_media_trash_focus_identity = "#library-media-trash-row-0"
+        self._library_media_trash_focus_authority_generation = (
+            self._library_notes_focus_intent_generation
+        )
+        self._library_media_trash_focus_request_key = None
         controller = self._library_media_trash_browse_controller
         controller.invalidate()
         controller.state = MediaTrashBrowseState()
@@ -25998,6 +26157,13 @@ class LibraryScreen(BaseAppScreen):
             else "#library-media-trash-type-filter"
         )
         self._library_media_trash_focus_identity = target
+        # This focus intent is created by the same real Enter that advanced
+        # the global focus generation.  Claim that generation before sync so
+        # the opener is not mistaken for a newer intent and restored over the
+        # chooser it just opened.
+        self._library_media_trash_focus_authority_generation = (
+            self._library_notes_focus_intent_generation
+        )
         self._sync_library_media_trash_state(target)
 
     @on(OptionList.OptionSelected, "#library-media-trash-type-choices")
@@ -26101,6 +26267,12 @@ class LibraryScreen(BaseAppScreen):
         media_id = str(getattr(event.button, "media_id", "") or "")
         if not media_id:
             return
+        button_id = getattr(event.button, "id", None)
+        if button_id:
+            self._library_media_trash_focus_identity = f"#{button_id}"
+            self._library_media_trash_focus_authority_generation = (
+                self._library_notes_focus_intent_generation
+            )
         self._library_media_trash_browse_controller.select(media_id)
 
     @on(Button.Pressed, "#library-media-trash-back")
@@ -26125,6 +26297,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_trash_input_error = ""
         self._library_media_trash_type_choices_visible = False
         self._library_media_trash_focus_identity = "#library-media-trash-row-0"
+        self._library_media_trash_focus_request_key = None
         media_return = self._library_media_trash_return
         self._library_media_trash_return = None
         self.call_next(self._apply_library_media_list_return, media_return)
@@ -26135,8 +26308,16 @@ class LibraryScreen(BaseAppScreen):
         ``check_action`` gates this to the media canvas genuinely showing
         its Trash view, so it only ever fires there.
         """
-        if not self._library_media_bulk_delete_in_flight:
-            self._exit_library_media_trash()
+        if self._library_media_bulk_delete_in_flight:
+            return
+        if self._library_media_trash_type_choices_visible:
+            self._library_media_trash_type_choices_visible = False
+            self._library_media_trash_focus_authority_generation = (
+                self._library_notes_focus_intent_generation
+            )
+            self._sync_library_media_trash_state("#library-media-trash-type-filter")
+            return
+        self._exit_library_media_trash()
 
     def _focus_library_media_trash_entry(self) -> None:
         """Compatibility callback for restore paths; resolve semantic intent."""
@@ -40320,6 +40501,7 @@ class LibraryScreen(BaseAppScreen):
             trash_state = self._build_library_media_trash_state()
             return LibraryMediaTrashCanvas(
                 trash_state,
+                **self._library_media_trash_canvas_presentation(),
                 id="library-media-trash-canvas",
             )
         media_state = self._build_library_media_state()

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -595,6 +595,7 @@ from ..Library_Modules.library_media_browse_controller import (
 )
 from ..Library_Modules.library_media_trash_browse_controller import (
     LibraryMediaTrashBrowseController,
+    MediaTrashMutationClaim,
 )
 from ..Library_Modules.library_collections_browse_controller import (
     LibraryCollectionsBrowseController,
@@ -3846,6 +3847,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_trash_focus_request_key: (
             tuple[MediaTrashScope, str] | None
         ) = None
+        self._library_media_trash_mounted_authority: bool = False
         self._library_media_detail: Mapping[str, Any] | None = None
         # task-15458: the exact detail object the last viewer compose rendered,
         # compared by IDENTITY. ``_refresh_library_media_detail``'s arrival
@@ -4075,7 +4077,8 @@ class LibraryScreen(BaseAppScreen):
             ),
             sync_view=lambda: self._sync_library_media_trash_state,
             request_is_active=lambda: (
-                self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
+                self._library_media_trash_mounted_authority
+                and self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
                 and self._library_media_view == "trash"
             ),
         )
@@ -10488,6 +10491,7 @@ class LibraryScreen(BaseAppScreen):
         viewer) that ``apply_navigation_context`` could not run before mount.
         """
         self._library_conversation_reader_mounted_authority = True
+        self._library_media_trash_mounted_authority = True
         self._register_footer_shortcuts()
         self.call_after_refresh(self._sync_library_media_reader_layout_from_shell)
         self.call_after_refresh(self._sync_library_ordinary_rail_width_contract)
@@ -10704,6 +10708,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_current_owner = None
         self._library_media_geometry_floor_owner_identity = None
         self._library_media_geometry_floor = 0
+        self._library_media_trash_mounted_authority = False
         self._library_media_browse_controller.invalidate()
         self._library_media_trash_browse_controller.invalidate()
         self._library_collections_browse_controller.invalidate()
@@ -27486,21 +27491,22 @@ class LibraryScreen(BaseAppScreen):
         captured = controller.state.confirmation_target
         if captured is None:
             return
-        target = controller.claim_mutation()
-        if target != captured:
+        claim = controller.claim_mutation()
+        if claim is None or claim.target != captured:
             return
         self._library_media_bulk_delete_in_flight = True
         self._begin_library_media_mutation()
         self.run_worker(
-            self._permanently_delete_library_media_from_trash(target),
+            self._permanently_delete_library_media_from_trash(claim),
             exclusive=True,
             group="library_media_bulk_delete",
         )
 
     async def _permanently_delete_library_media_from_trash(
-        self, target: MediaTrashMutationTarget
+        self, claim: MediaTrashMutationClaim
     ) -> None:
         """Permanently delete one captured Trash item through the sole service seam."""
+        target = claim.target
         committed = False
         failure_copy: str | None = None
         try:
@@ -27527,10 +27533,9 @@ class LibraryScreen(BaseAppScreen):
 
             title = LibraryScreen._bounded_library_media_trash_title(target.title)
             notice = f"Deleted '{title}' permanently."
-            self._library_media_trash_browse_controller.finish_mutation_commit(
-                target, notice
+            committed = self._library_media_trash_browse_controller.finish_mutation_commit(
+                claim, notice
             )
-            committed = True
         finally:
             self._complete_library_media_mutation(
                 committed=committed,
@@ -27538,16 +27543,22 @@ class LibraryScreen(BaseAppScreen):
                 stale_normal_media=False,
             )
             if failure_copy is not None:
-                self._library_media_trash_focus_identity = "#library-media-trash-delete"
-                self._library_media_trash_focus_authority_generation = getattr(
-                    self, "_library_notes_focus_intent_generation", 0
+                accepted = (
+                    self._library_media_trash_browse_controller.finish_mutation_failure(
+                        claim, failure_copy
+                    )
                 )
-                self._library_media_trash_browse_controller.finish_mutation_failure(
-                    target, failure_copy
-                )
-                self._notify_library_media_delete_warning(failure_copy)
+                if accepted:
+                    self._library_media_trash_focus_identity = (
+                        "#library-media-trash-delete"
+                    )
+                    self._library_media_trash_focus_authority_generation = getattr(
+                        self, "_library_notes_focus_intent_generation", 0
+                    )
+                    self._notify_library_media_delete_warning(failure_copy)
             elif committed:
                 self._library_media_trash_browse_controller.request_after_mutation(
+                    claim,
                     focus_identity=f"#library-media-trash-row-{target.page_index}"
                 )
 
@@ -27571,19 +27582,19 @@ class LibraryScreen(BaseAppScreen):
         event.stop()
         if self._library_media_bulk_delete_in_flight:
             return
-        target = self._library_media_trash_browse_controller.claim_mutation()
-        if target is None:
+        claim = self._library_media_trash_browse_controller.claim_mutation()
+        if claim is None:
             return
         self._library_media_bulk_delete_in_flight = True
         self._begin_library_media_mutation()
         self.run_worker(
-            self._restore_library_media_from_trash(target),
+            self._restore_library_media_from_trash(claim),
             exclusive=True,
             group="library_media_bulk_delete",
         )
 
     async def _restore_library_media_from_trash(
-        self, target: MediaTrashMutationTarget
+        self, claim: MediaTrashMutationClaim
     ) -> None:
         """Restore one trashed item via the existing seam (task-4025).
 
@@ -27606,6 +27617,7 @@ class LibraryScreen(BaseAppScreen):
             target: Immutable row identity captured by the Trash controller
                 before it fences outstanding reads.
         """
+        target = claim.target
         committed = False
         failure_copy: str | None = None
         try:
@@ -27632,6 +27644,14 @@ class LibraryScreen(BaseAppScreen):
                 failure_copy = "Could not restore this media item."
                 return
 
+            title = LibraryScreen._bounded_library_media_trash_title(target.title)
+            notice = f"Restored '{title}'."
+            committed = self._library_media_trash_browse_controller.finish_mutation_commit(
+                claim, notice
+            )
+            if not committed:
+                return
+
             existing_ids = {
                 self._source_record_id(record)
                 for record in self._local_source_records.get("media", ())
@@ -27643,13 +27663,6 @@ class LibraryScreen(BaseAppScreen):
                 self._local_source_counts["media"] = (
                     self._local_source_counts.get("media", 0) + 1
                 )
-
-            title = LibraryScreen._bounded_library_media_trash_title(target.title)
-            notice = f"Restored '{title}'."
-            self._library_media_trash_browse_controller.finish_mutation_commit(
-                target, notice
-            )
-            committed = True
 
             if self.is_mounted:
                 # Full recompose, mirroring ``_undo_library_media_bulk_
@@ -27665,18 +27678,22 @@ class LibraryScreen(BaseAppScreen):
                 stale_normal_media=committed,
             )
             if failure_copy is not None:
-                self._library_media_trash_focus_identity = (
-                    "#library-media-trash-restore"
+                accepted = (
+                    self._library_media_trash_browse_controller.finish_mutation_failure(
+                        claim, failure_copy
+                    )
                 )
-                self._library_media_trash_focus_authority_generation = getattr(
-                    self, "_library_notes_focus_intent_generation", 0
-                )
-                self._library_media_trash_browse_controller.finish_mutation_failure(
-                    target, failure_copy
-                )
-                self._notify_library_media_delete_warning(failure_copy)
+                if accepted:
+                    self._library_media_trash_focus_identity = (
+                        "#library-media-trash-restore"
+                    )
+                    self._library_media_trash_focus_authority_generation = getattr(
+                        self, "_library_notes_focus_intent_generation", 0
+                    )
+                    self._notify_library_media_delete_warning(failure_copy)
             elif committed:
                 self._library_media_trash_browse_controller.request_after_mutation(
+                    claim,
                     focus_identity=f"#library-media-trash-row-{target.page_index}"
                 )
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -17696,13 +17696,12 @@ class LibraryScreen(BaseAppScreen):
             or is_trash != 0
             or type(title) is not str
             or type(media_type) is not str
-            or not media_type.strip()
         ):
             return None
         return {
             "id": restored_id,
             "title": title.strip() or "Untitled",
-            "type": media_type.strip(),
+            "type": media_type.strip() or None,
             "deleted": deleted,
             "is_trash": is_trash,
         }

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -11270,6 +11270,8 @@ class LibraryScreen(BaseAppScreen):
             # Focus bubbles are queued. A transactional Media rollback may
             # restore its prior live focus before the abandoned target's
             # earlier bubble arrives; that stale event owns no authority.
+            if self._library_notes_programmatic_focus_target is focused:
+                self._library_notes_programmatic_focus_target = None
             return
         self._remember_library_notes_authority_focus(focused)
         target_restore = self._library_notes_programmatic_focus_target is focused

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1071,6 +1071,7 @@ class _LibraryMediaReturnSettlement:
     items_host_identity: int | None
     owner_identity: int | None
     exclusive_geometry_floor: int
+    focus_anchor: Widget | None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -4597,6 +4598,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_pending_list_entry_media_return: (
             _LibraryMediaReturnReceipt | None
         ) = None
+        self._library_pending_list_entry_focus_anchor: Widget | None = None
         self._library_media_viewer_return: _LibraryMediaReturnReceipt | None = None
         self._library_media_trash_return: _LibraryMediaReturnReceipt | None = None
         # task-2856 review (PR #1410, Qodo): the settle-window timer
@@ -6816,10 +6818,35 @@ class LibraryScreen(BaseAppScreen):
             and request.shell_identity == id(shell)
             and request.items_host_identity == id(items_host)
             and request.owner_identity == id(owner)
+            and request.focus_anchor
+            is self._library_pending_list_entry_focus_anchor
+            and self._library_media_live_focus_is_allowed(
+                request.focus_anchor,
+                receipt.stable_id,
+            )
             and self._library_media_current_owner is owner
             and self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
             and self._library_media_reader_layout.items_open
             and items_host.display
+        )
+
+    def _library_media_live_focus_is_allowed(
+        self,
+        focus_anchor: Widget | None,
+        stable_id: str,
+        target: Widget | None = None,
+    ) -> bool:
+        """Return whether live focus still belongs to one exact return."""
+        focused = self.focused
+        if focused is None or focused is focus_anchor:
+            return True
+        guarded_target = target or self._library_notes_programmatic_focus_target
+        return bool(
+            guarded_target is not None
+            and focused is guarded_target
+            and self._library_notes_programmatic_focus_target is guarded_target
+            and focused.has_class("library-media-row")
+            and str(getattr(focused, "media_id", "") or "") == stable_id
         )
 
     def _arm_library_media_return_settlement(
@@ -6833,6 +6860,10 @@ class LibraryScreen(BaseAppScreen):
             or not self._library_media_exact_return_candidate(receipt)
             or self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
             or self._library_media_view != "list"
+            or not self._library_media_live_focus_is_allowed(
+                self._library_pending_list_entry_focus_anchor,
+                receipt.stable_id,
+            )
         ):
             self._library_media_return_settlement = None
             return None
@@ -6890,6 +6921,7 @@ class LibraryScreen(BaseAppScreen):
             items_host_identity=id(items_host),
             owner_identity=owner_identity,
             exclusive_geometry_floor=floor,
+            focus_anchor=self._library_pending_list_entry_focus_anchor,
         )
         self._library_media_return_settlement = request
         latest = owner.latest_geometry
@@ -6958,6 +6990,12 @@ class LibraryScreen(BaseAppScreen):
         )
         if target is None:
             return False
+        if not self._library_media_live_focus_is_allowed(
+            request.focus_anchor,
+            request.receipt.stable_id,
+            target,
+        ):
+            return False
 
         owner.scroll_to(
             x=desired[0],
@@ -6967,6 +7005,12 @@ class LibraryScreen(BaseAppScreen):
             immediate=True,
         )
         if (int(owner.scroll_x), int(owner.scroll_y)) != desired:
+            return False
+        if not self._library_media_live_focus_is_allowed(
+            request.focus_anchor,
+            request.receipt.stable_id,
+            target,
+        ):
             return False
         self._library_notes_programmatic_focus_target = target
         self.set_focus(target, scroll_visible=False)
@@ -10153,6 +10197,7 @@ class LibraryScreen(BaseAppScreen):
         ``False`` after removal) -- so this call is what actually closes
         the window, not the guard.
         """
+        self._disarm_library_list_entry_focus()
         self._invalidate_library_notes_tree_for_unmount()
         self._library_conversation_reader_mounted_authority = False
         self._invalidate_library_conversation_reader_authority()
@@ -11100,6 +11145,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_list_entry_focus_generation += 1
         self._library_pending_list_entry_focus = True
         self._library_pending_list_entry_media_return = media_return
+        self._library_pending_list_entry_focus_anchor = self.focused
         exact_media_return = self._library_media_exact_return_candidate(media_return)
         if exact_media_return:
             self._arm_library_media_return_settlement(media_return)
@@ -11141,6 +11187,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_list_entry_focus_generation += 1
         self._library_pending_list_entry_focus = False
         self._library_pending_list_entry_media_return = None
+        self._library_pending_list_entry_focus_anchor = None
         self._library_media_return_settlement = None
         if self._library_list_entry_focus_timer is not None:
             self._library_list_entry_focus_timer.stop()

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -16580,6 +16580,8 @@ class LibraryScreen(BaseAppScreen):
         committed: bool = False,
         remove_ids: tuple[str, ...] = (),
         upsert_items: tuple[Mapping[str, Any], ...] = (),
+        refresh_normal_media: bool = True,
+        stale_normal_media: bool = False,
     ) -> None:
         """Release the write interlock and refresh its full applied scope."""
         scope = self._library_media_mutation_scope
@@ -16595,10 +16597,15 @@ class LibraryScreen(BaseAppScreen):
                 self._sync_library_media_browse_state(None)
             return
         controller = self._library_media_browse_controller
-        controller.reconcile_committed_mutation(
-            remove_ids=remove_ids,
-            upsert_items=upsert_items,
-        )
+        if stale_normal_media:
+            controller.mark_stale_after_trash_restore()
+        elif refresh_normal_media and (committed or remove_ids or upsert_items):
+            controller.reconcile_committed_mutation(
+                remove_ids=remove_ids,
+                upsert_items=upsert_items,
+            )
+        if not refresh_normal_media:
+            return
         refresh_scope = scope or controller.mutation_refresh_scope
         if (
             not has_authority
@@ -16622,6 +16629,14 @@ class LibraryScreen(BaseAppScreen):
             "media_type": record.get("media_type", record.get("type")),
             "updated_at": record.get("updated_at", record.get("last_modified")),
         }
+
+    @staticmethod
+    def _bounded_library_media_trash_title(title: str, limit: int = 80) -> str:
+        """Bound mutation receipts without changing confirmation identity."""
+        readable = str(title).strip()
+        if len(readable) <= limit:
+            return readable
+        return f"{readable[: limit - 3].rstrip()}..."
 
     @staticmethod
     def _restore_library_media_scope(state: Mapping[str, Any]) -> MediaBrowseScope:
@@ -17037,6 +17052,8 @@ class LibraryScreen(BaseAppScreen):
             error = state.error_copy or state.stale_copy
             if error and self._library_media_trash_retry_visible():
                 error = f"{error.rstrip('.')} · Retry"
+                if state.committed_notice:
+                    error = f"{state.committed_notice} {error}"
         presentation = build_library_media_trash_state(
             records,
             total=total,
@@ -17091,6 +17108,8 @@ class LibraryScreen(BaseAppScreen):
             "controls_disabled_reason": (
                 "Trash is refreshing." if mutation_in_flight else ""
             ),
+            "confirmation_target": state.confirmation_target,
+            "commit_pending": state.mutation_pending,
         }
 
     def _sync_library_media_trash_state(self, focus_identity: str | None) -> None:
@@ -17200,7 +17219,13 @@ class LibraryScreen(BaseAppScreen):
         """Return deterministic fallbacks for one semantic Trash identity."""
         selectors = [identity]
         if identity.startswith("#library-media-trash-row-"):
-            selectors.extend((".library-media-trash-row", "#library-media-trash-back"))
+            try:
+                page_index = int(identity.rsplit("-", 1)[1])
+            except ValueError:
+                page_index = 0
+            if page_index > 0:
+                selectors.append(f"#library-media-trash-row-{page_index - 1}")
+            selectors.append("#library-media-trash-back")
         elif identity == "#library-media-trash-next":
             selectors.extend(
                 ("#library-media-trash-previous", "#library-media-trash-back")
@@ -26309,13 +26334,23 @@ class LibraryScreen(BaseAppScreen):
             event: Button press event emitted by the "‹ Media" action.
         """
         event.stop()
+        if (
+            getattr(
+                self._library_media_trash_browse_controller.state,
+                "confirmation_target",
+                None,
+            )
+            is not None
+        ):
+            self._cancel_library_media_trash_delete_confirmation()
+            return
         self._exit_library_media_trash()
 
     def _exit_library_media_trash(self) -> None:
         """Fence Trash work, leave it, and reuse guarded Media list return."""
-        if self._library_media_bulk_delete_in_flight:
-            return
         controller = self._library_media_trash_browse_controller
+        if bool(getattr(controller.state, "mutation_pending", False)):
+            return
         controller.invalidate()
         self._library_media_view = "list"
         controller.state = MediaTrashBrowseState()
@@ -26334,7 +26369,11 @@ class LibraryScreen(BaseAppScreen):
         ``check_action`` gates this to the media canvas genuinely showing
         its Trash view, so it only ever fires there.
         """
-        if self._library_media_bulk_delete_in_flight:
+        controller = self._library_media_trash_browse_controller
+        if controller.state.mutation_pending:
+            return
+        if controller.state.confirmation_target is not None:
+            self._cancel_library_media_trash_delete_confirmation()
             return
         if self._library_media_trash_type_choices_visible:
             self._library_media_trash_type_choices_visible = False
@@ -26348,6 +26387,105 @@ class LibraryScreen(BaseAppScreen):
     def _focus_library_media_trash_entry(self) -> None:
         """Compatibility callback for restore paths; resolve semantic intent."""
         self._focus_library_media_trash_intent()
+
+    @on(Button.Pressed, "#library-media-trash-delete")
+    def handle_library_media_trash_delete(self, event: Button.Pressed) -> None:
+        """Open inline confirmation for one captured fresh Trash identity."""
+        event.stop()
+        if self._library_media_bulk_delete_in_flight:
+            return
+        self._library_media_trash_focus_identity = "#library-media-trash-delete-cancel"
+        self._library_media_trash_focus_authority_generation = getattr(
+            self, "_library_notes_focus_intent_generation", 0
+        )
+        target = self._library_media_trash_browse_controller.open_delete_confirmation()
+        if target is None:
+            self._library_media_trash_focus_identity = "#library-media-trash-delete"
+
+    def _cancel_library_media_trash_delete_confirmation(self) -> None:
+        """Close confirmation and return focus to its permanent-delete opener."""
+        self._library_media_trash_focus_identity = "#library-media-trash-delete"
+        self._library_media_trash_focus_authority_generation = getattr(
+            self, "_library_notes_focus_intent_generation", 0
+        )
+        self._library_media_trash_browse_controller.cancel_delete_confirmation()
+
+    @on(Button.Pressed, "#library-media-trash-delete-cancel")
+    def handle_library_media_trash_delete_cancel(self, event: Button.Pressed) -> None:
+        """Cancel permanent deletion without invoking a service."""
+        event.stop()
+        if self._library_media_trash_browse_controller.state.mutation_pending:
+            return
+        self._cancel_library_media_trash_delete_confirmation()
+
+    @on(Button.Pressed, "#library-media-trash-delete-confirm")
+    def handle_library_media_trash_delete_confirm(self, event: Button.Pressed) -> None:
+        """Synchronously claim the shared interlock before scheduling deletion."""
+        event.stop()
+        if self._library_media_bulk_delete_in_flight:
+            return
+        controller = self._library_media_trash_browse_controller
+        captured = controller.state.confirmation_target
+        if captured is None:
+            return
+        target = controller.claim_mutation()
+        if target != captured:
+            return
+        self._library_media_bulk_delete_in_flight = True
+        self._begin_library_media_mutation()
+        self.run_worker(
+            self._permanently_delete_library_media_from_trash(target),
+            exclusive=True,
+            group="library_media_bulk_delete",
+        )
+
+    async def _permanently_delete_library_media_from_trash(
+        self, target: MediaTrashMutationTarget
+    ) -> None:
+        """Permanently delete one captured Trash item through the sole service seam."""
+        committed = False
+        try:
+            service = getattr(self.app_instance, "media_reading_scope_service", None)
+            permanently_delete = getattr(service, "permanently_delete_media_item", None)
+            result: Any = None
+            if callable(permanently_delete):
+                try:
+                    result = await self._run_library_service_call(
+                        permanently_delete,
+                        mode="local",
+                        media_id=target.backing_media_id,
+                        isolate_in_worker=True,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to permanently delete a Library media item from "
+                        "Trash (error_type={}).",
+                        type(exc).__name__,
+                    )
+            if not isinstance(result, Mapping) or result.get("ok") is not True:
+                copy = "Could not delete this media item permanently."
+                self._library_media_trash_browse_controller.finish_mutation_failure(
+                    target, copy
+                )
+                self._notify_library_media_delete_warning(copy)
+                return
+
+            title = LibraryScreen._bounded_library_media_trash_title(target.title)
+            notice = f"Deleted '{title}' permanently."
+            self._library_media_trash_browse_controller.finish_mutation_commit(
+                target, notice
+            )
+            committed = True
+        finally:
+            self._complete_library_media_mutation(
+                committed=committed,
+                refresh_normal_media=False,
+                stale_normal_media=False,
+            )
+            if committed:
+                self._library_media_trash_browse_controller.request_after_mutation(
+                    focus_identity=f"#library-media-trash-row-{target.page_index}"
+                )
 
     @on(Button.Pressed, "#library-media-trash-restore")
     def handle_library_media_trash_restore(self, event: Button.Pressed) -> None:
@@ -26404,7 +26542,6 @@ class LibraryScreen(BaseAppScreen):
             target: Immutable row identity captured by the Trash controller
                 before it fences outstanding reads.
         """
-        restored_item: Mapping[str, Any] | None = None
         committed = False
         try:
             service = getattr(self.app_instance, "media_reading_scope_service", None)
@@ -26420,9 +26557,6 @@ class LibraryScreen(BaseAppScreen):
                     )
                     if isinstance(result, Mapping):
                         restored_record = result
-                        restored_item = self._library_media_mutation_summary(
-                            target.stable_id, result
-                        )
                 except Exception as exc:
                     logger.warning(
                         "Failed to restore a Library media item from the "
@@ -26450,8 +26584,8 @@ class LibraryScreen(BaseAppScreen):
                     self._local_source_counts.get("media", 0) + 1
                 )
 
-            title = str(restored_record.get("title") or "").strip()
-            notice = f"Restored '{title}'." if title else "Restored 1 item."
+            title = LibraryScreen._bounded_library_media_trash_title(target.title)
+            notice = f"Restored '{title}'."
             self._library_media_trash_browse_controller.finish_mutation_commit(
                 target, notice
             )
@@ -26466,13 +26600,13 @@ class LibraryScreen(BaseAppScreen):
                 self.call_after_refresh(self._focus_library_media_trash_entry)
         finally:
             self._complete_library_media_mutation(
-                upsert_items=(restored_item,) if restored_item is not None else (),
+                committed=committed,
+                refresh_normal_media=False,
+                stale_normal_media=committed,
             )
             if committed:
                 self._library_media_trash_browse_controller.request_after_mutation(
-                    focus_identity=(
-                        f"#library-media-trash-row-{max(0, target.page_index - 1)}"
-                    )
+                    focus_identity=f"#library-media-trash-row-{target.page_index}"
                 )
 
     @on(Button.Pressed, "#library-media-open-viewer")
@@ -28903,10 +29037,14 @@ class LibraryScreen(BaseAppScreen):
         if action == "library_media_trash_back":
             # task-4025: only while the media canvas genuinely shows its
             # Trash view -- mirrors the viewer-back gate above.
+            trash_controller = getattr(
+                self, "_library_media_trash_browse_controller", None
+            )
+            trash_state = getattr(trash_controller, "state", None)
             return (
                 self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
                 and getattr(self, "_library_media_view", "list") == "trash"
-                and not self._library_media_bulk_delete_in_flight
+                and not bool(getattr(trash_state, "mutation_pending", False))
             )
         if action == "library_note_editor_back":
             return (

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -11682,6 +11682,12 @@ class LibraryScreen(BaseAppScreen):
             self._library_list_entry_focus_timer.stop()
             self._library_list_entry_focus_timer = None
 
+    def _disarm_library_media_return_for_route_change(self) -> None:
+        """Clear all transient Media-return state at an admitted route exit."""
+        self._disarm_library_list_entry_focus()
+        self._library_media_last_settlement_outcome = None
+        self._library_notes_programmatic_focus_target = None
+
     def on_descendant_focus(self, event: DescendantFocus) -> None:
         """Record Notes focus intent and disarm foreign list-entry focus.
 
@@ -25850,6 +25856,12 @@ class LibraryScreen(BaseAppScreen):
         self._advance_library_stage_interaction()
         if self._try_switch_retained_library_notes_route(row_id):
             return
+        if (
+            self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
+            and self._library_media_view == "list"
+            and row_id != LIBRARY_ROW_BROWSE_MEDIA
+        ):
+            self._disarm_library_media_return_for_route_change()
         self._acknowledge_library_destination_change()
         self._cancel_library_media_selection_settlement()
         if row_id != LIBRARY_ROW_BROWSE_MEDIA:
@@ -27141,6 +27153,7 @@ class LibraryScreen(BaseAppScreen):
         if self._library_media_bulk_delete_in_flight:
             return
         self._library_media_trash_return = self._capture_library_media_trash_return()
+        self._disarm_library_media_return_for_route_change()
         self._exit_library_media_select_mode(announce_discard=True)
         self._library_media_delete_receipt_ids = ()
         self._library_media_type_choices_visible = False

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -6653,6 +6653,32 @@ class LibraryScreen(BaseAppScreen):
             self._library_notes_stage_signature()
         )
 
+    def _project_library_media_stage_classes(self, shell_grid: Widget) -> bool:
+        """Project effective Media stage classes; return whether they changed."""
+        changed = False
+        if shell_grid.has_class("library-notes-compact"):
+            shell_grid.remove_class("library-notes-compact")
+            changed = True
+        if shell_grid.has_class("library-adaptive-compact") != self._library_notes_compact:
+            shell_grid.set_class(
+                self._library_notes_compact,
+                "library-adaptive-compact",
+            )
+            changed = True
+        return changed
+
+    def _reconcile_library_media_stage_presentation(self) -> bool:
+        """Equality-reconcile the mounted Media stage; return whether it changed."""
+        try:
+            self.query_one("#library-media-reader-shell", LibraryMediaReaderShell)
+            shell_grid = self.query_one("#library-shell-grid", Widget)
+        except (NoMatches, QueryError):
+            return False
+        changed = self._project_library_media_stage_classes(shell_grid)
+        if changed:
+            self.refresh(layout=True)
+        return changed
+
     def _apply_library_notes_stage_legs(self) -> None:
         """Apply compact classes and mutually exclusive mounted stage visibility."""
         if not self.is_mounted:
@@ -8249,6 +8275,7 @@ class LibraryScreen(BaseAppScreen):
         }:
             self._sync_library_skills_reader_layout_from_shell()
         else:
+            self._reconcile_library_media_stage_presentation()
             self._sync_library_media_reader_layout_from_shell()
 
     def _sync_library_ingest_rail_for_width(self, width: int) -> None:
@@ -15026,6 +15053,7 @@ class LibraryScreen(BaseAppScreen):
             self.call_after_refresh(self._ensure_library_conversation_reader_selection)
             return
         if shell.canvas_kind == "media":
+            self._project_library_media_stage_classes(shell_grid)
             rail = LibraryRail(
                 shell,
                 preferences,

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1065,11 +1065,11 @@ class _LibraryMediaReturnSettlement:
     presentation_epoch: int
     content_signature: tuple[object, ...]
     layout_signature: tuple[object, ...]
-    route_identity: object
+    route_identity: tuple[object, ...]
     media_view_identity: str
-    shell_identity: int | None
-    items_host_identity: int | None
-    owner_identity: int | None
+    shell_identity: int
+    items_host_identity: int
+    owner_identity: int
     exclusive_geometry_floor: int
     focus_anchor: Widget | None
 
@@ -3758,6 +3758,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_last_exact_settlement: (
             tuple[_LibraryMediaReturnSettlement, int] | None
         ) = None
+        self._library_media_last_settlement_attempt: tuple[int, int] | None = None
         # task-4022 AC2: the ids from the most recently completed media
         # delete (bulk OR, since task-14901, the single-item viewer
         # delete), rendered as a "✓ deleted · N items" receipt (with
@@ -6852,8 +6853,10 @@ class LibraryScreen(BaseAppScreen):
     def _arm_library_media_return_settlement(
         self,
         receipt: _LibraryMediaReturnReceipt,
+        *,
+        consume_latest_geometry: bool = True,
     ) -> _LibraryMediaReturnSettlement | None:
-        """Create current-owner exact authority and consume ready geometry."""
+        """Create current-owner authority and optionally consume ready geometry."""
         if (
             not self._library_pending_list_entry_focus
             or self._library_pending_list_entry_media_return is not receipt
@@ -6881,7 +6884,7 @@ class LibraryScreen(BaseAppScreen):
             tree,
         ):
             latest = owner.latest_geometry
-            if latest is not None:
+            if consume_latest_geometry and latest is not None:
                 self._settle_library_media_return_from_geometry(
                     current,
                     owner,
@@ -6925,7 +6928,11 @@ class LibraryScreen(BaseAppScreen):
         )
         self._library_media_return_settlement = request
         latest = owner.latest_geometry
-        if latest is not None and latest.revision > floor:
+        if (
+            consume_latest_geometry
+            and latest is not None
+            and latest.revision > floor
+        ):
             self._settle_library_media_return_from_geometry(request, owner, latest)
         return self._library_media_return_settlement
 
@@ -6968,6 +6975,13 @@ class LibraryScreen(BaseAppScreen):
             and last_exact[1] >= geometry.revision
         ):
             return True
+        last_attempt = self._library_media_last_settlement_attempt
+        if (
+            last_attempt is not None
+            and last_attempt[0] == request.request_id
+            and last_attempt[1] >= geometry.revision
+        ):
+            return False
 
         desired = request.receipt.scroll_offset
         if desired is None or desired[0] < 0 or desired[1] < 0:
@@ -6996,32 +7010,65 @@ class LibraryScreen(BaseAppScreen):
             target,
         ):
             return False
-
-        owner.scroll_to(
-            x=desired[0],
-            y=desired[1],
-            animate=False,
-            force=True,
-            immediate=True,
+        pre_scroll = (int(owner.scroll_x), int(owner.scroll_y))
+        pre_focus = self.focused
+        committed = False
+        self._library_media_last_settlement_attempt = (
+            request.request_id,
+            geometry.revision,
         )
-        if (int(owner.scroll_x), int(owner.scroll_y)) != desired:
-            return False
-        if not self._library_media_live_focus_is_allowed(
-            request.focus_anchor,
-            request.receipt.stable_id,
-            target,
-        ):
-            return False
-        self._library_notes_programmatic_focus_target = target
-        self.set_focus(target, scroll_visible=False)
-        if self.focused is not target:
-            return False
-        if (int(owner.scroll_x), int(owner.scroll_y)) != desired:
-            return False
-
-        self._library_media_last_exact_settlement = (request, geometry.revision)
-        self._library_media_return_settlement = None
-        return True
+        try:
+            owner.scroll_to(
+                x=desired[0],
+                y=desired[1],
+                animate=False,
+                force=True,
+                immediate=True,
+            )
+            if (int(owner.scroll_x), int(owner.scroll_y)) == desired and (
+                self._library_media_live_focus_is_allowed(
+                    request.focus_anchor,
+                    request.receipt.stable_id,
+                    target,
+                )
+            ):
+                self._library_notes_programmatic_focus_target = target
+                self.set_focus(target, scroll_visible=False)
+                committed = bool(
+                    self.focused is target
+                    and (int(owner.scroll_x), int(owner.scroll_y)) == desired
+                )
+                if committed:
+                    self._library_media_last_exact_settlement = (
+                        request,
+                        geometry.revision,
+                    )
+                    self._library_media_return_settlement = None
+        finally:
+            self._library_notes_programmatic_focus_target = None
+            if not committed:
+                owner.scroll_to(
+                    x=pre_scroll[0],
+                    y=pre_scroll[1],
+                    animate=False,
+                    force=True,
+                    immediate=True,
+                )
+                valid_pre_focus = bool(
+                    pre_focus is not None
+                    and pre_focus.is_attached
+                    and self in pre_focus.ancestors
+                )
+                if self.focused is not pre_focus:
+                    self.set_focus(
+                        pre_focus if valid_pre_focus else None,
+                        scroll_visible=False,
+                    )
+        if committed:
+            # Keep the existing one-event guard for the queued Focus bubble;
+            # every failed path leaves it cleared by the finally block above.
+            self._library_notes_programmatic_focus_target = target
+        return committed
 
     @on(LibraryMediaRowGeometryChanged)
     def _handle_library_media_row_geometry_changed(
@@ -7037,7 +7084,10 @@ class LibraryScreen(BaseAppScreen):
         receipt = self._library_pending_list_entry_media_return
         if receipt is None or receipt.final_focus_policy != "row":
             return
-        request = self._arm_library_media_return_settlement(receipt)
+        request = self._arm_library_media_return_settlement(
+            receipt,
+            consume_latest_geometry=False,
+        )
         if request is not None:
             self._settle_library_media_return_from_geometry(
                 request,
@@ -11189,6 +11239,8 @@ class LibraryScreen(BaseAppScreen):
         self._library_pending_list_entry_media_return = None
         self._library_pending_list_entry_focus_anchor = None
         self._library_media_return_settlement = None
+        self._library_media_last_exact_settlement = None
+        self._library_media_last_settlement_attempt = None
         if self._library_list_entry_focus_timer is not None:
             self._library_list_entry_focus_timer.stop()
             self._library_list_entry_focus_timer = None

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -6778,6 +6778,8 @@ class LibraryScreen(BaseAppScreen):
     def _advance_library_media_presentation_epoch(
         self,
         owner: LibraryMediaRowScroll | None,
+        *,
+        rearm: bool = True,
     ) -> None:
         """Fence geometry already emitted before a Media presentation change."""
         self._library_media_presentation_epoch += 1
@@ -6794,7 +6796,11 @@ class LibraryScreen(BaseAppScreen):
             )
         self._library_media_return_settlement = None
         receipt = self._library_pending_list_entry_media_return
-        if owner is not None and self._library_media_return_candidate(receipt):
+        if (
+            rearm
+            and owner is not None
+            and self._library_media_return_candidate(receipt)
+        ):
             self._arm_library_media_return_settlement(receipt)
 
     def _library_media_return_candidate(
@@ -6822,6 +6828,19 @@ class LibraryScreen(BaseAppScreen):
             and receipt.layout_signature == self._library_media_layout_signature()
         )
 
+    def _library_media_semantic_row_is_current(
+        self,
+        receipt: _LibraryMediaReturnReceipt,
+        items_host: Vertical,
+    ) -> bool:
+        """Return whether the receipt's attached row belongs to current Items."""
+        return any(
+            row.is_attached
+            and str(getattr(row, "media_id", "") or "") == receipt.stable_id
+            and items_host in row.ancestors
+            for row in self.query(".library-media-row")
+        )
+
     def _library_media_request_matches_current_authority(
         self,
         request: _LibraryMediaReturnSettlement,
@@ -6840,6 +6859,8 @@ class LibraryScreen(BaseAppScreen):
             and request.media_lifecycle_generation
             == self._library_media_lifecycle_generation
             and request.presentation_epoch == self._library_media_presentation_epoch
+            and request.content_signature == self._library_media_content_signature()
+            and request.layout_signature == self._library_media_layout_signature()
             and request.route_identity == self._library_entry_route_key()
             and request.media_view_identity == self._library_media_view == "list"
             and request.shell_identity == id(shell)
@@ -6955,6 +6976,16 @@ class LibraryScreen(BaseAppScreen):
             return None
         shell, items_host, owner = tree
         self._adopt_library_media_row_owner(owner)
+        if (
+            receipt.final_focus_policy == "row"
+            and not self._library_media_exact_return_candidate(receipt)
+            and not self._library_media_semantic_row_is_current(receipt, items_host)
+        ):
+            # A revised list that removed the semantic origin uses the
+            # established retained-row/recovery focus path. It cannot mint a
+            # geometry settlement whose row identity is already gone.
+            self._library_media_return_settlement = None
+            return None
 
         current = self._library_media_return_settlement
         if current is not None:
@@ -7112,6 +7143,8 @@ class LibraryScreen(BaseAppScreen):
             desired,
             outcome,
         )
+        if committed and revised:
+            self._disarm_library_list_entry_focus()
         return committed
 
     def _resolve_library_media_settlement_target(
@@ -7126,7 +7159,7 @@ class LibraryScreen(BaseAppScreen):
         rows = [
             row
             for row in self.query(".library-media-row")
-            if items_host in row.ancestors
+            if row.is_attached and items_host in row.ancestors
         ]
         semantic_row = next(
             (
@@ -7162,9 +7195,14 @@ class LibraryScreen(BaseAppScreen):
                         and not bool(getattr(candidate, "disabled", False))
                     ):
                         control = candidate
-            if control is not None:
+            if semantic_row is None:
+                if not revised:
+                    return None
+                if rows:
+                    return rows[0], True
+            elif control is not None:
                 return control, False
-            if not responsive_layout_revised:
+            if semantic_row is not None and not responsive_layout_revised:
                 return None
             if semantic_row is not None:
                 return semantic_row, True
@@ -8625,10 +8663,15 @@ class LibraryScreen(BaseAppScreen):
         if layout_changed:
             tree = self._library_media_settlement_tree()
             self._advance_library_media_presentation_epoch(
-                tree[2] if tree is not None else None
+                tree[2] if tree is not None else None,
+                rearm=False,
             )
         shell.sync_layout(layout)
         self._library_media_reader_layout = layout
+        if layout_changed:
+            receipt = self._library_pending_list_entry_media_return
+            if self._library_media_return_candidate(receipt):
+                self._arm_library_media_return_settlement(receipt)
         if hidden_focus_target is not None:
             self._focus_library_media_grip_if_current(
                 generation,
@@ -11695,10 +11738,21 @@ class LibraryScreen(BaseAppScreen):
             receipt = self._library_pending_list_entry_media_return
             if self._library_media_return_candidate(receipt):
                 self._arm_library_media_return_settlement(receipt)
-                if self._library_media_settlement_tree() is None:
+                tree = self._library_media_settlement_tree()
+                revised_row_without_origin = bool(
+                    receipt is not None
+                    and receipt.final_focus_policy == "row"
+                    and not self._library_media_exact_return_candidate(receipt)
+                    and tree is not None
+                    and not self._library_media_semantic_row_is_current(
+                        receipt,
+                        tree[1],
+                    )
+                )
+                if tree is None or revised_row_without_origin:
                     # Empty Media has no row-scroll geometry owner. Preserve
-                    # its established Import/recovery focus path; there is no
-                    # list offset to order before that control focus.
+                    # its Import/recovery focus path; a revised list whose
+                    # origin disappeared likewise uses its retained first row.
                     self._focus_library_list_entry()
                 return
             self._focus_library_list_entry()
@@ -17652,7 +17706,7 @@ class LibraryScreen(BaseAppScreen):
                     is pending_receipt
                     and pending_receipt is not None
                 ):
-                    self._arm_library_media_return_settlement(pending_receipt)
+                    self._focus_library_list_entry_if_current(exact_generation)
 
             then = arm_exact_return
         elif pending_entry_focus_generation is not None:
@@ -27038,19 +27092,13 @@ class LibraryScreen(BaseAppScreen):
             pass
         else:
             scroll_offset = (int(scroll.scroll_x), int(scroll.scroll_y))
-        focused = self.focused
-        focus_identity = (
-            str(focused.id)
-            if focused is not None and focused.id
-            else "library-media-trash-open"
-        )
         return _LibraryMediaReturnReceipt(
             stable_id=self._selected_media_id,
             scroll_offset=scroll_offset,
             content_signature=self._library_media_content_signature(),
             layout_signature=self._library_media_layout_signature(),
             final_focus_policy="control",
-            final_focus_identity=focus_identity,
+            final_focus_identity="library-media-trash-open",
         )
 
     @on(Input.Changed, "#library-media-trash-search")

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -7118,7 +7118,7 @@ class LibraryScreen(BaseAppScreen):
         return self._library_media_return_settlement
 
     def _bind_library_media_settlement_deadline(self, request_id: int) -> None:
-        """Bind the existing outer deadline to one ABA-safe request ID."""
+        """Bind the outer deadline to its Media request and focus generation."""
         deadline = self._library_list_entry_focus_deadline
         if deadline is None or not self._library_pending_list_entry_focus:
             return
@@ -7127,7 +7127,11 @@ class LibraryScreen(BaseAppScreen):
         remaining = max(0.0, deadline - time.monotonic())
         self._library_list_entry_focus_timer = self.set_timer(
             remaining,
-            partial(self._expire_library_media_return_settlement, request_id),
+            partial(
+                self._expire_library_media_return_settlement,
+                request_id,
+                self._library_list_entry_focus_generation,
+            ),
         )
 
     def _settle_library_media_return_from_geometry(
@@ -7433,12 +7437,20 @@ class LibraryScreen(BaseAppScreen):
             self._library_notes_programmatic_focus_target = target
         return committed
 
-    def _expire_library_media_return_settlement(self, request_id: int) -> None:
+    def _expire_library_media_return_settlement(
+        self,
+        request_id: int,
+        outer_generation: int,
+    ) -> None:
         """Finish one ABA-bound outer arm without inferring layout readiness."""
+        if (
+            request_id != self._library_media_return_request_id
+            or outer_generation != self._library_list_entry_focus_generation
+        ):
+            return
         request = self._library_media_return_settlement
         if request is None:
-            if request_id == self._library_media_return_request_id:
-                self._disarm_library_list_entry_focus()
+            self._disarm_library_list_entry_focus()
             return
         if request.request_id != request_id:
             return

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1082,6 +1082,16 @@ class _LibraryMediaReturnSettlement:
 
 
 @dataclasses.dataclass(frozen=True)
+class _LibraryMediaSuccessfulFocusOwnership:
+    """ABA-fenced focus ownership retained after one exact settlement."""
+
+    request: _LibraryMediaReturnSettlement
+    outer_generation: int
+    selected_media_id: str | None
+    target: Widget
+
+
+@dataclasses.dataclass(frozen=True)
 class _LibraryEmergencyReturnEligibility:
     """One immutable truth source for narrow-canvas recovery chrome."""
 
@@ -3773,6 +3783,9 @@ class LibraryScreen(BaseAppScreen):
                 tuple[object, ...],
             ]
             | None
+        ) = None
+        self._library_media_successful_focus_ownership: (
+            _LibraryMediaSuccessfulFocusOwnership | None
         ) = None
         self._library_media_last_settlement_attempt: tuple[int, int] | None = None
         self._library_media_last_settlement_outcome: (
@@ -6890,13 +6903,54 @@ class LibraryScreen(BaseAppScreen):
             return True
         guarded_target = target or self._library_notes_programmatic_focus_target
         receipt = self._library_pending_list_entry_media_return
-        return bool(
+        transient_focus_allowed = bool(
             guarded_target is not None
             and focused is guarded_target
             and self._library_notes_programmatic_focus_target is guarded_target
             and receipt is not None
             and self._library_media_focus_target_matches_receipt(
                 focused,
+                receipt,
+                stable_id,
+            )
+        )
+        return transient_focus_allowed or bool(
+            receipt is not None
+            and self._library_media_successful_focus_is_allowed(
+                receipt,
+                stable_id,
+            )
+        )
+
+    def _library_media_successful_focus_is_allowed(
+        self,
+        receipt: _LibraryMediaReturnReceipt,
+        stable_id: str,
+    ) -> bool:
+        """Recognize exact-settled focus for this outer arm only."""
+        ownership = self._library_media_successful_focus_ownership
+        if ownership is None:
+            return False
+        request = ownership.request
+        target = ownership.target
+        return bool(
+            self._library_pending_list_entry_focus
+            and self._library_pending_list_entry_media_return is receipt
+            and ownership.outer_generation
+            == self._library_list_entry_focus_generation
+            and request.receipt is receipt
+            and request.request_id <= self._library_media_return_request_id
+            and request.focus_intent_generation
+            == self._library_notes_focus_intent_generation
+            and request.route_identity == self._library_entry_route_key()
+            and request.media_view_identity == self._library_media_view == "list"
+            and request.final_focus_policy == receipt.final_focus_policy
+            and request.final_focus_identity == receipt.final_focus_identity
+            and request.receipt.stable_id == stable_id
+            and ownership.selected_media_id == self._selected_media_id == stable_id
+            and self.focused is target
+            and self._library_media_focus_target_matches_receipt(
+                target,
                 receipt,
                 stable_id,
             )
@@ -7049,7 +7103,9 @@ class LibraryScreen(BaseAppScreen):
             focus_anchor=self._library_pending_list_entry_focus_anchor,
         )
         self._library_media_return_settlement = request
+        self._library_media_last_exact_settlement = None
         self._library_media_last_successful_settlement = None
+        self._library_media_last_settlement_attempt = None
         self._library_media_last_settlement_outcome = None
         self._bind_library_media_settlement_deadline(request.request_id)
         latest = owner.latest_geometry
@@ -7337,6 +7393,16 @@ class LibraryScreen(BaseAppScreen):
                         geometry.revision,
                         current_content_signature,
                         current_layout_signature,
+                    )
+                    self._library_media_successful_focus_ownership = (
+                        _LibraryMediaSuccessfulFocusOwnership(
+                            request=request,
+                            outer_generation=self._library_list_entry_focus_generation,
+                            selected_media_id=pre_selected_id,
+                            target=target,
+                        )
+                        if outcome == "exact-settled"
+                        else None
                     )
                     self._library_media_return_settlement = None
         finally:
@@ -11554,6 +11620,7 @@ class LibraryScreen(BaseAppScreen):
         new one is scheduled, so only the most recent arm's timer is ever
         live.
         """
+        self._library_media_successful_focus_ownership = None
         if self._library_list_entry_focus_timer is not None:
             self._library_list_entry_focus_timer.stop()
             self._library_list_entry_focus_timer = None
@@ -11608,6 +11675,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_return_settlement = None
         self._library_media_last_exact_settlement = None
         self._library_media_last_successful_settlement = None
+        self._library_media_successful_focus_ownership = None
         self._library_media_last_settlement_attempt = None
         self._library_list_entry_focus_deadline = None
         if self._library_list_entry_focus_timer is not None:
@@ -11644,18 +11712,26 @@ class LibraryScreen(BaseAppScreen):
             return
         self._remember_library_notes_authority_focus(focused)
         target_restore = self._library_notes_programmatic_focus_target is focused
+        pending_receipt = self._library_pending_list_entry_media_return
+        successful_return_focus = bool(
+            pending_receipt is not None
+            and self._library_media_successful_focus_is_allowed(
+                pending_receipt,
+                pending_receipt.stable_id,
+            )
+        )
         programmatic = bool(
             target_restore
+            or successful_return_focus
             or self._library_notes_restoring_focus
             or self._library_notes_resize_settling
         )
-        pending_receipt = self._library_pending_list_entry_media_return
         if (
             self._library_pending_list_entry_focus
             and pending_receipt is not None
         ):
             guarded_return_focus = bool(
-                target_restore
+                (target_restore or successful_return_focus)
                 and focused is not None
                 and self._library_media_focus_target_matches_receipt(
                     focused,
@@ -11711,7 +11787,11 @@ class LibraryScreen(BaseAppScreen):
 
         if not self._library_pending_list_entry_focus:
             return
-        if target_restore and pending_receipt is not None and focused is not None:
+        if (
+            (target_restore or successful_return_focus)
+            and pending_receipt is not None
+            and focused is not None
+        ):
             if self._library_media_focus_target_matches_receipt(
                 focused,
                 pending_receipt,

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -6697,11 +6697,6 @@ class LibraryScreen(BaseAppScreen):
 
     def _project_library_media_stage_classes(self, shell_grid: Widget) -> bool:
         """Project effective Media stage classes; return whether they changed."""
-        current_owner: LibraryMediaRowScroll | None = None
-        if shell_grid.is_attached:
-            tree = self._library_media_settlement_tree()
-            if tree is not None and shell_grid in tree[0].ancestors:
-                current_owner = tree[2]
         changed = False
         if shell_grid.has_class("library-notes-compact"):
             shell_grid.remove_class("library-notes-compact")
@@ -6713,6 +6708,11 @@ class LibraryScreen(BaseAppScreen):
             )
             changed = True
         if changed:
+            current_owner: LibraryMediaRowScroll | None = None
+            if shell_grid.is_attached:
+                tree = self._library_media_settlement_tree()
+                if tree is not None and shell_grid in tree[0].ancestors:
+                    current_owner = tree[2]
             self._advance_library_media_presentation_epoch(current_owner)
         return changed
 
@@ -7035,6 +7035,7 @@ class LibraryScreen(BaseAppScreen):
             )
         )
         adaptive_notes = bool(self.query("#library-notes-reader-shell"))
+        adaptive_media = bool(self.query("#library-media-reader-shell"))
         # Only the grid and canvas host participate in compact CSS selectors;
         # tagging the rail and inner Notes canvas forced two needless global
         # stylesheet matches on every breakpoint crossing. Apply these before
@@ -7045,11 +7046,16 @@ class LibraryScreen(BaseAppScreen):
         legacy_compact = self._library_notes_compact and (
             not adaptive_reader or adaptive_notes
         )
-        for widget in (shell, canvas):
+        compact_widgets = (canvas,) if adaptive_media else (shell, canvas)
+        for widget in compact_widgets:
             if widget.has_class("library-notes-compact") != legacy_compact:
                 widget.set_class(legacy_compact, "library-notes-compact")
         adaptive_compact = self._library_notes_compact and adaptive_reader
-        if shell.has_class("library-adaptive-compact") != adaptive_compact:
+        if adaptive_media:
+            # Media's Task 1 projection is the single class writer and the
+            # presentation-epoch/floor producer for its adaptive shell.
+            self._project_library_media_stage_classes(shell)
+        elif shell.has_class("library-adaptive-compact") != adaptive_compact:
             shell.set_class(adaptive_compact, "library-adaptive-compact")
         if self._apply_library_emergency_geometry(
             shell=shell,
@@ -11097,6 +11103,13 @@ class LibraryScreen(BaseAppScreen):
         exact_media_return = self._library_media_exact_return_candidate(media_return)
         if exact_media_return:
             self._arm_library_media_return_settlement(media_return)
+            # Preserve the bounded outer-arm continuation. It may construct
+            # fresh authority after composition, but `_arm` still requires a
+            # current owner's public geometry before exact settlement.
+            self.call_after_refresh(
+                self._focus_library_list_entry_if_current,
+                self._library_list_entry_focus_generation,
+            )
         elif media_return is None:
             self.call_after_refresh(self._focus_library_list_entry)
         else:
@@ -11161,6 +11174,23 @@ class LibraryScreen(BaseAppScreen):
             or self._library_notes_restoring_focus
             or self._library_notes_resize_settling
         )
+        pending_receipt = self._library_pending_list_entry_media_return
+        if (
+            self._library_pending_list_entry_focus
+            and pending_receipt is not None
+            and pending_receipt.final_focus_policy == "row"
+        ):
+            guarded_return_focus = bool(
+                target_restore
+                and focused is not None
+                and focused.has_class("library-media-row")
+                and str(getattr(focused, "media_id", "") or "")
+                == pending_receipt.stable_id
+            )
+            if not guarded_return_focus:
+                # Revoke the retained receipt before a genuine row selection
+                # can recompose Media and expose any newer owner geometry.
+                self._disarm_library_list_entry_focus()
         if (
             focused is not None
             and focused.has_class("library-media-row")

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1037,6 +1037,13 @@ class _LibraryEntryFocusCapture:
 
 
 _LibraryMediaFinalFocusPolicy: TypeAlias = Literal["row", "control"]
+_LibraryMediaSettlementOutcome: TypeAlias = Literal[
+    "exact-settled",
+    "exact-scroll-focus-fallback",
+    "clamped-after-revision",
+    "clamped-after-settlement-failure",
+    "layout-settlement-failed",
+]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -3758,7 +3765,19 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_last_exact_settlement: (
             tuple[_LibraryMediaReturnSettlement, int] | None
         ) = None
+        self._library_media_last_successful_settlement: (
+            tuple[
+                _LibraryMediaReturnSettlement,
+                int,
+                tuple[object, ...],
+                tuple[object, ...],
+            ]
+            | None
+        ) = None
         self._library_media_last_settlement_attempt: tuple[int, int] | None = None
+        self._library_media_last_settlement_outcome: (
+            tuple[int, _LibraryMediaSettlementOutcome, int | None] | None
+        ) = None
         # task-4022 AC2: the ids from the most recently completed media
         # delete (bulk OR, since task-14901, the single-item viewer
         # delete), rendered as a "✓ deleted · N items" receipt (with
@@ -4612,6 +4631,7 @@ class LibraryScreen(BaseAppScreen):
         # the handle here lets ``_arm_library_list_entry_focus`` cancel any
         # prior timer before scheduling a new one -- see both methods.
         self._library_list_entry_focus_timer: Timer | None = None
+        self._library_list_entry_focus_deadline: float | None = None
         # task-15459: seed from the app-scoped snapshot cache now, pre-mount,
         # so a warm revisit's FIRST ``compose_content`` already renders real
         # data instead of the loading placeholder -- see
@@ -6774,22 +6794,30 @@ class LibraryScreen(BaseAppScreen):
             )
         self._library_media_return_settlement = None
         receipt = self._library_pending_list_entry_media_return
-        if (
-            owner is not None
-            and receipt is not None
-            and receipt.final_focus_policy == "row"
-        ):
+        if owner is not None and self._library_media_return_candidate(receipt):
             self._arm_library_media_return_settlement(receipt)
+
+    def _library_media_return_candidate(
+        self,
+        receipt: _LibraryMediaReturnReceipt | None,
+    ) -> bool:
+        """Return whether one retained receipt can enter Media settlement."""
+        return bool(
+            receipt is not None
+            and receipt.final_focus_policy in {"row", "control"}
+            and receipt.scroll_offset is not None
+            and receipt.scroll_offset[0] >= 0
+            and receipt.scroll_offset[1] >= 0
+        )
 
     def _library_media_exact_return_candidate(
         self,
         receipt: _LibraryMediaReturnReceipt | None,
     ) -> bool:
-        """Return whether Task 2 may attempt an unchanged exact row return."""
+        """Return whether one retained Media coordinate system is unchanged."""
         return bool(
-            receipt is not None
-            and receipt.final_focus_policy == "row"
-            and receipt.scroll_offset is not None
+            self._library_media_return_candidate(receipt)
+            and receipt is not None
             and receipt.content_signature == self._library_media_content_signature()
             and receipt.layout_signature == self._library_media_layout_signature()
         )
@@ -6812,8 +6840,6 @@ class LibraryScreen(BaseAppScreen):
             and request.media_lifecycle_generation
             == self._library_media_lifecycle_generation
             and request.presentation_epoch == self._library_media_presentation_epoch
-            and request.content_signature == self._library_media_content_signature()
-            and request.layout_signature == self._library_media_layout_signature()
             and request.route_identity == self._library_entry_route_key()
             and request.media_view_identity == self._library_media_view == "list"
             and request.shell_identity == id(shell)
@@ -6842,12 +6868,65 @@ class LibraryScreen(BaseAppScreen):
         if focused is None or focused is focus_anchor:
             return True
         guarded_target = target or self._library_notes_programmatic_focus_target
+        receipt = self._library_pending_list_entry_media_return
         return bool(
             guarded_target is not None
             and focused is guarded_target
             and self._library_notes_programmatic_focus_target is guarded_target
-            and focused.has_class("library-media-row")
-            and str(getattr(focused, "media_id", "") or "") == stable_id
+            and receipt is not None
+            and self._library_media_focus_target_matches_receipt(
+                focused,
+                receipt,
+                stable_id,
+            )
+        )
+
+    def _library_media_focus_target_matches_receipt(
+        self,
+        target: Widget,
+        receipt: _LibraryMediaReturnReceipt,
+        stable_id: str,
+    ) -> bool:
+        """Return whether a guarded target satisfies one receipt's policy."""
+        if not target.is_attached or self not in target.ancestors:
+            return False
+        target_is_semantic_row = bool(
+            target.has_class("library-media-row")
+            and str(getattr(target, "media_id", "") or "") == stable_id
+        )
+        if receipt.final_focus_policy == "row":
+            if target_is_semantic_row:
+                return True
+            revised = bool(
+                receipt.content_signature != self._library_media_content_signature()
+                or receipt.layout_signature != self._library_media_layout_signature()
+            )
+            return revised and bool(
+                target.has_class("library-media-row")
+                or target.id
+                in {
+                    "library-media-trash-open",
+                    "library-media-type-filter",
+                    "library-media-empty-import",
+                }
+            )
+        if (
+            receipt.final_focus_policy == "control"
+            and receipt.final_focus_identity
+            and target.id == receipt.final_focus_identity
+        ):
+            return True
+        responsive_layout_revised = bool(
+            receipt.layout_signature != self._library_media_layout_signature()
+        )
+        return responsive_layout_revised and bool(
+            target_is_semantic_row
+            or target.id
+            in {
+                "library-media-trash-open",
+                "library-media-type-filter",
+                "library-media-empty-import",
+            }
         )
 
     def _arm_library_media_return_settlement(
@@ -6860,7 +6939,7 @@ class LibraryScreen(BaseAppScreen):
         if (
             not self._library_pending_list_entry_focus
             or self._library_pending_list_entry_media_return is not receipt
-            or not self._library_media_exact_return_candidate(receipt)
+            or not self._library_media_return_candidate(receipt)
             or self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
             or self._library_media_view != "list"
             or not self._library_media_live_focus_is_allowed(
@@ -6878,25 +6957,37 @@ class LibraryScreen(BaseAppScreen):
         self._adopt_library_media_row_owner(owner)
 
         current = self._library_media_return_settlement
-        if current is not None and self._library_media_request_matches_current_authority(
-            current,
-            receipt,
-            tree,
-        ):
-            latest = owner.latest_geometry
-            if consume_latest_geometry and latest is not None:
-                self._settle_library_media_return_from_geometry(
-                    current,
-                    owner,
-                    latest,
-                )
-            return self._library_media_return_settlement
+        if current is not None:
+            if self._library_media_request_matches_current_authority(
+                current,
+                receipt,
+                tree,
+            ):
+                latest = owner.latest_geometry
+                if consume_latest_geometry and latest is not None:
+                    self._settle_library_media_return_from_geometry(
+                        current,
+                        owner,
+                        latest,
+                    )
+                return self._library_media_return_settlement
+            # A request that lost any non-geometry fence cannot renew itself
+            # from the geometry event it was waiting for. Real replacement or
+            # presentation seams clear the old request before arming authority
+            # for their current tree.
+            self._library_media_return_settlement = None
+            return None
 
-        last_exact = self._library_media_last_exact_settlement
-        if last_exact is not None and self._library_media_request_matches_current_authority(
-            last_exact[0],
-            receipt,
-            tree,
+        last_success = self._library_media_last_successful_settlement
+        if (
+            last_success is not None
+            and self._library_media_request_matches_current_authority(
+                last_success[0],
+                receipt,
+                tree,
+            )
+            and last_success[2] == self._library_media_content_signature()
+            and last_success[3] == self._library_media_layout_signature()
         ):
             return None
 
@@ -6927,6 +7018,9 @@ class LibraryScreen(BaseAppScreen):
             focus_anchor=self._library_pending_list_entry_focus_anchor,
         )
         self._library_media_return_settlement = request
+        self._library_media_last_successful_settlement = None
+        self._library_media_last_settlement_outcome = None
+        self._bind_library_media_settlement_deadline(request.request_id)
         latest = owner.latest_geometry
         if (
             consume_latest_geometry
@@ -6936,13 +7030,26 @@ class LibraryScreen(BaseAppScreen):
             self._settle_library_media_return_from_geometry(request, owner, latest)
         return self._library_media_return_settlement
 
+    def _bind_library_media_settlement_deadline(self, request_id: int) -> None:
+        """Bind the existing outer deadline to one ABA-safe request ID."""
+        deadline = self._library_list_entry_focus_deadline
+        if deadline is None or not self._library_pending_list_entry_focus:
+            return
+        if self._library_list_entry_focus_timer is not None:
+            self._library_list_entry_focus_timer.stop()
+        remaining = max(0.0, deadline - time.monotonic())
+        self._library_list_entry_focus_timer = self.set_timer(
+            remaining,
+            partial(self._expire_library_media_return_settlement, request_id),
+        )
+
     def _settle_library_media_return_from_geometry(
         self,
         request: _LibraryMediaReturnSettlement,
         owner: LibraryMediaRowScroll,
         geometry: LibraryMediaRowGeometry,
     ) -> bool:
-        """Commit exact scroll and then row focus from current-owner geometry."""
+        """Commit one honest scroll/focus outcome from current-owner geometry."""
         if (
             self._library_media_return_settlement is not request
             or self._library_media_return_settlement.request_id != request.request_id
@@ -6959,15 +7066,19 @@ class LibraryScreen(BaseAppScreen):
                 receipt,
                 tree,
             )
-            or request.content_signature != request.receipt.content_signature
-            or request.layout_signature != request.receipt.layout_signature
-            or request.receipt.stable_id != self._selected_media_id
             or geometry.revision <= request.exclusive_geometry_floor
             or owner.latest_geometry != geometry
             or (owner.size, owner.virtual_size, owner.container_size)
             != (geometry.size, geometry.virtual_size, geometry.container_size)
         ):
             return False
+        last_outcome = self._library_media_last_settlement_outcome
+        if (
+            last_outcome is not None
+            and last_outcome[0] == request.request_id
+            and last_outcome[2] == geometry.revision
+        ):
+            return True
         last_exact = self._library_media_last_exact_settlement
         if (
             last_exact is not None
@@ -6975,43 +7086,167 @@ class LibraryScreen(BaseAppScreen):
             and last_exact[1] >= geometry.revision
         ):
             return True
+        desired = request.receipt.scroll_offset
+        if desired is None:
+            return False
+        revised = not self._library_media_exact_return_candidate(request.receipt)
+        if not revised and request.receipt.stable_id != self._selected_media_id:
+            return False
+        if revised:
+            desired = (
+                min(desired[0], int(owner.max_scroll_x)),
+                min(desired[1], int(owner.max_scroll_y)),
+            )
+            outcome: _LibraryMediaSettlementOutcome = "clamped-after-revision"
+        else:
+            if (
+                desired[0] > int(owner.max_scroll_x)
+                or desired[1] > int(owner.max_scroll_y)
+            ):
+                return False
+            outcome = "exact-settled"
+        committed = self._commit_library_media_return(
+            request,
+            owner,
+            geometry,
+            desired,
+            outcome,
+        )
+        return committed
+
+    def _resolve_library_media_settlement_target(
+        self,
+        request: _LibraryMediaReturnSettlement,
+        items_host: Vertical,
+        *,
+        revised: bool,
+        responsive_layout_revised: bool,
+    ) -> tuple[Widget, bool] | None:
+        """Resolve final semantic/control focus before settlement mutation."""
+        rows = [
+            row
+            for row in self.query(".library-media-row")
+            if items_host in row.ancestors
+        ]
+        semantic_row = next(
+            (
+                row
+                for row in rows
+                if str(getattr(row, "media_id", "") or "")
+                == request.receipt.stable_id
+            ),
+            None,
+        )
+        if request.final_focus_policy == "row":
+            if semantic_row is not None:
+                return semantic_row, False
+            if not revised:
+                return None
+            if rows:
+                return rows[0], True
+
+        else:
+            control: Widget | None = None
+            identity = request.final_focus_identity
+            if identity:
+                try:
+                    candidate = self.query_one(f"#{identity}", Widget)
+                except (NoMatches, QueryError):
+                    pass
+                else:
+                    if (
+                        candidate.is_attached
+                        and self in candidate.ancestors
+                        and candidate.display
+                        and candidate.can_focus
+                        and not bool(getattr(candidate, "disabled", False))
+                    ):
+                        control = candidate
+            if control is not None:
+                return control, False
+            if not responsive_layout_revised:
+                return None
+            if semantic_row is not None:
+                return semantic_row, True
+        for selector in (
+            "#library-media-trash-open",
+            "#library-media-type-filter",
+            "#library-media-empty-import",
+        ):
+            try:
+                fallback = self.query_one(selector, Widget)
+            except (NoMatches, QueryError):
+                continue
+            if (
+                fallback.is_attached
+                and fallback.display
+                and fallback.can_focus
+                and not bool(getattr(fallback, "disabled", False))
+            ):
+                return fallback, True
+        return None
+
+    def _commit_library_media_return(
+        self,
+        request: _LibraryMediaReturnSettlement,
+        owner: LibraryMediaRowScroll,
+        geometry: LibraryMediaRowGeometry,
+        desired: tuple[int, int],
+        outcome: _LibraryMediaSettlementOutcome,
+        *,
+        allow_reused_geometry: bool = False,
+    ) -> bool:
+        """Transactionally apply scroll, guarded focus, and terminal outcome."""
+        tree = self._library_media_settlement_tree()
+        receipt = self._library_pending_list_entry_media_return
+        if (
+            tree is None
+            or receipt is None
+            or tree[2] is not owner
+            or not self._library_media_request_matches_current_authority(
+                request,
+                receipt,
+                tree,
+            )
+        ):
+            return False
+        current_content_signature = self._library_media_content_signature()
+        current_layout_signature = self._library_media_layout_signature()
+        responsive_layout_revised = bool(
+            receipt.layout_signature != current_layout_signature
+        )
+        revised = bool(
+            responsive_layout_revised
+            or receipt.content_signature != current_content_signature
+        )
+        resolved = self._resolve_library_media_settlement_target(
+            request,
+            tree[1],
+            revised=revised,
+            responsive_layout_revised=responsive_layout_revised,
+        )
+        if resolved is None:
+            return False
+        target, focus_fallback = resolved
+        if not self._library_media_live_focus_is_allowed(
+            request.focus_anchor,
+            receipt.stable_id,
+            target,
+        ):
+            return False
         last_attempt = self._library_media_last_settlement_attempt
         if (
-            last_attempt is not None
+            not allow_reused_geometry
+            and last_attempt is not None
             and last_attempt[0] == request.request_id
             and last_attempt[1] >= geometry.revision
         ):
             return False
 
-        desired = request.receipt.scroll_offset
-        if desired is None or desired[0] < 0 or desired[1] < 0:
-            return False
-        if (
-            desired[0] > int(owner.max_scroll_x)
-            or desired[1] > int(owner.max_scroll_y)
-        ):
-            return False
-        items_host = tree[1]
-        target = next(
-            (
-                row
-                for row in self.query(".library-media-row")
-                if str(getattr(row, "media_id", "") or "")
-                == request.receipt.stable_id
-                and items_host in row.ancestors
-            ),
-            None,
-        )
-        if target is None:
-            return False
-        if not self._library_media_live_focus_is_allowed(
-            request.focus_anchor,
-            request.receipt.stable_id,
-            target,
-        ):
-            return False
         pre_scroll = (int(owner.scroll_x), int(owner.scroll_y))
         pre_focus = self.focused
+        pre_selected_id = self._selected_media_id
+        pre_outcome = self._library_media_last_settlement_outcome
         committed = False
         self._library_media_last_settlement_attempt = (
             request.request_id,
@@ -7037,11 +7272,33 @@ class LibraryScreen(BaseAppScreen):
                 committed = bool(
                     self.focused is target
                     and (int(owner.scroll_x), int(owner.scroll_y)) == desired
+                    and self._selected_media_id == pre_selected_id
                 )
                 if committed:
-                    self._library_media_last_exact_settlement = (
+                    if (
+                        request.final_focus_policy == "control"
+                        and focus_fallback
+                        and desired == receipt.scroll_offset
+                    ):
+                        outcome = "exact-scroll-focus-fallback"
+                    if outcome in {
+                        "exact-settled",
+                        "exact-scroll-focus-fallback",
+                    }:
+                        self._library_media_last_exact_settlement = (
+                            request,
+                            geometry.revision,
+                        )
+                    self._library_media_last_settlement_outcome = (
+                        request.request_id,
+                        outcome,
+                        geometry.revision,
+                    )
+                    self._library_media_last_successful_settlement = (
                         request,
                         geometry.revision,
+                        current_content_signature,
+                        current_layout_signature,
                     )
                     self._library_media_return_settlement = None
         finally:
@@ -7064,11 +7321,72 @@ class LibraryScreen(BaseAppScreen):
                         pre_focus if valid_pre_focus else None,
                         scroll_visible=False,
                     )
+                self._selected_media_id = pre_selected_id
+                self._library_media_last_settlement_outcome = pre_outcome
         if committed:
             # Keep the existing one-event guard for the queued Focus bubble;
             # every failed path leaves it cleared by the finally block above.
             self._library_notes_programmatic_focus_target = target
         return committed
+
+    def _expire_library_media_return_settlement(self, request_id: int) -> None:
+        """Finish one ABA-bound outer arm without inferring layout readiness."""
+        request = self._library_media_return_settlement
+        if request is None:
+            if request_id == self._library_media_return_request_id:
+                self._disarm_library_list_entry_focus()
+            return
+        if request.request_id != request_id:
+            return
+        tree = self._library_media_settlement_tree()
+        receipt = self._library_pending_list_entry_media_return
+        if (
+            tree is None
+            or receipt is None
+            or not self._library_media_request_matches_current_authority(
+                request,
+                receipt,
+                tree,
+            )
+        ):
+            self._disarm_library_list_entry_focus()
+            return
+
+        owner = tree[2]
+        geometry = owner.latest_geometry
+        committed = False
+        if (
+            geometry is not None
+            and geometry.revision > request.exclusive_geometry_floor
+            and (owner.size, owner.virtual_size, owner.container_size)
+            == (geometry.size, geometry.virtual_size, geometry.container_size)
+        ):
+            desired = request.receipt.scroll_offset
+            if desired is not None:
+                committed = self._commit_library_media_return(
+                    request,
+                    owner,
+                    geometry,
+                    (
+                        min(desired[0], int(owner.max_scroll_x)),
+                        min(desired[1], int(owner.max_scroll_y)),
+                    ),
+                    "clamped-after-settlement-failure",
+                    allow_reused_geometry=True,
+                )
+        if not committed:
+            self._library_media_last_settlement_outcome = (
+                request.request_id,
+                "layout-settlement-failed",
+                geometry.revision if geometry is not None else None,
+            )
+        notify = getattr(self.app_instance, "notify", None)
+        if callable(notify):
+            notify(
+                "Media return layout did not settle before its deadline.",
+                severity="warning",
+            )
+        self._disarm_library_list_entry_focus()
 
     @on(LibraryMediaRowGeometryChanged)
     def _handle_library_media_row_geometry_changed(
@@ -7082,7 +7400,7 @@ class LibraryScreen(BaseAppScreen):
             return
         self._adopt_library_media_row_owner(event.owner)
         receipt = self._library_pending_list_entry_media_return
-        if receipt is None or receipt.final_focus_policy != "row":
+        if not self._library_media_return_candidate(receipt):
             return
         request = self._arm_library_media_return_settlement(
             receipt,
@@ -8319,7 +8637,7 @@ class LibraryScreen(BaseAppScreen):
         elif (
             layout.items_open
             and self._library_pending_list_entry_focus
-            and not self._library_media_exact_return_candidate(
+            and not self._library_media_return_candidate(
                 self._library_pending_list_entry_media_return
             )
             and (
@@ -8721,7 +9039,7 @@ class LibraryScreen(BaseAppScreen):
             self._reconcile_library_media_stage_presentation()
             self._sync_library_media_reader_layout_from_shell()
             receipt = self._library_pending_list_entry_media_return
-            if receipt is not None and receipt.final_focus_policy == "row":
+            if self._library_media_return_candidate(receipt):
                 # Shell lifecycle establishes the replacement identity fences;
                 # only owner Resize geometry may complete the request.
                 self._arm_library_media_return_settlement(receipt)
@@ -10261,6 +10579,7 @@ class LibraryScreen(BaseAppScreen):
         self._invalidate_library_prompt_detail_generation()
         self._library_media_lifecycle_generation += 1
         self._library_media_return_settlement = None
+        self._library_media_last_settlement_outcome = None
         self._library_media_current_owner = None
         self._library_media_geometry_floor_owner_identity = None
         self._library_media_geometry_floor = 0
@@ -11192,12 +11511,18 @@ class LibraryScreen(BaseAppScreen):
         new one is scheduled, so only the most recent arm's timer is ever
         live.
         """
+        if self._library_list_entry_focus_timer is not None:
+            self._library_list_entry_focus_timer.stop()
+            self._library_list_entry_focus_timer = None
+        self._library_list_entry_focus_deadline = (
+            time.monotonic() + LIBRARY_LIST_ENTRY_FOCUS_ARMED_SECONDS
+        )
         self._library_list_entry_focus_generation += 1
         self._library_pending_list_entry_focus = True
         self._library_pending_list_entry_media_return = media_return
         self._library_pending_list_entry_focus_anchor = self.focused
-        exact_media_return = self._library_media_exact_return_candidate(media_return)
-        if exact_media_return:
+        settlement_media_return = self._library_media_return_candidate(media_return)
+        if settlement_media_return:
             self._arm_library_media_return_settlement(media_return)
             # Preserve the bounded outer-arm continuation. It may construct
             # fresh authority after composition, but `_arm` still requires a
@@ -11213,12 +11538,11 @@ class LibraryScreen(BaseAppScreen):
                 self._focus_library_list_entry_if_current,
                 self._library_list_entry_focus_generation,
             )
-        if self._library_list_entry_focus_timer is not None:
-            self._library_list_entry_focus_timer.stop()
-        self._library_list_entry_focus_timer = self.set_timer(
-            LIBRARY_LIST_ENTRY_FOCUS_ARMED_SECONDS,
-            self._disarm_library_list_entry_focus,
-        )
+        if self._library_list_entry_focus_timer is None:
+            self._library_list_entry_focus_timer = self.set_timer(
+                LIBRARY_LIST_ENTRY_FOCUS_ARMED_SECONDS,
+                self._disarm_library_list_entry_focus,
+            )
 
     def _disarm_library_list_entry_focus(self) -> None:
         """End an entry-focus request's settle window (task-2856 AC1).
@@ -11240,7 +11564,9 @@ class LibraryScreen(BaseAppScreen):
         self._library_pending_list_entry_focus_anchor = None
         self._library_media_return_settlement = None
         self._library_media_last_exact_settlement = None
+        self._library_media_last_successful_settlement = None
         self._library_media_last_settlement_attempt = None
+        self._library_list_entry_focus_deadline = None
         if self._library_list_entry_focus_timer is not None:
             self._library_list_entry_focus_timer.stop()
             self._library_list_entry_focus_timer = None
@@ -11284,14 +11610,15 @@ class LibraryScreen(BaseAppScreen):
         if (
             self._library_pending_list_entry_focus
             and pending_receipt is not None
-            and pending_receipt.final_focus_policy == "row"
         ):
             guarded_return_focus = bool(
                 target_restore
                 and focused is not None
-                and focused.has_class("library-media-row")
-                and str(getattr(focused, "media_id", "") or "")
-                == pending_receipt.stable_id
+                and self._library_media_focus_target_matches_receipt(
+                    focused,
+                    pending_receipt,
+                    pending_receipt.stable_id,
+                )
             )
             if not guarded_return_focus:
                 # Revoke the retained receipt before a genuine row selection
@@ -11341,6 +11668,13 @@ class LibraryScreen(BaseAppScreen):
 
         if not self._library_pending_list_entry_focus:
             return
+        if target_restore and pending_receipt is not None and focused is not None:
+            if self._library_media_focus_target_matches_receipt(
+                focused,
+                pending_receipt,
+                pending_receipt.stable_id,
+            ):
+                return
         row_class = _LIBRARY_LIST_ROW_CLASS_BY_ROW_ID.get(self._library_selected_row_id)
         widget = event.widget
         if row_class is not None and widget is not None and widget.has_class(row_class):
@@ -11359,8 +11693,13 @@ class LibraryScreen(BaseAppScreen):
             and generation == self._library_list_entry_focus_generation
         ):
             receipt = self._library_pending_list_entry_media_return
-            if self._library_media_exact_return_candidate(receipt):
+            if self._library_media_return_candidate(receipt):
                 self._arm_library_media_return_settlement(receipt)
+                if self._library_media_settlement_tree() is None:
+                    # Empty Media has no row-scroll geometry owner. Preserve
+                    # its established Import/recovery focus path; there is no
+                    # list offset to order before that control focus.
+                    self._focus_library_list_entry()
                 return
             self._focus_library_list_entry()
 
@@ -13100,32 +13439,6 @@ class LibraryScreen(BaseAppScreen):
         if viewer is not None:
             self._sync_library_media_viewer_state(viewer)
         self._arm_library_list_entry_focus(media_return=media_return)
-        if (
-            media_return is not None
-            and media_return.final_focus_policy == "control"
-        ):
-            self.call_after_refresh(
-                self._restore_library_media_trash_return_focus,
-                media_return,
-                self._library_list_entry_focus_generation,
-            )
-
-    def _restore_library_media_trash_return_focus(
-        self,
-        receipt: _LibraryMediaReturnReceipt,
-        generation: int,
-    ) -> None:
-        """Restore toolbar focus after the guarded row/scroll return lands."""
-        if (
-            self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
-            or self._library_media_view != "list"
-            or generation != self._library_list_entry_focus_generation
-        ):
-            return
-        self._focus_library_list_entry_if_current(generation)
-        self._disarm_library_list_entry_focus()
-        if receipt.final_focus_identity:
-            self._focus_library_control(f"#{receipt.final_focus_identity}")
 
     async def _reconcile_library_entry_state(
         self, generation: int, route_key: tuple[object, ...]
@@ -15168,7 +15481,7 @@ class LibraryScreen(BaseAppScreen):
         # exactly one.
         if self._library_pending_list_entry_focus:
             pending_media_return = self._library_pending_list_entry_media_return
-            if self._library_media_exact_return_candidate(pending_media_return):
+            if self._library_media_return_candidate(pending_media_return):
                 focused = self.focused
                 if focused is not None and focused.has_class("library-media-row"):
                     # The focused row is about to be replaced. Prevent Textual
@@ -17073,12 +17386,17 @@ class LibraryScreen(BaseAppScreen):
 
     def _library_media_layout_signature(self) -> tuple[object, ...]:
         """Return terminal allocation plus pure effective Media pane layout."""
+        reader_width = self._library_media_reader_layout.reader_width
+        pure_layout = resolve_media_reader_layout(
+            reader_width,
+            self._library_media_reader_preferences,
+        )
         return (
             int(self.size.width),
             int(self.size.height),
             self._library_notes_compact,
             self._library_media_reader_preferences,
-            self._library_media_reader_layout,
+            pure_layout,
         )
 
     def _library_media_canvas_presentation(self) -> dict[str, Any]:
@@ -17283,7 +17601,7 @@ class LibraryScreen(BaseAppScreen):
         exact_pending_return = bool(
             self._library_pending_list_entry_focus
             and focus_identity is None
-            and self._library_media_exact_return_candidate(pending_receipt)
+            and self._library_media_return_candidate(pending_receipt)
         )
         if exact_pending_return:
             self._library_media_return_settlement = None
@@ -26944,6 +27262,10 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_trash_focus_request_key = None
         media_return = self._library_media_trash_return
         self._library_media_trash_return = None
+        if self._library_media_return_candidate(media_return):
+            # The Trash Back control is leaving the tree. Do not let Textual
+            # choose a replacement descendant before settlement owns focus.
+            self.set_focus(None)
         self.call_next(self._apply_library_media_list_return, media_return)
 
     def action_library_media_trash_back(self) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -192,7 +192,6 @@ from ...Library.library_media_state import (
     LibraryMediaTrashState,
     MediaBrowseScope,
     MediaTrashBrowseState,
-    MediaTrashMutationTarget,
     MediaTrashScope,
     build_library_media_browse_state,
     build_library_media_state,
@@ -17657,6 +17656,58 @@ class LibraryScreen(BaseAppScreen):
         return f"{readable[: limit - 3].rstrip()}..."
 
     @staticmethod
+    def _valid_library_media_trash_delete_ack(
+        result: Any,
+        *,
+        media_id: int,
+    ) -> bool:
+        """Accept only the local delete contract for the captured identity."""
+        if not isinstance(result, Mapping):
+            return False
+        acknowledged_id = result.get("media_id")
+        return (
+            result.get("ok") is True
+            and type(acknowledged_id) is int
+            and acknowledged_id == media_id
+        )
+
+    @staticmethod
+    def _validated_library_media_trash_restore_summary(
+        result: Any,
+        *,
+        media_id: int,
+    ) -> Mapping[str, Any] | None:
+        """Validate a restore response and retain only its bounded summary."""
+        if not isinstance(result, Mapping):
+            return None
+        if "ok" in result and result.get("ok") is not True:
+            return None
+        restored_id = result.get("id")
+        deleted = result.get("deleted")
+        is_trash = result.get("is_trash")
+        title = result.get("title")
+        media_type = result.get("type")
+        if (
+            type(restored_id) is not int
+            or restored_id != media_id
+            or type(deleted) is not int
+            or deleted != 0
+            or type(is_trash) is not int
+            or is_trash != 0
+            or type(title) is not str
+            or type(media_type) is not str
+            or not media_type.strip()
+        ):
+            return None
+        return {
+            "id": restored_id,
+            "title": title.strip() or "Untitled",
+            "type": media_type.strip(),
+            "deleted": deleted,
+            "is_trash": is_trash,
+        }
+
+    @staticmethod
     def _restore_library_media_scope(state: Mapping[str, Any]) -> MediaBrowseScope:
         """Return one strict dispatch-safe applied Media scope from saved state."""
         saved = state.get("library_media_scope")
@@ -27527,7 +27578,10 @@ class LibraryScreen(BaseAppScreen):
                         "Trash (error_type={}).",
                         type(exc).__name__,
                     )
-            if not isinstance(result, Mapping) or result.get("ok") is not True:
+            if not LibraryScreen._valid_library_media_trash_delete_ack(
+                result,
+                media_id=target.backing_media_id,
+            ):
                 failure_copy = "Could not delete this media item permanently."
                 return
 
@@ -27605,16 +27659,17 @@ class LibraryScreen(BaseAppScreen):
         row; this path never rewrites the row's ``url``, so task-4026's
         one-directional url-canonicalization edge -- which lives only in
         ``add_media_with_keywords``'s restore-by-re-import -- cannot occur
-        here). The returned freshly restored row is inserted straight back
-        into ``_local_source_records["media"]`` and the rail count is
-        incremented in place, mirroring ``_undo_library_media_bulk_delete``.
+        here). The response is validated against the captured identity and
+        restored state, then only a bounded title/type/state summary is
+        retained in ``_local_source_records["media"]``. Content, documents,
+        and versions never enter the retained rail snapshot.
 
         No receipt is left (ADR-055: receipts accompany destruction;
         restore is recovery) -- feedback is the row leaving the Trash
         list, both counts moving, and the transient notice line.
 
         Args:
-            target: Immutable row identity captured by the Trash controller
+            claim: Immutable row identity and lifecycle captured by the controller
                 before it fences outstanding reads.
         """
         target = claim.target
@@ -27630,10 +27685,16 @@ class LibraryScreen(BaseAppScreen):
                         restore_media_item,
                         mode="local",
                         media_id=target.backing_media_id,
+                        include_content=False,
+                        include_versions=False,
                         isolate_in_worker=True,
                     )
-                    if isinstance(result, Mapping):
-                        restored_record = result
+                    restored_record = (
+                        LibraryScreen._validated_library_media_trash_restore_summary(
+                            result,
+                            media_id=target.backing_media_id,
+                        )
+                    )
                 except Exception as exc:
                     logger.warning(
                         "Failed to restore a Library media item from the "

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -17003,7 +17003,7 @@ class LibraryScreen(BaseAppScreen):
         error = self._library_media_trash_input_error
         if not error:
             error = state.error_copy or state.stale_copy
-            if error:
+            if error and (state.failed_scope is not None or state.stale_copy):
                 error = f"{error.rstrip('.')} · Retry"
         presentation = build_library_media_trash_state(
             records,
@@ -17033,10 +17033,9 @@ class LibraryScreen(BaseAppScreen):
             return
         if focus_identity is not None:
             self._library_media_trash_focus_identity = focus_identity
-        if (
-            self._library_media_trash_input_error
-            or self._library_media_trash_browse_controller.state.error_copy
-            or self._library_media_trash_browse_controller.state.stale_copy
+        state = self._library_media_trash_browse_controller.state
+        if not self._library_media_trash_input_error and (
+            state.failed_scope is not None or state.stale_copy
         ):
             self._library_media_trash_focus_identity = "#library-media-trash-retry"
         _sync_library_canvas(

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -26444,6 +26444,7 @@ class LibraryScreen(BaseAppScreen):
     ) -> None:
         """Permanently delete one captured Trash item through the sole service seam."""
         committed = False
+        failure_copy: str | None = None
         try:
             service = getattr(self.app_instance, "media_reading_scope_service", None)
             permanently_delete = getattr(service, "permanently_delete_media_item", None)
@@ -26463,11 +26464,7 @@ class LibraryScreen(BaseAppScreen):
                         type(exc).__name__,
                     )
             if not isinstance(result, Mapping) or result.get("ok") is not True:
-                copy = "Could not delete this media item permanently."
-                self._library_media_trash_browse_controller.finish_mutation_failure(
-                    target, copy
-                )
-                self._notify_library_media_delete_warning(copy)
+                failure_copy = "Could not delete this media item permanently."
                 return
 
             title = LibraryScreen._bounded_library_media_trash_title(target.title)
@@ -26482,7 +26479,16 @@ class LibraryScreen(BaseAppScreen):
                 refresh_normal_media=False,
                 stale_normal_media=False,
             )
-            if committed:
+            if failure_copy is not None:
+                self._library_media_trash_focus_identity = "#library-media-trash-delete"
+                self._library_media_trash_focus_authority_generation = getattr(
+                    self, "_library_notes_focus_intent_generation", 0
+                )
+                self._library_media_trash_browse_controller.finish_mutation_failure(
+                    target, failure_copy
+                )
+                self._notify_library_media_delete_warning(failure_copy)
+            elif committed:
                 self._library_media_trash_browse_controller.request_after_mutation(
                     focus_identity=f"#library-media-trash-row-{target.page_index}"
                 )
@@ -26543,6 +26549,7 @@ class LibraryScreen(BaseAppScreen):
                 before it fences outstanding reads.
         """
         committed = False
+        failure_copy: str | None = None
         try:
             service = getattr(self.app_instance, "media_reading_scope_service", None)
             restore_media_item = getattr(service, "restore_media_item", None)
@@ -26564,12 +26571,7 @@ class LibraryScreen(BaseAppScreen):
                         type(exc).__name__,
                     )
             if restored_record is None:
-                self._library_media_trash_browse_controller.finish_mutation_failure(
-                    target, "Could not restore this media item."
-                )
-                self._notify_library_media_delete_warning(
-                    "Could not restore this media item."
-                )
+                failure_copy = "Could not restore this media item."
                 return
 
             existing_ids = {
@@ -26604,7 +26606,18 @@ class LibraryScreen(BaseAppScreen):
                 refresh_normal_media=False,
                 stale_normal_media=committed,
             )
-            if committed:
+            if failure_copy is not None:
+                self._library_media_trash_focus_identity = (
+                    "#library-media-trash-restore"
+                )
+                self._library_media_trash_focus_authority_generation = getattr(
+                    self, "_library_notes_focus_intent_generation", 0
+                )
+                self._library_media_trash_browse_controller.finish_mutation_failure(
+                    target, failure_copy
+                )
+                self._notify_library_media_delete_warning(failure_copy)
+            elif committed:
                 self._library_media_trash_browse_controller.request_after_mutation(
                     focus_identity=f"#library-media-trash-row-{target.page_index}"
                 )

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from rich.markup import escape as escape_markup
+from textual import events
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
+from textual.geometry import Size
+from textual.message import Message
 from textual.widgets import Button, Input, OptionList, Static
 from textual.widgets.option_list import Option
 
@@ -32,6 +36,54 @@ from tldw_chatbook.Widgets.recompose_capture_guard import RecomposeCaptureGuard
 
 _MEDIA_ROW_COMPACT_HEIGHT = 1
 _MEDIA_ROW_WIDE_HEIGHT = 2
+
+
+@dataclass(frozen=True)
+class LibraryMediaRowGeometry:
+    """One public Textual geometry revision from a Media row-scroll owner."""
+
+    revision: int
+    size: Size
+    virtual_size: Size
+    container_size: Size | None
+
+
+class LibraryMediaRowGeometryChanged(Message):
+    """Report one concrete Media row-scroll owner's revised geometry."""
+
+    def __init__(
+        self,
+        owner: "LibraryMediaRowScroll",
+        geometry: LibraryMediaRowGeometry,
+    ) -> None:
+        super().__init__()
+        self.owner = owner
+        self.geometry = geometry
+
+
+class LibraryMediaRowScroll(VerticalScroll):
+    """Publish distinct Resize-derived geometry for the owning Media list."""
+
+    latest_geometry: LibraryMediaRowGeometry | None = None
+
+    def on_resize(self, event: events.Resize) -> None:
+        """Publish distinct, monotonically revised owner geometry after reflow."""
+        previous = self.latest_geometry
+        geometry_values = (event.size, event.virtual_size, event.container_size)
+        if previous is not None and geometry_values == (
+            previous.size,
+            previous.virtual_size,
+            previous.container_size,
+        ):
+            return
+        geometry = LibraryMediaRowGeometry(
+            revision=1 if previous is None else previous.revision + 1,
+            size=event.size,
+            virtual_size=event.virtual_size,
+            container_size=event.container_size,
+        )
+        self.latest_geometry = geometry
+        self.post_message(LibraryMediaRowGeometryChanged(self, geometry))
 
 
 def _media_row_label_rest(
@@ -610,7 +662,7 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         with workbench:
             media_list = Vertical(id="library-media-list")
             with media_list:
-                with VerticalScroll(id="library-media-row-scroll"):
+                with LibraryMediaRowScroll(id="library-media-row-scroll"):
                     row_height = (
                         _MEDIA_ROW_COMPACT_HEIGHT
                         if self.compact

--- a/tldw_chatbook/Widgets/Library/library_media_trash_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_trash_canvas.py
@@ -15,8 +15,9 @@ from typing import Any
 
 from rich.markup import escape as escape_markup
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
-from textual.widgets import Button, Static
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widgets import Button, Input, OptionList, Static
+from textual.widgets.option_list import Option
 
 from tldw_chatbook.Library.library_media_state import (
     LIBRARY_MEDIA_TRASH_RESTORE_DISABLED_EMPTY_TOOLTIP,
@@ -25,6 +26,7 @@ from tldw_chatbook.Library.library_media_state import (
     LIBRARY_MEDIA_TRASH_RESTORE_TOOLTIP,
     LibraryMediaTrashState,
 )
+from tldw_chatbook.Library.library_pager_state import LibraryPagerDisplay
 from tldw_chatbook.Library.library_shell_state import (
     library_disabled_action_label,
 )
@@ -45,18 +47,71 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
     def __init__(
         self,
         canvas: LibraryMediaTrashState,
+        *,
+        pager: LibraryPagerDisplay | None = None,
+        types: tuple[str, ...] = (),
+        query_draft: str = "",
+        applied_scope_label: str = "",
+        applied_type: str | None = None,
+        type_choices_visible: bool = False,
+        action_disabled_reason: str = "",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        self.canvas = canvas
+        self._set_presentation(
+            canvas,
+            pager=pager,
+            types=types,
+            query_draft=query_draft,
+            applied_scope_label=applied_scope_label,
+            applied_type=applied_type,
+            type_choices_visible=type_choices_visible,
+            action_disabled_reason=action_disabled_reason,
+        )
         # Same width contract as ``LibraryMediaCanvas`` -- this view swaps
         # in for the list inside the same canvas host. 1fr (never 13fr):
         # see that canvas's constructor comment -- an independent 13fr
         # resolves ~13x wider than the host and clips children.
         self.styles.width = "1fr"
-        self.styles.min_width = 40
+        self.styles.min_width = 0
+        self.styles.height = "100%"
+        self.styles.min_height = 0
+        self.styles.overflow = ("hidden", "hidden")
 
-    def sync_state(self, canvas: LibraryMediaTrashState) -> None:
+    def _set_presentation(
+        self,
+        canvas: LibraryMediaTrashState,
+        *,
+        pager: LibraryPagerDisplay | None,
+        types: tuple[str, ...],
+        query_draft: str,
+        applied_scope_label: str,
+        applied_type: str | None,
+        type_choices_visible: bool,
+        action_disabled_reason: str,
+    ) -> None:
+        """Store the screen-owned presentation without deriving authority."""
+        self.canvas = canvas
+        self.pager = pager
+        self.types = tuple(types)
+        self.query_draft = query_draft
+        self.applied_scope_label = applied_scope_label
+        self.applied_type = applied_type
+        self.type_choices_visible = type_choices_visible
+        self.action_disabled_reason = action_disabled_reason
+
+    def sync_state(
+        self,
+        canvas: LibraryMediaTrashState,
+        *,
+        pager: LibraryPagerDisplay | None = None,
+        types: tuple[str, ...] = (),
+        query_draft: str = "",
+        applied_scope_label: str = "",
+        applied_type: str | None = None,
+        type_choices_visible: bool = False,
+        action_disabled_reason: str = "",
+    ) -> None:
         """Refresh the canvas from new state.
 
         Args:
@@ -65,7 +120,16 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
         Returns:
             None.
         """
-        self.canvas = canvas
+        self._set_presentation(
+            canvas,
+            pager=pager,
+            types=types,
+            query_draft=query_draft,
+            applied_scope_label=applied_scope_label,
+            applied_type=applied_type,
+            type_choices_visible=type_choices_visible,
+            action_disabled_reason=action_disabled_reason,
+        )
         self.refresh(recompose=True)
 
     def compose(self) -> ComposeResult:
@@ -74,10 +138,11 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
         Returns:
             ComposeResult for the Trash view.
         """
-        # Heading: the "‹ <list>" back affordance + a titled count, the
-        # same heading shape the note-load view uses ("‹ Notes" + title).
+        bounded = self.pager is not None
         heading = Horizontal(classes="ds-toolbar", id="library-media-trash-heading")
-        heading.styles.height = "auto"
+        heading.styles.height = 1
+        heading.styles.min_height = 1
+        heading.styles.overflow = ("hidden", "hidden")
         with heading:
             yield Button(
                 "‹ Media",
@@ -85,21 +150,93 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
                 classes="library-canvas-action",
                 compact=True,
             )
+            title = (
+                "Local Trash"
+                if self.pager is None or self.pager.title_count is None
+                else (
+                    f"Local Trash · {self.pager.title_count} matching"
+                    if self.applied_scope_label
+                    else f"Local Trash · {self.pager.title_count} items"
+                )
+            )
             yield Static(
-                f"Trash ({self.canvas.count})",
+                title if bounded else f"Trash ({self.canvas.count})",
                 id="library-media-trash-title",
                 classes="library-toolbar-count",
                 markup=False,
             )
 
-        # Restore feedback (never a receipt -- see the module docstring).
-        notice = Static(
-            self.canvas.notice,
-            id="library-media-trash-notice",
-            markup=False,
-        )
-        notice.display = bool(self.canvas.notice)
-        yield notice
+        if bounded:
+            filters = Horizontal(id="library-media-trash-filters")
+            filters.styles.height = 1
+            filters.styles.min_height = 1
+            filters.styles.overflow = ("hidden", "hidden")
+            with filters:
+                if self.type_choices_visible:
+                    options: list[Option] = []
+                    highlighted = 0
+                    for index, value in enumerate((None, *self.types)):
+                        display = "All types" if value is None else value
+                        option = Option(
+                            f"✓ {display}" if value == self.applied_type else display,
+                            id=f"library-media-trash-type-option-{index}",
+                        )
+                        option.choice_value = value
+                        options.append(option)
+                        if value == self.applied_type:
+                            highlighted = index
+                    choices = OptionList(
+                        *options,
+                        id="library-media-trash-type-choices",
+                        compact=True,
+                        markup=False,
+                    )
+                    choices.highlighted = highlighted
+                    choices.styles.width = "100%"
+                    choices.styles.height = 1
+                    choices.styles.min_height = 1
+                    yield choices
+                else:
+                    search = Input(
+                        self.query_draft,
+                        placeholder="Search Trash",
+                        max_length=200,
+                        id="library-media-trash-search",
+                        compact=True,
+                    )
+                    search.styles.width = "1fr"
+                    search.styles.min_width = 5
+                    search.styles.height = 1
+                    search.styles.min_height = 1
+                    search.styles.padding = 0
+                    search.styles.border = ("none", "transparent")
+                    yield search
+                    yield Button(
+                        f"Type: {self.applied_type or 'All'}",
+                        id="library-media-trash-type-filter",
+                        classes="library-canvas-action",
+                        compact=True,
+                        tooltip="Choose a Trash media type.",
+                    )
+                    scope = Static(
+                        self.applied_scope_label,
+                        id="library-media-trash-scope",
+                        classes="destination-purpose",
+                        markup=False,
+                    )
+                    scope.styles.width = "auto"
+                    scope.styles.max_width = 28
+                    scope.styles.height = 1
+                    yield scope
+        else:
+            # Compatibility for the pre-paging standalone canvas contract.
+            notice = Static(
+                self.canvas.notice,
+                id="library-media-trash-notice",
+                markup=False,
+            )
+            notice.display = bool(self.canvas.notice)
+            yield notice
 
         # One status line, in honesty order: a fetch error outranks
         # everything; loading outranks the empty copy (an unloaded Trash
@@ -109,6 +246,10 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
             status_text = self.canvas.error
         elif self.canvas.loading:
             status_text = "Loading Trash…"
+        elif bounded and self.canvas.notice:
+            status_text = self.canvas.notice
+        elif bounded and self.pager is not None and self.pager.status_copy:
+            status_text = self.pager.status_copy
         else:
             status_text = self.canvas.status_copy or self.canvas.empty_copy
         status = Static(
@@ -116,10 +257,15 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
             id="library-media-trash-status",
             markup=False,
         )
-        status.display = bool(status_text)
+        status.styles.height = 1 if bounded else "auto"
+        status.styles.min_height = 1 if bounded else 0
+        status.styles.max_height = 3
+        status.styles.overflow = ("hidden", "hidden")
+        status.tooltip = status_text or None
+        status.display = bounded or bool(status_text)
         yield status
 
-        trash_list = Vertical(id="library-media-trash-list")
+        trash_list = VerticalScroll(id="library-media-trash-list")
         # PR-1505 review (the L3a clipping lesson -- a plain auto-height
         # Vertical clips content past the fold, and a 200-item trash page
         # pushed the Restore toolbar ~100 rows off a 24-row terminal): the
@@ -136,9 +282,7 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
             for index, row in enumerate(self.canvas.rows):
                 # Selected-row grammar: leading "▸ " (task-4023 AC#5).
                 marker = "▸" if row.selected else " "
-                label_rest = (
-                    f" {_visible_row_title(row.title)}\n    {row.secondary}"
-                )
+                label_rest = f" {_visible_row_title(row.title)}\n    {row.secondary}"
                 button = Button(
                     f"{marker}{label_rest}",
                     id=f"library-media-trash-row-{index}",
@@ -156,31 +300,134 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
                 button.styles.min_height = 2
                 yield button
 
-        toolbar = Horizontal(classes="ds-toolbar")
-        toolbar.styles.height = "auto"
+        if bounded and self.pager is not None:
+            pager = Vertical(id="library-media-trash-pager")
+            pager.styles.height = 2
+            pager.styles.min_height = 2
+            pager.styles.overflow = ("hidden", "hidden")
+            with pager:
+                copy = Horizontal(id="library-media-trash-pager-copy")
+                copy.styles.height = 1
+                copy.styles.min_height = 1
+                copy.styles.overflow = ("hidden", "hidden")
+                with copy:
+                    yield Static(
+                        self.pager.range_copy,
+                        id="library-media-trash-range",
+                        markup=False,
+                    )
+                    yield Static(
+                        self.pager.page_copy,
+                        id="library-media-trash-page",
+                        markup=False,
+                    )
+                controls = Horizontal(
+                    classes="ds-toolbar", id="library-media-trash-pager-controls"
+                )
+                controls.styles.height = 1
+                controls.styles.min_height = 1
+                controls.styles.overflow = ("hidden", "hidden")
+                with controls:
+                    previous = Button(
+                        library_disabled_action_label(
+                            "Previous", self.pager.previous_disabled
+                        ),
+                        id="library-media-trash-previous",
+                        classes="library-canvas-action",
+                        compact=True,
+                        disabled=self.pager.previous_disabled,
+                        tooltip=self.pager.previous_reason or None,
+                    )
+                    previous.styles.min_width = 0
+                    previous.styles.padding = 0
+                    yield previous
+                    if self.pager.retry_visible:
+                        retry = Button(
+                            "Retry",
+                            id="library-media-trash-retry",
+                            classes="library-canvas-action",
+                            compact=True,
+                            tooltip="Retry the failed Trash request.",
+                        )
+                        retry.styles.min_width = 0
+                        retry.styles.padding = 0
+                        yield retry
+                    next_button = Button(
+                        library_disabled_action_label("Next", self.pager.next_disabled),
+                        id="library-media-trash-next",
+                        classes="library-canvas-action",
+                        compact=True,
+                        disabled=self.pager.next_disabled,
+                        tooltip=self.pager.next_reason or None,
+                    )
+                    next_button.styles.min_width = 0
+                    next_button.styles.padding = 0
+                    yield next_button
+
+        toolbar = Horizontal(classes="ds-toolbar", id="library-media-trash-actions")
+        toolbar.styles.height = 1
+        toolbar.styles.min_height = 1
+        toolbar.styles.padding = 0
+        toolbar.styles.overflow = ("hidden", "hidden")
         with toolbar:
-            restore_disabled = self.canvas.loading or not self.canvas.rows
+            if bounded:
+                disabled_reason = self.action_disabled_reason
+                action_disabled = bool(disabled_reason)
+                restore_tooltip = (
+                    disabled_reason
+                    if action_disabled
+                    else LIBRARY_MEDIA_TRASH_RESTORE_TOOLTIP
+                )
+            else:
+                action_disabled = self.canvas.loading or not self.canvas.rows
+                if not action_disabled:
+                    restore_tooltip = LIBRARY_MEDIA_TRASH_RESTORE_TOOLTIP
+                elif self.canvas.error:
+                    restore_tooltip = LIBRARY_MEDIA_TRASH_RESTORE_DISABLED_ERROR_TOOLTIP
+                elif self.canvas.loading:
+                    restore_tooltip = (
+                        LIBRARY_MEDIA_TRASH_RESTORE_DISABLED_LOADING_TOOLTIP
+                    )
+                else:
+                    restore_tooltip = LIBRARY_MEDIA_TRASH_RESTORE_DISABLED_EMPTY_TOOLTIP
             restore = Button(
                 # F-018 + task-4023 AC#1: disabled carries the non-colour
                 # "○" marker and a reason tooltip.
-                library_disabled_action_label("Restore", restore_disabled),
+                library_disabled_action_label("Restore", action_disabled),
                 id="library-media-trash-restore",
                 classes="library-canvas-action",
                 compact=True,
             )
             restore._library_disabled_marker_base = "Restore"
-            restore.disabled = restore_disabled
-            # Disabled reasons in the status line's own honesty order
-            # (error > loading > empty): a failed fetch also leaves zero
-            # rows, so without the error branch the tooltip claimed
-            # "Nothing in Trash" for a Trash that merely could not be
-            # read (PR-1505 review; F-018 demands the TRUE reason).
-            if not restore_disabled:
-                restore.tooltip = LIBRARY_MEDIA_TRASH_RESTORE_TOOLTIP
-            elif self.canvas.error:
-                restore.tooltip = LIBRARY_MEDIA_TRASH_RESTORE_DISABLED_ERROR_TOOLTIP
-            elif self.canvas.loading:
-                restore.tooltip = LIBRARY_MEDIA_TRASH_RESTORE_DISABLED_LOADING_TOOLTIP
-            else:
-                restore.tooltip = LIBRARY_MEDIA_TRASH_RESTORE_DISABLED_EMPTY_TOOLTIP
+            restore.disabled = action_disabled
+            restore.tooltip = restore_tooltip
+            restore.styles.min_width = 0
+            restore.styles.padding = 0
+            # Textual's non-removable Button line-pad reserves one blank cell
+            # on each edge. At the shipped 32-column compact Items allocation,
+            # the two exact disabled labels need 33 content/line-pad cells.
+            # Overlap only those adjacent blank edge cells; both labels and
+            # both focus targets remain whole and inside the action row.
+            restore.styles.margin = (0, -1, 0, 0)
             yield restore
+            if bounded:
+                delete = Button(
+                    library_disabled_action_label(
+                        "Delete permanently", action_disabled
+                    ),
+                    id="library-media-trash-delete",
+                    classes="library-canvas-action",
+                    compact=True,
+                    disabled=action_disabled,
+                    tooltip=(
+                        disabled_reason
+                        if action_disabled
+                        else "Delete this Trash item permanently."
+                    ),
+                )
+                delete._library_disabled_marker_base = "Delete permanently"
+                delete.styles.min_width = 0
+                delete.styles.padding = 0
+                delete.styles.margin = 0
+                delete.styles.offset = (-1, 0)
+                yield delete

--- a/tldw_chatbook/Widgets/Library/library_media_trash_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_trash_canvas.py
@@ -470,7 +470,7 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
             confirmation.styles.overflow = ("hidden", "hidden")
             with confirmation:
                 consequence = Static(
-                    "This permanently deletes the selected item and cannot be undone.",
+                    "This cannot be undone.",
                     id="library-media-trash-delete-confirm-consequence",
                     markup=False,
                 )
@@ -482,7 +482,7 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
                 details = VerticalScroll(
                     id="library-media-trash-delete-confirm-details"
                 )
-                details.styles.height = 2
+                details.styles.height = 1
                 details.styles.min_height = 1
                 details.styles.overflow_y = "auto"
                 details.styles.overflow_x = "hidden"
@@ -493,25 +493,33 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
                         markup=False,
                     )
 
-                identity = Horizontal(id="library-media-trash-delete-confirm-identity")
-                identity.styles.height = 1
-                identity.styles.min_height = 1
+                identity = Vertical(id="library-media-trash-delete-confirm-identity")
+                identity.styles.height = 2
+                identity.styles.min_height = 2
                 identity.styles.overflow = ("hidden", "hidden")
                 with identity:
                     media_type = self.confirmation_target.media_type or "Unknown type"
                     trash_date = (
                         self.confirmation_target.trash_date or "Unknown deletion time"
                     )
-                    yield Static(
+                    type_identity = Static(
                         media_type,
                         id="library-media-trash-delete-confirm-type",
                         markup=False,
                     )
-                    yield Static(
+                    type_identity.styles.height = 1
+                    type_identity.styles.min_height = 1
+                    type_identity.styles.overflow = ("hidden", "hidden")
+                    yield type_identity
+                    time_identity = Static(
                         trash_date,
                         id="library-media-trash-delete-confirm-time",
                         markup=False,
                     )
+                    time_identity.styles.height = 1
+                    time_identity.styles.min_height = 1
+                    time_identity.styles.overflow = ("hidden", "hidden")
+                    yield time_identity
 
                 buttons = Horizontal(
                     classes="ds-toolbar",
@@ -521,18 +529,27 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
                 buttons.styles.min_height = 1
                 buttons.styles.overflow = ("hidden", "hidden")
                 with buttons:
-                    yield Button(
+                    cancel = Button(
                         "Cancel",
                         id="library-media-trash-delete-cancel",
                         classes="library-canvas-action",
                         compact=True,
                     )
-                    yield Button(
+                    cancel.styles.min_width = 0
+                    cancel.styles.padding = 0
+                    cancel.styles.margin = (0, -1, 0, 0)
+                    yield cancel
+                    confirm = Button(
                         "Delete permanently",
                         id="library-media-trash-delete-confirm",
                         classes="library-canvas-action",
                         compact=True,
                     )
+                    confirm.styles.min_width = 0
+                    confirm.styles.padding = 0
+                    confirm.styles.margin = 0
+                    confirm.styles.offset = (-1, 0)
+                    yield confirm
             return
 
         toolbar = Horizontal(classes="ds-toolbar", id="library-media-trash-actions")

--- a/tldw_chatbook/Widgets/Library/library_media_trash_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_trash_canvas.py
@@ -25,6 +25,7 @@ from tldw_chatbook.Library.library_media_state import (
     LIBRARY_MEDIA_TRASH_RESTORE_DISABLED_LOADING_TOOLTIP,
     LIBRARY_MEDIA_TRASH_RESTORE_TOOLTIP,
     LibraryMediaTrashState,
+    MediaTrashMutationTarget,
 )
 from tldw_chatbook.Library.library_pager_state import LibraryPagerDisplay
 from tldw_chatbook.Library.library_shell_state import (
@@ -57,6 +58,8 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
         action_disabled_reason: str = "",
         retry_visible: bool | None = None,
         controls_disabled_reason: str = "",
+        confirmation_target: MediaTrashMutationTarget | None = None,
+        commit_pending: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -71,6 +74,8 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
             action_disabled_reason=action_disabled_reason,
             retry_visible=retry_visible,
             controls_disabled_reason=controls_disabled_reason,
+            confirmation_target=confirmation_target,
+            commit_pending=commit_pending,
         )
         # Same width contract as ``LibraryMediaCanvas`` -- this view swaps
         # in for the list inside the same canvas host. 1fr (never 13fr):
@@ -95,6 +100,8 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
         action_disabled_reason: str,
         retry_visible: bool | None,
         controls_disabled_reason: str,
+        confirmation_target: MediaTrashMutationTarget | None,
+        commit_pending: bool,
     ) -> None:
         """Store the screen-owned presentation without deriving authority."""
         self.canvas = canvas
@@ -111,6 +118,8 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
             else retry_visible
         )
         self.controls_disabled_reason = controls_disabled_reason
+        self.confirmation_target = confirmation_target
+        self.commit_pending = commit_pending
 
     def sync_state(
         self,
@@ -125,6 +134,8 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
         action_disabled_reason: str = "",
         retry_visible: bool | None = None,
         controls_disabled_reason: str = "",
+        confirmation_target: MediaTrashMutationTarget | None = None,
+        commit_pending: bool = False,
     ) -> None:
         """Refresh the canvas from new state.
 
@@ -145,6 +156,8 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
             action_disabled_reason=action_disabled_reason,
             retry_visible=retry_visible,
             controls_disabled_reason=controls_disabled_reason,
+            confirmation_target=confirmation_target,
+            commit_pending=commit_pending,
         )
         self.refresh(recompose=True)
 
@@ -186,12 +199,15 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
         heading.styles.min_height = 1
         heading.styles.overflow = ("hidden", "hidden")
         with heading:
-            yield Button(
+            back = Button(
                 "‹ Media",
                 id="library-media-trash-back",
                 classes="library-canvas-action",
                 compact=True,
             )
+            back.disabled = self.commit_pending
+            back.tooltip = "Finishing this action…" if self.commit_pending else None
+            yield back
             title = (
                 "Local Trash"
                 if self.pager is None or self.pager.title_count is None
@@ -295,7 +311,9 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
         # everything; loading outranks the empty copy (an unloaded Trash
         # must never claim to be empty); then the truncation line or the
         # honest empty state.
-        if self.canvas.error:
+        if self.commit_pending:
+            status_text = "Finishing this action…"
+        elif self.canvas.error:
             status_text = self.canvas.error
         elif self.canvas.loading:
             status_text = "Loading Trash…"
@@ -444,6 +462,78 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
                     next_button.styles.min_width = 0
                     next_button.styles.padding = 0
                     yield next_button
+
+        if self.confirmation_target is not None:
+            confirmation = Vertical(id="library-media-trash-delete-confirmation")
+            confirmation.styles.height = 5
+            confirmation.styles.min_height = 5
+            confirmation.styles.overflow = ("hidden", "hidden")
+            with confirmation:
+                consequence = Static(
+                    "This permanently deletes the selected item and cannot be undone.",
+                    id="library-media-trash-delete-confirm-consequence",
+                    markup=False,
+                )
+                consequence.styles.height = 1
+                consequence.styles.min_height = 1
+                consequence.styles.overflow = ("hidden", "hidden")
+                yield consequence
+
+                details = VerticalScroll(
+                    id="library-media-trash-delete-confirm-details"
+                )
+                details.styles.height = 2
+                details.styles.min_height = 1
+                details.styles.overflow_y = "auto"
+                details.styles.overflow_x = "hidden"
+                with details:
+                    yield Static(
+                        self.confirmation_target.title,
+                        id="library-media-trash-delete-confirm-title",
+                        markup=False,
+                    )
+
+                identity = Horizontal(id="library-media-trash-delete-confirm-identity")
+                identity.styles.height = 1
+                identity.styles.min_height = 1
+                identity.styles.overflow = ("hidden", "hidden")
+                with identity:
+                    media_type = self.confirmation_target.media_type or "Unknown type"
+                    trash_date = (
+                        self.confirmation_target.trash_date or "Unknown deletion time"
+                    )
+                    yield Static(
+                        media_type,
+                        id="library-media-trash-delete-confirm-type",
+                        markup=False,
+                    )
+                    yield Static(
+                        trash_date,
+                        id="library-media-trash-delete-confirm-time",
+                        markup=False,
+                    )
+
+                buttons = Horizontal(
+                    classes="ds-toolbar",
+                    id="library-media-trash-delete-confirm-actions",
+                )
+                buttons.styles.height = 1
+                buttons.styles.min_height = 1
+                buttons.styles.overflow = ("hidden", "hidden")
+                with buttons:
+                    yield Button(
+                        "Cancel",
+                        id="library-media-trash-delete-cancel",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                    yield Button(
+                        "Delete permanently",
+                        id="library-media-trash-delete-confirm",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+            return
 
         toolbar = Horizontal(classes="ds-toolbar", id="library-media-trash-actions")
         toolbar.styles.height = 1

--- a/tldw_chatbook/Widgets/Library/library_media_trash_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_trash_canvas.py
@@ -55,6 +55,8 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
         applied_type: str | None = None,
         type_choices_visible: bool = False,
         action_disabled_reason: str = "",
+        retry_visible: bool | None = None,
+        controls_disabled_reason: str = "",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -67,6 +69,8 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
             applied_type=applied_type,
             type_choices_visible=type_choices_visible,
             action_disabled_reason=action_disabled_reason,
+            retry_visible=retry_visible,
+            controls_disabled_reason=controls_disabled_reason,
         )
         # Same width contract as ``LibraryMediaCanvas`` -- this view swaps
         # in for the list inside the same canvas host. 1fr (never 13fr):
@@ -89,6 +93,8 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
         applied_type: str | None,
         type_choices_visible: bool,
         action_disabled_reason: str,
+        retry_visible: bool | None,
+        controls_disabled_reason: str,
     ) -> None:
         """Store the screen-owned presentation without deriving authority."""
         self.canvas = canvas
@@ -99,6 +105,12 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
         self.applied_type = applied_type
         self.type_choices_visible = type_choices_visible
         self.action_disabled_reason = action_disabled_reason
+        self.retry_visible = (
+            bool(pager and pager.retry_visible)
+            if retry_visible is None
+            else retry_visible
+        )
+        self.controls_disabled_reason = controls_disabled_reason
 
     def sync_state(
         self,
@@ -111,6 +123,8 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
         applied_type: str | None = None,
         type_choices_visible: bool = False,
         action_disabled_reason: str = "",
+        retry_visible: bool | None = None,
+        controls_disabled_reason: str = "",
     ) -> None:
         """Refresh the canvas from new state.
 
@@ -129,8 +143,36 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
             applied_type=applied_type,
             type_choices_visible=type_choices_visible,
             action_disabled_reason=action_disabled_reason,
+            retry_visible=retry_visible,
+            controls_disabled_reason=controls_disabled_reason,
         )
         self.refresh(recompose=True)
+
+    def on_mount(self) -> None:
+        """Measure compact status overflow after the first layout."""
+        self.call_after_refresh(self._update_status_fold)
+
+    def on_resize(self) -> None:
+        """Re-evaluate status wrapping against the current Items width."""
+        self.call_after_refresh(self._update_status_fold)
+
+    def _after_recompose(self) -> None:
+        """Measure the newly mounted status without delaying focus wiring."""
+        self.call_after_refresh(self._update_status_fold)
+
+    def _update_status_fold(self) -> None:
+        """Expose a fold row only when the status needs more than two rows."""
+        if self.pager is None:
+            return
+        try:
+            status = self.query_one("#library-media-trash-status", Static)
+            fold = self.query_one("#library-media-trash-status-fold", Static)
+        except Exception:
+            return
+        width = status.content_size.width or status.region.width
+        if width < 1:
+            return
+        fold.display = status.visual.get_height(status.styles, width) > 2
 
     def compose(self) -> ComposeResult:
         """Render the heading, status/notice lines, trash rows, and Restore.
@@ -195,6 +237,8 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
                     choices.styles.width = "100%"
                     choices.styles.height = 1
                     choices.styles.min_height = 1
+                    choices.disabled = bool(self.controls_disabled_reason)
+                    choices.tooltip = self.controls_disabled_reason or None
                     yield choices
                 else:
                     search = Input(
@@ -203,6 +247,7 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
                         max_length=200,
                         id="library-media-trash-search",
                         compact=True,
+                        disabled=bool(self.controls_disabled_reason),
                     )
                     search.styles.width = "1fr"
                     search.styles.min_width = 5
@@ -210,13 +255,21 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
                     search.styles.min_height = 1
                     search.styles.padding = 0
                     search.styles.border = ("none", "transparent")
+                    search.tooltip = self.controls_disabled_reason or None
                     yield search
+                    type_disabled = bool(self.controls_disabled_reason)
                     yield Button(
-                        f"Type: {self.applied_type or 'All'}",
+                        library_disabled_action_label(
+                            f"Type: {self.applied_type or 'All'}", type_disabled
+                        ),
                         id="library-media-trash-type-filter",
                         classes="library-canvas-action",
                         compact=True,
-                        tooltip="Choose a Trash media type.",
+                        disabled=type_disabled,
+                        tooltip=(
+                            self.controls_disabled_reason
+                            or "Choose a Trash media type."
+                        ),
                     )
                     scope = Static(
                         self.applied_scope_label,
@@ -238,7 +291,7 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
             notice.display = bool(self.canvas.notice)
             yield notice
 
-        # One status line, in honesty order: a fetch error outranks
+        # One bounded status region, in honesty order: a fetch error outranks
         # everything; loading outranks the empty copy (an unloaded Trash
         # must never claim to be empty); then the truncation line or the
         # honest empty state.
@@ -257,13 +310,26 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
             id="library-media-trash-status",
             markup=False,
         )
-        status.styles.height = 1 if bounded else "auto"
+        status.styles.height = "auto"
         status.styles.min_height = 1 if bounded else 0
-        status.styles.max_height = 3
+        status.styles.max_height = 2 if bounded else 3
         status.styles.overflow = ("hidden", "hidden")
         status.tooltip = status_text or None
         status.display = bounded or bool(status_text)
         yield status
+        if bounded:
+            fold = Static(
+                "▼ more status",
+                id="library-media-trash-status-fold",
+                classes="destination-purpose",
+                markup=False,
+            )
+            fold.styles.height = 1
+            fold.styles.min_height = 1
+            fold.styles.overflow = ("hidden", "hidden")
+            fold.tooltip = status_text or None
+            fold.display = False
+            yield fold
 
         trash_list = VerticalScroll(id="library-media-trash-list")
         # PR-1505 review (the L3a clipping lesson -- a plain auto-height
@@ -328,37 +394,52 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
                 controls.styles.min_height = 1
                 controls.styles.overflow = ("hidden", "hidden")
                 with controls:
+                    controls_disabled = bool(self.controls_disabled_reason)
+                    previous_disabled = (
+                        self.pager.previous_disabled or controls_disabled
+                    )
                     previous = Button(
-                        library_disabled_action_label(
-                            "Previous", self.pager.previous_disabled
-                        ),
+                        library_disabled_action_label("Previous", previous_disabled),
                         id="library-media-trash-previous",
                         classes="library-canvas-action",
                         compact=True,
-                        disabled=self.pager.previous_disabled,
-                        tooltip=self.pager.previous_reason or None,
+                        disabled=previous_disabled,
+                        tooltip=(
+                            self.controls_disabled_reason
+                            or self.pager.previous_reason
+                            or None
+                        ),
                     )
                     previous.styles.min_width = 0
                     previous.styles.padding = 0
                     yield previous
-                    if self.pager.retry_visible:
+                    if self.retry_visible:
                         retry = Button(
-                            "Retry",
+                            library_disabled_action_label("Retry", controls_disabled),
                             id="library-media-trash-retry",
                             classes="library-canvas-action",
                             compact=True,
-                            tooltip="Retry the failed Trash request.",
+                            disabled=controls_disabled,
+                            tooltip=(
+                                self.controls_disabled_reason
+                                or "Retry the failed Trash request."
+                            ),
                         )
                         retry.styles.min_width = 0
                         retry.styles.padding = 0
                         yield retry
+                    next_disabled = self.pager.next_disabled or controls_disabled
                     next_button = Button(
-                        library_disabled_action_label("Next", self.pager.next_disabled),
+                        library_disabled_action_label("Next", next_disabled),
                         id="library-media-trash-next",
                         classes="library-canvas-action",
                         compact=True,
-                        disabled=self.pager.next_disabled,
-                        tooltip=self.pager.next_reason or None,
+                        disabled=next_disabled,
+                        tooltip=(
+                            self.controls_disabled_reason
+                            or self.pager.next_reason
+                            or None
+                        ),
                     )
                     next_button.styles.min_width = 0
                     next_button.styles.padding = 0


### PR DESCRIPTION
## Summary
- add exact-total, bounded Media Trash paging with complete-source filters, Retry, Restore, confirmed permanent delete, and responsive collapse behavior
- add deterministic normal-Media return settlement using current-owner Resize geometry, immutable authority, focus/route/deadline fencing, and truthful terminal outcomes
- harden permanent-delete privacy and atomicity, mutation lifecycle validation, bounded restore reconciliation, documentation, and production-shaped four-size closeout evidence

## Test Plan
- [x] Pure paging and mutation gate: 113 passed, 191 deselected
- [x] DB, service, state, controller, and privacy owners: 341 passed
- [x] Mounted Media Trash: 74 passed
- [x] Cross-reader settlement and side-by-side: 73 passed
- [x] Live 160×50 / 120×35 / 100×30 / 80×24 closeout: 5 passed
- [x] Five fresh exact-return processes passed
- [x] Ruff, py_compile, and git diff --check passed

## Architecture
- ADR-067: Library top-level pagination contracts
- ADR-104: Library Media return settlement boundary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds exact 20-item recovery to Library Media Trash so every deleted local item is reachable through stable pages, title/type filters, Restore, and confirmed permanent delete. Returning from Trash to normal Media now restores the exact list scroll and row focus deterministically instead of clamping to transient presenter geometry.

**Media Trash paging**

- Trash pages 20 deleted items at a time, newest-first, with exact range and total while the page is fresh.
- Title search and an exact type chooser filter the whole Trash collection before paging; empty titles render as `Untitled`.
- Trash owns its own page state, selection, loading, and staleness instead of borrowing the normal Media browse controller.
- During loading or after a failed refresh, the last good page stays visible but paging and destructive actions are disabled until Retry restores authority.
- Restore marks the retained normal Media page stale without inserting or reordering the restored item.
- Permanent delete requires an explicit confirmation, commits atomically with FTS cleanup, and its completion and results are validated.

**Media return settlement**

- Previously a Trash round trip could clamp the desired scroll `(0, 42)` to a transient `(0, 33)` before the replacement list received Media's presentation contract.
- The Media row-scroll owner now reports its own Textual `Resize` geometry, and settlement publishes exact scroll and focus only when that geometry proves the offset is representable.
- Route, generation, and deadline fences stop stale focus rollbacks from applying after a route change or recompose.

<sup>Written for commit f9761058ec83dd50bac77cd9387a004556642487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

