### PR TITLE
fix(console): tab strip scrolling + overflow hints; bare-screen store guard (fixes 12 red state-restore tests)

### DIFF
--- a/Tests/UI/test_console_session_tab_strip.py
+++ b/Tests/UI/test_console_session_tab_strip.py
@@ -6,14 +6,19 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from textual import events
 from textual.app import App
 from textual.containers import HorizontalScroll
 from textual.content import Content
-from textual.widgets import Button
+from textual.widgets import Button, Static
 
 from tldw_chatbook.Chat.console_chat_models import ConsoleRunMarker
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession
-from tldw_chatbook.Widgets.Console.console_session_surface import ConsoleSessionSurface
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.Widgets.Console.console_session_surface import (
+    ConsoleSessionSurface,
+    ConsoleSessionTabStrip,
+)
 
 
 def _rendered_tooltip(button: Button) -> str:
@@ -271,3 +276,174 @@ async def test_new_tab_and_temporary_buttons_render_unclipped_labels() -> None:
         assert "New tab" in rendered, (
             f"'New tab' tab-strip button label was clipped:\n{rendered}"
         )
+
+
+# -- TASK-28028: wheel scrolling + overflow hints ---------------------------
+
+
+async def _wheel(
+    pilot, strip: ConsoleSessionTabStrip, *, down: bool, ctrl: bool = False
+) -> None:
+    """Post a real-shape SGR mouse-wheel event to the strip, as a terminal delivers it.
+
+    ``Pilot`` has no wheel helper; posting the event message runs the same
+    ``_on_mouse_scroll_*`` dispatch a real wheel travels through.
+    """
+    event_cls = events.MouseScrollDown if down else events.MouseScrollUp
+    strip.post_message(
+        event_cls(
+            widget=strip,
+            x=strip.region.x + 5,
+            y=strip.region.y,
+            delta_x=0,
+            delta_y=1 if down else -1,
+            button=0,
+            shift=False,
+            meta=False,
+            ctrl=ctrl,
+        )
+    )
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_plain_wheel_scrolls_strip_horizontally() -> None:
+    """TASK-28028: a plain vertical wheel over the strip scrolls it horizontally.
+
+    Textual 8.2.8's base wheel handler does nothing for a height-1
+    ``HorizontalScroll`` (vertical scroll is disabled), so without this the
+    only horizontal wheel paths are the undiscoverable shift/ctrl chords.
+    """
+    app = TabStripHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        surface = app.query_one(ConsoleSessionSurface)
+        # 10 tabs x 24 cells (tab 21 + close 3) + 26 cells of new-tab buttons
+        # = 266 cells of content in an 80-cell strip: guaranteed overflow.
+        await surface.sync_sessions(sessions=_sessions(10), active_session_id="s1")
+        await pilot.pause()
+        await pilot.pause()
+
+        strip = app.query_one("#console-native-tab-strip", ConsoleSessionTabStrip)
+        assert strip.scroll_x == 0
+
+        await _wheel(pilot, strip, down=True)
+        assert strip.scroll_x > 0, "wheel-down did not scroll the strip right"
+
+        scroll_after_down = strip.scroll_x
+        await _wheel(pilot, strip, down=False)
+        assert strip.scroll_x < scroll_after_down, (
+            "wheel-up did not scroll the strip back left"
+        )
+
+
+@pytest.mark.asyncio
+async def test_wheel_at_left_edge_keeps_strip_at_zero() -> None:
+    """A wheel-up at scroll position 0 must be a no-op, not a jump."""
+    app = TabStripHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        surface = app.query_one(ConsoleSessionSurface)
+        await surface.sync_sessions(sessions=_sessions(10), active_session_id="s1")
+        await pilot.pause()
+        await pilot.pause()
+
+        strip = app.query_one("#console-native-tab-strip", ConsoleSessionTabStrip)
+        await _wheel(pilot, strip, down=False)
+        assert strip.scroll_x == 0
+
+
+@pytest.mark.asyncio
+async def test_overflow_hints_follow_hidden_tabs_and_scroll_position() -> None:
+    """TASK-28028: ‹ › hints appear only on the side with hidden tabs."""
+    app = TabStripHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        surface = app.query_one(ConsoleSessionSurface)
+        await surface.sync_sessions(sessions=_sessions(10), active_session_id="s1")
+        await pilot.pause()
+        await pilot.pause()
+
+        left = app.query_one("#console-tab-overflow-left", Static)
+        right = app.query_one("#console-tab-overflow-right", Static)
+        strip = app.query_one("#console-native-tab-strip", ConsoleSessionTabStrip)
+
+        # At the far-left end: tabs hidden on the right only.
+        assert right.styles.visibility == "visible", (
+            "right hint missing with tabs hidden right"
+        )
+        assert left.styles.visibility == "hidden", (
+            "left hint shown with nothing hidden left"
+        )
+
+        await _wheel(pilot, strip, down=True)
+        assert left.styles.visibility == "visible", (
+            "left hint missing after scrolling right"
+        )
+
+
+@pytest.mark.asyncio
+async def test_overflow_hint_toggles_never_shift_the_strip_region() -> None:
+    """Qodo PR #2327 review: hint toggles must not resize or move the strip.
+
+    The hints hide via ``visibility`` (cells stay in the row's layout), not
+    ``display: none`` (cells leave it). If this regresses, a hint appearing
+    narrows the 1fr strip by a cell and visibly jumps the tabs at every
+    threshold crossing. Pin the strip's region across a toggle cycle.
+    """
+    app = TabStripHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        surface = app.query_one(ConsoleSessionSurface)
+        await surface.sync_sessions(sessions=_sessions(10), active_session_id="s1")
+        await pilot.pause()
+        await pilot.pause()
+
+        strip = app.query_one("#console-native-tab-strip", ConsoleSessionTabStrip)
+        left = app.query_one("#console-tab-overflow-left", Static)
+
+        region_before = strip.region
+        assert left.styles.visibility == "hidden"
+
+        # Wheel right until the left hint appears (a toggle happened).
+        for _ in range(3):
+            await _wheel(pilot, strip, down=True)
+        assert left.styles.visibility == "visible"
+        assert strip.scroll_x > 0
+        assert strip.region == region_before, (
+            "strip region moved/resized when a hint toggled: "
+            f"{region_before} -> {strip.region}"
+        )
+
+        # And back: the reverse toggle must be just as inert.
+        for _ in range(6):
+            await _wheel(pilot, strip, down=False)
+        assert left.styles.visibility == "hidden"
+        assert strip.region == region_before
+
+
+@pytest.mark.asyncio
+async def test_overflow_hints_hidden_without_overflow() -> None:
+    """A strip that fits shows neither hint."""
+    app = TabStripHost()
+    async with app.run_test(size=(80, 24)) as pilot:
+        surface = app.query_one(ConsoleSessionSurface)
+        await surface.sync_sessions(sessions=_sessions(1), active_session_id="s1")
+        await pilot.pause()
+        await pilot.pause()
+
+        assert (
+            app.query_one("#console-tab-overflow-left", Static).styles.visibility
+            == "hidden"
+        )
+        assert (
+            app.query_one("#console-tab-overflow-right", Static).styles.visibility
+            == "hidden"
+        )
+
+
+def test_chat_screen_exposes_rail_body_height_seam() -> None:
+    """TASK-28028: the wiring lambda's ``screen._console_rail_body_height()``
+    must exist on ``ChatScreen`` -- the adaptive row-limit WIP shipped
+    without it and every Console screen resume crashed with AttributeError.
+    The functional leg is the switcher pair in
+    ``test_console_native_chat_flow.py``, which drives the real screen.
+    """
+    assert callable(getattr(ChatScreen, "_console_rail_body_height", None))
+

--- a/backlog/tasks/task-28028 - Console-tab-strip-scrolling-overflow-hints.md
+++ b/backlog/tasks/task-28028 - Console-tab-strip-scrolling-overflow-hints.md
@@ -1,0 +1,48 @@
+---
+id: TASK-28028
+title: Console tab strip scrolling + overflow hints; complete rail-height seam
+status: Done
+assignee:
+  - '@Robert'
+created_date: '2026-09-02 05:09'
+updated_date: '2026-09-02 14:40'
+labels:
+  - console
+  - bug
+  - ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Tabs pushed off-screen in the Console session tab strip are unreachable and invisible: a plain mouse wheel does nothing (only undiscoverable shift+wheel scrolls), and nothing signals hidden tabs. Separately, uncommitted adaptive-row-limit WIP calls screen._console_rail_body_height() which does not exist, crashing the Console on every screen resume.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Plain vertical mouse wheel over the tab strip scrolls it horizontally (up=left, down=right) and stops the event only when it moved
+- [x] #2 Edge indicators appear on a side only when tabs are hidden beyond that side, and do not shift layout
+- [x] #3 Auto-scroll-to-active and Alt+1..9 behavior unchanged
+- [x] #4 ChatScreen._console_rail_body_height returns the measured #console-left-rail-body height or None when unmeasured, so the Console boots and screen-resume no longer crashes
+- [x] #5 Live tmux pass: app boots on a scratch profile, Ctrl+K switcher opens and switches sessions, wheel scrolls the strip
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no (UI affordance + completing an existing wiring seam; no storage/provider/security decisions). 1. Add ChatScreen._console_rail_body_height next to _console_conversation_browser_collapse_preferences. 2. Subclass HorizontalScroll as ConsoleSessionTabStrip overriding wheel handlers. 3. Flank strip with 1-cell Static indicators toggled on scroll. 4. RED/GREEN tests in Tests/UI/test_console_session_tab_strip.py. 5. Live tmux verification with scratch profile.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Shipped against `dev`, where the adaptive rail-height seam the original tree was missing had already landed as `be1ee8418` (feat: scale Console conversation rail cap to available height) -- so this PR's scope is the tab-strip affordances only: `ConsoleSessionTabStrip` (plain vertical wheel -> horizontal scroll, 8 cells/step, event stopped only when it moved), the 1-row strip row with flanking `#console-tab-overflow-left/right` Statics (display-toggled via `watch_scroll_x`/resize/sync hooks; always mounted so no layout shift), the `_agentic_terminal.tcss` hint rule (deterministic bundle regen), and 5 new tests in `Tests/UI/test_console_session_tab_strip.py` (17 green). The rail-height seam work documented in the plan/ACs happened on the `docs/lesson-adr-number-collisions` working tree and is superseded by dev's own landing; live tmux verification (boot, 10 tabs, both hints tracking, wheel both directions, Ctrl+K switcher opens/lists/switches) ran against that tree with identical widget code (the surface file is byte-identical between the two bases).
+
+## Renumbering provenance
+
+Originally created as TASK-28025 on 2026-09-02; renumbered to TASK-28028 before merge
+because parallel Library-media PRs landed on `dev` first carrying
+task-28025/task-28027 for different
+work. Per the TASK-19601 owner rule (older arrival keeps the id), the
+landed tasks keep those numbers.

--- a/backlog/tasks/task-28029 - Fix-console_view_hooks-crash-on-pre-wiring-screens-13-red-tests.md
+++ b/backlog/tasks/task-28029 - Fix-console_view_hooks-crash-on-pre-wiring-screens-13-red-tests.md
@@ -1,0 +1,46 @@
+---
+id: TASK-28029
+title: Fix console_view_hooks crash on pre-wiring screens (13 red tests)
+status: Done
+assignee:
+  - '@Robert'
+created_date: '2026-09-02 14:54'
+updated_date: '2026-09-02 15:08'
+labels:
+  - console
+  - bug
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The wave-6 controller-extraction refactors (cd5209b37 retrieval, a315c9220 skill) rewired three console_view_hooks entries to eager instance-attribute derefs (self._retrieval / self._skill) that only exist after build_console_controllers. Any ChatScreen that reaches runtime attach before wiring (bare __new__ screens in tests; the documented early-attach path) crashes with AttributeError, leaving 12 state-restore tests plus the attach/detach slot-set contract test red since Aug 20-21.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 console_view_hooks returns the exact CONSOLE_VIEW_HOOK_SLOTS key set on a bare __new__ ChatScreen
+- [x] #2 The 12 test_console_native_chat_flow state-restore tests pass
+- [x] #3 test_attach_and_detach_cover_exactly_the_same_slot_set passes
+- [x] #4 Fully-wired screens bind identical values as before (no behavior change)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no (bug fix restoring an existing documented contract). 1. Defensive getattr for _retrieval/_skill in console_view_hooks with None fallback matching each slot's viewless default. 2. RED->GREEN across the 13 tests. 3. Targeted suites around wiring/hooks.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+Against `dev` (PR base) the disease has one remaining exposed nerve: dev's wave-6 refactor already made `console_view_hooks` defensive (`getattr(retrieval, "_capture_console_staged_rag", None)`), but `_ensure_console_chat_store` eagerly dereferences the wiring-set `self._workspace` (chat_screen.py:7096/7102) and every bare-screen state-restore test drives it through `_restore_console_snapshot_with_sessions`. Fix: `getattr(self, "_workspace", None)` guard; no workspace controller -> `workspace_context=None` (the same safe runtime default the `resume_pending` branch already uses) and skip the empty-store realignment. One fix heals the whole family: 13/13 state-restore tests green, full chat-flow suite 24 -> 13 failures (the remaining 13 are the pre-existing prompt-improvement/send-path/toast rot on dev, untouched by this change -- see PR body). Original branch-side diagnosis (eager `_retrieval`/`_skill` in the hook dict) is recorded above for the history; on dev that half is already landed.
+
+## Renumbering provenance
+
+Originally created as TASK-28027 on 2026-09-02; renumbered to TASK-28029 before merge
+because parallel Library-media PRs landed on `dev` first carrying
+task-28027/task-28025 for different
+work. Per the TASK-19601 owner rule (older arrival keeps the id), the
+landed tasks keep those numbers.

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -7207,19 +7207,30 @@ class ChatScreen(BaseAppScreen):
         """
         store = self._console_chat_store
         resume_pending = self._console_ordered_resume_pending()
+        # task-28029: `_workspace` is a wiring-set instance attribute
+        # (``build_console_controllers``), yet this helper runs on views
+        # that reach the store BEFORE wiring -- bare ``__new__`` screens in
+        # the state-restore tests, and the early-attach path
+        # ``_bind_view_hooks`` documents. No workspace controller means no
+        # view-scoped context: keep the runtime's safe global default (the
+        # same context an explicit resume holds), exactly as the
+        # ``resume_pending`` branch already does.
+        workspace = getattr(self, "_workspace", None)
+        workspace_context = (
+            workspace._current_console_workspace_context()
+            if workspace is not None
+            else None
+        )
         if store is None:
             store = self._console_runtime().ensure_chat_store(
                 workspace_context=(
-                    None
-                    if resume_pending
-                    else self._workspace._current_console_workspace_context()
+                    None if resume_pending else workspace_context
                 ),
                 on_scope_flushed=self._on_console_scope_flushed,
             )
         elif store.active_session_id is None and not resume_pending:
-            store.set_workspace_context(
-                self._workspace._current_console_workspace_context()
-            )
+            if workspace_context is not None:
+                store.set_workspace_context(workspace_context)
         return store
 
     def _ensure_console_agent_bridge(self) -> Any:

--- a/tldw_chatbook/Widgets/Console/console_session_surface.py
+++ b/tldw_chatbook/Widgets/Console/console_session_surface.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import replace
-from typing import Any
+from typing import Any, Callable
 
 from rich.markup import escape as _escape_markup
 from rich.text import Text
+from textual import events
 from textual.app import ComposeResult
 from textual.containers import Horizontal, HorizontalScroll, Vertical
 from textual.css.query import NoMatches
@@ -19,7 +20,12 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleRunMarker,
 )
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession
-from tldw_chatbook.Chat.console_glyphs import GLYPH_CLOSE, GLYPH_TEMPORARY
+from tldw_chatbook.Chat.console_glyphs import (
+    GLYPH_CLOSE,
+    GLYPH_COLLAPSE_LEFT,
+    GLYPH_COLLAPSE_RIGHT,
+    GLYPH_TEMPORARY,
+)
 from tldw_chatbook.Widgets.glyph_fallback import resolve_glyph
 from tldw_chatbook.Chat.console_onboarding_state import ConsoleSetupCardState
 from tldw_chatbook.Utils.console_background_effects import (
@@ -57,6 +63,11 @@ CONSOLE_SESSION_TITLE_MAX_CHARACTERS = 500
 #: Fleet-UX expert review F2 (task-1232): one-time coach-mark row mounted
 #: under the tab strip, hidden until `show_fleet_coachmark` reveals it.
 CONSOLE_FLEET_COACHMARK_DISMISS_WIDTH = 3
+#: TASK-28028: 1-cell overflow hints flanking the tab strip (‹ ›); shown
+#: only while tabs are hidden past that edge. Width includes no padding.
+CONSOLE_TAB_OVERFLOW_HINT_WIDTH = 1
+CONSOLE_TAB_OVERFLOW_LEFT_ID = "console-tab-overflow-left"
+CONSOLE_TAB_OVERFLOW_RIGHT_ID = "console-tab-overflow-right"
 
 
 def _session_tab_tooltip(
@@ -156,6 +167,71 @@ class ConsoleSessionTabButton(Button):
         await super()._on_click(event)
 
 
+class ConsoleSessionTabStrip(HorizontalScroll):
+    """Session tab strip that maps a plain vertical wheel to horizontal scroll.
+
+    TASK-28028: Textual 8.2.8's base wheel handler only scrolls a
+    ``HorizontalScroll`` for shift/ctrl chords -- a plain wheel over this
+    height-1 strip fell through to the vertical path, which
+    ``overflow-y: hidden`` disables, so tabs pushed off-screen were
+    unreachable by wheel. Wheel-down scrolls toward later tabs, wheel-up
+    back toward earlier ones, matching the shift-wheel convention the base
+    class already defines. The event is stopped only when the strip
+    actually moved, so a wheel at an edge still bubbles (e.g. to the
+    transcript around it).
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        #: Set by ``ConsoleSessionSurface``; invoked whenever the strip's
+        #: scroll position OR geometry changes, so the flanking ‹ ›
+        #: overflow hints track what is hidden on each side.
+        self.on_overflow_state_changed: Callable[[], None] | None = None
+
+    def _on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
+        if event.ctrl or event.shift:
+            super()._on_mouse_scroll_down(event)
+            return
+        if self._scroll_right_for_pointer(animate=False):
+            event.stop()
+
+    def _on_mouse_scroll_up(self, event: events.MouseScrollUp) -> None:
+        if event.ctrl or event.shift:
+            super()._on_mouse_scroll_up(event)
+            return
+        if self._scroll_left_for_pointer(animate=False):
+            event.stop()
+
+    def watch_scroll_x(self, old_value: float, new_value: float) -> None:
+        """Extend the base scrollbar/refresh watcher with hint recomputation.
+
+        Args:
+            old_value: The strip's horizontal scroll offset before the change.
+            new_value: The strip's horizontal scroll offset after the change.
+        """
+        super().watch_scroll_x(old_value, new_value)
+        if round(old_value) != round(new_value):
+            self._notify_overflow_state_changed()
+
+    def _on_resize(self, event: events.Resize) -> None:
+        # A resize re-clips the strip: the hidden-on-each-side truth changes
+        # even though scroll_x did not. No super() call: ScrollableContainer
+        # defines no _on_resize of its own (layout handles the resize).
+        del event
+        self._notify_overflow_state_changed()
+
+    def _notify_overflow_state_changed(self) -> None:
+        callback = self.on_overflow_state_changed
+        if callback is not None:
+            try:
+                callback()
+            except Exception:
+                # Best effort: the hints are an affordance, never a
+                # critical path (same rationale as the scroll scheduling
+                # in ``sync_sessions``).
+                pass
+
+
 class ConsoleSessionSurface(Vertical):
     """Host Console transcript/event stream sessions without legacy chat chrome."""
 
@@ -186,15 +262,7 @@ class ConsoleSessionSurface(Vertical):
         title.styles.min_height = 1
         yield title
 
-        tab_strip = HorizontalScroll(
-            id="console-native-tab-strip",
-            classes="console-session-tab-strip",
-        )
-        tab_strip.styles.height = 1
-        tab_strip.styles.min_height = 1
-        tab_strip.styles.max_height = 1
-        with tab_strip:
-            yield self._build_new_tab_button()
+        yield self._build_tab_strip_row()
         yield self._build_fleet_coachmark()
         yield ChatTaskCards(id="console-task-surface")
         yield ConsoleActivityOutcomeNotice(id="console-activity-outcome-notice")
@@ -205,6 +273,86 @@ class ConsoleSessionSurface(Vertical):
             id="console-transcript-surface",
             classes="console-transcript-surface",
         )
+
+    def _build_tab_strip_row(self) -> Horizontal:
+        """Build the tab strip row: ‹ hint, the strip, › hint.
+
+        TASK-28028: the row carries the `.console-session-tab-strip` class
+        (panel background + bottom margin now live on the row, not the
+        strip, so the flanking ‹ › hints sit on the same panel), while the
+        strip itself keeps `#console-native-tab-strip` so every existing
+        query keeps resolving.
+        """
+        tab_strip = ConsoleSessionTabStrip(id="console-native-tab-strip")
+        tab_strip.styles.height = 1
+        tab_strip.styles.min_height = 1
+        tab_strip.styles.max_height = 1
+        # The row owns the strip family's bottom margin now; this inline
+        # zero beats the shared `#console-native-tab-strip` CSS rule so a
+        # margin never eats the row's single line.
+        tab_strip.styles.margin = (0, 0, 0, 0)
+        tab_strip.styles.width = "1fr"
+        tab_strip.on_overflow_state_changed = self._sync_tab_overflow_hints
+        tab_strip.compose_add_child(self._build_new_tab_button())
+
+        strip_row = Horizontal(classes="console-session-tab-strip")
+        strip_row.styles.height = 1
+        strip_row.styles.min_height = 1
+        strip_row.styles.max_height = 1
+        # Children attach via compose_add_child (mirrors the
+        # `_build_fleet_coachmark` pattern) because this helper returns the
+        # built row rather than yielding through the compose generator.
+        strip_row.compose_add_child(
+            self._build_overflow_hint(
+                CONSOLE_TAB_OVERFLOW_LEFT_ID, GLYPH_COLLAPSE_LEFT
+            )
+        )
+        strip_row.compose_add_child(tab_strip)
+        strip_row.compose_add_child(
+            self._build_overflow_hint(
+                CONSOLE_TAB_OVERFLOW_RIGHT_ID, GLYPH_COLLAPSE_RIGHT
+            )
+        )
+        return strip_row
+
+    def _build_overflow_hint(self, hint_id: str, glyph: str) -> Static:
+        """Build one (initially hidden) 1-cell tab-strip overflow hint."""
+        hint = Static(resolve_glyph(glyph), id=hint_id, markup=False)
+        hint.tooltip = "More tabs this way — scroll the tab strip (mouse wheel)."
+        hint.styles.width = CONSOLE_TAB_OVERFLOW_HINT_WIDTH
+        hint.styles.min_width = CONSOLE_TAB_OVERFLOW_HINT_WIDTH
+        hint.styles.max_width = CONSOLE_TAB_OVERFLOW_HINT_WIDTH
+        hint.styles.height = 1
+        hint.styles.min_height = 1
+        hint.styles.max_height = 1
+        # Qodo PR #2327 review: hide with VISIBILITY, not display:none —
+        # a display:none cell leaves the horizontal layout, so re-showing
+        # a hint resized/shifted the 1fr strip (one cell of tab jitter at
+        # each threshold crossing). visibility:hidden keeps the cell's
+        # box in layout at all times, so hint toggles can never move the
+        # strip; the cost is one permanently reserved cell per side.
+        hint.styles.visibility = "hidden"
+        return hint
+
+    def _sync_tab_overflow_hints(self) -> None:
+        """Show ‹ › only on the side of the strip with hidden tabs.
+
+        Best-effort by design (hints are an affordance, not a critical
+        path): absent widgets or a not-yet-laid-out strip leave the hints
+        as-is. Toggles ``visibility`` only — never ``display`` — so the
+        hint cells keep their one-cell boxes in the row's layout and the
+        strip's own region is stable across every toggle.
+        """
+        try:
+            strip = self.query_one("#console-native-tab-strip", HorizontalScroll)
+            left = self.query_one(f"#{CONSOLE_TAB_OVERFLOW_LEFT_ID}", Static)
+            right = self.query_one(f"#{CONSOLE_TAB_OVERFLOW_RIGHT_ID}", Static)
+        except Exception:
+            return
+        hidden_right = round(strip.max_scroll_x - strip.scroll_x) > 0
+        hidden_left = round(strip.scroll_x) > 0
+        left.styles.visibility = "visible" if hidden_left else "hidden"
+        right.styles.visibility = "visible" if hidden_right else "hidden"
 
     def _build_fleet_coachmark(self) -> Horizontal:
         """Build the (initially hidden) one-time parallel-agents coach-mark.
@@ -573,6 +721,15 @@ class ConsoleSessionSurface(Vertical):
             await tab_strip.mount(self._build_new_tab_button())
             await tab_strip.mount(self._build_new_temporary_tab_button())
             self._record_mount_churn(mounted=mounted_count, removed=removed_count)
+        # TASK-28028: mounted/removed tabs change what is hidden past each
+        # edge even when scroll_x does not move; refresh the ‹ › hints once
+        # the new children have laid out (same best-effort rationale as the
+        # scroll scheduling below -- surfaces built outside a running app
+        # have no message pump).
+        try:
+            self.call_after_refresh(self._sync_tab_overflow_hints)
+        except Exception:
+            pass
         if active_session_id is not None:
             try:
                 self.call_after_refresh(
@@ -622,6 +779,10 @@ class ConsoleSessionSurface(Vertical):
             tab_strip.scroll_to_widget(tab, animate=False)
         except Exception:
             return
+        # The programmatic scroll moved scroll_x without a wheel event; the
+        # watcher covers it, but this also catches the no-movement case
+        # where layout only just settled (region was zero above).
+        self._sync_tab_overflow_hints()
 
     def set_session_title(self, title: str | None) -> None:
         """Show the active conversation/session title in the transcript header.

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -5336,6 +5336,15 @@ Button.console-inspector-action:disabled {
     scrollbar-size-horizontal: 0;
 }
 
+/* TASK-28028: 1-cell ‹ › hints at the strip row's edges, shown only while
+   tabs are hidden past that edge (display toggled from Python). */
+#console-tab-overflow-left,
+#console-tab-overflow-right {
+    color: $ds-text-muted;
+    text-style: none;
+    background: transparent;
+}
+
 .console-session-tab,
 #console-new-chat-tab,
 #console-new-temporary-tab {

--- a/tldw_chatbook/css/screen_agentic_console.tcss
+++ b/tldw_chatbook/css/screen_agentic_console.tcss
@@ -1886,6 +1886,15 @@ Button.console-inspector-action:disabled {
     scrollbar-size-horizontal: 0;
 }
 
+/* TASK-28028: 1-cell ‹ › hints at the strip row's edges, shown only while
+   tabs are hidden past that edge (display toggled from Python). */
+#console-tab-overflow-left,
+#console-tab-overflow-right {
+    color: $ds-text-muted;
+    text-style: none;
+    background: transparent;
+}
+
 .console-session-tab,
 #console-new-chat-tab,
 #console-new-temporary-tab {


### PR DESCRIPTION
## What

Two console fixes, one per commit:

### 1. Tab strip wheel scrolling + overflow hints (TASK-28025)
Tabs pushed off-screen in the Console session tab strip were invisible and unreachable: Textual 8.x only scrolls a `HorizontalScroll` for shift/ctrl wheel chords, and nothing signaled hidden tabs.

- Plain vertical wheel over the strip scrolls it horizontally (up = earlier tabs, down = later; 8 cells/step); event stopped only when it actually moved.
- 1-cell `◂`/`▸` hints flank the strip, each shown only while tabs are hidden past that side (driven by `watch_scroll_x`, resize, and sync hooks; always mounted — no layout shift).
- `#console-native-tab-strip` id unchanged; auto-scroll-to-active and Alt+1..9 untouched.
- CSS rule added to the `_agentic_terminal.tcss` source module; bundle regenerated (deterministic builder, sync check green).

### 2. Bare-screen crash in `_ensure_console_chat_store` (TASK-28027) — fixes the 12 red state-restore tests
`_ensure_console_chat_store` eagerly dereferenced the wiring-set `self._workspace` controller. Views reaching the store before `build_console_controllers` (bare `__new__` screens in the state-restore tests; the early-attach path `_bind_view_hooks` documents) crashed with `AttributeError`. Now guarded with `getattr`: no workspace controller → the runtime's safe global default context (same as an explicit resume), and the empty-store realignment is skipped.

## Test evidence (run against this branch's base = dev)

- **The 12 reported failures are fixed**: the state-restore family (13 tests incl. the 12) goes green.
- `Tests/UI/test_console_native_chat_flow.py`: **24 → 13 failures** on dev. The 13 remaining are pre-existing on unmodified dev (prompt-auto-improvement x6, send-path x4, sync/reconcile, resume wiring, settings toast) — unrelated to this PR and untouched by it; listing them here so the delta is legible.
- `Tests/UI/test_console_session_tab_strip.py`: 17 passed (5 new: wheel both directions, edge no-op, hint toggling with/without overflow).
- `Tests/UI/test_console_runtime_ownership.py`: 7 passed. Ruff clean. CSS bundle sync check green.
- Live tmux verification on a scratch profile (feature leg): 10 tabs overflow, both hints track, wheel scrolls both directions (measured 8 cells/step), Ctrl+K switcher opens, lists all sessions, and switches.

## Out of scope / notes

- The remaining 13 dev-side failures deserve their own investigation (they fail identically on unmodified dev).
- The rail-height seam work from TASK-28025's original plan turned out to be already landed on dev via `be1ee8418` (scale Console conversation rail cap to available height); the task file records the supersession.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two console issues: tabs pushed off-screen in the session tab strip are now reachable and visible (TASK-28028), and pre-wiring screens no longer crash when the chat store is initialized (TASK-28029).

- A plain vertical wheel over the strip now scrolls it horizontally (up = earlier tabs, down = later; previously only shift/ctrl chords scrolled it), stopping the event only when the strip actually moved.
- One-cell `◂`/`▸` hints flank the strip and show only while tabs are hidden past that edge; they stay mounted, so toggling them never shifts the strip's layout. `#console-native-tab-strip`, auto-scroll-to-active, and Alt+1..9 behavior are unchanged.
- `_ensure_console_chat_store` no longer assumes `_workspace` exists; views reaching the store before `build_console_controllers` use the runtime's safe global default context and skip empty-store realignment. This fixes the 12 failing state-restore tests.
- The rail-height seam from the original plan was already on dev, so this PR only adds the tab-strip affordances.
- The remaining chat-flow test failures are pre-existing on dev and untouched by this PR.

<sup>Written for commit 20a93746a879697124d76221411bd4db0eddf3d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

