### PR TITLE
feat(scheduling): automation definitions/results sync + review pushback (handoff PR-3)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1818,8 +1818,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 7,
-      "diagnostic_digest": "ea51505e1926a730b29a",
+      "call_count": 12,
+      "diagnostic_digest": "927d5aba887481491ecf",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/services/sync_engine.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11156,6 +11156,6 @@
     "path_privacy_candidate_calls": 711,
     "persistent_sink_files": 9,
     "task_492_calls": 1308,
-    "task_494_calls": 7446
+    "task_494_calls": 7451
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1811,8 +1811,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 14,
-      "diagnostic_digest": "98a01bb1a4ac9eb198ad",
+      "call_count": 15,
+      "diagnostic_digest": "df915f1387a84393d915",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/services/scheduling_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11156,6 +11156,6 @@
     "path_privacy_candidate_calls": 711,
     "persistent_sink_files": 9,
     "task_492_calls": 1308,
-    "task_494_calls": 7451
+    "task_494_calls": 7452
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1818,8 +1818,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 12,
-      "diagnostic_digest": "927d5aba887481491ecf",
+      "call_count": 18,
+      "diagnostic_digest": "87613ce9bc0539378f25",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/services/sync_engine.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11156,6 +11156,6 @@
     "path_privacy_candidate_calls": 711,
     "persistent_sink_files": 9,
     "task_492_calls": 1308,
-    "task_494_calls": 7452
+    "task_494_calls": 7458
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1819,7 +1819,7 @@
     },
     {
       "call_count": 18,
-      "diagnostic_digest": "87613ce9bc0539378f25",
+      "diagnostic_digest": "19f690eb882b7d5c9ba7",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/services/sync_engine.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Tests/RuntimePolicy/test_runtime_policy_core.py
+++ b/Tests/RuntimePolicy/test_runtime_policy_core.py
@@ -1330,6 +1330,7 @@ EXPECTED_ACTION_IDS_BY_CAPABILITY = {
         research.sessions.update.server
     """),
     "scheduler_workflows": _action_ids("""
+        scheduler.automations.configure.server
         scheduler.automations.launch.server
         scheduler.automations.list.server
         scheduler.workflows.configure.server

--- a/Tests/Scheduling/fixtures/server_responses/automation_results_list.json
+++ b/Tests/Scheduling/fixtures/server_responses/automation_results_list.json
@@ -1,0 +1,63 @@
+{
+  "items": [
+    {
+      "id": "res_01J5RHPQWXYZ1234567890AB",
+      "owner_id": "server:42",
+      "definition_id": "def_01J5RHPQWXYZ1234567890AB",
+      "run_id": "run_01J5RHPQWXYZ1234567890AB",
+      "kind": "finding",
+      "title": "Daily stand-up summary",
+      "summary": "Two blockers reported: CI flakiness and a pending API review.",
+      "answer": "The team is blocked on CI flakiness and an API review.",
+      "answer_mode": "synthesized",
+      "confidence": {
+        "score": 0.82,
+        "basis": "evidence_coverage"
+      },
+      "source_refs": [
+        {"source_type": "message", "source_id": "msg_1"}
+      ],
+      "dedupe_key": "recurring_question:def_01J5RHPQWXYZ1234567890AB:2026-08-30",
+      "visibility_destination": {
+        "scope": "private"
+      },
+      "review_state": "unread",
+      "reviewed_at": null,
+      "reviewed_by": null,
+      "review_note": null,
+      "created_at": "2026-08-30T09:00:05+00:00",
+      "updated_at": "2026-08-30T09:00:05+00:00"
+    },
+    {
+      "id": "res_01J5RHPQWXYZ1234567890CD",
+      "owner_id": "server:42",
+      "definition_id": "def_01J5RHPQWXYZ1234567890CD",
+      "run_id": "run_01J5RHPQWXYZ1234567890CD",
+      "kind": "digest",
+      "title": "Weekly library digest",
+      "summary": "10 new items ingested into the library this week.",
+      "answer": null,
+      "answer_mode": "evidence_only",
+      "confidence": {},
+      "source_refs": [
+        {"source_type": "media", "source_id": "media_101"},
+        {"source_type": "media", "source_id": "media_102"}
+      ],
+      "dedupe_key": "agent_task:def_01J5RHPQWXYZ1234567890CD:2026-08-24",
+      "visibility_destination": {
+        "scope": "private"
+      },
+      "review_state": "read",
+      "reviewed_at": "2026-08-25T08:15:00+00:00",
+      "reviewed_by": "user:42",
+      "review_note": null,
+      "created_at": "2026-08-24T07:00:02+00:00",
+      "updated_at": "2026-08-25T08:15:00+00:00"
+    }
+  ],
+  "total": 2,
+  "limit": 50,
+  "offset": 0,
+  "has_more": false,
+  "next_offset": null
+}

--- a/Tests/Scheduling/fixtures/server_responses/automation_results_list.json
+++ b/Tests/Scheduling/fixtures/server_responses/automation_results_list.json
@@ -33,7 +33,7 @@
       "owner_id": "server:42",
       "definition_id": "def_01J5RHPQWXYZ1234567890CD",
       "run_id": "run_01J5RHPQWXYZ1234567890CD",
-      "kind": "digest",
+      "kind": "failure",
       "title": "Weekly library digest",
       "summary": "10 new items ingested into the library this week.",
       "answer": null,

--- a/Tests/Scheduling/test_automation_handler.py
+++ b/Tests/Scheduling/test_automation_handler.py
@@ -356,6 +356,31 @@ async def test_schedule_is_advanced_before_the_executor_completes(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_scheduled_advance_does_not_bump_definition_version(tmp_path):
+    """PR-2 parked item: the handler's `next_run_at` advance is not an edit
+    -- `version` (used for optimistic-lock conflict detection) must stay
+    stable across a dispatch."""
+    db = _make_db(tmp_path)
+    row = _make_definition(db)
+    assert row["version"] == 1
+
+    async def fast_executor(app, definition_row):
+        return _FakeOutcome(outcome="finding")
+
+    handler = AutomationDefinitionHandler(
+        db=db, executors={"recurring_question": fast_executor}
+    )
+
+    await handler.handle(row)
+    await _drain(handler)
+
+    updated = db.get_automation_definition(row["id"])
+    assert updated is not None
+    assert updated["next_run_at"] != row["next_run_at"]
+    assert updated["version"] == 1
+
+
+@pytest.mark.asyncio
 async def test_on_queue_changed_fires_once_after_a_successful_scheduled_advance(
     tmp_path,
 ):

--- a/Tests/Scheduling/test_automation_results_client.py
+++ b/Tests/Scheduling/test_automation_results_client.py
@@ -1,0 +1,253 @@
+"""Server-client + notifications-service wiring for scheduled-task results.
+
+Task 2 of the schedules-handoff PR-3 plan: stacks the slice-2 pattern
+(tldw_api client -> ``ServerNotificationsService`` policy gate ->
+``SchedulingServerClient`` wrapper) for the results-list and
+review-pushback seams that ``SyncEngine`` will consume in Task 4.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from tldw_chatbook.Notifications import ServerNotificationsService
+from tldw_chatbook.Scheduling.services.server_client import (
+    SchedulingServerClient,
+    ServerClientNotFoundError,
+    ServerClientPolicyError,
+    ServerClientServerError,
+    ServerUnavailableError,
+)
+from tldw_chatbook.runtime_policy.types import PolicyDecision, PolicyDeniedError
+
+
+class _FakeResponse:
+    """Minimal stand-in for a pydantic response model."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def model_dump(self, mode="json"):
+        return dict(self._payload)
+
+
+class AutomationResultsNotificationsService:
+    """Stub notifications service implementing the two new methods."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def list_scheduled_automation_results(
+        self, *, limit=50, offset=0, definition_id=None, review_state=None
+    ):
+        self.calls.append(("list", limit, offset, definition_id, review_state))
+        return {
+            "items": [
+                {
+                    "id": "res-1",
+                    "definition_id": "def-1",
+                    "run_id": "run-1",
+                    "kind": "finding",
+                    "title": "T",
+                    "summary": "S",
+                    "dedupe_key": "dk-1",
+                    "review_state": "unread",
+                }
+            ],
+            "total": 1,
+        }
+
+    async def review_scheduled_automation_result(
+        self, result_id, review_state, *, review_note=None
+    ):
+        self.calls.append(("review", result_id, review_state, review_note))
+        return {
+            "id": result_id,
+            "definition_id": "def-1",
+            "run_id": "run-1",
+            "kind": "finding",
+            "title": "T",
+            "summary": "S",
+            "dedupe_key": "dk-1",
+            "review_state": review_state,
+        }
+
+
+@pytest.mark.asyncio
+async def test_list_automation_results_passes_filters_through():
+    inner = AutomationResultsNotificationsService()
+    client = SchedulingServerClient(inner)
+
+    result = await client.list_automation_results(
+        limit=25, offset=50, definition_id="def-1", review_state="unread"
+    )
+
+    assert result["total"] == 1
+    assert result["items"][0]["id"] == "res-1"
+    assert inner.calls == [("list", 25, 50, "def-1", "unread")]
+
+
+@pytest.mark.asyncio
+async def test_review_automation_result_returns_updated_row():
+    inner = AutomationResultsNotificationsService()
+    client = SchedulingServerClient(inner)
+
+    result = await client.review_automation_result(
+        "res-1", "dismissed", review_note="not relevant"
+    )
+
+    assert result["review_state"] == "dismissed"
+    assert inner.calls == [("review", "res-1", "dismissed", "not relevant")]
+
+
+@pytest.mark.asyncio
+async def test_review_automation_result_is_retried_on_server_error():
+    # Replaying the same review state is idempotent server-side -- unlike
+    # run-now, a retry here cannot double-fire anything.
+    attempts = {"count": 0}
+
+    class FlakyThenOk:
+        async def review_scheduled_automation_result(
+            self, result_id, review_state, *, review_note=None
+        ):
+            attempts["count"] += 1
+            if attempts["count"] < 2:
+                raise ServerClientServerError("boom")
+            return {"id": result_id, "review_state": review_state}
+
+    from tldw_chatbook.Scheduling.services.server_client import ServerClientConfig
+
+    client = SchedulingServerClient(
+        FlakyThenOk(), config=ServerClientConfig(retry_delay=0.0)
+    )
+    result = await client.review_automation_result("res-1", "read")
+
+    assert attempts["count"] == 2
+    assert result["review_state"] == "read"
+
+
+@pytest.mark.asyncio
+async def test_review_automation_result_not_found_maps_to_typed_error():
+    class DeletedService:
+        async def review_scheduled_automation_result(
+            self, result_id, review_state, *, review_note=None
+        ):
+            raise ServerClientNotFoundError("gone")
+
+    client = SchedulingServerClient(DeletedService())
+    with pytest.raises(ServerClientNotFoundError):
+        await client.review_automation_result("res-1", "read")
+
+
+@pytest.mark.asyncio
+async def test_automation_results_methods_require_a_connected_server():
+    client = SchedulingServerClient(None)
+    with pytest.raises(ServerUnavailableError):
+        await client.list_automation_results()
+    with pytest.raises(ServerUnavailableError):
+        await client.review_automation_result("res-1", "read")
+
+
+@pytest.mark.asyncio
+async def test_automation_results_policy_denial_maps_to_policy_error():
+    class DenyingService(AutomationResultsNotificationsService):
+        async def list_scheduled_automation_results(self, **kwargs):
+            raise PolicyDeniedError(
+                action_id="scheduler.automations.list.server",
+                reason_code="server_mode_required",
+                user_message="scheduler.automations.list.server requires server mode.",
+                effective_source="local",
+                authority_owner="server",
+            )
+
+    client = SchedulingServerClient(DenyingService())
+    with pytest.raises(ServerClientPolicyError):
+        await client.list_automation_results()
+
+
+@pytest.mark.asyncio
+async def test_notifications_service_gates_list_results_under_the_list_action():
+    inner = Mock()
+
+    async def _list(**kwargs):
+        inner.calls_list = kwargs
+        return _FakeResponse({"items": [], "total": 0})
+
+    inner.list_scheduled_task_results = _list
+
+    policy = Mock()
+    service = ServerNotificationsService(client=inner, policy_enforcer=policy)
+
+    listed = await service.list_scheduled_automation_results(
+        limit=10, offset=5, definition_id="def-1", review_state="unread"
+    )
+
+    assert listed["total"] == 0
+    policy.require_allowed.assert_called_once_with(
+        action_id="scheduler.automations.list.server"
+    )
+    assert inner.calls_list == {
+        "limit": 10,
+        "offset": 5,
+        "definition_id": "def-1",
+        "review_state": "unread",
+    }
+
+
+@pytest.mark.asyncio
+async def test_notifications_service_gates_review_under_the_configure_action():
+    inner = Mock()
+
+    async def _review(*args, **kwargs):
+        inner.review_args = (args, kwargs)
+        return _FakeResponse(
+            {
+                "id": "res-1",
+                "definition_id": "def-1",
+                "run_id": "run-1",
+                "kind": "finding",
+                "title": "T",
+                "summary": "S",
+                "dedupe_key": "dk-1",
+                "review_state": "dismissed",
+            }
+        )
+
+    inner.review_scheduled_task_result = _review
+
+    policy = Mock()
+    service = ServerNotificationsService(client=inner, policy_enforcer=policy)
+
+    reviewed = await service.review_scheduled_automation_result(
+        "res-1", "dismissed", review_note="not relevant"
+    )
+
+    assert reviewed["review_state"] == "dismissed"
+    # Reviewing mutates a result (not a list, not a run trigger) -- the
+    # configure-class action, same reasoning family as
+    # notifications.reminders.configure.server for reminder CRUD.
+    policy.require_allowed.assert_called_once_with(
+        action_id="scheduler.automations.configure.server"
+    )
+    assert inner.review_args == (
+        ("res-1", "dismissed"),
+        {"review_note": "not relevant"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_notifications_service_hard_stops_denied_result_review():
+    policy = Mock()
+    policy.require_allowed = None
+    policy.require_ui_action_allowed = Mock(
+        return_value=PolicyDecision(
+            allowed=False,
+            reason_code="authority_denied",
+            user_message="Blocked.",
+            effective_source="server",
+            authority_owner="server",
+        )
+    )
+    service = ServerNotificationsService(client=Mock(), policy_enforcer=policy)
+    with pytest.raises(PolicyDeniedError):
+        await service.review_scheduled_automation_result("res-1", "read")

--- a/Tests/Scheduling/test_automation_sync_end_to_end.py
+++ b/Tests/Scheduling/test_automation_sync_end_to_end.py
@@ -68,6 +68,26 @@ class _FakeAutomationServerClient:
         return {"id": result_id, "review_state": review_state}
 
 
+class _StaleEchoServerClient(_FakeAutomationServerClient):
+    """Push succeeds but ``list_automation_results`` doesn't reflect it.
+
+    Simulates a server whose write and its own read path haven't caught
+    up within the same round trip (Task 5 same-cycle echo, Qodo finding):
+    ``review_automation_result`` reports success and records the call, but
+    deliberately does NOT mutate ``self._item`` the way the base fake
+    does -- so ``list_automation_results`` keeps echoing the pre-push
+    ("unread") state for the rest of the SAME sync cycle.
+    """
+
+    async def review_automation_result(
+        self, result_id: str, review_state: str, *, review_note: str | None = None
+    ) -> dict:
+        self.review_calls.append((result_id, review_state, review_note))
+        if self.push_should_fail:
+            raise ServerUnavailableError("offline")
+        return {"id": result_id, "review_state": review_state}
+
+
 @pytest.fixture
 def db(tmp_path):
     database = ScheduledTasksDB(tmp_path / "scheduled_tasks.db")
@@ -133,3 +153,39 @@ async def test_failed_pushback_keeps_local_review_and_pending_mutation(db):
     pending = db.get_pending_mutations(owner, primitive="automation_result_review")
     assert len(pending) == 1, "the mutation must be retained for retry"
     assert db.get_automation_result(local_id)["review_state"] == "dismissed"
+
+
+@pytest.mark.asyncio
+async def test_same_cycle_stale_results_pull_does_not_revert_just_pushed_review(db):
+    """Task 5 same-cycle echo (Qodo finding).
+
+    Unlike the round-trip test above, the push here succeeds (clearing the
+    mutation) but the SAME sync's own results pull still echoes the
+    pre-push state -- ``_StaleEchoServerClient`` never updates its held
+    item, simulating a server whose write and read path haven't converged
+    within one round trip. Without the pushed-this-cycle skip set, that
+    stale payload would silently revert the review the user just made,
+    and once the row falls out of the bounded newest-pages pull window no
+    later sync would ever fix it.
+    """
+    item = _load_result_item()
+    owner = item["owner_id"]
+    server_client = _StaleEchoServerClient(item)
+    svc = SchedulingService(db=db, server_client=server_client, runtime_source=owner)
+
+    await svc.sync_now()
+    local_id = db.list_automation_results(owner)[0]["id"]
+    await svc.review_automation_result(local_id, "dismissed", "handled")
+
+    # Second sync: pushback succeeds and clears the mutation, but the
+    # fake's results page -- pulled in this SAME sync_now() call -- still
+    # reports the pre-review "unread" state.
+    await svc.sync_now()
+
+    assert server_client.review_calls == [(item["id"], "dismissed", "handled")]
+    assert db.get_pending_mutations(owner, primitive="automation_result_review") == []
+    refreshed = db.get_automation_result(local_id)
+    assert refreshed["review_state"] == "dismissed", (
+        "the same-cycle stale echo must not revert the review just pushed"
+    )
+    assert refreshed["review_note"] == "handled"

--- a/Tests/Scheduling/test_automation_sync_end_to_end.py
+++ b/Tests/Scheduling/test_automation_sync_end_to_end.py
@@ -1,0 +1,135 @@
+"""End-to-end automation-results sync + review pushback (schedules-handoff PR-3, task 6).
+
+Drives ``SchedulingService.sync_now``/``review_automation_result`` against a
+real tmp_path ``ScheduledTasksDB`` and a hand-rolled fake server client
+shaped from the recorded ``automation_results_list.json`` fixture. The fake
+is stateful (unlike the ``AsyncMock`` doubles in ``test_sync_engine.py``)
+because these tests exercise a round trip across TWO ``sync_now`` calls: a
+push whose effect must be visible on the NEXT pull, exactly like a real
+server would echo it back.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+from tldw_chatbook.Scheduling.services import SchedulingService
+from tldw_chatbook.Scheduling.services.server_client import ServerUnavailableError
+
+_FIXTURE = (
+    Path(__file__).resolve().parent
+    / "fixtures"
+    / "server_responses"
+    / "automation_results_list.json"
+)
+
+
+def _load_result_item() -> dict:
+    """One server result item from the recorded fixture (unread, server-owned)."""
+    data = json.loads(_FIXTURE.read_text())
+    return copy.deepcopy(data["items"][0])
+
+
+class _FakeAutomationServerClient:
+    """Stateful fake shaped from the recorded ``/results`` fixture.
+
+    ``review_automation_result`` mutates its own held item in place so a
+    later ``list_automation_results`` call echoes the review, the way a
+    real server would after the pushback lands.
+    """
+
+    def __init__(self, item: dict, push_should_fail: bool = False) -> None:
+        self._item = item
+        self.push_should_fail = push_should_fail
+        self.review_calls: list[tuple[str, str, str | None]] = []
+
+    async def list_reminders(self) -> dict:
+        return {"items": []}
+
+    async def list_automation_definitions(self, *, limit: int = 50, offset: int = 0) -> dict:
+        return {"items": [], "total": 0, "has_more": False}
+
+    async def list_automation_results(self, *, limit: int = 50, offset: int = 0) -> dict:
+        return {"items": [dict(self._item)], "total": 1, "has_more": False}
+
+    async def review_automation_result(
+        self, result_id: str, review_state: str, *, review_note: str | None = None
+    ) -> dict:
+        self.review_calls.append((result_id, review_state, review_note))
+        if self.push_should_fail:
+            raise ServerUnavailableError("offline")
+        self._item["review_state"] = review_state
+        self._item["review_note"] = review_note
+        return {"id": result_id, "review_state": review_state}
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = ScheduledTasksDB(tmp_path / "scheduled_tasks.db")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+@pytest.mark.asyncio
+async def test_review_pushback_round_trips_through_two_syncs(db):
+    item = _load_result_item()
+    owner = item["owner_id"]
+    server_client = _FakeAutomationServerClient(item)
+    svc = SchedulingService(db=db, server_client=server_client, runtime_source=owner)
+
+    # 1. First sync seeds the server-mirrored result, unread.
+    await svc.sync_now()
+    rows = db.list_automation_results(owner)
+    assert len(rows) == 1
+    local_id = rows[0]["id"]
+    assert rows[0]["review_state"] == "unread"
+
+    # 2. Review it locally -- the row has a server_id, so a pending
+    # automation_result_review mutation is queued.
+    ok = await svc.review_automation_result(local_id, "dismissed", "handled")
+    assert ok is True
+    assert db.get_automation_result(local_id)["review_state"] == "dismissed"
+    assert len(db.get_pending_mutations(owner, primitive="automation_result_review")) == 1
+
+    # 3. Second sync: pushback (phase order per task 4) replays the review
+    # and clears the mutation; the fake echoes the post-review state on
+    # this same round's results pull, which then upserts it back onto the
+    # local row.
+    await svc.sync_now()
+
+    assert server_client.review_calls == [(item["id"], "dismissed", "handled")]
+    assert db.get_pending_mutations(owner, primitive="automation_result_review") == []
+    refreshed = db.get_automation_result(local_id)
+    assert refreshed["review_state"] == "dismissed"
+    assert refreshed["review_note"] == "handled"
+
+
+@pytest.mark.asyncio
+async def test_failed_pushback_keeps_local_review_and_pending_mutation(db):
+    item = _load_result_item()
+    owner = item["owner_id"]
+    server_client = _FakeAutomationServerClient(item)
+    svc = SchedulingService(db=db, server_client=server_client, runtime_source=owner)
+
+    await svc.sync_now()
+    local_id = db.list_automation_results(owner)[0]["id"]
+    await svc.review_automation_result(local_id, "dismissed", "handled")
+
+    # The push fails this round, so the fake never applies the review --
+    # its list payload still reports "unread". The pending-review guard in
+    # upsert_automation_results_from_server must skip the review-fields
+    # update for this row rather than let that stale mirror clobber it.
+    server_client.push_should_fail = True
+    await svc.sync_now()
+
+    assert len(server_client.review_calls) == 1
+    pending = db.get_pending_mutations(owner, primitive="automation_result_review")
+    assert len(pending) == 1, "the mutation must be retained for retry"
+    assert db.get_automation_result(local_id)["review_state"] == "dismissed"

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -942,6 +942,7 @@ def test_review_transitions_and_unread_count(tmp_path):
     assert db.update_result_review(rid, "read", reviewed_by="local")
     assert db.count_unread_results("local") == 1
     assert db.list_automation_results("local", review_state="read")[0]["id"] == rid
+    assert not db.update_result_review("missing", "dismissed")
 
 
 # ----------------------------------------------------------------------
@@ -1154,4 +1155,3 @@ def test_upsert_results_skips_item_missing_id(tmp_path):
     counts = db.upsert_automation_results_from_server("server:42", [item])
     assert counts == {"inserted": 0, "updated": 0, "skipped_dedupe": 0}
     assert db.list_automation_results("server:42") == []
-    assert not db.update_result_review("missing", "dismissed")

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -942,4 +942,216 @@ def test_review_transitions_and_unread_count(tmp_path):
     assert db.update_result_review(rid, "read", reviewed_by="local")
     assert db.count_unread_results("local") == 1
     assert db.list_automation_results("local", review_state="read")[0]["id"] == rid
+
+
+# ----------------------------------------------------------------------
+# Server-mirror upserts (schedules-handoff PR-3, task 3)
+# ----------------------------------------------------------------------
+
+
+def _definition_item(**overrides):
+    item = {
+        "id": "srv-def-1",
+        "owner_id": "server:42",
+        "family": "recurring_question",
+        "name": "Daily stand-up",
+        "lifecycle": "configured",
+        "health": "execution_unavailable",
+        "schedule": {"kind": "cron", "expression": "0 9 * * 1-5"},
+        "created_at": "2026-07-18T09:00:00+00:00",
+        "updated_at": "2026-07-18T09:00:00+00:00",
+    }
+    item.update(overrides)
+    return item
+
+
+def test_upsert_definitions_inserts_new_row(tmp_path):
+    db = _mk_db(tmp_path)
+    counts = db.upsert_automation_definitions_from_server(
+        "server:42", [_definition_item()]
+    )
+    assert counts == {"inserted": 1, "updated": 0}
+    rows = db.list_automation_definitions(owner_id="server:42")
+    assert len(rows) == 1
+    assert rows[0]["server_id"] == "srv-def-1"
+    assert rows[0]["name"] == "Daily stand-up"
+    assert rows[0]["schedule"] == {"kind": "cron", "expression": "0 9 * * 1-5"}
+
+
+def test_upsert_definitions_server_wins_on_update(tmp_path):
+    db = _mk_db(tmp_path)
+    db.upsert_automation_definitions_from_server("server:42", [_definition_item()])
+    counts = db.upsert_automation_definitions_from_server(
+        "server:42",
+        [_definition_item(name="Renamed", lifecycle="paused")],
+    )
+    assert counts == {"inserted": 0, "updated": 1}
+    rows = db.list_automation_definitions(owner_id="server:42")
+    assert len(rows) == 1
+    assert rows[0]["name"] == "Renamed"
+    assert rows[0]["lifecycle"] == "paused"
+
+
+def test_upsert_definitions_never_clears_local_transfer_state(tmp_path):
+    """spec §6 parked finding: a server payload must never clear a local
+    transfer marker."""
+    db = _mk_db(tmp_path)
+    db.upsert_automation_definitions_from_server("server:42", [_definition_item()])
+    local_id = db.list_automation_definitions(owner_id="server:42")[0]["id"]
+    db.update_automation_definition(local_id, transfer_state="pending_pull")
+
+    # Server payload carries no transfer_state at all (the real server never
+    # sends one, it's local-only) -- the update must not touch the column.
+    db.upsert_automation_definitions_from_server(
+        "server:42", [_definition_item(name="Renamed")]
+    )
+    row = db.get_automation_definition(local_id)
+    assert row["transfer_state"] == "pending_pull"
+    assert row["name"] == "Renamed"
+
+    # Even if a server payload somehow carried transfer_state, it must still
+    # be ignored -- the exclusion is unconditional.
+    db.upsert_automation_definitions_from_server(
+        "server:42", [_definition_item(transfer_state="server_side_value")]
+    )
+    row = db.get_automation_definition(local_id)
+    assert row["transfer_state"] == "pending_pull"
+
+
+def test_upsert_definitions_archived_lifecycle_mirrors_not_deletes(tmp_path):
+    db = _mk_db(tmp_path)
+    db.upsert_automation_definitions_from_server("server:42", [_definition_item()])
+    local_id = db.list_automation_definitions(owner_id="server:42")[0]["id"]
+    db.upsert_automation_definitions_from_server(
+        "server:42",
+        [_definition_item(lifecycle="archived", archived_at="2026-08-01T00:00:00+00:00")],
+    )
+    row = db.get_automation_definition(local_id)
+    assert row["lifecycle"] == "archived"
+    assert row["archived_at"] is not None
+
+
+def test_upsert_definitions_skips_item_missing_id(tmp_path):
+    db = _mk_db(tmp_path)
+    item = _definition_item()
+    del item["id"]
+    counts = db.upsert_automation_definitions_from_server("server:42", [item])
+    assert counts == {"inserted": 0, "updated": 0}
+    assert db.list_automation_definitions(owner_id="server:42") == []
+
+
+def _result_item(**overrides):
+    item = {
+        "id": "srv-res-1",
+        "owner_id": "server:42",
+        "definition_id": "srv-def-1",
+        "run_id": "srv-run-1",
+        "kind": "finding",
+        "title": "Daily stand-up summary",
+        "summary": "Two blockers reported.",
+        "answer": "text",
+        "answer_mode": "synthesized",
+        "confidence": {"score": 0.8},
+        "source_refs": [{"source_type": "message", "source_id": "m1"}],
+        "dedupe_key": "recurring_question:srv-def-1:2026-08-30",
+        "review_state": "unread",
+        "reviewed_at": None,
+        "reviewed_by": None,
+        "review_note": None,
+        "created_at": "2026-08-30T09:00:05+00:00",
+        "updated_at": "2026-08-30T09:00:05+00:00",
+    }
+    item.update(overrides)
+    return item
+
+
+def test_upsert_results_inserts_new_row(tmp_path):
+    db = _mk_db(tmp_path)
+    counts = db.upsert_automation_results_from_server("server:42", [_result_item()])
+    assert counts == {"inserted": 1, "updated": 0, "skipped_dedupe": 0}
+    rows = db.list_automation_results("server:42")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["server_id"] == "srv-res-1"
+    assert row["definition_id"] == "srv-def-1"  # plain TEXT, no local resolve
+    assert row["run_id"] == "srv-run-1"
+    assert row["answer"] == "text"
+    assert row["source_refs"] == [{"source_type": "message", "source_id": "m1"}]
+
+
+def test_upsert_results_update_touches_only_review_fields(tmp_path):
+    db = _mk_db(tmp_path)
+    db.upsert_automation_results_from_server("server:42", [_result_item()])
+    counts = db.upsert_automation_results_from_server(
+        "server:42",
+        [
+            _result_item(
+                title="Different title server-side",
+                summary="Different summary",
+                review_state="read",
+                reviewed_at="2026-08-31T00:00:00+00:00",
+                reviewed_by="user:42",
+                review_note="looks fine",
+                updated_at="2026-08-31T00:00:00+00:00",
+            )
+        ],
+    )
+    assert counts == {"inserted": 0, "updated": 1, "skipped_dedupe": 0}
+    row = db.list_automation_results("server:42")[0]
+    # Review fields updated...
+    assert row["review_state"] == "read"
+    assert row["reviewed_by"] == "user:42"
+    assert row["review_note"] == "looks fine"
+    # ...but non-review fields are left alone even though the server item
+    # carried different values for them.
+    assert row["title"] == "Daily stand-up summary"
+    assert row["summary"] == "Two blockers reported."
+
+
+def test_upsert_results_pending_review_mutation_blocks_update(tmp_path):
+    db = _mk_db(tmp_path)
+    db.upsert_automation_results_from_server("server:42", [_result_item()])
+    local_id = db.list_automation_results("server:42")[0]["id"]
+    db.record_pending_mutation(
+        local_id,
+        "automation_result_review",
+        "server:42",
+        {"server_result_id": "srv-res-1", "review_state": "dismissed"},
+    )
+
+    counts = db.upsert_automation_results_from_server(
+        "server:42",
+        [_result_item(review_state="read", reviewed_by="user:42")],
+    )
+    assert counts == {"inserted": 0, "updated": 0, "skipped_dedupe": 0}
+    row = db.list_automation_results("server:42")[0]
+    # The local unpushed review outranks the mirror until it replays.
+    assert row["review_state"] == "unread"
+
+
+def test_upsert_results_dedupe_conflict_with_local_row_is_skipped(tmp_path):
+    db = _mk_db(tmp_path)
+    local_id = db.create_automation_result(
+        "server:42", "local-def", "local-run", "finding", "Local title",
+        "Local summary", "recurring_question:srv-def-1:2026-08-30",
+    )
+    assert local_id is not None
+
+    counts = db.upsert_automation_results_from_server(
+        "server:42", [_result_item()]  # same dedupe_key as the local row
+    )
+    assert counts == {"inserted": 0, "updated": 0, "skipped_dedupe": 1}
+    rows = db.list_automation_results("server:42")
+    assert len(rows) == 1
+    assert rows[0]["id"] == local_id
+    assert rows[0]["server_id"] is None  # untouched, still the local-only row
+
+
+def test_upsert_results_skips_item_missing_id(tmp_path):
+    db = _mk_db(tmp_path)
+    item = _result_item()
+    del item["id"]
+    counts = db.upsert_automation_results_from_server("server:42", [item])
+    assert counts == {"inserted": 0, "updated": 0, "skipped_dedupe": 0}
+    assert db.list_automation_results("server:42") == []
     assert not db.update_result_review("missing", "dismissed")

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -1,10 +1,12 @@
 """Tests for ScheduledTasksDB CRUD operations."""
 
 import json
+import sqlite3
 import tempfile
 from contextlib import closing
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -1187,6 +1189,95 @@ def test_upsert_results_pending_review_mutation_blocks_update(tmp_path):
     row = db.list_automation_results("server:42")[0]
     # The local unpushed review outranks the mirror until it replays.
     assert row["review_state"] == "unread"
+
+
+def test_upsert_results_pending_mutation_recorded_mid_loop_still_blocks_update(tmp_path):
+    """Qodo TOCTOU finding: the pending-mutation guard used to snapshot
+    ``get_pending_mutations()`` ONCE before the write transaction even
+    opened. A review recorded concurrently (the review service writes via
+    ``to_thread`` while this upsert runs on the event loop) after that
+    snapshot but before the loop reached the row would be invisible to
+    the stale snapshot -- clobbering a review whose own pending mutation
+    genuinely existed by the time this row's write happened.
+
+    This test proves the fix (a per-row SELECT inside the same write
+    transaction, immediately before that row's own UPDATE) by inserting
+    row 2's pending mutation, via a separate real connection, DURING this
+    very upsert call -- timed to land right as row 1 is being processed,
+    i.e. strictly after any pre-loop snapshot would have been taken. The
+    old snapshot-based guard would have missed it; the new per-row check
+    catches it.
+    """
+    db = _mk_db(tmp_path)
+    db.upsert_automation_results_from_server(
+        "server:42",
+        [
+            _result_item(id="srv-res-1", dedupe_key="key-1"),
+            _result_item(id="srv-res-2", dedupe_key="key-2"),
+        ],
+    )
+    rows_by_server_id = {
+        row["server_id"]: row["id"] for row in db.list_automation_results("server:42")
+    }
+    local_id_2 = rows_by_server_id["srv-res-2"]
+
+    # sqlite3.Connection is an immutable C type -- its bound methods can't
+    # be monkeypatched directly. `set_trace_callback` is the supported hook
+    # for observing every SQL statement a connection runs, so it's used
+    # here to detect the exact moment ("SELECT id FROM automation_results",
+    # row 1's existence check) at which the OLD code's pre-loop snapshot
+    # would already have been taken and gone stale.
+    real_get_connection = ScheduledTasksDB._get_connection
+    injected = {"done": False}
+
+    def _get_connection_with_injector(self):
+        conn = real_get_connection(self)
+
+        def _on_statement(sql):
+            if injected["done"] or "SELECT id FROM automation_results" not in sql:
+                return
+            injected["done"] = True
+            # Simulate the review service's concurrent to_thread write
+            # landing mid-loop: a totally separate connection records row
+            # 2's pending review mutation right now, before this upsert
+            # call has reached row 2.
+            side_conn = sqlite3.connect(str(tmp_path / "s.db"))
+            try:
+                side_conn.execute(
+                    "INSERT INTO pending_mutations "
+                    "(local_id, primitive, owner_id, payload, created_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (local_id_2, "automation_result_review", "server:42", "{}",
+                     "2026-09-01T00:00:00+00:00"),
+                )
+                side_conn.commit()
+            finally:
+                side_conn.close()
+
+        conn.set_trace_callback(_on_statement)
+        return conn
+
+    with mock.patch.object(
+        ScheduledTasksDB, "_get_connection", _get_connection_with_injector
+    ):
+        counts = db.upsert_automation_results_from_server(
+            "server:42",
+            [
+                _result_item(id="srv-res-1", review_state="read", reviewed_by="user:42"),
+                _result_item(id="srv-res-2", review_state="read", reviewed_by="user:42"),
+            ],
+        )
+
+    assert injected["done"], "the spy never saw the expected SELECT -- test setup is stale"
+    assert counts == {"inserted": 0, "updated": 1, "skipped_dedupe": 0}
+    rows_by_server_id = {
+        row["server_id"]: row for row in db.list_automation_results("server:42")
+    }
+    # Row 1 had no pending mutation at any point -- it updates normally.
+    assert rows_by_server_id["srv-res-1"]["review_state"] == "read"
+    # Row 2's mutation was recorded mid-loop, after any pre-loop snapshot
+    # would have run -- the per-row in-transaction check still catches it.
+    assert rows_by_server_id["srv-res-2"]["review_state"] == "unread"
 
 
 def test_upsert_results_dedupe_conflict_with_local_row_is_skipped(tmp_path):

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -945,6 +945,65 @@ def test_review_transitions_and_unread_count(tmp_path):
     assert not db.update_result_review("missing", "dismissed")
 
 
+def test_update_result_review_writes_pending_mutation_in_same_transaction(tmp_path):
+    """review round 1 finding: the review UPDATE and its outbox mutation
+    insert must land as one write, so a server-mirrored review is never
+    left un-pushed (or pushed for a review that didn't actually commit)."""
+    db = _mk_db(tmp_path)
+    rid = db.create_automation_result(
+        "server:1", "d1", "r1", "finding", "T", "S", "k1", server_id="srv-1"
+    )
+
+    assert db.update_result_review(
+        rid,
+        "dismissed",
+        "noise",
+        pending_mutation={
+            "local_id": rid,
+            "primitive": "automation_result_review",
+            "owner_id": "server:1",
+            "payload": {"server_result_id": "srv-1", "review_state": "dismissed"},
+        },
+    )
+
+    row = db.get_automation_result(rid)
+    assert row["review_state"] == "dismissed"
+    pending = db.get_pending_mutations("server:1", primitive="automation_result_review")
+    assert len(pending) == 1
+    assert pending[0]["payload"]["server_result_id"] == "srv-1"
+    assert pending[0]["payload"]["idempotency_key"]  # generated, same as the standalone method
+
+
+def test_update_result_review_pending_mutation_atomic_rollback_on_insert_failure(tmp_path):
+    """Fault-inject a genuine DB failure in the mutation INSERT (a NULL
+    owner_id violates pending_mutations' NOT NULL constraint) and confirm
+    the review UPDATE in the SAME transaction rolls back with it -- the
+    atomicity the review round 1 finding required."""
+    db = _mk_db(tmp_path)
+    rid = db.create_automation_result(
+        "server:1", "d1", "r1", "finding", "T", "S", "k1", server_id="srv-1"
+    )
+
+    with pytest.raises(Exception):
+        db.update_result_review(
+            rid,
+            "dismissed",
+            "noise",
+            pending_mutation={
+                "local_id": rid,
+                "primitive": "automation_result_review",
+                "owner_id": None,  # NOT NULL violation -> INSERT raises
+                "payload": {"server_result_id": "srv-1", "review_state": "dismissed"},
+            },
+        )
+
+    row = db.get_automation_result(rid)
+    assert row["review_state"] == "unread"  # the UPDATE rolled back too
+    assert (
+        db.get_pending_mutations("server:1", primitive="automation_result_review") == []
+    )
+
+
 # ----------------------------------------------------------------------
 # Server-mirror upserts (schedules-handoff PR-3, task 3)
 # ----------------------------------------------------------------------

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -631,6 +631,38 @@ def test_update_automation_definition_empty_kwargs_returns_false(
     assert db.update_automation_definition(def_id) is False
 
 
+def test_update_automation_definition_bump_version_false_skips_increment(
+    db: ScheduledTasksDB,
+) -> None:
+    """PR-2 parked item: a schedule advance (`next_run_at` only) is not an
+    edit -- `bump_version=False` must leave `version` unchanged, while the
+    default (`bump_version=True`) keeps bumping it for real edits."""
+    def_id = db.create_automation_definition(
+        owner_id="local",
+        family="recurring_question",
+        name="Original",
+        schedule={"kind": "cron", "expression": "0 9 * * *"},
+    )
+
+    advanced = db.update_automation_definition(
+        def_id,
+        bump_version=False,
+        next_run_at=_utc(2026, 1, 2),
+    )
+    assert advanced is True
+
+    row = db.get_automation_definition(def_id)
+    assert row is not None
+    assert row["version"] == 1
+
+    edited = db.update_automation_definition(def_id, name="Updated")
+    assert edited is True
+
+    row = db.get_automation_definition(def_id)
+    assert row is not None
+    assert row["version"] == 2
+
+
 def test_delete_automation_definition(db: ScheduledTasksDB) -> None:
     def_id = db.create_automation_definition(
         owner_id="local", family="recurring_question", name="To delete"

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -778,6 +778,30 @@ async def test_review_automation_result_server_mirrored_records_pending_mutation
 
 
 @pytest.mark.asyncio
+async def test_review_automation_result_records_mutation_under_row_owner(db):
+    """F1 (task-23105-review): the row's own owner_id is authoritative.
+
+    The workbench can toggle the service's active owner independently of
+    which owner a given result row belongs to -- recording the pending
+    mutation under ``self.owner_id`` would strand it where the row's real
+    owner never sees it via ``get_pending_mutations``.
+    """
+    result_id = db.create_automation_result(
+        "server:1", "def-1", "run-1", "finding", "T", "S", "key-1",
+        server_id="srv-res-1",
+    )
+    svc = SchedulingService(db=db, runtime_source="local")
+
+    ok = await svc.review_automation_result(result_id, "dismissed", "noise")
+
+    assert ok is True
+    pending = db.get_pending_mutations("server:1", primitive="automation_result_review")
+    assert len(pending) == 1
+    assert pending[0]["local_id"] == result_id
+    assert db.get_pending_mutations("local", primitive="automation_result_review") == []
+
+
+@pytest.mark.asyncio
 async def test_review_automation_result_rejects_unknown_review_state(db):
     result_id = db.create_automation_result(
         "local", "def-1", "run-1", "finding", "T", "S", "key-1"

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -822,3 +822,45 @@ async def test_review_automation_result_unknown_id_returns_false(db):
     ok = await svc.review_automation_result("no-such-id", "dismissed")
 
     assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_review_automation_result_server_mirrored_makes_a_single_db_call(db):
+    """review round 1 finding: the review write and its outbox mutation
+    must be ONE ``update_result_review(..., pending_mutation=...)`` call --
+    not a separate ``record_pending_mutation`` call after -- so the two
+    can never land in different transactions.
+    """
+    result_id = db.create_automation_result(
+        "server:1", "def-1", "run-1", "finding", "T", "S", "key-1",
+        server_id="srv-res-1",
+    )
+    svc = SchedulingService(db=db, runtime_source="server:1")
+
+    real_update = db.update_result_review
+    calls: list[dict] = []
+
+    def _spy_update(*args, **kwargs):
+        calls.append(kwargs)
+        return real_update(*args, **kwargs)
+
+    db.update_result_review = _spy_update  # type: ignore[method-assign]
+    db.record_pending_mutation = MagicMock(  # type: ignore[method-assign]
+        side_effect=AssertionError(
+            "record_pending_mutation must not be called separately from "
+            "review_automation_result -- it must go through "
+            "update_result_review(pending_mutation=...)"
+        )
+    )
+
+    ok = await svc.review_automation_result(result_id, "dismissed", "noise")
+
+    assert ok is True
+    assert len(calls) == 1
+    mutation = calls[0]["pending_mutation"]
+    assert mutation["local_id"] == result_id
+    assert mutation["owner_id"] == "server:1"
+    assert mutation["payload"]["server_result_id"] == "srv-res-1"
+
+    pending = db.get_pending_mutations("server:1", primitive="automation_result_review")
+    assert len(pending) == 1

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -729,3 +729,72 @@ def test_app_wiring_briefing_projection_is_live_not_a_frozen_none():
         app.scheduling_service.briefing_projection
         is app.scheduler_loop.queue.briefing_projection
     )
+
+
+# ---------------------------------------------------------------------------
+# review_automation_result (schedules-handoff PR-3, task 5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_automation_result_local_only_updates_without_mutation(db):
+    result_id = db.create_automation_result(
+        "local", "def-1", "run-1", "finding", "T", "S", "key-1"
+    )
+    svc = SchedulingService(db=db, runtime_source="local")
+
+    ok = await svc.review_automation_result(result_id, "dismissed", "not relevant")
+
+    assert ok is True
+    row = db.get_automation_result(result_id)
+    assert row["review_state"] == "dismissed"
+    assert row["review_note"] == "not relevant"
+    assert db.get_pending_mutations("local", primitive="automation_result_review") == []
+
+
+@pytest.mark.asyncio
+async def test_review_automation_result_server_mirrored_records_pending_mutation(db):
+    result_id = db.create_automation_result(
+        "server:1", "def-1", "run-1", "finding", "T", "S", "key-1",
+        server_id="srv-res-1",
+    )
+    svc = SchedulingService(db=db, runtime_source="server:1")
+
+    ok = await svc.review_automation_result(result_id, "dismissed", "noise")
+
+    assert ok is True
+    row = db.get_automation_result(result_id)
+    assert row["review_state"] == "dismissed"
+
+    pending = db.get_pending_mutations("server:1", primitive="automation_result_review")
+    assert len(pending) == 1
+    assert pending[0]["local_id"] == result_id
+    assert pending[0]["payload"] == {
+        "server_result_id": "srv-res-1",
+        "review_state": "dismissed",
+        "review_note": "noise",
+        "idempotency_key": pending[0]["payload"]["idempotency_key"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_review_automation_result_rejects_unknown_review_state(db):
+    result_id = db.create_automation_result(
+        "local", "def-1", "run-1", "finding", "T", "S", "key-1"
+    )
+    svc = SchedulingService(db=db, runtime_source="local")
+
+    ok = await svc.review_automation_result(result_id, "bogus")
+
+    assert ok is False
+    row = db.get_automation_result(result_id)
+    assert row["review_state"] == "unread"  # untouched
+
+
+@pytest.mark.asyncio
+async def test_review_automation_result_unknown_id_returns_false(db):
+    svc = SchedulingService(db=db, runtime_source="local")
+
+    ok = await svc.review_automation_result("no-such-id", "dismissed")
+
+    assert ok is False

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -950,3 +950,299 @@ async def test_sync_now_returns_error_outcome_on_server_error(tmp_path):
     assert "boom" in (outcome.error or "")
     state = db.get_sync_state("local") or {}
     assert state.get("sync_errors"), "the failure must still be recorded"
+
+
+# ----------------------------------------------------------------------
+# Automation definitions/results sync mirrors + review pushback
+# (schedules-handoff PR-3, task 4)
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def captured_logs():
+    """Collect loguru records emitted during the test."""
+    from loguru import logger
+
+    records: list[tuple[str, str]] = []
+    sink_id = logger.add(
+        lambda message: records.append(
+            (message.record["level"].name, message.record["message"])
+        ),
+        level="DEBUG",
+    )
+    yield records
+    logger.remove(sink_id)
+
+
+def _empty_reminders_client() -> AsyncMock:
+    server_client = AsyncMock()
+    server_client.list_reminders.return_value = {"items": []}
+    return server_client
+
+
+def _definition_page(items, has_more=False):
+    return {"items": items, "total": len(items), "has_more": has_more}
+
+
+def _result_page(items, has_more=False):
+    return {"items": items, "total": len(items), "has_more": has_more}
+
+
+def _result_items(n, prefix="res"):
+    return [
+        {
+            "id": f"{prefix}-{i}",
+            "definition_id": "def-1",
+            "run_id": "run-1",
+            "kind": "finding",
+            "title": f"Result {i}",
+            "summary": "S",
+            "dedupe_key": f"key-{prefix}-{i}",
+            "review_state": "unread",
+            "created_at": "2026-08-30T09:00:00+00:00",
+            "updated_at": "2026-08-30T09:00:00+00:00",
+        }
+        for i in range(n)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sync_now_replays_review_mutation_and_clears_on_success(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    result_id = db.create_automation_result(
+        "server:1", "def-1", "run-1", "finding", "T", "S", "key-1"
+    )
+    db.record_pending_mutation(
+        result_id,
+        "automation_result_review",
+        "server:1",
+        {"server_result_id": "srv-res-1", "review_state": "dismissed"},
+    )
+
+    server_client = _empty_reminders_client()
+    server_client.review_automation_result.return_value = {"id": "srv-res-1"}
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    server_client.review_automation_result.assert_awaited_once_with(
+        "srv-res-1", "dismissed", review_note=None
+    )
+    assert db.get_pending_mutations("server:1", primitive="automation_result_review") == []
+
+
+@pytest.mark.asyncio
+async def test_sync_now_review_mutation_not_found_clears_it(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    result_id = db.create_automation_result(
+        "server:1", "def-1", "run-1", "finding", "T", "S", "key-1"
+    )
+    db.record_pending_mutation(
+        result_id,
+        "automation_result_review",
+        "server:1",
+        {"server_result_id": "srv-res-1", "review_state": "read"},
+    )
+
+    server_client = _empty_reminders_client()
+    server_client.review_automation_result.side_effect = ServerClientNotFoundError(
+        "retired"
+    )
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    assert db.get_pending_mutations("server:1", primitive="automation_result_review") == []
+    state = db.get_sync_state("server:1") or {}
+    assert not (state.get("sync_errors") or []), "a retired result is not a sync error"
+
+
+@pytest.mark.asyncio
+async def test_sync_now_review_mutation_other_error_retains_it(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    result_id = db.create_automation_result(
+        "server:1", "def-1", "run-1", "finding", "T", "S", "key-1"
+    )
+    db.record_pending_mutation(
+        result_id,
+        "automation_result_review",
+        "server:1",
+        {"server_result_id": "srv-res-1", "review_state": "read"},
+    )
+
+    server_client = _empty_reminders_client()
+    server_client.review_automation_result.side_effect = ServerUnavailableError("offline")
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"  # the reminder phase itself still succeeded
+    pending = db.get_pending_mutations("server:1", primitive="automation_result_review")
+    assert len(pending) == 1, "the mutation must be left queued for retry"
+    state = db.get_sync_state("server:1") or {}
+    assert state.get("sync_errors"), "a genuine server failure must be recorded"
+
+
+@pytest.mark.asyncio
+async def test_sync_now_pulls_and_upserts_definitions(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = _empty_reminders_client()
+    server_client.list_automation_definitions.return_value = _definition_page(
+        [{"id": "srv-def-1", "family": "recurring_question", "name": "Daily"}]
+    )
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    rows = db.list_automation_definitions(owner_id="server:1")
+    assert len(rows) == 1
+    assert rows[0]["server_id"] == "srv-def-1"
+    assert rows[0]["name"] == "Daily"
+
+
+@pytest.mark.asyncio
+async def test_sync_now_pages_definitions_until_has_more_false(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = _empty_reminders_client()
+    server_client.list_automation_definitions.side_effect = [
+        _definition_page(
+            [{"id": f"srv-def-{i}", "family": "recurring_question", "name": f"D{i}"}
+             for i in range(50)],
+            has_more=True,
+        ),
+        _definition_page(
+            [{"id": "srv-def-50", "family": "recurring_question", "name": "D50"}],
+            has_more=False,
+        ),
+    ]
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    assert server_client.list_automation_definitions.await_count == 2
+    assert len(db.list_automation_definitions(owner_id="server:1")) == 51
+
+
+@pytest.mark.asyncio
+async def test_sync_now_pulls_and_upserts_results(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = _empty_reminders_client()
+    server_client.list_automation_results.return_value = _result_page(
+        _result_items(2)
+    )
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    rows = db.list_automation_results("server:1")
+    assert len(rows) == 2
+
+
+@pytest.mark.asyncio
+async def test_sync_now_results_pull_stops_early_on_short_page(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = _empty_reminders_client()
+    server_client.list_automation_results.return_value = _result_page(
+        _result_items(3), has_more=True  # fewer than the 50-page size wins
+    )
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    await engine.sync_now()
+
+    assert server_client.list_automation_results.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_now_results_pull_caps_at_max_pages_and_logs(tmp_path, captured_logs):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = _empty_reminders_client()
+    server_client.list_automation_results.side_effect = [
+        _result_page(_result_items(50, prefix=f"p{page}"), has_more=True)
+        for page in range(4)
+    ]
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    await engine.sync_now()
+
+    assert server_client.list_automation_results.await_count == 4  # _RESULTS_MAX_PAGES
+    assert len(db.list_automation_results("server:1", limit=1000)) == 200
+    assert any(
+        "cap" in message.lower() and level == "INFO" for level, message in captured_logs
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_now_definitions_phase_failure_does_not_abort_results_phase(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = _empty_reminders_client()
+    server_client.list_automation_definitions.side_effect = ServerUnavailableError("down")
+    server_client.list_automation_results.return_value = _result_page(_result_items(1))
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"  # the reminder phase still succeeded
+    assert len(db.list_automation_results("server:1")) == 1
+    state = db.get_sync_state("server:1") or {}
+    assert state.get("sync_errors"), "the definitions-phase failure must be recorded"
+
+
+@pytest.mark.asyncio
+async def test_sync_now_definitions_policy_refusal_is_not_recorded_as_error(tmp_path):
+    from tldw_chatbook.Scheduling.services.server_client import (
+        ServerClientPolicyError,
+    )
+
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = _empty_reminders_client()
+    server_client.list_automation_definitions.side_effect = ServerClientPolicyError(
+        "requires server mode"
+    )
+    server_client.list_automation_results.return_value = _result_page(_result_items(1))
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    assert len(db.list_automation_results("server:1")) == 1  # later phase still ran
+    state = db.get_sync_state("server:1") or {}
+    assert not (state.get("sync_errors") or [])
+
+
+@pytest.mark.asyncio
+async def test_pull_gains_definitions_and_results_without_pushback(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    result_id = db.create_automation_result(
+        "server:1", "def-1", "run-1", "finding", "T", "S", "key-1"
+    )
+    db.record_pending_mutation(
+        result_id,
+        "automation_result_review",
+        "server:1",
+        {"server_result_id": "srv-res-1", "review_state": "dismissed"},
+    )
+    server_client = AsyncMock()
+    server_client.list_reminders.return_value = {"items": []}
+    server_client.list_automation_definitions.return_value = _definition_page(
+        [{"id": "srv-def-1", "family": "recurring_question", "name": "Daily"}]
+    )
+    server_client.list_automation_results.return_value = _result_page(_result_items(1))
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    await engine.pull()
+
+    assert len(db.list_automation_definitions(owner_id="server:1")) == 1
+    # 2 rows: the pre-existing local-only result plus the server-pulled one.
+    rows = db.list_automation_results("server:1", limit=10)
+    assert len(rows) == 2
+    assert any(row["server_id"] == "res-0" for row in rows)
+    server_client.review_automation_result.assert_not_awaited()
+    # The pending review mutation is untouched -- pull() never pushes.
+    assert len(
+        db.get_pending_mutations("server:1", primitive="automation_result_review")
+    ) == 1

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -1078,7 +1078,11 @@ async def test_sync_now_review_mutation_other_error_retains_it(tmp_path):
 
     outcome = await engine.sync_now()
 
-    assert outcome.status == "ok"  # the reminder phase itself still succeeded
+    # task-23105-review F2: the reminder phase itself succeeded, but a
+    # pushback phase failed -- that must surface as an error outcome, not
+    # a clean "ok" beside a fresh error badge.
+    assert outcome.status == "error"
+    assert "offline" in (outcome.error or "")
     pending = db.get_pending_mutations("server:1", primitive="automation_result_review")
     assert len(pending) == 1, "the mutation must be left queued for retry"
     state = db.get_sync_state("server:1") or {}
@@ -1128,6 +1132,33 @@ async def test_sync_now_pages_definitions_until_has_more_false(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_sync_now_definitions_pull_caps_at_max_pages_and_logs(
+    tmp_path, captured_logs
+):
+    """F4: the definitions pull was an unbounded `while True` -- a server
+    that always claims `has_more=True` must not spin forever."""
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = _empty_reminders_client()
+    server_client.list_automation_definitions.side_effect = [
+        _definition_page(
+            [{"id": f"srv-def-p{page}-{i}", "family": "recurring_question",
+              "name": f"D{page}-{i}"} for i in range(50)],
+            has_more=True,
+        )
+        for page in range(10)
+    ]
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    await engine.sync_now()
+
+    assert server_client.list_automation_definitions.await_count == 4  # _SYNC_MAX_PAGES
+    assert len(db.list_automation_definitions(owner_id="server:1")) == 200
+    assert any(
+        "cap" in message.lower() and level == "INFO" for level, message in captured_logs
+    )
+
+
+@pytest.mark.asyncio
 async def test_sync_now_pulls_and_upserts_results(tmp_path):
     db = ScheduledTasksDB(tmp_path / "db.db")
     server_client = _empty_reminders_client()
@@ -1169,7 +1200,7 @@ async def test_sync_now_results_pull_caps_at_max_pages_and_logs(tmp_path, captur
 
     await engine.sync_now()
 
-    assert server_client.list_automation_results.await_count == 4  # _RESULTS_MAX_PAGES
+    assert server_client.list_automation_results.await_count == 4  # _SYNC_MAX_PAGES
     assert len(db.list_automation_results("server:1", limit=1000)) == 200
     assert any(
         "cap" in message.lower() and level == "INFO" for level, message in captured_logs
@@ -1186,7 +1217,13 @@ async def test_sync_now_definitions_phase_failure_does_not_abort_results_phase(t
 
     outcome = await engine.sync_now()
 
-    assert outcome.status == "ok"  # the reminder phase still succeeded
+    # task-23105-review F2: a failed automation phase must surface as an
+    # error outcome even though the reminder phase (and the later results
+    # phase) still ran to completion -- results are still pulled, but the
+    # workbench must not toast "Sync completed" next to a fresh error
+    # badge (the controller ruled the prior "ok" pin a plan artifact).
+    assert outcome.status == "error"
+    assert "down" in (outcome.error or "")
     assert len(db.list_automation_results("server:1")) == 1
     state = db.get_sync_state("server:1") or {}
     assert state.get("sync_errors"), "the definitions-phase failure must be recorded"

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -1246,3 +1246,89 @@ async def test_pull_gains_definitions_and_results_without_pushback(tmp_path):
     assert len(
         db.get_pending_mutations("server:1", primitive="automation_result_review")
     ) == 1
+
+
+# --- review round 1 #1: reminder-phase failures must not short-circuit the
+# automation phases in either entry point --------------------------------
+
+
+def _break_apply_pulled_reminders(db: ScheduledTasksDB, message: str = "boom") -> None:
+    """Force the reminder DB-transaction phase to fail (test-only)."""
+
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError(message)
+
+    db._apply_pulled_reminders = _raise  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
+async def test_pull_reminder_network_failure_still_pulls_automation_results(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = AsyncMock()
+    server_client.list_reminders.side_effect = ServerUnavailableError("down")
+    server_client.list_automation_results.return_value = _result_page(_result_items(1))
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    await engine.pull()
+
+    assert len(db.list_automation_results("server:1")) == 1
+    state = db.get_sync_state("server:1") or {}
+    assert state.get("sync_errors"), "the reminder network failure must still be recorded"
+
+
+@pytest.mark.asyncio
+async def test_pull_reminder_transaction_failure_still_pulls_automation_results(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    _break_apply_pulled_reminders(db)
+    server_client = AsyncMock()
+    server_client.list_reminders.return_value = {
+        "items": [{"id": "srv-1", "title": "A"}]
+    }
+    server_client.list_automation_results.return_value = _result_page(_result_items(1))
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    await engine.pull()
+
+    assert len(db.list_automation_results("server:1")) == 1
+    state = db.get_sync_state("server:1") or {}
+    assert state.get(
+        "sync_errors"
+    ), "the reminder transaction failure must still be recorded"
+
+
+@pytest.mark.asyncio
+async def test_sync_now_reminder_network_failure_still_pulls_automation_results(
+    tmp_path,
+):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = AsyncMock()
+    server_client.list_reminders.side_effect = ServerUnavailableError("down")
+    server_client.list_automation_results.return_value = _result_page(_result_items(1))
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    # The reminder phase's own outcome/status semantics are unchanged.
+    assert outcome.status == "error"
+    assert "down" in (outcome.error or "")
+    assert len(db.list_automation_results("server:1")) == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_now_reminder_transaction_failure_still_pulls_automation_results(
+    tmp_path,
+):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    _break_apply_pulled_reminders(db)
+    server_client = AsyncMock()
+    server_client.list_reminders.return_value = {
+        "items": [{"id": "srv-1", "title": "A"}]
+    }
+    server_client.list_automation_results.return_value = _result_page(_result_items(1))
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "error"
+    assert "boom" in (outcome.error or "")
+    assert len(db.list_automation_results("server:1")) == 1

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -1369,3 +1369,68 @@ async def test_sync_now_reminder_transaction_failure_still_pulls_automation_resu
     assert outcome.status == "error"
     assert "boom" in (outcome.error or "")
     assert len(db.list_automation_results("server:1")) == 1
+
+
+# --- review round 2: "not_applicable" reminder phase must not mask a ------
+# --- genuinely-failed automation phase -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_now_reminder_policy_refusal_does_not_mask_automation_error(
+    tmp_path,
+):
+    """The reminder phase's own policy action can be refused
+    (`not_applicable`) while a DIFFERENT policy action -- an automation
+    phase -- genuinely fails. The old `status == "ok"` guard only caught
+    this when the reminder phase was "ok"; "not_applicable" let the
+    automation failure through unreported."""
+    from tldw_chatbook.Scheduling.services.server_client import (
+        ServerClientPolicyError,
+    )
+
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = AsyncMock()
+    server_client.list_reminders.side_effect = ServerClientPolicyError(
+        "requires server mode"
+    )
+    server_client.list_automation_definitions.side_effect = ServerUnavailableError(
+        "defs down"
+    )
+    server_client.list_automation_results.return_value = _result_page(_result_items(1))
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "error"
+    assert "defs down" in (outcome.error or "")
+    assert len(db.list_automation_results("server:1")) == 1  # later phase still ran
+    state = db.get_sync_state("server:1") or {}
+    assert state.get("sync_errors"), "the definitions-phase failure must be recorded"
+
+
+@pytest.mark.asyncio
+async def test_sync_now_all_policy_refusal_stays_not_applicable(tmp_path):
+    """A pure all-refusal round (every phase's policy action refused) is
+    still `not_applicable`, not `error` -- refusals are never errors."""
+    from tldw_chatbook.Scheduling.services.server_client import (
+        ServerClientPolicyError,
+    )
+
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = AsyncMock()
+    server_client.list_reminders.side_effect = ServerClientPolicyError(
+        "requires server mode"
+    )
+    server_client.list_automation_definitions.side_effect = ServerClientPolicyError(
+        "requires server mode"
+    )
+    server_client.list_automation_results.side_effect = ServerClientPolicyError(
+        "requires server mode"
+    )
+    engine = SyncEngine(db, server_client, owner_id="local")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "not_applicable"
+    state = db.get_sync_state("local") or {}
+    assert not (state.get("sync_errors") or [])

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -1090,6 +1090,62 @@ async def test_sync_now_review_mutation_other_error_retains_it(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_sync_now_skips_review_fields_for_just_pushed_result_this_cycle(tmp_path):
+    """Task 5 same-cycle echo (Qodo finding): `_replay_review_mutations`'
+    pushed `server_result_id`s must thread into `_pull_results` as
+    `skip_review_server_ids`. By the time this SAME sync's results pull
+    runs, the pending mutation the pushback phase just cleared is already
+    gone, so the pending-mutation guard alone can no longer protect this
+    row. Without the pushed-this-cycle skip set, a results page that
+    still echoes the pre-review server state (server write/read-path lag)
+    would revert the review that was just pushed.
+    """
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = _empty_reminders_client()
+
+    # First sync: seed a server-mirrored, unread result locally.
+    stale_item = _result_items(1)[0]
+    server_client.list_automation_results.return_value = _result_page([stale_item])
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+    await engine.sync_now()
+    local_id = db.list_automation_results("server:1")[0]["id"]
+
+    # Review it locally with a pending mutation queued, mirroring what
+    # SchedulingService.review_automation_result does.
+    db.update_result_review(
+        local_id, "dismissed", "handled", "user:1",
+        pending_mutation={
+            "local_id": local_id,
+            "primitive": "automation_result_review",
+            "owner_id": "server:1",
+            "payload": {
+                "server_result_id": stale_item["id"],
+                "review_state": "dismissed",
+                "review_note": "handled",
+            },
+        },
+    )
+
+    # Second sync: pushback succeeds (mutation cleared), but the results
+    # page mock is left UNCHANGED -- still reporting "unread" -- to
+    # simulate the server's own read path lagging its just-committed write
+    # within this same round trip.
+    server_client.review_automation_result.return_value = {"id": stale_item["id"]}
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    server_client.review_automation_result.assert_awaited_once_with(
+        stale_item["id"], "dismissed", review_note="handled"
+    )
+    assert db.get_pending_mutations("server:1", primitive="automation_result_review") == []
+    refreshed = db.get_automation_result(local_id)
+    assert refreshed["review_state"] == "dismissed", (
+        "the same-cycle stale echo must not revert the review just pushed"
+    )
+    assert refreshed["review_note"] == "handled"
+
+
+@pytest.mark.asyncio
 async def test_sync_now_pulls_and_upserts_definitions(tmp_path):
     db = ScheduledTasksDB(tmp_path / "db.db")
     server_client = _empty_reminders_client()

--- a/Tests/tldw_api/test_scheduled_tasks_automation_client.py
+++ b/Tests/tldw_api/test_scheduled_tasks_automation_client.py
@@ -1,5 +1,7 @@
 """Client routing + schema tests for the scheduled-tasks automation control plane."""
 
+import json
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -10,6 +12,8 @@ from tldw_chatbook.tldw_api.scheduled_tasks_automation_schemas import (
     ScheduledTaskAutomationDefinitionList,
     ScheduledTaskAutomationRunNowResponse,
     ScheduledTaskAuditList,
+    ScheduledTaskResult,
+    ScheduledTaskResultList,
 )
 
 
@@ -154,3 +158,110 @@ async def test_definition_audit_routes_to_audit_endpoint_with_filters(monkeypatc
     assert result.items[0].event_type == "run_succeeded"
     assert result.items[0].after == {"run_id": "run-1", "status": "succeeded"}
     assert result.total == 1
+
+
+_RESULTS_FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "Scheduling"
+    / "fixtures"
+    / "server_responses"
+    / "automation_results_list.json"
+)
+
+
+@pytest.mark.asyncio
+async def test_list_results_routes_to_results_endpoint_with_pagination_only(
+    monkeypatch,
+):
+    client = TLDWAPIClient("http://localhost:8000")
+    mocked = AsyncMock(return_value=json.loads(_RESULTS_FIXTURE.read_text()))
+    monkeypatch.setattr(client, "_request", mocked)
+
+    result = await client.list_scheduled_task_results(limit=25, offset=0)
+
+    assert mocked.await_args.args[:2] == ("GET", "/api/v1/scheduled-tasks/results")
+    # definition_id/review_state are unset -- must not appear in params.
+    assert mocked.await_args.kwargs["params"] == {"limit": 25, "offset": 0}
+    assert isinstance(result, ScheduledTaskResultList)
+    assert result.total == 2
+    assert result.items[0].id == "res_01J5RHPQWXYZ1234567890AB"
+    assert result.items[0].review_state == "unread"
+    assert result.items[0].answer_mode == "synthesized"
+    assert result.items[1].review_state == "read"
+    assert result.items[1].reviewed_by == "user:42"
+
+
+@pytest.mark.asyncio
+async def test_list_results_includes_only_the_filters_that_are_set(monkeypatch):
+    client = TLDWAPIClient("http://localhost:8000")
+    mocked = AsyncMock(return_value={"items": [], "total": 0})
+    monkeypatch.setattr(client, "_request", mocked)
+
+    await client.list_scheduled_task_results(
+        definition_id="def-1", review_state="unread"
+    )
+
+    assert mocked.await_args.kwargs["params"] == {
+        "limit": 50,
+        "offset": 0,
+        "definition_id": "def-1",
+        "review_state": "unread",
+    }
+
+
+@pytest.mark.asyncio
+async def test_review_result_posts_to_review_route(monkeypatch):
+    client = TLDWAPIClient("http://localhost:8000")
+    mocked = AsyncMock(
+        return_value={
+            "id": "res-1",
+            "definition_id": "def-1",
+            "run_id": "run-1",
+            "kind": "finding",
+            "title": "T",
+            "summary": "S",
+            "dedupe_key": "dk-1",
+            "review_state": "dismissed",
+        }
+    )
+    monkeypatch.setattr(client, "_request", mocked)
+
+    result = await client.review_scheduled_task_result(
+        "res-1", review_state="dismissed", review_note="not relevant"
+    )
+
+    assert mocked.await_args.args[:2] == (
+        "POST",
+        "/api/v1/scheduled-tasks/results/res-1/review",
+    )
+    assert mocked.await_args.kwargs["json_data"] == {
+        "review_state": "dismissed",
+        "review_note": "not relevant",
+    }
+    assert isinstance(result, ScheduledTaskResult)
+    assert result.review_state == "dismissed"
+
+
+@pytest.mark.asyncio
+async def test_review_result_sends_null_note_when_not_given(monkeypatch):
+    client = TLDWAPIClient("http://localhost:8000")
+    mocked = AsyncMock(
+        return_value={
+            "id": "res-1",
+            "definition_id": "def-1",
+            "run_id": "run-1",
+            "kind": "finding",
+            "title": "T",
+            "summary": "S",
+            "dedupe_key": "dk-1",
+            "review_state": "read",
+        }
+    )
+    monkeypatch.setattr(client, "_request", mocked)
+
+    await client.review_scheduled_task_result("res-1", review_state="read")
+
+    assert mocked.await_args.kwargs["json_data"] == {
+        "review_state": "read",
+        "review_note": None,
+    }

--- a/tldw_chatbook/Notifications/server_notifications_service.py
+++ b/tldw_chatbook/Notifications/server_notifications_service.py
@@ -337,3 +337,67 @@ class ServerNotificationsService:
                 definition_id, idempotency_key=idempotency_key
             )
         )
+
+    async def list_scheduled_automation_results(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        definition_id: str | None = None,
+        review_state: str | None = None,
+    ) -> dict[str, Any]:
+        """List the server's scheduled-task results (spec §4.2).
+
+        Args:
+            limit: Page size to request from the server.
+            offset: Pagination offset to request from the server.
+            definition_id: Optional filter to one definition's results.
+            review_state: Optional review-state filter.
+
+        Returns:
+            The result list response (``items`` plus total/has_more
+            pagination fields) as a JSON-mode dict.
+        """
+        self._enforce("scheduler.automations.list.server")
+        return self._dump(
+            await self._require_client().list_scheduled_task_results(
+                limit=limit,
+                offset=offset,
+                definition_id=definition_id,
+                review_state=review_state,
+            )
+        )
+
+    async def review_scheduled_automation_result(
+        self,
+        result_id: str,
+        review_state: str,
+        *,
+        review_note: str | None = None,
+    ) -> dict[str, Any]:
+        """Set one result's review state.
+
+        Unlike ``run_scheduled_automation_now`` (which uses the LAUNCH
+        action -- it dispatches a brand-new execution), reviewing a result
+        only mutates existing metadata; it never launches or lists
+        anything. That makes it a CONFIGURE-class action, the same
+        reasoning ``notifications.reminders.configure.server`` uses for
+        reminder create/update/delete.
+
+        Args:
+            result_id: The server result to update.
+            review_state: New review state (``read``/``dismissed``/etc).
+            review_note: Optional free-text note attached to the review.
+
+        Returns:
+            The updated result row.
+
+        Raises:
+            PolicyDeniedError: If the runtime policy refuses the action.
+        """
+        self._enforce("scheduler.automations.configure.server")
+        return self._dump(
+            await self._require_client().review_scheduled_task_result(
+                result_id, review_state, review_note=review_note
+            )
+        )

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -1560,8 +1560,22 @@ class ScheduledTasksDB(BaseDB):
         review_state: str,
         review_note: str | None = None,
         reviewed_by: str | None = None,
+        *,
+        pending_mutation: dict[str, Any] | None = None,
     ) -> bool:
-        """Set a result's review state; returns False for an unknown id."""
+        """Set a result's review state; returns False for an unknown id.
+
+        When ``pending_mutation`` is given, its
+        ``automation_result_review`` mutation is inserted into
+        ``pending_mutations`` in the SAME transaction as the review
+        UPDATE, so a crash between the two can never leave a local
+        review recorded without the outbox row that pushes it (or vice
+        versa). The dict mirrors ``record_pending_mutation``'s
+        parameters: ``local_id``, ``primitive``, ``owner_id``,
+        ``payload`` -- an ``idempotency_key`` is generated into the
+        payload if one isn't already present, same as the standalone
+        method.
+        """
         now_iso = self._to_utc_iso(datetime.now(timezone.utc))
         with self.transaction() as conn:
             cursor = conn.execute(
@@ -1573,7 +1587,28 @@ class ScheduledTasksDB(BaseDB):
                 """,
                 (review_state, review_note, reviewed_by, now_iso, now_iso, result_id),
             )
-            return cursor.rowcount > 0
+            if cursor.rowcount == 0:
+                return False
+
+            if pending_mutation is not None:
+                stored_payload = dict(pending_mutation["payload"])
+                if not stored_payload.get("idempotency_key"):
+                    stored_payload["idempotency_key"] = str(uuid.uuid4())
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO pending_mutations
+                    (local_id, primitive, owner_id, payload, created_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        pending_mutation["local_id"],
+                        pending_mutation["primitive"],
+                        pending_mutation["owner_id"],
+                        self._to_json(stored_payload),
+                        now_iso,
+                    ),
+                )
+            return True
 
     # ------------------------------------------------------------------
     # Server-mirror upserts (schedules-handoff PR-3)

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -1566,6 +1566,247 @@ class ScheduledTasksDB(BaseDB):
             return cursor.rowcount > 0
 
     # ------------------------------------------------------------------
+    # Server-mirror upserts (schedules-handoff PR-3)
+    # ------------------------------------------------------------------
+
+    #: Primitive name pending `automation_result_review` mutations are
+    #: stored under (matches the SyncEngine module constant of the same
+    #: value -- see sync_engine.py's `_RESULT_REVIEW_PRIMITIVE`).
+    _RESULT_REVIEW_PRIMITIVE = "automation_result_review"
+
+    #: Result columns that may be copied verbatim from a server item on
+    #: insert, beyond id/server_id/owner_id (handled separately).
+    _AUTOMATION_RESULT_INSERT_FIELDS = _AUTOMATION_RESULT_COLUMNS | {
+        "definition_id", "run_id", "kind", "title", "summary", "dedupe_key",
+        "created_at",
+    }
+
+    #: Result fields a server-mirror update is allowed to touch on an
+    #: existing row -- review state only (spec §5: "results sync down,
+    #: review pushes up").
+    _AUTOMATION_RESULT_REVIEW_FIELDS = {
+        "review_state", "reviewed_at", "reviewed_by", "review_note", "updated_at",
+    }
+
+    def upsert_automation_definitions_from_server(
+        self, owner_id: str, items: list[dict[str, Any]]
+    ) -> dict[str, int]:
+        """Server-wins mirror of automation definitions pulled from the server.
+
+        Matches local rows by ``(owner_id, server_id)``. Absent -> insert a
+        new mirror row (server ``id`` becomes local ``server_id``; local
+        ``id`` is a fresh UUID). Present -> every server-carried field is
+        written EXCEPT ``transfer_state``: a server payload must never
+        clear a local transfer marker (spec-2026-08-31-schedules-handoff-
+        parity.md §6 parked finding). Archived lifecycle mirrors like any
+        other field -- rows are never deleted here.
+
+        Returns:
+            ``{"inserted": n, "updated": n}``.
+        """
+        inserted = 0
+        updated = 0
+        with self.transaction() as conn:
+            for item in items:
+                server_id = item.get("id")
+                if not server_id:
+                    continue
+
+                fields: dict[str, Any] = {
+                    key: item[key]
+                    for key in self._AUTOMATION_DEFINITION_COLUMNS
+                    if key in item and key not in {"id", "server_id", "owner_id"}
+                }
+                # §6 parked finding: transfer_state is a local-only marker
+                # a server mirror must never overwrite, even if a payload
+                # somehow carried one.
+                fields.pop("transfer_state", None)
+
+                existing = conn.execute(
+                    "SELECT id FROM automation_definitions "
+                    "WHERE owner_id = ? AND server_id = ?",
+                    (owner_id, server_id),
+                ).fetchone()
+
+                if existing is None:
+                    local_id = str(uuid.uuid4())
+                    now_iso = self._to_utc_iso(datetime.now(timezone.utc))
+                    insert_fields = dict(fields)
+                    insert_fields["id"] = local_id
+                    insert_fields["server_id"] = server_id
+                    insert_fields["owner_id"] = owner_id
+                    insert_fields.setdefault("family", "recurring_question")
+                    insert_fields.setdefault("name", "Untitled automation")
+                    insert_fields.setdefault("lifecycle", "configured")
+                    insert_fields.setdefault("health", "execution_unavailable")
+                    insert_fields.setdefault("version", 1)
+                    insert_fields.setdefault("created_at", now_iso)
+                    insert_fields.setdefault("updated_at", now_iso)
+                    serialized = self._serialize_definition_fields(insert_fields)
+                    self._validate_sql_identifiers(list(serialized.keys()))
+                    columns = ", ".join(serialized.keys())
+                    placeholders = ", ".join(["?"] * len(serialized))
+                    conn.execute(
+                        f"INSERT INTO automation_definitions ({columns}) "
+                        f"VALUES ({placeholders})",
+                        list(serialized.values()),
+                    )
+                    inserted += 1
+                else:
+                    if not fields:
+                        continue
+                    serialized = self._serialize_definition_fields(fields)
+                    self._validate_sql_identifiers(list(serialized.keys()))
+                    updates = ", ".join(f"{key} = ?" for key in serialized)
+                    conn.execute(
+                        f"UPDATE automation_definitions SET {updates} WHERE id = ?",
+                        [*serialized.values(), existing["id"]],
+                    )
+                    updated += 1
+        return {"inserted": inserted, "updated": updated}
+
+    def _serialize_definition_fields(self, fields: dict[str, Any]) -> dict[str, Any]:
+        """Apply the same JSON/datetime conversion `update_automation_definition` uses."""
+        serialized: dict[str, Any] = {}
+        for key, value in fields.items():
+            if key in self._AUTOMATION_JSON_FIELDS:
+                serialized[key] = self._to_json(value)
+            elif key in self._DATETIME_FIELDS:
+                serialized[key] = self._to_utc_iso(value)
+            else:
+                serialized[key] = value
+        return serialized
+
+    def upsert_automation_results_from_server(
+        self, owner_id: str, items: list[dict[str, Any]]
+    ) -> dict[str, int]:
+        """Server-wins mirror of scheduled-task results pulled from the server.
+
+        Matches local rows by ``(owner_id, server_id)``.
+
+        Absent -> insert the full row (local ``id`` is a fresh UUID;
+        ``definition_id`` and ``run_id`` are stored exactly as the server
+        sent them -- plain TEXT, no local row to resolve to, same
+        treatment the spec gives ``run_id``, spec §4.2). A ``dedupe_key``
+        UNIQUE conflict against a locally-created row (not yet known to
+        the server) is not an error: the insert is skipped and counted --
+        the local row keeps ownership until its own push resolves the
+        collision.
+
+        Present -> update ONLY the review fields (``review_state``,
+        ``reviewed_at``, ``reviewed_by``, ``review_note``, ``updated_at``),
+        and only when no pending ``automation_result_review`` mutation is
+        queued for that row: an unpushed local review outranks the mirror
+        until SyncEngine's pushback phase (which runs before this pull)
+        has replayed it -- otherwise a stale server payload would clobber
+        a review the user just made.
+
+        Returns:
+            ``{"inserted": n, "updated": n, "skipped_dedupe": n}``.
+        """
+        inserted = 0
+        updated = 0
+        skipped_dedupe = 0
+        pending_local_ids = {
+            mutation["local_id"]
+            for mutation in self.get_pending_mutations(
+                owner_id, primitive=self._RESULT_REVIEW_PRIMITIVE
+            )
+        }
+        with self.transaction() as conn:
+            for item in items:
+                server_id = item.get("id")
+                if not server_id:
+                    continue
+
+                existing = conn.execute(
+                    "SELECT id FROM automation_results "
+                    "WHERE owner_id = ? AND server_id = ?",
+                    (owner_id, server_id),
+                ).fetchone()
+
+                if existing is None:
+                    local_id = str(uuid.uuid4())
+                    now_iso = self._to_utc_iso(datetime.now(timezone.utc))
+                    fields: dict[str, Any] = {
+                        key: item[key]
+                        for key in self._AUTOMATION_RESULT_INSERT_FIELDS
+                        if key in item
+                    }
+                    fields["id"] = local_id
+                    fields["server_id"] = server_id
+                    fields["owner_id"] = owner_id
+                    fields.setdefault("definition_id", "")
+                    fields.setdefault("run_id", "")
+                    fields.setdefault("kind", "finding")
+                    fields.setdefault("title", "Untitled result")
+                    fields.setdefault("summary", "")
+                    fields.setdefault("dedupe_key", f"server:{server_id}")
+                    fields.setdefault("review_state", "unread")
+                    fields.setdefault("answer_mode", "none")
+                    fields.setdefault("created_at", now_iso)
+                    fields.setdefault("updated_at", now_iso)
+                    serialized = self._serialize_result_fields(fields)
+                    self._validate_sql_identifiers(list(serialized.keys()))
+                    columns = ", ".join(serialized.keys())
+                    placeholders = ", ".join(["?"] * len(serialized))
+                    try:
+                        conn.execute(
+                            f"INSERT INTO automation_results ({columns}) "
+                            f"VALUES ({placeholders})",
+                            list(serialized.values()),
+                        )
+                    except sqlite3.IntegrityError as exc:
+                        if "UNIQUE constraint failed" not in str(exc):
+                            raise
+                        # (owner_id, dedupe_key) collided with a
+                        # locally-created row -- skip, don't overwrite it.
+                        skipped_dedupe += 1
+                        continue
+                    inserted += 1
+                else:
+                    if existing["id"] in pending_local_ids:
+                        continue
+                    review_fields = {
+                        key: item[key]
+                        for key in self._AUTOMATION_RESULT_REVIEW_FIELDS
+                        if key in item
+                    }
+                    if not review_fields:
+                        continue
+                    serialized = self._serialize_result_fields(review_fields)
+                    self._validate_sql_identifiers(list(serialized.keys()))
+                    updates = ", ".join(f"{key} = ?" for key in serialized)
+                    conn.execute(
+                        f"UPDATE automation_results SET {updates} WHERE id = ?",
+                        [*serialized.values(), existing["id"]],
+                    )
+                    updated += 1
+        return {
+            "inserted": inserted,
+            "updated": updated,
+            "skipped_dedupe": skipped_dedupe,
+        }
+
+    def _serialize_result_fields(self, fields: dict[str, Any]) -> dict[str, Any]:
+        """Apply the same JSON conversion `create_automation_result` uses.
+
+        Datetime-shaped fields (``reviewed_at``, ``created_at``, ...) are
+        passed through raw, mirroring `create_automation_result`'s own
+        loop (which only special-cases actual ``datetime`` instances) --
+        server items already carry UTC ISO-8601 strings.
+        """
+        serialized: dict[str, Any] = {}
+        for key, value in fields.items():
+            if key in self._AUTOMATION_RESULT_JSON_FIELDS:
+                serialized[key] = json.dumps(value)
+            elif isinstance(value, datetime):
+                serialized[key] = self._to_utc_iso(value)
+            else:
+                serialized[key] = value
+        return serialized
+
+    # ------------------------------------------------------------------
     # Sync helpers
     # ------------------------------------------------------------------
 

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -1544,6 +1544,16 @@ class ScheduledTasksDB(BaseDB):
             row = cursor.fetchone()
             return int(row[0]) if row else 0
 
+    def get_automation_result(self, result_id: str) -> Optional[dict[str, Any]]:
+        """Fetch an automation result by local id."""
+        with closing(self._get_connection()) as conn:
+            cursor = conn.execute(
+                "SELECT * FROM automation_results WHERE id = ?", (result_id,)
+            )
+            return self._row_to_dict(
+                cursor.fetchone(), json_fields=self._AUTOMATION_RESULT_JSON_FIELDS
+            )
+
     def update_result_review(
         self,
         result_id: str,

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -1767,6 +1767,12 @@ class ScheduledTasksDB(BaseDB):
                 else:
                     if existing["id"] in pending_local_ids:
                         continue
+                    # Once the mutation above is gone (pushback just
+                    # replayed it), a same-round-trip results page that
+                    # echoes the pre-review state can still overwrite this
+                    # row -- unguarded by design (review round 1 #4,
+                    # Medium/attempt-bounded): a stale echo self-heals on
+                    # the next sync once the server catches up.
                     review_fields = {
                         key: item[key]
                         for key in self._AUTOMATION_RESULT_REVIEW_FIELDS

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -1157,11 +1157,16 @@ class ScheduledTasksDB(BaseDB):
                 )
             return self._rows_to_dicts(rows, json_fields=self._AUTOMATION_JSON_FIELDS)
 
-    def update_automation_definition(self, definition_id: str, **kwargs: Any) -> bool:
+    def update_automation_definition(
+        self, definition_id: str, *, bump_version: bool = True, **kwargs: Any
+    ) -> bool:
         """Update automation-definition fields. Returns True if a row changed.
 
         The ``version`` column is automatically incremented for optimistic
-        locking; any ``version`` value supplied in kwargs is ignored.
+        locking; any ``version`` value supplied in kwargs is ignored. Pass
+        ``bump_version=False`` for a non-edit update (e.g. the scheduler's
+        `next_run_at` advance) so version churn doesn't pollute conflict
+        detection -- PR-2 final-review parking note.
         """
         if not kwargs:
             return False
@@ -1191,7 +1196,8 @@ class ScheduledTasksDB(BaseDB):
             return False
 
         self._validate_sql_identifiers([key.split(" ", 1)[0] for key in updates])
-        updates.append("version = version + 1")
+        if bump_version:
+            updates.append("version = version + 1")
         updates.append("updated_at = ?")
         params.append(self._to_utc_iso(datetime.now(timezone.utc)))
         params.append(definition_id)

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -1545,7 +1545,15 @@ class ScheduledTasksDB(BaseDB):
             return int(row[0]) if row else 0
 
     def get_automation_result(self, result_id: str) -> Optional[dict[str, Any]]:
-        """Fetch an automation result by local id."""
+        """Fetch an automation result by local id.
+
+        Args:
+            result_id: Local ``automation_results.id`` to look up.
+
+        Returns:
+            The result row as a dict (JSON fields already decoded), or
+            ``None`` if no row matches ``result_id``.
+        """
         with closing(self._get_connection()) as conn:
             cursor = conn.execute(
                 "SELECT * FROM automation_results WHERE id = ?", (result_id,)
@@ -1723,7 +1731,11 @@ class ScheduledTasksDB(BaseDB):
         return serialized
 
     def upsert_automation_results_from_server(
-        self, owner_id: str, items: list[dict[str, Any]]
+        self,
+        owner_id: str,
+        items: list[dict[str, Any]],
+        *,
+        skip_review_server_ids: frozenset[str] = frozenset(),
     ) -> dict[str, int]:
         """Server-wins mirror of scheduled-task results pulled from the server.
 
@@ -1739,12 +1751,35 @@ class ScheduledTasksDB(BaseDB):
         collision.
 
         Present -> update ONLY the review fields (``review_state``,
-        ``reviewed_at``, ``reviewed_by``, ``review_note``, ``updated_at``),
-        and only when no pending ``automation_result_review`` mutation is
-        queued for that row: an unpushed local review outranks the mirror
-        until SyncEngine's pushback phase (which runs before this pull)
-        has replayed it -- otherwise a stale server payload would clobber
-        a review the user just made.
+        ``reviewed_at``, ``reviewed_by``, ``review_note``, ``updated_at``).
+        Two guard layers decide whether that update actually happens
+        (Qodo TOCTOU/same-cycle-echo review):
+
+        1. Pending-mutation guard (unpushed reviews): a per-row
+           ``pending_mutations`` SELECT is run INSIDE this same write
+           transaction, immediately before the row's own UPDATE -- not
+           snapshotted once before the loop starts, which left a window
+           for a concurrently-recorded review (the review service writes
+           via ``to_thread`` while this upsert runs on the event loop) to
+           land between the snapshot and this row's write and then get
+           clobbered by a stale server payload despite its own mutation
+           existing. An unpushed local review outranks the mirror until
+           SyncEngine's pushback phase (which runs before this pull) has
+           replayed it.
+        2. Pushed-this-cycle guard (just-pushed reviews): ``server_id in
+           skip_review_server_ids`` skips rows SyncEngine's pushback phase
+           already replayed THIS sync cycle. Their pending mutation is
+           already gone by the time this pull runs, so guard 1 can't see
+           them -- without this second layer, a same-cycle results page
+           that still echoes the pre-review server state (server write/
+           read-path lag) would revert the review that was just pushed,
+           and once the row ages out of the bounded newest-pages pull
+           window, no later sync would ever correct it.
+
+        The residual exposure after both layers is only a server that
+        lies about its own committed writes (reports success on push,
+        then immediately echoes different data back on pull) -- not
+        something a client-side guard can detect.
 
         Returns:
             ``{"inserted": n, "updated": n, "skipped_dedupe": n}``.
@@ -1752,12 +1787,6 @@ class ScheduledTasksDB(BaseDB):
         inserted = 0
         updated = 0
         skipped_dedupe = 0
-        pending_local_ids = {
-            mutation["local_id"]
-            for mutation in self.get_pending_mutations(
-                owner_id, primitive=self._RESULT_REVIEW_PRIMITIVE
-            )
-        }
         with self.transaction() as conn:
             for item in items:
                 server_id = item.get("id")
@@ -1810,14 +1839,25 @@ class ScheduledTasksDB(BaseDB):
                         continue
                     inserted += 1
                 else:
-                    if existing["id"] in pending_local_ids:
+                    if server_id in skip_review_server_ids:
+                        # Guard 2 (pushed-this-cycle): just replayed by
+                        # this same sync's pushback phase -- see the
+                        # design comment on this method.
                         continue
-                    # Once the mutation above is gone (pushback just
-                    # replayed it), a same-round-trip results page that
-                    # echoes the pre-review state can still overwrite this
-                    # row -- unguarded by design (review round 1 #4,
-                    # Medium/attempt-bounded): a stale echo self-heals on
-                    # the next sync once the server catches up.
+                    has_pending_review = conn.execute(
+                        """
+                        SELECT 1 FROM pending_mutations
+                        WHERE local_id = ? AND primitive = ? AND owner_id = ?
+                        LIMIT 1
+                        """,
+                        (existing["id"], self._RESULT_REVIEW_PRIMITIVE, owner_id),
+                    ).fetchone()
+                    if has_pending_review is not None:
+                        # Guard 1 (pending-mutation): checked here, inside
+                        # this row's own write transaction, not via a
+                        # snapshot taken before the loop started -- see
+                        # the design comment on this method.
+                        continue
                     review_fields = {
                         key: item[key]
                         for key in self._AUTOMATION_RESULT_REVIEW_FIELDS

--- a/tldw_chatbook/Scheduling/scheduler/handlers/automation_handler.py
+++ b/tldw_chatbook/Scheduling/scheduler/handlers/automation_handler.py
@@ -365,6 +365,7 @@ class AutomationDefinitionHandler:
                     await asyncio.to_thread(
                         self.db.update_automation_definition,
                         definition_id,
+                        bump_version=False,
                         next_run_at=compute_next_run_at(
                             schedule if isinstance(schedule, dict) else {}, now=now
                         ),

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -514,6 +514,12 @@ class SchedulingService:
         ``automation_result_review`` pending mutation carrying the SERVER
         result id -- so ``SyncEngine._replay_review_mutations`` can push it
         without a local join (spec §5.1's payload-not-reference rule).
+        The mutation is recorded under the ROW's own ``owner_id`` (falling
+        back to ``self.owner_id`` only if the row has none) since the
+        workbench can toggle the service's active owner independently of
+        which owner a given result row belongs to -- recording under
+        ``self.owner_id`` would strand the mutation where
+        ``get_pending_mutations`` for the row's real owner never sees it.
         Never notifies the queue: results don't arm anything the scheduler
         dispatches.
 
@@ -551,10 +557,12 @@ class SchedulingService:
 
         server_id = row.get("server_id")
         if server_id:
-            self.db.record_pending_mutation(
+            mutation_owner = row.get("owner_id") or self.owner_id
+            await asyncio.to_thread(
+                self.db.record_pending_mutation,
                 result_id,
                 _RESULT_REVIEW_PRIMITIVE,
-                self.owner_id,
+                mutation_owner,
                 {
                     "server_result_id": server_id,
                     "review_state": review_state,

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -18,7 +18,12 @@ from loguru import logger
 
 from tldw_chatbook.Scheduling.automation_health import compute_local_health
 from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
-from tldw_chatbook.Scheduling.models import ReminderTask, ScheduleKind, ScheduledTask
+from tldw_chatbook.Scheduling.models import (
+    ReminderTask,
+    ReviewState,
+    ScheduleKind,
+    ScheduledTask,
+)
 from tldw_chatbook.Scheduling.services.briefing_projection import BriefingProjection
 from tldw_chatbook.Scheduling.services.server_client import (
     SchedulingServerClient,
@@ -28,6 +33,12 @@ from tldw_chatbook.Scheduling.services.sync_engine import SyncEngine
 from tldw_chatbook.Scheduling.services.watchlist_projection import WatchlistProjection
 
 _REMINDER_PRIMITIVE = "reminder_task"
+
+#: Matches ScheduledTasksDB._RESULT_REVIEW_PRIMITIVE / SyncEngine's module
+#: constant of the same value -- duplicated locally rather than imported,
+#: mirroring how _REMINDER_PRIMITIVE is independently defined in each of
+#: those modules too.
+_RESULT_REVIEW_PRIMITIVE = "automation_result_review"
 
 # Fields that are local-only and should not be sent to the server.
 _LOCAL_ONLY_FIELDS = {
@@ -489,6 +500,68 @@ class SchedulingService:
         handler = self.automation_handler_getter()
         run_id = await handler.run_now(row)
         return {"run_id": run_id, "deduped": run_id is None}
+
+    async def review_automation_result(
+        self,
+        result_id: str,
+        review_state: str,
+        review_note: str | None = None,
+    ) -> bool:
+        """Set a local automation result's review state (local entry point).
+
+        Always writes the local row first. When that row is a server
+        mirror (``server_id`` set), also records an
+        ``automation_result_review`` pending mutation carrying the SERVER
+        result id -- so ``SyncEngine._replay_review_mutations`` can push it
+        without a local join (spec §5.1's payload-not-reference rule).
+        Never notifies the queue: results don't arm anything the scheduler
+        dispatches.
+
+        Args:
+            result_id: The result's local id.
+            review_state: New review state; must be a valid
+                ``ReviewState`` value or the call is refused.
+            review_note: Optional free-text note attached to the review.
+
+        Returns:
+            ``True`` on a successful local write; ``False`` for an
+            invalid ``review_state`` or an unknown ``result_id`` (no DB
+            write in either case).
+        """
+        valid_states = {state.value for state in ReviewState}
+        if review_state not in valid_states:
+            logger.warning(
+                "review_automation_result refused for {result_id}: invalid "
+                "review_state {review_state!r} (must be one of {valid_states})",
+                result_id=result_id,
+                review_state=review_state,
+                valid_states=sorted(valid_states),
+            )
+            return False
+
+        row = await asyncio.to_thread(self.db.get_automation_result, result_id)
+        if row is None:
+            return False
+
+        updated = await asyncio.to_thread(
+            self.db.update_result_review, result_id, review_state, review_note
+        )
+        if not updated:
+            return False
+
+        server_id = row.get("server_id")
+        if server_id:
+            self.db.record_pending_mutation(
+                result_id,
+                _RESULT_REVIEW_PRIMITIVE,
+                self.owner_id,
+                {
+                    "server_result_id": server_id,
+                    "review_state": review_state,
+                    "review_note": review_note,
+                },
+            )
+        return True
 
     def _use_server(self) -> bool:
         """Return True when server operations should be attempted."""

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -509,12 +509,16 @@ class SchedulingService:
     ) -> bool:
         """Set a local automation result's review state (local entry point).
 
-        Always writes the local row first. When that row is a server
-        mirror (``server_id`` set), also records an
-        ``automation_result_review`` pending mutation carrying the SERVER
-        result id -- so ``SyncEngine._replay_review_mutations`` can push it
-        without a local join (spec §5.1's payload-not-reference rule).
-        The mutation is recorded under the ROW's own ``owner_id`` (falling
+        Writes the local row via a single ``update_result_review`` call.
+        When that row is a server mirror (``server_id`` set), the same
+        call also records an ``automation_result_review`` pending
+        mutation carrying the SERVER result id -- in the SAME DB
+        transaction as the review UPDATE, so a crash between the two
+        writes can never leave a local review that never pushes (or an
+        outbox row for a review that was rolled back) -- so
+        ``SyncEngine._replay_review_mutations`` can push it without a
+        local join (spec §5.1's payload-not-reference rule). The
+        mutation is recorded under the ROW's own ``owner_id`` (falling
         back to ``self.owner_id`` only if the row has none) since the
         workbench can toggle the service's active owner independently of
         which owner a given result row belongs to -- recording under
@@ -549,27 +553,29 @@ class SchedulingService:
         if row is None:
             return False
 
-        updated = await asyncio.to_thread(
-            self.db.update_result_review, result_id, review_state, review_note
-        )
-        if not updated:
-            return False
-
         server_id = row.get("server_id")
+        pending_mutation: dict[str, Any] | None = None
         if server_id:
             mutation_owner = row.get("owner_id") or self.owner_id
-            await asyncio.to_thread(
-                self.db.record_pending_mutation,
-                result_id,
-                _RESULT_REVIEW_PRIMITIVE,
-                mutation_owner,
-                {
+            pending_mutation = {
+                "local_id": result_id,
+                "primitive": _RESULT_REVIEW_PRIMITIVE,
+                "owner_id": mutation_owner,
+                "payload": {
                     "server_result_id": server_id,
                     "review_state": review_state,
                     "review_note": review_note,
                 },
-            )
-        return True
+            }
+
+        updated = await asyncio.to_thread(
+            self.db.update_result_review,
+            result_id,
+            review_state,
+            review_note,
+            pending_mutation=pending_mutation,
+        )
+        return updated
 
     def _use_server(self) -> bool:
         """Return True when server operations should be attempted."""

--- a/tldw_chatbook/Scheduling/services/server_client.py
+++ b/tldw_chatbook/Scheduling/services/server_client.py
@@ -387,3 +387,77 @@ class SchedulingServerClient:
             definition_id,
             retry=False,
         )
+
+    async def list_automation_results(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        definition_id: str | None = None,
+        review_state: str | None = None,
+    ) -> dict[str, Any]:
+        """List the server's scheduled-task results (spec §4.2).
+
+        Args:
+            limit: Page size to request from the server.
+            offset: Pagination offset to request from the server.
+            definition_id: Optional filter to one definition's results.
+            review_state: Optional review-state filter.
+
+        Returns:
+            The result list response (``items``/``total``/pagination).
+
+        Raises:
+            ServerUnavailableError: If no scheduling server is connected.
+            ServerClientValidationError: If the request is rejected by policy
+                or the server.
+            ServerClientServerError: If the server returns a server error after
+                retries are exhausted.
+            ServerClientTimeoutError: If the request times out after retries.
+        """
+        return await self._call_with_retry(
+            "list_scheduled_automation_results",
+            limit=limit,
+            offset=offset,
+            definition_id=definition_id,
+            review_state=review_state,
+            is_read=True,
+        )
+
+    async def review_automation_result(
+        self,
+        result_id: str,
+        review_state: str,
+        *,
+        review_note: str | None = None,
+    ) -> dict[str, Any]:
+        """Set one result's review state, retried on failure.
+
+        Unlike ``run_automation_definition_now``, replaying the same review
+        state is idempotent server-side -- a retry cannot double-fire
+        anything, so this call keeps the default retry behavior.
+
+        Args:
+            result_id: The server result to update.
+            review_state: New review state (``read``/``dismissed``/etc).
+            review_note: Optional free-text note attached to the review.
+
+        Returns:
+            The updated result row.
+
+        Raises:
+            ServerUnavailableError: If no scheduling server is connected.
+            ServerClientNotFoundError: If the result does not exist
+                server-side (e.g. retired).
+            ServerClientValidationError: If the request is rejected by policy
+                or the server.
+            ServerClientServerError: If the server returns a server error after
+                retries are exhausted.
+            ServerClientTimeoutError: If the request times out after retries.
+        """
+        return await self._call_with_retry(
+            "review_scheduled_automation_result",
+            result_id,
+            review_state,
+            review_note=review_note,
+        )

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -100,7 +100,24 @@ class SyncEngine:
         target_owner = owner_id if owner_id is not None else self.owner_id
         if self.server_client is None:
             return
+
+        await self._pull_reminders(target_owner)
+
+        # Automation mirrors run regardless of reminder-phase health (review
+        # round 1 #1): a reminder network/transaction failure says nothing
+        # about the automation endpoints, and each phase below is already
+        # independently error-contained via `_run_phase`.
+        await self._run_phase(
+            target_owner, "Automation definitions pull", self._pull_definitions
+        )
+        await self._run_phase(
+            target_owner, "Automation results pull", self._pull_results
+        )
+
+    async def _pull_reminders(self, target_owner: str) -> None:
+        """The reminder-only half of `pull()` (original body, unchanged)."""
         client = self.server_client
+        assert client is not None
 
         try:
             response = await client.list_reminders()
@@ -154,7 +171,24 @@ class SyncEngine:
             logger.exception(f"Sync pull transaction failed for {target_owner}: {exc}")
             self._record_sync_error(str(exc), target_owner)
 
-        # Read-only variant: the two automation mirrors, no pushback.
+    async def sync_now(self, owner_id: str | None = None) -> SyncOutcome:
+        target_owner = owner_id if owner_id is not None else self.owner_id
+        if self.server_client is None:
+            return SyncOutcome("not_applicable")
+
+        reminder_outcome = await self._sync_reminders(target_owner)
+
+        # Automation mirrors, appended after the reminder phase (task 4) and
+        # run REGARDLESS of the reminder phase's own outcome (review round 1
+        # #1): a reminder network/transaction failure says nothing about the
+        # automation endpoints, and each phase below is already
+        # independently error-contained via `_run_phase`. Pushback runs
+        # first so a fresh results mirror can't clobber a review the user
+        # just made locally (its own pending mutation is cleared before the
+        # pull below re-reads that same row).
+        await self._run_phase(
+            target_owner, "Automation review pushback", self._replay_review_mutations
+        )
         await self._run_phase(
             target_owner, "Automation definitions pull", self._pull_definitions
         )
@@ -162,11 +196,13 @@ class SyncEngine:
             target_owner, "Automation results pull", self._pull_results
         )
 
-    async def sync_now(self, owner_id: str | None = None) -> SyncOutcome:
-        target_owner = owner_id if owner_id is not None else self.owner_id
-        if self.server_client is None:
-            return SyncOutcome("not_applicable")
+        # The reminder phase's own outcome/status semantics are preserved
+        # unchanged (`_sync_reminders` is the original method body) -- only
+        # the control flow changed so the automation phases above always run.
+        return reminder_outcome
 
+    async def _sync_reminders(self, target_owner: str) -> SyncOutcome:
+        """The reminder-only half of `sync_now()` (original body, unchanged)."""
         try:
             (
                 pulled_items,
@@ -259,22 +295,6 @@ class SyncEngine:
             self._record_sync_error(str(exc), target_owner)
             return SyncOutcome("error", error=str(exc))
 
-        # Automation mirrors, appended after the reminder phase (task 4):
-        # each runs in its own containment shape so one phase's failure
-        # never blocks the phases after it. Pushback runs first so a
-        # fresh results mirror can't clobber a review the user just made
-        # locally (its own pending mutation is cleared before the pull
-        # below re-reads that same row).
-        await self._run_phase(
-            target_owner, "Automation review pushback", self._replay_review_mutations
-        )
-        await self._run_phase(
-            target_owner, "Automation definitions pull", self._pull_definitions
-        )
-        await self._run_phase(
-            target_owner, "Automation results pull", self._pull_results
-        )
-
         # staged_outcomes already includes the tombstone outcomes (see
         # _network_phase), so it IS the pushed count. Automation
         # definitions/results are mirrors, not reminder push/pull, so they
@@ -346,9 +366,14 @@ class SyncEngine:
             self.db.delete_pending_mutation(mutation["id"])
 
     async def _pull_definitions(self, owner_id: str) -> dict[str, int]:
-        """Page the server's automation definitions and mirror them locally."""
+        """Page the server's automation definitions, upserting page by page.
+
+        Upserted per page (not batched to the end) so a later page's
+        failure still leaves earlier pages' rows mirrored -- the same
+        partial-progress-survives-a-failure shape as `_pull_results`.
+        """
         assert self.server_client is not None
-        items: list[dict[str, Any]] = []
+        totals: dict[str, int] = {}
         offset = 0
         while True:
             response = await self.server_client.list_automation_definitions(
@@ -357,11 +382,12 @@ class SyncEngine:
             if not isinstance(response, dict):
                 response = {}
             page = list(response.get("items") or [])
-            items.extend(page)
+            counts = self.db.upsert_automation_definitions_from_server(owner_id, page)
+            for key, value in counts.items():
+                totals[key] = totals.get(key, 0) + value
             offset += len(page)
             if not page or not response.get("has_more"):
-                break
-        return self.db.upsert_automation_definitions_from_server(owner_id, items)
+                return totals
 
     async def _pull_results(self, owner_id: str) -> dict[str, int]:
         """Walk up to `_RESULTS_MAX_PAGES` newest pages of server results.

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import Any
 
@@ -31,12 +31,14 @@ _DEFINITION_PRIMITIVE = "automation_definition"
 #: (Task 5) are replayed to the server here.
 _RESULT_REVIEW_PRIMITIVE = "automation_result_review"
 
-#: Page size for the results pull, and the bounded newest-pages walk
-#: (spec §5.2 limitation: the server's /results endpoint exposes no
-#: updated_at filter, so incremental sync is a bounded newest-N-pages
-#: walk rather than a true delta).
+#: Page size for the results/definitions pulls, and the bounded
+#: newest-pages walk both phases use (spec §5.2 limitation: the server's
+#: /results endpoint exposes no updated_at filter, so incremental sync is
+#: a bounded newest-N-pages walk rather than a true delta; the
+#: definitions pull shares the same cap so an unbounded `while True` can
+#: never spin forever against a misbehaving server).
 _RESULTS_PAGE_SIZE = 50
-_RESULTS_MAX_PAGES = 4
+_SYNC_MAX_PAGES = 4
 
 
 @dataclass(frozen=True)
@@ -107,12 +109,18 @@ class SyncEngine:
         # round 1 #1): a reminder network/transaction failure says nothing
         # about the automation endpoints, and each phase below is already
         # independently error-contained via `_run_phase`.
-        await self._run_phase(
+        _, definitions_counts = await self._run_phase(
             target_owner, "Automation definitions pull", self._pull_definitions
         )
-        await self._run_phase(
+        if definitions_counts:
+            logger.info(
+                f"Automation definitions pull for {target_owner}: {definitions_counts}"
+            )
+        _, results_counts = await self._run_phase(
             target_owner, "Automation results pull", self._pull_results
         )
+        if results_counts:
+            logger.info(f"Automation results pull for {target_owner}: {results_counts}")
 
     async def _pull_reminders(self, target_owner: str) -> None:
         """The reminder-only half of `pull()` (original body, unchanged)."""
@@ -186,19 +194,43 @@ class SyncEngine:
         # first so a fresh results mirror can't clobber a review the user
         # just made locally (its own pending mutation is cleared before the
         # pull below re-reads that same row).
-        await self._run_phase(
+        phase_errors: list[str] = []
+
+        error, counts = await self._run_phase(
             target_owner, "Automation review pushback", self._replay_review_mutations
         )
-        await self._run_phase(
+        if error:
+            phase_errors.append(error)
+        if counts:
+            logger.info(f"Automation review pushback for {target_owner}: {counts}")
+
+        error, counts = await self._run_phase(
             target_owner, "Automation definitions pull", self._pull_definitions
         )
-        await self._run_phase(
+        if error:
+            phase_errors.append(error)
+        if counts:
+            logger.info(f"Automation definitions pull for {target_owner}: {counts}")
+
+        error, counts = await self._run_phase(
             target_owner, "Automation results pull", self._pull_results
         )
+        if error:
+            phase_errors.append(error)
+        if counts:
+            logger.info(f"Automation results pull for {target_owner}: {counts}")
 
         # The reminder phase's own outcome/status semantics are preserved
-        # unchanged (`_sync_reminders` is the original method body) -- only
-        # the control flow changed so the automation phases above always run.
+        # unchanged (`_sync_reminders` is the original method body) when it
+        # already failed or was not applicable. But an "ok" reminder phase
+        # sitting beside a failed automation phase used to report clean --
+        # the exact dishonesty task-23105 fixed for reminders (F2): surface
+        # the first automation-phase error so the caller doesn't toast
+        # success next to a fresh error badge. Results/definitions already
+        # pulled by an earlier phase this round are not rolled back.
+        if reminder_outcome.status == "ok" and phase_errors:
+            return replace(reminder_outcome, status="error", error=phase_errors[0])
+
         return reminder_outcome
 
     async def _sync_reminders(self, target_owner: str) -> SyncOutcome:
@@ -308,7 +340,7 @@ class SyncEngine:
 
     async def _run_phase(
         self, owner_id: str, label: str, phase: Any,
-    ) -> None:
+    ) -> tuple[str | None, dict[str, int] | None]:
         """Run one self-contained sync phase, containing its own failure.
 
         Mirrors the top-level pull()/sync_now() error discipline (task-2722):
@@ -316,16 +348,29 @@ class SyncEngine:
         applicable, never persisted; any other error is recorded via
         `_record_sync_error` and swallowed so the phases after this one
         still run.
+
+        Returns:
+            A ``(error, counts)`` tuple. ``error`` is ``None`` on success
+            or a policy refusal (not an error); otherwise the message that
+            was also recorded via `_record_sync_error`. ``counts`` is the
+            phase's own return value (an upsert-count dict) on success, or
+            ``None`` when the phase raised or returned nothing -- callers
+            use it so a truncated/failed phase never silently discards
+            what did land (F2/F8).
         """
         try:
-            await phase(owner_id)
+            counts = await phase(owner_id)
+            return None, counts
         except ServerClientPolicyError as exc:
             logger.info(f"{label} not applicable for {owner_id}: {exc}")
+            return None, None
         except ServerClientError as exc:
             self._record_sync_error(str(exc), owner_id)
+            return str(exc), None
         except Exception as exc:  # noqa: BLE001
             logger.exception(f"{label} failed for {owner_id}: {exc}")
             self._record_sync_error(str(exc), owner_id)
+            return str(exc), None
 
     async def _replay_review_mutations(self, owner_id: str) -> None:
         """Replay pending `automation_result_review` mutations to the server.
@@ -366,16 +411,19 @@ class SyncEngine:
             self.db.delete_pending_mutation(mutation["id"])
 
     async def _pull_definitions(self, owner_id: str) -> dict[str, int]:
-        """Page the server's automation definitions, upserting page by page.
+        """Page up to `_SYNC_MAX_PAGES` of the server's automation definitions.
 
         Upserted per page (not batched to the end) so a later page's
         failure still leaves earlier pages' rows mirrored -- the same
         partial-progress-survives-a-failure shape as `_pull_results`.
+        Stops early on an empty page or `has_more=False`; logs (info) when
+        the cap was hit with more remaining, so a truncated pull is never
+        silent (F4: this was an unbounded `while True` against the server).
         """
         assert self.server_client is not None
         totals: dict[str, int] = {}
         offset = 0
-        while True:
+        for _page_num in range(_SYNC_MAX_PAGES):
             response = await self.server_client.list_automation_definitions(
                 limit=_RESULTS_PAGE_SIZE, offset=offset
             )
@@ -388,9 +436,14 @@ class SyncEngine:
             offset += len(page)
             if not page or not response.get("has_more"):
                 return totals
+        logger.info(
+            f"Automation definitions pull hit the {_SYNC_MAX_PAGES}-page cap for "
+            f"{owner_id} with more definitions remaining server-side"
+        )
+        return totals
 
     async def _pull_results(self, owner_id: str) -> dict[str, int]:
-        """Walk up to `_RESULTS_MAX_PAGES` newest pages of server results.
+        """Walk up to `_SYNC_MAX_PAGES` newest pages of server results.
 
         The server's /results endpoint exposes no `updated_at` filter
         (verified at origin/dev), so this is a bounded newest-pages walk
@@ -402,7 +455,7 @@ class SyncEngine:
         assert self.server_client is not None
         totals: dict[str, int] = {}
         offset = 0
-        for _page_num in range(_RESULTS_MAX_PAGES):
+        for _page_num in range(_SYNC_MAX_PAGES):
             response = await self.server_client.list_automation_results(
                 limit=_RESULTS_PAGE_SIZE, offset=offset
             )
@@ -416,7 +469,7 @@ class SyncEngine:
             if len(page) < _RESULTS_PAGE_SIZE or not response.get("has_more"):
                 return totals
         logger.info(
-            f"Automation results pull hit the {_RESULTS_MAX_PAGES}-page cap for "
+            f"Automation results pull hit the {_SYNC_MAX_PAGES}-page cap for "
             f"{owner_id} with more results remaining server-side"
         )
         return totals

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -20,6 +20,24 @@ from tldw_chatbook.Scheduling.services.server_client import (
 _REMINDER_PRIMITIVE = "reminder_task"
 _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
+#: Reserved for the PR-5 definition-push primitive (create/update/lifecycle
+#: mutation replay) -- unused here since PR-3 ships only the definitions
+#: pull mirror, not a push path (schedules-handoff plan, task 4 deviation
+#: 1). Named now so the pending-mutation primitive namespace is settled.
+_DEFINITION_PRIMITIVE = "automation_definition"
+
+#: Matches ScheduledTasksDB._RESULT_REVIEW_PRIMITIVE -- pending mutations
+#: recorded when a local review is made on a server-mirrored result
+#: (Task 5) are replayed to the server here.
+_RESULT_REVIEW_PRIMITIVE = "automation_result_review"
+
+#: Page size for the results pull, and the bounded newest-pages walk
+#: (spec §5.2 limitation: the server's /results endpoint exposes no
+#: updated_at filter, so incremental sync is a bounded newest-N-pages
+#: walk rather than a true delta).
+_RESULTS_PAGE_SIZE = 50
+_RESULTS_MAX_PAGES = 4
+
 
 @dataclass(frozen=True)
 class SyncOutcome:
@@ -136,6 +154,14 @@ class SyncEngine:
             logger.exception(f"Sync pull transaction failed for {target_owner}: {exc}")
             self._record_sync_error(str(exc), target_owner)
 
+        # Read-only variant: the two automation mirrors, no pushback.
+        await self._run_phase(
+            target_owner, "Automation definitions pull", self._pull_definitions
+        )
+        await self._run_phase(
+            target_owner, "Automation results pull", self._pull_results
+        )
+
     async def sync_now(self, owner_id: str | None = None) -> SyncOutcome:
         target_owner = owner_id if owner_id is not None else self.owner_id
         if self.server_client is None:
@@ -232,13 +258,142 @@ class SyncEngine:
             logger.exception(f"Sync transaction failed for {target_owner}: {exc}")
             self._record_sync_error(str(exc), target_owner)
             return SyncOutcome("error", error=str(exc))
+
+        # Automation mirrors, appended after the reminder phase (task 4):
+        # each runs in its own containment shape so one phase's failure
+        # never blocks the phases after it. Pushback runs first so a
+        # fresh results mirror can't clobber a review the user just made
+        # locally (its own pending mutation is cleared before the pull
+        # below re-reads that same row).
+        await self._run_phase(
+            target_owner, "Automation review pushback", self._replay_review_mutations
+        )
+        await self._run_phase(
+            target_owner, "Automation definitions pull", self._pull_definitions
+        )
+        await self._run_phase(
+            target_owner, "Automation results pull", self._pull_results
+        )
+
         # staged_outcomes already includes the tombstone outcomes (see
-        # _network_phase), so it IS the pushed count.
+        # _network_phase), so it IS the pushed count. Automation
+        # definitions/results are mirrors, not reminder push/pull, so they
+        # are intentionally not folded into these counts (SyncOutcome's
+        # contract is documented as reminder-scoped).
         return SyncOutcome(
             "ok",
             pulled=len(pulled_items),
             pushed=len(staged_outcomes),
         )
+
+    async def _run_phase(
+        self, owner_id: str, label: str, phase: Any,
+    ) -> None:
+        """Run one self-contained sync phase, containing its own failure.
+
+        Mirrors the top-level pull()/sync_now() error discipline (task-2722):
+        a runtime-mode policy refusal is logged and treated as not
+        applicable, never persisted; any other error is recorded via
+        `_record_sync_error` and swallowed so the phases after this one
+        still run.
+        """
+        try:
+            await phase(owner_id)
+        except ServerClientPolicyError as exc:
+            logger.info(f"{label} not applicable for {owner_id}: {exc}")
+        except ServerClientError as exc:
+            self._record_sync_error(str(exc), owner_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception(f"{label} failed for {owner_id}: {exc}")
+            self._record_sync_error(str(exc), owner_id)
+
+    async def _replay_review_mutations(self, owner_id: str) -> None:
+        """Replay pending `automation_result_review` mutations to the server.
+
+        Success and a 404 (the result was retired server-side) both clear
+        the mutation. Any other error is left in place -- and re-raised so
+        `_run_phase` records one sync error for the phase and stops
+        attempting further mutations this round, mirroring
+        `_push_mutation`'s "abort the whole push phase on a retryable
+        server error" discipline for reminders.
+        """
+        assert self.server_client is not None
+        mutations = self.db.get_pending_mutations(
+            owner_id, primitive=_RESULT_REVIEW_PRIMITIVE
+        )
+        for mutation in mutations:
+            payload = mutation.get("payload") or {}
+            server_result_id = payload.get("server_result_id")
+            if not server_result_id:
+                logger.warning(
+                    f"Pending automation_result_review mutation {mutation.get('id')} "
+                    "has no server_result_id; dropping (nothing to replay)"
+                )
+                self.db.delete_pending_mutation(mutation["id"])
+                continue
+            try:
+                await self.server_client.review_automation_result(
+                    server_result_id,
+                    payload.get("review_state"),
+                    review_note=payload.get("review_note"),
+                )
+            except ServerClientNotFoundError as exc:
+                logger.info(
+                    f"Automation result {server_result_id} retired server-side "
+                    f"({exc}); dropping its pending review mutation"
+                )
+            # Success or a confirmed retirement: the mutation is settled.
+            self.db.delete_pending_mutation(mutation["id"])
+
+    async def _pull_definitions(self, owner_id: str) -> dict[str, int]:
+        """Page the server's automation definitions and mirror them locally."""
+        assert self.server_client is not None
+        items: list[dict[str, Any]] = []
+        offset = 0
+        while True:
+            response = await self.server_client.list_automation_definitions(
+                limit=_RESULTS_PAGE_SIZE, offset=offset
+            )
+            if not isinstance(response, dict):
+                response = {}
+            page = list(response.get("items") or [])
+            items.extend(page)
+            offset += len(page)
+            if not page or not response.get("has_more"):
+                break
+        return self.db.upsert_automation_definitions_from_server(owner_id, items)
+
+    async def _pull_results(self, owner_id: str) -> dict[str, int]:
+        """Walk up to `_RESULTS_MAX_PAGES` newest pages of server results.
+
+        The server's /results endpoint exposes no `updated_at` filter
+        (verified at origin/dev), so this is a bounded newest-pages walk
+        rather than a true incremental pull (spec §5.2 limitation): review
+        drift older than the window waits for a later sync. Stops early
+        on a short page or `has_more=False`; logs (info) when the cap was
+        hit with more remaining, so a truncated pull is never silent.
+        """
+        assert self.server_client is not None
+        totals: dict[str, int] = {}
+        offset = 0
+        for _page_num in range(_RESULTS_MAX_PAGES):
+            response = await self.server_client.list_automation_results(
+                limit=_RESULTS_PAGE_SIZE, offset=offset
+            )
+            if not isinstance(response, dict):
+                response = {}
+            page = list(response.get("items") or [])
+            counts = self.db.upsert_automation_results_from_server(owner_id, page)
+            for key, value in counts.items():
+                totals[key] = totals.get(key, 0) + value
+            offset += len(page)
+            if len(page) < _RESULTS_PAGE_SIZE or not response.get("has_more"):
+                return totals
+        logger.info(
+            f"Automation results pull hit the {_RESULTS_MAX_PAGES}-page cap for "
+            f"{owner_id} with more results remaining server-side"
+        )
+        return totals
 
     async def _network_phase(
         self, owner_id: str

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -222,13 +222,20 @@ class SyncEngine:
 
         # The reminder phase's own outcome/status semantics are preserved
         # unchanged (`_sync_reminders` is the original method body) when it
-        # already failed or was not applicable. But an "ok" reminder phase
+        # already failed. But an "ok" OR "not_applicable" reminder phase
         # sitting beside a failed automation phase used to report clean --
         # the exact dishonesty task-23105 fixed for reminders (F2): surface
         # the first automation-phase error so the caller doesn't toast
-        # success next to a fresh error badge. Results/definitions already
-        # pulled by an earlier phase this round are not rolled back.
-        if reminder_outcome.status == "ok" and phase_errors:
+        # success (or silent no-op) next to a fresh error badge.
+        # "not_applicable" belongs here too (review round 2): it means the
+        # REMINDER phase's own policy action was refused, which says
+        # nothing about the automation phases' (different policy actions)
+        # own genuinely-failed attempt -- that error must not be masked by
+        # the reminder side's non-error status. An "error" reminder phase
+        # already carries its own message and is left alone. Results/
+        # definitions already pulled by an earlier phase this round are
+        # not rolled back.
+        if reminder_outcome.status in ("ok", "not_applicable") and phase_errors:
             return replace(reminder_outcome, status="error", error=phase_errors[0])
 
         return reminder_outcome

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -196,13 +196,23 @@ class SyncEngine:
         # pull below re-reads that same row).
         phase_errors: list[str] = []
 
-        error, counts = await self._run_phase(
+        error, pushed_review_ids = await self._run_phase(
             target_owner, "Automation review pushback", self._replay_review_mutations
         )
         if error:
             phase_errors.append(error)
-        if counts:
-            logger.info(f"Automation review pushback for {target_owner}: {counts}")
+        if pushed_review_ids:
+            logger.info(
+                f"Automation review pushback for {target_owner}: "
+                f"pushed {len(pushed_review_ids)} review(s)"
+            )
+        # Task 5 same-cycle echo (Qodo finding): thread the server_result_ids
+        # just replayed above into this SAME results pull as
+        # `skip_review_server_ids` -- their pending mutation is already gone
+        # by now, so the pull's own pending-mutation guard can't stop a
+        # server payload that still echoes the pre-review state (write/
+        # read-path lag) from reverting the review that was just pushed.
+        skip_review_server_ids = frozenset(pushed_review_ids or ())
 
         error, counts = await self._run_phase(
             target_owner, "Automation definitions pull", self._pull_definitions
@@ -213,7 +223,10 @@ class SyncEngine:
             logger.info(f"Automation definitions pull for {target_owner}: {counts}")
 
         error, counts = await self._run_phase(
-            target_owner, "Automation results pull", self._pull_results
+            target_owner,
+            "Automation results pull",
+            self._pull_results,
+            skip_review_server_ids=skip_review_server_ids,
         )
         if error:
             phase_errors.append(error)
@@ -346,28 +359,31 @@ class SyncEngine:
         )
 
     async def _run_phase(
-        self, owner_id: str, label: str, phase: Any,
-    ) -> tuple[str | None, dict[str, int] | None]:
+        self, owner_id: str, label: str, phase: Any, **phase_kwargs: Any,
+    ) -> tuple[str | None, Any | None]:
         """Run one self-contained sync phase, containing its own failure.
 
         Mirrors the top-level pull()/sync_now() error discipline (task-2722):
         a runtime-mode policy refusal is logged and treated as not
         applicable, never persisted; any other error is recorded via
         `_record_sync_error` and swallowed so the phases after this one
-        still run.
+        still run. ``phase_kwargs`` are forwarded to ``phase`` after the
+        positional ``owner_id`` (e.g. `_pull_results`'s
+        `skip_review_server_ids`).
 
         Returns:
-            A ``(error, counts)`` tuple. ``error`` is ``None`` on success
+            A ``(error, result)`` tuple. ``error`` is ``None`` on success
             or a policy refusal (not an error); otherwise the message that
-            was also recorded via `_record_sync_error`. ``counts`` is the
-            phase's own return value (an upsert-count dict) on success, or
+            was also recorded via `_record_sync_error`. ``result`` is the
+            phase's own return value (an upsert-count dict, or the
+            pushed-review-ids set for the pushback phase) on success, or
             ``None`` when the phase raised or returned nothing -- callers
             use it so a truncated/failed phase never silently discards
             what did land (F2/F8).
         """
         try:
-            counts = await phase(owner_id)
-            return None, counts
+            result = await phase(owner_id, **phase_kwargs)
+            return None, result
         except ServerClientPolicyError as exc:
             logger.info(f"{label} not applicable for {owner_id}: {exc}")
             return None, None
@@ -379,7 +395,7 @@ class SyncEngine:
             self._record_sync_error(str(exc), owner_id)
             return str(exc), None
 
-    async def _replay_review_mutations(self, owner_id: str) -> None:
+    async def _replay_review_mutations(self, owner_id: str) -> frozenset[str]:
         """Replay pending `automation_result_review` mutations to the server.
 
         Success and a 404 (the result was retired server-side) both clear
@@ -388,11 +404,21 @@ class SyncEngine:
         attempting further mutations this round, mirroring
         `_push_mutation`'s "abort the whole push phase on a retryable
         server error" discipline for reminders.
+
+        Returns:
+            The ``server_result_id``s settled this cycle (pushed
+            successfully or confirmed retired). `sync_now` feeds this set
+            into the results pull as `skip_review_server_ids` so a stale
+            same-cycle echo of these rows' pre-review state can't revert
+            what was just pushed (Task 5 same-cycle echo, Qodo finding) --
+            see the design comment on
+            `ScheduledTasksDB.upsert_automation_results_from_server`.
         """
         assert self.server_client is not None
         mutations = self.db.get_pending_mutations(
             owner_id, primitive=_RESULT_REVIEW_PRIMITIVE
         )
+        pushed_server_ids: set[str] = set()
         for mutation in mutations:
             payload = mutation.get("payload") or {}
             server_result_id = payload.get("server_result_id")
@@ -416,6 +442,8 @@ class SyncEngine:
                 )
             # Success or a confirmed retirement: the mutation is settled.
             self.db.delete_pending_mutation(mutation["id"])
+            pushed_server_ids.add(server_result_id)
+        return frozenset(pushed_server_ids)
 
     async def _pull_definitions(self, owner_id: str) -> dict[str, int]:
         """Page up to `_SYNC_MAX_PAGES` of the server's automation definitions.
@@ -449,7 +477,11 @@ class SyncEngine:
         )
         return totals
 
-    async def _pull_results(self, owner_id: str) -> dict[str, int]:
+    async def _pull_results(
+        self,
+        owner_id: str,
+        skip_review_server_ids: frozenset[str] = frozenset(),
+    ) -> dict[str, int]:
         """Walk up to `_SYNC_MAX_PAGES` newest pages of server results.
 
         The server's /results endpoint exposes no `updated_at` filter
@@ -458,6 +490,10 @@ class SyncEngine:
         drift older than the window waits for a later sync. Stops early
         on a short page or `has_more=False`; logs (info) when the cap was
         hit with more remaining, so a truncated pull is never silent.
+
+        ``skip_review_server_ids`` (Task 5 same-cycle echo) is forwarded
+        unchanged to every page's upsert call -- see the design comment on
+        `ScheduledTasksDB.upsert_automation_results_from_server`.
         """
         assert self.server_client is not None
         totals: dict[str, int] = {}
@@ -469,7 +505,9 @@ class SyncEngine:
             if not isinstance(response, dict):
                 response = {}
             page = list(response.get("items") or [])
-            counts = self.db.upsert_automation_results_from_server(owner_id, page)
+            counts = self.db.upsert_automation_results_from_server(
+                owner_id, page, skip_review_server_ids=skip_review_server_ids
+            )
             for key, value in counts.items():
                 totals[key] = totals.get(key, 0) + value
             offset += len(page)

--- a/tldw_chatbook/runtime_policy/registry.py
+++ b/tldw_chatbook/runtime_policy/registry.py
@@ -1152,8 +1152,10 @@ AUDITED_CAPABILITY_SEEDS = (
             # server's definitions and triggering a manual run are distinct
             # from workflow jobs -- the notifications.reminders resource
             # covers reminder CRUD, this one covers the agent-automation
-            # control plane.
-            _resource("scheduler.automations", actions=(LIST, LAUNCH)),
+            # control plane. CONFIGURE (schedules-handoff PR-3) gates
+            # reviewing a result's review_state/note -- a metadata mutation,
+            # not a launch or a list, same class as reminder CRUD.
+            _resource("scheduler.automations", actions=(LIST, LAUNCH, CONFIGURE)),
         ),
     ),
     _capability(

--- a/tldw_chatbook/tldw_api/client.py
+++ b/tldw_chatbook/tldw_api/client.py
@@ -984,6 +984,8 @@ from .scheduled_tasks_automation_schemas import (
     ScheduledTaskAutomationDefinitionList,
     ScheduledTaskAutomationRunNowResponse,
     ScheduledTaskAuditList,
+    ScheduledTaskResult,
+    ScheduledTaskResultList,
 )
 from .outputs_schemas import (
     OutputArtifact,
@@ -8126,6 +8128,61 @@ class TLDWAPIClient:
             },
         )
         return ScheduledTaskAuditList.model_validate(response)
+
+    async def list_scheduled_task_results(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        definition_id: str | None = None,
+        review_state: str | None = None,
+    ) -> ScheduledTaskResultList:
+        """List the authenticated user's scheduled-task results (spec §4.2).
+
+        Args:
+            limit: Page size to request. The server clamps to 1..200.
+            offset: Pagination offset to request.
+            definition_id: Optional filter to one definition's results.
+            review_state: Optional filter (``unread``/``read``/``dismissed``).
+
+        Returns:
+            The result list response (items plus total/has_more pagination).
+        """
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if definition_id is not None:
+            params["definition_id"] = definition_id
+        if review_state is not None:
+            params["review_state"] = review_state
+        response = await self._request(
+            "GET",
+            "/api/v1/scheduled-tasks/results",
+            params=params,
+        )
+        return ScheduledTaskResultList.model_validate(response)
+
+    async def review_scheduled_task_result(
+        self,
+        result_id: str,
+        review_state: str,
+        *,
+        review_note: str | None = None,
+    ) -> ScheduledTaskResult:
+        """Set one result's review state (``ScheduledTaskResultReviewRequest``).
+
+        Args:
+            result_id: The server result to update.
+            review_state: New review state (``read``/``dismissed``/etc).
+            review_note: Optional free-text note attached to the review.
+
+        Returns:
+            The updated result row.
+        """
+        response = await self._request(
+            "POST",
+            f"/api/v1/scheduled-tasks/results/{result_id}/review",
+            json_data={"review_state": review_state, "review_note": review_note},
+        )
+        return ScheduledTaskResult.model_validate(response)
 
     async def list_output_templates(
         self,

--- a/tldw_chatbook/tldw_api/scheduled_tasks_automation_schemas.py
+++ b/tldw_chatbook/tldw_api/scheduled_tasks_automation_schemas.py
@@ -68,6 +68,48 @@ class ScheduledTaskAutomationRunNowResponse(BaseModel):
     deduped: bool = False
 
 
+class ScheduledTaskResult(BaseModel):
+    """One server-side scheduled-task result row (spec §4.2 / server
+    ``ScheduledTaskResultResponse``, ``/api/v1/scheduled-tasks/results``).
+
+    Datetimes are ``str | None`` here (not ``datetime``) to match the
+    reminder/notification schemas' style elsewhere in this package --
+    results are consumed as opaque ISO strings, never date-arithmetic'd
+    client-side.
+    """
+
+    id: str
+    owner_id: str | None = None
+    definition_id: str
+    run_id: str
+    kind: str
+    title: str
+    summary: str
+    answer: Any | None = None
+    answer_mode: str = "none"
+    confidence: dict[str, Any] = Field(default_factory=dict)
+    source_refs: list[dict[str, Any]] = Field(default_factory=list)
+    dedupe_key: str
+    visibility_destination: dict[str, Any] = Field(default_factory=dict)
+    review_state: str = "unread"
+    reviewed_at: str | None = None
+    reviewed_by: str | None = None
+    review_note: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class ScheduledTaskResultList(BaseModel):
+    """Paginated list of server-side scheduled-task results."""
+
+    items: list[ScheduledTaskResult] = Field(default_factory=list)
+    total: int = Field(default=0, ge=0)
+    limit: int = Field(default=50, ge=1)
+    offset: int = Field(default=0, ge=0)
+    has_more: bool = False
+    next_offset: int | None = Field(default=None, ge=0)
+
+
 class ScheduledTaskAuditEvent(BaseModel):
     """One durable audit event from a definition's execution trail.
 


### PR DESCRIPTION
PR-3 of the schedules-handoff program (spec: backlog/docs/spec-2026-08-31-schedules-handoff-parity.md §5; PR-2 was #2295). Server automation definitions and results now mirror into the local store under the ADR-018 sync discipline, and local review-state changes push back.

- **Sync phases** (SyncEngine, per-phase error containment — a reminder failure never gates the automation phases, and any phase failure surfaces honestly in the outcome instead of toasting "Sync completed" beside an error badge): review pushback → definitions pull → results pull, all bounded to 4×50 newest pages (the server's `/results` endpoint exposes no `updated_at` filter — verified at origin/dev — so incremental sync is a bounded newest-pages walk; truncation logged, never silent).
- **Server-wins upserts**: definitions keyed `(owner_id, server_id)`, archived mirrored never deleted, and `transfer_state` never overwritten by a server payload (the PR-2 ledgered §6 guard); results insert-full / update-review-fields-only, with a pending-review guard so an unpushed local review outranks a stale mirror.
- **Review pushback**: `SchedulingService.review_automation_result` validates against `ReviewState`, updates locally, and enqueues an `automation_result_review` mutation under the ROW's owner (not the service's active owner — the workbench can toggle owners) carrying the server result id; replay clears on success or NotFound (retired result), retains on real errors.
- **Client seams**: `GET /scheduled-tasks/results` + `POST /results/{id}/review` through the slice-2 stack, with a new `scheduler.automations.configure.server` policy action (golden-list updated).
- Also closes a PR-2 parked item: the schedule advance no longer bumps definition `version`.

Single-executor invariant re-verified end-to-end: pulled mirrors are always server-owned, can never arm locally (accessor owner filter + queue guard), and local rows are invisible to every sync phase.

Ruled deviations (ledgered): definition-PUSH replay lands with PR-5 (its first producer, transfer); notification-triggered results pull lands with PR-6 (the inbox UI). Parked with notes: `UNIQUE(owner_id, server_id)` + index in a future v5 migration; non-UTC server timestamp sort latency (server emits +00:00 today).

Tests: `Tests/Scheduling/` 531 passed (incl. sync E2E over recorded server fixtures: echo-success and failed-push-guard paths); census 971/972; diagnostics pin regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WocisXw6SEEG6nb1aKFHtv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs server automation definitions and results into the local store and pushes local review-state changes back to the server.

**Sync phases**
- Sync runs review pushback → definitions pull → results pull, in that order.
- Each phase is error-contained, so a reminder failure never gates the automation phases and a phase failure surfaces in the outcome instead of reporting clean sync.
- The outcome is marked failed when the reminder phase is `ok` or `not_applicable`; policy-refused automation phases stay non-errors.
- Both pulls are bounded to 4×50 newest pages because the server's `/results` endpoint has no `updated_at` filter; hitting the cap logs a truncation warning.
- Definition upserts are server-wins keyed by `(owner_id, server_id)`; archived mirrors are never deleted, and `transfer_state` is never overwritten by a server payload.
- Result upserts insert full rows but update only review fields. Updates are skipped for rows with an in-transaction pending-review check and for rows whose reviews were pushed back earlier in the same sync, so a stale server echo can't revert a local review.

**Review pushback**
- `review_automation_result` validates against `ReviewState`, writes locally, and enqueues a mutation carrying the server result id under the row's owner.
- The review update and outbox insert commit in one transaction, so a crash can't leave a local review that never pushes or an outbox row for a rolled-back review.
- Replay clears the mutation on success or NotFound (retired result) and retains it on real errors.
- Adds `GET /scheduled-tasks/results` and `POST /results/{id}/review` client seams with a new `scheduler.automations.configure.server` policy action.
- Schedule advance no longer bumps definition `version`, since it's not an edit.

<sup>Written for commit d07235191e4e95e95dc88215f2e824c2868b21f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

