### PR TITLE
perf(console): derive the workspace tab title only when a session is created

### DIFF
--- a/Tests/UI/test_console_settings_title_laziness.py
+++ b/Tests/UI/test_console_settings_title_laziness.py
@@ -1,0 +1,119 @@
+"""The settings path must not query the Workspace DB for a title it discards.
+
+TASK-26837 (TASK-26834 cause 3). Sampled on the main thread in three separate
+in-terminal probe runs (30-60ms buckets):
+
+    registry_service.get_workspace
+      <- _console_workspace_session_title
+      <- _console_initial_session_title_for_workspace
+      <- _ensure_active_console_session_settings
+      <- _active_console_provider_model_display_uncached
+
+``store.ensure_session`` uses its ``title`` argument ONLY when creating a
+session -- with an active session the argument is discarded -- yet the caller
+computed it eagerly, which is a synchronous SQLite ``get_workspace`` per
+provider/model display rebuild once the active workspace is non-default.
+
+Shape borrowed from ``test_console_keystroke_workspace_reads.py``
+(TASK-21118), which gates the same disease on the keystroke path. The
+counter here includes its own control: the creation-path test proves the
+counter still sees real ``get_workspace`` traffic, so the zero in the lazy
+test can never pass against an unwired spy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from Tests.UI.test_console_dictation import _mounted_console, _ready_host
+from tldw_chatbook.Workspaces.registry_service import LocalWorkspaceRegistryService
+
+APP_SIZE = (140, 42)
+
+#: Any non-default workspace id: the default ids short-circuit before the
+#: registry, so only a non-default id exercises the lookup this gate is for.
+NON_DEFAULT_WORKSPACE_ID = "ws-title-laziness-probe"
+
+
+class _GetWorkspaceCounter:
+    """Count ``LocalWorkspaceRegistryService.get_workspace`` calls."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self._original = LocalWorkspaceRegistryService.get_workspace
+
+    def __enter__(self) -> "_GetWorkspaceCounter":
+        counter = self
+        original = self._original
+
+        def counting(service, workspace_id):
+            counter.calls += 1
+            return original(service, workspace_id)
+
+        LocalWorkspaceRegistryService.get_workspace = counting
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        LocalWorkspaceRegistryService.get_workspace = self._original
+
+
+async def _console_on_non_default_workspace(host, pilot):
+    """Return the mounted Console with its store on a non-default workspace."""
+    console = await _mounted_console(host, pilot)
+    store = console._session._ensure_console_chat_store()
+    store.set_workspace_context(
+        replace(
+            store.workspace_context,
+            active_workspace_id=NON_DEFAULT_WORKSPACE_ID,
+        )
+    )
+    return console, store
+
+
+@pytest.mark.asyncio
+async def test_settings_with_an_active_session_never_queries_the_registry():
+    """The discarded-title lookup: zero ``get_workspace`` with a session live."""
+    _app, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, store = await _console_on_non_default_workspace(host, pilot)
+        # Establish the active session first (this call MAY create).
+        console._session._ensure_active_console_session_settings()
+        assert store.active_session_id is not None
+
+        with _GetWorkspaceCounter() as counter:
+            for _ in range(5):
+                console._session._ensure_active_console_session_settings()
+        assert counter.calls == 0, (
+            f"{counter.calls} get_workspace round-trips for 5 settings reads "
+            "with an active session -- ensure_session discards the title, so "
+            "computing it is a pure main-thread SQLite tax (TASK-26837)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_title_seam_still_consults_the_registry():
+    """The counter control AND the behaviour pin, at the seam that owns it.
+
+    The full creation path cannot be driven with a fabricated workspace id --
+    the store coerces an unknown workspace back to the default and takes the
+    numbered default title, bypassing the seam. So the pin sits on
+    ``_console_initial_session_title_for_workspace`` itself: for a
+    non-default id it must consult the registry (proving the counter is
+    wired, so test 1's zero means something) and produce the "<name> Chat"
+    shape from whatever the registry answers.
+    """
+    _app, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console, _store = await _console_on_non_default_workspace(host, pilot)
+
+        with _GetWorkspaceCounter() as counter:
+            title = console._workspace._console_initial_session_title_for_workspace(
+                NON_DEFAULT_WORKSPACE_ID
+            )
+        assert counter.calls == 1, (
+            "the title seam no longer consults the registry -- either the "
+            "laziness over-reached into creation, or the counter is unwired"
+        )
+        assert title.endswith(" Chat")

--- a/Tests/UI/test_console_settings_title_laziness.py
+++ b/Tests/UI/test_console_settings_title_laziness.py
@@ -1,6 +1,6 @@
 """The settings path must not query the Workspace DB for a title it discards.
 
-TASK-26837 (TASK-26834 cause 3). Sampled on the main thread in three separate
+TASK-26839 (TASK-26834 cause 3). Sampled on the main thread in three separate
 in-terminal probe runs (30-60ms buckets):
 
     registry_service.get_workspace
@@ -88,7 +88,7 @@ async def test_settings_with_an_active_session_never_queries_the_registry():
         assert counter.calls == 0, (
             f"{counter.calls} get_workspace round-trips for 5 settings reads "
             "with an active session -- ensure_session discards the title, so "
-            "computing it is a pure main-thread SQLite tax (TASK-26837)"
+            "computing it is a pure main-thread SQLite tax (TASK-26839)"
         )
 
 

--- a/backlog/tasks/task-25715 - Three-Console-tests-are-red-on-dev-each-bisected-to-its-cause.md
+++ b/backlog/tasks/task-25715 - Three-Console-tests-are-red-on-dev-each-bisected-to-its-cause.md
@@ -211,6 +211,16 @@ markedly worse on dev than on the branch. Earlier full-file runs of this file
 races. No owner assigned here; recorded so the next sweep does not re-derive
 it.
 
+## Sixth finding (2026-09-01, TASK-26837 sweep): three composer reds on dev
+
+`test_console_command_composer.py` fails identically on pristine `origin/dev`
+and on the TASK-26837 branch (whole file, `-p no:randomly`):
+`test_raw_cli_collapsed_state_retains_danger_label_and_one_row_geometry`,
+`test_console_unknown_command_second_unmodified_enter_sends_as_text`,
+`test_console_collapsed_paste_starting_with_slash_sends_normally` --
+3 failed / 100 passed both trees. Pre-existing, owner unknown, recorded so
+the next sweep does not re-derive them.
+
 ## Notes
 
 Filed in the same spirit as TASK-15512. `origin/dev` had by this point absorbed

--- a/backlog/tasks/task-25715 - Three-Console-tests-are-red-on-dev-each-bisected-to-its-cause.md
+++ b/backlog/tasks/task-25715 - Three-Console-tests-are-red-on-dev-each-bisected-to-its-cause.md
@@ -211,10 +211,10 @@ markedly worse on dev than on the branch. Earlier full-file runs of this file
 races. No owner assigned here; recorded so the next sweep does not re-derive
 it.
 
-## Sixth finding (2026-09-01, TASK-26837 sweep): three composer reds on dev
+## Sixth finding (2026-09-01, TASK-26839 sweep): three composer reds on dev
 
 `test_console_command_composer.py` fails identically on pristine `origin/dev`
-and on the TASK-26837 branch (whole file, `-p no:randomly`):
+and on the TASK-26839 branch (whole file, `-p no:randomly`):
 `test_raw_cli_collapsed_state_retains_danger_label_and_one_row_geometry`,
 `test_console_unknown_command_second_unmodified_enter_sends_as_text`,
 `test_console_collapsed_paste_starting_with_slash_sends_normally` --

--- a/backlog/tasks/task-26837 - Console-settings-path-queries-the-Workspace-DB-for-a-title-it-discards.md
+++ b/backlog/tasks/task-26837 - Console-settings-path-queries-the-Workspace-DB-for-a-title-it-discards.md
@@ -1,0 +1,60 @@
+---
+id: TASK-26837
+title: Console settings path queries the Workspace DB for a title it discards
+status: Done
+assignee: []
+created_date: '2026-09-01 15:09'
+updated_date: '2026-09-01 15:20'
+labels:
+  - console
+  - performance
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TASK-26834 cause 3, sampled on the main thread in three separate in-terminal probe runs (30-60ms buckets). _ensure_active_console_session_settings computes the workspace tab title eagerly -- a synchronous registry get_workspace SQLite query -- and passes it to store.ensure_session, which uses the title ONLY when creating a session. With an active session (every provider/model display rebuild, every click that refreshes the control bar) the query runs and its result is discarded. The caller already computes creating_blank_session two lines above, so the title becomes conditional on it. Same disease TASK-21118 gated on the keystroke path, different entry.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 With an active session, _ensure_active_console_session_settings performs zero registry get_workspace calls, gated by a counter test on a non-default workspace
+- [x] #2 Creating a session still derives its title from the workspace registry exactly as before, pinned by test
+- [x] #3 The pathlib.stat recompute in build_console_workspace_state is recorded as a DELIBERATE non-fix (ADR-028 security posture), not silently left
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Two-line fix at the call site: `_ensure_active_console_session_settings`
+already computes `creating_blank_session` two lines above `ensure_session`,
+so the title argument becomes conditional on it -- the workspace-title seam
+(and its synchronous `get_workspace` SQLite query) runs only when a session
+is actually being created. With one active, `DEFAULT_CONSOLE_SESSION_TITLE`
+is passed and discarded exactly as any title would be.
+
+Tests (`Tests/UI/test_console_settings_title_laziness.py`, shape borrowed
+from TASK-21118's keystroke gate): the failing gate measured **5
+get_workspace round-trips for 5 settings reads** with an active session
+pre-fix, now 0; the control pins the seam still consulting the registry
+(and proves the counter is wired). Two fixture findings recorded in the
+file's docstrings: the harness boots with an active session, and the store
+coerces an UNKNOWN workspace id back to the default with a numbered title,
+so the creation pin sits on the seam rather than the full ensure path.
+
+**Deliberate non-fix (AC #3):** the `pathlib.stat` recompute in
+`build_console_workspace_state` (~20ms sampled) stays. Its docstring and
+ADR-028 record that stored status is NEVER trusted for local-filesystem
+bindings -- a vanished folder or symlink swap would otherwise keep a widened
+root reporting "ready". Removing a security recompute to save 20ms is a
+design decision for the ADR's owner, not a perf sweep.
+
+Sweep: 152 passed across 5 session-surface files; the 3
+`test_console_command_composer.py` reds are identical on pristine dev
+(verified in a detached worktree) and recorded on TASK-25715.
+
+Files: `tldw_chatbook/UI/Console_Modules/session.py` (one call site),
+`Tests/UI/test_console_settings_title_laziness.py` (new).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-26839 - Console-settings-path-queries-the-Workspace-DB-for-a-title-it-discards.md
+++ b/backlog/tasks/task-26839 - Console-settings-path-queries-the-Workspace-DB-for-a-title-it-discards.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-26837
+id: TASK-26839
 title: Console settings path queries the Workspace DB for a title it discards
 status: Done
 assignee: []
@@ -58,3 +58,16 @@ Sweep: 152 passed across 5 session-surface files; the 3
 Files: `tldw_chatbook/UI/Console_Modules/session.py` (one call site),
 `Tests/UI/test_console_settings_title_laziness.py` (new).
 <!-- SECTION:NOTES:END -->
+
+## Renumbering provenance
+
+This task previously held id TASK-26837, colliding with the older
+"Provider-setup-can-report-a-successful-connection-test-yet-write-no-
+api_settings-block" task that arrived on dev first while this one was still
+in flight on its branch. Per the owner rule decided 2026-08-21 in TASK-19601
+(**older id keeps it; the younger task renumbers with a provenance note,
+regardless of Done status**), it renumbered to TASK-26839. Citations to
+TASK-26837 in this branch's commit message, in PR #2291's body, and in
+`Tests/UI/test_console_settings_title_laziness.py` and `session.py` comments
+written before the renumber refer to THIS task; the other TASK-26837 holder
+is the older arrival and keeps the id.

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -3151,7 +3151,7 @@ class ConsoleSessionController:
         ):
             return defaults
         workspace_id = store.workspace_context.active_workspace_id
-        # TASK-26837: `ensure_session` uses `title` only when it CREATES a
+        # TASK-26839: `ensure_session` uses `title` only when it CREATES a
         # session; with one active the argument is discarded. Deriving the
         # workspace title is a synchronous registry `get_workspace` SQLite
         # query, and this method runs on every provider/model display

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -3151,8 +3151,19 @@ class ConsoleSessionController:
         ):
             return defaults
         workspace_id = store.workspace_context.active_workspace_id
+        # TASK-26837: `ensure_session` uses `title` only when it CREATES a
+        # session; with one active the argument is discarded. Deriving the
+        # workspace title is a synchronous registry `get_workspace` SQLite
+        # query, and this method runs on every provider/model display
+        # rebuild -- the in-terminal probe sampled that discarded lookup on
+        # the main thread in three separate sessions. Compute it only for
+        # the creation case this method already knows about.
         session = store.ensure_session(
-            title=self._workspace_initial_session_title(workspace_id),
+            title=(
+                self._workspace_initial_session_title(workspace_id)
+                if creating_blank_session
+                else DEFAULT_CONSOLE_SESSION_TITLE
+            ),
             workspace_id=workspace_id,
             settings=defaults,
             canonical_settings_baseline=defaults,


### PR DESCRIPTION
TASK-26839 — TASK-26834's cause 3, the small evidenced one.

## The waste

The in-terminal probe sampled this stack on the main thread in **three separate sessions** (30–60 ms buckets):

```
registry_service.get_workspace          <- synchronous SQLite
  <- _console_workspace_session_title
  <- _ensure_active_console_session_settings
  <- _active_console_provider_model_display_uncached
```

`store.ensure_session` uses its `title` argument **only when creating** a session — with one active, the argument is discarded. The caller computed it eagerly anyway, so every provider/model display rebuild paid a registry query for a string that went straight to the floor.

## The fix

Two lines: `creating_blank_session` is already computed two lines above, so the title expression becomes conditional on it. Creation behavior is unchanged and pinned.

## Verification (TDD)

- **Failing gate first**: measured **5 `get_workspace` round-trips for 5 settings reads** with an active session on a non-default workspace; now 0. Shape borrowed from TASK-21118's keystroke gate — same disease, different entry.
- **Control**: the title seam still consults the registry for a non-default workspace, proving the counter is wired — the zero can never pass against an unwired spy.
- Two fixture facts recorded in the test docstrings, both discovered by failing assertions: the harness boots with an active session, and the store coerces an *unknown* workspace id back to the default with a numbered title — so the creation pin sits on the seam that owns the lookup, not on a fabricated end-to-end path.

## Deliberate non-fix, recorded in the task

The other small find from the same probe runs — `pathlib.stat` inside `build_console_workspace_state` (~20 ms) — **stays**. ADR-028 makes stored status untrusted for local-filesystem bindings: a vanished folder or symlink swap would otherwise keep a widened root reporting "ready". Trading a security recompute for 20 ms is the ADR owner's design call, not a perf sweep's.

Sweep: 152 passed across 5 session-surface files; the 3 `test_console_command_composer.py` reds are identical on pristine dev (detached-worktree verified, both trees whole-file) and recorded on TASK-25715's dev-red ledger.

`preflight`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrN2mbF8byxMfPNPtVJwFb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TASK-26839 (renumbered from TASK-26837 when dev landed its own 26837): the console settings path no longer queries the workspace registry when a session is already active. Previously it computed the session title via a synchronous SQLite query on every provider/model display rebuild, then discarded the result, since `ensure_session` only uses the title when creating a session. Now the title lookup runs only when a session is being created.

- The title expression is now conditional on `creating_blank_session`; creation behavior is unchanged and pinned by tests.
- Adds `Tests/UI/test_console_settings_title_laziness.py` with a counter gate (zero lookups with active session) and a control test proving creation still consults the registry.
- Records a deliberate non-fix in the task: the `pathlib.stat` recompute in `build_console_workspace_state` stays per ADR-028 security posture.
- Task references in `session.py`, the test file, and the TASK-25715 ledger were updated to the new id.

<sup>Written for commit de86b5ce8224121d3e564cc43a2f54b243008032. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

> **Renumbered in flight:** dev landed its own TASK-26837 (provider-setup api_settings) while this PR was open, tripping the duplicate-ID gate. Per TASK-19601's owner rule the dev arrival keeps the id; this task is now **TASK-26839**, with a provenance section, and all in-branch references updated.
