### PR TITLE
docs(backlog): final attribution of the Console stalls; TASK-26835 closed refuted

### DIFF
--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -10384,6 +10384,37 @@ check".
 
 ---
 
+## A mechanism assembled from verified links is still a hypothesis
+
+**Incident.** TASK-26835, 2026-09-01. Chasing the Console's paint stalls, I
+read five Textual internals in source — `call_after_refresh`, the Screen's
+idle handler, `Timer._run`, `App._end_batch`, `App._on_idle` — verified each
+individually, composed them into a "screen frozen until the next input event"
+mechanism, and filed a HIGH task describing it as "verified link by link".
+The reproduction test refuted it the same hour: a bare app recomposing under
+batch paints promptly, because two relays my derivation had missed
+(`Widget.refresh` → widget Idle → `_check_refresh` → `Update`/`Layout` posted
+to the screen) close the loop. A second composed theory — deferred callbacks
+waiting on an ambient tick — died the same way earlier that day.
+
+What settled it was neither derivation: instrumenting the LIVE app to sample
+the actual invariants (`batch_count`, timer paused/running, dirty count, which
+idle branch ran) every 10ms inside stall windows. The real mechanism was
+nested App-level batches held open 250-400ms by tray recompose cascades —
+observable directly as `screen.Idle guarded(batch=3)` and
+`STATE batch=2 dirty=71`, no assembly required.
+
+**What to do.** Source-reading tells you what CAN happen; only a failing
+reproduction or live-state sampling tells you what DOES. Write the failing
+repro BEFORE filing the mechanism as fact — it is also what stops you
+shipping a fix against it. When a composed mechanism spans more than two
+components, prefer instrumenting the running system to derivation: print the
+invariants the theory depends on and let the system disagree. And when the
+repro passes unpatched, say REFUTED in the record, loudly — the plausible
+version left standing costs the next person a day.
+
+---
+
 ## Sweep the files that ASSERT on your change, not the files you edited
 
 **Incident.** TASK-25715, 2026-08-31. Across seven batches of Console Context

--- a/backlog/tasks/task-26834 - Console-interactive-stalls-session-tab-switch-subtree-remount-CSS-uncached-title-lookup.md
+++ b/backlog/tasks/task-26834 - Console-interactive-stalls-session-tab-switch-subtree-remount-CSS-uncached-title-lookup.md
@@ -166,3 +166,42 @@ tooltip/hover repaint. Clicks that legitimately paint nothing record as slow.
 **Ruled out:** the earlier suspicion that `call_after_refresh` waits for an
 ambient tick. `_on_idle` flushes callbacks directly when the screen is clean;
 the waits are batches and cascades, not a paused timer.
+
+## Fourth run (v6, live invariants): cause 1 fully attributed, fix targets exact
+
+Probe v6 sampled `batch_count`, the update-timer flag, dirty counts and the
+Idle branch every 10ms inside stall windows. Two shapes, directly observed:
+
+**The real freeze -- nested batches held open 250-400ms.** The 406ms tree
+click shows `screen.Idle guarded(batch=2, current=True)` at +107ms and
+`STATE batch=2 timer=PAUSED dirty=71 lay=1 rep=1` at +250ms, with widget
+mounts still landing at +261ms. The 325ms window reaches `batch=3`. Textual
+withholds ALL paints while any batch is open (by design); each tray/section
+recompose opens one, they nest, and the mount + CSS + reconcile storm runs
+INSIDE them. First paint = last batch closing. The earlier "frozen until next
+input" theory (TASK-26835) is refuted -- no input rescue is involved.
+
+**Not-a-bug shape, recorded so it is not chased:** several 215-273ms tree
+clicks show `dirty=0 cb=0 batch=0` for 26 straight ticks -- the app owed
+nothing; the click had no visible response and the eventual ~2.4KB paint was
+hover styling from the next mouse move. Probe framing artifact (window closes
+on first paint of ANY cause) plus, at most, a missing click acknowledgement.
+
+**Exact fix targets, in value order:**
+
+1. `tray.sync_state delta=conversation_browser` alone forces a FULL tray
+   recompose (observed directly). Browser-rows-only deltas should update the
+   browser section in place; the recompose (and its batch) disappears for
+   the most common tree/row interactions.
+2. One click recomposes BOTH tray instances (`console-workspaces-context`
+   AND `console-workspace-context`) back to back -- two nested batches, twice
+   the mounts, for one interaction.
+3. The `_run_scheduled_reconcile` x6 + `_schedule_recomposed_content_fit`
+   storm runs inside the batch window; coalescing it (one settled pass) or
+   letting it run after first paint shortens the batch either way.
+
+Also seen this run, small but real: the workspace-title `get_workspace`
+lookup (cause 3) sampled again at ~40ms across two stacks, and
+`_recompute_filesystem_binding_status` doing `pathlib.stat` on the main
+thread inside `build_console_workspace_state` (~20ms) -- filesystem I/O in a
+click-path state build.

--- a/backlog/tasks/task-26835 - Textual-batch-updates-leave-the-screen-frozen-until-the-next-input-event.md
+++ b/backlog/tasks/task-26835 - Textual-batch-updates-leave-the-screen-frozen-until-the-next-input-event.md
@@ -1,0 +1,86 @@
+---
+id: TASK-26835
+title: Textual batch updates leave the screen frozen until the next input event
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-09-01 14:27'
+updated_date: '2026-09-01 14:40'
+labels:
+  - console
+  - performance
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The dominant cause of TASK-26834's felt button lag, verified link by link in Textual 8.x source with the in-terminal probe. Any refresh(recompose=True) runs inside 'async with self.batch()'. If the Screen's queue drains while the batch is open, Screen._on_idle skips its paint-timer resume (batch guard). When the batch closes, App._end_batch calls check_idle on the APP's pump, and App._on_idle handles only resize -- nothing ever pokes the Screen again. Dirty widgets sit unpainted with the update timer paused until the next real input event lands on the Screen's queue. Measured: a rail section-header click completed all scheduling by +12.7ms and painted at +234.7ms, unblocked by a mouse-move; tray recomposes freeze the UI 300-700ms when the mouse holds still.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The claimed mechanism is either reproduced with a failing test or refuted with live-state evidence (REFUTED -- see notes)
+- [x] #2 The refutation and the actual mechanism are recorded where the fix work lives (TASK-26834)
+- [x] #3 No fix was shipped against the invalid premise
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing test: bare Textual app, recompose under batch with no input, assert a paint arrives promptly (fails unpatched)\n2. Utils/textual_batch_repaint.py: install patch on App._end_batch that pokes the current screen when the last batch closes\n3. Wire install next to install_stylesheet_fastpath in app.py\n4. Sweep console UI files incl. snapshots; preflight; PR with probe-verified before/after
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+This task's premise is REFUTED, twice over, and no fix was shipped against it.
+
+1. The bare-app reproduction paints promptly unpatched (first correction,
+   above): Textual's widget-idle relay posts Update/Layout to the screen and
+   closes the loop my derivation had open.
+2. Probe v6 then sampled the live invariants during real stalls. The frozen
+   windows show `screen.Idle guarded(batch=2..3)` and
+   `STATE batch=2 timer=PAUSED dirty=71 lay=1 rep=1` at +250ms: the paint is
+   withheld because NESTED App-level batches stay open for 250-400ms while
+   tray recomposes mount dozens of widgets and run their reconcile storm
+   inside the batch. First paint is the batch closing -- no input event is
+   involved. The windows that DID end on a mouse-move (`dirty=0` for 26
+   straight ticks) owed nothing at all: clicks with no visible response,
+   a probe framing artifact plus at most a missing click-ack.
+
+The real mechanism and its fix directions live on TASK-26834. The bare-app
+freeze test written here was deleted rather than shipped: it pins framework
+behavior that was never broken.
+
+Lesson credit: the no-fix-without-failing-repro rule is what stopped this
+twice -- the mechanism read plausibly in source both times.
+<!-- SECTION:NOTES:END -->
+
+## Correction (2026-09-01, before any fix): the composed mechanism is UNPROVEN
+
+The description above says "verified link by link" -- each link IS verified in
+source, but the COMPOSITION does not reproduce. A bare-app test that recomposes
+under batch and waits with raw `asyncio.sleep` (no input-shaped messages)
+paints promptly, unpatched: `Tests/UI/test_batch_repaint_unfreeze.py`, 2
+passed. Two relays my derivation missed both close the loop in the simple
+case:
+
+- `Widget.refresh()` pokes its own pump, whose Idle runs `_check_refresh`,
+  which posts `messages.Update/Layout` TO THE SCREEN -- queue activity, Idle,
+  resume, paint.
+- The screen's Idle is edge-triggered but those posts provide the edge.
+
+So the frozen windows (all work done by +12.7ms, paint at +234.7ms on a
+mouse-move; no recompose events in that window at all) have a mechanism not
+yet named. One noted hole, unproven: `_check_refresh` clears
+`_repaint_required` but posts NOTHING when `self.display` is False -- a
+refresh on a hidden widget is silently dropped rather than deferred.
+
+**No fix until a failing reproduction exists.** Next instrument (probe v6)
+samples the live invariants during stall windows -- `app._batch_count`,
+update-timer active flag, `len(screen._dirty_widgets)`,
+`_layout/_repaint_required`, `len(screen._callbacks)` -- plus trace events
+for `Screen._on_idle` (and which branch it took) and update-timer resumes.
+The frozen window's sequence will show directly which invariant sticks.


### PR DESCRIPTION
Backlog + lessons only. The close of the Console button-latency investigation's attribution phase — including a refutation of my own filed mechanism.

## What the live invariants showed (probe v6)

Sampling `batch_count`, the update-timer flag, dirty counts, and the idle branch every 10 ms inside real stall windows:

**The freeze is nested batches.** The 406 ms tree click: `screen.Idle guarded(batch=2, current=True)` at +107 ms, `STATE batch=2 timer=PAUSED dirty=71 lay=1 rep=1` at +250 ms, widget mounts still landing at +261 ms. Another window reaches `batch=3`. Textual withholds *all* paints while any batch is open — by design — and each tray/section recompose opens one; they nest, and the mount + CSS + reconcile storm runs inside them. First paint = last batch closing, 250–400 ms later.

**TASK-26835 is closed REFUTED, no fix shipped.** The "frozen until next input" mechanism I filed read plausibly in source — five internals verified individually — and died twice: a bare-app repro painted promptly unpatched (Textual's widget-idle relay closes the loop my derivation had open), and the live data shows no input rescue. Its bare-app test is deleted rather than shipped; it pins framework behavior that was never broken. The windows that *did* end on a mouse move owed nothing at all (`dirty=0` for 26 straight ticks — clicks with no visible response; a probe framing artifact).

## Exact fix targets now on TASK-26834, value order

1. `delta=conversation_browser` **alone** forces a full tray recompose (observed directly) — browser-only deltas should update in place, which deletes the batch for the most common tree/row interactions
2. **Both** tray instances recompose for one click — nested batches, double the mounts
3. The `_run_scheduled_reconcile` ×6 storm runs *inside* the batch window — coalesce it or let it run after first paint

Plus two small main-thread finds: the uncached `get_workspace` title lookup sampled again (~40 ms), and `pathlib.stat` filesystem I/O inside `build_console_workspace_state` (~20 ms) on the click path.

## Lesson recorded

*A mechanism assembled from individually-verified links is still a hypothesis.* Two composed theories died in one day; what settled it was printing the invariants the theory depends on and letting the system disagree. The no-fix-without-failing-repro rule is what kept both wrong mechanisms from becoming shipped patches.

`preflight`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrN2mbF8byxMfPNPtVJwFb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the final attribution of the Console button-latency stalls. TASK-26835's "frozen until next input" theory is closed REFUTED — the real mechanism is nested App-level batches held open 250–400 ms by tray recompose cascades.

- TASK-26835 is marked Done with the premise refuted: the bare-app repro painted promptly unpatched, and probe v6 live data shows no input rescue; no fix was shipped.
- TASK-26834 now carries three exact fix targets: browser-only deltas should update in place instead of forcing a full tray recompose, one click recomposes both tray instances, and the reconcile storm should be coalesced or deferred past first paint.
- Records two small main-thread finds on the click path: the uncached `get_workspace` title lookup (~40 ms) and `pathlib.stat` filesystem I/O in `build_console_workspace_state` (~20 ms).
- Records a testing lesson: a mechanism assembled from individually verified links is still a hypothesis.

<sup>Written for commit 6e958b665be037cea9ed7e41a603eb363865bba9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

