### PR TITLE
feat(library): media Reader action-row accelerator keys (task-28027)

### DIFF
--- a/Tests/UI/test_library_media_reader_flow.py
+++ b/Tests/UI/test_library_media_reader_flow.py
@@ -1515,14 +1515,21 @@ async def test_unmount_drains_pending_and_ambiguous_inflight_progress_writes():
 # ---------------------------------------------------------------------------
 
 
-def _reader_key_fake(*, view="viewer", external=False, substate=False):
+def _reader_key_fake(*, view="viewer", external=False, substate=False, pending=False):
     """A minimal screen fake for the Reader action-key check_action gates."""
     from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_MEDIA
 
+    media_id = "local:media:1"
     return SimpleNamespace(
         _library_selected_row_id=LIBRARY_ROW_BROWSE_MEDIA,
         _library_media_view=view,
-        _library_media_reader_session=SimpleNamespace(external_detail=external),
+        _selected_media_id=media_id,
+        _library_media_reader_session=SimpleNamespace(
+            external_detail=external,
+            pending_request=object() if pending else None,
+            # A settled Reader has its loaded id == the selected id.
+            loaded_id=None if pending else media_id,
+        ),
         _library_media_viewer_substate_active=lambda: substate,
     )
 
@@ -1560,6 +1567,16 @@ def test_reader_action_keys_gated_to_plain_local_viewer():
         "library_media_move_to_trash",
     ):
         assert LibraryScreen.check_action(listing, action, ()) is False, action
+
+    # Qodo #2317: while a detail request is pending (mid-load/traversal), the
+    # displayed detail is not yet the selected item -> all off.
+    loading = _reader_key_fake(pending=True)
+    for action in (
+        "library_media_read_later",
+        "library_media_use_in_console",
+        "library_media_move_to_trash",
+    ):
+        assert LibraryScreen.check_action(loading, action, ()) is False, action
 
 
 def test_t_key_arms_delete_confirmation():
@@ -1614,5 +1631,50 @@ async def test_t_key_in_reader_arms_delete_confirm_end_to_end():
         await pilot.press("t")
         await _wait_for_selector(screen, pilot, "#library-media-delete-confirm")
         assert screen._library_media_confirming_delete is True
+        for media_id in tuple(service.detail_release):
+            service.release(media_id)
+
+
+@pytest.mark.asyncio
+async def test_l_key_in_reader_toggles_read_later_end_to_end():
+    """task-28027 (Qodo #2317): 'l' in the mounted Reader saves read-it-later."""
+    app, service = _flow_app(count=3)
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=WIDE_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row_0(screen, service, pilot)
+
+        screen.query_one("#library-media-reader-find", Button).focus()
+        await pilot.pause()
+        await pilot.press("l")
+        await _wait_for_condition(
+            pilot,
+            lambda: bool(service.read_it_later_calls),
+            message="'l' did not toggle read-it-later.",
+        )
+        for media_id in tuple(service.detail_release):
+            service.release(media_id)
+
+
+@pytest.mark.asyncio
+async def test_c_key_in_reader_opens_console_handoff_end_to_end(monkeypatch):
+    """task-28027 (Qodo #2317): 'c' in the mounted Reader routes to the handoff."""
+    app, service = _flow_app(count=3)
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=WIDE_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row_0(screen, service, pilot)
+
+        calls = []
+        monkeypatch.setattr(
+            screen, "_open_selected_media_handoff", lambda: calls.append(1)
+        )
+        screen.query_one("#library-media-reader-find", Button).focus()
+        await pilot.pause()
+        await pilot.press("c")
+        await pilot.pause()
+        assert calls == [1]
         for media_id in tuple(service.detail_release):
             service.release(media_id)

--- a/Tests/UI/test_library_media_reader_flow.py
+++ b/Tests/UI/test_library_media_reader_flow.py
@@ -1508,3 +1508,111 @@ async def test_unmount_drains_pending_and_ambiguous_inflight_progress_writes():
         assert written.get(2) == {"scroll_x": 0, "scroll_y": 7}
         assert screen._library_media_progress_pending_writes == {}
         assert screen._library_media_progress_inflight_write is None
+
+
+# ---------------------------------------------------------------------------
+# task-28027: Reader action-row accelerator keys (l / c / t)
+# ---------------------------------------------------------------------------
+
+
+def _reader_key_fake(*, view="viewer", external=False, substate=False):
+    """A minimal screen fake for the Reader action-key check_action gates."""
+    from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_MEDIA
+
+    return SimpleNamespace(
+        _library_selected_row_id=LIBRARY_ROW_BROWSE_MEDIA,
+        _library_media_view=view,
+        _library_media_reader_session=SimpleNamespace(external_detail=external),
+        _library_media_viewer_substate_active=lambda: substate,
+    )
+
+
+def test_reader_action_keys_gated_to_plain_local_viewer():
+    """task-28027: l/c/t active only in a plain local Reader; c also for external."""
+    plain = _reader_key_fake()
+    for action in (
+        "library_media_read_later",
+        "library_media_use_in_console",
+        "library_media_move_to_trash",
+    ):
+        assert LibraryScreen.check_action(plain, action, ()) is True, action
+
+    # A sub-state (edit/confirm/analysis-edit) gates all three off.
+    sub = _reader_key_fake(substate=True)
+    for action in (
+        "library_media_read_later",
+        "library_media_use_in_console",
+        "library_media_move_to_trash",
+    ):
+        assert LibraryScreen.check_action(sub, action, ()) is False, action
+
+    # External (server) items: read-later/trash are local-only, Console works.
+    ext = _reader_key_fake(external=True)
+    assert LibraryScreen.check_action(ext, "library_media_read_later", ()) is False
+    assert LibraryScreen.check_action(ext, "library_media_move_to_trash", ()) is False
+    assert LibraryScreen.check_action(ext, "library_media_use_in_console", ()) is True
+
+    # Not in the viewer at all -> all off.
+    listing = _reader_key_fake(view="list")
+    for action in (
+        "library_media_read_later",
+        "library_media_use_in_console",
+        "library_media_move_to_trash",
+    ):
+        assert LibraryScreen.check_action(listing, action, ()) is False, action
+
+
+def test_t_key_arms_delete_confirmation():
+    """task-28027: 't' arms the same inline delete-confirm the button does."""
+    fake = SimpleNamespace(
+        _library_media_confirming_delete=False,
+        _library_media_delete_receipt_ids=("stale",),
+        _synced=0,
+    )
+    fake._sync_library_media_viewer_or_recompose = lambda: setattr(
+        fake, "_synced", fake._synced + 1
+    )
+    LibraryScreen.action_library_media_move_to_trash(fake)
+    assert fake._library_media_confirming_delete is True
+    assert fake._library_media_delete_receipt_ids == ()
+    assert fake._synced == 1
+
+
+def test_c_key_opens_console_handoff():
+    """task-28027: 'c' routes to the same Use-in-Console handoff as the button."""
+    calls = []
+    fake = SimpleNamespace(_open_selected_media_handoff=lambda: calls.append(1))
+    LibraryScreen.action_library_media_use_in_console(fake)
+    assert calls == [1]
+
+
+def test_l_key_starts_read_later_toggle():
+    """task-28027: 'l' starts the same read-it-later toggle as the button."""
+    started = []
+    fake = SimpleNamespace(
+        _start_library_media_read_later_toggle=lambda: started.append(1)
+    )
+    LibraryScreen.action_library_media_read_later(fake)
+    assert started == [1]
+
+
+@pytest.mark.asyncio
+async def test_t_key_in_reader_arms_delete_confirm_end_to_end():
+    """task-28027: pressing 't' in the mounted Reader arms the delete confirm."""
+    app, service = _flow_app(count=3)
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=WIDE_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row_0(screen, service, pilot)
+        assert screen._library_media_confirming_delete is False
+
+        # Focus a non-input Reader control so the printable 't' reaches the
+        # screen binding (not a search/filter Input).
+        screen.query_one("#library-media-reader-find", Button).focus()
+        await pilot.pause()
+        await pilot.press("t")
+        await _wait_for_selector(screen, pilot, "#library-media-delete-confirm")
+        assert screen._library_media_confirming_delete is True
+        for media_id in tuple(service.detail_release):
+            service.release(media_id)

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -2491,6 +2491,36 @@ def test_library_screen_bindings_are_all_gated_or_universal():
             )
 
 
+def test_action_show_workbench_help_lists_reader_action_keys(monkeypatch):
+    """task-28027: F1 in the media Reader advertises the l/c/t accelerators."""
+    from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_MEDIA
+    from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+    from tldw_chatbook.UI.Workbench.help import WorkbenchHelpPanel
+
+    app = _build_test_app()
+    screen = LibraryScreen(app)
+    screen._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
+    screen._library_media_view = "viewer"
+
+    pushed = []
+
+    class _FakeApp:
+        def push_screen(self, panel):
+            pushed.append(panel)
+
+    monkeypatch.setattr(
+        LibraryScreen, "app", property(lambda self: _FakeApp()), raising=False
+    )
+
+    screen.action_show_workbench_help()
+
+    assert len(pushed) == 1
+    panel = pushed[0]
+    assert isinstance(panel, WorkbenchHelpPanel)
+    keys = {key for key, _description in panel.state.shortcuts}
+    assert {"l", "c", "t"} <= keys
+
+
 def test_action_show_workbench_help_filters_bindings_by_check_action(monkeypatch):
     """task-2858 AC#2 (LIB-09): F1 on a non-skills, non-Search canvas must
     NOT advertise the skill editor's or Search/RAG's dead keys -- the

--- a/Tests/UI/test_screen_navigation.py
+++ b/Tests/UI/test_screen_navigation.py
@@ -2497,19 +2497,32 @@ def test_action_show_workbench_help_lists_reader_action_keys(monkeypatch):
     from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
     from tldw_chatbook.UI.Workbench.help import WorkbenchHelpPanel
 
+    from tldw_chatbook.Library.library_media_reader_state import (
+        LibraryMediaReaderSessionState,
+    )
+
     app = _build_test_app()
     screen = LibraryScreen(app)
     screen._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
     screen._library_media_view = "viewer"
+    # A settled Reader (loaded == selected, no pending request) so the l/c/t
+    # accelerators are genuinely active (task-28027 / Qodo #2317).
+    screen._selected_media_id = "local:media:1"
+    screen._library_media_reader_session = LibraryMediaReaderSessionState(
+        selected_id="local:media:1",
+        selected_backing_id=1,
+        loaded_id="local:media:1",
+        loaded_backing_id=1,
+    )
 
     pushed = []
 
-    class _FakeApp:
+    class FakeHelpApp:
         def push_screen(self, panel):
             pushed.append(panel)
 
     monkeypatch.setattr(
-        LibraryScreen, "app", property(lambda self: _FakeApp()), raising=False
+        LibraryScreen, "app", property(lambda self: FakeHelpApp()), raising=False
     )
 
     screen.action_show_workbench_help()

--- a/backlog/tasks/task-28027 - Library-media-Reader-accelerator-keys-for-the-viewer-action-row.md
+++ b/backlog/tasks/task-28027 - Library-media-Reader-accelerator-keys-for-the-viewer-action-row.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-28027
 title: Library media Reader - accelerator keys for the viewer action row
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-02 06:57'
+updated_date: '2026-09-02 16:04'
 labels:
   - library
   - media-ux
@@ -22,7 +23,13 @@ Split from task-28012 (which delivered select-mode keyboard access on the LIST).
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The common Reader actions (at least Find, Read later, Use in Console, Move to trash) have bound keys
-- [ ] #2 The keys are advertised in the viewer footer or F1 help and gated to the Reader
-- [ ] #3 A focused search/filter input still receives those printable keys
+- [x] #1 The common Reader actions (at least Find, Read later, Use in Console, Move to trash) have bound keys
+- [x] #2 The keys are advertised in the viewer footer or F1 help and gated to the Reader
+- [x] #3 A focused search/filter input still receives those printable keys
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reader action-row accelerator keys (l=Read later, c=Use in Console, t=Move to trash->confirm). Bindings show=False, gated in check_action to a plain media Reader (view=='viewer', no edit/confirm/analysis-edit sub-state); l/t are local-only (mirroring the buttons, hidden for external/server detail), c works for server items too. Actions reuse the button seams: extracted _start_library_media_read_later_toggle (shared by button + key), _open_selected_media_handoff for c, and the same confirm-arm for t. A focused search/filter Input consumes the printable key first (Textual routing, same as the existing r/s bindings), so they still type there. Advertised via F1 help (action_show_workbench_help auto-includes gated bindings) rather than the already-crowded reader footer (AC allows footer OR F1). Tests: check_action gating (plain/substate/external/list), 3 action unit tests, F1-lists-l/c/t, and t-key end-to-end arms the delete confirm. Files: UI/Screens/library_screen.py, Tests/UI/test_library_media_reader_flow.py, Tests/UI/test_screen_navigation.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -2443,6 +2443,13 @@ class LibraryScreen(BaseAppScreen):
             "Toggle selection",
             show=False,
         ),
+        # task-28027: Reader action-row accelerators. check_action gates them
+        # to a plain media Reader (l/t are local-only, c works for server
+        # items too); a focused Input consumes the printable key first, so
+        # they still type in the search/filter boxes.
+        Binding("l", "library_media_read_later", "Read later", show=False),
+        Binding("c", "library_media_use_in_console", "Use in Console", show=False),
+        Binding("t", "library_media_move_to_trash", "Move to trash", show=False),
     ]
 
     #: task-4023 AC#7: which canvas's "Export…" action opened the Export
@@ -30717,6 +30724,25 @@ class LibraryScreen(BaseAppScreen):
                 return False
             direction = 1 if action == "library_media_next_item" else -1
             return self._library_media_adjacent_row(direction) is not None
+        if action in (
+            "library_media_read_later",
+            "library_media_use_in_console",
+            "library_media_move_to_trash",
+        ):
+            # task-28027: Reader action-row accelerators. Only in a plain
+            # media Reader (no edit/confirm/analysis-edit sub-state). Read-
+            # later and Move-to-trash are local-only (mirroring the buttons,
+            # which are hidden for external/server detail); Use-in-Console
+            # works for server items too.
+            if (
+                self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
+                or self._library_media_view != "viewer"
+                or self._library_media_viewer_substate_active()
+            ):
+                return False
+            if action == "library_media_use_in_console":
+                return True
+            return not self._library_media_reader_session.external_detail
         if action == "focus_previous_workbench_pane":
             return bool(self._library_selected_row_id)
         return True
@@ -43219,6 +43245,14 @@ class LibraryScreen(BaseAppScreen):
                 later" / "Remove from read-it-later" action.
         """
         event.stop()
+        self._start_library_media_read_later_toggle()
+
+    def _start_library_media_read_later_toggle(self) -> None:
+        """Kick the read-it-later toggle worker for the open item (task-28027).
+
+        Shared by the "Read later" button and the ``l`` accelerator so both
+        read the last-fetched saved state and dispatch the same worker.
+        """
         media_id = self._selected_media_id
         if not media_id:
             return
@@ -43233,6 +43267,24 @@ class LibraryScreen(BaseAppScreen):
                 media_id, currently_saved=currently_saved
             )
         )
+
+    def action_library_media_read_later(self) -> None:
+        """Keyboard 'l': toggle read-it-later for the open item (task-28027)."""
+        self._start_library_media_read_later_toggle()
+
+    def action_library_media_use_in_console(self) -> None:
+        """Keyboard 'c': hand the open item to Console (task-28027)."""
+        self._open_selected_media_handoff()
+
+    def action_library_media_move_to_trash(self) -> None:
+        """Keyboard 't': arm the inline delete confirmation (task-28027).
+
+        Mirrors ``handle_library_media_delete`` -- arming only; the actual
+        trash write still needs the confirm affordance.
+        """
+        self._library_media_confirming_delete = True
+        self._library_media_delete_receipt_ids = ()
+        self._sync_library_media_viewer_or_recompose()
 
     async def _toggle_library_media_read_later(
         self, media_id: str, *, currently_saved: bool

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -30542,6 +30542,16 @@ class LibraryScreen(BaseAppScreen):
         F1 contamination this task closes. Every action reachable from
         ``BINDINGS`` now has an explicit branch here; see
         ``test_library_screen_bindings_are_all_gated_or_universal``.
+
+        Args:
+            action: The binding's action name Textual is resolving.
+            parameters: The action's positional parameters (unused here;
+                every gated binding is parameterless).
+
+        Returns:
+            ``False`` to deactivate the binding in the current context,
+            ``True`` to force-activate it, or ``None`` to defer to Textual's
+            default resolution.
         """
         if action in {
             "library_notes_new",
@@ -30734,15 +30744,25 @@ class LibraryScreen(BaseAppScreen):
             # later and Move-to-trash are local-only (mirroring the buttons,
             # which are hidden for external/server detail); Use-in-Console
             # works for server items too.
+            session = self._library_media_reader_session
             if (
                 self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
                 or self._library_media_view != "viewer"
                 or self._library_media_viewer_substate_active()
             ):
                 return False
+            # Qodo #2317: while a detail request is pending, the selected id
+            # and the displayed detail differ (e.g. mid-traversal), so these
+            # actions would combine the new id with stale detail. Gate them
+            # off until the displayed detail is the settled selected item.
+            if (
+                session.pending_request is not None
+                or session.loaded_id != self._selected_media_id
+            ):
+                return False
             if action == "library_media_use_in_console":
                 return True
-            return not self._library_media_reader_session.external_detail
+            return not session.external_detail
         if action == "focus_previous_workbench_pane":
             return bool(self._library_selected_row_id)
         return True


### PR DESCRIPTION
## Summary

Third follow-up from the Library ▸ Media UX critique (after #2307 and #2309, both merged). Adds **task-28027 — Reader action-row accelerator keys**.

## Change

- **task-28027** — keyboard accelerators for the media Reader's common actions: **`l`** = Read later, **`c`** = Use in Console, **`t`** = Move to trash (arms the inline confirm). The live critique flagged that every Reader action was a Tab-walk (an Alex/power-user red flag).
  - Gated via `check_action` to a plain media Reader (no edit/confirm/analysis-edit sub-state). `l` and `t` are local-only — they mirror the buttons, which are hidden for external/server detail — while `c` works for server items too.
  - The actions reuse the existing button seams (a shared `_start_library_media_read_later_toggle`, `_open_selected_media_handoff`, and the same confirm-arm), so keyboard and mouse can't drift.
  - A focused search/filter input consumes the printable key first (Textual routing, same as the existing `r`/`s` bindings), so `l`/`c`/`t` still type there.
  - Advertised via **F1 help** (which auto-includes check_action-gated bindings) rather than the already-dense reader footer.

## Testing

- `check_action` gating (plain / sub-state / external / list), three action unit tests, an F1-lists-`l`/`c`/`t` test, and a `t`-key end-to-end test that arms the delete confirm in a mounted Reader.
- The only bindings-gate-audit failure is the pre-existing `focus_previous_workbench_pane` (fails on a bare unmounted screen on dev; unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds keyboard accelerators for the media Reader's common actions — `l` = Read later, `c` = Use in Console, `t` = Move to trash (arms the inline confirm) — so power users no longer have to Tab-walk the action row (task-28027).

**New Features**
- Gated via `check_action` to a plain Reader with a settled detail load; `l`/`t` are local-only while `c` also works for server items.
- Actions reuse the existing button seams so keyboard and mouse can't drift.
- A focused search/filter input still receives the printable keys.
- Advertised through F1 help rather than the already-dense reader footer.
- Tests cover gating, the three actions, F1 help listing, and end-to-end `l`/`c`/`t` behavior.

<sup>Written for commit 8b0f65dcff0b7a21f9c50409d2017f811e1b38e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

