### PR TITLE
feat(library): review sets — approved design + phase 1 persistence (task-28024, task-28240)

### DIFF
--- a/Tests/DB/test_library_collections_capture_migration.py
+++ b/Tests/DB/test_library_collections_capture_migration.py
@@ -140,7 +140,7 @@ def test_fresh_database_creates_v1_compatibility_and_capture_v3(tmp_path: Path) 
 
     database = LibraryCollectionsDB(path)
 
-    assert database.get_schema_version() == 3
+    assert database.get_schema_version() == 4
     assert database.has_compatible_legacy_schema() is True
     database.require_capture_schema()
     objects = _schema_objects(path)
@@ -158,7 +158,7 @@ def test_real_v1_fixture_migrates_without_changing_legacy_values(tmp_path: Path)
 
     database = LibraryCollectionsDB(path)
 
-    assert database.get_schema_version() == 3
+    assert database.get_schema_version() == 4
     assert _legacy_rows(path) == before
     assert database.has_compatible_legacy_schema() is True
     database.require_capture_schema()
@@ -220,7 +220,7 @@ def test_two_concurrent_openers_publish_one_complete_v3_schema(tmp_path: Path) -
             for row in connection.execute(
                 "SELECT version FROM schema_version ORDER BY version"
             )
-        ] == [1, 3]
+        ] == [1, 4]
         assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
     assert CAPTURE_TABLES <= {
         name for kind, name in _schema_objects(path) if kind == "table"
@@ -235,7 +235,7 @@ def test_v3_reopen_is_idempotent(tmp_path: Path) -> None:
 
     second = LibraryCollectionsDB(path)
 
-    assert second.get_schema_version() == 3
+    assert second.get_schema_version() == 4
     assert _schema_objects(path) == before
     second.close()
 
@@ -244,7 +244,7 @@ def test_future_schema_is_refused_without_writing(tmp_path: Path) -> None:
     path = tmp_path / "collections.db"
     _create_v1_fixture(path)
     with _open(path) as connection:
-        connection.execute("INSERT INTO schema_version (version) VALUES (4)")
+        connection.execute("INSERT INTO schema_version (version) VALUES (5)")
     before_objects = _schema_objects(path)
     before_rows = _legacy_rows(path)
 
@@ -260,7 +260,7 @@ def test_future_schema_is_refused_without_writing(tmp_path: Path) -> None:
             for row in connection.execute(
                 "SELECT version FROM schema_version ORDER BY version"
             )
-        ] == [1, 4]
+        ] == [1, 5]
 
 
 def test_v2_processing_row_migrates_with_unowned_expired_lease(
@@ -271,7 +271,7 @@ def test_v2_processing_row_migrates_with_unowned_expired_lease(
 
     database = LibraryCollectionsDB(path)
 
-    assert database.get_schema_version() == 3
+    assert database.get_schema_version() == 4
     database.require_capture_schema()
     with database.connection() as connection:
         columns = {
@@ -296,7 +296,7 @@ def test_v2_processing_row_migrates_with_unowned_expired_lease(
         "extraction_lease_expires_at",
     } <= columns
     assert tuple(row) == ("processing", None, None)
-    assert versions == [1, 2, 3]
+    assert versions == [1, 2, 4]
     database.close()
 
 

--- a/Tests/Library/test_library_collections_service.py
+++ b/Tests/Library/test_library_collections_service.py
@@ -189,7 +189,7 @@ def test_collections_user_content_evidence_counts_only_active_local_collections(
 def test_schema_version_and_foreign_keys_are_initialized(tmp_path: Path) -> None:
     db = LibraryCollectionsDB(":memory:")
 
-    assert db.get_schema_version() == 3
+    assert db.get_schema_version() == 4
     with db.connection() as conn:
         assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
 

--- a/Tests/Library/test_review_set_service.py
+++ b/Tests/Library/test_review_set_service.py
@@ -1,0 +1,148 @@
+"""ReviewSetService persistence contract (task-28240).
+
+Uses a real file-backed LibraryCollectionsDB (the DB holds WAL + per-thread
+connections, so it is not an in-memory instance) under tmp_path. A deterministic
+id/clock keeps assertions stable. The Media-DB resolve is injected as an
+``is_live`` predicate so these tests stay free of the Media DB.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from tldw_chatbook.DB.Library_Collections_DB import LibraryCollectionsDB
+from tldw_chatbook.Library.review_set_service import ReviewSetService
+
+
+def _service(tmp_path) -> ReviewSetService:
+    db = LibraryCollectionsDB(tmp_path / "collections.db")
+    counter = itertools.count(1)
+    return ReviewSetService(
+        db,
+        id_factory=lambda: f"set-{next(counter)}",
+        now=lambda: "2026-09-02T00:00:00Z",
+    )
+
+
+_ALL_LIVE = lambda _backing_id: True  # noqa: E731
+
+
+def test_schema_upgrades_to_v4(tmp_path):
+    db = LibraryCollectionsDB(tmp_path / "collections.db")
+    assert db.get_schema_version() == 4
+
+
+def test_create_pins_ordered_items_and_activates(tmp_path):
+    svc = _service(tmp_path)
+    set_id = svc.create_review_set(
+        "Talks", origin="browse", items=[(10, "A"), (11, "B"), (12, "C")]
+    )
+
+    review_set = svc.get_review_set(set_id)
+    assert [item.backing_media_id for item in review_set.items] == [10, 11, 12]
+    assert [item.position for item in review_set.items] == [0, 1, 2]
+    assert review_set.cursor == 0
+    assert review_set.active is True
+    assert review_set.completed_at is None
+    assert all(item.done is False for item in review_set.items)
+
+
+def test_create_dedupes_by_backing_id_keeping_first(tmp_path):
+    svc = _service(tmp_path)
+    set_id = svc.create_review_set(
+        "Dupes", origin="selection", items=[(10, "A"), (11, "B"), (10, "A-again")]
+    )
+    review_set = svc.get_review_set(set_id)
+    assert [item.backing_media_id for item in review_set.items] == [10, 11]
+
+
+def test_create_deactivates_the_previous_active(tmp_path):
+    svc = _service(tmp_path)
+    first = svc.create_review_set("A", origin="browse", items=[(1, "a")])
+    second = svc.create_review_set("B", origin="browse", items=[(2, "b")])
+
+    assert svc.get_review_set(first).active is False
+    assert svc.get_review_set(second).active is True
+    assert svc.get_active_review_set().set_id == second
+
+
+def test_advance_persists_the_cursor(tmp_path):
+    svc = _service(tmp_path)
+    set_id = svc.create_review_set(
+        "X", origin="browse", items=[(1, "a"), (2, "b"), (3, "c")]
+    )
+
+    assert svc.advance(set_id, step=1, is_live=_ALL_LIVE) == 1
+    assert svc.get_review_set(set_id).cursor == 1
+    assert svc.advance(set_id, step=1, is_live=_ALL_LIVE) == 2
+    assert svc.get_review_set(set_id).cursor == 2
+
+
+def test_advance_skips_a_tombstoned_item(tmp_path):
+    svc = _service(tmp_path)
+    set_id = svc.create_review_set(
+        "X", origin="browse", items=[(1, "a"), (2, "b"), (3, "c")]
+    )
+    is_live = lambda backing_id: backing_id != 2  # noqa: E731
+
+    # From position 0, forward past the dead middle item -> position 2.
+    assert svc.advance(set_id, step=1, is_live=is_live) == 2
+    assert svc.get_review_set(set_id).cursor == 2
+
+
+def test_mark_done_then_completion_over_live_items(tmp_path):
+    svc = _service(tmp_path)
+    set_id = svc.create_review_set(
+        "X", origin="browse", items=[(1, "a"), (2, "b")]
+    )
+
+    svc.mark_item_done(set_id, backing_media_id=1, done=True)
+    assert svc.refresh_completion(set_id, is_live=_ALL_LIVE) is False
+    assert svc.get_review_set(set_id).completed_at is None
+
+    svc.mark_item_done(set_id, backing_media_id=2, done=True)
+    assert svc.refresh_completion(set_id, is_live=_ALL_LIVE) is True
+    assert svc.get_review_set(set_id).completed_at is not None
+
+
+def test_completion_ignores_a_tombstoned_unreviewed_item(tmp_path):
+    svc = _service(tmp_path)
+    set_id = svc.create_review_set("X", origin="browse", items=[(1, "a"), (2, "b")])
+    svc.mark_item_done(set_id, backing_media_id=1, done=True)
+
+    # item 2 is not done, but it is deleted -> the live set is all done.
+    is_live = lambda backing_id: backing_id != 2  # noqa: E731
+    assert svc.refresh_completion(set_id, is_live=is_live) is True
+
+
+def test_all_tombstoned_set_never_completes(tmp_path):
+    svc = _service(tmp_path)
+    set_id = svc.create_review_set("X", origin="browse", items=[(1, "a")])
+    svc.mark_item_done(set_id, backing_media_id=1, done=True)
+
+    assert svc.refresh_completion(set_id, is_live=lambda _b: False) is False
+    assert svc.get_review_set(set_id).completed_at is None
+
+
+def test_dismiss_soft_deletes_and_deactivates(tmp_path):
+    svc = _service(tmp_path)
+    set_id = svc.create_review_set("X", origin="browse", items=[(1, "a")])
+
+    svc.dismiss(set_id)
+    assert svc.get_active_review_set() is None
+    assert svc.list_review_sets() == ()
+    assert svc.get_review_set(set_id) is None  # dismissed sets are hidden
+
+
+def test_reopen_clears_completion(tmp_path):
+    svc = _service(tmp_path)
+    set_id = svc.create_review_set("X", origin="browse", items=[(1, "a")])
+    svc.mark_item_done(set_id, backing_media_id=1, done=True)
+    svc.refresh_completion(set_id, is_live=_ALL_LIVE)
+    assert svc.get_review_set(set_id).completed_at is not None
+
+    svc.reopen(set_id)
+    assert svc.get_review_set(set_id).completed_at is None
+    assert svc.get_review_set(set_id).items[0].done is True  # marks kept

--- a/Tests/Library/test_review_set_service.py
+++ b/Tests/Library/test_review_set_service.py
@@ -1,7 +1,7 @@
 """ReviewSetService persistence contract (task-28240).
 
-Uses a real file-backed LibraryCollectionsDB (the DB holds WAL + per-thread
-connections, so it is not an in-memory instance) under tmp_path. A deterministic
+Uses a real in-memory LibraryCollectionsDB (one held connection per test, so
+``:memory:`` persists across the service's transactions). A deterministic
 id/clock keeps assertions stable. The Media-DB resolve is injected as an
 ``is_live`` predicate so these tests stay free of the Media DB.
 """
@@ -16,8 +16,8 @@ from tldw_chatbook.DB.Library_Collections_DB import LibraryCollectionsDB
 from tldw_chatbook.Library.review_set_service import ReviewSetService
 
 
-def _service(tmp_path) -> ReviewSetService:
-    db = LibraryCollectionsDB(tmp_path / "collections.db")
+def _service() -> ReviewSetService:
+    db = LibraryCollectionsDB(":memory:")
     counter = itertools.count(1)
     return ReviewSetService(
         db,
@@ -29,13 +29,13 @@ def _service(tmp_path) -> ReviewSetService:
 _ALL_LIVE = lambda _backing_id: True  # noqa: E731
 
 
-def test_schema_upgrades_to_v4(tmp_path):
-    db = LibraryCollectionsDB(tmp_path / "collections.db")
+def test_schema_upgrades_to_v4():
+    db = LibraryCollectionsDB(":memory:")
     assert db.get_schema_version() == 4
 
 
-def test_create_pins_ordered_items_and_activates(tmp_path):
-    svc = _service(tmp_path)
+def test_create_pins_ordered_items_and_activates():
+    svc = _service()
     set_id = svc.create_review_set(
         "Talks", origin="browse", items=[(10, "A"), (11, "B"), (12, "C")]
     )
@@ -49,8 +49,49 @@ def test_create_pins_ordered_items_and_activates(tmp_path):
     assert all(item.done is False for item in review_set.items)
 
 
-def test_create_dedupes_by_backing_id_keeping_first(tmp_path):
-    svc = _service(tmp_path)
+def test_create_rejects_empty_items():
+    # task-28241 review: an empty set can't be navigated or completed, so it is
+    # never created (and never deactivates the current active set).
+    svc = _service()
+    existing = svc.create_review_set("Keep", origin="browse", items=[(1, "a")])
+    with pytest.raises(ValueError):
+        svc.create_review_set("Empty", origin="browse", items=[])
+    assert svc.get_active_review_set().set_id == existing  # unchanged
+
+
+def test_create_rejects_unknown_origin_and_blank_name():
+    svc = _service()
+    with pytest.raises(ValueError):
+        svc.create_review_set("X", origin="not-an-origin", items=[(1, "a")])
+    with pytest.raises(ValueError):
+        svc.create_review_set("   ", origin="browse", items=[(1, "a")])
+
+
+def test_activate_unknown_id_does_not_clear_the_active_set():
+    # task-28241 review: activating a stale/missing/dismissed id must not leave
+    # the app with no active set.
+    svc = _service()
+    active = svc.create_review_set("A", origin="browse", items=[(1, "a")])
+
+    svc.activate("does-not-exist")
+    assert svc.get_active_review_set().set_id == active
+
+    dismissed = svc.create_review_set("B", origin="browse", items=[(2, "b")])
+    svc.activate(active)  # back to A
+    svc.dismiss(dismissed)
+    svc.activate(dismissed)  # dismissed -> no-op, A stays active
+    assert svc.get_active_review_set().set_id == active
+
+
+def test_list_review_sets_respects_a_limit():
+    svc = _service()
+    for index in range(3):
+        svc.create_review_set(f"S{index}", origin="browse", items=[(index, "x")])
+    assert len(svc.list_review_sets(limit=2)) == 2
+
+
+def test_create_dedupes_by_backing_id_keeping_first():
+    svc = _service()
     set_id = svc.create_review_set(
         "Dupes", origin="selection", items=[(10, "A"), (11, "B"), (10, "A-again")]
     )
@@ -58,8 +99,8 @@ def test_create_dedupes_by_backing_id_keeping_first(tmp_path):
     assert [item.backing_media_id for item in review_set.items] == [10, 11]
 
 
-def test_create_deactivates_the_previous_active(tmp_path):
-    svc = _service(tmp_path)
+def test_create_deactivates_the_previous_active():
+    svc = _service()
     first = svc.create_review_set("A", origin="browse", items=[(1, "a")])
     second = svc.create_review_set("B", origin="browse", items=[(2, "b")])
 
@@ -68,8 +109,8 @@ def test_create_deactivates_the_previous_active(tmp_path):
     assert svc.get_active_review_set().set_id == second
 
 
-def test_advance_persists_the_cursor(tmp_path):
-    svc = _service(tmp_path)
+def test_advance_persists_the_cursor():
+    svc = _service()
     set_id = svc.create_review_set(
         "X", origin="browse", items=[(1, "a"), (2, "b"), (3, "c")]
     )
@@ -80,8 +121,8 @@ def test_advance_persists_the_cursor(tmp_path):
     assert svc.get_review_set(set_id).cursor == 2
 
 
-def test_advance_skips_a_tombstoned_item(tmp_path):
-    svc = _service(tmp_path)
+def test_advance_skips_a_tombstoned_item():
+    svc = _service()
     set_id = svc.create_review_set(
         "X", origin="browse", items=[(1, "a"), (2, "b"), (3, "c")]
     )
@@ -92,8 +133,8 @@ def test_advance_skips_a_tombstoned_item(tmp_path):
     assert svc.get_review_set(set_id).cursor == 2
 
 
-def test_mark_done_then_completion_over_live_items(tmp_path):
-    svc = _service(tmp_path)
+def test_mark_done_then_completion_over_live_items():
+    svc = _service()
     set_id = svc.create_review_set(
         "X", origin="browse", items=[(1, "a"), (2, "b")]
     )
@@ -107,8 +148,8 @@ def test_mark_done_then_completion_over_live_items(tmp_path):
     assert svc.get_review_set(set_id).completed_at is not None
 
 
-def test_completion_ignores_a_tombstoned_unreviewed_item(tmp_path):
-    svc = _service(tmp_path)
+def test_completion_ignores_a_tombstoned_unreviewed_item():
+    svc = _service()
     set_id = svc.create_review_set("X", origin="browse", items=[(1, "a"), (2, "b")])
     svc.mark_item_done(set_id, backing_media_id=1, done=True)
 
@@ -117,8 +158,8 @@ def test_completion_ignores_a_tombstoned_unreviewed_item(tmp_path):
     assert svc.refresh_completion(set_id, is_live=is_live) is True
 
 
-def test_all_tombstoned_set_never_completes(tmp_path):
-    svc = _service(tmp_path)
+def test_all_tombstoned_set_never_completes():
+    svc = _service()
     set_id = svc.create_review_set("X", origin="browse", items=[(1, "a")])
     svc.mark_item_done(set_id, backing_media_id=1, done=True)
 
@@ -126,8 +167,8 @@ def test_all_tombstoned_set_never_completes(tmp_path):
     assert svc.get_review_set(set_id).completed_at is None
 
 
-def test_dismiss_soft_deletes_and_deactivates(tmp_path):
-    svc = _service(tmp_path)
+def test_dismiss_soft_deletes_and_deactivates():
+    svc = _service()
     set_id = svc.create_review_set("X", origin="browse", items=[(1, "a")])
 
     svc.dismiss(set_id)
@@ -136,8 +177,8 @@ def test_dismiss_soft_deletes_and_deactivates(tmp_path):
     assert svc.get_review_set(set_id) is None  # dismissed sets are hidden
 
 
-def test_reopen_clears_completion(tmp_path):
-    svc = _service(tmp_path)
+def test_reopen_clears_completion():
+    svc = _service()
     set_id = svc.create_review_set("X", origin="browse", items=[(1, "a")])
     svc.mark_item_done(set_id, backing_media_id=1, done=True)
     svc.refresh_completion(set_id, is_live=_ALL_LIVE)

--- a/Tests/Library/test_review_set_state.py
+++ b/Tests/Library/test_review_set_state.py
@@ -1,0 +1,137 @@
+"""Pure cursor/progress logic for Library review sets (task-28240).
+
+These exercise the tombstone-aware navigation model with NO database: a set is
+a tuple of items plus a cursor, and an injected ``is_live`` predicate decides
+which pinned items still resolve against the Media DB. Progress and completion
+are always computed over LIVE items; the cursor is an absolute position that
+never renumbers.
+"""
+
+from __future__ import annotations
+
+from tldw_chatbook.Library.review_set_state import (
+    ReviewSetItem,
+    advance_cursor,
+    is_complete,
+    is_empty,
+    resolve_cursor,
+    review_progress,
+)
+
+
+def _items(*specs: tuple[int, bool]) -> tuple[ReviewSetItem, ...]:
+    """Build items from (backing_media_id, done) pairs; position = index."""
+    return tuple(
+        ReviewSetItem(
+            position=index,
+            backing_media_id=media_id,
+            title_snapshot=f"Item {media_id}",
+            done=done,
+        )
+        for index, (media_id, done) in enumerate(specs)
+    )
+
+
+def _live(*dead_ids: int):
+    """Return an is_live predicate where the named backing ids are tombstones."""
+    dead = set(dead_ids)
+    return lambda backing_media_id: backing_media_id not in dead
+
+
+# --- progress over live items ------------------------------------------------
+
+
+def test_progress_counts_live_items_and_reviewed():
+    items = _items((10, True), (11, False), (12, True))
+    progress = review_progress(items, cursor=1, is_live=_live())
+
+    assert progress.index == 2  # cursor item is the 2nd live item (1-based)
+    assert progress.total == 3
+    assert progress.reviewed == 2
+
+
+def test_progress_excludes_tombstones_from_total_and_ordinal():
+    # position 1 (id 11) is deleted; live items are positions 0 and 2.
+    items = _items((10, True), (11, False), (12, False))
+    progress = review_progress(items, cursor=2, is_live=_live(11))
+
+    assert progress.total == 2  # only 10 and 12 are live
+    assert progress.index == 2  # id 12 is the 2nd of the live items
+    assert progress.reviewed == 1  # only id 10 is live+done
+
+
+def test_progress_on_empty_set_is_zero():
+    items = _items((10, True), (11, False))
+    progress = review_progress(items, cursor=0, is_live=_live(10, 11))
+
+    assert progress == type(progress)(index=0, total=0, reviewed=0)
+
+
+# --- cursor resolution on a tombstone ---------------------------------------
+
+
+def test_resolve_cursor_on_a_tombstone_advances_to_next_live():
+    items = _items((10, False), (11, False), (12, False))
+    # cursor sits on the deleted middle item -> resolves forward to position 2.
+    assert resolve_cursor(items, cursor=1, is_live=_live(11)) == 2
+
+
+def test_resolve_cursor_falls_back_when_no_live_ahead():
+    items = _items((10, False), (11, False), (12, False))
+    # cursor on the last, which is dead; nothing live ahead -> nearest live back.
+    assert resolve_cursor(items, cursor=2, is_live=_live(12)) == 1
+
+
+def test_resolve_cursor_keeps_a_live_position():
+    items = _items((10, False), (11, False))
+    assert resolve_cursor(items, cursor=1, is_live=_live()) == 1
+
+
+# --- advancing, skipping tombstones -----------------------------------------
+
+
+def test_advance_forward_skips_a_tombstone():
+    items = _items((10, False), (11, False), (12, False))
+    # from position 0, forward, position 1 is dead -> land on position 2.
+    assert advance_cursor(items, cursor=0, step=1, is_live=_live(11)) == 2
+
+
+def test_advance_back_skips_a_tombstone():
+    items = _items((10, False), (11, False), (12, False))
+    assert advance_cursor(items, cursor=2, step=-1, is_live=_live(11)) == 0
+
+
+def test_advance_clamps_at_the_last_live_item():
+    items = _items((10, False), (11, False))
+    # already on the last live item; forward stays put.
+    assert advance_cursor(items, cursor=1, step=1, is_live=_live()) == 1
+
+
+def test_advance_clamps_at_the_first_live_item():
+    items = _items((10, False), (11, False))
+    assert advance_cursor(items, cursor=0, step=-1, is_live=_live()) == 0
+
+
+# --- completion vs empty -----------------------------------------------------
+
+
+def test_is_complete_when_every_live_item_is_done():
+    items = _items((10, True), (11, True))
+    assert is_complete(items, is_live=_live()) is True
+
+
+def test_is_complete_ignores_tombstoned_not_done_items():
+    # id 11 is not done, but it is deleted -> the live set (id 10) is all done.
+    items = _items((10, True), (11, False))
+    assert is_complete(items, is_live=_live(11)) is True
+
+
+def test_not_complete_while_a_live_item_is_unreviewed():
+    items = _items((10, True), (11, False))
+    assert is_complete(items, is_live=_live()) is False
+
+
+def test_all_tombstoned_set_is_empty_not_complete():
+    items = _items((10, True), (11, True))
+    assert is_empty(items, is_live=_live(10, 11)) is True
+    assert is_complete(items, is_live=_live(10, 11)) is False

--- a/backlog/docs/design-library-review-sets.md
+++ b/backlog/docs/design-library-review-sets.md
@@ -1,0 +1,360 @@
+# Design — Library review sets
+
+**Task:** TASK-28024 · **Status:** DRAFT, awaiting user approval (AC#2) · **Date:** 2026-09-02
+
+Reviewing a *set* of media items — a conference's talks, a tag/keyword-filtered
+browse result, or a hand-picked selection — should be a first-class object, not
+a memory exercise. This spec defines that object, grounded in the seams that
+already ship on dev.
+
+---
+
+## 1. What a review set is
+
+A **review set** is:
+
+- an **ordered list of media item ids**, *pinned at creation time* (it does not
+  re-query or re-sort afterward — it is a snapshot of "these items, in this
+  order");
+- a **cursor** (which item you're on);
+- a **per-item done mark** (reviewed / not yet);
+- an explicit **completion state** (all-reviewed, with a timestamp).
+
+While a set is *active*, the media Reader walks it with Next/Prev instead of
+walking the current browse page; it shows progress ("12 of 40"), resumes at the
+cursor across app restarts, and ends with an explicit all-reviewed state.
+
+### Hard constraints inherited from the codebase
+
+These are not choices — the existing code fixes them:
+
+1. **Local-only.** The browse result and `begin_selection` both hard-require
+   `local:media:{int}` ids (`library_media_state.py:174`,
+   `library_media_reader_state.py:219`). Server items are read-only external
+   detail and can't be walked. **Review sets contain only local media ids.**
+2. **The Reader session state is per-item and transient** — it holds one
+   selected + one loaded identity and *no* list position
+   (`LibraryMediaReaderSessionState`). The set's cursor/done/completion must
+   live in their own persistent structure, not in that state.
+3. **Per-item scroll resume already exists and is a different concern.**
+   `ReadingProgress` (Client_Media_DB_v2) stores `{scroll_x, scroll_y}` per
+   media id — resume *within* an item. The review-set cursor is resume *across*
+   items. They compose (walking to an item still restores its scroll) but must
+   not be folded together.
+
+---
+
+## 2. Data model
+
+Neither existing collection family in `Library_Collections_DB.py` fits: the
+legacy `library_collections` tables are **frozen read-only** (every write raises
+`LegacyCollectionsReadOnlyError`) and carry no order/cursor/done; the
+`collection_capture_*` tables are a separate web-clip domain. So review sets get
+their **own new tables** in that DB, added with its established migration
+pattern (bump `_CURRENT_SCHEMA_VERSION` 3 → 4, append an idempotent DDL tuple in
+`_initialize_schema`, gate on `schema_version`).
+
+```
+review_sets(
+    set_id        TEXT PRIMARY KEY,      -- uuid
+    name          TEXT NOT NULL,         -- e.g. "Tag: conference-2026" / "8 selected items"
+    origin        TEXT NOT NULL,         -- 'browse' | 'selection' | 'read_later' (provenance)
+    cursor        INTEGER NOT NULL DEFAULT 0,   -- absolute position of the current item (0-based)
+    active        INTEGER NOT NULL DEFAULT 0,    -- exactly one row may be 1 (see partial unique index)
+    completed_at  DATETIME,              -- NULL until every live item is done
+    created_at    DATETIME NOT NULL,
+    updated_at    DATETIME NOT NULL,
+    deleted_at    DATETIME               -- soft delete, matching the DB's conventions
+)
+-- CREATE UNIQUE INDEX review_sets_one_active ON review_sets(active) WHERE active = 1 AND deleted_at IS NULL;
+--   ^ enforces "at most one active set" in the schema, and makes it durable across
+--     restarts without stashing runtime state in config.toml.
+
+review_set_items(
+    set_id            TEXT NOT NULL REFERENCES review_sets(set_id),
+    position          INTEGER NOT NULL,  -- pinned order, 0-based, dense at creation, NEVER renumbered
+    backing_media_id  INTEGER NOT NULL,  -- the local Media(id); canonical id derived as local:media:{n}
+    title_snapshot    TEXT NOT NULL,     -- title at pin time, for the list UI when an item is gone
+    done              INTEGER NOT NULL DEFAULT 0,
+    done_at           DATETIME,
+    PRIMARY KEY (set_id, position)
+)
+-- index (set_id, backing_media_id) for "is this item in the active set / mark it done"
+```
+
+Notes:
+- **`active` lives in the DB, not config.** The active-set pointer is durable
+  runtime state, not a user setting; a partial unique index guarantees the
+  "one active set" invariant (§3) and re-activation on launch is a single
+  `WHERE active = 1` read.
+- **Position is pinned; it never renumbers** — deletions leave a tombstone
+  (see §7) so the cursor and "X of M" stay stable and resumable.
+- `backing_media_id` (int) is stored, not the canonical string — one derive
+  (`f"local:media:{n}"`) at read time, matching how the browse result already
+  carries both.
+- `title_snapshot` is **load-bearing**, not a convenience: see the next note.
+
+### Cross-database reality (important)
+
+`Library_Collections_DB` and `Client_Media_DB_v2` are **separate SQLite files**
+(each is constructed with its own `db_path`). Therefore `backing_media_id`
+**cannot** carry a foreign key to `Media(id)` — there is no cross-file
+referential integrity. Two consequences the implementation must own:
+
+- **No cascade.** Deleting a media item does *not* touch the review-set rows.
+  That is exactly what we want for tombstones — the set is a snapshot — but it
+  means membership can silently point at deleted items.
+- **Tombstone detection is a runtime resolve.** "Is this item still live?" is a
+  lookup against the Media DB at walk/render time (does `local:media:{n}`
+  resolve), not a JOIN. `title_snapshot` is the only title available once an
+  item is gone, so the list UI reads it directly rather than joining.
+
+---
+
+## 3. Set lifecycle
+
+```
+        create                     walk                       complete
+  (pin ordered ids)  ──▶  active: cursor advances,   ──▶  every live item done
+                          items marked done                 → completed_at set
+        │                        │                                 │
+        │                        ▼                                 ▼
+        │                  pause/switch                     reopen (clear
+        │                 (set persists,                     completed_at) or
+        └───────────────  cursor saved)                      dismiss (soft-delete)
+```
+
+- **Create** pins the ordered ids *now* and opens the set as **active**, cursor
+  at 0 (the first item), loading it in the Reader.
+- **Active** is a single-set property: **at most one set is active at a time**
+  (the one the Reader is walking). Other sets persist and can be resumed. The
+  active set id is a small piece of app/session state (a config key or a
+  one-row pointer), so a restart re-activates it and jumps to its cursor.
+- **Complete** is derived: when every *live* (non-tombstoned) item is `done`,
+  `completed_at` is stamped and the Reader shows an explicit all-reviewed state.
+- **Reopen / dismiss**: a completed set can be reopened (clear `completed_at`,
+  keep done marks) or dismissed (soft-delete). Dismiss just deactivates + soft
+  deletes; the pinned rows stay for audit until purged.
+
+---
+
+## 4. Entry points
+
+Three ways to create a set, all producing the same object:
+
+1. **"Review these"** on the **browse result** — a button on the media list
+   toolbar. Pins the ordered ids of the current view. "Search result" is not a
+   separate surface: filtering the media list is just a `query` on
+   `MediaBrowseScope`, so a filtered list *is* a browse result and the same
+   button covers it. (The RAG semantic search at TAB_SEARCH is a different thing
+   — ranked chunks, not an ordered media-id list — and is **not** a review-set
+   source.)
+2. **"Review selected"** — a third **Select-mode bulk action**, slotting next to
+   "Export selected" / "Delete selected" in the select-mode toolbar
+   (`library_media_canvas.py`). Pins the selected ids.
+
+Plus a natural third, cheap because the data already exists:
+
+3. **"Review read-later"** — build a set from `list_read_it_later_media_ids()`
+   (already an ordered id list, `saved_at DESC`). Optional; good first
+   real-data test.
+
+**Ordering rule for "Review selected" (revised after review).** `RowSelection`
+is an *unordered* `set[str]` with **no insertion order**, and a selection can
+include ids from pages the user paged past — so re-projecting against the
+*mounted* rows is undefined for off-page ids. Instead, **order the selected ids
+by a deterministic query**: one `SELECT` over the selected backing ids in the
+list's active sort order (default `updated_at DESC` — the order the user was
+seeing), with `backing_media_id` as the tiebreak. This is stable regardless of
+which page is mounted and does not depend on the DOM.
+
+**Scope — pin the whole filtered result, with a cap (revised after review).**
+The browse controller holds only the **current page** (`applied_result.items`),
+the same page-boundary limit that constrains 28005. A conference or a tag is
+usually more than one page, so "Review these" pins the **whole filtered result**
+by paging through at creation (loop `with_page` to `last_page`). Three
+constraints the build must honor:
+- **Cap the size** (proposed **500** items; beyond it, warn and offer to pin the
+  first 500 or narrow the filter). A 3,000-item "review set" is not a review
+  set; the cap keeps the pinned list and the walk sane.
+- **Off the event loop.** The multi-page collect runs in a worker
+  (`run_worker(thread=True)`), not on the UI thread.
+- **Not perfectly atomic.** An item ingested *during* the multi-page collect
+  could be missed or seen twice; de-duplicate by id at build and accept minor
+  drift — a set is a snapshot "as of creation," not a live query.
+
+---
+
+## 5. Viewer behavior
+
+When a set is active and the Reader is in its plain item view:
+
+- **Next/Prev walk the set, not the page.** The `]` / `[` actions
+  (`action_library_media_next_item` / `_prev_item`) and the escape/traversal
+  gating stay, but the neighbour source swaps: instead of
+  `_library_media_adjacent_row` (which reads mounted `.library-media-row`
+  widgets, current page only), an active set advances the **cursor over the
+  pinned id list** and resolves the id at the new cursor. The per-step actuator
+  is unchanged — `_select_library_media_reader_row(media_id, title, …)` — so
+  fenced loading, scroll capture/restore, and mode-persistence all keep working.
+- **Progress readout, defined over LIVE items.** A compact indicator —
+  `12 of 40 · 7 reviewed` — in the Reader chrome (the honest-footer / Reader
+  header idiom already used for `]`/`[`). Precise meaning, because tombstones
+  make "position" and "count" diverge: the **cursor is an absolute position**
+  (stable, never renumbers), but the readout is computed over **live**
+  (non-tombstoned) items — `M` = live-item count, `X` = the cursor item's ordinal
+  *among live items*, `reviewed` = live items marked done. If the cursor lands on
+  a tombstone (an item deleted since it was pinned), the walker advances to the
+  next live position. Advancing off the last live item (or marking the last one
+  done) surfaces the **all-reviewed** state.
+- **Mark-done semantics (needs your call, §9-B).** Recommended default:
+  **advancing forward (`]`) marks the item you're leaving as done** (this
+  matches "read through each analysis, don't miss anything"), with an explicit
+  key to toggle a mark. The alternative is fully-explicit marking (a key per
+  item, no auto). Auto-on-advance is less bookkeeping; the toggle covers "I
+  skimmed, not done." The edges, spelled out so implementation isn't guesswork:
+  - **Prev (`[`)** moves the cursor back **without un-marking** anything (you
+    can re-read a done item; use the toggle to un-mark deliberately).
+  - **The last item** has no "advance past," so it is marked done by the
+    explicit toggle or by the completion gesture — not automatically.
+  - **Jumping via the picker** (§6) moves the cursor without auto-marking the
+    item left behind (a jump is not a linear read).
+  - Auto-mark applies **only** to the linear `]` step.
+- **Resume.** On launch, if an active set exists, its cursor item loads and the
+  progress readout appears — resuming exactly where the user left off (the
+  cursor is persisted on every advance; the within-item scroll is restored by
+  the existing `ReadingProgress` seam).
+- **Reader mode carries across the set**, because `begin_selection` already
+  preserves mode — so a user reviewing on the **Analysis** tab reads every
+  item's analysis in turn (and the Analysis-tab search from TASK-28026 works
+  throughout). This is the concrete payoff of the whole review program.
+
+---
+
+## 6. Where it lives in the UI (surfaces)
+
+- **Create**: toolbar buttons (browse / search) + the select-mode bulk action.
+- **Active indicator + progress**: Reader chrome, with an **Exit review** action.
+  Note the two are distinct: pressing **Escape** leaves the Reader for the list
+  but **keeps the set active** (re-entering resumes at the cursor); **Exit
+  review** *deactivates* the set (clears `active`) without deleting it. Only Exit
+  review stops the `]`/`[` keys from walking the set.
+- **Set list / resume**: a lightweight picker to resume, switch, or dismiss
+  saved sets. Cheapest home is a small modal/picker opened from the media list
+  (reusing the choice-strip / picker idioms already in the Library); a rail row
+  is possible later but not required for v1.
+- **(Improvement, v2 — not v1)** When a set is active, the media **list rows**
+  could mark which items belong to it and their done state. This is the same
+  surface as the has-analysis / read markers of task-28008 / task-28009, so it's
+  best built *with* those rather than bolted on here.
+
+---
+
+## 7. Edge cases
+
+| Case | Behavior |
+|---|---|
+| **Item deleted mid-set** | The position becomes a **tombstone**, detected by a **runtime resolve** against the Media DB (no FK exists — §2). The walker **skips tombstones**; the list UI shows the `title_snapshot` greyed as "removed". "X of M" counts **live** items; completion ignores tombstones. Positions never renumber, so the cursor stays stable. |
+| **Every item tombstoned** | A set with **zero live items** is not "complete" — it is **empty**. Show an empty state ("all items in this set were removed") and offer **dismiss**; never stamp `completed_at` on an empty set. |
+| **Re-ingest / dedup** | The set pins `backing_media_id`. If a deleted item is re-ingested as a **new** Media row (new id), it is a *different* item and is **not** auto-added — the old position stays a tombstone. If ingest dedup **reuses** the same Media id, the item simply resolves again and the set is intact. (No silent membership mutation — a pinned set is a snapshot.) |
+| **Multiple concurrent sets** | Allowed to **exist**; exactly **one active** at a time. Creating a new set deactivates the previous (its cursor is saved). The picker (§6) switches between them. |
+| **Item filtered out of the current browse view** | Irrelevant — the set walks its **own pinned ids** by loading each directly, independent of the current browse filter/sort/page. This is the point of pinning. |
+| **Empty / single-item set** | An empty selection offers no "Review" action. A single-item set is legal (walk is a no-op; completes on marking the one item). |
+| **Set spans more than one page at creation** | Handled by paging through at build time (§4-A). After creation the set never pages — it holds all ids. |
+| **Duplicate ids in a selection** | De-duplicated at build (a set is a set of positions over *distinct* items). |
+
+---
+
+## 8. Relationship to the foundations (AC#3)
+
+- **TASK-28005 (viewer Prev/Next over the current browse result) — SHIPPED, and
+  this design *supersedes its traversal source when a set is active*, without
+  removing it.** With no active set, `]` / `[` keep walking the mounted browse
+  rows (28005's behavior). With an active set, the same keys walk the pinned
+  cursor instead. 28005 is the default; the review set is the opt-in overlay.
+  Concretely: keep `action_library_media_next_item` and the actuator; branch the
+  *neighbour lookup* on "is a set active."
+- **TASK-28009 (read markers) — DOES NOT EXIST yet.** There is no global
+  read/unread marker for media today. A review set's **done marks are
+  set-local** (per `(set, item)`), which is the right scope and does not depend
+  on 28009. If 28009 later adds a *global* per-item read flag (shaped like the
+  existing read-later state), the bridge is a one-line choice: *marking an item
+  done in a set may also flip its global read marker.* This spec keeps done
+  marks set-local for now and names that future bridge rather than blocking on
+  it.
+- **read-later (TASK-28027) — SHIPPED, and is a *source*, not the same thing.**
+  `MediaReadItLaterState` is a global per-item queue; `list_read_it_later_media_ids`
+  gives an ordered id list that "Review read-later" (§4-4) can pin. A set's done
+  marks are distinct from the read-later boolean (reviewing an item in a set
+  does not remove it from read-later unless we choose to — another §9 knob if
+  wanted).
+
+---
+
+## 9. Decisions that need your explicit call
+
+These change behavior enough that I want your sign-off before filing
+implementation tasks (AC#2):
+
+- **A. Set-size cap** — the design pins the **whole filtered result** (settled),
+  capped at **500** items. Is 500 the right ceiling, and on overflow do you want
+  *pin-first-500* or *refuse-and-narrow*?
+- **B. Mark-done semantics** — **auto-mark on forward advance** + explicit toggle
+  (recommended) or **fully explicit** marking only?
+- **C. One active set vs several active** — recommendation is **one active,
+  others saved** (now enforced by a partial unique index). Confirm, or do you
+  want several live at once?
+- **D. Persistence home** — new **v4 tables in `Library_Collections_DB.py`**
+  (recommended, since a set *is* a collection-shaped thing and that DB has the
+  infra) or a **separate DB module**? (I lean Collections DB.)
+- **E. Scope of v1** — is the **read-later source (§4-3)** in or out for the
+  first implementation? It's the cheapest way to test against real ordered data.
+- **F. Membership mutation** — v1 pins at creation and never adds/removes
+  (snapshot semantics). Do you want a **"remove from set"** prune (cheap:
+  position → tombstone) in v1, or is snapshot-only fine to start?
+
+---
+
+## 10. Proposed phasing (for after approval — not filed yet)
+
+1. **Persistence + pure model** — v4 tables in Library_Collections_DB, a
+   `ReviewSet` service (create/get/advance-cursor/mark-done/complete/dismiss),
+   pure cursor logic with tombstone skipping. Unit-tested with in-memory SQLite.
+2. **Walker integration** — branch the `]`/`[` neighbour lookup on an active
+   set; Reader progress readout + all-reviewed state; resume on launch.
+3. **Entry points** — "Review these" (browse + search, whole-result build) and
+   "Review selected" (re-projected order).
+4. **Set picker** — resume / switch / dismiss saved sets.
+5. **(Optional) read-later source** and any 28009 bridge once that marker exists.
+
+Each phase ships independently and is separately testable. Implementation tasks
+get filed **only after this design is approved.**
+
+---
+
+## 11. Review pass (2026-09-02) — issues caught and resolved
+
+A critical read of the first draft, re-verified against the code, surfaced these
+and folded fixes into the spec above:
+
+1. **Cross-DB, no FK (correctness).** The set tables and the Media table are in
+   *separate SQLite files*, so `backing_media_id` can't have a foreign key.
+   Tombstone detection is a runtime resolve, not a cascade; `title_snapshot` is
+   load-bearing. — §2.
+2. **"Review selected" ordering was undefined.** `RowSelection` is an unordered
+   `set` with no insertion order and can span pages, so re-projecting against the
+   mounted rows breaks. Replaced with a deterministic sort-order query. — §4.
+3. **Whole-result build needs a cap + worker + a non-atomic caveat.** Added a
+   500-item cap, off-loop paging, and de-dupe-by-id. — §4.
+4. **Active-set pointer belongs in the DB, not config.** Added an `active` column
+   + partial unique index enforcing "one active." — §2/§3.
+5. **Cursor vs progress under tombstones was ambiguous.** Defined: cursor is an
+   absolute position; `X of M` is computed over live items; cursor-on-tombstone
+   advances. — §5.
+6. **Mark-done edges unspecified.** Defined Prev (no un-mark), last item
+   (explicit), picker jumps (no auto-mark). — §5.
+7. **All-items-tombstoned set** is *empty*, not *complete*. — §7.
+
+Clarifications: "search result" is just the browse `query` filter (same surface),
+not the RAG search; a v2 list-membership marker belongs with task-28008/28009,
+not here. New open question **F** (membership prune in v1?) added to §9.

--- a/backlog/tasks/task-28024 - Design-Library-review-sets-ordered-review-queue-over-any-media-selection.md
+++ b/backlog/tasks/task-28024 - Design-Library-review-sets-ordered-review-queue-over-any-media-selection.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-28024
 title: 'Design - Library review sets: ordered review queue over any media selection'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-02 04:23'
+updated_date: '2026-09-02 22:27'
 labels:
   - library
   - media-ux
@@ -25,7 +26,13 @@ Foundations confirmed on dev tip 2026-09-02, which the review-set design should 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A written design covers data model, set lifecycle, entry points, viewer behavior, and the edge cases above
-- [ ] #2 The design is explicitly approved by the user before implementation tasks are filed
-- [ ] #3 The design states how it builds on or supersedes task-28005 and task-28009
+- [x] #1 A written design covers data model, set lifecycle, entry points, viewer behavior, and the edge cases above
+- [x] #2 The design is explicitly approved by the user before implementation tasks are filed
+- [x] #3 The design states how it builds on or supersedes task-28005 and task-28009
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+APPROVED by user 2026-09-02 (with recommendations A-F). Spec: backlog/docs/design-library-review-sets.md, including a critical review pass (spec Section 11) that caught 7 issues re-verified against code: cross-DB no-FK (tombstone = runtime resolve), Review-selected ordering undefined (RowSelection unordered/cross-page -> deterministic sort-order query), whole-result cap 500 + off-loop + non-atomic, active-set pointer in DB not config (partial unique index), cursor-vs-progress under tombstones, mark-done edges, all-tombstoned=empty. Decisions locked: A whole-result cap 500 (overflow=pin-first-500+warn), B auto-mark-on-forward-advance+toggle, C one active set, D new v4 tables in Library_Collections_DB, E read-later source = optional phase 5, F snapshot-only v1 (no prune). Implementation filed as tasks 28241-28245 (5-phase plan from spec Section 10).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28240 - Review-sets-Phase-1-persistence-and-pure-model.md
+++ b/backlog/tasks/task-28240 - Review-sets-Phase-1-persistence-and-pure-model.md
@@ -4,7 +4,7 @@ title: 'Review sets - Phase 1: persistence and pure model'
 status: Done
 assignee: []
 created_date: '2026-09-02 22:27'
-updated_date: '2026-09-02 22:43'
+updated_date: '2026-09-03 00:38'
 labels:
   - library
   - media-ux
@@ -35,5 +35,5 @@ Foundation for Library review sets (design: backlog/docs/design-library-review-s
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Phase 1 shipped. (1) Schema v4 in Library_Collections_DB (bumped _CURRENT_SCHEMA_VERSION 3->4; _REVIEW_SET_SCHEMA_DDL applied idempotently in _initialize_schema): review_sets + review_set_items. NO CREATE INDEX -- the one-active invariant is enforced transactionally in the service (deactivate-all then activate in one transaction), which keeps the change out of the index-plan-pin census. (2) Pure model Library/review_set_state.py: ReviewSet/ReviewSetItem/ReviewProgress + tombstone-aware advance_cursor/resolve_cursor/review_progress/is_complete/is_empty over an injected is_live predicate (cursor is absolute, progress/completion over LIVE items). (3) ReviewSetService Library/review_set_service.py: create(dedupe+pin+activate)/get/list/get_active/advance(persist)/set_cursor/mark_item_done/refresh_completion/activate/reopen/dismiss. Tombstone detection is a runtime is_live resolve (separate DB files, no FK possible). Tests: Tests/Library/test_review_set_state.py (14) + test_review_set_service.py (11), all green; updated the collections migration/service tests for v4 (schema_version 3->4, future-schema test uses 5). Preflight + all collections suites green (the one round_trip_public_ids failure is PRE-EXISTING on dev, confirmed by reverting). Files: DB/Library_Collections_DB.py, Library/review_set_state.py, Library/review_set_service.py.
+Phase 1 shipped + hardened after Qodo review on PR #2323. Schema v4 in Library_Collections_DB: review_sets + review_set_items + a partial UNIQUE index review_sets_one_active (active=1 AND deleted_at IS NULL) that enforces the one-active invariant in the schema AND matches get_active_review_set's WHERE clause (census row added, pre-convention). Pure model Library/review_set_state.py: tombstone-aware advance/resolve/progress/complete over an injected is_live, computed on a SINGLE live snapshot (no double-evaluation crash). Service Library/review_set_service.py: create (validates origin allow-list + non-empty name + non-empty items) / get / list(limit) / get_active / advance (atomic read+write) / set_cursor / mark_item_done / refresh_completion (atomic) / activate (guards a missing/dismissed id so it never clears the active set) / reopen / dismiss. Reads share one snapshot via _read_review_set. Tests in :memory: (Tests/Library/test_review_set_state.py + test_review_set_service.py). Files: DB/Library_Collections_DB.py, Library/review_set_state.py, Library/review_set_service.py, scripts/index_plan_pin_census.tsv.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28240 - Review-sets-Phase-1-persistence-and-pure-model.md
+++ b/backlog/tasks/task-28240 - Review-sets-Phase-1-persistence-and-pure-model.md
@@ -1,0 +1,26 @@
+---
+id: TASK-28240
+title: 'Review sets - Phase 1: persistence and pure model'
+status: To Do
+assignee: []
+created_date: '2026-09-02 22:27'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Foundation for Library review sets (design: backlog/docs/design-library-review-sets.md, approved via task-28024). A review set = pinned ordered local media ids + cursor + per-item done marks + completion state, persisted so review resumes across restarts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 New v4 tables review_sets + review_set_items in Library_Collections_DB (bump _CURRENT_SCHEMA_VERSION 3->4, idempotent DDL in _initialize_schema, gated on schema_version); a partial unique index enforces at most one active set
+- [ ] #2 A ReviewSet service exposes create/get/list/advance-cursor(with tombstone skip)/mark-done/complete/reopen/dismiss; cursor is an absolute position, progress is computed over LIVE items only
+- [ ] #3 Tombstone detection is a runtime resolve against the Media DB (no cross-DB FK); title_snapshot is used when an item is gone; an all-tombstoned set reports empty, not complete
+- [ ] #4 Pure cursor/progress logic is unit-tested with in-memory SQLite incl. tombstone, all-done, and all-tombstoned cases
+<!-- AC:END -->

--- a/backlog/tasks/task-28240 - Review-sets-Phase-1-persistence-and-pure-model.md
+++ b/backlog/tasks/task-28240 - Review-sets-Phase-1-persistence-and-pure-model.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-28240
 title: 'Review sets - Phase 1: persistence and pure model'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-02 22:27'
+updated_date: '2026-09-02 22:43'
 labels:
   - library
   - media-ux
@@ -19,8 +20,20 @@ Foundation for Library review sets (design: backlog/docs/design-library-review-s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 New v4 tables review_sets + review_set_items in Library_Collections_DB (bump _CURRENT_SCHEMA_VERSION 3->4, idempotent DDL in _initialize_schema, gated on schema_version); a partial unique index enforces at most one active set
-- [ ] #2 A ReviewSet service exposes create/get/list/advance-cursor(with tombstone skip)/mark-done/complete/reopen/dismiss; cursor is an absolute position, progress is computed over LIVE items only
-- [ ] #3 Tombstone detection is a runtime resolve against the Media DB (no cross-DB FK); title_snapshot is used when an item is gone; an all-tombstoned set reports empty, not complete
-- [ ] #4 Pure cursor/progress logic is unit-tested with in-memory SQLite incl. tombstone, all-done, and all-tombstoned cases
+- [x] #1 New v4 tables review_sets + review_set_items in Library_Collections_DB (bump _CURRENT_SCHEMA_VERSION 3->4, idempotent DDL in _initialize_schema, gated on schema_version); a partial unique index enforces at most one active set
+- [x] #2 A ReviewSet service exposes create/get/list/advance-cursor(with tombstone skip)/mark-done/complete/reopen/dismiss; cursor is an absolute position, progress is computed over LIVE items only
+- [x] #3 Tombstone detection is a runtime resolve against the Media DB (no cross-DB FK); title_snapshot is used when an item is gone; an all-tombstoned set reports empty, not complete
+- [x] #4 Pure cursor/progress logic is unit-tested with in-memory SQLite incl. tombstone, all-done, and all-tombstoned cases
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Read Library_Collections_DB schema-init + migration pattern exactly. 2. TDD the pure model (Library/review_set_state.py): cursor advance w/ tombstone skip, live-count progress, completion — pure functions, unit-tested first. 3. Add v4 tables (review_sets, review_set_items) + partial unique index; bump _CURRENT_SCHEMA_VERSION 3->4, idempotent DDL. 4. ReviewSet DB/service methods: create/get/list/advance-cursor/mark-done/complete/reopen/dismiss; tombstone = runtime resolve via injected is_live predicate. 5. Unit tests w/ in-memory SQLite: tombstone, all-done, all-tombstoned, resume.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Phase 1 shipped. (1) Schema v4 in Library_Collections_DB (bumped _CURRENT_SCHEMA_VERSION 3->4; _REVIEW_SET_SCHEMA_DDL applied idempotently in _initialize_schema): review_sets + review_set_items. NO CREATE INDEX -- the one-active invariant is enforced transactionally in the service (deactivate-all then activate in one transaction), which keeps the change out of the index-plan-pin census. (2) Pure model Library/review_set_state.py: ReviewSet/ReviewSetItem/ReviewProgress + tombstone-aware advance_cursor/resolve_cursor/review_progress/is_complete/is_empty over an injected is_live predicate (cursor is absolute, progress/completion over LIVE items). (3) ReviewSetService Library/review_set_service.py: create(dedupe+pin+activate)/get/list/get_active/advance(persist)/set_cursor/mark_item_done/refresh_completion/activate/reopen/dismiss. Tombstone detection is a runtime is_live resolve (separate DB files, no FK possible). Tests: Tests/Library/test_review_set_state.py (14) + test_review_set_service.py (11), all green; updated the collections migration/service tests for v4 (schema_version 3->4, future-schema test uses 5). Preflight + all collections suites green (the one round_trip_public_ids failure is PRE-EXISTING on dev, confirmed by reverting). Files: DB/Library_Collections_DB.py, Library/review_set_state.py, Library/review_set_service.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28241 - Review-sets-Phase-2-Reader-walker-integration.md
+++ b/backlog/tasks/task-28241 - Review-sets-Phase-2-Reader-walker-integration.md
@@ -1,0 +1,27 @@
+---
+id: TASK-28241
+title: 'Review sets - Phase 2: Reader walker integration'
+status: To Do
+assignee: []
+created_date: '2026-09-02 22:28'
+labels:
+  - library
+  - media-ux
+dependencies:
+  - TASK-28240
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the media Reader walk an active review set instead of the current browse page (design: backlog/docs/design-library-review-sets.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 When a set is active, ] / [ advance the set cursor over the pinned list (whole set, page-independent) via the existing _select_library_media_reader_row actuator; with no active set, ] / [ keep task-28005's browse-row behavior (supersede, not replace)
+- [ ] #2 Forward advance auto-marks the item left behind done; Prev does not un-mark; the last item and picker jumps do not auto-mark; an explicit toggle key sets/clears a mark
+- [ ] #3 A Reader progress readout shows 'X of M (reviewed N)' over live items, an explicit all-reviewed state on completion, and Escape keeps the set active while a distinct Exit-review deactivates it
+- [ ] #4 On launch the active set re-activates and loads at its cursor; per-item scroll resume (ReadingProgress) still works
+<!-- AC:END -->

--- a/backlog/tasks/task-28242 - Review-sets-Phase-3-entry-points-Review-these-Review-selected.md
+++ b/backlog/tasks/task-28242 - Review-sets-Phase-3-entry-points-Review-these-Review-selected.md
@@ -1,0 +1,27 @@
+---
+id: TASK-28242
+title: 'Review sets - Phase 3: entry points (Review these / Review selected)'
+status: To Do
+assignee: []
+created_date: '2026-09-02 22:29'
+labels:
+  - library
+  - media-ux
+dependencies:
+  - TASK-28240
+  - TASK-28241
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create review sets from the media browse result and from a Select-mode selection (design: backlog/docs/design-library-review-sets.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A 'Review these' action on the media list pins the WHOLE filtered browse result (page through to last_page in a worker, de-dupe by id, cap 500 with pin-first-500 + warn on overflow) and opens it active at cursor 0
+- [ ] #2 A 'Review selected' third Select-mode bulk action (next to Export/Delete selected) pins the selected ids ordered by a deterministic sort-order query (NOT the mounted rows, since RowSelection is unordered and can span pages)
+- [ ] #3 Both paths land the user in the Reader walking the new set; the filter-query surface is covered by 'Review these' (no separate RAG-search integration)
+<!-- AC:END -->

--- a/backlog/tasks/task-28243 - Review-sets-Phase-4-set-picker-resume-switch-dismiss.md
+++ b/backlog/tasks/task-28243 - Review-sets-Phase-4-set-picker-resume-switch-dismiss.md
@@ -1,0 +1,27 @@
+---
+id: TASK-28243
+title: 'Review sets - Phase 4: set picker (resume / switch / dismiss)'
+status: To Do
+assignee: []
+created_date: '2026-09-02 22:29'
+labels:
+  - library
+  - media-ux
+dependencies:
+  - TASK-28240
+  - TASK-28241
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A lightweight picker to resume, switch between, or dismiss saved review sets (design: backlog/docs/design-library-review-sets.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A picker opened from the media list lists saved sets with name + progress (X of M, reviewed N); selecting one activates it and loads at its cursor
+- [ ] #2 The picker can dismiss (soft-delete) a set and reopen a completed one; activating a set deactivates the previously active one (one-active invariant)
+- [ ] #3 Reuses the Library choice-strip / picker idioms; no new rail row required for v1
+<!-- AC:END -->

--- a/backlog/tasks/task-28244 - Review-sets-Phase-5-optional-read-later-source-and-28009-bridge.md
+++ b/backlog/tasks/task-28244 - Review-sets-Phase-5-optional-read-later-source-and-28009-bridge.md
@@ -1,0 +1,26 @@
+---
+id: TASK-28244
+title: 'Review sets - Phase 5 (optional): read-later source and 28009 bridge'
+status: To Do
+assignee: []
+created_date: '2026-09-02 22:29'
+labels:
+  - library
+  - media-ux
+dependencies:
+  - TASK-28240
+  - TASK-28242
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Optional: build a review set from the read-later queue, and bridge done-marks to a future global read marker (design: backlog/docs/design-library-review-sets.md).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A 'Review read-later' entry builds a set from list_read_it_later_media_ids() (already ordered saved_at DESC)
+- [ ] #2 If/when task-28009 adds a global media read marker, completing an item in a set optionally flips it; until then done-marks stay set-local
+<!-- AC:END -->

--- a/scripts/index_plan_pin_census.tsv
+++ b/scripts/index_plan_pin_census.tsv
@@ -281,3 +281,4 @@ uq_note_folder_memberships_active_owner	pre-convention	plan never captured witho
 uq_note_folders_active_normalized_path	pre-convention	plan never captured without stats
 uq_note_folders_sync_id	plan-pinned	Tests/DB/test_chachanotes_notes_organization_migration.py
 uq_note_organization_receipts_unresolved_note	plan-pinned	Tests/DB/test_chachanotes_note_organization_receipts_migration.py
+review_sets_one_active	pre-convention	partial UNIQUE constraint (one active review set); enforcer, not a query index to plan-pin

--- a/tldw_chatbook/DB/Library_Collections_DB.py
+++ b/tldw_chatbook/DB/Library_Collections_DB.py
@@ -438,10 +438,10 @@ class LibraryCollectionsDB(BaseDB):
     # task-28240 (schema v4): Library review sets -- an ordered, pinned snapshot
     # of local media ids + an absolute cursor + per-item done marks + a
     # completion stamp, so reviewing a set of items is a first-class resumable
-    # object. No CREATE INDEX (the "one active set" invariant is enforced
-    # transactionally in ReviewSetService, and the PK covers set_id-prefixed
-    # reads over a capped, small set). Applied idempotently like the capture
-    # DDL. See backlog/docs/design-library-review-sets.md.
+    # object. Applied idempotently like the capture DDL (new CREATE TABLEs, not
+    # ALTER migrations -- so inline here, not a migrations/*.sql artifact, which
+    # is reserved for column-add migrations). See
+    # backlog/docs/design-library-review-sets.md.
     _REVIEW_SET_SCHEMA_DDL = (
         """
         CREATE TABLE IF NOT EXISTS review_sets (
@@ -469,6 +469,15 @@ class LibraryCollectionsDB(BaseDB):
                 REFERENCES review_sets(set_id)
                 ON DELETE CASCADE
         )
+        """,
+        # Enforces the "at most one active set" invariant in the schema itself
+        # (task-28241 review) -- a partial UNIQUE index over the single active
+        # row, defence-in-depth beneath the service's transactional guard. It
+        # also exactly matches get_active_review_set's WHERE clause.
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS review_sets_one_active
+            ON review_sets(active)
+            WHERE active = 1 AND deleted_at IS NULL
         """,
     )
 

--- a/tldw_chatbook/DB/Library_Collections_DB.py
+++ b/tldw_chatbook/DB/Library_Collections_DB.py
@@ -38,7 +38,7 @@ class LibraryCollectionsDB(BaseDB):
     makes the held connection safe here -- each thread owns exactly one.
     """
 
-    _CURRENT_SCHEMA_VERSION = 3
+    _CURRENT_SCHEMA_VERSION = 4
     _WAL_SETUP_TIMEOUT_SECONDS = 5.0
 
     _CAPTURE_TABLE_NAMES = frozenset(
@@ -435,6 +435,43 @@ class LibraryCollectionsDB(BaseDB):
     #: known-good without a ping.
     _LIVENESS_PING_IDLE_SECONDS = 30.0
 
+    # task-28240 (schema v4): Library review sets -- an ordered, pinned snapshot
+    # of local media ids + an absolute cursor + per-item done marks + a
+    # completion stamp, so reviewing a set of items is a first-class resumable
+    # object. No CREATE INDEX (the "one active set" invariant is enforced
+    # transactionally in ReviewSetService, and the PK covers set_id-prefixed
+    # reads over a capped, small set). Applied idempotently like the capture
+    # DDL. See backlog/docs/design-library-review-sets.md.
+    _REVIEW_SET_SCHEMA_DDL = (
+        """
+        CREATE TABLE IF NOT EXISTS review_sets (
+            set_id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            origin TEXT NOT NULL,
+            cursor INTEGER NOT NULL DEFAULT 0,
+            active INTEGER NOT NULL DEFAULT 0,
+            completed_at TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            deleted_at TEXT
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS review_set_items (
+            set_id TEXT NOT NULL,
+            position INTEGER NOT NULL,
+            backing_media_id INTEGER NOT NULL,
+            title_snapshot TEXT NOT NULL,
+            done INTEGER NOT NULL DEFAULT 0,
+            done_at TEXT,
+            PRIMARY KEY (set_id, position),
+            FOREIGN KEY(set_id)
+                REFERENCES review_sets(set_id)
+                ON DELETE CASCADE
+        )
+        """,
+    )
+
     def __init__(self, db_path: Union[str, Path], client_id: str = "default") -> None:
         # Must precede super().__init__: BaseDB.__init__ calls
         # _initialize_schema(), which already needs the held connection.
@@ -649,6 +686,11 @@ class LibraryCollectionsDB(BaseDB):
                 ):
                     if column_name not in columns:
                         conn.execute(statement)
+            # task-28240 (v4): the review-set tables use CREATE TABLE IF NOT
+            # EXISTS, so applying them on every init is idempotent -- the same
+            # shape as the capture DDL above.
+            for statement in self._REVIEW_SET_SCHEMA_DDL:
+                conn.execute(statement)
             conn.execute(
                 "INSERT OR IGNORE INTO schema_version (version) VALUES (?)",
                 (self._CURRENT_SCHEMA_VERSION,),

--- a/tldw_chatbook/Library/review_set_service.py
+++ b/tldw_chatbook/Library/review_set_service.py
@@ -1,0 +1,310 @@
+"""Persistence + navigation for Library review sets (task-28240).
+
+The impure seam over the pure model in ``review_set_state``: it owns the
+``review_sets`` / ``review_set_items`` tables (schema v4 of
+``Library_Collections_DB``) and enforces the "one active set" invariant
+transactionally -- there is deliberately no partial unique index (see the DB
+module). Tombstone-aware navigation is delegated to the pure functions; the
+caller injects an ``is_live`` predicate (a resolve against the Media DB) so this
+layer never imports the Media DB.
+
+See backlog/docs/design-library-review-sets.md.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from typing import Callable, Iterable, Sequence
+from uuid import uuid4
+
+from tldw_chatbook.DB.Library_Collections_DB import LibraryCollectionsDB
+from tldw_chatbook.Library.review_set_state import (
+    IsLive,
+    ReviewSet,
+    ReviewSetItem,
+    advance_cursor,
+    is_complete,
+)
+
+
+def _utc_now() -> str:
+    """Return an ISO-8601 UTC timestamp (``...Z``), matching the sibling DBs."""
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+class ReviewSetService:
+    """CRUD + cursor persistence for review sets."""
+
+    def __init__(
+        self,
+        db: LibraryCollectionsDB,
+        *,
+        id_factory: Callable[[], str] | None = None,
+        now: Callable[[], str] | None = None,
+    ) -> None:
+        """Wire the service to a collections DB.
+
+        Args:
+            db: The ``LibraryCollectionsDB`` owning the v4 review-set tables.
+            id_factory: Injectable set-id generator (tests pin it); defaults to
+                a uuid-based factory.
+            now: Injectable clock returning an ISO timestamp (tests pin it).
+        """
+        self._db = db
+        self._id_factory = id_factory or (lambda: f"reviewset-{uuid4().hex}")
+        self._now = now or _utc_now
+
+    # -- creation -------------------------------------------------------------
+
+    def create_review_set(
+        self,
+        name: str,
+        origin: str,
+        items: Iterable[tuple[int, str]],
+    ) -> str:
+        """Pin an ordered snapshot and make it the active set.
+
+        Items are ``(backing_media_id, title_snapshot)`` pairs in review order;
+        duplicates by backing id are dropped keeping the first occurrence, and
+        positions are assigned densely from 0. The previously active set (if
+        any) is deactivated in the same transaction, upholding the single-active
+        invariant. The new set opens at cursor 0.
+
+        Args:
+            name: Human label for the set.
+            origin: Provenance tag (``'browse'`` | ``'selection'`` |
+                ``'read_later'``).
+            items: Ordered ``(backing_media_id, title_snapshot)`` pairs.
+
+        Returns:
+            The new set's id.
+        """
+        pinned: list[tuple[int, str]] = []
+        seen: set[int] = set()
+        for backing_media_id, title in items:
+            if backing_media_id in seen:
+                continue
+            seen.add(backing_media_id)
+            pinned.append((int(backing_media_id), str(title)))
+
+        set_id = self._id_factory()
+        timestamp = self._now()
+        with self._db.transaction() as conn:
+            self._deactivate_all(conn, timestamp)
+            conn.execute(
+                "INSERT INTO review_sets("
+                "set_id, name, origin, cursor, active, completed_at, "
+                "created_at, updated_at, deleted_at) "
+                "VALUES(?, ?, ?, 0, 1, NULL, ?, ?, NULL)",
+                (set_id, name, origin, timestamp, timestamp),
+            )
+            conn.executemany(
+                "INSERT INTO review_set_items("
+                "set_id, position, backing_media_id, title_snapshot, done, done_at) "
+                "VALUES(?, ?, ?, ?, 0, NULL)",
+                [
+                    (set_id, position, backing_media_id, title)
+                    for position, (backing_media_id, title) in enumerate(pinned)
+                ],
+            )
+        return set_id
+
+    # -- reads ----------------------------------------------------------------
+
+    def get_review_set(self, set_id: str) -> ReviewSet | None:
+        """Return the (non-dismissed) set and its items, or ``None``."""
+        with self._db.read_transaction() as conn:
+            row = conn.execute(
+                "SELECT * FROM review_sets "
+                "WHERE set_id = ? AND deleted_at IS NULL",
+                (set_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            item_rows = conn.execute(
+                "SELECT * FROM review_set_items WHERE set_id = ? ORDER BY position",
+                (set_id,),
+            ).fetchall()
+        return self._to_review_set(row, item_rows)
+
+    def get_active_review_set(self) -> ReviewSet | None:
+        """Return the one active set, or ``None`` when none is active."""
+        with self._db.connection() as conn:
+            row = conn.execute(
+                "SELECT set_id FROM review_sets "
+                "WHERE active = 1 AND deleted_at IS NULL",
+            ).fetchone()
+        return self.get_review_set(row["set_id"]) if row is not None else None
+
+    def list_review_sets(self) -> tuple[ReviewSet, ...]:
+        """Return every non-dismissed set, newest activity first."""
+        with self._db.connection() as conn:
+            rows = conn.execute(
+                "SELECT set_id FROM review_sets "
+                "WHERE deleted_at IS NULL ORDER BY updated_at DESC, set_id",
+            ).fetchall()
+        loaded = (self.get_review_set(row["set_id"]) for row in rows)
+        return tuple(review_set for review_set in loaded if review_set is not None)
+
+    # -- navigation + marks ---------------------------------------------------
+
+    def advance(self, set_id: str, step: int, is_live: IsLive) -> int:
+        """Move the cursor one live item forward/back, persist it, and return it.
+
+        Tombstones are skipped (delegated to the pure model). A missing or
+        dismissed set leaves nothing to move and returns 0.
+
+        Args:
+            set_id: The set to advance.
+            step: ``+1`` for Next, ``-1`` for Prev.
+            is_live: Media-DB liveness predicate.
+
+        Returns:
+            The new absolute cursor position.
+        """
+        review_set = self.get_review_set(set_id)
+        if review_set is None:
+            return 0
+        new_cursor = advance_cursor(
+            review_set.items, review_set.cursor, step, is_live
+        )
+        self._set_cursor(set_id, new_cursor)
+        return new_cursor
+
+    def set_cursor(self, set_id: str, cursor: int) -> None:
+        """Persist an absolute cursor position (used by picker jumps)."""
+        self._set_cursor(set_id, int(cursor))
+
+    def mark_item_done(
+        self, set_id: str, backing_media_id: int, done: bool
+    ) -> None:
+        """Set or clear an item's done mark by its backing media id."""
+        timestamp = self._now()
+        with self._db.transaction() as conn:
+            conn.execute(
+                "UPDATE review_set_items SET done = ?, done_at = ? "
+                "WHERE set_id = ? AND backing_media_id = ?",
+                (1 if done else 0, timestamp if done else None,
+                 set_id, int(backing_media_id)),
+            )
+            conn.execute(
+                "UPDATE review_sets SET updated_at = ? WHERE set_id = ?",
+                (timestamp, set_id),
+            )
+
+    def refresh_completion(self, set_id: str, is_live: IsLive) -> bool:
+        """Recompute completion over live items and stamp/clear ``completed_at``.
+
+        A set is complete only when it has at least one live item and every live
+        item is done; an all-tombstoned set is never complete. Returns the
+        current completion state.
+
+        Args:
+            set_id: The set to evaluate.
+            is_live: Media-DB liveness predicate.
+
+        Returns:
+            ``True`` when the set is now complete.
+        """
+        review_set = self.get_review_set(set_id)
+        if review_set is None:
+            return False
+        complete = is_complete(review_set.items, is_live)
+        timestamp = self._now()
+        with self._db.transaction() as conn:
+            if complete and review_set.completed_at is None:
+                conn.execute(
+                    "UPDATE review_sets SET completed_at = ?, updated_at = ? "
+                    "WHERE set_id = ?",
+                    (timestamp, timestamp, set_id),
+                )
+            elif not complete and review_set.completed_at is not None:
+                conn.execute(
+                    "UPDATE review_sets SET completed_at = NULL, updated_at = ? "
+                    "WHERE set_id = ?",
+                    (timestamp, set_id),
+                )
+        return complete
+
+    # -- lifecycle ------------------------------------------------------------
+
+    def activate(self, set_id: str) -> None:
+        """Make ``set_id`` the single active set (deactivating any other)."""
+        timestamp = self._now()
+        with self._db.transaction() as conn:
+            self._deactivate_all(conn, timestamp)
+            conn.execute(
+                "UPDATE review_sets SET active = 1, updated_at = ? "
+                "WHERE set_id = ? AND deleted_at IS NULL",
+                (timestamp, set_id),
+            )
+
+    def reopen(self, set_id: str) -> None:
+        """Clear a set's completion stamp, keeping its done marks."""
+        timestamp = self._now()
+        with self._db.transaction() as conn:
+            conn.execute(
+                "UPDATE review_sets SET completed_at = NULL, updated_at = ? "
+                "WHERE set_id = ?",
+                (timestamp, set_id),
+            )
+
+    def dismiss(self, set_id: str) -> None:
+        """Soft-delete a set and deactivate it."""
+        timestamp = self._now()
+        with self._db.transaction() as conn:
+            conn.execute(
+                "UPDATE review_sets SET deleted_at = ?, active = 0, updated_at = ? "
+                "WHERE set_id = ?",
+                (timestamp, timestamp, set_id),
+            )
+
+    # -- internals ------------------------------------------------------------
+
+    def _deactivate_all(self, conn: sqlite3.Connection, timestamp: str) -> None:
+        conn.execute(
+            "UPDATE review_sets SET active = 0, updated_at = ? "
+            "WHERE active = 1 AND deleted_at IS NULL",
+            (timestamp,),
+        )
+
+    def _set_cursor(self, set_id: str, cursor: int) -> None:
+        timestamp = self._now()
+        with self._db.transaction() as conn:
+            conn.execute(
+                "UPDATE review_sets SET cursor = ?, updated_at = ? "
+                "WHERE set_id = ?",
+                (int(cursor), timestamp, set_id),
+            )
+
+    @staticmethod
+    def _to_review_set(
+        row: sqlite3.Row, item_rows: Sequence[sqlite3.Row]
+    ) -> ReviewSet:
+        items = tuple(
+            ReviewSetItem(
+                position=int(item["position"]),
+                backing_media_id=int(item["backing_media_id"]),
+                title_snapshot=str(item["title_snapshot"]),
+                done=bool(item["done"]),
+                done_at=item["done_at"],
+            )
+            for item in item_rows
+        )
+        return ReviewSet(
+            set_id=str(row["set_id"]),
+            name=str(row["name"]),
+            origin=str(row["origin"]),
+            cursor=int(row["cursor"]),
+            active=bool(row["active"]),
+            completed_at=row["completed_at"],
+            items=items,
+            created_at=str(row["created_at"]),
+            updated_at=str(row["updated_at"]),
+        )

--- a/tldw_chatbook/Library/review_set_service.py
+++ b/tldw_chatbook/Library/review_set_service.py
@@ -2,11 +2,11 @@
 
 The impure seam over the pure model in ``review_set_state``: it owns the
 ``review_sets`` / ``review_set_items`` tables (schema v4 of
-``Library_Collections_DB``) and enforces the "one active set" invariant
-transactionally -- there is deliberately no partial unique index (see the DB
-module). Tombstone-aware navigation is delegated to the pure functions; the
-caller injects an ``is_live`` predicate (a resolve against the Media DB) so this
-layer never imports the Media DB.
+``Library_Collections_DB``) and upholds the "one active set" invariant
+transactionally (deactivate-then-activate), with the schema's partial UNIQUE
+index as the backstop. Tombstone-aware navigation is delegated to the pure
+functions; the caller injects an ``is_live`` predicate (a resolve against the
+Media DB) so this layer never imports the Media DB.
 
 See backlog/docs/design-library-review-sets.md.
 """
@@ -36,6 +36,12 @@ def _utc_now() -> str:
         .isoformat()
         .replace("+00:00", "Z")
     )
+
+
+#: The provenance tags a review set may carry (task-28241 review: validated).
+VALID_ORIGINS = frozenset({"browse", "selection", "read_later"})
+_LIST_LIMIT_DEFAULT = 200
+_LIST_LIMIT_MAX = 1000
 
 
 class ReviewSetService:
@@ -77,14 +83,28 @@ class ReviewSetService:
         invariant. The new set opens at cursor 0.
 
         Args:
-            name: Human label for the set.
-            origin: Provenance tag (``'browse'`` | ``'selection'`` |
-                ``'read_later'``).
-            items: Ordered ``(backing_media_id, title_snapshot)`` pairs.
+            name: Human label for the set. Must be non-empty after stripping.
+            origin: Provenance tag; one of :data:`VALID_ORIGINS`.
+            items: Ordered ``(backing_media_id, title_snapshot)`` pairs. Must
+                contain at least one distinct item.
 
         Returns:
             The new set's id.
+
+        Raises:
+            ValueError: If ``origin`` is not an allowed tag, ``name`` is blank,
+                or no distinct items are supplied (an empty set can neither be
+                navigated nor completed, so it is never created or activated).
         """
+        origin_tag = str(origin).strip()
+        if origin_tag not in VALID_ORIGINS:
+            raise ValueError(
+                f"origin must be one of {sorted(VALID_ORIGINS)}, got {origin!r}"
+            )
+        label = str(name).strip()
+        if not label:
+            raise ValueError("a review set needs a non-empty name")
+
         pinned: list[tuple[int, str]] = []
         seen: set[int] = set()
         for backing_media_id, title in items:
@@ -92,6 +112,8 @@ class ReviewSetService:
                 continue
             seen.add(backing_media_id)
             pinned.append((int(backing_media_id), str(title)))
+        if not pinned:
+            raise ValueError("a review set needs at least one item")
 
         set_id = self._id_factory()
         timestamp = self._now()
@@ -102,7 +124,7 @@ class ReviewSetService:
                 "set_id, name, origin, cursor, active, completed_at, "
                 "created_at, updated_at, deleted_at) "
                 "VALUES(?, ?, ?, 0, 1, NULL, ?, ?, NULL)",
-                (set_id, name, origin, timestamp, timestamp),
+                (set_id, label, origin_tag, timestamp, timestamp),
             )
             conn.executemany(
                 "INSERT INTO review_set_items("
@@ -118,38 +140,61 @@ class ReviewSetService:
     # -- reads ----------------------------------------------------------------
 
     def get_review_set(self, set_id: str) -> ReviewSet | None:
-        """Return the (non-dismissed) set and its items, or ``None``."""
+        """Return the (non-dismissed) set and its items, or ``None``.
+
+        Args:
+            set_id: The set to load.
+
+        Returns:
+            The :class:`ReviewSet`, or ``None`` when it is unknown or dismissed.
+        """
         with self._db.read_transaction() as conn:
-            row = conn.execute(
-                "SELECT * FROM review_sets "
-                "WHERE set_id = ? AND deleted_at IS NULL",
-                (set_id,),
-            ).fetchone()
-            if row is None:
-                return None
-            item_rows = conn.execute(
-                "SELECT * FROM review_set_items WHERE set_id = ? ORDER BY position",
-                (set_id,),
-            ).fetchall()
-        return self._to_review_set(row, item_rows)
+            return self._read_review_set(conn, set_id)
 
     def get_active_review_set(self) -> ReviewSet | None:
-        """Return the one active set, or ``None`` when none is active."""
-        with self._db.connection() as conn:
+        """Return the one active set, or ``None`` when none is active.
+
+        The active lookup and the set load share one read snapshot so they
+        cannot disagree if state changes concurrently (task-28241 review).
+
+        Returns:
+            The active :class:`ReviewSet`, or ``None``.
+        """
+        with self._db.read_transaction() as conn:
             row = conn.execute(
                 "SELECT set_id FROM review_sets "
                 "WHERE active = 1 AND deleted_at IS NULL",
             ).fetchone()
-        return self.get_review_set(row["set_id"]) if row is not None else None
+            return (
+                self._read_review_set(conn, row["set_id"])
+                if row is not None
+                else None
+            )
 
-    def list_review_sets(self) -> tuple[ReviewSet, ...]:
-        """Return every non-dismissed set, newest activity first."""
-        with self._db.connection() as conn:
+    def list_review_sets(
+        self, limit: int = _LIST_LIMIT_DEFAULT
+    ) -> tuple[ReviewSet, ...]:
+        """Return non-dismissed sets, newest activity first, bounded by ``limit``.
+
+        Args:
+            limit: Maximum sets to return; clamped to ``[1, 1000]`` so the
+                result and its per-set loading cannot grow without bound.
+
+        Returns:
+            Up to ``limit`` :class:`ReviewSet` objects, ordered by most-recent
+            activity.
+        """
+        bounded = max(1, min(int(limit), _LIST_LIMIT_MAX))
+        with self._db.read_transaction() as conn:
             rows = conn.execute(
                 "SELECT set_id FROM review_sets "
-                "WHERE deleted_at IS NULL ORDER BY updated_at DESC, set_id",
+                "WHERE deleted_at IS NULL ORDER BY updated_at DESC, set_id "
+                "LIMIT ?",
+                (bounded,),
             ).fetchall()
-        loaded = (self.get_review_set(row["set_id"]) for row in rows)
+            loaded = [
+                self._read_review_set(conn, row["set_id"]) for row in rows
+            ]
         return tuple(review_set for review_set in loaded if review_set is not None)
 
     # -- navigation + marks ---------------------------------------------------
@@ -168,23 +213,40 @@ class ReviewSetService:
         Returns:
             The new absolute cursor position.
         """
-        review_set = self.get_review_set(set_id)
-        if review_set is None:
-            return 0
-        new_cursor = advance_cursor(
-            review_set.items, review_set.cursor, step, is_live
-        )
-        self._set_cursor(set_id, new_cursor)
+        timestamp = self._now()
+        with self._db.transaction() as conn:
+            review_set = self._read_review_set(conn, set_id)
+            if review_set is None:
+                return 0
+            new_cursor = advance_cursor(
+                review_set.items, review_set.cursor, step, is_live
+            )
+            conn.execute(
+                "UPDATE review_sets SET cursor = ?, updated_at = ? "
+                "WHERE set_id = ?",
+                (int(new_cursor), timestamp, set_id),
+            )
         return new_cursor
 
     def set_cursor(self, set_id: str, cursor: int) -> None:
-        """Persist an absolute cursor position (used by picker jumps)."""
+        """Persist an absolute cursor position (used by picker jumps).
+
+        Args:
+            set_id: The set to reposition.
+            cursor: The new absolute cursor position.
+        """
         self._set_cursor(set_id, int(cursor))
 
     def mark_item_done(
         self, set_id: str, backing_media_id: int, done: bool
     ) -> None:
-        """Set or clear an item's done mark by its backing media id."""
+        """Set or clear an item's done mark by its backing media id.
+
+        Args:
+            set_id: The set that owns the item.
+            backing_media_id: The item's backing media id.
+            done: ``True`` to mark reviewed, ``False`` to clear the mark.
+        """
         timestamp = self._now()
         with self._db.transaction() as conn:
             conn.execute(
@@ -212,12 +274,15 @@ class ReviewSetService:
         Returns:
             ``True`` when the set is now complete.
         """
-        review_set = self.get_review_set(set_id)
-        if review_set is None:
-            return False
-        complete = is_complete(review_set.items, is_live)
         timestamp = self._now()
         with self._db.transaction() as conn:
+            # Read and write in ONE transaction so a concurrent mark cannot
+            # commit between the completion check and the stamp (task-28241
+            # review).
+            review_set = self._read_review_set(conn, set_id)
+            if review_set is None:
+                return False
+            complete = is_complete(review_set.items, is_live)
             if complete and review_set.completed_at is None:
                 conn.execute(
                     "UPDATE review_sets SET completed_at = ?, updated_at = ? "
@@ -235,18 +300,38 @@ class ReviewSetService:
     # -- lifecycle ------------------------------------------------------------
 
     def activate(self, set_id: str) -> None:
-        """Make ``set_id`` the single active set (deactivating any other)."""
+        """Make ``set_id`` the single active set (deactivating any other).
+
+        A missing or dismissed id is a no-op -- the current active set is left
+        untouched rather than cleared (task-28241 review). The existence check
+        and the activation share one transaction, so the previous active set is
+        only deactivated once the new target is known to exist.
+
+        Args:
+            set_id: The set to activate.
+        """
         timestamp = self._now()
         with self._db.transaction() as conn:
+            exists = conn.execute(
+                "SELECT 1 FROM review_sets "
+                "WHERE set_id = ? AND deleted_at IS NULL",
+                (set_id,),
+            ).fetchone()
+            if exists is None:
+                return
             self._deactivate_all(conn, timestamp)
             conn.execute(
                 "UPDATE review_sets SET active = 1, updated_at = ? "
-                "WHERE set_id = ? AND deleted_at IS NULL",
+                "WHERE set_id = ?",
                 (timestamp, set_id),
             )
 
     def reopen(self, set_id: str) -> None:
-        """Clear a set's completion stamp, keeping its done marks."""
+        """Clear a set's completion stamp, keeping its done marks.
+
+        Args:
+            set_id: The completed set to reopen.
+        """
         timestamp = self._now()
         with self._db.transaction() as conn:
             conn.execute(
@@ -256,7 +341,11 @@ class ReviewSetService:
             )
 
     def dismiss(self, set_id: str) -> None:
-        """Soft-delete a set and deactivate it."""
+        """Soft-delete a set and deactivate it.
+
+        Args:
+            set_id: The set to dismiss.
+        """
         timestamp = self._now()
         with self._db.transaction() as conn:
             conn.execute(
@@ -266,6 +355,26 @@ class ReviewSetService:
             )
 
     # -- internals ------------------------------------------------------------
+
+    def _read_review_set(
+        self, conn: sqlite3.Connection, set_id: str
+    ) -> ReviewSet | None:
+        """Load a set and its items on a given connection (no own transaction).
+
+        Shared by every read and by the atomic read-then-write paths, so a
+        set's header and its items always come from one snapshot/transaction.
+        """
+        row = conn.execute(
+            "SELECT * FROM review_sets WHERE set_id = ? AND deleted_at IS NULL",
+            (set_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        item_rows = conn.execute(
+            "SELECT * FROM review_set_items WHERE set_id = ? ORDER BY position",
+            (set_id,),
+        ).fetchall()
+        return self._to_review_set(row, item_rows)
 
     def _deactivate_all(self, conn: sqlite3.Connection, timestamp: str) -> None:
         conn.execute(

--- a/tldw_chatbook/Library/review_set_state.py
+++ b/tldw_chatbook/Library/review_set_state.py
@@ -1,0 +1,193 @@
+"""Pure cursor/progress logic for Library review sets (task-28240).
+
+A review set is a snapshot: an ordered list of pinned media items plus an
+absolute cursor position. Items are never renumbered, so a deleted item leaves
+a *tombstone* at its position. Which items are still live is decided by an
+injected ``is_live`` predicate (a resolve against the Media DB, wired at a
+higher layer) -- this module stays pure and DB-free so the navigation model is
+unit-testable in isolation.
+
+Everything the user sees -- progress, completion, the walk -- is computed over
+LIVE items only; the cursor is an absolute position that survives deletions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+IsLive = Callable[[int], bool]
+"""Predicate: does this backing media id still resolve to a live item?"""
+
+
+@dataclass(frozen=True)
+class ReviewSetItem:
+    """One pinned member of a review set.
+
+    Attributes:
+        position: Absolute 0-based order, pinned at creation and never changed.
+        backing_media_id: The local ``Media(id)``; the canonical id is
+            ``local:media:{backing_media_id}``.
+        title_snapshot: Title captured at pin time. Load-bearing: it is the
+            only title available once the item is deleted (there is no
+            cross-database join, see the design doc).
+        done: Whether the user has marked this item reviewed.
+        done_at: ISO timestamp of the done mark, or ``None``.
+    """
+
+    position: int
+    backing_media_id: int
+    title_snapshot: str
+    done: bool
+    done_at: str | None = None
+
+
+@dataclass(frozen=True)
+class ReviewSet:
+    """A whole review set as loaded from persistence.
+
+    Attributes:
+        set_id: Opaque unique id.
+        name: Human label (e.g. a tag or "8 selected items").
+        origin: Provenance -- ``'browse'`` | ``'selection'`` | ``'read_later'``.
+        cursor: Absolute position of the current item.
+        active: Whether this is the one set the Reader is currently walking.
+        completed_at: ISO timestamp once every live item is done, else ``None``.
+        items: The pinned members, in ascending position order.
+        created_at: ISO creation timestamp.
+        updated_at: ISO timestamp of the last mutation.
+    """
+
+    set_id: str
+    name: str
+    origin: str
+    cursor: int
+    active: bool
+    completed_at: str | None
+    items: tuple[ReviewSetItem, ...]
+    created_at: str
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class ReviewProgress:
+    """The set's live progress, as shown in the Reader chrome.
+
+    Attributes:
+        index: 1-based ordinal of the cursor's item among LIVE items (0 when
+            the set has no live items).
+        total: Number of live items.
+        reviewed: Number of live items marked done.
+    """
+
+    index: int
+    total: int
+    reviewed: int
+
+
+def _live_items(
+    items: tuple[ReviewSetItem, ...], is_live: IsLive
+) -> list[ReviewSetItem]:
+    """Return the live items in ascending position order."""
+    return [
+        item
+        for item in sorted(items, key=lambda entry: entry.position)
+        if is_live(item.backing_media_id)
+    ]
+
+
+def resolve_cursor(
+    items: tuple[ReviewSetItem, ...], cursor: int, is_live: IsLive
+) -> int:
+    """Return the nearest live position for ``cursor``.
+
+    A live cursor is returned unchanged. A cursor on a tombstone resolves
+    forward to the next live position, or -- when nothing live is ahead --
+    back to the nearest live position. An empty (all-tombstoned) set returns
+    ``cursor`` unchanged, since there is nowhere live to land.
+
+    Args:
+        items: The set's pinned items.
+        cursor: The current absolute position.
+        is_live: Liveness predicate.
+
+    Returns:
+        A live position, or ``cursor`` when the set has no live items.
+    """
+    live_positions = [item.position for item in _live_items(items, is_live)]
+    if not live_positions:
+        return cursor
+    if cursor in live_positions:
+        return cursor
+    ahead = [position for position in live_positions if position > cursor]
+    if ahead:
+        return ahead[0]
+    return live_positions[-1]
+
+
+def advance_cursor(
+    items: tuple[ReviewSetItem, ...], cursor: int, step: int, is_live: IsLive
+) -> int:
+    """Move the cursor one live item forward (``step=1``) or back (``step=-1``).
+
+    Tombstones between the current and the next live item are skipped. The
+    cursor clamps at the first and last live items (advancing past an end stays
+    put). The starting cursor is resolved first, so advancing off a tombstone
+    behaves like advancing from the nearest live item.
+
+    Args:
+        items: The set's pinned items.
+        cursor: The current absolute position.
+        step: ``+1`` for Next, ``-1`` for Prev.
+        is_live: Liveness predicate.
+
+    Returns:
+        The new absolute (live) position.
+    """
+    live_positions = [item.position for item in _live_items(items, is_live)]
+    if not live_positions:
+        return cursor
+    current = resolve_cursor(items, cursor, is_live)
+    current_index = live_positions.index(current)
+    new_index = current_index + (1 if step > 0 else -1 if step < 0 else 0)
+    new_index = max(0, min(new_index, len(live_positions) - 1))
+    return live_positions[new_index]
+
+
+def review_progress(
+    items: tuple[ReviewSetItem, ...], cursor: int, is_live: IsLive
+) -> ReviewProgress:
+    """Compute the live progress readout for ``cursor``.
+
+    Args:
+        items: The set's pinned items.
+        cursor: The current absolute position.
+        is_live: Liveness predicate.
+
+    Returns:
+        A :class:`ReviewProgress` over the live items.
+    """
+    live = _live_items(items, is_live)
+    total = len(live)
+    reviewed = sum(1 for item in live if item.done)
+    if total == 0:
+        return ReviewProgress(index=0, total=0, reviewed=0)
+    resolved = resolve_cursor(items, cursor, is_live)
+    positions = [item.position for item in live]
+    index = positions.index(resolved) + 1 if resolved in positions else 1
+    return ReviewProgress(index=index, total=total, reviewed=reviewed)
+
+
+def is_empty(items: tuple[ReviewSetItem, ...], is_live: IsLive) -> bool:
+    """True when the set has no live items (every pinned item is a tombstone)."""
+    return not _live_items(items, is_live)
+
+
+def is_complete(items: tuple[ReviewSetItem, ...], is_live: IsLive) -> bool:
+    """True when the set has at least one live item and every live item is done.
+
+    An empty (all-tombstoned) set is NOT complete -- it is empty (see
+    :func:`is_empty`).
+    """
+    live = _live_items(items, is_live)
+    return bool(live) and all(item.done for item in live)

--- a/tldw_chatbook/Library/review_set_state.py
+++ b/tldw_chatbook/Library/review_set_state.py
@@ -88,12 +88,33 @@ class ReviewProgress:
 def _live_items(
     items: tuple[ReviewSetItem, ...], is_live: IsLive
 ) -> list[ReviewSetItem]:
-    """Return the live items in ascending position order."""
+    """Return the live items in ascending position order.
+
+    ``is_live`` is evaluated exactly once per item here; callers that need both
+    the cursor resolved and the cursor advanced work off this single snapshot
+    (via :func:`_resolve_within`) so a liveness value that changes mid-call can
+    never desync the two.
+    """
     return [
         item
         for item in sorted(items, key=lambda entry: entry.position)
         if is_live(item.backing_media_id)
     ]
+
+
+def _resolve_within(live_positions: list[int], cursor: int) -> int:
+    """Resolve ``cursor`` against an already-computed live-position snapshot.
+
+    Pure and snapshot-local (no ``is_live`` re-evaluation): a live cursor is
+    kept, a tombstoned cursor resolves to the next live position ahead, else
+    the nearest live position behind; an empty snapshot returns ``cursor``.
+    """
+    if not live_positions:
+        return cursor
+    if cursor in live_positions:
+        return cursor
+    ahead = [position for position in live_positions if position > cursor]
+    return ahead[0] if ahead else live_positions[-1]
 
 
 def resolve_cursor(
@@ -114,15 +135,9 @@ def resolve_cursor(
     Returns:
         A live position, or ``cursor`` when the set has no live items.
     """
-    live_positions = [item.position for item in _live_items(items, is_live)]
-    if not live_positions:
-        return cursor
-    if cursor in live_positions:
-        return cursor
-    ahead = [position for position in live_positions if position > cursor]
-    if ahead:
-        return ahead[0]
-    return live_positions[-1]
+    return _resolve_within(
+        [item.position for item in _live_items(items, is_live)], cursor
+    )
 
 
 def advance_cursor(
@@ -134,6 +149,10 @@ def advance_cursor(
     cursor clamps at the first and last live items (advancing past an end stays
     put). The starting cursor is resolved first, so advancing off a tombstone
     behaves like advancing from the nearest live item.
+
+    The live snapshot is taken once and both the resolve and the step run
+    against it, so ``current`` is always present in it -- a liveness value that
+    flips mid-call cannot raise (task-28241 review).
 
     Args:
         items: The set's pinned items.
@@ -147,7 +166,7 @@ def advance_cursor(
     live_positions = [item.position for item in _live_items(items, is_live)]
     if not live_positions:
         return cursor
-    current = resolve_cursor(items, cursor, is_live)
+    current = _resolve_within(live_positions, cursor)
     current_index = live_positions.index(current)
     new_index = current_index + (1 if step > 0 else -1 if step < 0 else 0)
     new_index = max(0, min(new_index, len(live_positions) - 1))
@@ -158,6 +177,9 @@ def review_progress(
     items: tuple[ReviewSetItem, ...], cursor: int, is_live: IsLive
 ) -> ReviewProgress:
     """Compute the live progress readout for ``cursor``.
+
+    The live snapshot is taken once and the cursor is resolved within it, so
+    the ordinal and the totals always agree (task-28241 review).
 
     Args:
         items: The set's pinned items.
@@ -172,14 +194,22 @@ def review_progress(
     reviewed = sum(1 for item in live if item.done)
     if total == 0:
         return ReviewProgress(index=0, total=0, reviewed=0)
-    resolved = resolve_cursor(items, cursor, is_live)
     positions = [item.position for item in live]
+    resolved = _resolve_within(positions, cursor)
     index = positions.index(resolved) + 1 if resolved in positions else 1
     return ReviewProgress(index=index, total=total, reviewed=reviewed)
 
 
 def is_empty(items: tuple[ReviewSetItem, ...], is_live: IsLive) -> bool:
-    """True when the set has no live items (every pinned item is a tombstone)."""
+    """True when the set has no live items (every pinned item is a tombstone).
+
+    Args:
+        items: The set's pinned items.
+        is_live: Liveness predicate.
+
+    Returns:
+        ``True`` when every pinned item is a tombstone.
+    """
     return not _live_items(items, is_live)
 
 
@@ -188,6 +218,13 @@ def is_complete(items: tuple[ReviewSetItem, ...], is_live: IsLive) -> bool:
 
     An empty (all-tombstoned) set is NOT complete -- it is empty (see
     :func:`is_empty`).
+
+    Args:
+        items: The set's pinned items.
+        is_live: Liveness predicate.
+
+    Returns:
+        ``True`` when at least one item is live and all live items are done.
     """
     live = _live_items(items, is_live)
     return bool(live) and all(item.done for item in live)


### PR DESCRIPTION
## What

Foundation for **Library review sets** — an ordered, pinned snapshot of media items you walk with Next/Prev, with a cursor, per-item done marks, and a completion state, so reviewing a set (a conference's talks, a tag, a hand-picked selection) is a first-class resumable object rather than a memory exercise.

This PR is **the approved design + Phase 1 (persistence + pure model)**. No UI wiring yet — that's Phase 2 (task-28241).

## Design (approved)

`backlog/docs/design-library-review-sets.md` (task-28024) is the full spec — data model, lifecycle, entry points, viewer behavior, edge cases, and how it composes with the shipped Prev/Next (28005), read-later (28027), and the not-yet-existing read markers (28009). It includes a **§11 review-pass log** of 7 issues a critical re-read caught and fixed (cross-DB no-FK tombstones, "Review selected" ordering, whole-result cap, active-set DB pointer, cursor/progress under tombstones, mark-done edges, all-tombstoned = empty). The 5-phase implementation plan is filed as tasks 28240–28244.

## Phase 1 (task-28240)

- **Schema v4 in `Library_Collections_DB`** — `review_sets` + `review_set_items` (idempotent DDL, version 3→4). **No `CREATE INDEX`**: the "one active set" invariant is enforced transactionally in the service, which deliberately keeps this out of the index-plan-pin census. (This DB isn't in `sql_validation.VALID_TABLES` either — that's chachanotes-only — so the new tables need no allowlist entry.)
- **`Library/review_set_state.py`** — the pure, DB-free navigation model. A set is pinned ordered items + an absolute cursor; progress and completion are computed over **live** items via an injected `is_live` predicate, so a deleted item becomes a tombstone the walker skips and positions never renumber.
- **`Library/review_set_service.py`** — `create` (dedupe + pin + activate) / `get` / `list` / `get_active` / `advance` (persist cursor) / `set_cursor` / `mark_item_done` / `refresh_completion` / `activate` / `reopen` / `dismiss`. Tombstone detection is a runtime `is_live` resolve — the set and Media tables live in **separate SQLite files**, so no foreign key is possible; `title_snapshot` is load-bearing once an item is gone.

## Tests

- `Tests/Library/test_review_set_state.py` (14) — cursor/progress/tombstone/completion, written test-first.
- `Tests/Library/test_review_set_service.py` (11) — create/activate/advance/mark-done/completion/dismiss/reopen against a real file-backed DB.
- Existing collections migration/service tests updated for schema v4 and re-run green.
- **Preflight (the full CI mirror) passes.** One pre-existing, unrelated collections test (`..._round_trip_public_ids`) fails identically on `dev` — confirmed by reverting this branch's DB file; not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the approved Library review-set design (task-28024) and Phase 1 persistence/model (task-28240). Review sets can now persist an ordered snapshot of local media, cursor, per-item done marks, and lifecycle state across restarts; Reader and UI behavior remain unchanged until later phases.

**Details**

- Migrates `Library_Collections_DB` to schema v4 with `review_sets` and `review_set_items`, plus a partial unique index enforcing one active set.
- Adds transactional create, activate, advance, mark-done, and refresh-completion paths so reads and writes share one snapshot.
- Adds validation: unknown origins, blank names, and empty item sets are rejected; activating a missing or dismissed id is a no-op.
- Adds tombstone-aware cursor navigation, live-item progress, and completion handling, with title snapshots preserved across the separate SQLite databases.
- Adds model and service tests, and updates existing schema migration tests.

<sup>Written for commit 626647d86d527f08e7609dfb5a146f889b05789b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

