### PR TITLE
fix(trace): render repeated turn segments safely

### DIFF
--- a/Tests/UI/test_trace_responsive.py
+++ b/Tests/UI/test_trace_responsive.py
@@ -29,6 +29,8 @@ from .test_trajectory_screen import base_snapshot
 
 
 VIEWPORTS = ((60, 18), (80, 24), (100, 30), (120, 35))
+
+
 class _TraceHost(ConsolidatedCSSApp):
     CSS_PATH = BUNDLED_STYLESHEET
 
@@ -177,7 +179,7 @@ async def test_responsive_rebuild_preserves_stable_event_selection_and_filters()
     assistant = next(record for record in _flat(snapshot) if record.kind == "assistant")
     async with _mounted(snapshot, size=(80, 24)) as (app, pilot, screen):
         table = screen.query_one("#trajectory-table", DataTable)
-        selected_key = assistant.event_id
+        selected_key = screen._record_key(assistant)
         table.move_cursor(row=table.get_row_index(selected_key), animate=False)
         screen._collapsed.add("t2")
         screen._query = "checking"
@@ -800,7 +802,9 @@ async def test_projected_generic_retrieval_payload_is_preserved_as_safe_json() -
 
     async with _mounted(snapshot, size=(60, 18)) as (app, pilot, screen):
         table = screen.query_one("#trajectory-table", DataTable)
-        table.move_cursor(row=table.get_row_index(record.event_id), animate=False)
+        table.move_cursor(
+            row=table.get_row_index(screen._record_key(record)), animate=False
+        )
         await pilot.press("enter")
         await pilot.pause()
 
@@ -1077,7 +1081,8 @@ async def test_paused_live_append_retains_selected_event_outside_newest_page() -
     snapshot = _snapshot_with_records(records)
     async with _mounted(snapshot, size=(80, 24)) as (app, pilot, screen):
         table = screen.query_one("#trajectory-table", DataTable)
-        table.move_cursor(row=table.get_row_index("event-2"), animate=False)
+        selected_key = screen._record_key(records[1])
+        table.move_cursor(row=table.get_row_index(selected_key), animate=False)
         screen._follow = False
 
         appended = _snapshot_with_records(
@@ -1086,8 +1091,8 @@ async def test_paused_live_append_retains_selected_event_outside_newest_page() -
         screen._apply_live_snapshot(appended)
         await pilot.pause()
 
-        assert screen._cursor_key() == "event-2"
-        assert "event-2" in screen._visible_keys
+        assert screen._cursor_key() == selected_key
+        assert selected_key in screen._visible_keys
         assert screen._visible_count >= PAGE_SIZE + 1
 
 
@@ -1247,5 +1252,9 @@ async def test_record_label_prefers_projection_label_then_generic_sentence_case(
     ]
     async with _mounted(_snapshot_with_records(records)) as (app, pilot, screen):
         table = screen.query_one("#trajectory-table", DataTable)
-        assert str(table.get_row("event-1")[1]) == "Provider-specific step"
-        assert str(table.get_row("event-2")[1]) == "Future custom kind"
+        assert str(table.get_row(screen._record_key(records[0]))[1]) == (
+            "Provider-specific step"
+        )
+        assert str(table.get_row(screen._record_key(records[1]))[1]) == (
+            "Future custom kind"
+        )

--- a/Tests/UI/test_trajectory_screen.py
+++ b/Tests/UI/test_trajectory_screen.py
@@ -32,6 +32,7 @@ from tldw_chatbook.UI.Screens.trajectory_screen import (
     PAGE_SIZE,
     WORKER_THRESHOLD,
     TrajectoryScreen,
+    _number_logical_turns,
 )
 
 # ---------------------------------------------------------------------------
@@ -234,6 +235,20 @@ def repeated_turn_segments_with_live_tail() -> TrajectorySnapshot:
     return TrajectorySnapshot(snapshot.turns + (TrajectoryTurn("tail", tail_records),))
 
 
+def repeated_turn_segments_with_colliding_event_id() -> TrajectorySnapshot:
+    """A record event ID collides with the generated second-segment header."""
+
+    snapshot = repeated_turn_segments_snapshot()
+    first, middle, last = snapshot.turns
+    middle_records = (
+        replace(middle.records[0], event_id="turn-segment:2:t1"),
+        *middle.records[1:],
+    )
+    return TrajectorySnapshot(
+        (first, TrajectoryTurn(middle.turn_id, middle_records), last)
+    )
+
+
 class _Harness(App[None]):
     """Minimal host so the screen can be pushed like the Console would."""
 
@@ -282,6 +297,25 @@ def _inspector_content(screen: TrajectoryScreen) -> Static:
 # ---------------------------------------------------------------------------
 
 
+def test_number_logical_turns_uses_first_occurrence() -> None:
+    snapshot = repeated_turn_segments_snapshot()
+
+    assert _number_logical_turns(snapshot.turns) == {"t1": 1, "t2": 2}
+
+
+def test_visible_count_for_turn_header_resolves_segment_and_colon_id() -> None:
+    screen = TrajectoryScreen(repeated_turn_segments_with_live_tail())
+
+    assert screen._visible_count_for_turn_header("turn:thread:t1") == (
+        screen._total_records
+    )
+    assert screen._visible_count_for_turn_header("turn-segment:2:thread:t1") == (
+        screen._total_records - 3
+    )
+    assert screen._visible_count_for_turn_header("turn:missing") is None
+    assert screen._visible_count_for_turn_header("turn-segment:not-a-number:t1") is None
+
+
 @pytest.mark.asyncio
 async def test_mount_renders_one_row_per_record_plus_turn_headers() -> None:
     async with _mounted(base_snapshot()) as (app, pilot, screen):
@@ -309,6 +343,29 @@ async def test_mount_renders_repeated_turn_segments_with_unique_headers() -> Non
         assert header_keys[0] == "turn:t1"
         for seq in range(1, 7):
             assert table.get_row_index(_record_key_for_seq(screen, seq)) is not None
+
+
+@pytest.mark.asyncio
+async def test_record_event_id_cannot_collide_with_segment_header() -> None:
+    async with _mounted(repeated_turn_segments_with_colliding_event_id()) as (
+        app,
+        pilot,
+        screen,
+    ):
+        table = screen.query_one("#trajectory-table", DataTable)
+        record_key = _record_key_for_seq(screen, 5)
+
+        assert table.row_count == 9
+        assert record_key == "record:turn-segment:2:t1"
+        assert table.get_row_index("turn-segment:2:t1") is not None
+        assert table.get_row_index(record_key) is not None
+
+        table.move_cursor(row=table.get_row_index(record_key))
+        await pilot.press("enter")
+        await pilot.pause()
+        inspector = str(_inspector_content(screen).render())
+        assert "event id turn-segment:2:t1" in inspector
+        assert "event id record:turn-segment:2:t1" not in inspector
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_trajectory_screen.py
+++ b/Tests/UI/test_trajectory_screen.py
@@ -11,13 +11,14 @@ governance suite pattern (``test_schedules_ux_fixes.py``).
 from __future__ import annotations
 
 import contextlib
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from types import SimpleNamespace
 
 import pytest
 from textual.app import App, ComposeResult
 from textual.containers import VerticalScroll
 from textual.widgets import DataTable, Input, Static
+from textual.widgets.data_table import RowDoesNotExist
 
 from tldw_chatbook.Chat.provider_usage import ProviderUsage
 from tldw_chatbook.Chat.console_exchange_capture import CaptureDetail
@@ -187,6 +188,52 @@ def many_records_snapshot(record_count: int):
     return derive_trajectory(messages, {}, [], [], [])
 
 
+def repeated_turn_segments_snapshot(
+    first_turn_id: str = "t1",
+) -> TrajectorySnapshot:
+    """One logical turn split around another turn: t1 -> t2 -> t1."""
+
+    snapshot = base_snapshot()
+    first, second = snapshot.turns
+    first_records = tuple(
+        replace(record, turn_id=first_turn_id) for record in first.records
+    )
+    return TrajectorySnapshot(
+        (
+            TrajectoryTurn(first_turn_id, first_records[:1]),
+            second,
+            TrajectoryTurn(first_turn_id, first_records[1:]),
+        )
+    )
+
+
+def repeated_turn_segments_with_live_tail() -> TrajectorySnapshot:
+    """Repeated colon-bearing turn followed by enough events to paginate it."""
+
+    snapshot = repeated_turn_segments_snapshot("thread:t1")
+    tail_records = tuple(
+        TrajectoryRecord(
+            seq=seq,
+            kind="assistant",
+            turn_id="tail",
+            message_id=f"tail-{seq}",
+            content_preview=f"tail event {seq}",
+            usage=None,
+            step_started_at=None,
+            first_token_at=None,
+            completed_at=None,
+            model=None,
+            provider=None,
+            payload=None,
+            variants=(),
+            depth=0,
+            event_id=f"tail:{seq}",
+        )
+        for seq in range(7, PAGE_SIZE + 8)
+    )
+    return TrajectorySnapshot(snapshot.turns + (TrajectoryTurn("tail", tail_records),))
+
+
 class _Harness(App[None]):
     """Minimal host so the screen can be pushed like the Console would."""
 
@@ -247,6 +294,82 @@ async def test_mount_renders_one_row_per_record_plus_turn_headers() -> None:
         # Tool rows are present and nested under the assistant step.
         tool_row = table.get_row(_record_key_for_seq(screen, 3))
         assert "Tool call" in str(tool_row[1])
+
+
+@pytest.mark.asyncio
+async def test_mount_renders_repeated_turn_segments_with_unique_headers() -> None:
+    async with _mounted(repeated_turn_segments_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+
+        assert table.row_count == 9
+        header_keys = list(screen._row_turn_ids)
+        assert len(header_keys) == 3
+        assert len(set(header_keys)) == 3
+        assert [screen._row_turn_ids[key] for key in header_keys] == ["t1", "t2", "t1"]
+        assert header_keys[0] == "turn:t1"
+        for seq in range(1, 7):
+            assert table.get_row_index(_record_key_for_seq(screen, seq)) is not None
+
+
+@pytest.mark.asyncio
+async def test_repeated_turn_segment_actions_use_logical_turn() -> None:
+    async with _mounted(repeated_turn_segments_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        t1_headers = [
+            key for key, turn_id in screen._row_turn_ids.items() if turn_id == "t1"
+        ]
+
+        assert len(t1_headers) == 2
+        for key in t1_headers:
+            row = table.get_row(key)
+            assert "Turn 1" in str(row[2])
+
+        table.move_cursor(row=table.get_row_index(t1_headers[1]))
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert "Turn 1 · 4 events · expanded · id t1" in str(
+            _inspector_content(screen).render()
+        )
+
+        await pilot.press("t")
+        await pilot.pause()
+        assert table.row_count == 5
+        for key in t1_headers:
+            assert table.get_row_index(key) is not None
+        for seq in range(1, 5):
+            with pytest.raises(RowDoesNotExist):
+                table.get_row_index(_record_key_for_seq(screen, seq))
+
+
+@pytest.mark.asyncio
+async def test_live_snapshot_preserves_first_repeated_turn_header_cursor() -> None:
+    async with _mounted(base_snapshot()) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        table.move_cursor(row=table.get_row_index("turn:t1"))
+        await pilot.pause()
+
+        screen._apply_live_snapshot(repeated_turn_segments_snapshot())
+        await pilot.pause()
+
+        assert screen._cursor_key() == "turn:t1"
+
+
+@pytest.mark.asyncio
+async def test_live_snapshot_pages_selected_repeated_header_back_into_view() -> None:
+    initial = repeated_turn_segments_snapshot("thread:t1")
+    async with _mounted(initial) as (app, pilot, screen):
+        table = screen.query_one("#trajectory-table", DataTable)
+        selected_key = "turn:thread:t1"
+        table.move_cursor(row=table.get_row_index(selected_key))
+        screen._follow = False
+        await pilot.pause()
+
+        screen._apply_live_snapshot(repeated_turn_segments_with_live_tail())
+        await pilot.pause()
+
+        assert screen._cursor_key() == selected_key
+        assert table.get_row_index(selected_key) is not None
 
 
 @pytest.mark.asyncio

--- a/backlog/tasks/task-28023 - Trajectory-ledger-render-repeated-causal-turn-segments-without-duplicate-row-keys.md
+++ b/backlog/tasks/task-28023 - Trajectory-ledger-render-repeated-causal-turn-segments-without-duplicate-row-keys.md
@@ -41,11 +41,11 @@ Reason: This is a localized bug fix that preserves the existing projection, UI o
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Implemented segment-aware Trajectory ledger row identity without altering causal projection output. The first occurrence retains its existing turn:<id> key for live cursor stability; later occurrences use turn-segment:<occurrence>:<id> and map back to the logical turn for inspection and collapse. Logical turn numbering now follows first occurrence, inspector counts aggregate records across repeated segments, and paused live refresh expands the pagination window when needed to restore a selected segment header.
+Implemented segment-aware Trajectory ledger row identity without altering causal projection output. The first occurrence retains its existing turn:<id> key for live cursor stability; later occurrences use turn-segment:<occurrence>:<id> and map back to the logical turn for inspection and collapse. Record rows use a disjoint record:<identity> table-key namespace so unrestricted imported event IDs cannot collide with generated headers or controls. Logical turn numbering now follows first occurrence, inspector counts aggregate records across repeated segments, and paused live refresh expands the pagination window when needed to restore a selected segment header.
 
-Added mounted Textual regression coverage for repeated t1 -> t2 -> t1 rendering, unique headers, complete record rendering, logical-turn actions, live first-header stability, and page-boundary restoration with a colon-bearing turn ID.
+Added mounted Textual regression coverage for repeated t1 -> t2 -> t1 rendering, unique headers, complete record rendering, imported event-ID collisions, logical-turn actions, live first-header stability, and page-boundary restoration with a colon-bearing turn ID. Added direct unit coverage for logical turn numbering and header-window calculations.
 
-Modified files: tldw_chatbook/UI/Screens/trajectory_screen.py; Tests/UI/test_trajectory_screen.py. No user documentation or ADR update was required because this preserves existing behavior and boundaries.
+Modified files: tldw_chatbook/UI/Screens/trajectory_screen.py; Tests/UI/test_trajectory_screen.py; Tests/UI/test_trace_responsive.py. No user documentation or ADR update was required because this preserves existing behavior and boundaries.
 
-Verification: 67 targeted Trajectory screen, timeline-integration, and live tests passed; Ruff format/check and git diff --check passed.
+Verification: 107 targeted Trajectory screen, responsive-layout, timeline-integration, and live tests passed; Ruff format/check and git diff --check passed. The full pre-merge sweep stops at `Tests/Actor_Packs/test_actor_pack_activation.py::test_create_new_persona_preserves_incoming_uuid`; the same failure was reproduced on an isolated `origin/dev` checkout at e7026bd5e, confirming it is a base-branch failure unrelated to this change.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28023 - Trajectory-ledger-render-repeated-causal-turn-segments-without-duplicate-row-keys.md
+++ b/backlog/tasks/task-28023 - Trajectory-ledger-render-repeated-causal-turn-segments-without-duplicate-row-keys.md
@@ -1,0 +1,51 @@
+---
+id: TASK-28023
+title: >-
+  Trajectory ledger - render repeated causal turn segments without duplicate row
+  keys
+status: Done
+assignee: []
+created_date: '2026-09-02 04:16'
+updated_date: '2026-09-02 04:27'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prevent the Trajectory screen from crashing when the causal projection preserves a logical turn as multiple non-contiguous segments.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A trajectory snapshot containing repeated non-contiguous segments for the same logical turn mounts without DuplicateKey and renders every segment and record.
+- [x] #2 Turn-level collapse and inspection continue to resolve segment headers to the original logical turn identifier.
+- [x] #3 Focused Trajectory screen tests cover the repeated-segment regression and pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a mounted TrajectoryScreen regression test with logical turns t1, t2, t1; assert every record renders, header row keys are unique, and each segment maps back to its logical turn.
+2. Run the focused test and confirm it fails with Textual DuplicateKey before changing production code.
+3. Generate a stable segment-specific header key during row-spec construction while preserving explicit header-key-to-logical-turn mapping for collapse and inspection.
+4. Run the focused regression and the Trajectory screen, timeline-integration, and live test modules, then run scoped static checks.
+
+ADR required: no
+ADR path: N/A
+Reason: This is a localized bug fix that preserves the existing projection, UI ownership, and cross-module interfaces.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented segment-aware Trajectory ledger row identity without altering causal projection output. The first occurrence retains its existing turn:<id> key for live cursor stability; later occurrences use turn-segment:<occurrence>:<id> and map back to the logical turn for inspection and collapse. Logical turn numbering now follows first occurrence, inspector counts aggregate records across repeated segments, and paused live refresh expands the pagination window when needed to restore a selected segment header.
+
+Added mounted Textual regression coverage for repeated t1 -> t2 -> t1 rendering, unique headers, complete record rendering, logical-turn actions, live first-header stability, and page-boundary restoration with a colon-bearing turn ID.
+
+Modified files: tldw_chatbook/UI/Screens/trajectory_screen.py; Tests/UI/test_trajectory_screen.py. No user documentation or ADR update was required because this preserves existing behavior and boundaries.
+
+Verification: 67 targeted Trajectory screen, timeline-integration, and live tests passed; Ruff format/check and git diff --check passed.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/trajectory_screen.py
+++ b/tldw_chatbook/UI/Screens/trajectory_screen.py
@@ -58,6 +58,7 @@ import asyncio
 import hashlib
 import json
 import time
+from collections import Counter
 from collections.abc import Callable
 from dataclasses import asdict, replace
 from datetime import datetime
@@ -108,6 +109,8 @@ WORKER_THRESHOLD = 5000
 
 #: DataTable row key of the "load earlier" control row.
 LOAD_EARLIER_ROW_KEY = "__load_earlier__"
+
+_TURN_SEGMENT_ROW_PREFIX = "turn-segment:"
 
 _NARROW_COLUMNS = (
     ("#", 6),
@@ -182,6 +185,15 @@ def _fmt_span(start: float | None, end: float | None) -> str | None:
     if start is None or end is None:
         return None
     return f"{end - start:.2f}s"
+
+
+def _number_logical_turns(turns: tuple[TrajectoryTurn, ...]) -> dict[str, int]:
+    """Assign display numbers by each logical turn's first occurrence."""
+
+    numbers: dict[str, int] = {}
+    for turn in turns:
+        numbers.setdefault(turn.turn_id, len(numbers) + 1)
+    return numbers
 
 
 class TrajectoryScreen(ModalScreen[None]):
@@ -360,9 +372,7 @@ class TrajectoryScreen(ModalScreen[None]):
         #: in-flight ``f`` before its deferred ``scroll_end`` lands.
         self._follow_grace_until = 0.0
         self._turns: tuple[TrajectoryTurn, ...] = snapshot.turns
-        self._turn_numbers: dict[str, int] = {
-            turn.turn_id: index + 1 for index, turn in enumerate(self._turns)
-        }
+        self._turn_numbers = _number_logical_turns(self._turns)
         self._collapsed: set[str] = set()
         self._query = ""
         self._width_tier: str | None = None
@@ -787,9 +797,7 @@ class TrajectoryScreen(ModalScreen[None]):
             self._failure = None
             self._retry_target = None
             self._retry_in_flight = False
-        self._turn_numbers = {
-            turn.turn_id: index + 1 for index, turn in enumerate(self._turns)
-        }
+        self._turn_numbers = _number_logical_turns(self._turns)
         # Feed the strip the same data the ledger renders. set_snapshot
         # resets the widget's brush/selection WITHOUT posting, so keep an
         # active brush alive across the swap (a 0.5s revision tick must
@@ -824,6 +832,11 @@ class TrajectoryScreen(ModalScreen[None]):
                     self._visible_count = max(self._visible_count, len(flat) - index)
                     self._pending_restore_key = selected_key
                     break
+            else:
+                header_visible_count = self._visible_count_for_turn_header(selected_key)
+                if header_visible_count is not None:
+                    self._visible_count = max(self._visible_count, header_visible_count)
+                    self._pending_restore_key = selected_key
         self._render_ledger()
         try:
             self.query_one("#trajectory-title", Static).update(self._title_text())
@@ -892,8 +905,7 @@ class TrajectoryScreen(ModalScreen[None]):
         policy = f"Future exchange capture: {future} · c Change…"
         if snapshot.active_run_detail is not None:
             policy += (
-                f" · Active run frozen at "
-                f"{snapshot.active_run_detail.value.title()}"
+                f" · Active run frozen at {snapshot.active_run_detail.value.title()}"
             )
         return title + "\n" + policy
 
@@ -965,9 +977,43 @@ class TrajectoryScreen(ModalScreen[None]):
         start = max(0, len(flat) - self._visible_count)
         return flat[start:]
 
+    def _visible_count_for_turn_header(self, key: str) -> int | None:
+        """Return the newest-record window needed to include a turn header."""
+
+        if key.startswith(_TURN_SEGMENT_ROW_PREFIX):
+            _, occurrence_text, turn_id = key.split(":", 2)
+            try:
+                target_occurrence = int(occurrence_text)
+            except ValueError:
+                return None
+        elif key.startswith("turn:"):
+            target_occurrence = 1
+            turn_id = key.removeprefix("turn:")
+        else:
+            return None
+
+        occurrence = 0
+        records_before = 0
+        for turn in self._turns:
+            if turn.turn_id == turn_id:
+                occurrence += 1
+                if occurrence == target_occurrence:
+                    return self._total_records - records_before
+            records_before += len(turn.records)
+        return None
+
     def _build_row_specs(self) -> list[tuple[str, tuple[Text, ...]]]:
         """Row specs (key, cells) for the current window/filter/collapse state."""
         specs: list[tuple[str, tuple[Text, ...]]] = []
+        turn_occurrences: Counter[str] = Counter()
+        segment_header_keys: dict[int, str] = {}
+        for turn in self._turns:
+            turn_occurrences[turn.turn_id] += 1
+            occurrence = turn_occurrences[turn.turn_id]
+            if occurrence > 1:
+                segment_header_keys[id(turn)] = (
+                    f"{_TURN_SEGMENT_ROW_PREFIX}{occurrence}:{turn.turn_id}"
+                )
         if self._hidden_earlier:
             specs.append(
                 (
@@ -986,12 +1032,26 @@ class TrajectoryScreen(ModalScreen[None]):
         turn_records: list[TrajectoryRecord] = []
         for turn, record in self._flat_slice():
             if open_turn is not None and turn.turn_id != open_turn.turn_id:
-                specs.extend(self._turn_row_specs(open_turn, turn_records, query))
+                specs.extend(
+                    self._turn_row_specs(
+                        open_turn,
+                        turn_records,
+                        query,
+                        header_key=segment_header_keys.get(id(open_turn)),
+                    )
+                )
                 turn_records = []
             open_turn = turn
             turn_records.append(record)
         if open_turn is not None:
-            specs.extend(self._turn_row_specs(open_turn, turn_records, query))
+            specs.extend(
+                self._turn_row_specs(
+                    open_turn,
+                    turn_records,
+                    query,
+                    header_key=segment_header_keys.get(id(open_turn)),
+                )
+            )
         return specs
 
     def _turn_row_specs(
@@ -999,6 +1059,8 @@ class TrajectoryScreen(ModalScreen[None]):
         turn: TrajectoryTurn,
         records: list[TrajectoryRecord],
         query: str,
+        *,
+        header_key: str | None = None,
     ) -> list[tuple[str, tuple[Text, ...]]]:
         """Header row + child rows for one turn under the current filter.
 
@@ -1016,7 +1078,7 @@ class TrajectoryScreen(ModalScreen[None]):
         filtering = bool(query) or self._filter_bar.state.is_active
         if filtering and not matching:
             return []  # nothing in this turn is visible: header included, hidden
-        header_key = f"turn:{turn.turn_id}"
+        header_key = header_key or f"turn:{turn.turn_id}"
         collapsed = turn.turn_id in self._collapsed
         number = self._turn_numbers.get(turn.turn_id, 0)
         marker = "▸" if collapsed else "▾"
@@ -1185,7 +1247,9 @@ class TrajectoryScreen(ModalScreen[None]):
         for key, cells in specs:
             table.add_row(*cells, key=key)
             self._visible_keys.append(key)
-            if key.startswith("turn:"):
+            if key.startswith(_TURN_SEGMENT_ROW_PREFIX):
+                self._row_turn_ids[key] = key.split(":", 2)[2]
+            elif key.startswith("turn:"):
                 self._row_turn_ids[key] = key.removeprefix("turn:")
             elif key != LOAD_EARLIER_ROW_KEY:
                 self._row_records[key] = None  # resolved below
@@ -1432,8 +1496,8 @@ class TrajectoryScreen(ModalScreen[None]):
     def _inspector_text_for_turn(self, turn_id: str) -> str:
         number = self._turn_numbers.get(turn_id, 0)
         state = "collapsed" if turn_id in self._collapsed else "expanded"
-        count = next(
-            (len(turn.records) for turn in self._turns if turn.turn_id == turn_id), 0
+        count = sum(
+            len(turn.records) for turn in self._turns if turn.turn_id == turn_id
         )
         text = f"Turn {number} · {count} events · {state} · id {turn_id}"
         if self._conversation_id:

--- a/tldw_chatbook/UI/Screens/trajectory_screen.py
+++ b/tldw_chatbook/UI/Screens/trajectory_screen.py
@@ -110,6 +110,7 @@ WORKER_THRESHOLD = 5000
 #: DataTable row key of the "load earlier" control row.
 LOAD_EARLIER_ROW_KEY = "__load_earlier__"
 
+_RECORD_ROW_PREFIX = "record:"
 _TURN_SEGMENT_ROW_PREFIX = "turn-segment:"
 
 _NARROW_COLUMNS = (
@@ -619,6 +620,11 @@ class TrajectoryScreen(ModalScreen[None]):
         self._record_keys = keys
 
     def _record_key(self, record: TrajectoryRecord) -> str:
+        return f"{_RECORD_ROW_PREFIX}{self._record_identity(record)}"
+
+    def _record_identity(self, record: TrajectoryRecord) -> str:
+        """Return the stable source identity without the table-row namespace."""
+
         return self._record_keys[id(record)]
 
     @property
@@ -1386,7 +1392,7 @@ class TrajectoryScreen(ModalScreen[None]):
             f"{rec.label or rec.kind.replace('_', ' ').strip().capitalize() or 'Event'} "
             f"· turn {rec.turn_id}"
         ]
-        event_id = self._record_key(rec)
+        event_id = self._record_identity(rec)
         lines.append(f"event id {event_id} · raw kind {rec.kind}")
         conversation_id = self._conversation_id or rec.conversation_id
         if conversation_id:


### PR DESCRIPTION
## Summary

- prevent TrajectoryScreen from crashing when a logical turn appears in non-contiguous segments
- preserve logical turn numbering, collapse, inspection, and live cursor restoration across segment headers
- add mounted regressions for duplicate keys, pagination boundaries, and colon-bearing turn IDs

## Verification

- 67 targeted trajectory screen, timeline-integration, and live tests passed
- Ruff check and format check passed
- git diff --check passed
- independent review completed with no remaining findings

Backlog: TASK-28023

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TASK-28023: the Trajectory screen no longer crashes with a duplicate-row-key error when a logical turn appears in non-contiguous segments (for example, t1 → t2 → t1) or when an imported event ID collides with a generated row key.

**Bug Fixes**
- The first occurrence of a repeated turn keeps its `turn:<id>` row key; later occurrences use `turn-segment:<occurrence>:<id>`.
- Record rows now use a `record:<identity>` key namespace so imported event IDs can't collide with generated headers or controls.
- Turn numbering, collapse, and inspection still resolve repeated segment headers to the original logical turn.
- Live snapshot refresh expands the pagination window when needed to restore a selected repeated header.
- Adds regression tests for repeated segments, event-ID collisions, colon-bearing turn IDs, and pagination boundaries.

<sup>Written for commit 0dd6fc3b149f41538961e2a9bc87b1efbcb494af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

