### PR TITLE
Restore UI-ready startup module budget

### DIFF
--- a/Tests/Chat/test_permission_summary_wiring.py
+++ b/Tests/Chat/test_permission_summary_wiring.py
@@ -1,5 +1,7 @@
 """ADR-090: fire-once trigger matrix + guarded delivery, no real threads."""
 
+import builtins
+
 import threading
 from types import SimpleNamespace
 
@@ -61,6 +63,25 @@ def test_mode_off_never_fires(monkeypatch):
     }
     ctrl._maybe_fire_permission_summary(_payload())
     assert _ThreadStub.started == []
+    assert ctrl._pending_approval_rounds["r1"]["summary_fired"] is True
+
+
+def test_summary_service_import_failure_is_advisory(monkeypatch):
+    ctrl = _bare_controller()
+    ctrl._pending_approval_rounds["r1"] = {
+        "event": threading.Event(), "summary_fired": False,
+    }
+    real_import = builtins.__import__
+
+    def fail_summary_service_import(name, *args, **kwargs):
+        if name == "tldw_chatbook.Chat.permission_summary_service":
+            raise ImportError("summary service unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_summary_service_import)
+
+    ctrl._maybe_fire_permission_summary(_payload())
+
     assert ctrl._pending_approval_rounds["r1"]["summary_fired"] is True
 
 

--- a/Tests/Chat/test_permission_summary_wiring.py
+++ b/Tests/Chat/test_permission_summary_wiring.py
@@ -4,6 +4,7 @@ import threading
 from types import SimpleNamespace
 
 from tldw_chatbook.Chat import console_chat_controller as ccc
+from tldw_chatbook.Chat import permission_summary_service as summary_service
 from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
 from tldw_chatbook.Chat.permission_summary_service import (
     PermissionSummaryResolution,
@@ -44,7 +45,9 @@ class _ThreadStub:
 
 def _armed(monkeypatch, mode, active=True):
     monkeypatch.setattr(
-        ccc, "resolve_permission_summary", lambda cfg: _resolution(mode, active)
+        summary_service,
+        "resolve_permission_summary",
+        lambda cfg: _resolution(mode, active),
     )
     _ThreadStub.started = []
     monkeypatch.setattr(ccc.threading, "Thread", _ThreadStub)

--- a/Tests/Performance/test_ui_ready_module_census.py
+++ b/Tests/Performance/test_ui_ready_module_census.py
@@ -139,6 +139,8 @@ ABSENT_AT_READY_MODULES = (
     "tldw_chatbook.Sync_Interop.notes_organization",
     "tldw_chatbook.Sync_Interop.notes_organization_sync_service",
     "tldw_chatbook.Sync_Interop.notes_outbox_producer",
+    # ADR-090: the external-summary LLM graph is approval-time work.
+    "tldw_chatbook.Chat.permission_summary_service",
     # TASK-23113.7: normalization is idle maintenance. Its adapter and worker
     # import graph must stay outside the first-interactive-frame window even
     # on slow runners where mount settling continues after ``_ui_ready``.

--- a/Tests/Terminal/test_contracts.py
+++ b/Tests/Terminal/test_contracts.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 import inspect
+import os
+import subprocess
+import sys
+import textwrap
 from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
 
 import pytest
 
@@ -37,6 +42,103 @@ from tldw_chatbook.Terminal.contracts import (
     slot_held,
     validate_transition,
 )
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_isolated_terminal_import(
+    tmp_path: Path, code: str
+) -> subprocess.CompletedProcess[str]:
+    """Run an import-boundary assertion in a clean Python process."""
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "HOME": str(tmp_path / "home"),
+            "XDG_CONFIG_HOME": str(tmp_path / "config"),
+            "XDG_DATA_HOME": str(tmp_path / "data"),
+            "TLDW_TEST_MODE": "1",
+        }
+    )
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_package_terminal_backend_export_is_lazy_and_bounded(tmp_path: Path) -> None:
+    result = _run_isolated_terminal_import(
+        tmp_path,
+        """
+        import sys
+        import tldw_chatbook.Terminal as terminal
+
+        assert "tldw_chatbook.Terminal.backend" not in sys.modules
+        try:
+            terminal.not_a_real_export
+        except AttributeError as exc:
+            assert exc.args == ("not_a_real_export",)
+        else:
+            raise AssertionError("unsupported package attribute unexpectedly resolved")
+        assert "tldw_chatbook.Terminal.backend" not in sys.modules
+
+        backend = terminal.TerminalBackend
+        assert backend.__module__ == "tldw_chatbook.Terminal.backend"
+        assert backend.__name__ == "TerminalBackend"
+        assert "tldw_chatbook.Terminal.backend" in sys.modules
+        """,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_deferred_annotations_resolve_without_loading_implementations(
+    tmp_path: Path,
+) -> None:
+    result = _run_isolated_terminal_import(
+        tmp_path,
+        """
+        import sys
+        from typing import Any, get_type_hints
+
+        from tldw_chatbook.Terminal import session_manager
+
+        deferred_terminal = {
+            "tldw_chatbook.Terminal.backend",
+            "tldw_chatbook.Terminal.io_actors",
+            "tldw_chatbook.Terminal.screen_model",
+        }
+        assert deferred_terminal.isdisjoint(sys.modules)
+        assert get_type_hints(session_manager.TerminalSessionView)["screen"] is Any
+        assert get_type_hints(session_manager.TerminalSessionManager.offer_output)["return"] is Any
+        assert deferred_terminal.isdisjoint(sys.modules)
+
+        from tldw_chatbook.Chat import console_trace_projection as projection
+        assert "tldw_chatbook.Chat.trace_export_profiles" not in sys.modules
+        assert get_type_hints(projection.project_capture_for_viewer)["profile"] is Any
+        assert "tldw_chatbook.Chat.trace_export_profiles" not in sys.modules
+
+        from tldw_chatbook.Chat import console_trace_provenance as provenance
+        assert "tldw_chatbook.Chat.console_semantic_revision" not in sys.modules
+        assert get_type_hints(provenance.admit_message_provenance)["coordinator"] is Any
+        assert "tldw_chatbook.Chat.console_semantic_revision" not in sys.modules
+
+        from tldw_chatbook.Widgets.Console import console_conversation_inspector as inspector
+        getter = inspector.ConsoleConversationInspector.viewer_profile.fget
+        assert getter is not None
+        assert get_type_hints(getter)["return"] is Any
+
+        import tldw_chatbook.app as app
+        assert "tldw_chatbook.Terminal.backend" not in sys.modules
+        assert get_type_hints(app._build_terminal_backend)["return"] is Any
+        assert "tldw_chatbook.Terminal.backend" not in sys.modules
+        """,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
 
 
 def running_projection() -> TerminalProjection:

--- a/backlog/tasks/task-26046 - Defer-permission-summary-imports-from-UI-ready-startup.md
+++ b/backlog/tasks/task-26046 - Defer-permission-summary-imports-from-UI-ready-startup.md
@@ -4,7 +4,7 @@ title: Defer permission-summary imports from UI-ready startup
 status: Done
 assignee: []
 created_date: '2026-09-01 02:24'
-updated_date: '2026-09-01 02:50'
+updated_date: '2026-09-01 02:58'
 labels: []
 dependencies: []
 ---
@@ -31,5 +31,5 @@ Restore the existing UI-ready module ceiling after permission-request summaries 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Deferred permission-summary, terminal support, trace disclosure, and briefing TTS helpers from UI-ready startup; added focused lazy-boundary coverage; verified the 972-module macOS ceiling, removed the two Linux-only eager TTS modules identified by CI, and passed focused behavior, inspector, terminal, briefing-audio, performance, lint, compile, diff, and diagnostic inventory checks. ADR required: no; implements ADR-090 and ADR-097.
+Deferred permission-summary, terminal support, trace disclosure, and briefing TTS helpers from UI-ready startup; added focused lazy-boundary coverage; preserved runtime type-hint resolution with non-eager Any fallbacks; documented the lazy export hook; verified supported and unsupported TerminalBackend export behavior; kept the 972-module macOS ceiling; removed the two Linux-only eager TTS modules identified by CI; and passed focused behavior, inspector, terminal, briefing-audio, performance, lint, compile, diff, and diagnostic inventory checks. One batched Textual timing test timed out under load and passed immediately in isolation (4.15s). ADR required: no; implements ADR-090 and ADR-097.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-26046 - Defer-permission-summary-imports-from-UI-ready-startup.md
+++ b/backlog/tasks/task-26046 - Defer-permission-summary-imports-from-UI-ready-startup.md
@@ -1,0 +1,35 @@
+---
+id: TASK-26046
+title: Defer permission-summary imports from UI-ready startup
+status: Done
+assignee: []
+created_date: '2026-09-01 02:24'
+updated_date: '2026-09-01 02:43'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Restore the existing UI-ready module ceiling after permission-request summaries made their LLM and trace dependency graph resident before the first interactive frame.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Current dev's UI-ready module census passes without raising its ceiling.
+- [x] #2 Permission summaries retain their existing behavior.
+- [x] #3 Focused permission-summary and startup-budget tests pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm the eager import path against the failing dev census\n2. Defer permission-summary service imports to the actions that use them\n3. Add focused regression coverage for the lazy boundary\n4. Run focused behavior, import-budget, lint, and artifact checks\n5. ADR required: no; ADR path: N/A; reason: direct regression fix implementing existing ADR-090 and ADR-097 boundaries
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Deferred permission-summary, terminal support, and trace disclosure imports from UI-ready startup; added focused lazy-boundary coverage; verified the 972-module ceiling plus focused behavior, inspector, terminal, performance, lint, compile, diff, and diagnostic inventory checks. ADR required: no; implements ADR-090 and ADR-097.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-26046 - Defer-permission-summary-imports-from-UI-ready-startup.md
+++ b/backlog/tasks/task-26046 - Defer-permission-summary-imports-from-UI-ready-startup.md
@@ -4,7 +4,7 @@ title: Defer permission-summary imports from UI-ready startup
 status: Done
 assignee: []
 created_date: '2026-09-01 02:24'
-updated_date: '2026-09-01 02:43'
+updated_date: '2026-09-01 02:50'
 labels: []
 dependencies: []
 ---
@@ -31,5 +31,5 @@ Restore the existing UI-ready module ceiling after permission-request summaries 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Deferred permission-summary, terminal support, and trace disclosure imports from UI-ready startup; added focused lazy-boundary coverage; verified the 972-module ceiling plus focused behavior, inspector, terminal, performance, lint, compile, diff, and diagnostic inventory checks. ADR required: no; implements ADR-090 and ADR-097.
+Deferred permission-summary, terminal support, trace disclosure, and briefing TTS helpers from UI-ready startup; added focused lazy-boundary coverage; verified the 972-module macOS ceiling, removed the two Linux-only eager TTS modules identified by CI, and passed focused behavior, inspector, terminal, briefing-audio, performance, lint, compile, diff, and diagnostic inventory checks. ADR required: no; implements ADR-090 and ADR-097.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-26046 - Defer-permission-summary-imports-from-UI-ready-startup.md
+++ b/backlog/tasks/task-26046 - Defer-permission-summary-imports-from-UI-ready-startup.md
@@ -4,7 +4,7 @@ title: Defer permission-summary imports from UI-ready startup
 status: Done
 assignee: []
 created_date: '2026-09-01 02:24'
-updated_date: '2026-09-01 02:58'
+updated_date: '2026-09-01 03:01'
 labels: []
 dependencies: []
 ---
@@ -25,11 +25,15 @@ Restore the existing UI-ready module ceiling after permission-request summaries 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Confirm the eager import path against the failing dev census\n2. Defer permission-summary service imports to the actions that use them\n3. Add focused regression coverage for the lazy boundary\n4. Run focused behavior, import-budget, lint, and artifact checks\n5. ADR required: no; ADR path: N/A; reason: direct regression fix implementing existing ADR-090 and ADR-097 boundaries
+1. Confirm the eager import path against the failing dev census
+2. Defer permission-summary service imports to the actions that use them
+3. Add focused regression coverage for the lazy boundary
+4. Run focused behavior, import-budget, lint, and artifact checks
+5. ADR required: no; ADR path: N/A; reason: direct regression fix implementing existing ADR-090 and ADR-097 boundaries
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Deferred permission-summary, terminal support, trace disclosure, and briefing TTS helpers from UI-ready startup; added focused lazy-boundary coverage; preserved runtime type-hint resolution with non-eager Any fallbacks; documented the lazy export hook; verified supported and unsupported TerminalBackend export behavior; kept the 972-module macOS ceiling; removed the two Linux-only eager TTS modules identified by CI; and passed focused behavior, inspector, terminal, briefing-audio, performance, lint, compile, diff, and diagnostic inventory checks. One batched Textual timing test timed out under load and passed immediately in isolation (4.15s). ADR required: no; implements ADR-090 and ADR-097.
+Deferred permission-summary, terminal support, trace disclosure, and briefing TTS helpers from UI-ready startup; added focused lazy-boundary coverage; preserved runtime type-hint resolution with non-eager Any fallbacks; documented and tested the lazy TerminalBackend export; moved the deferred permission-summary import inside the advisory failure boundary with a red-green import-failure regression; repaired the Backlog plan formatting; kept the 972-module macOS ceiling; removed the two Linux-only eager TTS modules identified by CI; and passed focused behavior, inspector, terminal, briefing-audio, performance, lint, compile, diff, and diagnostic inventory checks. One batched Textual timing test timed out under load and passed immediately in isolation (4.15s). ADR required: no; implements ADR-090 and ADR-097.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -321,13 +321,6 @@ from tldw_chatbook.Chat.console_skill_resolver import (
     resolve_skill_command,
 )
 from tldw_chatbook.Chat.prompt_history import PromptHistory
-from tldw_chatbook.Chat.permission_summary_service import (
-    build_messages_tail,
-    pending_calls_info_from_payload,
-    resolve_permission_summary,
-    summarize_pending_round,
-)
-
 if TYPE_CHECKING:
     from tldw_chatbook.Agents.agent_lesson_promotion import ManagedSkillProposalGate
     from tldw_chatbook.Agents.persona_policy import PersonaToolPolicy
@@ -11195,6 +11188,10 @@ class ConsoleChatController:
         rows = payload.get("calls") or []
         if not round_id or not rows:
             return
+        from tldw_chatbook.Chat.permission_summary_service import (
+            resolve_permission_summary,
+        )
+
         # Lock order: config lock FIRST, then `_approval_state_lock` (see
         # `run_if_runtime_config_generation_current` in config.py) -- so the
         # config read happens before the approval lock is taken.
@@ -11239,6 +11236,12 @@ class ConsoleChatController:
         unaffected; a slow call that outlives the round is dropped on
         delivery. Content-free failures only (ADR-090).
         """
+        from tldw_chatbook.Chat.permission_summary_service import (
+            build_messages_tail,
+            pending_calls_info_from_payload,
+            summarize_pending_round,
+        )
+
         try:
             tail = build_messages_tail(
                 self._summary_tail_messages(payload), resolution.tail_max_chars

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -11188,14 +11188,14 @@ class ConsoleChatController:
         rows = payload.get("calls") or []
         if not round_id or not rows:
             return
-        from tldw_chatbook.Chat.permission_summary_service import (
-            resolve_permission_summary,
-        )
-
         # Lock order: config lock FIRST, then `_approval_state_lock` (see
         # `run_if_runtime_config_generation_current` in config.py) -- so the
         # config read happens before the approval lock is taken.
         try:
+            from tldw_chatbook.Chat.permission_summary_service import (
+                resolve_permission_summary,
+            )
+
             resolution = resolve_permission_summary(
                 get_runtime_config_snapshot().values
             )

--- a/tldw_chatbook/Chat/console_trace_projection.py
+++ b/tldw_chatbook/Chat/console_trace_projection.py
@@ -12,7 +12,7 @@ import json
 import math
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
-from typing import Literal, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Literal, TypeAlias, TypeVar
 
 from loguru import logger
 
@@ -21,10 +21,8 @@ from tldw_chatbook.Chat.console_exchange_capture import (
     ExchangeCapture,
     capture_from_storage,
 )
-from tldw_chatbook.Chat.trace_export_profiles import (
-    TraceExportProfile,
-    TraceViewerProfile,
-)
+if TYPE_CHECKING:
+    from tldw_chatbook.Chat.trace_export_profiles import TraceViewerProfile
 
 
 @dataclass(frozen=True, slots=True)
@@ -114,6 +112,10 @@ def project_capture_for_viewer(
     # Keep the Inspector's first-paint import closure small. Export projection is
     # needed only when a call body is actually opened.
     from tldw_chatbook.Chat.console_exchange_export import project_exchange_export
+    from tldw_chatbook.Chat.trace_export_profiles import (
+        TraceExportProfile,
+        TraceViewerProfile,
+    )
 
     if not isinstance(profile, TraceViewerProfile):
         raise TypeError("profile")

--- a/tldw_chatbook/Chat/console_trace_projection.py
+++ b/tldw_chatbook/Chat/console_trace_projection.py
@@ -12,7 +12,7 @@ import json
 import math
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Literal, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypeVar
 
 from loguru import logger
 
@@ -23,6 +23,8 @@ from tldw_chatbook.Chat.console_exchange_capture import (
 )
 if TYPE_CHECKING:
     from tldw_chatbook.Chat.trace_export_profiles import TraceViewerProfile
+else:
+    TraceViewerProfile = Any
 
 
 @dataclass(frozen=True, slots=True)

--- a/tldw_chatbook/Chat/console_trace_provenance.py
+++ b/tldw_chatbook/Chat/console_trace_provenance.py
@@ -11,13 +11,17 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Literal, TypeAlias, cast
+from typing import TYPE_CHECKING, Literal, TypeAlias, cast
 
-from tldw_chatbook.Chat.console_semantic_revision import SemanticRevisionCoordinator
 from tldw_chatbook.Chat.console_trace_models import (
     FrozenTracePolicy,
     SemanticRevisionRef,
 )
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Chat.console_semantic_revision import (
+        SemanticRevisionCoordinator,
+    )
 
 
 MAX_PROVENANCE_TRANSFORM_INPUTS = 256

--- a/tldw_chatbook/Chat/console_trace_provenance.py
+++ b/tldw_chatbook/Chat/console_trace_provenance.py
@@ -11,7 +11,7 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
 
 from tldw_chatbook.Chat.console_trace_models import (
     FrozenTracePolicy,
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
     from tldw_chatbook.Chat.console_semantic_revision import (
         SemanticRevisionCoordinator,
     )
+else:
+    SemanticRevisionCoordinator = Any
 
 
 MAX_PROVENANCE_TRANSFORM_INPUTS = 256

--- a/tldw_chatbook/Subscriptions/briefing_audio.py
+++ b/tldw_chatbook/Subscriptions/briefing_audio.py
@@ -215,9 +215,7 @@ from tldw_chatbook.TTS.audio_stitch import (
     wav_duration_seconds,
 )
 from tldw_chatbook.TTS.legacy_bridge import LEGACY_PROVIDER_IDS
-from tldw_chatbook.TTS.legacy_request_builder import build_legacy_speech_request
 from tldw_chatbook.TTS.playground_types import TTSRequestedSelectionSnapshot
-from tldw_chatbook.TTS.text_processing import TextChunker
 from tldw_chatbook.Utils.path_validation import is_safe_path
 from tldw_chatbook.Utils.private_paths import (
     atomic_private_write_bytes,
@@ -387,6 +385,8 @@ def _split_turn_text(text: str) -> list[str]:
     """
     if len(text) <= MAX_TURN_CHARS:
         return [text]
+
+    from tldw_chatbook.TTS.text_processing import TextChunker
 
     chunker = TextChunker(max_tokens=_CHUNK_MAX_TOKENS)
     pieces = [chunk.text for chunk in chunker.chunk_text(text) if chunk.text.strip()]
@@ -680,6 +680,8 @@ async def _synthesize_legacy_chunk(
             f"speaker {selection.speaker!r} turn {turn_index}: no voice is "
             "selected for this provider"
         )
+
+    from tldw_chatbook.TTS.legacy_request_builder import build_legacy_speech_request
 
     request, internal_model_id = build_legacy_speech_request(
         provider_id=selection.provider_id,

--- a/tldw_chatbook/Terminal/__init__.py
+++ b/tldw_chatbook/Terminal/__init__.py
@@ -39,7 +39,17 @@ if TYPE_CHECKING:
 
 
 def __getattr__(name: str) -> Any:
-    """Load the backend protocol only for callers that request it."""
+    """Load the backend protocol only for callers that request it.
+
+    Args:
+        name: Package attribute requested by the caller.
+
+    Returns:
+        The lazily imported :class:`TerminalBackend` protocol.
+
+    Raises:
+        AttributeError: If ``name`` is not a supported lazy package export.
+    """
 
     if name == "TerminalBackend":
         from .backend import TerminalBackend

--- a/tldw_chatbook/Terminal/__init__.py
+++ b/tldw_chatbook/Terminal/__init__.py
@@ -1,6 +1,7 @@
 """Platform-neutral contracts for persistent terminal sessions."""
 
-from .backend import TerminalBackend
+from typing import TYPE_CHECKING, Any
+
 from .contracts import (
     MAX_IO_CHUNK_BYTES,
     MAX_PARSER_TURN_BYTES,
@@ -32,6 +33,19 @@ from .contracts import (
     slot_held,
     validate_transition,
 )
+
+if TYPE_CHECKING:
+    from .backend import TerminalBackend
+
+
+def __getattr__(name: str) -> Any:
+    """Load the backend protocol only for callers that request it."""
+
+    if name == "TerminalBackend":
+        from .backend import TerminalBackend
+
+        return TerminalBackend
+    raise AttributeError(name)
 
 __all__ = [
     "AdmissionGate",

--- a/tldw_chatbook/Terminal/session_manager.py
+++ b/tldw_chatbook/Terminal/session_manager.py
@@ -37,6 +37,15 @@ if TYPE_CHECKING:
         TerminalOutputActor,
     )
     from .screen_model import TerminalScreenSnapshot
+else:
+    TerminalBackend = Any
+    InputOfferResult = Any
+    OutputOfferResult = Any
+    ParserTurnResult = Any
+    TerminalInputActor = Any
+    TerminalInputEvent = Any
+    TerminalOutputActor = Any
+    TerminalScreenSnapshot = Any
 
 
 @dataclass(frozen=True, slots=True)

--- a/tldw_chatbook/Terminal/session_manager.py
+++ b/tldw_chatbook/Terminal/session_manager.py
@@ -8,10 +8,9 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field, replace
 from threading import Event, Lock, RLock
 from time import monotonic
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from .backend import TerminalBackend
 from .contracts import (
     AdmissionGate,
     CleanupAttempt,
@@ -26,16 +25,18 @@ from .contracts import (
     TerminalReceipt,
     apply_event,
 )
-from .io_actors import (
-    InputOfferResult,
-    OutputOfferResult,
-    ParserTurnResult,
-    TerminalInputActor,
-    TerminalInputEvent,
-    TerminalOutputActor,
-)
-from .launch import normalize_session_name
-from .screen_model import TerminalScreenModel, TerminalScreenSnapshot
+
+if TYPE_CHECKING:
+    from .backend import TerminalBackend
+    from .io_actors import (
+        InputOfferResult,
+        OutputOfferResult,
+        ParserTurnResult,
+        TerminalInputActor,
+        TerminalInputEvent,
+        TerminalOutputActor,
+    )
+    from .screen_model import TerminalScreenSnapshot
 
 
 @dataclass(frozen=True, slots=True)
@@ -231,6 +232,9 @@ class TerminalSessionManager:
         Returns:
             Content-free admission result and immutable projection when admitted.
         """
+        from .io_actors import TerminalInputActor, TerminalOutputActor
+        from .launch import normalize_session_name
+
         with self._lock:
             refusal = self._creation_refusal_locked()
             if refusal is not None:
@@ -516,6 +520,8 @@ class TerminalSessionManager:
 
     def offer_output(self, session_id: str, data: bytes) -> OutputOfferResult:
         """Offer bounded backend bytes to a healthy retained parser path."""
+        from .io_actors import OutputOfferResult
+
         with self._lock:
             record = self._sessions.get(session_id)
             actor = None if record is None else record.output_actor
@@ -614,6 +620,8 @@ class TerminalSessionManager:
 
     def view_state(self, view: TerminalViewToken) -> TerminalViewState | None:
         """Return immutable projections only to the current generation."""
+        from .screen_model import TerminalScreenSnapshot
+
         with self._lock:
             if not self._valid_view_locked(view):
                 return None
@@ -836,6 +844,8 @@ class TerminalSessionManager:
         view: TerminalViewToken,
     ) -> bool:
         """Rename a retained record under normalized unique-name policy."""
+        from .launch import normalize_session_name
+
         with self._lock:
             if not self._valid_view_locked(view):
                 return False
@@ -866,6 +876,8 @@ class TerminalSessionManager:
         view: TerminalViewToken,
     ) -> InputOfferResult:
         """Offer one key event through the manager-owned bounded input actor."""
+        from .io_actors import InputOfferResult
+
         with self._lock:
             actor = self._input_actor_for_view_locked(session_id, view)
             if actor is None:
@@ -881,6 +893,8 @@ class TerminalSessionManager:
         view: TerminalViewToken,
     ) -> InputOfferResult:
         """Offer one atomic paste through the manager-owned input actor."""
+        from .io_actors import InputOfferResult
+
         with self._lock:
             actor = self._input_actor_for_view_locked(session_id, view)
             if actor is None:
@@ -972,6 +986,8 @@ class TerminalSessionManager:
     def _make_screen_model(self, columns: int, rows: int) -> Any:
         if self._screen_model_factory is not None:
             return self._screen_model_factory(columns, rows)
+        from .screen_model import TerminalScreenModel
+
         return TerminalScreenModel(columns=columns, rows=rows)
 
     def _begin_cleanup_locked(

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -95,7 +95,6 @@ from ...Chat.console_provider_support import (
     supported_console_provider_catalog,
 )
 from ...Chat.console_session_settings import CONSOLE_SETTINGS_EXECUTION_PROVIDER_KEYS
-from ...Chat.permission_summary_service import permission_summary_settings_payload
 from ...ACP_Interop.runtime_session import ACPRuntimeSessionState
 from ...runtime_policy.server_event_scope import event_principal_id_from_active_context
 from ...Sync_Interop.sync_promotion_state import (
@@ -4383,6 +4382,10 @@ class SettingsScreen(BaseAppScreen):
         compose-time widget values and the instant-apply no-op guard can
         never disagree about what "saved" means.
         """
+        from ...Chat.permission_summary_service import (
+            permission_summary_settings_payload,
+        )
+
         section = load_settings().get("permission_summary")
         section = section if isinstance(section, dict) else {}
         return permission_summary_settings_payload(
@@ -5088,6 +5091,10 @@ class SettingsScreen(BaseAppScreen):
         saved config are skipped (no-op guard) so merely viewing the
         category never rewrites config.toml.
         """
+        from ...Chat.permission_summary_service import (
+            permission_summary_settings_payload,
+        )
+
         try:
             mode = self._select_text_value(
                 self.query_one("#settings-permission-summary-mode", Select).value

--- a/tldw_chatbook/Widgets/Console/console_conversation_inspector.py
+++ b/tldw_chatbook/Widgets/Console/console_conversation_inspector.py
@@ -69,7 +69,7 @@ from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 from textual import on
@@ -103,7 +103,6 @@ from tldw_chatbook.Chat.console_exchange_capture import (
 )
 from tldw_chatbook.Chat.console_project_instructions import EPHEMERAL_ORIGIN_KEY
 from tldw_chatbook.Chat.console_trace_projection import project_capture_for_viewer
-from tldw_chatbook.Chat.trace_export_profiles import TraceViewerProfile
 from tldw_chatbook.Chat.provider_usage import ProviderUsage
 from tldw_chatbook.LLM_Calls.pricing_catalog import get_pricing_catalog
 from tldw_chatbook.Utils.log_sanitizer import content_fingerprint
@@ -112,13 +111,16 @@ from tldw_chatbook.Widgets.pausable_progress import PausableLoadingIndicator
 from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
 from tldw_chatbook.Utils.token_counter import estimate_tokens
 from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
-from tldw_chatbook.Widgets.Console.console_project_instructions import (
-    ConsoleProjectInstructionContextPanel,
-)
 from tldw_chatbook.Widgets.Console.console_capture_policy_dialog import (
     CapturePolicyBindings,
     ConsoleTracePrivacyDialog,
 )
+from tldw_chatbook.Widgets.Console.console_project_instructions import (
+    ConsoleProjectInstructionContextPanel,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from tldw_chatbook.Chat.trace_export_profiles import TraceViewerProfile
 
 MODAL_ID = "console-inspector-modal"
 CLOSE_BUTTON_ID = "console-inspector-close"
@@ -434,6 +436,8 @@ class ConsoleConversationInspector(SafeModalDismissMixin, ModalScreen[None]):
             initial_tab: Which tab id starts active -- ``"inspector-costs"``
                 from the cost chip, ``"inspector-next-send"`` from Ctrl+Shift+P.
         """
+        from tldw_chatbook.Chat.trace_export_profiles import TraceViewerProfile
+
         super().__init__()
         self._rows = list(rows)
         self._totals = totals
@@ -746,6 +750,8 @@ class ConsoleConversationInspector(SafeModalDismissMixin, ModalScreen[None]):
 
     async def action_viewer_profile(self) -> None:
         """Switch disclosure profile, confirming every Safe-to-Full change."""
+
+        from tldw_chatbook.Chat.trace_export_profiles import TraceViewerProfile
 
         if self._viewer_profile is TraceViewerProfile.FULL:
             self._viewer_profile = TraceViewerProfile.SAFE

--- a/tldw_chatbook/Widgets/Console/console_conversation_inspector.py
+++ b/tldw_chatbook/Widgets/Console/console_conversation_inspector.py
@@ -121,6 +121,8 @@ from tldw_chatbook.Widgets.Console.console_project_instructions import (
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from tldw_chatbook.Chat.trace_export_profiles import TraceViewerProfile
+else:
+    TraceViewerProfile = Any
 
 MODAL_ID = "console-inspector-modal"
 CLOSE_BUTTON_ID = "console-inspector-close"

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -220,8 +220,10 @@ from tldw_chatbook.Chat.console_settings_defaults import ConsoleDefaultDurabilit
 from tldw_chatbook.Chat.server_chat_conversation_service import (
     ServerChatConversationService,
 )
-from tldw_chatbook.Terminal.backend import TerminalBackend  # noqa: E402
 from tldw_chatbook.Terminal.session_manager import TerminalSessionManager  # noqa: E402
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from tldw_chatbook.Terminal.backend import TerminalBackend
+
 from tldw_chatbook.DB.Client_Media_DB_v2 import (
     DatabaseError as MediaDatabaseError,
     InputError as MediaInputError,
@@ -1068,7 +1070,7 @@ def _read_app_raw_cli_permitted(app: object) -> bool:
     return isinstance(console, Mapping) and console.get("raw_cli_permitted") is True
 
 
-def _build_terminal_backend() -> TerminalBackend:
+def _build_terminal_backend() -> "TerminalBackend":
     """Build the supported platform backend without eager platform imports."""
     if os.name != "posix":
         raise OSError("persistent Terminal backend unavailable")

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -221,8 +221,6 @@ from tldw_chatbook.Chat.server_chat_conversation_service import (
     ServerChatConversationService,
 )
 from tldw_chatbook.Terminal.session_manager import TerminalSessionManager  # noqa: E402
-if TYPE_CHECKING:  # pragma: no cover - typing only
-    from tldw_chatbook.Terminal.backend import TerminalBackend
 
 from tldw_chatbook.DB.Client_Media_DB_v2 import (
     DatabaseError as MediaDatabaseError,
@@ -769,11 +767,14 @@ from tldw_chatbook.Audio_Services_Interop import (  # noqa: E402
 from .Evals.eval_orchestrator import EvaluationOrchestrator  # noqa: E402
 
 if TYPE_CHECKING:
+    from tldw_chatbook.Terminal.backend import TerminalBackend
     from tldw_chatbook.Model_Artifacts.service import ArtifactRef
     from tldw_chatbook.LLM_Provider_Catalog.model_discovery_disk_cache import (
         ModelCatalogDiskStore,
     )
     from tldw_chatbook.tldw_api import MCPUnifiedClient
+else:
+    TerminalBackend = Any
 
 API_IMPORTS_SUCCESSFUL = True
 


### PR DESCRIPTION
## Summary

- defer permission-summary service imports until summary resolution/persistence is actually requested
- defer terminal support and trace disclosure helpers off the pre-interactive startup path
- pin the lazy permission-summary boundary in the UI-ready census

## Verification

- 191 focused permission-summary, terminal, trace, inspector, and UI-ready tests passed
- 11/11 targeted performance workflow tests passed
- UI-ready census: 972/972 without raising the ceiling
- Ruff, compileall, git diff check, and persistent diagnostic inventory passed

## Architecture

ADR required: no. This is a direct regression fix implementing existing ADR-090 and ADR-097 boundaries.

Backlog: TASK-26046

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the UI-ready startup module budget by deferring permission-summary, terminal, trace-disclosure, and briefing TTS imports until their features are needed, while keeping type annotations resolvable without eagerly loading implementations.

- The permission-summary LLM graph was becoming resident before the first interactive frame; those imports now happen inside the approval and settings actions that need them, and an unavailable service fails advisably instead of crashing the round.
- `TerminalBackend` is exposed through a lazy module attribute, and `session_manager` imports io actors, screen models, and launch helpers only inside the methods that use them.
- Trace export profiles and briefing TTS helpers (text chunking, legacy request building) load only when a capture is projected, a disclosure profile is switched, or audio is synthesized.
- Type annotations fall back to `Any` at runtime so deferred dependencies resolve in `get_type_hints` without being imported.
- Pins the lazy permission-summary boundary in the 972-module census and adds regression coverage verifying summaries behave the same when loaded lazily and that import failures stay advisory.

<sup>Written for commit 54aba518fdeb8cb6ddfccb22758d19bb61bf27c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

