### PR TITLE
docs: withdraw the #2252 attribution — that test is a flake, not a regression

### DIFF
--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -10343,3 +10343,35 @@ minutes, and it is the only step that catches the file you did not think to name
 every one of them before writing any of them off. Three of the five here were
 new since the branch point and two of those three traced to a single commit
 (#2220) — a pattern invisible if you check only the failure you recognise.
+
+---
+
+## Establish that a failure is DETERMINISTIC before bisecting it
+
+**Incident.** TASK-25715, 2026-08-31, immediately after the entry above. Of the
+three failures I bisected there, one was flaky, and the bisect did not tell me
+so — it returned a specific, plausible, wrong commit (`0ef6f3fd4`, #2252), which
+I then published in two PR bodies as an attribution.
+
+A binary search assumes the predicate is a function of the commit. Run once per
+step against a ~1-in-12 flake, it instead converges on wherever the coin landed.
+Measured after the fact: **11 passed / 1 failed of 12 at the very commit the
+search had called FIRST BAD**, and 12/12 at the tip. Even the two failures that
+made me open the investigation were the flake — hit twice while the machine was
+busy running other pytest processes concurrently.
+
+Nothing about the output looked wrong. `GOOD / GOOD / BAD / GOOD` reads exactly
+the same whether the predicate is real or a coin. The two genuinely deterministic
+failures in the same batch re-measured 0/5, and their bisects held.
+
+**What to do.** Before bisecting, run the failing test **N times at the tip and N
+times at the presumed-good base** (N≈10 is cheap for a UI test). Bisect only if
+it is 0/N at one end and N/N at the other. If both ends are mixed, you have a
+flake — a different defect with a different owner, and no commit to blame. After
+a bisect names a commit, confirm by re-running the test several times at that
+commit and its parent; a single run at each is the same coin flip that produced
+the answer.
+
+**And be suspicious of your own machine.** Concurrent test runs raise flake rates
+for timing-sensitive UI tests, so failures observed while sweeps or other bisects
+are running deserve a quiet-machine re-check before they become findings.

--- a/backlog/tasks/task-25715 - Three-Console-tests-are-red-on-dev-each-bisected-to-its-cause.md
+++ b/backlog/tasks/task-25715 - Three-Console-tests-are-red-on-dev-each-bisected-to-its-cause.md
@@ -1,6 +1,6 @@
 ---
 id: TASK-25715
-title: 'Three Console tests are red on dev, each bisected to its cause'
+title: 'Three Console tests are red on dev: two bisected to #2220, one a flake'
 status: To Do
 assignee: []
 created_date: '2026-08-31 14:27'
@@ -20,7 +20,7 @@ Two Console rail tests pass at 4da99a884 and fail on origin/dev at 46c2b0e5f0fb.
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [ ] #1 test_context_section_headers_match_inspector_title_band passes, or the contract it pins is deliberately retired with the Inspector/Context divergence recorded
-- [ ] #2 test_active_reveal_queue_retains_only_identity_across_target_and_rail_removal passes, or the reveal callback is documented as not surviving rail removal
+- [ ] #2 test_active_reveal_queue_retains_only_identity_across_target_and_rail_removal is made deterministic -- it fails intermittently (~1 in 12) at every commit measured, so it is a flake, not a regression
 - [ ] #3 test_console_workbench_standard_width_inspector_snapshot passes, or its "Blocked impact" assertion is updated to the Inspector's current copy
 - [ ] #4 No test in this set is left red on dev without an owner
 <!-- AC:END -->
@@ -92,6 +92,45 @@ both asserting `'Library search:'` -- fail at `4da99a884` as well, so they
 predate this work entirely. TASK-23147 already owns that label drift, and
 TASK-23148 owns the rail-handle arithmetic in the same file. Recorded here only
 so the next person to run this file sees five failures and knows which is which.
+
+## Correction (2026-08-31): finding 2 is a FLAKE, and its bisect was invalid
+
+Posted before this correction, in PR #2260's body and PR #2266's table:
+`test_active_reveal_queue_retains_only_identity_across_target_and_rail_removal`
+was attributed to `0ef6f3fd4` (#2252). **That attribution is withdrawn.**
+
+A post-merge stability check caught it. Running the test alone, same command,
+`-p no:randomly`, three times in a row: fail, pass, pass. Measured properly:
+
+| Commit | Result |
+|---|---|
+| `46c2b0e5f0fb` -- the commit the bisect called FIRST BAD | **11 passed / 1 failed of 12** |
+| `d81bd7a23` (dev after this work) | 12 passed / 0 failed of 12 |
+| `d81bd7a23`, under 8-way CPU saturation | 10 passed / 0 failed of 10 |
+
+It fails intermittently at roughly 1 in 12 to 1 in 24 **at both commits**, so it
+is not a regression from #2252 or from anything else. My bisect ran the test
+once per step; over a flaky test that search does not converge on a cause, it
+converges on wherever the coin happened to land. It produced a specific,
+plausible, wrong commit -- and the two initial failures that made me start the
+search at all were themselves the flake, hit twice while the machine was busy
+with concurrent test runs.
+
+CPU saturation does not reproduce it, so the trigger is not simple load.
+
+**What the test is actually racing.** It calls `await rail.remove()` and then
+fires the queued reveal callback, which resolves `#console-left-rail-body`.
+Textual's `remove()` only schedules the prune, so whether that id still resolves
+depends on when the Prune message is processed -- the same deferred-detach
+behaviour already documented for the conversation action menu, where a same-id
+remount over a not-yet-pruned widget raises `DuplicateIds`. Either the test
+should await the detachment it depends on, or the reveal callback should guard
+the lookup and no-op when its rail is gone. The second is probably the real fix:
+production has the same race, and the test was written to pin that it degrades
+quietly.
+
+**Findings 1 and 3 are unaffected** -- both re-measured 0 passed / 5 failed of
+5, deterministic, and their bisects to `c2f64f690` (#2220) stand.
 
 ## Notes
 


### PR DESCRIPTION
Backlog + lessons only. **Correcting a wrong attribution I published in two merged PRs.**

## What I got wrong

In #2260 and #2266 I attributed `test_active_reveal_queue_retains_only_identity_across_target_and_rail_removal` to `0ef6f3fd4` (#2252), on the strength of a first-parent bisect. That attribution is withdrawn.

A post-merge stability check caught it: same command, same test, alone, `-p no:randomly`, three times — **fail, pass, pass**.

| Commit | Result |
|---|---|
| `46c2b0e5f0fb` — the commit my bisect called **FIRST BAD** | **11 passed / 1 failed of 12** |
| `d81bd7a23` (dev after this work) | 12 passed / 0 of 12 |
| `d81bd7a23`, under 8-way CPU saturation | 10 passed / 0 of 10 |

It fails at ~1 in 12 **at both ends of the range I bisected**, so it is not a regression from #2252 or anything else.

## Why the bisect lied

A binary search assumes its predicate is a function of the commit. Run once per step against a 1-in-12 flake, it converges on wherever the coin landed — and `GOOD / GOOD / BAD / GOOD` reads identically whether the predicate is real or random. The two failures that made me open the investigation were themselves the flake, hit while the machine was busy with concurrent pytest runs.

## What the test is actually racing

It awaits `rail.remove()`, then fires a queued callback that resolves `#console-left-rail-body`. `remove()` only *schedules* the prune, so whether that id still resolves depends on when the Prune message is processed — the same deferred-detach behaviour already documented for the conversation action menu (where a same-id remount over an unpruned widget raises `DuplicateIds`). Production has the same race, and the test exists to pin that it degrades quietly — so guarding the callback is likely the real fix, not just awaiting detachment in the test.

## What still stands

Findings 1 and 3 re-measured **0 passed / 5 failed of 5** — deterministic, both bisecting to `c2f64f690` (#2220). Unaffected.

## Lesson recorded

Establish a failure is deterministic — 0/N at one end, N/N at the other, N≈10 — *before* bisecting, and re-confirm at the named commit afterwards. Also: failures seen while your own sweeps are running deserve a quiet-machine re-check before they become findings.

`preflight`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrN2mbF8byxMfPNPtVJwFb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Withdraws the #2252 attribution for `test_active_reveal_queue_retains_only_identity_across_target_and_rail_removal`: the one-run bisect labeled it a regression, but repeated runs show it flakes at both ends of the range. Updates TASK-25715 and the testing lessons to record it as a nondeterministic deferred-prune race.

**Findings**

- Keeps the two deterministic failures attributed to #2220.
- Records repeated-run evidence and recommends confirming determinism before bisecting and rechecking the named commit afterward.
- Documents the likely production race and leaves the test or callback fix for follow-up.

<sup>Written for commit 069bfc149bc57ceecab0b4e691e7c7bbf7cf03c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

