### PR TITLE
style(chat): clean citation Ruff formatter debt

### DIFF
--- a/Docs/superpowers/plans/2026-09-02-task-26944-ruff-chat-citations.md
+++ b/Docs/superpowers/plans/2026-09-02-task-26944-ruff-chat-citations.md
@@ -1,0 +1,292 @@
+# TASK-26944 Ruff Chat Citations Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove Ruff 0.15.22 formatter debt from the three `ruff-chat-citations` paths while proving Python semantics and comment attachment are unchanged.
+
+**Architecture:** Reconcile the manifest-owned paths after a fresh `origin/dev` rebase, capture pre-format structure with a one-time standard-library guard in `/tmp`, and format only the reconciled owned set. Compare post-format structure, run direct citation tests and repository governance checks, then close the Backlog task with exact evidence.
+
+**Tech Stack:** Python 3.12.11 standard library (`ast`, `tokenize`, `json`, `hashlib`), Ruff 0.15.22, pytest, Git, Backlog.md CLI
+
+---
+
+## File Map
+
+- Modify: `Tests/Chat/test_citation_service_factory.py` — Ruff-generated layout only.
+- Modify: `Tests/Chat/test_citation_trace_builder.py` — Ruff-generated layout only while retaining seven inline `# type: ignore[...]` directives.
+- Modify: `tldw_chatbook/Chat/citation_trace_builder.py` — Ruff-generated production layout only.
+- Modify: `backlog/tasks/task-26944 - Clean Ruff formatter debt for ruff-chat-citations.md` — plan, acceptance evidence, and closeout state.
+- Create: `Docs/superpowers/plans/2026-09-02-task-26944-ruff-chat-citations.md` — executable implementation plan.
+- Ephemeral only: `/tmp/task26944_paths.txt`, `/tmp/task26944_format_guard.py`, and `/tmp/task26944_before.json` — reconciled input manifest and uncommitted invariant capture.
+
+No production helper, dependency, test module, schema, or ADR is added.
+
+### Task 1: Rebase, Reconcile, and Capture the Baseline
+
+**Files:**
+
+- Inspect: `Docs/superpowers/reviews/evidence/task-26000/ruff-formatter-debt.json`
+- Inspect: the three assigned Python paths
+- Create outside repository: `/tmp/task26944_paths.txt`
+- Create outside repository: `/tmp/task26944_format_guard.py`
+- Create outside repository: `/tmp/task26944_before.json`
+
+- [ ] **Step 1: Verify the pinned toolchain**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c 'import sys; assert sys.version_info[:3] == (3, 12, 11), sys.version'
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c 'import subprocess; actual = subprocess.check_output(["/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python", "-m", "ruff", "--version"], text=True).strip(); assert actual == "ruff 0.15.22", actual'
+```
+
+Expected: both commands exit 0. Any mismatch blocks capture and formatting.
+
+- [ ] **Step 2: Refresh and rebase the isolated branch**
+
+Run:
+
+```bash
+git status --short --branch
+git fetch origin dev
+git rebase origin/dev
+git rev-parse origin/dev
+git merge-base --is-ancestor origin/dev HEAD
+```
+
+Expected: the worktree is clean before the fetch; rebase succeeds; the final
+ancestry command exits 0. Record the fetched `origin/dev` SHA. Resolve only
+documentation conflicts owned by this task; stop on any Python-path conflict.
+
+- [ ] **Step 3: Reconcile the three manifest paths and freeze one input list**
+
+Run:
+
+```bash
+git diff --name-status --find-renames e555df102c950c29beed5e7119f433d35eee1f3c HEAD
+git ls-tree -r --name-only HEAD -- Tests/Chat/test_citation_service_factory.py Tests/Chat/test_citation_trace_builder.py tldw_chatbook/Chat/citation_trace_builder.py
+```
+
+The unrestricted rename-aware diff is required so a destination outside the three
+original path names cannot be missed. For any rename candidate, confirm lineage
+from the original blob/history and search all `TASK-26933`–`TASK-27015` task files
+for competing destination ownership.
+
+After reconciliation, create `/tmp/task26944_paths.txt` with `apply_patch`: one
+sorted, present effective-owned path per line. On the approved baseline it must
+contain exactly the original three paths. All later capture, Ruff, diff, and stage
+commands consume this one list. If the list changes, amend this plan and the task
+with the lineage and revised expected counts before continuing. If it is empty,
+stop and amend the task as a reconciled no-op; never invoke Ruff with no path.
+
+Run:
+
+```bash
+test -s /tmp/task26944_paths.txt
+xargs /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check < /tmp/task26944_paths.txt
+```
+
+Expected on the approved baseline: the manifest has three lines and Ruff reports
+that all three would be reformatted.
+
+- [ ] **Step 4: Reconfirm the focused baseline**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_citation_service_factory.py Tests/Chat/test_citation_trace_builder.py -q
+```
+
+Expected on the approved no-drift baseline: 57 tests pass. These test paths are
+the present test members of the reconciled list; amend the plan before proceeding
+if reconciliation changes either test path. Record warnings separately from the
+exit status.
+
+- [ ] **Step 5: Build the ephemeral invariant guard**
+
+Create `/tmp/task26944_format_guard.py` with no third-party imports and two CLI
+operations: `capture OUTPUT PATH...` and `compare BASELINE PATH...`. The capture
+must emit stable, sorted JSON containing, per path:
+
+- SHA-256 of the source bytes;
+- the `ast.dump(..., include_attributes=False)` after parsing with
+  `type_comments=True` and recursively replacing only every
+  `ast.TypeIgnore.lineno` with zero;
+- all `tokenize.COMMENT` strings in source order;
+- for inline `# noqa`, `# type: ignore`, and `# ruff:` directives, the deepest
+  spanning AST node's field/index route plus the number of significant tokens
+  preceding the comment in its logical statement;
+- for standalone Ruff directives, the preceding and following `ast.stmt`
+  field/index routes; and
+- for each non-nested `# fmt: off` / `# fmt: on` pair, the ordered field/index
+  routes of every enclosed AST node.
+
+Treat `ENCODING`, `NL`, `NEWLINE`, `INDENT`, `DEDENT`, `COMMENT`, and `ENDMARKER`
+as non-significant tokens. Fail on parse/tokenize errors, a missing or non-unique
+deepest anchor, or unmatched/nested format ranges. `compare` must recapture the
+current paths, ignore only source SHA-256, and exit nonzero with a per-field
+diagnostic if any structural/comment value differs.
+
+- [ ] **Step 6: Capture and sanity-check the baseline**
+
+Run:
+
+```bash
+test -s /tmp/task26944_paths.txt
+xargs /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python /tmp/task26944_format_guard.py capture /tmp/task26944_before.json < /tmp/task26944_paths.txt
+xargs /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python /tmp/task26944_format_guard.py compare /tmp/task26944_before.json < /tmp/task26944_paths.txt
+```
+
+Expected: both commands exit 0; the second reports all three paths structurally
+identical to the capture.
+
+### Task 2: Apply Ruff and Prove the Change
+
+**Files:**
+
+- Modify: `Tests/Chat/test_citation_service_factory.py`
+- Modify: `Tests/Chat/test_citation_trace_builder.py`
+- Modify: `tldw_chatbook/Chat/citation_trace_builder.py`
+
+- [ ] **Step 1: Format exactly the reconciled owned set**
+
+Run:
+
+```bash
+test -s /tmp/task26944_paths.txt
+xargs /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format < /tmp/task26944_paths.txt
+```
+
+Expected: Ruff reports three reformatted files. Do not hand-edit the result.
+
+- [ ] **Step 2: Compare semantic and comment evidence**
+
+Run:
+
+```bash
+test -s /tmp/task26944_paths.txt
+xargs /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python /tmp/task26944_format_guard.py compare /tmp/task26944_before.json < /tmp/task26944_paths.txt
+```
+
+Expected: exit 0 with equal AST, ordered comments, directive anchors, standalone
+directive placement, and format-range intervals for every path. On failure, stop;
+restore only the listed paths with
+`xargs git restore --source=HEAD -- < /tmp/task26944_paths.txt`, then investigate
+without editing around the guard.
+
+- [ ] **Step 3: Prove the Python diff is exactly owned**
+
+Run:
+
+```bash
+diff -u /tmp/task26944_paths.txt <(git diff --name-only -- '*.py')
+xargs git diff --stat -- < /tmp/task26944_paths.txt
+```
+
+Expected on the approved baseline: the sorted changed-Python output equals the
+three-line reconciled manifest. If reconciliation found an already-clean path,
+instead require the changed-Python output to be a subset of the manifest and
+record why equality is not expected.
+
+- [ ] **Step 4: Run Ruff verification**
+
+Run:
+
+```bash
+test -s /tmp/task26944_paths.txt
+xargs /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check < /tmp/task26944_paths.txt
+xargs /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check < /tmp/task26944_paths.txt
+```
+
+Expected: lint passes and Ruff reports three files already formatted.
+
+- [ ] **Step 5: Run focused and governance tests**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_citation_service_factory.py Tests/Chat/test_citation_trace_builder.py -q
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/CI/test_backlog_task_id_uniqueness.py -q
+git diff --check
+```
+
+Expected: 57 focused tests pass; the Backlog uniqueness test passes; Git reports
+no whitespace errors.
+
+- [ ] **Step 6: Self-review the formatter-only diff**
+
+Run:
+
+```bash
+xargs git diff --word-diff=porcelain -- < /tmp/task26944_paths.txt
+git status --short
+```
+
+Expected: only Ruff-generated layout changes are present; no token, string,
+comment, or behavior change appears.
+
+- [ ] **Step 7: Commit the Python formatting**
+
+Run:
+
+```bash
+xargs git add -- < /tmp/task26944_paths.txt
+git diff --cached --check
+git commit -m "style(chat): format citation helpers"
+```
+
+Expected: one commit containing only the three assigned Python paths.
+
+### Task 3: Close the Backlog Record
+
+**Files:**
+
+- Modify: `backlog/tasks/task-26944 - Clean Ruff formatter debt for ruff-chat-citations.md`
+
+- [ ] **Step 1: Record evidence and complete every acceptance criterion**
+
+Use `apply_patch` to check all eight criteria and add concise Implementation Notes
+containing the fetched/rebased SHA, reconciliation result, exact tool versions,
+invariant result, focused-test rationale, exact verification commands/results,
+Python changed-path proof, and the Python-formatting commit ID. State that no new
+ADR or lesson was required and list the modified files.
+
+- [ ] **Step 2: Mark the task Done through Backlog.md**
+
+Run:
+
+```bash
+backlog task edit 26944 -s Done
+backlog task 26944 --plain
+```
+
+Expected: the CLI reports `Done` and resolves the canonical task file. If the CLI
+normalizes the filename, restore the tracked canonical filename with `apply_patch`
+without changing task content, then rerun the view command.
+
+- [ ] **Step 3: Rerun closeout governance**
+
+Run:
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/CI/test_backlog_task_id_uniqueness.py -q
+git diff --check
+git status --short
+```
+
+Expected: the uniqueness test passes; no whitespace error exists; only the task
+record remains uncommitted.
+
+- [ ] **Step 4: Commit the closeout**
+
+Run:
+
+```bash
+git add 'backlog/tasks/task-26944 - Clean Ruff formatter debt for ruff-chat-citations.md'
+git diff --cached --check
+git commit -m "docs(task-26944): close Ruff citation cleanup"
+git status --short --branch
+```
+
+Expected: the closeout commit contains only the task record and the final worktree
+is clean.

--- a/Docs/superpowers/specs/2026-09-02-task-26944-ruff-chat-citations-design.md
+++ b/Docs/superpowers/specs/2026-09-02-task-26944-ruff-chat-citations-design.md
@@ -34,17 +34,26 @@ The isolated implementation branch starts from the fetched `origin/dev` revision
 - the `TASK-26000` manifest assigns the paths together with no captured conflict
   basis at its evidence pin.
 
-Before formatting, implementation rechecks the branch against current
-`origin/dev`. Any upstream deletion, rename, content change, or completed
-formatting is recorded in the task notes and reconciled mechanically. A path is
-never silently dropped or replaced by an unassigned path.
+Before formatting, implementation fetches `origin/dev`, records the fetched SHA,
+rebases the task branch onto it, and then reproduces Ruff status at the rebased
+head. Each original assigned path is compared with the `TASK-26000` evidence pin
+and traced through Git history so that unchanged paths, content changes, deletions,
+renames, and already-clean paths are explicit.
+
+That reconciliation produces an effective owned-path set. An unambiguous rename
+may replace its original path after the task record is amended with the lineage; a
+deleted path is recorded and has no formatter input; and an already-clean path
+remains owned and is still a valid Ruff input but need not produce a diff. An
+ambiguous rename or copy, an unassigned destination already owned elsewhere, or
+any other ownership ambiguity fails closed for user review. A path is never
+silently dropped and an unassigned path is never absorbed.
 
 ## Implementation
 
 Use the repository's pinned Ruff 0.15.22 through Python 3.12.11 to format exactly
-the three assigned paths in one invocation. Do not hand-edit the formatted Python
-output and do not add a dependency, production helper, or abstraction for this
-one-time cleanup.
+the present files in the reconciled owned-path set in one invocation. The Ruff
+input list must equal that set. Do not hand-edit the formatted Python output and do
+not add a dependency, production helper, or abstraction for this one-time cleanup.
 
 The task is a formatter-only maintenance change. The expected Python diff is
 layout-only. Any semantic or comment-invariant difference is a failure, not a
@@ -59,18 +68,22 @@ compare it with the same capture after formatting:
 2. Recursively normalize only `TypeIgnore.lineno`.
 3. Require identical `ast.dump(..., include_attributes=False)` output.
 4. Preserve ordered comment-token text.
-5. For inline `# noqa`, `# type: ignore`, and single-target Ruff directives,
-   preserve the deepest AST-node path and significant-token position to which the
-   comment is anchored.
+5. Express every AST-node path as a stable route of named AST fields and list
+   indexes from the module root. For each inline `# noqa`, `# type: ignore`, and
+   single-target Ruff directive, select the deepest node whose source span covers
+   the comment's physical line and record that route. Also record the comment's
+   significant-token ordinal within its containing logical statement as the
+   position tie-breaker. Require both values to remain equal.
 6. For standalone file directives, preserve the adjacent statement paths between
    which each directive appears.
 7. For every `# fmt: off` / `# fmt: on` pair, preserve the ordered AST-node
    interval enclosed by the pair.
 
 The capture can use an ephemeral script outside the repository. Only its result,
-commands, and relevant summary belong in the task notes. If an invariant differs,
-restore the affected Python path to the pre-format state and investigate before
-continuing.
+commands, and relevant summary belong in the task notes. Tokenization or parse
+errors, non-unique or missing anchors, and unmatched, nested, or otherwise invalid
+`fmt` ranges fail closed. If an invariant differs, restore the affected Python path
+to the pre-format state and investigate before continuing.
 
 ## Verification
 
@@ -80,12 +93,15 @@ After formatting, verify all of the following against the exact owned paths:
 - `ruff check` passes;
 - `ruff format --check` passes;
 - `pytest Tests/Chat/test_citation_service_factory.py Tests/Chat/test_citation_trace_builder.py`
-  passes because these are the direct tests for the production helper and the
-  batch's recorded focused-test surface;
+  passes because these are the two directly assigned test modules and exercise the
+  production helper; this is a proportionate narrowing from the manifest's broader
+  recorded `Tests/Chat` surface for a formatter-only change;
 - `pytest Tests/CI/test_backlog_task_id_uniqueness.py` passes;
 - `git diff --check` passes;
-- the changed-Python set is exactly the assigned set, with no unassigned Python
-  path; and
+- every formatter input equals a present path in the reconciled owned set, and the
+  changed-Python set is contained within that set; if reconciliation confirms all
+  three original paths still exist and fail at those paths, the changed-Python set
+  must equal the original three-path set; and
 - review of the Python diff confirms Ruff-generated layout changes only.
 
 The task does not require the repository-wide test suite: its only Python changes

--- a/Docs/superpowers/specs/2026-09-02-task-26944-ruff-chat-citations-design.md
+++ b/Docs/superpowers/specs/2026-09-02-task-26944-ruff-chat-citations-design.md
@@ -1,0 +1,115 @@
+# TASK-26944 Ruff Chat Citations Cleanup Design
+
+**Status:** proposed for implementation
+
+**Task:** `TASK-26944`
+
+## Goal
+
+Remove the Ruff 0.15.22 formatter debt in the `ruff-chat-citations` batch without
+changing Python behavior, comment meaning, or any Python file outside the batch.
+The cleanup stays within the ownership boundary established by `TASK-26000`.
+
+## Scope
+
+The only Python paths owned by this task are:
+
+- `Tests/Chat/test_citation_service_factory.py`
+- `Tests/Chat/test_citation_trace_builder.py`
+- `tldw_chatbook/Chat/citation_trace_builder.py`
+
+Task documentation and this design may also change. No other Python path is in
+scope. If completion appears to require another Python path or a hand-written
+behavior change, implementation stops and the task boundary is reconsidered.
+
+## Current Baseline and Reconciliation
+
+The isolated implementation branch starts from the fetched `origin/dev` revision
+`c7096ea1513539b124aa040d6a040a91bc7702d9`. At that revision:
+
+- all three assigned paths exist;
+- Ruff 0.15.22 reports that all three would be reformatted;
+- the two assigned test modules pass together: 57 tests passed, with one existing
+  dependency-version warning; and
+- the `TASK-26000` manifest assigns the paths together with no captured conflict
+  basis at its evidence pin.
+
+Before formatting, implementation rechecks the branch against current
+`origin/dev`. Any upstream deletion, rename, content change, or completed
+formatting is recorded in the task notes and reconciled mechanically. A path is
+never silently dropped or replaced by an unassigned path.
+
+## Implementation
+
+Use the repository's pinned Ruff 0.15.22 through Python 3.12.11 to format exactly
+the three assigned paths in one invocation. Do not hand-edit the formatted Python
+output and do not add a dependency, production helper, or abstraction for this
+one-time cleanup.
+
+The task is a formatter-only maintenance change. The expected Python diff is
+layout-only. Any semantic or comment-invariant difference is a failure, not a
+change to explain away.
+
+## Semantic and Comment Invariants
+
+Capture the following evidence from every assigned path before formatting and
+compare it with the same capture after formatting:
+
+1. Parse with Python 3.12.11 using `ast.parse(..., type_comments=True)`.
+2. Recursively normalize only `TypeIgnore.lineno`.
+3. Require identical `ast.dump(..., include_attributes=False)` output.
+4. Preserve ordered comment-token text.
+5. For inline `# noqa`, `# type: ignore`, and single-target Ruff directives,
+   preserve the deepest AST-node path and significant-token position to which the
+   comment is anchored.
+6. For standalone file directives, preserve the adjacent statement paths between
+   which each directive appears.
+7. For every `# fmt: off` / `# fmt: on` pair, preserve the ordered AST-node
+   interval enclosed by the pair.
+
+The capture can use an ephemeral script outside the repository. Only its result,
+commands, and relevant summary belong in the task notes. If an invariant differs,
+restore the affected Python path to the pre-format state and investigate before
+continuing.
+
+## Verification
+
+After formatting, verify all of the following against the exact owned paths:
+
+- the AST and comment evidence is equal before and after;
+- `ruff check` passes;
+- `ruff format --check` passes;
+- `pytest Tests/Chat/test_citation_service_factory.py Tests/Chat/test_citation_trace_builder.py`
+  passes because these are the direct tests for the production helper and the
+  batch's recorded focused-test surface;
+- `pytest Tests/CI/test_backlog_task_id_uniqueness.py` passes;
+- `git diff --check` passes;
+- the changed-Python set is exactly the assigned set, with no unassigned Python
+  path; and
+- review of the Python diff confirms Ruff-generated layout changes only.
+
+The task does not require the repository-wide test suite: its only Python changes
+are formatting in one production helper and its direct tests, and the focused
+tests exercise that behavior. Any failure is diagnosed before additional changes
+are made.
+
+## Closeout
+
+Once verification passes:
+
+- check every acceptance criterion in `TASK-26944`;
+- add concise Implementation Notes containing the reconciliation result, focused
+  test rationale, exact commands and results, invariant result, and files changed;
+- run a final self-review of the scoped diff; and
+- set `TASK-26944` to `Done` through the Backlog CLI, then verify that the
+  canonical task file and task-ID uniqueness remain intact.
+
+## ADR Check
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: this task mechanically applies the formatter-only contract and ownership
+boundary already established by `TASK-26000`. It introduces no storage, runtime,
+security, service, dependency, or long-lived UX decision.

--- a/Tests/Chat/test_citation_service_factory.py
+++ b/Tests/Chat/test_citation_service_factory.py
@@ -165,9 +165,7 @@ def test_enabled_factory_does_not_replace_missing_key_for_existing_rows(
         db,
         sidecar_path=tmp_path / "chat_rag_context.json",
         policy=CitationProvenanceRuntimePolicy(canonical_writes_enabled=True),
-        key_provider=KeyringCitationFingerprintKeyProvider(
-            keyring_backend=backend
-        ),
+        key_provider=KeyringCitationFingerprintKeyProvider(keyring_backend=backend),
     )
 
     assert repository.local_citation_writes_ready is False

--- a/Tests/Chat/test_citation_trace_builder.py
+++ b/Tests/Chat/test_citation_trace_builder.py
@@ -1113,16 +1113,13 @@ def test_initial_answer_records_known_repeated_and_unknown_occurrences() -> None
         StructuralValidationState.VALID,
         StructuralValidationState.UNKNOWN_MARKER,
     ]
-    assert [
-        (item.marker_start, item.marker_end) for item in attempt.occurrences
-    ] == [
+    assert [(item.marker_start, item.marker_end) for item in attempt.occurrences] == [
         (first_start, first_start + len("[S1]")),
         (repeated_start, repeated_start + len("[S1]")),
         (unknown_start, unknown_start + len("[S99]")),
     ]
     assert [
-        answer_body[item.marker_start : item.marker_end]
-        for item in attempt.occurrences
+        answer_body[item.marker_start : item.marker_end] for item in attempt.occurrences
     ] == ["[S1]", "[S1]", "[S99]"]
     assert all(
         item.marker_namespace is MarkerNamespace.CHATBOOK_S_V1

--- a/backlog/tasks/task-26944 - Clean Ruff formatter debt for ruff-chat-citations.md
+++ b/backlog/tasks/task-26944 - Clean Ruff formatter debt for ruff-chat-citations.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-26944
 title: Clean Ruff formatter debt for ruff-chat-citations
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-31 18:31'
-updated_date: '2026-09-02 19:56'
+updated_date: '2026-09-02 21:06'
 labels:
   - maintenance
   - formatting
@@ -42,18 +42,19 @@ Clean the `ruff-chat-citations` Ruff formatter batch at the owner boundary recor
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 After rebasing onto current `origin/dev`, reproduce and reconcile every TASK-26000 assigned path; if upstream deleted, renamed, modified, or already formatted it, record that lineage and amend ownership mechanically without silently dropping it or absorbing an unassigned path. <!-- TASK-26000-CONTRACT: rebase-reconcile --><!-- TASK-26000-CONTRACT: drift-reconciliation -->
-- [ ] #2 Run Ruff 0.15.22 formatting on only the assigned paths, with no unassigned Python path changed. <!-- TASK-26000-CONTRACT: assigned-paths-only -->
-- [ ] #3 Before and after formatting, parse each assigned file on Python 3.12.11 with `ast.parse(..., type_comments=True)`, normalize only `TypeIgnore.lineno`, and require equal `ast.dump(..., include_attributes=False)`. <!-- TASK-26000-CONTRACT: ast-type-comments -->
-- [ ] #4 Preserve ordered comment-token text; anchor inline `# noqa`, `# type: ignore`, and single-target Ruff directives to the same deepest AST-node path and significant-token position, preserve standalone file directives between the same adjacent statement paths, and require each `# fmt: off` / `# fmt: on` range to enclose the same ordered AST-node interval. <!-- TASK-26000-CONTRACT: comment-directives -->
-- [ ] #5 Ruff lint and `ruff format --check` pass on every touched Python path. <!-- TASK-26000-CONTRACT: ruff-checks -->
-- [ ] #6 Implementation Notes record the focused-test rationale and every exact test command/result. <!-- TASK-26000-CONTRACT: focused-tests -->
-- [ ] #7 `git diff --check` and `Tests/CI/test_backlog_task_id_uniqueness.py` pass. <!-- TASK-26000-CONTRACT: governance -->
-- [ ] #8 The diff contains no hand-written production behavior change. <!-- TASK-26000-CONTRACT: no-handwritten-behavior -->
+- [x] #1 After rebasing onto current `origin/dev`, reproduce and reconcile every TASK-26000 assigned path; if upstream deleted, renamed, modified, or already formatted it, record that lineage and amend ownership mechanically without silently dropping it or absorbing an unassigned path. <!-- TASK-26000-CONTRACT: rebase-reconcile --><!-- TASK-26000-CONTRACT: drift-reconciliation -->
+- [x] #2 Run Ruff 0.15.22 formatting on only the assigned paths, with no unassigned Python path changed. <!-- TASK-26000-CONTRACT: assigned-paths-only -->
+- [x] #3 Before and after formatting, parse each assigned file on Python 3.12.11 with `ast.parse(..., type_comments=True)`, normalize only `TypeIgnore.lineno`, and require equal `ast.dump(..., include_attributes=False)`. <!-- TASK-26000-CONTRACT: ast-type-comments -->
+- [x] #4 Preserve ordered comment-token text; anchor inline `# noqa`, `# type: ignore`, and single-target Ruff directives to the same deepest AST-node path and significant-token position, preserve standalone file directives between the same adjacent statement paths, and require each `# fmt: off` / `# fmt: on` range to enclose the same ordered AST-node interval. <!-- TASK-26000-CONTRACT: comment-directives -->
+- [x] #5 Ruff lint and `ruff format --check` pass on every touched Python path. <!-- TASK-26000-CONTRACT: ruff-checks -->
+- [x] #6 Implementation Notes record the focused-test rationale and every exact test command/result. <!-- TASK-26000-CONTRACT: focused-tests -->
+- [x] #7 `git diff --check` and `Tests/CI/test_backlog_task_id_uniqueness.py` pass. <!-- TASK-26000-CONTRACT: governance -->
+- [x] #8 The diff contains no hand-written production behavior change. <!-- TASK-26000-CONTRACT: no-handwritten-behavior -->
 <!-- AC:END -->
 
 ## Implementation Plan
 
+<!-- SECTION:PLAN:BEGIN -->
 ADR required: no
 
 ADR path: N/A
@@ -69,3 +70,63 @@ contract and introduces no architectural boundary or durable policy.
    layout-only change.
 4. Record exact evidence, check all acceptance criteria, set the task to `Done`,
    and commit the closeout.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Final base and lineage: fetched and rebased onto `origin/dev`
+  `985265b91f23540648f332316477112bee827127`; the rebased implementation head
+  before this closeout record was `de3c269fffa07b22133e38f87c0cc6bdaf1239b0`,
+  and `git merge-base --is-ancestor origin/dev HEAD` exited 0. The final rebase
+  retained the unrelated upstream Anthropic subscription, media-UX,
+  single-page-pager, TASK-25900 planning, console trace-compaction, and semantic
+  trace-ledger closeout, Library review-set phase-one, and MCP live-wiring
+  evidence commits; none touched the assigned paths. All three
+  original assigned paths still existed at their original names;
+  their blobs at
+  TASK-26000 pin `e555df102c950c29beed5e7119f433d35eee1f3c` equaled the blobs at the
+  formatting parent, proving no rename, deletion, or content drift before
+  formatting. Each path reproduced as a Ruff failure (`3 files would be
+  reformatted`).
+- Toolchain and formatter: Python 3.12.11 and Ruff 0.15.22. Ruff formatted exactly
+  the three manifest paths in commit
+  `de3c269fffa07b22133e38f87c0cc6bdaf1239b0` (`style(chat): format citation
+  helpers`, parent `eb930bae6473c003702dd03618ba49cb8dbede81`). Replaying Ruff 0.15.22
+  against those parent blobs produced byte-for-byte matches for all three
+  committed blobs; the rebased blobs also equal the accepted pre-rebase
+  formatting commit.
+- Semantic/comment guard: `xargs /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python /tmp/task26944_format_guard.py compare /tmp/task26944_before.json < /tmp/task26944_paths.txt`
+  reported `structural evidence matches for 3 paths`. The comparison preserved
+  the normalized type-comment AST, ordered comments, inline and standalone
+  directive anchors, and format-range node intervals; source SHA-256 alone was
+  excluded from equality.
+- Focused verification: the two directly assigned citation test modules exercise
+  the production citation trace helper and are a proportionate narrowing from
+  the recorded `Tests/Chat` surface for a formatter-only change.
+  `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test_citation_service_factory.py Tests/Chat/test_citation_trace_builder.py -q`
+  passed 57 tests. The non-blocking output comprised the existing
+  `RequestsDependencyWarning` and pytest temporary-directory cleanup warnings.
+- Ruff and governance verification:
+  `xargs /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check < /tmp/task26944_paths.txt`
+  reported `All checks passed!`;
+  `xargs /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff format --check < /tmp/task26944_paths.txt`
+  reported `3 files already formatted`;
+  `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/CI/test_backlog_task_id_uniqueness.py -q`
+  passed 3 tests; `git diff --check` and `git diff --cached --check` exited 0.
+  Comparing `/tmp/task26944_paths.txt` with both the formatting commit's changed
+  paths and `git diff --name-only origin/dev..HEAD -- '*.py'` produced empty
+  diffs, proving exactly the three assigned Python paths and no unassigned Python
+  path changed. Fetch also emitted the known non-blocking Git `gc.log` and
+  unreachable-loose-object housekeeping warning.
+- Added files: `Docs/superpowers/specs/2026-09-02-task-26944-ruff-chat-citations-design.md`
+  and `Docs/superpowers/plans/2026-09-02-task-26944-ruff-chat-citations.md`.
+- Modified files: `Tests/Chat/test_citation_service_factory.py`,
+  `Tests/Chat/test_citation_trace_builder.py`,
+  `tldw_chatbook/Chat/citation_trace_builder.py`, and
+  `backlog/tasks/task-26944 - Clean Ruff formatter debt for ruff-chat-citations.md`.
+- ADR required: no. ADR path: N/A. Reason: this applies the existing formatter-only
+  contract without changing architecture. No new lesson was required because no
+  new generalizable incident arose; the known Backlog CLI filename normalization
+  behavior is already covered by `backlog/docs/lessons-backlog-hygiene.md`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-26944 - Clean Ruff formatter debt for ruff-chat-citations.md
+++ b/backlog/tasks/task-26944 - Clean Ruff formatter debt for ruff-chat-citations.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-26944
 title: Clean Ruff formatter debt for ruff-chat-citations
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-08-31 18:31'
-updated_date: '2026-08-31 18:31'
+updated_date: '2026-09-02 19:56'
 labels:
   - maintenance
   - formatting
@@ -13,19 +14,20 @@ dependencies:
   - TASK-26000
 references:
   - Docs/superpowers/specs/2026-08-30-task-26000-ruff-formatter-debt-design.md
+  - Docs/superpowers/specs/2026-09-02-task-26944-ruff-chat-citations-design.md
   - Docs/superpowers/reviews/evidence/task-26000/ruff-formatter-debt.json
 priority: medium
 ---
-
-<!-- TASK-26000-BATCH: ruff-chat-citations -->
-<!-- TASK-26000-PATHS-SHA256: 6149803c4606eb131c95d8713504d1213a98aac1b4fc15f4fb5aea4fb9a73129 -->
-<!-- TASK-26000-FINAL: false -->
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
 Clean the `ruff-chat-citations` Ruff formatter batch at the owner boundary recorded as: Chat citation construction and trace helpers with direct tests.. The focused test surface recorded by TASK-26000 is `["Tests/Chat"]`.
 <!-- SECTION:DESCRIPTION:END -->
+
+<!-- TASK-26000-BATCH: ruff-chat-citations -->
+<!-- TASK-26000-PATHS-SHA256: 6149803c4606eb131c95d8713504d1213a98aac1b4fc15f4fb5aea4fb9a73129 -->
+<!-- TASK-26000-FINAL: false -->
 
 ## Assigned Paths
 
@@ -39,12 +41,12 @@ Clean the `ruff-chat-citations` Ruff formatter batch at the owner boundary recor
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] After rebasing onto current `origin/dev`, reproduce and reconcile every TASK-26000 assigned path; if upstream deleted, renamed, modified, or already formatted it, record that lineage and amend ownership mechanically without silently dropping it or absorbing an unassigned path. <!-- TASK-26000-CONTRACT: rebase-reconcile --><!-- TASK-26000-CONTRACT: drift-reconciliation -->
-- [ ] Run Ruff 0.15.22 formatting on only the assigned paths, with no unassigned Python path changed. <!-- TASK-26000-CONTRACT: assigned-paths-only -->
-- [ ] Before and after formatting, parse each assigned file on Python 3.12.11 with `ast.parse(..., type_comments=True)`, normalize only `TypeIgnore.lineno`, and require equal `ast.dump(..., include_attributes=False)`. <!-- TASK-26000-CONTRACT: ast-type-comments -->
-- [ ] Preserve ordered comment-token text; anchor inline `# noqa`, `# type: ignore`, and single-target Ruff directives to the same deepest AST-node path and significant-token position, preserve standalone file directives between the same adjacent statement paths, and require each `# fmt: off` / `# fmt: on` range to enclose the same ordered AST-node interval. <!-- TASK-26000-CONTRACT: comment-directives -->
-- [ ] Ruff lint and `ruff format --check` pass on every touched Python path. <!-- TASK-26000-CONTRACT: ruff-checks -->
-- [ ] Implementation Notes record the focused-test rationale and every exact test command/result. <!-- TASK-26000-CONTRACT: focused-tests -->
-- [ ] `git diff --check` and `Tests/CI/test_backlog_task_id_uniqueness.py` pass. <!-- TASK-26000-CONTRACT: governance -->
-- [ ] The diff contains no hand-written production behavior change. <!-- TASK-26000-CONTRACT: no-handwritten-behavior -->
+- [ ] #1 After rebasing onto current `origin/dev`, reproduce and reconcile every TASK-26000 assigned path; if upstream deleted, renamed, modified, or already formatted it, record that lineage and amend ownership mechanically without silently dropping it or absorbing an unassigned path. <!-- TASK-26000-CONTRACT: rebase-reconcile --><!-- TASK-26000-CONTRACT: drift-reconciliation -->
+- [ ] #2 Run Ruff 0.15.22 formatting on only the assigned paths, with no unassigned Python path changed. <!-- TASK-26000-CONTRACT: assigned-paths-only -->
+- [ ] #3 Before and after formatting, parse each assigned file on Python 3.12.11 with `ast.parse(..., type_comments=True)`, normalize only `TypeIgnore.lineno`, and require equal `ast.dump(..., include_attributes=False)`. <!-- TASK-26000-CONTRACT: ast-type-comments -->
+- [ ] #4 Preserve ordered comment-token text; anchor inline `# noqa`, `# type: ignore`, and single-target Ruff directives to the same deepest AST-node path and significant-token position, preserve standalone file directives between the same adjacent statement paths, and require each `# fmt: off` / `# fmt: on` range to enclose the same ordered AST-node interval. <!-- TASK-26000-CONTRACT: comment-directives -->
+- [ ] #5 Ruff lint and `ruff format --check` pass on every touched Python path. <!-- TASK-26000-CONTRACT: ruff-checks -->
+- [ ] #6 Implementation Notes record the focused-test rationale and every exact test command/result. <!-- TASK-26000-CONTRACT: focused-tests -->
+- [ ] #7 `git diff --check` and `Tests/CI/test_backlog_task_id_uniqueness.py` pass. <!-- TASK-26000-CONTRACT: governance -->
+- [ ] #8 The diff contains no hand-written production behavior change. <!-- TASK-26000-CONTRACT: no-handwritten-behavior -->
 <!-- AC:END -->

--- a/backlog/tasks/task-26944 - Clean Ruff formatter debt for ruff-chat-citations.md
+++ b/backlog/tasks/task-26944 - Clean Ruff formatter debt for ruff-chat-citations.md
@@ -15,6 +15,7 @@ dependencies:
 references:
   - Docs/superpowers/specs/2026-08-30-task-26000-ruff-formatter-debt-design.md
   - Docs/superpowers/specs/2026-09-02-task-26944-ruff-chat-citations-design.md
+  - Docs/superpowers/plans/2026-09-02-task-26944-ruff-chat-citations.md
   - Docs/superpowers/reviews/evidence/task-26000/ruff-formatter-debt.json
 priority: medium
 ---
@@ -50,3 +51,21 @@ Clean the `ruff-chat-citations` Ruff formatter batch at the owner boundary recor
 - [ ] #7 `git diff --check` and `Tests/CI/test_backlog_task_id_uniqueness.py` pass. <!-- TASK-26000-CONTRACT: governance -->
 - [ ] #8 The diff contains no hand-written production behavior change. <!-- TASK-26000-CONTRACT: no-handwritten-behavior -->
 <!-- AC:END -->
+
+## Implementation Plan
+
+ADR required: no
+
+ADR path: N/A
+
+Reason: this is a formatter-only application of the existing TASK-26000 cleanup
+contract and introduces no architectural boundary or durable policy.
+
+1. Fetch and rebase onto current `origin/dev`, reconcile every assigned path, and
+   capture the pre-format AST/comment evidence with the pinned toolchain.
+2. Run Ruff 0.15.22 on only the reconciled owned paths and require identical
+   semantic/comment evidence.
+3. Run the scoped Ruff, focused-test, governance, and diff checks; self-review the
+   layout-only change.
+4. Record exact evidence, check all acceptance criteria, set the task to `Done`,
+   and commit the closeout.

--- a/tldw_chatbook/Chat/citation_trace_builder.py
+++ b/tldw_chatbook/Chat/citation_trace_builder.py
@@ -635,17 +635,14 @@ class CitationTraceBuilder:
         if self._answer_attempts:
             raise ValueError("initial answer attempt is already recorded")
         if len(self._answer_attempts) >= ANSWER_ATTEMPTS_MAX:
-            raise ValueError(
-                f"answer attempts exceeds {ANSWER_ATTEMPTS_MAX} entries"
-            )
+            raise ValueError(f"answer attempts exceeds {ANSWER_ATTEMPTS_MAX} entries")
         if not isinstance(prompt_evidence_set_id, str):
             raise TypeError("prompt_evidence_set_id must be a string")
         if not isinstance(answer_body, str):
             raise TypeError("answer_body must be a string")
         if len(answer_body.encode("utf-8")) > ANSWER_ATTEMPT_BODY_UTF8_BYTES_MAX:
             raise ValueError(
-                "answer_body exceeds "
-                f"{ANSWER_ATTEMPT_BODY_UTF8_BYTES_MAX} UTF-8 bytes"
+                f"answer_body exceeds {ANSWER_ATTEMPT_BODY_UTF8_BYTES_MAX} UTF-8 bytes"
             )
         if not isinstance(completed_at, datetime):
             raise TypeError("completed_at must be a datetime")
@@ -662,9 +659,7 @@ class CitationTraceBuilder:
             raise ValueError("duplicate prompt evidence set reference")
         prompt_set = matching_prompt_sets[0]
         if completed_at < prompt_set.created_at:
-            raise ValueError(
-                "answer attempt cannot precede its prompt evidence set"
-            )
+            raise ValueError("answer attempt cannot precede its prompt evidence set")
         try:
             marker_spans = eligible_citation_marker_spans(
                 answer_body,
@@ -674,8 +669,7 @@ class CitationTraceBuilder:
         except ValueError:
             raise CitationTraceBuildUnavailable() from None
         evidence_by_marker = {
-            entry.marker_ordinal: entry.evidence_ordinal
-            for entry in prompt_set.entries
+            entry.marker_ordinal: entry.evidence_ordinal for entry in prompt_set.entries
         }
         occurrences = tuple(
             CitationOccurrence(
@@ -748,9 +742,7 @@ class CitationTraceBuilder:
 
     @staticmethod
     def _canonical_payload_bytes(
-        payload: EvidenceRunPayload
-        | EvidenceSnapshotPayload
-        | AnswerAttemptPayload,
+        payload: EvidenceRunPayload | EvidenceSnapshotPayload | AnswerAttemptPayload,
     ) -> int:
         return len(
             json.dumps(
@@ -773,9 +765,7 @@ class CitationTraceBuilder:
         if not self._evidence_runs:
             raise ValueError("citation trace requires at least one evidence run")
         if not self._prompt_evidence_sets:
-            raise ValueError(
-                "citation trace requires at least one prompt evidence set"
-            )
+            raise ValueError("citation trace requires at least one prompt evidence set")
         if not self._answer_attempts:
             raise ValueError("citation trace requires at least one answer attempt")
         selected_attempts = [
@@ -806,9 +796,7 @@ class CitationTraceBuilder:
                 if run is None:
                     raise ValueError("prompt entry references an unknown evidence run")
                 if run.ended_at is None:
-                    raise ValueError(
-                        "every evidence run requires ended_at before seal"
-                    )
+                    raise ValueError("every evidence run requires ended_at before seal")
                 if run.ended_at > prompt_set.created_at:
                     raise ValueError(
                         "prompt evidence set cannot precede its evidence run end"
@@ -832,11 +820,7 @@ class CitationTraceBuilder:
         lifecycle_boundaries = [
             self._created_at,
             *(run.started_at for run in self._evidence_runs),
-            *(
-                run.ended_at
-                for run in self._evidence_runs
-                if run.ended_at is not None
-            ),
+            *(run.ended_at for run in self._evidence_runs if run.ended_at is not None),
             *(prompt.created_at for prompt in self._prompt_evidence_sets),
             *(attempt.created_at for attempt in self._answer_attempts),
         ]
@@ -863,8 +847,7 @@ class CitationTraceBuilder:
             completeness_at_seal=CitationCompleteness.UNAVAILABLE,
         )
         snapshot_payload_index = {
-            payload.payload_id: payload
-            for payload in self._evidence_snapshot_payloads
+            payload.payload_id: payload for payload in self._evidence_snapshot_payloads
         }
         completeness = reduce_selected_attempt_completeness(
             provisional_trace,


### PR DESCRIPTION
## Summary

- format the three TASK-26944 citation helper and direct-test paths with Ruff 0.15.22
- preserve normalized AST, type-comment, ordered-comment, and directive-anchor invariants
- add the approved design and implementation plan, then close TASK-26944 with 8/8 acceptance criteria

## Verification

- Python 3.12.11 structural guard: 3 paths matched before and after formatting
- Ruff check: passed
- Ruff format --check: 3 files already formatted
- focused citation tests: 57 passed
- Backlog task-ID uniqueness tests: 3 passed
- git diff --check: passed

The repository-wide pytest sweep was not run, following the repository policy and approved focused scope for this formatter-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formats the three `ruff-chat-citations` Python paths with Ruff 0.15.22 and closes TASK-26944. The diff is layout-only; runtime behavior and source semantics are unchanged.

**Verification**

- Structural checks preserve the normalized AST, type comments, ordered comments, directive anchors, and `fmt` ranges.
- Ruff checks, 57 focused citation tests, 3 Backlog uniqueness tests, and `git diff --check` pass.
- TASK-26944 is marked Done with all eight acceptance criteria checked.
- The repository-wide pytest sweep was not run under the focused-test policy.

<sup>Written for commit d9a3d009032f5c8f4a2e91f3a0e7463968427b17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

