### PR TITLE
feat(library): suppress single-page pager noise (task-28016)

### DIFF
--- a/Tests/Library/test_library_pager_state.py
+++ b/Tests/Library/test_library_pager_state.py
@@ -86,6 +86,47 @@ def test_one_row_page_has_both_visible_boundary_reasons():
     assert display.next_reason == "No more results."
 
 
+def test_single_page_fresh_result_is_flagged_single_page():
+    # task-28016: one full page (total <= page_size) is a single page, so the
+    # media canvas can drop the "Page 1 of 1" / boundary-reason chrome.
+    display = _fresh_display(applied_page=1, requested_page=1, total=3, row_count=3)
+
+    assert display.single_page is True
+    assert display.page_copy == "Page 1 of 1"
+
+
+def test_empty_fresh_result_is_flagged_single_page():
+    display = _fresh_display(applied_page=1, requested_page=1, total=0, row_count=0)
+
+    assert display.single_page is True
+
+
+def test_multi_page_result_is_not_single_page():
+    # _fresh_display defaults to 45 rows over a 20-row page (3 pages).
+    assert _fresh_display().single_page is False
+
+
+def test_loading_single_page_is_not_flagged_single_page():
+    display = _fresh_display(
+        applied_page=1, requested_page=2, total=3, row_count=3, loading=True
+    )
+
+    assert display.single_page is False
+
+
+def test_uninitialized_state_is_not_flagged_single_page():
+    display = build_library_pager_display(
+        applied_page=None,
+        requested_page=1,
+        page_size=20,
+        row_count=0,
+        total=None,
+        freshness="uninitialized",
+    )
+
+    assert display.single_page is False
+
+
 def test_successfully_empty_collection_is_not_uninitialized():
     display = _fresh_display(
         applied_page=1,

--- a/Tests/UI/test_library_media_side_by_side.py
+++ b/Tests/UI/test_library_media_side_by_side.py
@@ -1289,6 +1289,27 @@ async def test_compact_media_pager_receipt_and_empty_states_remain_contained() -
         assert not empty_screen.query("#library-media-pager")
 
 
+@pytest.mark.asyncio
+async def test_single_page_media_list_drops_pager_boundary_noise() -> None:
+    # task-28016: one page of results has nowhere to page to, so the
+    # "Page 1 of 1" counter and the boundary reasons ("Already on the first
+    # page.", "No more results.") are suppressed; the item range stays and the
+    # (disabled) controls remain so nothing shifts once a second page exists.
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items(3))
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=WIDE_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        status = await _wait_for_selector(
+            screen, pilot, "#library-media-page-status"
+        )
+        assert str(status.renderable) == "1-3 of 3"
+        assert not screen.query("#library-media-disabled-reason")
+        assert screen.query_one("#library-media-next", Button).disabled is True
+        assert screen.query_one("#library-media-previous", Button).disabled is True
+
+
 # ---------------------------------------------------------------------------
 # The wide-only detail placeholder (Collections' detail-pane grammar).
 # ---------------------------------------------------------------------------

--- a/backlog/tasks/task-28014 - Library-rail-media-counts-stale-after-Trash-restore.md
+++ b/backlog/tasks/task-28014 - Library-rail-media-counts-stale-after-Trash-restore.md
@@ -4,6 +4,7 @@ title: Library rail - media counts stale after Trash restore
 status: To Do
 assignee: []
 created_date: '2026-09-02 04:11'
+updated_date: '2026-09-02 21:08'
 labels:
   - library
   - bug
@@ -25,3 +26,9 @@ Re-verified 2026-09-02 live on dev tip (worktree media-ux-fixes @ b7e89b6de, tmu
 - [ ] #1 Rail media count and Details tally match the canvas immediately after restore and other Trash mutations
 - [ ] #2 A pinning test covers the restore-count path
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RECON (not started — needs reproduction-based debugging): rail/Details count = cached _local_source_counts['media'] (delta-mutated, not a live query). Delete = unconditional -1 (library_screen.py:42135/27367) + refresh_normal_media=True -> authoritative controller.request. Restore (_restore_library_media_from_trash ~28118) = GUARDED +1 behind 'if _source_record_id(restored_record) not in existing_ids' + refresh_normal_media=False (defers canvas to manual Retry, which never writes _local_source_counts). CAVEAT: static analysis does NOT cleanly explain the 'rail stuck low' symptom -- the restore summary emits id as a BARE INT (_validated_library_media_trash_restore_summary:17963 {'id': restored_id:int}) while _local_source_records use canonical 'local:media:N' strings, so _source_record_id(restored)='5' should NOT match existing {'local:media:5'} -> guard TRUE -> +1 SHOULD fire (opposite of symptom). Needs a reproduction test driving delete->restore that asserts _local_source_counts['media'] to see the real mechanism before fixing. Sibling _undo_library_media_bulk_delete (~27547) has the same guarded-increment pattern. Only existing test (test_library_media_trash.py:1771) asserts nothing about the count.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28015 - Library-media-Trash-Restore-action-renders-detached-far-below-the-item-row.md
+++ b/backlog/tasks/task-28015 - Library-media-Trash-Restore-action-renders-detached-far-below-the-item-row.md
@@ -4,6 +4,7 @@ title: Library media Trash - Restore action renders detached far below the item 
 status: To Do
 assignee: []
 created_date: '2026-09-02 04:11'
+updated_date: '2026-09-02 21:08'
 labels:
   - library
   - bug
@@ -25,3 +26,9 @@ Re-verified 2026-09-02 live on dev tip (worktree media-ux-fixes @ b7e89b6de, tmu
 - [ ] #1 Restore is visually associated with the trashed item list (no dead gap)
 - [ ] #2 A keyboard path from a trash row to Restore exists
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RECON (not started — layout geometry + a11y): AC#1 (Restore not detached from the row list) is caused by the deliberate 'height: 1fr' on #library-media-trash-list (library_media_trash_canvas.py:361) which fills all available height even with few rows, docking the pager+Restore controls at the panel bottom with a big gap. The 1fr was chosen (comment :353-360) so a 200-item trash page does not push controls off a 24-row terminal. Fix is 'auto up to available' (height:auto + max_height bounded so it scrolls only when tall) -- same class as deferred 28010, needs LIVE geometry verification (the L3a clipping lesson / geometry-pilot rule), not a blind CSS edit. AC#2 (keyboard path from a trash row to Restore) needs a binding/focus-order addition. Recommend pairing with 28010's viewer scroll-model work.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28016 - Library-media-list-suppress-pager-chrome-on-single-page-results.md
+++ b/backlog/tasks/task-28016 - Library-media-list-suppress-pager-chrome-on-single-page-results.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-28016
 title: Library media list - suppress pager chrome on single-page results
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-02 04:11'
+updated_date: '2026-09-02 21:06'
 labels:
   - library
   - media-ux
@@ -22,6 +23,12 @@ With three items, the list still renders the full pager including the lines Alre
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Single-page results show no pager status noise
-- [ ] #2 The pager appears when a second page exists
+- [x] #1 Single-page results show no pager status noise
+- [x] #2 The pager appears when a second page exists
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a single_page flag to LibraryPagerDisplay (fresh, non-loading, one page) and used it in the media canvas _compose_pager to drop the 'Page 1 of 1' counter and the boundary reasons ('Already on the first page.', 'No more results.') on single-page results -- keeping the item range and the (disabled) controls so nothing shifts once a second page exists. Files: Library/library_pager_state.py, Widgets/Library/library_media_canvas.py; tests in Tests/Library/test_library_pager_state.py + Tests/UI/test_library_media_side_by_side.py. Note: the range line ('1-3 of 3') is retained (it is informative, not the noise the task named); AC#2 is satisfied as a regression guard -- multi-page pagers are unaffected.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28017 - Library-import-run-level-jump-to-the-imported-items.md
+++ b/backlog/tasks/task-28017 - Library-import-run-level-jump-to-the-imported-items.md
@@ -4,6 +4,7 @@ title: Library import - run-level jump to the imported items
 status: To Do
 assignee: []
 created_date: '2026-09-02 04:11'
+updated_date: '2026-09-02 21:07'
 labels:
   - library
   - media-ux
@@ -25,3 +26,9 @@ Completing an import leaves the user on the Import canvas; new items are reachab
 - [ ] #1 A completed run offers one action that lands the user in the media list showing the run's items
 - [ ] #2 Per-row links keep working
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RECON (not started — bigger than polish): filtering the media list to a run's exact items needs an id-set filter added to MediaBrowseScope (Library/library_media_state.py) threaded through LibraryMediaBrowseController._search -> service.search_media, which has no id-list param today. The per-row 'Open in Library' (handle_library_ingest_open -> _open_job_in_library -> _navigate_to_media) opens the SINGLE-item viewer, not a scoped list. Run->media-ids exists only per-job (ingest_jobs.batch_id + media_id in Library_Ingest_Jobs_DB) with no query that consumes it. Natural anchor for the action: the run-group header in library_ingest_canvas.py (IngestQueueGroup.batch_id/job_ids). Lazy alt: switch to the media list on default last_modified_desc so the fresh run floats to top (skips new filter code; fails if user re-sorted or concurrent edits interleave).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28018 - Library-import-point-the-no-provider-analysis-hint-at-Settings-instead-of-raw-config.md
+++ b/backlog/tasks/task-28018 - Library-import-point-the-no-provider-analysis-hint-at-Settings-instead-of-raw-config.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-02 04:11'
+updated_date: '2026-09-02 21:07'
 labels:
   - library
   - media-ux
@@ -27,3 +28,9 @@ The pre-Start hint reads: Set provider under [analysis_defaults] in your config 
 - [ ] #1 The hint names the in-app Settings location for configuring the analysis provider
 - [ ] #2 Wording is verified against the actual Settings IA
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RECON (not started — blocked/feature): there is NO in-app Settings control for the ingest analysis provider. analysis_defaults is not referenced anywhere under UI/; the Import canvas has an 'Analyze after import' toggle but no provider picker. So AC#1 ('name the in-app Settings location') cannot be satisfied as filed -- the location does not exist. Real fixes: (a) add a Settings control for [analysis_defaults] provider, then point the hint at it; or (b) fall back to the user's configured chat/default provider when analysis_defaults is unset (a behavior change with cost implications -- wants product sign-off). Hint source: Library/ingest_analysis.py:163-190 (two hints, both instruct raw [analysis_defaults] TOML editing).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28019 - First-run-wizard-offer-a-media-first-path.md
+++ b/backlog/tasks/task-28019 - First-run-wizard-offer-a-media-first-path.md
@@ -4,6 +4,7 @@ title: First-run wizard - offer a media-first path
 status: To Do
 assignee: []
 created_date: '2026-09-02 04:11'
+updated_date: '2026-09-02 21:07'
 labels:
   - onboarding
   - media-ux
@@ -28,3 +29,9 @@ Re-verified 2026-09-02: wizard is now six steps (Welcome/Provider/Model/Voice/Pr
 - [ ] #2 Skipping remains one gesture
 - [ ] #3 Startup modals do not interrupt the user's first navigation
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RECON (attempted, then DEFERRED — the "contained" placement is not actually contained): the routing works cleanly — a Summary-step "Import" exit button -> _finish(TAB_INGEST) + the app-side completed-exit gate (_handle_first_run_wizard_result) accepting TAB_INGEST alongside TAB_CHAT/TAB_HOME navigates correctly (verified by a unit test). BUT a FOURTH action button does not fit the Summary step's docked `.setup-summary-actions` row at the wizard's tested 80x24 budget: "Review provider setup" (21 chars) + 3 more actions + the wizard's border/padding exceed 80 cols, so Textual truncates the last label ("Review setti"). Tried min-width:0 (buttons size to label — helped but not enough), compact buttons, and tightened row padding/margin; none fit four full labels because the existing "Review provider setup" is the long pole and is not this task's label to change. A clean fix needs a DIFFERENT placement (a Welcome-step media/import track, or a summary-body affordance) — a design decision, not a drop-in. `test_summary_three_actions_visible_and_focused_on_full_track[size0=(80,24)]` enforces all actions painted at 80x24 and is the guardrail to respect. AC#3 (startup consent modal) remains a separate startup-sequencing concern (see the recon in the original filing).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28021 - Library-media-viewer-match-count-and-highlight-undercount-multiple-matches-per-line.md
+++ b/backlog/tasks/task-28021 - Library-media-viewer-match-count-and-highlight-undercount-multiple-matches-per-line.md
@@ -6,6 +6,7 @@ title: >-
 status: To Do
 assignee: []
 created_date: '2026-09-02 04:11'
+updated_date: '2026-09-02 21:07'
 labels:
   - library
   - bug
@@ -28,3 +29,9 @@ find_content_matches reports a line at most once and the raw-mode highlighter st
 - [ ] #2 All occurrences on a line are highlighted in raw mode
 - [ ] #3 Rendered mode either highlights matches or states why it cannot
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RECON (not started — split by AC): AC#2 (highlight ALL occurrences per line in raw mode) is CONTAINED to library_media_raw_view.py (_hit_for_line returns all offsets; loop stylize in render_line) + flip Tests/Library/test_library_media_raw_view.py::test_highlight_styles_only_the_first_occurrence_on_a_wrapped_line. AC#3 (rendered/Markdown mode) is DOCUMENT-ONLY ('states why it cannot'): sync_search targets the raw widget only; Textual Markdown exposes no per-source-line span-styling API. AC#1 (coherent 'Match X of Y' occurrence count) is NOT contained: find_content_matches returns LINE indices (each line once); making the count occurrence-accurate while Prev/Next stay per-line yields an incoherent X-of-Y in different units. Coherent count forces per-occurrence navigation -> change the primitive's return type (tuple[int,...] -> (line,col)) rippling through ~8 sites/4 files (screen memo+advance+scroll, viewer compose x2, sync signatures, set_match_lines/_hit_for_line, _status_text) + flip Tests/Library/test_library_media_viewer_state.py + test_library_media_content.py + test_library_media_reader_match_nav_t22209.py. Recommend own PR.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28022 - Command-palette-near-duplicate-Library-entries-invite-off-by-one-selection.md
+++ b/backlog/tasks/task-28022 - Command-palette-near-duplicate-Library-entries-invite-off-by-one-selection.md
@@ -4,6 +4,7 @@ title: Command palette - near-duplicate Library entries invite off-by-one select
 status: To Do
 assignee: []
 created_date: '2026-09-02 04:11'
+updated_date: '2026-09-02 21:08'
 labels:
   - ux
 dependencies: []
@@ -26,3 +27,9 @@ Also from the 2026-09-02 run: no palette command reaches the media Trash view at
 - [ ] #1 A library query presents visually distinct, deduplicated choices
 - [ ] #2 The most common destination ranks first
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+RECON (not started — cross-provider palette curation): the near-duplicate entries come from 3 providers in app.py: TabNavigationProvider ('Tab Navigation: Switch to Library' + LIBRARY_SUBROUTE_COMMANDS 'Library — Skills'), MediaProvider ('Media & Content: Open Media Library'->TAB_MEDIA, 'Import New Media'->TAB_INGEST, 'Search Transcripts'->TAB_SEARCH), LibraryIngestProvider ('Library: Import…'->ingest). Redundancy: 'Import New Media' and 'Library: Import…' both open the import experience. AC#2 ('most common destination ranks first') needs cross-provider score influence (palette merges hits by score). The second concern ('no palette command reaches media Trash') is a NEW command to ADD, not dedup. Labels are PINNED by Tests/UI/test_command_palette_providers.py (503 'Switch to Library' fuzzy-match, 796-797 MediaProvider labels, 850/861 'Library: Import…'). Own PR.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/library_pager_state.py
+++ b/tldw_chatbook/Library/library_pager_state.py
@@ -25,6 +25,10 @@ class LibraryPagerDisplay:
     previous_reason: str
     next_reason: str
     retry_visible: bool
+    #: task-28016: a fresh, non-loading result that fits one page. Sources may
+    #: use it to drop pager chrome (Page 1 of 1, boundary reasons) that is pure
+    #: noise when there is nowhere to page to.
+    single_page: bool = False
 
 
 def build_library_pager_display(
@@ -99,6 +103,7 @@ def build_library_pager_display(
     if loading and error_copy:
         raise ValueError("loading and error_copy cannot both be set")
 
+    single_page = False
     if freshness == "fresh":
         if applied_page is None or total is None:
             raise ValueError("fresh state requires applied_page and total")
@@ -107,6 +112,7 @@ def build_library_pager_display(
         if requested_page != applied_page and not (loading or error_copy):
             raise ValueError("idle fresh state requires matching pages")
         total_pages = max(1, (total + page_size - 1) // page_size)
+        single_page = not loading and not error_copy and total_pages == 1
         if applied_page > total_pages:
             raise ValueError("applied_page exceeds the final page")
         expected_rows = min(page_size, max(0, total - (applied_page - 1) * page_size))
@@ -171,4 +177,5 @@ def build_library_pager_display(
         previous_reason=previous_reason,
         next_reason=next_reason,
         retry_visible=not loading and (bool(error_copy) or freshness == "stale"),
+        single_page=single_page,
     )

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -794,21 +794,33 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
 
     def _compose_pager(self, pager: LibraryPagerDisplay) -> ComposeResult:
         """Render the controller-owned Media pager below the row viewport."""
-        disabled_reasons = tuple(
-            dict.fromkeys(
-                reason
-                for disabled, reason in (
-                    (pager.previous_disabled, pager.previous_reason),
-                    (pager.next_disabled, pager.next_reason),
+        # task-28016: a single-page result has nowhere to page to, so the
+        # "Page 1 of 1" counter and the boundary reasons ("Already on the
+        # first page.", "No more results.") are pure noise. Show only the item
+        # range and keep the (disabled) controls; both return the moment a
+        # second page exists.
+        disabled_reasons = (
+            ()
+            if pager.single_page
+            else tuple(
+                dict.fromkeys(
+                    reason
+                    for disabled, reason in (
+                        (pager.previous_disabled, pager.previous_reason),
+                        (pager.next_disabled, pager.next_reason),
+                    )
+                    if disabled and reason
                 )
-                if disabled and reason
             )
+        )
+        status_parts = (
+            (pager.range_copy,)
+            if pager.single_page
+            else (pager.range_copy, pager.page_copy)
         )
         with Vertical(id="library-media-pager", classes="library-source-pager"):
             yield Static(
-                " · ".join(
-                    copy for copy in (pager.range_copy, pager.page_copy) if copy
-                ),
+                " · ".join(copy for copy in status_parts if copy),
                 id="library-media-page-status",
                 classes="library-source-pager-status",
                 markup=False,


### PR DESCRIPTION
## What

**task-28016** — a single-page media list stops rendering pager noise. A `single_page` flag on `LibraryPagerDisplay` (fresh, non-loading, one page) lets the media canvas drop the "Page 1 of 1" counter and the boundary reasons ("Already on the first page.", "No more results.") when there is nowhere to page to. The item range and the (disabled) controls stay, so nothing shifts the moment a second page exists.

## Why just this one

The user picked the "P2 polish batch" (28014–28022) expecting low-risk contained fixes. Reconciling each item against the current dev tip (with focused recon) showed that **only 28016 is genuinely contained** — the rest each turned out bigger than polish:

- **28014** (rail count after restore) — the "rail stuck low" symptom isn't explained by static analysis (the restore record's id shape means the dedup guard should *fire* the +1); needs reproduction-based debugging.
- **28015** (Trash Restore detached) — a `height: 1fr` fill; needs live geometry verification (like the deferred 28010) plus an a11y binding.
- **28017** (import → media-list jump) — needs an id-set filter threaded through `MediaBrowseScope` → `search_media`; no such filter exists.
- **28018** (analysis hint → Settings) — there is **no in-app Settings control** for the analysis provider; needs a new control or a chat-provider fallback.
- **28019** (wizard media-first path) — the routing works, but a fourth action button doesn't fit the wizard Summary's docked row at the tested 80×24 budget; needs a different placement (a design decision).
- **28021** (match undercount) — a coherent occurrence count requires restructuring the line-indexed match model through ~8 sites / 4 files.
- **28022** (palette near-duplicates) — cross-provider curation + a new Trash command + ranking; labels are pinned by `test_command_palette_providers.py`.

Each of those tasks now carries a detailed reconnaissance note describing exactly what it needs, so the analysis isn't lost. Rather than rush guessed fixes into a polish PR, they're left for a follow-up decision.

## Changes

- `Library/library_pager_state.py` — `single_page` field + derivation (fresh, non-loading, `total_pages == 1`).
- `Widgets/Library/library_media_canvas.py` — `_compose_pager` suppresses `page_copy` and the boundary-reason line on a single page.

## Tests

- `Tests/Library/test_library_pager_state.py` — `single_page` derivation (single/empty/multi/loading/uninitialized).
- `Tests/UI/test_library_media_side_by_side.py` — a single-page list drops the noise, keeps the range and the disabled controls; the receipt/empty/multi-page cases stay green.

No new logging; derived-artifact checks (diagnostic inventory, CSS bundle, backlog IDs) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses pager noise on single-page media lists (task-28016). A one-page result no longer shows "Page 1 of 1" or the boundary reasons ("Already on the first page.", "No more results."); the item range and disabled controls stay, and multi-page results are unchanged.

- Adds a `single_page` flag to `LibraryPagerDisplay`, set when the result is fresh, not loading, and fits one page.
- Records reconnaissance notes on tasks 28014, 28015, and 28017-28022 explaining why each is bigger than a contained polish fix and what it needs.

<sup>Written for commit 08cf7e81e1958f804fcde7a9a32fd488bbc8aa1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

