### PR TITLE
feat: add independent Terminal launch arm

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2805,8 +2805,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 48,
-      "diagnostic_digest": "d208eed5dde389af9d4d",
+      "call_count": 49,
+      "diagnostic_digest": "cba6dce7dcecb41b01ab",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/settings_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11135,6 +11135,6 @@
     "path_privacy_candidate_calls": 711,
     "persistent_sink_files": 9,
     "task_492_calls": 1308,
-    "task_494_calls": 7423
+    "task_494_calls": 7424
   }
 }

--- a/Tests/UI/test_settings_raw_cli.py
+++ b/Tests/UI/test_settings_raw_cli.py
@@ -44,6 +44,15 @@ RAW_CLI_DISCLOSURE = (
     "Command text and bounded output may persist in local run logs.",
     "This is not a sandbox and is not limited to your workspace.",
 )
+HOST_ACCESS_UNLOCK_DISCLOSURE = (
+    "This saved setting only makes one-shot raw CLI and Persistent Terminal "
+    "eligible on this device.",
+    "It arms neither feature. Each must be armed separately after every Chatbook "
+    "launch.",
+    "Both features have the full file, process, and network authority of your OS "
+    "user. Neither is sandboxed or confined to a workspace.",
+    "Review each feature's separate arm disclosure before use.",
+)
 
 
 async def _wait_until(pilot, predicate, *, timeout: float = 1.0) -> None:
@@ -154,9 +163,16 @@ async def test_raw_cli_unlock_and_arm_are_separate_confirmed_gates():
         error_color = card.query_one("#settings-raw-cli-state", Static).styles.color
         assert (
             str(card.query_one("#settings-raw-cli-title", Static).content)
-            == "DANGER!!! RAW CLI HOST ACCESS"
+            == "DANGER!!! RAW CLI + TERMINAL HOST ACCESS"
         )
         text = _visible_text(card)
+        assert "One-shot raw CLI" in text
+        assert "Persistent Terminal" in text
+        assert (
+            str(card.query_one("#settings-raw-cli-permitted", Checkbox).label)
+            == "Allow raw CLI and Terminal access on this device"
+        )
+        assert "Each feature still arms separately for this Chatbook launch." in text
         for disclosure in RAW_CLI_DISCLOSURE:
             assert disclosure in text
         assert "sandboxed" not in text.lower()
@@ -193,8 +209,8 @@ async def test_raw_cli_unlock_and_arm_are_separate_confirmed_gates():
         screen.action_settings_save_category()
         await _wait_until(pilot, lambda: isinstance(host.screen, ConfirmationDialog))
         unlock_dialog = host.screen
-        assert unlock_dialog.title == "Unlock raw CLI host access"
-        assert unlock_dialog.message == "\n\n".join(RAW_CLI_DISCLOSURE)
+        assert unlock_dialog.title == "Unlock raw CLI and Terminal host access"
+        assert unlock_dialog.message == "\n\n".join(HOST_ACCESS_UNLOCK_DISCLOSURE)
         await _wait_until(
             pilot,
             lambda: getattr(host.focused, "id", None) == "cancel-button",
@@ -215,6 +231,8 @@ async def test_raw_cli_unlock_and_arm_are_separate_confirmed_gates():
         assert type(app.app_config["console"]["raw_cli_permitted"]) is bool
         assert app.app_config["console"]["raw_cli_permitted"] is True
         assert app.raw_cli_runtime.permitted is True
+        assert app.terminal_session_manager.permitted is True
+        assert app.terminal_session_manager.armed is False
         assert SettingsCategoryId.PRIVACY_SECURITY not in screen._settings_drafts
         assert "Unlocked, not armed" in str(
             card.query_one("#settings-raw-cli-state", Static).content
@@ -251,6 +269,7 @@ async def test_raw_cli_unlock_and_arm_are_separate_confirmed_gates():
 
         card = screen.query_one("#settings-raw-cli-card")
         assert app.raw_cli_runtime.armed is True
+        assert app.terminal_session_manager.armed is False
         assert card.has_class("settings-raw-cli-armed")
         armed_border = card.styles.border
         armed_edges = (
@@ -265,7 +284,7 @@ async def test_raw_cli_unlock_and_arm_are_separate_confirmed_gates():
         armed_background = card.styles.background
         assert armed_background != locked_background
         assert armed_background == error_color.with_alpha(0.1)
-        assert "ARMED — HOST ACCESS" in str(
+        assert "ARMED — HOST SHELL" in str(
             card.query_one("#settings-raw-cli-state", Static).content
         )
         assert "raw_cli_armed" not in app.app_config.get("console", {})
@@ -399,6 +418,7 @@ async def test_raw_cli_unlock_uses_ordinary_settings_revert():
 async def test_raw_cli_disarm_is_immediate_and_saved_lock_starts_cleanup(monkeypatch):
     app = _build_test_app(config_overrides={"console": {"raw_cli_permitted": True}})
     assert app.raw_cli_runtime.arm().armed is True
+    assert app.terminal_session_manager.arm(acknowledge_disclosure=True).armed is True
     authority_revocations: list[str] = []
     app.raw_cli_runtime.set_model_authority_revoker(
         lambda: authority_revocations.append("revoked")
@@ -416,12 +436,13 @@ async def test_raw_cli_disarm_is_immediate_and_saved_lock_starts_cleanup(monkeyp
         assert app.raw_cli_runtime.armed is True
 
         disarm_button = screen.query_one("#settings-raw-cli-arm", Button)
-        assert str(disarm_button.label) == "Disarm now"
+        assert str(disarm_button.label) == "Disarm raw CLI"
         assert disarm_button.disabled is False
         disarm_button.press()
         await pilot.pause()
 
         assert app.raw_cli_runtime.armed is False
+        assert app.terminal_session_manager.armed is True
         assert authority_revocations == ["revoked"]
         assert screen._settings_drafts[SettingsCategoryId.PRIVACY_SECURITY] is draft
         assert draft.values == {"console.raw_cli_permitted": False}
@@ -441,11 +462,26 @@ async def test_raw_cli_disarm_is_immediate_and_saved_lock_starts_cleanup(monkeyp
             return result
 
         monkeypatch.setattr(app.raw_cli_runtime, "disarm", tracked_disarm)
+        original_terminal_disarm = app.terminal_session_manager.disarm
+        terminal_disarm_calls = 0
+
+        def tracked_terminal_disarm() -> None:
+            nonlocal terminal_disarm_calls
+            terminal_disarm_calls += 1
+            original_terminal_disarm()
+
+        monkeypatch.setattr(
+            app.terminal_session_manager,
+            "disarm",
+            tracked_terminal_disarm,
+        )
         screen.action_settings_save_category()
         await _wait_for_save(pilot)
 
         assert disarm_calls == [()]
+        assert terminal_disarm_calls == 1
         assert app.raw_cli_runtime.armed is False
+        assert app.terminal_session_manager.armed is False
         assert authority_revocations == ["revoked", "revoked"]
         assert type(app.app_config["console"]["raw_cli_permitted"]) is bool
         assert app.app_config["console"]["raw_cli_permitted"] is False
@@ -480,7 +516,7 @@ async def test_failed_raw_cli_lock_save_keeps_saved_authority_and_draft(monkeypa
         assert app.app_config["console"]["raw_cli_permitted"] is True
         assert screen._category_has_unsaved_changes(SettingsCategoryId.PRIVACY_SECURITY)
         assert screen.query_one("#settings-raw-cli-permitted", Checkbox).value is False
-        assert "ARMED — HOST ACCESS" in str(
+        assert "ARMED — HOST SHELL" in str(
             screen.query_one("#settings-raw-cli-state", Static).content
         )
         assert screen._raw_cli_save_pending is False
@@ -1120,19 +1156,23 @@ async def test_raw_cli_disclosure_wraps_and_disabled_arm_paints_above_contrast_f
             assert disclosure in text
 
         body = screen.query_one("#settings-detail-pane-body")
-        arm_button = card.query_one("#settings-raw-cli-arm", Button)
+        arm_buttons = (
+            card.query_one("#settings-raw-cli-arm", Button),
+            card.query_one("#settings-terminal-arm", Button),
+        )
         assert body.max_scroll_y > 0
         assert any(
             static.region.height > 1
             for static in card.query(".settings-raw-cli-disclosure")
         )
-        body.scroll_to_widget(arm_button, animate=False, force=True)
-        await pilot.pause()
-        assert arm_button.region.width > 0
-        assert body.content_region.contains_region(arm_button.region)
+        for arm_button in arm_buttons:
+            body.scroll_to_widget(arm_button, animate=False, force=True)
+            await pilot.pause()
+            assert arm_button.region.width > 0
+            assert body.content_region.contains_region(arm_button.region)
 
-        painted = _painted_style_of_text(host, arm_button)
-        assert painted is not None
-        assert painted.color is not None and painted.bgcolor is not None
-        ratio = _painted_contrast(painted.color, painted.bgcolor)
-        assert ratio >= 3.0, f"disabled Arm label paints at only {ratio:.2f}:1"
+            painted = _painted_style_of_text(host, arm_button)
+            assert painted is not None
+            assert painted.color is not None and painted.bgcolor is not None
+            ratio = _painted_contrast(painted.color, painted.bgcolor)
+            assert ratio >= 3.0, f"disabled Arm label paints at only {ratio:.2f}:1"

--- a/Tests/UI/test_settings_terminal.py
+++ b/Tests/UI/test_settings_terminal.py
@@ -1,0 +1,256 @@
+"""Mounted Settings contracts for the persistent Terminal authority gate."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from textual.widgets import Button, Checkbox, Static
+
+from Tests.UI.test_screen_navigation import _build_test_app
+from Tests.UI.test_settings_configuration_hub import StyledSettingsDestinationHarness
+from Tests.UI.test_settings_raw_cli import (
+    _open_privacy,
+    _published_snapshot,
+    _wait_for_save,
+    _wait_until,
+)
+from tldw_chatbook.Terminal.session_manager import TerminalArmResult
+from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
+from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
+
+
+TERMINAL_DISCLOSURE = (
+    "The Terminal shell and every program run with the same OS permissions as "
+    "Chatbook.",
+    "Programs may read, modify, or delete any accessible data, use the network, "
+    "invoke credentialed clients, or exhaust machine resources.",
+    "Chatbook starts Terminal from a scrubbed environment, but normal shell profile "
+    "and startup files run and may restore secrets, credentials, agents, proxies, "
+    "aliases, environment variables, or arbitrary commands.",
+    "Shells and programs may save history, files, logs, caches, and other side "
+    "effects outside Chatbook.",
+    "Your active workspace—or your home directory when no workspace is selected—is "
+    "only the starting directory. Terminal is not sandboxed or confined there.",
+    "Closing, disarming, or quitting Chatbook attempts bounded cleanup, but "
+    "deliberately detached processes may survive and cleanup may remain unproven.",
+    "Terminal content is user-only and is not sent to a model.",
+)
+
+
+class RecordingTerminalRuntime:
+    """Small Settings spy; manager concurrency is covered by Terminal tests."""
+
+    def __init__(self, *, armed: bool, session_count: int) -> None:
+        self.armed = armed
+        self.disclosure_acknowledged = armed
+        self.arm_calls: list[bool] = []
+        self.disarm_calls = 0
+        self._projections = tuple(
+            SimpleNamespace(session_id=f"session-{index}")
+            for index in range(session_count)
+        )
+
+    def arm(self, *, acknowledge_disclosure: bool = False) -> TerminalArmResult:
+        self.arm_calls.append(acknowledge_disclosure)
+        if not self.disclosure_acknowledged and not acknowledge_disclosure:
+            return TerminalArmResult(disclosure_required=True)
+        self.disclosure_acknowledged = True
+        self.armed = True
+        return TerminalArmResult(armed=True)
+
+    def disarm(self) -> None:
+        self.disarm_calls += 1
+        self.armed = False
+
+    def projections(self) -> tuple[object, ...]:
+        return self._projections
+
+
+@pytest.mark.asyncio
+async def test_terminal_control_uses_shared_unlock_and_an_independent_launch_arm():
+    app = _build_test_app(config_overrides={"console": {"raw_cli_permitted": True}})
+    host = StyledSettingsDestinationHarness(app, "settings")
+
+    async with host.run_test(size=(80, 24)) as pilot:
+        screen = await _open_privacy(pilot)
+        checkbox = screen.query_one("#settings-raw-cli-permitted", Checkbox)
+        terminal_button = screen.query_one("#settings-terminal-arm", Button)
+
+        assert str(checkbox.label) == "Allow raw CLI and Terminal access on this device"
+        assert "Unlocked, not armed" in str(
+            screen.query_one("#settings-terminal-state", Static).content
+        )
+        assert str(terminal_button.label) == "Arm Terminal"
+        assert terminal_button.disabled is False
+
+        assert app.raw_cli_runtime.arm().armed is True
+        screen._refresh_raw_cli_state()
+        assert app.terminal_session_manager.armed is False
+        assert "Unlocked, not armed" in str(
+            screen.query_one("#settings-terminal-state", Static).content
+        )
+
+        terminal_button.press()
+        await _wait_until(pilot, lambda: isinstance(host.screen, ConfirmationDialog))
+        assert await pilot.click("#confirm-button")
+        await _wait_until(pilot, lambda: host.screen is screen)
+
+        assert app.terminal_session_manager.armed is True
+        assert app.raw_cli_runtime.armed is True
+        app.raw_cli_runtime.disarm()
+        screen._refresh_raw_cli_state()
+        assert app.terminal_session_manager.armed is True
+
+    fresh_app = _build_test_app(
+        config_overrides={"console": {"raw_cli_permitted": True}}
+    )
+    assert fresh_app.raw_cli_runtime.armed is False
+    assert fresh_app.terminal_session_manager.armed is False
+    assert fresh_app.terminal_session_manager.disclosure_acknowledged is False
+
+
+@pytest.mark.asyncio
+async def test_terminal_disclosure_is_static_once_per_launch_and_armed_state_is_red(
+    monkeypatch,
+):
+    monkeypatch.setenv("TASK22512_TERMINAL_SECRET", "must-not-appear-in-disclosure")
+    app = _build_test_app(config_overrides={"console": {"raw_cli_permitted": True}})
+    real_arm = app.terminal_session_manager.arm
+    arm_calls: list[bool] = []
+
+    def tracked_arm(*, acknowledge_disclosure: bool = False):
+        arm_calls.append(acknowledge_disclosure)
+        return real_arm(acknowledge_disclosure=acknowledge_disclosure)
+
+    monkeypatch.setattr(app.terminal_session_manager, "arm", tracked_arm)
+    host = StyledSettingsDestinationHarness(app, "settings")
+
+    async with host.run_test(size=(120, 35)) as pilot:
+        screen = await _open_privacy(pilot)
+        terminal_button = screen.query_one("#settings-terminal-arm", Button)
+        terminal_button.press()
+        await _wait_until(pilot, lambda: isinstance(host.screen, ConfirmationDialog))
+
+        dialog = host.screen
+        assert dialog.title == "Arm Terminal for this launch"
+        assert dialog.message == "\n\n".join(TERMINAL_DISCLOSURE)
+        assert "must-not-appear-in-disclosure" not in dialog.message
+        confirm_button = dialog.query_one("#confirm-button", Button)
+        assert confirm_button.region.width > 0
+        assert dialog.screen.region.contains_region(confirm_button.region)
+        assert await pilot.click("#confirm-button")
+        await _wait_until(pilot, lambda: host.screen is screen)
+
+        card = screen.query_one("#settings-raw-cli-card")
+        assert arm_calls == [True]
+        assert app.terminal_session_manager.armed is True
+        assert card.has_class("settings-raw-cli-armed")
+        error_color = card.query_one("#settings-raw-cli-state", Static).styles.color
+        armed_border = card.styles.border
+        assert all(
+            kind == "solid" and color == error_color
+            for kind, color in (
+                armed_border.top,
+                armed_border.right,
+                armed_border.bottom,
+                armed_border.left,
+            )
+        )
+        assert card.styles.background == error_color.with_alpha(0.1)
+        assert "ARMED — HOST TERMINAL" in str(
+            screen.query_one("#settings-terminal-state", Static).content
+        )
+        assert "HOST TERMINAL - FULL USER ACCESS" in str(
+            screen.query_one("#settings-terminal-host-access", Static).content
+        )
+        assert "terminal_armed" not in app.app_config.get("console", {})
+        assert "terminal_armed" not in vars(screen)
+        assert "terminal_armed" not in repr(screen.save_state())
+        assert all(
+            "terminal_armed" not in draft.values
+            for draft in screen._settings_drafts.values()
+        )
+
+        screen.query_one("#settings-terminal-arm", Button).press()
+        await pilot.pause()
+        assert app.terminal_session_manager.armed is False
+
+        screen.query_one("#settings-terminal-arm", Button).press()
+        await pilot.pause()
+        assert host.screen is screen
+        assert app.terminal_session_manager.armed is True
+        assert arm_calls == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_terminal_disarm_confirms_one_cleanup_cohort_without_revoking_raw(
+    monkeypatch,
+):
+    app = _build_test_app(config_overrides={"console": {"raw_cli_permitted": True}})
+    assert app.raw_cli_runtime.arm().armed is True
+    terminal = RecordingTerminalRuntime(armed=True, session_count=2)
+    app.terminal_session_manager = terminal
+    notifications: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        StyledSettingsDestinationHarness,
+        "notify",
+        lambda _self, message, *, severity="information", **_kwargs: (
+            notifications.append((message, severity))
+        ),
+    )
+    host = StyledSettingsDestinationHarness(app, "settings")
+
+    async with host.run_test(size=(120, 35)) as pilot:
+        screen = await _open_privacy(pilot)
+        terminal_button = screen.query_one("#settings-terminal-arm", Button)
+        assert str(terminal_button.label) == "Disarm Terminal"
+
+        terminal_button.press()
+        await _wait_until(pilot, lambda: isinstance(host.screen, ConfirmationDialog))
+        dialog = host.screen
+        assert dialog.title == "Disarm Terminal and close sessions?"
+        assert "2 live Terminal sessions" in dialog.message
+        dialog_depth = len(host.screen_stack)
+        screen.handle_terminal_arm_pressed(Button.Pressed(terminal_button))
+        await pilot.pause()
+        assert host.screen is dialog
+        assert len(host.screen_stack) == dialog_depth
+        assert terminal.disarm_calls == 0
+        assert await pilot.click("#confirm-button")
+        await _wait_until(pilot, lambda: host.screen is screen)
+
+        assert terminal.disarm_calls == 1
+        assert terminal.armed is False
+        assert app.raw_cli_runtime.armed is True
+        assert any(
+            "pending or unproven" in message.lower() for message, _ in notifications
+        )
+
+        terminal.armed = True
+        notifications.clear()
+        checkbox = screen.query_one("#settings-raw-cli-permitted", Checkbox)
+        checkbox.value = False
+        await pilot.pause()
+        locked_values = dict(app.app_config)
+        locked_values["console"] = dict(app.app_config["console"])
+        locked_values["console"]["raw_cli_permitted"] = False
+        monkeypatch.setattr(
+            SettingsScreen,
+            "_save_raw_cli_permitted_value",
+            staticmethod(lambda _value: (True, _published_snapshot(locked_values))),
+        )
+
+        screen.action_settings_save_category()
+        await _wait_for_save(pilot)
+
+        assert terminal.disarm_calls == 2
+        assert terminal.armed is False
+        assert app.raw_cli_runtime.armed is False
+        assert app.app_config["console"]["raw_cli_permitted"] is False
+        assert any(
+            "pending or unproven" in message.lower() for message, _ in notifications
+        )
+        assert "Locked" in str(
+            screen.query_one("#settings-terminal-state", Static).content
+        )

--- a/Tests/UI/test_settings_terminal.py
+++ b/Tests/UI/test_settings_terminal.py
@@ -149,6 +149,15 @@ async def test_terminal_control_uses_shared_unlock_and_an_independent_launch_arm
 
         terminal_button.press()
         await _wait_until(pilot, lambda: isinstance(host.screen, ConfirmationDialog))
+        dialog = host.screen
+        confirm_button = dialog.query_one("#confirm-button", Button)
+        await _wait_until(
+            pilot,
+            lambda: (
+                confirm_button.region.width > 0
+                and dialog.screen.region.contains_region(confirm_button.region)
+            ),
+        )
         assert await pilot.click("#confirm-button")
         await _wait_until(pilot, lambda: host.screen is screen)
 

--- a/Tests/UI/test_settings_terminal.py
+++ b/Tests/UI/test_settings_terminal.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import inspect
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -15,6 +17,7 @@ from Tests.UI.test_settings_raw_cli import (
     _wait_for_save,
     _wait_until,
 )
+from tldw_chatbook.Terminal.contracts import TerminalLifecycle
 from tldw_chatbook.Terminal.session_manager import TerminalArmResult
 from tldw_chatbook.UI.Screens.settings_screen import SettingsScreen
 from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
@@ -47,7 +50,10 @@ class RecordingTerminalRuntime:
         self.arm_calls: list[bool] = []
         self.disarm_calls = 0
         self._projections = tuple(
-            SimpleNamespace(session_id=f"session-{index}")
+            SimpleNamespace(
+                session_id=f"session-{index}",
+                lifecycle=TerminalLifecycle.RUNNING,
+            )
             for index in range(session_count)
         )
 
@@ -65,6 +71,56 @@ class RecordingTerminalRuntime:
 
     def projections(self) -> tuple[object, ...]:
         return self._projections
+
+
+def test_terminal_arm_handler_has_google_style_parameter_docs():
+    docstring = inspect.getdoc(SettingsScreen.handle_terminal_arm_pressed) or ""
+
+    assert "Args:" in docstring
+    assert "event:" in docstring
+
+
+def _count_terminal_sessions(runtime: object | None) -> int | None:
+    screen = SimpleNamespace(_terminal_runtime=lambda: runtime)
+    return SettingsScreen._terminal_live_session_count(screen)
+
+
+def test_terminal_live_session_count_only_counts_actionable_lifecycles():
+    assert _count_terminal_sessions(None) == 0
+
+    runtime = SimpleNamespace(projections=lambda: ())
+    assert _count_terminal_sessions(runtime) == 0
+
+    runtime = SimpleNamespace(
+        projections=lambda: tuple(
+            SimpleNamespace(lifecycle=lifecycle) for lifecycle in TerminalLifecycle
+        )
+    )
+    assert _count_terminal_sessions(runtime) == 6
+
+    runtime = SimpleNamespace(
+        projections=lambda: tuple(
+            SimpleNamespace(lifecycle=lifecycle)
+            for lifecycle in (
+                TerminalLifecycle.EXITED,
+                TerminalLifecycle.CLOSED,
+                TerminalLifecycle.CLEANUP_UNPROVEN,
+            )
+        )
+    )
+    assert _count_terminal_sessions(runtime) == 0
+
+
+def test_terminal_live_session_count_failure_logs_safe_runtime_context(caplog):
+    def fail_projections() -> tuple[object, ...]:
+        raise RuntimeError("projection failure")
+
+    runtime = SimpleNamespace(projections=fail_projections)
+
+    with caplog.at_level(logging.ERROR):
+        assert _count_terminal_sessions(runtime) is None
+
+    assert "runtime_type=SimpleNamespace" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_settings_terminal.py
+++ b/Tests/UI/test_settings_terminal.py
@@ -12,6 +12,7 @@ from textual.widgets import Button, Checkbox, Static
 from Tests.UI.test_screen_navigation import _build_test_app
 from Tests.UI.test_settings_configuration_hub import StyledSettingsDestinationHarness
 from Tests.UI.test_settings_raw_cli import (
+    _install_runtime_generation_state,
     _open_privacy,
     _published_snapshot,
     _wait_for_save,
@@ -121,6 +122,40 @@ def test_terminal_live_session_count_failure_logs_safe_runtime_context(caplog):
         assert _count_terminal_sessions(runtime) is None
 
     assert "runtime_type=SimpleNamespace" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_unlock_save_warns_when_terminal_cleanup_inspection_fails(monkeypatch):
+    app = _build_test_app(config_overrides={"console": {"raw_cli_permitted": True}})
+    terminal = RecordingTerminalRuntime(armed=True, session_count=0)
+
+    def fail_projections() -> tuple[object, ...]:
+        raise RuntimeError("projection failure")
+
+    terminal.projections = fail_projections
+    app.terminal_session_manager = terminal
+    notifications: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        StyledSettingsDestinationHarness,
+        "notify",
+        lambda _self, message, *, severity="information", **_kwargs: (
+            notifications.append((message, severity))
+        ),
+    )
+    locked_values = dict(app.app_config)
+    locked_values["console"] = dict(app.app_config["console"])
+    locked_values["console"]["raw_cli_permitted"] = False
+    snapshot = _published_snapshot(locked_values)
+    _install_runtime_generation_state(monkeypatch, snapshot)
+    host = StyledSettingsDestinationHarness(app, "settings")
+
+    async with host.run_test(size=(120, 35)) as pilot:
+        screen = await _open_privacy(pilot)
+        screen._apply_raw_cli_save_result(True, snapshot, False)
+        await pilot.pause()
+
+    assert notifications[-1][1] == "warning"
+    assert "could not be inspected" in notifications[-1][0]
 
 
 @pytest.mark.asyncio

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -783,6 +783,31 @@ RAW_CLI_DISCLOSURE_LINES = (
     "Command text and bounded output may persist in local run logs.",
     "This is not a sandbox and is not limited to your workspace.",
 )
+HOST_ACCESS_UNLOCK_DISCLOSURE_LINES = (
+    "This saved setting only makes one-shot raw CLI and Persistent Terminal "
+    "eligible on this device.",
+    "It arms neither feature. Each must be armed separately after every Chatbook "
+    "launch.",
+    "Both features have the full file, process, and network authority of your OS "
+    "user. Neither is sandboxed or confined to a workspace.",
+    "Review each feature's separate arm disclosure before use.",
+)
+TERMINAL_DISCLOSURE_LINES = (
+    "The Terminal shell and every program run with the same OS permissions as "
+    "Chatbook.",
+    "Programs may read, modify, or delete any accessible data, use the network, "
+    "invoke credentialed clients, or exhaust machine resources.",
+    "Chatbook starts Terminal from a scrubbed environment, but normal shell profile "
+    "and startup files run and may restore secrets, credentials, agents, proxies, "
+    "aliases, environment variables, or arbitrary commands.",
+    "Shells and programs may save history, files, logs, caches, and other side "
+    "effects outside Chatbook.",
+    "Your active workspace—or your home directory when no workspace is selected—is "
+    "only the starting directory. Terminal is not sandboxed or confined there.",
+    "Closing, disarming, or quitting Chatbook attempts bounded cleanup, but "
+    "deliberately detached processes may survive and cleanup may remain unproven.",
+    "Terminal content is user-only and is not sent to a model.",
+)
 
 # ADR-090: ids of the instant-apply [permission_summary] controls, for the
 # same focus-tracking reason as MODEL_CATALOG_FIELD_IDS above.
@@ -2521,6 +2546,7 @@ class SettingsScreen(BaseAppScreen):
         self._raw_cli_save_pending = False
         self._raw_cli_unlock_confirmation_pending = False
         self._raw_cli_arm_confirmation_pending = False
+        self._terminal_confirmation_pending = False
 
         # Network category pending edits. Deliberately NOT a SettingsDraft in
         # _settings_drafts: the category bypasses the draft-staging machinery
@@ -4359,6 +4385,7 @@ class SettingsScreen(BaseAppScreen):
         )
         self._update_draft_status_widgets(category)
         self._refresh_raw_cli_state()
+        self._refresh_terminal_state()
 
     def _raw_cli_is_armed(self) -> bool:
         runtime = self._raw_cli_runtime()
@@ -4366,32 +4393,122 @@ class SettingsScreen(BaseAppScreen):
 
     def _raw_cli_state_text(self) -> str:
         if self._raw_cli_is_armed():
-            return "ARMED — HOST ACCESS"
+            return "ARMED — HOST SHELL"
         if self._loaded_raw_cli_permitted():
             return "Unlocked, not armed"
         return "Locked"
 
     def _raw_cli_arm_button_state(self) -> tuple[str, bool]:
         if self._raw_cli_is_armed():
-            return "Disarm now", False
+            return "Disarm raw CLI", False
         if self._loaded_raw_cli_permitted() and not self._category_has_unsaved_changes(
             SettingsCategoryId.PRIVACY_SECURITY
         ):
-            return "Arm for this launch", False
+            return "Arm raw CLI", False
         return "Save unlock first", True
+
+    def _terminal_runtime(self) -> Any | None:
+        """Return the app-owned launch-local Terminal manager, when available."""
+        return getattr(self.app_instance, "terminal_session_manager", None)
+
+    def _terminal_is_armed(self) -> bool:
+        runtime = self._terminal_runtime()
+        return bool(runtime is not None and getattr(runtime, "armed", False))
+
+    def _terminal_state_text(self) -> str:
+        if self._terminal_is_armed():
+            return "ARMED — HOST TERMINAL"
+        if self._loaded_raw_cli_permitted():
+            return "Unlocked, not armed"
+        return "Locked"
+
+    def _terminal_arm_button_state(self) -> tuple[str, bool]:
+        if self._terminal_is_armed():
+            return "Disarm Terminal", False
+        if self._loaded_raw_cli_permitted() and not self._category_has_unsaved_changes(
+            SettingsCategoryId.PRIVACY_SECURITY
+        ):
+            return "Arm Terminal", False
+        return "Save unlock first", True
+
+    def _terminal_live_session_count(self) -> int | None:
+        """Return the live retained-session count, or None when unavailable."""
+        runtime = self._terminal_runtime()
+        if runtime is None:
+            return 0
+        try:
+            projections = tuple(runtime.projections())
+        except Exception:
+            logger.exception("Failed to inspect Terminal sessions before disarm")
+            return None
+        count = 0
+        for projection in projections:
+            lifecycle = getattr(projection, "lifecycle", None)
+            lifecycle_value = getattr(lifecycle, "value", lifecycle)
+            if lifecycle_value not in {"closed", "exited"}:
+                count += 1
+        return count
+
+    def _disarm_terminal_runtime(
+        self, runtime: Any, *, session_count: int | None
+    ) -> None:
+        """Revoke Terminal authority and report its content-free cleanup state."""
+        runtime.disarm()
+        self._refresh_terminal_state()
+        self._refresh_raw_cli_state()
+        if session_count:
+            self.app.notify(
+                "Terminal disarmed. Cleanup started for "
+                f"{session_count} sessions; pending or unproven cleanup remains "
+                "available in Terminal.",
+                severity="warning",
+            )
+        elif session_count is None:
+            self.app.notify(
+                "Terminal disarmed. Session cleanup status could not be inspected; "
+                "check Terminal for pending or unproven cleanup.",
+                severity="warning",
+            )
+        else:
+            self.app.notify("Terminal disarmed for this launch.", severity="warning")
+
+    def _host_access_is_armed(self) -> bool:
+        return self._raw_cli_is_armed() or self._terminal_is_armed()
+
+    def _refresh_host_access_card(self) -> None:
+        try:
+            card = self.query_one("#settings-raw-cli-card")
+        except QueryError:
+            return
+        card.set_class(self._host_access_is_armed(), "settings-raw-cli-armed")
 
     def _refresh_raw_cli_state(self) -> None:
         """Refresh raw CLI authority from persisted config and runtime only."""
         try:
-            card = self.query_one("#settings-raw-cli-card")
             state = self.query_one("#settings-raw-cli-state", Static)
             button = self.query_one("#settings-raw-cli-arm", Button)
         except QueryError:
             return
-        armed = self._raw_cli_is_armed()
-        card.set_class(armed, "settings-raw-cli-armed")
+        self._refresh_host_access_card()
         state.update(self._raw_cli_state_text())
         label, disabled = self._raw_cli_arm_button_state()
+        button.label = label
+        button.disabled = disabled
+        button.refresh(layout=True)
+
+    def _refresh_terminal_state(self) -> None:
+        """Refresh Terminal authority from persisted config and manager state."""
+        try:
+            state = self.query_one("#settings-terminal-state", Static)
+            banner = self.query_one("#settings-terminal-host-access", Static)
+            button = self.query_one("#settings-terminal-arm", Button)
+        except QueryError:
+            return
+        self._refresh_host_access_card()
+        armed = self._terminal_is_armed()
+        state.update(self._terminal_state_text())
+        banner.update("HOST TERMINAL - FULL USER ACCESS" if armed else "")
+        label, disabled = self._terminal_arm_button_state()
         button.label = label
         button.disabled = disabled
         button.refresh(layout=True)
@@ -4405,6 +4522,7 @@ class SettingsScreen(BaseAppScreen):
         with checkbox.prevent(Checkbox.Changed):
             checkbox.value = self._raw_cli_draft_value()
         self._refresh_raw_cli_state()
+        self._refresh_terminal_state()
 
     def _chat_defaults(self) -> dict:
         app_config = self._app_config_section_target()
@@ -17443,8 +17561,9 @@ class SettingsScreen(BaseAppScreen):
                     id="settings-privacy-check-result",
                     classes="settings-status-row",
                 )
-            armed_for_launch = self._raw_cli_is_armed()
+            armed_for_launch = self._host_access_is_armed()
             raw_cli_label, raw_cli_disabled = self._raw_cli_arm_button_state()
+            terminal_label, terminal_disabled = self._terminal_arm_button_state()
             with Vertical(
                 id="settings-raw-cli-card",
                 classes=(
@@ -17453,24 +17572,32 @@ class SettingsScreen(BaseAppScreen):
                 ),
             ):
                 yield Static(
-                    "DANGER!!! RAW CLI HOST ACCESS",
+                    "DANGER!!! RAW CLI + TERMINAL HOST ACCESS",
                     id="settings-raw-cli-title",
                     classes="destination-section",
                 )
                 yield Static(
-                    self._raw_cli_state_text(),
-                    id="settings-raw-cli-state",
+                    "One saved unlock controls eligibility for both host-authority "
+                    "features. Each feature still arms separately for this Chatbook "
+                    "launch.",
+                    id="settings-host-access-separation",
+                    classes="settings-raw-cli-disclosure",
                 )
                 for line in RAW_CLI_DISCLOSURE_LINES:
                     yield Static(line, classes="settings-raw-cli-disclosure")
                 yield Checkbox(
-                    "Allow raw CLI host access",
+                    "Allow raw CLI and Terminal access on this device",
                     value=self._raw_cli_draft_value(),
                     id="settings-raw-cli-permitted",
                     tooltip=(
-                        "Stage the persistent raw CLI unlock; Save and Revert use the "
-                        "ordinary Settings draft."
+                        "Stage the shared host-access unlock. Saving it does not arm "
+                        "raw CLI or Terminal."
                     ),
+                )
+                yield Static("One-shot raw CLI", classes="destination-section")
+                yield Static(
+                    self._raw_cli_state_text(),
+                    id="settings-raw-cli-state",
                 )
                 with Vertical(classes="settings-raw-cli-action-row"):
                     yield Static(
@@ -17487,6 +17614,30 @@ class SettingsScreen(BaseAppScreen):
                     )
                     arm_button.disabled = raw_cli_disabled
                     yield arm_button
+                yield Static("Persistent Terminal", classes="destination-section")
+                yield Static(
+                    self._terminal_state_text(),
+                    id="settings-terminal-state",
+                )
+                yield Static(
+                    (
+                        "HOST TERMINAL - FULL USER ACCESS"
+                        if self._terminal_is_armed()
+                        else ""
+                    ),
+                    id="settings-terminal-host-access",
+                )
+                with Vertical(classes="settings-raw-cli-action-row"):
+                    terminal_button = Button(
+                        terminal_label,
+                        id="settings-terminal-arm",
+                        tooltip=(
+                            "Arm persistent Terminal for this launch or disarm it and "
+                            "start cleanup for retained sessions."
+                        ),
+                    )
+                    terminal_button.disabled = terminal_disabled
+                    yield terminal_button
 
         elif category is SettingsCategoryId.NETWORK:
             yield from self._render_network_detail()
@@ -23386,6 +23537,107 @@ class SettingsScreen(BaseAppScreen):
             self._raw_cli_arm_confirmation_pending = False
             raise
 
+    @on(Button.Pressed, "#settings-terminal-arm")
+    def handle_terminal_arm_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        if getattr(self, "_terminal_confirmation_pending", False):
+            self.app.notify(
+                "Terminal confirmation is already open.", severity="warning"
+            )
+            return
+        runtime = self._terminal_runtime()
+        if runtime is None:
+            self.app.notify("Terminal runtime is unavailable.", severity="error")
+            return
+        if self._terminal_is_armed():
+            session_count = self._terminal_live_session_count()
+            if session_count == 0:
+                self._disarm_terminal_runtime(runtime, session_count=0)
+                return
+
+            async def _confirmed_disarm() -> None:
+                self._terminal_confirmation_pending = False
+                self._disarm_terminal_runtime(
+                    runtime,
+                    session_count=session_count,
+                )
+
+            async def _cancelled_disarm() -> None:
+                self._terminal_confirmation_pending = False
+
+            count_copy = (
+                f"{session_count} live Terminal sessions"
+                if session_count is not None
+                else "retained Terminal sessions whose status could not be inspected"
+            )
+            self._terminal_confirmation_pending = True
+            try:
+                self.app.push_screen(
+                    ConfirmationDialog(
+                        title="Disarm Terminal and close sessions?",
+                        message=(
+                            f"Disarming will terminate {count_copy}. One shared "
+                            "five-second cleanup attempt starts immediately. "
+                            "Deliberately detached processes may survive, and cleanup "
+                            "may remain unproven."
+                        ),
+                        confirm_label="Disarm and clean up",
+                        cancel_label="Keep Terminal armed",
+                        confirm_callback=_confirmed_disarm,
+                        cancel_callback=_cancelled_disarm,
+                    )
+                )
+            except Exception:
+                self._terminal_confirmation_pending = False
+                raise
+            return
+
+        _label, disabled = self._terminal_arm_button_state()
+        if disabled:
+            self._refresh_terminal_state()
+            return
+
+        def _apply_arm(*, acknowledge_disclosure: bool) -> None:
+            result = runtime.arm(
+                acknowledge_disclosure=acknowledge_disclosure,
+            )
+            self._refresh_terminal_state()
+            self._refresh_raw_cli_state()
+            if getattr(result, "armed", False):
+                self.app.notify("Terminal armed for this launch.", severity="warning")
+            else:
+                self.app.notify(
+                    "Terminal could not be armed; save the shared unlock first.",
+                    severity="error",
+                )
+
+        if getattr(runtime, "disclosure_acknowledged", False):
+            _apply_arm(acknowledge_disclosure=False)
+            return
+
+        async def _confirmed_arm() -> None:
+            self._terminal_confirmation_pending = False
+            _apply_arm(acknowledge_disclosure=True)
+
+        async def _cancelled_arm() -> None:
+            self._terminal_confirmation_pending = False
+
+        self._terminal_confirmation_pending = True
+        try:
+            self.app.push_screen(
+                ConfirmationDialog(
+                    title="Arm Terminal for this launch",
+                    message="\n\n".join(TERMINAL_DISCLOSURE_LINES),
+                    confirm_label="Arm full-user Terminal",
+                    cancel_label="Cancel",
+                    confirm_callback=_confirmed_arm,
+                    cancel_callback=_cancelled_arm,
+                )
+            )
+        except Exception:
+            self._terminal_confirmation_pending = False
+            raise
+
     @on(Button.Pressed, "#settings-open-provider-credentials")
     def handle_open_provider_credentials(self, event: Button.Pressed) -> None:
         event.stop()
@@ -23600,20 +23852,44 @@ class SettingsScreen(BaseAppScreen):
                 saved_value,
                 current_value,
             )
+        terminal_cleanup_count: int | None = 0
         if not value or not saved_value:
             runtime = self._raw_cli_runtime()
             if runtime is not None:
                 runtime.disarm()
+            terminal_runtime = self._terminal_runtime()
+            if terminal_runtime is not None:
+                terminal_cleanup_count = self._terminal_live_session_count()
+                terminal_runtime.disarm()
         self._sync_raw_cli_widgets()
         self._update_draft_status_widgets(category)
+        cleanup_suffix = ""
+        if terminal_cleanup_count:
+            cleanup_suffix = (
+                f" Terminal cleanup started for {terminal_cleanup_count} sessions; "
+                "pending or unproven cleanup remains available in Terminal."
+            )
+        elif terminal_cleanup_count is None:
+            cleanup_suffix = (
+                " Terminal cleanup status could not be inspected; check Terminal "
+                "for pending or unproven cleanup."
+            )
         if stable and saved_value is value:
             self.app.notify(
-                "Raw CLI unlock saved on." if value else "Raw CLI unlock saved off.",
-                severity="warning" if value else "information",
+                (
+                    "Raw CLI and Terminal unlock saved on."
+                    if value
+                    else "Raw CLI and Terminal unlock saved off."
+                )
+                + cleanup_suffix,
+                severity=(
+                    "warning" if value or terminal_cleanup_count else "information"
+                ),
             )
         else:
             self.app.notify(
-                "Raw CLI unlock reconciled to the latest saved state.",
+                "Raw CLI and Terminal unlock reconciled to the latest saved state."
+                + cleanup_suffix,
                 severity="warning",
             )
 
@@ -23675,8 +23951,8 @@ class SettingsScreen(BaseAppScreen):
         try:
             self.app.push_screen(
                 ConfirmationDialog(
-                    title="Unlock raw CLI host access",
-                    message="\n\n".join(RAW_CLI_DISCLOSURE_LINES),
+                    title="Unlock raw CLI and Terminal host access",
+                    message="\n\n".join(HOST_ACCESS_UNLOCK_DISCLOSURE_LINES),
                     confirm_label="Save unlock",
                     cancel_label="Cancel",
                     confirm_callback=_confirmed_unlock,

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -4439,13 +4439,24 @@ class SettingsScreen(BaseAppScreen):
         try:
             projections = tuple(runtime.projections())
         except Exception:
-            logger.exception("Failed to inspect Terminal sessions before disarm")
+            logger.exception(
+                "Failed to inspect Terminal sessions before disarm "
+                "(runtime_type=%s)",
+                type(runtime).__name__,
+            )
             return None
         count = 0
         for projection in projections:
             lifecycle = getattr(projection, "lifecycle", None)
             lifecycle_value = getattr(lifecycle, "value", lifecycle)
-            if lifecycle_value not in {"closed", "exited"}:
+            if lifecycle_value in {
+                "reserved",
+                "creating",
+                "admitting",
+                "running",
+                "draining",
+                "closing",
+            }:
                 count += 1
         return count
 
@@ -23539,6 +23550,11 @@ class SettingsScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#settings-terminal-arm")
     def handle_terminal_arm_pressed(self, event: Button.Pressed) -> None:
+        """Arm or disarm persistent Terminal authority for this launch.
+
+        Args:
+            event: Press event from the Terminal authority button.
+        """
         event.stop()
         if getattr(self, "_terminal_confirmation_pending", False):
             self.app.notify(

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -23899,7 +23899,9 @@ class SettingsScreen(BaseAppScreen):
                 )
                 + cleanup_suffix,
                 severity=(
-                    "warning" if value or terminal_cleanup_count else "information"
+                    "warning"
+                    if value or terminal_cleanup_count is None or terminal_cleanup_count
+                    else "information"
                 ),
             )
         else:


### PR DESCRIPTION
## Summary

- make the saved dangerous-host-access setting an explicit shared eligibility gate for raw CLI and persistent Terminal
- add a separate process-local Terminal arm with once-per-launch full-user disclosure and a persistent red armed state
- disarm Terminal independently, use the manager cleanup cohort for live sessions, and revoke both runtimes when the shared unlock is saved off

## Verification

- focused Raw CLI and Terminal settings tests: 24 passed
- Ruff check passed for production and tests
- formatter ratchet passed
- Impeccable detector clean
- broader Settings run: 421 passed; only the same 3 inherited failures reproduced before this change (category count, Network inspector guidance, Schedules mutability)

## References

- TASK-22512
- ADR-099

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an independent launch-local arm for the persistent Terminal so it can run separately from one-shot raw CLI, while both share the same saved host-access unlock. Arming Terminal now requires its own full-user disclosure once per launch, and saving the shared unlock off revokes both runtimes.

**New Features**
- Terminal gets a red "ARMED — HOST TERMINAL" state with a full-user-access banner and its own Arm/Disarm button.
- Disarming Terminal with live sessions confirms first and starts one cleanup cohort, warning about pending or unproven cleanup.
- Saves and disarms also warn when session cleanup status can't be inspected.
- The shared unlock is rebranded to cover both runtimes, and raw CLI states read "ARMED — HOST SHELL" / "Disarm raw CLI" to distinguish the arms.

<sup>Written for commit ce8a8f362d390035a1aa9c67efa310282288ee5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

