### PR TITLE
fix(schedules): reminders toast on fire + visible New button

### DIFF
--- a/Tests/Scheduling/test_reminder_handler.py
+++ b/Tests/Scheduling/test_reminder_handler.py
@@ -2,6 +2,9 @@ import pytest
 from unittest.mock import Mock
 
 from tldw_chatbook.Scheduling.scheduler.handlers.reminder_handler import ReminderHandler
+from tldw_chatbook.Notifications.notification_dispatch_service import (
+    NotificationDispatchService,
+)
 
 
 @pytest.fixture
@@ -102,3 +105,58 @@ async def test_reminder_handler_tolerates_getter_returning_none():
     handler = ReminderHandler(dispatch_service=service, app_getter=lambda: None)
     await handler.handle({"id": "6", "title": "T"})
     assert service.dispatch.call_args.kwargs["app"] is None
+
+
+class _FakeNotificationStore:
+    """Minimal store double: records inserts, reports notifications enabled."""
+
+    def __init__(self):
+        self.inserted = []
+
+    def insert_notification(self, **kwargs):
+        self.inserted.append(kwargs)
+        return dict(kwargs)
+
+    def get_settings(self):
+        return {"enabled": True, "toast_enabled": True, "persist_enabled": True}
+
+
+class _FakeApp:
+    """App double exposing only ``notify`` (no ``show_toast``), matching
+    ``show_notification``'s real fallback contract."""
+
+    def __init__(self):
+        self.notify_calls = []
+
+    def notify(self, message, severity="information", timeout=None):
+        self.notify_calls.append(
+            {"message": message, "severity": severity, "timeout": timeout}
+        )
+
+
+@pytest.mark.asyncio
+async def test_reminder_handler_integration_persists_and_toasts_through_real_dispatch_service():
+    """End-to-end through the real NotificationDispatchService (Qodo finding):
+    the inbox row must be persisted AND the toast path must fire when an app
+    is available, while the no-app case still persists without a toast."""
+    store = _FakeNotificationStore()
+    service = NotificationDispatchService(store=store)
+    app = _FakeApp()
+    handler = ReminderHandler(dispatch_service=service, app_getter=lambda: app)
+
+    await handler.handle({"id": "int-1", "title": "Pay rent", "body": "Due today"})
+
+    assert len(store.inserted) == 1
+    assert store.inserted[0]["title"] == "Pay rent"
+    assert store.inserted[0]["message"] == "Due today"
+
+    assert len(app.notify_calls) == 1
+    assert "Pay rent" in app.notify_calls[0]["message"]
+
+    # No-app case: still persists, but never attempts toast delivery.
+    handler_no_app = ReminderHandler(dispatch_service=service, app_getter=None)
+    await handler_no_app.handle({"id": "int-2", "title": "No app", "body": "Body"})
+
+    assert len(store.inserted) == 2
+    assert store.inserted[1]["title"] == "No app"
+    assert len(app.notify_calls) == 1  # unchanged

--- a/Tests/Scheduling/test_reminder_handler.py
+++ b/Tests/Scheduling/test_reminder_handler.py
@@ -13,6 +13,7 @@ def handler():
 async def test_reminder_handler_dispatches_notification(handler):
     await handler.handle({"id": "1", "title": "T", "body": "B", "link_type": None})
     handler.dispatch_service.dispatch.assert_called_once_with(
+        app=None,
         category="reminder",
         title="T",
         message="B",
@@ -25,6 +26,7 @@ async def test_reminder_handler_dispatches_notification(handler):
 async def test_reminder_handler_uses_default_title_when_missing(handler):
     await handler.handle({"id": "2", "body": "B"})
     handler.dispatch_service.dispatch.assert_called_once_with(
+        app=None,
         category="reminder",
         title="Reminder",
         message="B",
@@ -37,6 +39,7 @@ async def test_reminder_handler_uses_default_title_when_missing(handler):
 async def test_reminder_handler_uses_empty_message_when_body_missing(handler):
     await handler.handle({"id": "3", "title": "T"})
     handler.dispatch_service.dispatch.assert_called_once_with(
+        app=None,
         category="reminder",
         title="T",
         message="",
@@ -49,6 +52,7 @@ async def test_reminder_handler_uses_empty_message_when_body_missing(handler):
 async def test_reminder_handler_uses_empty_message_when_body_is_none(handler):
     await handler.handle({"id": "4", "title": "T", "body": None})
     handler.dispatch_service.dispatch.assert_called_once_with(
+        app=None,
         category="reminder",
         title="T",
         message="",
@@ -61,6 +65,7 @@ async def test_reminder_handler_uses_empty_message_when_body_is_none(handler):
 async def test_reminder_handler_allows_missing_id(handler):
     await handler.handle({"title": "T", "body": "B"})
     handler.dispatch_service.dispatch.assert_called_once_with(
+        app=None,
         category="reminder",
         title="T",
         message="B",
@@ -73,9 +78,27 @@ async def test_reminder_handler_allows_missing_id(handler):
 async def test_reminder_handler_is_callable(handler):
     await handler({"id": "5", "title": "T", "body": "B"})
     handler.dispatch_service.dispatch.assert_called_once_with(
+        app=None,
         category="reminder",
         title="T",
         message="B",
         source_entity_kind="scheduled_task",
         source_entity_id="5",
     )
+
+
+@pytest.mark.asyncio
+async def test_reminder_handler_passes_app_from_getter():
+    app = object()
+    service = Mock()
+    handler = ReminderHandler(dispatch_service=service, app_getter=lambda: app)
+    await handler.handle({"id": "5", "title": "T", "body": "B"})
+    assert service.dispatch.call_args.kwargs["app"] is app
+
+
+@pytest.mark.asyncio
+async def test_reminder_handler_tolerates_getter_returning_none():
+    service = Mock()
+    handler = ReminderHandler(dispatch_service=service, app_getter=lambda: None)
+    await handler.handle({"id": "6", "title": "T"})
+    assert service.dispatch.call_args.kwargs["app"] is None

--- a/Tests/UI/test_schedules_new_button.py
+++ b/Tests/UI/test_schedules_new_button.py
@@ -1,0 +1,40 @@
+"""Visible New button in the Schedule Queue pane (UX F-07).
+
+The only create affordance used to be the `c` key in the footer. This adds
+a primary button beside the "Schedule Queue" pane title, wired to the
+existing `action_create_reminder`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import (
+    ReminderForm,
+    SchedulesWorkbench,
+)
+
+
+class LocalOnlyTestApp(ConsolidatedCSSApp):
+    scheduling_service = None
+
+
+@pytest.mark.asyncio
+async def test_new_button_exists_and_opens_create_form():
+    app = LocalOnlyTestApp()
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        button = workbench.query_one("#scheduling-new-task", Button)
+        assert "New" in str(button.label)
+
+        pushed: list = []
+        workbench.app.push_screen = lambda screen, callback=None: pushed.append(screen)
+        button.press()
+        await pilot.pause()
+
+        assert pushed and isinstance(pushed[0], ReminderForm)

--- a/Tests/UI/test_schedules_new_button.py
+++ b/Tests/UI/test_schedules_new_button.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import pytest
 from textual.widgets import Button
 
-from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
 from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import (
     ReminderForm,
     SchedulesWorkbench,
@@ -19,6 +19,18 @@ from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import (
 
 class LocalOnlyTestApp(ConsolidatedCSSApp):
     scheduling_service = None
+
+
+class LocalOnlyBundledCSSTestApp(LocalOnlyTestApp):
+    """Loads the app-level CSS bundle so `.compact` display rules resolve.
+
+    ``ConsolidatedCSSApp`` only registers the screen/modal sheets by
+    default; the scheduling feature CSS (``_scheduling.tcss``) lives in the
+    app bundle, so a test asserting on its `display: none` rules needs this
+    tier too (same pattern as ``Tests/UI/test_trace_responsive.py``).
+    """
+
+    CSS_PATH = BUNDLED_STYLESHEET
 
 
 @pytest.mark.asyncio
@@ -38,3 +50,26 @@ async def test_new_button_exists_and_opens_create_form():
         await pilot.pause()
 
         assert pushed and isinstance(pushed[0], ReminderForm)
+
+
+@pytest.mark.asyncio
+async def test_new_button_row_hidden_in_compact_mode():
+    """Compact mode (see on_resize) reclaims the header's row for the table.
+
+    Hiding the whole header -- not just the title -- keeps the pre-change
+    row budget: the New button stays reachable via the `c` key, which the
+    footer advertises, instead of eating the one spare row at 80x24.
+    """
+    app = LocalOnlyBundledCSSTestApp()
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        # Same class on_resize applies to #scheduling-workbench once
+        # hide_detail is true (width < 84).
+        workbench.query_one("#scheduling-workbench").add_class("compact")
+        await pilot.pause()
+
+        header = workbench.query_one("#scheduling-list-header")
+        assert header.display is False

--- a/tldw_chatbook/Scheduling/scheduler/handlers/reminder_handler.py
+++ b/tldw_chatbook/Scheduling/scheduler/handlers/reminder_handler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
 from tldw_chatbook.Notifications.notification_dispatch_service import (
     NotificationDispatchService,
@@ -12,8 +12,18 @@ from tldw_chatbook.Notifications.notification_dispatch_service import (
 class ReminderHandler:
     """Dispatch a reminder notification for a scheduled task."""
 
-    def __init__(self, dispatch_service: NotificationDispatchService) -> None:
+    def __init__(
+        self,
+        dispatch_service: NotificationDispatchService,
+        app_getter: Callable[[], Any] | None = None,
+    ) -> None:
         self.dispatch_service = dispatch_service
+        #: Zero-arg getter for the running app, resolved fresh per dispatch
+        #: (BriefingJobHandler's chachanotes_db_getter discipline): the
+        #: handler is constructed before app wiring completes, and
+        #: dispatch() only attempts transient toast delivery when given a
+        #: live app handle.
+        self.app_getter = app_getter
 
     async def handle(self, task: dict[str, Any]) -> None:
         """Dispatch a reminder notification.
@@ -21,7 +31,9 @@ class ReminderHandler:
         Args:
             task: A scheduled task row from ``reminder_tasks``.
         """
+        app = self.app_getter() if self.app_getter is not None else None
         self.dispatch_service.dispatch(
+            app=app,
             category="reminder",
             title=task.get("title", "Reminder"),
             message=task.get("body") or "",

--- a/tldw_chatbook/Scheduling/scheduler/handlers/reminder_handler.py
+++ b/tldw_chatbook/Scheduling/scheduler/handlers/reminder_handler.py
@@ -17,12 +17,18 @@ class ReminderHandler:
         dispatch_service: NotificationDispatchService,
         app_getter: Callable[[], Any] | None = None,
     ) -> None:
+        """Initialize the handler.
+
+        Args:
+            dispatch_service: Service used to persist the reminder as an
+                inbox notification and attempt transient (toast) delivery.
+            app_getter: Zero-arg getter for the running app, resolved fresh
+                per dispatch (BriefingJobHandler's chachanotes_db_getter
+                discipline): the handler is constructed before app wiring
+                completes, and dispatch() only attempts transient toast
+                delivery when given a live app handle.
+        """
         self.dispatch_service = dispatch_service
-        #: Zero-arg getter for the running app, resolved fresh per dispatch
-        #: (BriefingJobHandler's chachanotes_db_getter discipline): the
-        #: handler is constructed before app wiring completes, and
-        #: dispatch() only attempts transient toast delivery when given a
-        #: live app handle.
         self.app_getter = app_getter
 
     async def handle(self, task: dict[str, Any]) -> None:

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -236,11 +236,18 @@ class SchedulesWorkbench(BaseAppScreen):
                 with TabPane("Queue", id="scheduling-queue-tab"):
                     with Horizontal(id="scheduling-workbench"):
                         with Vertical(id="scheduling-list-pane"):
-                            yield Static(
-                                "Schedule Queue",
-                                id="scheduling-list-title",
-                                classes="scheduling-column-title",
-                            )
+                            with Horizontal(id="scheduling-list-header"):
+                                yield Static(
+                                    "Schedule Queue",
+                                    id="scheduling-list-title",
+                                    classes="scheduling-column-title",
+                                )
+                                yield Button(
+                                    "+ New",
+                                    id="scheduling-new-task",
+                                    variant="primary",
+                                    tooltip="Schedule a new task (c).",
+                                )
                             yield Input(
                                 placeholder="Filter: title, type, or status…",
                                 id="scheduling-queue-filter",
@@ -675,6 +682,11 @@ class SchedulesWorkbench(BaseAppScreen):
             exclusive=True,
             group="schedules-delete-task",
         )  # type: ignore[arg-type]
+
+    @on(Button.Pressed, "#scheduling-new-task")
+    def _on_new_task_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.action_create_reminder()
 
     @on(Button.Pressed, "#schedules-follow-in-console")
     def follow_latest_schedule_run_in_console(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -9659,7 +9659,8 @@ class TldwCli(
 
         handlers: dict[str, Handler] = {
             "reminder": ReminderHandler(
-                dispatch_service=self.notification_dispatch_service
+                dispatch_service=self.notification_dispatch_service,
+                app_getter=lambda: self,
             ),
         }
         if watchlist_handler is not None:

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -265,7 +265,10 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
 }
 
 /* Compact mode (see SchedulesWorkbench.on_resize): the Queue tab label
- * already names the pane; the in-pane title's row goes to the table. */
-#scheduling-workbench.compact #scheduling-list-title {
+ * already names the pane; the in-pane title/New-button row goes to the
+ * table (80x24 has exactly one spare row -- the New button stays reachable
+ * via the `c` key, which the footer advertises). Hiding the header hides
+ * the title Static nested inside it too. */
+#scheduling-workbench.compact #scheduling-list-header {
     display: none;
 }

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -131,6 +131,19 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     margin-bottom: 1;
 }
 
+#scheduling-list-header {
+    height: auto;
+}
+
+#scheduling-list-header #scheduling-list-title {
+    width: 1fr;
+}
+
+#scheduling-new-task {
+    width: auto;
+    min-width: 9;
+}
+
 /* Empty state */
 #scheduling-task-detail-empty-state {
     color: $text-muted;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13587,6 +13587,19 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     margin-bottom: 1;
 }
 
+#scheduling-list-header {
+    height: auto;
+}
+
+#scheduling-list-header #scheduling-list-title {
+    width: 1fr;
+}
+
+#scheduling-new-task {
+    width: auto;
+    min-width: 9;
+}
+
 /* Empty state */
 #scheduling-task-detail-empty-state {
     color: $text-muted;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13721,8 +13721,11 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
 }
 
 /* Compact mode (see SchedulesWorkbench.on_resize): the Queue tab label
- * already names the pane; the in-pane title's row goes to the table. */
-#scheduling-workbench.compact #scheduling-list-title {
+ * already names the pane; the in-pane title/New-button row goes to the
+ * table (80x24 has exactly one spare row -- the New button stays reachable
+ * via the `c` key, which the footer advertises). Hiding the header hides
+ * the title Static nested inside it too. */
+#scheduling-workbench.compact #scheduling-list-header {
     display: none;
 }
 


### PR DESCRIPTION
Phase-0 riders of the schedules-handoff program (spec: backlog/docs/spec-2026-08-31-schedules-handoff-parity.md §9, lands with PR-1 #TBD).

**Toast fix** — `ReminderHandler` was the only `dispatch()` caller in the repo omitting `app=`, so a fired reminder wrote an inbox row and showed no toast. Fixed with the zero-arg-getter pattern `BriefingJobHandler` already uses; 6 pinning tests updated, 2 added.

**Visible New button** — the only create affordance was the `c` key in the footer. A primary `+ New` button now sits beside the Schedule Queue pane title, routing through the existing `action_create_reminder`. Hidden in compact mode (<84 cols) to preserve the razor-thin 80×24 row budget (review finding, fixed with a CSS-cascade-driven test on a bundled-stylesheet harness).

**Verified live**: button renders at 235×52, click opens the create modal, hidden at 80×24. Tests: 138 UI green + 38 scheduling handler/loop.

Note for merge: dev's b62407e25 also touched the CSS bundle — if this conflicts, rebuild via `tldw_chatbook/css/build_css.py` rather than hand-merging the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WocisXw6SEEG6nb1aKFHtv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes fired reminders to show a toast again (they previously only wrote an inbox row) and makes schedule creation visible with a `+ New` button next to the Schedule Queue title.

**Bug Fixes**
- `ReminderHandler` was the only `dispatch()` caller omitting `app=`, so reminders never showed a toast; it now resolves the app via a zero-arg getter matching `BriefingJobHandler`.
- The getter keeps toast delivery optional when no live app handle exists, and an end-to-end test pins the persist-and-toast boundary through the real `NotificationDispatchService`.

**New Features**
- A primary `+ New` button beside the Schedule Queue title routes through `action_create_reminder`.
- The header row hides in compact mode (<84 columns) to preserve the 80×24 row budget; the `c` key still opens the form.

If the bundled stylesheet conflicts during merge, rebuild via `tldw_chatbook/css/build_css.py` rather than hand-merging.

<sup>Written for commit 57823b30d2a5c9ffb3dde49bd5ccdf713709f59c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

