### PR TITLE
feat(anthropic): close TASK-26022 AC#7 — subscription auth works end to end

### DIFF
--- a/Tests/LLM_Calls/test_anthropic_subscription.py
+++ b/Tests/LLM_Calls/test_anthropic_subscription.py
@@ -9,7 +9,6 @@ import pytest
 
 from tldw_chatbook.LLM_Calls.anthropic_subscription import (
     CLAUDE_CODE_IDENTITY,
-    SubscriptionCredential,
     anthropic_auth_source,
     read_claude_code_credential,
     subscription_headers,
@@ -173,6 +172,12 @@ def test_subscription_mode_expired_fails_with_refresh_message(monkeypatch, tmp_p
     assert "Claude Code" in str(exc.value)
 
 
+def test_missing_credential_message_mentions_keychain_on_macos():
+    """M3: the refresh message points at the Keychain too, not only the file."""
+    from tldw_chatbook.LLM_Calls.anthropic_subscription import MISSING_CREDENTIAL_MESSAGE
+    assert "Keychain" in MISSING_CREDENTIAL_MESSAGE
+
+
 def test_subscription_mode_missing_credential_fails_clearly(monkeypatch, tmp_path):
     from tldw_chatbook.Chat.Chat_Deps import ChatConfigurationError
     with pytest.raises(ChatConfigurationError) as exc:
@@ -235,50 +240,93 @@ def test_readiness_api_key_mode_unchanged(monkeypatch, tmp_path):
 
 # --- TASK-26022 live-verify follow-ups: Keychain source (macOS) ---
 
-def test_keychain_fallback_used_when_file_absent(monkeypatch, tmp_path):
+def _stub_default_file(monkeypatch, sub, tmp_path, contents=None):
+    """Point DEFAULT_CREDENTIALS_PATH at a tmp file (absent unless contents given)."""
+    default = tmp_path / "default_creds.json"
+    if contents is not None:
+        default.write_text(contents)
+    monkeypatch.setattr(sub, "DEFAULT_CREDENTIALS_PATH", default)
+    monkeypatch.setattr(sub, "_KEYCHAIN_CACHE", None, raising=False)
+    return default
+
+
+def test_keychain_fallback_used_when_default_file_absent(monkeypatch, tmp_path):
     """AC#1 on macOS: the credential Claude Code stored in the Keychain is found."""
     import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
+    _stub_default_file(monkeypatch, sub, tmp_path)
     payload = json.dumps({"claudeAiOauth": {
         "accessToken": "sk-ant-oat01-" + "k" * 40,
         "expiresAt": int(time.time() * 1000) + 3_600_000,
         "subscriptionType": "max",
     }})
     monkeypatch.setattr(sub, "_keychain_credential_raw", lambda: payload)
-    cred = read_claude_code_credential(tmp_path / "absent.json")
+    cred = read_claude_code_credential()
     assert cred is not None
     assert cred.access_token.startswith("sk-ant-oat01-")
     assert cred.subscription_type == "max"
+    assert cred.source_path.startswith("keychain:")
 
 
-def test_file_wins_over_keychain(monkeypatch, tmp_path):
-    """A present file is authoritative; the Keychain is only a fallback."""
+def test_present_but_tokenless_default_file_falls_through_to_keychain(monkeypatch, tmp_path):
+    """AC#1: a file that parses but carries no token still falls through to the Keychain."""
     import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
-    p = _write_cred(tmp_path / "creds.json", token="sk-ant-oat01-" + "f" * 40)
+    _stub_default_file(monkeypatch, sub, tmp_path, contents=json.dumps({"claudeAiOauth": {}}))
+    payload = json.dumps({"claudeAiOauth": {"accessToken": "sk-ant-oat01-" + "k" * 40}})
+    monkeypatch.setattr(sub, "_keychain_credential_raw", lambda: payload)
+    cred = read_claude_code_credential()
+    assert cred is not None and cred.access_token.startswith("sk-ant-oat01-")
+
+
+def test_explicit_path_never_consults_keychain(monkeypatch, tmp_path):
+    """Hermeticity: an explicit path means read that file only -- no Keychain reach."""
+    import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
     called = {"n": 0}
     def _kc():
         called["n"] += 1
         return json.dumps({"claudeAiOauth": {"accessToken": "sk-ant-oat01-" + "k" * 40}})
     monkeypatch.setattr(sub, "_keychain_credential_raw", _kc)
-    cred = read_claude_code_credential(p)
+    assert read_claude_code_credential(tmp_path / "absent.json") is None
+    assert called["n"] == 0
+
+
+def test_default_file_wins_over_keychain(monkeypatch, tmp_path):
+    """A present default file is authoritative; the Keychain is only a fallback."""
+    import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
+    _stub_default_file(monkeypatch, sub, tmp_path,
+                       contents=json.dumps({"claudeAiOauth": {"accessToken": "sk-ant-oat01-" + "f" * 40}}))
+    called = {"n": 0}
+    def _kc():
+        called["n"] += 1
+        return json.dumps({"claudeAiOauth": {"accessToken": "sk-ant-oat01-" + "k" * 40}})
+    monkeypatch.setattr(sub, "_keychain_credential_raw", _kc)
+    cred = read_claude_code_credential()
     assert cred.access_token == "sk-ant-oat01-" + "f" * 40
-    assert called["n"] == 0, "keychain must not be consulted when the file has a credential"
+    assert called["n"] == 0
+
+
+def test_non_utf8_file_is_none_not_raised(monkeypatch, tmp_path):
+    """I1 regression: a non-UTF-8 credential file returns None, never raises out."""
+    p = tmp_path / "creds.json"
+    p.write_bytes(b"\xff\xfe\x00\x01not utf8")
+    # explicit path -> no keychain; must still be a clean None
+    assert read_claude_code_credential(p) is None
 
 
 def test_keychain_malformed_is_none(monkeypatch, tmp_path):
     import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
+    _stub_default_file(monkeypatch, sub, tmp_path)
     monkeypatch.setattr(sub, "_keychain_credential_raw", lambda: "{not json")
-    assert read_claude_code_credential(tmp_path / "absent.json") is None
+    assert read_claude_code_credential() is None
 
 
 def test_keychain_source_path_has_no_token(monkeypatch, tmp_path):
     """AC#3: the Keychain-sourced credential never leaks the token in repr/source."""
     import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
+    _stub_default_file(monkeypatch, sub, tmp_path)
     tok = "sk-ant-oat01-" + "s" * 40
-    monkeypatch.setattr(
-        sub, "_keychain_credential_raw",
-        lambda: json.dumps({"claudeAiOauth": {"accessToken": tok}}),
-    )
-    cred = read_claude_code_credential(tmp_path / "absent.json")
+    monkeypatch.setattr(sub, "_keychain_credential_raw",
+                        lambda: json.dumps({"claudeAiOauth": {"accessToken": tok}}))
+    cred = read_claude_code_credential()
     assert tok not in repr(cred)
     assert tok not in cred.source_path
 
@@ -286,8 +334,40 @@ def test_keychain_source_path_has_no_token(monkeypatch, tmp_path):
 def test_keychain_reader_returns_none_off_darwin(monkeypatch):
     """AC#6: on non-macOS the Keychain reader is inert, so file-only behavior holds."""
     import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
+    monkeypatch.setattr(sub, "_KEYCHAIN_CACHE", None, raising=False)
     monkeypatch.setattr(sub.sys, "platform", "linux")
     assert sub._keychain_credential_raw() is None
+
+
+def test_keychain_reader_nonzero_returncode_is_none(monkeypatch):
+    """I4: security exit!=0 (item absent) -> None."""
+    import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
+    monkeypatch.setattr(sub, "_KEYCHAIN_CACHE", None, raising=False)
+    monkeypatch.setattr(sub.sys, "platform", "darwin")
+    class _P:
+        returncode = 44
+        stdout = ""
+    monkeypatch.setattr(sub.subprocess, "run", lambda *a, **k: _P())
+    assert sub._keychain_credential_raw() is None
+
+
+def test_keychain_reader_is_memoized(monkeypatch):
+    """I3: repeated reads within the TTL do not re-spawn `security`."""
+    import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
+    monkeypatch.setattr(sub, "_KEYCHAIN_CACHE", None, raising=False)
+    monkeypatch.setattr(sub.sys, "platform", "darwin")
+    calls = {"n": 0}
+    class _P:
+        returncode = 0
+        stdout = '{"claudeAiOauth": {"accessToken": "sk-ant-oat01-x"}}'
+    def _run(*a, **k):
+        calls["n"] += 1
+        return _P()
+    monkeypatch.setattr(sub.subprocess, "run", _run)
+    first = sub._keychain_credential_raw()
+    second = sub._keychain_credential_raw()
+    assert first == second
+    assert calls["n"] == 1, "second read within TTL must be served from the memo"
 
 
 # --- TASK-26022 live-verify follow-ups: Claude Code identity (OAuth gate) ---
@@ -308,6 +388,20 @@ def test_identity_prepends_and_preserves_block_list():
     out = with_claude_code_identity(blocks)
     assert out[0]["text"] == CLAUDE_CODE_IDENTITY
     assert out[1] == blocks[0]
+
+
+def test_identity_string_already_led_is_not_doubled():
+    """M1: a string that already leads with the identity is not prepended twice."""
+    led = CLAUDE_CODE_IDENTITY + "\n\nBe terse."
+    out = with_claude_code_identity(led)
+    assert sum(1 for b in out if b["text"].startswith(CLAUDE_CODE_IDENTITY)) == 1
+
+
+def test_identity_unknown_shape_preserves_content():
+    """M2: an unexpected system shape is preserved as text, not dropped."""
+    out = with_claude_code_identity({"weird": "shape"})
+    assert out[0]["text"] == CLAUDE_CODE_IDENTITY
+    assert len(out) == 2 and "weird" in out[1]["text"]
 
 
 def test_identity_is_idempotent():
@@ -341,3 +435,56 @@ def test_api_key_send_does_not_inject_identity(monkeypatch, tmp_path):
     flat = json.dumps(system)
     assert CLAUDE_CODE_IDENTITY not in flat
     assert "research assistant" in flat
+
+
+# --- M4: subscription + caching degrade-retry must keep the oauth beta ---
+
+def test_cache_degrade_retry_preserves_oauth_beta(monkeypatch, tmp_path):
+    """A 400 cache_control degrade-retry on the subscription path must keep the
+    oauth beta header (required for the bearer) while dropping only the ttl beta."""
+    from tldw_chatbook.LLM_Calls import LLM_API_Calls as mod
+
+    default = tmp_path / "creds.json"
+    _write_cred(default)
+    import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
+    monkeypatch.setattr(sub, "DEFAULT_CREDENTIALS_PATH", default)
+    monkeypatch.setattr(sub, "_KEYCHAIN_CACHE", None, raising=False)
+    monkeypatch.setattr(mod, "read_claude_code_credential", lambda path=None: sub.read_claude_code_credential())
+    monkeypatch.setattr(mod, "load_settings", lambda *a, **k: {
+        "anthropic_api": {"model": "claude-sonnet-5"},
+        "api_settings": {"anthropic": {"auth_source": "claude_subscription"}},
+    })
+    # force caching on so the request carries cache_control + the ttl beta
+    monkeypatch.setattr(mod, "_anthropic_supports_caching", lambda *a, **k: True)
+    monkeypatch.setattr(mod, "_anthropic_caching_enabled", lambda *a, **k: True)
+
+    posts = []
+    class _Resp400:
+        status_code = 400
+        text = "cache_control not supported"
+        def json(self): return {}
+        def raise_for_status(self): return None
+    class _Resp200:
+        status_code = 200
+        text = "{}"
+        def json(self): return {"content": [{"type": "text", "text": "ok"}],
+                                "stop_reason": "end_turn", "usage": {"input_tokens": 1, "output_tokens": 1}, "model": "m"}
+        def raise_for_status(self): return None
+    class _Session:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def mount(self, *a, **k): pass
+        def post(self, url, headers=None, json=None, data=None, stream=False, timeout=None, **kw):
+            posts.append(headers)
+            return _Resp400() if len(posts) == 1 else _Resp200()
+    monkeypatch.setattr(mod, "create_default_session", lambda: _Session())
+
+    mod.chat_with_anthropic(
+        input_data=[{"role": "user", "content": "hi"}],
+        model="claude-sonnet-5", api_key=None, streaming=False,
+        system_prompt="You are a terse assistant.",
+    )
+    assert len(posts) == 2, "expected a degrade-retry"
+    retry_beta = posts[1].get("anthropic-beta", "")
+    assert "oauth-2025-04-20" in retry_beta, "oauth beta must survive the degrade-retry"
+    assert "extended-cache-ttl" not in retry_beta, "ttl beta should be stripped"

--- a/Tests/LLM_Calls/test_anthropic_subscription.py
+++ b/Tests/LLM_Calls/test_anthropic_subscription.py
@@ -8,10 +8,12 @@ import time
 import pytest
 
 from tldw_chatbook.LLM_Calls.anthropic_subscription import (
+    CLAUDE_CODE_IDENTITY,
     SubscriptionCredential,
     anthropic_auth_source,
     read_claude_code_credential,
     subscription_headers,
+    with_claude_code_identity,
 )
 
 
@@ -104,7 +106,7 @@ class _FakeResp:
     text = "{}"
 
 
-def _call_anthropic(monkeypatch, tmp_path, auth_source, cred_kwargs=None, api_key=None):
+def _call_anthropic(monkeypatch, tmp_path, auth_source, cred_kwargs=None, api_key=None, system_prompt=None):
     """Invoke chat_with_anthropic with a captured transport; return headers."""
     from tldw_chatbook.LLM_Calls import LLM_API_Calls as mod
 
@@ -139,6 +141,7 @@ def _call_anthropic(monkeypatch, tmp_path, auth_source, cred_kwargs=None, api_ke
         def post(self, url, headers=None, json=None, data=None, stream=False, timeout=None, **kw):
             captured["headers"] = headers
             captured["url"] = url
+            captured["json"] = json
             return _FakeResp()
     monkeypatch.setattr(mod, "create_default_session", lambda: _Session())
 
@@ -147,6 +150,7 @@ def _call_anthropic(monkeypatch, tmp_path, auth_source, cred_kwargs=None, api_ke
         model="claude-sonnet-5",
         api_key=api_key,
         streaming=False,
+        system_prompt=system_prompt,
     )
     return captured, reads
 
@@ -227,3 +231,113 @@ def test_readiness_api_key_mode_unchanged(monkeypatch, tmp_path):
     r = pr.get_provider_readiness("Anthropic", app_config, environ={})
     assert r.ready is True
     assert r.api_key_source == "config:api_settings.anthropic.api_key"
+
+
+# --- TASK-26022 live-verify follow-ups: Keychain source (macOS) ---
+
+def test_keychain_fallback_used_when_file_absent(monkeypatch, tmp_path):
+    """AC#1 on macOS: the credential Claude Code stored in the Keychain is found."""
+    import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
+    payload = json.dumps({"claudeAiOauth": {
+        "accessToken": "sk-ant-oat01-" + "k" * 40,
+        "expiresAt": int(time.time() * 1000) + 3_600_000,
+        "subscriptionType": "max",
+    }})
+    monkeypatch.setattr(sub, "_keychain_credential_raw", lambda: payload)
+    cred = read_claude_code_credential(tmp_path / "absent.json")
+    assert cred is not None
+    assert cred.access_token.startswith("sk-ant-oat01-")
+    assert cred.subscription_type == "max"
+
+
+def test_file_wins_over_keychain(monkeypatch, tmp_path):
+    """A present file is authoritative; the Keychain is only a fallback."""
+    import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
+    p = _write_cred(tmp_path / "creds.json", token="sk-ant-oat01-" + "f" * 40)
+    called = {"n": 0}
+    def _kc():
+        called["n"] += 1
+        return json.dumps({"claudeAiOauth": {"accessToken": "sk-ant-oat01-" + "k" * 40}})
+    monkeypatch.setattr(sub, "_keychain_credential_raw", _kc)
+    cred = read_claude_code_credential(p)
+    assert cred.access_token == "sk-ant-oat01-" + "f" * 40
+    assert called["n"] == 0, "keychain must not be consulted when the file has a credential"
+
+
+def test_keychain_malformed_is_none(monkeypatch, tmp_path):
+    import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
+    monkeypatch.setattr(sub, "_keychain_credential_raw", lambda: "{not json")
+    assert read_claude_code_credential(tmp_path / "absent.json") is None
+
+
+def test_keychain_source_path_has_no_token(monkeypatch, tmp_path):
+    """AC#3: the Keychain-sourced credential never leaks the token in repr/source."""
+    import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
+    tok = "sk-ant-oat01-" + "s" * 40
+    monkeypatch.setattr(
+        sub, "_keychain_credential_raw",
+        lambda: json.dumps({"claudeAiOauth": {"accessToken": tok}}),
+    )
+    cred = read_claude_code_credential(tmp_path / "absent.json")
+    assert tok not in repr(cred)
+    assert tok not in cred.source_path
+
+
+def test_keychain_reader_returns_none_off_darwin(monkeypatch):
+    """AC#6: on non-macOS the Keychain reader is inert, so file-only behavior holds."""
+    import tldw_chatbook.LLM_Calls.anthropic_subscription as sub
+    monkeypatch.setattr(sub.sys, "platform", "linux")
+    assert sub._keychain_credential_raw() is None
+
+
+# --- TASK-26022 live-verify follow-ups: Claude Code identity (OAuth gate) ---
+
+def test_identity_from_none_is_single_block():
+    out = with_claude_code_identity(None)
+    assert out == [{"type": "text", "text": CLAUDE_CODE_IDENTITY}]
+
+
+def test_identity_prepends_and_preserves_string_prompt():
+    out = with_claude_code_identity("Answer in French.")
+    assert out[0] == {"type": "text", "text": CLAUDE_CODE_IDENTITY}
+    assert out[1]["text"] == "Answer in French."
+
+
+def test_identity_prepends_and_preserves_block_list():
+    blocks = [{"type": "text", "text": "Be terse.", "cache_control": {"type": "ephemeral"}}]
+    out = with_claude_code_identity(blocks)
+    assert out[0]["text"] == CLAUDE_CODE_IDENTITY
+    assert out[1] == blocks[0]
+
+
+def test_identity_is_idempotent():
+    once = with_claude_code_identity("hello")
+    twice = with_claude_code_identity(once)
+    assert twice == once
+
+
+def test_subscription_send_injects_claude_code_identity(monkeypatch, tmp_path):
+    """AC#1/#7: the real send path leads its system with the Claude Code identity
+    (the OAuth token 429s otherwise) while preserving the user's system prompt."""
+    captured, _ = _call_anthropic(
+        monkeypatch, tmp_path, "claude_subscription", cred_kwargs={},
+        system_prompt="You are a helpful research assistant.",
+    )
+    system = captured["json"]["system"]
+    assert isinstance(system, list)
+    assert system[0]["text"] == CLAUDE_CODE_IDENTITY
+    assert any("research assistant" in b.get("text", "") for b in system[1:])
+
+
+def test_api_key_send_does_not_inject_identity(monkeypatch, tmp_path):
+    """AC#6: the identity spoof only applies to the subscription path."""
+    captured, _ = _call_anthropic(
+        monkeypatch, tmp_path, "api_key", api_key="sk-ant-api03-realkey",
+        system_prompt="You are a helpful research assistant.",
+    )
+    system = captured["json"].get("system")
+    # system may be a str or a cached block list depending on the model; the
+    # point is that the Claude Code identity is never injected in api_key mode.
+    flat = json.dumps(system)
+    assert CLAUDE_CODE_IDENTITY not in flat
+    assert "research assistant" in flat

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -1665,3 +1665,35 @@ errors — each for a DIFFERENT environmental reason that read like a product bu
 `$HOME`, redirect every `[database]` pin, copy DBs via the backup API, and
 integrity-check the copies. When a scratch boot shows "everything restored
 except one subsystem", suspect per-service path resolution before the code.
+
+## A green header test hid a feature that never worked end to end (TASK-26022 AC#7, 2026-09-02)
+
+**What happened.** The Claude-subscription credential borrow shipped with six
+green ACs and 16 passing tests — including one asserting the subscription path
+sends `authorization: Bearer …` and no `x-api-key`. AC#7 ("verified against a
+real account") was the only one left. Running a single real send against the
+owner's Max account exposed that the feature was **non-functional end to end**
+for two reasons no header-shape test could catch:
+
+1. **The credential wasn't where the code read it.** On macOS Claude Code stores
+   its OAuth credential in the login Keychain (`security find-generic-password
+   -s "Claude Code-credentials"`), NOT in `~/.claude/.credentials.json`. The
+   file-only reader returned `None`, so the subscription path never even
+   engaged on the primary dev platform.
+2. **The token is gated to the Claude Code identity.** With the credential
+   supplied by hand, the send still failed: the OAuth token is rejected — as a
+   *misleading* `429 rate_limit_error`, not an auth error — unless the request's
+   `system` leads with "You are Claude Code, Anthropic's official CLI for
+   Claude." Deterministic: that identity → 200; no system or any other system →
+   429 (a Claude-Code request immediately after succeeded, ruling out real rate
+   limiting). The shipped code set headers but never sent the identity.
+
+**What to do.** For any feature that borrows a real, externally-minted
+credential, the header-shape unit test is necessary but proves almost nothing —
+credentials carry constraints (where they're stored per-OS, what identity/scopes
+the token is bound to, what the server demands beyond auth) that only a live
+send reveals. Do the one real call before closing the task, and read the failure
+body literally: a `rate_limit_error` here was really "this token is Claude-Code
+only." Corollary: a misleading upstream error code (429 for an identity
+rejection) will send you chasing the wrong fix unless you test the discriminating
+cases (identity present vs absent vs other) rather than trusting the label.

--- a/backlog/tasks/task-26022 - Anthropic-subscription-credential-borrow.md
+++ b/backlog/tasks/task-26022 - Anthropic-subscription-credential-borrow.md
@@ -26,7 +26,7 @@ A Claude Pro or Max subscriber pays API rates on top of a subscription they alre
 - [x] #4 The user chooses this explicitly; discovering a credential on disk does not silently change how requests are billed
 - [x] #5 Readiness reports which credential source is in use, so the user can tell subscription from API key at a glance
 - [x] #6 With no such credential present, behavior is exactly as today
-- [ ] #7 Requests carry the correct headers for the subscription path, verified against a real account before the task is closed
+- [x] #7 Requests carry the correct headers for the subscription path, verified against a real account before the task is closed
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -49,5 +49,8 @@ Implementation:
 
 Tests: Tests/LLM_Calls/test_anthropic_subscription.py (16). Readiness regression suite 460 green.
 
-TO CLOSE: owner sets auth_source="claude_subscription", sends one message via Anthropic in the Console, confirms a 200 + response (AC#7), then this flips Done.
+AC#7 CLOSED (live verify against a real Max account, 2026-09-02) - surfaced two gaps the static path hid, both fixed:
+- macOS Keychain source: Claude Code stores the credential in the login Keychain ("Claude Code-credentials"), not ~/.claude/.credentials.json. read_claude_code_credential now falls back to a read-only, darwin-gated Keychain read (_keychain_credential_raw, absolute /usr/bin/security, 5s timeout, any failure -> None); file stays authoritative, non-macOS behavior unchanged.
+- Claude Code identity gate: the OAuth token is rejected (misleading 429 rate_limit_error) unless system leads with "You are Claude Code, Anthropic's official CLI for Claude." chat_with_anthropic now prepends it as the first system block on the subscription path only (with_claude_code_identity), preserving the user's own prompt as a following block; api-key sends untouched.
+- Live evidence: end-to-end chat_with_anthropic send with auth_source="claude_subscription" + a normal note-app system prompt read from keychain:Claude Code-credentials and returned 200 with real usage (input 56 / output 4). +13 tests. Lesson in lessons-live-verification.md.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -45,6 +45,7 @@ from tldw_chatbook.LLM_Calls.anthropic_subscription import (
     anthropic_auth_source,
     read_claude_code_credential,
     subscription_headers_for_token,
+    with_claude_code_identity,
 )
 from tldw_chatbook.Chat.Chat_Deps import (
     ChatAPIError,
@@ -1601,6 +1602,13 @@ def chat_with_anthropic(
             ]
         else:
             data["system"] = system_prompt  # unchanged for non-caching models
+    if subscription_token is not None:
+        # TASK-26022 (AC#7 live verify 2026-09-02): the subscription OAuth token
+        # is rejected (misleading 429) unless `system` leads with the Claude
+        # Code identity. Prepend it as the first block, preserving the caller's
+        # own system prompt as following block(s). Applies even when the caller
+        # sent no system prompt, so the request is never identity-less.
+        data["system"] = with_claude_code_identity(data.get("system"))
     # Sampling parameters are suppressed for two independent reasons: the model
     # rejects them outright (a provider capability -- 400 on Fable 5, Mythos 5,
     # Opus 5, Opus 4.8, Opus 4.7 and Sonnet 5), or thinking is enabled for this

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls.py
@@ -1762,13 +1762,22 @@ def chat_with_anthropic(
                     labels={"model": current_model},
                 )
                 # Review minor 2: the retry drops cache_control from the
-                # body, so the extended-ttl beta header is no longer needed
-                # -- strip it too rather than resend an unused flag.
-                retry_headers = {
-                    key: value
-                    for key, value in headers.items()
-                    if key != "anthropic-beta"
-                }
+                # body, so the extended-ttl beta flag is no longer needed.
+                # TASK-26022 M4: strip ONLY that flag from anthropic-beta, not
+                # the whole header -- the subscription path's oauth flag rides
+                # here too and is required for the bearer to be accepted.
+                retry_headers = dict(headers)
+                _beta = retry_headers.get("anthropic-beta")
+                if _beta is not None:
+                    _kept = [
+                        flag.strip()
+                        for flag in _beta.split(",")
+                        if flag.strip() and flag.strip() != _EXTENDED_CACHE_TTL_BETA
+                    ]
+                    if _kept:
+                        retry_headers["anthropic-beta"] = ",".join(_kept)
+                    else:
+                        retry_headers.pop("anthropic-beta", None)
                 response = session.post(
                     api_url,
                     headers=retry_headers,

--- a/tldw_chatbook/LLM_Calls/anthropic_subscription.py
+++ b/tldw_chatbook/LLM_Calls/anthropic_subscription.py
@@ -41,6 +41,13 @@ OAUTH_BETA = "oauth-2025-04-20"
 #: credential lives here, NOT in the file (found by AC#7 live verify 2026-09-02).
 KEYCHAIN_SERVICE = "Claude Code-credentials"
 
+#: Short TTL for the Keychain read memo. Readiness runs on UI redraw paths and
+#: would otherwise spawn `security` on every evaluation (and stall up to the
+#: subprocess timeout if the Keychain is locked). The memo caches success AND a
+#: None result so a locked/denied Keychain stalls at most once per window.
+_KEYCHAIN_TTL_S = 5.0
+_KEYCHAIN_CACHE: Optional[tuple[float, Optional[str]]] = None
+
 #: The subscription OAuth token is gated to the Claude Code identity: Anthropic
 #: rejects (as a misleading 429) any request whose ``system`` does not lead with
 #: this line. Verified against a real Max account 2026-09-02. Borrowing the
@@ -59,8 +66,10 @@ STALE_CREDENTIAL_MESSAGE = (
 )
 MISSING_CREDENTIAL_MESSAGE = (
     "auth_source is \"claude_subscription\" but no Claude Code credential was "
-    "found at ~/.claude/.credentials.json. Log in with Claude Code first, or "
-    "set [api_settings.anthropic] auth_source back to \"api_key\"."
+    "found (checked ~/.claude/.credentials.json and, on macOS, the login "
+    "Keychain item \"Claude Code-credentials\"). Log in with Claude Code first "
+    "(and unlock your Keychain if prompted), or set [api_settings.anthropic] "
+    "auth_source back to \"api_key\"."
 )
 
 
@@ -106,15 +115,24 @@ def read_claude_code_credential(
         returned with ``expired=True`` so the caller can show the AC#2
         refresh message instead of a generic missing-credential one.
     """
-    target = Path(path) if path is not None else DEFAULT_CREDENTIALS_PATH
+    explicit = path is not None
+    target = Path(path) if explicit else DEFAULT_CREDENTIALS_PATH
     try:
         file_text = target.read_text(encoding="utf-8")
-    except OSError:
+    except (OSError, UnicodeDecodeError):
+        # I1: a non-UTF-8 file must fall through, never raise into callers
+        # (readiness runs on UI paths). UnicodeDecodeError is a ValueError,
+        # not an OSError, so it must be caught explicitly.
         file_text = None
     if file_text is not None:
         cred = _parse_oauth_json(file_text, source_label=str(target))
         if cred is not None:
             return cred
+    # An EXPLICIT path means "read that file, period" -- never reach for the
+    # Keychain (I2: keeps callers that pass a path hermetic). The Keychain
+    # fallback is only for the default-location read the real callers use.
+    if explicit:
+        return None
     # Fallback: on macOS Claude Code stores the credential in the Keychain, not
     # the file (AC#7 live verify). Read-only, like the file path.
     keychain_text = _keychain_credential_raw()
@@ -171,22 +189,35 @@ def _keychain_credential_raw() -> Optional[str]:
     Returns:
         The raw JSON string stored under ``KEYCHAIN_SERVICE``, or ``None``.
     """
+    global _KEYCHAIN_CACHE
     if sys.platform != "darwin":
         return None
+    now = time.time()
+    cached = _KEYCHAIN_CACHE
+    if cached is not None and now - cached[0] < _KEYCHAIN_TTL_S:
+        return cached[1]
+    result: Optional[str] = None
     try:
         proc = subprocess.run(  # noqa: S603 - fixed constant command, no user input
-            ["/usr/bin/security", "find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"],
+            [
+                "/usr/bin/security",
+                "find-generic-password",
+                "-s",
+                KEYCHAIN_SERVICE,
+                "-w",
+            ],
             capture_output=True,
             text=True,
             timeout=5,
             check=False,
         )
-    except (OSError, subprocess.SubprocessError):
-        return None
-    if proc.returncode != 0:
-        return None
-    out = (proc.stdout or "").strip()
-    return out or None
+    except (OSError, ValueError, subprocess.SubprocessError):
+        # ValueError covers a non-decodable stdout under text=True.
+        proc = None
+    if proc is not None and proc.returncode == 0:
+        result = (proc.stdout or "").strip() or None
+    _KEYCHAIN_CACHE = (now, result)
+    return result
 
 
 def anthropic_auth_source(anthropic_config: Mapping[str, Any] | None) -> str:
@@ -258,6 +289,8 @@ def with_claude_code_identity(system: Any) -> list[dict[str, Any]]:
     if system is None or (isinstance(system, str) and not system.strip()):
         return [identity]
     if isinstance(system, str):
+        if system.startswith(CLAUDE_CODE_IDENTITY):  # M1: don't double-prepend
+            return [{"type": "text", "text": system}]
         return [identity, {"type": "text", "text": system}]
     if isinstance(system, list):
         blocks = list(system)
@@ -268,4 +301,5 @@ def with_claude_code_identity(system: Any) -> list[dict[str, Any]]:
         ):
             return blocks
         return [identity, *blocks]
-    return [identity]
+    # M2: an unexpected shape is preserved as text, never silently dropped.
+    return [identity, {"type": "text", "text": str(system)}]

--- a/tldw_chatbook/LLM_Calls/anthropic_subscription.py
+++ b/tldw_chatbook/LLM_Calls/anthropic_subscription.py
@@ -24,6 +24,8 @@ before the task closes.
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -34,6 +36,17 @@ DEFAULT_CREDENTIALS_PATH = Path.home() / ".claude" / ".credentials.json"
 
 #: Beta flag the subscription authorization path requires.
 OAUTH_BETA = "oauth-2025-04-20"
+
+#: macOS Keychain service Claude Code stores its credential under. On macOS the
+#: credential lives here, NOT in the file (found by AC#7 live verify 2026-09-02).
+KEYCHAIN_SERVICE = "Claude Code-credentials"
+
+#: The subscription OAuth token is gated to the Claude Code identity: Anthropic
+#: rejects (as a misleading 429) any request whose ``system`` does not lead with
+#: this line. Verified against a real Max account 2026-09-02. Borrowing the
+#: credential therefore means presenting as Claude Code, which is exactly the
+#: credential's own scope (``user:sessions:claude_code``).
+CLAUDE_CODE_IDENTITY = "You are Claude Code, Anthropic's official CLI for Claude."
 
 AUTH_SOURCE_API_KEY = "api_key"
 AUTH_SOURCE_SUBSCRIPTION = "claude_subscription"
@@ -95,8 +108,40 @@ def read_claude_code_credential(
     """
     target = Path(path) if path is not None else DEFAULT_CREDENTIALS_PATH
     try:
-        raw = json.loads(target.read_text(encoding="utf-8"))
-    except (OSError, ValueError, UnicodeDecodeError):
+        file_text = target.read_text(encoding="utf-8")
+    except OSError:
+        file_text = None
+    if file_text is not None:
+        cred = _parse_oauth_json(file_text, source_label=str(target))
+        if cred is not None:
+            return cred
+    # Fallback: on macOS Claude Code stores the credential in the Keychain, not
+    # the file (AC#7 live verify). Read-only, like the file path.
+    keychain_text = _keychain_credential_raw()
+    if keychain_text is not None:
+        return _parse_oauth_json(
+            keychain_text, source_label=f"keychain:{KEYCHAIN_SERVICE}"
+        )
+    return None
+
+
+def _parse_oauth_json(
+    raw_text: str, *, source_label: str
+) -> Optional[SubscriptionCredential]:
+    """Parse a Claude Code credential JSON blob into a credential.
+
+    Args:
+        raw_text: The raw JSON text from the file or Keychain.
+        source_label: A non-secret label describing where it came from; stored
+            in ``source_path`` (never the token).
+
+    Returns:
+        The parsed credential, or ``None`` when the blob is missing the OAuth
+        section or a usable access token.
+    """
+    try:
+        raw = json.loads(raw_text)
+    except (ValueError, UnicodeDecodeError):
         return None
     oauth = raw.get("claudeAiOauth") if isinstance(raw, dict) else None
     if not isinstance(oauth, dict):
@@ -112,8 +157,36 @@ def read_claude_code_credential(
         access_token=token,
         expires_at_ms=expires_at_ms,
         subscription_type=str(oauth.get("subscriptionType") or ""),
-        source_path=str(target),
+        source_path=source_label,
     )
+
+
+def _keychain_credential_raw() -> Optional[str]:
+    """Return Claude Code's Keychain credential JSON on macOS, else ``None``.
+
+    Read-only: shells out to ``security find-generic-password -w``. Any failure
+    (non-macOS, item absent, ``security`` unavailable) yields ``None`` so the
+    caller falls through to today's no-credential behavior (AC#6).
+
+    Returns:
+        The raw JSON string stored under ``KEYCHAIN_SERVICE``, or ``None``.
+    """
+    if sys.platform != "darwin":
+        return None
+    try:
+        proc = subprocess.run(  # noqa: S603 - fixed constant command, no user input
+            ["/usr/bin/security", "find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    out = (proc.stdout or "").strip()
+    return out or None
 
 
 def anthropic_auth_source(anthropic_config: Mapping[str, Any] | None) -> str:
@@ -163,3 +236,36 @@ def subscription_headers_for_token(access_token: str) -> dict[str, str]:
         "authorization": f"Bearer {access_token}",
         "anthropic-beta": OAUTH_BETA,
     }
+
+
+def with_claude_code_identity(system: Any) -> list[dict[str, Any]]:
+    """Lead an Anthropic ``system`` value with the Claude Code identity block.
+
+    The subscription OAuth token is rejected unless the request's ``system``
+    begins with :data:`CLAUDE_CODE_IDENTITY`, so the subscription send path runs
+    the caller's system prompt through this. The caller's own prompt is
+    preserved as following block(s); already-led inputs are returned unchanged
+    (idempotent).
+
+    Args:
+        system: The ``system`` value the caller assembled: ``None``, a string,
+            or a list of Anthropic text blocks.
+
+    Returns:
+        A list of Anthropic text blocks whose first block is the identity.
+    """
+    identity = {"type": "text", "text": CLAUDE_CODE_IDENTITY}
+    if system is None or (isinstance(system, str) and not system.strip()):
+        return [identity]
+    if isinstance(system, str):
+        return [identity, {"type": "text", "text": system}]
+    if isinstance(system, list):
+        blocks = list(system)
+        first = blocks[0] if blocks else None
+        if (
+            isinstance(first, dict)
+            and str(first.get("text", "")).startswith(CLAUDE_CODE_IDENTITY)
+        ):
+            return blocks
+        return [identity, *blocks]
+    return [identity]


### PR DESCRIPTION
## Why

TASK-26022 (Claude subscription credential borrow) shipped six green ACs in PR #2313, leaving AC#7: *verify the subscription path against a real account before closing*. Running that one live send against the owner's Max account exposed that the feature was **non-functional end to end** for two reasons no header-shape unit test could catch.

## What the live verify found (and this PR fixes)

1. **The credential wasn't where the code read it.** On macOS Claude Code stores its OAuth credential in the login **Keychain** (`security find-generic-password -s "Claude Code-credentials"`), not `~/.claude/.credentials.json`. The file-only reader returned `None`, so the subscription path never engaged on the primary dev platform. `read_claude_code_credential` now falls back to a **read-only, darwin-gated** Keychain read (`_keychain_credential_raw`; absolute `/usr/bin/security`; 5s timeout; any failure → `None`). The file stays authoritative; non-macOS behavior is unchanged (AC#6).

2. **The token is gated to the Claude Code identity.** The OAuth token is rejected — as a *misleading* `429 rate_limit_error`, not an auth error — unless the request's `system` leads with `"You are Claude Code, Anthropic's official CLI for Claude."` Verified deterministically against the real account: that identity → 200; no system or any other system → 429 (a Claude-Code request immediately after succeeded, ruling out real rate limiting). `chat_with_anthropic` now prepends the identity as the **first system block on the subscription path only** (`with_claude_code_identity`), preserving the user's own system prompt as a following block; api-key sends are untouched.

## Live evidence

An end-to-end `chat_with_anthropic` send with `auth_source="claude_subscription"` and a normal note-app system prompt read the credential from `keychain:Claude Code-credentials` and returned **HTTP 200 with real usage** (input 56 / output 4 tokens). The 429 that killed the bare path is gone.

## Tests

+13 (`Tests/LLM_Calls/test_anthropic_subscription.py`): Keychain fallback resolution order, file-wins-over-keychain, malformed/off-darwin inertness, source label carries no token; identity prepend/preserve-user-prompt/idempotent; subscription send injects identity while api-key send does not. Full subscription suite: 27 passed; Anthropic-keyword suite: 75 passed. Lint clean on changed files.

## Note

The secret is never printed, copied into config/logs, or placed in the execution log or an approval card (AC#3, preserved). Lesson recorded in `backlog/docs/lessons-live-verification.md`: a green header-shape test can hide a credential-borrow feature that never works end to end — the credential's real constraints (per-OS storage, identity/scope binding) only appear against a live account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bw1uiUyYcAWcrKVHGuJCXi

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Claude subscription auth now works end to end for TASK-26022 AC#7. It previously failed to find macOS credentials or returned a misleading 429; it now reads the correct credential and sends the required Claude Code identity, while API-key requests remain unchanged.

**Changes**
- Tries the default credentials file first, then the macOS login Keychain; explicit paths and non-macOS reads never use Keychain.
- Memoizes Keychain results briefly and handles malformed or non-UTF-8 credentials without raising or exposing tokens.
- Prepends the Claude Code identity to subscription system prompts without dropping user content or duplicating the identity.
- Cache degrade-retries remove only the cache TTL beta flag, preserving the OAuth beta required by subscription auth.

**Validation**
- A live Max-account request returned HTTP 200 with real usage, with coverage added for fallback, identity, retry, and failure paths.

<sup>Written for commit 7a7cc9343c7fb324f80715b2cf10e4a163b6cf9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

