### PR TITLE
feat(library): make the media Analysis tab searchable (task-28026)

### DIFF
--- a/Tests/UI/test_library_media_reader_flow.py
+++ b/Tests/UI/test_library_media_reader_flow.py
@@ -1368,6 +1368,109 @@ async def test_offset_burst_settles_only_the_newest_value_per_item():
     assert fake._library_media_progress_persisted_offsets["local:media:3"] == (0, 17)
 
 
+@pytest.mark.asyncio
+async def test_capture_outside_read_never_persists_the_analysis_body_offset():
+    """task-28026: the Analysis body reuses ``#library-media-viewer-content``,
+    so capturing progress while a non-Read tab is active must NOT record that
+    scroll offset as the transcript's reading progress."""
+    calls = []
+
+    async def update_reading_progress(**kwargs):
+        calls.append(kwargs)
+
+    async def run_service_call(call, *args, **kwargs):
+        kwargs.pop("isolate_in_worker", None)
+        return await call(*args, **kwargs)
+
+    workers: list = []
+    fake = _progress_capture_fake(
+        workers=workers,
+        update_reading_progress=update_reading_progress,
+        run_service_call=run_service_call,
+        scroll_y=42,
+    )
+    fake._library_media_reader_session = set_mode(
+        fake._library_media_reader_session, "analysis"
+    )
+
+    LibraryScreen._capture_library_media_loaded_progress(fake)
+
+    assert workers == []
+    assert calls == []
+    assert fake._library_media_read_scroll_by_id == {}
+
+
+def test_find_from_analysis_clears_the_search_before_reading_the_transcript():
+    """task-28026: the always-visible Find action switches Analysis->Read, so
+    it must drop the analysis query/index/memo the same way the mode buttons
+    do -- otherwise a stale, possibly out-of-range match index scans the
+    transcript."""
+    session = set_mode(
+        LibraryMediaReaderSessionState(
+            selected_id="local:media:1",
+            selected_backing_id=1,
+            selected_title="A",
+            loaded_id="local:media:1",
+            loaded_backing_id=1,
+            loaded_title="A",
+        ),
+        "analysis",
+    )
+    fake = SimpleNamespace(
+        _library_media_reader_session=session,
+        _library_media_content_query="needle",
+        _library_media_content_match_index=5,
+        _library_media_content_match_memo=(object(), "needle", (1, 2, 3), "analysis"),
+        _sync_library_media_viewer_or_recompose=lambda: None,
+        call_after_refresh=lambda *a, **k: None,
+        _focus_library_media_content_search_input=lambda: None,
+    )
+    fake._reset_library_media_search_on_mode_change = MethodType(
+        LibraryScreen._reset_library_media_search_on_mode_change, fake
+    )
+
+    LibraryScreen.handle_library_media_reader_find(
+        fake, SimpleNamespace(stop=lambda: None)
+    )
+
+    assert fake._library_media_reader_session.mode == "read"
+    assert fake._library_media_content_query == ""
+    assert fake._library_media_content_match_index == 0
+    assert fake._library_media_content_match_memo is None
+
+
+def test_media_content_matches_scopes_corpus_to_the_active_reader_mode():
+    """task-28026: the match memo key includes reader mode, so the Analysis
+    tab searches the analysis text and Read searches the transcript -- a tab
+    switch never serves the other tab's matches from the one-slot memo."""
+    detail = {"id": 1}
+    state = SimpleNamespace(
+        content="alpha\nbeta\nalpha",
+        analysis="gamma\nalpha\ndelta",
+    )
+    fake = SimpleNamespace(
+        _library_media_detail=detail,
+        _library_media_content_query="alpha",
+        _library_media_content_match_memo=None,
+        _library_media_reader_session=LibraryMediaReaderSessionState(),
+        _library_media_viewer_state_cached=lambda _detail: state,
+    )
+
+    # Read tab -> transcript corpus ("alpha" on lines 0 and 2).
+    assert LibraryScreen._library_media_content_matches(fake) == (0, 2)
+    memo_after_read = fake._library_media_content_match_memo
+    assert memo_after_read is not None and memo_after_read[3] == "read"
+
+    # Same detail + query, Analysis tab: the memo must MISS on the mode and
+    # rescan the analysis text ("alpha" on line 1), not serve the cached
+    # transcript matches.
+    fake._library_media_reader_session = set_mode(
+        fake._library_media_reader_session, "analysis"
+    )
+    assert LibraryScreen._library_media_content_matches(fake) == (1,)
+    assert fake._library_media_content_match_memo[3] == "analysis"
+
+
 def test_capture_matching_fetched_progress_skips_the_write():
     """TASK-22210 probe: an offset already in the DB never re-writes."""
     workers: list = []

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -10328,10 +10328,12 @@ async def test_library_shell_media_viewer_shows_analysis_from_latest_version():
         screen.query_one("#library-media-row-1").press()
         await _wait_for_selector(screen, pilot, "#library-media-reader-select-analysis")
         screen.query_one("#library-media-reader-select-analysis", Button).press()
-        await _wait_for_selector(screen, pilot, "#library-media-viewer-analysis-text")
+        await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
 
+        # task-28026: a non-empty analysis renders in the searchable content
+        # body (its raw text is on ``.content``), not the plain Static.
         analysis_text = str(
-            screen.query_one("#library-media-viewer-analysis-text").renderable
+            screen.query_one("#library-media-viewer-content").content
         )
         assert analysis_text == "Roadmap analysis"
 
@@ -10421,8 +10423,10 @@ async def test_library_shell_media_analysis_save_persists_and_exits_edit_mode():
 
         assert screen._library_media_editing_analysis is False
         assert not screen.query("#library-media-analysis-edit-text")
+        # task-28026: a non-empty analysis renders in the searchable content
+        # body (its raw text is on ``.content``), not the plain Static.
         analysis_text = str(
-            screen.query_one("#library-media-viewer-analysis-text").renderable
+            screen.query_one("#library-media-viewer-content").content
         )
         assert analysis_text == "Revised analysis"
 
@@ -10462,8 +10466,10 @@ async def test_library_shell_media_analysis_cancel_discards():
 
         assert screen._library_media_editing_analysis is False
         assert not screen.query("#library-media-analysis-edit-text")
+        # task-28026: a non-empty analysis renders in the searchable content
+        # body (its raw text is on ``.content``), not the plain Static.
         analysis_text = str(
-            screen.query_one("#library-media-viewer-analysis-text").renderable
+            screen.query_one("#library-media-viewer-content").content
         )
         assert analysis_text == "Existing analysis"
 
@@ -33725,3 +33731,103 @@ async def test_commit_line_stays_visible_and_synced_while_a_gate_blocks(
         await pilot.pause()
         assert summary.display is True
         assert "1 will import" in str(summary.renderable)
+
+
+def _media_item_with_multiline_analysis():
+    """A media item whose analysis has two lines containing "budget"."""
+    items = _two_media_items()
+    items[0]["versions"] = [
+        {
+            "version_number": 1,
+            "analysis_content": "\n".join(
+                [
+                    "Summary intro line.",
+                    "The budget outlook is covered here.",
+                    "A neutral middle line.",
+                    "Second budget mention appears here too.",
+                ]
+            ),
+        }
+    ]
+    return items
+
+
+@pytest.mark.asyncio
+async def test_library_media_analysis_tab_is_searchable():
+    """task-28026: the Analysis tab has a search box that finds analysis matches."""
+    app = _build_test_app()
+    _seed_conversations(
+        app, _two_conversations(), media=_media_item_with_multiline_analysis()
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        screen.query_one("#library-row-browse-media").press()
+        await _wait_for_selector(screen, pilot, "#library-media-row-1")
+        screen.query_one("#library-media-row-1").press()
+        await _wait_for_selector(
+            screen, pilot, "#library-media-reader-select-analysis"
+        )
+        screen.query_one("#library-media-reader-select-analysis", Button).press()
+        # Wait for the analysis tab to settle (its Edit action is the stable
+        # signal the existing analysis tests use) before searching.
+        await _wait_for_selector(screen, pilot, "#library-media-analysis-edit")
+        search = screen.query_one("#library-media-content-search", Input)
+
+        search.value = "budget"
+        search.focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await _wait_for_condition(
+            pilot,
+            lambda: bool(
+                screen.query("#library-media-content-search-status")
+            )
+            and str(
+                screen.query("#library-media-content-search-status")
+                .first()
+                .renderable
+            )
+            == "Match 1 of 2 matches",
+            message="Analysis-tab search did not report its two matches.",
+        )
+        # Two analysis lines contain "budget" -> the search corpus is the
+        # analysis text, not the (empty here) transcript.
+
+
+@pytest.mark.asyncio
+async def test_library_media_switching_tabs_clears_the_search():
+    """task-28026: switching Reader tabs re-scopes -- the search does not carry over."""
+    app = _build_test_app()
+    _seed_conversations(
+        app, _two_conversations(), media=_media_item_with_multiline_analysis()
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        screen.query_one("#library-row-browse-media").press()
+        await _wait_for_selector(screen, pilot, "#library-media-row-1")
+        screen.query_one("#library-media-row-1").press()
+        # Read tab: search the transcript.
+        search = await _wait_for_selector(
+            screen, pilot, "#library-media-content-search"
+        )
+        search.value = "roadmap"
+        search.focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert screen._library_media_content_query == "roadmap"
+
+        # Switching to the Analysis tab drops the transcript search rather than
+        # carrying its query/highlights onto the analysis text.
+        screen.query_one("#library-media-reader-select-analysis", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-analysis-edit")
+        assert screen._library_media_content_query == ""
+        assert screen._library_media_content_match_index == 0

--- a/backlog/tasks/task-28026 - Library-media-viewer-search-the-Analysis-tab-text-not-only-the-transcript.md
+++ b/backlog/tasks/task-28026 - Library-media-viewer-search-the-Analysis-tab-text-not-only-the-transcript.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-28026
 title: 'Library media viewer - search the Analysis tab text, not only the transcript'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-02 06:46'
+updated_date: '2026-09-02 19:56'
 labels:
   - library
   - media-ux
@@ -22,7 +23,13 @@ From the 2026-09-01 Library media UX critique (task-28011 split): in-item conten
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Searching while the Analysis tab is active finds and highlights matches in the analysis text
-- [ ] #2 Match count, prev/next, and Enter-advance operate over whichever tab's text is being searched
-- [ ] #3 Switching tabs re-scopes the search corpus without stale highlights
+- [x] #1 Searching while the Analysis tab is active finds and highlights matches in the analysis text
+- [x] #2 Match count, prev/next, and Enter-advance operate over whichever tab's text is being searched
+- [x] #3 Switching tabs re-scopes the search corpus without stale highlights
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The Analysis tab is now searchable. When an analysis exists, _compose_analysis renders it in the SAME LibraryMediaContentSearchControls + LibraryMediaContentBody (raw mode) the Read tab uses, so the in-item find bar highlights matches in the analysis text (was a plain non-searchable Static). The screen's corpus (_library_media_content_matches) is mode-aware -- analysis text in the Analysis tab, transcript elsewhere -- with reader mode added to the memo key so a tab switch can't serve the other tab's matches. handle_library_media_reader_mode clears the search query/index/memo on a real tab switch (no stale highlights). Match count, Prev/Next, and Enter-advance all follow the active tab via the shared corpus. Tests: analysis-tab-is-searchable (status 'Match 1 of 2'), switching-tabs-clears-the-search; updated 3 existing analysis tests to read the analysis from the content body's .content (the non-empty analysis no longer uses #library-media-viewer-analysis-text -- that id remains for the empty/generating states). Test trap: the full test-file context recomposes the analysis tab via a background refresh, so wait for #library-media-analysis-edit to settle + poll the status rather than a fixed-pause query_one. Files: Widgets/Library/library_media_viewer.py, UI/Screens/library_screen.py, Tests/UI/test_library_shell.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -3999,8 +3999,11 @@ class LibraryScreen(BaseAppScreen):
         # ever replaced wholesale (a fetch settles) or cleared to None,
         # never mutated in place, so its identity is a sound document
         # marker; the None sentinel guarantees the first lookup misses.
+        # task-28026: keyed by (detail, query, MODE) -- the Read and Analysis
+        # tabs search different corpora of the same detail, so the mode is
+        # part of the key or a tab switch would serve the other tab's matches.
         self._library_media_content_match_memo: (
-            tuple[Any, str, tuple[int, ...]] | None
+            tuple[Any, str, tuple[int, ...], str] | None
         ) = None
         # LIB-13: "rendered" (Markdown, via the same render path Notes
         # Preview uses) or "raw" (plain/highlighted text). Reseeded per
@@ -42825,6 +42828,13 @@ class LibraryScreen(BaseAppScreen):
         self._capture_library_media_loaded_progress()
         if mode == "read":
             self._library_media_progress_restored_id = None
+        # task-28026: each tab searches its own corpus, so a tab switch drops
+        # the active query rather than carrying its highlights (and a stale
+        # match index) onto the other tab's text.
+        if mode != self._library_media_reader_session.mode:
+            self._library_media_content_query = ""
+            self._library_media_content_match_index = 0
+            self._library_media_content_match_memo = None
         self._library_media_reader_session = set_mode(
             self._library_media_reader_session,
             mode,  # type: ignore[arg-type]
@@ -43175,17 +43185,24 @@ class LibraryScreen(BaseAppScreen):
             self._library_media_content_match_memo = None
             return ()
         query = self._library_media_content_query
+        # task-28026: the Analysis tab searches the analysis text; every other
+        # mode searches the transcript. Mode is part of the memo key.
+        mode = self._library_media_reader_session.mode
         memo = self._library_media_content_match_memo
-        if memo is not None and memo[0] is detail and memo[1] == query:
+        if (
+            memo is not None
+            and memo[0] is detail
+            and memo[1] == query
+            and memo[3] == mode
+        ):
             return memo[2]
-        matches = find_content_matches(
-            # task-22208 memoizes the viewer state per detail arrival; going
-            # through it keeps this memo's miss path from re-copying the whole
-            # document that 22208 already built for this same arrival.
-            self._library_media_viewer_state_cached(detail).content,
-            query,
-        )
-        self._library_media_content_match_memo = (detail, query, matches)
+        # task-22208 memoizes the viewer state per detail arrival; going
+        # through it keeps this memo's miss path from re-copying the whole
+        # document that 22208 already built for this same arrival.
+        viewer_state = self._library_media_viewer_state_cached(detail)
+        corpus = viewer_state.analysis if mode == "analysis" else viewer_state.content
+        matches = find_content_matches(corpus, query)
+        self._library_media_content_match_memo = (detail, query, matches, mode)
         return matches
 
     def _advance_library_media_content_match(self, step: int) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -42818,7 +42818,11 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, ".library-media-reader-mode")
     def handle_library_media_reader_mode(self, event: Button.Pressed) -> None:
-        """Select one permanent Reader mode without reloading the item."""
+        """Select one permanent Reader mode without reloading the item.
+
+        Args:
+            event: The Reader mode button press; its id names the target mode.
+        """
         event.stop()
         button_id = str(event.button.id or "")
         prefix = "library-media-reader-select-"
@@ -42828,13 +42832,7 @@ class LibraryScreen(BaseAppScreen):
         self._capture_library_media_loaded_progress()
         if mode == "read":
             self._library_media_progress_restored_id = None
-        # task-28026: each tab searches its own corpus, so a tab switch drops
-        # the active query rather than carrying its highlights (and a stale
-        # match index) onto the other tab's text.
-        if mode != self._library_media_reader_session.mode:
-            self._library_media_content_query = ""
-            self._library_media_content_match_index = 0
-            self._library_media_content_match_memo = None
+        self._reset_library_media_search_on_mode_change(mode)
         self._library_media_reader_session = set_mode(
             self._library_media_reader_session,
             mode,  # type: ignore[arg-type]
@@ -42847,6 +42845,24 @@ class LibraryScreen(BaseAppScreen):
                     self._restore_library_media_loaded_progress, loaded_id
                 )
 
+    def _reset_library_media_search_on_mode_change(self, new_mode: str) -> None:
+        """Drop the in-item search when the Reader actually changes tab.
+
+        task-28026: each Reader tab searches its own corpus (the analysis
+        text vs the transcript), so a real mode transition clears the active
+        query, its match index, and the one-slot match memo rather than
+        carrying one tab's highlights -- and a possibly out-of-range match
+        index -- onto the other tab's text. A no-op re-press of the current
+        mode leaves the search intact.
+
+        Args:
+            new_mode: The Reader mode being switched to.
+        """
+        if new_mode != self._library_media_reader_session.mode:
+            self._library_media_content_query = ""
+            self._library_media_content_match_index = 0
+            self._library_media_content_match_memo = None
+
     def _capture_library_media_loaded_progress(self) -> None:
         """Snapshot and queue persistence of the local content body's offset.
 
@@ -42858,8 +42874,13 @@ class LibraryScreen(BaseAppScreen):
         """
         session = self._library_media_reader_session
         loaded_id = session.loaded_id
+        # task-28026: only the Read tab's content body carries transcript
+        # reading progress. The Analysis tab reuses the same
+        # #library-media-viewer-content id, so a capture taken in any other
+        # mode would persist an unrelated scroll offset as transcript progress.
         if (
             session.external_detail
+            or session.mode != "read"
             or loaded_id is None
             or not loaded_id.startswith("local:media:")
         ):
@@ -42992,8 +43013,16 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#library-media-reader-find")
     def handle_library_media_reader_find(self, event: Button.Pressed) -> None:
-        """Take Find to the loaded item's content body."""
+        """Take Find to the loaded item's content body.
+
+        Args:
+            event: The Find button press.
+        """
         event.stop()
+        # task-28026: Find is a real Analysis->Read transition too, so it
+        # clears any active analysis search before focusing the transcript
+        # find bar -- the same reset the Reader mode buttons apply.
+        self._reset_library_media_search_on_mode_change("read")
         self._library_media_reader_session = set_mode(
             self._library_media_reader_session, "read"
         )

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -571,12 +571,12 @@ class LibraryMediaViewer(Vertical):
         if self.editing_analysis:
             yield from self._compose_analysis_edit_form()
             return
-        yield Static(
-            self.viewer.analysis or "No analysis yet.",
-            id="library-media-viewer-analysis-text",
-            markup=False,
-        )
         if self.generating_analysis:
+            yield Static(
+                self.viewer.analysis or "No analysis yet.",
+                id="library-media-viewer-analysis-text",
+                markup=False,
+            )
             yield Static(
                 "Generating analysis…",
                 id="library-media-analysis-generating",
@@ -584,6 +584,35 @@ class LibraryMediaViewer(Vertical):
                 markup=False,
             )
             return
+        if self.viewer.analysis:
+            # task-28026: render the analysis in the SAME searchable/
+            # highlightable widgets the Read tab uses, so the in-item find
+            # bar works over the analysis text. The screen's search corpus
+            # (_library_media_content_matches) is mode-aware, so the query,
+            # match count, Prev/Next, and Enter-advance all follow the
+            # active tab. Analysis is plain text -> raw mode, not Markdown.
+            matches = find_content_matches(self.viewer.analysis, self.content_query)
+            yield LibraryMediaContentSearchControls(
+                is_markdown=False,
+                query=self.content_query,
+                matches=matches,
+                match_index=self.content_match_index,
+                id="library-media-content-search-controls",
+            )
+            yield LibraryMediaContentBody(
+                content=self.viewer.analysis,
+                is_markdown=False,
+                mode="raw",
+                query=self.content_query,
+                match_index=self.content_match_index,
+                id="library-media-viewer-content",
+            )
+        else:
+            yield Static(
+                "No analysis yet.",
+                id="library-media-viewer-analysis-text",
+                markup=False,
+            )
         with Horizontal(classes="ds-toolbar"):
             yield Button(
                 "Edit analysis" if self.viewer.analysis else "Add analysis",


### PR DESCRIPTION
## What

The Library media viewer's **Analysis tab** was not searchable — the in-item find bar (added in the reader search work) only scanned the transcript. This makes the Analysis tab searchable too, closing task-28026.

## Why it mattered

The power-user review workflow (read an analysis, jump to the phrase you half-remember, cross-check the transcript) broke the moment you switched to the Analysis tab: the search box either vanished or silently searched the wrong text. For a conference-worth of generated summaries this is exactly where find-in-item earns its keep.

## Changes

- **`Widgets/Library/library_media_viewer.py`** — when an analysis exists (and we're not editing/generating), `_compose_analysis` renders it in the same `LibraryMediaContentSearchControls` + `LibraryMediaContentBody` (raw mode) the Read tab uses, instead of a plain non-searchable `Static`. The empty/generating states keep the old `#library-media-viewer-analysis-text` Static.
- **`UI/Screens/library_screen.py`** — the search corpus (`_library_media_content_matches`) is now **mode-aware**: analysis text in the Analysis tab, transcript elsewhere. Reader mode is part of the match memo key so a tab switch can't serve the other tab's matches. `handle_library_media_reader_mode` clears the query/index/memo on a real tab switch — no stale highlights. Match count, Prev/Next and Enter-advance all follow the active tab through the shared corpus.
- **`Tests/UI/test_library_shell.py`** — new: `test_library_media_analysis_tab_is_searchable` (status reads "Match 1 of 2"), `test_library_media_switching_tabs_clears_the_search`; updated 3 existing analysis-text tests to read the analysis from the content body's `.content`.

## Tests

`Tests/UI/test_library_shell.py` (analysis/content/tab-switch), `test_library_media_reader_flow.py`, `Tests/Library/test_library_media_content.py`, `test_library_media_reader_shell.py`, `test_media_viewer_content_search_debounce.py` all green. Derived checks (diagnostic inventory, CSS bundle, backlog IDs) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Library media viewer's Analysis tab searchable, closing task-28026. The Analysis tab previously rendered analysis text as a plain, non-searchable view; it now uses the same search controls and content body as the Read tab, so find-in-item, match count, Prev/Next, and Enter-advance all work on the analysis text.

**New Features**
- The search corpus is mode-aware: analysis text on the Analysis tab, transcript everywhere else.
- Switching tabs clears the query, match index, and memo so highlights never carry over between tabs.

**Bug Fixes**
- Find clears an active analysis search when it moves Analysis→Read, so a stale match index can't scan the transcript.
- Progress capture is skipped outside Read mode so Analysis scrolling can't overwrite transcript reading progress.

<sup>Written for commit 3029c5191ec9a0f4c43370ba1b6e5bbe8d86576b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

