### PR TITLE
docs(backlog): the Inspector's blocked-state guidance is below the fold (TASK-25887)

### DIFF
--- a/backlog/tasks/task-25715 - Three-Console-tests-are-red-on-dev-each-bisected-to-its-cause.md
+++ b/backlog/tasks/task-25715 - Three-Console-tests-are-red-on-dev-each-bisected-to-its-cause.md
@@ -161,18 +161,36 @@ follows the Inspector instead -- `.console-rail-section-header` drops
 the section title gains a column the 27-column rail can use, and the border-top
 rule and 2-row minimum (TASK-23193, reviewer's explicit choice) are untouched.
 
-**Finding 3 -- a lead, not a fix.** The snapshot asserts `'Blocked impact'`, and
-that row is emitted in exactly ONE place: the `if setup_blocker_copy:` branch in
-`chat_screen.py` (~line 10976), which fires only when provider configuration is
-required. Everywhere else the label appears it is being *read* (the auto-open
-predicate at ~10367, the ownership map), never emitted. The same test file
-asserts the fixture is a configured, healthy run (`"Model: gpt-5.6-terra"`,
-`"Send disabled" not in svg`, `"Setup required" not in svg`), so the assertion
-wants a row that only exists in the blocked state while asserting the app is not
-in it. That reads as a stale assertion from when the fixture rendered blocked --
-but confirming which side is wrong needs someone who knows what #2220 intended
-the healthy-run Run group to contain, so it is left as AC #3 rather than guessed
-at.
+**Finding 3 -- REAL BUG, not test drift. Now TASK-25887.**
+
+Two earlier readings here were wrong and are left visible on purpose. First:
+"#2220 renamed or removed the copy" -- it did not. Second, written in this
+task: "the assertion is stale, it wants a blocked row from a healthy fixture"
+-- also wrong; the fixture IS provider-blocked.
+
+Probing from inside pytest settles it. Every row is mounted with the right
+text, and the three that carry the blocked-state message sit one row past the
+rail's visible bottom:
+
+```
+RAIL visible bottom y=34      BODY = 60 rows of content in a 28-row rail
+  y=29 vis      run-recipe        'Run recipe: OpenAI /'
+  y=33 vis      live-work         'Live work: No active work'
+  y=34 CLIPPED  setup             'Setup: Provider configuration'
+  y=36 CLIPPED  blocked-impact    'Blocked impact: Send is'
+  y=41 CLIPPED  next-action       'Next action: Set up provider'
+```
+
+So at 128x40 with no provider configured, the Inspector shows "Run recipe" and
+"Live work: No active work" and says nothing about send being blocked -- which
+is the one thing it exists to say in that state. The snapshot test is correct;
+the app is wrong.
+
+What made it look like drift: the same test asserts
+`next_action.render_line(0) == "Next action: Set up provider"` and that PASSES,
+because it reads the widget rather than the painted screen. A DOM assertion and
+a screenshot assertion on the same row disagree, and the disagreement is the
+bug. AC #3 moves to TASK-25887 with the full probe.
 
 ## Notes
 

--- a/backlog/tasks/task-25887 - Console-Inspector-the-blocked-state-guidance-is-below-the-fold-at-128x40.md
+++ b/backlog/tasks/task-25887 - Console-Inspector-the-blocked-state-guidance-is-below-the-fold-at-128x40.md
@@ -1,0 +1,76 @@
+---
+id: TASK-25887
+title: 'Console Inspector: the blocked-state guidance is below the fold at 128x40'
+status: To Do
+assignee: []
+created_date: '2026-08-31 21:35'
+labels:
+  - console
+  - ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When no provider is configured, the Inspector's entire job is to say so and tell the user what to do. At 128x40 with the Inspector open, the three rows that carry that message -- Setup, Blocked impact, and Next action: Set up provider -- all render below the rail's visible bottom. The user sees only 'Run recipe' and 'Live work: No active work', neither of which mentions that sending is blocked. This is what test_console_workbench_standard_width_inspector_snapshot has been failing on; the test is correct and the app is wrong.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 At 128x40 with the provider unconfigured and the Inspector open, the user can see that send is blocked and what to do about it, without scrolling
+- [ ] #2 test_console_workbench_standard_width_inspector_snapshot passes against the app rather than by weakening its assertion
+- [ ] #3 The chosen behaviour is pinned by a test that asserts on VISIBLE geometry, not just DOM presence
+<!-- AC:END -->
+
+## Evidence
+
+Probed from inside pytest (a standalone script does not reproduce it -- the
+`Tests/UI` conftest fixtures are what make `#console-inspector-rail-open`
+hittable). Harness identical to
+`test_console_workbench_standard_width_inspector_snapshot`: 128x40, onboarding
+complete, Inspector opened by click.
+
+```
+RAIL=(94, 6, 34, 28)  visible bottom y=34
+BODY=(96, 27, 30, 60)          <-- 60 rows of content in a 28-row rail
+
+  y= 28 vis      console-inspector-run-heading      'Run'
+  y= 29 vis      console-inspector-run-recipe       'Run recipe: OpenAI /'
+  y= 33 vis      console-inspector-live-work        'Live work: No active work'
+  y= 34 CLIPPED  console-inspector-setup            'Setup: Provider configuration'
+  y= 36 CLIPPED  console-inspector-blocked-impact   'Blocked impact: Send is'
+  y= 41 CLIPPED  console-inspector-next-action      'Next action: Set up provider'
+  y= 42 CLIPPED  console-inspector-provider         'Provider: blocked - openai is'
+```
+
+Every row is mounted with the right text. The three that matter are one row
+past the fold. What the user actually sees is "Run recipe" and "Live work: No
+active work" -- and *nothing that says sending is blocked*.
+
+## Why this was mistaken for test drift
+
+The failing assertion is `assert "Blocked impact" in normalized_svg`, and an
+SVG screenshot contains only what is painted. Two earlier readings of this were
+wrong and are recorded so the next person does not repeat them:
+
+1. "The row was renamed or removed by #2220." It was not -- it is mounted with
+   its original id and copy.
+2. "The assertion is stale: it wants a blocked row from a healthy fixture."
+   Also wrong. The fixture IS provider-blocked -- the same test asserts
+   `next_action.render_line(0) == "Next action: Set up provider"` and that
+   assertion passes, because it reads the widget directly rather than the
+   painted screen.
+
+That contrast is the useful part: a DOM assertion and a screenshot assertion on
+the same row disagree, and the disagreement IS the bug. The DOM one passes and
+hides it; the screenshot one fails and finds it.
+
+## Scope note
+
+Bisected to `c2f64f690` (#2220), which is also where TASK-25715's header-padding
+finding came from. The Inspector body renders 60 rows into 28. Deciding which
+rows earn the visible band -- or whether a blocked run should scroll its
+guidance into view -- is an Inspect rail design call, not a mechanical fix, so
+this is filed rather than patched.


### PR DESCRIPTION
Backlog only — but it reclassifies a test failure as a **user-facing bug**, and corrects my own diagnosis twice over.

## The finding

At 128×40 with no provider configured and the Inspector open, this is what the user sees:

```
RAIL visible bottom y=34      BODY = 60 rows of content in a 28-row rail

  y=28 vis      run-heading     'Run'
  y=29 vis      run-recipe      'Run recipe: OpenAI /'
  y=33 vis      live-work       'Live work: No active work'
  ────────────────────────────── fold ──────────────────────────────
  y=34 CLIPPED  setup           'Setup: Provider configuration'
  y=36 CLIPPED  blocked-impact  'Blocked impact: Send is'
  y=41 CLIPPED  next-action     'Next action: Set up provider'
```

Every row is mounted with the right text. The three that say *sending is blocked and here's what to do* are past the fold. The Inspector's entire job in that state is to deliver that message, and it delivers "Live work: No active work" instead.

So `test_console_workbench_standard_width_inspector_snapshot` is **correct**, and has been failing for a real reason since #2220.

## I had this backwards twice

Both wrong readings are left visible in the task rather than edited away:

1. *"#2220 renamed or removed the copy."* It didn't — the row is mounted under its original id with its original text.
2. *"The assertion is stale: it wants a blocked row from a healthy fixture."* Also wrong — the fixture **is** provider-blocked.

## What disguised it

The same test asserts `next_action.render_line(0) == "Next action: Set up provider"` — and **that assertion passes**, because it reads the widget instead of the painted screen.

A DOM assertion and a screenshot assertion on the same row disagree. The DOM one passes and hides the bug; the screenshot one fails and finds it. That disagreement *is* the defect, and it's the reason "just update the stale assertion" would have quietly deleted the only thing catching it.

Worth noting for the harness: probing this required running **inside pytest** — a standalone script can't reproduce it, because the `Tests/UI` conftest fixtures are what make `#console-inspector-rail-open` hittable.

## Not patched here

Bisected to `c2f64f690` (#2220), same commit as TASK-25715's header-padding finding. The Inspector renders **60 rows into 28**; deciding which earn the visible band — or whether a blocked run should scroll its guidance into view — is an Inspect rail design call, not a mechanical fix.

`preflight`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrN2mbF8byxMfPNPtVJwFb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reclassifies the Inspector snapshot test failure as a real user-facing bug and files it as TASK-25887, correcting TASK-25715's earlier misdiagnosis. At 128×40 with no provider configured, the three rows that explain the blocked state render below the rail's visible bottom, so users see only 'Run recipe' and 'Live work: No active work'.

**Details**
- The fixture is provider-blocked, and the `test_console_workbench_standard_width_inspector_snapshot` assertion is correct; the app is wrong.
- The DOM assertion and screenshot assertion disagree on the same row because one reads the widget and the other reads the painted screen; that disagreement is the defect.
- The fix is an Inspect rail design call (60 content rows in a 28-row rail), so it is filed rather than patched.

<sup>Written for commit f51d4700c8dfcd20a42a3fcc33f9670b8289f689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

