### PR TITLE
Fix Console row action menu dismissal

### DIFF
--- a/Tests/UI/test_console_workspace_action_menu.py
+++ b/Tests/UI/test_console_workspace_action_menu.py
@@ -15,6 +15,10 @@ from types import SimpleNamespace
 import pytest
 from textual.widgets import Button
 
+from Tests.UI.test_console_dictation import (
+    FakeDictationSession,
+    _wait_for_mic_label,
+)
 from Tests.UI.test_console_left_rail import (
     _click_rail_toggle,
     make_console_pilot,
@@ -22,6 +26,8 @@ from Tests.UI.test_console_left_rail import (
 from Tests.UI.test_console_workspace_tree_cursor_layout import (
     _console_with_probe_tree,
 )
+from tldw_chatbook.UI.Console_Modules import dictation as dictation_module
+from tldw_chatbook.Widgets.Console import ConsoleComposerBar
 from tldw_chatbook.Widgets.Console.console_conversation_action_menu import (
     ConsoleConversationActionMenu,
 )
@@ -61,6 +67,14 @@ def _request_menu(console, *, kind: str, **kwargs) -> None:
     console.on_workspace_tree_menu_requested(WorkspaceTreeMenuRequested(**payload))
 
 
+async def _click_tree_marker(pilot, tree, node) -> None:
+    """Click one rendered row marker through the mounted production tree."""
+    edge = tree.scrollable_content_region.width
+    line = int(node._line) - int(tree.scroll_offset.y)
+    assert await pilot.click(tree, offset=(edge - 1, line))
+    await pilot.pause(0.4)
+
+
 @pytest.mark.asyncio
 async def test_tree_rows_paint_distinct_right_edge_affordances() -> None:
     """Workspace and chat rows carry distinct openers in one edge column."""
@@ -96,6 +110,148 @@ async def test_tree_rows_paint_distinct_right_edge_affordances() -> None:
         assert not tree._pressed_menu_affordance(
             tree.conversation_nodes["conv-a0"].data
         )
+
+
+@pytest.mark.asyncio
+async def test_marker_menus_claim_escape_before_hands_free_exit(monkeypatch) -> None:
+    """A row popup owns Escape before the priority hands-free binding.
+
+    Removing the row-menu gate from ``check_action`` makes the first Escape
+    exit hands-free while leaving the popup stranded. This drives both real
+    marker paths and pins the approved submenu-back, root-close, then
+    hands-free-exit order.
+    """
+    fake = FakeDictationSession()
+    monkeypatch.setattr(
+        dictation_module.ConsoleDictationController,
+        "_create_console_dictation_session",
+        lambda self: fake,
+    )
+
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        host = pilot.app
+        console, _rail, tree = await _console_with_probe_tree(host, pilot)
+        console.app_instance.workspace_registry_service = _stub_registry()
+        await _click_rail_toggle(pilot, "workspace")
+        await pilot.pause(0.4)
+
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        console.action_toggle_console_hands_free()
+        await _wait_for_mic_label(composer, pilot, "Dictating")
+
+        await _click_tree_marker(pilot, tree, tree.workspace_nodes["ws-alpha"])
+        workspace_menu = console.query_one(ConsoleWorkspaceActionMenu)
+        next(
+            button
+            for button in workspace_menu.query(Button)
+            if getattr(button, "workspace_action_id", "") == "page:more"
+        ).press()
+        await pilot.pause(0.4)
+        assert workspace_menu.page == "more"
+
+        await pilot.press("escape")
+        await pilot.pause(0.4)
+        assert workspace_menu.page == "root"
+        assert console._console_hands_free is not None
+
+        await pilot.press("escape")
+        await pilot.pause(0.4)
+        assert not console.query(ConsoleWorkspaceActionMenu)
+        assert console._console_hands_free is not None
+
+        await _click_tree_marker(pilot, tree, tree.conversation_nodes["conv-a0"])
+        assert console.query(ConsoleConversationActionMenu)
+        console.set_focus(composer)
+        await pilot.pause()
+
+        await pilot.press("escape")
+        await pilot.pause(0.4)
+        assert not console.query(ConsoleConversationActionMenu)
+        assert console._console_hands_free is not None
+
+        await pilot.press("escape")
+        await _wait_for_mic_label(composer, pilot, "Dictate")
+        assert console._console_hands_free is None
+        assert fake.stop_calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("node_key", "menu_type", "handler_name"),
+    [
+        (
+            "ws-alpha",
+            ConsoleWorkspaceActionMenu,
+            "on_workspace_action_chosen",
+        ),
+        (
+            "conv-a0",
+            ConsoleConversationActionMenu,
+            "on_conversation_action_chosen",
+        ),
+    ],
+)
+async def test_real_marker_menu_dismisses_on_outside_click(
+    monkeypatch,
+    node_key: str,
+    menu_type: type[ConsoleWorkspaceActionMenu] | type[ConsoleConversationActionMenu],
+    handler_name: str,
+) -> None:
+    """The production marker path closes without acting or stealing focus."""
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        host = pilot.app
+        console, _rail, tree = await _console_with_probe_tree(host, pilot)
+        console.app_instance.workspace_registry_service = _stub_registry()
+        await _click_rail_toggle(pilot, "workspace")
+        await pilot.pause(0.4)
+
+        node = (
+            tree.workspace_nodes[node_key]
+            if node_key.startswith("ws-")
+            else tree.conversation_nodes[node_key]
+        )
+        await _click_tree_marker(pilot, tree, node)
+        assert console.query(menu_type)
+
+        dispatched: list[object] = []
+        monkeypatch.setattr(
+            console,
+            handler_name,
+            lambda event: dispatched.append(event),
+        )
+        composer = console.query_one("#console-native-composer")
+        assert await pilot.click(composer)
+        await pilot.pause(0.3)
+        assert not console.query(menu_type)
+        assert dispatched == []
+        assert pilot.app.focused is composer
+
+
+@pytest.mark.asyncio
+async def test_escape_focus_restore_keeps_two_row_workspace_tree_visible() -> None:
+    """The restored tree focus cue must not overpaint both visible rows."""
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        host = pilot.app
+        console, _rail, tree = await _console_with_probe_tree(host, pilot)
+        console.app_instance.workspace_registry_service = _stub_registry()
+        await _click_rail_toggle(pilot, "workspace")
+        tree.styles.height = 2
+        await pilot.pause(0.4)
+        assert tree.region.height == 2
+
+        await _click_tree_marker(pilot, tree, tree.workspace_nodes["ws-alpha"])
+        assert console.query(ConsoleWorkspaceActionMenu)
+        await pilot.press("escape")
+        await pilot.pause(0.4)
+
+        assert tree.has_focus
+        assert not tree.styles.outline, (
+            "the global focus outline consumes both rows of the compact tree"
+        )
+        rendered = "\n".join(
+            tree.render_line(row).text for row in range(tree.region.height)
+        )
+        assert "@" in rendered and "*" in rendered
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_workspace_action_menu.py
+++ b/Tests/UI/test_console_workspace_action_menu.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+from textual.color import Color
 from textual.widgets import Button
 
 from Tests.UI.test_console_dictation import (
@@ -27,7 +28,14 @@ from Tests.UI.test_console_workspace_tree_cursor_layout import (
     _console_with_probe_tree,
 )
 from tldw_chatbook.UI.Console_Modules import dictation as dictation_module
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 from tldw_chatbook.Widgets.Console import ConsoleComposerBar
+from tldw_chatbook.Widgets.Console import (
+    console_conversation_action_menu as conversation_action_menu_module,
+)
+from tldw_chatbook.Widgets.Console import (
+    console_workspace_action_menu as workspace_action_menu_module,
+)
 from tldw_chatbook.Widgets.Console.console_conversation_action_menu import (
     ConsoleConversationActionMenu,
 )
@@ -37,6 +45,9 @@ from tldw_chatbook.Widgets.Console.console_workspace_action_menu import (
 from tldw_chatbook.Widgets.Console.console_workspace_tree import (
     WorkspaceTreeMenuRequested,
 )
+
+
+_MENU_SETTLE_SECONDS = 0.4
 
 
 def _stub_registry():
@@ -72,7 +83,42 @@ async def _click_tree_marker(pilot, tree, node) -> None:
     edge = tree.scrollable_content_region.width
     line = int(node._line) - int(tree.scroll_offset.y)
     assert await pilot.click(tree, offset=(edge - 1, line))
-    await pilot.pause(0.4)
+    await pilot.pause(_MENU_SETTLE_SECONDS)
+
+
+@pytest.mark.parametrize(
+    ("conversation_menus", "workspace_menus", "expected"),
+    [
+        ([], [], False),
+        ([SimpleNamespace(_pruning=False)], [], True),
+        ([], [SimpleNamespace(_pruning=False)], True),
+        (
+            [SimpleNamespace(_pruning=True)],
+            [SimpleNamespace(_pruning=True)],
+            False,
+        ),
+    ],
+)
+def test_row_action_menu_open_tracks_only_live_unpruned_menus(
+    monkeypatch,
+    conversation_menus: list[SimpleNamespace],
+    workspace_menus: list[SimpleNamespace],
+    expected: bool,
+) -> None:
+    """The Escape gate ignores empty and already-pruning registries."""
+    monkeypatch.setattr(
+        conversation_action_menu_module,
+        "conversation_action_menus_on_screen",
+        lambda _screen: conversation_menus,
+    )
+    monkeypatch.setattr(
+        workspace_action_menu_module,
+        "workspace_action_menus_on_screen",
+        lambda _screen: workspace_menus,
+    )
+
+    screen = ChatScreen.__new__(ChatScreen)
+    assert screen._console_row_action_menu_open() is expected
 
 
 @pytest.mark.asyncio
@@ -83,7 +129,7 @@ async def test_tree_rows_paint_distinct_right_edge_affordances() -> None:
         console, _rail, tree = await _console_with_probe_tree(host, pilot)
 
         await _click_rail_toggle(pilot, "workspace")
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
         assert tree.region, "workspace section stayed collapsed"
 
         workspace_key = tree.workspace_nodes["ws-alpha"].data.key
@@ -133,7 +179,7 @@ async def test_marker_menus_claim_escape_before_hands_free_exit(monkeypatch) -> 
         console, _rail, tree = await _console_with_probe_tree(host, pilot)
         console.app_instance.workspace_registry_service = _stub_registry()
         await _click_rail_toggle(pilot, "workspace")
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
 
         composer = console.query_one("#console-native-composer", ConsoleComposerBar)
         console.action_toggle_console_hands_free()
@@ -146,16 +192,16 @@ async def test_marker_menus_claim_escape_before_hands_free_exit(monkeypatch) -> 
             for button in workspace_menu.query(Button)
             if getattr(button, "workspace_action_id", "") == "page:more"
         ).press()
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
         assert workspace_menu.page == "more"
 
         await pilot.press("escape")
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
         assert workspace_menu.page == "root"
         assert console._console_hands_free is not None
 
         await pilot.press("escape")
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
         assert not console.query(ConsoleWorkspaceActionMenu)
         assert console._console_hands_free is not None
 
@@ -165,7 +211,7 @@ async def test_marker_menus_claim_escape_before_hands_free_exit(monkeypatch) -> 
         await pilot.pause()
 
         await pilot.press("escape")
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
         assert not console.query(ConsoleConversationActionMenu)
         assert console._console_hands_free is not None
 
@@ -203,7 +249,7 @@ async def test_real_marker_menu_dismisses_on_outside_click(
         console, _rail, tree = await _console_with_probe_tree(host, pilot)
         console.app_instance.workspace_registry_service = _stub_registry()
         await _click_rail_toggle(pilot, "workspace")
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
 
         node = (
             tree.workspace_nodes[node_key]
@@ -229,29 +275,39 @@ async def test_real_marker_menu_dismisses_on_outside_click(
 
 @pytest.mark.asyncio
 async def test_escape_focus_restore_keeps_two_row_workspace_tree_visible() -> None:
-    """The restored tree focus cue must not overpaint both visible rows."""
+    """The restored focus cue remains visible without overpainting rows."""
     async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
         host = pilot.app
         console, _rail, tree = await _console_with_probe_tree(host, pilot)
         console.app_instance.workspace_registry_service = _stub_registry()
         await _click_rail_toggle(pilot, "workspace")
         tree.styles.height = 2
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
         assert tree.region.height == 2
 
         await _click_tree_marker(pilot, tree, tree.workspace_nodes["ws-alpha"])
         assert console.query(ConsoleWorkspaceActionMenu)
         await pilot.press("escape")
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
 
         assert tree.has_focus
         assert not tree.styles.outline, (
             "the global focus outline consumes both rows of the compact tree"
         )
+        focused_cursor = tree.get_component_styles("tree--cursor").background
+        assert focused_cursor == Color.parse("#51677e")
         rendered = "\n".join(
             tree.render_line(row).text for row in range(tree.region.height)
         )
         assert "@" in rendered and "*" in rendered
+
+        composer = console.query_one("#console-native-composer")
+        console.set_focus(composer)
+        await pilot.pause()
+        blurred_cursor = tree.get_component_styles("tree--cursor").background
+        assert focused_cursor != blurred_cursor, (
+            "the focused tree cursor is indistinguishable from its blurred state"
+        )
 
 
 @pytest.mark.asyncio
@@ -263,7 +319,7 @@ async def test_workspace_menu_opens_with_the_six_approved_entries(
         console.app_instance.workspace_registry_service = _stub_registry()
 
         _request_menu(console, kind="workspace")
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
 
         menu = console.query_one(ConsoleWorkspaceActionMenu)
         labels = [str(button.label).strip() for button in menu.query(Button)]
@@ -294,7 +350,7 @@ async def test_workspace_menu_pages_and_escapes_like_the_conversation_menu(
         console.app_instance.workspace_registry_service = _stub_registry()
 
         _request_menu(console, kind="workspace")
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
 
         more = next(
             b
@@ -361,7 +417,7 @@ async def test_unsaved_native_rows_get_none_and_gate_saved_only_actions() -> Non
         _request_menu(
             console, kind="conversation", conversation_id=None, title="Untitled"
         )
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
         menu = console.query_one(ConsoleConversationActionMenu)
         assert menu.target.conversation_id is None
         # Rename carries the unsaved reason regardless of whether the marks
@@ -382,7 +438,7 @@ async def test_tree_menu_target_carries_the_row_title() -> None:
             conversation_id="conv-a0",
             title="Alpha conversation 0",
         )
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
         menu = console.query_one(ConsoleConversationActionMenu)
         assert menu.target.title == "Alpha conversation 0"
 
@@ -473,7 +529,7 @@ async def test_tree_chat_row_opens_the_shared_conversation_menu() -> None:
         _request_menu(
             console, kind="conversation", conversation_id="conv-a0"
         )
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
 
         menu = console.query_one(ConsoleConversationActionMenu)
         labels = [str(button.label).strip() for button in menu.query(Button)]
@@ -495,7 +551,7 @@ async def test_m_binding_opens_the_menu_for_the_cursor_workspace_row(
         # (the section-header click a real user made first is what opens
         # it); click that toggle exactly as the rail suite's helper does.
         await _click_rail_toggle(pilot, "workspace")
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
         assert tree.region, "workspace section stayed collapsed"
 
         # Walk the cursor onto a workspace row.
@@ -524,7 +580,7 @@ async def test_workspace_menu_dismisses_on_outside_click_and_stranded_escape(
         console.app_instance.workspace_registry_service = _stub_registry()
 
         _request_menu(console, kind="workspace")
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
         assert console.query(ConsoleWorkspaceActionMenu)
 
         await pilot.click("#console-native-composer")
@@ -534,7 +590,7 @@ async def test_workspace_menu_dismisses_on_outside_click_and_stranded_escape(
         )
 
         _request_menu(console, kind="workspace")
-        await pilot.pause(0.4)
+        await pilot.pause(_MENU_SETTLE_SECONDS)
         composer = console.query_one("#console-native-composer")
         console.set_focus(composer)
         await pilot.pause()

--- a/backlog/tasks/task-28226 - Harden-Console-row-menu-dismissal-from-workspace-markers.md
+++ b/backlog/tasks/task-28226 - Harden-Console-row-menu-dismissal-from-workspace-markers.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@Codex'
 created_date: '2026-09-02 05:41'
-updated_date: '2026-09-02 06:25'
+updated_date: '2026-09-02 06:42'
 labels: []
 dependencies: []
 ---
@@ -41,8 +41,8 @@ contract, including priority hands-free key routing.
 4. Run the two row-menu suites, seam-adjacent hands-free tests, Ruff, and diff
    checks; record implementation evidence and complete the acceptance criteria.
 5. Reproduce the live-UAT focus-outline clipping in a two-row tree, add a
-   computed-style regression, and keep the existing cursor cue while removing
-   the overpainting outline.
+   computed-style regression, and replace the overpainting outline with a
+   focus-specific high-contrast cursor cue.
 
 ADR required: no
 ADR path: `backlog/decisions/068-console-text-selection-and-annotations.md`
@@ -70,15 +70,18 @@ boundary.
 - UAT exposed the global four-sided focus outline overpainting both rows of a
   compact workspace tree after Escape restored focus. Added a production-style
   two-row rendering regression and disabled that outline while retaining the
-  tree's existing focus background and cursor cues; regenerated the canonical
-  Console CSS bundle.
-- Verified the two row-menu suites plus Console popup etiquette (42 tests),
-  Ruff on the touched Python files, the CSS generator, and `git diff --check`.
-  The only warning is the repository environment's pre-existing Requests
-  dependency warning. A broader 173-test check produced 171 passes and two
-  failures proven unchanged on `origin/dev`: a stale inspector-handle CSS
-  expectation and an integer-CSS helper that rejects existing `!important`
-  declarations.
+  tree's focus tint; regenerated the canonical Console CSS bundle.
+- Addressed all three Qodo review findings: added direct empty/live/pruning
+  registry-state coverage, named the menu-settlement delay used throughout the
+  suite, and reused File Notes' `$ds-focus-bg`/`$ds-focus-fg` focused-cursor
+  contract so keyboard focus is distinct without consuming compact tree rows.
+- Verified the two row-menu suites plus Console popup etiquette (46 tests), 11
+  focused CSS generation/partition/parsing checks, Ruff on the touched Python
+  files, the CSS generator, and `git diff --check`. The only warning is the
+  repository environment's pre-existing Requests dependency warning. A broader
+  173-test check before review remediation produced 171 passes and two failures
+  proven unchanged on `origin/dev`: a stale inspector-handle CSS expectation
+  and an integer-CSS helper that rejects existing `!important` declarations.
 - ADR required: no. The implementation follows
   `backlog/decisions/068-console-text-selection-and-annotations.md`; no new
   storage, ownership, security, or interface decision was introduced.

--- a/backlog/tasks/task-28226 - Harden-Console-row-menu-dismissal-from-workspace-markers.md
+++ b/backlog/tasks/task-28226 - Harden-Console-row-menu-dismissal-from-workspace-markers.md
@@ -1,0 +1,88 @@
+---
+id: TASK-28226
+title: Harden Console row-menu dismissal from workspace markers
+status: Done
+assignee:
+  - '@Codex'
+created_date: '2026-09-02 05:41'
+updated_date: '2026-09-02 06:25'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure the workspace and chat action popups opened from the right-edge `@` and
+`*` markers always honor the established Escape and click-outside dismissal
+contract, including priority hands-free key routing.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Root `@` and `*` menus close on Escape before hands-free exits.
+- [x] #2 Submenu Escape returns to the root before a second Escape closes it.
+- [x] #3 Clicking outside either popup dismisses it without dispatching an action or restoring opener focus.
+- [x] #4 Real marker-pointer paths have regression coverage.
+- [x] #5 Targeted tests and lint pass.
+- [x] #6 Escape focus restoration leaves the two-row workspace tree and its markers visible.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a mounted Console regression proving an open row action menu claims the
+   priority hands-free Escape before the loop exits.
+2. Make the priority hands-free Escape binding yield while either row menu is
+   live so the existing menu and screen fallback handlers retain ownership.
+3. Extend the real Workspaces-tree marker tests to cover `@` and `*` dismissal
+   through outside click and root/submenu Escape without changing focus or
+   dispatch semantics.
+4. Run the two row-menu suites, seam-adjacent hands-free tests, Ruff, and diff
+   checks; record implementation evidence and complete the acceptance criteria.
+5. Reproduce the live-UAT focus-outline clipping in a two-row tree, add a
+   computed-style regression, and keep the existing cursor cue while removing
+   the overpainting outline.
+
+ADR required: no
+ADR path: `backlog/decisions/068-console-text-selection-and-annotations.md`
+Reason: this is a direct regression fix under the existing Console overlay
+dismissal contract and changes no storage, ownership, security, or interface
+boundary.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Gated the priority hands-free Escape binding while a live workspace or
+  conversation row menu is mounted, allowing the existing submenu-back,
+  root-close, and stranded-focus handlers to run before hands-free exits.
+- Reused the menus' weak registries and ignored nodes already scheduled for
+  pruning, avoiding both a Console DOM walk and a transient swallowed Escape
+  immediately after dismissal.
+- Added mounted production-style tests that click the real `@` and `*` tree
+  markers, cover menu-focused and stranded-focus Escape ordering, and prove
+  outside clicks neither dispatch actions nor steal focus from the click.
+- Real-terminal UAT used the full app, isolated scratch profile, actual `@` and
+  `*` tree markers, and terminal mouse events. It confirmed root Escape close,
+  submenu-to-root then close on two Escapes, and outside-click dismissal while
+  leaving the composer focused. The inspector remained in the Console context.
+- UAT exposed the global four-sided focus outline overpainting both rows of a
+  compact workspace tree after Escape restored focus. Added a production-style
+  two-row rendering regression and disabled that outline while retaining the
+  tree's existing focus background and cursor cues; regenerated the canonical
+  Console CSS bundle.
+- Verified the two row-menu suites plus Console popup etiquette (42 tests),
+  Ruff on the touched Python files, the CSS generator, and `git diff --check`.
+  The only warning is the repository environment's pre-existing Requests
+  dependency warning. A broader 173-test check produced 171 passes and two
+  failures proven unchanged on `origin/dev`: a stale inspector-handle CSS
+  expectation and an integer-CSS helper that rejects existing `!important`
+  declarations.
+- ADR required: no. The implementation follows
+  `backlog/decisions/068-console-text-selection-and-annotations.md`; no new
+  storage, ownership, security, or interface decision was introduced.
+- No new lesson was added: the existing live-verification guidance already
+  covers checking focused edge rows in the real terminal, and this incident is
+  now captured by the rendering regression and task record.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1855,8 +1855,13 @@ class ChatScreen(BaseAppScreen):
         if action == "exit_console_hands_free":
             # One-line delegation (wave-2 console decomposition, task 1).
             # See `ConsoleHandsFreeController.console_hands_free_exit_
-            # available` for the real implementation.
-            return self._hands_free.console_hands_free_exit_available()
+            # available` for the real implementation. TASK-28226: a row
+            # action menu claims Escape before the priority hands-free
+            # binding so its own submenu-back/root-close behavior can run.
+            return (
+                self._hands_free.console_hands_free_exit_available()
+                and not self._console_row_action_menu_open()
+            )
         return super().check_action(action, parameters)
 
     def action_exit_console_hands_free(self) -> None:
@@ -4834,6 +4839,32 @@ class ChatScreen(BaseAppScreen):
         self._workspace._create_console_workspace()
 
     # ---- Conversation action menu (TASK-23200) -------------------------
+
+    def _console_row_action_menu_open(self) -> bool:
+        """Return whether either kind of Console row action menu is open.
+
+        TASK-28226: the priority hands-free Escape binding must yield while
+        an ``@`` workspace menu or ``*`` conversation menu is mounted. This
+        lets the menu's existing key handler preserve submenu-back before
+        root-close, while the screen fallback still closes a menu whose
+        focus has moved elsewhere. Menus already scheduled for pruning do
+        not claim another key. The widget registries avoid a DOM walk.
+
+        Returns:
+            True when a conversation or workspace row menu is open.
+        """
+        from tldw_chatbook.Widgets.Console.console_conversation_action_menu import (
+            conversation_action_menus_on_screen,
+        )
+        from tldw_chatbook.Widgets.Console.console_workspace_action_menu import (
+            workspace_action_menus_on_screen,
+        )
+
+        menus = (
+            *conversation_action_menus_on_screen(self),
+            *workspace_action_menus_on_screen(self),
+        )
+        return any(not getattr(menu, "_pruning", False) for menu in menus)
 
     def _dismiss_console_conversation_action_menus(self) -> bool:
         """Fold any open row action menu; True when one was open.

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -4598,7 +4598,8 @@ ConsoleBoundedSection {
 #console-workspace-tree:focus {
     /* TASK-28226: this tree can be only two rows tall. The global four-sided
        focus outline overpaints both rows after an action menu restores focus;
-       the cursor treatment below and this background remain visible cues. */
+       the focus-specific cursor below supplies the content-safe high-contrast
+       cue while this tint reinforces which compact region owns focus. */
     outline: none;
     background: $ds-action-focus 12%;
 }
@@ -4606,6 +4607,12 @@ ConsoleBoundedSection {
 #console-workspace-tree > .tree--cursor {
     background: $surface;
     color: $text;
+    text-style: bold underline;
+}
+
+#console-workspace-tree:focus > .tree--cursor {
+    background: $ds-focus-bg;
+    color: $ds-focus-fg;
     text-style: bold underline;
 }
 

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -4596,6 +4596,10 @@ ConsoleBoundedSection {
 }
 
 #console-workspace-tree:focus {
+    /* TASK-28226: this tree can be only two rows tall. The global four-sided
+       focus outline overpaints both rows after an action menu restores focus;
+       the cursor treatment below and this background remain visible cues. */
+    outline: none;
     background: $ds-action-focus 12%;
 }
 

--- a/tldw_chatbook/css/screen_agentic_console.tcss
+++ b/tldw_chatbook/css/screen_agentic_console.tcss
@@ -1224,7 +1224,8 @@ ConsoleTerminalWorkspace#console-main-column {
 #console-workspace-tree:focus {
     /* TASK-28226: this tree can be only two rows tall. The global four-sided
        focus outline overpaints both rows after an action menu restores focus;
-       the cursor treatment below and this background remain visible cues. */
+       the focus-specific cursor below supplies the content-safe high-contrast
+       cue while this tint reinforces which compact region owns focus. */
     outline: none;
     background: $ds-action-focus 12%;
 }

--- a/tldw_chatbook/css/screen_agentic_console.tcss
+++ b/tldw_chatbook/css/screen_agentic_console.tcss
@@ -1222,6 +1222,10 @@ ConsoleTerminalWorkspace#console-main-column {
 }
 
 #console-workspace-tree:focus {
+    /* TASK-28226: this tree can be only two rows tall. The global four-sided
+       focus outline overpaints both rows after an action menu restores focus;
+       the cursor treatment below and this background remain visible cues. */
+    outline: none;
     background: $ds-action-focus 12%;
 }
 

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -3188,6 +3188,12 @@ ConsoleBoundedSection {
     text-style: bold underline;
 }
 
+#console-workspace-tree:focus > .tree--cursor {
+    background: $ds-focus-bg;
+    color: $ds-focus-fg;
+    text-style: bold underline;
+}
+
 #console-transcript-region,
 #console-session-surface {
     height: 1fr;


### PR DESCRIPTION
## Summary

- let workspace `@` and chat `*` action menus claim `Esc` before the priority hands-free exit binding
- preserve the existing submenu-to-root, root-to-close, and click-outside focus/dispatch behavior
- keep compact two-row workspace trees visible when popup dismissal restores focus
- add mounted regressions through the actual tree-marker pointer paths

## UAT

Passed in the full Textual app at 180x60 using an isolated scratch profile and real terminal mouse events:

- workspace `@`: opened root and More submenu; first `Esc` returned to root and second `Esc` closed
- chat `*`: `Esc` closed the root popup
- outside click on the composer dismissed the popup without dispatching an action and kept composer focus
- the Console context remained open throughout
- workspace and chat marker rows remained visible after focus restoration

The scratch profile and workspace were removed after the run.

## Verification

- `python -m pytest Tests/UI/test_console_conversation_action_menu.py Tests/UI/test_console_workspace_action_menu.py Tests/UI/test_console_popup_etiquette.py -q` — 42 passed
- `python -m ruff check tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_workspace_action_menu.py` — passed
- `python tldw_chatbook/css/build_css.py` — passed; canonical Console CSS regenerated
- `git diff --check` — passed

A broader 173-test targeted check produced 171 passes and two failures already present on `origin/dev`: the inspector-handle test expects `min-height: 20` while the base stylesheet declares `12`, and the focus-contract integer parser rejects the base stylesheet's existing `!important` declarations.

## Project record

- Backlog: TASK-28226
- ADR required: no; follows the existing Console overlay contract in ADR-068

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Console row action menu dismissal (TASK-28226) so `Esc` and click-outside close the `@` and `*` menus before hands-free exits, and keeps compact two-row workspace trees visible after focus restoration.

- The priority hands-free `Esc` binding now yields while a live workspace or conversation row menu is open, preserving submenu-back, root-close, and click-outside behavior.
- Replaces the workspace tree's global focus outline with a focus-specific cursor so a two-row tree stays visible after menu dismissal.
- Adds mounted regression tests for real marker clicks, outside clicks, menu-vs-hands-free `Esc` ordering, and two-row focus rendering.

<sup>Written for commit b31b1dd17c83387ff0ac27045b733dccbfd50f29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

