### PR TITLE
docs(backlog): rule out the obvious fix for TASK-25887

### DIFF
--- a/backlog/tasks/task-25887 - Console-Inspector-the-blocked-state-guidance-is-below-the-fold-at-128x40.md
+++ b/backlog/tasks/task-25887 - Console-Inspector-the-blocked-state-guidance-is-below-the-fold-at-128x40.md
@@ -74,3 +74,35 @@ finding came from. The Inspector body renders 60 rows into 28. Deciding which
 rows earn the visible band -- or whether a blocked run should scroll its
 guidance into view -- is an Inspect rail design call, not a mechanical fix, so
 this is filed rather than patched.
+
+## The obvious fix does not work — checked before proposing it
+
+`ROW_GROUPS` order drives display order (`console_inspector_ownership.py`, the
+`for owner, _heading_id, labels in ROW_GROUPS: for label in labels:` pass), and
+it lists the Run group as:
+
+```
+"Run recipe", "Live work", "Setup", "Send blocked",
+"Recovery action", "Blocked impact", "Next action", "Provider"
+```
+
+Two things make "just move the blocked rows to the front" look right:
+
+- `chat_screen.py` already expresses that intent -- it builds the blocked rows
+  and does `rows=setup_rows + inspector_state.rows`, i.e. **prepend**. The
+  ownership pass then re-sorts by the tuple above and silently discards it.
+- The tuple order is NOT a #2220 decision. `git show c2f64f690` touches only the
+  Source Readiness group (`Sources` -> `Retrieval`); the Run order dates from
+  `e472110e8` (2026-08-21) and carries no comment defending it.
+
+**It still does not fix this.** Measured from the probe, the Run group gets
+**6 visible rows** (y=28..33): one heading plus five. The blocked-state content
+needs nine — `Setup` wraps to 2, `Blocked impact` to 5, plus `Next action` and
+`Provider`. Reordering would surface `Setup` and part of `Blocked impact` and
+push `Next action: Set up provider` -- the only row that tells the user what to
+DO -- from y=41 to roughly y=36. Still clipped.
+
+So no permutation of these rows fits. The fix has to reduce what the blocked
+state renders (shorter copy, or one combined row), or scroll the guidance into
+view, or give the blocked state a compact summary that collapses the detail.
+That is why this stays a design call rather than a patch.


### PR DESCRIPTION
Backlog only. I was one edit away from shipping a half-fix; the arithmetic stopped it.

## What looked right

Reorder the `Run` group so the blocked-state rows lead. Two decent arguments for it:

- `chat_screen.py` **already expresses that intent** — it builds the blocked rows and does `rows=setup_rows + inspector_state.rows`. The ownership pass then re-sorts by `ROW_GROUPS` and silently discards the prepend.
- The tuple order is **not** a #2220 decision. `git show c2f64f690` touches only the Source Readiness group (`Sources` → `Retrieval`); the Run order dates from `e472110e8` (2026-08-21) and carries no comment defending it.

So: restoring an intent that a later pass defeats. That reads like a clean bug fix.

## Why it fails

The Run group gets **6 visible rows** (y=28..33) — one heading plus five. The blocked state needs **nine**: `Setup` wraps to 2, `Blocked impact` to 5, plus `Next action` and `Provider`.

Reordering surfaces `Setup` and part of `Blocked impact`, and moves `Next action: Set up provider` from y=41 to roughly y=36. **Still clipped** — and that's the only row that tells the user what to *do*.

No permutation of these rows fits in the space available.

## What that means

The fix has to reduce what the blocked state renders (shorter copy, or one combined row), scroll the guidance into view, or give the blocked state a compact summary. That's a design call, which is why TASK-25887 stays filed rather than patched.

Recorded on the task so the next person doesn't spend the same time arriving at a change that makes the test pass while the user still can't see the blocker — which would have been strictly worse than the current honest failure.

`preflight`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrN2mbF8byxMfPNPtVJwFb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a note to the TASK-25887 backlog entry ruling out reordering the Run group as a fix for the Console Inspector's clipped blocked-state guidance.

- The Run group fits 6 visible rows, but the blocked state needs 9; no row permutation fits.
- `chat_screen.py` prepends blocked rows, but the `ROW_GROUPS` ownership pass re-sorts and discards that intent.
- A working fix needs shorter copy, a combined row, scrolling, or a compact summary, so the task stays filed as a design call.

<sup>Written for commit 2aa92c65bd19c9ee512cf360b71f8e886230538d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

