### PR TITLE
feat: own terminal manager at app lifetime

### DIFF
--- a/Docs/superpowers/plans/2026-08-28-persistent-terminal-sessions-implementation.md
+++ b/Docs/superpowers/plans/2026-08-28-persistent-terminal-sessions-implementation.md
@@ -951,8 +951,14 @@ git commit -m "feat: add admitted windows conpty backend"
 
 **Files:**
 - Modify: `tldw_chatbook/app.py`
+- Modify: `tldw_chatbook/Terminal/backend.py`
+- Modify: `tldw_chatbook/Terminal/session_manager.py`
+- Modify: `tldw_chatbook/Terminal/posix_backend.py`
 - Modify: `Tests/UI/test_console_runtime_ownership.py`
-- Modify: `Tests/Chat/test_console_runtime_lifetime.py`
+- Modify: `Tests/Terminal/test_contracts.py`
+- Modify: `Tests/Terminal/test_session_manager.py`
+- Modify: `Tests/Terminal/test_posix_backend.py`
+- Reference: `Tests/Chat/test_console_runtime_lifetime.py`
 
 - [ ] **Step 1: Write app-ownership and launch-reset RED tests**
 
@@ -1013,7 +1019,15 @@ git diff --check
 Expected: PASS.
 
 ```bash
-git add tldw_chatbook/app.py Tests/UI/test_console_runtime_ownership.py Tests/Chat/test_console_runtime_lifetime.py
+git add tldw_chatbook/app.py \
+  tldw_chatbook/Terminal/backend.py \
+  tldw_chatbook/Terminal/session_manager.py \
+  tldw_chatbook/Terminal/posix_backend.py \
+  Tests/UI/test_console_runtime_ownership.py \
+  Tests/Terminal/test_contracts.py \
+  Tests/Terminal/test_session_manager.py \
+  Tests/Terminal/test_posix_backend.py \
+  Docs/superpowers/plans/2026-08-28-persistent-terminal-sessions-implementation.md
 git commit -m "feat: own terminal manager at app lifetime"
 ```
 

--- a/Docs/superpowers/reviews/evidence/task-22512/format-baseline.json
+++ b/Docs/superpowers/reviews/evidence/task-22512/format-baseline.json
@@ -1,15 +1,16 @@
 {
   "base_ref": "origin/dev",
-  "base_sha": "3e5e75e4aa884d4f362aa63c1e151c3855f07a36",
+  "base_sha": "49e648b7d12357871f1feeb8e497d422e7b68d71",
   "baseline_red_paths": [
     "tldw_chatbook/app.py",
     "tldw_chatbook/UI/Screens/settings_screen.py",
     "tldw_chatbook/UI/Screens/chat_screen.py",
     "tldw_chatbook/UI/Console_Modules/left_rail.py",
-    "tldw_chatbook/UI/Console_Modules/wiring.py",
     "Tests/Chat/test_console_runtime_lifetime.py",
+    "Tests/UI/test_console_left_rail.py",
     "Tests/UI/test_console_internals_decomposition.py",
-    "Tests/UI/test_console_workbench_contract.py"
+    "Tests/UI/test_console_workbench_contract.py",
+    "Tests/UI/test_console_shell_regions.py"
   ],
   "files": {
     "Tests/Chat/test_console_runtime_lifetime.py": {
@@ -116,11 +117,24 @@
       "source_sha256": "7f98fe1c4e4682c2e7d308430e5fc790d26c6915c8bba1501f6cafc6ebf078f0"
     },
     "Tests/UI/test_console_left_rail.py": {
-      "debt_units": 0,
-      "formatter_required": false,
-      "normalized_diff_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "source_hunks": [],
-      "source_sha256": "2e664a8df57823024c9a26fc434d5603b2d624feddec2e323b1ba38a489b16b7"
+      "debt_units": 6,
+      "formatter_required": true,
+      "normalized_diff_sha256": "6a6d86e5cc3c603b1bb911c991d94bfcbd3dc0a7d401f7b3ffa199da1634c091",
+      "source_hunks": [
+        [
+          327,
+          333
+        ],
+        [
+          361,
+          367
+        ],
+        [
+          377,
+          383
+        ]
+      ],
+      "source_sha256": "30a6973ecfc09f6c92275f9e798272ffe0fe3a137e48d72380763dfe8876e0d8"
     },
     "Tests/UI/test_console_runtime_ownership.py": {
       "debt_units": 0,
@@ -130,11 +144,16 @@
       "source_sha256": "8204eca8038f207149167f2537a18b066dde0be0016b8c7b8cc39d5617b1bd3a"
     },
     "Tests/UI/test_console_shell_regions.py": {
-      "debt_units": 0,
-      "formatter_required": false,
-      "normalized_diff_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "source_hunks": [],
-      "source_sha256": "9f3d18a74457e52e6474f60f19c5a54ca19f9ebff3e41dd7d1cd6d7125d71c73"
+      "debt_units": 3,
+      "formatter_required": true,
+      "normalized_diff_sha256": "222d98b8f225d6d872e8631d2e1747fb3372183882d762f47fe1492e24f74874",
+      "source_hunks": [
+        [
+          180,
+          187
+        ]
+      ],
+      "source_sha256": "673cb133aaa49bbc8d9930c51d56f2359868920df818e649b6d5e421a214da57"
     },
     "Tests/UI/test_console_workbench_contract.py": {
       "debt_units": 18,
@@ -188,167 +207,190 @@
       "normalized_diff_sha256": "25703729966bd42a20714f1ae6111c4c8c9bc5a61f78afb3fea1a0d486cd021c",
       "source_hunks": [
         [
-          278,
-          288
+          287,
+          297
         ],
         [
-          468,
-          476
+          477,
+          485
         ],
         [
-          637,
-          643
+          646,
+          652
         ],
         [
-          651,
-          659
+          660,
+          668
         ]
       ],
-      "source_sha256": "74939308da8eb5009d42e8f9c707e7333bc2aaf71ceb204a9632f7c049bae464"
+      "source_sha256": "43386a305520c74918496f2dcb3ae8db65b7b9d7d8593db160641acd0774284d"
     },
     "tldw_chatbook/UI/Console_Modules/wiring.py": {
-      "debt_units": 4,
-      "formatter_required": true,
-      "normalized_diff_sha256": "9e93e93be5d457d94d451a881443e96b8f30dc4162dd960a470889316bc9ca3c",
-      "source_hunks": [
-        [
-          759,
-          767
-        ]
-      ],
-      "source_sha256": "5ef07f17c492aac108c19f6761a0cdd570e3716eacdd786596c8990ce8c77d4e"
+      "debt_units": 0,
+      "formatter_required": false,
+      "normalized_diff_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "source_hunks": [],
+      "source_sha256": "278da46876e3b5e2b5f0bd75abf285b39fa7624616710a05e5c0dd9c13dbd200"
     },
     "tldw_chatbook/UI/Screens/chat_screen.py": {
-      "debt_units": 23,
+      "debt_units": 70,
       "formatter_required": true,
-      "normalized_diff_sha256": "4513da6a59c36cd13b4f3bfa19efb2c29af92f56aea934ce4256b3131c7405f5",
+      "normalized_diff_sha256": "99d9518e1fc7b3ec850cf5879d495adaeeaa972984e02b3a536e969a72575f79",
       "source_hunks": [
         [
-          4728,
-          4734
+          1536,
+          1544
         ],
         [
-          10099,
-          10115
+          4491,
+          4500
         ],
         [
-          18106,
-          18112
+          4604,
+          4621
         ],
         [
-          18253,
-          18268
+          5032,
+          5038
         ],
         [
-          18271,
-          18278
+          5159,
+          5167
+        ],
+        [
+          5185,
+          5193
+        ],
+        [
+          5283,
+          5289
+        ],
+        [
+          5387,
+          5393
+        ],
+        [
+          8623,
+          8635
+        ],
+        [
+          8648,
+          8656
+        ],
+        [
+          10921,
+          10937
+        ],
+        [
+          19014,
+          19020
+        ],
+        [
+          19161,
+          19176
+        ],
+        [
+          19179,
+          19186
         ]
       ],
-      "source_sha256": "c19022cef12aa2fadcfef017fe0e3a0cf1783e12fdbad568dcb1383870af06ce"
+      "source_sha256": "7a820a8d8465a72560753f4210d2c417f139b809fbabcdde83f653825c36aea3"
     },
     "tldw_chatbook/UI/Screens/settings_screen.py": {
-      "debt_units": 124,
+      "debt_units": 126,
       "formatter_required": true,
-      "normalized_diff_sha256": "b048b837a3969464e537a00b4c93e0f82b5ba361c82c0460d44ce474bc0aa662",
+      "normalized_diff_sha256": "1318b6b282ff2a18d419796d8d9c416931ed0e95764c5f589948d803fc8a3580",
       "source_hunks": [
         [
           106,
           111
         ],
         [
-          1098,
-          1106
+          1101,
+          1109
         ],
         [
-          2928,
-          2936
+          2932,
+          2940
         ],
         [
-          3195,
-          3203
+          3199,
+          3207
         ],
         [
-          3231,
-          3239
+          3235,
+          3243
         ],
         [
-          3269,
-          3278
+          3273,
+          3282
         ],
         [
-          3827,
-          3835
+          3831,
+          3839
         ],
         [
-          6238,
-          6244
+          6245,
+          6251
         ],
         [
-          6641,
-          6655
+          6648,
+          6662
         ],
         [
-          11380,
-          11394
+          11414,
+          11428
         ],
         [
-          11526,
-          11533
+          11560,
+          11567
         ],
         [
-          15294,
-          15300
+          15872,
+          15880
         ],
         [
-          15790,
-          15798
+          15890,
+          15909
         ],
         [
-          15808,
-          15827
+          16150,
+          16158
         ],
         [
-          16067,
-          16076
+          16242,
+          16250
         ],
         [
-          16160,
-          16168
+          16278,
+          16290
         ],
         [
-          16196,
-          16208
+          16381,
+          16389
         ],
         [
-          16299,
-          16307
+          19864,
+          19872
         ],
         [
-          19776,
-          19784
+          20587,
+          20594
         ],
         [
-          20397,
-          20404
+          20721,
+          20727
         ],
         [
-          20531,
-          20537
+          20813,
+          20823
         ],
         [
-          20628,
-          20634
-        ],
-        [
-          20644,
-          20652
-        ],
-        [
-          22729,
-          22740
+          22917,
+          22928
         ]
       ],
-      "source_sha256": "5fb43034ef3c2f03419728d955ce82bdb56ea9f2fceeb0a3e7292213342049fc"
+      "source_sha256": "25d3a2a44e8aa1372296273390f29bd0c6172b4b49cbd83fd7e1088414d81702"
     },
     "tldw_chatbook/UI/console_command_provider.py": {
       "debt_units": 0,
@@ -365,9 +407,9 @@
       "source_sha256": "89c2309596c907f9da9f9f7e3d3af3e45e0120630cbe01b68ec1abbebbf73b13"
     },
     "tldw_chatbook/app.py": {
-      "debt_units": 108,
+      "debt_units": 122,
       "formatter_required": true,
-      "normalized_diff_sha256": "4e5972fde078d1f27d964ec151080850022c943310a3a04bc94da64845ade27d",
+      "normalized_diff_sha256": "234967bfb4a010b1c4092f03e3ff39f1577c903360c07568fa8625dc7f56e8e0",
       "source_hunks": [
         [
           360,
@@ -386,62 +428,66 @@
           702
         ],
         [
-          3461,
-          3469
+          3469,
+          3477
         ],
         [
-          6078,
-          6087
+          6086,
+          6095
         ],
         [
-          6136,
-          6144
+          6144,
+          6152
         ],
         [
-          6191,
-          6199
+          6199,
+          6207
         ],
         [
-          6961,
-          6991
+          6964,
+          6974
         ],
         [
-          7692,
-          7699
+          7093,
+          7123
         ],
         [
-          8072,
-          8078
+          7829,
+          7836
         ],
         [
-          8395,
-          8405
+          8209,
+          8215
         ],
         [
-          8768,
-          8773
+          8532,
+          8542
         ],
         [
-          11016,
-          11024
+          8950,
+          8955
         ],
         [
-          13388,
-          13396
+          11233,
+          11241
         ],
         [
-          13411,
-          13419
+          13605,
+          13613
         ],
         [
-          13685,
-          13693
+          13628,
+          13636
+        ],
+        [
+          13881,
+          13889
         ]
       ],
-      "source_sha256": "8a43d9c54652b53f9faab79de5340bc565bc2b8d18a3c8821aa5c617c256f32c"
+      "source_sha256": "a651cb7191712718fa2a1772be7e5feab8c0395ad769144ecc8d08970e8d646f"
     }
   },
-  "generated_at_utc": "2026-08-30T19:47:59.472449+00:00",
+  "generated_at_utc": "2026-09-01T00:22:03.970478+00:00",
   "paths": [
     "tldw_chatbook/app.py",
     "tldw_chatbook/UI/Screens/settings_screen.py",

--- a/Tests/Terminal/test_contracts.py
+++ b/Tests/Terminal/test_contracts.py
@@ -144,6 +144,9 @@ def test_terminal_backend_protocol_signatures_match_the_brief() -> None:
         "request_priority_close": inspect.Signature(
             [parameter("self", positional)], return_annotation=None
         ),
+        "finalize_shutdown": inspect.Signature(
+            [parameter("self", positional)], return_annotation=None
+        ),
         "cleanup": inspect.Signature(
             [
                 parameter("self", positional),

--- a/Tests/Terminal/test_posix_backend.py
+++ b/Tests/Terminal/test_posix_backend.py
@@ -1247,6 +1247,62 @@ def test_finalize_shutdown_closes_the_master_without_waiting(
         os.fstat(master_fd)
 
 
+def test_finalize_shutdown_fences_master_publication_during_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = PosixTerminalBackend(environment_factory=lambda: _environment(tmp_path))
+    openpty_entered = Event()
+    release_openpty = Event()
+    real_openpty = os.openpty
+    opened_descriptors: list[int] = []
+    outcome: dict[str, object] = {}
+
+    def blocked_openpty() -> tuple[int, int]:
+        descriptors = real_openpty()
+        opened_descriptors.extend(descriptors)
+        openpty_entered.set()
+        assert release_openpty.wait(1)
+        return descriptors
+
+    def start_backend() -> None:
+        try:
+            outcome["identity"] = backend.start(
+                TerminalLaunchRequest(
+                    name="finalized-during-start",
+                    shell="bash",
+                    start_directory=str(tmp_path),
+                    columns=80,
+                    rows=24,
+                ),
+                AdmissionGate(admitted=True, token="finalized-during-start"),
+            )
+        except Exception as error:
+            outcome["error"] = error
+
+    monkeypatch.setattr(os, "openpty", blocked_openpty)
+    launch_thread = Thread(target=start_backend)
+    try:
+        launch_thread.start()
+        assert openpty_entered.wait(1)
+        backend.finalize_shutdown()
+        release_openpty.set()
+        launch_thread.join(3)
+
+        assert not launch_thread.is_alive()
+        assert isinstance(outcome.get("error"), RuntimeError)
+        assert "identity" not in outcome
+        assert backend._master_fd is None
+        for descriptor in opened_descriptors:
+            with pytest.raises(OSError):
+                os.fstat(descriptor)
+    finally:
+        release_openpty.set()
+        launch_thread.join(3)
+        monkeypatch.undo()
+        _cleanup_backend_exact(backend, require_proven=False)
+
+
 def test_exact_shell_exit_is_singly_reaped_and_pty_reaches_eof(
     backend: PosixTerminalBackend,
 ) -> None:

--- a/Tests/Terminal/test_posix_backend.py
+++ b/Tests/Terminal/test_posix_backend.py
@@ -1233,6 +1233,20 @@ def test_nonblocking_read_resize_winch_and_alternate_screen(
     assert b"\x1b[?1049l" in output
 
 
+def test_finalize_shutdown_closes_the_master_without_waiting(
+    backend: PosixTerminalBackend,
+) -> None:
+    master_fd = backend._master_fd
+    assert master_fd is not None
+
+    backend.finalize_shutdown()
+    backend.finalize_shutdown()
+
+    assert backend._master_fd is None
+    with pytest.raises(OSError):
+        os.fstat(master_fd)
+
+
 def test_exact_shell_exit_is_singly_reaped_and_pty_reaches_eof(
     backend: PosixTerminalBackend,
 ) -> None:

--- a/Tests/Terminal/test_session_manager.py
+++ b/Tests/Terminal/test_session_manager.py
@@ -1190,7 +1190,7 @@ async def test_finalize_shutdown_closes_each_retained_backend_once_without_waiti
     backend = FinalizableBackend()
     terminal = TerminalSessionManager(lambda: True, lambda: backend)
     terminal.arm(acknowledge_disclosure=True)
-    create_running_session(terminal, "final-handle-close")
+    session_id = create_running_session(terminal, "final-handle-close")
 
     try:
         assert await terminal.shutdown(deadline_seconds=0.01) is False
@@ -1199,6 +1199,7 @@ async def test_finalize_shutdown_closes_each_retained_backend_once_without_waiti
         assert backend.finalize_calls == 1
     finally:
         finish_cleanup.set()
+    assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
 
 
 def test_managed_process_inventory_is_test_only_and_content_free() -> None:

--- a/Tests/Terminal/test_session_manager.py
+++ b/Tests/Terminal/test_session_manager.py
@@ -1167,6 +1167,40 @@ async def test_shutdown_returns_at_its_wait_bound_when_cleanup_is_still_running(
     assert terminal.wait_for_cleanup(session_id, timeout_seconds=1)
 
 
+@pytest.mark.asyncio
+async def test_finalize_shutdown_closes_each_retained_backend_once_without_waiting() -> (
+    None
+):
+    cleanup_started = Event()
+    finish_cleanup = Event()
+
+    class FinalizableBackend(RecordingBackend):
+        def __init__(self) -> None:
+            super().__init__(on_cleanup=self._blocking_cleanup)
+            self.finalize_calls = 0
+
+        def _blocking_cleanup(self, _attempt: CleanupAttempt) -> CleanupProof:
+            cleanup_started.set()
+            assert finish_cleanup.wait(1)
+            return CleanupProof(True, True, True)
+
+        def finalize_shutdown(self) -> None:
+            self.finalize_calls += 1
+
+    backend = FinalizableBackend()
+    terminal = TerminalSessionManager(lambda: True, lambda: backend)
+    terminal.arm(acknowledge_disclosure=True)
+    create_running_session(terminal, "final-handle-close")
+
+    try:
+        assert await terminal.shutdown(deadline_seconds=0.01) is False
+        terminal.finalize_shutdown()
+        terminal.finalize_shutdown()
+        assert backend.finalize_calls == 1
+    finally:
+        finish_cleanup.set()
+
+
 def test_managed_process_inventory_is_test_only_and_content_free() -> None:
     class InventoryBackend(RecordingBackend):
         def managed_process_inventory_for_tests(

--- a/Tests/UI/test_console_runtime_ownership.py
+++ b/Tests/UI/test_console_runtime_ownership.py
@@ -25,6 +25,7 @@ import asyncio
 import inspect
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from textual.events import Key
@@ -267,6 +268,7 @@ def test_attach_and_detach_cover_exactly_the_same_slot_set():
             for name in inspect.signature(ConsoleFleetLifecycleController).parameters
         }
     )
+    screen._library_activity = SimpleNamespace(build_provider=no_op)
     declared = {slot.name for slot in CONSOLE_VIEW_HOOK_SLOTS}
     provided = set(ChatScreen.console_view_hooks(screen))
 

--- a/Tests/UI/test_console_runtime_ownership.py
+++ b/Tests/UI/test_console_runtime_ownership.py
@@ -754,6 +754,85 @@ async def test_terminal_manager_shutdown_is_shared_and_shielded_from_waiter_canc
     assert terminal < console < buddy, source
 
 
+@pytest.mark.asyncio
+async def test_app_shutdown_drains_and_finalizes_a_real_terminal_manager():
+    """The app boundary drives real manager cleanup through finalization."""
+    from tldw_chatbook.Terminal.contracts import (
+        AdmissionGate,
+        BackendIdentity,
+        CleanupAttempt,
+        CleanupProof,
+        TerminalLaunchRequest,
+    )
+    from tldw_chatbook.Terminal.session_manager import TerminalSessionManager
+    from tldw_chatbook.app import TldwCli
+
+    cleanup_entered = threading.Event()
+    cleanup_release = threading.Event()
+
+    class Backend:
+        def __init__(self) -> None:
+            self.finalize_calls = 0
+
+        def start(
+            self,
+            _request: TerminalLaunchRequest,
+            admission: AdmissionGate,
+        ) -> BackendIdentity:
+            return BackendIdentity(session_id=admission.token)
+
+        def read(self, _maximum: int = 64 * 1024) -> bytes | None:
+            return None
+
+        def write(self, _data: bytes) -> None:
+            return None
+
+        def resize(self, _columns: int, _rows: int) -> None:
+            return None
+
+        def request_priority_close(self) -> None:
+            return None
+
+        def cleanup(self, _attempt: CleanupAttempt) -> CleanupProof:
+            cleanup_entered.set()
+            assert cleanup_release.wait(1)
+            return CleanupProof()
+
+        def finalize_shutdown(self) -> None:
+            self.finalize_calls += 1
+
+    backend = Backend()
+    manager = TerminalSessionManager(lambda: True, lambda: backend)
+    manager.arm(acknowledge_disclosure=True)
+    created = manager.create_session(
+        TerminalLaunchRequest(
+            name="app-shutdown-integration",
+            shell="default",
+            start_directory=str(Path.cwd()),
+            columns=80,
+            rows=24,
+        )
+    )
+    assert created.admitted is True
+
+    app = object.__new__(TldwCli)
+    app.terminal_session_manager = manager
+    app._terminal_session_manager_shutdown_task = None
+
+    first = asyncio.create_task(TldwCli._shutdown_terminal_session_manager(app))
+    assert await asyncio.to_thread(cleanup_entered.wait, 1)
+    second = asyncio.create_task(TldwCli._shutdown_terminal_session_manager(app))
+
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    assert backend.finalize_calls == 0
+
+    cleanup_release.set()
+    await asyncio.wait_for(second, 1)
+    assert backend.finalize_calls == 1
+
+
 @pytest.mark.unit
 def test_persona_buddy_is_app_owned_and_shutdown_after_console_producers():
     """Console producers stop before Buddy drains, which precedes profiles.

--- a/Tests/UI/test_console_runtime_ownership.py
+++ b/Tests/UI/test_console_runtime_ownership.py
@@ -291,6 +291,7 @@ async def test_second_console_visit_reuses_the_runtime(tmp_path):
     app = _build_test_app()
     _attach_real_dbs(app, tmp_path)
     _configure_native_ready_console(app)
+    terminal_manager = app.terminal_session_manager
 
     async with app.run_test(size=(160, 48)) as pilot:
         chat = ChatScreen(app)
@@ -362,6 +363,7 @@ async def test_second_console_visit_reuses_the_runtime(tmp_path):
         controller_two = chat_two._ensure_console_chat_controller()
         runtime_two = getattr(app, CONSOLE_RUNTIME_ATTR, None)
         assert runtime_two is runtime_one, "the SAME runtime serves visit two"
+        assert app.terminal_session_manager is terminal_manager
         assert controller_two is controller_one
         assert runtime_two.chat_store is store_one
         assert runtime_two.agent_bridge is bridge_one
@@ -654,6 +656,34 @@ def test_raw_cli_runtime_is_app_owned_unarmed_and_reads_config_replacements():
     runtime.shutdown()
 
 
+@pytest.mark.unit
+def test_terminal_manager_is_app_owned_unarmed_and_reads_config_replacements():
+    """The app owns one launch-local Terminal arm over its latest config."""
+    from tldw_chatbook.Terminal.session_manager import TerminalSessionManager
+    from tldw_chatbook.app import TldwCli
+
+    initializer = inspect.getsource(TldwCli.__init__)
+    config_load = initializer.index("self.app_config = load_settings()")
+    terminal_manager = initializer.index("self.terminal_session_manager")
+    console_runtime = initializer.index("self.console_runtime")
+    assert config_load < terminal_manager < console_runtime, initializer
+
+    app = _build_test_app(config_overrides={"console": {"raw_cli_permitted": True}})
+    manager = app.terminal_session_manager
+    assert isinstance(manager, TerminalSessionManager)
+    assert manager.permitted is True
+    assert manager.armed is False
+
+    app.app_config = {"console": {"raw_cli_permitted": "true"}}
+    assert manager.arm(acknowledge_disclosure=True).armed is False
+    app.app_config = {"console": {"raw_cli_permitted": 1}}
+    assert manager.arm(acknowledge_disclosure=True).armed is False
+    app.app_config = {"console": {"raw_cli_permitted": True}}
+    assert manager.arm(acknowledge_disclosure=True).armed is True
+    assert app.terminal_session_manager is manager
+    manager.disarm()
+
+
 @pytest.mark.asyncio
 async def test_raw_cli_runtime_shutdown_is_once_and_precedes_console_shutdown():
     """Both Textual shutdown paths share one raw-runtime shutdown task."""
@@ -678,6 +708,50 @@ async def test_raw_cli_runtime_shutdown_is_once_and_precedes_console_shutdown():
     raw = source.index("_shutdown_raw_cli_runtime")
     console = source.index("_shutdown_console_runtime")
     assert raw < console, source
+
+
+@pytest.mark.asyncio
+async def test_terminal_manager_shutdown_is_shared_and_shielded_from_waiter_cancel():
+    """One app task owns the five-second drain and final handle closure."""
+    from tldw_chatbook.app import TldwCli
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    calls: list[object] = []
+
+    class Manager:
+        async def shutdown(self, *, deadline_seconds: float) -> bool:
+            calls.append(("shutdown", deadline_seconds))
+            entered.set()
+            await release.wait()
+            return False
+
+        def finalize_shutdown(self) -> None:
+            calls.append("finalize")
+
+    app = object.__new__(TldwCli)
+    app.terminal_session_manager = Manager()
+    app._terminal_session_manager_shutdown_task = None
+
+    first = asyncio.create_task(TldwCli._shutdown_terminal_session_manager(app))
+    await asyncio.wait_for(entered.wait(), 1)
+    second = asyncio.create_task(TldwCli._shutdown_terminal_session_manager(app))
+    await asyncio.sleep(0)
+
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    assert calls == [("shutdown", 5.0)]
+
+    release.set()
+    await asyncio.wait_for(second, 1)
+    assert calls == [("shutdown", 5.0), "finalize"]
+
+    source = inspect.getsource(TldwCli._shutdown_app_owned_lifecycles)
+    terminal = source.index("_shutdown_terminal_session_manager")
+    console = source.index("_shutdown_console_runtime")
+    buddy = source.index("_shutdown_persona_buddy")
+    assert terminal < console < buddy, source
 
 
 @pytest.mark.unit
@@ -868,6 +942,8 @@ async def test_app_fences_console_then_drains_buddy_before_profile_teardown(
 
     from tldw_chatbook.app import TldwCli
 
+    terminal_entered = asyncio.Event()
+    terminal_release = asyncio.Event()
     console_entered = asyncio.Event()
     console_release = asyncio.Event()
     buddy_entered = asyncio.Event()
@@ -895,6 +971,20 @@ async def test_app_fences_console_then_drains_buddy_before_profile_teardown(
     async def no_op_lifecycle() -> None:
         return None
 
+    terminal_task: asyncio.Task[None] | None = None
+
+    async def terminal_runner() -> None:
+        events.append("terminal-start")
+        terminal_entered.set()
+        await terminal_release.wait()
+        events.append("terminal-finished")
+
+    async def shutdown_terminal_manager() -> None:
+        nonlocal terminal_task
+        if terminal_task is None:
+            terminal_task = asyncio.create_task(terminal_runner())
+        await asyncio.shield(terminal_task)
+
     console_task: asyncio.Task[None] | None = None
 
     async def console_runner() -> None:
@@ -916,6 +1006,7 @@ async def test_app_fences_console_then_drains_buddy_before_profile_teardown(
     app.audio_cpp_model_install_owner = AsyncOwner()
     app._shutdown_notes_sync_runtime = no_op_lifecycle
     app._shutdown_raw_cli_runtime = no_op_lifecycle
+    app._shutdown_terminal_session_manager = shutdown_terminal_manager
     app._shutdown_console_image_edits = later_lifecycle
     app._shutdown_console_runtime = shutdown_console_runtime
     app._shutdown_file_notes_session_owner = later_lifecycle
@@ -926,8 +1017,8 @@ async def test_app_fences_console_then_drains_buddy_before_profile_teardown(
 
     monkeypatch.setattr(App, "_shutdown", profile_teardown)
     draining = asyncio.create_task(TldwCli._shutdown(app))
-    await asyncio.wait_for(console_entered.wait(), 2)
-    assert events == ["console-start"]
+    await asyncio.wait_for(terminal_entered.wait(), 2)
+    assert events == ["terminal-start"]
     assert not draining.done()
 
     draining.cancel()
@@ -935,17 +1026,27 @@ async def test_app_fences_console_then_drains_buddy_before_profile_teardown(
     draining.cancel()
     await asyncio.sleep(0)
     assert not draining.done()
+    assert not console_entered.is_set()
     assert not buddy_entered.is_set()
+
+    terminal_release.set()
+    await asyncio.wait_for(console_entered.wait(), 2)
+    assert events[:3] == [
+        "terminal-start",
+        "terminal-finished",
+        "console-start",
+    ]
 
     console_release.set()
     await asyncio.wait_for(buddy_entered.wait(), 2)
-    assert events[:3] == ["console-start", "console-finished", "buddy-start"]
+    assert events[2:5] == ["console-start", "console-finished", "buddy-start"]
     assert "profile-teardown" not in events
 
     buddy_release.set()
     with pytest.raises(asyncio.CancelledError):
         await draining
 
+    assert events.index("terminal-finished") < events.index("console-start")
     assert events.index("console-finished") < events.index("buddy-start")
     assert events.index("buddy-finished") < events.index("profile-teardown")
     assert events[-1] == "profile-teardown"

--- a/tldw_chatbook/Terminal/backend.py
+++ b/tldw_chatbook/Terminal/backend.py
@@ -49,6 +49,10 @@ class TerminalBackend(Protocol):
         """Request out-of-band idempotent cleanup."""
         ...
 
+    def finalize_shutdown(self) -> None:
+        """Close remaining parent-owned handles without waiting."""
+        ...
+
     def cleanup(self, attempt: CleanupAttempt) -> CleanupProof:
         """Run cleanup under one absolute attempt deadline.
 

--- a/tldw_chatbook/Terminal/backend.py
+++ b/tldw_chatbook/Terminal/backend.py
@@ -50,7 +50,7 @@ class TerminalBackend(Protocol):
         ...
 
     def finalize_shutdown(self) -> None:
-        """Close remaining parent-owned handles without waiting."""
+        """Fence future startup and close parent-owned handles without waiting."""
         ...
 
     def cleanup(self, attempt: CleanupAttempt) -> CleanupProof:

--- a/tldw_chatbook/Terminal/posix_backend.py
+++ b/tldw_chatbook/Terminal/posix_backend.py
@@ -278,6 +278,7 @@ class PosixTerminalBackend:
         self._input_pending = threading.Event()
         self._shell_reaped = threading.Event()
         self._monitor_stop = threading.Event()
+        self._shutdown_finalized = threading.Event()
         self._process: subprocess.Popen[bytes] | None = None
         self._provisional_process: subprocess.Popen[bytes] | None = None
         self._master_fd: int | None = None
@@ -320,6 +321,7 @@ class PosixTerminalBackend:
                 or self._provisional_process is not None
                 or self._master_fd is not None
                 or self._pre_admission_disposed
+                or self._shutdown_finalized.is_set()
             ):
                 raise RuntimeError("POSIX terminal startup failed")
         try:
@@ -375,9 +377,11 @@ class PosixTerminalBackend:
         unadmitted_reaped = False
         dispose_after_failure = False
         try:
+            self._raise_if_shutdown_finalized()
             with _SPAWN_LOCK:
                 with _stderr_context():
                     descriptors["master"], descriptors["slave"] = os.openpty()
+                    self._raise_if_shutdown_finalized()
                     _set_window_size(
                         int(descriptors["slave"]),
                         request.columns,
@@ -422,6 +426,7 @@ class PosixTerminalBackend:
                         pass_fds=pass_fds,
                         close_fds=True,
                     )
+                    self._raise_if_shutdown_finalized()
             for name in (
                 "slave",
                 "config_read",
@@ -448,6 +453,8 @@ class PosixTerminalBackend:
                 flags = fcntl.fcntl(master_fd, fcntl.F_GETFL)
                 fcntl.fcntl(master_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
                 with self._state_lock:
+                    if self._shutdown_finalized.is_set():
+                        raise RuntimeError("POSIX terminal startup failed")
                     self._process = process
                     self._master_fd = master_fd
                     self._identity = identity
@@ -619,6 +626,7 @@ class PosixTerminalBackend:
 
     def finalize_shutdown(self) -> None:
         """Close remaining parent-owned handles without another wait."""
+        self._shutdown_finalized.set()
         self.request_priority_close()
         self._monitor_stop.set()
         with self._io_lock:
@@ -626,6 +634,11 @@ class PosixTerminalBackend:
                 fd = self._master_fd
                 self._master_fd = None
             _safe_close(fd)
+
+    def _raise_if_shutdown_finalized(self) -> None:
+        """Refuse allocation or publication after the final shutdown fence."""
+        if self._shutdown_finalized.is_set():
+            raise RuntimeError("POSIX terminal startup failed")
 
     def cleanup(self, attempt: CleanupAttempt) -> CleanupProof:
         """Run identity-safe cleanup under absolute ADR-099 boundaries.

--- a/tldw_chatbook/Terminal/posix_backend.py
+++ b/tldw_chatbook/Terminal/posix_backend.py
@@ -617,6 +617,16 @@ class PosixTerminalBackend:
             self._input_pending.clear()
         self._input_pending.set()
 
+    def finalize_shutdown(self) -> None:
+        """Close remaining parent-owned handles without another wait."""
+        self.request_priority_close()
+        self._monitor_stop.set()
+        with self._io_lock:
+            with self._state_lock:
+                fd = self._master_fd
+                self._master_fd = None
+            _safe_close(fd)
+
     def cleanup(self, attempt: CleanupAttempt) -> CleanupProof:
         """Run identity-safe cleanup under absolute ADR-099 boundaries.
 

--- a/tldw_chatbook/Terminal/session_manager.py
+++ b/tldw_chatbook/Terminal/session_manager.py
@@ -153,6 +153,7 @@ class TerminalSessionManager:
         self._armed = False
         self._disclosure_acknowledged = False
         self._shutting_down = False
+        self._shutdown_finalized = False
         self._sessions: dict[str, _SessionRecord] = {}
         self._selected_session_id: str | None = None
         self._view_generation = 0
@@ -480,6 +481,26 @@ class TerminalSessionManager:
                 return False
         with self._lock:
             return not self._sessions
+
+    def finalize_shutdown(self) -> None:
+        """Close remaining app-owned backend handles without another wait."""
+        with self._lock:
+            if self._shutdown_finalized:
+                return
+            self._shutdown_finalized = True
+            backends = tuple(
+                {
+                    id(record.backend): record.backend
+                    for record in self._sessions.values()
+                    if record.backend is not None
+                }.values()
+            )
+        for backend in backends:
+            try:
+                backend.finalize_shutdown()
+            except Exception:
+                continue
+        self._cleanup_executor.shutdown(wait=False, cancel_futures=True)
 
     def accepts_input(self, session_id: str) -> bool:
         """Return whether a running record currently accepts input."""

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -220,6 +220,8 @@ from tldw_chatbook.Chat.console_settings_defaults import ConsoleDefaultDurabilit
 from tldw_chatbook.Chat.server_chat_conversation_service import (
     ServerChatConversationService,
 )
+from tldw_chatbook.Terminal.backend import TerminalBackend  # noqa: E402
+from tldw_chatbook.Terminal.session_manager import TerminalSessionManager  # noqa: E402
 from tldw_chatbook.DB.Client_Media_DB_v2 import (
     DatabaseError as MediaDatabaseError,
     InputError as MediaInputError,
@@ -1064,6 +1066,15 @@ def _read_app_raw_cli_permitted(app: object) -> bool:
         return False
     console = config.get("console")
     return isinstance(console, Mapping) and console.get("raw_cli_permitted") is True
+
+
+def _build_terminal_backend() -> TerminalBackend:
+    """Build the supported platform backend without eager platform imports."""
+    if os.name != "posix":
+        raise OSError("persistent Terminal backend unavailable")
+    from tldw_chatbook.Terminal.posix_backend import PosixTerminalBackend
+
+    return PosixTerminalBackend()
 
 
 # --- Global variable for config ---
@@ -7266,6 +7277,11 @@ class TldwCli(
         self.app_config = load_settings()
         self.raw_cli_runtime = RawCliRuntime(lambda: _read_app_raw_cli_permitted(self))
         self._raw_cli_runtime_shutdown_task: asyncio.Task[Any] | None = None
+        self.terminal_session_manager = TerminalSessionManager(
+            lambda: _read_app_raw_cli_permitted(self),
+            _build_terminal_backend,
+        )
+        self._terminal_session_manager_shutdown_task: asyncio.Task[None] | None = None
         # Default-save failures belong to the application lifetime rather
         # than whichever Console screen happens to be mounted.  New-chat
         # generation advances only after a Make Default intent is fully
@@ -15587,6 +15603,27 @@ class TldwCli(
             self._raw_cli_runtime_shutdown_task = task
         await asyncio.shield(task)
 
+    async def _run_terminal_session_manager_shutdown(self) -> None:
+        """Drain Terminal once, then close remaining parent-owned handles."""
+        manager = getattr(self, "terminal_session_manager", None)
+        if manager is None:
+            return
+        try:
+            await manager.shutdown(deadline_seconds=5.0)
+        finally:
+            manager.finalize_shutdown()
+
+    async def _shutdown_terminal_session_manager(self) -> None:
+        """Share one cancellation-resistant Terminal shutdown task."""
+        task = getattr(self, "_terminal_session_manager_shutdown_task", None)
+        if task is None:
+            task = asyncio.create_task(
+                self._run_terminal_session_manager_shutdown(),
+                name="shutdown_terminal_session_manager",
+            )
+            self._terminal_session_manager_shutdown_task = task
+        await asyncio.shield(task)
+
     async def _shutdown_console_settings_durability(self) -> None:
         """Drain admitted settings writes without cancelling thread work.
 
@@ -15613,6 +15650,7 @@ class TldwCli(
         # Console shutdown terminally fences every trusted Buddy producer
         # before Buddy itself closes admission and drains owned work.
         await self._shutdown_raw_cli_runtime()
+        await self._shutdown_terminal_session_manager()
         await self._shutdown_console_settings_durability()
         await self._shutdown_console_runtime()
         change_review = getattr(self, "change_review_consent_service", None)


### PR DESCRIPTION
## Summary

- construct one launch-local, initially unarmed `TerminalSessionManager` at app lifetime using the strict live raw-CLI permission reader and a lazy POSIX backend factory
- share one cancellation-resistant five-second shutdown task, ordered before Console and later resource teardown, then close retained parent-owned terminal handles without a second wait window
- add ownership/remount, shutdown ordering, backend-contract, manager-finalization, and real POSIX PTY handle-closure coverage; update the Task 10 plan file map

ADR required: yes
ADR path: `backlog/decisions/099-persistent-terminal-session-runtime-boundary.md`
Reason: this change directly implements the accepted app-lifetime and shutdown boundary; no new ADR is needed.

## Test Plan

- [x] `164 passed` — Console ownership/lifetime, Terminal contracts, and manager tests
- [x] `49 passed` — full real POSIX terminal backend suite on macOS host PTYs
- [x] Ruff checks passed for all changed Terminal/test files and undefined-name checks passed for `app.py`
- [x] Ruff format checks passed for all changed Terminal/test files
- [x] `git diff --check`

The cumulative formatter ratchet currently references an older stored base and reports unrelated upstream formatter drift. None of this PR's new `app.py` lines appears in Ruff's formatter diff; the ratchet baseline is regenerated after the required pre-merge rebase.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves terminal session ownership to app lifetime: the app now creates one launch-local, initially-unarmed `TerminalSessionManager` instead of building one per console visit. The manager reads the raw-CLI permission from the latest config on each arm; shutdown shares one cancellation-resistant five-second task ordered before Console teardown, then closes retained terminal handles without a second wait window and fences the backend against any later startup.

**Shutdown**

- `finalize_shutdown()` fences the backend so new `start()` calls fail, closes each retained backend handle once, and stops and cancels the cleanup executor's pending futures without waiting.
- The `TerminalBackend` contract now requires `finalize_shutdown()`; the POSIX backend closes its master FD idempotently and rejects startup after finalization.
- Terminal shutdown is shielded from cancellation and ordered before Console and later resource teardown.

**Tests**

- Adds app ownership/remount, shutdown-ordering, backend-contract, manager-finalization, startup-fencing, and real POSIX PTY handle-closure coverage.
- Updates the Task 10 plan file map and regenerates the formatter baseline.

<sup>Written for commit 2dc538919f87c5aac981d457650809849c8db0d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

