### PR TITLE
Console: clarify workspace and chat hierarchy

### DIFF
--- a/Docs/superpowers/plans/2026-09-01-console-workspace-chat-hierarchy.md
+++ b/Docs/superpowers/plans/2026-09-01-console-workspace-chat-hierarchy.md
@@ -1,0 +1,146 @@
+# Console Workspace and Chat Hierarchy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make workspace rows and their chats visually distinct through row-specific right-edge action markers and a four-cell child indent.
+
+**Architecture:** Keep the change inside the existing native Textual `ConsoleWorkspaceTree` renderer. Render workspace `@` and conversation `*` affordances into a shared right-edge column, derive pointer hit zones from the final painted geometry, and retain the existing menu messages and keyboard binding.
+
+**Tech Stack:** Python 3.11+, Textual 8.2.8, Rich `Text`, pytest/Textual pilot tests
+
+**Spec:** `backlog/tasks/task-27137 - Clarify-Console-workspace-and-chat-hierarchy.md`
+
+## Global Constraints
+
+- Workspace rows use `@`; conversation rows keep `*` with the same visual style.
+- Conversation rows sit four terminal cells beneath their owning workspace.
+- Long labels ellipsize before the action column; neither action glyph may move or disappear.
+- Pointer activation and the existing `m` binding continue to open the correct row menu.
+- No new dependency, persistent state, key binding, or data-model change.
+- ADR required: no. This is a renderer-level refinement of the existing Console tree and row-menu contract.
+
+---
+
+### Task 1: Align and distinguish Console tree rows
+
+**Files:**
+- Modify: `Tests/UI/test_console_workspace_tree.py`
+- Modify: `Tests/UI/test_console_workspace_action_menu.py`
+- Modify: `tldw_chatbook/Widgets/Console/console_workspace_tree.py`
+- Modify: `tldw_chatbook/Widgets/Console/console_workspace_action_menu.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py`
+- Modify: `backlog/tasks/task-27137 - Clarify-Console-workspace-and-chat-hierarchy.md`
+
+**Interfaces:**
+- Consumes: `ConsoleWorkspaceTree.render_label`, `WorkspaceTreeMenuRequested`, Textual tree guide geometry, and the existing `m` action.
+- Produces: right-edge workspace `@` and conversation `*` affordances with absolute widget-cell hit zones; no public API changes.
+
+- [x] **Step 1: Add failing tests for the approved row hierarchy**
+
+Extend the real Textual tree harness to collect `WorkspaceTreeMenuRequested`, then add behavior tests equivalent to:
+
+```python
+@pytest.mark.asyncio
+async def test_workspace_and_chat_action_markers_share_the_right_edge() -> None:
+    tree = _tree()
+    app = _TreeHarness(tree)
+    async with app.run_test(size=(60, 20)) as pilot:
+        await pilot.pause()
+        edge = tree.scrollable_content_region.width
+        assert tree._menu_zones["workspace:w1"] == (edge - 2, edge)
+        assert tree._menu_zones["conversation:c1"] == (edge - 2, edge)
+        assert tree.render_line(0).text[edge - 1] == "@"
+        assert tree.render_line(1).text[edge - 1] == "*"
+```
+
+```python
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("line", "kind"),
+    [(0, "workspace"), (1, "conversation")],
+)
+async def test_right_edge_marker_opens_the_matching_row_menu(line, kind) -> None:
+    tree = _tree()
+    app = _TreeHarness(tree)
+    async with app.run_test(size=(60, 20)) as pilot:
+        await pilot.pause()
+        edge = tree.scrollable_content_region.width - 1
+        assert await pilot.click(tree, offset=(edge, line))
+        await pilot.pause()
+        request = next(
+            message
+            for message in app.messages
+            if isinstance(message, WorkspaceTreeMenuRequested)
+        )
+        assert request.kind == kind
+```
+
+Change the native configuration assertion from `guide_depth == 2` to `guide_depth == 4`. Correct the pre-existing tooltip boundary fixtures to reserve the two-cell action column that TASK-25712 added; these fixtures currently fail on clean `dev` because they predate that column.
+
+- [x] **Step 2: Run the new tests and verify RED**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/UI/test_console_workspace_tree.py::test_native_configuration_and_literal_unicode_labels \
+  Tests/UI/test_console_workspace_tree.py::test_workspace_and_chat_action_markers_share_the_right_edge \
+  Tests/UI/test_console_workspace_tree.py::test_right_edge_marker_opens_the_matching_row_menu -q
+```
+
+Expected: failures show `guide_depth` is still `2`, the workspace marker is still `*`, and short-row action zones end beside the label instead of at the viewport edge.
+
+- [x] **Step 3: Implement the minimal renderer change**
+
+Replace the shared affordance with a row-kind mapping and fill the available content cells before appending it:
+
+```python
+_MENU_AFFORDANCES = {
+    "workspace": " @",
+    "conversation": " *",
+}
+
+affordance = _MENU_AFFORDANCES.get(kind)
+if affordance is not None and data is not None:
+    content_budget = self._label_budget(node)
+    label.truncate(content_budget, overflow="ellipsis")
+    label.append(" " * max(0, content_budget - label.cell_len), base_style)
+    label.append(affordance, base_style)
+    end = self._visible_guide_cells(node) + label.cell_len
+    self._menu_zones[data.key] = (end - len(affordance), end)
+```
+
+Set `guide_depth = 4`, share visible-guide measurement between the label budget and hit-zone calculation, and update comments/docstrings from “asterisk” to row-specific action affordances. Do not alter menu message payloads or keyboard actions.
+
+- [x] **Step 4: Run the tree and menu tests and verify GREEN**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest \
+  Tests/UI/test_console_workspace_tree.py \
+  Tests/UI/test_console_workspace_action_menu.py -q
+```
+
+Expected: all targeted tests pass; the six clean-`dev` baseline failures are resolved by the new geometry and corrected action-column fixtures.
+
+- [x] **Step 5: Run static and design checks**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check \
+  tldw_chatbook/Widgets/Console/console_workspace_tree.py \
+  Tests/UI/test_console_workspace_tree.py \
+  Tests/UI/test_console_workspace_action_menu.py
+```
+
+Then run Impeccable's mechanical detector once over the changed UI targets and inspect `git diff --check`.
+
+- [x] **Step 6: Close the task and commit the reviewable slice**
+
+Mark all acceptance criteria complete, add concise implementation notes including the clean-`dev` baseline finding and ADR rationale, set TASK-27137 to Done, stage only the planned files, and commit:
+
+```bash
+git commit -m "feat(console): clarify workspace and chat hierarchy"
+```

--- a/Docs/superpowers/specs/2026-08-31-workspace-files-inspector-design.md
+++ b/Docs/superpowers/specs/2026-08-31-workspace-files-inspector-design.md
@@ -66,9 +66,9 @@ The Console exposes workspaces and their agent activity but does not provide a d
 Two entry points open the same modal:
 
 - The active `ConsoleWorkspaceContext` card exposes **Show Files** on its own compact action row immediately after the existing **RAG Scope** row. It is not added to the width-sensitive **Switch** / **New** row.
-- Each named workspace row in the Workspaces tree exposes **Show files** through its existing asterisk action menu. The menu target captures the stable workspace ID and render-time folder availability; it never activates the row's workspace.
+- Each named workspace row in the Workspaces tree exposes **Show files** through its right-edge `@` action menu. The menu target captures the stable workspace ID and render-time folder availability; it never activates the row's workspace.
 
-The separate workspace switcher remains unchanged and does not gain a fourth persistent button. Both entry paths are text-labeled and keyboard reachable. In the active card, **Show Files** follows **RAG Scope** in focus order; for any visible tree workspace, the existing `m`/asterisk menu includes **Show files**. Both paths route a typed stable workspace ID into the same admission seam. Names, list positions, labels, and widget IDs are display data and are never parsed to resolve the workspace.
+The separate workspace switcher remains unchanged and does not gain a fourth persistent button. Both entry paths are text-labeled and keyboard reachable. In the active card, **Show Files** follows **RAG Scope** in focus order; for any visible tree workspace, the existing `m`/`@` menu includes **Show files**. Both paths route a typed stable workspace ID into the same admission seam. Names, list positions, labels, and widget IDs are display data and are never parsed to resolve the workspace.
 
 The default workspace and workspaces with no local-folder bindings keep the action visible as a focusable, pressable-but-blocked control rather than an unfocusable disabled button. Its tooltip and activation response both say `No local folders are attached. Add one in Settings.` A stale event that reaches the modal after bindings disappear opens the same empty recovery state rather than switching context or selecting another workspace.
 

--- a/Tests/UI/test_console_workspace_action_menu.py
+++ b/Tests/UI/test_console_workspace_action_menu.py
@@ -3,9 +3,9 @@
 TASK-25712. TASK-23200 gave the grouped browser's conversation rows an
 asterisk menu and TASK-25709 made it dismissable everywhere; this suite pins
 the same pattern on the Workspaces tree: workspace rows open the workspace
-action menu, chat rows open the shared conversation menu, the pointer
-affordance is the row's trailing asterisk, and the ``m`` binding is the
-keyboard equivalent.
+action menu through ``@``, chat rows open the shared conversation menu through
+``*``, both pointer affordances sit at the right edge, and the ``m`` binding is
+the keyboard equivalent.
 """
 
 from __future__ import annotations
@@ -62,19 +62,31 @@ def _request_menu(console, *, kind: str, **kwargs) -> None:
 
 
 @pytest.mark.asyncio
-async def test_tree_rows_paint_a_trailing_asterisk_affordance() -> None:
-    """Workspace and chat rows carry the opener; auxiliary rows do not."""
+async def test_tree_rows_paint_distinct_right_edge_affordances() -> None:
+    """Workspace and chat rows carry distinct openers in one edge column."""
     async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
         host = pilot.app
         console, _rail, tree = await _console_with_probe_tree(host, pilot)
 
+        await _click_rail_toggle(pilot, "workspace")
+        await pilot.pause(0.4)
+        assert tree.region, "workspace section stayed collapsed"
+
         workspace_key = tree.workspace_nodes["ws-alpha"].data.key
         conversation_key = tree.conversation_nodes["conv-a0"].data.key
-        assert workspace_key in tree._menu_zones, "workspace row lost its asterisk"
-        assert conversation_key in tree._menu_zones, "chat row lost its asterisk"
+        assert workspace_key in tree._menu_zones, "workspace row lost its @"
+        assert conversation_key in tree._menu_zones, "chat row lost its *"
 
-        start, end = tree._menu_zones[conversation_key]
-        assert start < end, "empty asterisk zone"
+        edge = tree.scrollable_content_region.width
+        workspace_zone = tree._menu_zones[workspace_key]
+        conversation_zone = tree._menu_zones[conversation_key]
+        assert workspace_zone == conversation_zone == (edge - 2, edge)
+        workspace = tree.workspace_nodes["ws-alpha"]
+        conversation = tree.conversation_nodes["conv-a0"]
+        assert tree.render_line(int(workspace._line)).text[edge - 1] == "@"
+        assert tree.render_line(int(conversation._line)).text[edge - 1] == "*"
+
+        start, end = conversation_zone
         # The affordance press is recognized inside the zone and not outside.
         tree._pressed_x = start
         assert tree._pressed_menu_affordance(

--- a/Tests/UI/test_console_workspace_tree.py
+++ b/Tests/UI/test_console_workspace_tree.py
@@ -18,6 +18,7 @@ from tldw_chatbook.Widgets.Console.console_workspace_tree import (
     WorkspaceTreeConversationSelected,
     WorkspaceTreeFocusRecoveryRequested,
     WorkspaceTreeLoadMoreRequested,
+    WorkspaceTreeMenuRequested,
     WorkspaceTreeNodeData,
     WorkspaceTreeRetryRequested,
     WorkspaceTreeStarRequested,
@@ -103,6 +104,11 @@ class _TreeHarness(App[None]):
     ) -> None:
         self.messages.append(event)
 
+    def on_workspace_tree_menu_requested(
+        self, event: WorkspaceTreeMenuRequested
+    ) -> None:
+        self.messages.append(event)
+
 
 def _tree() -> ConsoleWorkspaceTree:
     tree = ConsoleWorkspaceTree(id="console-workspace-tree")
@@ -128,7 +134,7 @@ def test_native_configuration_and_literal_unicode_labels() -> None:
     assert isinstance(tree, Tree)
     assert tree.show_root is False
     assert tree.auto_expand is False
-    assert tree.guide_depth == 2
+    assert tree.guide_depth == 4
     assert tree.root.is_expanded is True
     assert tree.root.allow_expand is False
     assert tree.ICON_NODE and tree.ICON_NODE_EXPANDED
@@ -137,6 +143,51 @@ def test_native_configuration_and_literal_unicode_labels() -> None:
     assert tree.conversation_nodes["c"].label.plain.endswith("[red]会話 🧪")
     assert isinstance(tree.workspace_nodes["w"].label, Text)
     assert tree.workspace_nodes["w"].data.raw_label == raw_workspace
+
+
+@pytest.mark.asyncio
+async def test_workspace_and_chat_action_markers_share_the_right_edge() -> None:
+    tree = _tree()
+    app = _TreeHarness(tree)
+    async with app.run_test(size=(60, 20)) as pilot:
+        await pilot.pause()
+        edge = tree.scrollable_content_region.width
+        workspace = tree.workspace_nodes["w1"]
+        conversation = tree.conversation_nodes["c1"]
+
+        assert tree._menu_zones[workspace.data.key] == (edge - 2, edge)
+        assert tree._menu_zones[conversation.data.key] == (edge - 2, edge)
+        assert tree.render_line(int(workspace._line)).text[edge - 1] == "@"
+        assert tree.render_line(int(conversation._line)).text[edge - 1] == "*"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("line", "kind"),
+    [
+        (0, WorkspaceTreeMenuRequested.KIND_WORKSPACE),
+        (1, WorkspaceTreeMenuRequested.KIND_CONVERSATION),
+    ],
+)
+async def test_right_edge_marker_opens_the_matching_row_menu(
+    line: int,
+    kind: str,
+) -> None:
+    tree = _tree()
+    app = _TreeHarness(tree)
+    async with app.run_test(size=(60, 20)) as pilot:
+        await pilot.pause()
+        edge = tree.scrollable_content_region.width - 1
+
+        assert await pilot.click(tree, offset=(edge, line))
+        await pilot.pause()
+
+        requests = [
+            message
+            for message in app.messages
+            if isinstance(message, WorkspaceTreeMenuRequested)
+        ]
+        assert [request.kind for request in requests] == [kind]
 
 
 def test_failed_page_offers_retry_without_a_competing_load_more_action() -> None:
@@ -466,8 +517,13 @@ async def test_tooltip_boundary_matches_compositor_painted_viewport(
         guide_cells = tree.guide_depth if nested else 0
         disclosure_cells = 0 if nested else 2
         marker_cells = 2
+        action_cells = 2
         exact_raw = "x" * (
-            viewport_cells - guide_cells - disclosure_cells - marker_cells
+            viewport_cells
+            - guide_cells
+            - disclosure_cells
+            - marker_cells
+            - action_cells
         )
         over_raw = exact_raw + "x"
 
@@ -521,7 +577,7 @@ async def test_fitting_collapsed_workspace_disclosure_has_no_tooltip() -> None:
     )
     app = _TreeHarness(tree)
     async with app.run_test(size=(40, 12)) as pilot:
-        tree.styles.width = 10
+        tree.styles.width = 12
         await pilot.pause()
         tree.move_cursor(tree.workspace_nodes["w"])
         await pilot.pause()

--- a/backlog/tasks/task-27137 - Clarify-Console-workspace-and-chat-hierarchy.md
+++ b/backlog/tasks/task-27137 - Clarify-Console-workspace-and-chat-hierarchy.md
@@ -1,0 +1,61 @@
+---
+id: TASK-27137
+title: Clarify Console workspace and chat hierarchy
+status: Done
+assignee: []
+created_date: '2026-09-02 03:52'
+updated_date: '2026-09-02 04:02'
+labels: []
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make workspace and conversation rows immediately distinguishable in the Console Context rail while keeping row actions predictable and usable at narrow widths.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Workspace rows render an @ action affordance at the far-right edge.
+- [x] #2 Conversation rows render the existing * action affordance in the same far-right column and are indented four cells beneath their workspace.
+- [x] #3 Long and narrow labels truncate before the affordance without obscuring it, and pointer plus keyboard menu activation still target the correct row.
+- [x] #4 Targeted workspace-tree tests cover the glyphs, indentation, hit zones, tooltip boundaries, and ASCII fallback.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing Textual renderer and pointer tests for the approved @/* action-column hierarchy and four-cell chat indent.
+2. Implement row-kind affordances, right-edge padding, and guide-aware hit zones in ConsoleWorkspaceTree.
+3. Update stale action-column tooltip fixtures and affected row-menu documentation.
+4. Run targeted tree/menu tests, Ruff, Impeccable detector, and diff hygiene checks.
+
+ADR required: no
+ADR path: N/A
+Reason: This is a renderer-level refinement of the existing Console tree and row-menu contract; it adds no storage, security, runtime, or cross-module boundary.
+
+Detailed plan: Docs/superpowers/plans/2026-09-01-console-workspace-chat-hierarchy.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented distinct right-edge workspace `@` and conversation `*` action
+markers, four-cell child guides, label padding/truncation, and guide-aware
+pointer hit zones in `ConsoleWorkspaceTree`. Preserved the existing menu
+messages, keyboard `m` action, selection behavior, and action-menu styling.
+
+Added renderer and real-Console coverage for marker identity, shared edge
+alignment, pointer activation, native indentation, tooltip boundaries, narrow
+layouts, and ASCII fallback. The clean `dev` baseline exposed six failures
+from TASK-25712's adjacent marker geometry and stale pre-action-column width
+fixtures; this slice resolves that click collision and updates those fixtures.
+
+Updated the workspace action-menu and Workspace Files documentation to use
+the new `@` affordance. No ADR was required because storage, ownership,
+security, menu payloads, and cross-module boundaries are unchanged. No new
+general lesson was added; the baseline-evidence incident is already covered
+by `backlog/docs/lessons-testing-evidence.md`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-27137 - Clarify-Console-workspace-and-chat-hierarchy.md
+++ b/backlog/tasks/task-27137 - Clarify-Console-workspace-and-chat-hierarchy.md
@@ -58,4 +58,7 @@ the new `@` affordance. No ADR was required because storage, ownership,
 security, menu payloads, and cross-module boundaries are unchanged. No new
 general lesson was added; the baseline-evidence incident is already covered
 by `backlog/docs/lessons-testing-evidence.md`.
+
+PR review follow-up documented the public `render_label` override's arguments
+and return value in the repository's required Google-style format.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -5020,7 +5020,7 @@ class ChatScreen(BaseAppScreen):
         screen_x: int,
         screen_y: int,
     ) -> None:
-        """Anchor the workspace action menu at the pressed tree asterisk.
+        """Anchor the workspace action menu at the pressed tree ``@``.
 
         Args:
             workspace_id: Registry id of the workspace row.
@@ -5165,7 +5165,7 @@ class ChatScreen(BaseAppScreen):
     def on_workspace_tree_menu_requested(
         self, event: "WorkspaceTreeMenuRequested"
     ) -> None:
-        """Mount the row menu a Workspaces-tree asterisk asked for.
+        """Mount the row menu a Workspaces-tree action marker asked for.
 
         Dispatched by handler-name convention (ADR-097 lazy-import rule).
         """

--- a/tldw_chatbook/Widgets/Console/console_workspace_action_menu.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_action_menu.py
@@ -1,6 +1,6 @@
 """Anchored action menu for one Console workspace tree node (TASK-25712).
 
-Opened by the trailing asterisk on a workspace row in the Workspaces tree
+Opened by the trailing ``@`` on a workspace row in the Workspaces tree
 (pointer) or the ``m`` binding (keyboard). Mirrors
 ``ConsoleConversationActionMenu``: an absolutely-positioned ``Vertical``
 overlaying the screen, keyboard navigable, paged in place ("More" swaps

--- a/tldw_chatbook/Widgets/Console/console_workspace_tree.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_tree.py
@@ -621,6 +621,14 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
         markers (``@`` and ``*``) in one right-edge column. Content is
         truncated and padded before the marker, and its absolute x-range is
         recorded in ``_menu_zones`` so painted and clickable geometry agree.
+
+        Args:
+            node: Tree node whose label is being rendered.
+            base_style: Style used for the unfocused row and action marker.
+            style: Style used for the focused cursor marker.
+
+        Returns:
+            The rendered row label with truncation and any action affordance.
         """
 
         label = super().render_label(node, base_style, style)

--- a/tldw_chatbook/Widgets/Console/console_workspace_tree.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_tree.py
@@ -23,8 +23,11 @@ from ..glyph_fallback import ascii_glyph_mode, resolve_glyph
 
 _TEXTUAL_PRIVATE_MOVE_VERSION = "8.2.8"
 
-#: TASK-25712: the trailing per-row menu opener glyph and its cell width.
-_MENU_AFFORDANCE = " *"
+#: TASK-27137: row-specific menu openers share one right-edge action column.
+_MENU_AFFORDANCES = {
+    "workspace": " @",
+    "conversation": " *",
+}
 _NodeKind = Literal["workspace", "conversation", "status", "load-more", "retry"]
 
 
@@ -172,8 +175,8 @@ class WorkspaceTreeFocusRecoveryRequested(Message):
 class WorkspaceTreeMenuRequested(Message):
     """The user asked for the row action menu on one tree node (TASK-25712).
 
-    Posted by a pointer press on a row's trailing asterisk cell or the ``m``
-    binding on the cursor row. The tree stays display-only: the owning
+    Posted by a pointer press on a row's right-edge action marker or the
+    ``m`` binding on the cursor row. The tree stays display-only: the owning
     ``ChatScreen`` mounts the anchored menu (the workspace action menu for a
     workspace node, the conversation action menu for a chat node).
     """
@@ -310,7 +313,7 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
         )
         self.show_root = False
         self.auto_expand = False
-        self.guide_depth = 2
+        self.guide_depth = 4
         self.root.expand()
         self.root.allow_expand = False
         self.workspace_nodes: dict[str, TreeNode[WorkspaceTreeNodeData]] = {}
@@ -328,11 +331,11 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
         self.can_focus = False
         self._pressed_node_key: str | None = None
         self._last_pointer_click_key: str | None = None
-        # TASK-25712: x-range (widget content cells, half-open) of the
-        # trailing asterisk each menu-bearing row painted in its LAST render
-        # pass, keyed by node key. Rebuilt by ``render_label``; cleared at
-        # the start of every ``sync_projection`` pass so removed rows can
-        # never keep a stale hit zone.
+        # TASK-25712/TASK-27137: x-range (widget content cells, half-open) of
+        # the right-edge action marker each menu-bearing row painted in its
+        # LAST render pass, keyed by node key. Rebuilt by ``render_label``;
+        # cleared at the start of every ``sync_projection`` pass so removed
+        # rows can never keep a stale hit zone.
         self._menu_zones: dict[str, tuple[int, int]] = {}
         self._pressed_x: int | None = None
         # TASK-22203: identity+geometry key of the last computed tooltip, so
@@ -451,7 +454,7 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
             return
         self._projection_memo = None
         # TASK-25712: a full pass rebuilds every label; drop the previous
-        # pass's asterisk hit zones so removed rows keep no stale target.
+        # pass's action-marker hit zones so removed rows keep no stale target.
         self._menu_zones.clear()
         hovered_node = (
             self.get_node_at_line(self.hover_line) if self.hover_line >= 0 else None
@@ -614,12 +617,10 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
     ) -> Text:
         """Render one literal row with an end ellipsis inside the Tree width.
 
-        TASK-25712: workspace and conversation rows also carry a trailing
-        ``*`` that opens the row's action menu when pressed. It is appended
-        AFTER truncation (with the budget reduced by its width) so a long
-        title can never ellipsize over it, and its x-range is recorded in
-        ``_menu_zones`` for the pointer hit-test -- the painted text IS the
-        geometry source, so the two cannot drift.
+        TASK-27137: workspace and conversation rows carry distinct action
+        markers (``@`` and ``*``) in one right-edge column. Content is
+        truncated and padded before the marker, and its absolute x-range is
+        recorded in ``_menu_zones`` so painted and clickable geometry agree.
         """
 
         label = super().render_label(node, base_style, style)
@@ -638,13 +639,15 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
             (marker, marker_style),
             label[toggle_length:],
         )
-        label.truncate(self._label_budget(node), overflow="ellipsis")
         data = node.data
         kind = data.kind if data is not None else None
-        if kind in {"workspace", "conversation"} and data is not None:
-            affordance = _MENU_AFFORDANCE
+        affordance = _MENU_AFFORDANCES.get(kind or "")
+        content_budget = self._label_budget(node)
+        label.truncate(content_budget, overflow="ellipsis")
+        if affordance is not None and data is not None:
+            label.append(" " * max(0, content_budget - label.cell_len), base_style)
             label.append(affordance, base_style)
-            end = label.cell_len
+            end = self._visible_guide_cells(node) + label.cell_len
             self._menu_zones[data.key] = (end - len(affordance), end)
         else:
             if data is not None:
@@ -654,27 +657,35 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
     def _label_budget(self, node: TreeNode[WorkspaceTreeNodeData]) -> int:
         """Return the content-cell budget for one row's label.
 
-        TASK-25712: menu-bearing rows reserve the trailing ``*`` affordance,
-        so their CONTENT truncates two cells early. Render and the tooltip
-        fit decision must share this -- a tooltip that ignores the reserved
-        cells fires for rows that only look truncated.
+        TASK-27137: menu-bearing rows reserve their right-edge action marker,
+        so content truncates two cells early. Render and the tooltip fit
+        decision share this budget.
         """
 
         budget = self._available_label_cells(node)
         data = node.data
-        if data is not None and data.kind in {"workspace", "conversation"}:
-            budget -= len(_MENU_AFFORDANCE)
+        affordance = _MENU_AFFORDANCES.get(data.kind) if data is not None else None
+        if affordance is not None:
+            budget -= len(affordance)
         return max(1, budget)
 
-    def _available_label_cells(self, node: TreeNode[WorkspaceTreeNodeData]) -> int:
-        """Return the painted label budget after visible native guides."""
+    def _visible_guide_cells(self, node: TreeNode[WorkspaceTreeNodeData]) -> int:
+        """Return the native guide cells painted before one node label."""
 
         guide_cells = 0
         ancestor = node.parent
         while ancestor is not None and (self.show_root or ancestor is not self.root):
             guide_cells += self.guide_depth
             ancestor = ancestor.parent
-        return max(1, self.scrollable_content_region.width - guide_cells)
+        return guide_cells
+
+    def _available_label_cells(self, node: TreeNode[WorkspaceTreeNodeData]) -> int:
+        """Return the painted label budget after visible native guides."""
+
+        return max(
+            1,
+            self.scrollable_content_region.width - self._visible_guide_cells(node),
+        )
 
     def _untruncated_visible_label(self, node: TreeNode[WorkspaceTreeNodeData]) -> str:
         """Return the complete literal label measured for truncation."""
@@ -947,7 +958,7 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
         self,
         data: WorkspaceTreeNodeData,
     ) -> bool:
-        """Whether the pressed cell was the row's trailing asterisk.
+        """Whether the pressed cell was the row's right-edge action marker.
 
         TASK-25712: the zone comes from the row's own last ``render_label``
         pass, so the hit-test matches what is painted without duplicating
@@ -983,9 +994,8 @@ class ConsoleWorkspaceTree(Tree[WorkspaceTreeNodeData]):
             if data.kind in {"workspace", "conversation"} and (
                 self._pressed_menu_affordance(data)
             ):
-                # TASK-25712: the asterisk opens the row's action menu
-                # instead of selecting/activating, exactly like the grouped
-                # browser's asterisk column.
+                # TASK-25712/TASK-27137: the edge marker opens the row's
+                # action menu instead of selecting or activating it.
                 self._last_pointer_click_key = None
                 conversation_id, title, native_sid = _menu_conversation_payload(data)
                 self.post_message(


### PR DESCRIPTION
## Summary

- render workspace action markers as right-edge `@` glyphs
- keep conversation action markers as right-edge `*` glyphs with matching styling
- indent chats four cells beneath their workspace
- align painted markers and pointer hit zones while preserving keyboard `m`, selection, and menu payload behavior
- update Workspace Files wording plus TASK-27137 documentation

## Testing

- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/UI/test_console_workspace_tree.py Tests/UI/test_console_workspace_action_menu.py -q` — 68 passed
- Ruff lint — passed
- Ruff formatting checks over every changed Python hunk — passed (whole-file formatting remains a pre-existing `dev` baseline issue)
- `git diff --check` — passed
- Impeccable layout detector — no findings

The full test suite was not run, following the repository policy to use targeted verification unless a full sweep is explicitly requested.

## Governance

- Task: TASK-27137
- ADR required: no; this refines the existing tree renderer and row-menu contract without changing persistence, security, ownership, or cross-module interfaces.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously workspace and chat rows shared the same `*` menu marker and a two-cell indent. Now workspace rows show a right-edge `@`, chats keep `*`, and chats indent four cells under their workspace.

**Behavior**
- Long labels truncate before the marker column, so both markers stay visible at narrow widths.
- Pointer hit zones and the keyboard `m` action still open the correct row menu.
- Updates the Workspace Files spec, implementation plan, and TASK-27137 docs to the new `@` affordance.

**Testing**
- Added tests for marker placement, pointer activation, and tooltip boundaries.
- Updated existing tree and action-menu tests and fixed stale fixtures that failed on clean `dev`.

<sup>Written for commit 9b9d2a6a0f6d8cf732b2ae291f34431a591a4adf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

