### PR TITLE
feat(library): media reading/keyboard P1s (Enter-advances-match, bulk-select keys)

### DIFF
--- a/Tests/UI/test_library_media_reader_flow.py
+++ b/Tests/UI/test_library_media_reader_flow.py
@@ -269,6 +269,37 @@ async def _load_row_0(screen, service, pilot):
 
 
 @pytest.mark.asyncio
+async def test_s_key_enters_select_mode_and_space_toggles_a_row():
+    """task-28012: keyboard-only bulk selection on the media list."""
+    app, service = _flow_app(count=3)
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=WIDE_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        assert screen._library_media_select_mode is False
+        assert ("s", "select") in screen._library_footer_shortcuts_for_current_state()
+
+        # "s" from a focused row enters select mode.
+        screen.query_one("#library-media-row-0", Button).focus()
+        await pilot.pause()
+        await pilot.press("s")
+        await pilot.pause()
+        assert screen._library_media_select_mode is True
+        footer = screen._library_footer_shortcuts_for_current_state()
+        assert ("space", "toggle selection") in footer
+        assert ("s", "done selecting") in footer
+
+        # Space toggles the focused row's selection.
+        row = screen.query_one("#library-media-row-0", Button)
+        row_id = str(row.media_id)
+        row.focus()
+        await pilot.pause()
+        await pilot.press("space")
+        await pilot.pause()
+        assert screen._library_media_row_selection.is_selected(row_id)
+
+
+@pytest.mark.asyncio
 async def test_bracket_keys_walk_to_next_and_previous_item_in_the_reader():
     """task-28005: ] opens the next browse item, [ the previous, from the Reader."""
     app, service = _flow_app(count=3)

--- a/Tests/UI/test_library_media_side_by_side.py
+++ b/Tests/UI/test_library_media_side_by_side.py
@@ -967,11 +967,11 @@ async def _assert_keyboard_traversal_and_viewer_entry(size):
             screen, pilot, compact=size[0] < 120
         )
 
-        # Footer honesty: the plain media list advertises the shared
-        # list-canvas set through the one seam, in BOTH layouts.
+        # Footer honesty: the plain media list advertises its own set
+        # (task-28012 adds the "s: select" key), in BOTH layouts.
         assert (
             screen._library_footer_shortcuts_for_current_state()
-            == screen.LIBRARY_LIST_SHORTCUTS
+            == screen.LIBRARY_MEDIA_LIST_SHORTCUTS
         )
 
         # Rows: Up/Down move DOM focus between rows.
@@ -1126,12 +1126,13 @@ async def _assert_select_mode_keyboard_toggle_and_footer(size):
         assert str(row_1.label).startswith("☑")
         assert "2 selected" in str(count.renderable)
 
-        # Footer honesty through the armed sub-state: arming bulk delete
-        # swaps the advertised set to the confirm context (esc cancels), in
-        # this layout exactly as in the other.
+        # Footer honesty through the armed sub-state: while selecting the
+        # footer advertises the select keys (task-28012); arming bulk delete
+        # swaps to the confirm context (esc cancels), in this layout exactly
+        # as in the other.
         assert (
             screen._library_footer_shortcuts_for_current_state()
-            == screen.LIBRARY_LIST_SHORTCUTS
+            == screen.LIBRARY_MEDIA_SELECT_SHORTCUTS
         )
         screen.query_one("#library-media-delete-selected", Button).press()
         await _wait_for_selector(
@@ -1146,7 +1147,7 @@ async def _assert_select_mode_keyboard_toggle_and_footer(size):
         assert not screen.query("#library-media-bulk-delete-confirm-copy")
         assert (
             screen._library_footer_shortcuts_for_current_state()
-            == screen.LIBRARY_LIST_SHORTCUTS
+            == screen.LIBRARY_MEDIA_SELECT_SHORTCUTS
         )
 
 

--- a/Tests/UI/test_library_media_side_by_side.py
+++ b/Tests/UI/test_library_media_side_by_side.py
@@ -704,6 +704,7 @@ async def test_media_toolbar_actions_fit_the_items_panel_at_wide_width() -> None
 
         for selector in (
             "#library-media-type-filter",
+            "#library-media-sort",
             "#library-media-export",
             "#library-media-trash-open",
             "#library-media-select-toggle",

--- a/Tests/UI/test_library_multiselect_media.py
+++ b/Tests/UI/test_library_multiselect_media.py
@@ -186,6 +186,31 @@ def test_space_action_noop_when_focus_is_not_a_row():
     assert fake._library_media_row_selection.count == 0
 
 
+def test_select_enter_available_matches_the_button_gate():
+    """task-28012 (Qodo #2309): entering select mode needs fresh rows.
+
+    The keyboard "s" must obey the same availability as the Select button
+    (disabled with no rows or on a stale page), so this predicate -- the
+    one check_action consults for entry -- gates on controller state.
+    """
+    fake = SimpleNamespace(
+        _library_media_browse_controller=SimpleNamespace(
+            freshness="fresh",
+            retained_items=({"id": "local:media:1"},),
+        )
+    )
+    assert LibraryScreen._library_media_select_enter_available(fake) is True
+
+    # No rows -> not available (matches the disabled Select button).
+    fake._library_media_browse_controller.retained_items = ()
+    assert LibraryScreen._library_media_select_enter_available(fake) is False
+
+    # Stale page -> not available even with rows.
+    fake._library_media_browse_controller.retained_items = ({"id": "x"},)
+    fake._library_media_browse_controller.freshness = "stale"
+    assert LibraryScreen._library_media_select_enter_available(fake) is False
+
+
 @pytest.mark.asyncio
 async def test_export_selected_builds_ids_scope():
     fake = _media_fake(select_mode=True)

--- a/Tests/UI/test_library_multiselect_media.py
+++ b/Tests/UI/test_library_multiselect_media.py
@@ -113,6 +113,10 @@ def _media_fake(
     fake._exit_library_media_select_mode = types.MethodType(
         LibraryScreen._exit_library_media_select_mode, fake
     )
+    # task-28012: the "Select"/"Done" button and the "s" key share this seam.
+    fake._toggle_library_media_select_mode = types.MethodType(
+        LibraryScreen._toggle_library_media_select_mode, fake
+    )
     fake._clear_library_media_selection_for_scope_change = types.MethodType(
         LibraryScreen._clear_library_media_selection_for_scope_change, fake
     )
@@ -143,6 +147,43 @@ def test_row_press_normal_mode_opens_viewer():
     LibraryScreen.handle_library_media_row(fake, event)
     assert fake._viewer_opened == ["7"]
     assert not fake._library_media_row_selection.is_selected("7")
+
+
+def _focused_media_row(media_id):
+    return SimpleNamespace(
+        media_id=media_id,
+        has_class=lambda cls: cls == "library-media-row",
+    )
+
+
+def test_space_action_toggles_focused_row_in_select_mode():
+    """task-28012: Space on a focused row toggles its selection in select mode."""
+    fake = _media_fake(select_mode=True)
+    fake.refresh = lambda **k: setattr(fake, "_refreshed", fake._refreshed + 1)
+    fake.focused = _focused_media_row("7")
+    LibraryScreen.action_library_media_toggle_row_selection(fake)
+    assert fake._library_media_row_selection.is_selected("7")
+    # Toggling again clears it.
+    LibraryScreen.action_library_media_toggle_row_selection(fake)
+    assert not fake._library_media_row_selection.is_selected("7")
+
+
+def test_space_action_noop_outside_select_mode():
+    """task-28012: Space does nothing on a row when not in select mode."""
+    fake = _media_fake(select_mode=False)
+    fake.refresh = lambda **k: None
+    fake.focused = _focused_media_row("7")
+    LibraryScreen.action_library_media_toggle_row_selection(fake)
+    assert not fake._library_media_row_selection.is_selected("7")
+
+
+def test_space_action_noop_when_focus_is_not_a_row():
+    """task-28012: Space toggles nothing when focus is not on a media row."""
+    fake = _media_fake(select_mode=True)
+    fake.refresh = lambda **k: None
+    fake.focused = SimpleNamespace(has_class=lambda cls: False)
+    LibraryScreen.action_library_media_toggle_row_selection(fake)
+    assert fake._library_media_row_selection.count == 0
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -10637,6 +10637,79 @@ async def _open_media_viewer(screen, pilot):
     await _wait_for_selector(screen, pilot, "#library-media-content-search")
 
 
+@pytest.mark.asyncio
+async def test_library_media_sort_chooser_applies_the_selected_order():
+    """task-28013: the media sort chooser re-fetches page one under the new order."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        screen.query_one("#library-row-browse-media").press()
+        await _wait_for_selector(screen, pilot, "#library-media-sort")
+        service = app.media_reading_scope_service
+
+        # Open the sort chooser; its direct-pick strip replaces the toolbar.
+        screen.query_one("#library-media-sort", Button).press()
+        await _wait_for_selector(screen, pilot, ".library-media-sort-choice")
+        assert screen._library_media_sort_choices_visible is True
+
+        # Pick "Title A-Z" -> the strip closes and a page-one fetch runs
+        # under sort_by=title_asc.
+        screen.query_one("#library-media-sort-title_asc", Button).press()
+        for _ in range(150):
+            if service.search_calls and service.search_calls[-1].get(
+                "sort_by"
+            ) == "title_asc":
+                break
+            await pilot.pause(0.02)
+        else:
+            raise AssertionError(
+                f"Sort was never applied. Calls: {service.search_calls[-3:]}"
+            )
+        assert screen._library_media_sort_choices_visible is False
+        last = service.search_calls[-1]
+        assert last["sort_by"] == "title_asc"
+        assert last.get("page", 1) == 1
+
+
+@pytest.mark.asyncio
+async def test_library_media_sort_and_type_choosers_are_mutually_exclusive():
+    """task-28013: opening one chooser closes the other; Escape closes the strip."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        screen.query_one("#library-row-browse-media").press()
+        await _wait_for_selector(screen, pilot, "#library-media-sort")
+
+        # Open the type chooser, then the sort chooser: only sort stays open.
+        screen.query_one("#library-media-type-filter", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-type-choices")
+        screen.query_one("#library-media-sort", Button).press()
+        await _wait_for_selector(screen, pilot, ".library-media-sort-choice")
+        assert screen._library_media_sort_choices_visible is True
+        assert screen._library_media_type_choices_visible is False
+
+        # The open strip advertises its own footer keys through the shared seam.
+        footer = screen._library_footer_shortcuts_for_current_state()
+        assert ("enter", "choose sort") in footer
+        assert ("esc", "cancel") in footer
+
+        # Escape closes the strip.
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen._library_media_sort_choices_visible is False
+        assert not screen.query(".library-media-sort-choice")
+
+
 async def _submit_content_search_query(screen, pilot, query):
     """Type ``query`` into the open viewer's content search box and press Enter."""
     search_input = screen.query_one("#library-media-content-search", Input)

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -10701,6 +10701,38 @@ async def test_library_shell_media_content_search_shows_match_count():
 
 
 @pytest.mark.asyncio
+async def test_library_shell_media_content_search_enter_advances_to_next_match():
+    """task-28011: re-pressing Enter on the same query walks to the next match."""
+    app = _build_test_app()
+    _seed_conversations(
+        app, _two_conversations(), media=_media_item_with_multiline_content()
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        await _open_media_viewer_and_submit_content_search(screen, pilot, "budget")
+        assert screen._library_media_content_match_index == 0
+
+        # Same query, Enter again -> advance (find-bar convention).
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        assert screen._library_media_content_match_index == 1
+        assert str(
+            screen.query_one("#library-media-content-search-status").renderable
+        ) == "Match 2 of 2 matches"
+
+        # Wraps back to the first match.
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        assert screen._library_media_content_match_index == 0
+
+
+@pytest.mark.asyncio
 async def test_library_shell_media_content_search_highlights_matches_in_body():
     """While searching, each query occurrence in the content body is styled."""
     app = _build_test_app()

--- a/backlog/tasks/task-28011 - Library-media-viewer-keyboard-match-navigation-and-analysis-inclusive-search.md
+++ b/backlog/tasks/task-28011 - Library-media-viewer-keyboard-match-navigation-and-analysis-inclusive-search.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-28011
 title: Library media viewer - keyboard match navigation and analysis-inclusive search
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-02 04:11'
+updated_date: '2026-09-02 06:46'
 labels:
   - library
   - media-ux
@@ -22,7 +23,13 @@ In-item search matches content only (find_content_matches over viewer.content, l
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Enter in the search input advances to the next match
-- [ ] #2 Prev and next match are reachable by keyboard and advertised
-- [ ] #3 Search finds text in the analysis section, not just content
+- [x] #1 Enter in the search input advances to the next content match (wrapping)
+- [x] #2 Match navigation is reachable by keyboard (Enter cycles all matches) and advertised in the footer
+- [x] #3 Analysis-tab corpus search split to task-28026 (scoped out of this task)
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Delivered the keyboard match-navigation half: re-pressing Enter on the same query calls _advance_library_media_content_match(1) instead of no-opping (find-bar convention, wraps), and the viewer footer advertises 'enter next match' while a search with matches is active. The analysis-tab corpus-breadth half (search finds text in the Analysis tab, not only the transcript) was genuinely larger (different widget/tab, re-scoped highlighting) and is split to task-28026. Tests: test_library_shell_media_content_search_enter_advances_to_next_match. Files: UI/Screens/library_screen.py, Tests/UI/test_library_shell.py. On follow-up branch feat/media-ux-p1 (stacked on the P0 PR #2307).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28012 - Library-media-keyboard-affordances-for-Select-mode-and-viewer-actions.md
+++ b/backlog/tasks/task-28012 - Library-media-keyboard-affordances-for-Select-mode-and-viewer-actions.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-28012
 title: Library media - keyboard affordances for Select mode and viewer actions
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-02 04:11'
+updated_date: '2026-09-02 06:58'
 labels:
   - library
   - media-ux
@@ -22,7 +23,14 @@ Originally covered both the old viewer's five-button action row (now obsolete - 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Row selection can be entered and toggled from the keyboard, advertised in the footer
-- [ ] #2 Viewer actions have bound keys shown in the footer or help panel
-- [ ] #3 Existing mouse paths are unchanged
+- [x] #1 Row selection can be entered ('s') and toggled (Space on the focused row) from the keyboard
+- [x] #2 The select keys are advertised in the media-list footer (s: select; in select mode space + done selecting)
+- [x] #3 Existing mouse paths (Select/Done button, row click) are unchanged
+- [x] #4 Viewer action-row accelerator keys split to task-28027 (scoped out here)
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Delivered keyboard access to bulk SELECTION on the media list (the concrete live gaps: Space was inert, no key entered select mode, nothing advertised). Discovery: Enter on a focused row ALREADY toggles selection (Textual Button binds Enter) - so only Space and the enter-select-mode key + footer were missing. Added: Binding 's' -> action_library_media_toggle_select_mode (reuses the extracted _toggle_library_media_select_mode seam the Select/Done button now shares); Binding 'space' -> action_library_media_toggle_row_selection (toggles the FOCUSED media row, mirroring handle_library_media_row's select branch). Both gated in check_action (s: media list view, not confirming/in-flight; space: select mode + focused media row). Footer: new LIBRARY_MEDIA_LIST_SHORTCUTS (adds 's: select') and LIBRARY_MEDIA_SELECT_SHORTCUTS (space toggle + s done) constants, wired into the footer seam; updated the two existing side-by-side footer tests that pinned the media list to LIBRARY_LIST_SHORTCUTS. A focused Input consumes printable s/space first, so they still type in the filter/search. Viewer action-row accelerators (old AC#2) split to task-28027. Tests: 3 fake unit tests + 1 integration (s enters, space toggles, footer). Files: UI/Screens/library_screen.py, Tests/UI/test_library_multiselect_media.py, Tests/UI/test_library_media_reader_flow.py, Tests/UI/test_library_media_side_by_side.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28013 - Library-media-list-in-canvas-filter-input-and-sort-control.md
+++ b/backlog/tasks/task-28013 - Library-media-list-in-canvas-filter-input-and-sort-control.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-28013
 title: Library media list - in-canvas filter input and sort control
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-02 04:11'
+updated_date: '2026-09-02 13:53'
 labels:
   - library
   - media-ux
@@ -22,7 +23,13 @@ Narrowed after live re-verification 2026-09-02: the in-canvas filter SHIPPED on 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Typing in an in-canvas filter narrows the media list in place
-- [ ] #2 Sort order is user-selectable from the canvas
-- [ ] #3 Active filter and sort state is visible and easy to clear
+- [x] #1 Typing in an in-canvas filter narrows the media list in place
+- [x] #2 Sort order is user-selectable from the canvas
+- [x] #3 Active filter and sort state is visible and easy to clear
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Adds a browse SORT chooser to the media list (the in-canvas filter half shipped earlier on dev). Mirrors the proven Prompts/Notes/type-filter choice-strip pattern exactly (task-14902 requires the strip, not a cycle): a Sort button opens a direct-pick strip (compose_library_choice_strip) offering Newest/Oldest/Title A-Z/Title Z-A (MEDIA_SORT_CHOICES; relevance is query-only so excluded, date_* dedups last_modified_* locally). Picking a new order re-fetches page one via _request_library_media_sort (dataclasses.replace(applied, sort_by=..., page=1)); the active sort persists in the scope. Wired through the shared seams: _library_open_choice_strip (footer 'enter: choose sort'/'esc: cancel' + Escape close), mutual-exclusivity with the type chooser, _begin_library_media_mutation clear, and the state builder (new LibraryMediaCanvasState.sort_by/sort_choices_visible defaults). GOTCHA the test caught: _close_open_library_choice_strip has a hard-coded visibility_attr->canvas_kind dict that needed the new sort attr or Escape KeyError'd. Tests: sort-applies + mutual-exclusivity/escape integration + 28025 5-button-fit extension. Files: Library/library_media_state.py, Widgets/Library/library_media_canvas.py, UI/Screens/library_screen.py, Tests/UI/test_library_shell.py + test_library_media_side_by_side.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28026 - Library-media-viewer-search-the-Analysis-tab-text-not-only-the-transcript.md
+++ b/backlog/tasks/task-28026 - Library-media-viewer-search-the-Analysis-tab-text-not-only-the-transcript.md
@@ -1,0 +1,28 @@
+---
+id: TASK-28026
+title: 'Library media viewer - search the Analysis tab text, not only the transcript'
+status: To Do
+assignee: []
+created_date: '2026-09-02 06:46'
+labels:
+  - library
+  - media-ux
+dependencies: []
+references:
+  - >-
+    .impeccable/critique/2026-09-02T04-00-36Z__tldw-chatbook-ui-screens-library-screen-py.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+From the 2026-09-01 Library media UX critique (task-28011 split): in-item content search (find_content_matches over viewer.content) searches the transcript ONLY. When the user is reading an analysis in the Reader's Analysis tab, the search box does not find text in the analysis. For the sequential-review flow (reading analyses), searching within the analysis is as useful as searching the transcript. Extend the search corpus to include the active tab's text (analysis when the Analysis tab is showing), with matching/highlighting/scroll targeting that tab. task-28011 delivered the keyboard match-navigation (Enter advances, wrapping, footer-advertised) for the content corpus; this task is the remaining corpus-breadth half.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Searching while the Analysis tab is active finds and highlights matches in the analysis text
+- [ ] #2 Match count, prev/next, and Enter-advance operate over whichever tab's text is being searched
+- [ ] #3 Switching tabs re-scopes the search corpus without stale highlights
+<!-- AC:END -->

--- a/backlog/tasks/task-28027 - Library-media-Reader-accelerator-keys-for-the-viewer-action-row.md
+++ b/backlog/tasks/task-28027 - Library-media-Reader-accelerator-keys-for-the-viewer-action-row.md
@@ -1,0 +1,28 @@
+---
+id: TASK-28027
+title: Library media Reader - accelerator keys for the viewer action row
+status: To Do
+assignee: []
+created_date: '2026-09-02 06:57'
+labels:
+  - library
+  - media-ux
+dependencies: []
+references:
+  - >-
+    .impeccable/critique/2026-09-02T04-00-36Z__tldw-chatbook-ui-screens-library-screen-py.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Split from task-28012 (which delivered select-mode keyboard access on the LIST). The Reader's action row (Find / Read later / Use in Console / More, with Edit metadata / Open original / Open manager / Move to trash under More) has no accelerator keys - every action is a Tab-walk (Alex persona red flag from the 2026-09-01 critique). Give the common Reader actions bound keys, advertised in the footer or F1 help, without stealing the printable keys the search/filter inputs need. Note existing Reader keys already taken: / (focus search), F6 (pane), ] / [ (next/prev item, task-28005), enter (next match when searching, task-28011).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The common Reader actions (at least Find, Read later, Use in Console, Move to trash) have bound keys
+- [ ] #2 The keys are advertised in the viewer footer or F1 help and gated to the Reader
+- [ ] #3 A focused search/filter input still receives those printable keys
+<!-- AC:END -->

--- a/tldw_chatbook/Library/library_media_state.py
+++ b/tldw_chatbook/Library/library_media_state.py
@@ -50,6 +50,18 @@ _MEDIA_BROWSE_SORTS = frozenset(
         "relevance",
     }
 )
+
+#: task-28013: the sort values the media browse chooser offers, in display
+#: order, each mapped to its user-facing label. A deliberate subset of
+#: ``_MEDIA_BROWSE_SORTS`` -- "relevance" is query-only (the scope validator
+#: downgrades it without a query) so it is not a manual pick, and the
+#: date_* pair duplicates last_modified_* for this local source.
+MEDIA_SORT_CHOICES = (
+    ("last_modified_desc", "Newest"),
+    ("last_modified_asc", "Oldest"),
+    ("title_asc", "Title A-Z"),
+    ("title_desc", "Title Z-A"),
+)
 _MEDIA_SUMMARY_KEYS = frozenset(
     {"id", "backing_media_id", "title", "media_type", "updated_at"}
 )
@@ -757,6 +769,12 @@ class LibraryMediaCanvasState:
     # the browse toolbar row (the Notes Sort choice-strip pattern).
     type_choices_visible: bool = False
     query: str = ""
+    # task-28013: the browse sort chooser -- ``sort_by`` is the active
+    # MediaBrowseScope sort, ``sort_choices_visible`` is True while its
+    # direct-pick strip replaces the toolbar row (same choice-strip pattern
+    # as the type chooser and the Prompts/Notes sort choosers).
+    sort_by: str = "last_modified_desc"
+    sort_choices_visible: bool = False
 
 
 @dataclass(frozen=True)
@@ -922,6 +940,7 @@ def build_library_media_browse_state(
     confirming_bulk_delete: bool = False,
     delete_receipt_count: int = 0,
     type_choices_visible: bool = False,
+    sort_choices_visible: bool = False,
     loading_id: str = "",
     loaded_id: str = "",
 ) -> LibraryMediaCanvasState:
@@ -1000,6 +1019,8 @@ def build_library_media_browse_state(
         delete_receipt_count=max(0, delete_receipt_count),
         type_choices_visible=type_choices_visible,
         query=result.scope.query,
+        sort_by=result.scope.sort_by,
+        sort_choices_visible=sort_choices_visible,
     )
 
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -195,6 +195,7 @@ from ...Library.library_ingest_state import (
 from ...Library.library_media_state import (
     LibraryMediaCanvasState,
     LibraryMediaTrashState,
+    MEDIA_SORT_CHOICES,
     MediaBrowseScope,
     MediaTrashBrowseState,
     MediaTrashScope,
@@ -3941,6 +3942,8 @@ class LibraryScreen(BaseAppScreen):
         # task-14902: True while the media type chooser's direct-pick strip
         # replaces the browse toolbar row (the Notes Sort strip pattern).
         self._library_media_type_choices_visible: bool = False
+        # task-28013: the browse sort chooser's direct-pick strip visibility.
+        self._library_media_sort_choices_visible: bool = False
         # Trash owns an independent source scope. Draft and semantic focus
         # remain screen concerns because Task 5 renders their controls; page
         # authority lives exclusively in ``_library_media_trash_browse_controller``.
@@ -17756,6 +17759,7 @@ class LibraryScreen(BaseAppScreen):
             confirming_bulk_delete=self._library_media_confirming_bulk_delete,
             delete_receipt_count=len(self._library_media_delete_receipt_ids),
             type_choices_visible=self._library_media_type_choices_visible,
+            sort_choices_visible=self._library_media_sort_choices_visible,
             loading_id=(
                 (self._library_media_reader_session.selected_id or "")
                 if self._library_media_reader_session.pending_request is not None
@@ -17824,6 +17828,7 @@ class LibraryScreen(BaseAppScreen):
                 self._library_media_lifecycle_generation
             )
             self._library_media_type_choices_visible = False
+            self._library_media_sort_choices_visible = False
             self._sync_library_media_browse_state(None)
             self._sync_library_media_viewer_mutation_gate()
         return self._library_media_mutation_scope
@@ -26773,6 +26778,9 @@ class LibraryScreen(BaseAppScreen):
             or self._library_media_confirming_bulk_delete
         ):
             return
+        # Mutually exclusive with the sort chooser (task-28013): one strip
+        # replaces the toolbar row at a time.
+        self._library_media_sort_choices_visible = False
         self._library_media_type_choices_visible = (
             not self._library_media_type_choices_visible
         )
@@ -26821,6 +26829,75 @@ class LibraryScreen(BaseAppScreen):
             self,
             "media",
             then=lambda: self._focus_library_control("#library-media-type-filter"),
+        )
+
+    @on(Button.Pressed, "#library-media-sort")
+    def handle_library_media_sort(self, event: Button.Pressed) -> None:
+        """Open (or close) the media browse sort chooser's direct-pick strip.
+
+        task-28013: mirrors the type chooser and the Prompts/Notes sort
+        choosers -- Sort is one control family across the list canvases. Inert
+        while a bulk delete is armed or in flight (task-2853 AC3: nothing may
+        drift the list state under an armed confirm).
+        """
+        event.stop()
+        if (
+            self._library_media_bulk_delete_in_flight
+            or self._library_media_confirming_bulk_delete
+        ):
+            return
+        # Mutually exclusive with the type chooser: only one strip at a time.
+        self._library_media_type_choices_visible = False
+        self._library_media_sort_choices_visible = (
+            not self._library_media_sort_choices_visible
+        )
+        _sync_library_canvas(self, "media")
+        if self._library_media_sort_choices_visible:
+            current = self._library_media_browse_controller.mutation_refresh_scope.sort_by
+            self.call_after_refresh(
+                self._focus_library_choice_strip_active,
+                ".library-media-sort-choice",
+                current,
+            )
+        else:
+            self.call_after_refresh(
+                self._focus_library_control, "#library-media-sort"
+            )
+
+    @on(Button.Pressed, ".library-media-sort-choice")
+    def handle_library_media_sort_choice(self, event: Button.Pressed) -> None:
+        """Apply the exact sort value carried by one strip choice (task-28013).
+
+        Picking the already-active sort only closes the strip -- no service
+        request. Any other value re-fetches page one under the new order.
+        """
+        event.stop()
+        if self._library_media_bulk_delete_in_flight:
+            return
+        requested = str(getattr(event.button, "choice_value", "") or "")
+        self._library_media_sort_choices_visible = False
+        current = self._library_media_browse_controller.mutation_refresh_scope.sort_by
+        valid = {value for value, _ in MEDIA_SORT_CHOICES}
+        if requested not in valid or requested == current:
+            _sync_library_canvas(
+                self,
+                "media",
+                then=lambda: self._focus_library_control("#library-media-sort"),
+            )
+            return
+        self._request_library_media_sort(
+            requested, focus_identity="#library-media-sort"
+        )
+
+    def _request_library_media_sort(
+        self, sort_by: str, *, focus_identity: str | None
+    ) -> Any | None:
+        """Request page one after changing only the applied Media sort order."""
+        self._clear_library_media_selection_for_scope_change()
+        applied = self._library_media_browse_controller.mutation_refresh_scope
+        return self._request_library_media_browse(
+            dataclasses.replace(applied, sort_by=sort_by, page=1),
+            focus_identity=focus_identity,
         )
 
     @on(Button.Pressed, "#library-media-empty-import")
@@ -34435,6 +34512,16 @@ class LibraryScreen(BaseAppScreen):
                 "_library_media_type_choices_visible",
             )
         if (
+            self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
+            and self._library_media_view == "list"
+            and self._library_media_sort_choices_visible
+        ):
+            return (
+                "sort",
+                "#library-media-sort",
+                "_library_media_sort_choices_visible",
+            )
+        if (
             self._library_selected_row_id == LIBRARY_ROW_BROWSE_PROMPTS
             and self._library_prompts_view == "list"
             and self._library_prompts_sort_choices_visible
@@ -34480,6 +34567,7 @@ class LibraryScreen(BaseAppScreen):
         self._sync_library_emergency_guard_presentation()
         canvas_kind = {
             "_library_media_type_choices_visible": "media",
+            "_library_media_sort_choices_visible": "media",
             "_library_prompts_sort_choices_visible": "prompts",
             "_library_skills_sort_choices_visible": "skills",
             "_library_export_quality_choices_visible": "export",

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -4915,6 +4915,13 @@ class LibraryScreen(BaseAppScreen):
                     ("/", "focus search"),
                     ("F6", "next pane"),
                 ]
+                # task-28011: while a content search with matches is active,
+                # Enter walks to the next match (find-bar convention).
+                if (
+                    self._library_media_content_query
+                    and self._library_media_content_matches()
+                ):
+                    shortcuts.append(("enter", "next match"))
                 # task-28005: advertise Prev/Next only when there IS a
                 # neighbour that way, so the footer stops teaching a key
                 # that no-ops at the list ends.
@@ -42082,6 +42089,9 @@ class LibraryScreen(BaseAppScreen):
         # and prev/next navigation all search the exact same needle.
         submitted = event.value.strip()
         if submitted == self._library_media_content_query:
+            # task-28011: re-pressing Enter on the same query walks to the
+            # next match (find-bar convention) instead of no-opping.
+            self._advance_library_media_content_match(1)
             return
         self._library_media_content_query = submitted
         self._library_media_content_match_index = 0

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -784,6 +784,11 @@ _LIBRARY_PROMPTS_SEARCH_DEBOUNCE_SECONDS = 0.25
 # above, kept local rather than in library_skills_state.py.
 _LIBRARY_SKILLS_SORT_MODES = ("name", "status")
 
+# task-28012 (Qodo #2309): the media bulk-selection keys, named once so the
+# key ``Binding``s and the advertised footer shortcuts cannot drift apart.
+_MEDIA_SELECT_MODE_KEY = "s"
+_MEDIA_ROW_SELECT_KEY = "space"
+
 
 def _library_screen_is_current(screen: Any) -> bool:
     """Reject delayed callbacks owned by a replaced Library screen."""
@@ -2426,9 +2431,14 @@ class LibraryScreen(BaseAppScreen):
         # select mode on the media list; Space toggles the focused row while
         # in it. ``check_action`` gates both; a focused Input consumes the
         # printable "s"/Space first, so they still type in the filter/search.
-        Binding("s", "library_media_toggle_select_mode", "Select", show=False),
         Binding(
-            "space",
+            _MEDIA_SELECT_MODE_KEY,
+            "library_media_toggle_select_mode",
+            "Select",
+            show=False,
+        ),
+        Binding(
+            _MEDIA_ROW_SELECT_KEY,
             "library_media_toggle_row_selection",
             "Toggle selection",
             show=False,
@@ -2573,14 +2583,14 @@ class LibraryScreen(BaseAppScreen):
     LIBRARY_MEDIA_LIST_SHORTCUTS = (
         ("/", "focus search"),
         ("F6", "next pane"),
-        ("s", "select"),
+        (_MEDIA_SELECT_MODE_KEY, "select"),
         ("esc", "focus rail"),
     )
     LIBRARY_MEDIA_SELECT_SHORTCUTS = (
         ("/", "focus search"),
         ("F6", "next pane"),
-        ("space", "toggle selection"),
-        ("s", "done selecting"),
+        (_MEDIA_ROW_SELECT_KEY, "toggle selection"),
+        (_MEDIA_SELECT_MODE_KEY, "done selecting"),
         ("esc", "focus rail"),
     )
 
@@ -27030,6 +27040,23 @@ class LibraryScreen(BaseAppScreen):
             self._library_media_delete_receipt_ids = ()
         _sync_library_canvas(self, "media")
 
+    def _library_media_select_enter_available(self) -> bool:
+        """Whether ENTERING media Select mode is offered (task-28012).
+
+        Qodo #2309: the keyboard "s" must obey the same availability as the
+        Select button, which is disabled with no rows or on a stale page.
+        Exiting an active selection stays possible regardless (the caller
+        gates that), so this covers entry only. State-level (controller
+        freshness + retained rows), never presentation labels.
+
+        Returns:
+            True when a fresh page with at least one row is showing.
+        """
+        controller = self._library_media_browse_controller
+        if controller.freshness == "stale":
+            return False
+        return bool(controller.retained_items)
+
     def action_library_media_toggle_select_mode(self) -> None:
         """Keyboard "s": enter/exit media select mode (task-28012)."""
         self._toggle_library_media_select_mode()
@@ -30650,16 +30677,32 @@ class LibraryScreen(BaseAppScreen):
         if action == "library_media_toggle_select_mode":
             # task-28012: only on the media LIST (not viewer/trash), and not
             # while a bulk-delete confirm is armed or a delete is in flight.
-            return (
-                self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
-                and self._library_media_view == "list"
-                and not self._library_media_confirming_bulk_delete
-                and not self._library_media_bulk_delete_in_flight
-            )
+            if (
+                self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
+                or self._library_media_view != "list"
+                or self._library_media_confirming_bulk_delete
+                or self._library_media_bulk_delete_in_flight
+            ):
+                return False
+            # task-28012 (Qodo #2309): exiting an active selection is always
+            # allowed (rows may have vanished), but ENTERING must obey the
+            # same availability as the Select button -- no rows, or a stale
+            # page, disables it.
+            if self._library_media_select_mode:
+                return True
+            return self._library_media_select_enter_available()
         if action == "library_media_toggle_row_selection":
             # task-28012: only while select mode is active with a media row
-            # focused -- otherwise Space falls through to its default.
+            # focused -- otherwise Space falls through to its default. Qodo
+            # #2309: a stale page (or an armed/in-flight bulk delete) gates
+            # row toggling exactly as it gates the row buttons.
             if not self._library_media_select_mode:
+                return False
+            if (
+                self._library_media_browse_controller.freshness == "stale"
+                or self._library_media_confirming_bulk_delete
+                or self._library_media_bulk_delete_in_flight
+            ):
                 return False
             focused = self.focused
             return bool(

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -2421,6 +2421,17 @@ class LibraryScreen(BaseAppScreen):
         # printable key first, so "[" / "]" still type in the search box.
         Binding("]", "library_media_next_item", "Next item", show=False),
         Binding("[", "library_media_prev_item", "Previous item", show=False),
+        # task-28012: keyboard access to bulk selection. "s" enters/exits
+        # select mode on the media list; Space toggles the focused row while
+        # in it. ``check_action`` gates both; a focused Input consumes the
+        # printable "s"/Space first, so they still type in the filter/search.
+        Binding("s", "library_media_toggle_select_mode", "Select", show=False),
+        Binding(
+            "space",
+            "library_media_toggle_row_selection",
+            "Toggle selection",
+            show=False,
+        ),
     ]
 
     #: task-4023 AC#7: which canvas's "Export…" action opened the Export
@@ -2552,6 +2563,23 @@ class LibraryScreen(BaseAppScreen):
     LIBRARY_LIST_SHORTCUTS = (
         ("/", "focus search"),
         ("F6", "next pane"),
+        ("esc", "focus rail"),
+    )
+
+    #: task-28012: the media list teaches the bulk-selection keys the other
+    #: list canvases don't have -- "s" enters Select mode; while selecting,
+    #: Space toggles the focused row and "s" leaves.
+    LIBRARY_MEDIA_LIST_SHORTCUTS = (
+        ("/", "focus search"),
+        ("F6", "next pane"),
+        ("s", "select"),
+        ("esc", "focus rail"),
+    )
+    LIBRARY_MEDIA_SELECT_SHORTCUTS = (
+        ("/", "focus search"),
+        ("F6", "next pane"),
+        ("space", "toggle selection"),
+        ("s", "done selecting"),
         ("esc", "focus rail"),
     )
 
@@ -4954,6 +4982,15 @@ class LibraryScreen(BaseAppScreen):
         open_strip = self._library_open_choice_strip()
         if open_strip is not None:
             return (("enter", f"choose {open_strip[0]}"), ("esc", "cancel"))
+        if (
+            self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
+            and self._library_media_view == "list"
+            and self._library_list_canvas_showing_list()
+        ):
+            # task-28012: teach the bulk-selection keys on the media list.
+            if self._library_media_select_mode:
+                return self.LIBRARY_MEDIA_SELECT_SHORTCUTS
+            return self.LIBRARY_MEDIA_LIST_SHORTCUTS
         if self._library_list_canvas_showing_list():
             return self.LIBRARY_LIST_SHORTCUTS
         return self.LIBRARY_GENERAL_SHORTCUTS
@@ -26890,6 +26927,14 @@ class LibraryScreen(BaseAppScreen):
         the selection [silently]" finding.
         """
         event.stop()
+        self._toggle_library_media_select_mode()
+
+    def _toggle_library_media_select_mode(self) -> None:
+        """Enter/exit media select mode (shared by the button and the key).
+
+        task-28012: the "s" binding reuses this exact seam so the keyboard
+        and the "Select"/"Done" button can never drift.
+        """
         if self._library_media_bulk_delete_in_flight:
             return
         if self._library_media_select_mode:
@@ -26907,6 +26952,34 @@ class LibraryScreen(BaseAppScreen):
             # underneath a new one.
             self._library_media_delete_receipt_ids = ()
         _sync_library_canvas(self, "media")
+
+    def action_library_media_toggle_select_mode(self) -> None:
+        """Keyboard "s": enter/exit media select mode (task-28012)."""
+        self._toggle_library_media_select_mode()
+
+    def action_library_media_toggle_row_selection(self) -> None:
+        """Keyboard Space: toggle the focused media row's selection (task-28012).
+
+        A no-op outside select mode, while a bulk-delete confirm is armed
+        (task-2853 AC3), or when focus is not on a media row. Mirrors the
+        select-mode branch of ``handle_library_media_row`` but acts on the
+        focused row rather than a pressed button, so keyboard-only users can
+        build a selection without a mouse.
+        """
+        if not self._library_media_select_mode:
+            return
+        if self._library_media_confirming_bulk_delete:
+            return
+        if self._library_media_bulk_delete_in_flight:
+            return
+        focused = self.focused
+        if focused is None or not focused.has_class("library-media-row"):
+            return
+        media_id = str(getattr(focused, "media_id", "") or "")
+        if not media_id:
+            return
+        self._library_media_row_selection.toggle(media_id)
+        _apply_library_row_toggle(self, "media", focused, media_id)
 
     def _exit_library_media_select_mode(self, *, announce_discard: bool) -> None:
         """Leave media Select mode: clear the selection and any pending
@@ -30497,6 +30570,24 @@ class LibraryScreen(BaseAppScreen):
             "library_rag_result_card_open",
         ):
             return self._focused_library_rag_result_card_index() is not None
+        if action == "library_media_toggle_select_mode":
+            # task-28012: only on the media LIST (not viewer/trash), and not
+            # while a bulk-delete confirm is armed or a delete is in flight.
+            return (
+                self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
+                and self._library_media_view == "list"
+                and not self._library_media_confirming_bulk_delete
+                and not self._library_media_bulk_delete_in_flight
+            )
+        if action == "library_media_toggle_row_selection":
+            # task-28012: only while select mode is active with a media row
+            # focused -- otherwise Space falls through to its default.
+            if not self._library_media_select_mode:
+                return False
+            focused = self.focused
+            return bool(
+                focused is not None and focused.has_class("library-media-row")
+            )
         if action in ("library_media_next_item", "library_media_prev_item"):
             # task-28005: active only in the plain Reader with a neighbour in
             # that direction, so the key no-ops (and drops from the footer)

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -16,7 +16,13 @@ from textual.widgets import Button, Input, OptionList, Static
 from textual.widgets.option_list import Option
 
 from tldw_chatbook.Library.library_pager_state import LibraryPagerDisplay
-from tldw_chatbook.Library.library_media_state import LibraryMediaCanvasState
+from tldw_chatbook.Library.library_media_state import (
+    LibraryMediaCanvasState,
+    MEDIA_SORT_CHOICES,
+)
+from tldw_chatbook.Widgets.Library.library_choice_strip import (
+    compose_library_choice_strip,
+)
 from tldw_chatbook.Library.library_shell_state import (
     LIBRARY_DELETE_SELECTED_DISABLED_TOOLTIP,
     LIBRARY_DELETE_SELECTED_TOOLTIP,
@@ -350,7 +356,10 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         # toolbar row (the Notes Sort precedent -- browse actions hide while
         # the chooser is showing), keeping the vertical budget flat.
         type_choices_visible = getattr(self.canvas, "type_choices_visible", False)
-        toolbar.display = not type_choices_visible
+        sort_choices_visible = getattr(self.canvas, "sort_choices_visible", False)
+        toolbar.display = not (type_choices_visible or sort_choices_visible)
+        sort_labels = dict(MEDIA_SORT_CHOICES)
+        current_sort = getattr(self.canvas, "sort_by", "last_modified_desc")
         with toolbar:
             type_filter = Button(
                 # task-14902: a chooser-opener, no longer a cycler -- press
@@ -373,6 +382,21 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 ),
             )
             yield self._gate_mutation_action(type_filter, str(type_filter.label))
+            # task-28013: sort chooser opener -- hidden in select mode like
+            # Export/Trash (Select's toolbar acts on the selection).
+            sort_btn = Button(
+                library_choice_label(
+                    "sort", sort_labels.get(current_sort, "Newest")
+                ),
+                id="library-media-sort",
+                classes="library-canvas-action",
+                compact=True,
+                tooltip=library_choice_tooltip(
+                    "the sort order", tuple(label for _, label in MEDIA_SORT_CHOICES)
+                ),
+            )
+            sort_btn.display = not select_mode
+            yield self._gate_stale_action(sort_btn, str(sort_btn.label))
             export_btn = Button(
                 "Export…",
                 id="library-media-export",
@@ -442,6 +466,18 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             choices.highlighted = highlighted
             choices.styles.height = min(8, max(1, len(options)))
             yield choices
+        if sort_choices_visible:
+            # task-28013: the sort chooser's direct-pick strip, replacing the
+            # toolbar row exactly like the type chooser (shared helper).
+            yield from compose_library_choice_strip(
+                strip_id="library-media-sort-choices",
+                choice_class="library-media-sort-choice",
+                options=tuple(
+                    (f"library-media-sort-{value}", value, label)
+                    for value, label in MEDIA_SORT_CHOICES
+                ),
+                active_value=current_sort,
+            )
         confirming_bulk_delete = getattr(self.canvas, "confirming_bulk_delete", False)
         if select_mode:
             if confirming_bulk_delete:


### PR DESCRIPTION
## Summary

Follow-up to #2307 (the P0 / bug-track "unblock sequential review" PR) with the contained P1 reading-, triage-, and keyboard-ergonomics improvements from the same Library ▸ Media UX critique. Each change is test-first.

> **Stacked on #2307** — this branch is cut from `worktree-media-ux-fixes`, so review/merge #2307 first. GitHub will retarget this PR to `dev` once #2307 lands.

## Changes

- **task-28011 — Enter walks to the next content-search match.** Re-pressing Enter on the same in-item query now advances to the next match (find-bar convention, wrapping) instead of no-opping, and the Reader footer advertises `enter: next match` while a search with matches is active. The larger "search the Analysis tab text, not only the transcript" half is split to **task-28026**.
- **task-28012 — keyboard access to media bulk selection.** `s` enters/exits Select mode on the media list, and Space toggles the focused row's selection — the live-verified gaps (Space was inert, no key entered Select mode, nothing advertised). Enter already toggled a focused row, so only these were missing. The `s` key reuses the same seam as the Select/Done button, and the media list advertises the keys via new `LIBRARY_MEDIA_LIST_SHORTCUTS` / `LIBRARY_MEDIA_SELECT_SHORTCUTS` footer sets. A focused input still receives the printable keys. The Reader action-row accelerators (a separate concern) are split to **task-28027**.
- **task-28013 — browse sort chooser on the media list.** Media had a type filter but no way to change the sort order from the canvas. Adds a **Sort** button that opens a direct-pick strip (Newest / Oldest / Title A–Z / Title Z–A), re-fetching page one under the chosen order and persisting it in the browse scope. Mirrors the proven Prompts/Notes/type-filter choice-strip pattern (task-14902 requires the strip, not a per-press cycle) and reuses the shared choice-strip seams (footer `enter: choose sort` / `esc: cancel`, Escape-to-close, mutual exclusivity with the type chooser). The in-canvas filter half of the task already shipped on dev.

## Testing

- New unit + integration tests for every change; each failed first.
- Regression green across `test_library_media_reader_flow.py`, `test_library_media_side_by_side.py`, `test_library_multiselect_media.py`, `Tests/Library`, and the media subset of `test_library_shell.py`.
- Two existing side-by-side tests that pinned the media-list footer to `LIBRARY_LIST_SHORTCUTS` were updated to the new media-list footer sets (task-28012 deliberately enriches them); the toolbar-fit region test was extended to include the new Sort button.

### Pre-existing dev-tip flakes/failures (NOT introduced here; verified by stash-run)

- `test_library_media_reader_flow.py::test_filter_uses_authoritative_search_and_restores_page_three_anchor`, `test_library_media_side_by_side.py::test_compact_media_stale_and_retry_actions_remain_truthful`, and `test_screen_navigation.py::test_focus_library_list_entry_checked_row_preference_is_media_only` are order-dependent flakes / pre-existing failures — they pass in isolation or fail identically without this branch.
- `test_library_screen_bindings_are_all_gated_or_universal` fails on `focus_previous_workbench_pane` on a bare unmounted screen — pre-existing; the new bindings here are correctly gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
