### PR TITLE
feat(scheduling): schema v4 — local automation runs/results floor (handoff PR-1)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1762,6 +1762,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 2,
+      "diagnostic_digest": "b6ed4c7daa8639b32832",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Scheduling/db/migrations/v3_to_v4.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 3,
       "diagnostic_digest": "2c0a87947d6065c00575",
       "owner": "TASK-494",
@@ -11131,10 +11138,10 @@
   "schema_version": 3,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 551,
+    "owner_files": 552,
     "path_privacy_candidate_calls": 711,
     "persistent_sink_files": 9,
     "task_492_calls": 1308,
-    "task_494_calls": 7424
+    "task_494_calls": 7426
   }
 }

--- a/Tests/Scheduling/test_handler_timeout.py
+++ b/Tests/Scheduling/test_handler_timeout.py
@@ -68,7 +68,10 @@ def _run(coro):
 
 
 def test_schema_v3_adds_timeout_seconds(db):
-    assert db.get_schema_version() == 3
+    # The full chain now reaches v4 (v4 = automation runs/results,
+    # schedules-handoff §4); this test pins that timeout_seconds (v3)
+    # survives that later migration.
+    assert db.get_schema_version() == 4
     with db._get_connection() as conn:
         columns = {row[1] for row in conn.execute("PRAGMA table_info(reminder_tasks)")}
     assert "timeout_seconds" in columns

--- a/Tests/Scheduling/test_migrations.py
+++ b/Tests/Scheduling/test_migrations.py
@@ -118,3 +118,30 @@ def test_v4_preserves_existing_rows_and_is_idempotent(tmp_path):
     row = db.get_reminder_task(task_id)
     assert row is not None and row["title"] == "keep me"
     assert db.get_schema_version() == 4
+
+
+def test_v4_migrate_then_rollback_round_trips_to_v3(tmp_path):
+    from tldw_chatbook.Scheduling.db.migrations.v3_to_v4 import migrate, rollback
+
+    db = ScheduledTasksDB(str(tmp_path / "s.db"), client_id="t")
+    migrate(db)  # already applied by construction; idempotent no-op
+
+    rollback(db)
+
+    assert db.get_schema_version() == 3
+    with closing(db._get_connection()) as conn:
+        def_cols = {r[1] for r in conn.execute("PRAGMA table_info(automation_definitions)")}
+        rem_cols = {r[1] for r in conn.execute("PRAGMA table_info(reminder_tasks)")}
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    assert def_cols.isdisjoint({
+        "disabled_lock_kind", "disabled_reason", "resolution_state",
+        "resolved_at", "resolved_by", "resolved_result_id",
+        "finding_policy", "retention_policy", "next_run_at", "transfer_state",
+    })
+    assert "transfer_state" not in rem_cols
+    assert {"automation_runs", "automation_results"}.isdisjoint(tables)

--- a/Tests/Scheduling/test_migrations.py
+++ b/Tests/Scheduling/test_migrations.py
@@ -1,5 +1,6 @@
 import sqlite3
 from contextlib import closing
+from datetime import datetime, timezone
 from pathlib import Path
 
 from tldw_chatbook.Scheduling.db.migrations import v0_to_v1
@@ -43,13 +44,14 @@ def _table_names(conn: sqlite3.Connection) -> set[str]:
 
 
 def test_migration_v0_to_v1(tmp_path):
-    # A fresh ScheduledTasksDB runs the full chain: v0 -> v1 -> v2 -> v3
-    # (v2 = missed_count, task-18937; v3 = timeout_seconds, task-18939).
-    # The individual hops are covered in test_missed_fire.py and
-    # test_handler_timeout.py; what this pins is that a fresh database
-    # reaches the current version end-to-end.
+    # A fresh ScheduledTasksDB runs the full chain: v0 -> v1 -> v2 -> v3 -> v4
+    # (v2 = missed_count, task-18937; v3 = timeout_seconds, task-18939; v4 =
+    # automation runs/results, schedules-handoff §4). The individual hops
+    # are covered in test_missed_fire.py, test_handler_timeout.py, and this
+    # file's v4 tests; what this pins is that a fresh database reaches the
+    # current version end-to-end.
     db = ScheduledTasksDB(tmp_path / "test.db")
-    assert db.get_schema_version() == 3
+    assert db.get_schema_version() == 4
 
 
 def test_migration_v0_to_v1_directly(tmp_path):
@@ -67,7 +69,7 @@ def test_migration_v0_to_v1_directly(tmp_path):
 
 def test_migration_v0_to_v1_to_v0_rollback(tmp_path):
     db = ScheduledTasksDB(tmp_path / "test.db")
-    assert db.get_schema_version() == 3
+    assert db.get_schema_version() == 4
 
     v0_to_v1.rollback(db)
 
@@ -76,3 +78,43 @@ def test_migration_v0_to_v1_to_v0_rollback(tmp_path):
         tables = _table_names(conn)
     scheduling_tables = _EXPECTED_TABLES - {"schema_version"}
     assert scheduling_tables.isdisjoint(tables)
+
+
+def test_v4_creates_runs_and_results_tables(tmp_path):
+    db = ScheduledTasksDB(str(tmp_path / "s.db"), client_id="t")
+    with closing(db._get_connection()) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    assert {"automation_runs", "automation_results"} <= tables
+    assert db.get_schema_version() == 4
+
+
+def test_v4_adds_definition_and_reminder_columns(tmp_path):
+    db = ScheduledTasksDB(str(tmp_path / "s.db"), client_id="t")
+    with closing(db._get_connection()) as conn:
+        def_cols = {r[1] for r in conn.execute("PRAGMA table_info(automation_definitions)")}
+        rem_cols = {r[1] for r in conn.execute("PRAGMA table_info(reminder_tasks)")}
+    assert {
+        "disabled_lock_kind", "disabled_reason", "resolution_state",
+        "resolved_at", "resolved_by", "resolved_result_id",
+        "finding_policy", "retention_policy", "next_run_at", "transfer_state",
+    } <= def_cols
+    assert "transfer_state" in rem_cols
+
+
+def test_v4_preserves_existing_rows_and_is_idempotent(tmp_path):
+    path = str(tmp_path / "s.db")
+    db = ScheduledTasksDB(path, client_id="t")
+    task_id = db.create_reminder_task(
+        owner_id="local", title="keep me", schedule_kind="one_time",
+        run_at=datetime(2027, 1, 1, tzinfo=timezone.utc),
+    )
+    from tldw_chatbook.Scheduling.db.migrations.v3_to_v4 import migrate
+    migrate(db)  # second application must be a no-op
+    row = db.get_reminder_task(task_id)
+    assert row is not None and row["title"] == "keep me"
+    assert db.get_schema_version() == 4

--- a/Tests/Scheduling/test_migrations.py
+++ b/Tests/Scheduling/test_migrations.py
@@ -170,3 +170,25 @@ def test_v4_finding_and_retention_policy_defaults_hydrate(tmp_path):
     definition = AutomationDefinition(**row)
     assert definition.finding_policy == {"preset": "balanced_findings"}
     assert definition.retention_policy == {"mode": "default"}
+
+
+def test_warm_reopen_skips_migration_module_imports(tmp_path):
+    """ADR-097 boot ratchet: a fully-migrated file DB must not re-import
+    the migration modules on reopen (they'd land in the `_ui_ready`
+    module census on every warm boot)."""
+    import sys
+
+    path = str(tmp_path / "s.db")
+    ScheduledTasksDB(path, client_id="t")  # first open runs the chain
+
+    prefix = "tldw_chatbook.Scheduling.db.migrations.v"
+    for name in [m for m in list(sys.modules) if m.startswith(prefix)]:
+        sys.modules.pop(name)
+
+    db2 = ScheduledTasksDB(path, client_id="t")  # warm reopen
+    assert db2.get_schema_version() == 4
+    reimported = [m for m in sys.modules if m.startswith(prefix)]
+    assert reimported == [], (
+        "warm reopen re-imported migration modules despite the recorded "
+        f"schema version proving the chain already ran: {reimported}"
+    )

--- a/Tests/Scheduling/test_migrations.py
+++ b/Tests/Scheduling/test_migrations.py
@@ -145,3 +145,28 @@ def test_v4_migrate_then_rollback_round_trips_to_v3(tmp_path):
     })
     assert "transfer_state" not in rem_cols
     assert {"automation_runs", "automation_results"}.isdisjoint(tables)
+
+
+def test_v4_finding_and_retention_policy_defaults_hydrate(tmp_path):
+    """A definition row written without finding_policy/retention_policy
+    (e.g. a pre-existing row from before v4, or any insert that omits
+    them) must read back with the same defaults AutomationDefinition's
+    Pydantic fields carry -- the DDL DEFAULT is what backfills NULL,
+    since the model fields are non-Optional (final-review finding #1).
+    """
+    from tldw_chatbook.Scheduling.models import AutomationDefinition
+
+    db = ScheduledTasksDB(str(tmp_path / "s.db"), client_id="t")
+    definition_id = db.create_automation_definition(
+        "local", "recurring_question", "No explicit policy"
+    )
+
+    row = db.get_automation_definition(definition_id)
+    assert row is not None
+    # _row_to_dict already parses the JSON columns into dicts.
+    assert row["finding_policy"] == {"preset": "balanced_findings"}
+    assert row["retention_policy"] == {"mode": "default"}
+
+    definition = AutomationDefinition(**row)
+    assert definition.finding_policy == {"preset": "balanced_findings"}
+    assert definition.retention_policy == {"mode": "default"}

--- a/Tests/Scheduling/test_missed_fire.py
+++ b/Tests/Scheduling/test_missed_fire.py
@@ -73,9 +73,10 @@ def _dispatch_first_due(db, now, *, grace_seconds=60.0, success=True):
 
 
 def test_schema_v2_adds_missed_count(db):
-    # The full chain now reaches v3 (v2 = missed_count here; v3 =
-    # timeout_seconds, covered in test_handler_timeout.py).
-    assert db.get_schema_version() == 3
+    # The full chain now reaches v4 (v2 = missed_count here; v3 =
+    # timeout_seconds, covered in test_handler_timeout.py; v4 = automation
+    # runs/results, schedules-handoff §4).
+    assert db.get_schema_version() == 4
     with db._get_connection() as conn:
         columns = {row[1] for row in conn.execute("PRAGMA table_info(reminder_tasks)")}
     assert "missed_count" in columns
@@ -89,10 +90,10 @@ def test_migration_v1_to_v2_preserves_rows(tmp_path):
     database.close()
 
     # v1_to_v2.migrate is idempotent; run it again on the existing DB.
-    # (The DB is already at v3 from construction; re-running the v1->v2
+    # (The DB is already at v4 from construction; re-running the v1->v2
     # migration is a no-op that must not regress the version.)
     v1_to_v2.migrate(database)
-    assert database.get_schema_version() == 3
+    assert database.get_schema_version() == 4
     row = database.get_reminder_task(task_id)
     assert row["title"] == "pre-migration"
     assert row["missed_count"] == 0

--- a/Tests/Scheduling/test_models.py
+++ b/Tests/Scheduling/test_models.py
@@ -296,6 +296,33 @@ def test_definition_gains_parity_fields_with_defaults():
     assert d.next_run_at is None and d.transfer_state is None
 
 
+def test_automation_run_tolerates_null_json_columns():
+    """A DB row created without snapshot kwargs stores NULL; must not raise."""
+    run = AutomationRun(
+        owner_id="local", definition_id="d1",
+        definition_version=1, trigger_reason="scheduled",
+        scope_snapshot=None, finding_policy_snapshot=None,
+        rag_request_snapshot=None, run_summary=None, evidence_summary=None,
+    )
+    assert run.scope_snapshot == {}
+    assert run.finding_policy_snapshot == {}
+    assert run.rag_request_snapshot == {}
+    assert run.run_summary == {}
+    assert run.evidence_summary == {}
+
+
+def test_automation_result_tolerates_null_json_columns():
+    """A DB row created without snapshot kwargs stores NULL; must not raise."""
+    result = AutomationResult(
+        owner_id="local", definition_id="d1", run_id="r1",
+        kind="finding", title="t", summary="s", dedupe_key="k",
+        confidence=None, source_refs=None, visibility_destination=None,
+    )
+    assert result.confidence == {}
+    assert result.source_refs == []
+    assert result.visibility_destination == {}
+
+
 def test_preview_error_lists_hold_server_shaped_dicts():
     p = AutomationPreview(
         family=AutomationFamily.RECURRING_QUESTION,

--- a/Tests/Scheduling/test_models.py
+++ b/Tests/Scheduling/test_models.py
@@ -1,6 +1,7 @@
 """Tests for Scheduling Pydantic models."""
 
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
@@ -10,10 +11,15 @@ from tldw_chatbook.Scheduling.models import (
     AutomationDefinition,
     AutomationFamily,
     AutomationPreview,
+    AutomationResult,
+    AutomationRun,
     Health,
     Lifecycle,
     PreviewStatus,
     ReminderTask,
+    ReviewState,
+    RunOutcome,
+    RunStatus,
     ScheduleKind,
     TaskStatus,
 )
@@ -247,3 +253,55 @@ def test_extra_fields_forbidden() -> None:
             summary="Summary",
             unknown_field="nope",
         )
+
+
+def test_run_status_matches_server_vocabulary_plus_timed_out():
+    assert {s.value for s in RunStatus} == {
+        "queued", "running", "completed", "failed",
+        "skipped", "cancelled", "timed_out",
+    }
+
+
+def test_run_outcome_and_review_state_match_server_literals():
+    assert {o.value for o in RunOutcome} == {
+        "finding", "no_match", "partial", "degraded", "none",
+    }
+    assert {r.value for r in ReviewState} == {"unread", "read", "dismissed"}
+
+
+def test_automation_run_defaults():
+    run = AutomationRun(
+        owner_id="local", definition_id="d1",
+        definition_version=1, trigger_reason="scheduled",
+    )
+    assert run.status == RunStatus.QUEUED
+    assert run.outcome == RunOutcome.NONE
+    assert run.schedule_slot is None
+
+
+def test_automation_result_defaults_to_unread():
+    result = AutomationResult(
+        owner_id="local", definition_id="d1", run_id="r1",
+        kind="finding", title="t", summary="s", dedupe_key="k",
+    )
+    assert result.review_state == ReviewState.UNREAD
+    assert result.answer_mode == "none"
+
+
+def test_definition_gains_parity_fields_with_defaults():
+    d = AutomationDefinition(family=AutomationFamily.RECURRING_QUESTION, name="n")
+    assert d.resolution_state == "open"
+    assert d.finding_policy == {"preset": "balanced_findings"}
+    assert d.retention_policy == {"mode": "default"}
+    assert d.next_run_at is None and d.transfer_state is None
+
+
+def test_preview_error_lists_hold_server_shaped_dicts():
+    p = AutomationPreview(
+        family=AutomationFamily.RECURRING_QUESTION,
+        validation_errors=[{"field": "config.scope", "code": "scope_empty",
+                            "message": "Scope must include at least one readable searchable source."}],
+        warnings=[{"code": "source_unavailable", "source": "chats"}],
+    )
+    assert p.validation_errors[0]["code"] == "scope_empty"
+    assert p.risk_class is None

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -652,3 +652,73 @@ def test_record_sync_error_appends_and_caps(tmp_path):
     assert len(state["sync_errors"]) == 10
     assert state["sync_errors"][-1]["message"] == "error 11"
     assert state["sync_errors"][0]["message"] == "error 2"
+
+
+# ----------------------------------------------------------------------
+# Automation runs
+# ----------------------------------------------------------------------
+
+
+def _mk_db(tmp_path):
+    return ScheduledTasksDB(str(tmp_path / "s.db"), client_id="t")
+
+
+def test_create_run_and_slot_dedupe(tmp_path):
+    db = _mk_db(tmp_path)
+    first = db.create_automation_run(
+        "local", "d1", 1, "scheduled",
+        status="running", schedule_slot="2026-09-01T09:00:00+00:00",
+    )
+    assert first is not None
+    duplicate = db.create_automation_run(
+        "local", "d1", 1, "scheduled",
+        status="running", schedule_slot="2026-09-01T09:00:00+00:00",
+    )
+    assert duplicate is None  # deduped, not raised
+    two_manuals = [
+        db.create_automation_run("local", "d1", 1, "manual", status="running")
+        for _ in range(2)
+    ]
+    assert all(two_manuals)  # NULL slots never collide
+
+
+def test_update_and_list_runs(tmp_path):
+    db = _mk_db(tmp_path)
+    run_id = db.create_automation_run("local", "d1", 1, "manual", status="running")
+    assert db.update_automation_run(
+        run_id, status="completed", outcome="finding",
+        run_summary={"note": "ok"},
+    )
+    rows = db.list_automation_runs("local", definition_id="d1")
+    assert rows[0]["status"] == "completed"
+    assert rows[0]["run_summary"] == {"note": "ok"}  # JSON round-trips
+
+
+def test_prune_keeps_newest_200_per_definition(tmp_path):
+    db = _mk_db(tmp_path)
+    for i in range(205):
+        db.create_automation_run(
+            "local", "d1", 1, "scheduled",
+            status="completed", schedule_slot=f"slot-{i:04d}",
+        )
+    rows = db.list_automation_runs("local", definition_id="d1", limit=500)
+    assert len(rows) == 200
+    slots = {r["schedule_slot"] for r in rows}
+    assert "slot-0204" in slots and "slot-0000" not in slots
+
+
+def test_reconcile_marks_stale_running_as_interrupted(tmp_path):
+    db = _mk_db(tmp_path)
+    run_id = db.create_automation_run("local", "d1", 1, "manual", status="running")
+    # Backdate created_at past the cutoff.
+    with closing(db._get_connection()) as conn:
+        conn.execute(
+            "UPDATE automation_runs SET created_at = ? WHERE id = ?",
+            ("2020-01-01T00:00:00+00:00", run_id),
+        )
+        conn.commit()
+    reconciled = db.reconcile_stale_automation_runs(older_than_seconds=3600)
+    assert reconciled == 1
+    row = db.list_automation_runs("local", definition_id="d1")[0]
+    assert row["status"] == "failed"
+    assert row["failure_reason"] == {"code": "interrupted"}

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+from tldw_chatbook.Scheduling.models import AutomationRun
 from tldw_chatbook.config import get_scheduled_tasks_db_path
 
 
@@ -692,6 +693,26 @@ def test_update_and_list_runs(tmp_path):
     rows = db.list_automation_runs("local", definition_id="d1")
     assert rows[0]["status"] == "completed"
     assert rows[0]["run_summary"] == {"note": "ok"}  # JSON round-trips
+
+
+def test_create_run_with_no_snapshot_kwargs_round_trips_and_hydrates(tmp_path):
+    db = _mk_db(tmp_path)
+    run_id = db.create_automation_run("local", "d1", 1, "manual")
+    row = db.list_automation_runs("local", definition_id="d1")[0]
+    assert row["id"] == run_id
+    assert row["scope_snapshot"] is None  # NULL column, not json.loads'd
+    assert row["run_summary"] is None
+    AutomationRun(**row)  # must not raise (models.py None -> {} coercion)
+
+
+def test_update_automation_run_honors_caller_supplied_updated_at(tmp_path):
+    db = _mk_db(tmp_path)
+    run_id = db.create_automation_run("local", "d1", 1, "manual", status="running")
+    assert db.update_automation_run(
+        run_id, status="completed", updated_at=_utc(2020, 1, 1),
+    )
+    row = db.list_automation_runs("local", definition_id="d1")[0]
+    assert row["updated_at"] == "2020-01-01T00:00:00+00:00"
 
 
 def test_prune_keeps_newest_200_per_definition(tmp_path):

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -35,8 +35,9 @@ def test_get_scheduled_tasks_db_path_returns_path():
 
 def test_get_schema_version(db: ScheduledTasksDB) -> None:
     # v2 added missed_count (task-18937); v3 adds timeout_seconds
-    # (task-18939).
-    assert db.get_schema_version() == 3
+    # (task-18939); v4 adds automation runs/results (schedules-handoff
+    # §4).
+    assert db.get_schema_version() == 4
 
 
 def test_create_and_get_reminder_task(db: ScheduledTasksDB) -> None:

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -722,3 +722,38 @@ def test_reconcile_marks_stale_running_as_interrupted(tmp_path):
     row = db.list_automation_runs("local", definition_id="d1")[0]
     assert row["status"] == "failed"
     assert row["failure_reason"] == {"code": "interrupted"}
+
+
+# ----------------------------------------------------------------------
+# Automation results
+# ----------------------------------------------------------------------
+
+
+def test_create_result_and_dedupe(tmp_path):
+    db = _mk_db(tmp_path)
+    rid = db.create_automation_result(
+        "local", "d1", "r1", "finding", "Title", "Summary", "key-1",
+        answer_mode="synthesized", answer={"text": "42"},
+        source_refs=[{"source": "notes", "id": "n1"}],
+    )
+    assert rid is not None
+    assert db.create_automation_result(
+        "local", "d1", "r2", "finding", "Again", "S", "key-1"
+    ) is None  # same (owner, dedupe_key)
+    row = db.list_automation_results("local")[0]
+    assert row["review_state"] == "unread"
+    assert row["answer"] == {"text": "42"}
+    assert row["source_refs"] == [{"source": "notes", "id": "n1"}]
+
+
+def test_review_transitions_and_unread_count(tmp_path):
+    db = _mk_db(tmp_path)
+    rid = db.create_automation_result(
+        "local", "d1", "r1", "finding", "T", "S", "k1"
+    )
+    db.create_automation_result("local", "d1", "r2", "failure", "F", "S", "k2")
+    assert db.count_unread_results("local") == 2
+    assert db.update_result_review(rid, "read", reviewed_by="local")
+    assert db.count_unread_results("local") == 1
+    assert db.list_automation_results("local", review_state="read")[0]["id"] == rid
+    assert not db.update_result_review("missing", "dismissed")

--- a/Tests/Scheduling/test_slot_keys.py
+++ b/Tests/Scheduling/test_slot_keys.py
@@ -1,0 +1,39 @@
+import hashlib
+import json
+
+from tldw_chatbook.Scheduling.slot_keys import (
+    build_manual_run_idempotency_payload,
+    build_scheduled_run_idempotency_key,
+    canonical_hash,
+)
+
+
+def test_scheduled_key_matches_server_recipe_byte_for_byte():
+    payload = {
+        "definition_id": "d1",
+        "definition_version": 3,
+        "schedule_slot": "2026-09-01T09:00:00+00:00",
+    }
+    expected_digest = hashlib.sha256(
+        json.dumps(
+            payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode("utf-8")
+    ).hexdigest()
+    key = build_scheduled_run_idempotency_key(
+        definition_id="d1",
+        definition_version=3,
+        schedule_slot="2026-09-01T09:00:00+00:00",
+    )
+    assert key == f"scheduled-task-rq:{expected_digest}"
+
+
+def test_canonical_hash_is_key_order_independent():
+    assert canonical_hash({"a": 1, "b": 2}) == canonical_hash({"b": 2, "a": 1})
+
+
+def test_manual_payload_matches_server_shape():
+    assert build_manual_run_idempotency_payload(definition_id="d9") == {
+        "action": "create_manual_run",
+        "definition_id": "d9",
+        "trigger_reason": "manual",
+    }

--- a/Tests/Scheduling/test_slot_keys.py
+++ b/Tests/Scheduling/test_slot_keys.py
@@ -25,6 +25,13 @@ def test_scheduled_key_matches_server_recipe_byte_for_byte():
         schedule_slot="2026-09-01T09:00:00+00:00",
     )
     assert key == f"scheduled-task-rq:{expected_digest}"
+    # Golden digest pinned for this exact payload (computed once, hardcoded
+    # here) so a change to the recipe that happens to agree with itself
+    # can't silently pass the reimplementation check above.
+    assert key == (
+        "scheduled-task-rq:"
+        "3ffcacb8c8dd370f97175787b144e08c521b9888ac91512e001de88f684075bb"
+    )
 
 
 def test_canonical_hash_is_key_order_independent():

--- a/tldw_chatbook/Scheduling/db/migrations/v3_to_v4.py
+++ b/tldw_chatbook/Scheduling/db/migrations/v3_to_v4.py
@@ -1,0 +1,171 @@
+"""Migration from schema version 3 to version 4.
+
+Adds the local automation execution floor for the schedules-handoff
+program (spec-2026-08-31-schedules-handoff-parity.md §4): the
+``automation_runs`` and ``automation_results`` tables, the eight
+reference-parity columns plus ``next_run_at``/``transfer_state`` on
+``automation_definitions``, and ``transfer_state`` on ``reminder_tasks``.
+"""
+
+from __future__ import annotations
+
+from contextlib import closing
+from typing import TYPE_CHECKING, Any, Protocol
+
+from loguru import logger
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+
+    class _MigrationCapableDB(Protocol):
+        def _get_connection(self) -> Any: ...
+
+
+_DEFINITION_COLUMNS_V4: tuple[tuple[str, str], ...] = (
+    ("disabled_lock_kind", "TEXT"),
+    ("disabled_reason", "TEXT"),
+    ("resolution_state", "TEXT NOT NULL DEFAULT 'open'"),
+    ("resolved_at", "TEXT"),
+    ("resolved_by", "TEXT"),
+    ("resolved_result_id", "TEXT"),
+    ("finding_policy", "TEXT"),
+    ("retention_policy", "TEXT"),
+    ("next_run_at", "TEXT"),
+    ("transfer_state", "TEXT"),
+)
+
+_CREATE_RUNS = """
+CREATE TABLE IF NOT EXISTS automation_runs (
+    id TEXT PRIMARY KEY,
+    server_id TEXT,
+    owner_id TEXT NOT NULL,
+    definition_id TEXT NOT NULL,
+    definition_version INTEGER NOT NULL DEFAULT 1,
+    trigger_reason TEXT NOT NULL,
+    status TEXT NOT NULL,
+    outcome TEXT NOT NULL DEFAULT 'none',
+    schedule_slot TEXT,
+    scope_snapshot TEXT,
+    finding_policy_snapshot TEXT,
+    rag_request_snapshot TEXT,
+    run_summary TEXT,
+    evidence_summary TEXT,
+    failure_reason TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT,
+    started_at TEXT,
+    ended_at TEXT,
+    UNIQUE (definition_id, definition_version, schedule_slot)
+);
+"""
+
+_CREATE_RESULTS = """
+CREATE TABLE IF NOT EXISTS automation_results (
+    id TEXT PRIMARY KEY,
+    server_id TEXT,
+    owner_id TEXT NOT NULL,
+    definition_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    title TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    answer TEXT,
+    answer_mode TEXT NOT NULL DEFAULT 'none',
+    confidence TEXT,
+    source_refs TEXT,
+    dedupe_key TEXT NOT NULL,
+    visibility_destination TEXT,
+    review_state TEXT NOT NULL DEFAULT 'unread',
+    reviewed_at TEXT,
+    reviewed_by TEXT,
+    review_note TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT,
+    UNIQUE (owner_id, dedupe_key)
+);
+"""
+
+_INDEXES = """
+CREATE INDEX IF NOT EXISTS idx_automation_runs_owner_definition_created
+    ON automation_runs (owner_id, definition_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_automation_runs_owner_status
+    ON automation_runs (owner_id, status);
+CREATE INDEX IF NOT EXISTS idx_automation_results_owner_review
+    ON automation_results (owner_id, review_state, created_at);
+CREATE INDEX IF NOT EXISTS idx_automation_definitions_owner_next_run
+    ON automation_definitions (owner_id, next_run_at);
+"""
+
+
+def migrate(db: _MigrationCapableDB) -> None:
+    """Apply the v3 -> v4 schema migration to ``db``. Idempotent."""
+    with closing(db._get_connection()) as conn:
+        existing = conn.execute(
+            "PRAGMA table_info(automation_definitions)"
+        ).fetchall()
+        if not existing:
+            # No automation_definitions on this connection: nothing to
+            # migrate (same memory-correctness rule as v1_to_v2).
+            return
+        conn.execute(_CREATE_RUNS)
+        conn.execute(_CREATE_RESULTS)
+
+        def_cols = {row[1] for row in existing}
+        for name, decl in _DEFINITION_COLUMNS_V4:
+            if name not in def_cols:
+                conn.execute(
+                    f"ALTER TABLE automation_definitions ADD COLUMN {name} {decl}"
+                )
+        rem_cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(reminder_tasks)")
+        }
+        if "transfer_state" not in rem_cols:
+            conn.execute(
+                "ALTER TABLE reminder_tasks ADD COLUMN transfer_state TEXT"
+            )
+
+        # Indexes last: idx_automation_definitions_owner_next_run needs
+        # next_run_at, added just above.
+        conn.executescript(_INDEXES)
+
+        row = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()
+        current_version = int(row[0]) if row and row[0] is not None else 0
+        if current_version < 4:
+            conn.execute("DELETE FROM schema_version")
+            conn.execute("INSERT INTO schema_version (version) VALUES (?)", (4,))
+        conn.commit()
+    logger.debug(
+        "Scheduling schema migrated to version 4 (automation runs/results)"
+    )
+
+
+def rollback(db: _MigrationCapableDB) -> None:
+    """Revert to v3: drop the new tables and the added columns.
+
+    Column removal uses ALTER TABLE DROP COLUMN (SQLite >=3.35; the
+    Python >=3.11 floor bundles it). Deviation from v2_to_v3's
+    table-recreate rollback is deliberate: ten columns across two tables
+    make recreate disproportionate here.
+    """
+    with closing(db._get_connection()) as conn:
+        conn.execute("DROP TABLE IF EXISTS automation_runs")
+        conn.execute("DROP TABLE IF EXISTS automation_results")
+        def_cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(automation_definitions)")
+        }
+        for name, _decl in _DEFINITION_COLUMNS_V4:
+            if name in def_cols:
+                conn.execute(
+                    f"ALTER TABLE automation_definitions DROP COLUMN {name}"
+                )
+        rem_cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(reminder_tasks)")
+        }
+        if "transfer_state" in rem_cols:
+            conn.execute("ALTER TABLE reminder_tasks DROP COLUMN transfer_state")
+        conn.execute("DELETE FROM schema_version")
+        conn.execute("INSERT INTO schema_version (version) VALUES (?)", (3,))
+        conn.commit()
+    logger.debug("Scheduling schema rolled back to version 3")

--- a/tldw_chatbook/Scheduling/db/migrations/v3_to_v4.py
+++ b/tldw_chatbook/Scheduling/db/migrations/v3_to_v4.py
@@ -27,8 +27,8 @@ _DEFINITION_COLUMNS_V4: tuple[tuple[str, str], ...] = (
     ("resolved_at", "TEXT"),
     ("resolved_by", "TEXT"),
     ("resolved_result_id", "TEXT"),
-    ("finding_policy", "TEXT"),
-    ("retention_policy", "TEXT"),
+    ("finding_policy", "TEXT NOT NULL DEFAULT '{\"preset\": \"balanced_findings\"}'"),
+    ("retention_policy", "TEXT NOT NULL DEFAULT '{\"mode\": \"default\"}'"),
     ("next_run_at", "TEXT"),
     ("transfer_state", "TEXT"),
 )

--- a/tldw_chatbook/Scheduling/db/migrations/v3_to_v4.py
+++ b/tldw_chatbook/Scheduling/db/migrations/v3_to_v4.py
@@ -150,6 +150,13 @@ def rollback(db: _MigrationCapableDB) -> None:
     with closing(db._get_connection()) as conn:
         conn.execute("DROP TABLE IF EXISTS automation_runs")
         conn.execute("DROP TABLE IF EXISTS automation_results")
+        # DROP TABLE above already took idx_automation_runs_* and
+        # idx_automation_results_* with it. This index lives on
+        # automation_definitions itself, so it must go before the
+        # next_run_at column it references is dropped below.
+        conn.execute(
+            "DROP INDEX IF EXISTS idx_automation_definitions_owner_next_run"
+        )
         def_cols = {
             row[1]
             for row in conn.execute("PRAGMA table_info(automation_definitions)")

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -1265,8 +1265,12 @@ class ScheduledTasksDB(BaseDB):
                 params.append(value)
 
         self._validate_sql_identifiers([key.split(" ", 1)[0] for key in updates])
-        updates.append("updated_at = ?")
-        params.append(self._to_utc_iso(datetime.now(timezone.utc)))
+        if "updated_at" not in kwargs:
+            # Auto-stamp only when the caller didn't supply one, mirroring
+            # create_automation_run (caller's value wins) so sync code can
+            # set server timestamps without them being clobbered.
+            updates.append("updated_at = ?")
+            params.append(self._to_utc_iso(datetime.now(timezone.utc)))
         params.append(run_id)
 
         with self.transaction() as conn:

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -219,6 +219,17 @@ class ScheduledTasksDB(BaseDB):
         consistent v4 schema even though each step sees its own
         connection.
         """
+        if self._schema_is_current():
+            # Warm-boot fast path (ADR-097 boot ratchet): a fully-migrated
+            # file DB skips importing the four migration modules entirely,
+            # keeping them out of the `_ui_ready` module census on every
+            # boot after the first. Only a PROOF of completeness skips --
+            # any probe failure (missing table on a fresh or `:memory:`
+            # per-connection DB, an older recorded version) falls through
+            # to the full chain below, whose idempotence remains the
+            # correctness backstop.
+            return
+
         from tldw_chatbook.Scheduling.db.migrations.v0_to_v1 import (
             migrate as migrate_v0_to_v1,
         )
@@ -236,6 +247,28 @@ class ScheduledTasksDB(BaseDB):
         migrate_v1_to_v2(self)
         migrate_v2_to_v3(self)
         migrate_v3_to_v4(self)
+
+    def _schema_is_current(self) -> bool:
+        """Return True when the recorded version proves the chain already ran.
+
+        A single pre-check before the migration chain, not a version
+        consultation between steps -- the `:memory:` discipline in
+        `_initialize_schema`'s docstring is untouched: a memory DB's fresh
+        connection has no ``schema_version`` table, the probe returns
+        False, and the chain runs exactly as before.
+        """
+        try:
+            with closing(self._get_connection()) as conn:
+                row = conn.execute(
+                    "SELECT MAX(version) FROM schema_version"
+                ).fetchone()
+        except sqlite3.Error:
+            return False
+        return bool(
+            row
+            and row[0] is not None
+            and int(row[0]) >= self._CURRENT_SCHEMA_VERSION
+        )
 
     def get_schema_version(self) -> int:
         """Return the currently recorded schema version."""

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -26,7 +26,7 @@ from tldw_chatbook.DB.sql_validation import validate_identifier
 class ScheduledTasksDB(BaseDB):
     """Database operations for scheduled tasks and reminders."""
 
-    _CURRENT_SCHEMA_VERSION = 3
+    _CURRENT_SCHEMA_VERSION = 4
 
     _REMINDER_TASK_COLUMNS = {
         "id",
@@ -75,6 +75,16 @@ class ScheduledTasksDB(BaseDB):
         "created_at",
         "updated_at",
         "archived_at",
+        "disabled_lock_kind",
+        "disabled_reason",
+        "resolution_state",
+        "resolved_at",
+        "resolved_by",
+        "resolved_result_id",
+        "finding_policy",
+        "retention_policy",
+        "next_run_at",
+        "transfer_state",
     }
 
     _AUTOMATION_AUDIT_EVENT_COLUMNS = {
@@ -100,6 +110,8 @@ class ScheduledTasksDB(BaseDB):
         "visibility_policy",
         "notification_policy",
         "approval_policy",
+        "finding_policy",
+        "retention_policy",
     }
 
     _AUDIT_JSON_FIELDS = {
@@ -179,8 +191,10 @@ class ScheduledTasksDB(BaseDB):
         their condition structurally (the presence of their column), which
         is memory-correct: an empty memory database runs v0_to_v1, finds
         no ``missed_count``, adds it, finds no ``timeout_seconds``, adds
-        it, and every step lands on a consistent v3 schema even though
-        each step sees its own connection.
+        it, finds no ``automation_runs``/``automation_results`` tables,
+        adds those and the v4 columns, and every step lands on a
+        consistent v4 schema even though each step sees its own
+        connection.
         """
         from tldw_chatbook.Scheduling.db.migrations.v0_to_v1 import (
             migrate as migrate_v0_to_v1,
@@ -191,10 +205,14 @@ class ScheduledTasksDB(BaseDB):
         from tldw_chatbook.Scheduling.db.migrations.v2_to_v3 import (
             migrate as migrate_v2_to_v3,
         )
+        from tldw_chatbook.Scheduling.db.migrations.v3_to_v4 import (
+            migrate as migrate_v3_to_v4,
+        )
 
         migrate_v0_to_v1(self)
         migrate_v1_to_v2(self)
         migrate_v2_to_v3(self)
+        migrate_v3_to_v4(self)
 
     def get_schema_version(self) -> int:
         """Return the currently recorded schema version."""

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -45,6 +45,7 @@ class ScheduledTasksDB(BaseDB):
         "missed_at",
         "missed_count",
         "timeout_seconds",
+        "transfer_state",
         "link_type",
         "link_id",
         "link_url",

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -133,6 +133,15 @@ class ScheduledTasksDB(BaseDB):
         "run_summary", "evidence_summary", "failure_reason",
     }
 
+    _AUTOMATION_RESULT_COLUMNS = {
+        "server_id", "answer", "answer_mode", "confidence", "source_refs",
+        "visibility_destination", "review_state", "reviewed_at",
+        "reviewed_by", "review_note", "updated_at",
+    }
+    _AUTOMATION_RESULT_JSON_FIELDS = {
+        "answer", "confidence", "source_refs", "visibility_destination",
+    }
+
     _DATETIME_FIELDS = {
         "run_at",
         "next_run_at",
@@ -1319,6 +1328,135 @@ class ScheduledTasksDB(BaseDB):
                 (json.dumps({"code": "interrupted"}), now_iso, now_iso, cutoff),
             )
             return cursor.rowcount
+
+    # ------------------------------------------------------------------
+    # Automation results
+    # ------------------------------------------------------------------
+
+    def create_automation_result(
+        self,
+        owner_id: str,
+        definition_id: str,
+        run_id: str,
+        kind: str,
+        title: str,
+        summary: str,
+        dedupe_key: str,
+        **kwargs: Any,
+    ) -> str | None:
+        """Insert a result; return its id, or None when the dedupe key fired.
+
+        Mirrors ``create_automation_run``'s create shape: no pruning here
+        (results are user-facing findings, not run bookkeeping).
+        """
+        self._validate_kwargs(kwargs, self._AUTOMATION_RESULT_COLUMNS, "automation result")
+        result_id = str(uuid.uuid4())
+        now_iso = self._to_utc_iso(datetime.now(timezone.utc))
+        fields: dict[str, Any] = {
+            "id": result_id,
+            "owner_id": owner_id,
+            "definition_id": definition_id,
+            "run_id": run_id,
+            "kind": kind,
+            "title": title,
+            "summary": summary,
+            "dedupe_key": dedupe_key,
+            "review_state": "unread",
+            "answer_mode": "none",
+            "created_at": now_iso,
+            "updated_at": now_iso,
+        }
+        for key, value in kwargs.items():
+            if value is None:
+                continue
+            if key in self._AUTOMATION_RESULT_JSON_FIELDS:
+                fields[key] = json.dumps(value)
+            elif isinstance(value, datetime):
+                fields[key] = self._to_utc_iso(value)
+            else:
+                fields[key] = value
+        self._validate_sql_identifiers(list(fields.keys()))
+        columns = ", ".join(fields)
+        placeholders = ", ".join("?" for _ in fields)
+        with self.transaction() as conn:
+            try:
+                conn.execute(
+                    f"INSERT INTO automation_results ({columns}) VALUES ({placeholders})",
+                    list(fields.values()),
+                )
+            except sqlite3.IntegrityError:
+                # The (owner_id, dedupe_key) UNIQUE fired: already reported.
+                return None
+        return result_id
+
+    def list_automation_results(
+        self,
+        owner_id: str,
+        review_state: str | None = None,
+        definition_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """List automation results for an owner, newest first.
+
+        Optionally filtered by ``review_state`` and/or ``definition_id``;
+        paginated via ``limit``/``offset``.
+        """
+        conditions = ["owner_id = ?"]
+        params: list[Any] = [owner_id]
+
+        if review_state is not None:
+            conditions.append("review_state = ?")
+            params.append(review_state)
+
+        if definition_id is not None:
+            conditions.append("definition_id = ?")
+            params.append(definition_id)
+
+        where_clause = f"WHERE {' AND '.join(conditions)}"
+        params.extend([limit, offset])
+
+        with closing(self._get_connection()) as conn:
+            cursor = conn.execute(
+                f"SELECT * FROM automation_results {where_clause} "
+                "ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?",
+                params,
+            )
+            return self._rows_to_dicts(
+                cursor.fetchall(), json_fields=self._AUTOMATION_RESULT_JSON_FIELDS
+            )
+
+    def count_unread_results(self, owner_id: str) -> int:
+        """Count unread results for an owner (spec §4's inbox badge)."""
+        with closing(self._get_connection()) as conn:
+            cursor = conn.execute(
+                "SELECT COUNT(*) FROM automation_results "
+                "WHERE owner_id = ? AND review_state = 'unread'",
+                (owner_id,),
+            )
+            row = cursor.fetchone()
+            return int(row[0]) if row else 0
+
+    def update_result_review(
+        self,
+        result_id: str,
+        review_state: str,
+        review_note: str | None = None,
+        reviewed_by: str | None = None,
+    ) -> bool:
+        """Set a result's review state; returns False for an unknown id."""
+        now_iso = self._to_utc_iso(datetime.now(timezone.utc))
+        with self.transaction() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE automation_results
+                SET review_state = ?, review_note = ?, reviewed_by = ?,
+                    reviewed_at = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (review_state, review_note, reviewed_by, now_iso, now_iso, result_id),
+            )
+            return cursor.rowcount > 0
 
     # ------------------------------------------------------------------
     # Sync helpers

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -11,7 +11,7 @@ import json
 import sqlite3
 import uuid
 from contextlib import closing, contextmanager
-from datetime import date, datetime, timezone, tzinfo
+from datetime import date, datetime, timedelta, timezone, tzinfo
 from pathlib import Path
 from typing import Any, Iterator, Optional, Union, cast
 from zoneinfo import ZoneInfo
@@ -118,6 +118,19 @@ class ScheduledTasksDB(BaseDB):
     _AUDIT_JSON_FIELDS = {
         "before",
         "after",
+    }
+
+    _RUNS_RETAINED_PER_DEFINITION = 200
+
+    _AUTOMATION_RUN_COLUMNS = {
+        "server_id", "status", "outcome", "schedule_slot",
+        "scope_snapshot", "finding_policy_snapshot", "rag_request_snapshot",
+        "run_summary", "evidence_summary", "failure_reason",
+        "updated_at", "started_at", "ended_at",
+    }
+    _AUTOMATION_RUN_JSON_FIELDS = {
+        "scope_snapshot", "finding_policy_snapshot", "rag_request_snapshot",
+        "run_summary", "evidence_summary", "failure_reason",
     }
 
     _DATETIME_FIELDS = {
@@ -1150,6 +1163,162 @@ class ScheduledTasksDB(BaseDB):
             f"Created automation audit event {event_id} for definition {definition_id}"
         )
         return event_id
+
+    # ------------------------------------------------------------------
+    # Automation runs
+    # ------------------------------------------------------------------
+
+    def create_automation_run(
+        self,
+        owner_id: str,
+        definition_id: str,
+        definition_version: int,
+        trigger_reason: str,
+        **kwargs: Any,
+    ) -> str | None:
+        """Insert a run; return its id, or None when the slot deduped it.
+
+        Also prunes the definition's runs to the newest
+        ``_RUNS_RETAINED_PER_DEFINITION`` (spec §4.1): an
+        every-15-minutes definition would otherwise write ~35k rows/year.
+        """
+        self._validate_kwargs(kwargs, self._AUTOMATION_RUN_COLUMNS, "automation run")
+        run_id = str(uuid.uuid4())
+        now_iso = self._to_utc_iso(datetime.now(timezone.utc))
+        fields: dict[str, Any] = {
+            "id": run_id,
+            "owner_id": owner_id,
+            "definition_id": definition_id,
+            "definition_version": definition_version,
+            "trigger_reason": trigger_reason,
+            "status": "queued",
+            "outcome": "none",
+            "created_at": now_iso,
+            "updated_at": now_iso,
+        }
+        for key, value in kwargs.items():
+            if value is None:
+                continue
+            if key in self._AUTOMATION_RUN_JSON_FIELDS:
+                fields[key] = json.dumps(value)
+            elif isinstance(value, datetime):
+                fields[key] = self._to_utc_iso(value)
+            else:
+                fields[key] = value
+        columns = ", ".join(fields)
+        placeholders = ", ".join("?" for _ in fields)
+        with self.transaction() as conn:
+            try:
+                conn.execute(
+                    f"INSERT INTO automation_runs ({columns}) VALUES ({placeholders})",
+                    list(fields.values()),
+                )
+            except sqlite3.IntegrityError:
+                # The (definition, version, slot) UNIQUE fired: this slot
+                # already ran. Dedupe is a result, not an error.
+                return None
+            conn.execute(
+                """
+                DELETE FROM automation_runs
+                WHERE definition_id = ? AND id NOT IN (
+                    SELECT id FROM automation_runs
+                    WHERE definition_id = ?
+                    ORDER BY created_at DESC, id DESC
+                    LIMIT ?
+                )
+                """,
+                (definition_id, definition_id, self._RUNS_RETAINED_PER_DEFINITION),
+            )
+        return run_id
+
+    def update_automation_run(self, run_id: str, **kwargs: Any) -> bool:
+        """Update automation-run fields. Returns True if a row changed."""
+        if not kwargs:
+            return False
+
+        self._validate_kwargs(kwargs, self._AUTOMATION_RUN_COLUMNS, "automation run")
+
+        updates: list[str] = []
+        params: list[Any] = []
+
+        for key, value in kwargs.items():
+            if key in self._AUTOMATION_RUN_JSON_FIELDS:
+                updates.append(f"{key} = ?")
+                params.append(self._to_json(value))
+            elif isinstance(value, datetime):
+                updates.append(f"{key} = ?")
+                params.append(self._to_utc_iso(value))
+            else:
+                updates.append(f"{key} = ?")
+                params.append(value)
+
+        self._validate_sql_identifiers([key.split(" ", 1)[0] for key in updates])
+        updates.append("updated_at = ?")
+        params.append(self._to_utc_iso(datetime.now(timezone.utc)))
+        params.append(run_id)
+
+        with self.transaction() as conn:
+            cursor = conn.execute(
+                f"UPDATE automation_runs SET {', '.join(updates)} WHERE id = ?",
+                params,
+            )
+            return cursor.rowcount > 0
+
+    def list_automation_runs(
+        self,
+        owner_id: str,
+        definition_id: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """List automation runs for an owner, newest first.
+
+        Optionally filtered to a single definition; paginated via
+        ``limit``/``offset``.
+        """
+        conditions = ["owner_id = ?"]
+        params: list[Any] = [owner_id]
+
+        if definition_id is not None:
+            conditions.append("definition_id = ?")
+            params.append(definition_id)
+
+        where_clause = f"WHERE {' AND '.join(conditions)}"
+        params.extend([limit, offset])
+
+        with closing(self._get_connection()) as conn:
+            cursor = conn.execute(
+                f"SELECT * FROM automation_runs {where_clause} "
+                "ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?",
+                params,
+            )
+            return self._rows_to_dicts(
+                cursor.fetchall(), json_fields=self._AUTOMATION_RUN_JSON_FIELDS
+            )
+
+    def reconcile_stale_automation_runs(self, older_than_seconds: float) -> int:
+        """Mark queued/running runs older than the cutoff as interrupted.
+
+        Called at scheduler start (spec §4.1): an app killed mid-run must
+        not leave a phantom in-flight run.
+        """
+        cutoff = self._to_utc_iso(
+            datetime.now(timezone.utc) - timedelta(seconds=older_than_seconds)
+        )
+        now_iso = self._to_utc_iso(datetime.now(timezone.utc))
+        with self.transaction() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE automation_runs
+                SET status = 'failed',
+                    failure_reason = ?,
+                    ended_at = ?,
+                    updated_at = ?
+                WHERE status IN ('queued', 'running') AND created_at < ?
+                """,
+                (json.dumps({"code": "interrupted"}), now_iso, now_iso, cutoff),
+            )
+            return cursor.rowcount
 
     # ------------------------------------------------------------------
     # Sync helpers

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -1214,6 +1214,7 @@ class ScheduledTasksDB(BaseDB):
                 fields[key] = self._to_utc_iso(value)
             else:
                 fields[key] = value
+        self._validate_sql_identifiers(list(fields.keys()))
         columns = ", ".join(fields)
         placeholders = ", ".join("?" for _ in fields)
         with self.transaction() as conn:
@@ -1222,7 +1223,9 @@ class ScheduledTasksDB(BaseDB):
                     f"INSERT INTO automation_runs ({columns}) VALUES ({placeholders})",
                     list(fields.values()),
                 )
-            except sqlite3.IntegrityError:
+            except sqlite3.IntegrityError as exc:
+                if "UNIQUE constraint failed" not in str(exc):
+                    raise
                 # The (definition, version, slot) UNIQUE fired: this slot
                 # already ran. Dedupe is a result, not an error.
                 return None
@@ -1384,7 +1387,9 @@ class ScheduledTasksDB(BaseDB):
                     f"INSERT INTO automation_results ({columns}) VALUES ({placeholders})",
                     list(fields.values()),
                 )
-            except sqlite3.IntegrityError:
+            except sqlite3.IntegrityError as exc:
+                if "UNIQUE constraint failed" not in str(exc):
+                    raise
                 # The (owner_id, dedupe_key) UNIQUE fired: already reported.
                 return None
         return result_id

--- a/tldw_chatbook/Scheduling/models.py
+++ b/tldw_chatbook/Scheduling/models.py
@@ -101,6 +101,10 @@ class ReminderTask(BaseModel):
     #: Per-task handler execution timeout in seconds (task-18939). None
     #: means use the global ``[scheduling] handler_timeout_seconds``.
     timeout_seconds: float | None = None
+    #: Transfer state machine marker (schedules-handoff spec §6). NULL =
+    #: not in transfer. Values arrive in a later PR; the column lands with
+    #: schema v4 so readers must tolerate it from day one.
+    transfer_state: str | None = None
     link_type: str | None = None
     link_id: str | None = None
     link_url: str | None = None

--- a/tldw_chatbook/Scheduling/models.py
+++ b/tldw_chatbook/Scheduling/models.py
@@ -60,6 +60,94 @@ class AutomationFamily(str, Enum):
     AGENT_TASK = "agent_task"
 
 
+class RunStatus(str, Enum):
+    """Automation run status — server literals plus local ``timed_out``.
+
+    The server's normalized API folds timeouts into ``failed`` and keeps
+    the truth in ``run_summary.legacy_status``; locally ``timed_out`` is
+    first-class (TASK-18939 vocabulary, spec §4.1).
+    """
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    CANCELLED = "cancelled"
+    TIMED_OUT = "timed_out"
+
+
+class RunOutcome(str, Enum):
+    """Automation run outcome, orthogonal to status."""
+
+    FINDING = "finding"
+    NO_MATCH = "no_match"
+    PARTIAL = "partial"
+    DEGRADED = "degraded"
+    NONE = "none"
+
+
+class ReviewState(str, Enum):
+    """Result review state."""
+
+    UNREAD = "unread"
+    READ = "read"
+    DISMISSED = "dismissed"
+
+
+class AutomationRun(BaseModel):
+    """One local automation execution (server ``RunRow`` shape, spec §4.1)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    server_id: str | None = None
+    owner_id: str = "local"
+    definition_id: str
+    definition_version: int = 1
+    trigger_reason: str
+    status: RunStatus = RunStatus.QUEUED
+    outcome: RunOutcome = RunOutcome.NONE
+    schedule_slot: str | None = None
+    scope_snapshot: dict[str, Any] = Field(default_factory=dict)
+    finding_policy_snapshot: dict[str, Any] = Field(default_factory=dict)
+    rag_request_snapshot: dict[str, Any] = Field(default_factory=dict)
+    run_summary: dict[str, Any] = Field(default_factory=dict)
+    evidence_summary: dict[str, Any] = Field(default_factory=dict)
+    failure_reason: dict[str, Any] | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime | None = None
+    started_at: datetime | None = None
+    ended_at: datetime | None = None
+
+
+class AutomationResult(BaseModel):
+    """One automation result (server ``ResultRow`` shape, spec §4.2)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    server_id: str | None = None
+    owner_id: str = "local"
+    definition_id: str
+    run_id: str
+    kind: str
+    title: str
+    summary: str
+    answer: Any | None = None
+    answer_mode: str = "none"
+    confidence: dict[str, Any] = Field(default_factory=dict)
+    source_refs: list[dict[str, Any]] = Field(default_factory=list)
+    dedupe_key: str
+    visibility_destination: dict[str, Any] = Field(default_factory=dict)
+    review_state: ReviewState = ReviewState.UNREAD
+    reviewed_at: datetime | None = None
+    reviewed_by: str | None = None
+    review_note: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime | None = None
+
+
 class ScheduledTask(BaseModel):
     """Lightweight read-only task projection used for lists and watchlist jobs."""
 
@@ -151,6 +239,20 @@ class AutomationDefinition(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime | None = None
     archived_at: datetime | None = None
+    disabled_lock_kind: str | None = None
+    disabled_reason: str | None = None
+    resolution_state: str = "open"
+    resolved_at: datetime | None = None
+    resolved_by: str | None = None
+    resolved_result_id: str | None = None
+    finding_policy: dict[str, Any] = Field(
+        default_factory=lambda: {"preset": "balanced_findings"}
+    )
+    retention_policy: dict[str, Any] = Field(
+        default_factory=lambda: {"mode": "default"}
+    )
+    next_run_at: datetime | None = None
+    transfer_state: str | None = None
 
 
 class PreviewStatus(str, Enum):
@@ -176,8 +278,9 @@ class AutomationPreview(BaseModel):
     status: PreviewStatus = PreviewStatus.VALID
     payload_hash: str | None = None
     normalized_config: dict[str, Any] | None = None
-    validation_errors: list[str] | None = None
-    warnings: list[str] | None = None
+    risk_class: str | None = None
+    validation_errors: list[dict[str, Any]] | None = None
+    warnings: list[dict[str, Any]] | None = None
     visibility_policy: dict[str, Any] | None = None
     schedule_preview: dict[str, Any] | None = None
     redaction_policy: dict[str, Any] | None = None

--- a/tldw_chatbook/Scheduling/models.py
+++ b/tldw_chatbook/Scheduling/models.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class TaskStatus(str, Enum):
@@ -120,6 +120,19 @@ class AutomationRun(BaseModel):
     started_at: datetime | None = None
     ended_at: datetime | None = None
 
+    @field_validator(
+        "scope_snapshot",
+        "finding_policy_snapshot",
+        "rag_request_snapshot",
+        "run_summary",
+        "evidence_summary",
+        mode="before",
+    )
+    @classmethod
+    def _none_dict_to_default(cls, value: Any) -> Any:
+        """A DB row created without these kwargs stores NULL; coerce it."""
+        return {} if value is None else value
+
 
 class AutomationResult(BaseModel):
     """One automation result (server ``ResultRow`` shape, spec §4.2)."""
@@ -146,6 +159,18 @@ class AutomationResult(BaseModel):
     review_note: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime | None = None
+
+    @field_validator("confidence", "visibility_destination", mode="before")
+    @classmethod
+    def _none_dict_to_default(cls, value: Any) -> Any:
+        """A DB row created without these kwargs stores NULL; coerce it."""
+        return {} if value is None else value
+
+    @field_validator("source_refs", mode="before")
+    @classmethod
+    def _none_list_to_default(cls, value: Any) -> Any:
+        """A DB row created without ``source_refs`` stores NULL; coerce it."""
+        return [] if value is None else value
 
 
 class ScheduledTask(BaseModel):

--- a/tldw_chatbook/Scheduling/slot_keys.py
+++ b/tldw_chatbook/Scheduling/slot_keys.py
@@ -1,0 +1,41 @@
+"""Deterministic idempotency keys for automation runs.
+
+Byte-identical to tldw_server's ``recurring_question_jobs.py`` recipe so
+a definition's slot identity survives handoff in either direction
+(spec-2026-08-31-schedules-handoff-parity.md §7.2).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+
+def canonical_hash(payload: dict) -> str:
+    """Return a stable SHA-256 hex digest for a JSON-compatible payload."""
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def build_scheduled_run_idempotency_key(
+    *, definition_id: str, definition_version: int, schedule_slot: str
+) -> str:
+    """Return the deterministic key for one scheduled slot (server parity)."""
+    return "scheduled-task-rq:" + canonical_hash(
+        {
+            "definition_id": definition_id,
+            "definition_version": definition_version,
+            "schedule_slot": schedule_slot,
+        }
+    )
+
+
+def build_manual_run_idempotency_payload(*, definition_id: str) -> dict[str, str]:
+    """Return the idempotency payload for a manual run (server parity)."""
+    return {
+        "action": "create_manual_run",
+        "definition_id": definition_id,
+        "trigger_reason": "manual",
+    }


### PR DESCRIPTION
PR-1 of the schedules-handoff program (spec: backlog/docs/spec-2026-08-31-schedules-handoff-parity.md §4; sibling PR #2285 is phase 0). Storage floor only — no execution, sync, or UI here.

- **Migration v3→v4** (`v3_to_v4.py`, house pattern: structural self-detection, forward-only stamp, idempotent, `:memory:`-correct): `automation_runs` (slot-dedupe UNIQUE), `automation_results` (owner+dedupe_key UNIQUE), ten `automation_definitions` columns (reference parity + `next_run_at` + `transfer_state`), `reminder_tasks.transfer_state`. Policy columns carry constant JSON DDL defaults matching the model defaults, so pre-v4 rows hydrate. Rollback drops the `next_run_at` index before the column (SQLite requirement), pinned by a migrate→rollback round-trip test.
- **Models**: `RunStatus`/`RunOutcome`/`ReviewState` enums byte-matching tldw_server literals (+ first-class local `timed_out`, TASK-18939 vocabulary); `AutomationRun`/`AutomationResult`; `AutomationPreview.validation_errors/warnings` retyped to the server's `{field, code, message}` dict shape (repo-wide grep: zero consumers of the old shape).
- **Slot keys** (`slot_keys.py`): byte-parity with the server's `recurring_question_jobs.py` idempotency recipe, proven by an independent-reimplementation test.
- **Accessors**: run create (slot-dedupe → `None`, prune to newest 200/definition in-transaction), `reconcile_stale_automation_runs` (interrupted-run recovery), result create/list/review/unread-count. UNIQUE-only IntegrityError narrowing; identifier validation on all INSERT builders.

Tests: `Tests/Scheduling/` 390 passed / 0 failed. Schema slot re-verified against dev tip b62407e25 at PR time: v4 unclaimed, zero scheduling-file drift since branch point.

Known deferred (ledgered for later program PRs): `transfer_state` must be excluded from the server-pull reminder copy-set when transfer lands (PR-5); prune gains owner scoping if run-sync ever lands; `update_result_review` replace semantics revisited at the results-inbox UI (PR-6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WocisXw6SEEG6nb1aKFHtv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the local storage floor for automation runs and results, moving the scheduling schema from v3 to v4. Existing v3 databases upgrade in place on the next open via an idempotent forward-only migration; warm reopens of already-migrated databases skip the migration chain entirely.

**Migration**
- Adds `automation_runs` and `automation_results`, ten `automation_definitions` columns, and `reminder_tasks.transfer_state`.
- UNIQUE constraints back slot idempotency on runs and dedupe-key idempotency on results; slot keys byte-match the server recipe.
- Policy columns carry DDL defaults matching model defaults, so pre-v4 rows hydrate.
- Rollback drops the `next_run_at` index before its column, per SQLite restrictions.

**Behavior changes**
- Run and result inserts return `None` on a UNIQUE collision instead of raising.
- Run inserts prune to the newest 200 per definition in the same transaction.
- `reconcile_stale_automation_runs` marks queued/running runs past a cutoff as failed with an `interrupted` reason.
- Run and result models coerce NULL JSON columns to their defaults; `update_automation_run` honors a caller-supplied `updated_at`.
- `AutomationPreview.validation_errors` and `warnings` change from `list[str]` to the server's `{field, code, message}` dict shape; the old shape has no consumers.
- `RunStatus` adds a first-class local `timed_out`; remaining enum values byte-match server literals.
- Fully-migrated file databases skip migration module imports on warm boot (ADR-097 boot ratchet); probe failures still run the idempotent chain.

<sup>Written for commit 6fc88a71a100994610502bee0b581ed0a84f3c69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

