### PR TITLE
Fix Console close warning for saved conversations

### DIFF
--- a/Tests/UI/test_console_button_routing.py
+++ b/Tests/UI/test_console_button_routing.py
@@ -512,6 +512,57 @@ async def test_close_tab_button_drops_an_idle_saved_session_without_confirmation
 
 
 @pytest.mark.asyncio
+async def test_close_tab_button_confirms_for_unsaved_message_on_hidden_branch():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=_ROUTING_SIZE) as pilot:
+        console = await _mounted_console(host, pilot, "#console-native-composer")
+        store = console._ensure_console_chat_store()
+        keeper_id = store.active_session_id
+        root = ConsoleChatMessage(
+            id="saved-root",
+            role=ConsoleMessageRole.USER,
+            content="saved root",
+            persisted_message_id="saved-root",
+        )
+        saved_leaf = ConsoleChatMessage(
+            id="saved-leaf",
+            role=ConsoleMessageRole.ASSISTANT,
+            content="saved branch",
+            persisted_message_id="saved-leaf",
+            parent_message_id="saved-root",
+        )
+        saved = store.restore_persisted_session(
+            title="Saved chat with hidden work",
+            workspace_id=None,
+            persisted_conversation_id="saved-conversation",
+            all_nodes=(root, saved_leaf),
+            active_leaf_persisted_id="saved-leaf",
+        )
+        hidden_unsaved = store.create_sibling(
+            saved_leaf.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="unsaved hidden branch",
+        )
+        store.set_active_leaf(saved.id, saved_leaf.id)
+        assert hidden_unsaved.id not in store.active_path_message_ids(saved.id)
+        assert all(
+            message.persisted_message_id is not None
+            for message in store.messages_for_session(saved.id)
+        )
+        store.switch_session(keeper_id)
+        await console._sync_native_console_chat_ui()
+        await pilot.pause()
+
+        console.query_one(f"#console-close-session-tab-{saved.id}", Button).press()
+        dialog = await _wait_for_confirmation(host)
+
+        assert "Transcript messages: 1" in dialog.message
+        assert saved.id in {session.id for session in store.sessions()}
+
+
+@pytest.mark.asyncio
 async def test_close_tab_button_confirms_before_dropping_a_session_with_messages():
     app = _build_test_app()
     host = ConsoleHarness(app)

--- a/Tests/UI/test_console_button_routing.py
+++ b/Tests/UI/test_console_button_routing.py
@@ -49,7 +49,10 @@ from Tests.UI.test_destination_shells import _wait_for_selector
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
 )
-from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+)
 from tldw_chatbook.Chat.console_prompt_queue import PromptQueuePauseReason
 from tldw_chatbook.Chat.conversation_local_marks_service import (
     ConversationLocalMarksService,
@@ -472,6 +475,39 @@ async def test_close_tab_button_drops_an_empty_session_without_confirmation():
 
         assert doomed.id not in {session.id for session in store.sessions()}
         assert doomed.id not in console._console_undo_histories
+        assert not isinstance(host.screen_stack[-1], ConfirmationDialog)
+
+
+@pytest.mark.asyncio
+async def test_close_tab_button_drops_an_idle_saved_session_without_confirmation():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=_ROUTING_SIZE) as pilot:
+        console = await _mounted_console(host, pilot, "#console-native-composer")
+        store = console._ensure_console_chat_store()
+        keeper_id = store.active_session_id
+        saved = store.restore_persisted_session(
+            title="Saved chat",
+            workspace_id=None,
+            persisted_conversation_id="saved-conversation",
+            all_nodes=(
+                ConsoleChatMessage(
+                    role=ConsoleMessageRole.USER,
+                    content="already durable",
+                    persisted_message_id="saved-message",
+                ),
+            ),
+        )
+        store.switch_session(keeper_id)
+        await console._sync_native_console_chat_ui()
+        await pilot.pause()
+
+        console.query_one(f"#console-close-session-tab-{saved.id}", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert saved.id not in {session.id for session in store.sessions()}
         assert not isinstance(host.screen_stack[-1], ConfirmationDialog)
 
 

--- a/Tests/UI/test_console_session_close_impact.py
+++ b/Tests/UI/test_console_session_close_impact.py
@@ -1,0 +1,57 @@
+"""Focused coverage for Console session-close loss accounting."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleLifecycleImpact,
+    ConsoleMessageRole,
+)
+from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
+
+
+@pytest.mark.parametrize(
+    ("persisted_message_ids", "expected_unsaved_count"),
+    [
+        (("saved-1", "saved-2"), 0),
+        ((None, None), 2),
+        (("saved-1", None, "saved-2"), 1),
+    ],
+)
+def test_session_close_impact_counts_only_unsaved_conversation_tree_nodes(
+    persisted_message_ids: tuple[str | None, ...],
+    expected_unsaved_count: int,
+) -> None:
+    messages = [
+        ConsoleChatMessage(
+            role=ConsoleMessageRole.USER,
+            content=f"message-{index}",
+            persisted_message_id=persisted_message_id,
+        )
+        for index, persisted_message_id in enumerate(persisted_message_ids)
+    ]
+    store = SimpleNamespace(all_messages_for_session=lambda _session_id: messages)
+    lifecycle = ConsoleLifecycleImpact(
+        revision=7,
+        live_run_count=0,
+        queued_session_count=0,
+        unsent_prompt_count=0,
+    )
+    runtime = SimpleNamespace(
+        lifecycle_impact=lambda *, session_id: (
+            lifecycle if session_id == "session-1" else None
+        )
+    )
+    controller = ConsoleSessionController.__new__(ConsoleSessionController)
+    controller._chat_store_accessor = lambda: store
+    controller._ensure_console_chat_controller_fn = lambda: runtime
+
+    impact = controller._session_close_impact("session-1")
+
+    assert impact is not None
+    assert impact.transcript_message_count == expected_unsaved_count
+    assert impact.lifecycle is lifecycle

--- a/backlog/tasks/task-28001 - Fix-saved-Console-conversations-prompting-on-close.md
+++ b/backlog/tasks/task-28001 - Fix-saved-Console-conversations-prompting-on-close.md
@@ -4,7 +4,7 @@ title: Fix saved Console conversations prompting on close
 status: Done
 assignee: []
 created_date: '2026-09-02 04:06'
-updated_date: '2026-09-02 04:24'
+updated_date: '2026-09-02 04:45'
 labels:
   - console
   - ux
@@ -28,13 +28,14 @@ Prevent the Console close-session confirmation from warning about transcript los
 - [x] #2 An unsaved Console conversation with transcript messages still requires confirmation before close.
 - [x] #3 A saved Console conversation with live agent/tool activity or queued prompts still requires confirmation and preserves the revision recheck.
 - [x] #4 Focused Console close regressions and static checks pass.
+- [x] #5 Unsaved messages on inactive conversation-tree branches still require confirmation before close.
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
 1. Add a mounted regression for closing an idle saved conversation without confirmation and verify it fails against the current transcript-count predicate.
-2. Make session close impact count transcript loss only when the session has no persisted conversation id, while retaining lifecycle loss counts and revision fencing.
+2. Make session close impact count unpersisted messages across every branch owned by the session, while retaining lifecycle loss counts and revision fencing.
 3. Run the focused close tests, reached lifecycle tests, ruff, and diff checks; self-review the scoped change.
 
 ADR required: no
@@ -52,14 +53,22 @@ partially persisted row remains protected. Unsaved rows still require
 confirmation, and live-run, approval, queued-prompt, and revision-revalidation
 behavior is unchanged.
 
+Qodo review identified that the active transcript is only one projection of the
+conversation tree. Added a read-only store query for all session-owned tree
+nodes and based close impact on that complete set, so an unpersisted inactive
+branch cannot be deleted silently. Added direct unit cases for fully persisted,
+fully unpersisted, and mixed durability plus a mounted hidden-branch close
+regression.
+
 Added a mounted real-store regression for a restored persisted message alongside
 the existing unsaved-message close coverage. Before the fix, the restored
 session remained open behind the confirmation; after the fix it closes without
-a modal. Verification on a clean branch from current `origin/dev`: 12 reached
-close/lifecycle tests passed, including mounted saved/unsaved/queue close flows,
-native close UI, tombstone ordering, and reaction cleanup. Ruff, Python
-compilation, and `git diff --check` pass. The repository-wide suite was not run
-under the project's targeted-test policy.
+a modal. After rebasing onto current `origin/dev` and addressing Qodo review,
+22 focused tests passed across the direct close-impact unit cases and the full
+mounted Console button-routing file, including saved, unsaved, hidden-branch,
+queue, and revision-recheck close flows. Ruff, focused formatting, Python
+compilation, the backlog-ID guard, and `git diff --check` pass. The
+repository-wide suite was not run under the project's targeted-test policy.
 
 ADR required: no. ADR-046 and ADR-033 remain the governing decisions; no state
 owner, lifecycle boundary, or cross-module contract changed. No new
@@ -79,7 +88,7 @@ or queued agent work remain protected by the existing revision-pinned warning.
 <!-- DOD:BEGIN -->
 - [x] All acceptance criteria are complete.
 - [x] The approved plan was followed; the more precise per-message durability check is documented.
-- [x] Automated regression coverage protects saved and unsaved transcript impact.
+- [x] Unit and mounted regression coverage protects saved, unsaved, mixed, and inactive-branch transcript impact.
 - [x] Reached mounted, lifecycle, cleanup, and queue tests pass.
 - [x] Ruff, Python compilation, and whitespace checks pass.
 - [x] Implementation Notes and Final Summary document the completed change.

--- a/backlog/tasks/task-28001 - Fix-saved-Console-conversations-prompting-on-close.md
+++ b/backlog/tasks/task-28001 - Fix-saved-Console-conversations-prompting-on-close.md
@@ -1,0 +1,91 @@
+---
+id: TASK-28001
+title: Fix saved Console conversations prompting on close
+status: Done
+assignee: []
+created_date: '2026-09-02 04:06'
+updated_date: '2026-09-02 04:24'
+labels:
+  - console
+  - ux
+  - bug
+dependencies: []
+references:
+  - backlog/decisions/046-visible-bounded-console-prompt-queue.md
+  - backlog/decisions/033-application-session-state-ownership.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prevent the Console close-session confirmation from warning about transcript loss when the conversation is already durable and no agent, tool, approval, or queued-prompt work remains active.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 An idle saved Console conversation closes without a confirmation because its durable transcript is not at risk.
+- [x] #2 An unsaved Console conversation with transcript messages still requires confirmation before close.
+- [x] #3 A saved Console conversation with live agent/tool activity or queued prompts still requires confirmation and preserves the revision recheck.
+- [x] #4 Focused Console close regressions and static checks pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a mounted regression for closing an idle saved conversation without confirmation and verify it fails against the current transcript-count predicate.
+2. Make session close impact count transcript loss only when the session has no persisted conversation id, while retaining lifecycle loss counts and revision fencing.
+3. Run the focused close tests, reached lifecycle tests, ruff, and diff checks; self-review the scoped change.
+
+ADR required: no
+ADR path: backlog/decisions/046-visible-bounded-console-prompt-queue.md and backlog/decisions/033-application-session-state-ownership.md
+Reason: Existing ADRs already define combined Console loss confirmation, transient lifecycle ownership, and revision-pinned revalidation; this bug fix corrects the existing predicate without changing those boundaries.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Changed the close-impact transcript count from every visible message to only
+messages without a durable `persisted_message_id`. This is more precise than
+the planned conversation-id check: saved rows add zero loss risk while any
+partially persisted row remains protected. Unsaved rows still require
+confirmation, and live-run, approval, queued-prompt, and revision-revalidation
+behavior is unchanged.
+
+Added a mounted real-store regression for a restored persisted message alongside
+the existing unsaved-message close coverage. Before the fix, the restored
+session remained open behind the confirmation; after the fix it closes without
+a modal. Verification on a clean branch from current `origin/dev`: 12 reached
+close/lifecycle tests passed, including mounted saved/unsaved/queue close flows,
+native close UI, tombstone ordering, and reaction cleanup. Ruff, Python
+compilation, and `git diff --check` pass. The repository-wide suite was not run
+under the project's targeted-test policy.
+
+ADR required: no. ADR-046 and ADR-033 remain the governing decisions; no state
+owner, lifecycle boundary, or cross-module contract changed. No new
+generalizable lesson was produced.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Console close confirmation now counts only transcript rows that are not durably
+saved. Idle saved conversations close silently, while unsaved content and live
+or queued agent work remain protected by the existing revision-pinned warning.
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+
+<!-- DOD:BEGIN -->
+- [x] All acceptance criteria are complete.
+- [x] The approved plan was followed; the more precise per-message durability check is documented.
+- [x] Automated regression coverage protects saved and unsaved transcript impact.
+- [x] Reached mounted, lifecycle, cleanup, and queue tests pass.
+- [x] Ruff, Python compilation, and whitespace checks pass.
+- [x] Implementation Notes and Final Summary document the completed change.
+- [x] Self-review found no regression to lifecycle, privacy, persistence, or revision-fence ownership.
+- [x] No performance, security, or licence behavior changed.
+- [x] No new generalizable lesson was produced.
+- [x] ADR check completed against ADR-046 and ADR-033; no new ADR is required.
+- [x] Task status is Done.
+<!-- DOD:END -->

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -10466,6 +10466,19 @@ class ConsoleChatStore:
             self._snapshot(message) for message in self._messages_by_session[session_id]
         ]
 
+    def all_messages_for_session(self, session_id: str) -> list[ConsoleChatMessage]:
+        """Return snapshots of every conversation-tree node owned by a session.
+
+        Unlike :meth:`messages_for_session`, this includes inactive branches.
+        Display-only tool markers are excluded because they are not tree nodes.
+        """
+
+        self._session_or_raise(session_id)
+        return [
+            self._snapshot(message)
+            for message in self._nodes_by_session[session_id].values()
+        ]
+
     def read_only_messages_for_session(
         self, session_id: str
     ) -> list[ConsoleChatMessage]:

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -2559,11 +2559,11 @@ class ConsoleSessionController:
     def _session_close_impact(
         self, session_id: str
     ) -> ConsoleSessionCloseImpact | None:
-        """Capture transcript and controller loss impact for one exact session."""
+        """Capture tree-wide transcript and controller loss for one session."""
 
         store = self._ensure_console_chat_store()
         try:
-            messages = store.messages_for_session(session_id)
+            messages = store.all_messages_for_session(session_id)
         except KeyError:
             return None
         controller = self._ensure_console_chat_controller()

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -2569,7 +2569,9 @@ class ConsoleSessionController:
         controller = self._ensure_console_chat_controller()
         return ConsoleSessionCloseImpact(
             session_id=session_id,
-            transcript_message_count=len(messages),
+            transcript_message_count=sum(
+                message.persisted_message_id is None for message in messages
+            ),
             lifecycle=controller.lifecycle_impact(session_id=session_id),
         )
 


### PR DESCRIPTION
## Summary

- Count only transcript messages without a durable persisted message ID as close-time loss risk.
- Close idle saved Console conversations without a warning while retaining live-run, approval, queued-prompt, and revision-revalidation guards.
- Add a mounted regression for closing a restored saved conversation and complete TASK-28001.

## Verification

- 12 reached Console close, lifecycle, queue, native UI, and reaction-cleanup tests passed.
- Ruff passed for the changed production and test files.
- Python compilation and git diff checks passed.
- Backlog ID guard passed across 2,922 task files.
- Repository-wide pytest was not run under the project targeted-test policy.

## ADR

No new ADR required. Existing ADR-046 and ADR-033 already govern the loss-confirmation and state-ownership boundaries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Console close warning so idle saved conversations close without a confirmation dialog, while unsaved messages on any conversation branch still require confirmation. Previously any transcript message counted as loss risk; now only messages without a durable persisted message ID do, and the check covers the whole session tree, including hidden branches.

- Adds regression tests for closing restored saved chats and for unsaved messages on inactive branches, completing TASK-28001.
- Preserves live-run, approval, queued-prompt, and revision-revalidation guards.

<sup>Written for commit 77e50594fb1c85dbc1ee48781263c62731fd35b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

