### PR TITLE
feat(scheduling): local recurring_question execution (handoff PR-2)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1769,8 +1769,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 3,
-      "diagnostic_digest": "2c0a87947d6065c00575",
+      "call_count": 4,
+      "diagnostic_digest": "685580e35bcb1803ce11",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/db/scheduled_tasks_db.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1783,8 +1783,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 8,
-      "diagnostic_digest": "d50a579c6dee32d47bd8",
+      "call_count": 10,
+      "diagnostic_digest": "5d09f7b4ce9e3f0b1ca6",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/scheduler/handlers/automation_handler.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11156,6 +11156,6 @@
     "path_privacy_candidate_calls": 711,
     "persistent_sink_files": 9,
     "task_492_calls": 1308,
-    "task_494_calls": 7443
+    "task_494_calls": 7446
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1776,6 +1776,20 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 3,
+      "diagnostic_digest": "f2c767312b069c1d97b1",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Scheduling/schedule_compute.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 8,
+      "diagnostic_digest": "d50a579c6dee32d47bd8",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Scheduling/scheduler/handlers/automation_handler.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 10,
       "diagnostic_digest": "80ab1fa62feef88cc98c",
       "owner": "TASK-494",
@@ -1797,8 +1811,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 9,
-      "diagnostic_digest": "0351e6f0955020f0d9b8",
+      "call_count": 14,
+      "diagnostic_digest": "98a01bb1a4ac9eb198ad",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/services/scheduling_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3834,8 +3848,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 370,
-      "diagnostic_digest": "517770cd2c0c6b933ba0",
+      "call_count": 371,
+      "diagnostic_digest": "7565d9f9851d06366879",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11138,10 +11152,10 @@
   "schema_version": 3,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 552,
+    "owner_files": 554,
     "path_privacy_candidate_calls": 711,
     "persistent_sink_files": 9,
     "task_492_calls": 1308,
-    "task_494_calls": 7426
+    "task_494_calls": 7443
   }
 }

--- a/Tests/Scheduling/test_automation_end_to_end.py
+++ b/Tests/Scheduling/test_automation_end_to_end.py
@@ -1,0 +1,201 @@
+"""Unmocked end-to-end test for local `recurring_question` automation execution.
+
+Drives one scheduler tick through the real `PriorityQueue`/`SchedulerLoop`/
+`AutomationDefinitionHandler`/`NotificationDispatchService` stack against a
+real tmp_path `ScheduledTasksDB`. The ONLY faked seams are the two Library
+RAG boundaries (`run_library_rag_search`, `generate_library_rag_answer`,
+monkeypatched as module attributes on `automation_execution` -- the module
+that binds and calls them) and the notification store (a recording double,
+copied from `test_reminder_handler.py`'s `_FakeNotificationStore`). Provider
+resolution is exercised for real via the definition's own `input.provider`/
+`input.model`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tldw_chatbook.Library.library_rag_answer_service import (
+    ANSWER_STATUS_READY,
+    LibraryRagAnswer,
+)
+from tldw_chatbook.Library.library_rag_service import LibraryRagSearchOutcome
+from tldw_chatbook.Library.library_rag_state import LibraryRagResultRow
+from tldw_chatbook.Notifications.notification_dispatch_service import (
+    NotificationDispatchService,
+)
+from tldw_chatbook.Scheduling import automation_execution
+from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+from tldw_chatbook.Scheduling.schedule_compute import compute_next_run_at, schedule_slot_for
+from tldw_chatbook.Scheduling.scheduler.handlers.automation_handler import (
+    AutomationDefinitionHandler,
+)
+from tldw_chatbook.Scheduling.scheduler.loop import SchedulerLoop
+
+
+class _FakeNotificationStore:
+    """Minimal store double: records inserts, reports notifications enabled.
+
+    Copied from `Tests/Scheduling/test_reminder_handler.py`.
+    """
+
+    def __init__(self):
+        self.inserted = []
+
+    def insert_notification(self, **kwargs):
+        self.inserted.append(kwargs)
+        return dict(kwargs)
+
+    def get_settings(self):
+        return {"enabled": True, "toast_enabled": True, "persist_enabled": True}
+
+
+class _FakeApp:
+    """App double: `library_rag_search_service` (retrieval is monkeypatched,
+    so any non-None object satisfies it) plus `notify` for the toast path."""
+
+    def __init__(self):
+        self.notify_calls = []
+        self.library_rag_search_service = object()
+
+    def notify(self, message, severity="information", timeout=None):
+        self.notify_calls.append(
+            {"message": message, "severity": severity, "timeout": timeout}
+        )
+
+
+_CANNED_ROWS = (
+    LibraryRagResultRow(
+        result_id="note-1",
+        title="First matching note",
+        snippet="Snippet one.",
+        score=0.9,
+        source_id="note-1",
+        chunk_id="chunk-1",
+        citations=(),
+        provenance={"source_type": "notes"},
+    ),
+    LibraryRagResultRow(
+        result_id="note-2",
+        title="Second matching note",
+        snippet="Snippet two.",
+        score=0.8,
+        source_id="note-2",
+        chunk_id="chunk-2",
+        citations=(),
+        provenance={"source_type": "notes"},
+    ),
+)
+_ANSWER_TEXT = "Canned synthesized answer, grounded in the two notes above."
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = ScheduledTasksDB(tmp_path / "scheduler.db")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+@pytest.mark.asyncio
+async def test_recurring_question_end_to_end(db, monkeypatch):
+    # -- Fake the two Library RAG boundaries only (module attributes on the
+    # module that binds and calls them) --
+    async def _fake_run_library_rag_search(app_instance, request):
+        return LibraryRagSearchOutcome(status="ready", results=_CANNED_ROWS)
+
+    async def _fake_generate_library_rag_answer(
+        *, query, results, coverage_note, provider, model, chat=None
+    ):
+        return LibraryRagAnswer(
+            status=ANSWER_STATUS_READY,
+            text=_ANSWER_TEXT,
+            provider=provider,
+            model=model or "",
+        )
+
+    monkeypatch.setattr(
+        automation_execution, "run_library_rag_search", _fake_run_library_rag_search
+    )
+    monkeypatch.setattr(
+        automation_execution,
+        "generate_library_rag_answer",
+        _fake_generate_library_rag_answer,
+    )
+
+    # -- Definition: interval schedule (900s), provider/model set on the
+    # definition's own `input` so precedence resolves from that layer --
+    schedule = {"kind": "interval", "every_seconds": 900}
+    creation_time = datetime(2025, 12, 31, 23, 45, tzinfo=timezone.utc)
+    first_next_run_at = compute_next_run_at(schedule, now=creation_time)
+
+    definition_id = db.create_automation_definition(
+        owner_id="local",
+        family="recurring_question",
+        name="What changed this week?",
+        schedule=schedule,
+        input={
+            "question": "What changed this week?",
+            "provider": "openai",
+            "model": "gpt-x",
+        },
+        config={"generation_mode": "optional"},
+        next_run_at=first_next_run_at,
+    )
+
+    store = _FakeNotificationStore()
+    dispatch_service = NotificationDispatchService(store=store)
+    app = _FakeApp()
+    handler = AutomationDefinitionHandler(
+        db=db, app_getter=lambda: app, dispatch_service=dispatch_service
+    )
+
+    loop = SchedulerLoop(
+        db,
+        handlers={"automation_definition": handler},
+        clock=lambda: first_next_run_at,
+    )
+    loop.queue.load()
+
+    real_before = datetime.now(timezone.utc)
+    await loop.tick()
+    await asyncio.gather(*handler._pending)
+    real_after = datetime.now(timezone.utc)
+
+    # -- Run row: completed/finding, slotted at the due time --
+    runs = db.list_automation_runs(owner_id="local", definition_id=definition_id)
+    assert len(runs) == 1
+    run = runs[0]
+    assert run["status"] == "completed"
+    assert run["outcome"] == "finding"
+    assert run["schedule_slot"] == schedule_slot_for(first_next_run_at)
+
+    # -- Result row: unread, synthesized, source_refs carry the canned rows --
+    results = db.list_automation_results(owner_id="local", definition_id=definition_id)
+    assert len(results) == 1
+    result = results[0]
+    assert result["review_state"] == "unread"
+    assert result["answer_mode"] == "synthesized"
+    assert result["answer"] == _ANSWER_TEXT
+    source_ids = {ref["id"] for ref in result["source_refs"]}
+    assert source_ids == {"note-1", "note-2"}
+    assert all(ref["source"] == "notes" for ref in result["source_refs"])
+
+    # -- Notification: persisted in the store, toast recorded on the fake app --
+    assert len(store.inserted) == 1
+    notification = store.inserted[0]
+    assert notification["payload"]["kind"] == "automation_run_succeeded"
+    assert notification["payload"]["run_id"] == run["id"]
+    assert len(app.notify_calls) == 1
+
+    # -- Definition next_run_at advanced by 900s from the real dispatch time
+    # (`_dispatch`'s advance uses the wall clock, not the injected test
+    # clock) -- bounded to the [before, after] window this tick ran in. --
+    definition = db.get_automation_definition(definition_id)
+    new_next_run_at = datetime.fromisoformat(definition["next_run_at"])
+    assert real_before + timedelta(seconds=900) <= new_next_run_at
+    assert new_next_run_at <= real_after + timedelta(seconds=900)

--- a/Tests/Scheduling/test_automation_execution.py
+++ b/Tests/Scheduling/test_automation_execution.py
@@ -343,3 +343,24 @@ def test_bounded_caps_at_1000_chars_with_ellipsis():
 
 def test_bounded_leaves_short_text_untouched():
     assert automation_execution._bounded("short") == "short"
+
+
+# --- _classify: missing-answer guard (was `assert answer is not None`) -----
+
+
+def test_classify_missing_answer_after_attempted_generation_degrades_honestly():
+    """`_classify`'s "generation was attempted" branch used to `assert
+    answer is not None` -- unreachable through `execute_recurring_question`
+    (it only reaches this branch after actually calling
+    `generate_library_rag_answer`), but a production `assert` is stripped
+    under `-O` and is not a real guard. It must degrade honestly rather than
+    crash or silently fall through."""
+    outcome = automation_execution._classify(
+        retrieval_status="ok",
+        results=(_row(),),
+        generation_mode="optional",
+        answer=None,
+    )
+    assert outcome.outcome == "degraded"
+    assert outcome.failure_reason == {"code": "generation_unavailable"}
+    assert outcome.evidence_summary["answer_present"] is False

--- a/Tests/Scheduling/test_automation_execution.py
+++ b/Tests/Scheduling/test_automation_execution.py
@@ -1,0 +1,345 @@
+"""Tests for the `recurring_question` execution core (schedules-handoff PR-2,
+task 3): `resolve_execution_target`'s precedence, and the six-row
+`classify_rag_response`-parity ladder in `execute_recurring_question`.
+
+`run_library_rag_search`/`generate_library_rag_answer` are the only faked
+seams (monkeypatched as `automation_execution` module attributes, per the
+plan's Step 1) -- everything else (scope normalization, finding-policy ->
+top_k, classification) runs for real.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.Library.library_rag_answer_service import (
+    ANSWER_STATUS_ABSTAINED,
+    ANSWER_STATUS_FAILED,
+    ANSWER_STATUS_NO_EVIDENCE,
+    ANSWER_STATUS_READY,
+    LibraryRagAnswer,
+)
+from tldw_chatbook.Library.library_rag_service import LibraryRagSearchOutcome
+from tldw_chatbook.Library.library_rag_state import LibraryRagResultRow
+from tldw_chatbook.Scheduling import automation_execution
+from tldw_chatbook.Scheduling.automation_execution import (
+    RESULT_SUMMARY_MAX_CHARS,
+    ExecutionOutcome,
+    execute_recurring_question,
+    resolve_execution_target,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _row(source_type: str = "media", score: float | None = 0.9, result_id: str = "r1") -> LibraryRagResultRow:
+    return LibraryRagResultRow(
+        result_id=result_id,
+        title=f"Title {result_id}",
+        snippet="snippet",
+        score=score,
+        source_id="src-1",
+        chunk_id="chunk-1",
+        citations=(),
+        provenance=MappingProxyType({"source_type": source_type}),
+    )
+
+
+def _definition_row(**overrides: Any) -> dict:
+    row: dict[str, Any] = {
+        "input": {"question": "What changed?"},
+        "config": {},
+        "finding_policy": {"preset": "balanced_findings"},
+    }
+    row.update(overrides)
+    return row
+
+
+class _FakeApp:
+    """Stand-in `app` -- `run_library_rag_search` is monkeypatched, so this
+    never actually reads `library_rag_search_service`; it exists only
+    because `execute_recurring_question`'s signature takes an `app`.
+    """
+
+
+# --- resolve_execution_target: precedence -----------------------------------
+
+
+def test_resolve_execution_target_definition_wins():
+    row = _definition_row(input={"question": "q", "provider": "anthropic", "model": "opus", "max_tokens": 500})
+    target = resolve_execution_target(row)
+    assert target == {"provider": "anthropic", "model": "opus", "max_tokens": 500}
+
+
+def test_resolve_execution_target_falls_through_blank_definition_to_config(monkeypatch):
+    row = _definition_row(input={"question": "q", "provider": "  ", "model": None, "max_tokens": 0})
+
+    def fake_get_cli_setting(section, key, default=None):
+        assert section == "scheduling"
+        return {
+            "executor_provider": "openai",
+            "executor_model": "gpt-5",
+            "executor_max_tokens": 700,
+        }.get(key, default)
+
+    monkeypatch.setattr(automation_execution, "get_cli_setting", fake_get_cli_setting)
+    target = resolve_execution_target(row)
+    assert target == {"provider": "openai", "model": "gpt-5", "max_tokens": 700}
+
+
+def test_resolve_execution_target_falls_through_to_library_provider(monkeypatch):
+    row = _definition_row(input={"question": "q"})
+    monkeypatch.setattr(automation_execution, "get_cli_setting", lambda *a, **k: None)
+    monkeypatch.setattr(
+        automation_execution,
+        "resolve_library_rag_answer_provider",
+        lambda: ("deepseek", None),
+    )
+    target = resolve_execution_target(row)
+    assert target == {"provider": "deepseek", "model": None, "max_tokens": 1000}
+
+
+def test_resolve_execution_target_max_tokens_capped_at_4000(monkeypatch):
+    row = _definition_row(input={"question": "q", "max_tokens": 999999})
+    monkeypatch.setattr(automation_execution, "get_cli_setting", lambda *a, **k: None)
+    monkeypatch.setattr(
+        automation_execution, "resolve_library_rag_answer_provider", lambda: (None, None)
+    )
+    target = resolve_execution_target(row)
+    assert target["max_tokens"] == 4000
+
+
+# --- execute_recurring_question: question_empty ------------------------------
+
+
+@pytest.mark.asyncio
+async def test_question_empty_returns_degraded_without_calling_retrieval(monkeypatch):
+    called = False
+
+    async def fake_search(app, request):
+        nonlocal called
+        called = True
+        return LibraryRagSearchOutcome(status="ready", results=(_row(),))
+
+    monkeypatch.setattr(automation_execution, "run_library_rag_search", fake_search)
+    outcome = await execute_recurring_question(_FakeApp(), _definition_row(input={"question": "   "}))
+    assert outcome.outcome == "degraded"
+    assert outcome.answer_mode == "none"
+    assert outcome.failure_reason == {"code": "question_empty"}
+    assert called is False
+
+
+# --- the six-row classification ladder ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_row1_retrieval_blocked_is_degraded(monkeypatch):
+    async def fake_search(app, request):
+        return LibraryRagSearchOutcome(status="blocked", results=())
+
+    monkeypatch.setattr(automation_execution, "run_library_rag_search", fake_search)
+    outcome = await execute_recurring_question(_FakeApp(), _definition_row())
+    assert outcome.outcome == "degraded"
+    assert outcome.answer_mode == "none"
+    assert outcome.failure_reason == {"code": "retrieval_blocked"}
+    assert outcome.source_refs == []
+
+
+@pytest.mark.asyncio
+async def test_row1_retrieval_failed_is_degraded(monkeypatch):
+    async def fake_search(app, request):
+        return LibraryRagSearchOutcome(status="failed", results=())
+
+    monkeypatch.setattr(automation_execution, "run_library_rag_search", fake_search)
+    outcome = await execute_recurring_question(_FakeApp(), _definition_row())
+    assert outcome.outcome == "degraded"
+    assert outcome.failure_reason == {"code": "retrieval_failed"}
+
+
+@pytest.mark.asyncio
+async def test_row2_zero_results_is_no_match(monkeypatch):
+    async def fake_search(app, request):
+        return LibraryRagSearchOutcome(status="empty", results=())
+
+    monkeypatch.setattr(automation_execution, "run_library_rag_search", fake_search)
+    outcome = await execute_recurring_question(_FakeApp(), _definition_row())
+    assert outcome.outcome == "no_match"
+    assert outcome.answer_mode == "none"
+    assert outcome.title == "No matching sources found"
+    assert outcome.failure_reason is None
+
+
+@pytest.mark.asyncio
+async def test_row3_generation_disabled_is_evidence_only_without_generation_call(monkeypatch):
+    generate_called = False
+
+    async def fake_search(app, request):
+        return LibraryRagSearchOutcome(status="ready", results=(_row(),))
+
+    async def fake_generate(**kwargs):
+        nonlocal generate_called
+        generate_called = True
+        raise AssertionError("generation must not be called when generation_mode is disabled")
+
+    monkeypatch.setattr(automation_execution, "run_library_rag_search", fake_search)
+    monkeypatch.setattr(automation_execution, "generate_library_rag_answer", fake_generate)
+    outcome = await execute_recurring_question(
+        _FakeApp(), _definition_row(config={"generation_mode": "disabled"})
+    )
+    assert outcome.outcome == "finding"
+    assert outcome.answer_mode == "evidence_only"
+    assert outcome.title == "Relevant evidence found"
+    assert generate_called is False
+    assert outcome.source_refs == [{"source": "media", "id": "r1", "title": "Title r1"}]
+
+
+@pytest.mark.asyncio
+async def test_row4_ready_answer_is_synthesized_finding(monkeypatch):
+    async def fake_search(app, request):
+        return LibraryRagSearchOutcome(status="ready", results=(_row(),))
+
+    async def fake_generate(**kwargs):
+        return LibraryRagAnswer(status=ANSWER_STATUS_READY, text="The answer is 42.", citation_status="validated")
+
+    monkeypatch.setattr(automation_execution, "run_library_rag_search", fake_search)
+    monkeypatch.setattr(automation_execution, "generate_library_rag_answer", fake_generate)
+    outcome = await execute_recurring_question(_FakeApp(), _definition_row())
+    assert outcome.outcome == "finding"
+    assert outcome.answer_mode == "synthesized"
+    assert outcome.title == "Possible answer found"
+    assert outcome.answer == "The answer is 42."
+    assert outcome.summary == "The answer is 42."
+    assert outcome.confidence == {"citation_status": "validated"}
+    assert outcome.evidence_summary["answer_present"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status", [ANSWER_STATUS_ABSTAINED, ANSWER_STATUS_NO_EVIDENCE, ANSWER_STATUS_FAILED]
+)
+async def test_row5_optional_not_ready_is_evidence_only_with_answer_dropped(monkeypatch, status):
+    async def fake_search(app, request):
+        return LibraryRagSearchOutcome(status="ready", results=(_row(),))
+
+    async def fake_generate(**kwargs):
+        return LibraryRagAnswer(status=status, text="ignored")
+
+    monkeypatch.setattr(automation_execution, "run_library_rag_search", fake_search)
+    monkeypatch.setattr(automation_execution, "generate_library_rag_answer", fake_generate)
+    outcome = await execute_recurring_question(
+        _FakeApp(), _definition_row(config={"generation_mode": "optional"})
+    )
+    assert outcome.outcome == "finding"
+    assert outcome.answer_mode == "evidence_only"
+    assert outcome.answer is None
+    assert outcome.evidence_summary["answer_present"] is False
+    assert outcome.evidence_summary["generation_status"] == status
+    assert outcome.failure_reason is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status", [ANSWER_STATUS_ABSTAINED, ANSWER_STATUS_NO_EVIDENCE, ANSWER_STATUS_FAILED]
+)
+async def test_row6_required_not_ready_is_degraded(monkeypatch, status):
+    async def fake_search(app, request):
+        return LibraryRagSearchOutcome(status="ready", results=(_row(),))
+
+    async def fake_generate(**kwargs):
+        return LibraryRagAnswer(status=status, text="ignored")
+
+    monkeypatch.setattr(automation_execution, "run_library_rag_search", fake_search)
+    monkeypatch.setattr(automation_execution, "generate_library_rag_answer", fake_generate)
+    outcome = await execute_recurring_question(
+        _FakeApp(), _definition_row(config={"generation_mode": "required"})
+    )
+    assert outcome.outcome == "degraded"
+    assert outcome.answer_mode == "none"
+    assert outcome.failure_reason == {"code": "generation_required_unavailable"}
+    assert outcome.source_refs == []
+
+
+# --- finding_policy: top_k + high_confidence_only score post-filter ---------
+
+
+@pytest.mark.asyncio
+async def test_finding_policy_top_k_override_is_passed_through_in_range(monkeypatch):
+    captured = {}
+
+    async def fake_search(app, request):
+        captured["top_k"] = request.top_k
+        return LibraryRagSearchOutcome(status="empty", results=())
+
+    monkeypatch.setattr(automation_execution, "run_library_rag_search", fake_search)
+    await execute_recurring_question(
+        _FakeApp(), _definition_row(finding_policy={"preset": "balanced_findings", "top_k": 25})
+    )
+    assert captured["top_k"] == 25
+
+
+@pytest.mark.asyncio
+async def test_finding_policy_top_k_override_out_of_range_falls_back_to_default(monkeypatch):
+    """`coerce_int_setting`'s bounds semantics (the `_coerce_int` precedent
+    this reuses) reject an out-of-range value back to the default rather
+    than clamping it -- 500 is outside the 1-100 ceiling, so the preset's
+    own top_k (10) is used instead of 100."""
+    captured = {}
+
+    async def fake_search(app, request):
+        captured["top_k"] = request.top_k
+        return LibraryRagSearchOutcome(status="empty", results=())
+
+    monkeypatch.setattr(automation_execution, "run_library_rag_search", fake_search)
+    await execute_recurring_question(
+        _FakeApp(), _definition_row(finding_policy={"preset": "balanced_findings", "top_k": 500})
+    )
+    assert captured["top_k"] == 10
+
+
+@pytest.mark.asyncio
+async def test_high_confidence_only_drops_weak_scored_rows(monkeypatch):
+    strong = _row(result_id="strong", score=0.9)
+    weak = _row(result_id="weak", score=0.1)
+    unscored = LibraryRagResultRow(
+        result_id="unscored",
+        title="Unscored",
+        snippet="",
+        score=None,
+        source_id="s",
+        chunk_id="c",
+        citations=(),
+        provenance=MappingProxyType({"source_type": "note"}),
+    )
+
+    async def fake_search(app, request):
+        return LibraryRagSearchOutcome(status="ready", results=(strong, weak, unscored))
+
+    async def fake_generate(**kwargs):
+        assert {row.result_id for row in kwargs["results"]} == {"strong", "unscored"}
+        return LibraryRagAnswer(status=ANSWER_STATUS_READY, text="answer")
+
+    monkeypatch.setattr(automation_execution, "run_library_rag_search", fake_search)
+    monkeypatch.setattr(automation_execution, "generate_library_rag_answer", fake_generate)
+    outcome = await execute_recurring_question(
+        _FakeApp(),
+        _definition_row(finding_policy={"preset": "high_confidence_only"}),
+    )
+    assert outcome.outcome == "finding"
+    assert {ref["id"] for ref in outcome.source_refs} == {"strong", "unscored"}
+
+
+# --- _bounded --------------------------------------------------------------
+
+
+def test_bounded_caps_at_1000_chars_with_ellipsis():
+    long_text = "x" * 2000
+    bounded = automation_execution._bounded(long_text)
+    assert len(bounded) == RESULT_SUMMARY_MAX_CHARS
+    assert bounded.endswith("…")
+
+
+def test_bounded_leaves_short_text_untouched():
+    assert automation_execution._bounded("short") == "short"

--- a/Tests/Scheduling/test_automation_execution.py
+++ b/Tests/Scheduling/test_automation_execution.py
@@ -132,6 +132,55 @@ async def test_question_empty_returns_degraded_without_calling_retrieval(monkeyp
     assert called is False
 
 
+# --- scope errors: non-retryable refusal, never unscoped fallback (Finding B) --
+
+
+@pytest.mark.asyncio
+async def test_unsupported_scope_mode_returns_degraded_without_calling_retrieval(monkeypatch):
+    called = False
+
+    async def fake_search(app, request):
+        nonlocal called
+        called = True
+        return LibraryRagSearchOutcome(status="ready", results=(_row(),))
+
+    monkeypatch.setattr(automation_execution, "run_library_rag_search", fake_search)
+    outcome = await execute_recurring_question(
+        _FakeApp(),
+        _definition_row(config={"scope": {"mode": "bogus_mode"}}),
+    )
+    assert outcome.outcome == "degraded"
+    assert outcome.answer_mode == "none"
+    assert outcome.failure_reason["code"] == "unsupported"
+    assert outcome.failure_reason["errors"] == [
+        {
+            "field": "config.scope.mode",
+            "code": "unsupported",
+            "message": "Unsupported scope mode: bogus_mode",
+        }
+    ]
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_empty_resolved_scope_returns_degraded_without_calling_retrieval(monkeypatch):
+    called = False
+
+    async def fake_search(app, request):
+        nonlocal called
+        called = True
+        return LibraryRagSearchOutcome(status="ready", results=(_row(),))
+
+    monkeypatch.setattr(automation_execution, "run_library_rag_search", fake_search)
+    outcome = await execute_recurring_question(
+        _FakeApp(),
+        _definition_row(config={"scope": {"mode": "sources", "sources": ["not_a_real_source"]}}),
+    )
+    assert outcome.outcome == "degraded"
+    assert outcome.failure_reason["code"] == "scope_empty"
+    assert called is False
+
+
 # --- the six-row classification ladder ---------------------------------------
 
 

--- a/Tests/Scheduling/test_automation_handler.py
+++ b/Tests/Scheduling/test_automation_handler.py
@@ -103,6 +103,27 @@ class _RaiseOnceOnUpdateThenDelegate:
         return getattr(self._db, name)
 
 
+class _RaiseOnceOnUpdateDefinitionThenDelegate:
+    """Wraps a real `ScheduledTasksDB`; the first `update_automation_definition`
+    call (the schedule advance) raises, every call after delegates to the
+    real accessor. Everything else passes straight through via
+    `__getattr__`."""
+
+    def __init__(self, db: ScheduledTasksDB, *, exc: Exception) -> None:
+        self._db = db
+        self._exc = exc
+        self._raised = False
+
+    def update_automation_definition(self, *args: Any, **kwargs: Any) -> Any:
+        if not self._raised:
+            self._raised = True
+            raise self._exc
+        return self._db.update_automation_definition(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._db, name)
+
+
 def _make_definition(db: ScheduledTasksDB, **overrides: Any) -> dict[str, Any]:
     kwargs: dict[str, Any] = dict(
         owner_id="local",
@@ -335,6 +356,81 @@ async def test_schedule_is_advanced_before_the_executor_completes(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_on_queue_changed_fires_once_after_a_successful_scheduled_advance(
+    tmp_path,
+):
+    """Finding D: the in-memory queue only reloads periodically (~30 min);
+    without a callback, a schedule advance written to the DB by `handle`
+    would not reach the live queue until that periodic reload -- an
+    every-15-min definition would then run every 30. `on_queue_changed`
+    closes that gap; it must fire exactly once per successful scheduled
+    dispatch, and a broken callback must never fail the dispatch."""
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    calls: list[int] = []
+
+    async def fake_executor(app, definition_row):
+        return _FakeOutcome(outcome="finding")
+
+    handler = AutomationDefinitionHandler(
+        db=db,
+        executors={"recurring_question": fake_executor},
+        on_queue_changed=lambda: calls.append(1),
+    )
+
+    await handler.handle(row)
+    await _drain(handler)
+
+    assert calls == [1]
+
+
+@pytest.mark.asyncio
+async def test_on_queue_changed_broken_callback_does_not_fail_the_dispatch(tmp_path):
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+
+    def boom() -> None:
+        raise RuntimeError("callback is broken")
+
+    async def fake_executor(app, definition_row):
+        return _FakeOutcome(outcome="finding")
+
+    handler = AutomationDefinitionHandler(
+        db=db,
+        executors={"recurring_question": fake_executor},
+        on_queue_changed=boom,
+    )
+
+    run_id = await handler.handle(row)  # must not raise
+    await _drain(handler)
+
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert runs[0]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_on_queue_changed_fires_after_run_now_dispatch(tmp_path):
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    calls: list[int] = []
+
+    async def fake_executor(app, definition_row):
+        return _FakeOutcome(outcome="finding")
+
+    handler = AutomationDefinitionHandler(
+        db=db,
+        executors={"recurring_question": fake_executor},
+        on_queue_changed=lambda: calls.append(1),
+    )
+
+    run_id = await handler.run_now(row)
+    assert run_id is not None
+    await _drain(handler)
+
+    assert calls == [1]
+
+
+@pytest.mark.asyncio
 async def test_notification_policy_on_failure_false_suppresses_the_notification(
     tmp_path,
 ):
@@ -507,6 +603,57 @@ async def test_a_db_error_inserting_the_running_row_does_not_strand_the_claim(
     assert len(runs) == 1
     assert runs[0]["status"] == "completed"
     assert not any(r["status"] == "skipped" for r in runs)
+
+
+@pytest.mark.asyncio
+async def test_advance_schedule_failure_terminalizes_the_run_and_releases_the_claim(
+    tmp_path,
+):
+    """Finding C: if `update_automation_definition` (the schedule advance)
+    raises after the `running` row was already inserted, the run must not
+    be left stranded at `running` forever with the claim also stuck (the
+    wedge) -- it must be best-effort terminalized as `failed`/`degraded`
+    without spawning the executor, and the claim must be released so a
+    later dispatch for a different slot proceeds normally."""
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    flaky = _RaiseOnceOnUpdateDefinitionThenDelegate(
+        db, exc=sqlite3.OperationalError("database is locked")
+    )
+    called: list[int] = []
+
+    async def fake_executor(app, definition_row):
+        called.append(1)
+        return _FakeOutcome(outcome="finding")
+
+    handler = AutomationDefinitionHandler(
+        db=flaky, executors={"recurring_question": fake_executor}
+    )
+
+    await handler.handle(row)  # advance raises -- must not raise out, must not spawn
+
+    assert called == []  # the executor was never spawned
+    assert handler._claimed == set()  # the claim was released
+    assert handler._pending == set()  # nothing was spawned
+
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert len(runs) == 1
+    assert runs[0]["status"] == "failed"
+    assert runs[0]["outcome"] == "degraded"
+    assert runs[0]["failure_reason"]["code"] == "advance_error"
+
+    # A subsequent dispatch for a DIFFERENT slot (the flaky wrapper only
+    # raises once) proceeds normally -- the handler itself is not wedged.
+    row2 = dict(row)
+    row2["next_run_at"] = "2026-01-02T00:00:00+00:00"
+    await handler.handle(row2)
+    await _drain(handler)
+
+    assert called == [1]
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert len(runs) == 2
+    statuses = sorted(r["status"] for r in runs)
+    assert statuses == ["completed", "failed"]
 
 
 @pytest.mark.asyncio

--- a/Tests/Scheduling/test_automation_handler.py
+++ b/Tests/Scheduling/test_automation_handler.py
@@ -82,6 +82,27 @@ class _RaiseOnceThenDelegate:
         return getattr(self._db, name)
 
 
+class _RaiseOnceOnUpdateThenDelegate:
+    """Wraps a real `ScheduledTasksDB`; the first `update_automation_run`
+    call raises, every call after (including the handler's own best-effort
+    retry) delegates to the real accessor. Everything else passes straight
+    through via `__getattr__`."""
+
+    def __init__(self, db: ScheduledTasksDB, *, exc: Exception) -> None:
+        self._db = db
+        self._exc = exc
+        self._raised = False
+
+    def update_automation_run(self, *args: Any, **kwargs: Any) -> Any:
+        if not self._raised:
+            self._raised = True
+            raise self._exc
+        return self._db.update_automation_run(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._db, name)
+
+
 def _make_definition(db: ScheduledTasksDB, **overrides: Any) -> dict[str, Any]:
     kwargs: dict[str, Any] = dict(
         owner_id="local",
@@ -486,3 +507,90 @@ async def test_a_db_error_inserting_the_running_row_does_not_strand_the_claim(
     assert len(runs) == 1
     assert runs[0]["status"] == "completed"
     assert not any(r["status"] == "skipped" for r in runs)
+
+
+@pytest.mark.asyncio
+async def test_a_db_error_in_post_execution_bookkeeping_does_not_escape_the_spawned_task(
+    tmp_path,
+):
+    """`_run`'s completed-path bookkeeping (`update_automation_run` after a
+    successful executor call) must be contained the same way the executor
+    call itself is: a DB error there must not become an unretrieved
+    exception on the spawned task, must not strand the claim, and must
+    still notify (as a failure, via the best-effort retry)."""
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    flaky = _RaiseOnceOnUpdateThenDelegate(
+        db, exc=sqlite3.OperationalError("database is locked")
+    )
+    spy = _DispatchSpy()
+
+    async def fake_executor(app, definition_row):
+        return _FakeOutcome(outcome="finding")
+
+    handler = AutomationDefinitionHandler(
+        db=flaky,
+        dispatch_service=spy,
+        executors={"recurring_question": fake_executor},
+    )
+
+    await handler.handle(row)
+
+    # No exception escapes the spawned task -- `gather` must return cleanly.
+    pending = list(handler._pending)
+    await asyncio.gather(*pending)
+
+    # The claim is released despite the bookkeeping failure.
+    assert handler._claimed == set()
+
+    # The best-effort retry (this fake's SECOND `update_automation_run`
+    # call) goes through: the run lands `failed`/`degraded`, not stranded
+    # at `running`.
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert len(runs) == 1
+    assert runs[0]["status"] == "failed"
+    assert runs[0]["outcome"] == "degraded"
+    assert runs[0]["failure_reason"]["code"] == "bookkeeping_error"
+
+    # The notification still fires, as a failure.
+    assert len(spy.calls) == 1
+    assert spy.calls[0]["payload"]["kind"] == "automation_run_failed"
+    assert spy.calls[0]["severity"] == "warning"
+
+
+@pytest.mark.asyncio
+async def test_degraded_completed_outcome_notifies_with_the_failure_code_not_completed(
+    tmp_path,
+):
+    """A `degraded` outcome on the "completed" status path must not send
+    the generic "Completed." message -- that reads as success on every
+    degraded interval run."""
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    spy = _DispatchSpy()
+
+    async def degraded_executor(app, definition_row):
+        return _FakeOutcome(
+            outcome="degraded",
+            title="",
+            summary="",
+            failure_reason={"code": "retrieval_blocked"},
+        )
+
+    handler = AutomationDefinitionHandler(
+        db=db,
+        dispatch_service=spy,
+        executors={"recurring_question": degraded_executor},
+    )
+
+    await handler.handle(row)
+    await _drain(handler)
+
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert runs[0]["status"] == "completed"
+    assert runs[0]["outcome"] == "degraded"
+
+    assert len(spy.calls) == 1
+    message = spy.calls[0]["message"]
+    assert "retrieval_blocked" in message
+    assert message != "Completed."

--- a/Tests/Scheduling/test_automation_handler.py
+++ b/Tests/Scheduling/test_automation_handler.py
@@ -1,0 +1,316 @@
+"""Tests for the automation-definition scheduler handler (schedules-handoff
+PR-2 task 4).
+
+`AutomationDefinitionHandler.handle` follows `BriefingJobHandler`'s spawn
+shape: synchronous claim-check + run-row insert + schedule advance, then a
+spawned `asyncio.Task` for the actual execution. Every executor here is a
+fake injected via `executors={"recurring_question": fake}` -- no Library
+imports in this suite, so a fake `ExecutionOutcome`-shaped dataclass stands
+in for the real one (`automation_execution.ExecutionOutcome` pulls in the
+Library RAG seams this handler module deliberately avoids at import time).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+from tldw_chatbook.Scheduling.schedule_compute import schedule_slot_for
+from tldw_chatbook.Scheduling.scheduler.handlers.automation_handler import (
+    AutomationDefinitionHandler,
+)
+
+pytestmark = pytest.mark.unit
+
+NEXT_RUN_ISO = "2026-01-01T00:00:00+00:00"
+
+
+@dataclass
+class _FakeOutcome:
+    """Stands in for `automation_execution.ExecutionOutcome` (same fields)."""
+
+    outcome: str
+    title: str = "Found something"
+    summary: str = "A short summary."
+    answer: Any = None
+    answer_mode: str = "none"
+    confidence: dict = field(default_factory=dict)
+    source_refs: list = field(default_factory=list)
+    evidence_summary: dict = field(default_factory=dict)
+    failure_reason: dict | None = None
+
+
+class _DispatchSpy:
+    """Records dispatch kwargs; mirrors NotificationDispatchService.dispatch."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def dispatch(self, **kwargs: Any) -> dict:
+        self.calls.append(kwargs)
+        return {"persisted": True}
+
+
+def _make_db(tmp_path) -> ScheduledTasksDB:
+    return ScheduledTasksDB(str(tmp_path / "s.db"), client_id="t")
+
+
+def _make_definition(db: ScheduledTasksDB, **overrides: Any) -> dict[str, Any]:
+    kwargs: dict[str, Any] = dict(
+        owner_id="local",
+        family="recurring_question",
+        name="Daily Q",
+        schedule={"kind": "interval", "every_seconds": 3600},
+        input={"question": "What happened today?"},
+        config={},
+        finding_policy={},
+        notification_policy={},
+        next_run_at=NEXT_RUN_ISO,
+    )
+    kwargs.update(overrides)
+    definition_id = db.create_automation_definition(**kwargs)
+    row = db.get_automation_definition(definition_id)
+    assert row is not None
+    row["type"] = "automation_definition"
+    return row
+
+
+async def _drain(handler: AutomationDefinitionHandler) -> None:
+    """Await every currently-pending spawned run to completion."""
+    pending = list(handler._pending)
+    if pending:
+        await asyncio.gather(*pending)
+
+
+@pytest.mark.asyncio
+async def test_happy_path_writes_running_then_completed_plus_finding_and_notifies(
+    tmp_path,
+):
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    spy = _DispatchSpy()
+    app_marker = object()
+
+    async def fake_executor(app, definition_row):
+        assert app is app_marker
+        assert definition_row["id"] == row["id"]
+        return _FakeOutcome(
+            outcome="finding",
+            title="Found it",
+            summary="Here you go",
+            source_refs=[{"source": "notes", "id": "n1"}],
+        )
+
+    handler = AutomationDefinitionHandler(
+        db=db,
+        app_getter=lambda: app_marker,
+        dispatch_service=spy,
+        executors={"recurring_question": fake_executor},
+    )
+
+    await handler.handle(row)
+
+    # The running row is committed before `handle` returns -- proof by
+    # ordering, not timing: nothing has awaited the executor yet.
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert len(runs) == 1
+    assert runs[0]["status"] == "running"
+
+    await _drain(handler)
+
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert len(runs) == 1
+    assert runs[0]["status"] == "completed"
+    assert runs[0]["outcome"] == "finding"
+
+    results = db.list_automation_results("local", definition_id=row["id"])
+    assert len(results) == 1
+    assert results[0]["kind"] == "finding"
+    assert results[0]["review_state"] == "unread"
+
+    assert len(spy.calls) == 1
+    call = spy.calls[0]
+    assert call["payload"]["kind"] == "automation_run_succeeded"
+    assert call["app"] is app_marker
+    assert call["severity"] == "information"
+
+
+@pytest.mark.asyncio
+async def test_timeout_path_records_timed_out_and_notifies(tmp_path):
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    spy = _DispatchSpy()
+
+    async def slow_executor(app, definition_row):
+        await asyncio.sleep(10)
+        return _FakeOutcome(outcome="finding")
+
+    handler = AutomationDefinitionHandler(
+        db=db,
+        dispatch_service=spy,
+        handler_timeout_seconds=0.05,
+        executors={"recurring_question": slow_executor},
+    )
+
+    await handler.handle(row)
+    await _drain(handler)
+
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert runs[0]["status"] == "timed_out"
+    assert runs[0]["outcome"] == "degraded"
+    assert runs[0]["failure_reason"] == {"code": "execution_timeout"}
+
+    assert len(spy.calls) == 1
+    assert spy.calls[0]["payload"]["kind"] == "automation_run_timed_out"
+    assert spy.calls[0]["severity"] == "warning"
+
+
+@pytest.mark.asyncio
+async def test_executor_exception_records_failed_and_notifies(tmp_path):
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    spy = _DispatchSpy()
+
+    async def raising_executor(app, definition_row):
+        raise RuntimeError("boom")
+
+    handler = AutomationDefinitionHandler(
+        db=db,
+        dispatch_service=spy,
+        executors={"recurring_question": raising_executor},
+    )
+
+    await handler.handle(row)
+    await _drain(handler)
+
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert runs[0]["status"] == "failed"
+    assert runs[0]["outcome"] == "degraded"
+    assert runs[0]["failure_reason"] == {
+        "code": "execution_error",
+        "error_type": "RuntimeError",
+    }
+
+    assert len(spy.calls) == 1
+    assert spy.calls[0]["payload"]["kind"] == "automation_run_failed"
+    assert spy.calls[0]["severity"] == "warning"
+
+
+@pytest.mark.asyncio
+async def test_overlap_claim_writes_one_skipped_row_no_double_execution(tmp_path):
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    gate = asyncio.Event()
+    calls: list[int] = []
+
+    async def gated_executor(app, definition_row):
+        calls.append(1)
+        await gate.wait()
+        return _FakeOutcome(outcome="finding")
+
+    handler = AutomationDefinitionHandler(
+        db=db, executors={"recurring_question": gated_executor}
+    )
+
+    await handler.handle(row)  # spawns and claims definition_id
+    await handler.handle(row)  # sees the claim; writes a skipped row instead
+
+    gate.set()
+    await _drain(handler)
+
+    assert calls == [1]  # the executor was never invoked a second time
+
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert len(runs) == 2
+    statuses = sorted(r["status"] for r in runs)
+    assert statuses == ["completed", "skipped"]
+
+    skipped = next(r for r in runs if r["status"] == "skipped")
+    expected_slot = schedule_slot_for(datetime.fromisoformat(NEXT_RUN_ISO))
+    assert skipped["run_summary"] == {
+        "skipped": "overlap",
+        "claimed_slot": expected_slot,
+    }
+    assert skipped["schedule_slot"] is None
+
+
+@pytest.mark.asyncio
+async def test_same_slot_dispatched_twice_second_handle_writes_nothing(tmp_path):
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    calls: list[int] = []
+
+    async def fake_executor(app, definition_row):
+        calls.append(1)
+        return _FakeOutcome(outcome="finding")
+
+    handler = AutomationDefinitionHandler(
+        db=db, executors={"recurring_question": fake_executor}
+    )
+
+    await handler.handle(row)
+    await _drain(handler)
+    assert len(db.list_automation_runs("local", definition_id=row["id"])) == 1
+
+    # Same (now-stale) `row` -> same next_run_at -> same slot. The claim
+    # was already released by the drained run above, so this reaches the
+    # slot-dedupe UNIQUE, not the overlap-claim branch.
+    await handler.handle(row)
+    await _drain(handler)
+
+    assert len(db.list_automation_runs("local", definition_id=row["id"])) == 1
+    assert calls == [1]
+
+
+@pytest.mark.asyncio
+async def test_schedule_is_advanced_before_the_executor_completes(tmp_path):
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    gate = asyncio.Event()
+
+    async def gated_executor(app, definition_row):
+        await gate.wait()
+        return _FakeOutcome(outcome="finding")
+
+    handler = AutomationDefinitionHandler(
+        db=db, executors={"recurring_question": gated_executor}
+    )
+
+    await handler.handle(row)
+
+    updated = db.get_automation_definition(row["id"])
+    assert updated is not None
+    assert updated["next_run_at"] != row["next_run_at"]
+
+    gate.set()
+    await _drain(handler)
+
+
+@pytest.mark.asyncio
+async def test_notification_policy_on_failure_false_suppresses_the_notification(
+    tmp_path,
+):
+    db = _make_db(tmp_path)
+    row = _make_definition(db, notification_policy={"on_failure": False})
+    spy = _DispatchSpy()
+
+    async def raising_executor(app, definition_row):
+        raise RuntimeError("boom")
+
+    handler = AutomationDefinitionHandler(
+        db=db,
+        dispatch_service=spy,
+        executors={"recurring_question": raising_executor},
+    )
+
+    await handler.handle(row)
+    await _drain(handler)
+
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert runs[0]["status"] == "failed"  # the row is still written
+    assert spy.calls == []  # but the notification is suppressed

--- a/Tests/Scheduling/test_automation_handler.py
+++ b/Tests/Scheduling/test_automation_handler.py
@@ -13,6 +13,7 @@ Library RAG seams this handler module deliberately avoids at import time).
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
@@ -58,6 +59,27 @@ class _DispatchSpy:
 
 def _make_db(tmp_path) -> ScheduledTasksDB:
     return ScheduledTasksDB(str(tmp_path / "s.db"), client_id="t")
+
+
+class _RaiseOnceThenDelegate:
+    """Wraps a real `ScheduledTasksDB`; the first `create_automation_run`
+    call raises, every call after (including a later `handle`'s own retry)
+    delegates to the real accessor. Everything else passes straight
+    through via `__getattr__`."""
+
+    def __init__(self, db: ScheduledTasksDB, *, exc: Exception) -> None:
+        self._db = db
+        self._exc = exc
+        self._raised = False
+
+    def create_automation_run(self, *args: Any, **kwargs: Any) -> Any:
+        if not self._raised:
+            self._raised = True
+            raise self._exc
+        return self._db.create_automation_run(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._db, name)
 
 
 def _make_definition(db: ScheduledTasksDB, **overrides: Any) -> dict[str, Any]:
@@ -314,3 +336,37 @@ async def test_notification_policy_on_failure_false_suppresses_the_notification(
     runs = db.list_automation_runs("local", definition_id=row["id"])
     assert runs[0]["status"] == "failed"  # the row is still written
     assert spy.calls == []  # but the notification is suppressed
+
+
+@pytest.mark.asyncio
+async def test_a_db_error_inserting_the_running_row_does_not_strand_the_claim(
+    tmp_path,
+):
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    flaky = _RaiseOnceThenDelegate(
+        db, exc=sqlite3.OperationalError("database is locked")
+    )
+
+    async def fake_executor(app, definition_row):
+        return _FakeOutcome(outcome="finding")
+
+    handler = AutomationDefinitionHandler(
+        db=flaky, executors={"recurring_question": fake_executor}
+    )
+
+    with pytest.raises(sqlite3.OperationalError):
+        await handler.handle(row)
+
+    # The claim must not be stranded by the unexpected DB failure.
+    assert handler._claimed == set()
+
+    # A second `handle` for the same definition must proceed past the
+    # claim check (it is not treated as an overlap) -- no `skipped` row.
+    await handler.handle(row)
+    await _drain(handler)
+
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert len(runs) == 1
+    assert runs[0]["status"] == "completed"
+    assert not any(r["status"] == "skipped" for r in runs)

--- a/Tests/Scheduling/test_automation_handler.py
+++ b/Tests/Scheduling/test_automation_handler.py
@@ -339,6 +339,122 @@ async def test_notification_policy_on_failure_false_suppresses_the_notification(
 
 
 @pytest.mark.asyncio
+async def test_run_now_writes_manual_trigger_reason_null_slot_no_advance(tmp_path):
+    """Task 6: manual dispatch writes trigger_reason="manual", slot=None,
+    and leaves the definition's next_run_at untouched (no schedule advance)."""
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+
+    async def fake_executor(app, definition_row):
+        return _FakeOutcome(outcome="finding")
+
+    handler = AutomationDefinitionHandler(
+        db=db, executors={"recurring_question": fake_executor}
+    )
+
+    run_id = await handler.run_now(row)
+    assert run_id is not None
+
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert len(runs) == 1
+    assert runs[0]["id"] == run_id
+    assert runs[0]["trigger_reason"] == "manual"
+    assert runs[0]["schedule_slot"] is None
+    assert runs[0]["status"] == "running"
+
+    # No schedule advance: next_run_at is exactly what it was before.
+    updated = db.get_automation_definition(row["id"])
+    assert updated is not None
+    assert updated["next_run_at"] == row["next_run_at"]
+
+    await _drain(handler)
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert runs[0]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_run_now_does_not_slot_collide_with_a_scheduled_run(tmp_path):
+    """NULL schedule_slot is distinct in the UNIQUE: manual runs never dedupe
+    against, or get deduped by, a scheduled run for the same definition."""
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    calls: list[str] = []
+
+    async def fake_executor(app, definition_row):
+        calls.append("run")
+        return _FakeOutcome(outcome="finding")
+
+    handler = AutomationDefinitionHandler(
+        db=db, executors={"recurring_question": fake_executor}
+    )
+
+    await handler.handle(row)  # scheduled dispatch, claims + releases
+    await _drain(handler)
+    assert len(db.list_automation_runs("local", definition_id=row["id"])) == 1
+
+    run_id = await handler.run_now(row)  # manual dispatch, same slot moment
+    await _drain(handler)
+
+    assert run_id is not None
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert len(runs) == 2
+    assert calls == ["run", "run"]
+
+
+@pytest.mark.asyncio
+async def test_run_now_claim_refused_records_skipped_row_with_manual_reason(
+    tmp_path,
+):
+    """A run already claimed (scheduled or manual) refuses a manual run the
+    same way `handle`'s own overlap guard does: one skipped row, no second
+    execution."""
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    gate = asyncio.Event()
+    calls: list[int] = []
+
+    async def gated_executor(app, definition_row):
+        calls.append(1)
+        await gate.wait()
+        return _FakeOutcome(outcome="finding")
+
+    handler = AutomationDefinitionHandler(
+        db=db, executors={"recurring_question": gated_executor}
+    )
+
+    await handler.handle(row)  # spawns and claims definition_id
+    run_id = await handler.run_now(row)  # sees the claim; skipped, no spawn
+    assert run_id is None
+
+    gate.set()
+    await _drain(handler)
+
+    assert calls == [1]  # the executor was never invoked a second time
+
+    runs = db.list_automation_runs("local", definition_id=row["id"])
+    assert len(runs) == 2
+    statuses = sorted(r["status"] for r in runs)
+    assert statuses == ["completed", "skipped"]
+
+    skipped = next(r for r in runs if r["status"] == "skipped")
+    assert skipped["trigger_reason"] == "manual"
+    assert skipped["schedule_slot"] is None
+    assert skipped["run_summary"] == {"skipped": "overlap", "claimed_slot": None}
+
+
+@pytest.mark.asyncio
+async def test_run_now_no_executor_for_family_returns_none(tmp_path):
+    db = _make_db(tmp_path)
+    row = _make_definition(db, family="agent_task")
+    handler = AutomationDefinitionHandler(db=db, executors={})
+
+    run_id = await handler.run_now(row)
+
+    assert run_id is None
+    assert db.list_automation_runs("local", definition_id=row["id"]) == []
+
+
+@pytest.mark.asyncio
 async def test_a_db_error_inserting_the_running_row_does_not_strand_the_claim(
     tmp_path,
 ):

--- a/Tests/Scheduling/test_automation_health.py
+++ b/Tests/Scheduling/test_automation_health.py
@@ -40,8 +40,14 @@ def test_capability_unavailable_when_rag_service_is_none():
     assert reason
 
 
+def _fake_search_service() -> SimpleNamespace:
+    """A minimal stand-in with a callable `search` -- what a real
+    `LibraryLocalRagSearchService` (or any capable seam) actually exposes."""
+    return SimpleNamespace(search=lambda *args, **kwargs: None)
+
+
 def test_permission_required_when_no_provider_resolves(monkeypatch):
-    app = SimpleNamespace(library_rag_search_service=object())
+    app = SimpleNamespace(library_rag_search_service=_fake_search_service())
     monkeypatch.setattr(
         automation_health,
         "resolve_execution_target",
@@ -55,7 +61,7 @@ def test_permission_required_when_no_provider_resolves(monkeypatch):
 
 
 def test_ready_when_rag_service_present_and_provider_resolves(monkeypatch):
-    app = SimpleNamespace(library_rag_search_service=object())
+    app = SimpleNamespace(library_rag_search_service=_fake_search_service())
     monkeypatch.setattr(
         automation_health,
         "resolve_execution_target",
@@ -81,3 +87,22 @@ def test_capability_check_short_circuits_before_resolving_provider(monkeypatch):
     health, _reason = automation_health.compute_local_health(app, DEFINITION_ROW)
 
     assert health == "capability_unavailable"
+
+
+def test_capability_unavailable_when_service_has_no_callable_search(monkeypatch):
+    """Finding H: a `library_rag_search_service` that is present but does
+    not expose a callable `search` (e.g. a stub/misconfigured object) is
+    not a capable seam -- it must not be reported `ready` or
+    `permission_required`, either of which would tell a caller it is safe
+    to dispatch."""
+    app = SimpleNamespace(library_rag_search_service=object())
+
+    def _boom(row):
+        raise AssertionError("resolve_execution_target must not be called")
+
+    monkeypatch.setattr(automation_health, "resolve_execution_target", _boom)
+
+    health, reason = automation_health.compute_local_health(app, DEFINITION_ROW)
+
+    assert health == "capability_unavailable"
+    assert reason

--- a/Tests/Scheduling/test_automation_health.py
+++ b/Tests/Scheduling/test_automation_health.py
@@ -1,0 +1,83 @@
+"""Read-time health tests for local automation definitions (schedules-handoff
+PR-2 Task 6).
+
+`compute_local_health` is pure and read-time-only: it never touches the DB
+or persists anything. Fake ``app`` objects stand in for the running app;
+``resolve_execution_target`` (lazily imported inside the health module and
+exposed as a monkeypatchable module attribute -- see
+``automation_health.py``'s own docstring) is patched directly so these tests
+never need the real Library RAG seams importable.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Scheduling import automation_health
+
+pytestmark = pytest.mark.unit
+
+DEFINITION_ROW: dict = {"id": "def-1", "input": {}}
+
+
+def test_capability_unavailable_when_app_has_no_rag_service():
+    app = SimpleNamespace()  # no library_rag_search_service attribute at all
+
+    health, reason = automation_health.compute_local_health(app, DEFINITION_ROW)
+
+    assert health == "capability_unavailable"
+    assert reason
+
+
+def test_capability_unavailable_when_rag_service_is_none():
+    app = SimpleNamespace(library_rag_search_service=None)
+
+    health, reason = automation_health.compute_local_health(app, DEFINITION_ROW)
+
+    assert health == "capability_unavailable"
+    assert reason
+
+
+def test_permission_required_when_no_provider_resolves(monkeypatch):
+    app = SimpleNamespace(library_rag_search_service=object())
+    monkeypatch.setattr(
+        automation_health,
+        "resolve_execution_target",
+        lambda row: {"provider": None, "model": None, "max_tokens": 1000},
+    )
+
+    health, reason = automation_health.compute_local_health(app, DEFINITION_ROW)
+
+    assert health == "permission_required"
+    assert reason
+
+
+def test_ready_when_rag_service_present_and_provider_resolves(monkeypatch):
+    app = SimpleNamespace(library_rag_search_service=object())
+    monkeypatch.setattr(
+        automation_health,
+        "resolve_execution_target",
+        lambda row: {"provider": "openai", "model": "gpt-4", "max_tokens": 1000},
+    )
+
+    health, reason = automation_health.compute_local_health(app, DEFINITION_ROW)
+
+    assert health == "ready"
+    assert reason == ""
+
+
+def test_capability_check_short_circuits_before_resolving_provider(monkeypatch):
+    """capability_unavailable must win even if resolve_execution_target would
+    otherwise blow up -- the function must not be called at all."""
+    app = SimpleNamespace(library_rag_search_service=None)
+
+    def _boom(row):
+        raise AssertionError("resolve_execution_target must not be called")
+
+    monkeypatch.setattr(automation_health, "resolve_execution_target", _boom)
+
+    health, _reason = automation_health.compute_local_health(app, DEFINITION_ROW)
+
+    assert health == "capability_unavailable"

--- a/Tests/Scheduling/test_recurring_question_scope.py
+++ b/Tests/Scheduling/test_recurring_question_scope.py
@@ -1,0 +1,98 @@
+from tldw_chatbook.Scheduling.recurring_question_scope import (
+    DEFAULT_SEARCHABLE_SOURCES,
+    SUPPORTED_SCOPE_FIELDS,
+    engine_source_types,
+    normalize_recurring_question_scope,
+)
+
+
+def test_default_mode_resolves_all_three_sources():
+    normalized, errors, warnings = normalize_recurring_question_scope({})
+    assert normalized == {
+        "mode": "all_searchable_library",
+        "resolved_sources": list(DEFAULT_SEARCHABLE_SOURCES),
+    }
+    assert errors == []
+    assert warnings == []
+
+
+def test_unknown_scope_field_reports_unsupported_error():
+    normalized, errors, warnings = normalize_recurring_question_scope({"bogus": 1})
+    assert errors == [
+        {
+            "field": "config.scope.bogus",
+            "code": "unsupported",
+            "message": "Unsupported scope field: bogus",
+        }
+    ]
+    # Still resolves the default mode since "mode" itself was not the bad field.
+    assert normalized["mode"] == "all_searchable_library"
+
+
+def test_unknown_mode_returns_single_unsupported_error():
+    normalized, errors, warnings = normalize_recurring_question_scope({"mode": "bogus_mode"})
+    assert normalized == {"mode": "bogus_mode"}
+    assert errors == [
+        {
+            "field": "config.scope.mode",
+            "code": "unsupported",
+            "message": "Unsupported scope mode: bogus_mode",
+        }
+    ]
+    assert warnings == []
+
+
+def test_sources_mode_drops_unavailable_sources_into_warnings():
+    normalized, errors, warnings = normalize_recurring_question_scope(
+        {"mode": "sources", "sources": ["notes", "not_a_real_source"]},
+        available_sources=["media_db", "notes", "chats"],
+    )
+    assert normalized == {"mode": "sources", "sources": ["notes"]}
+    assert errors == []
+    assert warnings == [{"code": "source_unavailable", "source": "not_a_real_source"}]
+
+
+def test_empty_resolution_reports_scope_empty_error():
+    normalized, errors, warnings = normalize_recurring_question_scope(
+        {"mode": "sources", "sources": ["nope"]},
+        available_sources=["media_db"],
+    )
+    assert normalized == {"mode": "sources", "sources": []}
+    assert errors == [
+        {
+            "field": "config.scope",
+            "code": "scope_empty",
+            "message": "Scope must include at least one readable searchable source.",
+        }
+    ]
+
+
+def test_supported_scope_fields_matches_server_set():
+    assert SUPPORTED_SCOPE_FIELDS == {
+        "mode",
+        "sources",
+        "collection_ids",
+        "tag_ids",
+        "saved_search_ids",
+        "source_types",
+        "date_window",
+        "workspace_id",
+        "advanced_filters",
+    }
+
+
+def test_engine_source_types_maps_all_searchable_library_mode():
+    result = engine_source_types(
+        {"mode": "all_searchable_library", "resolved_sources": ["media_db", "notes", "chats"]}
+    )
+    assert result == ("media", "note", "conversation")
+
+
+def test_engine_source_types_maps_sources_mode():
+    result = engine_source_types({"mode": "sources", "sources": ["chats", "media_db"]})
+    assert result == ("conversation", "media")
+
+
+def test_engine_source_types_skips_unknown_names():
+    result = engine_source_types({"mode": "sources", "sources": ["notes", "mystery_source"]})
+    assert result == ("note",)

--- a/Tests/Scheduling/test_recurring_question_scope.py
+++ b/Tests/Scheduling/test_recurring_question_scope.py
@@ -1,7 +1,7 @@
 from tldw_chatbook.Scheduling.recurring_question_scope import (
     DEFAULT_SEARCHABLE_SOURCES,
     SUPPORTED_SCOPE_FIELDS,
-    engine_source_types,
+    library_source_types,
     normalize_recurring_question_scope,
 )
 
@@ -81,18 +81,33 @@ def test_supported_scope_fields_matches_server_set():
     }
 
 
-def test_engine_source_types_maps_all_searchable_library_mode():
-    result = engine_source_types(
+def test_library_source_types_maps_all_searchable_library_mode():
+    result = library_source_types(
         {"mode": "all_searchable_library", "resolved_sources": ["media_db", "notes", "chats"]}
     )
-    assert result == ("media", "note", "conversation")
+    assert result == ("media", "notes", "conversations")
 
 
-def test_engine_source_types_maps_sources_mode():
-    result = engine_source_types({"mode": "sources", "sources": ["chats", "media_db"]})
-    assert result == ("conversation", "media")
+def test_library_source_types_maps_sources_mode():
+    result = library_source_types({"mode": "sources", "sources": ["chats", "media_db"]})
+    assert result == ("conversations", "media")
 
 
-def test_engine_source_types_skips_unknown_names():
-    result = engine_source_types({"mode": "sources", "sources": ["notes", "mystery_source"]})
-    assert result == ("note",)
+def test_library_source_types_skips_unknown_names():
+    result = library_source_types({"mode": "sources", "sources": ["notes", "mystery_source"]})
+    assert result == ("notes",)
+
+
+def test_library_source_types_map_is_a_subset_of_the_library_service_fts_servable_types():
+    """Drift guard (Finding A): `library_source_types` maps into the
+    LIBRARY service's vocabulary, not the retrieval engine's. If the
+    Library service's servable source-type set ever changes, this test
+    must break instead of silently unmapping a source name.
+    """
+    from tldw_chatbook.Library.library_local_rag_search_service import (
+        _FTS_SERVABLE_SOURCE_TYPES,
+    )
+    from tldw_chatbook.Scheduling.recurring_question_scope import _LIBRARY_SOURCE_TYPE_MAP
+
+    for library_source_type in _LIBRARY_SOURCE_TYPE_MAP.values():
+        assert library_source_type in _FTS_SERVABLE_SOURCE_TYPES

--- a/Tests/Scheduling/test_run_now.py
+++ b/Tests/Scheduling/test_run_now.py
@@ -15,6 +15,7 @@ import pytest
 from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
 from tldw_chatbook.Scheduling.models import TaskStatus
 from tldw_chatbook.Scheduling.scheduler.loop import SchedulerLoop
+from tldw_chatbook.Scheduling.services import scheduling_service as scheduling_service_module
 from tldw_chatbook.Scheduling.services.scheduling_service import SchedulingService
 
 NOW = datetime(2026, 8, 19, 12, 0, 0, tzinfo=timezone.utc)
@@ -233,6 +234,166 @@ def test_service_run_now_missing_task_returns_none(db):
     service = SchedulingService(db=db, server_client=None, runtime_source="local")
     loop = _make_loop(db, AsyncMock())
     assert asyncio.run(service.run_reminder_now("no-such-id", loop=loop)) is None
+
+
+class _FakeAutomationHandler:
+    """Stands in for `AutomationDefinitionHandler`; only `run_now` is used
+    by `SchedulingService.run_automation_now` (Task 6). `run_id=None`
+    simulates the handler's own overlap-claim refusal (deduped)."""
+
+    def __init__(self, run_id: str | None = "run-1"):
+        self.calls: list[dict] = []
+        self._run_id = run_id
+
+    async def run_now(self, definition_row: dict):
+        self.calls.append(definition_row)
+        return self._run_id
+
+
+def _make_automation_definition(db, **overrides):
+    kwargs = dict(
+        owner_id="local",
+        family="recurring_question",
+        name="Daily Q",
+        schedule={"kind": "interval", "every_seconds": 3600},
+        input={"question": "What happened today?"},
+        config={},
+    )
+    kwargs.update(overrides)
+    return db.create_automation_definition(**kwargs)
+
+
+def _service_with_automation_handler(db, handler):
+    return SchedulingService(
+        db=db,
+        server_client=None,
+        runtime_source="local",
+        automation_handler_getter=lambda: handler,
+    )
+
+
+def _stub_health(monkeypatch, health="ready", reason=""):
+    monkeypatch.setattr(
+        scheduling_service_module,
+        "compute_local_health",
+        lambda app, row: (health, reason),
+    )
+
+
+def test_service_run_automation_now_no_handler_getter_refuses(db):
+    """No `automation_handler_getter` wired -> explicit None, not a crash --
+    same honesty as `run_reminder_now(loop=None)`."""
+    definition_id = _make_automation_definition(db)
+    service = SchedulingService(db=db, server_client=None, runtime_source="local")
+
+    result = asyncio.run(service.run_automation_now(definition_id))
+
+    assert result is None
+
+
+def test_service_run_automation_now_missing_definition_returns_none(db):
+    handler = _FakeAutomationHandler()
+    service = _service_with_automation_handler(db, handler)
+
+    result = asyncio.run(service.run_automation_now("no-such-id"))
+
+    assert result is None
+    assert handler.calls == []
+
+
+def test_service_run_automation_now_server_scoped_owner_refuses(db):
+    definition_id = _make_automation_definition(db, owner_id="server:abc")
+    handler = _FakeAutomationHandler()
+    service = _service_with_automation_handler(db, handler)
+
+    result = asyncio.run(service.run_automation_now(definition_id))
+
+    assert result is None
+    assert handler.calls == []
+
+
+@pytest.mark.parametrize("lifecycle", ["archived", "disabled"])
+def test_service_run_automation_now_lifecycle_not_configured_or_paused_refuses(
+    db, lifecycle
+):
+    definition_id = _make_automation_definition(db, lifecycle=lifecycle)
+    handler = _FakeAutomationHandler()
+    service = _service_with_automation_handler(db, handler)
+
+    result = asyncio.run(service.run_automation_now(definition_id))
+
+    assert result is None
+    assert handler.calls == []
+
+
+def test_service_run_automation_now_transfer_pending_refuses(db, monkeypatch):
+    definition_id = _make_automation_definition(db, transfer_state="pending")
+    handler = _FakeAutomationHandler()
+    service = _service_with_automation_handler(db, handler)
+    _stub_health(monkeypatch)  # would otherwise also refuse; isolate this check
+
+    result = asyncio.run(service.run_automation_now(definition_id))
+
+    assert result is None
+    assert handler.calls == []
+
+
+def test_service_run_automation_now_health_not_ready_refuses(db, monkeypatch):
+    definition_id = _make_automation_definition(db)
+    handler = _FakeAutomationHandler()
+    service = _service_with_automation_handler(db, handler)
+    _stub_health(monkeypatch, health="capability_unavailable", reason="no rag service")
+
+    result = asyncio.run(service.run_automation_now(definition_id))
+
+    assert result is None
+    assert handler.calls == []
+
+
+def test_service_run_automation_now_paused_lifecycle_reaches_the_handler(
+    db, monkeypatch
+):
+    """`paused` clears the lifecycle gate -- proven by reaching the handler."""
+    definition_id = _make_automation_definition(db, lifecycle="paused")
+    handler = _FakeAutomationHandler(run_id="run-9")
+    service = _service_with_automation_handler(db, handler)
+    _stub_health(monkeypatch)
+
+    result = asyncio.run(service.run_automation_now(definition_id))
+
+    assert result == {"run_id": "run-9", "deduped": False}
+    assert len(handler.calls) == 1
+
+
+def test_service_run_automation_now_success_dispatches_and_returns_run_id(
+    db, monkeypatch
+):
+    definition_id = _make_automation_definition(db)
+    handler = _FakeAutomationHandler(run_id="run-42")
+    service = _service_with_automation_handler(db, handler)
+    _stub_health(monkeypatch)
+
+    result = asyncio.run(service.run_automation_now(definition_id))
+
+    assert result == {"run_id": "run-42", "deduped": False}
+    assert len(handler.calls) == 1
+    assert handler.calls[0]["id"] == definition_id
+
+
+def test_service_run_automation_now_deduped_when_handler_claim_refuses(
+    db, monkeypatch
+):
+    """The handler's own overlap claim (a run already in flight) declines
+    the dispatch -- still a "success" from the service's own refusal
+    checks, surfaced as `run_id=None, deduped=True` rather than `None`."""
+    definition_id = _make_automation_definition(db)
+    handler = _FakeAutomationHandler(run_id=None)
+    service = _service_with_automation_handler(db, handler)
+    _stub_health(monkeypatch)
+
+    result = asyncio.run(service.run_automation_now(definition_id))
+
+    assert result == {"run_id": None, "deduped": True}
 
 
 def test_queue_remove_by_id(db):

--- a/Tests/Scheduling/test_schedule_compute.py
+++ b/Tests/Scheduling/test_schedule_compute.py
@@ -1,0 +1,56 @@
+from datetime import datetime, timedelta, timezone
+
+from tldw_chatbook.Scheduling.schedule_compute import (
+    compute_next_run_at,
+    schedule_slot_for,
+)
+
+NOW = datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def test_one_time_future_passes_through_and_past_returns_none():
+    future = "2026-09-02T09:00:00+00:00"
+    assert compute_next_run_at({"kind": "one_time", "run_at": future}, now=NOW) \
+        == datetime(2026, 9, 2, 9, 0, tzinfo=timezone.utc)
+    assert compute_next_run_at(
+        {"kind": "one_time", "run_at": "2026-08-01T09:00:00+00:00"}, now=NOW
+    ) is None
+
+
+def test_interval_advances_from_now_never_replays():
+    nxt = compute_next_run_at({"kind": "interval", "every_seconds": 900}, now=NOW)
+    assert nxt == NOW + timedelta(seconds=900)
+
+
+def test_interval_below_floor_is_invalid():
+    assert compute_next_run_at({"kind": "interval", "every_seconds": 30}, now=NOW) is None
+
+
+def test_daily_respects_timezone():
+    nxt = compute_next_run_at(
+        {"kind": "daily", "time_of_day": "09:00", "timezone": "America/New_York"},
+        now=NOW,  # 12:00 UTC = 08:00 New York -> today's 09:00 NY is next
+    )
+    assert nxt == datetime(2026, 9, 1, 13, 0, tzinfo=timezone.utc)
+
+
+def test_weekly_picks_next_weekday_occurrence():
+    # 2026-09-01 is a Tuesday (weekday 1). Ask for Monday (0) 09:00 UTC.
+    nxt = compute_next_run_at(
+        {"kind": "weekly", "weekday": 0, "time_of_day": "09:00", "timezone": "UTC"},
+        now=NOW,
+    )
+    assert nxt == datetime(2026, 9, 7, 9, 0, tzinfo=timezone.utc)
+
+
+def test_cron_and_junk():
+    nxt = compute_next_run_at({"kind": "cron", "cron": "0 9 * * *"}, now=NOW)
+    assert nxt == datetime(2026, 9, 2, 9, 0, tzinfo=timezone.utc)
+    assert compute_next_run_at({"kind": "cron", "cron": "not cron"}, now=NOW) is None
+    assert compute_next_run_at({"kind": "nope"}, now=NOW) is None
+    assert compute_next_run_at("junk", now=NOW) is None
+
+
+def test_slot_string_is_canonical_utc_iso():
+    assert schedule_slot_for(datetime(2026, 9, 2, 9, 0, tzinfo=timezone.utc)) \
+        == "2026-09-02T09:00:00+00:00"

--- a/Tests/Scheduling/test_schedule_compute.py
+++ b/Tests/Scheduling/test_schedule_compute.py
@@ -1,4 +1,8 @@
+import os
+import time
 from datetime import datetime, timedelta, timezone
+
+import pytest
 
 from tldw_chatbook.Scheduling.schedule_compute import (
     compute_next_run_at,
@@ -54,3 +58,84 @@ def test_cron_and_junk():
 def test_slot_string_is_canonical_utc_iso():
     assert schedule_slot_for(datetime(2026, 9, 2, 9, 0, tzinfo=timezone.utc)) \
         == "2026-09-02T09:00:00+00:00"
+
+
+# --- Finding E: no-explicit-timezone path must not use a fixed-offset snapshot ---
+
+
+def test_daily_no_explicit_timezone_localizes_per_candidate_date_not_a_fixed_snapshot():
+    """Finding E: `_machine_timezone()` used to memoize
+    `datetime.now().astimezone().tzinfo` -- a FIXED UTC-offset snapshot of
+    whatever the real wall-clock offset happens to be when the function
+    runs -- and apply that SAME offset to every computed candidate
+    regardless of the candidate's own date. That is wrong across a DST
+    boundary. The fix instead resolves each candidate's offset per its own
+    date via a naive `datetime.astimezone()` call (which, per Python's
+    documented behavior, applies the platform's local DST rule for
+    whatever date the naive value actually carries).
+
+    Proof: force the process's local zone to America/New_York (a DST
+    zone) for the duration of this test, then compute the SAME
+    no-explicit-timezone daily schedule for a `now` inside DST (July) and
+    one outside DST (January). A fixed-offset snapshot would use one
+    offset for both regardless of which `now` was passed; per-date
+    localization must pick EDT for July and EST for January -- a
+    different UTC hour for the identical local wall-clock target.
+    """
+    if not hasattr(time, "tzset"):
+        pytest.skip("time.tzset() is POSIX-only; cannot force the local zone here")
+
+    original_tz = os.environ.get("TZ")
+    os.environ["TZ"] = "America/New_York"
+    time.tzset()
+    try:
+        schedule = {"kind": "daily", "time_of_day": "09:00"}  # no explicit timezone
+        winter_next = compute_next_run_at(
+            schedule, now=datetime(2026, 1, 15, 12, 0, tzinfo=timezone.utc)
+        )
+        summer_next = compute_next_run_at(
+            schedule, now=datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc)
+        )
+        assert winter_next is not None
+        assert summer_next is not None
+        # EST is UTC-5, EDT is UTC-4: the same 09:00 local wall-clock
+        # target lands at a different UTC hour depending on which one is
+        # in effect for that candidate's own date -- proof the offset was
+        # resolved per-date, not from one snapshot shared by both calls.
+        assert winter_next.hour != summer_next.hour
+    finally:
+        if original_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original_tz
+        time.tzset()
+
+
+# --- Finding F: DST fall-back must never compute a past instant ---------------
+
+
+def test_weekly_dst_fallback_final_guard_never_returns_a_past_instant():
+    """Finding F: during the America/New_York 2026-11-01 fall-back, wall
+    clock 01:00-01:59 occurs twice (EDT then EST). `_compute_weekly` adds
+    `candidate += timedelta(days=days_ahead)` unconditionally -- even when
+    `days_ahead == 0` -- and Python's documented arithmetic behavior on an
+    aware datetime always resets the result's `fold` to 0. That can flip a
+    correctly-resolved EST (fold=1) candidate to an EDT (fold=0)
+    interpretation, producing a UTC instant up to an hour earlier than
+    intended. Regression-tested here with a `now` that lands in the
+    second (EST, fold=1) occurrence of 01:00, asking for that same
+    Sunday's 01:05 -- the final guard must detect a result <= now and
+    advance one more period rather than ever handing back a past instant.
+    """
+    now = datetime(2026, 11, 1, 6, 0, tzinfo=timezone.utc)  # 01:00 EST, post-fallback
+    nxt = compute_next_run_at(
+        {
+            "kind": "weekly",
+            "weekday": 6,  # Sunday -- 2026-11-01 is a Sunday
+            "time_of_day": "01:05",
+            "timezone": "America/New_York",
+        },
+        now=now,
+    )
+    assert nxt is not None
+    assert nxt > now

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -562,6 +562,31 @@ def test_list_armable_automation_definitions_sorted_by_next_run_at(
     assert [row["id"] for row in armable] == [earlier, later]
 
 
+def test_list_armable_automation_definitions_caps_at_500(
+    db: ScheduledTasksDB,
+) -> None:
+    cap = ScheduledTasksDB._ARMABLE_DEFINITIONS_CAP
+    base = _utc(2026, 1, 1)
+    ids = []
+    for i in range(cap + 1):
+        ids.append(
+            db.create_automation_definition(
+                owner_id="local",
+                family="recurring_question",
+                name=f"Def {i}",
+                next_run_at=base + timedelta(seconds=i),
+            )
+        )
+
+    armable = db.list_armable_automation_definitions()
+
+    assert len(armable) == cap
+    # Oldest (earliest next_run_at) cap rows are kept, in ascending order;
+    # the newest-scheduled row (last inserted) is the one dropped.
+    assert [row["id"] for row in armable] == ids[:cap]
+    assert ids[-1] not in {row["id"] for row in armable}
+
+
 def test_update_automation_definition(db: ScheduledTasksDB) -> None:
     schedule = {"kind": "cron", "expression": "0 9 * * *"}
     def_id = db.create_automation_definition(

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -454,6 +454,114 @@ def test_list_automation_definitions_filters(db: ScheduledTasksDB) -> None:
     assert paused_agent[0]["id"] == a1
 
 
+# ---------------------------------------------------------------------------
+# list_armable_automation_definitions (schedules-handoff PR-2, Task 5)
+# ---------------------------------------------------------------------------
+
+
+def test_list_armable_automation_definitions_arms_a_qualifying_row(
+    db: ScheduledTasksDB,
+) -> None:
+    def_id = db.create_automation_definition(
+        owner_id="local",
+        family="recurring_question",
+        name="Daily standup question",
+        next_run_at=_utc(2026, 1, 1),
+    )
+
+    armable = db.list_armable_automation_definitions()
+
+    assert [row["id"] for row in armable] == [def_id]
+    assert armable[0]["family"] == "recurring_question"
+
+
+def test_list_armable_automation_definitions_excludes_wrong_family(
+    db: ScheduledTasksDB,
+) -> None:
+    db.create_automation_definition(
+        owner_id="local",
+        family="agent_task",
+        name="Not v1's family",
+        next_run_at=_utc(2026, 1, 1),
+    )
+
+    assert db.list_armable_automation_definitions() == []
+
+
+def test_list_armable_automation_definitions_excludes_wrong_lifecycle(
+    db: ScheduledTasksDB,
+) -> None:
+    db.create_automation_definition(
+        owner_id="local",
+        family="recurring_question",
+        name="Paused",
+        lifecycle="paused",
+        next_run_at=_utc(2026, 1, 1),
+    )
+
+    assert db.list_armable_automation_definitions() == []
+
+
+def test_list_armable_automation_definitions_excludes_missing_next_run_at(
+    db: ScheduledTasksDB,
+) -> None:
+    db.create_automation_definition(
+        owner_id="local",
+        family="recurring_question",
+        name="Never scheduled",
+    )
+
+    assert db.list_armable_automation_definitions() == []
+
+
+def test_list_armable_automation_definitions_excludes_transfer_pending(
+    db: ScheduledTasksDB,
+) -> None:
+    def_id = db.create_automation_definition(
+        owner_id="local",
+        family="recurring_question",
+        name="Mid-handoff",
+        next_run_at=_utc(2026, 1, 1),
+    )
+    db.update_automation_definition(def_id, transfer_state="to_server_sent")
+
+    assert db.list_armable_automation_definitions() == []
+
+
+def test_list_armable_automation_definitions_excludes_other_owner(
+    db: ScheduledTasksDB,
+) -> None:
+    db.create_automation_definition(
+        owner_id="server:user-1",
+        family="recurring_question",
+        name="Server-owned",
+        next_run_at=_utc(2026, 1, 1),
+    )
+
+    assert db.list_armable_automation_definitions(owner_id="local") == []
+
+
+def test_list_armable_automation_definitions_sorted_by_next_run_at(
+    db: ScheduledTasksDB,
+) -> None:
+    later = db.create_automation_definition(
+        owner_id="local",
+        family="recurring_question",
+        name="Later",
+        next_run_at=_utc(2026, 1, 2),
+    )
+    earlier = db.create_automation_definition(
+        owner_id="local",
+        family="recurring_question",
+        name="Earlier",
+        next_run_at=_utc(2026, 1, 1),
+    )
+
+    armable = db.list_armable_automation_definitions()
+
+    assert [row["id"] for row in armable] == [earlier, later]
+
+
 def test_update_automation_definition(db: ScheduledTasksDB) -> None:
     schedule = {"kind": "cron", "expression": "0 9 * * *"}
     def_id = db.create_automation_definition(

--- a/Tests/Scheduling/test_scheduler_loop.py
+++ b/Tests/Scheduling/test_scheduler_loop.py
@@ -343,6 +343,64 @@ def test_queue_pop_due_skips_items_without_next_run_at(db):
     assert len(queue) == 0
 
 
+# ---------------------------------------------------------------------------
+# Automation-definition feed (schedules-handoff PR-2, Task 5)
+# ---------------------------------------------------------------------------
+
+
+def test_queue_arms_a_qualifying_automation_definition(db):
+    """A local, configured, due `recurring_question` definition is a real
+    queue row tagged `type="automation_definition"`, sorted alongside
+    everything else -- not a projection (spec §7.2)."""
+    def_id = db.create_automation_definition(
+        owner_id="local",
+        family="recurring_question",
+        name="Daily standup question",
+        next_run_at="2026-01-01T00:00:01+00:00",
+    )
+    _create_reminder(db, "Reminder", "2026-01-01T00:00:02+00:00")
+
+    queue = PriorityQueue(db)
+    queue.load()
+
+    assert len(queue) == 2
+    first = queue.peek()
+    assert first["id"] == def_id
+    assert first["type"] == "automation_definition"
+
+
+def test_queue_never_arms_a_transfer_pending_automation_definition(db):
+    def_id = db.create_automation_definition(
+        owner_id="local",
+        family="recurring_question",
+        name="Mid-handoff",
+        next_run_at="2026-01-01T00:00:01+00:00",
+    )
+    db.update_automation_definition(def_id, transfer_state="to_server_sent")
+
+    queue = PriorityQueue(db)
+    queue.load()
+
+    assert len(queue) == 0
+
+
+def test_queue_never_arms_a_server_scoped_automation_definition(db):
+    """Defense in depth (Task 5 brief): the queue-level `is_server_scoped_owner`
+    guard drops a server-owned definition even though the accessor's own
+    `owner_id="local"` filter already would have."""
+    db.create_automation_definition(
+        owner_id="server:42",
+        family="recurring_question",
+        name="Server-owned",
+        next_run_at="2026-01-01T00:00:01+00:00",
+    )
+
+    queue = PriorityQueue(db)
+    queue.load()
+
+    assert len(queue) == 0
+
+
 class _FakeWatchlistProjection(WatchlistProjection):
     """Projection stub that returns canned jobs without touching SubscriptionsDB."""
 

--- a/tldw_chatbook/Scheduling/automation_execution.py
+++ b/tldw_chatbook/Scheduling/automation_execution.py
@@ -122,6 +122,15 @@ def resolve_execution_target(definition_row: dict) -> dict:
     is no config-default fallback for `max_tokens`). `max_tokens` defaults
     to `_DEFAULT_MAX_TOKENS` when nothing resolves one, and is always capped
     at `_MAX_TOKENS_CAP`.
+
+    Args:
+        definition_row: An automation-definition row (as a dict). Its
+            ``input`` field, when a mapping, is consulted first.
+
+    Returns:
+        A dict with ``provider``, ``model``, and ``max_tokens`` keys.
+        ``provider``/``model`` may be ``None`` if no layer resolved a
+        value; ``max_tokens`` is always a positive int.
     """
     definition_input = definition_row.get("input") if isinstance(definition_row, Mapping) else None
     if not isinstance(definition_input, Mapping):
@@ -360,6 +369,15 @@ async def execute_recurring_question(app: Any, definition_row: dict) -> Executio
     function's own bug, an unhardened seam change) is the caller's job:
     `AutomationDefinitionHandler._run`'s spawned-task wrapper is the actual
     "never raises" boundary for a scheduled run.
+
+    Args:
+        app: The running `TldwCli` app instance, passed through to
+            `run_library_rag_search`.
+        definition_row: The `recurring_question` automation-definition row
+            (as a dict) to execute.
+
+    Returns:
+        The classified `ExecutionOutcome` for this run.
     """
     row = definition_row if isinstance(definition_row, Mapping) else {}
 

--- a/tldw_chatbook/Scheduling/automation_execution.py
+++ b/tldw_chatbook/Scheduling/automation_execution.py
@@ -282,7 +282,22 @@ def _classify(
         )
 
     # generation_mode is "optional" or "required": generation was attempted.
-    assert answer is not None
+    if answer is None:
+        # Defensive: `execute_recurring_question` only reaches this branch
+        # when generation was actually attempted (its own guard mirrors
+        # these same three preconditions), so this should be unreachable --
+        # but an internal invariant break must degrade honestly rather than
+        # crash the spawned run task (server parity: `classify_rag_response`
+        # never asserts either).
+        return _degraded(
+            failure_code="generation_unavailable",
+            evidence_summary=_evidence_summary(
+                result_count=result_count,
+                answer_present=False,
+                retrieval_status=retrieval_status,
+                generation_status="",
+            ),
+        )
     confidence = {"citation_status": answer.citation_status} if answer.citation_status else {}
 
     if answer.status == ANSWER_STATUS_READY:
@@ -336,7 +351,16 @@ def _classify(
 
 async def execute_recurring_question(app: Any, definition_row: dict) -> ExecutionOutcome:
     """Run one `recurring_question` definition: scope -> retrieval -> (maybe)
-    generation -> classification. Never raises."""
+    generation -> classification.
+
+    Composes `run_library_rag_search` and `generate_library_rag_answer`,
+    both hardened not to raise for their own internal failures -- but this
+    function does not itself add a blanket try/except around that
+    composition. Containment for anything that still escapes (this
+    function's own bug, an unhardened seam change) is the caller's job:
+    `AutomationDefinitionHandler._run`'s spawned-task wrapper is the actual
+    "never raises" boundary for a scheduled run.
+    """
     row = definition_row if isinstance(definition_row, Mapping) else {}
 
     definition_input = row.get("input")
@@ -387,6 +411,9 @@ async def execute_recurring_question(app: Any, definition_row: dict) -> Executio
         and generation_mode != "disabled"
     ):
         target = resolve_execution_target(row)
+        # target["max_tokens"] is resolved for future executors (agent_task)
+        # but not passed here: `generate_library_rag_answer` computes its own
+        # budget via `_effective_max_tokens` (reasoning-aware, model-keyed).
         answer = await generate_library_rag_answer(
             query=question,
             results=results,

--- a/tldw_chatbook/Scheduling/automation_execution.py
+++ b/tldw_chatbook/Scheduling/automation_execution.py
@@ -36,7 +36,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from ..config import coerce_int_setting, get_cli_setting
-from .recurring_question_scope import engine_source_types, normalize_recurring_question_scope
+from .recurring_question_scope import library_source_types, normalize_recurring_question_scope
 from ..Library.library_rag_answer_service import (
     ANSWER_STATUS_READY,
     LibraryRagAnswer,
@@ -216,7 +216,9 @@ def _evidence_summary(
     }
 
 
-def _degraded(*, failure_code: str, evidence_summary: dict) -> ExecutionOutcome:
+def _degraded(
+    *, failure_code: str, evidence_summary: dict, failure_reason: dict | None = None
+) -> ExecutionOutcome:
     return ExecutionOutcome(
         outcome="degraded",
         title="",
@@ -226,7 +228,7 @@ def _degraded(*, failure_code: str, evidence_summary: dict) -> ExecutionOutcome:
         confidence={},
         source_refs=[],
         evidence_summary=evidence_summary,
-        failure_reason={"code": failure_code},
+        failure_reason=failure_reason if failure_reason is not None else {"code": failure_code},
     )
 
 
@@ -403,8 +405,26 @@ async def execute_recurring_question(app: Any, definition_row: dict) -> Executio
     if generation_mode not in _VALID_GENERATION_MODES:
         generation_mode = "optional"
 
-    normalized_scope, _errors, _warnings = normalize_recurring_question_scope(config.get("scope"))
-    source_types = engine_source_types(normalized_scope)
+    normalized_scope, scope_errors, _warnings = normalize_recurring_question_scope(config.get("scope"))
+    if scope_errors:
+        # Server parity: an unsupported scope mode/field or an empty
+        # resolved scope (`scope_empty`) is a non-retryable refusal, not a
+        # signal to fall back to unscoped (everything) retrieval -- the
+        # opposite of what a scoped definition asked for (Finding B).
+        return _degraded(
+            failure_code=scope_errors[0].get("code", "scope_invalid"),
+            evidence_summary=_evidence_summary(
+                result_count=0,
+                answer_present=False,
+                retrieval_status="",
+                generation_status="",
+            ),
+            failure_reason={
+                "code": scope_errors[0].get("code", "scope_invalid"),
+                "errors": scope_errors,
+            },
+        )
+    source_types = library_source_types(normalized_scope)
 
     top_k, high_confidence_only = _resolve_finding_policy(row.get("finding_policy"))
 

--- a/tldw_chatbook/Scheduling/automation_execution.py
+++ b/tldw_chatbook/Scheduling/automation_execution.py
@@ -1,0 +1,404 @@
+"""Execution core for local `recurring_question` automation definitions.
+
+Composes two already-hardened Library seams -- `run_library_rag_search`
+(retrieval) and `generate_library_rag_answer` (contained, citation-grounded
+generation) -- with `recurring_question_scope`'s normalizer, and classifies
+the pair of results into an `ExecutionOutcome` mirroring the server's
+`classify_rag_response` vocabulary (`finding`/`no_match`/`degraded` x
+`synthesized`/`evidence_only`/`none`). No new retrieval or generation
+machinery lives here.
+
+This module is imported lazily, inside the spawned run coroutine (Task 4's
+`AutomationDefinitionHandler`), never at that handler module's top level --
+the two Library seams it imports are heavier than the boot-census ratchet
+(ADR-097) allows a handler-module import to carry.
+
+Score-filter decision (`finding_policy` preset `high_confidence_only`):
+`LibraryRagResultRow.score` exists, but it is not a single comparable
+"confidence" number on its own -- it sits on different scales depending on
+`row.score_kind` (a plain vector cosine similarity, an RRF-fused rank score,
+or an unbounded reranker score; see `Library/library_rag_score_kinds.py`,
+which exists specifically to stop code from banding a fused ~0.02 the way a
+cosine similarity of 0.5 would band). The post-filter therefore resolves
+each row's comparable similarity via `library_rag_similarity_input(...)` and
+keeps it when that similarity is `>= LIBRARY_RAG_MATCH_STRONG_THRESHOLD` --
+the same threshold the evidence panel bands "match: strong" on. A row with
+no comparable similarity at all (a reranked row, or an FTS-leg-only hybrid
+row) resolves to `None` and is KEPT rather than dropped: dropping it would
+assert a confidence judgement about a number the row does not carry, which
+is exactly the invented claim the score-kind machinery exists to prevent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ..config import coerce_int_setting, get_cli_setting
+from .recurring_question_scope import engine_source_types, normalize_recurring_question_scope
+from ..Library.library_rag_answer_service import (
+    ANSWER_STATUS_READY,
+    LibraryRagAnswer,
+    generate_library_rag_answer,
+    resolve_library_rag_answer_provider,
+)
+from ..Library.library_rag_score_kinds import library_rag_similarity_input
+from ..Library.library_rag_service import (
+    LibraryRagSearchRequest,
+    run_library_rag_search,
+)
+from ..Library.library_rag_state import LIBRARY_RAG_MATCH_STRONG_THRESHOLD
+
+#: Every summary this module writes is bounded to this length (server parity).
+RESULT_SUMMARY_MAX_CHARS = 1000
+_SUMMARY_ELLIPSIS = "…"
+
+#: `resolve_execution_target` bounds.
+_MAX_TOKENS_CAP = 4000
+_DEFAULT_MAX_TOKENS = 1000
+
+#: `finding_policy` -> retrieval `top_k`.
+_FINDING_POLICY_TOP_K_DEFAULT = 10
+_FINDING_POLICY_TOP_K_MIN = 1
+_FINDING_POLICY_TOP_K_MAX = 100
+_HIGH_CONFIDENCE_PRESET = "high_confidence_only"
+
+_VALID_GENERATION_MODES = {"disabled", "optional", "required"}
+_RETRIEVAL_DEGRADED_STATUSES = frozenset({"blocked", "failed"})
+
+
+@dataclass(frozen=True)
+class ExecutionOutcome:
+    """One `recurring_question` run's result, in the server's vocabulary."""
+
+    outcome: str  # finding | no_match | degraded
+    title: str
+    summary: str
+    answer: Any | None
+    answer_mode: str  # synthesized | evidence_only | none
+    confidence: dict
+    source_refs: list[dict]
+    evidence_summary: dict  # {result_count, answer_present, retrieval_status, generation_status}
+    failure_reason: dict | None
+
+
+def _bounded(text: str | None) -> str:
+    """Cap `text` at `RESULT_SUMMARY_MAX_CHARS`, ellipsis included."""
+    value = str(text or "")
+    if len(value) <= RESULT_SUMMARY_MAX_CHARS:
+        return value
+    return value[: RESULT_SUMMARY_MAX_CHARS - len(_SUMMARY_ELLIPSIS)] + _SUMMARY_ELLIPSIS
+
+
+def _sanitize_text(value: Any) -> str | None:
+    """A non-blank stripped string, or `None` for blank/junk input."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _sanitize_positive_int(value: Any) -> int | None:
+    """A positive int, or `None` for blank/junk/non-positive input."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        as_int = int(value)
+    except (TypeError, ValueError):
+        return None
+    return as_int if as_int > 0 else None
+
+
+def resolve_execution_target(definition_row: dict) -> dict:
+    """Resolve `{provider, model, max_tokens}` for one execution.
+
+    Precedence, sanitized independently at each layer before it is
+    consulted (server review-#5 discipline -- a blank or junk value at a
+    layer falls through to the next one, it never wins by being present):
+    definition `input.provider`/`input.model`/`input.max_tokens`, then
+    `[scheduling] executor_provider`/`executor_model`/`executor_max_tokens`,
+    then `resolve_library_rag_answer_provider()` for provider/model (there
+    is no config-default fallback for `max_tokens`). `max_tokens` defaults
+    to `_DEFAULT_MAX_TOKENS` when nothing resolves one, and is always capped
+    at `_MAX_TOKENS_CAP`.
+    """
+    definition_input = definition_row.get("input") if isinstance(definition_row, Mapping) else None
+    if not isinstance(definition_input, Mapping):
+        definition_input = {}
+
+    provider = _sanitize_text(definition_input.get("provider"))
+    model = _sanitize_text(definition_input.get("model"))
+    max_tokens = _sanitize_positive_int(definition_input.get("max_tokens"))
+
+    if provider is None:
+        provider = _sanitize_text(get_cli_setting("scheduling", "executor_provider", None))
+    if model is None:
+        model = _sanitize_text(get_cli_setting("scheduling", "executor_model", None))
+    if max_tokens is None:
+        max_tokens = _sanitize_positive_int(
+            get_cli_setting("scheduling", "executor_max_tokens", None)
+        )
+
+    if provider is None or model is None:
+        fallback_provider, fallback_model = resolve_library_rag_answer_provider()
+        if provider is None:
+            provider = fallback_provider
+        if model is None:
+            model = fallback_model
+
+    if max_tokens is None:
+        max_tokens = _DEFAULT_MAX_TOKENS
+    max_tokens = min(max_tokens, _MAX_TOKENS_CAP)
+
+    return {"provider": provider, "model": model, "max_tokens": max_tokens}
+
+
+def _resolve_finding_policy(finding_policy: Any) -> tuple[int, bool]:
+    """`(top_k, high_confidence_only)` from a `finding_policy` dict."""
+    policy = finding_policy if isinstance(finding_policy, Mapping) else {}
+    preset = str(policy.get("preset") or "balanced_findings")
+    top_k = _FINDING_POLICY_TOP_K_DEFAULT
+    if "top_k" in policy:
+        top_k = coerce_int_setting(
+            policy.get("top_k"),
+            top_k,
+            minimum=_FINDING_POLICY_TOP_K_MIN,
+            maximum=_FINDING_POLICY_TOP_K_MAX,
+        )
+    return top_k, preset == _HIGH_CONFIDENCE_PRESET
+
+
+def _filter_high_confidence(results: tuple) -> tuple:
+    """Keep rows whose comparable similarity is strong, or has none at all."""
+    kept = []
+    for row in results:
+        similarity = library_rag_similarity_input(
+            row.score, score_kind=row.score_kind, vector_score=row.vector_score
+        )
+        if similarity is None or similarity >= LIBRARY_RAG_MATCH_STRONG_THRESHOLD:
+            kept.append(row)
+    return tuple(kept)
+
+
+def _source_refs(results: tuple) -> list[dict]:
+    """One `{source, id, title}` dict per row, from fields the row carries."""
+    refs = []
+    for row in results:
+        provenance = row.provenance if isinstance(row.provenance, Mapping) else {}
+        refs.append(
+            {
+                "source": provenance.get("source_type", ""),
+                "id": row.result_id,
+                "title": row.title,
+            }
+        )
+    return refs
+
+
+def _evidence_summary(
+    *, result_count: int, answer_present: bool, retrieval_status: str, generation_status: str
+) -> dict:
+    return {
+        "result_count": result_count,
+        "answer_present": answer_present,
+        "retrieval_status": retrieval_status,
+        "generation_status": generation_status,
+    }
+
+
+def _degraded(*, failure_code: str, evidence_summary: dict) -> ExecutionOutcome:
+    return ExecutionOutcome(
+        outcome="degraded",
+        title="",
+        summary="",
+        answer=None,
+        answer_mode="none",
+        confidence={},
+        source_refs=[],
+        evidence_summary=evidence_summary,
+        failure_reason={"code": failure_code},
+    )
+
+
+def _classify(
+    *,
+    retrieval_status: str,
+    results: tuple,
+    generation_mode: str,
+    answer: LibraryRagAnswer | None,
+) -> ExecutionOutcome:
+    """The six-row classification ladder (server `classify_rag_response`,
+    adapted to the `run_library_rag_search`/`generate_library_rag_answer`
+    seams)."""
+    if retrieval_status in _RETRIEVAL_DEGRADED_STATUSES:
+        return _degraded(
+            failure_code=f"retrieval_{retrieval_status}",
+            evidence_summary=_evidence_summary(
+                result_count=0,
+                answer_present=False,
+                retrieval_status=retrieval_status,
+                generation_status="",
+            ),
+        )
+
+    if not results:
+        return ExecutionOutcome(
+            outcome="no_match",
+            title="No matching sources found",
+            summary="",
+            answer=None,
+            answer_mode="none",
+            confidence={},
+            source_refs=[],
+            evidence_summary=_evidence_summary(
+                result_count=0,
+                answer_present=False,
+                retrieval_status=retrieval_status,
+                generation_status="",
+            ),
+            failure_reason=None,
+        )
+
+    result_count = len(results)
+    source_refs = _source_refs(results)
+
+    if generation_mode == "disabled":
+        return ExecutionOutcome(
+            outcome="finding",
+            title="Relevant evidence found",
+            summary="",
+            answer=None,
+            answer_mode="evidence_only",
+            confidence={},
+            source_refs=source_refs,
+            evidence_summary=_evidence_summary(
+                result_count=result_count,
+                answer_present=False,
+                retrieval_status=retrieval_status,
+                generation_status="",
+            ),
+            failure_reason=None,
+        )
+
+    # generation_mode is "optional" or "required": generation was attempted.
+    assert answer is not None
+    confidence = {"citation_status": answer.citation_status} if answer.citation_status else {}
+
+    if answer.status == ANSWER_STATUS_READY:
+        return ExecutionOutcome(
+            outcome="finding",
+            title="Possible answer found",
+            summary=_bounded(answer.text),
+            answer=answer.text,
+            answer_mode="synthesized",
+            confidence=confidence,
+            source_refs=source_refs,
+            evidence_summary=_evidence_summary(
+                result_count=result_count,
+                answer_present=True,
+                retrieval_status=retrieval_status,
+                generation_status=answer.status,
+            ),
+            failure_reason=None,
+        )
+
+    if generation_mode == "required":
+        return _degraded(
+            failure_code="generation_required_unavailable",
+            evidence_summary=_evidence_summary(
+                result_count=result_count,
+                answer_present=False,
+                retrieval_status=retrieval_status,
+                generation_status=answer.status,
+            ),
+        )
+
+    # optional, and the answer abstained / had no evidence / failed: keep the
+    # evidence, drop the (unusable) answer text.
+    return ExecutionOutcome(
+        outcome="finding",
+        title="Relevant evidence found",
+        summary="",
+        answer=None,
+        answer_mode="evidence_only",
+        confidence=confidence,
+        source_refs=source_refs,
+        evidence_summary=_evidence_summary(
+            result_count=result_count,
+            answer_present=False,
+            retrieval_status=retrieval_status,
+            generation_status=answer.status,
+        ),
+        failure_reason=None,
+    )
+
+
+async def execute_recurring_question(app: Any, definition_row: dict) -> ExecutionOutcome:
+    """Run one `recurring_question` definition: scope -> retrieval -> (maybe)
+    generation -> classification. Never raises."""
+    row = definition_row if isinstance(definition_row, Mapping) else {}
+
+    definition_input = row.get("input")
+    if not isinstance(definition_input, Mapping):
+        definition_input = {}
+    question = _sanitize_text(definition_input.get("question"))
+    if question is None:
+        return _degraded(
+            failure_code="question_empty",
+            evidence_summary=_evidence_summary(
+                result_count=0,
+                answer_present=False,
+                retrieval_status="",
+                generation_status="",
+            ),
+        )
+
+    config = row.get("config")
+    if not isinstance(config, Mapping):
+        config = {}
+    generation_mode = config.get("generation_mode")
+    if generation_mode not in _VALID_GENERATION_MODES:
+        generation_mode = "optional"
+
+    normalized_scope, _errors, _warnings = normalize_recurring_question_scope(config.get("scope"))
+    source_types = engine_source_types(normalized_scope)
+
+    top_k, high_confidence_only = _resolve_finding_policy(row.get("finding_policy"))
+
+    retrieval_outcome = await run_library_rag_search(
+        app,
+        LibraryRagSearchRequest(
+            query=question,
+            source_types=source_types,
+            mode="rag",
+            top_k=top_k,
+            include_citations=True,
+        ),
+    )
+    results = retrieval_outcome.results
+    if high_confidence_only:
+        results = _filter_high_confidence(results)
+
+    answer: LibraryRagAnswer | None = None
+    if (
+        retrieval_outcome.status not in _RETRIEVAL_DEGRADED_STATUSES
+        and results
+        and generation_mode != "disabled"
+    ):
+        target = resolve_execution_target(row)
+        answer = await generate_library_rag_answer(
+            query=question,
+            results=results,
+            coverage_note="",
+            provider=target["provider"],
+            model=target["model"],
+            chat=None,
+        )
+
+    return _classify(
+        retrieval_status=retrieval_outcome.status,
+        results=results,
+        generation_mode=generation_mode,
+        answer=answer,
+    )

--- a/tldw_chatbook/Scheduling/automation_health.py
+++ b/tldw_chatbook/Scheduling/automation_health.py
@@ -36,8 +36,10 @@ def compute_local_health(app: Any, definition_row: dict) -> tuple[str, str]:
     Checks, in order:
 
     1. `capability_unavailable` -- `app.library_rag_search_service` is
-       absent or `None` (the `recurring_question` family's only retrieval
-       seam today).
+       absent, `None`, or does not expose a callable `search` (the
+       `recurring_question` family's only retrieval seam today; a service
+       object without a callable `search` is not actually usable, however
+       present the attribute is).
     2. `permission_required` -- `resolve_execution_target` resolves no
        `provider` at any of its layers (definition `input`, `[scheduling]`
        config, or the Library RAG answer-provider default).
@@ -58,7 +60,8 @@ def compute_local_health(app: Any, definition_row: dict) -> tuple[str, str]:
     """
     global resolve_execution_target
 
-    if getattr(app, "library_rag_search_service", None) is None:
+    service = getattr(app, "library_rag_search_service", None)
+    if service is None or not callable(getattr(service, "search", None)):
         return Health.CAPABILITY_UNAVAILABLE.value, _CAPABILITY_UNAVAILABLE_REASON
 
     if resolve_execution_target is None:

--- a/tldw_chatbook/Scheduling/automation_health.py
+++ b/tldw_chatbook/Scheduling/automation_health.py
@@ -42,6 +42,19 @@ def compute_local_health(app: Any, definition_row: dict) -> tuple[str, str]:
        `provider` at any of its layers (definition `input`, `[scheduling]`
        config, or the Library RAG answer-provider default).
     3. Otherwise `"ready"`, with an empty reason.
+
+    Args:
+        app: The running `TldwCli` app instance, checked for
+            `library_rag_search_service` and passed through to
+            `resolve_execution_target`.
+        definition_row: The automation-definition row (as a dict) to
+            evaluate.
+
+    Returns:
+        A `(health, reason)` tuple: `health` is one of `Health`'s string
+        values (`capability_unavailable`, `permission_required`, `ready`);
+        `reason` is a human-readable explanation, or `""` when `health` is
+        `ready`.
     """
     global resolve_execution_target
 

--- a/tldw_chatbook/Scheduling/automation_health.py
+++ b/tldw_chatbook/Scheduling/automation_health.py
@@ -1,0 +1,62 @@
+"""Read-time health for local automation definitions (schedules-handoff PR-2, Task 6).
+
+`compute_local_health` is never persisted onto the definition row (spec
+§7.4): capability/permission state can change between reads (a provider
+configured, a service wired up), and a stored value would go stale. Callers
+recompute it every time they need it -- today that is
+`SchedulingService.run_automation_now`'s pre-dispatch refusal check; a later
+PR (PR-6) surfaces it in the UI.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_chatbook.Scheduling.models import Health
+
+_CAPABILITY_UNAVAILABLE_REASON = (
+    "Library RAG search is not available in this app instance."
+)
+_PERMISSION_REQUIRED_REASON = (
+    "No LLM provider is configured for automation execution."
+)
+
+#: Lazily populated with `automation_execution.resolve_execution_target` on
+#: first real use -- `automation_execution` pulls in the Library RAG
+#: answer-provider seams, heavier than this module's boot-census budget
+#: (ADR-097), so it must not be imported at module scope. Kept as a real
+#: module attribute (not a function-local import) so tests can monkeypatch
+#: it directly instead of needing the Library seams importable at all.
+resolve_execution_target: Any = None
+
+
+def compute_local_health(app: Any, definition_row: dict) -> tuple[str, str]:
+    """Return `(health, reason)` for one local automation definition.
+
+    Checks, in order:
+
+    1. `capability_unavailable` -- `app.library_rag_search_service` is
+       absent or `None` (the `recurring_question` family's only retrieval
+       seam today).
+    2. `permission_required` -- `resolve_execution_target` resolves no
+       `provider` at any of its layers (definition `input`, `[scheduling]`
+       config, or the Library RAG answer-provider default).
+    3. Otherwise `"ready"`, with an empty reason.
+    """
+    global resolve_execution_target
+
+    if getattr(app, "library_rag_search_service", None) is None:
+        return Health.CAPABILITY_UNAVAILABLE.value, _CAPABILITY_UNAVAILABLE_REASON
+
+    if resolve_execution_target is None:
+        from tldw_chatbook.Scheduling.automation_execution import (
+            resolve_execution_target as _resolve_execution_target,
+        )
+
+        resolve_execution_target = _resolve_execution_target
+
+    target = resolve_execution_target(definition_row)
+    if not target.get("provider"):
+        return Health.PERMISSION_REQUIRED.value, _PERMISSION_REQUIRED_REASON
+
+    return Health.READY.value, ""

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -1098,6 +1098,38 @@ class ScheduledTasksDB(BaseDB):
                 cursor.fetchall(), json_fields=self._AUTOMATION_JSON_FIELDS
             )
 
+    def list_armable_automation_definitions(
+        self, owner_id: str = "local"
+    ) -> list[dict[str, Any]]:
+        """List local definitions ready to feed the scheduler queue (§7.2).
+
+        A row arms only when all four hold: ``family='recurring_question'``
+        (v1 -- the only executor registered), ``lifecycle='configured'``,
+        a real ``next_run_at``, and no transfer in flight
+        (``transfer_state IS NULL`` -- a definition mid-handoff to the
+        server is not this side's to run, spec §6). ``owner_id`` defaults
+        to ``"local"``: this is the accessor half of the defense-in-depth
+        pairing with `PriorityQueue`'s own `is_server_scoped_owner` guard
+        (slice 1) -- neither alone is trusted to keep a server-scoped
+        definition from arming locally.
+        """
+        with closing(self._get_connection()) as conn:
+            cursor = conn.execute(
+                """
+                SELECT * FROM automation_definitions
+                WHERE family = 'recurring_question'
+                  AND lifecycle = 'configured'
+                  AND next_run_at IS NOT NULL
+                  AND transfer_state IS NULL
+                  AND owner_id = ?
+                ORDER BY next_run_at
+                """,
+                (owner_id,),
+            )
+            return self._rows_to_dicts(
+                cursor.fetchall(), json_fields=self._AUTOMATION_JSON_FIELDS
+            )
+
     def update_automation_definition(self, definition_id: str, **kwargs: Any) -> bool:
         """Update automation-definition fields. Returns True if a row changed.
 

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -28,6 +28,13 @@ class ScheduledTasksDB(BaseDB):
 
     _CURRENT_SCHEMA_VERSION = 4
 
+    #: Defensive cap on `list_armable_automation_definitions` -- mirrors the
+    #: Automations tab's `AUTOMATIONS_LOAD_MAX_ROWS` cap-500 precedent
+    #: (`UI/Screens/scheduling/schedules_workbench.py`). Not a design limit
+    #: on how many local automations may exist -- see the truncation
+    #: warning this method logs when the cap is hit.
+    _ARMABLE_DEFINITIONS_CAP = 500
+
     _REMINDER_TASK_COLUMNS = {
         "id",
         "server_id",
@@ -1112,6 +1119,19 @@ class ScheduledTasksDB(BaseDB):
         pairing with `PriorityQueue`'s own `is_server_scoped_owner` guard
         (slice 1) -- neither alone is trusted to keep a server-scoped
         definition from arming locally.
+
+        The result is bounded to `_ARMABLE_DEFINITIONS_CAP` rows, ordered by
+        `next_run_at` ascending, so the soonest-due definitions are kept and
+        any overflow is the latest-scheduled tail. A `logger.warning` fires
+        when the cap is hit, since a truncated arm set must never fail
+        silently.
+
+        Args:
+            owner_id: Owner scope to arm for. Defaults to ``"local"``.
+
+        Returns:
+            Armable definition rows (as dicts), ordered by ``next_run_at``
+            ascending, capped at `_ARMABLE_DEFINITIONS_CAP` rows.
         """
         with closing(self._get_connection()) as conn:
             cursor = conn.execute(
@@ -1123,12 +1143,19 @@ class ScheduledTasksDB(BaseDB):
                   AND transfer_state IS NULL
                   AND owner_id = ?
                 ORDER BY next_run_at
+                LIMIT ?
                 """,
-                (owner_id,),
+                (owner_id, self._ARMABLE_DEFINITIONS_CAP),
             )
-            return self._rows_to_dicts(
-                cursor.fetchall(), json_fields=self._AUTOMATION_JSON_FIELDS
-            )
+            rows = cursor.fetchall()
+            if len(rows) == self._ARMABLE_DEFINITIONS_CAP:
+                logger.warning(
+                    "list_armable_automation_definitions: armable set truncated "
+                    "at _ARMABLE_DEFINITIONS_CAP={} rows for owner_id={!r}",
+                    self._ARMABLE_DEFINITIONS_CAP,
+                    owner_id,
+                )
+            return self._rows_to_dicts(rows, json_fields=self._AUTOMATION_JSON_FIELDS)
 
     def update_automation_definition(self, definition_id: str, **kwargs: Any) -> bool:
         """Update automation-definition fields. Returns True if a row changed.

--- a/tldw_chatbook/Scheduling/recurring_question_scope.py
+++ b/tldw_chatbook/Scheduling/recurring_question_scope.py
@@ -1,0 +1,125 @@
+"""Scope normalization for Recurring Question scheduled tasks.
+
+Ported from tldw_server `recurring_question_scope.py` @ 5921014aa9 — byte-parity
+except imports; regenerate the parity tests when the server module changes
+(spec §7.1 drift rule).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Inlined from tldw_server `recurring_question_models.py` @ 5921014aa9
+# (only the two constants this module needs).
+DEFAULT_SEARCHABLE_SOURCES = ("media_db", "notes", "chats")
+SUPPORTED_SCOPE_FIELDS = {
+    "mode",
+    "sources",
+    "collection_ids",
+    "tag_ids",
+    "saved_search_ids",
+    "source_types",
+    "date_window",
+    "workspace_id",
+    "advanced_filters",
+}
+
+# Maps server source names onto the retrieval engine vocabulary
+# (the `rag_service` docstring's own vocabulary).
+_ENGINE_SOURCE_TYPE_MAP = {
+    "media_db": "media",
+    "notes": "note",
+    "chats": "conversation",
+}
+
+
+def normalize_recurring_question_scope(
+    scope: Any,
+    *,
+    available_sources: list[str] | tuple[str, ...] | None = None,
+) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Normalize a Recurring Question scope without binding to source-specific UI."""
+    readable_sources = list(dict.fromkeys(available_sources or DEFAULT_SEARCHABLE_SOURCES))
+    raw_scope = scope if isinstance(scope, dict) else {}
+    errors: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+
+    for field in raw_scope:
+        if field not in SUPPORTED_SCOPE_FIELDS:
+            errors.append(
+                {
+                    "field": f"config.scope.{field}",
+                    "code": "unsupported",
+                    "message": f"Unsupported scope field: {field}",
+                }
+            )
+
+    mode = raw_scope.get("mode")
+    if mode is not None and mode not in {"all_searchable_library", "sources"}:
+        return {
+            "mode": str(mode),
+        }, [
+            {
+                "field": "config.scope.mode",
+                "code": "unsupported",
+                "message": f"Unsupported scope mode: {mode}",
+            }
+        ], warnings
+
+    if mode == "all_searchable_library" or (mode is None and "sources" not in raw_scope):
+        normalized = {
+            "mode": "all_searchable_library",
+            "resolved_sources": readable_sources,
+        }
+        if not readable_sources:
+            errors.append(_scope_empty_error())
+        return normalized, errors, warnings
+
+    requested_sources = _string_list(raw_scope.get("sources"))
+    resolved_sources: list[str] = []
+    for source in requested_sources:
+        if source in readable_sources:
+            resolved_sources.append(source)
+        else:
+            warnings.append({"code": "source_unavailable", "source": source})
+
+    normalized = {"mode": "sources", "sources": list(dict.fromkeys(resolved_sources))}
+    for field in (
+        "collection_ids",
+        "tag_ids",
+        "saved_search_ids",
+        "source_types",
+        "date_window",
+        "workspace_id",
+        "advanced_filters",
+    ):
+        if field in raw_scope:
+            normalized[field] = raw_scope[field]
+
+    if not normalized["sources"]:
+        errors.append(_scope_empty_error())
+    return normalized, errors, warnings
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _scope_empty_error() -> dict[str, str]:
+    return {
+        "field": "config.scope",
+        "code": "scope_empty",
+        "message": "Scope must include at least one readable searchable source.",
+    }
+
+
+def engine_source_types(normalized_scope: dict[str, Any]) -> tuple[str, ...]:
+    """Map a normalized scope's source names onto retrieval engine source types.
+
+    Reads `resolved_sources` (all-library mode) or `sources` (sources mode).
+    Unknown source names are skipped rather than raised.
+    """
+    names = normalized_scope.get("resolved_sources") or normalized_scope.get("sources") or []
+    return tuple(_ENGINE_SOURCE_TYPE_MAP[name] for name in names if name in _ENGINE_SOURCE_TYPE_MAP)

--- a/tldw_chatbook/Scheduling/recurring_question_scope.py
+++ b/tldw_chatbook/Scheduling/recurring_question_scope.py
@@ -3,6 +3,11 @@
 Ported from tldw_server `recurring_question_scope.py` @ 5921014aa9 — byte-parity
 except imports; regenerate the parity tests when the server module changes
 (spec §7.1 drift rule).
+
+Function docstrings (Args/Returns sections) are a local addition on top of
+the ported bodies and are excluded from the parity comparison -- the parity
+claim above covers behavior/code, not docstrings. A future re-sync should
+diff from each `def` body, not from the docstring text.
 """
 
 from __future__ import annotations
@@ -38,7 +43,20 @@ def normalize_recurring_question_scope(
     *,
     available_sources: list[str] | tuple[str, ...] | None = None,
 ) -> tuple[dict[str, Any], list[dict[str, Any]], list[dict[str, Any]]]:
-    """Normalize a Recurring Question scope without binding to source-specific UI."""
+    """Normalize a Recurring Question scope without binding to source-specific UI.
+
+    Args:
+        scope: The raw scope dict from a definition's `config.scope` field
+            (or any value -- non-dict input normalizes as an empty scope).
+        available_sources: The readable searchable source names to resolve
+            against. Defaults to `DEFAULT_SEARCHABLE_SOURCES` when omitted.
+
+    Returns:
+        A `(normalized_scope, errors, warnings)` tuple. `normalized_scope`
+        always carries a `mode`; `errors` and `warnings` are lists of
+        field-coded dicts describing any unsupported fields, an unsupported
+        mode, an empty resolved scope, or unavailable requested sources.
+    """
     readable_sources = list(dict.fromkeys(available_sources or DEFAULT_SEARCHABLE_SOURCES))
     raw_scope = scope if isinstance(scope, dict) else {}
     errors: list[dict[str, Any]] = []
@@ -120,6 +138,14 @@ def engine_source_types(normalized_scope: dict[str, Any]) -> tuple[str, ...]:
 
     Reads `resolved_sources` (all-library mode) or `sources` (sources mode).
     Unknown source names are skipped rather than raised.
+
+    Args:
+        normalized_scope: A scope dict as returned by
+            `normalize_recurring_question_scope`.
+
+    Returns:
+        A tuple of retrieval-engine source-type strings (e.g. `"media"`,
+        `"note"`, `"conversation"`), in the order the source names appeared.
     """
     names = normalized_scope.get("resolved_sources") or normalized_scope.get("sources") or []
     return tuple(_ENGINE_SOURCE_TYPE_MAP[name] for name in names if name in _ENGINE_SOURCE_TYPE_MAP)

--- a/tldw_chatbook/Scheduling/recurring_question_scope.py
+++ b/tldw_chatbook/Scheduling/recurring_question_scope.py
@@ -29,12 +29,20 @@ SUPPORTED_SCOPE_FIELDS = {
     "advanced_filters",
 }
 
-# Maps server source names onto the retrieval engine vocabulary
-# (the `rag_service` docstring's own vocabulary).
-_ENGINE_SOURCE_TYPE_MAP = {
+# Maps server source names onto the LIBRARY service's vocabulary
+# (`library_local_rag_search_service.py`'s `search()`, this module's only
+# real consumer via `automation_execution.py` -> `LibraryRagSearchRequest.
+# source_types`). The Library speaks plurals -- `media`, `notes`,
+# `conversations`, `prompts` (see that module's `_ENGINE_KEYWORD_SOURCE_
+# TYPES` comment block) -- which is a different vocabulary than the
+# retrieval ENGINE's own singular `rag_service` spelling
+# (`media`/`note`/`conversation`); the Library service translates between
+# the two internally, so this map must stay in the Library's vocabulary,
+# not the engine's.
+_LIBRARY_SOURCE_TYPE_MAP = {
     "media_db": "media",
-    "notes": "note",
-    "chats": "conversation",
+    "notes": "notes",
+    "chats": "conversations",
 }
 
 
@@ -133,8 +141,8 @@ def _scope_empty_error() -> dict[str, str]:
     }
 
 
-def engine_source_types(normalized_scope: dict[str, Any]) -> tuple[str, ...]:
-    """Map a normalized scope's source names onto retrieval engine source types.
+def library_source_types(normalized_scope: dict[str, Any]) -> tuple[str, ...]:
+    """Map a normalized scope's source names onto Library service source types.
 
     Reads `resolved_sources` (all-library mode) or `sources` (sources mode).
     Unknown source names are skipped rather than raised.
@@ -144,8 +152,9 @@ def engine_source_types(normalized_scope: dict[str, Any]) -> tuple[str, ...]:
             `normalize_recurring_question_scope`.
 
     Returns:
-        A tuple of retrieval-engine source-type strings (e.g. `"media"`,
-        `"note"`, `"conversation"`), in the order the source names appeared.
+        A tuple of `LibraryLocalRagSearchService.search()` source-type
+        strings (e.g. `"media"`, `"notes"`, `"conversations"`), in the
+        order the source names appeared.
     """
     names = normalized_scope.get("resolved_sources") or normalized_scope.get("sources") or []
-    return tuple(_ENGINE_SOURCE_TYPE_MAP[name] for name in names if name in _ENGINE_SOURCE_TYPE_MAP)
+    return tuple(_LIBRARY_SOURCE_TYPE_MAP[name] for name in names if name in _LIBRARY_SOURCE_TYPE_MAP)

--- a/tldw_chatbook/Scheduling/schedule_compute.py
+++ b/tldw_chatbook/Scheduling/schedule_compute.py
@@ -37,10 +37,6 @@ def _naive_as_utc(dt: datetime) -> datetime:
     return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
 
 
-def _machine_timezone() -> Any:
-    return datetime.now().astimezone().tzinfo or timezone.utc
-
-
 def _resolve_timezone(name: Any, *, default: Any) -> Any:
     if not name:
         return default
@@ -87,16 +83,53 @@ def _compute_interval(schedule: dict[str, Any], now: datetime) -> datetime | Non
     return now + timedelta(seconds=every_seconds)
 
 
+def _local_now_for_schedule(schedule: dict[str, Any], now: datetime) -> datetime:
+    """Local "now" to build daily/weekly candidates from.
+
+    An explicit IANA ``timezone`` resolves through ``ZoneInfo`` as before
+    (fold-aware, DST-correct for that zone). With no explicit timezone
+    (Finding E), this returns a NAIVE local wall-clock value instead of
+    localizing through a single fixed-offset snapshot (the old
+    ``_machine_timezone()``, which memoized ``datetime.now().astimezone()
+    .tzinfo`` -- wrong across a DST boundary, since every computed
+    candidate got that one snapshot's offset regardless of the
+    candidate's own date). A naive datetime's own ``.astimezone()`` (see
+    ``_localize_after`` below) instead resolves the platform's local rule
+    per the date it actually carries.
+    """
+    explicit_tz_name = schedule.get("timezone")
+    if explicit_tz_name:
+        return now.astimezone(_resolve_timezone(explicit_tz_name, default=timezone.utc))
+    return now.astimezone().replace(tzinfo=None)
+
+
+def _localize_after(candidate: datetime, now: datetime, period: timedelta) -> datetime:
+    """Localize ``candidate`` (aware or naive-local) to UTC.
+
+    Guards against DST fall-back computing a past instant (Finding F):
+    Python's aware-datetime arithmetic always resets ``fold`` to 0 on its
+    result (documented behavior), which can silently flip a
+    correctly-resolved second-occurrence (``fold=1``) candidate to the
+    first occurrence's interpretation after a ``candidate += timedelta``
+    -- up to an hour earlier than intended. If the localized result is
+    not strictly after ``now``, advance one more ``period`` (a day or a
+    week) and recompute rather than ever handing back a stale slot.
+    """
+    result = candidate.astimezone(timezone.utc)
+    if result <= now:
+        result = (candidate + period).astimezone(timezone.utc)
+    return result
+
+
 def _compute_daily(schedule: dict[str, Any], now: datetime) -> datetime | None:
     tod = _parse_time_of_day(schedule.get("time_of_day"))
     if tod is None:
         return None
-    tz = _resolve_timezone(schedule.get("timezone"), default=_machine_timezone())
-    local_now = now.astimezone(tz)
+    local_now = _local_now_for_schedule(schedule, now)
     candidate = local_now.replace(hour=tod.hour, minute=tod.minute, second=0, microsecond=0)
     if candidate <= local_now:
         candidate += timedelta(days=1)
-    return candidate.astimezone(timezone.utc)
+    return _localize_after(candidate, now, timedelta(days=1))
 
 
 def _compute_weekly(schedule: dict[str, Any], now: datetime) -> datetime | None:
@@ -104,14 +137,13 @@ def _compute_weekly(schedule: dict[str, Any], now: datetime) -> datetime | None:
     weekday = schedule.get("weekday")
     if tod is None or isinstance(weekday, bool) or not isinstance(weekday, int) or not (0 <= weekday <= 6):
         return None
-    tz = _resolve_timezone(schedule.get("timezone"), default=_machine_timezone())
-    local_now = now.astimezone(tz)
+    local_now = _local_now_for_schedule(schedule, now)
     candidate = local_now.replace(hour=tod.hour, minute=tod.minute, second=0, microsecond=0)
     days_ahead = (weekday - candidate.weekday()) % 7
     candidate += timedelta(days=days_ahead)
     if candidate <= local_now:
         candidate += timedelta(days=7)
-    return candidate.astimezone(timezone.utc)
+    return _localize_after(candidate, now, timedelta(days=7))
 
 
 def _compute_cron(schedule: dict[str, Any], now: datetime) -> datetime | None:
@@ -145,6 +177,13 @@ def compute_next_run_at(schedule: dict[str, Any], *, now: datetime) -> datetime 
     any invalid/junk schedule -- this never raises, since a bad row must
     not take down the queue.
 
+    Nonexistent local times (the spring-forward gap -- e.g. a ``daily``/
+    ``weekly`` ``time_of_day`` that falls in the hour skipped when clocks
+    jump forward) resolve FORWARD per ``zoneinfo``/PEP 495 fold semantics:
+    02:30 becomes 03:30 that same day, matching common cron behavior. This
+    is deliberate and unchanged (Finding G) -- not a case this function
+    treats as invalid or shifts to a different day.
+
     Args:
         schedule: A schedule dict with a ``kind`` key (one of
             ``_KIND_COMPUTERS``: ``one_time``, ``interval``, ``daily``,
@@ -168,5 +207,17 @@ def compute_next_run_at(schedule: dict[str, Any], *, now: datetime) -> datetime 
 
 
 def schedule_slot_for(next_run: datetime) -> str:
-    """Canonical UTC ISO string used as a run's ``schedule_slot``."""
+    """Canonical UTC ISO string used as a run's ``schedule_slot``.
+
+    Args:
+        next_run: The next scheduled run time. Every caller in this
+            codebase passes an aware datetime (this module's own
+            computers always return one); a naive value here would be
+            interpreted as system-local time by ``astimezone()``, not UTC.
+
+    Returns:
+        ``next_run`` converted to UTC and rendered as an ISO 8601 string --
+        the value stored as a run's ``schedule_slot`` and used in its
+        ``(definition_id, definition_version, schedule_slot)`` UNIQUE.
+    """
     return next_run.astimezone(timezone.utc).isoformat()

--- a/tldw_chatbook/Scheduling/schedule_compute.py
+++ b/tldw_chatbook/Scheduling/schedule_compute.py
@@ -1,0 +1,162 @@
+"""Schedule computation for the five reference schedule kinds.
+
+Pure module (no I/O, no imports of other Scheduling submodules): given a
+schedule dict and the current time, compute the next UTC run time. Never
+raises -- a malformed schedule row must not kill the queue; invalid/junk
+input yields ``None`` (logged at debug).
+
+Advance-from-now semantics (spec Sec 4.3 / TASK-18937 discipline): elapsed
+slots are skipped, never replayed. For example an ``interval`` schedule's
+next run is always ``now + every_seconds``, never a replay of a slot that
+has already passed.
+
+Supported kinds (matches the server's ``_SUPPORTED_SCHEDULE_KINDS``):
+
+- ``one_time``: ``run_at`` (ISO datetime string).
+- ``interval``: ``every_seconds`` (int, floor 60).
+- ``daily``: ``time_of_day`` ("HH:MM"), optional IANA ``timezone``
+  (defaults to the machine's local zone).
+- ``weekly``: ``daily`` fields plus ``weekday`` (0-6, 0=Monday).
+- ``cron``: ``cron`` (5-field cron expression, via ``croniter``), optional
+  IANA ``timezone`` (defaults to UTC).
+"""
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta, timezone
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from croniter import croniter
+from loguru import logger
+
+_MIN_INTERVAL_SECONDS = 60
+
+
+def _naive_as_utc(dt: datetime) -> datetime:
+    """Naive datetimes are assumed UTC, matching ``_to_utc_iso``'s discipline."""
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def _machine_timezone() -> Any:
+    return datetime.now().astimezone().tzinfo or timezone.utc
+
+
+def _resolve_timezone(name: Any, *, default: Any) -> Any:
+    if not name:
+        return default
+    try:
+        return ZoneInfo(str(name))
+    except (ZoneInfoNotFoundError, ValueError, KeyError):
+        logger.debug(f"schedule_compute: unknown timezone {name!r}, falling back to UTC")
+        return timezone.utc
+
+
+def _parse_time_of_day(value: Any) -> time | None:
+    if not isinstance(value, str):
+        return None
+    parts = value.split(":")
+    if len(parts) != 2:
+        return None
+    try:
+        hour, minute = int(parts[0]), int(parts[1])
+    except ValueError:
+        return None
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        return None
+    return time(hour=hour, minute=minute)
+
+
+def _compute_one_time(schedule: dict[str, Any], now: datetime) -> datetime | None:
+    run_at = schedule.get("run_at")
+    if not isinstance(run_at, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(run_at)
+    except ValueError:
+        return None
+    parsed = _naive_as_utc(parsed).astimezone(timezone.utc)
+    return parsed if parsed > now else None
+
+
+def _compute_interval(schedule: dict[str, Any], now: datetime) -> datetime | None:
+    every_seconds = schedule.get("every_seconds")
+    if isinstance(every_seconds, bool) or not isinstance(every_seconds, (int, float)):
+        return None
+    if every_seconds < _MIN_INTERVAL_SECONDS:
+        return None
+    return now + timedelta(seconds=every_seconds)
+
+
+def _compute_daily(schedule: dict[str, Any], now: datetime) -> datetime | None:
+    tod = _parse_time_of_day(schedule.get("time_of_day"))
+    if tod is None:
+        return None
+    tz = _resolve_timezone(schedule.get("timezone"), default=_machine_timezone())
+    local_now = now.astimezone(tz)
+    candidate = local_now.replace(hour=tod.hour, minute=tod.minute, second=0, microsecond=0)
+    if candidate <= local_now:
+        candidate += timedelta(days=1)
+    return candidate.astimezone(timezone.utc)
+
+
+def _compute_weekly(schedule: dict[str, Any], now: datetime) -> datetime | None:
+    tod = _parse_time_of_day(schedule.get("time_of_day"))
+    weekday = schedule.get("weekday")
+    if tod is None or isinstance(weekday, bool) or not isinstance(weekday, int) or not (0 <= weekday <= 6):
+        return None
+    tz = _resolve_timezone(schedule.get("timezone"), default=_machine_timezone())
+    local_now = now.astimezone(tz)
+    candidate = local_now.replace(hour=tod.hour, minute=tod.minute, second=0, microsecond=0)
+    days_ahead = (weekday - candidate.weekday()) % 7
+    candidate += timedelta(days=days_ahead)
+    if candidate <= local_now:
+        candidate += timedelta(days=7)
+    return candidate.astimezone(timezone.utc)
+
+
+def _compute_cron(schedule: dict[str, Any], now: datetime) -> datetime | None:
+    cron_expr = schedule.get("cron")
+    if not isinstance(cron_expr, str) or not cron_expr.strip():
+        return None
+    tz = _resolve_timezone(schedule.get("timezone"), default=timezone.utc)
+    local_now = now.astimezone(tz)
+    try:
+        next_run = croniter(cron_expr, local_now).get_next(datetime)
+    except (ValueError, KeyError):
+        logger.debug(f"schedule_compute: invalid cron expression {cron_expr!r}")
+        return None
+    return next_run.astimezone(timezone.utc)
+
+
+_KIND_COMPUTERS = {
+    "one_time": _compute_one_time,
+    "interval": _compute_interval,
+    "daily": _compute_daily,
+    "weekly": _compute_weekly,
+    "cron": _compute_cron,
+}
+
+
+def compute_next_run_at(schedule: dict[str, Any], *, now: datetime) -> datetime | None:
+    """Compute the next UTC run time for a schedule dict.
+
+    Advance-from-now semantics (spec Sec 4.3): elapsed slots are skipped,
+    never replayed. Returns ``None`` for a spent ``one_time`` schedule or
+    any invalid/junk schedule -- this never raises, since a bad row must
+    not take down the queue.
+    """
+    if not isinstance(schedule, dict):
+        return None
+    computer = _KIND_COMPUTERS.get(schedule.get("kind"))
+    if computer is None:
+        return None
+    try:
+        return computer(schedule, now)
+    except Exception:
+        logger.debug(f"schedule_compute: failed to compute next run for {schedule!r}", exc_info=True)
+        return None
+
+
+def schedule_slot_for(next_run: datetime) -> str:
+    """Canonical UTC ISO string used as a run's ``schedule_slot``."""
+    return next_run.astimezone(timezone.utc).isoformat()

--- a/tldw_chatbook/Scheduling/schedule_compute.py
+++ b/tldw_chatbook/Scheduling/schedule_compute.py
@@ -144,6 +144,16 @@ def compute_next_run_at(schedule: dict[str, Any], *, now: datetime) -> datetime 
     never replayed. Returns ``None`` for a spent ``one_time`` schedule or
     any invalid/junk schedule -- this never raises, since a bad row must
     not take down the queue.
+
+    Args:
+        schedule: A schedule dict with a ``kind`` key (one of
+            ``_KIND_COMPUTERS``: ``one_time``, ``interval``, ``daily``,
+            ``weekly``, ``cron``) plus that kind's own fields.
+        now: The current time, used as the basis to advance from.
+
+    Returns:
+        The next UTC run time, or ``None`` if the schedule is spent,
+        malformed, or of an unrecognized ``kind``.
     """
     if not isinstance(schedule, dict):
         return None

--- a/tldw_chatbook/Scheduling/scheduler/handlers/automation_handler.py
+++ b/tldw_chatbook/Scheduling/scheduler/handlers/automation_handler.py
@@ -384,7 +384,16 @@ class AutomationDefinitionHandler:
         becomes asyncio's "Task exception was never retrieved". The
         execution timeout (task-18939 semantics) wraps only the executor
         call, per `handler_timeout_seconds` (`<=0` disables the bound,
-        `SchedulerLoop._effective_timeout_seconds` precedent).
+        `SchedulerLoop._effective_timeout_seconds` precedent). The outer
+        `except Exception` below is the same containment for the
+        bookkeeping that runs AFTER a successful (or already-handled
+        timeout/error) executor call -- `update_automation_run`/
+        `create_automation_result` can themselves raise (DB busy/locked),
+        and without this guard that escaped the same way, stranding the
+        run row at `running` and dropping the notification. Best-effort:
+        it tries once to mark the run `failed` and to notify, but a
+        failure inside THAT attempt is swallowed too -- the DB may be the
+        broken thing.
         """
         try:
             app = self.app_getter() if self.app_getter is not None else None
@@ -480,12 +489,50 @@ class AutomationDefinitionHandler:
                     confidence=outcome.confidence,
                     source_refs=outcome.source_refs,
                 )
+            if outcome.outcome == "degraded":
+                code = (
+                    outcome.failure_reason.get("code")
+                    if isinstance(outcome.failure_reason, dict)
+                    else None
+                )
+                message = f"Run degraded: {code}." if code else "Run degraded."
+            else:
+                message = outcome.summary or outcome.title or "Completed."
             self._notify(
                 task,
                 run_id=run_id,
                 status="completed",
                 outcome_value=outcome.outcome,
-                message=outcome.summary or outcome.title or "Completed.",
+                message=message,
+            )
+        except Exception as exc:  # noqa: BLE001 - must never escape the spawned task
+            logger.exception(
+                f"Automation run {run_id} for definition {definition_id!r} "
+                f"bookkeeping failed after execution: {type(exc).__name__}"
+            )
+            try:
+                await asyncio.to_thread(
+                    self.db.update_automation_run,
+                    run_id,
+                    status="failed",
+                    outcome="degraded",
+                    ended_at=datetime.now(timezone.utc),
+                    failure_reason={
+                        "code": "bookkeeping_error",
+                        "error_type": type(exc).__name__,
+                    },
+                )
+            except Exception:  # noqa: BLE001 - the DB may be the broken thing
+                pass
+            self._notify(
+                task,
+                run_id=run_id,
+                status="failed",
+                outcome_value="degraded",
+                message=(
+                    f"{task.get('name') or 'Automation'} failed: bookkeeping "
+                    f"error ({type(exc).__name__})."
+                ),
             )
         finally:
             self._claimed.discard(definition_id)

--- a/tldw_chatbook/Scheduling/scheduler/handlers/automation_handler.py
+++ b/tldw_chatbook/Scheduling/scheduler/handlers/automation_handler.py
@@ -125,6 +125,7 @@ class AutomationDefinitionHandler:
         dispatch_service: "NotificationDispatchService | None" = None,
         handler_timeout_seconds: float | None = None,
         executors: dict[str, Executor] | None = None,
+        on_queue_changed: Callable[[], None] | None = None,
     ) -> None:
         """Initialize the handler.
 
@@ -148,10 +149,20 @@ class AutomationDefinitionHandler:
                 `execute_recurring_question` -- so `agent_task` can add a
                 second entry later without touching this handler's shape.
                 Tests inject fakes here directly.
+            on_queue_changed: Called (guarded, never fails the dispatch)
+                after a successful schedule advance in `_dispatch` and
+                after `run_now`'s dispatch (`SchedulingService.
+                on_queue_changed` seam precedent) -- the in-memory queue
+                only reloads periodically (~30 min), so without this an
+                advanced `next_run_at` would not reach the live queue
+                until that reload, and an every-15-min definition would
+                run every 30 (Finding D). `None` (the default) makes it a
+                no-op.
         """
         self.db = db
         self.app_getter = app_getter
         self.dispatch_service = dispatch_service
+        self.on_queue_changed = on_queue_changed
         self.handler_timeout_seconds = coerce_positive_float(
             handler_timeout_seconds
             if handler_timeout_seconds is not None
@@ -247,13 +258,15 @@ class AutomationDefinitionHandler:
             )
             return None
 
-        return await self._dispatch(
+        run_id = await self._dispatch(
             definition_row,
             executor=executor,
             trigger_reason="manual",
             schedule_slot=None,
             advance_schedule=False,
         )
+        self._notify_queue_changed()
+        return run_id
 
     async def _dispatch(
         self,
@@ -348,13 +361,47 @@ class AutomationDefinitionHandler:
 
             if advance_schedule:
                 schedule = task.get("schedule")
-                await asyncio.to_thread(
-                    self.db.update_automation_definition,
-                    definition_id,
-                    next_run_at=compute_next_run_at(
-                        schedule if isinstance(schedule, dict) else {}, now=now
-                    ),
-                )
+                try:
+                    await asyncio.to_thread(
+                        self.db.update_automation_definition,
+                        definition_id,
+                        next_run_at=compute_next_run_at(
+                            schedule if isinstance(schedule, dict) else {}, now=now
+                        ),
+                    )
+                except Exception as exc:  # noqa: BLE001 - must not wedge the definition
+                    # The `running` row already exists but the schedule
+                    # could not be advanced: letting this propagate would
+                    # strand that row at `running` forever (the claim is
+                    # released by the `finally` below either way, but
+                    # nothing would ever mark the run terminal, and the
+                    # next dispatch of this same still-unadvanced slot
+                    # would just hit the UNIQUE and dedupe -- Finding C).
+                    # Best-effort terminalize instead, and never spawn.
+                    logger.warning(
+                        f"Automation definition {definition_id!r} schedule "
+                        f"advance failed after run {run_id!r} was claimed: "
+                        f"{type(exc).__name__}"
+                    )
+                    try:
+                        await asyncio.to_thread(
+                            self.db.update_automation_run,
+                            run_id,
+                            status="failed",
+                            outcome="degraded",
+                            ended_at=datetime.now(timezone.utc),
+                            failure_reason={
+                                "code": "advance_error",
+                                "error_type": type(exc).__name__,
+                            },
+                        )
+                    except Exception:  # noqa: BLE001 - the DB may be the broken thing
+                        pass
+                    return None
+                # Advance succeeded: push the new `next_run_at` to the live
+                # queue now rather than waiting for its periodic reload
+                # (Finding D).
+                self._notify_queue_changed()
 
             spawned = asyncio.create_task(
                 self._run(executor, task, run_id=run_id, definition_id=definition_id, owner_id=owner_id),
@@ -536,6 +583,24 @@ class AutomationDefinitionHandler:
             )
         finally:
             self._claimed.discard(definition_id)
+
+    def _notify_queue_changed(self) -> None:
+        """Invoke `on_queue_changed`, tolerating a broken callback.
+
+        Same containment discipline as `SchedulingService.
+        _notify_queue_changed`: a wiring failure here must never fail the
+        dispatch that triggered it.
+        """
+        if self.on_queue_changed is None:
+            return
+        try:
+            self.on_queue_changed()
+        except Exception:  # noqa: BLE001 - callback failure is not the caller's
+            logger.exception(
+                "AutomationDefinitionHandler on_queue_changed callback "
+                "failed; the dispatch itself succeeded and the scheduler "
+                "queue will reload on its periodic interval."
+            )
 
     def _notify(
         self,

--- a/tldw_chatbook/Scheduling/scheduler/handlers/automation_handler.py
+++ b/tldw_chatbook/Scheduling/scheduler/handlers/automation_handler.py
@@ -1,0 +1,451 @@
+"""Handler for scheduled `automation_definition` rows (schedules-handoff §7.2).
+
+Local-owner, `lifecycle=configured` automation definitions with a
+`next_run_at` feed `PriorityQueue.load` as real rows, keyed by `"type":
+"automation_definition"` -- one handler instance registers in
+`SchedulerLoop.handlers` for all of them, dispatching to a family-keyed
+executor registry (`agent_task` drops in a second registry entry later;
+this module never grows a second handler class for it).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+from loguru import logger
+
+from tldw_chatbook.Scheduling.constants import HANDLER_TIMEOUT_SECONDS, coerce_positive_float
+from tldw_chatbook.Scheduling.schedule_compute import compute_next_run_at, schedule_slot_for
+from tldw_chatbook.Scheduling.slot_keys import canonical_hash
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from tldw_chatbook.Notifications.notification_dispatch_service import (
+        NotificationDispatchService,
+    )
+    from tldw_chatbook.Scheduling.automation_execution import ExecutionOutcome
+    from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+
+#: One definition row in, one `ExecutionOutcome` out (see
+#: `automation_execution.ExecutionOutcome`, imported lazily below so this
+#: module's own top level never carries the Library seams the real
+#: implementation pulls in). `Any` here, not the real dataclass -- the
+#: alias must be evaluable at import time even though the class it
+#: describes is only ever imported inside the spawned coroutine.
+Executor = Callable[[Any, dict], Awaitable[Any]]
+
+#: `NotificationKind` values this handler can emit, per terminal run
+#: status (server `NOTIFICATION_KIND_BY_STATUS` parity,
+#: `tldw_api/notifications_reminders_schemas.py`).
+_NOTIFICATION_KIND_BY_STATUS = {
+    "completed": "automation_run_succeeded",
+    "failed": "automation_run_failed",
+    "timed_out": "automation_run_timed_out",
+    "skipped": "automation_run_skipped",
+}
+
+#: (notification_policy key, default when the key is absent, severity) per
+#: status. `on_failure` gates both `failed` and `timed_out` -- a timeout is
+#: a failure from the notification policy's point of view. `on_skip`
+#: defaults False (server parity: skipped runs are silent unless asked
+#: for), the only status here whose default is not True.
+_NOTIFICATION_GATE_BY_STATUS = {
+    "completed": ("on_success", True, "information"),
+    "failed": ("on_failure", True, "warning"),
+    "timed_out": ("on_failure", True, "warning"),
+    "skipped": ("on_skip", False, "information"),
+}
+
+
+def _parse_next_run_at(value: Any) -> datetime | None:
+    """Parse a definition row's `next_run_at` into an aware UTC datetime.
+
+    Same naive-means-UTC discipline as `schedule_compute._naive_as_utc`.
+    Junk or missing input yields `None` rather than raising -- a malformed
+    row must not kill the queue.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+async def _execute_recurring_question(app: Any, definition_row: dict) -> "ExecutionOutcome":
+    """Default `recurring_question` executor: a lazy-import wrapper.
+
+    `automation_execution` imports two Library RAG seams at its own top
+    level -- heavier than the boot-census ratchet (ADR-097) allows this
+    handler module to carry. The import happens here, inside the
+    coroutine the scheduler loop never awaits directly (it is only ever
+    reached from inside `AutomationDefinitionHandler._run`, itself only
+    reached from a spawned `asyncio.Task`), so it costs nothing until a
+    `recurring_question` definition actually fires.
+    """
+    from tldw_chatbook.Scheduling.automation_execution import execute_recurring_question
+
+    return await execute_recurring_question(app, definition_row)
+
+
+class AutomationDefinitionHandler:
+    """Fire-and-forget scheduled automation-definition execution.
+
+    Follows `BriefingJobHandler`'s spawn shape (spec §7.2, design-review
+    correction: not optional). `SchedulerLoop.tick` awaits every handler
+    serially, inline (briefings phase-4 locked decision), and a
+    `recurring_question` run is RAG retrieval plus an LLM call -- awaiting
+    it here would stall every other due task behind whichever provider is
+    slowest. `handle` therefore does only synchronous, in-memory-cheap
+    work (family lookup, the claim check, the run-row insert, and
+    advancing the schedule) and spawns the actual execution as an
+    independent `asyncio.Task`, returning before that task has had a
+    chance to run at all.
+
+    Claim guard (briefing precedent, spec §7.2 "Overlap guard"): `_claimed`
+    holds the definition ids with a run currently in flight, from just
+    before the `running` row is inserted (`handle`) until the spawned
+    task's own `finally` releases it (`_run`) -- so an interval shorter
+    than the run's own duration degrades to back-to-back runs, never
+    concurrent ones. `_pending` is the strong-reference set that keeps a
+    spawned task alive (a bare `asyncio.create_task` result with nothing
+    else holding it is only weakly referenced by the event loop); the name
+    is pinned by a later end-to-end test that awaits it directly to drain
+    in-flight runs.
+    """
+
+    def __init__(
+        self,
+        db: "ScheduledTasksDB",
+        app_getter: Callable[[], Any] | None = None,
+        dispatch_service: "NotificationDispatchService | None" = None,
+        handler_timeout_seconds: float | None = None,
+        executors: dict[str, Executor] | None = None,
+    ) -> None:
+        """Initialize the handler.
+
+        Args:
+            db: The `ScheduledTasksDB` automation runs/results/definitions
+                are read from and written to.
+            app_getter: Zero-arg getter for the running app, resolved
+                fresh per execution (`ReminderHandler`/`BriefingJobHandler`
+                late-binding discipline) and passed both to the executor
+                and to `dispatch_service.dispatch`.
+            dispatch_service: Notification seam. `None` (the default)
+                makes every notification a no-op -- headless/tests.
+            handler_timeout_seconds: Per-handler execution timeout
+                override; `None` (the default) falls back to the module
+                default `HANDLER_TIMEOUT_SECONDS`, itself disabled by a
+                zero/negative config value (`coerce_positive_float`
+                discipline, `SchedulerLoop.__init__` precedent).
+            executors: Family-keyed executor registry. `None` (the
+                default) registers only `"recurring_question"`, wired to a
+                lazy-import wrapper around Task 3's
+                `execute_recurring_question` -- so `agent_task` can add a
+                second entry later without touching this handler's shape.
+                Tests inject fakes here directly.
+        """
+        self.db = db
+        self.app_getter = app_getter
+        self.dispatch_service = dispatch_service
+        self.handler_timeout_seconds = coerce_positive_float(
+            handler_timeout_seconds
+            if handler_timeout_seconds is not None
+            else HANDLER_TIMEOUT_SECONDS,
+            HANDLER_TIMEOUT_SECONDS,
+            allow_zero=True,
+        )
+        self.executors: dict[str, Executor] = (
+            dict(executors)
+            if executors is not None
+            else {"recurring_question": _execute_recurring_question}
+        )
+        #: Definition ids with a run currently claimed -- see class
+        #: docstring for the exact window this covers.
+        self._claimed: set[str] = set()
+        #: Strong references to spawned run tasks -- see class docstring.
+        self._pending: set[asyncio.Task[Any]] = set()
+
+    async def handle(self, task: dict[str, Any]) -> None:
+        """Process one scheduled `automation_definition` row.
+
+        `task` is the definition row dict (Task 5's queue projection adds
+        `"type": "automation_definition"`, not consulted here -- the loop
+        already routed on it). Every DB write below runs through
+        `asyncio.to_thread` (`dispatch_reminder`'s own convention for this
+        loop), so `handle` itself never blocks the event loop even though
+        it is all synchronous, in-order work.
+
+        Args:
+            task: The definition row being dispatched.
+        """
+        definition_id = task.get("id")
+        family = task.get("family")
+        executor = self.executors.get(family)
+        if executor is None:
+            logger.warning(
+                f"No executor registered for automation family {family!r} "
+                f"(definition {definition_id!r}); skipping dispatch."
+            )
+            return
+
+        next_run = _parse_next_run_at(task.get("next_run_at"))
+        if next_run is None:
+            logger.warning(
+                f"Automation definition {definition_id!r} has no usable "
+                f"next_run_at; skipping dispatch."
+            )
+            return
+        # Computed up front (not literally step 3, spec numbering
+        # notwithstanding): the overlap-claim skip row below needs it too.
+        slot = schedule_slot_for(next_run)
+        owner_id = task.get("owner_id") or "local"
+        version = task.get("version") or 1
+
+        if definition_id in self._claimed:
+            # Not an error: the interval fired again before the previous
+            # run finished. The claim -- held by that still-running
+            # execution -- is the refusal.
+            logger.info(
+                f"Skipping automation definition {definition_id!r}: a run "
+                f"is already in flight for it."
+            )
+            skipped_run_id = await asyncio.to_thread(
+                self.db.create_automation_run,
+                owner_id,
+                definition_id,
+                version,
+                "scheduled",
+                status="skipped",
+                outcome="none",
+                schedule_slot=None,
+                run_summary={"skipped": "overlap", "claimed_slot": slot},
+            )
+            self._notify(
+                task,
+                run_id=skipped_run_id,
+                status="skipped",
+                outcome_value="none",
+                message=(
+                    f"{task.get('name') or 'Automation'} skipped: a run "
+                    f"was already in progress."
+                ),
+            )
+            return
+
+        self._claimed.add(definition_id)
+        now = datetime.now(timezone.utc)
+        config = task.get("config")
+        run_id = await asyncio.to_thread(
+            self.db.create_automation_run,
+            owner_id,
+            definition_id,
+            version,
+            "scheduled",
+            status="running",
+            schedule_slot=slot,
+            started_at=now,
+            scope_snapshot=config.get("scope") if isinstance(config, dict) else None,
+            finding_policy_snapshot=task.get("finding_policy"),
+        )
+        if run_id is None:
+            # The (definition, version, slot) UNIQUE fired: this slot
+            # already ran. Dedupe is a result, not an error -- nothing
+            # else to do, and nothing was spawned to release the claim.
+            self._claimed.discard(definition_id)
+            return
+
+        schedule = task.get("schedule")
+        await asyncio.to_thread(
+            self.db.update_automation_definition,
+            definition_id,
+            next_run_at=compute_next_run_at(
+                schedule if isinstance(schedule, dict) else {}, now=now
+            ),
+        )
+
+        spawned = asyncio.create_task(
+            self._run(executor, task, run_id=run_id, definition_id=definition_id, owner_id=owner_id),
+            name=f"automation_run_{run_id}",
+        )
+        self._pending.add(spawned)
+        spawned.add_done_callback(self._pending.discard)
+
+    async def _run(
+        self,
+        executor: Executor,
+        task: dict[str, Any],
+        *,
+        run_id: str,
+        definition_id: str,
+        owner_id: str,
+    ) -> None:
+        """Run one execution to completion, containing every failure.
+
+        This coroutine is the whole body of the spawned task, so nothing
+        it does may raise: an exception escaping a task nobody awaits
+        becomes asyncio's "Task exception was never retrieved". The
+        execution timeout (task-18939 semantics) wraps only the executor
+        call, per `handler_timeout_seconds` (`<=0` disables the bound,
+        `SchedulerLoop._effective_timeout_seconds` precedent).
+        """
+        try:
+            app = self.app_getter() if self.app_getter is not None else None
+            timeout = self.handler_timeout_seconds
+            try:
+                if timeout is not None and timeout > 0:
+                    outcome: "ExecutionOutcome" = await asyncio.wait_for(
+                        executor(app, task), timeout=timeout
+                    )
+                else:
+                    outcome = await executor(app, task)
+            except asyncio.TimeoutError:
+                await asyncio.to_thread(
+                    self.db.update_automation_run,
+                    run_id,
+                    status="timed_out",
+                    outcome="degraded",
+                    ended_at=datetime.now(timezone.utc),
+                    failure_reason={"code": "execution_timeout"},
+                )
+                logger.warning(
+                    f"Automation run {run_id} for definition "
+                    f"{definition_id!r} timed out after {timeout}s"
+                )
+                self._notify(
+                    task,
+                    run_id=run_id,
+                    status="timed_out",
+                    outcome_value="degraded",
+                    message=(
+                        f"{task.get('name') or 'Automation'} timed out "
+                        f"after {timeout}s."
+                    ),
+                )
+                return
+            except Exception as exc:  # noqa: BLE001 - must never escape uncaught
+                logger.warning(
+                    f"Automation run {run_id} for definition "
+                    f"{definition_id!r} failed: {type(exc).__name__}"
+                )
+                await asyncio.to_thread(
+                    self.db.update_automation_run,
+                    run_id,
+                    status="failed",
+                    outcome="degraded",
+                    ended_at=datetime.now(timezone.utc),
+                    failure_reason={
+                        "code": "execution_error",
+                        "error_type": type(exc).__name__,
+                    },
+                )
+                self._notify(
+                    task,
+                    run_id=run_id,
+                    status="failed",
+                    outcome_value="degraded",
+                    message=(
+                        f"{task.get('name') or 'Automation'} failed: "
+                        f"{type(exc).__name__}."
+                    ),
+                )
+                return
+
+            await asyncio.to_thread(
+                self.db.update_automation_run,
+                run_id,
+                status="completed",
+                outcome=outcome.outcome,
+                run_summary={"title": outcome.title, "summary": outcome.summary},
+                evidence_summary=outcome.evidence_summary,
+                failure_reason=outcome.failure_reason,
+                ended_at=datetime.now(timezone.utc),
+            )
+            if outcome.outcome == "finding":
+                dedupe_key = canonical_hash(
+                    {
+                        "definition_id": definition_id,
+                        "run_id": run_id,
+                        "kind": "finding",
+                    }
+                )
+                await asyncio.to_thread(
+                    self.db.create_automation_result,
+                    owner_id,
+                    definition_id,
+                    run_id,
+                    "finding",
+                    outcome.title,
+                    outcome.summary,
+                    dedupe_key,
+                    answer=outcome.answer,
+                    answer_mode=outcome.answer_mode,
+                    confidence=outcome.confidence,
+                    source_refs=outcome.source_refs,
+                )
+            self._notify(
+                task,
+                run_id=run_id,
+                status="completed",
+                outcome_value=outcome.outcome,
+                message=outcome.summary or outcome.title or "Completed.",
+            )
+        finally:
+            self._claimed.discard(definition_id)
+
+    def _notify(
+        self,
+        task: dict[str, Any],
+        *,
+        run_id: str | None,
+        status: str,
+        outcome_value: str,
+        message: str,
+    ) -> None:
+        """Dispatch one notification for a terminal run status.
+
+        No-op without a dispatch service; the `notification_policy` gate
+        (`_NOTIFICATION_GATE_BY_STATUS`) ports the server's
+        `_notification_enabled(definition, status)` semantics. Never
+        raises -- a notification failure must never surface as a
+        scheduling failure (same containment rule as
+        `BriefingJobHandler._notify_result`).
+        """
+        if self.dispatch_service is None:
+            return
+        kind = _NOTIFICATION_KIND_BY_STATUS.get(status)
+        gate = _NOTIFICATION_GATE_BY_STATUS.get(status)
+        if kind is None or gate is None:
+            return
+        gate_key, gate_default, severity = gate
+        policy = task.get("notification_policy")
+        if not isinstance(policy, dict):
+            policy = {}
+        if not bool(policy.get(gate_key, gate_default)):
+            return
+        definition_id = task.get("id")
+        try:
+            app = self.app_getter() if self.app_getter is not None else None
+            self.dispatch_service.dispatch(
+                app=app,
+                category="automation",
+                title=str(task.get("name") or "Automation"),
+                message=message,
+                severity=severity,
+                source_entity_kind="automation_definition",
+                source_entity_id=definition_id,
+                payload={"kind": kind, "run_id": run_id, "outcome": outcome_value},
+            )
+        except Exception as exc:  # noqa: BLE001 - must never escape uncaught
+            logger.warning(
+                f"Automation notification dispatch failed for definition "
+                f"{definition_id!r}: {type(exc).__name__}"
+            )
+
+    async def __call__(self, task: dict[str, Any]) -> None:
+        """Allow the handler to be invoked directly by the scheduler loop."""
+        await self.handle(task)

--- a/tldw_chatbook/Scheduling/scheduler/handlers/automation_handler.py
+++ b/tldw_chatbook/Scheduling/scheduler/handlers/automation_handler.py
@@ -200,16 +200,92 @@ class AutomationDefinitionHandler:
                 f"next_run_at; skipping dispatch."
             )
             return
-        # Computed up front (not literally step 3, spec numbering
-        # notwithstanding): the overlap-claim skip row below needs it too.
         slot = schedule_slot_for(next_run)
+
+        await self._dispatch(
+            task,
+            executor=executor,
+            trigger_reason="scheduled",
+            schedule_slot=slot,
+            advance_schedule=True,
+        )
+
+    async def run_now(self, definition_row: dict[str, Any]) -> str | None:
+        """Dispatch one definition immediately (manual "Run now", Task 6).
+
+        Reuses `handle`'s claim/spawn machinery via `_dispatch`, with
+        `trigger_reason="manual"` and `schedule_slot=None` -- manual runs
+        never slot-collide (NULL is distinct from every other value in the
+        run's `(definition_id, definition_version, schedule_slot)`
+        UNIQUE, so a manual run never dedupes against, or is deduped by, a
+        scheduled one) -- and no schedule advance: a manual run does not
+        consume or move the definition's next scheduled occurrence.
+
+        The service seam (`SchedulingService.run_automation_now`) has
+        already applied the owner/lifecycle/transfer/health refusals
+        before calling this; the only refusal left here is the same
+        overlap claim `handle` itself enforces.
+
+        Args:
+            definition_row: The definition row, shaped like `handle`'s
+                `task` argument (a `"next_run_at"` is not required -- a
+                manual run needs no slot).
+
+        Returns:
+            The new run's id, or `None` when a run was already claimed for
+            this definition -- the skip is recorded exactly as `handle`'s
+            own overlap guard records it (`status="skipped"`,
+            `trigger_reason="manual"`).
+        """
+        definition_id = definition_row.get("id")
+        family = definition_row.get("family")
+        executor = self.executors.get(family)
+        if executor is None:
+            logger.warning(
+                f"No executor registered for automation family {family!r} "
+                f"(definition {definition_id!r}); skipping manual dispatch."
+            )
+            return None
+
+        return await self._dispatch(
+            definition_row,
+            executor=executor,
+            trigger_reason="manual",
+            schedule_slot=None,
+            advance_schedule=False,
+        )
+
+    async def _dispatch(
+        self,
+        task: dict[str, Any],
+        *,
+        executor: Executor,
+        trigger_reason: str,
+        schedule_slot: str | None,
+        advance_schedule: bool,
+    ) -> str | None:
+        """Claim, insert the `running` row, spawn the run -- the shared post-claim body.
+
+        Extracted from `handle` (Task 6): `handle` calls this with
+        `trigger_reason="scheduled"`, a real `schedule_slot`, and
+        `advance_schedule=True`; `run_now` calls it with
+        `trigger_reason="manual"`, `schedule_slot=None`, and
+        `advance_schedule=False`. See the class docstring's "Claim guard"
+        for the exact window `_claimed` covers.
+
+        Returns the new run's id, or `None` when the definition already
+        has a run claimed (a `skipped` row is written first, exactly as
+        the pre-extraction `handle` wrote it) or the slot's UNIQUE deduped
+        the insert.
+        """
+        definition_id = task.get("id")
         owner_id = task.get("owner_id") or "local"
         version = task.get("version") or 1
 
         if definition_id in self._claimed:
-            # Not an error: the interval fired again before the previous
-            # run finished. The claim -- held by that still-running
-            # execution -- is the refusal.
+            # Not an error: another dispatch (scheduled or manual) fired
+            # before the previous run finished. The claim -- held by that
+            # still-running execution -- is the refusal.
             logger.info(
                 f"Skipping automation definition {definition_id!r}: a run "
                 f"is already in flight for it."
@@ -219,11 +295,11 @@ class AutomationDefinitionHandler:
                 owner_id,
                 definition_id,
                 version,
-                "scheduled",
+                trigger_reason,
                 status="skipped",
                 outcome="none",
                 schedule_slot=None,
-                run_summary={"skipped": "overlap", "claimed_slot": slot},
+                run_summary={"skipped": "overlap", "claimed_slot": schedule_slot},
             )
             self._notify(
                 task,
@@ -235,7 +311,7 @@ class AutomationDefinitionHandler:
                     f"was already in progress."
                 ),
             )
-            return
+            return None
 
         self._claimed.add(definition_id)
         # From here to the successful spawn below, `_run`'s own `finally`
@@ -257,9 +333,9 @@ class AutomationDefinitionHandler:
                 owner_id,
                 definition_id,
                 version,
-                "scheduled",
+                trigger_reason,
                 status="running",
-                schedule_slot=slot,
+                schedule_slot=schedule_slot,
                 started_at=now,
                 scope_snapshot=config.get("scope") if isinstance(config, dict) else None,
                 finding_policy_snapshot=task.get("finding_policy"),
@@ -268,16 +344,17 @@ class AutomationDefinitionHandler:
                 # The (definition, version, slot) UNIQUE fired: this slot
                 # already ran. Dedupe is a result, not an error -- nothing
                 # else to do; the finally below releases the claim.
-                return
+                return None
 
-            schedule = task.get("schedule")
-            await asyncio.to_thread(
-                self.db.update_automation_definition,
-                definition_id,
-                next_run_at=compute_next_run_at(
-                    schedule if isinstance(schedule, dict) else {}, now=now
-                ),
-            )
+            if advance_schedule:
+                schedule = task.get("schedule")
+                await asyncio.to_thread(
+                    self.db.update_automation_definition,
+                    definition_id,
+                    next_run_at=compute_next_run_at(
+                        schedule if isinstance(schedule, dict) else {}, now=now
+                    ),
+                )
 
             spawned = asyncio.create_task(
                 self._run(executor, task, run_id=run_id, definition_id=definition_id, owner_id=owner_id),
@@ -286,6 +363,7 @@ class AutomationDefinitionHandler:
             self._pending.add(spawned)
             spawned.add_done_callback(self._pending.discard)
             claim_released_by_spawn = True
+            return run_id
         finally:
             if not claim_released_by_spawn:
                 self._claimed.discard(definition_id)

--- a/tldw_chatbook/Scheduling/scheduler/handlers/automation_handler.py
+++ b/tldw_chatbook/Scheduling/scheduler/handlers/automation_handler.py
@@ -238,42 +238,57 @@ class AutomationDefinitionHandler:
             return
 
         self._claimed.add(definition_id)
-        now = datetime.now(timezone.utc)
-        config = task.get("config")
-        run_id = await asyncio.to_thread(
-            self.db.create_automation_run,
-            owner_id,
-            definition_id,
-            version,
-            "scheduled",
-            status="running",
-            schedule_slot=slot,
-            started_at=now,
-            scope_snapshot=config.get("scope") if isinstance(config, dict) else None,
-            finding_policy_snapshot=task.get("finding_policy"),
-        )
-        if run_id is None:
-            # The (definition, version, slot) UNIQUE fired: this slot
-            # already ran. Dedupe is a result, not an error -- nothing
-            # else to do, and nothing was spawned to release the claim.
-            self._claimed.discard(definition_id)
-            return
+        # From here to the successful spawn below, `_run`'s own `finally`
+        # does not exist yet to release the claim -- and this span has two
+        # real awaits (`create_automation_run`, `update_automation_
+        # definition`), either of which can raise (DB busy/locked) or be
+        # cancelled (the loop's per-handler `wait_for`). Without this
+        # try/finally an exception here stranded the claim forever (the
+        # definition became un-runnable until process restart) and, past
+        # the insert, orphaned the `running` row. `claim_released_by_spawn`
+        # is the only path that must NOT discard here: once `_run` is
+        # actually spawned, IT owns the release (its own `finally`).
+        claim_released_by_spawn = False
+        try:
+            now = datetime.now(timezone.utc)
+            config = task.get("config")
+            run_id = await asyncio.to_thread(
+                self.db.create_automation_run,
+                owner_id,
+                definition_id,
+                version,
+                "scheduled",
+                status="running",
+                schedule_slot=slot,
+                started_at=now,
+                scope_snapshot=config.get("scope") if isinstance(config, dict) else None,
+                finding_policy_snapshot=task.get("finding_policy"),
+            )
+            if run_id is None:
+                # The (definition, version, slot) UNIQUE fired: this slot
+                # already ran. Dedupe is a result, not an error -- nothing
+                # else to do; the finally below releases the claim.
+                return
 
-        schedule = task.get("schedule")
-        await asyncio.to_thread(
-            self.db.update_automation_definition,
-            definition_id,
-            next_run_at=compute_next_run_at(
-                schedule if isinstance(schedule, dict) else {}, now=now
-            ),
-        )
+            schedule = task.get("schedule")
+            await asyncio.to_thread(
+                self.db.update_automation_definition,
+                definition_id,
+                next_run_at=compute_next_run_at(
+                    schedule if isinstance(schedule, dict) else {}, now=now
+                ),
+            )
 
-        spawned = asyncio.create_task(
-            self._run(executor, task, run_id=run_id, definition_id=definition_id, owner_id=owner_id),
-            name=f"automation_run_{run_id}",
-        )
-        self._pending.add(spawned)
-        spawned.add_done_callback(self._pending.discard)
+            spawned = asyncio.create_task(
+                self._run(executor, task, run_id=run_id, definition_id=definition_id, owner_id=owner_id),
+                name=f"automation_run_{run_id}",
+            )
+            self._pending.add(spawned)
+            spawned.add_done_callback(self._pending.discard)
+            claim_released_by_spawn = True
+        finally:
+            if not claim_released_by_spawn:
+                self._claimed.discard(definition_id)
 
     async def _run(
         self,

--- a/tldw_chatbook/Scheduling/scheduler/queue.py
+++ b/tldw_chatbook/Scheduling/scheduler/queue.py
@@ -63,9 +63,15 @@ class PriorityQueue:
         briefing jobs that have a ``next_run_at``, and sorts the combined list
         by ``next_run_at``.
 
+        Local automation definitions (schedules-handoff PR-2, Task 5) are
+        armed the same way: real DB rows, not a projection (spec §7.2) --
+        loaded unconditionally, each tagged ``"type": "automation_definition"``
+        so ``SchedulerLoop`` routes it to the registered handler.
+
         The ``now`` parameter is retained for back-compat and tests: when
         provided, only reminder tasks scheduled at or before ``now`` are loaded;
-        projections are still appended unconditionally.
+        projections and automation definitions are still appended
+        unconditionally.
         """
         if now is None:
             self._items = self.db.list_reminder_tasks(enabled=True)
@@ -74,10 +80,20 @@ class PriorityQueue:
         else:
             self._items = self.db.reminders_due_before(now)
 
+        for definition in self.db.list_armable_automation_definitions(
+            owner_id=_DEFAULT_OWNER_ID
+        ):
+            definition["type"] = "automation_definition"
+            self._items.append(definition)
+
         # ADR-077 decision 1 (single-owner execution): server-scoped rows
         # are the server's to execute. They are dropped at the queue seam
         # so no tick, reload, or load-path variant can ever dispatch one
         # locally -- their notifications arrive through the server feed.
+        # Automation-definition rows are included here too (defense in
+        # depth with `list_armable_automation_definitions`'s own
+        # `owner_id` filter above): neither guard alone is trusted to keep
+        # a server-scoped definition from arming locally.
         self._items = [
             item
             for item in self._items

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -8,6 +8,7 @@ server identity (``server:<user_id>``).
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 from typing import Any, Callable
 from zoneinfo import ZoneInfo
@@ -440,7 +441,7 @@ class SchedulingService:
             )
             return None
 
-        row = self.db.get_automation_definition(definition_id)
+        row = await asyncio.to_thread(self.db.get_automation_definition, definition_id)
         if row is None:
             return None
 

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -15,6 +15,7 @@ from zoneinfo import ZoneInfo
 from croniter import croniter
 from loguru import logger
 
+from tldw_chatbook.Scheduling.automation_health import compute_local_health
 from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
 from tldw_chatbook.Scheduling.models import ReminderTask, ScheduleKind, ScheduledTask
 from tldw_chatbook.Scheduling.services.briefing_projection import BriefingProjection
@@ -69,6 +70,8 @@ class SchedulingService:
         watchlist_projection: WatchlistProjection | None = None,
         briefing_projection: BriefingProjection | None = None,
         on_queue_changed: Callable[[], None] | None = None,
+        app_getter: Callable[[], Any] | None = None,
+        automation_handler_getter: Callable[[], Any] | None = None,
     ) -> None:
         self.db = db
         self.server_client = server_client or SchedulingServerClient()
@@ -77,6 +80,21 @@ class SchedulingService:
         self.watchlist_projection = watchlist_projection
         self.briefing_projection = briefing_projection
         self.sync_engine = SyncEngine(db, self.server_client, self.owner_id)
+        #: Zero-arg getter for the running app, used by
+        #: ``run_automation_now`` to compute read-time health
+        #: (``compute_local_health``). Late-binding like
+        #: ``on_queue_changed`` below: the app wires this to ``lambda:
+        #: self`` at construction time, before ``self`` itself is fully
+        #: built out.
+        self.app_getter = app_getter
+        #: Zero-arg getter for the (lazily constructed, memoized)
+        #: ``AutomationDefinitionHandler``. Injected rather than imported
+        #: directly -- this module must not import the handler module
+        #: (ADR-097 boot-census rule) -- and resolved fresh per call so a
+        #: manual run reuses the SAME handler instance (and its
+        #: ``_claimed``/``_pending`` overlap-guard state) as the scheduled
+        #: dispatch path.
+        self.automation_handler_getter = automation_handler_getter
         #: Called after any reminder mutation that can change what the
         #: scheduler should dispatch (create/update/delete, local or
         #: server-persisted). The app wires this to
@@ -381,6 +399,95 @@ class SchedulingService:
         if row is None or not succeeded:
             return None
         return self._row_to_reminder(row)
+
+    async def run_automation_now(self, definition_id: str) -> dict[str, Any] | None:
+        """Dispatch a local automation definition immediately (manual run).
+
+        The service seam for the workbench's Run-now action on
+        `automation_definition` rows (schedules-handoff PR-2 Task 6):
+        delegates to ``AutomationDefinitionHandler.run_now`` -- the SAME
+        claim/spawn machinery ``handle`` (the scheduled dispatch path)
+        uses, with ``trigger_reason="manual"`` and no schedule slot -- so
+        a manual run reuses the identical overlap guard and never
+        double-executes against a concurrent scheduled run, and never
+        advances the definition's next scheduled occurrence.
+
+        Refuses (returns ``None``, reason logged) without dispatching for,
+        in order: no automation handler wired (mirrors
+        ``run_reminder_now``'s honest refusal when no loop is available),
+        a server-scoped owner (ADR-077 decision 1: the server executes
+        those), a ``lifecycle`` outside ``{configured, paused}``, a
+        pending transfer (``transfer_state`` not ``NULL``), or a
+        read-time health other than ``"ready"`` (``compute_local_health``
+        -- never the possibly-stale ``health`` column).
+
+        Args:
+            definition_id: The definition's local id.
+
+        Returns:
+            ``None`` on refusal or when the definition does not exist.
+            On success, ``{"run_id": ..., "deduped": bool}``: ``run_id``
+            is ``None`` and ``deduped`` is ``True`` when the handler's own
+            overlap claim declined the run (a run was already in flight
+            for this definition) -- that is still a "success" from this
+            method's own refusal checks above, just a no-op dispatch.
+        """
+        if self.automation_handler_getter is None:
+            logger.warning(
+                "Manual automation run refused for definition {definition_id}: "
+                "no automation handler available",
+                definition_id=definition_id,
+            )
+            return None
+
+        row = self.db.get_automation_definition(definition_id)
+        if row is None:
+            return None
+
+        # ADR-077 decision 1: server-scoped rows are executed by the
+        # server (same guard `run_reminder_now` applies to reminders).
+        from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
+
+        if is_server_scoped_owner(row.get("owner_id")):
+            logger.warning(
+                "Manual automation run refused for definition {definition_id}: "
+                "server-scoped (executed by the server per ADR-077)",
+                definition_id=definition_id,
+            )
+            return None
+
+        if row.get("lifecycle") not in ("configured", "paused"):
+            logger.warning(
+                "Manual automation run refused for definition {definition_id}: "
+                "lifecycle {lifecycle!r} is not configured/paused",
+                definition_id=definition_id,
+                lifecycle=row.get("lifecycle"),
+            )
+            return None
+
+        if row.get("transfer_state") is not None:
+            logger.warning(
+                "Manual automation run refused for definition {definition_id}: "
+                "a transfer is in progress",
+                definition_id=definition_id,
+            )
+            return None
+
+        app = self.app_getter() if self.app_getter is not None else None
+        health, reason = compute_local_health(app, row)
+        if health != "ready":
+            logger.warning(
+                "Manual automation run refused for definition {definition_id}: "
+                "health is {health!r} ({reason})",
+                definition_id=definition_id,
+                health=health,
+                reason=reason,
+            )
+            return None
+
+        handler = self.automation_handler_getter()
+        run_id = await handler.run_now(row)
+        return {"run_id": run_id, "deduped": run_id is None}
 
     def _use_server(self) -> bool:
         """Return True when server operations should be attempted."""

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -9668,6 +9668,42 @@ class TldwCli(
         if briefing_handler is not None:
             handlers["briefing_job"] = briefing_handler
 
+        # schedules-handoff PR-2, Task 5: local automation definitions
+        # (`family="recurring_question"` in v1) are real queue rows, not
+        # gated behind a config flag the way watchlist/briefing checks are
+        # -- `PriorityQueue.load` only ever arms a row that is already
+        # `lifecycle="configured"` with a real `next_run_at`, so there is
+        # nothing here for an absent handler to leave silently unhandled.
+        #
+        # ADR-097 (boot-census ratchet): `AutomationDefinitionHandler`'s
+        # import chain (the handler module + `schedule_compute` +
+        # `slot_keys`) stays OFF the boot path -- constructed lazily on
+        # the first dispatched `automation_definition` row, not here at
+        # wiring time, then cached on `self` so every later dispatch
+        # reuses the SAME instance. The overlap-claim guard
+        # (`_claimed`/`_pending` on the handler) only works across calls
+        # if it is the same object each time; building a fresh handler
+        # per dispatch would silently defeat that guard.
+        async def _dispatch_automation_definition(task: dict[str, Any]) -> None:
+            handler = getattr(self, "_automation_definition_handler", None)
+            if handler is None:
+                from .Scheduling.scheduler.handlers.automation_handler import (
+                    AutomationDefinitionHandler,
+                )
+
+                handler = AutomationDefinitionHandler(
+                    db=self.scheduling_service.db,
+                    app_getter=lambda: self,
+                    dispatch_service=self.notification_dispatch_service,
+                    handler_timeout_seconds=get_cli_setting(
+                        "scheduling", "handler_timeout_seconds", HANDLER_TIMEOUT_SECONDS
+                    ),
+                )
+                self._automation_definition_handler = handler
+            await handler.handle(task)
+
+        handlers["automation_definition"] = _dispatch_automation_definition
+
         self.scheduler_loop = SchedulerLoop(
             self.scheduling_service.db,
             handlers=handlers,
@@ -13617,6 +13653,24 @@ class TldwCli(
             documentation="Total time for on_mount() method",
         )
         self.loguru_logger.info(f"on_mount completed in {mount_duration:.3f} seconds")
+
+        # Stale-run reconciliation (spec §4.1): an app killed mid-run must
+        # not leave a phantom `running`/`queued` automation_runs row in the
+        # UI forever. Cutoff is generous on purpose -- longer than any run
+        # this process itself would let live (handler timeout) plus two
+        # poll intervals of scheduling slack -- so a run still genuinely
+        # in flight is never reconciled out from under itself. Guarded:
+        # a diagnostics-adjacent startup step must never block the
+        # scheduler from starting.
+        try:
+            self.scheduling_service.db.reconcile_stale_automation_runs(
+                older_than_seconds=HANDLER_TIMEOUT_SECONDS
+                + 2 * SCHEDULER_POLL_INTERVAL_SECONDS
+            )
+        except Exception:
+            self.loguru_logger.exception(
+                "Failed to reconcile stale automation runs at startup"
+            )
 
         # Start the background scheduler loop for reminders and scheduled tasks.
         # A COROUTINE worker, never thread=True: scheduled watchlist checks

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -10289,6 +10289,14 @@ class TldwCli(
                 handler_timeout_seconds=get_cli_setting(
                     "scheduling", "handler_timeout_seconds", HANDLER_TIMEOUT_SECONDS
                 ),
+                # task-18937/Finding D precedent (`on_queue_changed` above):
+                # a schedule advance written here would otherwise sit
+                # unseen by the live queue until its periodic ~30-minute
+                # reload. Same lazy-getattr discipline -- `scheduler_loop`
+                # is constructed after `self.scheduling_service`, so this
+                # lambda must not resolve it eagerly.
+                on_queue_changed=lambda: getattr(self, "scheduler_loop", None)
+                and self.scheduler_loop.request_reload(),
             )
             self._automation_definition_handler = handler
         return handler

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -9607,6 +9607,20 @@ class TldwCli(
                 if getattr(self, "scheduler_loop", None) is not None
                 else None
             ),
+            # schedules-handoff PR-2, Task 6: `run_automation_now` (manual
+            # dispatch) resolves the app for read-time health
+            # (`compute_local_health`) and the automation handler through
+            # these getters rather than importing the handler module
+            # itself (ADR-097 boot-census rule) or holding either
+            # reference directly -- both are late-binding lambdas closing
+            # over `self`, same discipline as `on_queue_changed` above:
+            # `self` is still mid-`__init__` here, and
+            # `_get_automation_definition_handler` reads
+            # `self.scheduling_service` (assigned by this very statement)
+            # and `self.notification_dispatch_service`, neither resolved
+            # until the getter is actually called.
+            app_getter=lambda: self,
+            automation_handler_getter=lambda: self._get_automation_definition_handler(),
         )
 
         watchlist_checks_enabled = get_cli_setting(
@@ -9685,21 +9699,7 @@ class TldwCli(
         # if it is the same object each time; building a fresh handler
         # per dispatch would silently defeat that guard.
         async def _dispatch_automation_definition(task: dict[str, Any]) -> None:
-            handler = getattr(self, "_automation_definition_handler", None)
-            if handler is None:
-                from .Scheduling.scheduler.handlers.automation_handler import (
-                    AutomationDefinitionHandler,
-                )
-
-                handler = AutomationDefinitionHandler(
-                    db=self.scheduling_service.db,
-                    app_getter=lambda: self,
-                    dispatch_service=self.notification_dispatch_service,
-                    handler_timeout_seconds=get_cli_setting(
-                        "scheduling", "handler_timeout_seconds", HANDLER_TIMEOUT_SECONDS
-                    ),
-                )
-                self._automation_definition_handler = handler
+            handler = self._get_automation_definition_handler()
             await handler.handle(task)
 
         handlers["automation_definition"] = _dispatch_automation_definition
@@ -10260,6 +10260,38 @@ class TldwCli(
             self.notification_dispatch_service
         )
         self.local_watchlists_service.notification_app = self
+
+    def _get_automation_definition_handler(self) -> Any:
+        """Lazily construct and memoize the automation-definition handler.
+
+        ADR-097 (boot-census ratchet): `AutomationDefinitionHandler`'s
+        import chain (the handler module + `schedule_compute` +
+        `slot_keys`) stays OFF the boot path -- built on first use, then
+        cached on `self` so every later call (scheduled dispatch via
+        `_dispatch_automation_definition` above, and manual dispatch via
+        `SchedulingService.run_automation_now`'s injected
+        `automation_handler_getter`) reuses the SAME instance. The
+        overlap-claim guard (`_claimed`/`_pending` on the handler) only
+        works across calls if it is the same object each time; a fresh
+        handler per call would silently defeat it -- and would let a
+        manual run race a scheduled one for the same definition.
+        """
+        handler = getattr(self, "_automation_definition_handler", None)
+        if handler is None:
+            from .Scheduling.scheduler.handlers.automation_handler import (
+                AutomationDefinitionHandler,
+            )
+
+            handler = AutomationDefinitionHandler(
+                db=self.scheduling_service.db,
+                app_getter=lambda: self,
+                dispatch_service=self.notification_dispatch_service,
+                handler_timeout_seconds=get_cli_setting(
+                    "scheduling", "handler_timeout_seconds", HANDLER_TIMEOUT_SECONDS
+                ),
+            )
+            self._automation_definition_handler = handler
+        return handler
 
     def _backfill_subscription_items_fts(self) -> None:
         """Worker body: index subscription_items rows that predate the FTS


### PR DESCRIPTION
PR-2 of the schedules-handoff program (spec: backlog/docs/spec-2026-08-31-schedules-handoff-parity.md §7; PR-1 was #2286). Local-owner `recurring_question` automation definitions now execute on the chatbook scheduler, end to end.

**Pipeline** — no new retrieval/generation machinery: the run composes two existing hardened seams, `run_library_rag_search` (retrieval) and `generate_library_rag_answer` (contained, citation-validating generation), with tldw_server's semantics ported around them:
- `schedule_compute.py` — next-run for the five reference schedule kinds (one_time/interval/daily/weekly/cron), DST-correct, advance-from-now, junk-safe.
- `recurring_question_scope.py` — byte-parity port of the server's scope normalizer (@5921014aa9) + engine source-type mapping.
- `automation_execution.py` — provider precedence (definition → `[scheduling] executor_*` → Library default) and the server's outcome-classification ladder (`finding/no_match/degraded` × `synthesized/evidence_only/none`).
- `automation_handler.py` — BriefingJobHandler spawn discipline (claim guard, strong-ref pending set), slot dedupe via PR-1's UNIQUE, timeout→`timed_out`, unread result rows, policy-gated `automation_run_*` notifications with honest degraded messages, contained bookkeeping failures.
- Queue arms local-owner/`configured`/transfer-NULL definitions only (single-executor invariant, defense-in-depth with slice-1's owner filter); `run_automation_now` + read-time health (`ready`/`capability_unavailable`/`permission_required`).

**ADR-097 census**: handler registration is lazy (memoized closure in app.py) — the execution stack imports on first dispatch, not at boot; census 971/972 verified. Diagnostics pin regenerated for the new modules' static log statements.

Tests: `Tests/Scheduling/` 476 passed incl. an unmocked end-to-end (real DB/queue/loop/handler/dispatch service; only the two Library seams faked, built from their real dataclasses). Full run/result/review vocabulary greps clean against the PR-1 enums.

Known deferred (ledgered): definition `version` auto-bumps on every schedule advance (harmless to slot dedupe; make the advance non-versioning in PR-3); `kind="failure"` result rows not written (degraded runs live in run rows; PR-6's inbox decides); live server-seam verification scheduled with PR-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WocisXw6SEEG6nb1aKFHtv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Local `recurring_question` automation definitions now run end to end on the chatbook scheduler.

- Computes next-run slots for the five schedule kinds (`one_time`/`interval`/`daily`/`weekly`/`cron`) with DST-correct, advance-from-now semantics; malformed or wedged schedules yield `None`, never raise.
- Execution composes existing `run_library_rag_search` and `generate_library_rag_answer` seams; no new retrieval or generation machinery.
- Ports the server's scope normalizer and outcome ladder (`finding`/`no_match`/`degraded` × `synthesized`/`evidence_only`/`none`) for parity; scope errors refuse the run, and the library source vocabulary is aligned.
- Adds `AutomationDefinitionHandler` with a claim guard, schedule advance, timeout handling, and policy-gated notifications with honest degraded messages.
- Queue arms only local-owner, `configured`, non-transferring definitions, capped at 500 armable rows with a truncation warning; adds `run_automation_now` and read-time health (`ready`/`capability_unavailable`/`permission_required`).
- Execution stack loads lazily on first dispatch, holding the ADR-097 boot census; adds an unmocked end-to-end test with only the Library seams faked.

**Known deferrals**
- Definition `version` auto-bumps on every schedule advance; harmless to slot dedupe, fix lands in PR-3.
- Degraded runs don't write `kind="failure"` result rows; PR-6's inbox decides.
- Live server-seam parity verification planned with PR-6.

<sup>Written for commit ba2200805d29bb0c0088b7ce62f7efbecdb7c10b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

