### PR TITLE
docs(backlog): Console interactive-stall evidence + its measuring instrument

### DIFF
--- a/Helper_Scripts/console_latency_probe.py
+++ b/Helper_Scripts/console_latency_probe.py
@@ -1,20 +1,23 @@
 """In-terminal Console latency probe (TASK-26834's baseline instrument).
 
-Runs the real app with three instruments attached:
+Runs the real app with four instruments attached:
 
-* every Click/Key is stamped at ``Screen._forward_event`` and its window
-  closes at the next ``_compositor_refresh`` -- interaction -> first paint;
+* every Click/Key is stamped at ``Screen._forward_event``; its window closes
+  at the next ``_compositor_refresh`` -- interaction -> first paint;
 * a daemon thread samples the MAIN thread's stack every 10ms while a window
   is open; stalls >100ms report the stacks that occupied them;
-* when the main thread is idle-in-select during a window, every OTHER
-  thread's stack is sampled too, so waiting is attributed, not just noticed.
+* when the main thread is idle-in-select, every OTHER thread is sampled too,
+  so waiting is attributed, not just noticed;
+* every ``set_timer``/``call_later``/``call_after_refresh`` issued inside a
+  window is recorded, so a stall with the whole process idle decomposes into
+  named scheduling hops (the SCHEDULING TIMELINE section).
 
 Run it in the terminal you actually use, poke the interactions that feel
-slow, quit with ctrl+q; the report prints on exit. Findings that produced
-this tool and how to read its output (including which idle-thread stacks
-are noise): TASK-26834. Known limitation: the window closes at the FIRST
-paint after the event, so an interaction that paints a cheap ack early
-under-reports its real answer.
+slow, quit with ctrl+q; the report prints on exit. How to read it -- including
+which idle-thread stacks are noise and the known framing artifact where a
+click with NO visible response records as slow -- is on TASK-26834. Window
+semantics: closes at the FIRST paint after the event, so early-ack
+interactions under-report; medians are optimistic, the tail is trustworthy.
 
 Usage: .venv/bin/python Helper_Scripts/console_latency_probe.py
 """
@@ -38,6 +41,8 @@ STATS = {
     "worker_stacks": collections.Counter(),  # what OTHER threads did while main waited
     "window_samples": [],
     "window_worker_samples": [],
+    "window_trace": [],
+    "slow_traces": [],
     "main_thread_id": None,
     "sampler_thread_id": None,
 }
@@ -133,6 +138,49 @@ def _install() -> None:
 
         LinuxDriver.write = write
 
+    # v4: while a window is open, record every scheduling call, so a wait
+    # with the whole process idle decomposes into named timer/deferred hops.
+    from textual.message_pump import MessagePump
+
+    def _cb_name(callback) -> str:
+        target = getattr(callback, "__func__", callback)
+        name = getattr(target, "__qualname__", None) or repr(target)
+        return name[:60]
+
+    def _trace(owner, api, detail) -> None:
+        with _LOCK:
+            p = STATS["pending"]
+            if p is None:
+                return
+            offset = (time.perf_counter() - p[1]) * 1000
+            STATS["window_trace"].append(
+                (offset, f"{api} {detail} by {type(owner).__name__}")
+            )
+
+    o_set_timer = MessagePump.set_timer
+
+    def set_timer(self, delay, callback=None, *a, **k):
+        _trace(self, "set_timer", f"{delay:.3f}s -> {_cb_name(callback)}")
+        return o_set_timer(self, delay, callback, *a, **k)
+
+    MessagePump.set_timer = set_timer
+
+    o_call_later = MessagePump.call_later
+
+    def call_later(self, callback, *a, **k):
+        _trace(self, "call_later", _cb_name(callback))
+        return o_call_later(self, callback, *a, **k)
+
+    MessagePump.call_later = call_later
+
+    o_car = MessagePump.call_after_refresh
+
+    def call_after_refresh(self, callback, *a, **k):
+        _trace(self, "call_after_refresh", _cb_name(callback))
+        return o_car(self, callback, *a, **k)
+
+    MessagePump.call_after_refresh = call_after_refresh
+
     o_forward = Screen._forward_event
 
     def forward(self, event):
@@ -150,6 +198,7 @@ def _install() -> None:
             with _LOCK:
                 STATS["pending"] = (label, time.perf_counter(), STATS["full"], STATS["bytes"])
                 STATS["window_samples"] = []
+                STATS["window_trace"] = []
         return o_forward(self, event)
 
     Screen._forward_event = forward
@@ -171,9 +220,16 @@ def _install() -> None:
                         STATS["stall_stacks"][stack] += 1
                     for stack in STATS["window_worker_samples"]:
                         STATS["worker_stacks"][stack] += 1
+                if dur >= 100:
+                    STATS["slow_traces"].append(
+                        (dur, label, list(STATS["window_trace"])[:40])
+                    )
+                    STATS["slow_traces"].sort(key=lambda e: -e[0])
+                    del STATS["slow_traces"][8:]
                 STATS["pending"] = None
                 STATS["window_samples"] = []
                 STATS["window_worker_samples"] = []
+                STATS["window_trace"] = []
         return r
 
     Screen._compositor_refresh = refresh
@@ -218,6 +274,17 @@ def _report() -> None:
             print(f"\n  ~{n * 10:>5d} ms total, {n} samples:")
             for line in stack:
                 print(f"      {line}")
+    if STATS["slow_traces"]:
+        print("\nSCHEDULING TIMELINE of the slowest windows")
+        print("(+ms after the input event; what was scheduled, by whom)")
+        for dur, label, trace in STATS["slow_traces"][:5]:
+            print(f"\n  {label[:52]}  ({dur:.0f} ms to first paint)")
+            if not trace:
+                print("      (nothing scheduled inside the window)")
+            for offset, line in trace[:14]:
+                print(f"      +{offset:7.1f} ms  {line}")
+            if len(trace) > 14:
+                print(f"      ... {len(trace) - 14} more")
     print("=" * 70)
 
 

--- a/Helper_Scripts/console_latency_probe.py
+++ b/Helper_Scripts/console_latency_probe.py
@@ -1,0 +1,234 @@
+"""In-terminal Console latency probe (TASK-26834's baseline instrument).
+
+Runs the real app with three instruments attached:
+
+* every Click/Key is stamped at ``Screen._forward_event`` and its window
+  closes at the next ``_compositor_refresh`` -- interaction -> first paint;
+* a daemon thread samples the MAIN thread's stack every 10ms while a window
+  is open; stalls >100ms report the stacks that occupied them;
+* when the main thread is idle-in-select during a window, every OTHER
+  thread's stack is sampled too, so waiting is attributed, not just noticed.
+
+Run it in the terminal you actually use, poke the interactions that feel
+slow, quit with ctrl+q; the report prints on exit. Findings that produced
+this tool and how to read its output (including which idle-thread stacks
+are noise): TASK-26834. Known limitation: the window closes at the FIRST
+paint after the event, so an interaction that paints a cheap ack early
+under-reports its real answer.
+
+Usage: .venv/bin/python Helper_Scripts/console_latency_probe.py
+"""
+import collections
+import statistics
+import sys
+import threading
+import time
+
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+STATS = {
+    "events": [],
+    "pending": None,      # (label, t0, full0, bytes0)
+    "full": 0,
+    "partial": 0,
+    "bytes": 0,
+    "stall_stacks": collections.Counter(),   # stack-tuple -> samples (10ms each)
+    "worker_stacks": collections.Counter(),  # what OTHER threads did while main waited
+    "window_samples": [],
+    "window_worker_samples": [],
+    "main_thread_id": None,
+    "sampler_thread_id": None,
+}
+_LOCK = threading.Lock()
+
+
+def _fmt_frame(frame) -> str:
+    code = frame.f_code
+    fn = code.co_filename
+    short = fn.split("/")[-1]
+    if "/textual/" in fn or "/site-packages/" in fn:
+        short = "lib:" + short
+    elif "/tldw_chatbook/" in fn:
+        short = "app:" + short
+    return f"{short}:{frame.f_lineno}:{code.co_name}"
+
+
+def _stack_of(frame) -> tuple:
+    stack = []
+    depth = 0
+    while frame is not None and depth < 25:
+        stack.append(_fmt_frame(frame))
+        frame = frame.f_back
+        depth += 1
+    return tuple(stack[:6])
+
+
+_IDLE_TOKENS = ("selectors.py", "threading.py", "queue.py", "socket.py")
+
+
+def _looks_idle(stack: tuple) -> bool:
+    top = stack[0] if stack else ""
+    return any(tok in top for tok in _IDLE_TOKENS) and (
+        ":select" in top or ":wait" in top or ":get" in top or ":accept" in top
+        or ":_recv" in top or ":recv" in top
+    )
+
+
+def _sampler() -> None:
+    while True:
+        time.sleep(0.010)
+        with _LOCK:
+            pending = STATS["pending"]
+        if pending is None:
+            continue
+        frames = sys._current_frames()
+        main = frames.get(STATS["main_thread_id"])
+        if main is None:
+            continue
+        main_stack = _stack_of(main)
+        busy_workers = []
+        if _looks_idle(main_stack):
+            # Main is waiting: what is everyone else doing?
+            for tid, frame in frames.items():
+                if tid in (STATS["main_thread_id"], STATS["sampler_thread_id"]):
+                    continue
+                stack = _stack_of(frame)
+                if stack and not _looks_idle(stack):
+                    busy_workers.append(stack)
+        with _LOCK:
+            STATS["window_samples"].append(main_stack)
+            STATS["window_worker_samples"].extend(busy_workers)
+
+
+def _install() -> None:
+    STATS["main_thread_id"] = threading.get_ident()
+    from textual._compositor import Compositor
+    from textual.screen import Screen
+    from textual import events
+
+    o_full = Compositor.render_full_update
+    o_part = Compositor.render_partial_update
+
+    def sfull(self, *a, **k):
+        STATS["full"] += 1
+        return o_full(self, *a, **k)
+
+    def spart(self, *a, **k):
+        STATS["partial"] += 1
+        return o_part(self, *a, **k)
+
+    Compositor.render_full_update = sfull
+    Compositor.render_partial_update = spart
+
+    from textual.drivers.linux_driver import LinuxDriver
+
+    if hasattr(LinuxDriver, "write"):
+        o_write = LinuxDriver.write
+
+        def write(self, data, _o=o_write):
+            STATS["bytes"] += len(data)
+            return _o(self, data)
+
+        LinuxDriver.write = write
+
+    o_forward = Screen._forward_event
+
+    def forward(self, event):
+        if isinstance(event, (events.Click, events.Key)):
+            label = "click"
+            if isinstance(event, events.Key):
+                label = f"key:{event.key}"
+            else:
+                try:
+                    widget, _ = self.get_widget_at(event.screen_x, event.screen_y)
+                    wid = getattr(widget, "id", None) or type(widget).__name__
+                    label = f"click:{wid}"
+                except Exception:
+                    pass
+            with _LOCK:
+                STATS["pending"] = (label, time.perf_counter(), STATS["full"], STATS["bytes"])
+                STATS["window_samples"] = []
+        return o_forward(self, event)
+
+    Screen._forward_event = forward
+
+    o_refresh = Screen._compositor_refresh
+
+    def refresh(self):
+        r = o_refresh(self)
+        with _LOCK:
+            p = STATS["pending"]
+            if p is not None:
+                label, t0, f0, b0 = p
+                dur = (time.perf_counter() - t0) * 1000
+                STATS["events"].append(
+                    (label, dur, STATS["full"] - f0, STATS["bytes"] - b0)
+                )
+                if dur >= 100 and STATS["window_samples"]:
+                    for stack in STATS["window_samples"]:
+                        STATS["stall_stacks"][stack] += 1
+                    for stack in STATS["window_worker_samples"]:
+                        STATS["worker_stacks"][stack] += 1
+                STATS["pending"] = None
+                STATS["window_samples"] = []
+                STATS["window_worker_samples"] = []
+        return r
+
+    Screen._compositor_refresh = refresh
+
+    t = threading.Thread(target=_sampler, daemon=True, name="latency-sampler")
+    t.start()
+    STATS["sampler_thread_id"] = t.ident
+
+
+def _report() -> None:
+    ev = STATS["events"]
+    if not ev:
+        print("\nno interactions recorded")
+        return
+    print("\n" + "=" * 70)
+    print("INTERACTION -> PAINT (v2)")
+    print("=" * 70)
+    ms = sorted(e[1] for e in ev)
+    p95 = ms[int(len(ms) * 0.95)] if len(ms) > 1 else ms[0]
+    print(f"\nall interactions (n={len(ev)}): median {statistics.median(ms):6.1f} ms  "
+          f"p95 {p95:6.1f} ms  max {max(ms):7.1f} ms")
+    print(f"totals: {STATS['full']} full redraws, {STATS['partial']} partial, "
+          f"{STATS['bytes']:,} bytes written")
+
+    slow = sorted(ev, key=lambda e: -e[1])[:8]
+    print("\nslowest 8 interactions (what was clicked):")
+    for label, dur, full, nbytes in slow:
+        print(f"  {dur:8.1f} ms  {label[:44]:44} full={full} bytes={nbytes:,}")
+
+    if STATS["stall_stacks"]:
+        print("\nWHAT THE MAIN THREAD WAS DOING during stalls >100ms")
+        print("(each sample ~10ms; innermost frame first)")
+        for stack, n in STATS["stall_stacks"].most_common(8):
+            print(f"\n  ~{n * 10:>5d} ms total, {n} samples:")
+            for line in stack:
+                print(f"      {line}")
+    else:
+        print("\nno stalls >=100ms sampled")
+    if STATS["worker_stacks"]:
+        print("\nWHAT OTHER THREADS WERE DOING while the main thread waited")
+        for stack, n in STATS["worker_stacks"].most_common(8):
+            print(f"\n  ~{n * 10:>5d} ms total, {n} samples:")
+            for line in stack:
+                print(f"      {line}")
+    print("=" * 70)
+
+
+def main() -> None:
+    _install()
+    from tldw_chatbook.app import main_cli_runner
+    try:
+        main_cli_runner()
+    finally:
+        _report()
+
+
+if __name__ == "__main__":
+    main()

--- a/backlog/tasks/task-26834 - Console-interactive-stalls-session-tab-switch-subtree-remount-CSS-uncached-title-lookup.md
+++ b/backlog/tasks/task-26834 - Console-interactive-stalls-session-tab-switch-subtree-remount-CSS-uncached-title-lookup.md
@@ -114,3 +114,55 @@ under-report — median figures are optimistic, the tail is trustworthy.
 **Next instrument, if the timer-chain suspicion needs proof:** log
 `Timer.__init__`/`call_later`/`call_after_refresh` call sites with timestamps
 while a window is open, so a 300ms wait decomposes into named hops.
+
+## Third run (v4, scheduling timelines): cause 1 RESOLVED to the tray recompose batch
+
+The v4 probe recorded every `set_timer`/`call_later`/`call_after_refresh`
+issued inside each stall window. Slowest interactive clicks this run:
+`console-workspace-conversation-2` 557ms, `console-workspace-conversation-1`
+484ms — both full=0, i.e. no full redraw, just a LATE first paint.
+
+The conversation-row timeline names the whole chain, and each link was then
+verified in source:
+
+```
++  2.6ms  set_timer 0.200s -> remove_class            (Button press effect)
++  4.4ms  call_after_refresh _prepare_allocation_reconcile   ConsoleLeftRail
++ 27.7ms  call_after_refresh _schedule_recomposed_content_fit  x2  Tray
++ 27.8ms  call_after_refresh _run_scheduled_reconcile   _ContextBoundedSection
++ 33.5ms  call_after_refresh _schedule_recomposed_content_fit  x2  Tray
++ 90.9ms  call_after_refresh refresh_bindings
++127.4ms  call_after_refresh _run_scheduled_reconcile  x2
+... 26 more, first paint at +557ms
+```
+
+**Verified mechanism, link by link:**
+
+1. A row click changes tray state; `ConsoleWorkspaceContextTray` recomposes
+   unless `_can_skip_recompose` can PROVE the mounted DOM current (the guard
+   is deliberately conservative -- its own comments record that skipping
+   recompose broke collapse rendering, so "no proof" means full recompose).
+2. Textual's `Widget.recompose()` runs `async with self.batch()` --
+   **no compositor paints while the batch is open** (`_on_timer_update` and
+   `_on_idle` both skip under `app._batch_count`).
+3. The remount pays per-node CSS apply -- the 90-150ms `stylesheet.apply`
+   buckets sampled in every run -- plus the `call_after_refresh` reconcile
+   hops visible above, stretching the batch's wall time.
+4. First paint (including the selection highlight the user clicked FOR)
+   lands only when the batch closes: ~500ms of frozen screen per row click.
+
+Fix directions, in preference order: (a) make row selection an in-place
+update (toggle row classes) that never recomposes the tray; (b) teach
+`_can_skip_recompose` to prove selection-only changes; (c) at minimum, paint
+a selection ack before entering the recompose path.
+
+**Also resolved -- a probe framing artifact, recorded so it is not chased:**
+`click:console-workspace-tree` 354ms shows ONE deferral at +1ms then 341ms of
+nothing: a click with no visible response at all. `Screen._on_idle` invokes
+pending callbacks immediately when nothing is dirty, so the callback ran
+promptly; the "answering paint" that closed the window was an unrelated
+tooltip/hover repaint. Clicks that legitimately paint nothing record as slow.
+
+**Ruled out:** the earlier suspicion that `call_after_refresh` waits for an
+ambient tick. `_on_idle` flushes callbacks directly when the screen is clean;
+the waits are batches and cascades, not a paused timer.

--- a/backlog/tasks/task-26834 - Console-interactive-stalls-session-tab-switch-subtree-remount-CSS-uncached-title-lookup.md
+++ b/backlog/tasks/task-26834 - Console-interactive-stalls-session-tab-switch-subtree-remount-CSS-uncached-title-lookup.md
@@ -1,0 +1,116 @@
+---
+id: TASK-26834
+title: >-
+  Console interactive stalls: session-tab switch, subtree remount CSS, uncached
+  title lookup
+status: To Do
+assignee: []
+created_date: '2026-09-01 06:23'
+labels:
+  - console
+  - performance
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+In-terminal sampling of the real app (2026-08-31, iTerm2, 55 clicks) shows Console clicks are fast at the median (15.7ms to first paint) but carry a heavy tail: p95 735ms, max 1255ms. The tail, not the median, is the reported button sluggishness. Each stall over 100ms was stack-sampled at 10ms resolution and attributes to three causes below; screen NAVIGATION cost (nav-console 1255ms) is excluded here as already owned by TASK-1320/TASK-24452/TASK-24455.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Clicking a session tab paints its answer in under 150ms on the reference terminal, or the remaining wait is attributed to a named worker operation with its own task
+- [ ] #2 Interactions that restyle or remount a Console subtree no longer spend >100ms in stylesheet apply/selector matching on the main thread
+- [ ] #3 _active_console_provider_model_display_uncached no longer performs a registry get_workspace per invocation on the click path
+- [ ] #4 Improvements are measured with the same in-terminal sampler that produced the baseline, before and after
+<!-- AC:END -->
+
+## Evidence (real app, real terminal — not a headless harness)
+
+Probe: `Screen._forward_event` stamps each Click; `Screen._compositor_refresh`
+closes the window; a daemon thread samples the main thread's stack every 10ms
+while a window is open. iTerm2 3.5.14, local, 55 clicks. Headless harnesses
+measured this same app at ~10-30ms per click for a week and missed all of it —
+none of the causes below reproduce without real session state.
+
+```
+all interactions (n=55): median 15.7ms  p95 734.8ms  max 1255.2ms
+slowest: nav-console 1255ms(owned elsewhere) | workspace-tree 848ms |
+         session-tab 735ms | RoleplayMarkdownParagraph 518ms |
+         session-tab 402ms | model-search-picker-input 378ms
+```
+
+### Cause 1 — waiting, not computing (~720ms sampled in `selectors.py:select`)
+
+The largest bucket has the main thread IDLE in the event loop while a click's
+answering paint is pending. Session-tab clicks (735ms, 402ms, full=0) fit
+this: the click dispatches work to a worker and the UI paints only on its
+callback. The main-thread sampler cannot see into the worker; probe v3
+(all-thread sampling) exists to name it. Do not start on this cause without
+that attribution — "waiting" has looked like three different culprits already
+this week and been wrong twice.
+
+### Cause 2 — CSS selector matching over remounted subtrees (~550ms sampled)
+
+Five distinct stacks, all `stylesheet.apply -> _check_rule -> match`, arriving
+via `app.py:_register` (fresh mounts) and `update_nodes/update_styles`
+(restyles). They pass through `textual_css_fastpath.py:127` — the NARROWED
+branch, so the TASK-15450-era fastpath is installed and working; the residual
+cost is per-NODE volume, not per-rule: a session-tab switch remounts a
+transcript's worth of widgets and each pays narrowed matching. Same disease as
+TASK-24452's "re-mints 559 widgets", but for in-Console interactions rather
+than screen entry. Likely shape of a fix: reuse/recycle transcript widgets on
+session switch instead of remounting.
+
+### Cause 3 — uncached registry lookup on the click path (~60ms sampled)
+
+`registry_service.py:499:get_workspace` inside
+`workspace.py:3855:_console_workspace_session_title` inside
+`chat_screen.py:6778:_active_console_provider_model_display_uncached`. The
+function's own name says uncached; the samples say it runs during click
+handling.
+
+### Excluded, already owned
+
+`click:nav-console` 1255ms is screen-switch cost: TASK-1320 (mount I/O off the
+message pump, In Progress), TASK-24452 (559 re-minted widgets), TASK-24455
+(598 query_one lookups). Evidence here corroborates them; no new task filed.
+
+## Second run (v3, all-thread sampling): the waits are TIMERS, not work
+
+The v3 probe sampled every thread while the main thread sat idle in a
+click->paint window. Result: **no thread in the process was computing.**
+The two large "other threads" buckets decode as noise, recorded so nobody
+chases them:
+
+- `thread.py:90:_worker`, 528 samples — idle ThreadPoolExecutor threads
+  blocked in C-level `SimpleQueue.get` (the C frame is invisible, so the
+  Python caller shows as top-of-stack). 528 ≈ 87 sampling ticks x ~6 pool
+  threads.
+- `ui_responsiveness.py:79:_drain_stalls`, 87 samples — the stall monitor's
+  own drain thread, blocked the same way.
+
+So the residual stall class (this run: `model-search-picker-input` 352ms and
+192ms with 720/126-byte answering paints, `SelectOverlay` 300ms,
+`ConsoleModelPopover` 142ms) is **scheduling latency**: the answering paint
+arrives when a timer or deferred-callback chain fires, not when work
+completes. The Console leans heavily on `call_after_refresh` chains, and each
+hop waits for a refresh tick. The picker's `_BLUR_RESTORE_DELAY_SECONDS` is
+only 0.05s, so no single constant explains 300ms — multi-hop chains are the
+suspect, unproven.
+
+Cause-2 CSS matching measured ~150ms total this session vs ~550ms in run 1 —
+the cost tracks how much remounting the session's clicks did, consistent with
+the per-node-volume reading.
+
+**Instrument preserved** as `Helper_Scripts/console_latency_probe.py` (this
+task's AC requires re-measuring with the same sampler; the scratchpad copy
+dies with the session). Known limitation documented in its docstring: the
+window closes at the FIRST paint, so interactions that ack early
+under-report — median figures are optimistic, the tail is trustworthy.
+
+**Next instrument, if the timer-chain suspicion needs proof:** log
+`Timer.__init__`/`call_later`/`call_after_refresh` call sites with timestamps
+while a window is open, so a 300ms wait decomposes into named hops.


### PR DESCRIPTION
Backlog + one diagnostic script. The output of the Console button-latency investigation's real-terminal phase.

## What two in-terminal runs established

Median click is **fast** (7.7–15.7 ms to first paint). The felt slowness is a **tail**: p95 255–735 ms, max 1255 ms — roughly 1 click in 20. Every stall >100 ms was stack-sampled at 10 ms resolution, eventually on **every thread**.

| Cause | Sampled | Owner |
|---|---|---|
| CSS selector matching over remounted subtrees (via the fastpath's *narrowed* branch — per-node volume, not per-rule) | ~550 ms (run 1), ~150 ms (run 2, tracks remount volume) | **TASK-26834** |
| Screen-switch cost (`nav-console` 1255 ms, `nav-personas` 424 ms) | — | TASK-1320 (in progress), TASK-24452, TASK-24455 — corroborated, not re-filed |
| `get_workspace` registry lookup inside `_active_console_provider_model_display_uncached` | ~60 ms | TASK-26834 |
| Main thread **idle in select** while the answer is pending | ~720–870 ms | TASK-26834, attributed below |

## The subtle one

All-thread sampling shows that during the idle-wait stalls **no thread in the process is computing**. The two big "worker" stacks decode to noise — idle ThreadPoolExecutor threads and the stall monitor's drain thread, both blocked in C-level `SimpleQueue.get` (528 samples ≈ 87 ticks × 6 pool threads). The record spells this out so nobody chases `thread.py:90:_worker`.

That leaves **scheduling latency**: the answering paint fires from a timer or a `call_after_refresh` chain, not from completed work. No single constant explains it (the picker's blur-restore delay is 0.05 s), so the task names multi-hop deferred chains as the suspect and specifies the next instrument — log timer/deferred scheduling call sites inside stall windows — rather than asserting a cause.

## Why the instrument is checked in

TASK-26834's AC requires re-measuring with the same sampler; the copy lived in a session scratchpad that dies with the session. `Helper_Scripts/console_latency_probe.py` is that sampler, docstring carrying its known limitation: the window closes at the **first** paint, so early-ack interactions under-report — medians are optimistic, the tail is trustworthy.

Also worth recording: headless harnesses measured this same app at 10–30 ms per click for days and missed every cause above. None reproduce without real session state and a real TTY.

`preflight`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrN2mbF8byxMfPNPtVJwFb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backlog task TASK-26834 with real-terminal evidence that Console button sluggishness is a latency tail (p95 255–735 ms, max 1255 ms), not the fast median click, and resolves the largest stall cause to the tray recompose batch. Checks in `Helper_Scripts/console_latency_probe.py`, the in-terminal sampler used for the baseline, so the task's acceptance criteria can re-measure with the same instrument. Both files are new; no runtime code changes.

**Findings**
- Largest stall cause: row clicks recompose `ConsoleWorkspaceContextTray` inside a Textual batch that blocks all paints until it closes (~500 ms frozen per row click); the suggested fix is in-place row selection that never recomposes the tray.
- Secondary causes: CSS selector matching over remounted subtrees and an uncached `get_workspace` registry lookup on the click path.
- Records noise so nobody chases it: idle "worker" stacks are ThreadPoolExecutor threads blocked in `SimpleQueue.get`; screen-navigation stalls are already owned elsewhere.

**Instrument**
- Stack-samples the main thread every 10 ms within each click-to-first-paint window and logs timer/deferred scheduling calls.
- Window closes at first paint, so medians are optimistic but the tail is trustworthy.
- Headless harnesses missed every cause; they only reproduce with real session state and a real TTY.

<sup>Written for commit dda42a0836a43ece6bbaa9af753ab2479b974e0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

