### PR TITLE
feat(trace): add lossless chunk-row encoding (TASK-24206)

### DIFF
--- a/Docs/User_Guide/console/semantic-trace-capture.md
+++ b/Docs/User_Guide/console/semantic-trace-capture.md
@@ -155,6 +155,16 @@ Copy and export obey the active Safe or Full projection and every frozen mask.
 Full copy/export asks for confirmation. Exported files are independent copies;
 later trace deletion cannot recall them.
 
+When a trace contains token-level text, reasoning, or tool-call stream events,
+Console may store a consecutive run as one compact physical row. This changes
+only database layout: the Inspector, replay, copy, and export paths receive the
+same individual events, with their original boundaries, identities, order, and
+timestamps. Short, mixed, unknown, and older unencoded records remain readable.
+If a row claims a packed format that Console does not support, or its contents
+do not reconstruct safely, Console reports a format or corruption diagnostic
+instead of showing a partial history. Persistence flush boundaries can reduce
+the compression ratio but cannot change the reconstructed conversation.
+
 Purge detaches one conversation's trace owner. Background garbage collection
 can then remove objects no remaining conversation or fork owns. Logical
 reclamation, SQLite free pages, WAL bytes, and the allocated database file are

--- a/Docs/superpowers/plans/2026-09-02-console-trace-chunk-row-encoding.md
+++ b/Docs/superpowers/plans/2026-09-02-console-trace-chunk-row-encoding.md
@@ -1,0 +1,43 @@
+# TASK-24206 Console Trace Chunk-Row Encoding Plan
+
+## Goal
+
+Provide a lossless, versioned storage-row codec for future streamed Console
+trace deltas without changing the canonical logical event model or current
+capture/runtime wiring.
+
+## Implementation
+
+1. Add focused red tests in `Tests/Chat/test_console_trace_chunk_rows.py` for
+   exact round trips, compatibility boundaries, split persistence batches,
+   malformed/unsupported rows, legacy pass-through, Unicode, empty chunks,
+   timestamp gaps, interrupted streams, short runs, and mixed kinds.
+2. Implement the smallest strict codec in
+   `tldw_chatbook/Chat/console_trace_chunk_rows.py`, using exact-key admission,
+   three storage-only v1 tags, and explicit corruption/format exceptions.
+3. Add `Tests/Benchmarks/benchmark_console_trace_chunk_rows.py` and its focused
+   test to compare SQLite row count/bytes and encode/decode cost against
+   unencoded JSON rows.
+4. Record the representative benchmark and format contract in the user-facing
+   trace documentation, then update the task acceptance criteria and concise
+   implementation notes.
+5. Run the focused codec/benchmark tests, relevant semantic-trace regression
+   tests, Ruff, Python compilation, and `git diff --check`.
+
+## Review risks
+
+- Physical storage tags must never be accepted as logical event types.
+- Unknown or extended logical events must pass through verbatim.
+- A malformed claimed row must never decode a valid prefix.
+- Sequence and timestamp delta arithmetic must remain within signed 64-bit
+  bounds so JSON/SQLite round trips are deterministic.
+- Persistence batch shape may affect compression ratio but not decoded history.
+
+## ADR check
+
+ADR required: no
+
+ADR path: `backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md`
+
+Reason: this is the direct physical-codec follow-up already separated by
+ADR-097 and does not change durable schema or ownership.

--- a/Docs/superpowers/specs/2026-09-02-console-trace-chunk-row-encoding-design.md
+++ b/Docs/superpowers/specs/2026-09-02-console-trace-chunk-row-encoding-design.md
@@ -1,0 +1,92 @@
+# Console Trace Chunk-Row Encoding Design
+
+**Task:** TASK-24206
+
+**Status:** Approved by the existing task acceptance criteria and ADR-097 boundary
+
+**Reference:** DeepSeek Harness `chunk-rows.ts`
+
+## Problem
+
+Future token-level Console traces can produce hundreds of consecutive text,
+reasoning, or tool-call argument deltas. Persisting every delta as a complete
+JSON event row repeats the same segment, turn, call, block, and type envelope
+and makes physical storage scale with envelope overhead rather than payload.
+
+The semantic trace ledger already defines one canonical logical event history.
+Packing must remain invisible above persistence: readers receive the same
+ordinary events in the same order, and existing unencoded records remain valid.
+
+## Decision
+
+Add a pure, versioned codec in `tldw_chatbook.Chat.console_trace_chunk_rows`.
+It accepts JSON-compatible canonical event mappings and emits storage records.
+Only an exact `stream_delta` event shape with a text, reasoning, or tool-call
+delta may pack. Events with extra fields, invalid primitive types, unsupported
+kinds, non-consecutive sequence values, or changed segment/turn/call/block
+identity remain verbatim.
+
+A compatible run of at least three events becomes one physical row tagged with
+a storage-only `trace-*-chunks-v1` value. The row stores the first sequence and
+timestamp, exact event identities and payload boundaries, and timestamp gaps.
+The tag is not an event type and never escapes decoding.
+
+Encoding is stateless per persistence batch. A run split across flushes may
+produce more rows than the same run encoded in one batch, but concatenating the
+decoded batches always reproduces the original history exactly. This preserves
+durability without making callers retain or coordinate partial runs.
+
+The decoder passes records without a storage tag through unchanged. A record
+that claims any chunk-row storage tag must use the supported v1 tag and validate
+its exact envelope, member arity, identities, integer bounds, and reconstructed
+sequence/timestamp range. Unsupported formats raise a format diagnostic;
+malformed supported rows raise a corruption diagnostic. Neither path yields a
+partial history.
+
+## Canonical stream-delta shape
+
+Canonical events use exactly these fields:
+
+- `event_id`, `segment_id`, `turn_id`, `call_id`, and `block_id`: non-empty strings
+- `event_type`: `stream_delta`
+- `delta_kind`: `text`, `reasoning`, or `tool_call`
+- `sequence`: a non-negative signed-64-bit integer
+- `timestamp_us`: a signed-64-bit integer
+- `payload`: the exact string delta, including empty strings and Unicode
+
+Exact-key recognition is deliberate. A future logical field or event variant
+loses compression until the codec is revised, never data.
+
+## Benchmark
+
+The benchmark writes the same representative event stream to SQLite once as
+ordinary JSON rows and once through the codec. It reports logical event count,
+physical row count, allocated database bytes, encoded payload bytes, encode
+time, and decode time. Tests require exact reconstruction plus physical row and
+byte reduction; timing is reported rather than treated as a cross-platform
+hard threshold.
+
+The 6,000-event reference run on macOS 15.6 arm64, Python 3.12.11, and SQLite
+3.49.1 produced:
+
+| Measurement | Ordinary rows | Packed rows |
+| --- | ---: | ---: |
+| Physical rows | 6,000 | 3 |
+| JSON bytes | 1,564,655 | 182,547 |
+| SQLite allocated bytes | 1,724,416 | 192,512 |
+| Encode time | 8.702 ms | 5.955 ms |
+| Decode time | 6.636 ms | 2.653 ms |
+
+Run the repeatable benchmark with
+`python -m Tests.Benchmarks.benchmark_console_trace_chunk_rows --events 6000`.
+The test gate asserts exact reconstruction and row/byte reduction; it does not
+assert these machine-specific timing values.
+
+## ADR check
+
+ADR required: no
+
+ADR path: `backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md`
+
+Reason: ADR-097 already chose a physical codec beneath one logical trace model.
+No database schema, migration, ownership, privacy, or runtime boundary changes.

--- a/Tests/Benchmarks/benchmark_console_trace_chunk_rows.py
+++ b/Tests/Benchmarks/benchmark_console_trace_chunk_rows.py
@@ -1,0 +1,150 @@
+"""Representative storage benchmark for Console trace chunk rows."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterable, Mapping
+import json
+from pathlib import Path
+import sqlite3
+import tempfile
+import time
+from typing import TypedDict
+
+from tldw_chatbook.Chat.console_trace_chunk_rows import (
+    decode_trace_storage_records,
+    pack_trace_event_rows,
+)
+
+
+class ChunkRowBenchmarkResult(TypedDict):
+    """Measurements for one raw-versus-packed benchmark run."""
+
+    logical_events: int
+    raw_rows: int
+    packed_rows: int
+    raw_json_bytes: int
+    packed_json_bytes: int
+    raw_database_bytes: int
+    packed_database_bytes: int
+    raw_encode_ms: float
+    packed_encode_ms: float
+    raw_decode_ms: float
+    packed_decode_ms: float
+
+
+def representative_events(event_count: int) -> list[dict[str, object]]:
+    """Build a deterministic stream covering every supported delta kind."""
+
+    if event_count < 9:
+        raise ValueError("event_count must be at least 9")
+    kinds = ("text", "reasoning", "tool_call")
+    events: list[dict[str, object]] = []
+    for sequence in range(event_count):
+        kind_index = min(sequence * len(kinds) // event_count, len(kinds) - 1)
+        kind = kinds[kind_index]
+        events.append(
+            {
+                "event_id": f"event-{sequence:08d}",
+                "segment_id": "segment-benchmark",
+                "sequence": sequence,
+                "event_type": "stream_delta",
+                "timestamp_us": 1_800_000_000_000_000 + (sequence * 1_137),
+                "turn_id": "turn-benchmark",
+                "call_id": "call-benchmark",
+                "block_id": f"block-{kind}",
+                "delta_kind": kind,
+                "payload": ("token-🙂" if sequence % 17 == 0 else "token"),
+            }
+        )
+    return events
+
+
+def _serialize(
+    records: Iterable[Mapping[str, object]],
+) -> tuple[list[str], float]:
+    started = time.perf_counter_ns()
+    rows = [
+        json.dumps(record, ensure_ascii=False, separators=(",", ":"))
+        for record in records
+    ]
+    elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+    return rows, elapsed_ms
+
+
+def _decode(rows: list[str]) -> tuple[tuple[object, ...], float]:
+    started = time.perf_counter_ns()
+    decoded = decode_trace_storage_records(json.loads(row) for row in rows)
+    elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+    return decoded, elapsed_ms
+
+
+def _write_database(path: Path, rows: list[str]) -> int:
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(
+            "CREATE TABLE trace_records (position INTEGER PRIMARY KEY, body TEXT NOT NULL)"
+        )
+        connection.executemany(
+            "INSERT INTO trace_records(body) VALUES (?)",
+            ((row,) for row in rows),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    return path.stat().st_size
+
+
+def run_benchmark(event_count: int = 6_000) -> ChunkRowBenchmarkResult:
+    """Compare raw event rows with lossless packed rows in fresh SQLite files."""
+
+    events = representative_events(event_count)
+    raw_rows, raw_encode_ms = _serialize(events)
+
+    packed_started = time.perf_counter_ns()
+    packed_records = pack_trace_event_rows(events)
+    packed_rows = [
+        json.dumps(record, ensure_ascii=False, separators=(",", ":"))
+        for record in packed_records
+    ]
+    packed_encode_ms = (time.perf_counter_ns() - packed_started) / 1_000_000
+
+    raw_decoded, raw_decode_ms = _decode(raw_rows)
+    packed_decoded, packed_decode_ms = _decode(packed_rows)
+    expected = tuple(events)
+    if raw_decoded != expected or packed_decoded != expected:
+        raise AssertionError("benchmark storage did not reconstruct the exact trace")
+
+    with tempfile.TemporaryDirectory(prefix="trace-chunk-row-benchmark-") as directory:
+        benchmark_dir = Path(directory)
+        raw_database_bytes = _write_database(benchmark_dir / "raw.sqlite3", raw_rows)
+        packed_database_bytes = _write_database(
+            benchmark_dir / "packed.sqlite3", packed_rows
+        )
+
+    return {
+        "logical_events": len(events),
+        "raw_rows": len(raw_rows),
+        "packed_rows": len(packed_rows),
+        "raw_json_bytes": sum(len(row.encode("utf-8")) for row in raw_rows),
+        "packed_json_bytes": sum(len(row.encode("utf-8")) for row in packed_rows),
+        "raw_database_bytes": raw_database_bytes,
+        "packed_database_bytes": packed_database_bytes,
+        "raw_encode_ms": raw_encode_ms,
+        "packed_encode_ms": packed_encode_ms,
+        "raw_decode_ms": raw_decode_ms,
+        "packed_decode_ms": packed_decode_ms,
+    }
+
+
+def main() -> None:
+    """Run the benchmark and print machine-readable JSON."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--events", type=int, default=6_000)
+    args = parser.parse_args()
+    print(json.dumps(run_benchmark(args.events), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/Tests/Benchmarks/test_console_trace_chunk_rows.py
+++ b/Tests/Benchmarks/test_console_trace_chunk_rows.py
@@ -1,0 +1,17 @@
+"""Release checks for the Console trace chunk-row benchmark."""
+
+from Tests.Benchmarks.benchmark_console_trace_chunk_rows import run_benchmark
+
+
+def test_chunk_rows_reduce_representative_storage_without_losing_events() -> None:
+    result = run_benchmark(event_count=1_200)
+
+    assert result["logical_events"] == 1_200
+    assert result["raw_rows"] == 1_200
+    assert result["packed_rows"] == 3
+    assert result["packed_json_bytes"] < result["raw_json_bytes"]
+    assert result["packed_database_bytes"] < result["raw_database_bytes"]
+    assert result["raw_encode_ms"] >= 0
+    assert result["packed_encode_ms"] >= 0
+    assert result["raw_decode_ms"] >= 0
+    assert result["packed_decode_ms"] >= 0

--- a/Tests/Chat/test_console_trace_chunk_rows.py
+++ b/Tests/Chat/test_console_trace_chunk_rows.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from tldw_chatbook.Chat.console_trace_chunk_rows import (
+    TraceChunkRowCorruption,
+    TraceChunkRowFormatError,
+    decode_trace_storage_record,
+    decode_trace_storage_records,
+    pack_trace_event_rows,
+)
+
+
+def _delta(
+    sequence: int,
+    payload: str,
+    *,
+    kind: str = "text",
+    timestamp_us: int | None = None,
+    event_id: str | None = None,
+    segment_id: str = "segment-a",
+    turn_id: str = "turn-a",
+    call_id: str = "call-a",
+    block_id: str = "block-a",
+) -> dict[str, object]:
+    return {
+        "event_id": event_id or f"event-{sequence}",
+        "segment_id": segment_id,
+        "sequence": sequence,
+        "event_type": "stream_delta",
+        "timestamp_us": sequence * 10 if timestamp_us is None else timestamp_us,
+        "turn_id": turn_id,
+        "call_id": call_id,
+        "block_id": block_id,
+        "delta_kind": kind,
+        "payload": payload,
+    }
+
+
+def _round_trip(events: list[dict[str, object]]) -> tuple[Mapping[str, object], ...]:
+    return decode_trace_storage_records(pack_trace_event_rows(events))
+
+
+def test_text_run_packs_once_and_round_trips_unicode_and_empty_boundaries() -> None:
+    events = [
+        _delta(0, ""),
+        _delta(1, "hé"),
+        _delta(2, "🙂"),
+        _delta(3, "\u0000tail"),
+    ]
+
+    rows = pack_trace_event_rows(events)
+
+    assert len(rows) == 1
+    assert rows[0]["storage_type"] == "trace-text-chunks-v1"
+    assert "event_type" not in rows[0]
+    assert _round_trip(events) == tuple(events)
+
+
+def test_reasoning_run_preserves_positive_zero_and_negative_timestamp_gaps() -> None:
+    events = [
+        _delta(7, "a", kind="reasoning", timestamp_us=1_000),
+        _delta(8, "b", kind="reasoning", timestamp_us=1_050),
+        _delta(9, "c", kind="reasoning", timestamp_us=1_050),
+        _delta(10, "d", kind="reasoning", timestamp_us=900),
+    ]
+
+    rows = pack_trace_event_rows(events)
+
+    assert rows[0]["storage_type"] == "trace-reasoning-chunks-v1"
+    assert rows[0]["data"]["timestamp_deltas_us"] == [50, 0, -150]
+    assert decode_trace_storage_records(rows) == tuple(events)
+
+
+def test_tool_call_runs_require_one_exact_block_identity() -> None:
+    first = [
+        _delta(index, payload, kind="tool_call", block_id="tool-1")
+        for index, payload in enumerate(("{", '"x":', "1"))
+    ]
+    second = [
+        _delta(index, payload, kind="tool_call", block_id="tool-2")
+        for index, payload in enumerate(("[", "2", "]"), start=3)
+    ]
+
+    rows = pack_trace_event_rows([*first, *second])
+
+    assert [row["storage_type"] for row in rows] == [
+        "trace-tool-call-chunks-v1",
+        "trace-tool-call-chunks-v1",
+    ]
+    assert decode_trace_storage_records(rows) == tuple([*first, *second])
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        {"delta_kind": "reasoning"},
+        {"segment_id": "segment-b"},
+        {"turn_id": "turn-b"},
+        {"call_id": "call-b"},
+        {"block_id": "block-b"},
+        {"sequence": 8},
+    ],
+)
+def test_incompatible_delta_breaks_a_run_without_reordering(
+    changed: dict[str, object],
+) -> None:
+    events = [_delta(0, "a"), _delta(1, "b")]
+    third = _delta(2, "c")
+    third.update(changed)
+    events.append(third)
+
+    rows = pack_trace_event_rows(events)
+
+    assert rows == tuple(events)
+    assert decode_trace_storage_records(rows) == tuple(events)
+
+
+def test_structural_extended_and_short_events_remain_verbatim_boundaries() -> None:
+    structural = {
+        "event_id": "boundary",
+        "segment_id": "segment-a",
+        "sequence": 3,
+        "event_type": "call_outcome",
+        "call_id": "call-a",
+    }
+    extended = _delta(7, "future")
+    extended["future_field"] = True
+    events = [
+        _delta(0, "a"),
+        _delta(1, "b"),
+        _delta(2, "c"),
+        structural,
+        _delta(4, "d"),
+        _delta(5, "e"),
+        _delta(6, "f"),
+        extended,
+    ]
+
+    rows = pack_trace_event_rows(events)
+
+    assert len(rows) == 4
+    assert rows[1] is structural
+    assert rows[-1] is extended
+    assert decode_trace_storage_records(rows) == tuple(events)
+
+
+def test_split_persistence_batches_need_no_run_alignment() -> None:
+    events = [_delta(index, str(index)) for index in range(8)]
+
+    split_rows = [
+        *pack_trace_event_rows(events[:2]),
+        *pack_trace_event_rows(events[2:5]),
+        *pack_trace_event_rows(events[5:]),
+    ]
+
+    assert len(split_rows) == 4
+    assert decode_trace_storage_records(split_rows) == tuple(events)
+
+
+def test_interrupted_stream_packs_without_a_terminal_event() -> None:
+    events = [_delta(index, value) for index, value in enumerate(("one", "two", ""))]
+
+    rows = pack_trace_event_rows(events)
+
+    assert len(rows) == 1
+    assert decode_trace_storage_records(rows) == tuple(events)
+
+
+def test_existing_unencoded_trace_record_reads_unchanged() -> None:
+    event = {
+        "event_id": "existing",
+        "segment_id": "segment-a",
+        "sequence": 0,
+        "event_type": "surface_append",
+        "turn_id": "turn-a",
+        "surface_node_id": "surface-a",
+    }
+
+    assert decode_trace_storage_record(event) == (event,)
+    assert decode_trace_storage_records((event,)) == (event,)
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        {"storage_type": "trace-text-chunks-v1"},
+        {
+            "storage_type": "trace-text-chunks-v1",
+            "segment_id": "segment-a",
+            "sequence0": 0,
+            "timestamp0_us": 0,
+            "data": {
+                "event_ids": ["a", "b", "c"],
+                "turn_id": "turn-a",
+                "call_id": "call-a",
+                "block_id": "block-a",
+                "timestamp_deltas_us": [1],
+                "payloads": ["a", "b", "c"],
+            },
+        },
+        {
+            "storage_type": "trace-tool-call-chunks-v1",
+            "segment_id": "segment-a",
+            "sequence0": 0,
+            "timestamp0_us": 0,
+            "data": {
+                "event_ids": ["a", "b", ""],
+                "turn_id": "turn-a",
+                "call_id": "call-a",
+                "block_id": "block-a",
+                "timestamp_deltas_us": [1, 1],
+                "payloads": ["a", "b", "c"],
+            },
+        },
+    ],
+)
+def test_malformed_claimed_rows_fail_closed(record: dict[str, object]) -> None:
+    with pytest.raises(TraceChunkRowCorruption, match="malformed trace chunk row"):
+        decode_trace_storage_record(record)
+
+
+def test_unsupported_claimed_row_format_fails_closed() -> None:
+    with pytest.raises(TraceChunkRowFormatError, match="unsupported trace chunk"):
+        decode_trace_storage_record({"storage_type": "trace-text-chunks-v2"})
+
+
+@pytest.mark.parametrize(
+    ("sequence0", "timestamp0", "timestamp_deltas", "reason"),
+    [
+        (2**63 - 2, 0, [0, 0], "sequence range"),
+        (0, 2**63 - 1, [1, 0], "timestamp range"),
+        (0, -(2**63), [-1, 0], "timestamp range"),
+    ],
+)
+def test_claimed_rows_reject_reconstructed_int64_overflow(
+    sequence0: int,
+    timestamp0: int,
+    timestamp_deltas: list[int],
+    reason: str,
+) -> None:
+    record = {
+        "storage_type": "trace-text-chunks-v1",
+        "segment_id": "segment-a",
+        "sequence0": sequence0,
+        "timestamp0_us": timestamp0,
+        "data": {
+            "event_ids": ["a", "b", "c"],
+            "turn_id": "turn-a",
+            "call_id": "call-a",
+            "block_id": "block-a",
+            "timestamp_deltas_us": timestamp_deltas,
+            "payloads": ["a", "b", "c"],
+        },
+    }
+
+    with pytest.raises(TraceChunkRowCorruption, match=reason):
+        decode_trace_storage_record(record)
+
+
+def test_bad_row_never_returns_a_valid_prefix() -> None:
+    good = _delta(0, "ordinary")
+    malformed = {"storage_type": "trace-reasoning-chunks-v1"}
+
+    with pytest.raises(TraceChunkRowCorruption):
+        decode_trace_storage_records((good, malformed))
+
+
+def test_invalid_or_extended_stream_shapes_lose_compression_not_data() -> None:
+    invalid = [
+        _delta(0, "a"),
+        _delta(1, "b"),
+        _delta(2, "c"),
+    ]
+    invalid[0]["sequence"] = True
+    invalid[1]["timestamp_us"] = 1.5
+    invalid[2]["payload"] = b"c"
+
+    rows = pack_trace_event_rows(invalid)
+
+    assert rows == tuple(invalid)
+    assert decode_trace_storage_records(rows) == tuple(invalid)

--- a/backlog/tasks/task-24206 - Add-lossless-chunk-row-encoding-for-streamed-trace-events.md
+++ b/backlog/tasks/task-24206 - Add-lossless-chunk-row-encoding-for-streamed-trace-events.md
@@ -1,8 +1,9 @@
 ---
 id: TASK-24206
 title: Add lossless chunk-row encoding for streamed trace events
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-28 14:38'
 labels:
   - console
@@ -13,6 +14,9 @@ dependencies: []
 references:
   - >-
     https://github.com/deepseek-ai/deepseek-harness/blob/master/packages/core/session/src/chunk-rows.ts
+  - Docs/superpowers/specs/2026-09-02-console-trace-chunk-row-encoding-design.md
+  - Docs/superpowers/plans/2026-09-02-console-trace-chunk-row-encoding.md
+  - backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
 priority: medium
 ---
 
@@ -24,13 +28,13 @@ Add an optional physical encoding for future token-level Console trace events th
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Encoding followed by decoding reproduces every canonical event exactly including type payload sequence timestamp turn call and block identity
-- [ ] #2 Only consecutive compatible same-kind delta runs are packed and incompatible mixed or structural events preserve their original boundaries and order
-- [ ] #3 Packing across persistence flush boundaries remains correct without requiring callers to coordinate batch shapes
-- [ ] #4 Malformed or unsupported packed rows fail closed with a specific corruption or format diagnostic rather than yielding partial history
-- [ ] #5 Existing unencoded traces remain readable and the physical encoding does not create a second logical event model
-- [ ] #6 Targeted tests cover text reasoning and tool-call deltas Unicode empty chunks timestamp gaps interrupted streams short runs and mixed event kinds
-- [ ] #7 A representative streaming benchmark reports database bytes row count encode cost and decode cost before and after the feature
+- [x] #1 Encoding followed by decoding reproduces every canonical event exactly including type payload sequence timestamp turn call and block identity
+- [x] #2 Only consecutive compatible same-kind delta runs are packed and incompatible mixed or structural events preserve their original boundaries and order
+- [x] #3 Packing across persistence flush boundaries remains correct without requiring callers to coordinate batch shapes
+- [x] #4 Malformed or unsupported packed rows fail closed with a specific corruption or format diagnostic rather than yielding partial history
+- [x] #5 Existing unencoded traces remain readable and the physical encoding does not create a second logical event model
+- [x] #6 Targeted tests cover text reasoning and tool-call deltas Unicode empty chunks timestamp gaps interrupted streams short runs and mixed event kinds
+- [x] #7 A representative streaming benchmark reports database bytes row count encode cost and decode cost before and after the feature
 <!-- AC:END -->
 
 ## Renumbering provenance
@@ -40,3 +44,33 @@ PR #2200, add-commit provenance showed that the boot-import-closure repair
 reached `dev` first in `d4bd5ff91e`; this later semantic-trace follow-up arrived
 in `7cf89de6c0`. Under the TASK-19601 older-arrival owner rule, the boot repair
 keeps `TASK-23112` and this task moves to `TASK-24206`.
+
+## Implementation Plan
+
+1. Define one strict versioned physical-row codec beneath the canonical trace-event boundary; exact stream-delta shapes may pack, while structural, unknown, or extended events remain verbatim.
+2. Implement lossless text, reasoning, and tool-call delta run packing plus fail-closed row validation and exact decoding.
+3. Prove batch-boundary independence, Unicode and empty payloads, timestamp gaps, interrupted streams, short runs, mixed event kinds, and corrupt/unsupported row diagnostics with focused tests.
+4. Add a representative SQLite benchmark that reports logical/physical rows, allocated bytes, and encode/decode cost for encoded and unencoded storage.
+5. Document the format, benchmark result, and integration boundary; run focused tests, lint, compilation, and diff validation before closeout.
+
+ADR required: no
+ADR path: backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
+Reason: ADR-097 already defines chunk-row encoding as a physical codec rather than a parallel event vocabulary. This task adds no database schema, migration, ownership, privacy, or runtime-boundary decision.
+
+## Implementation Notes
+
+- Added a strict, stateless v1 physical codec for consecutive text, reasoning,
+  and tool-call stream deltas. Exact canonical events decode unchanged; short,
+  mixed, extended, and existing unencoded events remain verbatim.
+- Claimed packed rows validate exact shape, arity, identity, and signed-64-bit
+  arithmetic. Unsupported versions and corrupt rows fail with distinct
+  diagnostics before any partial history is returned.
+- Added focused codec and SQLite benchmark coverage plus user/design
+  documentation. The 6,000-event reference run reduced 6,000 rows to 3,
+  JSON bytes from 1,564,655 to 182,547, and allocated SQLite bytes from
+  1,724,416 to 192,512; encode/decode timings are reported but not gated.
+- Verification: 23 focused codec/benchmark checks and 113 codec/repository/
+  service checks passed; Ruff, Python compilation, and whitespace validation
+  passed. The full repository suite was not run per the targeted-test policy.
+- ADR required: no. ADR-097 already owns the physical-codec boundary; no
+  schema, migration, ownership, privacy, or runtime boundary changed.

--- a/tldw_chatbook/Chat/console_trace_chunk_rows.py
+++ b/tldw_chatbook/Chat/console_trace_chunk_rows.py
@@ -1,0 +1,302 @@
+"""Lossless physical row packing for canonical Console stream-delta events.
+
+Packed row tags belong only to persistence. Decoding always returns ordinary
+canonical event mappings, so this module does not introduce a second logical
+trace-event vocabulary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Never, TypeAlias
+
+TraceEventMapping: TypeAlias = Mapping[str, object]
+TraceStorageRecord: TypeAlias = Mapping[str, object]
+
+MIN_PACKED_RUN = 3
+_INT64_MIN = -(2**63)
+_INT64_MAX = 2**63 - 1
+_CANONICAL_KEYS = frozenset(
+    {
+        "event_id",
+        "segment_id",
+        "sequence",
+        "event_type",
+        "timestamp_us",
+        "turn_id",
+        "call_id",
+        "block_id",
+        "delta_kind",
+        "payload",
+    }
+)
+_ROW_KEYS = frozenset(
+    {"storage_type", "segment_id", "sequence0", "timestamp0_us", "data"}
+)
+_DATA_KEYS = frozenset(
+    {
+        "event_ids",
+        "turn_id",
+        "call_id",
+        "block_id",
+        "timestamp_deltas_us",
+        "payloads",
+    }
+)
+_KIND_TO_TAG = {
+    "text": "trace-text-chunks-v1",
+    "reasoning": "trace-reasoning-chunks-v1",
+    "tool_call": "trace-tool-call-chunks-v1",
+}
+_TAG_TO_KIND = {tag: kind for kind, tag in _KIND_TO_TAG.items()}
+
+
+class TraceChunkRowError(ValueError):
+    """Base class for claimed physical chunk-row failures."""
+
+
+class TraceChunkRowFormatError(TraceChunkRowError):
+    """A storage-tagged record uses an unsupported codec format."""
+
+
+class TraceChunkRowCorruption(TraceChunkRowError):
+    """A supported storage-tagged record is malformed or out of bounds."""
+
+
+def pack_trace_event_rows(
+    events: Iterable[TraceEventMapping],
+) -> tuple[TraceStorageRecord, ...]:
+    """Pack compatible stream-delta runs into versioned physical rows.
+
+    Events that are not an exact supported canonical shape pass through
+    verbatim. Encoding is stateless per call, so persistence batch boundaries
+    can reduce compression without changing decoded history.
+
+    Args:
+        events: Canonical trace events in persistence order.
+
+    Returns:
+        Storage records in the same logical order.
+    """
+
+    packed: list[TraceStorageRecord] = []
+    run: list[TraceEventMapping] = []
+    run_kind: str | None = None
+
+    def flush() -> None:
+        nonlocal run, run_kind
+        if run_kind is not None and len(run) >= MIN_PACKED_RUN:
+            packed.append(_pack_run(run_kind, run))
+        else:
+            packed.extend(run)
+        run = []
+        run_kind = None
+
+    for event in events:
+        kind = _classify(event)
+        if kind is None:
+            flush()
+            packed.append(event)
+            continue
+        if run and (kind != run_kind or not _continues(run[-1], event)):
+            flush()
+        run_kind = kind
+        run.append(event)
+    flush()
+    return tuple(packed)
+
+
+def decode_trace_storage_record(
+    record: TraceStorageRecord,
+) -> tuple[TraceEventMapping, ...]:
+    """Decode one physical record into its canonical logical event sequence.
+
+    Args:
+        record: One parsed storage record.
+
+    Returns:
+        One verbatim ordinary event or all events represented by a packed row.
+
+    Raises:
+        TraceChunkRowFormatError: If a storage tag names an unsupported format.
+        TraceChunkRowCorruption: If a supported row is malformed.
+    """
+
+    if "storage_type" not in record:
+        return (record,)
+    tag = record.get("storage_type")
+    if type(tag) is not str or tag not in _TAG_TO_KIND:
+        raise TraceChunkRowFormatError(
+            f"unsupported trace chunk storage row: {tag!r}"
+        )
+    return _decode_claimed_row(record, tag)
+
+
+def decode_trace_storage_records(
+    records: Iterable[TraceStorageRecord],
+) -> tuple[TraceEventMapping, ...]:
+    """Decode storage records atomically into one canonical event sequence.
+
+    The function returns only after every claimed packed row validates, so a
+    corrupt later row cannot expose a partially decoded history to the caller.
+
+    Args:
+        records: Parsed physical records in persistence order.
+
+    Returns:
+        The complete decoded canonical event sequence.
+
+    Raises:
+        TraceChunkRowError: If any claimed packed row is unsupported or corrupt.
+    """
+
+    events: list[TraceEventMapping] = []
+    for record in records:
+        events.extend(decode_trace_storage_record(record))
+    return tuple(events)
+
+
+def _classify(event: TraceEventMapping) -> str | None:
+    if set(event) != _CANONICAL_KEYS:
+        return None
+    if event.get("event_type") != "stream_delta":
+        return None
+    kind = event.get("delta_kind")
+    if type(kind) is not str or kind not in _KIND_TO_TAG:
+        return None
+    if not _nonempty_strings(
+        event,
+        "event_id",
+        "segment_id",
+        "turn_id",
+        "call_id",
+        "block_id",
+    ):
+        return None
+    if type(event.get("payload")) is not str:
+        return None
+    sequence = event.get("sequence")
+    timestamp = event.get("timestamp_us")
+    if not _is_int64(sequence) or sequence < 0 or not _is_int64(timestamp):
+        return None
+    return kind
+
+
+def _continues(previous: TraceEventMapping, current: TraceEventMapping) -> bool:
+    previous_sequence = previous["sequence"]
+    current_sequence = current["sequence"]
+    if current_sequence != previous_sequence + 1:
+        return False
+    for key in (
+        "segment_id",
+        "event_type",
+        "delta_kind",
+        "turn_id",
+        "call_id",
+        "block_id",
+    ):
+        if current[key] != previous[key]:
+            return False
+    return _is_int64(current["timestamp_us"] - previous["timestamp_us"])
+
+
+def _pack_run(kind: str, run: list[TraceEventMapping]) -> dict[str, object]:
+    first = run[0]
+    return {
+        "storage_type": _KIND_TO_TAG[kind],
+        "segment_id": first["segment_id"],
+        "sequence0": first["sequence"],
+        "timestamp0_us": first["timestamp_us"],
+        "data": {
+            "event_ids": [event["event_id"] for event in run],
+            "turn_id": first["turn_id"],
+            "call_id": first["call_id"],
+            "block_id": first["block_id"],
+            "timestamp_deltas_us": [
+                run[index]["timestamp_us"] - run[index - 1]["timestamp_us"]
+                for index in range(1, len(run))
+            ],
+            "payloads": [event["payload"] for event in run],
+        },
+    }
+
+
+def _decode_claimed_row(
+    record: TraceStorageRecord,
+    tag: str,
+) -> tuple[TraceEventMapping, ...]:
+    if set(record) != _ROW_KEYS:
+        _malformed(tag, "envelope keys")
+    segment_id = record.get("segment_id")
+    if type(segment_id) is not str or not segment_id:
+        _malformed(tag, "segment_id")
+    sequence0 = record.get("sequence0")
+    timestamp0 = record.get("timestamp0_us")
+    if not _is_int64(sequence0) or sequence0 < 0:
+        _malformed(tag, "sequence0")
+    if not _is_int64(timestamp0):
+        _malformed(tag, "timestamp0_us")
+    data = record.get("data")
+    if not isinstance(data, Mapping) or set(data) != _DATA_KEYS:
+        _malformed(tag, "data keys")
+    if not _nonempty_strings(data, "turn_id", "call_id", "block_id"):
+        _malformed(tag, "turn/call/block identity")
+    event_ids = data.get("event_ids")
+    payloads = data.get("payloads")
+    timestamp_deltas = data.get("timestamp_deltas_us")
+    if (
+        type(event_ids) is not list
+        or len(event_ids) < MIN_PACKED_RUN
+        or any(type(value) is not str or not value for value in event_ids)
+    ):
+        _malformed(tag, "event_ids")
+    if (
+        type(payloads) is not list
+        or len(payloads) != len(event_ids)
+        or any(type(value) is not str for value in payloads)
+    ):
+        _malformed(tag, "payloads")
+    if (
+        type(timestamp_deltas) is not list
+        or len(timestamp_deltas) != len(event_ids) - 1
+        or any(not _is_int64(value) for value in timestamp_deltas)
+    ):
+        _malformed(tag, "timestamp_deltas_us")
+    if sequence0 > _INT64_MAX - (len(event_ids) - 1):
+        _malformed(tag, "sequence range")
+
+    kind = _TAG_TO_KIND[tag]
+    events: list[TraceEventMapping] = []
+    timestamp = timestamp0
+    for index, (event_id, payload) in enumerate(zip(event_ids, payloads, strict=True)):
+        if index:
+            timestamp += timestamp_deltas[index - 1]
+            if not _is_int64(timestamp):
+                _malformed(tag, "timestamp range")
+        events.append(
+            {
+                "event_id": event_id,
+                "segment_id": segment_id,
+                "sequence": sequence0 + index,
+                "event_type": "stream_delta",
+                "timestamp_us": timestamp,
+                "turn_id": data["turn_id"],
+                "call_id": data["call_id"],
+                "block_id": data["block_id"],
+                "delta_kind": kind,
+                "payload": payload,
+            }
+        )
+    return tuple(events)
+
+
+def _nonempty_strings(record: Mapping[str, object], *keys: str) -> bool:
+    return all(type(record.get(key)) is str and bool(record[key]) for key in keys)
+
+
+def _is_int64(value: object) -> bool:
+    return type(value) is int and _INT64_MIN <= value <= _INT64_MAX
+
+
+def _malformed(tag: str, reason: str) -> Never:
+    raise TraceChunkRowCorruption(f"malformed trace chunk row {tag}: {reason}")


### PR DESCRIPTION
## Summary
- add a strict v1 physical codec for compatible text, reasoning, and tool-call stream deltas
- preserve the canonical event model with verbatim fallback and fail-closed packed-row diagnostics
- add focused coverage, a repeatable SQLite benchmark, and trace storage documentation

## Benchmark
A 6,000-event reference run reduced 6,000 rows to 3, JSON bytes from 1,564,655 to 182,547, and allocated SQLite bytes from 1,724,416 to 192,512. Timing is reported but not used as a cross-machine gate.

## Verification
- 23 focused codec and benchmark checks passed
- 113 codec, trace repository, and trace service checks passed
- Ruff, Python compilation, and git diff validation passed
- full repository suite not run per targeted-test policy

## Architecture
No new ADR is required. ADR-097 already owns this physical-codec boundary; this change adds no schema, migration, ownership, privacy, or runtime-boundary decision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds lossless chunk-row encoding for Console trace stream deltas, reducing storage by packing consecutive compatible events into a single physical row while preserving the canonical event model.

- Packs runs of at least 3 text, reasoning, or tool-call deltas with identical segment/turn/call/block identity and consecutive sequence numbers into a versioned v1 storage row.
- Decoding reconstructs the exact original events; unencoded, short, mixed, and unknown events remain verbatim.
- Malformed or unsupported packed rows raise format or corruption diagnostics instead of returning partial history.
- Encoding is stateless per persistence batch, so flush boundaries may reduce compression but never change decoded history.
- A 6,000-event benchmark reduces physical rows from 6,000 to 3 and SQLite bytes from 1,724,416 to 192,512; timings are reported but not gated.
- Adds focused codec and benchmark tests, updates trace documentation, and marks TASK-24206 as done.

<sup>Written for commit 2ecbbd4e8271d96773e7305ee1332a686a2ee0d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

