### PR TITLE
fix(console): restore the Context/Inspector header band, Context following

### DIFF
--- a/backlog/tasks/task-25715 - Three-Console-tests-are-red-on-dev-each-bisected-to-its-cause.md
+++ b/backlog/tasks/task-25715 - Three-Console-tests-are-red-on-dev-each-bisected-to-its-cause.md
@@ -149,6 +149,31 @@ traceback with `--tb=long` from an actual failure.
 **Findings 1 and 3 are unaffected** -- both re-measured 0 passed / 5 failed of
 5, deterministic, and their bisects to `c2f64f690` (#2220) stand.
 
+## Progress (2026-08-31)
+
+**Finding 1 is FIXED.** `test_context_section_headers_match_inspector_title_band`
+passes. Not by re-indenting the Inspector: that would have restored the band by
+re-opening the heading/row misalignment TASK-24609 deliberately fixed, and
+padding the inspector ROWS instead was already measured and rejected there (it
+costs each row a column and wrapped two live-work rows at 46 columns). Context
+follows the Inspector instead -- `.console-rail-section-header` drops
+`padding: 0 1` to `padding: 0`. The raised background still spans the full row,
+the section title gains a column the 27-column rail can use, and the border-top
+rule and 2-row minimum (TASK-23193, reviewer's explicit choice) are untouched.
+
+**Finding 3 -- a lead, not a fix.** The snapshot asserts `'Blocked impact'`, and
+that row is emitted in exactly ONE place: the `if setup_blocker_copy:` branch in
+`chat_screen.py` (~line 10976), which fires only when provider configuration is
+required. Everywhere else the label appears it is being *read* (the auto-open
+predicate at ~10367, the ownership map), never emitted. The same test file
+asserts the fixture is a configured, healthy run (`"Model: gpt-5.6-terra"`,
+`"Send disabled" not in svg`, `"Setup required" not in svg`), so the assertion
+wants a row that only exists in the blocked state while asserting the app is not
+in it. That reads as a stale assertion from when the fixture rendered blocked --
+but confirming which side is wrong needs someone who knows what #2220 intended
+the healthy-run Run group to contain, so it is left as AC #3 rather than guessed
+at.
+
 ## Notes
 
 Filed in the same spirit as TASK-15512. `origin/dev` had by this point absorbed

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -3940,11 +3940,26 @@ with stray left-edge border fragments), and padding 0 1 so the full
     content-align: left middle;
 }
 
+/* TASK-25715: the Context header and the Inspector's group heading are one
+   shared band -- same background, colour and padding -- and a contract test
+   pins them together. #2220/TASK-24609 moved the Inspector side to `padding:
+   0` so its headings start in the same column as the rows they label, which
+   silently broke the band from the other side.
+
+   Context follows the Inspector rather than the reverse. Re-indenting the
+   Inspector heading would restore the band by re-opening the heading/row
+   misalignment TASK-24609 fixed, and padding its ROWS instead was already
+   measured and rejected there: it costs each row a column and wrapped two
+   live-work rows at the rail's 46-column width. Dropping this indent costs
+   the Context header nothing -- the raised background still spans the full
+   row -- and gives the section title one more column, which the 27-column
+   rail can use. The border-top rule and the 2-row minimum are deliberate
+   (TASK-23193) and stay. */
 .console-rail-section-header {
     height: auto;
     min-height: 2;
     border-top: solid $ds-column-line;
-    padding: 0 1;
+    padding: 0;
     background: $ds-surface-raised;
     color: $ds-text-primary;
     content-align: center middle;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -6142,11 +6142,26 @@ with stray left-edge border fragments), and padding 0 1 so the full
     content-align: left middle;
 }
 
+/* TASK-25715: the Context header and the Inspector's group heading are one
+   shared band -- same background, colour and padding -- and a contract test
+   pins them together. #2220/TASK-24609 moved the Inspector side to `padding:
+   0` so its headings start in the same column as the rows they label, which
+   silently broke the band from the other side.
+
+   Context follows the Inspector rather than the reverse. Re-indenting the
+   Inspector heading would restore the band by re-opening the heading/row
+   misalignment TASK-24609 fixed, and padding its ROWS instead was already
+   measured and rejected there: it costs each row a column and wrapped two
+   live-work rows at the rail's 46-column width. Dropping this indent costs
+   the Context header nothing -- the raised background still spans the full
+   row -- and gives the section title one more column, which the 27-column
+   rail can use. The border-top rule and the 2-row minimum are deliberate
+   (TASK-23193) and stay. */
 .console-rail-section-header {
     height: auto;
     min-height: 2;
     border-top: solid $ds-column-line;
-    padding: 0 1;
+    padding: 0;
     background: $ds-surface-raised;
     color: $ds-text-primary;
     content-align: center middle;


### PR DESCRIPTION
TASK-25715 finding 1. Closes one of the two deterministic reds on `dev`.

## The conflict

The Context section header and the Inspector's group heading are one shared band — same background, colour and padding — pinned by `test_context_section_headers_match_inspector_title_band`. #2220/TASK-24609 moved the **Inspector** side to `padding: 0` so its headings start in the same column as the rows they label. That broke the band from the other side.

The obvious fix — re-indent the Inspector back to `0 1` — is the wrong one, and #2220's own comment says why:

> rows start in the same column as the heading that labels them. The first attempt gave ROWS `padding: 0 0 0 1`… it costs every inspector row one column of content width, and at the rail's 46-column measured width two live-work rows wrapped that had previously fit, moving the bounded section's row demand from 20 to 22. The heading gives up its indent instead.

So restoring the band from the Inspector side re-opens the heading↔row misalignment TASK-24609 deliberately fixed. Two alignment goals in direct conflict.

## The resolution

**Context follows the Inspector.** `.console-rail-section-header` drops `padding: 0 1` → `padding: 0`.

- Band restored, contract test green — honestly, not by retiring it
- #2220's heading↔row alignment preserved, no row loses width
- The raised background still spans the full row
- The section title *gains* a column, which a 27-column rail can use

**Explicitly not touched:** the `border-top` rule and the 2-row minimum. Those are TASK-23193's deliberate choice, made by the reviewer on screenshots, and they're what the 140×40 fit (TASK-25714) is still waiting on. This is a padding change only.

Source edited, bundle regenerated with `build_css.py` — never hand-merged.

## Verification

`test_context_section_headers_match_inspector_title_band` passes. A 10-file Console sweep **including `test_workbench_visual_snapshots.py`** — the file whose omission cost me twice this week — gives **152 passed**, no new failures. The 3 remaining reds are the pre-existing `Library search:` pair (TASK-23147) and finding 3.

## A lead on finding 3, not a fix

`'Blocked impact'` is emitted in exactly one place: the `if setup_blocker_copy:` branch of `chat_screen.py` (~10976), which fires only when provider configuration is required. Every other occurrence *reads* the label. Meanwhile the same test fixture asserts a configured, healthy run (`"Model: gpt-5.6-terra"`, `"Send disabled" not in svg`).

So the snapshot asserts a row that exists only in the blocked state while asserting the app is not in it. That reads as a stale assertion — but which side is wrong depends on what #2220 intended the healthy-run Run group to contain, so it stays AC #3 rather than something I guess at.

`preflight`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrN2mbF8byxMfPNPtVJwFb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Context/Inspector header band so `test_context_section_headers_match_inspector_title_band` passes again on `dev`.

- Context header padding drops from `0 1` to `0`, so Context follows the Inspector's zero-padding headings; the raised background still spans the full row.
- Re-indenting the Inspector is rejected — it re-opens the heading/row misalignment TASK-24609 fixed, and padding Inspector rows was already measured and abandoned there.
- The `border-top` rule and 2-row minimum stay; they're TASK-23193's deliberate choice.
- The bundle is regenerated with `build_css.py`.
- Documents a lead on finding 3: `'Blocked impact'` is emitted only in the provider-blocked branch, so the snapshot asserts a row that only exists in a state the fixture says it isn't in.

<sup>Written for commit 8aa421df683524d6b038c35da83af945186ac54f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

