### PR TITLE
feat(scheduling): recurring-question authoring modal + owner-dispatched preview (handoff PR-4)

### DIFF
--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -46,9 +46,23 @@ off"), and the **Clear** button only appears once a sync error exists.
 
 ## Creating a scheduled task
 
-Press **c** to open the create form. The form scrolls when the terminal
-is short; the live "Runs: …" preview, validation, and Save/Cancel stay
-pinned at the bottom while you edit.
+Press **c**, or click **+ New** in the Queue tab's pane header, to open
+the create form. Clicking **+ New** first asks which kind of task you
+want — **Reminder…** or **Recurring question…** — since a recurring
+question is a different kind of definition, not just another schedule
+shape; **c** always opens the reminder form directly. The form scrolls
+when the terminal is short; the live "Runs: …" preview, validation, and
+Save/Cancel stay pinned at the bottom while you edit.
+
+Every create/edit form also has a **Runs on** selector — **This device**
+or **Server (\<id\>)** when a scheduling server is connected — defaulting
+to whatever owner the Schedules screen is currently showing. Choosing the
+server writes the task there directly when the server is reachable, or
+authors it locally and queues it to sync up on the next successful sync
+when it is not (the sync bar and the task's own state say which
+happened). An existing reminder's owner is fixed once created — the
+selector shows it but is not editable — moving a task between owners is
+a separate action, not part of editing.
 
 - **One-time**: type a plain local time like `2026-08-28 09:00` — no
   offset needed. It is interpreted in your machine's timezone and the
@@ -181,12 +195,34 @@ double execution — one owner, one executor). Pressing **r** on one refuses
 with a toast saying so. This is the single-owner execution rule the
 server-offload design is built on; local-owner reminders are unaffected.
 
+## Creating a recurring question
+
+A recurring question runs a scoped search on a schedule and reports what
+it finds — a different kind of task than a reminder. Open its create
+form from the Queue tab's **+ New** chooser ("Recurring question…") or
+the Automations tab's own **+ New** button. Its v1 fields: a name, the
+question itself, which sources to search (all readable library sources,
+or a specific choice of Media / Notes / Chats — collections, tags, and
+saved searches are not offered yet), the schedule (the same one-time/
+recurring controls as a reminder), when to generate a draft answer
+(always, only when something new is found, or never), a finding-policy
+preset, whether to be notified, and an optional provider/model pin.
+
+**Preview** runs the same validation the save itself will run and shows
+the next few scheduled occurrences without saving anything; a rejected
+preview highlights the specific field that needs fixing. **Save** always
+previews first — an invalid definition is never written. Only the
+`recurring_question` family can be authored here; agent-task automations
+are not yet supported from this form.
+
 ## Automations tab — server-scheduled automations
 
 The **Automations** tab lists the automation definitions that live on a
 connected server (name, family, lifecycle, health) — the server owns
 their execution, which is why they do not appear in the local Queue. With
 no server connected the tab says so instead of showing an empty list.
+Automations you create with a **Runs on: This device** owner are not
+shown in this list yet — it currently reflects the connected server only.
 
 Press **r** on a highlighted definition to dispatch one immediate run
 **on the server** through the same pipeline its schedule uses — a real
@@ -227,3 +263,8 @@ The default bound is `handler_timeout_seconds` under `[scheduling]` in
 `config.toml` (**300** seconds). Set it to `0` (or negative) to disable the
 bound entirely — every handler may then run as long as it likes, and a
 wedged handler will wedge the scheduler, which is why the default is on.
+
+*Verified against working tree — 2026-09-01 (schedules-handoff PR-4 task 5:
+recurring-question create form, the Queue tab's New/Reminder/Recurring-
+question chooser, the Automations tab's own New button, and the "Runs on"
+selector on both forms).*

--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -215,38 +215,53 @@ previews first — an invalid definition is never written. Only the
 `recurring_question` family can be authored here; agent-task automations
 are not yet supported from this form.
 
-## Automations tab — server-scheduled automations
+## Automations tab — local and server automations
 
-The **Automations** tab lists the automation definitions that live on a
-connected server (name, family, lifecycle, health) — the server owns
-their execution, which is why they do not appear in the local Queue. With
-no server connected the tab says so instead of showing an empty list.
-Automations you create with a **Runs on: This device** owner are not
-shown in this list yet — it currently reflects the connected server only.
+The **Automations** tab lists automation definitions from **both**
+owners: this device's own local `recurring_question` automations and
+whatever a connected server reports — the server ones execute there,
+which is why they do not appear in the local Queue. Each row's Name cell
+is prefixed with its owner (`[This device] …` or `[<server id>] …`) so
+the two are never ambiguous side by side; saving a new "Runs on: This
+device" automation shows up here immediately (the tab refreshes after
+every save). With no server connected the tab shows local automations
+alone instead of an empty list.
 
-Press **r** on a highlighted definition to dispatch one immediate run
-**on the server** through the same pipeline its schedule uses — a real
-dispatch, not a preview. The toast reports the run slot (and whether the
-server collapsed it into an already-queued run); the result comes back
-through the server's notification feed, not into the local queue. A
-paused or archived definition refuses with the server's own reason.
+Press **r** on a highlighted definition to run it immediately — a real
+dispatch, not a preview, routed by that row's own owner. A local
+automation runs through the same claim/spawn machinery the scheduler's
+own tick uses (no risk of it double-firing against a scheduled run) and
+refuses honestly when it is missing, paused/archived, mid-transfer, or
+its read-time health is not ready — the toast says which. A server
+automation dispatches **on the server** through its own control-plane
+pipeline; the toast reports the run slot (and whether the server
+collapsed it into an already-queued run), and the result arrives through
+the server's notification feed, not the local queue. A paused or
+archived server definition refuses with the server's own reason.
+
+Press **e** on a highlighted `recurring_question` definition (either
+owner) to edit it — the same form Save opens, pre-filled from the row.
+Editing a server automation that has never synced to this device mirrors
+it locally first (automatic, no extra step); agent-task automations are
+not yet editable here.
 
 The **Model** column shows each automation's pinned execution target —
 `provider/model` when the definition carries its own selection (the
-server executor honors it per run), or `auto` when it pins nothing and
-the server resolves the target itself (its automation-config executor
-defaults, then the server default — both live in server config, not the
-definition). Per-task selection rides the definition payload, so one
-automation can run on a different model than the server-wide default
-without touching server config.
+executor honors it per run), or `auto` when it pins nothing and the
+executor resolves the target itself (config defaults, then the
+provider default). Per-task selection rides the definition payload, so
+one automation can run on a different model than the default without
+touching config.
 
-The right half of the tab is that definition's **Run history** — the
-server's durable audit trail, newest first (time, event, summary). It
-loads when you highlight a definition and refreshes right after a
-Run-now dispatch, so the run you just triggered appears without
-re-selecting the row. Every execution leaves its trail here: queued,
-succeeded, failed, timed out, skipped — the same events the server
-records for reconciliation.
+The right half of the tab is that definition's **Run history**. For a
+server automation this is the server's durable audit trail, newest first
+(time, event, summary) — it loads when you highlight the row and
+refreshes right after a Run-now dispatch, so the run you just triggered
+appears without re-selecting it. **Local automations do not have a
+durable run history yet** — the pane says so honestly rather than
+showing an empty server-shaped trail; every execution still leaves its
+trail here for server automations: queued, succeeded, failed, timed out,
+skipped, the same events the server records for reconciliation.
 
 ## Execution timeouts
 
@@ -264,7 +279,8 @@ The default bound is `handler_timeout_seconds` under `[scheduling]` in
 bound entirely — every handler may then run as long as it likes, and a
 wedged handler will wedge the scheduler, which is why the default is on.
 
-*Verified against working tree — 2026-09-01 (schedules-handoff PR-4 task 5:
-recurring-question create form, the Queue tab's New/Reminder/Recurring-
-question chooser, the Automations tab's own New button, and the "Runs on"
-selector on both forms).*
+*Verified against working tree — 2026-09-01 (schedules-handoff PR-4 task 5
++ fix round: recurring-question create/edit form, the Queue tab's
+New/Reminder/Recurring-question chooser, the Automations tab's own New
+button, the "Runs on" selector on both forms, the merged local+server
+Automations listing, and its local run-now/edit routing).*

--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -60,9 +60,14 @@ to whatever owner the Schedules screen is currently showing. Choosing the
 server writes the task there directly when the server is reachable, or
 authors it locally and queues it to sync up on the next successful sync
 when it is not (the sync bar and the task's own state say which
-happened). An existing reminder's owner is fixed once created — the
-selector shows it but is not editable — moving a task between owners is
-a separate action, not part of editing.
+happened -- a recurring question in that state is listed on the
+Automations tab as *\[\<server id\> · pending sync\]*, and Run now/run
+history say so rather than asking the server about a task it has never
+seen). If the server refuses the save outright rather than being
+unreachable, the form says so and nothing is queued -- retrying it later
+would only hit the same refusal. An existing reminder's owner is fixed
+once created — the selector shows it but is not editable — moving a task
+between owners is a separate action, not part of editing.
 
 - **One-time**: type a plain local time like `2026-08-28 09:00` — no
   offset needed. It is interpreted in your machine's timezone and the
@@ -280,7 +285,8 @@ bound entirely — every handler may then run as long as it likes, and a
 wedged handler will wedge the scheduler, which is why the default is on.
 
 *Verified against working tree — 2026-09-01 (schedules-handoff PR-4 task 5
-+ fix round: recurring-question create/edit form, the Queue tab's
++ final fix round: recurring-question create/edit form, the Queue tab's
 New/Reminder/Recurring-question chooser, the Automations tab's own New
 button, the "Runs on" selector on both forms, the merged local+server
-Automations listing, and its local run-now/edit routing).*
+Automations listing including not-yet-synced server-owned rows, and its
+local run-now/edit routing).*

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1811,15 +1811,15 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 15,
-      "diagnostic_digest": "df915f1387a84393d915",
+      "call_count": 17,
+      "diagnostic_digest": "37e99682dd7ff5e8b21c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/services/scheduling_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 18,
-      "diagnostic_digest": "19f690eb882b7d5c9ba7",
+      "call_count": 22,
+      "diagnostic_digest": "d31985fb76be2d5b6389",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/services/sync_engine.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2798,8 +2798,15 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 14,
-      "diagnostic_digest": "d32c6f0cfe356c8f2b6b",
+      "call_count": 2,
+      "diagnostic_digest": "9464185b1733c0018297",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 17,
+      "diagnostic_digest": "fdd7d562b3820a043e79",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11162,10 +11169,10 @@
   "schema_version": 3,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 553,
+    "owner_files": 554,
     "path_privacy_candidate_calls": 711,
     "persistent_sink_files": 10,
     "task_492_calls": 1312,
-    "task_494_calls": 7455
+    "task_494_calls": 7466
   }
 }

--- a/Tests/Scheduling/fixtures/server_responses/automation_endpoints.md
+++ b/Tests/Scheduling/fixtures/server_responses/automation_endpoints.md
@@ -260,3 +260,17 @@ Common automation error codes mapped by the server:
 - Date-time filters (`created_from`, `created_to`) must include a timezone; the server normalizes to UTC.
 - Mutating endpoints accept an optional `Idempotency-Key` request header.
 - The `capabilities` endpoint is synchronous (`def`, not `async def`) and returns the current server-side capability matrix.
+
+## Fixtures
+
+- `automation_preview_response.json` (task-1, schedules-handoff PR-4) holds
+  hand-assembled `ScheduledTaskPreviewCreateRequest`/`ScheduledTaskPreviewResponse`
+  pairs for `tldw_chatbook.Scheduling.automation_preview.preview_automation_definition`
+  (a pure local port of the server's preview-assembly logic above — no
+  server round trip). Two cases: a valid `recurring_question` create-preview,
+  and one with an unsupported `schedule.kind`. Each case pins a `now` value
+  so its `schedule_preview.next_occurrences` is deterministic —
+  `next_occurrences` is a **local addition**, not part of the server's
+  response (the server's `schedule_preview` is just the bare normalized
+  `schedule` dict; see `_create_preview`'s `schedule_preview=normalized["schedule"]`
+  in `scheduled_task_automation_service.py`).

--- a/Tests/Scheduling/fixtures/server_responses/automation_preview_response.json
+++ b/Tests/Scheduling/fixtures/server_responses/automation_preview_response.json
@@ -1,0 +1,124 @@
+{
+  "_comment": "Hand-assembled ScheduledTaskPreviewResponse-shaped fixtures for tldw_chatbook.Scheduling.automation_preview.preview_automation_definition (task-1, schedules-handoff PR-4). Field values were derived from reading tldw_server2 origin/dev tldw_Server_API/app/services/scheduled_task_automation_service.py's preview assembly (_normalize_preview/_create_preview/_preview_response) -- see automation_endpoints.md's ScheduledTaskPreviewCreateRequest/ScheduledTaskPreviewResponse tables for the field list. `schedule_preview.next_occurrences` is a LOCAL addition (not present in the server's response; the server just puts the bare normalized schedule dict there) -- see automation_preview.py's module docstring. Both `now` values are fixed so `next_occurrences` is deterministic; feed `request` through preview_automation_definition(request, now=<that fixture's now>) and compare validation_errors/status/schedule_preview.",
+  "valid_recurring_question_create": {
+    "now": "2026-01-01T00:00:00+00:00",
+    "request": {
+      "mode": "create",
+      "family": "recurring_question",
+      "name": "Daily stand-up summary",
+      "description": "Ask the team for yesterday's progress and today's blockers.",
+      "config": {
+        "scope": {"mode": "all_searchable_library"},
+        "finding_policy": {"preset": "balanced_findings"},
+        "retention_policy": {"mode": "default"},
+        "generation_mode": "optional"
+      },
+      "input": {"question": "What did you work on yesterday and what is blocking you today?"},
+      "schedule": {"kind": "daily", "time_of_day": "09:00", "timezone": "UTC"},
+      "visibility_policy": null,
+      "notification_policy": {"on_success": "silent", "on_failure": "toast"},
+      "approval_policy": {"mode": "auto"}
+    },
+    "response": {
+      "mode": "create",
+      "family": "recurring_question",
+      "definition_id": null,
+      "definition_version": null,
+      "status": "valid",
+      "normalized_config": {
+        "name": "Daily stand-up summary",
+        "description": "Ask the team for yesterday's progress and today's blockers.",
+        "config": {
+          "scope": {
+            "mode": "all_searchable_library",
+            "resolved_sources": ["media_db", "notes", "chats"]
+          },
+          "finding_policy": {"preset": "balanced_findings"},
+          "retention_policy": {"mode": "default"},
+          "generation_mode": "optional"
+        },
+        "input": {"question": "What did you work on yesterday and what is blocking you today?"},
+        "schedule": {"kind": "daily", "time_of_day": "09:00", "timezone": "UTC"},
+        "visibility_policy": "findings_only",
+        "notification_policy": {"on_success": "silent", "on_failure": "toast"},
+        "approval_policy": {"mode": "auto"},
+        "family": "recurring_question"
+      },
+      "validation_errors": [],
+      "warnings": [],
+      "visibility_policy": {"mode": "findings_only"},
+      "schedule_preview": {
+        "kind": "daily",
+        "time_of_day": "09:00",
+        "timezone": "UTC",
+        "next_occurrences": [
+          "2026-01-01T09:00:00+00:00",
+          "2026-01-02T09:00:00+00:00",
+          "2026-01-03T09:00:00+00:00"
+        ]
+      },
+      "redaction_policy": {"mode": "none", "fields": []}
+    }
+  },
+  "invalid_recurring_question_bad_schedule_kind": {
+    "now": "2026-01-01T00:00:00+00:00",
+    "request": {
+      "mode": "create",
+      "family": "recurring_question",
+      "name": "Daily stand-up summary",
+      "description": null,
+      "config": {
+        "scope": {"mode": "all_searchable_library"},
+        "finding_policy": {"preset": "balanced_findings"},
+        "retention_policy": {"mode": "default"},
+        "generation_mode": "optional"
+      },
+      "input": {"question": "What did you work on yesterday?"},
+      "schedule": {"kind": "monthly", "day_of_month": 1},
+      "visibility_policy": null,
+      "notification_policy": {},
+      "approval_policy": {}
+    },
+    "response": {
+      "mode": "create",
+      "family": "recurring_question",
+      "definition_id": null,
+      "definition_version": null,
+      "status": "invalid",
+      "normalized_config": {
+        "name": "Daily stand-up summary",
+        "description": null,
+        "config": {
+          "scope": {
+            "mode": "all_searchable_library",
+            "resolved_sources": ["media_db", "notes", "chats"]
+          },
+          "finding_policy": {"preset": "balanced_findings"},
+          "retention_policy": {"mode": "default"},
+          "generation_mode": "optional"
+        },
+        "input": {"question": "What did you work on yesterday?"},
+        "schedule": {"kind": "monthly", "day_of_month": 1},
+        "visibility_policy": "findings_only",
+        "notification_policy": {},
+        "approval_policy": {},
+        "family": "recurring_question"
+      },
+      "validation_errors": [
+        {
+          "field": "schedule.kind",
+          "code": "unsupported",
+          "message": "Unsupported schedule kind: monthly"
+        }
+      ],
+      "warnings": [],
+      "visibility_policy": {"mode": "findings_only"},
+      "schedule_preview": {
+        "kind": "monthly",
+        "day_of_month": 1,
+        "next_occurrences": []
+      },
+      "redaction_policy": {"mode": "none", "fields": []}
+    }
+  }
+}

--- a/Tests/Scheduling/fixtures/server_responses/automation_preview_response.json
+++ b/Tests/Scheduling/fixtures/server_responses/automation_preview_response.json
@@ -15,7 +15,7 @@
       },
       "input": {"question": "What did you work on yesterday and what is blocking you today?"},
       "schedule": {"kind": "daily", "time_of_day": "09:00", "timezone": "UTC"},
-      "visibility_policy": null,
+      "visibility_policy": {},
       "notification_policy": {"on_success": "silent", "on_failure": "toast"},
       "approval_policy": {"mode": "auto"}
     },
@@ -75,7 +75,7 @@
       },
       "input": {"question": "What did you work on yesterday?"},
       "schedule": {"kind": "monthly", "day_of_month": 1},
-      "visibility_policy": null,
+      "visibility_policy": {},
       "notification_policy": {},
       "approval_policy": {}
     },

--- a/Tests/Scheduling/test_authoring_end_to_end.py
+++ b/Tests/Scheduling/test_authoring_end_to_end.py
@@ -1,0 +1,296 @@
+"""Authoring end-to-end tests (schedules-handoff PR-4, task 6).
+
+Two round trips through `SchedulingService.save_definition`, both against a
+real tmp_path `ScheduledTasksDB`:
+
+(a) Local owner: a saved definition's row is picked up by a real
+    `SchedulerLoop` tick, the same unmocked stack
+    `test_automation_end_to_end.py` (PR-2) drives -- only the two Library
+    RAG boundaries are faked, monkeypatched as module attributes on
+    `automation_execution`.
+(b) Server owner, offline-then-online: `save_definition` while the seam is
+    DOWN queues a `create` mutation and writes the local row; `sync_now`
+    with the seam UP replays preview -> create and adopts the server
+    identity onto that same row. The fake server client's preview/create
+    responses are built from the recorded `Tests/Scheduling/fixtures/
+    server_responses/` fixtures (Task 1's local-preview-parity fixture for
+    the preview envelope, the definitions-list fixture's first item for
+    the create echo).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Library.library_rag_answer_service import (
+    ANSWER_STATUS_READY,
+    LibraryRagAnswer,
+)
+from tldw_chatbook.Library.library_rag_service import LibraryRagSearchOutcome
+from tldw_chatbook.Library.library_rag_state import LibraryRagResultRow
+from tldw_chatbook.Notifications.notification_dispatch_service import (
+    NotificationDispatchService,
+)
+from tldw_chatbook.Scheduling import automation_execution
+from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+from tldw_chatbook.Scheduling.schedule_compute import schedule_slot_for
+from tldw_chatbook.Scheduling.scheduler.handlers.automation_handler import (
+    AutomationDefinitionHandler,
+)
+from tldw_chatbook.Scheduling.scheduler.loop import SchedulerLoop
+from tldw_chatbook.Scheduling.services import SchedulingService
+from tldw_chatbook.Scheduling.services.server_client import ServerUnavailableError
+
+_FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "server_responses"
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = ScheduledTasksDB(tmp_path / "scheduled_tasks.db")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+# --- (a) local authoring -> save -> a real SchedulerLoop tick picks it up --
+
+
+class _FakeNotificationStore:
+    """Minimal store double, copied from `test_automation_end_to_end.py`."""
+
+    def __init__(self):
+        self.inserted = []
+
+    def insert_notification(self, **kwargs):
+        self.inserted.append(kwargs)
+        return dict(kwargs)
+
+    def get_settings(self):
+        return {"enabled": True, "toast_enabled": True, "persist_enabled": True}
+
+
+class _FakeApp:
+    """App double: any non-None `library_rag_search_service` satisfies the
+    handler (retrieval itself is monkeypatched below)."""
+
+    def __init__(self):
+        self.notify_calls = []
+        self.library_rag_search_service = object()
+
+    def notify(self, message, severity="information", timeout=None):
+        self.notify_calls.append(
+            {"message": message, "severity": severity, "timeout": timeout}
+        )
+
+
+_CANNED_ROWS = (
+    LibraryRagResultRow(
+        result_id="note-1",
+        title="First matching note",
+        snippet="Snippet one.",
+        score=0.9,
+        source_id="note-1",
+        chunk_id="chunk-1",
+        citations=(),
+        provenance={"source_type": "notes"},
+    ),
+)
+_ANSWER_TEXT = "Canned synthesized answer for the authored definition."
+
+
+def _local_definition_payload(**overrides) -> dict:
+    """A valid recurring_question authoring payload, provider/model set on
+    `input` so execution resolves them without config-default fallbacks."""
+    payload = {
+        "family": "recurring_question",
+        "name": "What changed this week?",
+        "description": "Weekly digest of notes activity",
+        "config": {"generation_mode": "optional"},
+        "input": {
+            "question": "What changed this week?",
+            "provider": "openai",
+            "model": "gpt-x",
+        },
+        "schedule": {"kind": "interval", "every_seconds": 900},
+        "visibility_policy": "findings_only",
+        "notification_policy": {},
+        "approval_policy": {},
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_local_authoring_saved_row_is_picked_up_by_a_scheduler_tick(
+    db, monkeypatch
+):
+    async def _fake_run_library_rag_search(app_instance, request):
+        return LibraryRagSearchOutcome(status="ready", results=_CANNED_ROWS)
+
+    async def _fake_generate_library_rag_answer(
+        *, query, results, coverage_note, provider, model, chat=None
+    ):
+        return LibraryRagAnswer(
+            status=ANSWER_STATUS_READY,
+            text=_ANSWER_TEXT,
+            provider=provider,
+            model=model or "",
+        )
+
+    monkeypatch.setattr(
+        automation_execution, "run_library_rag_search", _fake_run_library_rag_search
+    )
+    monkeypatch.setattr(
+        automation_execution,
+        "generate_library_rag_answer",
+        _fake_generate_library_rag_answer,
+    )
+
+    # -- Author locally through the facade --
+    svc = SchedulingService(db=db, runtime_source="local")
+    outcome = await svc.save_definition(_local_definition_payload(), "local")
+
+    assert outcome.status == "saved"
+    definition_id = outcome.definition_id
+    saved_row = db.get_automation_definition(definition_id)
+    assert saved_row["next_run_at"], "an interval schedule always computes one"
+    due_at = datetime.fromisoformat(saved_row["next_run_at"])
+
+    # -- A real SchedulerLoop tick against that exact row --
+    store = _FakeNotificationStore()
+    dispatch_service = NotificationDispatchService(store=store)
+    app = _FakeApp()
+    handler = AutomationDefinitionHandler(
+        db=db, app_getter=lambda: app, dispatch_service=dispatch_service
+    )
+    loop = SchedulerLoop(
+        db, handlers={"automation_definition": handler}, clock=lambda: due_at
+    )
+    loop.queue.load()
+
+    await loop.tick()
+    await asyncio.gather(*handler._pending)
+
+    runs = db.list_automation_runs(owner_id="local", definition_id=definition_id)
+    assert len(runs) == 1
+    assert runs[0]["status"] == "completed"
+    assert runs[0]["outcome"] == "finding"
+    assert runs[0]["schedule_slot"] == schedule_slot_for(due_at)
+
+    results = db.list_automation_results(owner_id="local", definition_id=definition_id)
+    assert len(results) == 1
+    assert results[0]["answer"] == _ANSWER_TEXT
+
+
+# --- (b) server-owned authoring: offline queue -> online replay ------------
+
+
+def _load_preview_response() -> dict:
+    """Task 1's local-preview-parity fixture response, with the HTTP-only
+    `id` field added (that fixture is for the pure local preview function,
+    which never assigns a server preview id -- a real server response
+    does, and `_push_definition_create` needs it to call `create`)."""
+    data = json.loads((_FIXTURES_DIR / "automation_preview_response.json").read_text())
+    response = copy.deepcopy(data["valid_recurring_question_create"]["response"])
+    response.setdefault("id", "prev-fixture-1")
+    return response
+
+
+def _load_authoring_payload() -> dict:
+    data = json.loads((_FIXTURES_DIR / "automation_preview_response.json").read_text())
+    return copy.deepcopy(data["valid_recurring_question_create"]["request"])
+
+
+def _load_created_definition_echo() -> dict:
+    """The definitions-list fixture's first item -- a valid recurring_question
+    `ScheduledTaskDefinitionResponse`-shaped row, reused as the create echo."""
+    data = json.loads((_FIXTURES_DIR / "automation_definition_list.json").read_text())
+    return copy.deepcopy(data["items"][0])
+
+
+class _ToggleableDefinitionServerClient:
+    """Fake server client for the offline-then-online authoring round trip.
+
+    `preview_automation_definition` raises while `up` is False (simulating
+    the offline save), and returns the fixture-derived response once
+    flipped `up` for the sync replay. `list_reminders`/
+    `list_automation_definitions`/`list_automation_results` are the empty
+    pull-phase stubs `sync_now` also touches every cycle.
+    """
+
+    def __init__(self, preview_response: dict, created_echo: dict):
+        self.up = False
+        self._preview_response = preview_response
+        self._created_echo = created_echo
+        self.preview_calls: list[dict] = []
+        self.create_calls: list[str] = []
+
+    async def list_reminders(self):
+        return {"items": []}
+
+    async def list_automation_definitions(self, *, limit: int = 50, offset: int = 0):
+        return {"items": [], "total": 0, "has_more": False}
+
+    async def list_automation_results(self, *, limit: int = 50, offset: int = 0):
+        return {"items": [], "total": 0, "has_more": False}
+
+    async def preview_automation_definition(self, payload: dict) -> dict:
+        self.preview_calls.append(payload)
+        if not self.up:
+            raise ServerUnavailableError("offline")
+        return copy.deepcopy(self._preview_response)
+
+    async def create_automation_definition(
+        self, preview_id: str, *, initial_lifecycle: str = "configured"
+    ) -> dict:
+        self.create_calls.append(preview_id)
+        return copy.deepcopy(self._created_echo)
+
+
+@pytest.mark.asyncio
+async def test_server_owned_authoring_offline_queue_then_online_sync_replay(db):
+    owner = "server:42"  # matches the definitions-list fixture's owner_id
+    preview_response = _load_preview_response()
+    created_echo = _load_created_definition_echo()
+    assert created_echo["family"] == "recurring_question"
+    payload = _load_authoring_payload()
+
+    server_client = _ToggleableDefinitionServerClient(preview_response, created_echo)
+    svc = SchedulingService(db=db, server_client=server_client, runtime_source=owner)
+
+    # -- Seam DOWN: offline save writes the local row and queues one
+    # `create` mutation; the local pure preview (this payload is Task 1's
+    # own "valid" fixture) stands in for the unreachable server's verdict.
+    outcome = await svc.save_definition(payload, owner)
+
+    assert outcome.status == "queued"
+    definition_id = outcome.definition_id
+    assert definition_id
+    offline_row = db.get_automation_definition(definition_id)
+    assert offline_row["server_id"] is None
+    assert offline_row["owner_id"] == owner
+    pending = db.get_pending_mutations(owner, primitive="automation_definition")
+    assert len(pending) == 1
+    assert pending[0]["local_id"] == definition_id
+    assert pending[0]["payload"]["action"] == "create"
+    assert pending[0]["payload"]["server_definition_id"] is None
+    assert len(server_client.preview_calls) == 1  # the failed offline attempt
+
+    # -- Seam UP: sync_now's push phase replays preview -> create --
+    server_client.up = True
+    await svc.sync_now()
+
+    assert len(server_client.preview_calls) == 2  # offline attempt + replay
+    assert server_client.create_calls == [preview_response["id"]]
+
+    refreshed = db.get_automation_definition(definition_id)
+    assert refreshed["server_id"] == created_echo["id"]
+    assert db.get_pending_mutations(owner, primitive="automation_definition") == []
+    assert len(db.list_automation_definitions(owner_id=owner)) == 1

--- a/Tests/Scheduling/test_authoring_end_to_end.py
+++ b/Tests/Scheduling/test_authoring_end_to_end.py
@@ -304,3 +304,92 @@ async def test_server_owned_authoring_offline_queue_then_online_sync_replay(db):
     assert refreshed["server_id"] == created_echo["id"]
     assert db.get_pending_mutations(owner, primitive="automation_definition") == []
     assert len(db.list_automation_definitions(owner_id=owner)) == 1
+
+
+@pytest.mark.parametrize("owner_kind", ["local", "offline_server"])
+@pytest.mark.asyncio
+async def test_authored_finding_policy_reaches_its_own_db_column(db, owner_kind):
+    """Qodo HIGH: the chosen finding/retention policy must land on the ROW's
+    dedicated columns, not only inside `config`.
+
+    `automation_execution._resolve_finding_policy` reads
+    `row["finding_policy"]` and `automation_handler` snapshots
+    `task["finding_policy"]` -- a policy stored only under `config` left
+    every authored definition running the column DEFAULT
+    (`balanced_findings`) whatever the author picked. Asserted on the row
+    (and through the real resolver), never through a faked executor.
+    """
+    from tldw_chatbook.Scheduling.automation_execution import _resolve_finding_policy
+
+    payload = _local_definition_payload(
+        config={
+            "generation_mode": "optional",
+            "finding_policy": {"preset": "high_confidence_only"},
+            "retention_policy": {"mode": "custom"},
+        }
+    )
+
+    if owner_kind == "local":
+        owner = "local"
+        svc = SchedulingService(db=db, runtime_source="local")
+        expected_status = "saved"
+    else:
+        # The offline server-owned path writes the local row through the same
+        # helper; it queues a mutation rather than reaching the server (the
+        # fake client is DOWN by default). `visibility_policy` is sent in the
+        # server request's own dict shape, which the fake validates.
+        owner = "server:42"
+        payload["visibility_policy"] = {"mode": "findings_only"}
+        server_client = _ToggleableDefinitionServerClient(
+            _load_preview_response(), _load_created_definition_echo()
+        )
+        svc = SchedulingService(
+            db=db, server_client=server_client, runtime_source=owner
+        )
+        expected_status = "queued"
+
+    outcome = await svc.save_definition(payload, owner)
+    assert outcome.status == expected_status
+
+    row = db.get_automation_definition(outcome.definition_id)
+    assert row["finding_policy"] == {"preset": "high_confidence_only"}
+    assert row["retention_policy"] == {"mode": "custom"}
+    # The real resolver, on the real row: this is what a scheduled run sees.
+    top_k, high_confidence_only = _resolve_finding_policy(row.get("finding_policy"))
+    assert high_confidence_only is True
+    assert top_k == 10
+
+
+@pytest.mark.asyncio
+async def test_editing_a_definition_updates_its_finding_policy_column(db):
+    """The update branch carries the policy too -- switching the preset on an
+    existing definition must move the column, not just `config`."""
+    svc = SchedulingService(db=db, runtime_source="local")
+    created = await svc.save_definition(
+        _local_definition_payload(
+            config={
+                "generation_mode": "optional",
+                "finding_policy": {"preset": "balanced_findings"},
+            }
+        ),
+        "local",
+    )
+    assert created.status == "saved"
+    assert db.get_automation_definition(created.definition_id)["finding_policy"] == {
+        "preset": "balanced_findings"
+    }
+
+    edited = await svc.save_definition(
+        _local_definition_payload(
+            config={
+                "generation_mode": "optional",
+                "finding_policy": {"preset": "high_confidence_only"},
+            }
+        ),
+        "local",
+        definition_id=created.definition_id,
+    )
+    assert edited.status == "saved"
+    assert db.get_automation_definition(created.definition_id)["finding_policy"] == {
+        "preset": "high_confidence_only"
+    }

--- a/Tests/Scheduling/test_authoring_end_to_end.py
+++ b/Tests/Scheduling/test_authoring_end_to_end.py
@@ -46,6 +46,9 @@ from tldw_chatbook.Scheduling.scheduler.handlers.automation_handler import (
 from tldw_chatbook.Scheduling.scheduler.loop import SchedulerLoop
 from tldw_chatbook.Scheduling.services import SchedulingService
 from tldw_chatbook.Scheduling.services.server_client import ServerUnavailableError
+from tldw_chatbook.tldw_api.scheduled_tasks_automation_schemas import (
+    ScheduledTaskPreviewCreateRequest,
+)
 
 _FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "server_responses"
 
@@ -223,6 +226,12 @@ class _ToggleableDefinitionServerClient:
     flipped `up` for the sync replay. `list_reminders`/
     `list_automation_definitions`/`list_automation_results` are the empty
     pull-phase stubs `sync_now` also touches every cycle.
+
+    Every payload handed to `preview_automation_definition` is validated
+    against the real wire schema first (final review M7): a fake seam that
+    accepts anything is exactly how a schema mismatch reaches the server
+    unnoticed (the PR-2 faked-seam lesson) -- and it caught one, the
+    shipped fixture's `visibility_policy: null`.
     """
 
     def __init__(self, preview_response: dict, created_echo: dict):
@@ -242,6 +251,7 @@ class _ToggleableDefinitionServerClient:
         return {"items": [], "total": 0, "has_more": False}
 
     async def preview_automation_definition(self, payload: dict) -> dict:
+        ScheduledTaskPreviewCreateRequest.model_validate(payload)
         self.preview_calls.append(payload)
         if not self.up:
             raise ServerUnavailableError("offline")

--- a/Tests/Scheduling/test_automation_authoring_client.py
+++ b/Tests/Scheduling/test_automation_authoring_client.py
@@ -1,0 +1,265 @@
+"""Server-client + notifications-service wiring for definition authoring.
+
+Task 2 of the schedules-handoff PR-4 plan: stacks the slice-2/PR-3 pattern
+(tldw_api client -> ``ServerNotificationsService`` policy gate ->
+``SchedulingServerClient`` wrapper) for the preview/create/update seams
+(spec §5.1) that ``SyncEngine`` will consume in Task 3 to replay locally
+authored definitions to the server.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from tldw_chatbook.Notifications import ServerNotificationsService
+from tldw_chatbook.Scheduling.services.server_client import (
+    SchedulingServerClient,
+    ServerClientConfig,
+    ServerClientNotFoundError,
+    ServerClientPolicyError,
+    ServerClientServerError,
+    ServerUnavailableError,
+)
+from tldw_chatbook.runtime_policy.types import PolicyDecision, PolicyDeniedError
+
+
+class _FakeResponse:
+    """Minimal stand-in for a pydantic response model."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def model_dump(self, mode="json"):
+        return dict(self._payload)
+
+
+_PREVIEW_REQUEST = {
+    "mode": "create",
+    "family": "recurring_question",
+    "name": "Daily stand-up summary",
+    "schedule": {"kind": "daily", "time_of_day": "09:00", "timezone": "UTC"},
+}
+
+
+class AutomationAuthoringNotificationsService:
+    """Stub notifications service implementing the three new methods."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def preview_scheduled_automation_definition(self, request):
+        self.calls.append(("preview", request))
+        return {
+            "mode": request.get("mode", "create"),
+            "family": request["family"],
+            "status": "valid",
+            "validation_errors": [],
+            "normalized_config": {"family": request["family"]},
+        }
+
+    async def create_scheduled_automation_definition(
+        self, preview_id, *, initial_lifecycle="configured"
+    ):
+        self.calls.append(("create", preview_id, initial_lifecycle))
+        return {
+            "id": "def-1",
+            "family": "recurring_question",
+            "name": "Daily stand-up summary",
+            "lifecycle": initial_lifecycle,
+            "preview_id": preview_id,
+        }
+
+    async def update_scheduled_automation_definition(self, definition_id, preview_id):
+        self.calls.append(("update", definition_id, preview_id))
+        return {
+            "id": definition_id,
+            "family": "recurring_question",
+            "name": "Renamed",
+            "lifecycle": "configured",
+            "preview_id": preview_id,
+        }
+
+
+@pytest.mark.asyncio
+async def test_preview_automation_definition_passes_payload_through():
+    inner = AutomationAuthoringNotificationsService()
+    client = SchedulingServerClient(inner)
+
+    result = await client.preview_automation_definition(_PREVIEW_REQUEST)
+
+    assert result["status"] == "valid"
+    assert result["family"] == "recurring_question"
+    assert inner.calls == [("preview", _PREVIEW_REQUEST)]
+
+
+@pytest.mark.asyncio
+async def test_create_automation_definition_passes_preview_id_and_lifecycle():
+    inner = AutomationAuthoringNotificationsService()
+    client = SchedulingServerClient(inner)
+
+    result = await client.create_automation_definition(
+        "prev-1", initial_lifecycle="paused"
+    )
+
+    assert result["id"] == "def-1"
+    assert result["lifecycle"] == "paused"
+    assert inner.calls == [("create", "prev-1", "paused")]
+
+
+@pytest.mark.asyncio
+async def test_create_automation_definition_defaults_lifecycle_to_configured():
+    inner = AutomationAuthoringNotificationsService()
+    client = SchedulingServerClient(inner)
+
+    await client.create_automation_definition("prev-2")
+
+    assert inner.calls == [("create", "prev-2", "configured")]
+
+
+@pytest.mark.asyncio
+async def test_update_automation_definition_passes_definition_and_preview_ids():
+    inner = AutomationAuthoringNotificationsService()
+    client = SchedulingServerClient(inner)
+
+    result = await client.update_automation_definition("def-1", "prev-3")
+
+    assert result["id"] == "def-1"
+    assert result["preview_id"] == "prev-3"
+    assert inner.calls == [("update", "def-1", "prev-3")]
+
+
+@pytest.mark.asyncio
+async def test_preview_and_create_are_retried_on_server_error():
+    # Replaying a preview or a create-from-preview hits the server's
+    # payload-hash idempotency, so a transient failure is safe to retry
+    # (spec §5.1) -- unlike run-now, it cannot double-create anything.
+    attempts = {"preview": 0, "create": 0}
+
+    class FlakyThenOk:
+        async def preview_scheduled_automation_definition(self, request):
+            attempts["preview"] += 1
+            if attempts["preview"] < 2:
+                raise ServerClientServerError("boom")
+            return {"status": "valid"}
+
+        async def create_scheduled_automation_definition(
+            self, preview_id, *, initial_lifecycle="configured"
+        ):
+            attempts["create"] += 1
+            if attempts["create"] < 2:
+                raise ServerClientServerError("boom")
+            return {"id": "def-1"}
+
+    client = SchedulingServerClient(
+        FlakyThenOk(), config=ServerClientConfig(retry_delay=0.0)
+    )
+
+    preview_result = await client.preview_automation_definition(_PREVIEW_REQUEST)
+    create_result = await client.create_automation_definition("prev-1")
+
+    assert attempts["preview"] == 2
+    assert attempts["create"] == 2
+    assert preview_result["status"] == "valid"
+    assert create_result["id"] == "def-1"
+
+
+@pytest.mark.asyncio
+async def test_update_automation_definition_not_found_maps_to_typed_error():
+    class DeletedService:
+        async def update_scheduled_automation_definition(self, definition_id, preview_id):
+            raise ServerClientNotFoundError("gone")
+
+    client = SchedulingServerClient(DeletedService())
+    with pytest.raises(ServerClientNotFoundError):
+        await client.update_automation_definition("def-1", "prev-1")
+
+
+@pytest.mark.asyncio
+async def test_automation_authoring_methods_require_a_connected_server():
+    client = SchedulingServerClient(None)
+    with pytest.raises(ServerUnavailableError):
+        await client.preview_automation_definition(_PREVIEW_REQUEST)
+    with pytest.raises(ServerUnavailableError):
+        await client.create_automation_definition("prev-1")
+    with pytest.raises(ServerUnavailableError):
+        await client.update_automation_definition("def-1", "prev-1")
+
+
+@pytest.mark.asyncio
+async def test_automation_authoring_policy_denial_maps_to_policy_error():
+    class DenyingService(AutomationAuthoringNotificationsService):
+        async def preview_scheduled_automation_definition(self, request):
+            raise PolicyDeniedError(
+                action_id="scheduler.automations.configure.server",
+                reason_code="server_mode_required",
+                user_message="scheduler.automations.configure.server requires server mode.",
+                effective_source="local",
+                authority_owner="server",
+            )
+
+    client = SchedulingServerClient(DenyingService())
+    with pytest.raises(ServerClientPolicyError):
+        await client.preview_automation_definition(_PREVIEW_REQUEST)
+
+
+@pytest.mark.asyncio
+async def test_notifications_service_gates_all_three_seams_under_configure_action():
+    inner = Mock()
+
+    async def _preview(request):
+        inner.preview_args = request
+        return _FakeResponse({"status": "valid", "family": request.family})
+
+    async def _create(preview_id, *, initial_lifecycle="configured"):
+        inner.create_args = (preview_id, initial_lifecycle)
+        return _FakeResponse({"id": "def-1", "lifecycle": initial_lifecycle})
+
+    async def _update(definition_id, preview_id):
+        inner.update_args = (definition_id, preview_id)
+        return _FakeResponse({"id": definition_id, "preview_id": preview_id})
+
+    inner.preview_scheduled_task_definition = _preview
+    inner.create_scheduled_task_definition = _create
+    inner.update_scheduled_task_definition = _update
+
+    policy = Mock()
+    service = ServerNotificationsService(client=inner, policy_enforcer=policy)
+
+    previewed = await service.preview_scheduled_automation_definition(_PREVIEW_REQUEST)
+    created = await service.create_scheduled_automation_definition(
+        "prev-1", initial_lifecycle="paused"
+    )
+    updated = await service.update_scheduled_automation_definition("def-1", "prev-2")
+
+    assert previewed["status"] == "valid"
+    assert created["lifecycle"] == "paused"
+    assert updated["preview_id"] == "prev-2"
+    assert [c.kwargs["action_id"] for c in policy.require_allowed.call_args_list] == [
+        "scheduler.automations.configure.server",
+        "scheduler.automations.configure.server",
+        "scheduler.automations.configure.server",
+    ]
+    # The service builds a real ScheduledTaskPreviewCreateRequest from the
+    # raw dict before calling the typed client method.
+    assert inner.preview_args.family == "recurring_question"
+    assert inner.preview_args.name == "Daily stand-up summary"
+    assert inner.create_args == ("prev-1", "paused")
+    assert inner.update_args == ("def-1", "prev-2")
+
+
+@pytest.mark.asyncio
+async def test_notifications_service_hard_stops_denied_preview():
+    policy = Mock()
+    policy.require_allowed = None
+    policy.require_ui_action_allowed = Mock(
+        return_value=PolicyDecision(
+            allowed=False,
+            reason_code="authority_denied",
+            user_message="Blocked.",
+            effective_source="server",
+            authority_owner="server",
+        )
+    )
+    service = ServerNotificationsService(client=Mock(), policy_enforcer=policy)
+    with pytest.raises(PolicyDeniedError):
+        await service.preview_scheduled_automation_definition(_PREVIEW_REQUEST)

--- a/Tests/Scheduling/test_automation_authoring_client.py
+++ b/Tests/Scheduling/test_automation_authoring_client.py
@@ -164,6 +164,31 @@ async def test_preview_and_create_are_retried_on_server_error():
 
 
 @pytest.mark.asyncio
+async def test_update_automation_definition_is_not_retried():
+    """Qodo HIGH: the update PATCH consumes its preview, so a transport-level
+    retry after an unobserved success gets the preview-already-consumed 409
+    back and the save reports "the server refused your edit" for an edit the
+    server actually APPLIED. One attempt only -- an ambiguous transport
+    failure then falls through to `save_definition`'s offline queue, whose
+    replay takes a FRESH update-mode preview (the only safe retry here)."""
+    attempts = {"count": 0}
+
+    class AlwaysFailing:
+        async def update_scheduled_automation_definition(self, definition_id, preview_id):
+            attempts["count"] += 1
+            raise ServerClientServerError("boom")
+
+    client = SchedulingServerClient(
+        AlwaysFailing(), config=ServerClientConfig(retry_delay=0.0)
+    )
+
+    with pytest.raises(ServerClientServerError):
+        await client.update_automation_definition("def-1", "prev-1")
+
+    assert attempts["count"] == 1
+
+
+@pytest.mark.asyncio
 async def test_update_automation_definition_not_found_maps_to_typed_error():
     class DeletedService:
         async def update_scheduled_automation_definition(self, definition_id, preview_id):

--- a/Tests/Scheduling/test_automation_health.py
+++ b/Tests/Scheduling/test_automation_health.py
@@ -47,12 +47,16 @@ def _fake_search_service() -> SimpleNamespace:
 
 
 def _readable_app(**overrides: object) -> SimpleNamespace:
-    """A fake app with a capable RAG service and both scoped-source DBs
-    present -- the baseline every source-readable test starts from and
-    overrides pieces of."""
+    """A fake app with a capable RAG service and all three scoped-source
+    seams present -- the baseline every source-readable test starts from
+    and overrides pieces of. `media_reading_scope_service`/
+    `notes_scope_service`/`chachanotes_db` are the real attributes
+    `Library/library_local_rag_search_service.py`'s `_search_media`/
+    `_search_notes`/`_search_conversations` gate on."""
     attrs: dict[str, object] = {
         "library_rag_search_service": _fake_search_service(),
-        "media_db": object(),
+        "media_reading_scope_service": object(),
+        "notes_scope_service": object(),
         "chachanotes_db": object(),
     }
     attrs.update(overrides)
@@ -153,10 +157,9 @@ def test_ready_when_default_scope_sources_all_readable(monkeypatch):
 
 
 def test_capability_unavailable_when_a_scoped_source_db_is_missing(monkeypatch):
-    """`chachanotes_db` missing (no notes/chats DB) blocks health even
-    though the provider would otherwise resolve -- and the reason names the
-    unreadable source."""
-    app = _readable_app(chachanotes_db=None)
+    """`notes_scope_service` missing blocks health even though the provider
+    would otherwise resolve -- and the reason names the unreadable source."""
+    app = _readable_app(notes_scope_service=None)
 
     def _boom(row):
         raise AssertionError("resolve_execution_target must not be called")
@@ -167,14 +170,14 @@ def test_capability_unavailable_when_a_scoped_source_db_is_missing(monkeypatch):
 
     assert health == "capability_unavailable"
     # First unreadable Library source type in iteration order (media, notes,
-    # conversations) -- media_db is present, notes is the first miss.
+    # conversations) -- media is present, notes is the first miss.
     assert "notes" in reason
 
 
 def test_ready_ignores_a_missing_db_for_a_source_outside_the_scope(monkeypatch):
     """A scope that only asks for `chats` must not be blocked by a missing
-    `media_db` -- readability is scoped, not blanket."""
-    app = _readable_app(media_db=None)
+    `media_reading_scope_service` -- readability is scoped, not blanket."""
+    app = _readable_app(media_reading_scope_service=None)
     monkeypatch.setattr(
         automation_health,
         "resolve_execution_target",
@@ -208,7 +211,12 @@ def test_deps_missing_takes_precedence_over_unreadable_source(monkeypatch):
     """RAG-deps unavailability (no `library_rag_search_service`) must win
     over a scoped source being unreadable -- the source-specific reason
     must never leak when the seam itself is the actual blocker."""
-    app = SimpleNamespace(library_rag_search_service=None, media_db=None, chachanotes_db=None)
+    app = SimpleNamespace(
+        library_rag_search_service=None,
+        media_reading_scope_service=None,
+        notes_scope_service=None,
+        chachanotes_db=None,
+    )
 
     def _boom(row):
         raise AssertionError("resolve_execution_target must not be called")

--- a/Tests/Scheduling/test_automation_health.py
+++ b/Tests/Scheduling/test_automation_health.py
@@ -46,8 +46,21 @@ def _fake_search_service() -> SimpleNamespace:
     return SimpleNamespace(search=lambda *args, **kwargs: None)
 
 
+def _readable_app(**overrides: object) -> SimpleNamespace:
+    """A fake app with a capable RAG service and both scoped-source DBs
+    present -- the baseline every source-readable test starts from and
+    overrides pieces of."""
+    attrs: dict[str, object] = {
+        "library_rag_search_service": _fake_search_service(),
+        "media_db": object(),
+        "chachanotes_db": object(),
+    }
+    attrs.update(overrides)
+    return SimpleNamespace(**attrs)
+
+
 def test_permission_required_when_no_provider_resolves(monkeypatch):
-    app = SimpleNamespace(library_rag_search_service=_fake_search_service())
+    app = _readable_app()
     monkeypatch.setattr(
         automation_health,
         "resolve_execution_target",
@@ -61,7 +74,7 @@ def test_permission_required_when_no_provider_resolves(monkeypatch):
 
 
 def test_ready_when_rag_service_present_and_provider_resolves(monkeypatch):
-    app = SimpleNamespace(library_rag_search_service=_fake_search_service())
+    app = _readable_app()
     monkeypatch.setattr(
         automation_health,
         "resolve_execution_target",
@@ -106,3 +119,103 @@ def test_capability_unavailable_when_service_has_no_callable_search(monkeypatch)
 
     assert health == "capability_unavailable"
     assert reason
+
+
+# --- Sources-readable check (plan Task 6) -----------------------------------
+#
+# Default scope (no `config`, or `config.scope` omitted) normalizes to
+# "all_searchable_library" over all three server source names
+# (`media_db`/`notes`/`chats`), which `library_source_types` maps onto the
+# Library's plural vocabulary (`media`/`notes`/`conversations`) -- the same
+# mapping `automation_execution.py` uses for retrieval.
+
+SCOPED_TO_CHATS_ONLY: dict = {
+    "id": "def-scoped",
+    "input": {},
+    "config": {"scope": {"mode": "sources", "sources": ["chats"]}},
+}
+
+
+def test_ready_when_default_scope_sources_all_readable(monkeypatch):
+    """Every default-scope source (media/notes/conversations) resolves to a
+    live DB attribute -- the new check must not block a `ready` app."""
+    app = _readable_app()
+    monkeypatch.setattr(
+        automation_health,
+        "resolve_execution_target",
+        lambda row: {"provider": "openai", "model": "gpt-4", "max_tokens": 1000},
+    )
+
+    health, reason = automation_health.compute_local_health(app, DEFINITION_ROW)
+
+    assert health == "ready"
+    assert reason == ""
+
+
+def test_capability_unavailable_when_a_scoped_source_db_is_missing(monkeypatch):
+    """`chachanotes_db` missing (no notes/chats DB) blocks health even
+    though the provider would otherwise resolve -- and the reason names the
+    unreadable source."""
+    app = _readable_app(chachanotes_db=None)
+
+    def _boom(row):
+        raise AssertionError("resolve_execution_target must not be called")
+
+    monkeypatch.setattr(automation_health, "resolve_execution_target", _boom)
+
+    health, reason = automation_health.compute_local_health(app, DEFINITION_ROW)
+
+    assert health == "capability_unavailable"
+    # First unreadable Library source type in iteration order (media, notes,
+    # conversations) -- media_db is present, notes is the first miss.
+    assert "notes" in reason
+
+
+def test_ready_ignores_a_missing_db_for_a_source_outside_the_scope(monkeypatch):
+    """A scope that only asks for `chats` must not be blocked by a missing
+    `media_db` -- readability is scoped, not blanket."""
+    app = _readable_app(media_db=None)
+    monkeypatch.setattr(
+        automation_health,
+        "resolve_execution_target",
+        lambda row: {"provider": "openai", "model": "gpt-4", "max_tokens": 1000},
+    )
+
+    health, reason = automation_health.compute_local_health(app, SCOPED_TO_CHATS_ONLY)
+
+    assert health == "ready"
+    assert reason == ""
+
+
+def test_capability_unavailable_when_the_in_scope_source_db_is_missing(monkeypatch):
+    """The inverse of the previous test: `chats` IS in scope and its DB is
+    missing -- must block, naming `conversations` (the Library vocabulary
+    `chats` maps onto)."""
+    app = _readable_app(chachanotes_db=None)
+
+    def _boom(row):
+        raise AssertionError("resolve_execution_target must not be called")
+
+    monkeypatch.setattr(automation_health, "resolve_execution_target", _boom)
+
+    health, reason = automation_health.compute_local_health(app, SCOPED_TO_CHATS_ONLY)
+
+    assert health == "capability_unavailable"
+    assert "conversations" in reason
+
+
+def test_deps_missing_takes_precedence_over_unreadable_source(monkeypatch):
+    """RAG-deps unavailability (no `library_rag_search_service`) must win
+    over a scoped source being unreadable -- the source-specific reason
+    must never leak when the seam itself is the actual blocker."""
+    app = SimpleNamespace(library_rag_search_service=None, media_db=None, chachanotes_db=None)
+
+    def _boom(row):
+        raise AssertionError("resolve_execution_target must not be called")
+
+    monkeypatch.setattr(automation_health, "resolve_execution_target", _boom)
+
+    health, reason = automation_health.compute_local_health(app, DEFINITION_ROW)
+
+    assert health == "capability_unavailable"
+    assert reason == automation_health._CAPABILITY_UNAVAILABLE_REASON

--- a/Tests/Scheduling/test_automation_preview.py
+++ b/Tests/Scheduling/test_automation_preview.py
@@ -1,0 +1,179 @@
+"""Unit + fixture-parity tests for the pure local automation preview service."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Scheduling.automation_preview import preview_automation_definition
+from tldw_chatbook.Scheduling.models import AutomationFamily, PreviewStatus
+
+_FIXTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "server_responses" / "automation_preview_response.json"
+)
+
+
+def _valid_payload() -> dict:
+    return {
+        "mode": "create",
+        "family": "recurring_question",
+        "name": "Daily stand-up summary",
+        "description": "Ask the team.",
+        "config": {
+            "scope": {"mode": "all_searchable_library"},
+            "finding_policy": {"preset": "balanced_findings"},
+            "retention_policy": {"mode": "default"},
+            "generation_mode": "optional",
+        },
+        "input": {"question": "What did you work on yesterday?"},
+        "schedule": {"kind": "daily", "time_of_day": "09:00", "timezone": "UTC"},
+    }
+
+
+# --- direct unit tests -------------------------------------------------------
+
+
+def test_valid_payload_yields_valid_status_and_no_errors():
+    result = preview_automation_definition(_valid_payload(), now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    assert result.status == PreviewStatus.VALID
+    assert result.validation_errors == []
+    assert result.family == AutomationFamily.RECURRING_QUESTION
+
+
+def test_invalid_schedule_kind_yields_invalid_status_with_one_error():
+    payload = _valid_payload()
+    payload["schedule"] = {"kind": "monthly", "day_of_month": 1}
+    result = preview_automation_definition(payload, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    assert result.status == PreviewStatus.INVALID
+    assert result.validation_errors == [
+        {
+            "field": "schedule.kind",
+            "code": "unsupported",
+            "message": "Unsupported schedule kind: monthly",
+        }
+    ]
+    assert result.schedule_preview["next_occurrences"] == []
+
+
+def test_schedule_preview_has_up_to_three_next_occurrences():
+    result = preview_automation_definition(_valid_payload(), now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    assert result.schedule_preview["next_occurrences"] == [
+        "2026-01-01T09:00:00+00:00",
+        "2026-01-02T09:00:00+00:00",
+        "2026-01-03T09:00:00+00:00",
+    ]
+    # And the base normalized-schedule keys are still present (server parity).
+    assert result.schedule_preview["kind"] == "daily"
+    assert result.schedule_preview["time_of_day"] == "09:00"
+
+
+def test_one_time_schedule_yields_single_occurrence():
+    payload = _valid_payload()
+    payload["schedule"] = {"kind": "one_time", "run_at": "2026-06-01T12:00:00+00:00"}
+    result = preview_automation_definition(payload, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    assert result.schedule_preview["next_occurrences"] == ["2026-06-01T12:00:00+00:00"]
+
+
+def test_visibility_policy_defaults_to_findings_only_for_recurring_question():
+    result = preview_automation_definition(_valid_payload(), now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    assert result.visibility_policy == {"mode": "findings_only"}
+    assert result.normalized_config["visibility_policy"] == "findings_only"
+
+
+def test_normalized_config_carries_family_and_notification_approval_policies():
+    payload = _valid_payload()
+    payload["notification_policy"] = {"on_success": "silent"}
+    payload["approval_policy"] = {"mode": "auto"}
+    result = preview_automation_definition(payload, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    assert result.normalized_config["family"] == "recurring_question"
+    assert result.normalized_config["notification_policy"] == {"on_success": "silent"}
+    assert result.normalized_config["approval_policy"] == {"mode": "auto"}
+
+
+def test_update_mode_requires_definition_id_and_version():
+    payload = _valid_payload()
+    payload["mode"] = "update"
+    result = preview_automation_definition(payload, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    assert result.status == PreviewStatus.INVALID
+    codes = {(err["field"], err["code"]) for err in result.validation_errors}
+    assert ("definition_id", "required_for_update") in codes
+    assert ("definition_version", "required_for_update") in codes
+
+
+def test_update_mode_accepts_definition_id_and_version():
+    payload = _valid_payload()
+    payload["mode"] = "update"
+    payload["definition_id"] = "def_123"
+    payload["definition_version"] = 2
+    result = preview_automation_definition(payload, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    assert result.status == PreviewStatus.VALID
+    assert result.definition_id == "def_123"
+    assert result.definition_version == 2
+
+
+def test_create_mode_rejects_definition_id_and_version():
+    payload = _valid_payload()
+    payload["definition_id"] = "def_123"
+    payload["definition_version"] = 1
+    result = preview_automation_definition(payload, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    codes = {(err["field"], err["code"]) for err in result.validation_errors}
+    assert ("definition_id", "not_allowed_for_create") in codes
+    assert ("definition_version", "not_allowed_for_create") in codes
+
+
+def test_agent_task_family_yields_single_unsupported_error():
+    payload = _valid_payload()
+    payload["family"] = "agent_task"
+    result = preview_automation_definition(payload, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    assert result.status == PreviewStatus.INVALID
+    assert result.validation_errors == [
+        {
+            "field": "family",
+            "code": "unsupported",
+            "message": "Unsupported automation family: agent_task",
+        }
+    ]
+
+
+def test_unrecognized_family_raises_value_error():
+    payload = _valid_payload()
+    payload["family"] = "bogus_family"
+    with pytest.raises(ValueError):
+        preview_automation_definition(payload, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+
+def test_now_defaults_to_current_time_when_omitted():
+    # Just exercises the default-`now` path -- no crash, occurrences computed.
+    result = preview_automation_definition(_valid_payload())
+    assert len(result.schedule_preview["next_occurrences"]) == 3
+
+
+# --- fixture parity -----------------------------------------------------------
+
+
+def _load_fixture() -> dict:
+    return json.loads(_FIXTURE_PATH.read_text())
+
+
+@pytest.mark.parametrize(
+    "case_name",
+    ["valid_recurring_question_create", "invalid_recurring_question_bad_schedule_kind"],
+)
+def test_fixture_parity(case_name: str):
+    fixture = _load_fixture()[case_name]
+    now = datetime.fromisoformat(fixture["now"])
+    result = preview_automation_definition(fixture["request"], now=now)
+    expected = fixture["response"]
+
+    assert result.status.value == expected["status"]
+    assert result.validation_errors == expected["validation_errors"]
+    assert result.schedule_preview == expected["schedule_preview"]
+    assert result.warnings == expected["warnings"]
+    assert result.visibility_policy == expected["visibility_policy"]
+    assert result.redaction_policy == expected["redaction_policy"]
+    assert result.normalized_config == expected["normalized_config"]
+    assert result.mode == expected["mode"]
+    assert result.family.value == expected["family"]
+    assert result.definition_id == expected["definition_id"]
+    assert result.definition_version == expected["definition_version"]

--- a/Tests/Scheduling/test_automation_validation.py
+++ b/Tests/Scheduling/test_automation_validation.py
@@ -1,0 +1,218 @@
+"""Direct unit tests for the ported automation-authoring validators.
+
+One accept + one reject per distinct code path the server has, per
+`automation_validation.py`'s port-parity docstring.
+"""
+
+from tldw_chatbook.Scheduling.automation_validation import (
+    FINDING_POLICY_PRESETS,
+    GENERATION_MODES,
+    RETENTION_POLICY_MODES,
+    field_error,
+    normalize_finding_policy,
+    normalize_retention_policy,
+    validate_recurring_question_config,
+    validate_schedule,
+)
+
+
+# --- field_error -----------------------------------------------------------
+
+
+def test_field_error_shape():
+    assert field_error("x.y", "required", "X is required.") == {
+        "field": "x.y",
+        "code": "required",
+        "message": "X is required.",
+    }
+
+
+# --- validate_schedule -------------------------------------------------------
+
+
+def test_validate_schedule_accepts_supported_kind():
+    normalized, errors, warnings = validate_schedule({"kind": "daily", "time_of_day": "09:00"})
+    assert normalized == {"kind": "daily", "time_of_day": "09:00"}
+    assert errors == []
+    assert warnings == []
+
+
+def test_validate_schedule_rejects_non_dict():
+    normalized, errors, warnings = validate_schedule("not-a-dict")
+    assert normalized == {}
+    assert errors == [
+        {"field": "schedule", "code": "invalid_type", "message": "Schedule must be an object."}
+    ]
+
+
+def test_validate_schedule_rejects_missing_kind():
+    normalized, errors, warnings = validate_schedule({})
+    assert normalized == {}
+    assert errors == [
+        {"field": "schedule.kind", "code": "required", "message": "Schedule kind is required."}
+    ]
+
+
+def test_validate_schedule_rejects_unsupported_kind():
+    normalized, errors, warnings = validate_schedule({"kind": "monthly"})
+    assert normalized == {"kind": "monthly"}
+    assert errors == [
+        {
+            "field": "schedule.kind",
+            "code": "unsupported",
+            "message": "Unsupported schedule kind: monthly",
+        }
+    ]
+
+
+# --- normalize_finding_policy ------------------------------------------------
+
+
+def test_normalize_finding_policy_accepts_supported_preset():
+    errors = []
+    result = normalize_finding_policy({"preset": "high_confidence_only"}, errors)
+    assert result == {"preset": "high_confidence_only"}
+    assert errors == []
+    assert "high_confidence_only" in FINDING_POLICY_PRESETS
+
+
+def test_normalize_finding_policy_defaults_when_missing():
+    errors = []
+    result = normalize_finding_policy(None, errors)
+    assert result == {"preset": "balanced_findings"}
+    assert errors == []
+
+
+def test_normalize_finding_policy_rejects_unsupported_preset():
+    errors = []
+    result = normalize_finding_policy({"preset": "bogus"}, errors)
+    # Still returns a normalized dict (server keeps the bad value visible).
+    assert result == {"preset": "bogus"}
+    assert errors == [
+        {
+            "field": "config.finding_policy.preset",
+            "code": "unsupported",
+            "message": "Unsupported finding policy preset: bogus",
+        }
+    ]
+
+
+# --- normalize_retention_policy -----------------------------------------------
+
+
+def test_normalize_retention_policy_accepts_supported_mode():
+    errors = []
+    result = normalize_retention_policy({"mode": "custom"}, errors)
+    assert result == {"mode": "custom"}
+    assert errors == []
+    assert "custom" in RETENTION_POLICY_MODES
+
+
+def test_normalize_retention_policy_defaults_when_missing():
+    errors = []
+    result = normalize_retention_policy(None, errors)
+    assert result == {"mode": "default"}
+    assert errors == []
+
+
+def test_normalize_retention_policy_rejects_unsupported_mode():
+    errors = []
+    result = normalize_retention_policy({"mode": "bogus"}, errors)
+    assert result == {"mode": "bogus"}
+    assert errors == [
+        {
+            "field": "config.retention_policy.mode",
+            "code": "unsupported",
+            "message": "Unsupported retention policy mode: bogus",
+        }
+    ]
+
+
+# --- validate_recurring_question_config ---------------------------------------
+
+
+def _valid_config() -> dict:
+    return {
+        "name": "Daily stand-up",
+        "description": "Ask the team.",
+        "config": {
+            "scope": {"mode": "all_searchable_library"},
+            "finding_policy": {"preset": "balanced_findings"},
+            "retention_policy": {"mode": "default"},
+            "generation_mode": "optional",
+        },
+        "input": {"question": "What did you work on?"},
+    }
+
+
+def test_validate_recurring_question_config_accepts_valid_config():
+    normalized, errors, warnings = validate_recurring_question_config(_valid_config())
+    assert errors == []
+    assert warnings == []
+    assert normalized["name"] == "Daily stand-up"
+    assert normalized["input"] == {"question": "What did you work on?"}
+    assert normalized["config"] == {
+        "scope": {"mode": "all_searchable_library", "resolved_sources": ["media_db", "notes", "chats"]},
+        "finding_policy": {"preset": "balanced_findings"},
+        "retention_policy": {"mode": "default"},
+        "generation_mode": "optional",
+    }
+
+
+def test_validate_recurring_question_config_rejects_missing_name():
+    config = _valid_config()
+    config["name"] = ""
+    normalized, errors, warnings = validate_recurring_question_config(config)
+    assert {"field": "name", "code": "required", "message": "Name is required."} in errors
+
+
+def test_validate_recurring_question_config_rejects_missing_question():
+    config = _valid_config()
+    config["input"] = {}
+    normalized, errors, warnings = validate_recurring_question_config(config)
+    assert {
+        "field": "input.question",
+        "code": "required",
+        "message": "Question is required.",
+    } in errors
+
+
+def test_validate_recurring_question_config_rejects_unsupported_generation_mode():
+    config = _valid_config()
+    config["config"]["generation_mode"] = "bogus"
+    normalized, errors, warnings = validate_recurring_question_config(config)
+    assert {
+        "field": "config.generation_mode",
+        "code": "unsupported",
+        "message": "Unsupported generation mode: bogus",
+    } in errors
+    assert "bogus" not in GENERATION_MODES
+
+
+def test_validate_recurring_question_config_defaults_generation_mode_when_absent():
+    config = _valid_config()
+    del config["config"]["generation_mode"]
+    normalized, errors, warnings = validate_recurring_question_config(config)
+    assert normalized["config"]["generation_mode"] == "optional"
+    assert errors == []
+
+
+def test_validate_recurring_question_config_folds_in_scope_errors():
+    config = _valid_config()
+    config["config"]["scope"] = {"mode": "bogus_mode"}
+    normalized, errors, warnings = validate_recurring_question_config(config)
+    assert {
+        "field": "config.scope.mode",
+        "code": "unsupported",
+        "message": "Unsupported scope mode: bogus_mode",
+    } in errors
+
+
+def test_validate_recurring_question_config_reduces_scope_warnings_to_codes():
+    config = _valid_config()
+    config["config"]["scope"] = {"mode": "sources", "sources": ["not_a_real_source"]}
+    normalized, errors, warnings = validate_recurring_question_config(config)
+    # The scope warning dict is `{"code": "source_unavailable", "source": ...}`;
+    # only the "code" string survives into this function's own warnings list
+    # (a real server behavior, ported as-is -- see the docstring).
+    assert warnings == ["source_unavailable"]

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -1102,6 +1102,68 @@ def test_upsert_definitions_skips_item_missing_id(tmp_path):
     assert db.list_automation_definitions(owner_id="server:42") == []
 
 
+# ----------------------------------------------------------------------
+# adopt_server_definition_identity (schedules-handoff PR-4, task 3)
+# ----------------------------------------------------------------------
+
+
+def test_adopt_server_definition_identity_sets_server_id_and_fields(tmp_path):
+    db = _mk_db(tmp_path)
+    local_id = db.create_automation_definition(
+        "server:42", "recurring_question", "Draft name"
+    )
+
+    adopted = db.adopt_server_definition_identity(
+        local_id,
+        {
+            "id": "srv-def-9",
+            "name": "Server-confirmed name",
+            "lifecycle": "configured",
+            "schedule": {"kind": "cron", "expression": "0 9 * * 1-5"},
+        },
+    )
+
+    assert adopted is True
+    row = db.get_automation_definition(local_id)
+    assert row["server_id"] == "srv-def-9"
+    assert row["name"] == "Server-confirmed name"
+    assert row["schedule"] == {"kind": "cron", "expression": "0 9 * * 1-5"}
+
+
+def test_adopt_server_definition_identity_never_clears_local_transfer_state(tmp_path):
+    """Same §6 parked-finding rule as the pull-mirror upsert."""
+    db = _mk_db(tmp_path)
+    local_id = db.create_automation_definition(
+        "server:42", "recurring_question", "Draft"
+    )
+    db.update_automation_definition(local_id, transfer_state="pending_pull")
+
+    db.adopt_server_definition_identity(
+        local_id, {"id": "srv-def-1", "transfer_state": "server_side_value"}
+    )
+
+    row = db.get_automation_definition(local_id)
+    assert row["transfer_state"] == "pending_pull"
+
+
+def test_adopt_server_definition_identity_missing_server_id_returns_false(tmp_path):
+    db = _mk_db(tmp_path)
+    local_id = db.create_automation_definition(
+        "server:42", "recurring_question", "Draft"
+    )
+    assert db.adopt_server_definition_identity(local_id, {"name": "No id"}) is False
+    row = db.get_automation_definition(local_id)
+    assert row["server_id"] is None
+
+
+def test_adopt_server_definition_identity_unknown_local_id_returns_false(tmp_path):
+    db = _mk_db(tmp_path)
+    assert (
+        db.adopt_server_definition_identity("does-not-exist", {"id": "srv-def-1"})
+        is False
+    )
+
+
 def _result_item(**overrides):
     item = {
         "id": "srv-res-1",

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -1164,6 +1164,132 @@ def test_adopt_server_definition_identity_unknown_local_id_returns_false(tmp_pat
     )
 
 
+# ----------------------------------------------------------------------
+# create/update_automation_definition pending_mutation +
+# get_automation_definition_by_server_id (schedules-handoff PR-4, task 4)
+# ----------------------------------------------------------------------
+
+
+def test_create_automation_definition_pending_mutation_recorded_in_same_transaction(
+    tmp_path,
+):
+    """The authoring facade's offline server-owned create: the INSERT and
+    its outbox mutation must land as one write, keyed by the id this call
+    generates (the caller cannot know it ahead of time)."""
+    db = _mk_db(tmp_path)
+
+    def_id = db.create_automation_definition(
+        "server:1",
+        "recurring_question",
+        "Draft name",
+        pending_mutation={
+            "primitive": "automation_definition",
+            "owner_id": "server:1",
+            "payload": {
+                "action": "create",
+                "definition_payload": {"family": "recurring_question"},
+                "server_definition_id": None,
+            },
+        },
+    )
+
+    row = db.get_automation_definition(def_id)
+    assert row is not None
+    pending = db.get_pending_mutations("server:1", primitive="automation_definition")
+    assert len(pending) == 1
+    assert pending[0]["local_id"] == def_id
+    assert pending[0]["payload"]["action"] == "create"
+    assert pending[0]["payload"]["idempotency_key"]  # generated
+
+
+def test_create_automation_definition_pending_mutation_atomic_rollback_on_insert_failure(
+    tmp_path,
+):
+    """Fault-inject a genuine DB failure in the mutation INSERT (a NULL
+    owner_id violates pending_mutations' NOT NULL constraint) and confirm
+    the definition INSERT in the SAME transaction rolls back with it."""
+    db = _mk_db(tmp_path)
+
+    with pytest.raises(Exception):
+        db.create_automation_definition(
+            "server:1",
+            "recurring_question",
+            "Draft name",
+            pending_mutation={
+                "primitive": "automation_definition",
+                "owner_id": None,  # NOT NULL violation -> INSERT raises
+                "payload": {"action": "create"},
+            },
+        )
+
+    assert db.list_automation_definitions(owner_id="server:1") == []
+    assert db.get_pending_mutations("server:1", primitive="automation_definition") == []
+
+
+def test_update_automation_definition_pending_mutation_recorded_in_same_transaction(
+    tmp_path,
+):
+    db = _mk_db(tmp_path)
+    def_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Original", server_id="srv-def-1"
+    )
+
+    updated = db.update_automation_definition(
+        def_id,
+        name="Updated",
+        pending_mutation={
+            "primitive": "automation_definition",
+            "owner_id": "server:1",
+            "payload": {
+                "action": "update",
+                "definition_payload": {"name": "Updated", "definition_version": 1},
+                "server_definition_id": "srv-def-1",
+            },
+        },
+    )
+
+    assert updated is True
+    pending = db.get_pending_mutations("server:1", primitive="automation_definition")
+    assert len(pending) == 1
+    assert pending[0]["local_id"] == def_id
+    assert pending[0]["payload"]["server_definition_id"] == "srv-def-1"
+
+
+def test_update_automation_definition_pending_mutation_not_recorded_when_row_unknown(
+    tmp_path,
+):
+    """No row changed -> nothing to push; the mutation must not be queued
+    for a definition that was never actually written."""
+    db = _mk_db(tmp_path)
+
+    updated = db.update_automation_definition(
+        "does-not-exist",
+        name="Updated",
+        pending_mutation={
+            "primitive": "automation_definition",
+            "owner_id": "server:1",
+            "payload": {"action": "update"},
+        },
+    )
+
+    assert updated is False
+    assert db.get_pending_mutations("server:1", primitive="automation_definition") == []
+
+
+def test_get_automation_definition_by_server_id_found_and_missing(tmp_path):
+    db = _mk_db(tmp_path)
+    def_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Mirrored", server_id="srv-def-7"
+    )
+
+    row = db.get_automation_definition_by_server_id("server:1", "srv-def-7")
+    assert row is not None
+    assert row["id"] == def_id
+
+    assert db.get_automation_definition_by_server_id("server:1", "no-such-id") is None
+    assert db.get_automation_definition_by_server_id("server:2", "srv-def-7") is None
+
+
 def _result_item(**overrides):
     item = {
         "id": "srv-res-1",

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -1040,6 +1040,42 @@ def test_upsert_definitions_inserts_new_row(tmp_path):
     assert rows[0]["schedule"] == {"kind": "cron", "expression": "0 9 * * 1-5"}
 
 
+def test_upsert_definitions_strips_resolved_sources_from_scope(tmp_path):
+    """Task 6 fix-round finding: a server item's `config.scope` may echo
+    back `resolved_sources` (the client's own local preview does, for the
+    `"all_searchable_library"` default scope -- plausibly the server's
+    parity port does too). That key is an OUTPUT-only projection
+    `normalize_recurring_question_scope` computes fresh on every call, not
+    an accepted input field; persisting it verbatim would make any later
+    re-normalization of this row's scope (a scheduled dispatch, the
+    sources-readable health check) report a spurious "unsupported field"
+    error and degrade every run. Must round-trip through the mirror path
+    without it."""
+    from tldw_chatbook.Scheduling.recurring_question_scope import (
+        normalize_recurring_question_scope,
+    )
+
+    db = _mk_db(tmp_path)
+    item = _definition_item(
+        config={
+            "scope": {
+                "mode": "all_searchable_library",
+                "resolved_sources": ["media_db", "notes", "chats"],
+            },
+            "generation_mode": "optional",
+        }
+    )
+
+    db.upsert_automation_definitions_from_server("server:42", [item])
+
+    row = db.list_automation_definitions(owner_id="server:42")[0]
+    stored_scope = row["config"]["scope"]
+    assert "resolved_sources" not in stored_scope
+    assert stored_scope["mode"] == "all_searchable_library"
+    _normalized, errors, _warnings = normalize_recurring_question_scope(stored_scope)
+    assert errors == []
+
+
 def test_upsert_definitions_server_wins_on_update(tmp_path):
     db = _mk_db(tmp_path)
     db.upsert_automation_definitions_from_server("server:42", [_definition_item()])
@@ -1144,6 +1180,40 @@ def test_adopt_server_definition_identity_never_clears_local_transfer_state(tmp_
 
     row = db.get_automation_definition(local_id)
     assert row["transfer_state"] == "pending_pull"
+
+
+def test_adopt_server_definition_identity_strips_resolved_sources_from_scope(tmp_path):
+    """Same fix-round finding as the pull-mirror upsert's, on the push-echo
+    mirror path (`SyncEngine._push_definition_create`'s
+    `create`/`update_automation_definition` server response)."""
+    from tldw_chatbook.Scheduling.recurring_question_scope import (
+        normalize_recurring_question_scope,
+    )
+
+    db = _mk_db(tmp_path)
+    local_id = db.create_automation_definition(
+        "server:42", "recurring_question", "Draft"
+    )
+
+    db.adopt_server_definition_identity(
+        local_id,
+        {
+            "id": "srv-def-9",
+            "config": {
+                "scope": {
+                    "mode": "all_searchable_library",
+                    "resolved_sources": ["media_db", "notes", "chats"],
+                },
+            },
+        },
+    )
+
+    row = db.get_automation_definition(local_id)
+    stored_scope = row["config"]["scope"]
+    assert "resolved_sources" not in stored_scope
+    assert stored_scope["mode"] == "all_searchable_library"
+    _normalized, errors, _warnings = normalize_recurring_question_scope(stored_scope)
+    assert errors == []
 
 
 def test_adopt_server_definition_identity_missing_server_id_returns_false(tmp_path):

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -1652,3 +1652,70 @@ async def test_save_definition_online_success_clears_stale_offline_mutation(db):
     rows = db.list_automation_definitions(owner_id="server:1")
     assert len(rows) == 1
     assert rows[0]["server_id"] == "srv-def-1"
+
+
+@pytest.mark.asyncio
+async def test_create_reminder_targets_another_owner_without_flipping_owner_id(db):
+    """Qodo HIGH: a cross-owner save threads its owner through the call
+    instead of flipping the service's shared `owner_id` around the awaited
+    network round-trip -- concurrent workers (sync, refresh, run-now) read
+    that attribute and must never observe the temporary owner."""
+    observed: list[str] = []
+
+    class _ObservingClient:
+        notifications_service = object()
+
+        async def create_reminder(self, **payload):
+            # Stands in for any concurrent worker reading the shared owner
+            # while this call is in flight.
+            observed.append(svc.owner_id)
+            raise ServerUnavailableError("offline")
+
+    svc = SchedulingService(
+        db=db, server_client=_ObservingClient(), runtime_source="local"
+    )
+
+    task = await svc.create_reminder(
+        _reminder_payload("Server reminder"), owner_id="server:1"
+    )
+
+    assert observed == ["local"], "the active owner must stay untouched"
+    assert svc.owner_id == "local"
+    assert svc.sync_engine.owner_id == "local"
+    # The row and its queued push both land under the TARGET owner.
+    rows = db.list_reminder_tasks(owner_id="server:1")
+    assert [row["id"] for row in rows] == [task.id]
+    assert db.list_reminder_tasks(owner_id="local") == []
+    pending = db.get_pending_mutations("server:1", primitive="reminder_task")
+    assert len(pending) == 1
+    assert pending[0]["payload"]["action"] == "create"
+
+
+@pytest.mark.asyncio
+async def test_update_reminder_targets_another_owner_without_flipping_owner_id(db):
+    """Same threading rule on the update path."""
+    svc = SchedulingService(db=db, runtime_source="local")
+    created = await svc.create_reminder(_reminder_payload("Server reminder"))
+    # Already known to the server, so the update takes the PATCH branch.
+    db.update_reminder_task(created.id, server_id="srv-1")
+
+    offline_client = AsyncMock()
+    offline_client.notifications_service = object()
+    offline_client.update_reminder.side_effect = ServerUnavailableError("offline")
+    svc.server_client = offline_client
+
+    await svc.update_reminder(created.id, {"title": "Renamed"}, owner_id="server:1")
+
+    assert svc.owner_id == "local"
+    pending = db.get_pending_mutations("server:1", primitive="reminder_task")
+    assert len(pending) == 1
+    assert pending[0]["payload"]["action"] == "update"
+    assert db.get_reminder_task(created.id)["title"] == "Renamed"
+
+
+@pytest.mark.asyncio
+async def test_reminder_owner_defaults_to_the_active_owner(db):
+    """The new parameter is optional: every pre-existing caller is unchanged."""
+    svc = SchedulingService(db=db, runtime_source="local")
+    task = await svc.create_reminder(_reminder_payload("Default owner"))
+    assert db.get_reminder_task(task.id)["owner_id"] == "local"

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -864,3 +864,455 @@ async def test_review_automation_result_server_mirrored_makes_a_single_db_call(d
 
     pending = db.get_pending_mutations("server:1", primitive="automation_result_review")
     assert len(pending) == 1
+
+
+# ----------------------------------------------------------------------
+# preview_definition / save_definition (schedules-handoff PR-4, task 4)
+# ----------------------------------------------------------------------
+
+
+def _definition_payload(**overrides):
+    """Build a valid recurring_question authoring payload for tests."""
+    payload = {
+        "family": "recurring_question",
+        "name": "Daily standup question",
+        "description": "Asks a daily question",
+        "config": {},
+        "input": {"question": "What did you work on today?"},
+        "schedule": {"kind": "interval", "every_seconds": 3600},
+        "visibility_policy": "findings_only",
+        "notification_policy": {},
+        "approval_policy": {},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _server_definition_echo(**overrides):
+    """A `ScheduledTaskDefinitionResponse`-shaped create/update echo."""
+    item = {
+        "id": "srv-def-1",
+        "owner_id": "server:1",
+        "family": "recurring_question",
+        "name": "Daily standup question",
+        "lifecycle": "configured",
+        "health": "execution_unavailable",
+        "schedule": {"kind": "interval", "every_seconds": 3600},
+        "input": {"question": "What did you work on today?"},
+        "config": {},
+        "visibility_policy": {"mode": "findings_only"},
+        "notification_policy": {},
+        "approval_policy": {},
+        "version": 1,
+        "created_at": "2026-09-01T09:00:00+00:00",
+        "updated_at": "2026-09-01T09:00:00+00:00",
+    }
+    item.update(overrides)
+    return item
+
+
+@pytest.mark.asyncio
+async def test_preview_definition_local_owner_valid(db):
+    svc = SchedulingService(db=db, runtime_source="local")
+    preview = await svc.preview_definition(_definition_payload(), "local")
+
+    assert preview.status == "valid"
+    assert preview.normalized_config["name"] == "Daily standup question"
+
+
+@pytest.mark.asyncio
+async def test_preview_definition_local_owner_invalid(db):
+    svc = SchedulingService(db=db, runtime_source="local")
+    preview = await svc.preview_definition(_definition_payload(name=""), "local")
+
+    assert preview.status == "invalid"
+    assert any(error["field"] == "name" for error in preview.validation_errors)
+
+
+@pytest.mark.asyncio
+async def test_preview_definition_rejects_unsupported_family(db):
+    """v1 scope guard: `agent_task` is rejected before Task 1's pure preview
+    runs, so its fabricated `family: unsupported` scope-cut error (a
+    documented gap, not real server parity) never reaches a caller through
+    this facade."""
+    svc = SchedulingService(db=db, runtime_source="local")
+    preview = await svc.preview_definition(
+        _definition_payload(family="agent_task"), "local"
+    )
+
+    assert preview.status == "invalid"
+    assert preview.validation_errors == [
+        {
+            "field": "family",
+            "code": "unsupported",
+            "message": (
+                "Only recurring_question automations can be authored here "
+                "(agent_task authoring is not yet available)."
+            ),
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_preview_definition_server_owner_online(db):
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-1",
+        "mode": "create",
+        "family": "recurring_question",
+        "status": "valid",
+        "normalized_config": {"name": "Daily standup question"},
+        "validation_errors": [],
+        "warnings": [],
+        "visibility_policy": {"mode": "findings_only"},
+        "schedule_preview": {"kind": "interval", "every_seconds": 3600},
+    }
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    preview = await svc.preview_definition(_definition_payload(), "server:1")
+
+    assert preview.status == "valid"
+    assert preview.id == "prev-1"
+    server_client.preview_automation_definition.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_preview_definition_server_owner_falls_back_local_on_unreachable(db):
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.side_effect = ServerUnavailableError(
+        "offline"
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    preview = await svc.preview_definition(_definition_payload(), "server:1")
+
+    assert preview.status == "valid"  # local validation still runs offline
+    assert any(
+        warning["field"] == "_owner" and warning["code"] == "server_unreachable"
+        for warning in preview.warnings
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_definition_local_create(db):
+    svc = SchedulingService(db=db, runtime_source="local")
+
+    outcome = await svc.save_definition(_definition_payload(), "local")
+
+    assert outcome.status == "saved"
+    assert outcome.errors == []
+    assert outcome.definition_id
+    row = db.get_automation_definition(outcome.definition_id)
+    assert row["name"] == "Daily standup question"
+    assert row["family"] == "recurring_question"
+    assert row["owner_id"] == "local"
+    assert row["schedule"] == {"kind": "interval", "every_seconds": 3600}
+    # visibility_policy on the DB row comes from the preview's wrapped
+    # top-level field, not normalized_config's flat mode string.
+    assert row["visibility_policy"] == {"mode": "findings_only"}
+    assert row["next_run_at"]  # an interval schedule always computes one
+
+
+@pytest.mark.asyncio
+async def test_save_definition_local_edit(db):
+    svc = SchedulingService(db=db, runtime_source="local")
+    created = await svc.save_definition(_definition_payload(), "local")
+
+    outcome = await svc.save_definition(
+        _definition_payload(name="Updated standup question"),
+        "local",
+        definition_id=created.definition_id,
+    )
+
+    assert outcome.status == "saved"
+    assert outcome.definition_id == created.definition_id
+    row = db.get_automation_definition(created.definition_id)
+    assert row["name"] == "Updated standup question"
+    assert row["version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_save_definition_local_invalid_writes_nothing(db):
+    svc = SchedulingService(db=db, runtime_source="local")
+
+    outcome = await svc.save_definition(_definition_payload(name=""), "local")
+
+    assert outcome.status == "invalid"
+    assert any(error["field"] == "name" for error in outcome.errors)
+    assert db.list_automation_definitions(owner_id="local") == []
+
+
+@pytest.mark.asyncio
+async def test_save_definition_family_guard_writes_nothing(db):
+    svc = SchedulingService(db=db, runtime_source="local")
+
+    outcome = await svc.save_definition(
+        _definition_payload(family="agent_task"), "local"
+    )
+
+    assert outcome.status == "invalid"
+    assert outcome.errors[0]["field"] == "family"
+    assert db.list_automation_definitions(owner_id="local") == []
+
+
+@pytest.mark.asyncio
+async def test_save_definition_unknown_definition_id_returns_error(db):
+    svc = SchedulingService(db=db, runtime_source="local")
+
+    outcome = await svc.save_definition(
+        _definition_payload(), "local", definition_id="no-such-id"
+    )
+
+    assert outcome.status == "error"
+    assert outcome.errors[0]["code"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_save_definition_server_owner_online_create_mirrors_new_row(db):
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-1",
+        "status": "valid",
+        "validation_errors": [],
+    }
+    server_client.create_automation_definition.return_value = _server_definition_echo()
+
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+    outcome = await svc.save_definition(_definition_payload(), "server:1")
+
+    assert outcome.status == "saved"
+    assert outcome.definition_id
+    row = db.get_automation_definition(outcome.definition_id)
+    assert row["server_id"] == "srv-def-1"
+    assert row["owner_id"] == "server:1"
+    server_client.create_automation_definition.assert_awaited_once_with("prev-1")
+
+
+@pytest.mark.asyncio
+async def test_save_definition_server_owner_online_edit_adopts_existing_row(db):
+    """An edit of an already-synced row must adopt onto the SAME local
+    row, never insert a second mirror for the same definition."""
+    def_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Original", server_id="srv-def-1"
+    )
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-2",
+        "status": "valid",
+        "validation_errors": [],
+    }
+    server_client.update_automation_definition.return_value = _server_definition_echo(
+        name="Updated standup question"
+    )
+
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+    outcome = await svc.save_definition(
+        _definition_payload(name="Updated standup question"),
+        "server:1",
+        definition_id=def_id,
+    )
+
+    assert outcome.status == "saved"
+    assert outcome.definition_id == def_id
+    assert len(db.list_automation_definitions(owner_id="server:1")) == 1
+    row = db.get_automation_definition(def_id)
+    assert row["name"] == "Updated standup question"
+    server_client.update_automation_definition.assert_awaited_once_with(
+        "srv-def-1", "prev-2"
+    )
+
+    # The outgoing preview request carried the local row's version, per
+    # the server's required_for_update check (Task 3's handoff note).
+    request = server_client.preview_automation_definition.await_args.args[0]
+    assert request["definition_version"] == 1
+    assert request["definition_id"] == "srv-def-1"
+
+
+@pytest.mark.asyncio
+async def test_save_definition_server_owner_online_preview_rejected_writes_nothing(db):
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.return_value = {
+        "status": "invalid",
+        "validation_errors": [
+            {"field": "name", "code": "required", "message": "Name is required."}
+        ],
+    }
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    outcome = await svc.save_definition(_definition_payload(), "server:1")
+
+    assert outcome.status == "invalid"
+    assert outcome.errors[0]["field"] == "name"
+    assert db.list_automation_definitions(owner_id="server:1") == []
+    server_client.create_automation_definition.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_save_definition_server_owner_offline_create_queues_one_mutation(db):
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.side_effect = ServerUnavailableError(
+        "offline"
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    outcome = await svc.save_definition(_definition_payload(), "server:1")
+
+    assert outcome.status == "queued"
+    assert outcome.definition_id
+    row = db.get_automation_definition(outcome.definition_id)
+    assert row["owner_id"] == "server:1"
+    assert row["server_id"] is None
+    assert row["lifecycle"] == "configured"
+
+    pending = db.get_pending_mutations("server:1", primitive="automation_definition")
+    assert len(pending) == 1
+    assert pending[0]["local_id"] == outcome.definition_id
+    assert pending[0]["payload"]["action"] == "create"
+    assert pending[0]["payload"]["server_definition_id"] is None
+    assert (
+        pending[0]["payload"]["definition_payload"]["family"] == "recurring_question"
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_definition_server_owner_offline_create_is_a_single_atomic_db_call(
+    db,
+):
+    """Same atomicity pin as `review_automation_result`'s: the row write
+    and its outbox mutation must be ONE DB call -- not a separate
+    ``record_pending_mutation`` call after -- so the two can never land in
+    different transactions."""
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.side_effect = ServerUnavailableError(
+        "offline"
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    real_create = db.create_automation_definition
+    calls: list[dict] = []
+
+    def _spy_create(*args, **kwargs):
+        calls.append(kwargs)
+        return real_create(*args, **kwargs)
+
+    db.create_automation_definition = _spy_create  # type: ignore[method-assign]
+    db.record_pending_mutation = MagicMock(  # type: ignore[method-assign]
+        side_effect=AssertionError(
+            "record_pending_mutation must not be called separately from "
+            "save_definition -- it must go through "
+            "create_automation_definition(pending_mutation=...)"
+        )
+    )
+
+    outcome = await svc.save_definition(_definition_payload(), "server:1")
+
+    assert outcome.status == "queued"
+    assert len(calls) == 1
+    assert calls[0]["pending_mutation"]["owner_id"] == "server:1"
+    pending = db.get_pending_mutations("server:1", primitive="automation_definition")
+    assert len(pending) == 1
+
+
+@pytest.mark.asyncio
+async def test_save_definition_server_owner_offline_edit_queues_update_mutation(db):
+    def_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Original", server_id="srv-def-9"
+    )
+    db.update_automation_definition(def_id, name="Original v2")  # bump version to 2
+
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.side_effect = ServerUnavailableError(
+        "offline"
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    outcome = await svc.save_definition(
+        _definition_payload(name="Updated standup question"),
+        "server:1",
+        definition_id=def_id,
+    )
+
+    assert outcome.status == "queued"
+    assert outcome.definition_id == def_id
+    assert len(db.list_automation_definitions(owner_id="server:1")) == 1
+    row = db.get_automation_definition(def_id)
+    assert row["name"] == "Updated standup question"
+
+    pending = db.get_pending_mutations("server:1", primitive="automation_definition")
+    assert len(pending) == 1
+    assert pending[0]["payload"]["action"] == "update"
+    assert pending[0]["payload"]["server_definition_id"] == "srv-def-9"
+    assert pending[0]["payload"]["definition_payload"]["definition_version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_save_definition_server_owner_offline_invalid_writes_nothing(db):
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.side_effect = ServerUnavailableError(
+        "offline"
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    outcome = await svc.save_definition(_definition_payload(name=""), "server:1")
+
+    assert outcome.status == "invalid"
+    assert db.list_automation_definitions(owner_id="server:1") == []
+    assert db.get_pending_mutations("server:1", primitive="automation_definition") == []
+
+
+@pytest.mark.asyncio
+async def test_save_definition_server_owner_commit_failure_falls_back_offline(db):
+    """The seam can fail AFTER a valid preview too (the commit call
+    itself) -- that must fall back to the same offline path as a preview
+    failure, not raise or silently drop the save."""
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-1",
+        "status": "valid",
+        "validation_errors": [],
+    }
+    server_client.create_automation_definition.side_effect = ServerUnavailableError(
+        "offline"
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    outcome = await svc.save_definition(_definition_payload(), "server:1")
+
+    assert outcome.status == "queued"
+    pending = db.get_pending_mutations("server:1", primitive="automation_definition")
+    assert len(pending) == 1
+
+
+@pytest.mark.asyncio
+async def test_save_definition_missing_family_rejected_not_crashed(db):
+    """`AutomationFamily(None)` raises `ValueError` internally -- the guard
+    must catch it and reject cleanly, not propagate."""
+    svc = SchedulingService(db=db, runtime_source="local")
+    payload = _definition_payload()
+    del payload["family"]
+
+    outcome = await svc.save_definition(payload, "local")
+
+    assert outcome.status == "invalid"
+    assert outcome.errors[0]["field"] == "family"
+    assert db.list_automation_definitions(owner_id="local") == []

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -11,7 +11,10 @@ from tldw_chatbook.Scheduling.models import ReminderTask, ScheduledTask, TaskSta
 from tldw_chatbook.Scheduling.scheduler.queue import PriorityQueue
 from tldw_chatbook.Scheduling.services import SchedulingServerClient, SchedulingService
 from tldw_chatbook.Scheduling.services.briefing_projection import BriefingProjection
-from tldw_chatbook.Scheduling.services.server_client import ServerUnavailableError
+from tldw_chatbook.Scheduling.services.server_client import (
+    ServerClientPolicyError,
+    ServerUnavailableError,
+)
 from tldw_chatbook.Scheduling.services.watchlist_projection import WatchlistProjection
 from tldw_chatbook.Subscriptions.watchlist_bundle_service import WatchlistBundleService
 
@@ -1316,3 +1319,124 @@ async def test_save_definition_missing_family_rejected_not_crashed(db):
     assert outcome.status == "invalid"
     assert outcome.errors[0]["field"] == "family"
     assert db.list_automation_definitions(owner_id="local") == []
+
+
+# ----------------------------------------------------------------------
+# preview_definition / save_definition fix round 1: ServerClientPolicyError
+# handling + stale-mutation clearing on a successful online save
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_definition_server_owner_policy_denied_uses_policy_wording(db):
+    """review finding 3: a deterministic policy refusal must not be
+    reported with connectivity wording ("could not reach the server")
+    since retrying will never change the outcome."""
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.side_effect = ServerClientPolicyError(
+        "automation authoring is disabled for this account"
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    preview = await svc.preview_definition(_definition_payload(), "server:1")
+
+    assert preview.status == "valid"  # local validation still runs offline
+    warning = next(w for w in preview.warnings if w["field"] == "_owner")
+    assert warning["code"] == "policy_denied"
+    assert "could not reach" not in warning["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_save_definition_server_owner_preview_policy_denied_returns_error(db):
+    """review finding 1: a policy refusal on the preview call must report
+    status="error" and write nothing -- NOT fall back to the offline
+    queue, since a replay would hit the identical refusal and SyncEngine
+    swallows it silently (the save would be "queued" forever)."""
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.side_effect = ServerClientPolicyError(
+        "automation authoring is disabled for this account"
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    outcome = await svc.save_definition(_definition_payload(), "server:1")
+
+    assert outcome.status == "error"
+    assert outcome.errors[0]["code"] == "policy_denied"
+    assert db.list_automation_definitions(owner_id="server:1") == []
+    assert db.get_pending_mutations("server:1", primitive="automation_definition") == []
+
+
+@pytest.mark.asyncio
+async def test_save_definition_server_owner_commit_policy_denied_returns_error(db):
+    """Same as above, but the refusal happens on the commit call (preview
+    was valid) rather than the preview call itself."""
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-1",
+        "status": "valid",
+        "validation_errors": [],
+    }
+    server_client.create_automation_definition.side_effect = ServerClientPolicyError(
+        "automation authoring is disabled for this account"
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    outcome = await svc.save_definition(_definition_payload(), "server:1")
+
+    assert outcome.status == "error"
+    assert outcome.errors[0]["code"] == "policy_denied"
+    assert db.list_automation_definitions(owner_id="server:1") == []
+    assert db.get_pending_mutations("server:1", primitive="automation_definition") == []
+
+
+@pytest.mark.asyncio
+async def test_save_definition_online_success_clears_stale_offline_mutation(db):
+    """review finding 2: a successful ONLINE save must clear any pending
+    `automation_definition` mutation left queued by an earlier offline
+    save on the same row -- otherwise the next sync replays the stale
+    mutation, creating a duplicate server-side definition (never-synced
+    row) or silently reverting this save's newer edit (already-synced
+    row)."""
+    offline_client = AsyncMock()
+    offline_client.preview_automation_definition.side_effect = ServerUnavailableError(
+        "offline"
+    )
+    svc = SchedulingService(
+        db=db, server_client=offline_client, runtime_source="server:1"
+    )
+
+    queued = await svc.save_definition(_definition_payload(), "server:1")
+    assert queued.status == "queued"
+    assert (
+        len(db.get_pending_mutations("server:1", primitive="automation_definition"))
+        == 1
+    )
+
+    online_client = AsyncMock()
+    online_client.preview_automation_definition.return_value = {
+        "id": "prev-1",
+        "status": "valid",
+        "validation_errors": [],
+    }
+    online_client.create_automation_definition.return_value = _server_definition_echo()
+    svc.server_client = online_client
+
+    outcome = await svc.save_definition(
+        _definition_payload(name="Updated standup question"),
+        "server:1",
+        definition_id=queued.definition_id,
+    )
+
+    assert outcome.status == "saved"
+    assert outcome.definition_id == queued.definition_id
+    assert db.get_pending_mutations("server:1", primitive="automation_definition") == []
+    # No duplicate row: the online save adopted the SAME local row.
+    rows = db.list_automation_definitions(owner_id="server:1")
+    assert len(rows) == 1
+    assert rows[0]["server_id"] == "srv-def-1"

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -13,6 +13,7 @@ from tldw_chatbook.Scheduling.services import SchedulingServerClient, Scheduling
 from tldw_chatbook.Scheduling.services.briefing_projection import BriefingProjection
 from tldw_chatbook.Scheduling.services.server_client import (
     ServerClientPolicyError,
+    ServerClientValidationError,
     ServerUnavailableError,
 )
 from tldw_chatbook.Scheduling.services.watchlist_projection import WatchlistProjection
@@ -1260,10 +1261,20 @@ async def test_save_definition_server_owner_offline_create_is_a_single_atomic_db
 
 @pytest.mark.asyncio
 async def test_save_definition_server_owner_offline_edit_queues_update_mutation(db):
-    def_id = db.create_automation_definition(
-        "server:1", "recurring_question", "Original", server_id="srv-def-9"
+    """Final review C1: the queued `definition_version` must stay equal to
+    the version the SERVER holds (the local column is a mirror of it), and
+    an offline edit must not move that mirror -- the server checks it for
+    exact equality and a drifted value is rejected (409) forever."""
+    server_version = 7
+    db.upsert_automation_definitions_from_server(
+        "server:1",
+        [
+            _server_definition_echo(
+                id="srv-def-9", name="Original", version=server_version
+            )
+        ],
     )
-    db.update_automation_definition(def_id, name="Original v2")  # bump version to 2
+    def_id = db.get_automation_definition_by_server_id("server:1", "srv-def-9")["id"]
 
     server_client = AsyncMock()
     server_client.preview_automation_definition.side_effect = ServerUnavailableError(
@@ -1284,12 +1295,185 @@ async def test_save_definition_server_owner_offline_edit_queues_update_mutation(
     assert len(db.list_automation_definitions(owner_id="server:1")) == 1
     row = db.get_automation_definition(def_id)
     assert row["name"] == "Updated standup question"
+    assert row["version"] == server_version  # the mirror did not drift
 
     pending = db.get_pending_mutations("server:1", primitive="automation_definition")
     assert len(pending) == 1
     assert pending[0]["payload"]["action"] == "update"
     assert pending[0]["payload"]["server_definition_id"] == "srv-def-9"
-    assert pending[0]["payload"]["definition_payload"]["definition_version"] == 2
+    assert (
+        pending[0]["payload"]["definition_payload"]["definition_version"]
+        == server_version
+    )
+
+    # A SECOND offline edit REPLACES that mutation (pending_mutations is
+    # UNIQUE(local_id, primitive, owner_id)) -- the replacement must still
+    # carry the server's version, not a locally-bumped one.
+    outcome = await svc.save_definition(
+        _definition_payload(name="Updated again"), "server:1", definition_id=def_id
+    )
+
+    assert outcome.status == "queued"
+    assert db.get_automation_definition(def_id)["version"] == server_version
+    pending = db.get_pending_mutations("server:1", primitive="automation_definition")
+    assert len(pending) == 1
+    assert (
+        pending[0]["payload"]["definition_payload"]["definition_version"]
+        == server_version
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_definition_server_owner_server_rejection_is_error_not_queued(db):
+    """Final review C2: a server-side 4xx (here a 409 version conflict,
+    mapped to `ServerClientValidationError`) is deterministic -- replaying
+    it hits the identical refusal, so the save must report `error` and
+    write/queue nothing, exactly like the policy refusal it sits beside."""
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.side_effect = (
+        ServerClientValidationError("scheduled_task_definition_version_conflict")
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    outcome = await svc.save_definition(_definition_payload(), "server:1")
+
+    assert outcome.status == "error"
+    assert outcome.errors[0]["code"] == "server_rejected"
+    assert "version_conflict" in outcome.errors[0]["message"]
+    assert db.list_automation_definitions(owner_id="server:1") == []
+    assert db.get_pending_mutations("server:1", primitive="automation_definition") == []
+
+
+@pytest.mark.asyncio
+async def test_save_definition_server_owner_commit_rejection_is_error_not_queued(db):
+    """Same as above for the COMMIT call (the preview was accepted) -- the
+    PATCH is where the real 409s live."""
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-1",
+        "status": "valid",
+        "validation_errors": [],
+    }
+    server_client.create_automation_definition.side_effect = ServerClientValidationError(
+        "scheduled_task_schedule_invalid"
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    outcome = await svc.save_definition(_definition_payload(), "server:1")
+
+    assert outcome.status == "error"
+    assert outcome.errors[0]["code"] == "server_rejected"
+    assert db.list_automation_definitions(owner_id="server:1") == []
+    assert db.get_pending_mutations("server:1", primitive="automation_definition") == []
+
+
+@pytest.mark.asyncio
+async def test_save_definition_edit_preserves_fields_the_payload_does_not_carry(db):
+    """Final review I4: the v1 modal exposes neither `description` nor the
+    visibility/approval/retention policies (nor `input.max_tokens`), so a
+    rename must not wipe them -- in the DB row OR in the update payload
+    that goes to the server."""
+    db.upsert_automation_definitions_from_server(
+        "server:1",
+        [
+            _server_definition_echo(
+                id="srv-def-5",
+                version=3,
+                description="Digest of everything that changed",
+                visibility_policy={"mode": "metadata_only"},
+                approval_policy={"mode": "manual"},
+                config={
+                    "scope": {"mode": "all_searchable_library"},
+                    "retention_policy": {"mode": "custom", "keep_days": 30},
+                },
+                input={"question": "What changed?", "max_tokens": 4096},
+                notification_policy={"on_success": True, "channels": ["email"]},
+            )
+        ],
+    )
+    def_id = db.get_automation_definition_by_server_id("server:1", "srv-def-5")["id"]
+
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.side_effect = ServerUnavailableError(
+        "offline"
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    # The v1 form's payload shape: no description, no policies, no max_tokens.
+    outcome = await svc.save_definition(
+        {
+            "family": "recurring_question",
+            "mode": "update",
+            "name": "Renamed",
+            "input": {"question": "What changed?", "provider": None, "model": None},
+            "schedule": {"kind": "interval", "every_seconds": 3600},
+            "config": {
+                "scope": {"mode": "all_searchable_library"},
+                "generation_mode": "optional",
+                "finding_policy": {"preset": "balanced_findings"},
+            },
+            "notification_policy": {"on_success": False, "on_failure": False},
+        },
+        "server:1",
+        definition_id=def_id,
+    )
+
+    assert outcome.status == "queued"
+    row = db.get_automation_definition(def_id)
+    assert row["name"] == "Renamed"
+    assert row["description"] == "Digest of everything that changed"
+    assert row["visibility_policy"] == {"mode": "metadata_only"}
+    assert row["approval_policy"] == {"mode": "manual"}
+    assert row["config"]["retention_policy"] == {"mode": "custom", "keep_days": 30}
+    assert row["input"]["max_tokens"] == 4096
+    assert row["notification_policy"]["channels"] == ["email"]
+    # The form's own fields still win over the stored ones.
+    assert row["notification_policy"]["on_success"] is False
+    assert row["input"].get("provider") is None
+
+    outgoing = db.get_pending_mutations(
+        "server:1", primitive="automation_definition"
+    )[0]["payload"]["definition_payload"]
+    assert outgoing["description"] == "Digest of everything that changed"
+    assert outgoing["visibility_policy"] == {"mode": "metadata_only"}
+    assert outgoing["approval_policy"] == {"mode": "manual"}
+    assert outgoing["config"]["retention_policy"] == {"mode": "custom", "keep_days": 30}
+    assert outgoing["input"]["max_tokens"] == 4096
+
+
+@pytest.mark.asyncio
+async def test_save_definition_edit_still_clears_a_field_the_payload_carries(db):
+    """The merge fills OMITTED keys only -- a payload that does carry a
+    field (here `input.provider`, which the form exposes and emits as
+    `None` when blank) still clears the stored value."""
+    def_id = db.create_automation_definition(
+        "local",
+        "recurring_question",
+        "Pinned",
+        input={"question": "What changed?", "provider": "openai", "model": "gpt-5"},
+        schedule={"kind": "interval", "every_seconds": 3600},
+    )
+    svc = SchedulingService(db=db, runtime_source="local")
+
+    outcome = await svc.save_definition(
+        _definition_payload(
+            name="Pinned",
+            input={"question": "What changed?", "provider": None, "model": None},
+        ),
+        "local",
+        definition_id=def_id,
+    )
+
+    assert outcome.status == "saved"
+    row = db.get_automation_definition(def_id)
+    assert row["input"]["provider"] is None
+    assert row["input"]["model"] is None
 
 
 @pytest.mark.asyncio

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -1021,6 +1021,34 @@ async def test_save_definition_local_create(db):
 
 
 @pytest.mark.asyncio
+async def test_save_definition_local_create_strips_derived_resolved_sources(db):
+    """Task 6 E2E finding: a default (`all_searchable_library`) scope's
+    preview-normalized form injects a `resolved_sources` projection that
+    `normalize_recurring_question_scope` itself does not accept as input
+    (`SUPPORTED_SCOPE_FIELDS` has no such field). Persisting it verbatim
+    made every later re-normalization of this row's stored scope --
+    `automation_execution.py`'s dispatch, `automation_health.py`'s
+    sources-readable check -- report a spurious "unsupported field" error
+    and degrade every scheduled run. The stored row must not carry it."""
+    from tldw_chatbook.Scheduling.recurring_question_scope import (
+        normalize_recurring_question_scope,
+    )
+
+    svc = SchedulingService(db=db, runtime_source="local")
+
+    outcome = await svc.save_definition(_definition_payload(), "local")
+
+    row = db.get_automation_definition(outcome.definition_id)
+    stored_scope = row["config"]["scope"]
+    assert "resolved_sources" not in stored_scope
+    assert stored_scope["mode"] == "all_searchable_library"
+    # And the stored value must be safe to re-normalize, the way a real
+    # scheduled dispatch or health check does.
+    _normalized, errors, _warnings = normalize_recurring_question_scope(stored_scope)
+    assert errors == []
+
+
+@pytest.mark.asyncio
 async def test_save_definition_local_edit(db):
     svc = SchedulingService(db=db, runtime_source="local")
     created = await svc.save_definition(_definition_payload(), "local")

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -1212,6 +1212,68 @@ async def test_sync_now_replays_definition_create_and_dedupes_same_cycle_pull(tm
 
 
 @pytest.mark.asyncio
+async def test_sync_now_definition_create_orphan_clears_mutation_and_reports_both_ids(
+    tmp_path,
+):
+    """Qodo MEDIUM: the local row is deleted between queueing the create and
+    replaying it, so `adopt_server_definition_identity` finds nothing to
+    write and the fresh server definition has no local home.
+
+    The mutation is still cleared -- replaying it would create a SECOND
+    server definition, not recover the first -- and a sync error naming BOTH
+    ids makes the orphan discoverable. (Deleting it server-side is a
+    lifecycle action, out of scope here.)"""
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    local_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Draft"
+    )
+    db.record_pending_mutation(
+        local_id,
+        "automation_definition",
+        "server:1",
+        {
+            "action": "create",
+            "definition_payload": {
+                "family": "recurring_question",
+                "name": "Daily digest",
+                "schedule": {"kind": "cron", "expression": "0 9 * * 1-5"},
+            },
+            "server_definition_id": None,
+        },
+    )
+
+    server_client = _empty_reminders_client()
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-1",
+        "status": "valid",
+        "validation_errors": [],
+    }
+    server_client.create_automation_definition.return_value = {
+        "id": "srv-def-9",
+        "family": "recurring_question",
+        "name": "Daily digest",
+        "lifecycle": "configured",
+    }
+    server_client.list_automation_definitions.return_value = _definition_page([])
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    # The row vanishes after the mutation is queued but before the replay.
+    assert db.delete_automation_definition(local_id) is True
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    assert (
+        db.get_pending_mutations("server:1", primitive="automation_definition") == []
+    ), "replaying would create a duplicate server definition"
+    state = db.get_sync_state("server:1")
+    messages = [err["message"] for err in (state["sync_errors"] or [])]
+    assert any(
+        local_id in message and "srv-def-9" in message for message in messages
+    ), f"the orphan error must name both ids; got {messages}"
+
+
+@pytest.mark.asyncio
 async def test_sync_now_definition_create_invalid_preview_clears_and_records_error(
     tmp_path,
 ):

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -1145,6 +1145,275 @@ async def test_sync_now_skips_review_fields_for_just_pushed_result_this_cycle(tm
     assert refreshed["review_note"] == "handled"
 
 
+# ----------------------------------------------------------------------
+# Definition create/update push replay (schedules-handoff PR-4, task 3)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_now_replays_definition_create_and_dedupes_same_cycle_pull(tmp_path):
+    """Task 3 pull-ordering note: a successful create's server_id must land
+    before the same-cycle definitions pull runs, so the pull matches the
+    existing local row by (owner_id, server_id) instead of inserting a
+    duplicate mirror."""
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    local_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Draft"
+    )
+    db.record_pending_mutation(
+        local_id,
+        "automation_definition",
+        "server:1",
+        {
+            "action": "create",
+            "definition_payload": {
+                "family": "recurring_question",
+                "name": "Daily digest",
+                "schedule": {"kind": "cron", "expression": "0 9 * * 1-5"},
+            },
+            "server_definition_id": None,
+        },
+    )
+
+    server_client = _empty_reminders_client()
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-1",
+        "status": "valid",
+        "validation_errors": [],
+    }
+    server_client.create_automation_definition.return_value = {
+        "id": "srv-def-1",
+        "family": "recurring_question",
+        "name": "Daily digest",
+        "lifecycle": "configured",
+    }
+    # Same-cycle pull returns the exact row that was just created.
+    server_client.list_automation_definitions.return_value = _definition_page(
+        [{"id": "srv-def-1", "family": "recurring_question", "name": "Daily digest"}]
+    )
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    request = server_client.preview_automation_definition.await_args.args[0]
+    assert request["mode"] == "create"
+    assert "definition_id" not in request
+    server_client.create_automation_definition.assert_awaited_once_with(
+        "prev-1", initial_lifecycle="configured"
+    )
+    assert (
+        db.get_pending_mutations("server:1", primitive="automation_definition") == []
+    )
+    rows = db.list_automation_definitions(owner_id="server:1")
+    assert len(rows) == 1, "create replay + same-cycle pull must yield exactly one row"
+    assert rows[0]["id"] == local_id
+    assert rows[0]["server_id"] == "srv-def-1"
+
+
+@pytest.mark.asyncio
+async def test_sync_now_definition_create_invalid_preview_clears_and_records_error(
+    tmp_path,
+):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    local_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Draft"
+    )
+    db.record_pending_mutation(
+        local_id,
+        "automation_definition",
+        "server:1",
+        {
+            "action": "create",
+            "definition_payload": {"family": "recurring_question"},
+            "server_definition_id": None,
+        },
+    )
+    server_client = _empty_reminders_client()
+    server_client.preview_automation_definition.return_value = {
+        "id": None,
+        "status": "invalid",
+        "validation_errors": [
+            {"field": "schedule.kind", "code": "required", "message": "Schedule kind is required."}
+        ],
+    }
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    server_client.create_automation_definition.assert_not_awaited()
+    assert (
+        db.get_pending_mutations("server:1", primitive="automation_definition") == []
+    ), "a rejected payload will never succeed by retrying -- clear it"
+    state = db.get_sync_state("server:1") or {}
+    errors = state.get("sync_errors") or []
+    assert errors
+    assert "schedule.kind:required" in errors[-1]["message"]
+    row = db.get_automation_definition(local_id)
+    assert row["server_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_sync_now_replays_definition_update(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    local_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Old name", server_id="srv-def-2"
+    )
+    db.record_pending_mutation(
+        local_id,
+        "automation_definition",
+        "server:1",
+        {
+            "action": "update",
+            "definition_payload": {"family": "recurring_question", "name": "New name"},
+            "server_definition_id": "srv-def-2",
+        },
+    )
+    server_client = _empty_reminders_client()
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-2",
+        "status": "valid",
+        "validation_errors": [],
+    }
+    server_client.update_automation_definition.return_value = {
+        "id": "srv-def-2",
+        "name": "New name",
+    }
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    request = server_client.preview_automation_definition.await_args.args[0]
+    assert request["mode"] == "update"
+    assert request["definition_id"] == "srv-def-2"
+    server_client.update_automation_definition.assert_awaited_once_with(
+        "srv-def-2", "prev-2"
+    )
+    assert (
+        db.get_pending_mutations("server:1", primitive="automation_definition") == []
+    )
+    row = db.get_automation_definition(local_id)
+    assert row["name"] == "New name"
+
+
+@pytest.mark.asyncio
+async def test_sync_now_definition_update_without_server_id_converts_to_create(
+    tmp_path,
+):
+    """Authored offline, never synced -- mirrors `_push_mutation`'s reminder
+    offline-create-conversion precedent."""
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    local_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Offline draft"
+    )
+    db.record_pending_mutation(
+        local_id,
+        "automation_definition",
+        "server:1",
+        {
+            "action": "update",
+            "definition_payload": {
+                "family": "recurring_question", "name": "Offline draft"
+            },
+            "server_definition_id": None,
+        },
+    )
+    server_client = _empty_reminders_client()
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-3",
+        "status": "valid",
+        "validation_errors": [],
+    }
+    server_client.create_automation_definition.return_value = {"id": "srv-def-3"}
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    server_client.update_automation_definition.assert_not_awaited()
+    request = server_client.preview_automation_definition.await_args.args[0]
+    assert request["mode"] == "create"
+    server_client.create_automation_definition.assert_awaited_once_with(
+        "prev-3", initial_lifecycle="configured"
+    )
+    row = db.get_automation_definition(local_id)
+    assert row["server_id"] == "srv-def-3"
+
+
+@pytest.mark.asyncio
+async def test_sync_now_definition_update_not_found_converts_to_create(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    local_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Stale", server_id="srv-def-deleted"
+    )
+    db.record_pending_mutation(
+        local_id,
+        "automation_definition",
+        "server:1",
+        {
+            "action": "update",
+            "definition_payload": {"family": "recurring_question", "name": "Stale"},
+            "server_definition_id": "srv-def-deleted",
+        },
+    )
+    server_client = _empty_reminders_client()
+    server_client.preview_automation_definition.side_effect = [
+        {"id": "prev-4", "status": "valid", "validation_errors": []},  # update preview
+        {"id": "prev-5", "status": "valid", "validation_errors": []},  # create preview
+    ]
+    server_client.update_automation_definition.side_effect = ServerClientNotFoundError(
+        "gone"
+    )
+    server_client.create_automation_definition.return_value = {"id": "srv-def-new"}
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    server_client.create_automation_definition.assert_awaited_once_with(
+        "prev-5", initial_lifecycle="configured"
+    )
+    row = db.get_automation_definition(local_id)
+    assert row["server_id"] == "srv-def-new"
+    assert (
+        db.get_pending_mutations("server:1", primitive="automation_definition") == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_now_definition_create_retryable_error_retains_mutation(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    local_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Draft"
+    )
+    db.record_pending_mutation(
+        local_id,
+        "automation_definition",
+        "server:1",
+        {
+            "action": "create",
+            "definition_payload": {"family": "recurring_question"},
+            "server_definition_id": None,
+        },
+    )
+    server_client = _empty_reminders_client()
+    server_client.preview_automation_definition.side_effect = ServerUnavailableError(
+        "offline"
+    )
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "error"
+    assert "offline" in (outcome.error or "")
+    pending = db.get_pending_mutations("server:1", primitive="automation_definition")
+    assert len(pending) == 1, "the mutation must be left queued for retry"
+    row = db.get_automation_definition(local_id)
+    assert row["server_id"] is None
+
+
 @pytest.mark.asyncio
 async def test_sync_now_pulls_and_upserts_definitions(tmp_path):
     db = ScheduledTasksDB(tmp_path / "db.db")

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -1415,6 +1415,80 @@ async def test_sync_now_definition_create_retryable_error_retains_mutation(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_sync_now_definition_poisoned_mutation_does_not_block_the_rest(tmp_path):
+    """Final review I3: a non-retryable 4xx on ONE definition mutation used
+    to raise out of the replay loop and abort the whole push phase, so one
+    permanently-rejected payload stopped every other definition mutation
+    for that owner forever. It must settle that mutation (cleared, error
+    recorded) and carry on with the queue."""
+    from tldw_chatbook.Scheduling.services.server_client import (
+        ServerClientValidationError,
+    )
+
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    poisoned_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Poisoned", server_id="srv-def-old"
+    )
+    db.record_pending_mutation(
+        poisoned_id,
+        "automation_definition",
+        "server:1",
+        {
+            "action": "update",
+            "definition_payload": {
+                "family": "recurring_question",
+                "name": "Poisoned",
+                "definition_version": 2,
+            },
+            "server_definition_id": "srv-def-old",
+        },
+    )
+    healthy_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Healthy"
+    )
+    db.record_pending_mutation(
+        healthy_id,
+        "automation_definition",
+        "server:1",
+        {
+            "action": "create",
+            "definition_payload": {
+                "family": "recurring_question",
+                "name": "Healthy",
+            },
+            "server_definition_id": None,
+        },
+    )
+
+    server_client = _empty_reminders_client()
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-1",
+        "status": "valid",
+        "validation_errors": [],
+    }
+    server_client.update_automation_definition.side_effect = ServerClientValidationError(
+        "scheduled_task_definition_version_conflict"
+    )
+    server_client.create_automation_definition.return_value = {
+        "id": "srv-def-new",
+        "family": "recurring_question",
+        "name": "Healthy",
+        "lifecycle": "configured",
+    }
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    # The healthy create went through despite the poisoned update ahead of it.
+    assert db.get_automation_definition(healthy_id)["server_id"] == "srv-def-new"
+    # And the poisoned one is settled, not left to jam the queue forever.
+    assert db.get_pending_mutations("server:1", primitive="automation_definition") == []
+    errors = (db.get_sync_state("server:1") or {}).get("sync_errors") or []
+    assert any("version_conflict" in error["message"] for error in errors)
+
+
+@pytest.mark.asyncio
 async def test_sync_now_pulls_and_upserts_definitions(tmp_path):
     db = ScheduledTasksDB(tmp_path / "db.db")
     server_client = _empty_reminders_client()

--- a/Tests/UI/schedules_test_helpers.py
+++ b/Tests/UI/schedules_test_helpers.py
@@ -24,9 +24,18 @@ class MockServerClient:
 class MockSchedulingDB:
     """Stub scheduled-tasks DB for test scheduling services."""
 
-    def __init__(self, sync_state: dict | None = None, conflicts: list | None = None) -> None:
+    def __init__(
+        self,
+        sync_state: dict | None = None,
+        conflicts: list | None = None,
+        automation_definitions: list[dict] | None = None,
+    ) -> None:
         self._sync_state = sync_state or {}
         self._conflicts = conflicts or []
+        #: task-5 fix round: local automation-definition rows this DB
+        #: "contains" -- mirrors the real ScheduledTasksDB surface the
+        #: Automations tab now reads (list_automation_definitions et al).
+        self._automation_definitions = list(automation_definitions or [])
 
     def get_sync_state(self, owner_id: str):
         return dict(self._sync_state)
@@ -36,6 +45,54 @@ class MockSchedulingDB:
 
     def get_conflicts(self, owner_id: str, primitive=None):
         return self._conflicts
+
+    def list_automation_definitions(self, owner_id=None, lifecycle=None, family=None):
+        return [
+            dict(row)
+            for row in self._automation_definitions
+            if (owner_id is None or row.get("owner_id") == owner_id)
+            and (lifecycle is None or row.get("lifecycle") == lifecycle)
+            and (family is None or row.get("family") == family)
+        ]
+
+    def get_automation_definition(self, definition_id: str):
+        for row in self._automation_definitions:
+            if row.get("id") == definition_id:
+                return dict(row)
+        return None
+
+    def get_automation_definition_by_server_id(self, owner_id: str, server_id: str):
+        for row in self._automation_definitions:
+            if row.get("owner_id") == owner_id and row.get("server_id") == server_id:
+                return dict(row)
+        return None
+
+    def upsert_automation_definitions_from_server(self, owner_id: str, items: list[dict]):
+        inserted = 0
+        updated = 0
+        for item in items:
+            server_id = item.get("id")
+            if not server_id:
+                continue
+            existing = next(
+                (
+                    row
+                    for row in self._automation_definitions
+                    if row.get("owner_id") == owner_id and row.get("server_id") == server_id
+                ),
+                None,
+            )
+            if existing is not None:
+                existing.update(item)
+                updated += 1
+                continue
+            local_row = dict(item)
+            local_row["id"] = f"local-mirror-{server_id}"
+            local_row["server_id"] = server_id
+            local_row["owner_id"] = owner_id
+            self._automation_definitions.append(local_row)
+            inserted += 1
+        return {"inserted": inserted, "updated": updated}
 
 
 class MockSchedulingServiceMixin:

--- a/Tests/UI/test_automation_definition_form.py
+++ b/Tests/UI/test_automation_definition_form.py
@@ -1,0 +1,435 @@
+"""Tests for the recurring-question automation-definition create modal.
+
+Modeled on ``Tests/UI/test_reminder_form.py`` for the harness pattern
+(``App.run_test()`` -- ``AppTest`` is unavailable here). Most tests drive
+a REAL ``SchedulingService`` over a real in-memory-file ``ScheduledTasksDB``
+(local owner needs no server client at all, since Task 1's preview/Task 4's
+save are pure/local for that owner) rather than a hand-rolled fake, per
+the "unmocked-integration-test" lesson (accessor-mock fakes have hidden
+protocol-signature mismatches in this codebase before). AsyncMock is used
+only where a real server round trip needs to be simulated.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from textual.app import App
+from textual.widgets import Checkbox, Input, Select, Static, TextArea
+
+from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+from tldw_chatbook.Scheduling.services.scheduling_service import SchedulingService
+from tldw_chatbook.Scheduling.services.server_client import ServerUnavailableError
+from tldw_chatbook.UI.Screens.scheduling.forms.automation_definition_form import (
+    AutomationDefinitionForm,
+)
+from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = ScheduledTasksDB(tmp_path / "scheduled_tasks.db")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+@pytest.fixture
+def local_service(db):
+    return SchedulingService(db=db, runtime_source="local")
+
+
+class _FormHost(App):
+    """Hosts the modal under test and captures its dismiss result."""
+
+    def __init__(self, service, **kwargs) -> None:
+        super().__init__()
+        self._service = service
+        self._form_kwargs = kwargs
+        self.result = "not-yet-dismissed"
+
+    def on_mount(self) -> None:
+        self.run_worker(self._drive)
+
+    async def _drive(self) -> None:
+        self.result = await self.push_screen_wait(
+            AutomationDefinitionForm(self._service, **self._form_kwargs)
+        )
+
+
+async def _wait_for_form_worker(pilot) -> None:
+    """Wait for the form's own preview/save worker to settle.
+
+    Plain ``pilot.app.workers.wait_for_complete()`` (no filter) waits for
+    EVERY worker, including ``_FormHost._drive`` -- that one only finishes
+    when the modal dismisses, which is exactly what several of these tests
+    are checking has NOT happened yet, so waiting on it unfiltered
+    deadlocks. Filtering by group does not fix it either: `WorkerManager.
+    wait_for_complete([])` falls back to "all workers" the moment the
+    local preview/save worker (no real I/O -- it resolves within a
+    handful of event-loop turns) has already finished and been pruned
+    before this coroutine gets to filter for it, reproducing the same
+    deadlock. A few plain pauses give the worker's task enough event-loop
+    turns to run to completion and update the UI, without depending on a
+    worker handle that may already be gone.
+    """
+    for _ in range(5):
+        await pilot.pause()
+
+
+def _future_run_at() -> str:
+    return (datetime.now(timezone.utc) + timedelta(days=1)).strftime("%Y-%m-%d %H:%M")
+
+
+async def _fill_minimal_valid_form(screen) -> None:
+    """Name + question + a valid future one-time run-at -- nothing else."""
+    screen.query_one("#automation-name", Input).value = "Daily standup digest"
+    screen.query_one("#automation-question", TextArea).text = "What shipped today?"
+    screen.query_one("#automation-run-at", Input).value = _future_run_at()
+
+
+# --- rendering ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_form_renders_expected_fields(local_service):
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        for selector in (
+            "#automation-runs-on",
+            "#automation-name",
+            "#automation-question",
+            "#automation-scope-mode",
+            "#automation-schedule-kind",
+            "#automation-generation-mode",
+            "#automation-finding-policy",
+            "#automation-notify",
+            "#automation-provider",
+            "#automation-model",
+            "#automation-preview-btn",
+            "#automation-save",
+            "#automation-cancel",
+        ):
+            assert screen.query_one(selector) is not None, selector
+
+        # Default schedule kind is one-time -- the run-at group is visible,
+        # the recurring cron group is not.
+        assert screen.query_one("#automation-run-at-group").display
+        assert not screen.query_one("#automation-cron-group").display
+
+
+@pytest.mark.asyncio
+async def test_scope_sources_checkboxes_hidden_until_sources_mode(local_service):
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert not screen.query_one("#automation-scope-sources-group").display
+
+        screen.query_one("#automation-scope-mode", Select).value = "sources"
+        await pilot.pause()
+
+        assert screen.query_one("#automation-scope-sources-group").display
+        for widget_id in (
+            "#automation-scope-media",
+            "#automation-scope-notes",
+            "#automation-scope-chats",
+        ):
+            assert screen.query_one(widget_id, Checkbox).value is True
+
+
+@pytest.mark.asyncio
+async def test_runs_on_select_offers_constructor_owners_and_defaults(local_service):
+    app = _FormHost(
+        local_service,
+        available_owners=[("This device", "local"), ("Server (example.com)", "server:example.com")],
+        default_owner="server:example.com",
+    )
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        select = app.screen.query_one("#automation-runs-on", Select)
+        option_values = [value for _label, value in select._options]
+        assert option_values == ["local", "server:example.com"]
+        assert select.value == "server:example.com"
+
+
+# --- payload building (unit-level, no worker/network involved) --------------
+
+
+@pytest.mark.asyncio
+async def test_build_payload_is_create_only_recurring_question(local_service):
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        await _fill_minimal_valid_form(screen)
+        await pilot.pause()
+
+        payload = screen._build_payload()
+        assert payload["family"] == "recurring_question"
+        assert payload["mode"] == "create"
+        assert "definition_id" not in payload
+        assert "definition_version" not in payload
+        assert payload["name"] == "Daily standup digest"
+        assert payload["input"]["question"] == "What shipped today?"
+        assert payload["schedule"]["kind"] == "one_time"
+        assert payload["config"]["scope"] == {"mode": "all_searchable_library"}
+        assert payload["config"]["generation_mode"] == "optional"
+        assert payload["config"]["finding_policy"] == {"preset": "balanced_findings"}
+        assert payload["notification_policy"] == {"on_success": True, "on_failure": True}
+
+
+@pytest.mark.asyncio
+async def test_build_payload_sources_scope_only_includes_checked_boxes(local_service):
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        await _fill_minimal_valid_form(screen)
+        screen.query_one("#automation-scope-mode", Select).value = "sources"
+        await pilot.pause()
+        screen.query_one("#automation-scope-notes", Checkbox).value = False
+        await pilot.pause()
+
+        payload = screen._build_payload()
+        assert payload["config"]["scope"] == {
+            "mode": "sources",
+            "sources": ["media_db", "chats"],
+        }
+
+
+@pytest.mark.asyncio
+async def test_build_payload_optional_provider_model_pin(local_service):
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        await _fill_minimal_valid_form(screen)
+        screen.query_one("#automation-provider", Input).value = "openai"
+        screen.query_one("#automation-model", Input).value = "gpt-5"
+        await pilot.pause()
+
+        payload = screen._build_payload()
+        assert payload["input"]["provider"] == "openai"
+        assert payload["input"]["model"] == "gpt-5"
+
+
+# --- client-side schedule guard -----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blank_run_at_blocks_preview_without_calling_the_service(local_service):
+    local_service.preview_definition = AsyncMock()
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen.query_one("#automation-name", Input).value = "No run at"
+        screen.query_one("#automation-question", TextArea).text = "Question?"
+        await pilot.pause()
+
+        await pilot.click("#automation-preview-btn")
+        await pilot.pause()
+
+        local_service.preview_definition.assert_not_awaited()
+        errors = screen.query_one("#automation-schedule-error", Static)
+        assert errors.display
+        assert "run at is required" in errors.visual.plain.lower()
+
+
+# --- preview -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_maps_validation_errors_onto_their_fields(local_service):
+    """A real local preview: blank name + blank question -> both field
+    errors render under their own widgets, not merged into one blob."""
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen.query_one("#automation-run-at", Input).value = _future_run_at()
+        await pilot.pause()
+
+        await pilot.click("#automation-preview-btn")
+        await pilot.pause()
+        await _wait_for_form_worker(pilot)
+        await pilot.pause()
+
+        name_error = screen.query_one("#automation-name-error", Static)
+        question_error = screen.query_one("#automation-question-error", Static)
+        assert name_error.display and "name is required" in name_error.visual.plain.lower()
+        assert (
+            question_error.display
+            and "question is required" in question_error.visual.plain.lower()
+        )
+        # No unmatched-field spillover for a fully-recognized error set.
+        assert not screen.query_one("#automation-form-errors", Static).display
+
+
+@pytest.mark.asyncio
+async def test_preview_shows_next_occurrences_when_valid(local_service):
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        await _fill_minimal_valid_form(screen)
+        await pilot.pause()
+
+        await pilot.click("#automation-preview-btn")
+        await pilot.pause()
+        await _wait_for_form_worker(pilot)
+        await pilot.pause()
+
+        preview_text = screen.query_one("#automation-preview-text", Static)
+        assert "Next runs:" in preview_text.visual.plain
+        assert not screen.query_one("#automation-name-error", Static).display
+
+
+@pytest.mark.asyncio
+async def test_set_validation_errors_puts_unrecognized_fields_in_form_level_area(
+    local_service,
+):
+    """Unit-level pin: an error whose `field` this form does not map
+    renders in the form-level area, not silently dropped -- covers a
+    server preview's own error vocabulary too (Task 4's report: not
+    guaranteed byte-identical to the local port's `code`/`message`, but
+    every error still carries a `field` to match on)."""
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._set_validation_errors(
+            [
+                {"field": "name", "message": "Name is required."},
+                {
+                    "field": "config.retention_policy.mode",
+                    "message": "Unsupported retention policy mode: bogus",
+                },
+            ]
+        )
+        await pilot.pause()
+        name_error = screen.query_one("#automation-name-error", Static)
+        form_errors = screen.query_one("#automation-form-errors", Static)
+        assert name_error.display
+        assert "name is required" in name_error.visual.plain.lower()
+        assert form_errors.display
+        assert "retention_policy" in form_errors.visual.plain
+
+
+# --- save ------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_local_writes_the_definition_and_dismisses(local_service, db):
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        await _fill_minimal_valid_form(screen)
+        await pilot.pause()
+
+        await pilot.click("#automation-save")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+    assert app.result is not None
+    assert app.result.status == "saved"
+    row = db.get_automation_definition(app.result.definition_id)
+    assert row is not None
+    assert row["name"] == "Daily standup digest"
+    assert row["owner_id"] == "local"
+    assert row["family"] == "recurring_question"
+
+
+@pytest.mark.asyncio
+async def test_save_invalid_shows_errors_and_stays_open(local_service):
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen.query_one("#automation-run-at", Input).value = _future_run_at()
+        await pilot.pause()
+
+        await pilot.click("#automation-save")
+        await pilot.pause()
+        await _wait_for_form_worker(pilot)
+        await pilot.pause()
+
+        assert app.result == "not-yet-dismissed"
+        assert isinstance(pilot.app.screen, AutomationDefinitionForm)
+        name_error = screen.query_one("#automation-name-error", Static)
+        assert name_error.display
+
+
+@pytest.mark.asyncio
+async def test_save_server_owner_offline_queues_and_reports_queued(db):
+    """A server owner whose seam is unreachable still writes the local row
+    and reports "queued" honestly (Task 4's save_definition contract) --
+    same offline-fallback shape `create_reminder` uses."""
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.side_effect = ServerUnavailableError(
+        "offline"
+    )
+    service = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+    app = _FormHost(
+        service,
+        available_owners=[("Server (1)", "server:1")],
+        default_owner="server:1",
+    )
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        await _fill_minimal_valid_form(screen)
+        await pilot.pause()
+
+        await pilot.click("#automation-save")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+    assert app.result is not None
+    assert app.result.status == "queued"
+    row = db.get_automation_definition(app.result.definition_id)
+    assert row is not None
+    assert row["owner_id"] == "server:1"
+    pending = db.get_pending_mutations("server:1", primitive="automation_definition")
+    assert len(pending) == 1
+    assert pending[0]["payload"]["action"] == "create"
+
+
+# --- discard guard -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_without_edits_dismisses_immediately(local_service):
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        await pilot.click("#automation-cancel")
+        await pilot.pause()
+
+    assert app.result is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_with_edits_asks_for_confirmation(local_service):
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen.query_one("#automation-name", Input).value = "Something typed"
+        await pilot.pause()
+
+        await pilot.click("#automation-cancel")
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, ConfirmationDialog)

--- a/Tests/UI/test_automation_definition_form.py
+++ b/Tests/UI/test_automation_definition_form.py
@@ -219,6 +219,24 @@ async def test_build_payload_optional_provider_model_pin(local_service):
         assert payload["input"]["model"] == "gpt-5"
 
 
+@pytest.mark.asyncio
+async def test_build_payload_emits_blank_provider_model_as_explicit_null(local_service):
+    """Final review I4: `save_definition` merges an edit payload onto the
+    stored row, where an OMITTED key keeps its stored value -- so the two
+    fields this form DOES expose must always be emitted, or clearing them
+    would silently resurrect the old provider/model."""
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        await _fill_minimal_valid_form(screen)
+        await pilot.pause()
+
+        payload = screen._build_payload()
+        assert payload["input"]["provider"] is None
+        assert payload["input"]["model"] is None
+
+
 # --- client-side schedule guard -----------------------------------------------
 
 

--- a/Tests/UI/test_automation_definition_form.py
+++ b/Tests/UI/test_automation_definition_form.py
@@ -630,3 +630,98 @@ async def test_edit_mode_payload_targets_server_definition_id_when_mirrored(
         payload = app.screen._build_payload()
         assert payload["definition_id"] == "srv-def-42"
         assert payload["definition_version"] == row["version"]
+
+
+@pytest.mark.parametrize("stored_zone", ["Pacific/Apia", "Mars/Olympus_Mons"])
+@pytest.mark.asyncio
+async def test_edit_mode_prefills_a_non_curated_stored_timezone(
+    local_service, db, stored_zone
+):
+    """Qodo HIGH: a definition saved with a valid-but-non-curated zone
+    (`Pacific/Apia`) assigned a Select value outside its own options and
+    raised `InvalidSelectValueError`, taking the whole edit modal down.
+
+    Mirrors `ReminderForm._timezone_options` (review F4): the row's own zone
+    is always offered, and a zone that does not even resolve locally is
+    offered with an honest label so an unrelated edit round-trips it rather
+    than silently rewriting it to the system zone."""
+    outcome = await local_service.save_definition(
+        {
+            "family": "recurring_question",
+            "mode": "create",
+            "name": "Apia digest",
+            "input": {"question": "What shipped?"},
+            "schedule": {"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+            "config": {},
+        },
+        "local",
+    )
+    assert outcome.status == "saved"
+    # Write the awkward zone straight onto the row: the normalizer may or
+    # may not accept it as authoring input, but the row can already hold it
+    # (a server mirror or an older client wrote it), and prefill must cope.
+    stored = db.get_automation_definition(outcome.definition_id)
+    stored["schedule"] = {**stored["schedule"], "timezone": stored_zone}
+
+    app = _FormHost(
+        local_service, definition_row=stored, definition_id=stored["id"]
+    )
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        tz_select = app.screen.query_one("#automation-timezone", Select)
+        assert tz_select.value == stored_zone
+        assert stored_zone in [value for _label, value in tz_select._options]
+
+
+@pytest.mark.asyncio
+async def test_preview_renders_junk_occurrences_instead_of_crashing(local_service):
+    """Qodo MEDIUM: `next_occurrences` crosses the network boundary from the
+    server preview, so entries are not guaranteed to be ISO-8601 strings --
+    or strings at all. `datetime.fromisoformat` raises `TypeError` (not
+    `ValueError`) on a non-string, which took the whole preview render down.
+    """
+    from tldw_chatbook.Scheduling.models import AutomationFamily, AutomationPreview
+    from tldw_chatbook.UI.Screens.scheduling.forms.automation_definition_form import (
+        _format_occurrence,
+    )
+
+    assert _format_occurrence("not-a-date") == "not-a-date"
+    assert _format_occurrence(12345) == "12345"
+    assert _format_occurrence(None) == "None"
+
+    app = _FormHost(local_service)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen._render_preview(
+            AutomationPreview(
+                mode="create",
+                family=AutomationFamily.RECURRING_QUESTION,
+                status="valid",
+                schedule_preview={
+                    "next_occurrences": [
+                        "2099-01-01T09:00:00+00:00",
+                        {"nope": 1},
+                        None,
+                    ]
+                },
+            )
+        )
+        await pilot.pause()
+        rendered = str(screen.query_one("#automation-preview-text", Static).render())
+        assert "Next runs:" in rendered
+        assert "{'nope': 1}" in rendered
+
+        # A non-list `next_occurrences` must not be sliced/iterated either.
+        screen._render_preview(
+            AutomationPreview(
+                mode="create",
+                family=AutomationFamily.RECURRING_QUESTION,
+                status="valid",
+                schedule_preview={"next_occurrences": "junk"},
+            )
+        )
+        await pilot.pause()
+        assert "Valid." in str(
+            screen.query_one("#automation-preview-text", Static).render()
+        )

--- a/Tests/UI/test_automation_definition_form.py
+++ b/Tests/UI/test_automation_definition_form.py
@@ -433,3 +433,147 @@ async def test_cancel_with_edits_asks_for_confirmation(local_service):
         await pilot.pause()
 
         assert isinstance(pilot.app.screen, ConfirmationDialog)
+
+
+# --- task-5 fix round: edit mode ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_mode_prefills_all_major_fields_and_disables_runs_on(
+    local_service, db
+):
+    """Create a real local definition via the facade, then reopen it in
+    edit mode and confirm every field reverse-maps correctly -- including
+    the cron schedule via `cron_to_preset` (the module-docstring fix)."""
+    create_payload = {
+        "family": "recurring_question",
+        "mode": "create",
+        "name": "Weekly digest",
+        "input": {"question": "What shipped this week?", "provider": "openai", "model": "gpt-5"},
+        "schedule": {"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+        "config": {
+            "scope": {"mode": "sources", "sources": ["notes", "chats"]},
+            "generation_mode": "required",
+            "finding_policy": {"preset": "high_confidence_only"},
+        },
+        "notification_policy": {"on_success": True, "on_failure": False},
+    }
+    outcome = await local_service.save_definition(create_payload, "local")
+    assert outcome.status == "saved"
+    row = db.get_automation_definition(outcome.definition_id)
+    assert row is not None
+
+    app = _FormHost(
+        local_service,
+        definition_row=row,
+        definition_id=row["id"],
+        available_owners=[("This device", "local")],
+        default_owner="local",
+    )
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+
+        assert screen.query_one("#automation-name", Input).value == "Weekly digest"
+        assert (
+            screen.query_one("#automation-question", TextArea).text
+            == "What shipped this week?"
+        )
+        assert screen.query_one("#automation-provider", Input).value == "openai"
+        assert screen.query_one("#automation-model", Input).value == "gpt-5"
+
+        assert screen.query_one("#automation-scope-mode", Select).value == "sources"
+        assert screen.query_one("#automation-scope-notes", Checkbox).value is True
+        assert screen.query_one("#automation-scope-chats", Checkbox).value is True
+        assert screen.query_one("#automation-scope-media", Checkbox).value is False
+
+        assert (
+            screen.query_one("#automation-generation-mode", Select).value == "required"
+        )
+        assert (
+            screen.query_one("#automation-finding-policy", Select).value
+            == "high_confidence_only"
+        )
+        assert screen.query_one("#automation-notify", Checkbox).value is True
+
+        # Schedule: cron_to_preset maps "0 9 * * 1" -> ("monday", "09:00").
+        assert (
+            screen.query_one("#automation-schedule-kind", Select).value == "recurring"
+        )
+        assert screen.query_one("#automation-cron-preset", Select).value == "monday"
+        assert screen.query_one("#automation-preset-time", Input).value == "09:00"
+        assert screen.query_one("#automation-cron", Input).value == "0 9 * * 1"
+        assert screen.query_one("#automation-timezone", Select).value == "UTC"
+
+        runs_on = screen.query_one("#automation-runs-on", Select)
+        assert runs_on.disabled
+        assert runs_on.value == "local"
+
+        assert "Edit Recurring Question" in str(screen.query_one(".form-title").render())
+
+
+@pytest.mark.asyncio
+async def test_edit_mode_unrecognized_schedule_falls_back_to_create_defaults(
+    local_service, db
+):
+    """A schedule shape this form cannot itself produce (e.g. `interval`)
+    must never crash prefill -- it is left at the one-time/blank default."""
+    outcome = await local_service.save_definition(
+        {
+            "family": "recurring_question",
+            "name": "Interval one",
+            "input": {"question": "Q?"},
+            "schedule": {"kind": "interval", "every_seconds": 3600},
+        },
+        "local",
+    )
+    assert outcome.status == "saved"
+    row = db.get_automation_definition(outcome.definition_id)
+
+    app = _FormHost(local_service, definition_row=row, definition_id=row["id"])
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        assert (
+            screen.query_one("#automation-schedule-kind", Select).value == "one_time"
+        )
+        assert screen.query_one("#automation-run-at", Input).value == ""
+
+
+@pytest.mark.asyncio
+async def test_edit_mode_save_updates_the_existing_row_via_definition_id(
+    local_service, db
+):
+    outcome = await local_service.save_definition(
+        {
+            "family": "recurring_question",
+            "name": "Original name",
+            "input": {"question": "Original question?"},
+            "schedule": {"kind": "one_time", "run_at": _future_run_at()},
+        },
+        "local",
+    )
+    assert outcome.status == "saved"
+    definition_id = outcome.definition_id
+    row = db.get_automation_definition(definition_id)
+    assert row["version"] == 1
+
+    app = _FormHost(local_service, definition_row=row, definition_id=definition_id)
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        screen.query_one("#automation-name", Input).value = "Renamed"
+        await pilot.pause()
+
+        await pilot.click("#automation-save")
+        await pilot.pause()
+        await _wait_for_form_worker(pilot)
+
+    assert app.result is not None
+    assert app.result.status == "saved"
+    assert app.result.definition_id == definition_id
+    updated_row = db.get_automation_definition(definition_id)
+    assert updated_row["name"] == "Renamed"
+    assert updated_row["version"] == 2
+    # No second row was created.
+    assert len(db.list_automation_definitions(owner_id="local")) == 1

--- a/Tests/UI/test_automation_definition_form.py
+++ b/Tests/UI/test_automation_definition_form.py
@@ -577,3 +577,38 @@ async def test_edit_mode_save_updates_the_existing_row_via_definition_id(
     assert updated_row["version"] == 2
     # No second row was created.
     assert len(db.list_automation_definitions(owner_id="local")) == 1
+
+
+@pytest.mark.asyncio
+async def test_edit_mode_payload_targets_server_definition_id_when_mirrored(
+    local_service, db
+):
+    """A server-mirrored row's preview payload must reference the SERVER's
+    definition id -- the local id means nothing to the server preview seam.
+    Local rows (no server_id) keep the local id."""
+    create_payload = {
+        "family": "recurring_question",
+        "mode": "create",
+        "name": "Mirrored digest",
+        "input": {"question": "Anything new?"},
+        "schedule": {"kind": "interval", "interval_minutes": 60},
+        "config": {"scope": {"mode": "sources", "sources": ["notes"]}},
+        "notification_policy": {"on_success": True, "on_failure": True},
+    }
+    outcome = await local_service.save_definition(create_payload, "local")
+    assert outcome.status == "saved"
+    row = dict(db.get_automation_definition(outcome.definition_id))
+    row["server_id"] = "srv-def-42"
+
+    app = _FormHost(
+        local_service,
+        definition_row=row,
+        definition_id=row["id"],
+        available_owners=[("This device", "local")],
+        default_owner="local",
+    )
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        payload = app.screen._build_payload()
+        assert payload["definition_id"] == "srv-def-42"
+        assert payload["definition_version"] == row["version"]

--- a/Tests/UI/test_reminder_form.py
+++ b/Tests/UI/test_reminder_form.py
@@ -688,3 +688,124 @@ async def test_footer_survives_wrapped_error_lines_at_45x24():
         run_at.focus()
         await pilot.pause()
         assert _painted_at_own_center(app, run_at)
+
+
+# --- task-5: "Runs on" owner selector --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runs_on_defaults_to_the_given_default_owner_when_creating():
+    """Create mode: the selector is enabled and starts on `default_owner`."""
+    app = FormTestApp()
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(
+            ReminderForm(
+                available_owners=[
+                    ("This device", "local"),
+                    ("Server (example.com)", "server:example.com"),
+                ],
+                default_owner="server:example.com",
+            )
+        )
+        await pilot.pause()
+        runs_on = pilot.app.screen.query_one("#reminder-runs-on", Select)
+        assert not runs_on.disabled
+        assert runs_on.value == "server:example.com"
+        option_values = [value for _label, value in runs_on._options]
+        assert option_values == ["local", "server:example.com"]
+
+
+@pytest.mark.asyncio
+async def test_runs_on_is_disabled_when_editing_an_existing_task():
+    """Edit mode: the owner is shown but fixed -- transfer is a separate feature."""
+    task = ReminderTask(
+        id="task-runs-on",
+        title="Existing",
+        schedule_kind=ScheduleKind.ONE_TIME,
+        run_at=datetime(2099, 7, 20, 14, 0, tzinfo=timezone.utc),
+        owner_id="local",
+    )
+    app = FormTestApp()
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(
+            ReminderForm(
+                task,
+                available_owners=[("This device", "local")],
+                default_owner="local",
+            )
+        )
+        await pilot.pause()
+        runs_on = pilot.app.screen.query_one("#reminder-runs-on", Select)
+        assert runs_on.disabled
+        assert runs_on.value == "local"
+
+
+@pytest.mark.asyncio
+async def test_runs_on_appends_a_drifted_task_owner_not_in_the_offered_list():
+    """Review F4 precedent (timezone selector): an edited task's real owner
+    always round-trips, even when the offered choices no longer include it
+    (e.g. the connected server changed since the task was created)."""
+    task = ReminderTask(
+        id="task-drifted-owner",
+        title="Server task",
+        schedule_kind=ScheduleKind.ONE_TIME,
+        run_at=datetime(2099, 7, 20, 14, 0, tzinfo=timezone.utc),
+        owner_id="server:drifted.example",
+    )
+    app = FormTestApp()
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(
+            ReminderForm(
+                task,
+                available_owners=[("This device", "local")],
+                default_owner="local",
+            )
+        )
+        await pilot.pause()
+        runs_on = pilot.app.screen.query_one("#reminder-runs-on", Select)
+        assert runs_on.disabled
+        assert runs_on.value == "server:drifted.example"
+        option_values = [value for _label, value in runs_on._options]
+        assert option_values == ["local", "server:drifted.example"]
+
+
+def test_initial_owner_prefers_the_tasks_own_owner_over_the_default():
+    task = ReminderTask(
+        id="task-owner-pref",
+        title="T",
+        schedule_kind=ScheduleKind.ONE_TIME,
+        run_at=datetime(2099, 7, 20, 14, 0, tzinfo=timezone.utc),
+        owner_id="server:1",
+    )
+    form = ReminderForm(task, default_owner="local")
+    assert form._initial_owner() == "server:1"
+
+
+def test_initial_owner_falls_back_to_default_when_creating():
+    form = ReminderForm(default_owner="server:2")
+    assert form._initial_owner() == "server:2"
+
+
+@pytest.mark.asyncio
+async def test_runs_on_selection_is_included_in_the_submitted_form_data():
+    app = FormTestApp()
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(
+            ReminderForm(
+                available_owners=[
+                    ("This device", "local"),
+                    ("Server (example.com)", "server:example.com"),
+                ],
+                default_owner="local",
+            )
+        )
+        await pilot.pause()
+        form = pilot.app.screen
+        form.query_one("#reminder-title", Input).value = "Owner-routed"
+        form.query_one("#reminder-run-at", Input).value = "2099-08-28 09:00"
+        form.query_one("#reminder-runs-on", Select).value = "server:example.com"
+        await pilot.click("#reminder-save")
+        await pilot.pause()
+
+        assert app.submitted is not None
+        assert app.submitted["owner_id"] == "server:example.com"

--- a/Tests/UI/test_schedules_automations_tab.py
+++ b/Tests/UI/test_schedules_automations_tab.py
@@ -1,22 +1,28 @@
 """Automations tab behavior on the Schedules workbench (task-18940 slice 2).
 
-The tab surfaces the server's automation definitions (ADR-077) and its
-``r`` Run-now dispatches through the server control plane -- never the
-local scheduler loop.
+The tab surfaces both the server's automation definitions (ADR-077, ``r``
+dispatches through the server control plane) and, since task-5's fix
+round, this device's own local-owned `recurring_question` definitions
+(``r`` routes those through `SchedulingService.run_automation_now`
+instead -- never the server client, and never both).
 """
 
 from unittest.mock import AsyncMock
 
 import pytest
-from textual.widgets import DataTable, TabbedContent
+from textual.widgets import DataTable, Input, Select, TabbedContent
 
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from Tests.UI.schedules_test_helpers import (
     MockSchedulingDB,
     MockSchedulingServiceMixin,
+    MockServerClient,
 )
 from tldw_chatbook.Scheduling.services.server_client import (
     ServerClientValidationError,
+)
+from tldw_chatbook.UI.Screens.scheduling.forms.automation_definition_form import (
+    AutomationDefinitionForm,
 )
 from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import SchedulesWorkbench
 
@@ -85,14 +91,45 @@ class AutomationsServerClient:
 class AutomationsMockService(MockSchedulingServiceMixin):
     """Scheduling service whose server client knows automations."""
 
-    def __init__(self, server_client) -> None:
+    def __init__(self, server_client, local_definitions=None) -> None:
         self.owner_id = "local"
         self.server_client = server_client
-        self.db = MockSchedulingDB()
+        self.db = MockSchedulingDB(automation_definitions=local_definitions or [])
         self.sync_engine = None
+        # task-5 fix round: the PR-2 local run-now seam
+        # (SchedulingService.run_automation_now) -- overridable per test.
+        self.run_automation_now = AsyncMock(
+            return_value={"run_id": "run-local-1", "deduped": False}
+        )
 
     async def list_tasks(self):
         return []
+
+
+def _local_definition(**overrides):
+    """A local `automation_definitions` row (task-5 fix round fixtures)."""
+    row = {
+        "id": "local-def-1",
+        "server_id": None,
+        "owner_id": "local",
+        "family": "recurring_question",
+        "name": "Local digest",
+        "lifecycle": "configured",
+        # DB placeholder (never trusted -- the tab must recompute this via
+        # automation_health.compute_local_health, not read it verbatim).
+        "health": "execution_unavailable",
+        "schedule": {"kind": "one_time", "run_at": "2099-01-01T00:00:00+00:00"},
+        "input": {"question": "What's new?"},
+        "config": {},
+        "visibility_policy": {"mode": "findings_only"},
+        "notification_policy": {},
+        "approval_policy": {},
+        "version": 1,
+        "created_at": "2026-08-01T00:00:00+00:00",
+        "updated_at": None,
+    }
+    row.update(overrides)
+    return row
 
 
 class _ServerRuntimeState:
@@ -369,3 +406,276 @@ async def test_definitions_table_shows_the_model_column():
         ]
         assert table.get_cell_at((0, 4)) == "anthropic/claude-x"
         assert table.get_cell_at((1, 4)) == "auto"
+
+
+# --- task-5 fix round: merged local + server listing ------------------------
+
+
+@pytest.mark.asyncio
+async def test_local_automation_appears_with_recomputed_health():
+    """Local rows appear even without a connected server, and their Health
+    cell is the freshly COMPUTED value (automation_health), never the DB's
+    unreliable create-time placeholder."""
+    server_client = MockServerClient(notifications_service=None)
+    service = AutomationsMockService(server_client, local_definitions=[_local_definition()])
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        table = workbench.query_one("#scheduling-automations-table", DataTable)
+        notice = workbench.query_one("#scheduling-automations-notice")
+
+        assert table.row_count == 1
+        assert table.get_cell_at((0, 0)) == "[This device] Local digest"
+        # No `library_rag_search_service` on the bare test app -> capability_unavailable,
+        # NOT the DB row's stored "execution_unavailable" placeholder.
+        assert table.get_cell_at((0, 3)) == "capability_unavailable"
+        assert "1 on this device" in str(notice.content)
+
+
+@pytest.mark.asyncio
+async def test_merged_list_shows_both_local_and_server_rows_with_owner_prefix():
+    server_client = AutomationsServerClient()
+    service = AutomationsMockService(
+        server_client, local_definitions=[_local_definition(name="Local one")]
+    )
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        table = workbench.query_one("#scheduling-automations-table", DataTable)
+
+        assert table.row_count == 3
+        names = [table.get_cell_at((i, 0)) for i in range(3)]
+        assert names[0] == "[This device] Local one"
+        assert names[1] == "[server-1] Morning brief"
+        assert names[2] == "[server-1] Paused one"
+
+
+@pytest.mark.asyncio
+async def test_run_now_routes_local_automation_through_the_service_seam():
+    """Local AND server rows both present -- selecting the local one must
+    route through the local seam and never touch the server client."""
+    server_client = AutomationsServerClient()
+    service = AutomationsMockService(server_client, local_definitions=[_local_definition()])
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        table = workbench.query_one("#scheduling-automations-table", DataTable)
+        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
+        tabs.active = "scheduling-automations-tab"
+        assert table.row_count == 3  # local row first, then the 2 server rows
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+        assert workbench._selected_automation_id == "local-def-1"
+
+        workbench.action_run_task_now()
+        await pilot.pause()
+        await pilot.pause()
+
+        service.run_automation_now.assert_awaited_once_with("local-def-1")
+        server_client.run_automation_definition_now.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_local_run_now_refusal_surfaces_without_raising():
+    server_client = MockServerClient(notifications_service=None)
+    service = AutomationsMockService(server_client, local_definitions=[_local_definition()])
+    service.run_automation_now = AsyncMock(return_value=None)
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        table = workbench.query_one("#scheduling-automations-table", DataTable)
+        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
+        tabs.active = "scheduling-automations-tab"
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+
+        workbench.action_run_task_now()
+        await pilot.pause()
+        await pilot.pause()
+
+        service.run_automation_now.assert_awaited_once()
+        assert workbench._selected_automation_id == "local-def-1"
+
+
+@pytest.mark.asyncio
+async def test_local_automation_history_says_not_available_yet():
+    server_client = MockServerClient(notifications_service=None)
+    service = AutomationsMockService(server_client, local_definitions=[_local_definition()])
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        table = workbench.query_one("#scheduling-automations-table", DataTable)
+        notice = workbench.query_one("#scheduling-automation-history-notice")
+
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+
+        assert "isn't available yet" in str(notice.content)
+
+
+@pytest.mark.asyncio
+async def test_refresh_after_local_save_shows_the_new_row():
+    """The exact gap the review named: a local save must not read as a no-op."""
+    server_client = MockServerClient(notifications_service=None)
+    service = AutomationsMockService(server_client, local_definitions=[])
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        table = workbench.query_one("#scheduling-automations-table", DataTable)
+        assert table.row_count == 0
+
+        # Simulate what save_definition("local") just wrote to the DB.
+        service.db._automation_definitions.append(_local_definition(name="Just saved"))
+
+        from types import SimpleNamespace
+
+        workbench._on_automation_form_result(
+            SimpleNamespace(status="saved", definition_id="local-def-1")
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        assert table.row_count == 1
+        assert table.get_cell_at((0, 0)) == "[This device] Just saved"
+
+
+# --- task-5 fix round: edit affordance ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_action_opens_form_prefilled_for_a_local_row():
+    server_client = MockServerClient(notifications_service=None)
+    service = AutomationsMockService(server_client, local_definitions=[_local_definition()])
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        table = workbench.query_one("#scheduling-automations-table", DataTable)
+        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
+        tabs.active = "scheduling-automations-tab"
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+
+        workbench.action_edit_task()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, AutomationDefinitionForm)
+        form = pilot.app.screen
+        assert form.query_one("#automation-name", Input).value == "Local digest"
+        runs_on = form.query_one("#automation-runs-on", Select)
+        assert runs_on.disabled
+        assert runs_on.value == "local"
+        assert form._definition_id == "local-def-1"
+
+
+@pytest.mark.asyncio
+async def test_edit_action_refuses_agent_task_rows():
+    server_client = AutomationsServerClient()
+    server_client.list_automation_definitions = AsyncMock(
+        return_value={
+            "items": [
+                {
+                    "id": "def-agent",
+                    "name": "Agent one",
+                    "family": "agent_task",
+                    "lifecycle": "configured",
+                    "health": "ready",
+                    "owner_id": "server:1",
+                }
+            ],
+            "total": 1,
+        }
+    )
+    service = AutomationsMockService(server_client)
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        table = workbench.query_one("#scheduling-automations-table", DataTable)
+        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
+        tabs.active = "scheduling-automations-tab"
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+
+        workbench.action_edit_task()
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, SchedulesWorkbench)
+        notifications = list(pilot.app._notifications)
+        assert any("recurring-question" in n.message for n in notifications)
+
+
+@pytest.mark.asyncio
+async def test_edit_action_mirrors_a_server_only_row_on_demand():
+    """A server row with no local shadow yet gets one created on the fly
+    (via the same upsert the sync pull uses) so `save_definition`'s
+    LOCAL-id contract for `definition_id` is honored."""
+    server_client = AutomationsServerClient()
+    service = AutomationsMockService(server_client)  # no local rows yet
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        table = workbench.query_one("#scheduling-automations-table", DataTable)
+        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
+        tabs.active = "scheduling-automations-tab"
+        table.cursor_coordinate = (0, 0)  # def-1, "Morning brief"
+        await pilot.pause()
+
+        assert service.db._automation_definitions == []
+
+        workbench.action_edit_task()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, AutomationDefinitionForm)
+        assert len(service.db._automation_definitions) == 1
+        mirrored = service.db._automation_definitions[0]
+        assert mirrored["server_id"] == "def-1"
+        assert mirrored["owner_id"] == "server:server-1"
+
+        form = pilot.app.screen
+        assert form._definition_id == mirrored["id"]
+        runs_on = form.query_one("#automation-runs-on", Select)
+        assert runs_on.disabled
+        assert runs_on.value == "server:server-1"
+
+
+@pytest.mark.asyncio
+async def test_edit_save_reports_updated_not_created():
+    """A save from the edit flow must say "updated", not the create-mode
+    "created" wording -- both routes share one result handler."""
+    server_client = MockServerClient(notifications_service=None)
+    service = AutomationsMockService(server_client, local_definitions=[_local_definition()])
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        from types import SimpleNamespace
+
+        workbench._on_automation_form_result(
+            SimpleNamespace(status="saved", definition_id="local-def-1"),
+            was_edit=True,
+        )
+        await pilot.pause()
+
+        notifications = list(pilot.app._notifications)
+        assert any(n.message == "Automation updated." for n in notifications)
+        assert not any(n.message == "Automation created." for n in notifications)

--- a/Tests/UI/test_schedules_automations_tab.py
+++ b/Tests/UI/test_schedules_automations_tab.py
@@ -455,6 +455,38 @@ async def test_merged_list_shows_both_local_and_server_rows_with_owner_prefix():
 
 
 @pytest.mark.asyncio
+async def test_offline_server_owned_row_is_listed_as_pending_sync():
+    """Final review I5: a "Runs on: Server" automation saved while offline
+    is owned by `server:*` but has no `server_id` yet -- it used to fall
+    between the local half (owner-filtered) and the server half (which has
+    never heard of it) and so appeared in NEITHER."""
+    pending_row = _local_definition(
+        id="local-def-pending",
+        owner_id="server:server-1",
+        server_id=None,
+        name="Queued digest",
+    )
+    server_client = AutomationsServerClient()
+    service = AutomationsMockService(server_client, local_definitions=[pending_row])
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        table = workbench.query_one("#scheduling-automations-table", DataTable)
+
+        names = [table.get_cell_at((i, 0)) for i in range(table.row_count)]
+        assert names[0] == "[server-1 · pending sync] Queued digest"
+        # Its `id` is the LOCAL one; editing must not treat it as a server
+        # id and mirror it back as a second row.
+        listed = workbench._automations[0]
+        assert (
+            await workbench._resolve_local_definition_id(service, listed)
+            == "local-def-pending"
+        )
+
+
+@pytest.mark.asyncio
 async def test_run_now_routes_local_automation_through_the_service_seam():
     """Local AND server rows both present -- selecting the local one must
     route through the local seam and never touch the server client."""

--- a/Tests/UI/test_schedules_new_button.py
+++ b/Tests/UI/test_schedules_new_button.py
@@ -1,8 +1,10 @@
 """Visible New button in the Schedule Queue pane (UX F-07).
 
 The only create affordance used to be the `c` key in the footer. This adds
-a primary button beside the "Schedule Queue" pane title, wired to the
-existing `action_create_reminder`.
+a primary button beside the "Schedule Queue" pane title. Task 5 upgrades
+its behavior from a direct reminder-form push to a two-item chooser
+(Reminder / Recurring question) -- the `c` key binding is unchanged and
+still opens the reminder form directly.
 """
 
 from __future__ import annotations
@@ -11,6 +13,9 @@ import pytest
 from textual.widgets import Button
 
 from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
+from tldw_chatbook.UI.Screens.scheduling.forms.new_task_choice_modal import (
+    NewTaskChoiceModal,
+)
 from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import (
     ReminderForm,
     SchedulesWorkbench,
@@ -34,7 +39,8 @@ class LocalOnlyBundledCSSTestApp(LocalOnlyTestApp):
 
 
 @pytest.mark.asyncio
-async def test_new_button_exists_and_opens_create_form():
+async def test_new_button_exists_and_opens_choice_chooser():
+    """task-5: the button now offers Reminder / Recurring question."""
     app = LocalOnlyTestApp()
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
@@ -49,7 +55,26 @@ async def test_new_button_exists_and_opens_create_form():
         button.press()
         await pilot.pause()
 
-        assert pushed and isinstance(pushed[0], ReminderForm)
+        assert pushed and isinstance(pushed[0], NewTaskChoiceModal)
+
+
+@pytest.mark.asyncio
+async def test_new_button_chooser_reminder_choice_opens_reminder_form():
+    """Picking "Reminder…" in the chooser opens the reminder form directly."""
+    app = LocalOnlyTestApp()
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        workbench.query_one("#scheduling-new-task", Button).press()
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, NewTaskChoiceModal)
+
+        await pilot.click("#new-task-choice-reminder")
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, ReminderForm)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -71,6 +71,10 @@ class MockSchedulingService(_MockSchedulingServiceMixin):
         self.updated: list[tuple[str, dict]] = []
         self.created: list[dict] = []
         self.deleted_ids: list[str] = []
+        # Mirrors the real signature's threaded owner (never a `set_owner`
+        # flip), so a cross-owner save is observable here.
+        self.created_owners: list[str | None] = []
+        self.updated_owners: list[str | None] = []
 
     async def list_reminders(self):
         return [
@@ -86,12 +90,16 @@ class MockSchedulingService(_MockSchedulingServiceMixin):
     async def list_tasks(self):
         return await self.list_reminders()
 
-    async def create_reminder(self, payload: dict):
+    async def create_reminder(self, payload: dict, *, owner_id: str | None = None):
         self.created.append(payload)
+        self.created_owners.append(owner_id)
         return ReminderTask(**payload)
 
-    async def update_reminder(self, task_id: str, fields: dict):
+    async def update_reminder(
+        self, task_id: str, fields: dict, *, owner_id: str | None = None
+    ):
         self.updated.append((task_id, fields))
+        self.updated_owners.append(owner_id)
         reminders = await self.list_reminders()
         task = reminders[0]
         for key, value in fields.items():
@@ -941,7 +949,10 @@ async def test_create_reminder_action_saves_new_reminder():
         assert len(service.created) == 1
         assert service.created[0]["title"] == "New reminder"
         assert service.created[0]["schedule_kind"] == "one_time"
+        # Owner threaded through the call, never a `set_owner` flip.
+        assert service.created_owners == [service.owner_id]
         notifications = list(pilot.app._notifications)
+        # Same-owner save: the plain toast, no "switch owner" hint.
         assert any(n.message == "Scheduled task created." for n in notifications)
 
 
@@ -983,8 +994,13 @@ async def test_create_reminder_for_a_different_runs_on_owner_queues_a_mutation(
     """task-5: picking a non-default "Runs on" owner in the create form
     rides the EXISTING `create_reminder` server-fallback/mutation path
     (no new persistence code) -- and the service's shared `owner_id` is
-    restored afterwards, not left pointed at the owner that was only
-    meant for this one save."""
+    never repointed at the owner that was only meant for this one save
+    (Qodo HIGH: the owner is threaded through the call, so no concurrent
+    worker can observe a temporary flip).
+
+    The toast is also checked here (Qodo MEDIUM): this list is owner-scoped,
+    so a reminder created for another owner cannot appear in it -- a bare
+    "Scheduled task created." reads as a lost save."""
     from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
     from tldw_chatbook.Scheduling.services.scheduling_service import SchedulingService
     from tldw_chatbook.Scheduling.services.server_client import ServerUnavailableError
@@ -1031,7 +1047,15 @@ async def test_create_reminder_for_a_different_runs_on_owner_queues_a_mutation(
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
-        assert service.owner_id == "local"  # flipped back after the save
+            toasts = [n.message for n in pilot.app._notifications]
+            assert any(
+                "Server (example.com)" in message
+                and "switch to that owner" in message
+                for message in toasts
+            ), f"the toast must name the owner it was created for; got {toasts}"
+
+        assert service.owner_id == "local"  # never repointed by the save
+        assert service.sync_engine.owner_id == "local"
         pending = db.get_pending_mutations(
             "server:example.com", primitive="reminder_task"
         )

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -11,7 +11,7 @@ import pytest
 # (TASK-15450); without it the widgets under test mount unstyled.
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from textual.containers import Horizontal
-from textual.widgets import Button, DataTable, Input, Static
+from textual.widgets import Button, DataTable, Input, Select, Static
 
 from tldw_chatbook.Scheduling.events import (
     DeleteTaskRequested,
@@ -974,6 +974,75 @@ async def test_edit_reminder_action_updates_existing_reminder():
         assert service.updated[0][1]["title"] == "Updated title"
         notifications = list(pilot.app._notifications)
         assert any(n.message == "Scheduled task updated." for n in notifications)
+
+
+@pytest.mark.asyncio
+async def test_create_reminder_for_a_different_runs_on_owner_queues_a_mutation(
+    tmp_path,
+):
+    """task-5: picking a non-default "Runs on" owner in the create form
+    rides the EXISTING `create_reminder` server-fallback/mutation path
+    (no new persistence code) -- and the service's shared `owner_id` is
+    restored afterwards, not left pointed at the owner that was only
+    meant for this one save."""
+    from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+    from tldw_chatbook.Scheduling.services.scheduling_service import SchedulingService
+    from tldw_chatbook.Scheduling.services.server_client import ServerUnavailableError
+
+    db = ScheduledTasksDB(tmp_path / "scheduled_tasks.db")
+    server_client = AsyncMock()
+    server_client.notifications_service = object()
+    server_client.create_reminder.side_effect = ServerUnavailableError("offline")
+    # A "server available" app also triggers the (unrelated) Automations-tab
+    # load on mount; give it a real return value so it settles cleanly
+    # instead of leaving an un-awaited AsyncMock coroutine at teardown.
+    server_client.list_automation_definitions = AsyncMock(
+        return_value={"items": [], "total": 0}
+    )
+    service = SchedulingService(db=db, server_client=server_client, runtime_source="local")
+
+    app = WorkbenchTestApp()
+    app.scheduling_service = service
+    app.runtime_policy = SimpleNamespace(
+        state=SimpleNamespace(active_server_id="example.com")
+    )
+    try:
+        async with app.run_test() as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+
+            pilot.app.screen.action_create_reminder()
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, ReminderForm)
+
+            runs_on = pilot.app.screen.query_one("#reminder-runs-on", Select)
+            option_values = [value for _label, value in runs_on._options]
+            assert option_values == ["local", "server:example.com"]
+            assert runs_on.value == "local"  # default = current screen owner
+            runs_on.value = "server:example.com"
+
+            pilot.app.screen.query_one("#reminder-title", Input).value = "Server reminder"
+            pilot.app.screen.query_one(
+                "#reminder-run-at", Input
+            ).value = "2099-08-28 09:00"
+
+            await pilot.click("#reminder-save")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+        assert service.owner_id == "local"  # flipped back after the save
+        pending = db.get_pending_mutations(
+            "server:example.com", primitive="reminder_task"
+        )
+        assert len(pending) == 1
+        assert pending[0]["payload"]["action"] == "create"
+        rows = db.list_reminder_tasks(owner_id="server:example.com")
+        assert len(rows) == 1
+        assert rows[0]["title"] == "Server reminder"
+        assert db.list_reminder_tasks(owner_id="local") == []
+    finally:
+        db.close()
 
 
 def test_sync_completed_event():

--- a/Tests/tldw_api/test_scheduled_tasks_automation_client.py
+++ b/Tests/tldw_api/test_scheduled_tasks_automation_client.py
@@ -12,6 +12,10 @@ from tldw_chatbook.tldw_api.scheduled_tasks_automation_schemas import (
     ScheduledTaskAutomationDefinitionList,
     ScheduledTaskAutomationRunNowResponse,
     ScheduledTaskAuditList,
+    ScheduledTaskDefinitionCreateRequest,
+    ScheduledTaskDefinitionUpdateRequest,
+    ScheduledTaskPreview,
+    ScheduledTaskPreviewCreateRequest,
     ScheduledTaskResult,
     ScheduledTaskResultList,
 )
@@ -265,3 +269,175 @@ async def test_review_result_sends_null_note_when_not_given(monkeypatch):
         "review_state": "read",
         "review_note": None,
     }
+
+
+_PREVIEW_FIXTURE = (
+    Path(__file__).resolve().parents[1]
+    / "Scheduling"
+    / "fixtures"
+    / "server_responses"
+    / "automation_preview_response.json"
+)
+
+
+def _load_preview_fixture_case(case_name: str) -> dict:
+    return json.loads(_PREVIEW_FIXTURE.read_text())[case_name]
+
+
+@pytest.mark.asyncio
+async def test_preview_definition_posts_to_previews_route(monkeypatch):
+    case = _load_preview_fixture_case("valid_recurring_question_create")
+    client = TLDWAPIClient("http://localhost:8000")
+    mocked = AsyncMock(return_value=case["response"])
+    monkeypatch.setattr(client, "_request", mocked)
+
+    request = ScheduledTaskPreviewCreateRequest(**case["request"])
+    result = await client.preview_scheduled_task_definition(request)
+
+    assert mocked.await_args.args[:2] == (
+        "POST",
+        "/api/v1/scheduled-tasks/previews",
+    )
+    assert mocked.await_args.kwargs["json_data"]["family"] == "recurring_question"
+    assert mocked.await_args.kwargs["json_data"]["name"] == "Daily stand-up summary"
+    # visibility_policy was null in the fixture request -- exclude_none drops it.
+    assert "visibility_policy" not in mocked.await_args.kwargs["json_data"]
+
+    assert isinstance(result, ScheduledTaskPreview)
+    assert result.status == "valid"
+    assert result.mode == "create"
+    assert result.family == "recurring_question"
+    assert result.schedule_preview == case["response"]["schedule_preview"]
+    assert result.normalized_config == case["response"]["normalized_config"]
+    # Round-trip-only fields are absent from the (pure-local-preview) fixture
+    # and default to None on the client model.
+    assert result.id is None
+    assert result.payload_hash is None
+
+
+@pytest.mark.asyncio
+async def test_preview_definition_excludes_unset_optional_fields_from_request_body(
+    monkeypatch,
+):
+    client = TLDWAPIClient("http://localhost:8000")
+    mocked = AsyncMock(
+        return_value={
+            "mode": "create",
+            "family": "recurring_question",
+            "status": "invalid",
+            "validation_errors": [],
+        }
+    )
+    monkeypatch.setattr(client, "_request", mocked)
+
+    request = ScheduledTaskPreviewCreateRequest(family="recurring_question")
+    await client.preview_scheduled_task_definition(request)
+
+    body = mocked.await_args.kwargs["json_data"]
+    assert body["mode"] == "create"
+    assert body["family"] == "recurring_question"
+    assert body["config"] == {}
+    assert body["schedule"] == {}
+    for optional_field in ("definition_id", "definition_version", "name", "description"):
+        assert optional_field not in body
+
+
+def test_preview_schema_validates_fixture_response_for_the_invalid_case():
+    case = _load_preview_fixture_case("invalid_recurring_question_bad_schedule_kind")
+    preview = ScheduledTaskPreview.model_validate(case["response"])
+    assert preview.status == "invalid"
+    assert preview.validation_errors == [
+        {
+            "field": "schedule.kind",
+            "code": "unsupported",
+            "message": "Unsupported schedule kind: monthly",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_definition_posts_to_definitions_route(monkeypatch):
+    client = TLDWAPIClient("http://localhost:8000")
+    mocked = AsyncMock(
+        return_value={
+            "id": "def-1",
+            "family": "recurring_question",
+            "name": "Daily stand-up summary",
+            "lifecycle": "paused",
+            "health": "ready",
+            "preview_id": "prev-1",
+        }
+    )
+    monkeypatch.setattr(client, "_request", mocked)
+
+    result = await client.create_scheduled_task_definition(
+        "prev-1", initial_lifecycle="paused"
+    )
+
+    assert mocked.await_args.args[:2] == (
+        "POST",
+        "/api/v1/scheduled-tasks/definitions",
+    )
+    assert mocked.await_args.kwargs["json_data"] == {
+        "preview_id": "prev-1",
+        "initial_lifecycle": "paused",
+    }
+    assert isinstance(result, ScheduledTaskAutomationDefinition)
+    assert result.id == "def-1"
+    assert result.lifecycle == "paused"
+    assert result.preview_id == "prev-1"
+
+
+@pytest.mark.asyncio
+async def test_create_definition_defaults_lifecycle_to_configured(monkeypatch):
+    client = TLDWAPIClient("http://localhost:8000")
+    mocked = AsyncMock(
+        return_value={
+            "id": "def-2",
+            "family": "recurring_question",
+            "name": "N",
+            "lifecycle": "configured",
+        }
+    )
+    monkeypatch.setattr(client, "_request", mocked)
+
+    await client.create_scheduled_task_definition("prev-2")
+
+    assert mocked.await_args.kwargs["json_data"] == {
+        "preview_id": "prev-2",
+        "initial_lifecycle": "configured",
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_definition_patches_definitions_route_with_id(monkeypatch):
+    client = TLDWAPIClient("http://localhost:8000")
+    mocked = AsyncMock(
+        return_value={
+            "id": "def-1",
+            "family": "recurring_question",
+            "name": "Renamed",
+            "lifecycle": "configured",
+            "version": 2,
+            "preview_id": "prev-3",
+        }
+    )
+    monkeypatch.setattr(client, "_request", mocked)
+
+    result = await client.update_scheduled_task_definition("def-1", "prev-3")
+
+    assert mocked.await_args.args[:2] == (
+        "PATCH",
+        "/api/v1/scheduled-tasks/definitions/def-1",
+    )
+    assert mocked.await_args.kwargs["json_data"] == {"preview_id": "prev-3"}
+    assert isinstance(result, ScheduledTaskAutomationDefinition)
+    assert result.version == 2
+    assert result.name == "Renamed"
+
+
+def test_definition_create_and_update_request_schemas_round_trip():
+    create = ScheduledTaskDefinitionCreateRequest(preview_id="prev-1")
+    assert create.initial_lifecycle == "configured"
+    update = ScheduledTaskDefinitionUpdateRequest(preview_id="prev-2")
+    assert update.preview_id == "prev-2"

--- a/Tests/tldw_api/test_scheduled_tasks_automation_client.py
+++ b/Tests/tldw_api/test_scheduled_tasks_automation_client.py
@@ -291,7 +291,14 @@ async def test_preview_definition_posts_to_previews_route(monkeypatch):
     mocked = AsyncMock(return_value=case["response"])
     monkeypatch.setattr(client, "_request", mocked)
 
-    request = ScheduledTaskPreviewCreateRequest(**case["request"])
+    # The fixture's `request` half models the local preview port's payload
+    # (where `visibility_policy` is `Any`-typed and sent as an explicit
+    # `null`), not the server's wire schema -- the wire schema types it as a
+    # plain non-nullable `dict[str, Any]` defaulting to `{}` per
+    # automation_endpoints.md, so drop that key here and let the model
+    # default apply instead of feeding the fixture's `null` into it.
+    request_payload = {k: v for k, v in case["request"].items() if k != "visibility_policy"}
+    request = ScheduledTaskPreviewCreateRequest(**request_payload)
     result = await client.preview_scheduled_task_definition(request)
 
     assert mocked.await_args.args[:2] == (
@@ -300,8 +307,9 @@ async def test_preview_definition_posts_to_previews_route(monkeypatch):
     )
     assert mocked.await_args.kwargs["json_data"]["family"] == "recurring_question"
     assert mocked.await_args.kwargs["json_data"]["name"] == "Daily stand-up summary"
-    # visibility_policy was null in the fixture request -- exclude_none drops it.
-    assert "visibility_policy" not in mocked.await_args.kwargs["json_data"]
+    # visibility_policy defaults to {} per the endpoints doc -- present
+    # (exclude_none only drops explicit None, not an empty-dict default).
+    assert mocked.await_args.kwargs["json_data"]["visibility_policy"] == {}
 
     assert isinstance(result, ScheduledTaskPreview)
     assert result.status == "valid"

--- a/tldw_chatbook/Notifications/server_notifications_service.py
+++ b/tldw_chatbook/Notifications/server_notifications_service.py
@@ -401,3 +401,94 @@ class ServerNotificationsService:
                 result_id, review_state, review_note=review_note
             )
         )
+
+    async def preview_scheduled_automation_definition(
+        self, request: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Create a server-side authoring preview (spec §5.1).
+
+        A preview never mutates a definition by itself -- it validates and
+        normalizes a payload and reports what the server WOULD persist --
+        but it still requires the same authoring credentials as create and
+        update, so all three of these seams gate on the CONFIGURE action (a
+        recorded plan ruling for this task; unlike ``review_scheduled_
+        automation_result`` above, there is no LIST/LAUNCH action here to
+        distinguish it from).
+
+        Args:
+            request: The preview request payload (``ScheduledTaskPreview
+                CreateRequest`` fields: ``mode``, ``family``,
+                ``definition_id``, ``definition_version``, ``name``,
+                ``description``, ``config``, ``input``, ``schedule``,
+                ``visibility_policy``, ``notification_policy``,
+                ``approval_policy``).
+
+        Returns:
+            The preview response (``status``/``validation_errors``/
+            ``normalized_config``/etc) as a JSON-mode dict.
+
+        Raises:
+            PolicyDeniedError: If the runtime policy refuses the action.
+        """
+        # Deferred import: avoid module-scope tldw_api schema import (task-285 phase 2).
+        from ..tldw_api.scheduled_tasks_automation_schemas import (
+            ScheduledTaskPreviewCreateRequest,
+        )
+
+        self._enforce("scheduler.automations.configure.server")
+        request_model = ScheduledTaskPreviewCreateRequest.model_validate(request)
+        return self._dump(
+            await self._require_client().preview_scheduled_task_definition(
+                request_model
+            )
+        )
+
+    async def create_scheduled_automation_definition(
+        self,
+        preview_id: str,
+        *,
+        initial_lifecycle: str = "configured",
+    ) -> dict[str, Any]:
+        """Create a server-side automation definition from a consumed preview.
+
+        Args:
+            preview_id: The valid create-mode preview to consume.
+            initial_lifecycle: Starting lifecycle -- ``"configured"``
+                (default) or ``"paused"``.
+
+        Returns:
+            The created definition row as a JSON-mode dict.
+
+        Raises:
+            PolicyDeniedError: If the runtime policy refuses the action.
+        """
+        self._enforce("scheduler.automations.configure.server")
+        return self._dump(
+            await self._require_client().create_scheduled_task_definition(
+                preview_id, initial_lifecycle=initial_lifecycle
+            )
+        )
+
+    async def update_scheduled_automation_definition(
+        self,
+        definition_id: str,
+        preview_id: str,
+    ) -> dict[str, Any]:
+        """Apply a consumed update-mode preview to an existing definition.
+
+        Args:
+            definition_id: The definition to update.
+            preview_id: The valid update-mode preview to consume.
+
+        Returns:
+            The updated definition row as a JSON-mode dict.
+
+        Raises:
+            PolicyDeniedError: If the runtime policy refuses the action.
+        """
+        self._enforce("scheduler.automations.configure.server")
+        return self._dump(
+            await self._require_client().update_scheduled_task_definition(
+                definition_id, preview_id
+            )
+        )

--- a/tldw_chatbook/Scheduling/automation_health.py
+++ b/tldw_chatbook/Scheduling/automation_health.py
@@ -10,9 +10,14 @@ PR (PR-6) surfaces it in the UI.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from tldw_chatbook.Scheduling.models import Health
+from tldw_chatbook.Scheduling.recurring_question_scope import (
+    library_source_types,
+    normalize_recurring_question_scope,
+)
 
 _CAPABILITY_UNAVAILABLE_REASON = (
     "Library RAG search is not available in this app instance."
@@ -21,6 +26,17 @@ _PERMISSION_REQUIRED_REASON = (
     "No LLM provider is configured for automation execution."
 )
 
+#: `library_source_types`'s Library-plural vocabulary (the same mapping
+#: `automation_execution.py` uses for retrieval, via
+#: `recurring_question_scope.py` -- imported above, not re-declared) mapped
+#: onto the `app` attribute that backs each source. `notes` and
+#: `conversations` both live in the same ChaChaNotes database.
+_SOURCE_DB_ATTR: dict[str, str] = {
+    "media": "media_db",
+    "notes": "chachanotes_db",
+    "conversations": "chachanotes_db",
+}
+
 #: Lazily populated with `automation_execution.resolve_execution_target` on
 #: first real use -- `automation_execution` pulls in the Library RAG
 #: answer-provider seams, heavier than this module's boot-census budget
@@ -28,6 +44,28 @@ _PERMISSION_REQUIRED_REASON = (
 #: module attribute (not a function-local import) so tests can monkeypatch
 #: it directly instead of needing the Library seams importable at all.
 resolve_execution_target: Any = None
+
+
+def _unreadable_scoped_source(app: Any, definition_row: dict) -> str | None:
+    """The first scoped source (Library-plural vocabulary) whose backing
+    `app` attribute is missing, or `None` when every scoped source resolves
+    to a live DB attribute.
+
+    Normalizes `definition_row["config"]["scope"]` with the same
+    `normalize_recurring_question_scope` / `library_source_types` pair
+    `automation_execution.py` uses for retrieval, so this check can never
+    name a source that a real run would not actually query (and vice
+    versa).
+    """
+    config = definition_row.get("config") if isinstance(definition_row, Mapping) else None
+    if not isinstance(config, Mapping):
+        config = {}
+    normalized_scope, _errors, _warnings = normalize_recurring_question_scope(config.get("scope"))
+    for source_type in library_source_types(normalized_scope):
+        attr = _SOURCE_DB_ATTR.get(source_type)
+        if attr is not None and getattr(app, attr, None) is None:
+            return source_type
+    return None
 
 
 def compute_local_health(app: Any, definition_row: dict) -> tuple[str, str]:
@@ -40,15 +78,19 @@ def compute_local_health(app: Any, definition_row: dict) -> tuple[str, str]:
        `recurring_question` family's only retrieval seam today; a service
        object without a callable `search` is not actually usable, however
        present the attribute is).
-    2. `permission_required` -- `resolve_execution_target` resolves no
+    2. `capability_unavailable` -- a source in the definition's scope
+       (`config.scope`) resolves to a Library source type whose backing
+       `app` DB attribute (`media_db`/`chachanotes_db`) is missing. The
+       reason names the unreadable source.
+    3. `permission_required` -- `resolve_execution_target` resolves no
        `provider` at any of its layers (definition `input`, `[scheduling]`
        config, or the Library RAG answer-provider default).
-    3. Otherwise `"ready"`, with an empty reason.
+    4. Otherwise `"ready"`, with an empty reason.
 
     Args:
         app: The running `TldwCli` app instance, checked for
-            `library_rag_search_service` and passed through to
-            `resolve_execution_target`.
+            `library_rag_search_service`/`media_db`/`chachanotes_db` and
+            passed through to `resolve_execution_target`.
         definition_row: The automation-definition row (as a dict) to
             evaluate.
 
@@ -63,6 +105,13 @@ def compute_local_health(app: Any, definition_row: dict) -> tuple[str, str]:
     service = getattr(app, "library_rag_search_service", None)
     if service is None or not callable(getattr(service, "search", None)):
         return Health.CAPABILITY_UNAVAILABLE.value, _CAPABILITY_UNAVAILABLE_REASON
+
+    unreadable_source = _unreadable_scoped_source(app, definition_row)
+    if unreadable_source is not None:
+        return (
+            Health.CAPABILITY_UNAVAILABLE.value,
+            f"The '{unreadable_source}' source is not available in this app instance.",
+        )
 
     if resolve_execution_target is None:
         from tldw_chatbook.Scheduling.automation_execution import (

--- a/tldw_chatbook/Scheduling/automation_health.py
+++ b/tldw_chatbook/Scheduling/automation_health.py
@@ -14,10 +14,9 @@ from collections.abc import Mapping
 from typing import Any
 
 from tldw_chatbook.Scheduling.models import Health
-from tldw_chatbook.Scheduling.recurring_question_scope import (
-    library_source_types,
-    normalize_recurring_question_scope,
-)
+
+# ADR-097: recurring_question_scope is imported function-level below -- this
+# module is boot-resident and the eager import tipped the ui-ready census.
 
 _CAPABILITY_UNAVAILABLE_REASON = (
     "Library RAG search is not available in this app instance."
@@ -64,6 +63,11 @@ def _unreadable_scoped_source(app: Any, definition_row: dict) -> str | None:
     config = definition_row.get("config") if isinstance(definition_row, Mapping) else None
     if not isinstance(config, Mapping):
         config = {}
+    from tldw_chatbook.Scheduling.recurring_question_scope import (
+        library_source_types,
+        normalize_recurring_question_scope,
+    )
+
     normalized_scope, _errors, _warnings = normalize_recurring_question_scope(config.get("scope"))
     for source_type in library_source_types(normalized_scope):
         attr = _SOURCE_DB_ATTR.get(source_type)

--- a/tldw_chatbook/Scheduling/automation_health.py
+++ b/tldw_chatbook/Scheduling/automation_health.py
@@ -29,11 +29,15 @@ _PERMISSION_REQUIRED_REASON = (
 #: `library_source_types`'s Library-plural vocabulary (the same mapping
 #: `automation_execution.py` uses for retrieval, via
 #: `recurring_question_scope.py` -- imported above, not re-declared) mapped
-#: onto the `app` attribute that backs each source. `notes` and
-#: `conversations` both live in the same ChaChaNotes database.
+#: onto the `app` attribute the real keyword-search seam
+#: (`Library/library_local_rag_search_service.py`) gates each source on:
+#: `_search_media`/`_search_notes` read `media_reading_scope_service`/
+#: `notes_scope_service` (never `media_db`/`chachanotes_db` -- those DB
+#: handles can be set while the scope service itself is unavailable, or
+#: vice versa), `_search_conversations` reads `chachanotes_db` directly.
 _SOURCE_DB_ATTR: dict[str, str] = {
-    "media": "media_db",
-    "notes": "chachanotes_db",
+    "media": "media_reading_scope_service",
+    "notes": "notes_scope_service",
     "conversations": "chachanotes_db",
 }
 
@@ -80,8 +84,9 @@ def compute_local_health(app: Any, definition_row: dict) -> tuple[str, str]:
        present the attribute is).
     2. `capability_unavailable` -- a source in the definition's scope
        (`config.scope`) resolves to a Library source type whose backing
-       `app` DB attribute (`media_db`/`chachanotes_db`) is missing. The
-       reason names the unreadable source.
+       `app` attribute (`media_reading_scope_service`/`notes_scope_service`/
+       `chachanotes_db` -- see `_SOURCE_DB_ATTR`) is missing. The reason
+       names the unreadable source.
     3. `permission_required` -- `resolve_execution_target` resolves no
        `provider` at any of its layers (definition `input`, `[scheduling]`
        config, or the Library RAG answer-provider default).
@@ -89,8 +94,9 @@ def compute_local_health(app: Any, definition_row: dict) -> tuple[str, str]:
 
     Args:
         app: The running `TldwCli` app instance, checked for
-            `library_rag_search_service`/`media_db`/`chachanotes_db` and
-            passed through to `resolve_execution_target`.
+            `library_rag_search_service`/`media_reading_scope_service`/
+            `notes_scope_service`/`chachanotes_db` and passed through to
+            `resolve_execution_target`.
         definition_row: The automation-definition row (as a dict) to
             evaluate.
 

--- a/tldw_chatbook/Scheduling/automation_preview.py
+++ b/tldw_chatbook/Scheduling/automation_preview.py
@@ -1,0 +1,224 @@
+"""Pure local preview service for Scheduled Tasks automation authoring.
+
+Runs the ported validators (`automation_validation.py`) against a payload
+shaped like the server's `ScheduledTaskPreviewCreateRequest`
+(`Tests/Scheduling/fixtures/server_responses/automation_endpoints.md`) and
+fills the existing `AutomationPreview` model -- no I/O, no server round
+trip. Mirrors the server's preview assembly (`_normalize_preview` /
+`_create_preview` in `scheduled_task_automation_service.py`): same
+mode-required/not-allowed errors, the same `normalized_config` shape, the
+same `warnings` shape (``[{"message": str}, ...]``), the same
+`visibility_policy` wrap (``{"mode": str}``), and the same
+``status = "invalid" if validation_errors else "valid"`` derivation.
+
+Only the `recurring_question` family is implemented. `agent_task`'s
+validator (`_validate_agent_task_config`, message redaction) is not
+ported in this task's scope; a payload requesting that family gets a
+single `family: unsupported` validation error rather than a crash. A
+`family` value that is not a recognized `AutomationFamily` member at all
+(not even `agent_task`) raises `ValueError` -- `family` is a UI-controlled
+selector, not free-form user input, so that is a caller-contract
+violation rather than a field error.
+
+`schedule_preview` is a local addition beyond the server's response: the
+server's response schema declares it as a bare `dict[str, Any]` and the
+service just puts the normalized `schedule` dict there (no next-run
+computation). Since this local preview never round-trips to a server, it
+adds a `next_occurrences` key -- up to three upcoming run times computed
+via `schedule_compute.compute_next_run_at` -- so an authoring modal has
+something concrete to show the user for "when will this run".
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from .automation_validation import (
+    field_error,
+    validate_recurring_question_config,
+    validate_schedule,
+)
+from .models import AutomationFamily, AutomationPreview, PreviewStatus
+from .schedule_compute import compute_next_run_at
+
+_OCCURRENCE_COUNT = 3
+
+
+def _normalize_visibility_policy(family: str, value: Any) -> str:
+    """Port of the server's `_normalize_visibility_policy`.
+
+    Args:
+        family: The automation family value (``"recurring_question"`` or
+            ``"agent_task"``), used only for the fallback default.
+        value: The raw ``visibility_policy`` payload value.
+
+    Returns:
+        A visibility-policy mode string: ``value`` itself when it is a
+        non-blank string; the ``"mode"``/``"visibility"``/``"policy"`` key
+        of ``value`` when it is a dict and one of those is a non-blank
+        string; otherwise the family's default (``"metadata_only"`` for
+        ``agent_task``, ``"findings_only"`` otherwise).
+    """
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if isinstance(value, dict):
+        mode = value.get("mode") or value.get("visibility") or value.get("policy")
+        if isinstance(mode, str) and mode.strip():
+            return mode.strip()
+    return "metadata_only" if family == "agent_task" else "findings_only"
+
+
+def _next_occurrences(schedule: dict[str, Any], *, now: datetime, count: int = _OCCURRENCE_COUNT) -> list[str]:
+    """Up to `count` sequential upcoming run times as UTC ISO-8601 strings.
+
+    Each occurrence is computed by advancing `now` to the previous
+    occurrence and calling `compute_next_run_at` again -- this naturally
+    terminates a spent `one_time` schedule at one entry and never raises,
+    since `compute_next_run_at` itself never raises on a malformed or
+    incomplete schedule (it just returns `None`, which stops the loop).
+
+    Args:
+        schedule: A normalized schedule dict (`validate_schedule`'s
+            output).
+        now: The time to compute occurrences from.
+        count: The maximum number of occurrences to return.
+
+    Returns:
+        Up to `count` ISO-8601 UTC datetime strings, in ascending order.
+    """
+    occurrences: list[str] = []
+    current = now
+    for _ in range(count):
+        next_run = compute_next_run_at(schedule, now=current)
+        if next_run is None:
+            break
+        occurrences.append(next_run.isoformat())
+        current = next_run
+    return occurrences
+
+
+def preview_automation_definition(payload: dict[str, Any], *, now: datetime | None = None) -> AutomationPreview:
+    """Validate and preview an automation-definition authoring payload.
+
+    Pure and synchronous -- no I/O. Runs the ported server validators
+    against a payload shaped like the server's
+    `ScheduledTaskPreviewCreateRequest` and returns a filled
+    `AutomationPreview`, matching the shape of the server's
+    `ScheduledTaskPreviewResponse`. Fields that are only meaningful after
+    a real server round trip (`id`, `payload_hash`, `risk_class`,
+    `expires_at`, `created_by`, `consumed_at`, `created_definition_id`)
+    are left at the model's defaults.
+
+    Args:
+        payload: A dict with `mode` (``"create"``/``"update"``, default
+            ``"create"``), `family` (required -- `"recurring_question"` or
+            `"agent_task"`), `definition_id`, `definition_version`,
+            `name`, `description`, `config`, `input`, `schedule`,
+            `visibility_policy`, `notification_policy`, `approval_policy`
+            -- see
+            `Tests/Scheduling/fixtures/server_responses/automation_endpoints.md`
+            (`ScheduledTaskPreviewCreateRequest`).
+        now: The current time, used to compute `schedule_preview`'s
+            upcoming occurrences. Defaults to `datetime.now(timezone.utc)`.
+
+    Returns:
+        An `AutomationPreview` with `status` `"valid"` or `"invalid"`,
+        `validation_errors` and `warnings` from every validator that ran,
+        and a `schedule_preview` dict (the normalized schedule plus a
+        `next_occurrences` list).
+
+    Raises:
+        ValueError: If `family` is missing or not a recognized
+            `AutomationFamily` member.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    family = AutomationFamily(payload.get("family"))
+    mode = payload.get("mode") or "create"
+    definition_id = payload.get("definition_id")
+    definition_version = payload.get("definition_version")
+
+    mode_errors: list[dict[str, Any]] = []
+    if mode == "update":
+        if not definition_id:
+            mode_errors.append(
+                field_error(
+                    "definition_id", "required_for_update", "Definition id is required for update previews."
+                )
+            )
+        if definition_version is None:
+            mode_errors.append(
+                field_error(
+                    "definition_version",
+                    "required_for_update",
+                    "Definition version is required for update previews.",
+                )
+            )
+    else:
+        if definition_id is not None:
+            mode_errors.append(
+                field_error(
+                    "definition_id", "not_allowed_for_create", "Definition id is not allowed for create previews."
+                )
+            )
+        if definition_version is not None:
+            mode_errors.append(
+                field_error(
+                    "definition_version",
+                    "not_allowed_for_create",
+                    "Definition version is not allowed for create previews.",
+                )
+            )
+
+    schedule, schedule_errors, schedule_warnings = validate_schedule(payload.get("schedule") or {})
+    visibility_policy_str = _normalize_visibility_policy(family.value, payload.get("visibility_policy"))
+
+    base: dict[str, Any] = {
+        "name": payload.get("name"),
+        "description": payload.get("description"),
+        "config": payload.get("config") or {},
+        "input": payload.get("input") or {},
+        "schedule": schedule,
+        "visibility_policy": visibility_policy_str,
+        "notification_policy": payload.get("notification_policy") or {},
+        "approval_policy": payload.get("approval_policy") or {},
+    }
+
+    family_errors: list[dict[str, Any]] = []
+    if family is AutomationFamily.RECURRING_QUESTION:
+        normalized, errors, warnings = validate_recurring_question_config(base)
+    else:
+        normalized = dict(base)
+        errors = []
+        warnings = []
+        family_errors.append(
+            field_error("family", "unsupported", f"Unsupported automation family: {family.value}")
+        )
+    redaction_policy: dict[str, Any] = {"mode": "none", "fields": []}
+
+    normalized["family"] = family.value
+    normalized["schedule"] = schedule
+    normalized["visibility_policy"] = visibility_policy_str
+
+    validation_errors = [*mode_errors, *family_errors, *errors, *schedule_errors]
+    combined_warnings = [*warnings, *schedule_warnings]
+    warnings_out = [{"message": warning} for warning in combined_warnings]
+
+    schedule_preview = {**schedule, "next_occurrences": _next_occurrences(schedule, now=now)}
+    status = PreviewStatus.INVALID if validation_errors else PreviewStatus.VALID
+
+    return AutomationPreview(
+        mode=mode,
+        family=family,
+        definition_id=definition_id,
+        definition_version=definition_version,
+        status=status,
+        normalized_config=normalized,
+        validation_errors=validation_errors,
+        warnings=warnings_out,
+        visibility_policy={"mode": visibility_policy_str},
+        schedule_preview=schedule_preview,
+        redaction_policy=redaction_policy,
+    )

--- a/tldw_chatbook/Scheduling/automation_validation.py
+++ b/tldw_chatbook/Scheduling/automation_validation.py
@@ -1,0 +1,211 @@
+"""Validators for Scheduled Tasks automation-definition authoring.
+
+Ported from tldw_server `scheduled_task_automation_service.py` @
+e3c198224 -- byte-parity on behavior/codes/messages, not on docstrings
+(spec §7.1 drift rule; regenerate the parity tests below if the server
+module changes). Only the four validators this module's
+callers need are ported here, with the leading underscore dropped:
+`validate_schedule`, `validate_recurring_question_config`,
+`normalize_finding_policy`, `normalize_retention_policy`. Each accumulates
+field-addressed errors shaped ``{"field": str, "code": str, "message":
+str}``, exactly as the server emits them.
+
+`_validate_agent_task_config` and `_normalize_visibility_policy` (the
+`agent_task` family's validator, and preview-response shaping) are NOT
+ported here -- out of this task's scope; see `automation_preview.py` for
+the local `family: unsupported` handling of `agent_task` payloads.
+
+Reuses the already-ported `normalize_recurring_question_scope`
+(`recurring_question_scope.py`) rather than duplicating it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .recurring_question_scope import normalize_recurring_question_scope
+
+# Inlined from tldw_server `recurring_question_models.py` (only the three
+# constants these validators need -- same precedent as
+# `recurring_question_scope.py`'s own constant inlining).
+FINDING_POLICY_PRESETS = {"balanced_findings", "high_confidence_only"}
+GENERATION_MODES = {"disabled", "optional", "required"}
+RETENTION_POLICY_MODES = {"default", "custom"}
+
+_SUPPORTED_SCHEDULE_KINDS = {"one_time", "interval", "daily", "weekly", "cron"}
+
+
+def field_error(field: str, code: str, message: str) -> dict[str, str]:
+    """Build a field-addressed validation error dict.
+
+    Args:
+        field: Dotted field path the error applies to (e.g. ``"schedule.kind"``).
+        code: Machine-readable error code.
+        message: Human-readable message.
+
+    Returns:
+        A ``{"field", "code", "message"}`` dict, matching the server's shape.
+    """
+    return {"field": field, "code": code, "message": message}
+
+
+def validate_schedule(schedule: Any) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+    """Validate and normalize a raw ``schedule`` payload field.
+
+    Port of the server's ``_validate_schedule``.
+
+    Args:
+        schedule: The raw ``schedule`` value from a preview/definition
+            payload -- any value; only a dict is accepted.
+
+    Returns:
+        A ``(normalized, errors, warnings)`` tuple. ``normalized`` is a
+        shallow copy of ``schedule`` (or ``{}`` when it was not a dict).
+        ``errors`` reports a missing or unsupported ``kind`` (or a
+        non-dict ``schedule`` itself). ``warnings`` is always empty --
+        reserved, matches the server's signature.
+    """
+    errors: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    if not isinstance(schedule, dict):
+        return {}, [field_error("schedule", "invalid_type", "Schedule must be an object.")], warnings
+
+    normalized = dict(schedule)
+    kind = normalized.get("kind")
+    if not isinstance(kind, str) or not kind.strip():
+        errors.append(field_error("schedule.kind", "required", "Schedule kind is required."))
+    elif kind not in _SUPPORTED_SCHEDULE_KINDS:
+        errors.append(field_error("schedule.kind", "unsupported", f"Unsupported schedule kind: {kind}"))
+    else:
+        normalized["kind"] = kind
+    return normalized, errors, warnings
+
+
+def normalize_finding_policy(value: Any, errors: list[dict[str, Any]]) -> dict[str, Any]:
+    """Normalize a ``config.finding_policy`` value, appending errors in place.
+
+    Port of the server's ``_normalize_finding_policy``.
+
+    Args:
+        value: The raw ``finding_policy`` value -- any value; only a dict
+            contributes fields, everything else normalizes to the default
+            preset.
+        errors: The caller's error accumulator; an unsupported preset is
+            appended to it (not returned separately), matching the
+            server's in-place accumulation style.
+
+    Returns:
+        The policy dict with its ``preset`` normalized (defaulting to
+        ``"balanced_findings"``); other keys of ``value`` pass through
+        unchanged.
+    """
+    policy = dict(value) if isinstance(value, dict) else {}
+    preset = str(policy.get("preset") or "balanced_findings").strip() or "balanced_findings"
+    if preset not in FINDING_POLICY_PRESETS:
+        errors.append(
+            field_error(
+                "config.finding_policy.preset",
+                "unsupported",
+                f"Unsupported finding policy preset: {preset}",
+            )
+        )
+    return {**policy, "preset": preset}
+
+
+def normalize_retention_policy(value: Any, errors: list[dict[str, Any]]) -> dict[str, Any]:
+    """Normalize a ``config.retention_policy`` value, appending errors in place.
+
+    Port of the server's ``_normalize_retention_policy``.
+
+    Args:
+        value: The raw ``retention_policy`` value -- any value; only a
+            dict contributes fields, everything else normalizes to the
+            default mode.
+        errors: The caller's error accumulator; an unsupported mode is
+            appended to it (not returned separately), matching the
+            server's in-place accumulation style.
+
+    Returns:
+        The policy dict with its ``mode`` normalized (defaulting to
+        ``"default"``); other keys of ``value`` pass through unchanged.
+    """
+    policy = dict(value) if isinstance(value, dict) else {}
+    mode = str(policy.get("mode") or "default").strip() or "default"
+    if mode not in RETENTION_POLICY_MODES:
+        errors.append(
+            field_error(
+                "config.retention_policy.mode",
+                "unsupported",
+                f"Unsupported retention policy mode: {mode}",
+            )
+        )
+    return {**policy, "mode": mode}
+
+
+def validate_recurring_question_config(
+    config: dict[str, Any],
+) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+    """Validate and normalize a ``recurring_question`` preview's base config.
+
+    Port of the server's ``_validate_recurring_question_config``. ``config``
+    is the whole preview-request base dict (``name``, ``description``,
+    ``config``, ``input``, ``schedule``, ...), not just its own ``config``
+    sub-field -- matching the server's calling convention in
+    ``_normalize_preview``.
+
+    Args:
+        config: The preview-request base dict. ``config["config"]`` holds
+            the recurring-question option config (``scope``,
+            ``finding_policy``, ``retention_policy``, ``generation_mode``);
+            ``config["input"]`` holds ``question``.
+
+    Returns:
+        A ``(normalized, errors, warnings)`` tuple. ``normalized`` is
+        ``config`` with ``name``, ``input``, and ``config`` replaced by
+        their validated/normalized forms (``schedule`` and other keys
+        pass through untouched -- the caller is expected to overwrite
+        those itself, matching the server's ``_normalize_preview``).
+        ``errors`` covers a missing ``name``/``input.question``, an
+        unsupported ``generation_mode``, unsupported finding/retention
+        policy values, and any scope errors. ``warnings`` holds only the
+        scope warnings' ``code`` strings (the scope warning's ``source``
+        is dropped here -- a real server behavior, ported as-is).
+    """
+    errors: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    name = str(config.get("name") or "").strip()
+    option_config = dict(config.get("config") or {})
+    input_config = dict(config.get("input") or {})
+    question = str(input_config.get("question") or "").strip()
+
+    if not name:
+        errors.append(field_error("name", "required", "Name is required."))
+    if not question:
+        errors.append(field_error("input.question", "required", "Question is required."))
+
+    scope, scope_errors, scope_warnings = normalize_recurring_question_scope(option_config.get("scope"))
+    finding_policy = normalize_finding_policy(option_config.get("finding_policy"), errors)
+    retention_policy = normalize_retention_policy(option_config.get("retention_policy"), errors)
+    generation_mode = str(option_config.get("generation_mode") or "optional").strip() or "optional"
+    if generation_mode not in GENERATION_MODES:
+        errors.append(
+            field_error(
+                "config.generation_mode",
+                "unsupported",
+                f"Unsupported generation mode: {generation_mode}",
+            )
+        )
+
+    normalized = dict(config)
+    normalized["name"] = name
+    normalized["input"] = {**input_config, "question": question}
+    normalized["config"] = {
+        **option_config,
+        "scope": scope,
+        "finding_policy": finding_policy,
+        "retention_policy": retention_policy,
+        "generation_mode": generation_mode,
+    }
+    errors.extend(scope_errors)
+    warnings.extend(warning["code"] for warning in scope_warnings)
+    return normalized, errors, warnings

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -1789,7 +1789,36 @@ class ScheduledTasksDB(BaseDB):
         return {"inserted": inserted, "updated": updated}
 
     def _serialize_definition_fields(self, fields: dict[str, Any]) -> dict[str, Any]:
-        """Apply the same JSON/datetime conversion `update_automation_definition` uses."""
+        """Apply the same JSON/datetime conversion `update_automation_definition` uses.
+
+        Also strips a `config.scope.resolved_sources` key when present
+        (task 6 fix-round finding): both server-mirror write paths --
+        `adopt_server_definition_identity` and
+        `upsert_automation_definitions_from_server` -- route every
+        definition write through here, so this is the single choke point
+        that covers both. `normalize_recurring_question_scope`'s
+        `"all_searchable_library"` branch (`recurring_question_scope.py`)
+        computes `resolved_sources` fresh on every call as an OUTPUT
+        projection, never an accepted input field -- persisting a
+        server-echoed copy of it would make any later re-normalization of
+        this row's scope (a scheduled dispatch, the sources-readable
+        health check) report a spurious "unsupported field" error and
+        degrade every run. Same bug, same fix shape as the local-authoring
+        path's (`SchedulingService._definition_db_fields_from_preview`),
+        which is a separate write path (`create_automation_definition`/
+        `update_automation_definition` serialize inline, never through
+        this method) and still needs its own strip.
+        """
+        config = fields.get("config")
+        if isinstance(config, dict):
+            scope = config.get("scope")
+            if isinstance(scope, dict) and "resolved_sources" in scope:
+                fields = dict(fields)
+                fields["config"] = {
+                    **config,
+                    "scope": {k: v for k, v in scope.items() if k != "resolved_sources"},
+                }
+
         serialized: dict[str, Any] = {}
         for key, value in fields.items():
             if key in self._AUTOMATION_JSON_FIELDS:

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -1012,13 +1012,30 @@ class ScheduledTasksDB(BaseDB):
     # ------------------------------------------------------------------
 
     def create_automation_definition(
-        self, owner_id: str, family: str, name: str, **kwargs: Any
+        self,
+        owner_id: str,
+        family: str,
+        name: str,
+        *,
+        pending_mutation: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> str:
         """Create an automation definition and return its generated local UUID.
 
         Defaults ``lifecycle`` to ``configured`` and ``health`` to
         ``execution_unavailable`` when not provided. JSON fields are serialized
         and datetime fields are converted to UTC ISO-8601 strings.
+
+        When ``pending_mutation`` is given (``{"primitive", "owner_id",
+        "payload"}``), an ``automation_definition`` mutation is recorded in
+        ``pending_mutations`` in the SAME transaction as the INSERT --
+        mirrors ``update_result_review``'s ``pending_mutation`` precedent,
+        so a crash between the two writes can never leave a local row
+        without the outbox row that pushes it. Unlike that precedent,
+        the dict carries no ``local_id``: this call generates the
+        definition's id itself, so the mutation is always keyed by the id
+        this call returns, not one the caller could have supplied ahead
+        of time.
         """
         self._validate_kwargs(
             kwargs, self._AUTOMATION_DEFINITION_COLUMNS, "automation definition"
@@ -1026,6 +1043,7 @@ class ScheduledTasksDB(BaseDB):
 
         definition_id = str(uuid.uuid4())
         now = datetime.now(timezone.utc)
+        now_iso = self._to_utc_iso(now)
 
         fields: dict[str, Any] = {
             "id": definition_id,
@@ -1035,8 +1053,8 @@ class ScheduledTasksDB(BaseDB):
             "lifecycle": "configured",
             "health": "execution_unavailable",
             "version": 1,
-            "created_at": self._to_utc_iso(now),
-            "updated_at": self._to_utc_iso(now),
+            "created_at": now_iso,
+            "updated_at": now_iso,
         }
 
         for key, value in kwargs.items():
@@ -1058,6 +1076,15 @@ class ScheduledTasksDB(BaseDB):
                 f"INSERT INTO automation_definitions ({columns}) VALUES ({placeholders})",
                 list(fields.values()),
             )
+            if pending_mutation is not None:
+                self._insert_pending_mutation_conn(
+                    conn,
+                    local_id=definition_id,
+                    primitive=pending_mutation["primitive"],
+                    owner_id=pending_mutation["owner_id"],
+                    payload=pending_mutation["payload"],
+                    now_iso=now_iso,
+                )
 
         logger.debug(
             f"Created automation definition {definition_id} for owner {owner_id}"
@@ -1069,6 +1096,25 @@ class ScheduledTasksDB(BaseDB):
         with closing(self._get_connection()) as conn:
             cursor = conn.execute(
                 "SELECT * FROM automation_definitions WHERE id = ?", (definition_id,)
+            )
+            return self._row_to_dict(
+                cursor.fetchone(), json_fields=self._AUTOMATION_JSON_FIELDS
+            )
+
+    def get_automation_definition_by_server_id(
+        self, owner_id: str, server_id: str
+    ) -> Optional[dict[str, Any]]:
+        """Fetch an automation definition by owner and server-side identifier.
+
+        Mirrors ``get_reminder_task_by_server_id``. Used by the authoring
+        facade (Task 4) to recover the local row an online create just
+        mirrored via ``upsert_automation_definitions_from_server`` -- that
+        upsert reports only insert/update counts, not the generated id.
+        """
+        with closing(self._get_connection()) as conn:
+            cursor = conn.execute(
+                "SELECT * FROM automation_definitions WHERE owner_id = ? AND server_id = ?",
+                (owner_id, server_id),
             )
             return self._row_to_dict(
                 cursor.fetchone(), json_fields=self._AUTOMATION_JSON_FIELDS
@@ -1158,7 +1204,12 @@ class ScheduledTasksDB(BaseDB):
             return self._rows_to_dicts(rows, json_fields=self._AUTOMATION_JSON_FIELDS)
 
     def update_automation_definition(
-        self, definition_id: str, *, bump_version: bool = True, **kwargs: Any
+        self,
+        definition_id: str,
+        *,
+        bump_version: bool = True,
+        pending_mutation: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> bool:
         """Update automation-definition fields. Returns True if a row changed.
 
@@ -1167,6 +1218,14 @@ class ScheduledTasksDB(BaseDB):
         ``bump_version=False`` for a non-edit update (e.g. the scheduler's
         `next_run_at` advance) so version churn doesn't pollute conflict
         detection -- PR-2 final-review parking note.
+
+        When ``pending_mutation`` is given (``{"primitive", "owner_id",
+        "payload"}``), an ``automation_definition`` mutation is recorded in
+        ``pending_mutations`` -- keyed by ``definition_id`` -- in the SAME
+        transaction as the UPDATE, same atomicity precedent as
+        ``create_automation_definition``'s. Never recorded when the row
+        didn't change (unknown ``definition_id``): there is nothing to
+        push.
         """
         if not kwargs:
             return False
@@ -1199,7 +1258,8 @@ class ScheduledTasksDB(BaseDB):
         if bump_version:
             updates.append("version = version + 1")
         updates.append("updated_at = ?")
-        params.append(self._to_utc_iso(datetime.now(timezone.utc)))
+        now_iso = self._to_utc_iso(datetime.now(timezone.utc))
+        params.append(now_iso)
         params.append(definition_id)
 
         with self.transaction() as conn:
@@ -1207,7 +1267,17 @@ class ScheduledTasksDB(BaseDB):
                 f"UPDATE automation_definitions SET {', '.join(updates)} WHERE id = ?",
                 params,
             )
-            return cursor.rowcount > 0
+            changed = cursor.rowcount > 0
+            if changed and pending_mutation is not None:
+                self._insert_pending_mutation_conn(
+                    conn,
+                    local_id=definition_id,
+                    primitive=pending_mutation["primitive"],
+                    owner_id=pending_mutation["owner_id"],
+                    payload=pending_mutation["payload"],
+                    now_iso=now_iso,
+                )
+            return changed
 
     def delete_automation_definition(self, definition_id: str) -> bool:
         """Delete an automation definition by local id."""
@@ -2037,6 +2107,37 @@ class ScheduledTasksDB(BaseDB):
     # ------------------------------------------------------------------
     # Pending mutations
     # ------------------------------------------------------------------
+
+    def _insert_pending_mutation_conn(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        local_id: str,
+        primitive: str,
+        owner_id: str,
+        payload: dict[str, Any],
+        now_iso: str,
+    ) -> None:
+        """Insert one pending-mutation row on an already-open transaction.
+
+        Shared by callers that record a mutation atomically alongside
+        another write -- same ``INSERT OR REPLACE`` + auto-filled
+        ``idempotency_key`` behavior as the standalone
+        ``record_pending_mutation``, factored out of ``update_result_
+        review``'s inline precedent so ``create_automation_definition``/
+        ``update_automation_definition`` can reuse it (Task 4).
+        """
+        stored_payload = dict(payload)
+        if not stored_payload.get("idempotency_key"):
+            stored_payload["idempotency_key"] = str(uuid.uuid4())
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO pending_mutations
+            (local_id, primitive, owner_id, payload, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (local_id, primitive, owner_id, self._to_json(stored_payload), now_iso),
+        )
 
     def record_pending_mutation(
         self,

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -1730,6 +1730,54 @@ class ScheduledTasksDB(BaseDB):
                 serialized[key] = value
         return serialized
 
+    def adopt_server_definition_identity(
+        self, local_id: str, server_item: dict[str, Any]
+    ) -> bool:
+        """Adopt a server identity onto a local row after a create/update push.
+
+        Called by `SyncEngine`'s definition push replay (Task 3) right
+        after a `create`/`update` mutation succeeds: sets `server_id` and
+        applies every server-wins field from `server_item` (the create/
+        update response echo) in ONE transaction, same field set and
+        `transfer_state` exclusion as `upsert_automation_definitions_from_
+        server`'s existing-row branch -- but keyed by the local row
+        directly (``id = local_id``) since the caller already knows which
+        local row this mutation came from, rather than matching by
+        ``(owner_id, server_id)``.
+
+        Args:
+            local_id: The local definition row that pushed the mutation.
+            server_item: The definition row echoed back by the server's
+                create/update response.
+
+        Returns:
+            ``True`` if a local row was found and updated, ``False``
+            otherwise (e.g. the row was deleted locally in the meantime).
+        """
+        server_id = server_item.get("id")
+        if not server_id:
+            return False
+
+        fields: dict[str, Any] = {
+            key: server_item[key]
+            for key in self._AUTOMATION_DEFINITION_COLUMNS
+            if key in server_item and key not in {"id", "server_id", "owner_id"}
+        }
+        # §6 parked finding, same as the pull-mirror upsert: transfer_state
+        # is a local-only marker a server echo must never overwrite.
+        fields.pop("transfer_state", None)
+        fields["server_id"] = server_id
+
+        serialized = self._serialize_definition_fields(fields)
+        self._validate_sql_identifiers(list(serialized.keys()))
+        updates = ", ".join(f"{key} = ?" for key in serialized)
+        with self.transaction() as conn:
+            cursor = conn.execute(
+                f"UPDATE automation_definitions SET {updates} WHERE id = ?",
+                [*serialized.values(), local_id],
+            )
+            return cursor.rowcount > 0
+
     def upsert_automation_results_from_server(
         self,
         owner_id: str,

--- a/tldw_chatbook/Scheduling/services/__init__.py
+++ b/tldw_chatbook/Scheduling/services/__init__.py
@@ -1,4 +1,4 @@
-from .scheduling_service import SchedulingService
+from .scheduling_service import SaveDefinitionOutcome, SchedulingService
 from .server_client import (
     SchedulingServerClient,
     ServerClientConfig,
@@ -14,6 +14,7 @@ __all__ = [
     "SchedulingServerClient",
     "ServerUnavailableError",
     "SchedulingService",
+    "SaveDefinitionOutcome",
     "ServerClientConfig",
     "ServerClientError",
     "ServerClientNotFoundError",

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -19,8 +19,10 @@ from croniter import croniter
 from loguru import logger
 
 from tldw_chatbook.Scheduling.automation_health import compute_local_health
-from tldw_chatbook.Scheduling.automation_preview import preview_automation_definition
-from tldw_chatbook.Scheduling.automation_validation import field_error
+# ADR-097: automation_preview / automation_validation / schedule_compute are
+# imported function-level in the authoring facade below -- this module is
+# boot-resident and eager imports of the authoring stack breached the
+# ui-ready census (975 > 972).
 from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
 from tldw_chatbook.Scheduling.models import (
     AutomationFamily,
@@ -31,7 +33,6 @@ from tldw_chatbook.Scheduling.models import (
     ScheduleKind,
     ScheduledTask,
 )
-from tldw_chatbook.Scheduling.schedule_compute import compute_next_run_at
 from tldw_chatbook.Scheduling.services.briefing_projection import BriefingProjection
 from tldw_chatbook.Scheduling.services.server_client import (
     SchedulingServerClient,
@@ -155,6 +156,8 @@ def _policy_denied_outcome(
     save this facade knows can never succeed must be reported as failed
     now, not queued as if it will eventually sync.
     """
+    from tldw_chatbook.Scheduling.automation_validation import field_error
+
     return SaveDefinitionOutcome(
         status="error",
         errors=[
@@ -706,6 +709,8 @@ class SchedulingService:
         `agent_task` that is a scope cut, not real server parity, and must
         never reach a caller through this facade.
         """
+        from tldw_chatbook.Scheduling.automation_preview import preview_automation_definition
+
         guard = self._reject_unsupported_family(payload)
         if guard is not None:
             return guard
@@ -776,6 +781,9 @@ class SchedulingService:
         never cleared), so queuing here would report "queued" for a save
         that can never sync (review round 1 finding 1).
         """
+        from tldw_chatbook.Scheduling.automation_preview import preview_automation_definition
+        from tldw_chatbook.Scheduling.automation_validation import field_error
+
         guard = self._reject_unsupported_family(payload)
         if guard is not None:
             return SaveDefinitionOutcome(
@@ -893,6 +901,8 @@ class SchedulingService:
         and queues exactly one `automation_definition` mutation in the
         SAME transaction as that write.
         """
+        from tldw_chatbook.Scheduling.automation_preview import preview_automation_definition
+
         logger.warning(
             "Server unreachable while saving automation definition for "
             "{owner_id} ({exc}); queuing for later sync",
@@ -1058,6 +1068,8 @@ class SchedulingService:
         config["visibility_policy"]`, which Task 1's preview deliberately
         leaves as the flat mode string.
         """
+        from tldw_chatbook.Scheduling.schedule_compute import compute_next_run_at
+
         normalized = preview.normalized_config or {}
         schedule = normalized.get("schedule") or {}
         return {
@@ -1087,6 +1099,8 @@ class SchedulingService:
             anything other than `recurring_question`; `None` when the
             guard passes and the caller should proceed to a real preview.
         """
+        from tldw_chatbook.Scheduling.automation_validation import field_error
+
         family_value = payload.get("family")
         if family_value == _SUPPORTED_AUTOMATION_FAMILY:
             return None

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -38,6 +38,7 @@ from tldw_chatbook.Scheduling.services.server_client import (
     SchedulingServerClient,
     ServerClientError,
     ServerClientPolicyError,
+    ServerClientValidationError,
     ServerUnavailableError,
 )
 from tldw_chatbook.Scheduling.services.sync_engine import SyncEngine
@@ -142,28 +143,43 @@ def _seam_failure_warning(exc: Exception) -> dict[str, str]:
     }
 
 
-def _policy_denied_outcome(
+def _server_refused_outcome(
     exc: Exception, definition_id: str | None
 ) -> SaveDefinitionOutcome:
-    """Build the `SaveDefinitionOutcome` for a `ServerClientPolicyError` refusal.
+    """Build the `SaveDefinitionOutcome` for a refusal that replaying cannot fix.
 
-    A deterministic, pre-network policy refusal must NOT fall back to the
-    offline queue path (review round 1 finding 1): `SyncEngine._push_
-    definition_create`/`_push_definition_update` would replay the identical
-    preview request and hit the identical refusal, and `_run_phase` treats
-    `ServerClientPolicyError` as "not applicable" and swallows it silently
-    -- no sync error recorded, mutation never cleared, never surfaced. A
-    save this facade knows can never succeed must be reported as failed
-    now, not queued as if it will eventually sync.
+    Covers every `ServerClientValidationError` -- a local pre-network
+    policy refusal (`ServerClientPolicyError`) AND any server-side 4xx
+    (`server_client._call_with_retry` maps 400..499 except 404 to this
+    class and never retries it): 409 `definition_version_conflict`, 409
+    `definition_archived`, 422 `schedule_invalid`, ...
+
+    None of these may fall back to the offline queue path (review round 1
+    finding 1, final review C2): `SyncEngine._push_definition_create`/
+    `_push_definition_update` would replay the identical request and hit
+    the identical refusal forever, and for a policy refusal `_run_phase`
+    even treats it as "not applicable" and swallows it silently -- no sync
+    error recorded, mutation never cleared, never surfaced. A save this
+    facade knows can never succeed must be reported as failed now, not
+    queued as if it will eventually sync.
+
+    Retryable failures (`ServerUnavailableError`/`ServerClientTimeoutError`
+    /`ServerClientServerError`, and a 404 the sync engine converts to a
+    create) still take the offline-queue path.
     """
     from tldw_chatbook.Scheduling.automation_validation import field_error
 
+    code = (
+        "policy_denied"
+        if isinstance(exc, ServerClientPolicyError)
+        else "server_rejected"
+    )
     return SaveDefinitionOutcome(
         status="error",
         errors=[
             field_error(
                 "_owner",
-                "policy_denied",
+                code,
                 f"The server refused this automation: {exc}",
             )
         ],
@@ -773,13 +789,17 @@ class SchedulingService:
         `create_automation_definition`/`update_automation_definition`'s
         `pending_mutation` kwarg) for `SyncEngine` to replay later.
 
-        Server owner, policy-refused (`ServerClientPolicyError` -- a
-        deterministic, pre-network refusal, not a transport failure):
-        returns `status="error"` and writes nothing. NOT queued -- a
-        replay would hit the identical refusal and `SyncEngine._run_phase`
-        swallows that error as "not applicable" (never surfaced, mutation
-        never cleared), so queuing here would report "queued" for a save
-        that can never sync (review round 1 finding 1).
+        Server owner, refused for good (`ServerClientValidationError` --
+        a deterministic pre-network policy refusal, or any server-side
+        4xx: 409 version conflict, 422 schedule invalid, ...): returns
+        `status="error"` and writes nothing. NOT queued -- a replay would
+        hit the identical refusal forever (review round 1 finding 1,
+        final review C2). See `_server_refused_outcome`.
+
+        Editing (`definition_id` given) MERGES the payload onto the stored
+        row (`_merge_definition_payload`), so a caller that omits a field
+        it does not author keeps that field's stored value instead of
+        wiping it (final review I4).
         """
         from tldw_chatbook.Scheduling.automation_preview import preview_automation_definition
         from tldw_chatbook.Scheduling.automation_validation import field_error
@@ -807,6 +827,7 @@ class SchedulingService:
                     ],
                     definition_id=definition_id,
                 )
+            payload = self._merge_definition_payload(payload, local_row)
 
         if not self._owner_uses_server(owner_id):
             mode = "update" if local_row is not None else "create"
@@ -845,8 +866,8 @@ class SchedulingService:
         assert self.server_client is not None
         try:
             response = await self.server_client.preview_automation_definition(request)
-        except ServerClientPolicyError as exc:
-            return _policy_denied_outcome(exc, definition_id)
+        except ServerClientValidationError as exc:
+            return _server_refused_outcome(exc, definition_id)
         except ServerClientError as exc:
             return await self._save_definition_offline(
                 request, owner_id, local_row, definition_id, server_mode, exc
@@ -870,8 +891,8 @@ class SchedulingService:
                 committed = await self.server_client.create_automation_definition(
                     preview_id
                 )
-        except ServerClientPolicyError as exc:
-            return _policy_denied_outcome(exc, definition_id)
+        except ServerClientValidationError as exc:
+            return _server_refused_outcome(exc, definition_id)
         except ServerClientError as exc:
             return await self._save_definition_offline(
                 request, owner_id, local_row, definition_id, server_mode, exc
@@ -900,6 +921,16 @@ class SchedulingService:
         payload still writes nothing. A valid one writes the local row
         and queues exactly one `automation_definition` mutation in the
         SAME transaction as that write.
+
+        The update branch passes `bump_version=False` (final review C1):
+        a server-owned row's `version` column MIRRORS the server's
+        (`upsert_automation_definitions_from_server`/`adopt_server_
+        definition_identity` copy it verbatim) and the server checks the
+        queued `definition_version` for exact equality. Bumping it locally
+        desynchronizes the mirror, and because `pending_mutations` is
+        `UNIQUE(local_id, primitive, owner_id)` a second offline edit
+        REPLACES the first with one carrying the drifted version -- which
+        the server then rejects (409) forever.
         """
         from tldw_chatbook.Scheduling.automation_preview import preview_automation_definition
 
@@ -933,6 +964,7 @@ class SchedulingService:
             await asyncio.to_thread(
                 self.db.update_automation_definition,
                 definition_id,
+                bump_version=False,
                 pending_mutation=pending_mutation,
                 **fields,
             )
@@ -1030,6 +1062,41 @@ class SchedulingService:
                 owner_id,
             )
         return saved_id
+
+    @staticmethod
+    def _merge_definition_payload(
+        payload: dict[str, Any], local_row: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Overlay an edit payload onto the stored row's fields (final review I4).
+
+        An authoring payload only carries the fields its author exposes --
+        the v1 modal has no input for `description`, `visibility_policy`,
+        `approval_policy` or `config.retention_policy`, and none for
+        `input.max_tokens` (which `automation_execution` reads). Without
+        this merge those fields are absent from the preview request, so the
+        normalizer defaults them, `_definition_db_fields_from_preview`
+        writes the defaults over the row, AND the server-owned update
+        PATCH sends the defaults too -- four fields silently destroyed by
+        a rename.
+
+        Rule: an OMITTED key keeps its stored value; a key the payload
+        carries wins, including an explicit `None` (so a caller that does
+        expose a field can still clear it). `config`/`input`/
+        `notification_policy` merge one level deep for the same reason,
+        which is why the form emits `provider`/`model` explicitly as
+        `None` when blank rather than omitting them.
+        """
+        merged: dict[str, Any] = {}
+        for key in ("description", "visibility_policy", "approval_policy"):
+            if key in local_row and local_row[key] is not None:
+                merged[key] = local_row[key]
+        merged.update(payload)
+        for key in ("config", "input", "notification_policy"):
+            stored = local_row.get(key)
+            incoming = payload.get(key)
+            if isinstance(stored, dict) and isinstance(incoming, dict):
+                merged[key] = {**stored, **incoming}
+        return merged
 
     @staticmethod
     def _build_definition_request(

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -9,6 +9,8 @@ server identity (``server:<user_id>``).
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
+from dataclasses import field as _dataclass_field
 from datetime import datetime, timezone
 from typing import Any, Callable
 from zoneinfo import ZoneInfo
@@ -17,16 +19,23 @@ from croniter import croniter
 from loguru import logger
 
 from tldw_chatbook.Scheduling.automation_health import compute_local_health
+from tldw_chatbook.Scheduling.automation_preview import preview_automation_definition
+from tldw_chatbook.Scheduling.automation_validation import field_error
 from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
 from tldw_chatbook.Scheduling.models import (
+    AutomationFamily,
+    AutomationPreview,
+    PreviewStatus,
     ReminderTask,
     ReviewState,
     ScheduleKind,
     ScheduledTask,
 )
+from tldw_chatbook.Scheduling.schedule_compute import compute_next_run_at
 from tldw_chatbook.Scheduling.services.briefing_projection import BriefingProjection
 from tldw_chatbook.Scheduling.services.server_client import (
     SchedulingServerClient,
+    ServerClientError,
     ServerUnavailableError,
 )
 from tldw_chatbook.Scheduling.services.sync_engine import SyncEngine
@@ -39,6 +48,16 @@ _REMINDER_PRIMITIVE = "reminder_task"
 #: mirroring how _REMINDER_PRIMITIVE is independently defined in each of
 #: those modules too.
 _RESULT_REVIEW_PRIMITIVE = "automation_result_review"
+
+#: Matches SyncEngine._DEFINITION_PRIMITIVE -- same duplication precedent
+#: as _RESULT_REVIEW_PRIMITIVE above (this module is the producer of these
+#: mutations, SyncEngine the consumer/replayer).
+_DEFINITION_PRIMITIVE = "automation_definition"
+
+#: v1 scope guard (schedules-handoff PR-4, task 4): only this family can be
+#: authored through `preview_definition`/`save_definition`. `agent_task`
+#: authoring rides a follow-up program -- see `_reject_unsupported_family`.
+_SUPPORTED_AUTOMATION_FAMILY = AutomationFamily.RECURRING_QUESTION.value
 
 # Fields that are local-only and should not be sent to the server.
 _LOCAL_ONLY_FIELDS = {
@@ -63,6 +82,49 @@ _REMINDER_SERVER_CREATE_FIELDS = {
     "link_id",
     "link_url",
 }
+
+
+@dataclass(slots=True)
+class SaveDefinitionOutcome:
+    """Result of `SchedulingService.save_definition` (Task 5's modal seam).
+
+    Attributes:
+        status: ``"saved"`` (committed locally, or to the server while
+            online), ``"queued"`` (server owner, seam unreachable -- the
+            local row was written and a mutation queued for the next
+            sync), ``"invalid"`` (the preview rejected the payload;
+            nothing was written), or ``"error"`` (an operational failure
+            unrelated to payload validity, e.g. an unknown
+            ``definition_id``).
+        errors: Field-addressed validation errors (``{"field", "code",
+            "message"}``), populated for ``"invalid"``/``"error"``.
+        definition_id: The local row id, when one exists after the call.
+            ``None`` only for ``"invalid"``/``"error"`` on a create (no
+            row was ever written).
+    """
+
+    status: str
+    errors: list[dict[str, Any]] = _dataclass_field(default_factory=list)
+    definition_id: str | None = None
+
+
+def _server_unreachable_warning(exc: Exception) -> dict[str, str]:
+    """Build the ``_owner``/``server_unreachable`` warning `preview_definition` appends.
+
+    Not a `field_error` (those are validation errors, not warnings) --
+    same ``{"field", "code", "message"}`` shape as `automation_preview.
+    py`'s own warning entries, addressed to the pseudo-field ``"_owner"``
+    since the failure is about the owner's server connectivity, not any
+    one authoring field.
+    """
+    return {
+        "field": "_owner",
+        "code": "server_unreachable",
+        "message": (
+            f"Could not reach the server to preview this automation ({exc}); "
+            "showing local validation only."
+        ),
+    }
 
 
 class SchedulingService:
@@ -576,6 +638,424 @@ class SchedulingService:
             pending_mutation=pending_mutation,
         )
         return updated
+
+    async def preview_definition(
+        self, payload: dict[str, Any], owner_id: str
+    ) -> AutomationPreview:
+        """Preview an automation-definition authoring payload (Task 5's live-feedback seam).
+
+        Routes by ``owner_id`` (not ``self.owner_id`` -- the modal can
+        preview for a different owner than the service's current active
+        one): a local owner runs Task 1's pure `preview_automation_
+        definition` directly (no I/O, so no `asyncio.to_thread`). A
+        server owner round-trips through `SchedulingServerClient.
+        preview_automation_definition`; when that round trip fails for
+        ANY reason (offline, timeout, 5xx, policy refusal), this falls
+        back to the same local pure preview with an extra warning
+        (``field="_owner"``, ``code="server_unreachable"``) appended, so
+        the modal still shows schedule feedback instead of a dead form.
+
+        v1 scope guard: `family` other than `"recurring_question"` is
+        rejected before any preview runs (`_reject_unsupported_family`) --
+        Task 1's pure preview fabricates a `family: unsupported` error for
+        `agent_task` that is a scope cut, not real server parity, and must
+        never reach a caller through this facade.
+        """
+        guard = self._reject_unsupported_family(payload)
+        if guard is not None:
+            return guard
+
+        if not self._owner_uses_server(owner_id):
+            return preview_automation_definition(payload)
+
+        assert self.server_client is not None
+        try:
+            response = await self.server_client.preview_automation_definition(
+                dict(payload)
+            )
+        except ServerClientError as exc:
+            logger.warning(
+                "Server preview unreachable for owner {owner_id} ({exc}); "
+                "falling back to local validation",
+                owner_id=owner_id,
+                exc=exc,
+            )
+            local_preview = preview_automation_definition(payload)
+            warnings = [*(local_preview.warnings or []), _server_unreachable_warning(exc)]
+            return local_preview.model_copy(update={"warnings": warnings})
+        return self._server_preview_to_model(response)
+
+    async def save_definition(
+        self,
+        payload: dict[str, Any],
+        owner_id: str,
+        definition_id: str | None = None,
+    ) -> SaveDefinitionOutcome:
+        """Create or update a local `recurring_question` automation definition.
+
+        Always previews first (create/save ruling 3): an invalid payload
+        writes nothing and returns its validation errors. ``definition_id``
+        (the LOCAL row id, ``None`` for a create) is this facade's own
+        source of truth for create-vs-update -- not whatever `payload`
+        happens to carry -- mirroring `SyncEngine`'s replay precedent
+        (Task 3) of overriding `mode`/`definition_id`/`definition_version`
+        on the outgoing request itself rather than trusting the payload.
+
+        Local owner: computes `next_run_at` and writes straight to
+        `ScheduledTasksDB` (`create_automation_definition`/
+        `update_automation_definition`).
+
+        Server owner, reachable: preview -> commit (`create_automation_
+        definition`/`update_automation_definition` on the server client)
+        -> mirror the echo locally. An existing local row is updated in
+        place (`adopt_server_definition_identity`, so an edit never
+        creates a second local row for the same definition); a brand-new
+        definition has no local row to adopt onto, so it goes through the
+        same server-mirror upsert the sync pull uses (`upsert_automation_
+        definitions_from_server`), then the freshly inserted row is
+        looked up by its new server id.
+
+        Server owner, seam unreachable (offline create, or an edit of a
+        row that was never synced): the LOCAL pure preview stands in for
+        the server's verdict (still "invalid -> write nothing"), the
+        local row is written (or updated), and one `automation_definition`
+        pending mutation is recorded atomically with it (same transaction,
+        `create_automation_definition`/`update_automation_definition`'s
+        `pending_mutation` kwarg) for `SyncEngine` to replay later.
+        """
+        guard = self._reject_unsupported_family(payload)
+        if guard is not None:
+            return SaveDefinitionOutcome(
+                status="invalid", errors=guard.validation_errors or [], definition_id=definition_id
+            )
+
+        local_row: dict[str, Any] | None = None
+        if definition_id is not None:
+            local_row = await asyncio.to_thread(
+                self.db.get_automation_definition, definition_id
+            )
+            if local_row is None:
+                return SaveDefinitionOutcome(
+                    status="error",
+                    errors=[
+                        field_error(
+                            "_definition",
+                            "not_found",
+                            f"Automation definition {definition_id} was not found.",
+                        )
+                    ],
+                    definition_id=definition_id,
+                )
+
+        if not self._owner_uses_server(owner_id):
+            mode = "update" if local_row is not None else "create"
+            request = self._build_definition_request(
+                payload,
+                mode=mode,
+                definition_id=definition_id if mode == "update" else None,
+                definition_version=local_row.get("version") if local_row else None,
+            )
+            preview = preview_automation_definition(request)
+            if preview.status != PreviewStatus.VALID:
+                return SaveDefinitionOutcome(
+                    status="invalid",
+                    errors=preview.validation_errors or [],
+                    definition_id=definition_id,
+                )
+            saved_id = await self._write_local_definition(
+                preview, owner_id, local_row, definition_id
+            )
+            self._notify_queue_changed()
+            return SaveDefinitionOutcome(status="saved", definition_id=saved_id)
+
+        # Server owner: offline-authored (never synced) rows push as a
+        # server create even when a local row already exists (Task 3's
+        # `_push_definition_mutation` precedent).
+        server_mode = (
+            "create" if local_row is None or not local_row.get("server_id") else "update"
+        )
+        request = self._build_definition_request(
+            payload,
+            mode=server_mode,
+            definition_id=local_row.get("server_id") if local_row else None,
+            definition_version=local_row.get("version") if local_row else None,
+        )
+
+        assert self.server_client is not None
+        try:
+            response = await self.server_client.preview_automation_definition(request)
+        except ServerClientError as exc:
+            return await self._save_definition_offline(
+                request, owner_id, local_row, definition_id, server_mode, exc
+            )
+
+        preview_dict = response if isinstance(response, dict) else {}
+        if preview_dict.get("status") != "valid":
+            return SaveDefinitionOutcome(
+                status="invalid",
+                errors=preview_dict.get("validation_errors") or [],
+                definition_id=definition_id,
+            )
+
+        preview_id = preview_dict.get("id")
+        try:
+            if server_mode == "update":
+                committed = await self.server_client.update_automation_definition(
+                    local_row["server_id"], preview_id
+                )
+            else:
+                committed = await self.server_client.create_automation_definition(
+                    preview_id
+                )
+        except ServerClientError as exc:
+            return await self._save_definition_offline(
+                request, owner_id, local_row, definition_id, server_mode, exc
+            )
+
+        committed = committed if isinstance(committed, dict) else {}
+        saved_id = await self._mirror_server_definition(
+            committed, owner_id, local_row, definition_id
+        )
+        self._notify_queue_changed()
+        return SaveDefinitionOutcome(status="saved", definition_id=saved_id)
+
+    async def _save_definition_offline(
+        self,
+        request: dict[str, Any],
+        owner_id: str,
+        local_row: dict[str, Any] | None,
+        definition_id: str | None,
+        server_mode: str,
+        exc: Exception,
+    ) -> SaveDefinitionOutcome:
+        """Server seam unreachable during save: local-first fallback.
+
+        Ruling 3 ("save always previews") still holds offline: the LOCAL
+        pure preview stands in for the server's verdict, so an invalid
+        payload still writes nothing. A valid one writes the local row
+        and queues exactly one `automation_definition` mutation in the
+        SAME transaction as that write.
+        """
+        logger.warning(
+            "Server unreachable while saving automation definition for "
+            "{owner_id} ({exc}); queuing for later sync",
+            owner_id=owner_id,
+            exc=exc,
+        )
+        local_preview = preview_automation_definition(request)
+        if local_preview.status != PreviewStatus.VALID:
+            return SaveDefinitionOutcome(
+                status="invalid",
+                errors=local_preview.validation_errors or [],
+                definition_id=definition_id,
+            )
+
+        fields = self._definition_db_fields_from_preview(local_preview)
+        mutation_payload = {
+            "action": server_mode,
+            "definition_payload": request,
+            "server_definition_id": local_row.get("server_id") if local_row else None,
+        }
+        pending_mutation = {
+            "primitive": _DEFINITION_PRIMITIVE,
+            "owner_id": owner_id,
+            "payload": mutation_payload,
+        }
+
+        if local_row is not None:
+            await asyncio.to_thread(
+                self.db.update_automation_definition,
+                definition_id,
+                pending_mutation=pending_mutation,
+                **fields,
+            )
+            saved_id = definition_id
+        else:
+            name = fields.pop("name")
+            saved_id = await asyncio.to_thread(
+                self.db.create_automation_definition,
+                owner_id,
+                _SUPPORTED_AUTOMATION_FAMILY,
+                name,
+                pending_mutation=pending_mutation,
+                **fields,
+            )
+
+        self._notify_queue_changed()
+        return SaveDefinitionOutcome(status="queued", definition_id=saved_id)
+
+    async def _write_local_definition(
+        self,
+        preview: AutomationPreview,
+        owner_id: str,
+        local_row: dict[str, Any] | None,
+        definition_id: str | None,
+    ) -> str:
+        """Write a valid local-owner preview's normalized fields to the DB."""
+        fields = self._definition_db_fields_from_preview(preview)
+        if local_row is not None:
+            await asyncio.to_thread(
+                self.db.update_automation_definition, definition_id, **fields
+            )
+            return definition_id
+
+        name = fields.pop("name")
+        return await asyncio.to_thread(
+            self.db.create_automation_definition,
+            owner_id,
+            _SUPPORTED_AUTOMATION_FAMILY,
+            name,
+            **fields,
+        )
+
+    async def _mirror_server_definition(
+        self,
+        server_item: dict[str, Any],
+        owner_id: str,
+        local_row: dict[str, Any] | None,
+        definition_id: str | None,
+    ) -> str | None:
+        """Mirror a create/update server echo onto the local cache; returns the local id.
+
+        An existing local row (an edit, synced or not) adopts the echoed
+        identity/fields in place (`adopt_server_definition_identity`) so
+        this never creates a second row for the same definition. A
+        brand-new definition has no local row to adopt onto, so it is
+        mirrored via the same server-mirror upsert the sync pull uses
+        (`upsert_automation_definitions_from_server`), then looked up by
+        its new server id -- that upsert reports only insert/update
+        counts, not the generated id.
+        """
+        if local_row is not None:
+            await asyncio.to_thread(
+                self.db.adopt_server_definition_identity, definition_id, server_item
+            )
+            return definition_id
+
+        await asyncio.to_thread(
+            self.db.upsert_automation_definitions_from_server, owner_id, [server_item]
+        )
+        server_id = server_item.get("id")
+        if server_id is None:
+            return None
+        mirrored = await asyncio.to_thread(
+            self.db.get_automation_definition_by_server_id, owner_id, server_id
+        )
+        return mirrored.get("id") if mirrored else None
+
+    @staticmethod
+    def _build_definition_request(
+        payload: dict[str, Any],
+        *,
+        mode: str,
+        definition_id: str | None,
+        definition_version: int | None,
+    ) -> dict[str, Any]:
+        """Build a server-preview-shaped request from an authoring payload.
+
+        Overrides `mode`/`definition_id`/`definition_version` from the
+        caller's own resolved state rather than trusting whatever the raw
+        payload carries -- this facade is the payload's producer, so it is
+        the authority on which mode a save/preview actually is (mirrors
+        `SyncEngine`'s replay precedent, Task 3).
+        """
+        request = dict(payload)
+        request["family"] = _SUPPORTED_AUTOMATION_FAMILY
+        request["mode"] = mode
+        if mode == "update":
+            request["definition_id"] = definition_id
+            request["definition_version"] = definition_version
+        else:
+            request.pop("definition_id", None)
+            request.pop("definition_version", None)
+        return request
+
+    @staticmethod
+    def _definition_db_fields_from_preview(preview: AutomationPreview) -> dict[str, Any]:
+        """Map a valid preview's normalized config onto automation-definition DB columns.
+
+        `visibility_policy` comes from the preview's own top-level field
+        (already wrapped `{"mode": str}`, matching the DB column's/server's
+        `ScheduledTaskDefinitionResponse` shape) rather than `normalized_
+        config["visibility_policy"]`, which Task 1's preview deliberately
+        leaves as the flat mode string.
+        """
+        normalized = preview.normalized_config or {}
+        schedule = normalized.get("schedule") or {}
+        return {
+            "name": normalized.get("name"),
+            "description": normalized.get("description"),
+            "schedule": schedule,
+            "input": normalized.get("input") or {},
+            "config": normalized.get("config") or {},
+            "visibility_policy": preview.visibility_policy or {},
+            "notification_policy": normalized.get("notification_policy") or {},
+            "approval_policy": normalized.get("approval_policy") or {},
+            "next_run_at": compute_next_run_at(schedule, now=datetime.now(timezone.utc)),
+        }
+
+    def _reject_unsupported_family(
+        self, payload: dict[str, Any]
+    ) -> AutomationPreview | None:
+        """v1 scope guard: only `family="recurring_question"` may be authored here.
+
+        Runs before any preview call so Task 1's local pure preview's
+        fabricated `family: unsupported` error for `agent_task` (a scope
+        cut it documents itself, not real server parity) never reaches a
+        caller through this facade.
+
+        Returns:
+            An already-invalid `AutomationPreview` when `family` is
+            anything other than `recurring_question`; `None` when the
+            guard passes and the caller should proceed to a real preview.
+        """
+        family_value = payload.get("family")
+        if family_value == _SUPPORTED_AUTOMATION_FAMILY:
+            return None
+        try:
+            family_enum = AutomationFamily(family_value)
+        except ValueError:
+            family_enum = AutomationFamily.RECURRING_QUESTION
+        return AutomationPreview(
+            mode=payload.get("mode") or "create",
+            family=family_enum,
+            definition_id=payload.get("definition_id"),
+            definition_version=payload.get("definition_version"),
+            status=PreviewStatus.INVALID,
+            validation_errors=[
+                field_error(
+                    "family",
+                    "unsupported",
+                    "Only recurring_question automations can be authored "
+                    "here (agent_task authoring is not yet available).",
+                )
+            ],
+        )
+
+    def _owner_uses_server(self, owner_id: str) -> bool:
+        """Return True when server operations should be attempted for `owner_id`.
+
+        Same rule as `_use_server`, parameterized: `preview_definition`/
+        `save_definition` take an explicit owner (the modal can target a
+        different owner than the service's current active one), so they
+        cannot use `_use_server`'s `self.owner_id`-bound check.
+        """
+        return self.server_client is not None and owner_id.startswith("server:")
+
+    def _server_preview_to_model(self, response: dict[str, Any]) -> AutomationPreview:
+        """Convert a server `ScheduledTaskPreviewResponse` dict into the model.
+
+        Drops null values before construction, mirroring `_row_to_
+        reminder`'s established idiom: every nullable server field already
+        has a model default (`None`, or `created_at`'s `default_factory`),
+        so a missing/null value falls back cleanly instead of failing
+        Pydantic validation (`created_at` is typed `datetime`, not
+        `datetime | None`).
+        """
+        if not isinstance(response, dict):
+            response = {}
+        fields = {key: value for key, value in response.items() if value is not None}
+        return AutomationPreview(**fields)
 
     def _use_server(self) -> bool:
         """Return True when server operations should be attempted."""

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -265,13 +265,28 @@ class SchedulingService:
         self.owner_id = owner_id
         self.sync_engine.owner_id = owner_id
 
-    async def create_reminder(self, payload: dict[str, Any]) -> ReminderTask:
+    async def create_reminder(
+        self, payload: dict[str, Any], *, owner_id: str | None = None
+    ) -> ReminderTask:
         """Create a reminder, preferring the server API when connected.
 
         If the server is unreachable or returns an error, the reminder is stored
         locally and a pending mutation is recorded so the sync engine can push it
         later.
+
+        Args:
+            payload: `ReminderTask` fields to create.
+            owner_id: Write this one reminder under a DIFFERENT owner than
+                the service's active one (the form's "Runs on" selector);
+                defaults to `self.owner_id`, so every existing caller is
+                unchanged. Explicit rather than a `set_owner` flip around
+                the awaited call: `owner_id` is shared mutable state that
+                concurrent workers (sync, refresh, run-now) read, and a
+                flip held across a network round-trip is visible to all of
+                them. Mirrors `_owner_uses_server(owner_id)`, the same
+                precedent `preview_definition`/`save_definition` use.
         """
+        owner_id = owner_id or self.owner_id
         task = ReminderTask(**payload)
         task.next_run_at = self._compute_next_run_at(task)
         server_payload = self._server_create_payload(task)
@@ -286,27 +301,29 @@ class SchedulingService:
             }
         )
 
-        use_server = self._use_server()
+        use_server = self._owner_uses_server(owner_id)
         if use_server:
             assert self.server_client is not None
             try:
                 response = await self.server_client.create_reminder(**server_payload)
-                return await self._persist_server_reminder_response(response)
+                return await self._persist_server_reminder_response(
+                    response, owner_id=owner_id
+                )
             except ServerUnavailableError:
                 logger.warning(
-                    f"Server unavailable while creating reminder for {self.owner_id}"
+                    f"Server unavailable while creating reminder for {owner_id}"
                 )
             except Exception as exc:  # noqa: BLE001 - server errors should fall back
                 logger.exception(
-                    f"Server create_reminder failed for {self.owner_id}: {exc}"
+                    f"Server create_reminder failed for {owner_id}: {exc}"
                 )
 
-        task_id = self.db.create_reminder_task(owner_id=self.owner_id, **db_fields)
+        task_id = self.db.create_reminder_task(owner_id=owner_id, **db_fields)
         if use_server:
             self.db.record_pending_mutation(
                 task_id,
                 _REMINDER_PRIMITIVE,
-                self.owner_id,
+                owner_id,
                 {"action": "create", "fields": server_payload},
             )
         self._notify_queue_changed()
@@ -341,18 +358,27 @@ class SchedulingService:
         return self._row_to_reminder(row)
 
     async def update_reminder(
-        self, task_id: str, payload: dict[str, Any]
+        self, task_id: str, payload: dict[str, Any], *, owner_id: str | None = None
     ) -> ReminderTask | None:
         """Update a reminder, preferring the server API when connected.
 
         Falls back to a local update plus a pending mutation if the server is
         unavailable or returns an error.
+
+        Args:
+            task_id: The local reminder row to update.
+            payload: The fields to change.
+            owner_id: The owner this update belongs to; defaults to
+                `self.owner_id`. Same rationale as `create_reminder`'s --
+                threaded explicitly so a cross-owner save never has to flip
+                the service's shared `owner_id` around an awaited call.
         """
+        owner_id = owner_id or self.owner_id
         row = self.db.get_reminder_task(task_id)
         if row is None:
             return None
 
-        use_server = self._use_server()
+        use_server = self._owner_uses_server(owner_id)
         if use_server:
             assert self.server_client is not None
             server_id = row.get("server_id")
@@ -368,15 +394,15 @@ class SchedulingService:
                         **merged_payload
                     )
                 return await self._persist_server_reminder_response(
-                    response, local_id=task_id
+                    response, local_id=task_id, owner_id=owner_id
                 )
             except ServerUnavailableError:
                 logger.warning(
-                    f"Server unavailable while updating reminder {task_id} for {self.owner_id}"
+                    f"Server unavailable while updating reminder {task_id} for {owner_id}"
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.exception(
-                    f"Server update_reminder failed for {task_id} ({self.owner_id}): {exc}"
+                    f"Server update_reminder failed for {task_id} ({owner_id}): {exc}"
                 )
 
         # Local path: compute next_run_at and clear stale schedule fields
@@ -399,7 +425,7 @@ class SchedulingService:
             self.db.record_pending_mutation(
                 task_id,
                 _REMINDER_PRIMITIVE,
-                self.owner_id,
+                owner_id,
                 {"action": "update", "fields": dict(payload)},
             )
         self._notify_queue_changed()
@@ -1164,6 +1190,16 @@ class SchedulingService:
             "visibility_policy": preview.visibility_policy or {},
             "notification_policy": normalized.get("notification_policy") or {},
             "approval_policy": normalized.get("approval_policy") or {},
+            # Dedicated DB columns, not merely `config` members: the executor
+            # reads `row["finding_policy"]` (`automation_execution.py`'s
+            # `_resolve_finding_policy`) and the run snapshot copies
+            # `task["finding_policy"]` (`automation_handler.py`), so a policy
+            # left only inside `config` reaches neither -- every locally
+            # authored or offline-queued definition ran with the column
+            # DEFAULT (`balanced_findings`) whatever the author picked.
+            # `retention_policy` has the same column and the same exposure.
+            "finding_policy": config.get("finding_policy") or {},
+            "retention_policy": config.get("retention_policy") or {},
             "next_run_at": compute_next_run_at(schedule, now=datetime.now(timezone.utc)),
         }
 
@@ -1290,8 +1326,16 @@ class SchedulingService:
         self,
         response: dict[str, Any],
         local_id: str | None = None,
+        *,
+        owner_id: str | None = None,
     ) -> ReminderTask:
-        """Insert or update the local cache from a server reminder response."""
+        """Insert or update the local cache from a server reminder response.
+
+        `owner_id` defaults to the service's active owner; `create_reminder`/
+        `update_reminder` pass their own so a cross-owner save lands under
+        the owner it was authored for.
+        """
+        owner_id = owner_id or self.owner_id
         local_fields = self._map_server_response_to_local(response)
         server_id = response.get("id")
 
@@ -1301,24 +1345,20 @@ class SchedulingService:
         else:
             existing = None
             if server_id:
-                existing = self.db.get_reminder_task_by_server_id(
-                    self.owner_id, server_id
-                )
+                existing = self.db.get_reminder_task_by_server_id(owner_id, server_id)
             if existing is not None:
                 task_id = existing["id"]
                 self.db.update_reminder_task(task_id, **local_fields)
             else:
                 task_id = self.db.create_reminder_task(
-                    owner_id=self.owner_id, **local_fields
+                    owner_id=owner_id, **local_fields
                 )
 
         if server_id:
-            self.db.set_sync_mapping(
-                task_id, server_id, _REMINDER_PRIMITIVE, self.owner_id
-            )
+            self.db.set_sync_mapping(task_id, server_id, _REMINDER_PRIMITIVE, owner_id)
 
         self.db.delete_pending_mutation_for_record(
-            task_id, _REMINDER_PRIMITIVE, self.owner_id
+            task_id, _REMINDER_PRIMITIVE, owner_id
         )
         self._notify_queue_changed()
 

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -1067,17 +1067,33 @@ class SchedulingService:
         `ScheduledTaskDefinitionResponse` shape) rather than `normalized_
         config["visibility_policy"]`, which Task 1's preview deliberately
         leaves as the flat mode string.
+
+        `config.scope.resolved_sources` (task 6 E2E finding) is stripped
+        before storage: `normalize_recurring_question_scope`'s
+        `"all_searchable_library"` branch (`recurring_question_scope.py`)
+        computes that key fresh on every call as an OUTPUT projection, not
+        an accepted input field (`SUPPORTED_SCOPE_FIELDS` has no such
+        entry). Persisting it verbatim made every later re-normalization of
+        this stored scope -- `automation_execution.py`'s own dispatch,
+        `automation_health.py`'s sources-readable check -- report a
+        spurious "unsupported field" error, degrading every scheduled run
+        of a default-scope (the common case) definition. It is always
+        recomputed on read, so dropping it here loses nothing.
         """
         from tldw_chatbook.Scheduling.schedule_compute import compute_next_run_at
 
         normalized = preview.normalized_config or {}
         schedule = normalized.get("schedule") or {}
+        config = dict(normalized.get("config") or {})
+        scope = config.get("scope")
+        if isinstance(scope, dict) and "resolved_sources" in scope:
+            config["scope"] = {k: v for k, v in scope.items() if k != "resolved_sources"}
         return {
             "name": normalized.get("name"),
             "description": normalized.get("description"),
             "schedule": schedule,
             "input": normalized.get("input") or {},
-            "config": normalized.get("config") or {},
+            "config": config,
             "visibility_policy": preview.visibility_policy or {},
             "notification_policy": normalized.get("notification_policy") or {},
             "approval_policy": normalized.get("approval_policy") or {},

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -36,6 +36,7 @@ from tldw_chatbook.Scheduling.services.briefing_projection import BriefingProjec
 from tldw_chatbook.Scheduling.services.server_client import (
     SchedulingServerClient,
     ServerClientError,
+    ServerClientPolicyError,
     ServerUnavailableError,
 )
 from tldw_chatbook.Scheduling.services.sync_engine import SyncEngine
@@ -108,15 +109,28 @@ class SaveDefinitionOutcome:
     definition_id: str | None = None
 
 
-def _server_unreachable_warning(exc: Exception) -> dict[str, str]:
-    """Build the ``_owner``/``server_unreachable`` warning `preview_definition` appends.
+def _seam_failure_warning(exc: Exception) -> dict[str, str]:
+    """Build the ``_owner`` warning `preview_definition` appends on a seam failure.
 
     Not a `field_error` (those are validation errors, not warnings) --
     same ``{"field", "code", "message"}`` shape as `automation_preview.
     py`'s own warning entries, addressed to the pseudo-field ``"_owner"``
-    since the failure is about the owner's server connectivity, not any
-    one authoring field.
+    since the failure is about the owner's server connection/permissions,
+    not any one authoring field. `ServerClientPolicyError` (a deterministic,
+    pre-network refusal) gets its own code/wording -- review round 1 finding
+    3: telling a permanently-refused user "showing local validation only"
+    with no other context reads as "try again once you're back online",
+    which retrying will never fix.
     """
+    if isinstance(exc, ServerClientPolicyError):
+        return {
+            "field": "_owner",
+            "code": "policy_denied",
+            "message": (
+                f"The server refused this automation ({exc}); showing local "
+                "validation only -- this will not resolve by retrying."
+            ),
+        }
     return {
         "field": "_owner",
         "code": "server_unreachable",
@@ -125,6 +139,33 @@ def _server_unreachable_warning(exc: Exception) -> dict[str, str]:
             "showing local validation only."
         ),
     }
+
+
+def _policy_denied_outcome(
+    exc: Exception, definition_id: str | None
+) -> SaveDefinitionOutcome:
+    """Build the `SaveDefinitionOutcome` for a `ServerClientPolicyError` refusal.
+
+    A deterministic, pre-network policy refusal must NOT fall back to the
+    offline queue path (review round 1 finding 1): `SyncEngine._push_
+    definition_create`/`_push_definition_update` would replay the identical
+    preview request and hit the identical refusal, and `_run_phase` treats
+    `ServerClientPolicyError` as "not applicable" and swallows it silently
+    -- no sync error recorded, mutation never cleared, never surfaced. A
+    save this facade knows can never succeed must be reported as failed
+    now, not queued as if it will eventually sync.
+    """
+    return SaveDefinitionOutcome(
+        status="error",
+        errors=[
+            field_error(
+                "_owner",
+                "policy_denied",
+                f"The server refused this automation: {exc}",
+            )
+        ],
+        definition_id=definition_id,
+    )
 
 
 class SchedulingService:
@@ -652,8 +693,12 @@ class SchedulingService:
         preview_automation_definition`; when that round trip fails for
         ANY reason (offline, timeout, 5xx, policy refusal), this falls
         back to the same local pure preview with an extra warning
-        (``field="_owner"``, ``code="server_unreachable"``) appended, so
-        the modal still shows schedule feedback instead of a dead form.
+        (``field="_owner"``) appended, so the modal still shows schedule
+        feedback instead of a dead form -- the warning's ``code``/
+        ``message`` distinguish a deterministic policy refusal
+        (``"policy_denied"``) from an actual connectivity failure
+        (``"server_unreachable"``), since only one of those is worth
+        retrying (review round 1 finding 3).
 
         v1 scope guard: `family` other than `"recurring_question"` is
         rejected before any preview runs (`_reject_unsupported_family`) --
@@ -681,7 +726,7 @@ class SchedulingService:
                 exc=exc,
             )
             local_preview = preview_automation_definition(payload)
-            warnings = [*(local_preview.warnings or []), _server_unreachable_warning(exc)]
+            warnings = [*(local_preview.warnings or []), _seam_failure_warning(exc)]
             return local_preview.model_copy(update={"warnings": warnings})
         return self._server_preview_to_model(response)
 
@@ -722,6 +767,14 @@ class SchedulingService:
         pending mutation is recorded atomically with it (same transaction,
         `create_automation_definition`/`update_automation_definition`'s
         `pending_mutation` kwarg) for `SyncEngine` to replay later.
+
+        Server owner, policy-refused (`ServerClientPolicyError` -- a
+        deterministic, pre-network refusal, not a transport failure):
+        returns `status="error"` and writes nothing. NOT queued -- a
+        replay would hit the identical refusal and `SyncEngine._run_phase`
+        swallows that error as "not applicable" (never surfaced, mutation
+        never cleared), so queuing here would report "queued" for a save
+        that can never sync (review round 1 finding 1).
         """
         guard = self._reject_unsupported_family(payload)
         if guard is not None:
@@ -784,6 +837,8 @@ class SchedulingService:
         assert self.server_client is not None
         try:
             response = await self.server_client.preview_automation_definition(request)
+        except ServerClientPolicyError as exc:
+            return _policy_denied_outcome(exc, definition_id)
         except ServerClientError as exc:
             return await self._save_definition_offline(
                 request, owner_id, local_row, definition_id, server_mode, exc
@@ -807,6 +862,8 @@ class SchedulingService:
                 committed = await self.server_client.create_automation_definition(
                     preview_id
                 )
+        except ServerClientPolicyError as exc:
+            return _policy_denied_outcome(exc, definition_id)
         except ServerClientError as exc:
             return await self._save_definition_offline(
                 request, owner_id, local_row, definition_id, server_mode, exc
@@ -925,23 +982,44 @@ class SchedulingService:
         (`upsert_automation_definitions_from_server`), then looked up by
         its new server id -- that upsert reports only insert/update
         counts, not the generated id.
+
+        Either way, any pending `automation_definition` mutation left over
+        from an earlier offline save on this row is cleared once this
+        online save actually lands -- same precedent as
+        `_persist_server_reminder_response`'s `delete_pending_mutation_
+        for_record` call. Without this, a stale queued mutation survives a
+        later successful online save and the next sync replays it: for a
+        never-synced row that just got its first server identity via
+        create, that means a SECOND server-side definition and an orphaned
+        adopt; for an already-synced row, it means the OLDER queued
+        payload silently overwriting this save's newer edit (review round
+        1 finding 2).
         """
         if local_row is not None:
             await asyncio.to_thread(
                 self.db.adopt_server_definition_identity, definition_id, server_item
             )
-            return definition_id
+            saved_id: str | None = definition_id
+        else:
+            await asyncio.to_thread(
+                self.db.upsert_automation_definitions_from_server, owner_id, [server_item]
+            )
+            server_id = server_item.get("id")
+            if server_id is None:
+                return None
+            mirrored = await asyncio.to_thread(
+                self.db.get_automation_definition_by_server_id, owner_id, server_id
+            )
+            saved_id = mirrored.get("id") if mirrored else None
 
-        await asyncio.to_thread(
-            self.db.upsert_automation_definitions_from_server, owner_id, [server_item]
-        )
-        server_id = server_item.get("id")
-        if server_id is None:
-            return None
-        mirrored = await asyncio.to_thread(
-            self.db.get_automation_definition_by_server_id, owner_id, server_id
-        )
-        return mirrored.get("id") if mirrored else None
+        if saved_id is not None:
+            await asyncio.to_thread(
+                self.db.delete_pending_mutation_for_record,
+                saved_id,
+                _DEFINITION_PRIMITIVE,
+                owner_id,
+            )
+        return saved_id
 
     @staticmethod
     def _build_definition_request(

--- a/tldw_chatbook/Scheduling/services/server_client.py
+++ b/tldw_chatbook/Scheduling/services/server_client.py
@@ -461,3 +461,102 @@ class SchedulingServerClient:
             review_state,
             review_note=review_note,
         )
+
+    async def preview_automation_definition(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Create a server-side authoring preview, retried on failure.
+
+        Retryable: the server derives the preview's idempotency from a hash
+        of the normalized payload (spec §5.1) -- replaying an identical
+        preview request after a transient failure returns the same preview
+        rather than creating a second one, so this keeps the default retry
+        behavior like ``review_automation_result``.
+
+        Args:
+            request: The preview request payload (``ScheduledTaskPreview
+                CreateRequest`` fields -- see
+                ``tldw_chatbook.tldw_api.scheduled_tasks_automation_schemas``).
+
+        Returns:
+            The preview response (``status``/``validation_errors``/
+            ``normalized_config``/etc).
+
+        Raises:
+            ServerUnavailableError: If no scheduling server is connected.
+            ServerClientValidationError: If the request is rejected by
+                policy or the server (e.g. an invalid family/mode).
+            ServerClientServerError: If the server returns a server error
+                after retries are exhausted.
+            ServerClientTimeoutError: If the request times out after
+                retries.
+        """
+        return await self._call_with_retry(
+            "preview_scheduled_automation_definition", request
+        )
+
+    async def create_automation_definition(
+        self,
+        preview_id: str,
+        *,
+        initial_lifecycle: str = "configured",
+    ) -> dict[str, Any]:
+        """Create a server-side automation definition, retried on failure.
+
+        Retryable: creating a definition from a preview inherits the same
+        payload-hash idempotency the preview itself is built from (spec
+        §5.1) -- replaying the same ``preview_id`` after a transient
+        failure resolves to the same definition rather than a duplicate,
+        so this is safe to retry like ``preview_automation_definition``.
+
+        Args:
+            preview_id: The valid create-mode preview to consume.
+            initial_lifecycle: Starting lifecycle -- ``"configured"``
+                (default) or ``"paused"``.
+
+        Returns:
+            The created definition row.
+
+        Raises:
+            ServerUnavailableError: If no scheduling server is connected.
+            ServerClientValidationError: If the preview is invalid,
+                expired, or already consumed, or policy denies the action.
+            ServerClientServerError: If the server returns a server error
+                after retries are exhausted.
+            ServerClientTimeoutError: If the request times out after
+                retries.
+        """
+        return await self._call_with_retry(
+            "create_scheduled_automation_definition",
+            preview_id,
+            initial_lifecycle=initial_lifecycle,
+        )
+
+    async def update_automation_definition(
+        self,
+        definition_id: str,
+        preview_id: str,
+    ) -> dict[str, Any]:
+        """Apply a consumed update-mode preview to an existing definition.
+
+        Args:
+            definition_id: The definition to update.
+            preview_id: The valid update-mode preview to consume.
+
+        Returns:
+            The updated definition row.
+
+        Raises:
+            ServerUnavailableError: If no scheduling server is connected.
+            ServerClientNotFoundError: If the definition does not exist
+                server-side.
+            ServerClientValidationError: If the preview is invalid,
+                expired, or already consumed, or policy denies the action.
+            ServerClientServerError: If the server returns a server error
+                after retries are exhausted.
+            ServerClientTimeoutError: If the request times out after
+                retries.
+        """
+        return await self._call_with_retry(
+            "update_scheduled_automation_definition",
+            definition_id,
+            preview_id,
+        )

--- a/tldw_chatbook/Scheduling/services/server_client.py
+++ b/tldw_chatbook/Scheduling/services/server_client.py
@@ -537,6 +537,12 @@ class SchedulingServerClient:
     ) -> dict[str, Any]:
         """Apply a consumed update-mode preview to an existing definition.
 
+        Retryable: a retried PATCH after an unobserved success fails clean
+        rather than double-applying anything -- the preview is already
+        consumed, so the replay gets the server's preview-already-consumed
+        409 back, which maps to ``ServerClientValidationError`` instead of
+        silently re-patching.
+
         Args:
             definition_id: The definition to update.
             preview_id: The valid update-mode preview to consume.

--- a/tldw_chatbook/Scheduling/services/server_client.py
+++ b/tldw_chatbook/Scheduling/services/server_client.py
@@ -537,11 +537,23 @@ class SchedulingServerClient:
     ) -> dict[str, Any]:
         """Apply a consumed update-mode preview to an existing definition.
 
-        Retryable: a retried PATCH after an unobserved success fails clean
-        rather than double-applying anything -- the preview is already
-        consumed, so the replay gets the server's preview-already-consumed
-        409 back, which maps to ``ServerClientValidationError`` instead of
-        silently re-patching.
+        NOT retryable at this level (``retry=False``, same precedent as
+        ``create_reminder``). The PATCH consumes the preview, so a retry
+        after an unobserved success does not double-apply -- but it does
+        get the server's preview-already-consumed 409, which maps to
+        ``ServerClientValidationError``: the caller then reports "the
+        server refused your edit" for an edit the server actually applied,
+        and the offline queue never gets the chance to sort it out.
+
+        Failing on the first ambiguous transport error instead routes the
+        save into ``SchedulingService.save_definition``'s existing
+        offline-queue fallback, whose replay runs a FRESH update-mode
+        preview before patching (``SyncEngine._push_definition_update``).
+        That is the only safe retry of this call: a new preview against
+        the definition's current version either succeeds or reports a real
+        conflict, and if the first PATCH did land the replay's preview
+        carries the already-applied fields, so it converges rather than
+        lying.
 
         Args:
             definition_id: The definition to update.
@@ -556,13 +568,12 @@ class SchedulingServerClient:
                 server-side.
             ServerClientValidationError: If the preview is invalid,
                 expired, or already consumed, or policy denies the action.
-            ServerClientServerError: If the server returns a server error
-                after retries are exhausted.
-            ServerClientTimeoutError: If the request times out after
-                retries.
+            ServerClientServerError: If the server returns a server error.
+            ServerClientTimeoutError: If the request times out.
         """
         return await self._call_with_retry(
             "update_scheduled_automation_definition",
             definition_id,
             preview_id,
+            retry=False,
         )

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -494,7 +494,7 @@ class SyncEngine:
 
         Returns:
             Counts of what happened this cycle (``created``/``updated``/
-            ``invalid``), for the caller's info log.
+            ``invalid``/``orphaned``), for the caller's info log.
         """
         assert self.server_client is not None
         mutations = self.db.get_pending_mutations(
@@ -578,7 +578,16 @@ class SyncEngine:
         definition_payload: dict[str, Any],
     ) -> str:
         """Preview(mode=create) then create; shared by `create` mutations and
-        `update` mutations converted to create (offline-authored or 404'd)."""
+        `update` mutations converted to create (offline-authored or 404'd).
+
+        If the local row is gone by the time the server echoes back (deleted
+        between queueing and replay), the adopt finds nothing to write and the
+        new server definition has no local home. The mutation is still cleared
+        -- replaying it would create a SECOND server definition, not recover
+        the first -- and a sync error naming both ids is recorded so the
+        orphan is discoverable. Deleting it server-side is not this method's
+        call; definition lifecycle actions are a later phase.
+        """
         request = dict(definition_payload)
         request["mode"] = "create"
         # The server's create-mode validator (mirrored locally by
@@ -600,8 +609,23 @@ class SyncEngine:
             preview.get("id"), initial_lifecycle=initial_lifecycle
         )
         created = created if isinstance(created, dict) else {}
-        self.db.adopt_server_definition_identity(local_id, created)
+        adopted = self.db.adopt_server_definition_identity(local_id, created)
         self.db.delete_pending_mutation(mutation_id)
+        if not adopted:
+            server_definition_id = created.get("id") or "unknown"
+            logger.warning(
+                f"Automation definition {local_id} vanished locally before its "
+                f"create push landed; server definition {server_definition_id} "
+                f"has no local row"
+            )
+            self._record_sync_error(
+                f"Automation definition {local_id} was removed while it was "
+                f"being created on the server; the server copy "
+                f"({server_definition_id}) is still there and is not linked "
+                f"to any local automation",
+                owner_id,
+            )
+            return "orphaned"
         return "created"
 
     async def _push_definition_update(

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -14,6 +14,7 @@ from tldw_chatbook.Scheduling.services.server_client import (
     ServerClientError,
     ServerClientNotFoundError,
     ServerClientPolicyError,
+    ServerClientValidationError,
 )
 
 
@@ -483,10 +484,13 @@ class SyncEngine:
         definition was deleted) converts the mutation into a create,
         mirroring `_push_mutation`'s reminder precedent.
 
-        Any other `ServerClientError` (network/retryable) propagates so
-        `_run_phase` records one sync error for the phase and leaves this
-        and any later mutation queued for the next cycle -- same
-        "abort the whole push phase" discipline as `_push_mutation`.
+        A retryable `ServerClientError` (timeout/5xx/unavailable)
+        propagates so `_run_phase` records one sync error for the phase
+        and leaves this and any later mutation queued for the next cycle
+        -- same "abort the whole push phase" discipline as
+        `_push_mutation`. A non-retryable 4xx does NOT abort: it settles
+        that one mutation and the loop continues with the rest (see
+        `_push_definition_mutation`).
 
         Returns:
             Counts of what happened this cycle (``created``/``updated``/
@@ -503,7 +507,22 @@ class SyncEngine:
         return counts
 
     async def _push_definition_mutation(self, mutation: dict, owner_id: str) -> str:
-        """Replay one pending `automation_definition` mutation. Returns what happened."""
+        """Replay one pending `automation_definition` mutation. Returns what happened.
+
+        A server-side 4xx (`ServerClientValidationError`, e.g. a 409
+        `definition_version_conflict` or a 422 `schedule_invalid`) is
+        non-retryable by construction -- `_call_with_retry` raises it
+        immediately without retrying -- so it is settled here exactly like
+        an invalid preview: the mutation is cleared and the reason
+        recorded as a sync error (`_reject_definition_mutation`). Letting
+        it raise instead aborted the whole push phase, so ONE poisoned
+        mutation blocked every other definition mutation for that owner
+        forever (final review I3). Only genuinely retryable errors
+        (timeout/5xx/unavailable) still abort the phase, and a
+        `ServerClientPolicyError` still propagates untouched -- that one is
+        an account-level refusal that may be granted later, so the user's
+        queued work must survive it rather than be discarded.
+        """
         local_id = mutation["local_id"]
         mutation_id = mutation["id"]
         payload = mutation.get("payload") or {}
@@ -511,16 +530,38 @@ class SyncEngine:
         definition_payload = payload.get("definition_payload") or {}
         server_definition_id = payload.get("server_definition_id")
 
-        if action == "update" and server_definition_id:
-            return await self._push_definition_update(
-                local_id, mutation_id, owner_id, server_definition_id, definition_payload
+        try:
+            if action == "update" and server_definition_id:
+                return await self._push_definition_update(
+                    local_id,
+                    mutation_id,
+                    owner_id,
+                    server_definition_id,
+                    definition_payload,
+                )
+            if action in ("create", "update"):
+                # A `create` action, or an `update` authored offline and never
+                # synced (no server_definition_id): both are pushed as a create.
+                return await self._push_definition_create(
+                    local_id, mutation_id, owner_id, definition_payload
+                )
+        except ServerClientPolicyError:
+            raise
+        except ServerClientValidationError as exc:
+            self._reject_definition_mutation(
+                local_id,
+                mutation_id,
+                owner_id,
+                # The server's own error code IS the useful text here, and
+                # `_reject_definition_mutation` records `field:code` pairs
+                # (not messages) -- so put it where the user will see it.
+                {
+                    "validation_errors": [
+                        {"field": "_server", "code": str(exc), "message": str(exc)}
+                    ]
+                },
             )
-        if action in ("create", "update"):
-            # A `create` action, or an `update` authored offline and never
-            # synced (no server_definition_id): both are pushed as a create.
-            return await self._push_definition_create(
-                local_id, mutation_id, owner_id, definition_payload
-            )
+            return "invalid"
 
         logger.warning(
             f"Unknown pending automation_definition mutation action {action!r} "

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -20,10 +20,11 @@ from tldw_chatbook.Scheduling.services.server_client import (
 _REMINDER_PRIMITIVE = "reminder_task"
 _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
-#: Reserved for the PR-5 definition-push primitive (create/update/lifecycle
-#: mutation replay) -- unused here since PR-3 ships only the definitions
-#: pull mirror, not a push path (schedules-handoff plan, task 4 deviation
-#: 1). Named now so the pending-mutation primitive namespace is settled.
+#: Pending mutations recorded when a local automation definition is
+#: created or updated (schedules-handoff PR-4, task 3 -- the authoring
+#: facade landing in task 4 records these) are replayed to the server by
+#: `SyncEngine._replay_definition_mutations`, mirroring
+#: `_RESULT_REVIEW_PRIMITIVE`'s review-pushback shape.
 _DEFINITION_PRIMITIVE = "automation_definition"
 
 #: Matches ScheduledTasksDB._RESULT_REVIEW_PRIMITIVE -- pending mutations
@@ -213,6 +214,24 @@ class SyncEngine:
         # server payload that still echoes the pre-review state (write/
         # read-path lag) from reverting the review that was just pushed.
         skip_review_server_ids = frozenset(pushed_review_ids or ())
+
+        # Definition create/update push replay (Task 3), also before the
+        # pulls: a successful create's server_id lands on the local row
+        # inside this phase's own transaction, so the definitions pull
+        # right after matches it by (owner_id, server_id) instead of
+        # inserting a duplicate mirror row (Task 3 pull-ordering note).
+        error, definition_push_counts = await self._run_phase(
+            target_owner,
+            "Automation definition push",
+            self._replay_definition_mutations,
+        )
+        if error:
+            phase_errors.append(error)
+        if definition_push_counts:
+            logger.info(
+                f"Automation definition push for {target_owner}: "
+                f"{definition_push_counts}"
+            )
 
         error, counts = await self._run_phase(
             target_owner, "Automation definitions pull", self._pull_definitions
@@ -444,6 +463,168 @@ class SyncEngine:
             self.db.delete_pending_mutation(mutation["id"])
             pushed_server_ids.add(server_result_id)
         return frozenset(pushed_server_ids)
+
+    async def _replay_definition_mutations(self, owner_id: str) -> dict[str, int]:
+        """Replay pending `automation_definition` mutations to the server.
+
+        `create` -> preview(mode="create") -> a `"valid"` preview is
+        consumed via `create_automation_definition`, and the response's
+        server identity plus every server-wins field is adopted onto the
+        local row in one transaction (`ScheduledTasksDB.
+        adopt_server_definition_identity`). An `"invalid"` preview can
+        never succeed by retrying the same payload, so the mutation is
+        cleared and the validation errors are recorded
+        (`_reject_definition_mutation`).
+
+        `update` -> preview(mode="update", definition_id=the server id)
+        -> PATCH via `update_automation_definition`. A missing
+        `server_definition_id` (authored offline, never synced) or a
+        `ServerClientNotFoundError` from either call (the server
+        definition was deleted) converts the mutation into a create,
+        mirroring `_push_mutation`'s reminder precedent.
+
+        Any other `ServerClientError` (network/retryable) propagates so
+        `_run_phase` records one sync error for the phase and leaves this
+        and any later mutation queued for the next cycle -- same
+        "abort the whole push phase" discipline as `_push_mutation`.
+
+        Returns:
+            Counts of what happened this cycle (``created``/``updated``/
+            ``invalid``), for the caller's info log.
+        """
+        assert self.server_client is not None
+        mutations = self.db.get_pending_mutations(
+            owner_id, primitive=_DEFINITION_PRIMITIVE
+        )
+        counts: dict[str, int] = {}
+        for mutation in mutations:
+            outcome = await self._push_definition_mutation(mutation, owner_id)
+            counts[outcome] = counts.get(outcome, 0) + 1
+        return counts
+
+    async def _push_definition_mutation(self, mutation: dict, owner_id: str) -> str:
+        """Replay one pending `automation_definition` mutation. Returns what happened."""
+        local_id = mutation["local_id"]
+        mutation_id = mutation["id"]
+        payload = mutation.get("payload") or {}
+        action = payload.get("action")
+        definition_payload = payload.get("definition_payload") or {}
+        server_definition_id = payload.get("server_definition_id")
+
+        if action == "update" and server_definition_id:
+            return await self._push_definition_update(
+                local_id, mutation_id, owner_id, server_definition_id, definition_payload
+            )
+        if action in ("create", "update"):
+            # A `create` action, or an `update` authored offline and never
+            # synced (no server_definition_id): both are pushed as a create.
+            return await self._push_definition_create(
+                local_id, mutation_id, owner_id, definition_payload
+            )
+
+        logger.warning(
+            f"Unknown pending automation_definition mutation action {action!r} "
+            f"for local {local_id}; dropping"
+        )
+        self.db.delete_pending_mutation(mutation_id)
+        return "unknown"
+
+    async def _push_definition_create(
+        self,
+        local_id: str,
+        mutation_id: int,
+        owner_id: str,
+        definition_payload: dict[str, Any],
+    ) -> str:
+        """Preview(mode=create) then create; shared by `create` mutations and
+        `update` mutations converted to create (offline-authored or 404'd)."""
+        request = dict(definition_payload)
+        request["mode"] = "create"
+        # The server's create-mode validator (mirrored locally by
+        # automation_preview.py) rejects definition_id/definition_version
+        # as "not_allowed_for_create" -- strip any left over from an
+        # update-shaped payload before this offline/404 conversion.
+        request.pop("definition_id", None)
+        request.pop("definition_version", None)
+
+        assert self.server_client is not None
+        preview = await self.server_client.preview_automation_definition(request)
+        preview = preview if isinstance(preview, dict) else {}
+        if preview.get("status") != "valid":
+            self._reject_definition_mutation(local_id, mutation_id, owner_id, preview)
+            return "invalid"
+
+        initial_lifecycle = definition_payload.get("initial_lifecycle") or "configured"
+        created = await self.server_client.create_automation_definition(
+            preview.get("id"), initial_lifecycle=initial_lifecycle
+        )
+        created = created if isinstance(created, dict) else {}
+        self.db.adopt_server_definition_identity(local_id, created)
+        self.db.delete_pending_mutation(mutation_id)
+        return "created"
+
+    async def _push_definition_update(
+        self,
+        local_id: str,
+        mutation_id: int,
+        owner_id: str,
+        server_definition_id: str,
+        definition_payload: dict[str, Any],
+    ) -> str:
+        """Preview(mode=update) then PATCH; converts to create on a 404."""
+        request = dict(definition_payload)
+        request["mode"] = "update"
+        request["definition_id"] = server_definition_id
+
+        assert self.server_client is not None
+        try:
+            preview = await self.server_client.preview_automation_definition(request)
+            preview = preview if isinstance(preview, dict) else {}
+            if preview.get("status") != "valid":
+                self._reject_definition_mutation(
+                    local_id, mutation_id, owner_id, preview
+                )
+                return "invalid"
+            updated = await self.server_client.update_automation_definition(
+                server_definition_id, preview.get("id")
+            )
+        except ServerClientNotFoundError:
+            return await self._push_definition_create(
+                local_id, mutation_id, owner_id, definition_payload
+            )
+        updated = updated if isinstance(updated, dict) else {}
+        self.db.adopt_server_definition_identity(local_id, updated)
+        self.db.delete_pending_mutation(mutation_id)
+        return "updated"
+
+    def _reject_definition_mutation(
+        self,
+        local_id: str,
+        mutation_id: int,
+        owner_id: str,
+        preview: dict[str, Any],
+    ) -> None:
+        """Clear an invalid-preview definition mutation and record why.
+
+        A payload the server has already rejected will never succeed by
+        retrying, so the mutation is dropped rather than left queued.
+        """
+        errors = preview.get("validation_errors") or []
+        codes = ", ".join(
+            f"{error.get('field')}:{error.get('code')}"
+            for error in errors
+            if isinstance(error, dict)
+        )
+        logger.warning(
+            f"Automation definition mutation for local {local_id} rejected by "
+            f"server preview: {codes or 'no field codes reported'}"
+        )
+        self._record_sync_error(
+            f"Automation definition {local_id} rejected by server: "
+            f"{codes or 'invalid preview'}",
+            owner_id,
+        )
+        self.db.delete_pending_mutation(mutation_id)
 
     async def _pull_definitions(self, owner_id: str) -> dict[str, int]:
         """Page up to `_SYNC_MAX_PAGES` of the server's automation definitions.

--- a/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
@@ -95,10 +95,19 @@ _FIELD_ERROR_WIDGET_IDS: dict[str, str] = {
 }
 
 
-def _format_occurrence(raw: str) -> str:
-    """Render one ISO-8601 `next_occurrences` entry as compact local text."""
+def _format_occurrence(raw: Any) -> str:
+    """Render one `next_occurrences` entry as compact local text.
+
+    `next_occurrences` crosses the network boundary from the server preview,
+    so entries are not guaranteed to be ISO-8601 strings -- or strings at
+    all. Anything unparseable renders as its own text rather than raising
+    (`datetime.fromisoformat` raises `TypeError`, not `ValueError`, on a
+    non-string) and taking the whole preview render down with it.
+    """
     from datetime import datetime
 
+    if not isinstance(raw, str):
+        return str(raw)
     try:
         parsed = datetime.fromisoformat(raw)
     except ValueError:
@@ -499,23 +508,46 @@ class AutomationDefinitionForm(ModalScreen):
             if time_text:
                 self.query_one("#automation-preset-time", Input).value = time_text
             self._update_preset_field_visibility(preset_key)
-            tz = schedule.get("timezone")
-            if tz and _is_valid_zone(str(tz)):
-                self.query_one("#automation-timezone", Select).value = str(tz)
+            tz = self._stored_timezone()
+            if tz:
+                self.query_one("#automation-timezone", Select).value = tz
             self._update_schedule_field_visibility(ScheduleKind.RECURRING.value)
 
     # -- timezone helpers (reuse reminder_form's pure functions) -------------
 
+    def _stored_timezone(self) -> str | None:
+        """The edited row's own `schedule.timezone`, if it has one."""
+        row = self._definition_row or {}
+        schedule = row.get("schedule") if isinstance(row.get("schedule"), dict) else {}
+        tz = schedule.get("timezone")
+        return str(tz) if tz else None
+
     def _timezone_options(self) -> list[tuple[str, str]]:
+        """System zone, then the curated list, then this row's stored zone.
+
+        The edited row's OWN zone is always offered, even when it is not in
+        the curated list and even when it does not resolve in local tzdata
+        (labeled honestly then) -- mirrors `ReminderForm._timezone_options`
+        (review F4). Without it, prefilling a definition saved with a valid
+        but non-curated zone (`Pacific/Apia`) assigned a value outside the
+        Select's own options and raised `InvalidSelectValueError`, taking
+        the whole edit modal down.
+        """
         detected = detect_system_timezone()
         zones = [detected or _DEFAULT_TIMEZONE]
-        for zone in _CURATED_TIMEZONES:
+        stored = self._stored_timezone()
+        for zone in list(_CURATED_TIMEZONES) + ([stored] if stored else []):
             if zone not in zones and _is_valid_zone(zone):
                 zones.append(zone)
-        return [(zone, zone) for zone in zones]
+        options = [(zone, zone) for zone in zones]
+        if stored and stored not in zones:
+            options.append(
+                (f"{stored} — stored on this automation, not recognized here", stored)
+            )
+        return options
 
     def _initial_timezone(self) -> str:
-        return system_timezone_name()
+        return self._stored_timezone() or system_timezone_name()
 
     # -- field visibility ------------------------------------------------------
 
@@ -622,6 +654,10 @@ class AutomationDefinitionForm(ModalScreen):
         timezone = str(self.query_one("#automation-timezone", Select).value)
         return {"kind": "cron", "cron": cron, "timezone": timezone}
 
+    def _save_mode(self) -> str:
+        """`"update"` when editing an existing definition, else `"create"`."""
+        return "update" if self._definition_id is not None else "create"
+
     def _build_payload(self) -> dict[str, Any]:
         """Build a `ScheduledTaskPreviewCreateRequest`-shaped payload.
 
@@ -662,7 +698,7 @@ class AutomationDefinitionForm(ModalScreen):
 
         payload: dict[str, Any] = {
             "family": _FAMILY,
-            "mode": "update" if self._definition_id is not None else "create",
+            "mode": self._save_mode(),
             "name": name,
             "input": input_fields,
             "schedule": self._schedule_payload(),
@@ -778,7 +814,15 @@ class AutomationDefinitionForm(ModalScreen):
                 payload, owner
             )
         except Exception:  # noqa: BLE001 - never let a preview crash the modal
-            logger.exception("Automation preview failed")
+            # Routing context only -- owner, which mode, which definition.
+            # NEVER the payload: it carries the user's question text.
+            logger.exception(
+                "Automation preview failed for owner {owner} "
+                "(mode={mode}, definition_id={definition_id})",
+                owner=owner,
+                mode=self._save_mode(),
+                definition_id=self._definition_id,
+            )
             self._set_form_error("Preview failed — check the log and try again.")
             return
         self._render_preview(preview)
@@ -789,7 +833,11 @@ class AutomationDefinitionForm(ModalScreen):
         if preview.status != PreviewStatus.VALID:
             preview_text.update("")
             return
-        occurrences = (preview.schedule_preview or {}).get("next_occurrences") or []
+        raw_occurrences = (preview.schedule_preview or {}).get("next_occurrences")
+        # `schedule_preview` is an untyped `dict[str, Any]` straight off the
+        # server response; a non-list here would otherwise be sliced and
+        # iterated (a str renders one character per "occurrence").
+        occurrences = raw_occurrences if isinstance(raw_occurrences, list) else []
         warnings = [str(w.get("message", "")) for w in (preview.warnings or []) if w.get("message")]
         lines = []
         if occurrences:
@@ -822,7 +870,14 @@ class AutomationDefinitionForm(ModalScreen):
                 payload, owner, definition_id=self._definition_id
             )
         except Exception:  # noqa: BLE001 - never let a save crash the modal
-            logger.exception("Automation save failed")
+            # Same rule as the preview log: routing context, never payload.
+            logger.exception(
+                "Automation save failed for owner {owner} "
+                "(mode={mode}, definition_id={definition_id})",
+                owner=owner,
+                mode=self._save_mode(),
+                definition_id=self._definition_id,
+            )
             self._set_form_error("Save failed — check the log and try again.")
             return
         if outcome.status in ("saved", "queued"):

--- a/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
@@ -626,9 +626,16 @@ class AutomationDefinitionForm(ModalScreen):
         """Build a `ScheduledTaskPreviewCreateRequest`-shaped payload.
 
         `visibility_policy`/`approval_policy`/`retention_policy` are not
-        exposed as v1 fields (spec sec 8) -- omitting them lets the
-        family default (`findings_only`) and the ported normalizers'
-        own defaults apply, matching a payload that never mentioned them.
+        exposed as v1 fields (spec sec 8), so this payload never mentions
+        them: on a CREATE the family default (`findings_only`) and the
+        ported normalizers' own defaults apply, and on an EDIT
+        `save_definition` merges the payload onto the stored row
+        (`SchedulingService._merge_definition_payload`), so an omitted key
+        keeps its stored value instead of being wiped (final review I4).
+        `provider`/`model` are the flip side of that rule: they ARE
+        exposed here, so they are always emitted -- `None` when blank --
+        or clearing them in the form would silently resurrect the stored
+        value through the same merge.
 
         `mode`/`definition_id`/`definition_version` here only drive the
         PREVIEW button's own local-validation presence checks
@@ -636,12 +643,10 @@ class AutomationDefinitionForm(ModalScreen):
         `save_definition`, which always rebuilds these three itself from
         its own `definition_id` parameter -- Task 4's contract, so this
         method's values never affect what actually gets saved). Editing
-        always sends the LOCAL id here, which is correct for a local-owned
-        row but not what a server-owned row's OWN preview endpoint expects
-        (it wants the server's id) -- Preview during a server-owned edit
-        therefore falls back to local-only validation feedback
-        (`preview_definition`'s existing `ServerClientError` catch-all),
-        never a hard failure. Save is unaffected either way.
+        sends the row's SERVER id when it has one (commit `938b03703`), so
+        a server-owned edit's preview reaches the server's own preview
+        endpoint; a local row falls back to its local id, which is what
+        the local preview wants.
         """
         name = self.query_one("#automation-name", Input).value.strip()
         question = self.query_one("#automation-question", TextArea).text.strip()
@@ -649,11 +654,11 @@ class AutomationDefinitionForm(ModalScreen):
         provider = self.query_one("#automation-provider", Input).value.strip()
         model = self.query_one("#automation-model", Input).value.strip()
 
-        input_fields: dict[str, Any] = {"question": question}
-        if provider:
-            input_fields["provider"] = provider
-        if model:
-            input_fields["model"] = model
+        input_fields: dict[str, Any] = {
+            "question": question,
+            "provider": provider or None,
+            "model": model or None,
+        }
 
         payload: dict[str, Any] = {
             "family": _FAMILY,

--- a/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
@@ -1,0 +1,683 @@
+"""Recurring-question automation-definition create modal (task-5).
+
+Mirrors `ReminderForm`'s structure (ADR-099 idiom parity: the modal box is
+its own scroll container, a docked footer keeps the live preview/errors/
+actions visible, Escape triggers a discard guard). The recurring-cron
+schedule sub-form reuses `reminder_form.py`'s task-23102 pure helpers
+(`preset_to_cron`, `cron_to_preset`, `parse_time_of_day`,
+`parse_forgiving_datetime`, timezone helpers) directly -- only the
+Textual wiring (widget ids, compose layout) is necessarily duplicated,
+since it is bound to this form's own field ids.
+
+v1 is create-only (spec sec 8 / plan task 4 handoff): the Automations tab
+has no local-definition listing or edit entry point yet (that is later
+program work, spec sec 9), so this form never receives an existing
+local row and always authors `mode="create"`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from croniter import croniter
+from loguru import logger
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Button, Checkbox, Input, Label, Select, Static, TextArea
+
+from tldw_chatbook.Scheduling.models import PreviewStatus, ScheduleKind
+
+from .reminder_form import (
+    _CURATED_TIMEZONES,
+    _DEFAULT_TIMEZONE,
+    _TIME_OF_DAY_PRESETS,
+    _is_valid_zone,
+    detect_system_timezone,
+    parse_forgiving_datetime,
+    preset_to_cron,
+    system_timezone_name,
+)
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Scheduling.models import AutomationPreview
+    from tldw_chatbook.Scheduling.services.scheduling_service import (
+        SaveDefinitionOutcome,
+        SchedulingService,
+    )
+
+#: recurring_question family per v1 scope guard (plan task 4).
+_FAMILY = "recurring_question"
+
+#: config.scope.sources vocabulary (recurring_question_scope.py); the v1
+#: form offers exactly these three -- collections/tags/saved-searches are
+#: deferred (spec sec 8).
+_SCOPE_SOURCE_CHECKBOXES: tuple[tuple[str, str], ...] = (
+    ("Media", "media_db"),
+    ("Notes", "notes"),
+    ("Chats", "chats"),
+)
+
+_GENERATION_MODE_OPTIONS: tuple[tuple[str, str], ...] = (
+    ("Only when something new is found", "optional"),
+    ("Always generate a draft", "required"),
+    ("Never generate a draft", "disabled"),
+)
+
+_FINDING_POLICY_OPTIONS: tuple[tuple[str, str], ...] = (
+    ("Balanced findings", "balanced_findings"),
+    ("High confidence only", "high_confidence_only"),
+)
+
+#: Validation-error `field` values this form can highlight in place, mapped
+#: to the id of the Static that renders under the offending widget. Any
+#: error whose field is not here (e.g. a payload-shape error this form
+#: never produces, or a server field this local port does not know) falls
+#: into the form-level error area instead of being silently dropped.
+_FIELD_ERROR_WIDGET_IDS: dict[str, str] = {
+    "name": "automation-name-error",
+    "input.question": "automation-question-error",
+    "config.scope.mode": "automation-scope-error",
+    "config.scope": "automation-scope-error",
+    "config.generation_mode": "automation-generation-mode-error",
+    "config.finding_policy.preset": "automation-finding-policy-error",
+    "schedule": "automation-schedule-error",
+    "schedule.kind": "automation-schedule-error",
+}
+
+
+def _format_occurrence(raw: str) -> str:
+    """Render one ISO-8601 `next_occurrences` entry as compact local text."""
+    from datetime import datetime
+
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return raw
+    return parsed.astimezone().strftime("%Y-%m-%d %H:%M")
+
+
+class AutomationDefinitionForm(ModalScreen):
+    """Create modal for a `recurring_question` automation definition."""
+
+    BINDINGS = [
+        Binding("escape", "dismiss", "Close", show=False),
+    ]
+
+    DEFAULT_CSS = """
+    AutomationDefinitionForm {
+        align: center middle;
+    }
+
+    AutomationDefinitionForm > VerticalScroll {
+        width: 84;
+        max-width: 100%;
+        height: auto;
+        max-height: 100%;
+        background: $surface;
+        border: thick $primary;
+        padding: 1 2;
+    }
+
+    #automation-form-footer {
+        dock: bottom;
+        height: auto;
+        background: $surface;
+    }
+
+    #automation-scope-sources-group,
+    #automation-run-at-group,
+    #automation-cron-group,
+    #automation-timezone-group,
+    #automation-preset-time-group,
+    #automation-cron-custom-group,
+    #automation-provider-group {
+        height: auto;
+    }
+
+    #automation-form-errors {
+        display: none;
+    }
+
+    #automation-question {
+        height: 3;
+        max-height: 5;
+    }
+
+    .form-title {
+        text-style: bold;
+        text-align: center;
+        padding: 0;
+    }
+
+    .form-label {
+        color: $text-muted;
+        padding: 1 0 0 0;
+    }
+
+    .form-helper {
+        color: $text-muted;
+        height: auto;
+        padding: 0;
+    }
+
+    .form-preview {
+        color: $text-muted;
+        height: auto;
+        min-height: 1;
+        padding: 0;
+    }
+
+    .error-text {
+        color: $error;
+        text-style: bold;
+        height: auto;
+        padding: 0;
+    }
+
+    .button-container {
+        align: center middle;
+        height: auto;
+        padding: 0;
+        margin-top: 1;
+    }
+
+    .button-container Button {
+        margin: 0 1;
+    }
+    """
+
+    def __init__(
+        self,
+        service: "SchedulingService",
+        *,
+        available_owners: Sequence[tuple[str, str]] = (("This device", "local"),),
+        default_owner: str = "local",
+    ) -> None:
+        """Initialize the create form.
+
+        Args:
+            service: The active `SchedulingService` -- this form calls its
+                `preview_definition`/`save_definition` facade directly
+                (Task 4), the same way the Preview button and Save need
+                live, in-modal feedback that a push_screen callback alone
+                cannot provide.
+            available_owners: `(label, owner_id)` options for "Runs on".
+            default_owner: The owner preselected on open (the current
+                screen owner, per spec sec 8).
+        """
+        super().__init__()
+        self._service = service
+        self._available_owners = list(available_owners) or [("This device", "local")]
+        self._default_owner = default_owner
+        self._dirty = False
+        self._ready = False
+
+    # -- discard guard (mirrors ReminderForm) --------------------------------
+
+    def action_dismiss(self) -> None:
+        self._maybe_discard()
+
+    def _maybe_discard(self) -> None:
+        if not self._dirty:
+            self.dismiss(None)
+            return
+        from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
+
+        async def _discard() -> None:
+            self.dismiss(None)
+
+        self.app.push_screen(
+            ConfirmationDialog(
+                title="Discard changes?",
+                message="You have unsaved changes in this form.",
+                confirm_label="Discard",
+                cancel_label="Keep editing",
+                confirm_callback=_discard,
+            )
+        )
+
+    # -- compose --------------------------------------------------------------
+
+    def compose(self) -> ComposeResult:
+        with VerticalScroll(id="automation-form-box"):
+            yield Label("New Recurring Question", classes="form-title")
+
+            yield Label("Runs on:", classes="form-label")
+            yield Select(
+                self._available_owners,
+                allow_blank=False,
+                value=self._default_owner,
+                id="automation-runs-on",
+            )
+            yield Static(
+                "Create it locally, or on the connected server if one is "
+                "available.",
+                classes="form-helper",
+            )
+
+            yield Label("Name:", classes="form-label")
+            yield Input(placeholder="Name this automation…", id="automation-name")
+            yield Static("", id="automation-name-error", classes="error-text")
+
+            yield Label("Question:", classes="form-label")
+            yield TextArea(id="automation-question")
+            yield Static("", id="automation-question-error", classes="error-text")
+
+            yield Label("Scope:", classes="form-label")
+            yield Select(
+                [
+                    ("All readable library sources", "all_searchable_library"),
+                    ("Choose specific sources…", "sources"),
+                ],
+                allow_blank=False,
+                value="all_searchable_library",
+                id="automation-scope-mode",
+            )
+            with Vertical(id="automation-scope-sources-group"):
+                for label, value in _SCOPE_SOURCE_CHECKBOXES:
+                    yield Checkbox(label, value=True, id=f"automation-scope-{value.split('_')[0]}")
+            yield Static("", id="automation-scope-error", classes="error-text")
+
+            yield Label("Schedule Kind:", classes="form-label")
+            yield Select(
+                [(kind.value.replace("_", " ").title(), kind.value) for kind in ScheduleKind],
+                allow_blank=False,
+                value=ScheduleKind.ONE_TIME.value,
+                id="automation-schedule-kind",
+            )
+            yield Static("", id="automation-schedule-error", classes="error-text")
+
+            with Vertical(id="automation-run-at-group"):
+                yield Label("Run at:", classes="form-label")
+                yield Input(placeholder="2026-08-28 09:00", id="automation-run-at")
+                yield Static(
+                    "A local time like 2026-08-28 09:00, or full ISO-8601 with offset.",
+                    classes="form-helper",
+                )
+
+            with Vertical(id="automation-cron-group"):
+                yield Label("Frequency:", classes="form-label")
+                yield Select(
+                    [
+                        ("Every day at…", "daily"),
+                        ("Every weekday at…", "weekday"),
+                        ("Every Monday at…", "monday"),
+                        ("Every hour", "hourly"),
+                        ("Custom cron…", "custom"),
+                    ],
+                    allow_blank=False,
+                    value="daily",
+                    id="automation-cron-preset",
+                )
+                with Vertical(id="automation-preset-time-group"):
+                    yield Label("Time of day (24-hour):", classes="form-label")
+                    yield Input(placeholder="09:00", id="automation-preset-time")
+                with Vertical(id="automation-cron-custom-group"):
+                    yield Label("Cron Expression:", classes="form-label")
+                    yield Input(placeholder="0 9 * * 1", id="automation-cron")
+
+            with Vertical(id="automation-timezone-group"):
+                yield Label("Timezone:", classes="form-label")
+                yield Select(
+                    self._timezone_options(),
+                    allow_blank=False,
+                    value=self._initial_timezone(),
+                    id="automation-timezone",
+                )
+
+            yield Label("Generation mode:", classes="form-label")
+            yield Select(
+                list(_GENERATION_MODE_OPTIONS),
+                allow_blank=False,
+                value="optional",
+                id="automation-generation-mode",
+            )
+            yield Static("", id="automation-generation-mode-error", classes="error-text")
+
+            yield Label("Finding policy:", classes="form-label")
+            yield Select(
+                list(_FINDING_POLICY_OPTIONS),
+                allow_blank=False,
+                value="balanced_findings",
+                id="automation-finding-policy",
+            )
+            yield Static("", id="automation-finding-policy-error", classes="error-text")
+
+            yield Checkbox(
+                "Notify me about results", value=True, id="automation-notify"
+            )
+
+            with Vertical(id="automation-provider-group"):
+                yield Label(
+                    "Provider/model pin (optional — leave blank for auto):",
+                    classes="form-label",
+                )
+                with Horizontal():
+                    yield Input(placeholder="provider", id="automation-provider")
+                    yield Input(placeholder="model", id="automation-model")
+
+            with Vertical(id="automation-form-footer"):
+                yield Static("", id="automation-preview-text", classes="form-preview")
+                yield Static("", id="automation-form-errors", classes="error-text")
+                with Horizontal(classes="button-container"):
+                    yield Button("Preview", id="automation-preview-btn")
+                    yield Button("Save", variant="success", id="automation-save")
+                    yield Button("Cancel", id="automation-cancel")
+
+    def on_mount(self) -> None:
+        self.query_one("#automation-preset-time", Input).value = "09:00"
+        self.query_one("#automation-cron", Input).value = "0 9 * * *"
+        self._update_schedule_field_visibility(ScheduleKind.ONE_TIME.value)
+        self._update_preset_field_visibility("daily")
+        self._update_scope_field_visibility("all_searchable_library")
+        self.call_after_refresh(self._mark_ready)
+
+    def _mark_ready(self) -> None:
+        self._dirty = False
+        self._ready = True
+
+    # -- timezone helpers (reuse reminder_form's pure functions) -------------
+
+    def _timezone_options(self) -> list[tuple[str, str]]:
+        detected = detect_system_timezone()
+        zones = [detected or _DEFAULT_TIMEZONE]
+        for zone in _CURATED_TIMEZONES:
+            if zone not in zones and _is_valid_zone(zone):
+                zones.append(zone)
+        return [(zone, zone) for zone in zones]
+
+    def _initial_timezone(self) -> str:
+        return system_timezone_name()
+
+    # -- field visibility ------------------------------------------------------
+
+    def _update_schedule_field_visibility(self, kind: str) -> None:
+        run_at_group = self.query_one("#automation-run-at-group", Vertical)
+        cron_group = self.query_one("#automation-cron-group", Vertical)
+        tz_group = self.query_one("#automation-timezone-group", Vertical)
+        one_time = kind == ScheduleKind.ONE_TIME.value
+        run_at_group.display = one_time
+        cron_group.display = not one_time
+        tz_group.display = not one_time
+        shown_group = run_at_group if one_time else cron_group
+        self.call_after_refresh(shown_group.scroll_visible)
+
+    def _update_preset_field_visibility(self, preset: str) -> None:
+        time_group = self.query_one("#automation-preset-time-group", Vertical)
+        custom_group = self.query_one("#automation-cron-custom-group", Vertical)
+        time_group.display = preset in _TIME_OF_DAY_PRESETS
+        custom_group.display = preset == "custom"
+
+    def _update_scope_field_visibility(self, mode: str) -> None:
+        group = self.query_one("#automation-scope-sources-group", Vertical)
+        group.display = mode == "sources"
+
+    def _selected_preset(self) -> str:
+        return str(self.query_one("#automation-cron-preset", Select).value)
+
+    def _regenerate_preset_cron(self) -> None:
+        preset = self._selected_preset()
+        if preset == "custom":
+            return
+        time_text = self.query_one("#automation-preset-time", Input).value
+        cron = preset_to_cron(preset, time_text)
+        if cron is not None:
+            self.query_one("#automation-cron", Input).value = cron
+
+    # -- change handlers --------------------------------------------------------
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        if not self._ready:
+            return
+        self._dirty = True
+        if event.select.id == "automation-schedule-kind":
+            self._update_schedule_field_visibility(str(event.value))
+        elif event.select.id == "automation-cron-preset":
+            preset = str(event.value)
+            self._update_preset_field_visibility(preset)
+            self._regenerate_preset_cron()
+        elif event.select.id == "automation-scope-mode":
+            self._update_scope_field_visibility(str(event.value))
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if not self._ready:
+            return
+        self._dirty = True
+        if event.input.id == "automation-preset-time":
+            self._regenerate_preset_cron()
+
+    def on_text_area_changed(self, event: TextArea.Changed) -> None:
+        if self._ready:
+            self._dirty = True
+
+    def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
+        if self._ready:
+            self._dirty = True
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "automation-cancel":
+            self._maybe_discard()
+        elif event.button.id == "automation-preview-btn":
+            self._run_preview()
+        elif event.button.id == "automation-save":
+            self._run_save()
+
+    # -- payload building -------------------------------------------------------
+
+    def _selected_owner(self) -> str:
+        return str(self.query_one("#automation-runs-on", Select).value)
+
+    def _scope_payload(self) -> dict[str, Any]:
+        mode = str(self.query_one("#automation-scope-mode", Select).value)
+        if mode != "sources":
+            return {"mode": "all_searchable_library"}
+        sources = [
+            value
+            for label, value in _SCOPE_SOURCE_CHECKBOXES
+            if self.query_one(f"#automation-scope-{value.split('_')[0]}", Checkbox).value
+        ]
+        return {"mode": "sources", "sources": sources}
+
+    def _schedule_payload(self) -> dict[str, Any]:
+        kind = str(self.query_one("#automation-schedule-kind", Select).value)
+        if kind == ScheduleKind.ONE_TIME.value:
+            raw = self.query_one("#automation-run-at", Input).value.strip()
+            parsed, _assumed_local = parse_forgiving_datetime(raw)
+            return {"kind": "one_time", "run_at": parsed.isoformat() if parsed else raw}
+
+        preset = self._selected_preset()
+        if preset == "custom":
+            cron = self.query_one("#automation-cron", Input).value.strip()
+        else:
+            time_text = self.query_one("#automation-preset-time", Input).value
+            cron = preset_to_cron(preset, time_text) or ""
+        timezone = str(self.query_one("#automation-timezone", Select).value)
+        return {"kind": "cron", "cron": cron, "timezone": timezone}
+
+    def _build_payload(self) -> dict[str, Any]:
+        """Build a `ScheduledTaskPreviewCreateRequest`-shaped payload.
+
+        v1 is create-only (module docstring): `mode` is always
+        `"create"`, and `definition_id`/`definition_version` are never
+        sent (the not-allowed-for-create validators would reject them).
+        `visibility_policy`/`approval_policy`/`retention_policy` are not
+        exposed as v1 fields (spec sec 8) -- omitting them lets the
+        family default (`findings_only`) and the ported normalizers'
+        own defaults apply, matching a payload that never mentioned them.
+        """
+        name = self.query_one("#automation-name", Input).value.strip()
+        question = self.query_one("#automation-question", TextArea).text.strip()
+        notify = bool(self.query_one("#automation-notify", Checkbox).value)
+        provider = self.query_one("#automation-provider", Input).value.strip()
+        model = self.query_one("#automation-model", Input).value.strip()
+
+        input_fields: dict[str, Any] = {"question": question}
+        if provider:
+            input_fields["provider"] = provider
+        if model:
+            input_fields["model"] = model
+
+        return {
+            "family": _FAMILY,
+            "mode": "create",
+            "name": name,
+            "input": input_fields,
+            "schedule": self._schedule_payload(),
+            "config": {
+                "scope": self._scope_payload(),
+                "generation_mode": str(
+                    self.query_one("#automation-generation-mode", Select).value
+                ),
+                "finding_policy": {
+                    "preset": str(
+                        self.query_one("#automation-finding-policy", Select).value
+                    )
+                },
+            },
+            "notification_policy": {"on_success": notify, "on_failure": notify},
+        }
+
+    # -- validation-error rendering -----------------------------------------------
+
+    def _set_validation_errors(self, errors: Sequence[dict[str, Any]]) -> None:
+        """Map `{field, code, message}` errors onto their field's error line.
+
+        An error whose `field` this form does not recognize renders in the
+        form-level error area instead of being silently dropped -- this
+        also covers a server preview's own error codes (Task 4's report:
+        not guaranteed byte-identical to the local port), which still
+        carry a `field` this form can match on even when the `code`/
+        `message` text differs.
+        """
+        per_field: dict[str, list[str]] = {}
+        unmatched: list[str] = []
+        for error in errors:
+            field = str(error.get("field") or "")
+            message = str(error.get("message") or error.get("code") or "Invalid value.")
+            widget_id = _FIELD_ERROR_WIDGET_IDS.get(field)
+            if widget_id is None:
+                unmatched.append(f"{field}: {message}" if field else message)
+            else:
+                per_field.setdefault(widget_id, []).append(message)
+
+        for widget_id in set(_FIELD_ERROR_WIDGET_IDS.values()):
+            error_widget = self.query_one(f"#{widget_id}", Static)
+            messages = per_field.get(widget_id, [])
+            error_widget.update("\n".join(messages))
+            error_widget.display = bool(messages)
+
+        form_errors = self.query_one("#automation-form-errors", Static)
+        form_errors.update("\n".join(unmatched))
+        form_errors.display = bool(unmatched)
+
+    def _set_form_error(self, message: str) -> None:
+        self._set_validation_errors([{"field": "", "message": message}] if message else [])
+
+    def _client_side_schedule_error(self) -> str | None:
+        """Same pre-flight schedule checks as `ReminderForm._save` runs.
+
+        `validate_schedule` (the ported server validator) only checks
+        `kind`, not kind-specific fields like `run_at`/`cron` -- a real
+        server-parity gap, not something to invent extra strictness for.
+        This mirrors ReminderForm's own client-side guard instead, so an
+        obviously bad run-at/cron is caught before a preview/save round
+        trip rather than silently producing a definition with no next run.
+        """
+        kind = str(self.query_one("#automation-schedule-kind", Select).value)
+        if kind == ScheduleKind.ONE_TIME.value:
+            raw = self.query_one("#automation-run-at", Input).value.strip()
+            if not raw:
+                return "Run at is required for one-time automations."
+            parsed, _assumed_local = parse_forgiving_datetime(raw)
+            if parsed is None:
+                return "Run at must be a date and time like 2026-08-28 09:00."
+            return None
+
+        preset = self._selected_preset()
+        if preset == "custom":
+            cron = self.query_one("#automation-cron", Input).value.strip()
+        else:
+            time_text = self.query_one("#automation-preset-time", Input).value
+            cron = preset_to_cron(preset, time_text) or ""
+        if not cron:
+            return "A frequency or cron expression is required."
+        if not croniter.is_valid(cron):
+            return "Cron expression is invalid."
+        return None
+
+    # -- preview ------------------------------------------------------------------
+
+    def _run_preview(self) -> None:
+        schedule_error = self._client_side_schedule_error()
+        if schedule_error:
+            self._set_validation_errors([{"field": "schedule", "message": schedule_error}])
+            return
+        payload = self._build_payload()
+        owner = self._selected_owner()
+
+        async def _do() -> None:
+            await self._preview_async(payload, owner)
+
+        self.run_worker(_do, exclusive=True, group="automation-form-preview")
+
+    async def _preview_async(self, payload: dict[str, Any], owner: str) -> None:
+        try:
+            preview: "AutomationPreview" = await self._service.preview_definition(
+                payload, owner
+            )
+        except Exception:  # noqa: BLE001 - never let a preview crash the modal
+            logger.exception("Automation preview failed")
+            self._set_form_error("Preview failed — check the log and try again.")
+            return
+        self._render_preview(preview)
+
+    def _render_preview(self, preview: "AutomationPreview") -> None:
+        self._set_validation_errors(preview.validation_errors or [])
+        preview_text = self.query_one("#automation-preview-text", Static)
+        if preview.status != PreviewStatus.VALID:
+            preview_text.update("")
+            return
+        occurrences = (preview.schedule_preview or {}).get("next_occurrences") or []
+        warnings = [str(w.get("message", "")) for w in (preview.warnings or []) if w.get("message")]
+        lines = []
+        if occurrences:
+            lines.append(
+                "Next runs: " + ", ".join(_format_occurrence(o) for o in occurrences[:3])
+            )
+        else:
+            lines.append("Valid.")
+        lines.extend(warnings)
+        preview_text.update("\n".join(lines))
+
+    # -- save ------------------------------------------------------------------------
+
+    def _run_save(self) -> None:
+        schedule_error = self._client_side_schedule_error()
+        if schedule_error:
+            self._set_validation_errors([{"field": "schedule", "message": schedule_error}])
+            return
+        payload = self._build_payload()
+        owner = self._selected_owner()
+
+        async def _do() -> None:
+            await self._save_async(payload, owner)
+
+        self.run_worker(_do, exclusive=True, group="automation-form-save")
+
+    async def _save_async(self, payload: dict[str, Any], owner: str) -> None:
+        try:
+            outcome: "SaveDefinitionOutcome" = await self._service.save_definition(
+                payload, owner
+            )
+        except Exception:  # noqa: BLE001 - never let a save crash the modal
+            logger.exception("Automation save failed")
+            self._set_form_error("Save failed — check the log and try again.")
+            return
+        if outcome.status in ("saved", "queued"):
+            self._set_validation_errors([])
+            self.dismiss(outcome)
+            return
+        self._set_validation_errors(outcome.errors or [])

--- a/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
@@ -1,18 +1,24 @@
-"""Recurring-question automation-definition create modal (task-5).
+"""Recurring-question automation-definition create/edit modal (task-5).
 
 Mirrors `ReminderForm`'s structure (ADR-099 idiom parity: the modal box is
 its own scroll container, a docked footer keeps the live preview/errors/
 actions visible, Escape triggers a discard guard). The recurring-cron
 schedule sub-form reuses `reminder_form.py`'s task-23102 pure helpers
-(`preset_to_cron`, `cron_to_preset`, `parse_time_of_day`,
-`parse_forgiving_datetime`, timezone helpers) directly -- only the
-Textual wiring (widget ids, compose layout) is necessarily duplicated,
-since it is bound to this form's own field ids.
+(`preset_to_cron`, `cron_to_preset`, `parse_forgiving_datetime`, timezone
+helpers) directly -- only the Textual wiring (widget ids, compose layout)
+is necessarily duplicated, since it is bound to this form's own field ids.
+`cron_to_preset` is used for edit-mode prefill (mapping a stored cron
+expression back onto the preset/time-of-day fields); nothing here needs
+`parse_time_of_day` directly since `cron_to_preset` already returns the
+time text ready to use.
 
-v1 is create-only (spec sec 8 / plan task 4 handoff): the Automations tab
-has no local-definition listing or edit entry point yet (that is later
-program work, spec sec 9), so this form never receives an existing
-local row and always authors `mode="create"`.
+Edit mode (task-5 fix round; spec sec 8 calls for one create/EDIT modal)
+takes an existing definition row via `definition_row` (used to prefill
+every field) and `definition_id` (the facade's own LOCAL-id authority for
+`save_definition`, resolved by the caller -- see `SchedulesWorkbench.
+_resolve_local_definition_id`, which mirrors a server-only row on demand
+since it may have no local shadow yet). Without them this is a plain
+create form, `mode="create"`.
 """
 
 from __future__ import annotations
@@ -35,6 +41,7 @@ from .reminder_form import (
     _DEFAULT_TIMEZONE,
     _TIME_OF_DAY_PRESETS,
     _is_valid_zone,
+    cron_to_preset,
     detect_system_timezone,
     parse_forgiving_datetime,
     preset_to_cron,
@@ -100,7 +107,7 @@ def _format_occurrence(raw: str) -> str:
 
 
 class AutomationDefinitionForm(ModalScreen):
-    """Create modal for a `recurring_question` automation definition."""
+    """Create/edit modal for a `recurring_question` automation definition."""
 
     BINDINGS = [
         Binding("escape", "dismiss", "Close", show=False),
@@ -193,10 +200,12 @@ class AutomationDefinitionForm(ModalScreen):
         self,
         service: "SchedulingService",
         *,
+        definition_row: dict[str, Any] | None = None,
+        definition_id: str | None = None,
         available_owners: Sequence[tuple[str, str]] = (("This device", "local"),),
         default_owner: str = "local",
     ) -> None:
-        """Initialize the create form.
+        """Initialize the create or edit form.
 
         Args:
             service: The active `SchedulingService` -- this form calls its
@@ -204,12 +213,28 @@ class AutomationDefinitionForm(ModalScreen):
                 (Task 4), the same way the Preview button and Save need
                 live, in-modal feedback that a push_screen callback alone
                 cannot provide.
+            definition_row: An existing definition's fields (local DB row
+                or a server list-response dict -- both shapes prefill the
+                same way) to edit, or `None` to create. Display/prefill
+                only -- NOT the save-routing authority (see
+                `definition_id`).
+            definition_id: The LOCAL row id to pass to `save_definition`
+                when editing (`None` for create). The caller resolves this
+                -- a server-only row may have no local shadow yet, and
+                mirroring one on demand needs DB access this form does not
+                have (`SchedulesWorkbench._resolve_local_definition_id`).
             available_owners: `(label, owner_id)` options for "Runs on".
-            default_owner: The owner preselected on open (the current
-                screen owner, per spec sec 8).
+            default_owner: The owner preselected on open -- the current
+                screen owner when creating, or the row's own owner when
+                editing (spec sec 8; "Runs on" is disabled while editing,
+                same as `ReminderForm`'s owner-is-fixed-once-created rule
+                -- moving a saved automation between owners is a separate,
+                not-yet-built feature).
         """
         super().__init__()
         self._service = service
+        self._definition_row = definition_row
+        self._definition_id = definition_id
         self._available_owners = list(available_owners) or [("This device", "local")]
         self._default_owner = default_owner
         self._dirty = False
@@ -243,7 +268,12 @@ class AutomationDefinitionForm(ModalScreen):
 
     def compose(self) -> ComposeResult:
         with VerticalScroll(id="automation-form-box"):
-            yield Label("New Recurring Question", classes="form-title")
+            yield Label(
+                "Edit Recurring Question"
+                if self._definition_row is not None
+                else "New Recurring Question",
+                classes="form-title",
+            )
 
             yield Label("Runs on:", classes="form-label")
             yield Select(
@@ -251,9 +281,12 @@ class AutomationDefinitionForm(ModalScreen):
                 allow_blank=False,
                 value=self._default_owner,
                 id="automation-runs-on",
+                disabled=self._definition_row is not None,
             )
             yield Static(
-                "Create it locally, or on the connected server if one is "
+                "Existing automations keep the owner they were created with."
+                if self._definition_row is not None
+                else "Create it locally, or on the connected server if one is "
                 "available.",
                 classes="form-helper",
             )
@@ -373,11 +406,103 @@ class AutomationDefinitionForm(ModalScreen):
         self._update_schedule_field_visibility(ScheduleKind.ONE_TIME.value)
         self._update_preset_field_visibility("daily")
         self._update_scope_field_visibility("all_searchable_library")
+        if self._definition_row is not None:
+            self._prefill_from_row(self._definition_row)
         self.call_after_refresh(self._mark_ready)
 
     def _mark_ready(self) -> None:
         self._dirty = False
         self._ready = True
+
+    def _prefill_from_row(self, row: dict[str, Any]) -> None:
+        """Reverse-map an existing definition's fields onto the form (edit mode).
+
+        Tolerant of both shapes `definition_row` can carry (a local DB
+        row or a raw server list-response dict) -- every lookup treats a
+        missing/wrong-typed field as absent rather than raising, since an
+        externally-sourced row is not this form's own contract to
+        validate. A schedule kind/shape this form cannot itself produce
+        (e.g. a real `interval`/`daily`/`weekly` schedule, or a `cron`
+        keyed differently than this local port's own `cron`/`timezone`)
+        is left at the create-mode default (one-time, blank run-at)
+        rather than guessed at -- the user sets an explicit new schedule
+        instead of silently keeping an un-editable one.
+        """
+        self.query_one("#automation-name", Input).value = str(row.get("name") or "")
+
+        input_fields = row.get("input") if isinstance(row.get("input"), dict) else {}
+        self.query_one("#automation-question", TextArea).text = str(
+            input_fields.get("question") or ""
+        )
+        provider = input_fields.get("provider")
+        if provider:
+            self.query_one("#automation-provider", Input).value = str(provider)
+        model = input_fields.get("model")
+        if model:
+            self.query_one("#automation-model", Input).value = str(model)
+
+        config = row.get("config") if isinstance(row.get("config"), dict) else {}
+        scope = config.get("scope") if isinstance(config.get("scope"), dict) else {}
+        scope_mode = (
+            scope.get("mode")
+            if scope.get("mode") in ("all_searchable_library", "sources")
+            else "all_searchable_library"
+        )
+        self.query_one("#automation-scope-mode", Select).value = scope_mode
+        self._update_scope_field_visibility(scope_mode)
+        if scope_mode == "sources":
+            selected_sources = set(scope.get("sources") or [])
+            for _label, value in _SCOPE_SOURCE_CHECKBOXES:
+                self.query_one(
+                    f"#automation-scope-{value.split('_')[0]}", Checkbox
+                ).value = value in selected_sources
+
+        generation_mode = config.get("generation_mode")
+        if generation_mode in {value for _, value in _GENERATION_MODE_OPTIONS}:
+            self.query_one("#automation-generation-mode", Select).value = generation_mode
+
+        finding_policy = (
+            config.get("finding_policy")
+            if isinstance(config.get("finding_policy"), dict)
+            else {}
+        )
+        preset_value = finding_policy.get("preset")
+        if preset_value in {value for _, value in _FINDING_POLICY_OPTIONS}:
+            self.query_one("#automation-finding-policy", Select).value = preset_value
+
+        notification_policy = (
+            row.get("notification_policy")
+            if isinstance(row.get("notification_policy"), dict)
+            else {}
+        )
+        notify = bool(notification_policy.get("on_success")) or bool(
+            notification_policy.get("on_failure")
+        )
+        self.query_one("#automation-notify", Checkbox).value = notify
+
+        schedule = row.get("schedule") if isinstance(row.get("schedule"), dict) else {}
+        kind = schedule.get("kind")
+        if kind == "one_time" and schedule.get("run_at"):
+            self.query_one("#automation-schedule-kind", Select).value = (
+                ScheduleKind.ONE_TIME.value
+            )
+            self.query_one("#automation-run-at", Input).value = str(schedule["run_at"])
+            self._update_schedule_field_visibility(ScheduleKind.ONE_TIME.value)
+        elif kind == "cron" and schedule.get("cron"):
+            self.query_one("#automation-schedule-kind", Select).value = (
+                ScheduleKind.RECURRING.value
+            )
+            cron_value = str(schedule["cron"])
+            self.query_one("#automation-cron", Input).value = cron_value
+            preset_key, time_text = cron_to_preset(cron_value)
+            self.query_one("#automation-cron-preset", Select).value = preset_key
+            if time_text:
+                self.query_one("#automation-preset-time", Input).value = time_text
+            self._update_preset_field_visibility(preset_key)
+            tz = schedule.get("timezone")
+            if tz and _is_valid_zone(str(tz)):
+                self.query_one("#automation-timezone", Select).value = str(tz)
+            self._update_schedule_field_visibility(ScheduleKind.RECURRING.value)
 
     # -- timezone helpers (reuse reminder_form's pure functions) -------------
 
@@ -500,13 +625,23 @@ class AutomationDefinitionForm(ModalScreen):
     def _build_payload(self) -> dict[str, Any]:
         """Build a `ScheduledTaskPreviewCreateRequest`-shaped payload.
 
-        v1 is create-only (module docstring): `mode` is always
-        `"create"`, and `definition_id`/`definition_version` are never
-        sent (the not-allowed-for-create validators would reject them).
         `visibility_policy`/`approval_policy`/`retention_policy` are not
         exposed as v1 fields (spec sec 8) -- omitting them lets the
         family default (`findings_only`) and the ported normalizers'
         own defaults apply, matching a payload that never mentioned them.
+
+        `mode`/`definition_id`/`definition_version` here only drive the
+        PREVIEW button's own local-validation presence checks
+        (`preview_definition` takes the payload as-is, unlike
+        `save_definition`, which always rebuilds these three itself from
+        its own `definition_id` parameter -- Task 4's contract, so this
+        method's values never affect what actually gets saved). Editing
+        always sends the LOCAL id here, which is correct for a local-owned
+        row but not what a server-owned row's OWN preview endpoint expects
+        (it wants the server's id) -- Preview during a server-owned edit
+        therefore falls back to local-only validation feedback
+        (`preview_definition`'s existing `ServerClientError` catch-all),
+        never a hard failure. Save is unaffected either way.
         """
         name = self.query_one("#automation-name", Input).value.strip()
         question = self.query_one("#automation-question", TextArea).text.strip()
@@ -520,9 +655,9 @@ class AutomationDefinitionForm(ModalScreen):
         if model:
             input_fields["model"] = model
 
-        return {
+        payload: dict[str, Any] = {
             "family": _FAMILY,
-            "mode": "create",
+            "mode": "update" if self._definition_id is not None else "create",
             "name": name,
             "input": input_fields,
             "schedule": self._schedule_payload(),
@@ -539,6 +674,10 @@ class AutomationDefinitionForm(ModalScreen):
             },
             "notification_policy": {"on_success": notify, "on_failure": notify},
         }
+        if self._definition_id is not None:
+            payload["definition_id"] = self._definition_id
+            payload["definition_version"] = (self._definition_row or {}).get("version")
+        return payload
 
     # -- validation-error rendering -----------------------------------------------
 
@@ -670,7 +809,7 @@ class AutomationDefinitionForm(ModalScreen):
     async def _save_async(self, payload: dict[str, Any], owner: str) -> None:
         try:
             outcome: "SaveDefinitionOutcome" = await self._service.save_definition(
-                payload, owner
+                payload, owner, definition_id=self._definition_id
             )
         except Exception:  # noqa: BLE001 - never let a save crash the modal
             logger.exception("Automation save failed")

--- a/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
@@ -675,8 +675,13 @@ class AutomationDefinitionForm(ModalScreen):
             "notification_policy": {"on_success": notify, "on_failure": notify},
         }
         if self._definition_id is not None:
-            payload["definition_id"] = self._definition_id
-            payload["definition_version"] = (self._definition_row or {}).get("version")
+            row = self._definition_row or {}
+            # A server-owned row's update preview goes to the SERVER seam,
+            # where only the server's own definition id means anything; the
+            # local id is the facade's save-path authority, passed separately
+            # (see the save handler). Local rows have no server_id.
+            payload["definition_id"] = row.get("server_id") or self._definition_id
+            payload["definition_version"] = row.get("version")
         return payload
 
     # -- validation-error rendering -----------------------------------------------

--- a/tldw_chatbook/UI/Screens/scheduling/forms/new_task_choice_modal.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/new_task_choice_modal.py
@@ -1,0 +1,98 @@
+"""Tiny choice between a reminder and a recurring-question automation.
+
+Smallest existing house pattern (task-5, ADR-099 idiom parity): a
+two-button confirm modal using `SafeModalDismissMixin`, same shape as
+`ManagedGGUFRuntimeChoiceModal` -- no dirty-state to guard, so the mixin's
+one-shot dismiss/backdrop handling is all this needs (unlike the create/
+edit forms, which have their own bespoke discard guard for real field
+state).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
+
+NewTaskChoice = Literal["reminder", "recurring_question"]
+
+
+class NewTaskChoiceModal(SafeModalDismissMixin, ModalScreen[NewTaskChoice | None]):
+    """Ask which kind of scheduled task to create."""
+
+    DEFAULT_CSS = """
+    NewTaskChoiceModal {
+        align: center middle;
+    }
+
+    NewTaskChoiceModal .new-task-choice-modal {
+        width: 64;
+        height: auto;
+        border: tall $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    NewTaskChoiceModal .new-task-choice-title {
+        text-style: bold;
+        margin-bottom: 1;
+    }
+
+    NewTaskChoiceModal .new-task-choice-copy {
+        height: auto;
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+
+    NewTaskChoiceModal .new-task-choice-actions {
+        height: 3;
+        align-horizontal: right;
+    }
+
+    NewTaskChoiceModal .new-task-choice-actions Button {
+        width: auto;
+        margin-left: 1;
+    }
+    """
+
+    BINDINGS = [("escape", "request_safe_cancel", "Cancel")]
+    SAFE_MODAL_CONTENT = ".new-task-choice-modal"
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="new-task-choice-modal"):
+            yield Static("New scheduled task", classes="new-task-choice-title", markup=False)
+            yield Static(
+                "A reminder fires once or on a cron schedule. A recurring "
+                "question runs a scoped search on a schedule and reports "
+                "what it finds.",
+                classes="new-task-choice-copy",
+                markup=False,
+            )
+            with Horizontal(classes="new-task-choice-actions"):
+                yield Button("Cancel", id="new-task-choice-cancel")
+                yield Button(
+                    "Recurring question…", id="new-task-choice-automation"
+                )
+                yield Button(
+                    "Reminder…", id="new-task-choice-reminder", variant="primary"
+                )
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        self.query_one("#new-task-choice-reminder", Button).focus()
+
+    @on(Button.Pressed)
+    async def _button_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        if event.button.id == "new-task-choice-reminder":
+            self.dismiss_safe_once("reminder")
+        elif event.button.id == "new-task-choice-automation":
+            self.dismiss_safe_once("recurring_question")
+        elif event.button.id == "new-task-choice-cancel":
+            await self.request_safe_cancel(source="visible")

--- a/tldw_chatbook/UI/Screens/scheduling/forms/reminder_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/reminder_form.py
@@ -370,6 +370,8 @@ class ReminderForm(ModalScreen):
         task: ReminderTask | None = None,
         *,
         known_timezones: Sequence[str] = (),
+        available_owners: Sequence[tuple[str, str]] = (("This device", "local"),),
+        default_owner: str = "local",
     ) -> None:
         """Initialize the form.
 
@@ -378,12 +380,35 @@ class ReminderForm(ModalScreen):
             known_timezones: Zones already used by existing tasks; offered
                 in the timezone selector alongside the system zone and the
                 curated common zones (task-23102).
+            available_owners: ``(label, owner_id)`` options offered by the
+                "Runs on" selector (task-5). The workbench computes these
+                from its own connected-server state.
+            default_owner: The owner preselected when creating a new
+                reminder -- the current screen owner (task-5 / spec sec 8).
         """
         super().__init__()
         self._reminder_task = task
         self._known_timezones = tuple(known_timezones)
+        self._available_owners = list(available_owners) or [("This device", "local")]
+        self._default_owner = default_owner
         self._dirty = False
         self._ready = False
+
+    def _runs_on_options(self) -> list[tuple[str, str]]:
+        """Runs-on choices: the offered owners, plus this task's own
+        owner when editing one that is not among them (review F4
+        precedent from the timezone selector: an edited row's actual
+        owner must always round-trip, not just the currently connected
+        choices)."""
+        options = list(self._available_owners)
+        task_owner = getattr(self._reminder_task, "owner_id", None)
+        if task_owner and task_owner not in {value for _, value in options}:
+            options.append((task_owner, task_owner))
+        return options
+
+    def _initial_owner(self) -> str:
+        task_owner = getattr(self._reminder_task, "owner_id", None)
+        return task_owner or self._default_owner
 
     def _timezone_options(self) -> list[tuple[str, str]]:
         """(label, zone) options: system zone first, then curated zones,
@@ -473,6 +498,21 @@ class ReminderForm(ModalScreen):
             yield Label(
                 "Edit Scheduled Task" if self._reminder_task else "New Scheduled Task",
                 classes="form-title",
+            )
+
+            yield Label("Runs on:", classes="form-label")
+            yield Select(
+                self._runs_on_options(),
+                allow_blank=False,
+                value=self._initial_owner(),
+                id="reminder-runs-on",
+                disabled=self._reminder_task is not None,
+            )
+            yield Static(
+                "Existing tasks keep the owner they were created with."
+                if self._reminder_task is not None
+                else "Create it locally, or on the connected server if one is available.",
+                classes="form-helper",
             )
 
             yield Label("Title:", classes="form-label")
@@ -682,6 +722,10 @@ class ReminderForm(ModalScreen):
         """The timezone currently selected."""
         return str(self.query_one("#reminder-timezone", Select).value)
 
+    def _selected_owner(self) -> str:
+        """The "Runs on" owner currently selected."""
+        return str(self.query_one("#reminder-runs-on", Select).value)
+
     def _update_preset_field_visibility(self, preset: str) -> None:
         """Show the time-of-day field for presets, the raw cron for custom."""
         time_group = self.query_one("#reminder-preset-time-group", Vertical)
@@ -818,6 +862,9 @@ class ReminderForm(ModalScreen):
             "title": title,
             "body": body,
             "schedule_kind": schedule_kind,
+            # Routing only (task-5) -- the workbench pops this before
+            # building the ReminderTask payload; it is never a task field.
+            "owner_id": self._selected_owner(),
         }
         if schedule_kind == ScheduleKind.ONE_TIME.value:
             form_data["run_at"] = parsed_run_at

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -135,7 +135,11 @@ def automation_name_cell(definition: dict[str, Any]) -> str:
 
     Returns:
         `"[This device] <name>"` for a local row, `"[<server id>] <name>"`
-        for a server-scoped one.
+        for a server-scoped one, and `"[<server id> · pending sync]
+        <name>"` for one authored offline that has not reached the server
+        yet (`pending_sync`, stamped by `_load_local_automations`) -- that
+        row is only on this device, and saying "server" flat would claim a
+        definition the server has never heard of (final review I5).
     """
     from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
 
@@ -143,6 +147,8 @@ def automation_name_cell(definition: dict[str, Any]) -> str:
     name = str(definition.get("name") or definition.get("id") or "")
     if is_server_scoped_owner(owner_id):
         label = owner_id.split(":", 1)[1] if ":" in owner_id else owner_id
+        if definition.get("pending_sync"):
+            label = f"{label} · pending sync"
     else:
         label = "This device"
     return f"[{label}] {name}"
@@ -1154,7 +1160,21 @@ class SchedulesWorkbench(BaseAppScreen):
     async def _load_local_automations(
         self, service: "SchedulingService"
     ) -> list[dict[str, Any]]:
-        """This device's own automation definitions, off the event loop.
+        """Every definition that exists ONLY on this device, off the event loop.
+
+        That is not the same as `owner_id="local"`: an automation authored
+        offline with "Runs on: Server" is stored under `owner_id=
+        "server:<id>"` with `server_id IS NULL` until a sync pushes it, so
+        filtering on the local owner hid it from this half while the
+        server half could not know about it either -- it appeared in
+        NEITHER list (final review I5). Any row with no `server_id`
+        belongs here, whoever owns it; rows that HAVE a `server_id` are the
+        server half's by construction, so the two halves cannot duplicate.
+
+        Rows in that pending state are stamped `pending_sync` so the
+        renderer can say so (`automation_name_cell`) and the actions that
+        need a real server id can refuse honestly rather than calling the
+        server with a local uuid.
 
         Health is never persisted (`automation_health.py`'s own docstring)
         -- it is computed fresh here the same way `run_automation_now`
@@ -1162,14 +1182,17 @@ class SchedulesWorkbench(BaseAppScreen):
         create-time placeholder (`execution_unavailable`) as if it were
         live.
         """
+        from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
+
         try:
-            rows = await asyncio.to_thread(
-                service.db.list_automation_definitions, owner_id="local"
-            )
+            all_rows = await asyncio.to_thread(service.db.list_automation_definitions)
         except Exception:  # noqa: BLE001
             logger.exception("Failed to load local automation definitions")
             return []
+        rows = [row for row in all_rows if not row.get("server_id")]
         for row in rows:
+            if is_server_scoped_owner(row.get("owner_id")):
+                row["pending_sync"] = True
             health, _reason = compute_local_health(self.app_instance, row)
             row["health"] = health
         return rows
@@ -1283,6 +1306,16 @@ class SchedulesWorkbench(BaseAppScreen):
         from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
 
         owner_id = (definition or {}).get("owner_id")
+        if (definition or {}).get("pending_sync"):
+            # Never synced: the audit endpoint has no id to look up, and
+            # asking it with a local uuid would render a bare error.
+            table.clear()
+            self._update_static_content(
+                notice,
+                "This automation hasn't synced to the server yet, so it has "
+                "no run history.",
+            )
+            return
         if not is_server_scoped_owner(owner_id):
             # Honest gap (task-5 fix round): local automation runs are not
             # tracked in a durable audit trail yet -- only the server side
@@ -1372,6 +1405,15 @@ class SchedulesWorkbench(BaseAppScreen):
         """
         from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
 
+        if definition.get("pending_sync"):
+            # Server-owned but never pushed: the server has no id for it,
+            # and this side must not run a server-owned definition (§3).
+            self.app_instance.notify(
+                "This automation hasn't synced to the server yet — it will "
+                "run there after the next successful sync.",
+                severity="warning",
+            )
+            return
         if is_server_scoped_owner(definition.get("owner_id")):
             self._run_automation_now_server(definition)
         else:
@@ -1569,7 +1611,11 @@ class SchedulesWorkbench(BaseAppScreen):
         from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
 
         owner_id = str(definition.get("owner_id") or "local")
-        if not is_server_scoped_owner(owner_id):
+        if definition.get("pending_sync") or not is_server_scoped_owner(owner_id):
+            # A `pending_sync` row IS a local row (server-owned, never
+            # synced): its `id` is already the local one, and treating it
+            # as a server id here would mirror it back as a SECOND row
+            # keyed by that uuid.
             local_id = definition.get("id")
             return str(local_id) if local_id else None
 

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 from collections.abc import Mapping
 from datetime import datetime, timezone
@@ -25,6 +26,7 @@ from ...Workbench.workbench_state import (
 )
 from ...Workbench.workbench_widgets import DestinationHeader, RecoveryCallout
 from ....runtime_policy.bootstrap import set_authoritative_runtime_source
+from ....Scheduling.automation_health import compute_local_health
 from ....Scheduling.events import (
     DeleteTaskRequested,
     DisableTaskRequested,
@@ -113,6 +115,38 @@ def automation_execution_target_label(definition: dict[str, Any]) -> str:
     if model:
         return model
     return "auto"
+
+
+def automation_name_cell(definition: dict[str, Any]) -> str:
+    """Name cell for the merged local+server Automations list (task-5 fix round).
+
+    The tab now mixes local-owned rows into what used to be a server-only
+    list, so every row needs a visible owner distinction or a local save
+    reads as indistinguishable from a server one. A prefix on the existing
+    Name cell is the smallest honest rendering -- no new column, no CSS
+    changes -- since the table's own `key=` already disambiguates rows for
+    everything that acts on them; this prefix is purely for the human
+    reading the table.
+
+    Args:
+        definition: One merged row (local DB dict or server API dict --
+            both carry `owner_id` and `name`, confirmed against the real
+            server fixture `automation_definition_list.json`).
+
+    Returns:
+        `"[This device] <name>"` for a local row, `"[<server id>] <name>"`
+        for a server-scoped one.
+    """
+    from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
+
+    owner_id = str(definition.get("owner_id") or "local")
+    name = str(definition.get("name") or definition.get("id") or "")
+    if is_server_scoped_owner(owner_id):
+        label = owner_id.split(":", 1)[1] if ":" in owner_id else owner_id
+    else:
+        label = "This device"
+    return f"[{label}] {name}"
+
 
 #: Delayed second fetch of the run-history pane after a Run-now dispatch:
 #: the terminal audit event lands only after the server finishes executing
@@ -814,18 +848,26 @@ class SchedulesWorkbench(BaseAppScreen):
         elif choice == "recurring_question":
             self.action_create_automation()
 
-    def _on_automation_form_result(self, outcome: Any | None) -> None:
-        """Notify and refresh the Automations list after a definition save."""
+    def _on_automation_form_result(
+        self, outcome: Any | None, *, was_edit: bool = False
+    ) -> None:
+        """Notify and refresh the Automations list after a definition save.
+
+        `was_edit` only changes the toast wording ("updated" vs
+        "created") -- an edit reusing the create-mode "created" copy
+        would misreport what actually happened.
+        """
         if outcome is None:
             return
         status = getattr(outcome, "status", None)
+        verb = "updated" if was_edit else "created"
         if status == "saved":
             self.app_instance.notify(
-                "Automation created.", severity="information"
+                f"Automation {verb}.", severity="information"
             )
         elif status == "queued":
             self.app_instance.notify(
-                "Automation created locally — it will sync to the server.",
+                f"Automation {verb} locally — it will sync to the server.",
                 severity="information",
             )
         self._request_automations_refresh()
@@ -1034,14 +1076,17 @@ class SchedulesWorkbench(BaseAppScreen):
         )  # type: ignore[arg-type]
 
     async def load_automations(self) -> None:
-        """Fetch server automation definitions for the Automations tab."""
+        """Fetch and merge local + server automation definitions (task-5 fix round).
+
+        This tab used to be server-only: a locally-saved recurring
+        question had no on-screen home. Local rows are now merged in
+        (owner distinguished via `automation_name_cell`'s Name-cell
+        prefix) so a local save's refresh actually shows the new row.
+        """
         notice = self.query_one("#scheduling-automations-notice", Static)
         table = self.query_one("#scheduling-automations-table", DataTable)
         service = self._scheduling_service
-        server_client = getattr(service, "server_client", None) if service else None
-        if server_client is None or not self._server_available(
-            service, self._active_server_id()
-        ):
+        if service is None:
             self._automations = []
             self._selected_automation_id = None
             table.clear()
@@ -1052,52 +1097,40 @@ class SchedulesWorkbench(BaseAppScreen):
                 "Run history needs a connected server."
             )
             return
+
         # task-15476 discipline: a rebuild must reconcile the selection by
         # id -- keep the cursor on the same definition when it survives the
-        # refresh, and clear it when it does not, so `r` can never act on a
-        # row the user is no longer looking at.
+        # refresh, and clear it when it does not, so `r`/`e` can never act
+        # on a row the user is no longer looking at.
         previous_selection = self._selected_automation_id
-        try:
-            # Follow `has_more` pages so the tab never silently hides the
-            # tail of a large definition list; the cap is a defensive bound,
-            # not an expected cliff.
-            items: list[dict[str, Any]] = []
-            total = 0
-            offset = 0
-            while True:
-                response = await server_client.list_automation_definitions(
-                    limit=50, offset=offset
+
+        local_items = await self._load_local_automations(service)
+
+        server_client = getattr(service, "server_client", None)
+        server_available = server_client is not None and self._server_available(
+            service, self._active_server_id()
+        )
+        server_items: list[dict[str, Any]] = []
+        total_server = 0
+        server_error = False
+        if server_available:
+            try:
+                server_items, total_server = await self._load_server_automations(
+                    server_client
                 )
-                page = list(response.get("items", []))
-                items.extend(page)
-                total = int(response.get("total", len(items)) or 0)
-                offset += len(page)
-                if (
-                    not page
-                    or not response.get("has_more")
-                    or len(items) >= AUTOMATIONS_LOAD_MAX_ROWS
-                ):
-                    break
-        except Exception:  # noqa: BLE001
-            logger.exception(
-                "Failed to load server automations (server_id={})",
-                self._active_server_id(),
-            )
-            self._automations = []
-            self._selected_automation_id = None
-            table.clear()
-            self._update_static_content(
-                notice, "Could not load server automations — see the log."
-            )
-            self._clear_automation_history(
-                "Run history unavailable — the definition list failed to load."
-            )
-            return
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Failed to load server automations (server_id={})",
+                    self._active_server_id(),
+                )
+                server_error = True
+
+        items = local_items + server_items
         self._automations = items
         table.clear()
         for definition in items:
             table.add_row(
-                str(definition.get("name") or definition.get("id")),
+                automation_name_cell(definition),
                 str(definition.get("family", "?")),
                 str(definition.get("lifecycle", "?")),
                 str(definition.get("health", "?")),
@@ -1112,14 +1145,101 @@ class SchedulesWorkbench(BaseAppScreen):
         else:
             self._selected_automation_id = None
             self._clear_automation_history("Select an automation to see its history.")
-        shown = len(items)
-        suffix = f" (showing {shown} of {total})" if total > shown else ""
-        self._update_static_content(
-            notice,
-            f"{shown} automation{'' if shown == 1 else 's'} on the server{suffix}."
-            if shown
-            else "No automations on the server yet.",
+
+        notice_text = self._automations_notice_text(
+            local_items, server_items, server_available, total_server, server_error
         )
+        self._update_static_content(notice, notice_text)
+
+    async def _load_local_automations(
+        self, service: "SchedulingService"
+    ) -> list[dict[str, Any]]:
+        """This device's own automation definitions, off the event loop.
+
+        Health is never persisted (`automation_health.py`'s own docstring)
+        -- it is computed fresh here the same way `run_automation_now`
+        computes it before dispatching, so the column never shows the
+        create-time placeholder (`execution_unavailable`) as if it were
+        live.
+        """
+        try:
+            rows = await asyncio.to_thread(
+                service.db.list_automation_definitions, owner_id="local"
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to load local automation definitions")
+            return []
+        for row in rows:
+            health, _reason = compute_local_health(self.app_instance, row)
+            row["health"] = health
+        return rows
+
+    async def _load_server_automations(
+        self, server_client: Any
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Follow `has_more` pages so the tab never silently hides the tail
+        of a large definition list; the cap is a defensive bound, not an
+        expected cliff.
+
+        Every item is stamped with `owner_id` if the response omitted one
+        (some fixtures/older server versions do): these rows are known to
+        be server-scoped by construction (this IS the server fetch), so
+        the run-now/history/edit routing that reads `owner_id` off the row
+        must never depend on the wire response actually including it.
+        """
+        items: list[dict[str, Any]] = []
+        total = 0
+        offset = 0
+        while True:
+            response = await server_client.list_automation_definitions(
+                limit=50, offset=offset
+            )
+            page = list(response.get("items", []))
+            items.extend(page)
+            total = int(response.get("total", len(items)) or 0)
+            offset += len(page)
+            if (
+                not page
+                or not response.get("has_more")
+                or len(items) >= AUTOMATIONS_LOAD_MAX_ROWS
+            ):
+                break
+        active_server_id = self._active_server_id()
+        for item in items:
+            if not item.get("owner_id"):
+                item["owner_id"] = f"server:{active_server_id}"
+        return items, total
+
+    @staticmethod
+    def _automations_notice_text(
+        local_items: list[dict[str, Any]],
+        server_items: list[dict[str, Any]],
+        server_available: bool,
+        total_server: int,
+        server_error: bool,
+    ) -> str:
+        """Compose the Automations-pane notice honestly from what actually loaded.
+
+        A server failure never hides local rows that DID load -- the two
+        sources degrade independently, so the server segment reports its
+        own outcome and a local-count addendum is appended only when there
+        is one to report.
+        """
+        if server_error:
+            base = "Could not load server automations — see the log."
+        elif server_available:
+            shown = len(server_items)
+            suffix = f" (showing {shown} of {total_server})" if total_server > shown else ""
+            base = (
+                f"{shown} automation{'' if shown == 1 else 's'} on the server{suffix}."
+                if shown
+                else "No automations on the server yet."
+            )
+        else:
+            base = "Server automations need a connected server."
+        if local_items:
+            base += f" {len(local_items)} on this device."
+        return base
 
     def _clear_automation_history(self, notice_text: str) -> None:
         """Reset the run-history pane to an explanatory notice."""
@@ -1159,6 +1279,20 @@ class SchedulesWorkbench(BaseAppScreen):
         # must never leave another definition's trail under the new title.
         table.clear()
         self._update_static_content(notice, "Loading run history…")
+
+        from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
+
+        owner_id = (definition or {}).get("owner_id")
+        if not is_server_scoped_owner(owner_id):
+            # Honest gap (task-5 fix round): local automation runs are not
+            # tracked in a durable audit trail yet -- only the server side
+            # is. Never claim a server-shaped history for a local row.
+            table.clear()
+            self._update_static_content(
+                notice, "Local automation history isn't available yet."
+            )
+            return
+
         service = self._scheduling_service
         server_client = getattr(service, "server_client", None) if service else None
         if server_client is None:
@@ -1229,6 +1363,69 @@ class SchedulesWorkbench(BaseAppScreen):
         return None
 
     def _run_automation_now(self, definition: dict[str, Any]) -> None:
+        """Dispatch one automation definition now, routed by its owner.
+
+        Local rows use the existing PR-2 `SchedulingService.run_automation_
+        now` seam (the same claim/spawn machinery the scheduled dispatch
+        path uses); server rows keep the existing control-plane dispatch.
+        Never both -- ADR-077 decision 1, one executor per owner.
+        """
+        from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
+
+        if is_server_scoped_owner(definition.get("owner_id")):
+            self._run_automation_now_server(definition)
+        else:
+            self._run_automation_now_local(definition)
+
+    def _run_automation_now_local(self, definition: dict[str, Any]) -> None:
+        """Dispatch a local automation through the existing run-now seam."""
+        service = self._scheduling_service
+        if service is None:
+            self.app_instance.notify(
+                "Scheduling service is unavailable; cannot run the automation.",
+                severity="warning",
+            )
+            return
+        definition_id = str(definition.get("id"))
+        name = str(definition.get("name") or definition_id)
+
+        async def _run() -> None:
+            try:
+                result = await service.run_automation_now(definition_id)
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Local automation run-now failed for definition {}",
+                    definition_id,
+                )
+                self.app_instance.notify(
+                    f"Failed to run '{name}'.", severity="error"
+                )
+                return
+            if result is None:
+                self.app_instance.notify(
+                    f"'{name}' did not run — it is missing, paused/"
+                    "archived, mid-transfer, or its health is not ready "
+                    "(the definition's own state shows which).",
+                    severity="warning",
+                )
+                return
+            deduped = (
+                " — deduped, a run was already in flight"
+                if result.get("deduped")
+                else ""
+            )
+            self.app_instance.notify(
+                f"'{name}' ran now{deduped}.", severity="information"
+            )
+            self._request_automations_refresh()
+
+        self.run_worker(
+            _run,
+            exclusive=True,
+            group="schedules-run-automation-now",
+        )  # type: ignore[arg-type]
+
+    def _run_automation_now_server(self, definition: dict[str, Any]) -> None:
         """Dispatch one server automation through the control-plane run endpoint."""
         service = self._scheduling_service
         server_client = getattr(service, "server_client", None) if service else None
@@ -1292,6 +1489,112 @@ class SchedulesWorkbench(BaseAppScreen):
             exclusive=True,
             group="schedules-run-automation-now",
         )  # type: ignore[arg-type]
+
+    def _edit_selected_automation(self) -> None:
+        """Open the selected automation definition for editing (e key).
+
+        `agent_task` rows are excluded -- only `recurring_question`
+        authoring exists (the same v1 scope guard `save_definition`
+        itself enforces via `_reject_unsupported_family`).
+        """
+        definition = self._selected_automation()
+        if definition is None:
+            self.app_instance.notify(
+                "Nothing to edit — select an automation first.",
+                severity="warning",
+            )
+            return
+        if definition.get("family") != "recurring_question":
+            self.app_instance.notify(
+                "Only recurring-question automations can be edited here "
+                "(agent-task authoring is not yet available).",
+                severity="warning",
+            )
+            return
+        service = self._scheduling_service
+        if service is None:
+            self.app_instance.notify(
+                "Scheduling service is unavailable; cannot edit the automation.",
+                severity="warning",
+            )
+            return
+
+        async def _open() -> None:
+            definition_id = await self._resolve_local_definition_id(
+                service, definition
+            )
+            if definition_id is None:
+                self.app_instance.notify(
+                    "Could not prepare this automation for editing — see "
+                    "the log.",
+                    severity="error",
+                )
+                return
+            owner_id = str(definition.get("owner_id") or "local")
+            options, _default = self._runs_on_options()
+            if owner_id not in {value for _, value in options}:
+                # Same defensive fallback as the reminder form's timezone/
+                # owner selectors: the row's real owner always round-trips
+                # even when it is not among the currently offered choices
+                # (e.g. a server owner other than the active one).
+                options = [*options, (owner_id, owner_id)]
+            self.app.push_screen(
+                AutomationDefinitionForm(
+                    service,
+                    definition_row=definition,
+                    definition_id=definition_id,
+                    available_owners=options,
+                    default_owner=owner_id,
+                ),
+                callback=lambda outcome: self._on_automation_form_result(
+                    outcome, was_edit=True
+                ),
+            )
+
+        self.run_worker(_open, exclusive=True, group="schedules-edit-automation")
+
+    async def _resolve_local_definition_id(
+        self, service: "SchedulingService", definition: dict[str, Any]
+    ) -> str | None:
+        """Return the LOCAL row id `save_definition`'s `definition_id` needs.
+
+        `save_definition`'s `definition_id` parameter is always a LOCAL
+        id (Task 4's own contract). A row shown here from a pure server
+        fetch may have no local shadow yet (nothing has synced or saved
+        it locally before) -- editing it still needs one, so this mirrors
+        it in place via the same `upsert_automation_definitions_from_
+        server` the sync pull and `save_definition`'s own online-create
+        path already use, rather than inventing a second mirroring path.
+        """
+        from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
+
+        owner_id = str(definition.get("owner_id") or "local")
+        if not is_server_scoped_owner(owner_id):
+            local_id = definition.get("id")
+            return str(local_id) if local_id else None
+
+        server_id = str(definition.get("id"))
+        existing = await asyncio.to_thread(
+            service.db.get_automation_definition_by_server_id, owner_id, server_id
+        )
+        if existing is not None:
+            return existing.get("id")
+        try:
+            await asyncio.to_thread(
+                service.db.upsert_automation_definitions_from_server,
+                owner_id,
+                [definition],
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Failed to mirror server automation {} before editing",
+                server_id,
+            )
+            return None
+        mirrored = await asyncio.to_thread(
+            service.db.get_automation_definition_by_server_id, owner_id, server_id
+        )
+        return mirrored.get("id") if mirrored else None
 
     def _set_reminder_enabled(self, task: ReminderTask, enabled: bool) -> None:
         """Update a reminder's enabled state and refresh the queue."""
@@ -1625,7 +1928,20 @@ class SchedulesWorkbench(BaseAppScreen):
         return self._visible_tasks[row]
 
     def action_edit_task(self) -> None:
-        """Open the highlighted task in the edit form (e key)."""
+        """Open the highlighted task/definition in its edit form (e key).
+
+        Routes by active tab, same shape as `action_run_task_now`: the
+        Automations tab's `e` opens `AutomationDefinitionForm` pre-filled
+        for a `recurring_question` row (either owner); everywhere else it
+        is the existing reminder edit flow.
+        """
+        try:
+            active_pane = self.query_one("#scheduling-tabs", TabbedContent).active
+        except Exception:  # noqa: BLE001
+            active_pane = None
+        if active_pane == "scheduling-automations-tab":
+            self._edit_selected_automation()
+            return
         task = self._selected_task()
         if task is None:
             self.app_instance.notify(

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -898,33 +898,34 @@ class SchedulesWorkbench(BaseAppScreen):
         # so a form built before this selector existed (or a caller that
         # omits it) behaves exactly as before.
         target_owner = form_data.pop("owner_id", None) or service.owner_id
+        # This list is owner-scoped, so a save aimed elsewhere cannot appear
+        # in it -- say where it went instead of a bare "created" that reads
+        # as a lost save. Label, not raw id: same vocabulary as the "Runs on"
+        # selector the owner was picked from.
+        owner_label = {
+            value: label for label, value in self._runs_on_options()[0]
+        }.get(target_owner, target_owner)
+        created_message = (
+            "Scheduled task created."
+            if target_owner == service.owner_id
+            else f"Scheduled task created for {owner_label} — switch to that "
+            "owner to see it."
+        )
 
         async def _save_and_refresh() -> None:
-            # ponytail: momentarily flipping the service's shared owner_id
-            # around the single create/update call (the EXISTING owner-
-            # switch path -- `set_owner`, also used by the Local/Server
-            # buttons) is the smallest way to let one save target a
-            # DIFFERENT owner than the screen's current one, reusing
-            # `create_reminder`/`update_reminder` completely unmodified.
-            # Ceiling: another worker reading `service.owner_id` during
-            # the awaited network call would transiently see the flipped
-            # owner. Upgrade path if that ever bites: thread an explicit
-            # `owner_id` parameter through `create_reminder`/
-            # `update_reminder`, mirroring `_owner_uses_server(owner_id)`
-            # (Task 4's precedent for `preview_definition`/
-            # `save_definition`).
-            original_owner = service.owner_id
-            switched = target_owner != original_owner
-            if switched:
-                service.set_owner(target_owner)
+            # The owner is threaded through the call rather than flipped onto
+            # the service around it: `service.owner_id` is shared mutable
+            # state that the sync/refresh/run-now workers also read, and a
+            # flip held across an awaited network round-trip is visible to
+            # every one of them.
             try:
                 if task_id is None:
-                    await service.create_reminder(form_data)
-                    self.app_instance.notify(
-                        "Scheduled task created.", severity="information"
-                    )
+                    await service.create_reminder(form_data, owner_id=target_owner)
+                    self.app_instance.notify(created_message, severity="information")
                 else:
-                    await service.update_reminder(task_id, form_data)
+                    await service.update_reminder(
+                        task_id, form_data, owner_id=target_owner
+                    )
                     self.app_instance.notify(
                         "Scheduled task updated.", severity="information"
                     )
@@ -934,9 +935,6 @@ class SchedulesWorkbench(BaseAppScreen):
                     "Failed to save the scheduled task. Check the form values and try again.",
                     severity="error",
                 )
-            finally:
-                if switched:
-                    service.set_owner(original_owner)
             self._request_tasks_refresh()
 
         self.run_worker(

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -41,6 +41,8 @@ from ....Scheduling.services.server_client import (
 )
 from ....UI.Screens.scheduling.conflicts_tab import ConflictsTab
 from ....UI.Screens.scheduling.sync_status_widget import SyncStatusWidget
+from .forms.automation_definition_form import AutomationDefinitionForm
+from .forms.new_task_choice_modal import NewTaskChoiceModal
 from .forms.reminder_form import ReminderForm
 from .task_detail import (
     SCHEDULES_EMPTY_CONSOLE_RECOVERY,
@@ -263,11 +265,18 @@ class SchedulesWorkbench(BaseAppScreen):
                 with TabPane("Automations", id="scheduling-automations-tab"):
                     with Horizontal(id="scheduling-automations-split"):
                         with Vertical(id="scheduling-automations-pane"):
-                            yield Static(
-                                "Server Automations",
-                                id="scheduling-automations-title",
-                                classes="scheduling-column-title",
-                            )
+                            with Horizontal(id="scheduling-automations-header"):
+                                yield Static(
+                                    "Server Automations",
+                                    id="scheduling-automations-title",
+                                    classes="scheduling-column-title",
+                                )
+                                yield Button(
+                                    "+ New",
+                                    id="scheduling-new-automation",
+                                    variant="primary",
+                                    tooltip="Schedule a new recurring question.",
+                                )
                             yield DataTable(
                                 id="scheduling-automations-table", cursor_type="row"
                             )
@@ -686,7 +695,12 @@ class SchedulesWorkbench(BaseAppScreen):
     @on(Button.Pressed, "#scheduling-new-task")
     def _on_new_task_pressed(self, event: Button.Pressed) -> None:
         event.stop()
-        self.action_create_reminder()
+        self._open_new_task_chooser()
+
+    @on(Button.Pressed, "#scheduling-new-automation")
+    def _on_new_automation_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.action_create_automation()
 
     @on(Button.Pressed, "#schedules-follow-in-console")
     def follow_latest_schedule_run_in_console(self, event: Button.Pressed) -> None:
@@ -739,12 +753,82 @@ class SchedulesWorkbench(BaseAppScreen):
                 zones.append(zone)
         return zones
 
+    def _runs_on_options(self) -> tuple[list[tuple[str, str]], str]:
+        """Runs-on choices for the reminder/automation forms.
+
+        The current screen owner leads and is always the default (spec
+        sec 8); "Server (<id>)" is offered only when a server owner is
+        actually connected (mirrors `_server_available`'s own gate). The
+        owner might not literally be "local" or match the offered server
+        option (e.g. it drifted to a different server id) -- appended as
+        a labeled fallback so the Select never receives a value outside
+        its own options (same precedent as the reminder form's timezone
+        selector, review F4).
+        """
+        service = self._service()
+        owner_id = service.owner_id if service else "local"
+        options: list[tuple[str, str]] = [("This device", "local")]
+        active_server_id = self._active_server_id()
+        if self._server_available(service, active_server_id):
+            options.append((f"Server ({active_server_id})", f"server:{active_server_id}"))
+        if owner_id not in {value for _, value in options}:
+            options.append((owner_id, owner_id))
+        return options, owner_id
+
     def action_create_reminder(self) -> None:
         """Open the create-reminder form."""
+        options, default_owner = self._runs_on_options()
         self.app.push_screen(
-            ReminderForm(known_timezones=self._task_timezones()),
+            ReminderForm(
+                known_timezones=self._task_timezones(),
+                available_owners=options,
+                default_owner=default_owner,
+            ),
             callback=self._on_reminder_form_result,
         )
+
+    def action_create_automation(self) -> None:
+        """Open the create-recurring-question-automation form (task-5)."""
+        service = self._scheduling_service
+        if service is None:
+            self.app_instance.notify(
+                "Scheduling service is unavailable; cannot create an automation.",
+                severity="warning",
+            )
+            return
+        options, default_owner = self._runs_on_options()
+        self.app.push_screen(
+            AutomationDefinitionForm(
+                service, available_owners=options, default_owner=default_owner
+            ),
+            callback=self._on_automation_form_result,
+        )
+
+    def _open_new_task_chooser(self) -> None:
+        """Ask which kind of scheduled task to create (task-5)."""
+        self.app.push_screen(NewTaskChoiceModal(), callback=self._on_new_task_choice)
+
+    def _on_new_task_choice(self, choice: str | None) -> None:
+        if choice == "reminder":
+            self.action_create_reminder()
+        elif choice == "recurring_question":
+            self.action_create_automation()
+
+    def _on_automation_form_result(self, outcome: Any | None) -> None:
+        """Notify and refresh the Automations list after a definition save."""
+        if outcome is None:
+            return
+        status = getattr(outcome, "status", None)
+        if status == "saved":
+            self.app_instance.notify(
+                "Automation created.", severity="information"
+            )
+        elif status == "queued":
+            self.app_instance.notify(
+                "Automation created locally — it will sync to the server.",
+                severity="information",
+            )
+        self._request_automations_refresh()
 
     def _on_reminder_form_result(
         self, form_data: dict[str, Any] | None, task_id: str | None = None
@@ -761,7 +845,30 @@ class SchedulesWorkbench(BaseAppScreen):
             )
             return
 
+        # Routing only (task-5): which owner the reminder is written under,
+        # not a ReminderTask field. Defaults to the service's current owner
+        # so a form built before this selector existed (or a caller that
+        # omits it) behaves exactly as before.
+        target_owner = form_data.pop("owner_id", None) or service.owner_id
+
         async def _save_and_refresh() -> None:
+            # ponytail: momentarily flipping the service's shared owner_id
+            # around the single create/update call (the EXISTING owner-
+            # switch path -- `set_owner`, also used by the Local/Server
+            # buttons) is the smallest way to let one save target a
+            # DIFFERENT owner than the screen's current one, reusing
+            # `create_reminder`/`update_reminder` completely unmodified.
+            # Ceiling: another worker reading `service.owner_id` during
+            # the awaited network call would transiently see the flipped
+            # owner. Upgrade path if that ever bites: thread an explicit
+            # `owner_id` parameter through `create_reminder`/
+            # `update_reminder`, mirroring `_owner_uses_server(owner_id)`
+            # (Task 4's precedent for `preview_definition`/
+            # `save_definition`).
+            original_owner = service.owner_id
+            switched = target_owner != original_owner
+            if switched:
+                service.set_owner(target_owner)
             try:
                 if task_id is None:
                     await service.create_reminder(form_data)
@@ -779,6 +886,9 @@ class SchedulesWorkbench(BaseAppScreen):
                     "Failed to save the scheduled task. Check the form values and try again.",
                     severity="error",
                 )
+            finally:
+                if switched:
+                    service.set_owner(original_owner)
             self._request_tasks_refresh()
 
         self.run_worker(
@@ -791,8 +901,14 @@ class SchedulesWorkbench(BaseAppScreen):
     def _on_edit_task_requested(self, event: EditTaskRequested) -> None:
         """Open the reminder form pre-filled for editing."""
         event.stop()
+        options, default_owner = self._runs_on_options()
         self.app.push_screen(
-            ReminderForm(event.task, known_timezones=self._task_timezones()),
+            ReminderForm(
+                event.task,
+                known_timezones=self._task_timezones(),
+                available_owners=options,
+                default_owner=default_owner,
+            ),
             callback=lambda result: self._on_reminder_form_result(
                 result, event.task.id
             ),

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -144,6 +144,21 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     min-width: 9;
 }
 
+/* Automations tab header (task-5): same title+button row shape as the
+ * Queue pane's #scheduling-list-header above. */
+#scheduling-automations-header {
+    height: auto;
+}
+
+#scheduling-automations-header #scheduling-automations-title {
+    width: 1fr;
+}
+
+#scheduling-new-automation {
+    width: auto;
+    min-width: 9;
+}
+
 /* Empty state */
 #scheduling-task-detail-empty-state {
     color: $text-muted;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13709,6 +13709,21 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     min-width: 9;
 }
 
+/* Automations tab header (task-5): same title+button row shape as the
+ * Queue pane's #scheduling-list-header above. */
+#scheduling-automations-header {
+    height: auto;
+}
+
+#scheduling-automations-header #scheduling-automations-title {
+    width: 1fr;
+}
+
+#scheduling-new-automation {
+    width: auto;
+    min-width: 9;
+}
+
 /* Empty state */
 #scheduling-task-detail-empty-state {
     color: $text-muted;

--- a/tldw_chatbook/tldw_api/client.py
+++ b/tldw_chatbook/tldw_api/client.py
@@ -981,9 +981,14 @@ from .server_notifications_schemas import (
     ServerNotificationStreamEvent,
 )
 from .scheduled_tasks_automation_schemas import (
+    ScheduledTaskAutomationDefinition,
     ScheduledTaskAutomationDefinitionList,
     ScheduledTaskAutomationRunNowResponse,
     ScheduledTaskAuditList,
+    ScheduledTaskDefinitionCreateRequest,
+    ScheduledTaskDefinitionUpdateRequest,
+    ScheduledTaskPreview,
+    ScheduledTaskPreviewCreateRequest,
     ScheduledTaskResult,
     ScheduledTaskResultList,
 )
@@ -8183,6 +8188,75 @@ class TLDWAPIClient:
             json_data={"review_state": review_state, "review_note": review_note},
         )
         return ScheduledTaskResult.model_validate(response)
+
+    async def preview_scheduled_task_definition(
+        self, request: ScheduledTaskPreviewCreateRequest
+    ) -> ScheduledTaskPreview:
+        """Create a server-side authoring preview (spec §5.1).
+
+        Args:
+            request: The preview request (mode/family/config/schedule/etc).
+
+        Returns:
+            The created preview, including ``status``, ``validation_errors``,
+            ``warnings``, and the ``normalized_config`` the server would
+            persist if the preview were consumed.
+        """
+        response = await self._request(
+            "POST",
+            "/api/v1/scheduled-tasks/previews",
+            json_data=request.model_dump(exclude_none=True, mode="json"),
+        )
+        return ScheduledTaskPreview.model_validate(response)
+
+    async def create_scheduled_task_definition(
+        self,
+        preview_id: str,
+        *,
+        initial_lifecycle: str = "configured",
+    ) -> ScheduledTaskAutomationDefinition:
+        """Create a server-side automation definition from a consumed preview.
+
+        Args:
+            preview_id: The valid create-mode preview to consume
+                (``ScheduledTaskPreview.id``).
+            initial_lifecycle: Starting lifecycle -- ``"configured"``
+                (default) or ``"paused"``.
+
+        Returns:
+            The created definition row.
+        """
+        request = ScheduledTaskDefinitionCreateRequest(
+            preview_id=preview_id, initial_lifecycle=initial_lifecycle
+        )
+        response = await self._request(
+            "POST",
+            "/api/v1/scheduled-tasks/definitions",
+            json_data=request.model_dump(mode="json"),
+        )
+        return ScheduledTaskAutomationDefinition.model_validate(response)
+
+    async def update_scheduled_task_definition(
+        self,
+        definition_id: str,
+        preview_id: str,
+    ) -> ScheduledTaskAutomationDefinition:
+        """Apply a consumed update-mode preview to an existing definition.
+
+        Args:
+            definition_id: The definition to update.
+            preview_id: The valid update-mode preview to consume.
+
+        Returns:
+            The updated definition row.
+        """
+        request = ScheduledTaskDefinitionUpdateRequest(preview_id=preview_id)
+        response = await self._request(
+            "PATCH",
+            f"/api/v1/scheduled-tasks/definitions/{definition_id}",
+            json_data=request.model_dump(mode="json"),
+        )
+        return ScheduledTaskAutomationDefinition.model_validate(response)
 
     async def list_output_templates(
         self,

--- a/tldw_chatbook/tldw_api/scheduled_tasks_automation_schemas.py
+++ b/tldw_chatbook/tldw_api/scheduled_tasks_automation_schemas.py
@@ -61,10 +61,6 @@ class ScheduledTaskPreviewCreateRequest(BaseModel):
 
     Mirrors the server's ``ScheduledTaskPreviewCreateRequest`` (see
     ``Tests/Scheduling/fixtures/server_responses/automation_endpoints.md``).
-    ``visibility_policy`` is nullable (not just default-``{}``) -- the local
-    preview port's ``_normalize_visibility_policy`` (``automation_preview.py``)
-    treats it as ``Any`` (string/dict/``None``), and the Task 1 fixture's
-    request payloads send it as an explicit ``null``.
     """
 
     mode: str = "create"
@@ -76,7 +72,7 @@ class ScheduledTaskPreviewCreateRequest(BaseModel):
     config: dict[str, Any] = Field(default_factory=dict)
     input: dict[str, Any] = Field(default_factory=dict)
     schedule: dict[str, Any] = Field(default_factory=dict)
-    visibility_policy: dict[str, Any] | None = None
+    visibility_policy: dict[str, Any] = Field(default_factory=dict)
     notification_policy: dict[str, Any] = Field(default_factory=dict)
     approval_policy: dict[str, Any] = Field(default_factory=dict)
 

--- a/tldw_chatbook/tldw_api/scheduled_tasks_automation_schemas.py
+++ b/tldw_chatbook/tldw_api/scheduled_tasks_automation_schemas.py
@@ -1,9 +1,10 @@
 """Schemas for the server's Scheduled Tasks automation control plane.
 
 Mirrors ``tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py``
-(the ``/api/v1/scheduled-tasks/definitions`` surface) for the subset the
-client consumes in ADR-077 phase 1: listing server-owned definitions and
-triggering a manual run. Enums are typed as ``str`` and nested policies as
+(the ``/api/v1/scheduled-tasks`` surface) for the subset the client
+consumes: listing/running/auditing server-owned definitions (ADR-077 phase
+1), results review (spec §4.2), and previewing/creating/updating
+definitions (spec §5.1). Enums are typed as ``str`` and nested policies as
 ``dict[str, Any]`` deliberately -- the server owns those vocabularies and
 the client must not break when a new lifecycle/health value ships.
 """
@@ -53,6 +54,82 @@ class ScheduledTaskAutomationDefinitionList(BaseModel):
     offset: int = Field(default=0, ge=0)
     has_more: bool = False
     next_offset: int | None = Field(default=None, ge=0)
+
+
+class ScheduledTaskPreviewCreateRequest(BaseModel):
+    """Request body for ``POST /api/v1/scheduled-tasks/previews``.
+
+    Mirrors the server's ``ScheduledTaskPreviewCreateRequest`` (see
+    ``Tests/Scheduling/fixtures/server_responses/automation_endpoints.md``).
+    ``visibility_policy`` is nullable (not just default-``{}``) -- the local
+    preview port's ``_normalize_visibility_policy`` (``automation_preview.py``)
+    treats it as ``Any`` (string/dict/``None``), and the Task 1 fixture's
+    request payloads send it as an explicit ``null``.
+    """
+
+    mode: str = "create"
+    family: str
+    definition_id: str | None = None
+    definition_version: int | None = Field(default=None, ge=1)
+    name: str | None = None
+    description: str | None = None
+    config: dict[str, Any] = Field(default_factory=dict)
+    input: dict[str, Any] = Field(default_factory=dict)
+    schedule: dict[str, Any] = Field(default_factory=dict)
+    visibility_policy: dict[str, Any] | None = None
+    notification_policy: dict[str, Any] = Field(default_factory=dict)
+    approval_policy: dict[str, Any] = Field(default_factory=dict)
+
+
+class ScheduledTaskPreview(BaseModel):
+    """One server preview row (``ScheduledTaskPreviewResponse``).
+
+    Datetimes are ``str | None`` here, matching this file's
+    ``ScheduledTaskResult`` style -- previews are consumed as opaque ISO
+    strings, never date-arithmetic'd client-side.
+
+    ``id``, ``owner_id``, ``payload_hash``, ``risk_class``, ``expires_at``,
+    ``created_by``, ``created_at``, ``consumed_at`` and
+    ``created_definition_id`` are only meaningful after a real server round
+    trip -- they default to ``None`` so this model also validates the Task 1
+    preview fixture (``automation_preview_response.json``), which -- being a
+    pure local preview with no server round trip -- omits them (see
+    ``automation_preview.py``'s module docstring).
+    """
+
+    id: str | None = None
+    owner_id: str | None = None
+    mode: str
+    family: str
+    definition_id: str | None = None
+    definition_version: int | None = Field(default=None, ge=1)
+    status: str
+    payload_hash: str | None = None
+    normalized_config: dict[str, Any] = Field(default_factory=dict)
+    validation_errors: list[dict[str, Any]] = Field(default_factory=list)
+    warnings: list[dict[str, Any]] = Field(default_factory=list)
+    risk_class: str | None = None
+    visibility_policy: dict[str, Any] = Field(default_factory=dict)
+    schedule_preview: dict[str, Any] = Field(default_factory=dict)
+    redaction_policy: dict[str, Any] = Field(default_factory=dict)
+    expires_at: str | None = None
+    created_by: str | None = None
+    created_at: str | None = None
+    consumed_at: str | None = None
+    created_definition_id: str | None = None
+
+
+class ScheduledTaskDefinitionCreateRequest(BaseModel):
+    """Request body for ``POST /api/v1/scheduled-tasks/definitions``."""
+
+    preview_id: str
+    initial_lifecycle: str = "configured"
+
+
+class ScheduledTaskDefinitionUpdateRequest(BaseModel):
+    """Request body for ``PATCH /api/v1/scheduled-tasks/definitions/{id}``."""
+
+    preview_id: str
 
 
 class ScheduledTaskAutomationRunNowResponse(BaseModel):


### PR DESCRIPTION
Phase 4 of the schedules-handoff program (spec: backlog/docs/spec-2026-08-31-schedules-handoff-parity.md §8, plan: backlog/docs/plan-2026-09-01-schedules-handoff-pr4.md). Satisfies the client half of TASK-18940 AC#2 for recurring_question by construction.

## What ships
- **Validator port + local preview** (`Scheduling/automation_validation.py`, `automation_preview.py`): the server's four authoring validators ported byte-parity (verified side-by-side against tldw_server origin/dev), wrapped in a pure `preview_automation_definition` returning the server's preview shape with field-addressed `{field, code, message}` errors. Fixture-parity contract per spec §7.1.
- **Server preview/create/update seams** (tldw_api schemas → client → policy-gated notifications seams under `scheduler.automations.configure` → retryable `SchedulingServerClient` wrappers) implementing the server's strict preview-then-commit contract (`POST /previews` → `POST /definitions {preview_id}`; update = update-mode preview → `PATCH`).
- **Definition create/update push replay** in `SyncEngine` (pulled forward from PR-5 so offline authoring is never inert): replays the preview→commit two-step at push time from the stored payload (never a stored preview id — 24h TTL, single-consume), adopts the server identity in one transaction, clears non-retryable rejections per-mutation without aborting the phase, converts orphaned updates to creates.
- **Owner-dispatched authoring facade** (`SchedulingService.preview_definition` / `save_definition`): save always previews first; local owner writes locally with computed `next_run_at`; server owner runs the two-step online or atomically queues row+mutation offline; policy/validation refusals surface as errors — never dishonest "queued". Merge-on-edit at a single choke point so fields the v1 form doesn't expose survive edits on both owners.
- **`AutomationDefinitionForm` modal** (ADR-099 idiom parity, reusing the TASK-23102 forgiving-schedule widgets) with create AND edit, live preview, field-addressed error highlighting, and a "Runs on: This device | Server" selector; the Queue "+ New" button offers Reminder / Recurring question; `ReminderForm` gains the same owner selector riding the existing reminder mutation path.
- **Both-owners Automations listing**: local and pending-sync rows are now visible (owner-labeled), with honest run-now/history refusals for rows that haven't synced.
- **Sources-readable health check** (PR-2 parked item) gating on the attributes the real Library search seam actually uses.
- **Authoring E2E**: local author→tick pickup, and offline server-owned author→queued mutation→replay→server-id adoption, against a real tmp_path DB and schema-validating fake client.

## Review trail
6 SDD tasks, each task-reviewed; final whole-branch review (opus) found 2 Critical + 3 Important (all reproduced, all fixed in the final wave, scoped re-review ALL RESOLVED). 767 tests green across Scheduling + scheduling UI; boot census 972/972 (ADR-097 pin held); diagnostics pin clean. No schema migration on either DB (coordinated with #2301's v4→v6 chain — no slot collision).

## Deferred (ledgered)
Schedule-kind field vocabulary vs server `build_trigger` (spec §4.4-sanctioned; PR-5 transfer must map or restrict), sync-error messages naming local UUIDs without a row link, durable local run-history in the Automations tab, agent_task authoring (follow-up program).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WocisXw6SEEG6nb1aKFHtv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds recurring-question automation authoring (TASK-18940 AC#2) with a create/edit modal, local server-parity preview, and owner-dispatched execution.

The new "Runs on" selector on both the reminder and automation forms chooses between This device and Server (`<id>`) execution. Server-owned saves follow the server's preview-then-commit flow; while offline they queue a mutation that `SyncEngine` replays when the seam is reachable. The Automations tab now lists local and pending-sync rows alongside server rows with owner labels, and the health check verifies the definition's scoped Library sources are readable on this device.

**Behavior changes**
- Saves always preview first; validation and policy refusals surface as errors, never as "queued".
- Non-retryable server rejections clear that mutation but no longer abort the whole definition-sync phase.
- Server-owned edits merge onto the stored row, so fields the v1 modal doesn't expose (description, retention/approval policies, `input.max_tokens`) survive.
- Finding and retention policies now write to their own DB columns, so locally authored and offline-queued definitions execute with them instead of the column default.
- Reminder saves thread their target owner through the call, so sync and refresh workers never observe a transient owner flip.
- The Queue pane's "+ New" button now offers Reminder… or Recurring question…; `c` still opens the reminder form directly.

<sup>Written for commit d59751e80e50955fe7cbe4d50bd4d0096351f475. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

