### PR TITLE
feat(library): review sets phase 2 - Reader walker (task-28241)

### DIFF
--- a/Tests/Library/test_review_set_service.py
+++ b/Tests/Library/test_review_set_service.py
@@ -177,6 +177,18 @@ def test_dismiss_soft_deletes_and_deactivates():
     assert svc.get_review_set(set_id) is None  # dismissed sets are hidden
 
 
+def test_deactivate_active_keeps_the_set_resumable():
+    svc = _service()
+    set_id = svc.create_review_set("X", origin="browse", items=[(1, "a")])
+
+    svc.deactivate_active()
+    assert svc.get_active_review_set() is None
+    # not deleted -- still listable and re-activatable at its cursor.
+    assert [rs.set_id for rs in svc.list_review_sets()] == [set_id]
+    svc.activate(set_id)
+    assert svc.get_active_review_set().set_id == set_id
+
+
 def test_reopen_clears_completion():
     svc = _service()
     set_id = svc.create_review_set("X", origin="browse", items=[(1, "a")])

--- a/Tests/Library/test_review_set_state.py
+++ b/Tests/Library/test_review_set_state.py
@@ -10,10 +10,13 @@ never renumbers.
 from __future__ import annotations
 
 from tldw_chatbook.Library.review_set_state import (
+    ReviewProgress,
     ReviewSetItem,
     advance_cursor,
+    format_review_progress,
     is_complete,
     is_empty,
+    plan_walk,
     resolve_cursor,
     review_progress,
 )
@@ -135,3 +138,66 @@ def test_all_tombstoned_set_is_empty_not_complete():
     items = _items((10, True), (11, True))
     assert is_empty(items, is_live=_live(10, 11)) is True
     assert is_complete(items, is_live=_live(10, 11)) is False
+
+
+# --- the walk planner (forward marks-done, back does not) --------------------
+
+
+def test_plan_walk_forward_marks_current_done_and_targets_next():
+    items = _items((10, False), (11, False), (12, False))
+    outcome = plan_walk(items, cursor=0, step=1, is_live=_live())
+
+    assert outcome.new_cursor == 1
+    assert outcome.mark_done_backing_id == 10  # the item we leave
+    assert outcome.target.backing_media_id == 11  # the item we load
+
+
+def test_plan_walk_forward_skips_a_tombstone_target():
+    items = _items((10, False), (11, False), (12, False))
+    outcome = plan_walk(items, cursor=0, step=1, is_live=_live(11))
+
+    assert outcome.new_cursor == 2
+    assert outcome.mark_done_backing_id == 10
+    assert outcome.target.backing_media_id == 12
+
+
+def test_plan_walk_back_does_not_mark_and_targets_prev():
+    items = _items((10, False), (11, False), (12, False))
+    outcome = plan_walk(items, cursor=2, step=-1, is_live=_live())
+
+    assert outcome.new_cursor == 1
+    assert outcome.mark_done_backing_id is None  # Prev never auto-marks
+    assert outcome.target.backing_media_id == 11
+
+
+def test_plan_walk_forward_on_last_item_marks_done_without_moving():
+    items = _items((10, False), (11, False))
+    outcome = plan_walk(items, cursor=1, step=1, is_live=_live())
+
+    assert outcome.new_cursor == 1  # clamped
+    assert outcome.mark_done_backing_id == 11  # the completion gesture
+    assert outcome.target is None  # nothing new to load
+
+
+# --- the progress readout string --------------------------------------------
+
+
+def test_format_progress_reads_x_of_m_reviewed_n():
+    assert (
+        format_review_progress(ReviewProgress(index=12, total=40, reviewed=7))
+        == "12 of 40 · 7 reviewed"
+    )
+
+
+def test_format_progress_all_reviewed():
+    assert (
+        format_review_progress(ReviewProgress(index=40, total=40, reviewed=40))
+        == "All 40 reviewed"
+    )
+
+
+def test_format_progress_empty_set():
+    assert (
+        format_review_progress(ReviewProgress(index=0, total=0, reviewed=0))
+        == "No items to review"
+    )

--- a/Tests/UI/test_review_set_walker.py
+++ b/Tests/UI/test_review_set_walker.py
@@ -26,7 +26,14 @@ def _service(tmp_path) -> ReviewSetService:
     )
 
 
-def _walker_fake(service: ReviewSetService, *, live_ids=None) -> SimpleNamespace:
+def _walker_fake(
+    service: ReviewSetService, *, live_ids=None, loaded=None
+) -> SimpleNamespace:
+    """Fake screen for the walker.
+
+    ``loaded`` is the backing id the Reader is currently showing (Qodo #2333:
+    the walk marks/advances from the DISPLAYED item, not the persisted cursor).
+    """
     calls: list[tuple[str, str]] = []
     fake = SimpleNamespace(
         _review_set_service=lambda: service,
@@ -38,6 +45,7 @@ def _walker_fake(service: ReviewSetService, *, live_ids=None) -> SimpleNamespace
         _select_library_media_reader_row=(
             lambda media_id, title, **_kwargs: calls.append((media_id, title))
         ),
+        _library_media_reader_session=SimpleNamespace(loaded_backing_id=loaded),
     )
     fake._select_calls = calls
     return fake
@@ -48,7 +56,7 @@ def test_walk_forward_advances_marks_left_done_and_loads_next(tmp_path):
     set_id = service.create_review_set(
         "X", origin="browse", items=[(10, "A"), (11, "B"), (12, "C")]
     )
-    fake = _walker_fake(service)
+    fake = _walker_fake(service, loaded=10)
 
     handled = LibraryScreen._walk_active_review_set(fake, 1)
 
@@ -66,7 +74,7 @@ def test_walk_back_moves_without_marking(tmp_path):
         "X", origin="browse", items=[(10, "A"), (11, "B"), (12, "C")]
     )
     service.set_cursor(set_id, 2)
-    fake = _walker_fake(service)
+    fake = _walker_fake(service, loaded=12)
 
     LibraryScreen._walk_active_review_set(fake, -1)
 
@@ -82,7 +90,7 @@ def test_walk_forward_skips_a_tombstoned_target(tmp_path):
         "X", origin="browse", items=[(10, "A"), (11, "B"), (12, "C")]
     )
     # id 11 is deleted -> forward from 0 lands on 12.
-    fake = _walker_fake(service, live_ids={10, 12})
+    fake = _walker_fake(service, live_ids={10, 12}, loaded=10)
 
     LibraryScreen._walk_active_review_set(fake, 1)
 
@@ -98,7 +106,7 @@ def test_walk_forward_on_last_item_completes_without_reloading(tmp_path):
     # The user has already reviewed the first item and is on the last.
     service.mark_item_done(set_id, backing_media_id=10, done=True)
     service.set_cursor(set_id, 1)
-    fake = _walker_fake(service)
+    fake = _walker_fake(service, loaded=11)
 
     LibraryScreen._walk_active_review_set(fake, 1)
 
@@ -107,6 +115,25 @@ def test_walk_forward_on_last_item_completes_without_reloading(tmp_path):
     assert review_set.items[1].done is True  # completion gesture marks the last
     assert review_set.completed_at is not None  # every live item done
     assert fake._select_calls == []  # nothing new to load
+
+
+def test_walk_resumes_at_cursor_without_marking_when_reader_is_off_set(tmp_path):
+    # Qodo #2333: if the Reader is showing a non-set item (fresh entry, or a
+    # browse item), the first ] must NOT mark an unseen item -- it resumes the
+    # set at its cursor.
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "X", origin="browse", items=[(10, "A"), (11, "B"), (12, "C")]
+    )
+    service.set_cursor(set_id, 1)
+    fake = _walker_fake(service, loaded=999)  # 999 is not in the set
+
+    LibraryScreen._walk_active_review_set(fake, 1)
+
+    review_set = service.get_review_set(set_id)
+    assert all(item.done is False for item in review_set.items)  # nothing marked
+    assert fake._select_calls == [("local:media:11", "B")]  # loaded the cursor item
+    assert review_set.cursor == 1  # unchanged (already a live position)
 
 
 def test_walk_returns_false_when_no_set_is_active(tmp_path):
@@ -166,6 +193,41 @@ def test_toggle_reviewed_marks_and_unmarks_the_loaded_item(tmp_path):
 
     LibraryScreen.action_library_media_toggle_reviewed(fake)
     assert service.get_review_set(set_id).items[0].done is False
+
+
+def test_review_set_live_ids_filters_deleted_and_trashed(tmp_path):
+    # Qodo #2333: exercise the REAL Media-DB liveness query (parameter binding,
+    # deleted/is_trash filtering, an unknown id), not the injected fake.
+    from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
+
+    media_db = MediaDatabase(db_path=str(tmp_path / "media.db"), client_id="t")
+    ids = []
+    for index in range(3):
+        media_id, _uuid, _msg = media_db.add_media_with_keywords(
+            title=f"Item {index}",
+            media_type="video",
+            content=f"content {index}",
+            url=f"http://example/{index}",
+        )
+        ids.append(media_id)
+    media_db.soft_delete_media(ids[1])  # deleted = 1
+    media_db.mark_as_trash(ids[2])  # is_trash = 1
+
+    fake = SimpleNamespace(
+        app_instance=SimpleNamespace(media_db=media_db),
+        _REVIEW_SET_LIVENESS_BATCH=LibraryScreen._REVIEW_SET_LIVENESS_BATCH,
+    )
+    live = LibraryScreen._review_set_live_ids(fake, ids + [999_999])
+
+    assert live == {ids[0]}  # only the live item; deleted/trashed/unknown excluded
+
+
+def test_review_set_live_ids_treats_ids_live_when_media_db_absent():
+    fake = SimpleNamespace(
+        app_instance=SimpleNamespace(media_db=None),
+        _REVIEW_SET_LIVENESS_BATCH=LibraryScreen._REVIEW_SET_LIVENESS_BATCH,
+    )
+    assert LibraryScreen._review_set_live_ids(fake, [1, 2, 3]) == {1, 2, 3}
 
 
 def test_review_set_active_reflects_the_service(tmp_path):

--- a/Tests/UI/test_review_set_walker.py
+++ b/Tests/UI/test_review_set_walker.py
@@ -1,0 +1,176 @@
+"""Screen-side review-set walker (task-28241).
+
+Drives ``LibraryScreen._walk_active_review_set`` with a SimpleNamespace fake so
+the walk logic is exercised without a live app: a real ReviewSetService over a
+tmp DB provides the set, an injected liveness set stands in for the Media DB,
+and the per-item actuator is recorded rather than mounting a Reader.
+"""
+
+from __future__ import annotations
+
+import itertools
+from types import SimpleNamespace
+
+from tldw_chatbook.DB.Library_Collections_DB import LibraryCollectionsDB
+from tldw_chatbook.Library.review_set_service import ReviewSetService
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+
+
+def _service(tmp_path) -> ReviewSetService:
+    db = LibraryCollectionsDB(tmp_path / "collections.db")
+    counter = itertools.count(1)
+    return ReviewSetService(
+        db,
+        id_factory=lambda: f"set-{next(counter)}",
+        now=lambda: "2026-09-02T00:00:00Z",
+    )
+
+
+def _walker_fake(service: ReviewSetService, *, live_ids=None) -> SimpleNamespace:
+    calls: list[tuple[str, str]] = []
+    fake = SimpleNamespace(
+        _review_set_service=lambda: service,
+        _review_set_live_ids=(
+            (lambda ids: {int(i) for i in ids})
+            if live_ids is None
+            else (lambda ids: set(live_ids))
+        ),
+        _select_library_media_reader_row=(
+            lambda media_id, title, **_kwargs: calls.append((media_id, title))
+        ),
+    )
+    fake._select_calls = calls
+    return fake
+
+
+def test_walk_forward_advances_marks_left_done_and_loads_next(tmp_path):
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "X", origin="browse", items=[(10, "A"), (11, "B"), (12, "C")]
+    )
+    fake = _walker_fake(service)
+
+    handled = LibraryScreen._walk_active_review_set(fake, 1)
+
+    assert handled is True
+    review_set = service.get_review_set(set_id)
+    assert review_set.cursor == 1
+    assert review_set.items[0].done is True  # the item we left
+    assert review_set.items[1].done is False
+    assert fake._select_calls == [("local:media:11", "B")]
+
+
+def test_walk_back_moves_without_marking(tmp_path):
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "X", origin="browse", items=[(10, "A"), (11, "B"), (12, "C")]
+    )
+    service.set_cursor(set_id, 2)
+    fake = _walker_fake(service)
+
+    LibraryScreen._walk_active_review_set(fake, -1)
+
+    review_set = service.get_review_set(set_id)
+    assert review_set.cursor == 1
+    assert all(item.done is False for item in review_set.items)  # Prev never marks
+    assert fake._select_calls == [("local:media:11", "B")]
+
+
+def test_walk_forward_skips_a_tombstoned_target(tmp_path):
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "X", origin="browse", items=[(10, "A"), (11, "B"), (12, "C")]
+    )
+    # id 11 is deleted -> forward from 0 lands on 12.
+    fake = _walker_fake(service, live_ids={10, 12})
+
+    LibraryScreen._walk_active_review_set(fake, 1)
+
+    assert service.get_review_set(set_id).cursor == 2
+    assert fake._select_calls == [("local:media:12", "C")]
+
+
+def test_walk_forward_on_last_item_completes_without_reloading(tmp_path):
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "X", origin="browse", items=[(10, "A"), (11, "B")]
+    )
+    # The user has already reviewed the first item and is on the last.
+    service.mark_item_done(set_id, backing_media_id=10, done=True)
+    service.set_cursor(set_id, 1)
+    fake = _walker_fake(service)
+
+    LibraryScreen._walk_active_review_set(fake, 1)
+
+    review_set = service.get_review_set(set_id)
+    assert review_set.cursor == 1  # clamped
+    assert review_set.items[1].done is True  # completion gesture marks the last
+    assert review_set.completed_at is not None  # every live item done
+    assert fake._select_calls == []  # nothing new to load
+
+
+def test_walk_returns_false_when_no_set_is_active(tmp_path):
+    service = _service(tmp_path)  # no set created
+    fake = _walker_fake(service)
+
+    assert LibraryScreen._walk_active_review_set(fake, 1) is False
+    assert fake._select_calls == []
+
+
+def test_walk_returns_false_when_service_is_absent():
+    fake = SimpleNamespace(_review_set_service=lambda: None, _select_calls=[])
+    assert LibraryScreen._walk_active_review_set(fake, 1) is False
+
+
+def test_active_review_set_progress_formats_the_line(tmp_path):
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "X", origin="browse", items=[(10, "A"), (11, "B"), (12, "C")]
+    )
+    service.mark_item_done(set_id, backing_media_id=10, done=True)
+    fake = _walker_fake(service)
+
+    assert LibraryScreen._active_review_set_progress(fake) == "1 of 3 · 1 reviewed"
+
+
+def test_active_review_set_progress_is_none_without_an_active_set(tmp_path):
+    fake = _walker_fake(_service(tmp_path))
+    assert LibraryScreen._active_review_set_progress(fake) is None
+
+
+def test_exit_review_deactivates_but_keeps_the_set(tmp_path):
+    service = _service(tmp_path)
+    set_id = service.create_review_set("X", origin="browse", items=[(1, "a")])
+    fake = _walker_fake(service)
+    fake._library_media_item_traversal_active = lambda: True
+    fake._sync_library_media_viewer_or_recompose = lambda: None
+
+    LibraryScreen.action_library_media_exit_review(fake)
+
+    assert service.get_active_review_set() is None
+    assert [rs.set_id for rs in service.list_review_sets()] == [set_id]  # not deleted
+
+
+def test_toggle_reviewed_marks_and_unmarks_the_loaded_item(tmp_path):
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "X", origin="browse", items=[(10, "A"), (11, "B")]
+    )
+    fake = _walker_fake(service)
+    fake._library_media_item_traversal_active = lambda: True
+    fake._sync_library_media_viewer_or_recompose = lambda: None
+    fake._library_media_reader_session = SimpleNamespace(loaded_backing_id=10)
+
+    LibraryScreen.action_library_media_toggle_reviewed(fake)
+    assert service.get_review_set(set_id).items[0].done is True
+
+    LibraryScreen.action_library_media_toggle_reviewed(fake)
+    assert service.get_review_set(set_id).items[0].done is False
+
+
+def test_review_set_active_reflects_the_service(tmp_path):
+    service = _service(tmp_path)
+    fake = _walker_fake(service)
+    assert LibraryScreen._review_set_active(fake) is False
+    service.create_review_set("X", origin="browse", items=[(1, "a")])
+    assert LibraryScreen._review_set_active(fake) is True

--- a/backlog/tasks/task-28241 - Review-sets-Phase-2-Reader-walker-integration.md
+++ b/backlog/tasks/task-28241 - Review-sets-Phase-2-Reader-walker-integration.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-28241
 title: 'Review sets - Phase 2: Reader walker integration'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-02 22:28'
+updated_date: '2026-09-03 01:53'
 labels:
   - library
   - media-ux
@@ -20,8 +21,20 @@ Make the media Reader walk an active review set instead of the current browse pa
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 When a set is active, ] / [ advance the set cursor over the pinned list (whole set, page-independent) via the existing _select_library_media_reader_row actuator; with no active set, ] / [ keep task-28005's browse-row behavior (supersede, not replace)
-- [ ] #2 Forward advance auto-marks the item left behind done; Prev does not un-mark; the last item and picker jumps do not auto-mark; an explicit toggle key sets/clears a mark
-- [ ] #3 A Reader progress readout shows 'X of M (reviewed N)' over live items, an explicit all-reviewed state on completion, and Escape keeps the set active while a distinct Exit-review deactivates it
-- [ ] #4 On launch the active set re-activates and loads at its cursor; per-item scroll resume (ReadingProgress) still works
+- [x] #1 When a set is active, ] / [ advance the set cursor over the pinned list (whole set, page-independent) via the existing _select_library_media_reader_row actuator; with no active set, ] / [ keep task-28005's browse-row behavior (supersede, not replace)
+- [x] #2 Forward advance auto-marks the item left behind done; Prev does not un-mark; the last item and picker jumps do not auto-mark; an explicit toggle key sets/clears a mark
+- [x] #3 A Reader progress readout shows 'X of M (reviewed N)' over live items, an explicit all-reviewed state on completion, and Escape keeps the set active while a distinct Exit-review deactivates it
+- [x] #4 SPLIT to task-28245: the set STATE resumes automatically (active flag + cursor persist), so ]/[ walk from the saved cursor on relaunch; only the convenience of AUTO-LOADING the cursor item on entry (startup-timing sensitive) is deferred there
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+2a. Wire ReviewSetService into the screen (LibraryCollectionsDB instance) + an is_live predicate resolving local:media:N against the Media DB. 2b. Branch _library_media_adjacent_row on an active set: cursor-walk the pinned list via _select_library_media_reader_row instead of mounted rows. 2c. Auto-mark-done on forward ] advance; toggle key; Prev/jumps don't auto-mark. 2d. Reader progress readout + all-reviewed state. 2e. Exit-review action (deactivate) distinct from Escape (keep active). 2f. Resume active set at cursor on launch. TDD each seam.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Phase 2 walker shipped (AC1-3; AC4 auto-load-on-entry split to task-28245). AC1: _select_library_media_adjacent_item branches to _walk_active_review_set when a set is active -- walks the pinned cursor over the WHOLE set via _select_library_media_reader_row (pure plan_walk, single live snapshot); with no set, falls through to 28005 browse rows. AC2: forward ] auto-marks the item left done (last-item = completion gesture), Prev never marks; explicit 'm' toggles the loaded item's mark (action_library_media_toggle_reviewed). AC3: footer shows progress ('X of M · N reviewed' / 'All N reviewed') + relabels ]/[ 'in set' + 'R' exit-review (deactivate, stays resumable) distinct from Escape (keeps active). Liveness = ONE batched Media-DB query (_review_set_live_ids: id IN(...) AND deleted=0 AND is_trash=0). New bindings R/m gated in check_action (binding audit passes; only pre-existing focus_previous_workbench_pane fails). Added service.deactivate_active(). Tests: Tests/UI/test_review_set_walker.py (12) + review_set_state plan_walk/format (7). Diagnostic inventory regen'd (one logger.debug). Files: UI/Screens/library_screen.py, Library/review_set_state.py, Library/review_set_service.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28245 - Review-sets-Phase-2b-resume-the-active-sets-cursor-item-on-entering-the-media-Reader.md
+++ b/backlog/tasks/task-28245 - Review-sets-Phase-2b-resume-the-active-sets-cursor-item-on-entering-the-media-Reader.md
@@ -1,0 +1,28 @@
+---
+id: TASK-28245
+title: >-
+  Review sets - Phase 2b: resume the active set's cursor item on entering the
+  media Reader
+status: To Do
+assignee: []
+created_date: '2026-09-03 01:47'
+labels:
+  - library
+  - media-ux
+dependencies:
+  - TASK-28241
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Split from task-28241 AC#4. The walker (AC1-3) resumes the SET STATE automatically (the active flag + cursor persist across restarts, so ]/[ walk from the saved cursor). What remains is the convenience of AUTO-LOADING the cursor item into the Reader when the user opens the media area with a set active, rather than requiring one keypress. This is startup/entry-timing sensitive (the browse list must settle first, and cold-start yanks the initial tab), so it is split out for careful live verification. Design: backlog/docs/design-library-review-sets.md AC4.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Opening the media Reader with an active set loads the set's cursor item automatically (no keypress needed)
+- [ ] #2 Per-item scroll resume (ReadingProgress) still restores within the loaded item
+- [ ] #3 Does not fire during cold-start tab switching or fight the initial-tab navigation
+<!-- AC:END -->

--- a/tldw_chatbook/Library/review_set_service.py
+++ b/tldw_chatbook/Library/review_set_service.py
@@ -354,6 +354,16 @@ class ReviewSetService:
                 (timestamp, timestamp, set_id),
             )
 
+    def deactivate_active(self) -> None:
+        """Deactivate the active set ("Exit review"), keeping it resumable.
+
+        task-28241: distinct from ``dismiss`` -- the set is not deleted, it just
+        stops being the one the Reader walks; a later ``activate`` resumes it at
+        its saved cursor. A no-op when nothing is active.
+        """
+        with self._db.transaction() as conn:
+            self._deactivate_all(conn, self._now())
+
     # -- internals ------------------------------------------------------------
 
     def _read_review_set(

--- a/tldw_chatbook/Library/review_set_state.py
+++ b/tldw_chatbook/Library/review_set_state.py
@@ -200,6 +200,92 @@ def review_progress(
     return ReviewProgress(index=index, total=total, reviewed=reviewed)
 
 
+@dataclass(frozen=True)
+class WalkOutcome:
+    """The result of planning one Next/Prev step over a set.
+
+    Attributes:
+        new_cursor: The absolute cursor position after the step.
+        mark_done_backing_id: The backing id to auto-mark done (the item being
+            left on a forward step), or ``None`` (Prev never marks; a no-op step
+            marks nothing except a forward press on the last item -- the
+            completion gesture).
+        target: The item to load at ``new_cursor``, or ``None`` when the step
+            did not move (nothing new to open).
+    """
+
+    new_cursor: int
+    mark_done_backing_id: int | None
+    target: ReviewSetItem | None
+
+
+def plan_walk(
+    items: tuple[ReviewSetItem, ...], cursor: int, step: int, is_live: IsLive
+) -> WalkOutcome:
+    """Plan one Reader step over the set (pure; the screen applies the effects).
+
+    Forward (``step > 0``) marks the current live item done -- "advancing marks
+    the item you leave" -- including a forward press on the last item, which
+    marks it done in place (the completion gesture). Prev (``step < 0``) never
+    marks. Tombstones are skipped when choosing the target.
+
+    Args:
+        items: The set's pinned items.
+        cursor: The current absolute position.
+        step: ``+1`` for Next, ``-1`` for Prev.
+        is_live: Liveness predicate.
+
+    Returns:
+        A :class:`WalkOutcome` describing the new cursor, any done mark, and the
+        item to load (``None`` when the cursor did not move).
+    """
+    # One live snapshot for the whole plan, so the resolve, the step, and the
+    # mark can never disagree if liveness flips mid-call (task-28241 review).
+    live = _live_items(items, is_live)
+    live_backing_ids = {item.backing_media_id for item in live}
+    live_positions = [item.position for item in live]
+    resolved = _resolve_within(live_positions, cursor)
+    if live_positions:
+        current_index = live_positions.index(resolved)
+        step_delta = 1 if step > 0 else -1 if step < 0 else 0
+        new_index = max(0, min(current_index + step_delta, len(live_positions) - 1))
+        new_cursor = live_positions[new_index]
+    else:
+        new_cursor = cursor
+    by_position = {item.position: item for item in items}
+    resolved_item = by_position.get(resolved)
+    mark_done_backing_id = (
+        resolved_item.backing_media_id
+        if step > 0
+        and resolved_item is not None
+        and resolved_item.backing_media_id in live_backing_ids
+        else None
+    )
+    target = by_position.get(new_cursor) if new_cursor != resolved else None
+    return WalkOutcome(
+        new_cursor=new_cursor,
+        mark_done_backing_id=mark_done_backing_id,
+        target=target,
+    )
+
+
+def format_review_progress(progress: ReviewProgress) -> str:
+    """Render the Reader's compact progress line.
+
+    Args:
+        progress: The live progress to render.
+
+    Returns:
+        ``"No items to review"`` for an empty set, ``"All N reviewed"`` once
+        every live item is done, else ``"X of M · N reviewed"``.
+    """
+    if progress.total == 0:
+        return "No items to review"
+    if progress.reviewed >= progress.total:
+        return f"All {progress.total} reviewed"
+    return f"{progress.index} of {progress.total} · {progress.reviewed} reviewed"
+
+
 def is_empty(items: tuple[ReviewSetItem, ...], is_live: IsLive) -> bool:
     """True when the set has no live items (every pinned item is a tombstone).
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -2450,6 +2450,11 @@ class LibraryScreen(BaseAppScreen):
         Binding("l", "library_media_read_later", "Read later", show=False),
         Binding("c", "library_media_use_in_console", "Use in Console", show=False),
         Binding("t", "library_media_move_to_trash", "Move to trash", show=False),
+        # task-28241: review-set keys, gated in check_action to a plain Reader
+        # with a set active. "R" exits (the set stays resumable); "m" toggles
+        # the current item's done mark (the manual counterpart to ]'s auto-mark).
+        Binding("R", "library_media_exit_review", "Exit review", show=False),
+        Binding("m", "library_media_toggle_reviewed", "Toggle reviewed", show=False),
     ]
 
     #: task-4023 AC#7: which canvas's "Export…" action opened the Export
@@ -4977,10 +4982,21 @@ class LibraryScreen(BaseAppScreen):
                 # neighbour that way, so the footer stops teaching a key
                 # that no-ops at the list ends.
                 if self._library_media_item_traversal_active():
-                    if self._library_media_adjacent_row(1) is not None:
-                        shortcuts.append(("]", "next item"))
-                    if self._library_media_adjacent_row(-1) is not None:
-                        shortcuts.append(("[", "prev item"))
+                    progress = self._active_review_set_progress()
+                    if progress is not None:
+                        # task-28241: in a review set, ] / [ walk the pinned set
+                        # (whole thing, not the page), and the footer carries
+                        # the progress plus an exit-review key.
+                        shortcuts.append(("]", "next in set"))
+                        shortcuts.append(("[", "prev in set"))
+                        shortcuts.append(("m", "toggle reviewed"))
+                        shortcuts.append(("R", "exit review"))
+                        shortcuts.append(("", progress))
+                    else:
+                        if self._library_media_adjacent_row(1) is not None:
+                            shortcuts.append(("]", "next item"))
+                        if self._library_media_adjacent_row(-1) is not None:
+                            shortcuts.append(("[", "prev item"))
                 shortcuts.append(("esc", self._library_media_escape_label()))
                 return tuple(shortcuts)
             return self.LIBRARY_DETAIL_BACK_SHORTCUTS
@@ -30766,6 +30782,17 @@ class LibraryScreen(BaseAppScreen):
             if action == "library_media_use_in_console":
                 return True
             return not session.external_detail
+        if action in (
+            "library_media_exit_review",
+            "library_media_toggle_reviewed",
+        ):
+            # task-28241: only in a plain Reader while a review set is active
+            # (so the keys -- and their footer hints -- appear exactly when
+            # there is a review to act on).
+            return (
+                self._library_media_item_traversal_active()
+                and self._review_set_active()
+            )
         if action == "focus_previous_workbench_pane":
             return bool(self._library_selected_row_id)
         return True
@@ -41701,11 +41728,208 @@ class LibraryScreen(BaseAppScreen):
     def _select_library_media_adjacent_item(self, direction: int) -> None:
         if not self._library_media_item_traversal_active():
             return
+        # task-28241: an active review set supersedes the browse-row traversal
+        # -- ] / [ walk its pinned cursor over the whole set instead of the
+        # mounted (current-page) rows. With no active set, fall through to
+        # task-28005's browse-row behavior.
+        if self._walk_active_review_set(direction):
+            return
         neighbour = self._library_media_adjacent_row(direction)
         if neighbour is None:
             return
         media_id, title = neighbour
         self._select_library_media_reader_row(media_id, title, immediate=True)
+
+    def _review_set_service(self):
+        """Return the review-set service, or ``None`` when storage is absent.
+
+        Lazily built from the app's Library collections DB and cached on the
+        screen. Returns ``None`` (never raises) when that DB is unavailable, so
+        every review-set call site can guard on it and fall back cleanly.
+
+        Returns:
+            A ``ReviewSetService`` or ``None``.
+        """
+        service = getattr(self, "_cached_review_set_service", None)
+        if service is not None:
+            return service
+        db = getattr(self.app_instance, "local_library_collections_db", None)
+        if db is None:
+            return None
+        from tldw_chatbook.Library.review_set_service import ReviewSetService
+
+        service = ReviewSetService(db)
+        self._cached_review_set_service = service
+        return service
+
+    def _review_set_live_ids(self, backing_ids: "Iterable[int]") -> set[int]:
+        """Return the subset of backing media ids that are still live.
+
+        Live means present in the Media table with ``deleted = 0`` and
+        ``is_trash = 0``. Resolved in ONE query so walking a capped set costs a
+        single round-trip per keypress, not one per item. When the Media DB is
+        unavailable the ids are treated as live -- the walker must not hide
+        items it cannot check.
+
+        Args:
+            backing_ids: The set's backing media ids.
+
+        Returns:
+            The subset that resolves to a live media item.
+        """
+        ids = [int(backing_id) for backing_id in backing_ids]
+        if not ids:
+            return set()
+        media_db = getattr(self.app_instance, "media_db", None)
+        if media_db is None:
+            return set(ids)
+        placeholders = ",".join("?" * len(ids))
+        try:
+            cursor = media_db.execute_query(
+                f"SELECT id FROM Media WHERE id IN ({placeholders}) "
+                "AND deleted = 0 AND is_trash = 0",
+                tuple(ids),
+            )
+            return {int(row[0]) for row in cursor.fetchall()}
+        except Exception:
+            logger.debug("Review-set liveness query failed", exc_info=True)
+            return set(ids)
+
+    def _walk_active_review_set(self, direction: int) -> bool:
+        """Walk the active review set one step; return ``True`` if it handled it.
+
+        task-28241: a forward step marks the item being left done (the
+        completion gesture on the last item), Prev never marks, and tombstones
+        are skipped -- all decided by the pure ``plan_walk``. The item at the
+        new cursor is loaded through the same actuator the browse traversal
+        uses, so fenced loading, scroll capture/restore, and mode-persistence
+        keep working.
+
+        Args:
+            direction: ``+1`` for Next, ``-1`` for Prev.
+
+        Returns:
+            ``True`` when an active set consumed the step; ``False`` to let the
+            browse-row traversal handle it.
+        """
+        service = self._review_set_service()
+        if service is None:
+            return False
+        review_set = service.get_active_review_set()
+        if review_set is None:
+            return False
+        from tldw_chatbook.Library.review_set_state import plan_walk
+
+        live_ids = self._review_set_live_ids(
+            item.backing_media_id for item in review_set.items
+        )
+        is_live = lambda backing_id: backing_id in live_ids  # noqa: E731
+        outcome = plan_walk(review_set.items, review_set.cursor, direction, is_live)
+        if outcome.mark_done_backing_id is not None:
+            service.mark_item_done(
+                review_set.set_id, outcome.mark_done_backing_id, True
+            )
+        if outcome.new_cursor != review_set.cursor:
+            service.set_cursor(review_set.set_id, outcome.new_cursor)
+        service.refresh_completion(review_set.set_id, is_live)
+        if outcome.target is not None:
+            self._select_library_media_reader_row(
+                f"local:media:{outcome.target.backing_media_id}",
+                outcome.target.title_snapshot,
+                immediate=True,
+            )
+        return True
+
+    def _active_review_set_progress(self) -> str | None:
+        """Return the active set's Reader progress line, or ``None``.
+
+        task-28241 (AC3): ``"12 of 40 · 7 reviewed"`` / ``"All N reviewed"`` /
+        ``"No items to review"`` -- computed over LIVE items so a deleted item
+        never inflates the count.
+
+        Returns:
+            The formatted progress string when a set is active, else ``None``.
+        """
+        service = self._review_set_service()
+        if service is None:
+            return None
+        review_set = service.get_active_review_set()
+        if review_set is None:
+            return None
+        from tldw_chatbook.Library.review_set_state import (
+            format_review_progress,
+            review_progress,
+        )
+
+        live_ids = self._review_set_live_ids(
+            item.backing_media_id for item in review_set.items
+        )
+        is_live = lambda backing_id: backing_id in live_ids  # noqa: E731
+        return format_review_progress(
+            review_progress(review_set.items, review_set.cursor, is_live)
+        )
+
+    def _review_set_active(self) -> bool:
+        """True when a review set is active (drives the Reader footer + gating)."""
+        service = self._review_set_service()
+        return service is not None and service.get_active_review_set() is not None
+
+    def action_library_media_exit_review(self) -> None:
+        """Exit review mode: deactivate the active set, keeping it resumable.
+
+        task-28241 (AC3): distinct from Escape (which keeps the set active and
+        just leaves the Reader). Only meaningful in the plain Reader with an
+        active set; a no-op otherwise.
+        """
+        if not self._library_media_item_traversal_active():
+            return
+        service = self._review_set_service()
+        if service is None or service.get_active_review_set() is None:
+            return
+        service.deactivate_active()
+        self._sync_library_media_viewer_or_recompose()
+
+    def action_library_media_toggle_reviewed(self) -> None:
+        """Toggle the current item's done mark in the active review set.
+
+        task-28241 (AC2): the explicit counterpart to forward-advance's
+        auto-mark -- lets a user un-mark a skimmed item, or mark the last one
+        without advancing. A no-op outside a plain Reader with an active set
+        whose cursor item is loaded.
+        """
+        if not self._library_media_item_traversal_active():
+            return
+        service = self._review_set_service()
+        if service is None:
+            return
+        review_set = service.get_active_review_set()
+        if review_set is None:
+            return
+        backing_id = self._library_media_reader_session.loaded_backing_id
+        if backing_id is None:
+            return
+        try:
+            backing_id = int(backing_id)
+        except (TypeError, ValueError):
+            return
+        current = next(
+            (
+                item
+                for item in review_set.items
+                if item.backing_media_id == backing_id
+            ),
+            None,
+        )
+        if current is None:
+            return
+        service.mark_item_done(review_set.set_id, backing_id, not current.done)
+        live_ids = self._review_set_live_ids(
+            item.backing_media_id for item in review_set.items
+        )
+        service.refresh_completion(
+            review_set.set_id, lambda candidate: candidate in live_ids
+        )
+        self._sync_library_media_viewer_or_recompose()
 
     def _focus_library_media_items_pane(self) -> None:
         """Focus the Items pane at its most useful control (task-28004).

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -16,6 +16,7 @@ import webbrowser
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from datetime import datetime, timezone
 from enum import Enum
+from contextlib import closing
 from functools import partial
 import hashlib
 from pathlib import Path
@@ -41762,14 +41763,19 @@ class LibraryScreen(BaseAppScreen):
         self._cached_review_set_service = service
         return service
 
+    #: Max ids per liveness ``IN (…)`` batch, safely under SQLite's default
+    #: 999-variable limit (Qodo #2333: bound the query even for a large set).
+    _REVIEW_SET_LIVENESS_BATCH = 900
+
     def _review_set_live_ids(self, backing_ids: "Iterable[int]") -> set[int]:
         """Return the subset of backing media ids that are still live.
 
         Live means present in the Media table with ``deleted = 0`` and
-        ``is_trash = 0``. Resolved in ONE query so walking a capped set costs a
-        single round-trip per keypress, not one per item. When the Media DB is
-        unavailable the ids are treated as live -- the walker must not hide
-        items it cannot check.
+        ``is_trash = 0``. Resolved in batched ``IN (…)`` queries (one round-trip
+        per ``_REVIEW_SET_LIVENESS_BATCH`` ids) so the query stays bounded even
+        for a large set, and each cursor is closed deterministically. When the
+        Media DB is unavailable the ids are treated as live -- the walker must
+        not hide items it cannot check.
 
         Args:
             backing_ids: The set's backing media ids.
@@ -41783,17 +41789,25 @@ class LibraryScreen(BaseAppScreen):
         media_db = getattr(self.app_instance, "media_db", None)
         if media_db is None:
             return set(ids)
-        placeholders = ",".join("?" * len(ids))
+        live: set[int] = set()
         try:
-            cursor = media_db.execute_query(
-                f"SELECT id FROM Media WHERE id IN ({placeholders}) "
-                "AND deleted = 0 AND is_trash = 0",
-                tuple(ids),
-            )
-            return {int(row[0]) for row in cursor.fetchall()}
+            for start in range(0, len(ids), self._REVIEW_SET_LIVENESS_BATCH):
+                chunk = ids[start : start + self._REVIEW_SET_LIVENESS_BATCH]
+                placeholders = ",".join("?" * len(chunk))
+                with closing(
+                    media_db.execute_query(
+                        f"SELECT id FROM Media WHERE id IN ({placeholders}) "
+                        "AND deleted = 0 AND is_trash = 0",
+                        tuple(chunk),
+                    )
+                ) as cursor:
+                    live.update(int(row[0]) for row in cursor.fetchall())
         except Exception:
-            logger.debug("Review-set liveness query failed", exc_info=True)
+            # Safe fallback: if the Media DB can't be queried, treat every id
+            # as live -- the walker must never HIDE an item it failed to check
+            # (better to show a possibly-deleted item than to skip a real one).
             return set(ids)
+        return live
 
     def _walk_active_review_set(self, direction: int) -> bool:
         """Walk the active review set one step; return ``True`` if it handled it.
@@ -41818,13 +41832,49 @@ class LibraryScreen(BaseAppScreen):
         review_set = service.get_active_review_set()
         if review_set is None:
             return False
-        from tldw_chatbook.Library.review_set_state import plan_walk
+        from tldw_chatbook.Library.review_set_state import plan_walk, resolve_cursor
 
         live_ids = self._review_set_live_ids(
             item.backing_media_id for item in review_set.items
         )
         is_live = lambda backing_id: backing_id in live_ids  # noqa: E731
-        outcome = plan_walk(review_set.items, review_set.cursor, direction, is_live)
+        by_position = {item.position: item for item in review_set.items}
+
+        # Qodo #2333: the walk marks/advances from the item the Reader is
+        # actually SHOWING, not the persisted cursor -- otherwise a step could
+        # mark an unseen item done. When the Reader is not on a set item (fresh
+        # entry, or a browse item), the first step just RESUMES the set at its
+        # cursor, marking nothing.
+        loaded_backing = self._library_media_reader_session.loaded_backing_id
+        try:
+            loaded_backing = int(loaded_backing) if loaded_backing is not None else None
+        except (TypeError, ValueError):
+            loaded_backing = None
+        displayed_position = next(
+            (
+                item.position
+                for item in review_set.items
+                if item.backing_media_id == loaded_backing
+            ),
+            None,
+        )
+        if displayed_position is None:
+            resumed = resolve_cursor(review_set.items, review_set.cursor, is_live)
+            target = by_position.get(resumed)
+            if target is None:
+                return True  # empty / all-tombstoned set: nothing to load
+            if resumed != review_set.cursor:
+                service.set_cursor(review_set.set_id, resumed)
+            self._select_library_media_reader_row(
+                f"local:media:{target.backing_media_id}",
+                target.title_snapshot,
+                immediate=True,
+            )
+            return True
+
+        outcome = plan_walk(
+            review_set.items, displayed_position, direction, is_live
+        )
         if outcome.mark_done_backing_id is not None:
             service.mark_item_done(
                 review_set.set_id, outcome.mark_done_backing_id, True


### PR DESCRIPTION
## What

Phase 2 of Library review sets (design: `backlog/docs/design-library-review-sets.md`). An **active review set now drives the media Reader** — building on the Phase 1 persistence/model that just landed.

Closes **task-28241** (AC1–3). AC4 (auto-load the cursor item on entry) is split to **task-28245** — the set *state* already resumes (the active flag + cursor persist, so `]`/`[` walk from the saved cursor on relaunch); only the entry auto-load, which is startup-timing sensitive, is deferred for careful live verification.

## Behavior

- **`]` / `[` walk the whole pinned set** (page-independent) via the same `_select_library_media_reader_row` actuator the browse traversal uses, so fenced loading, scroll capture/restore, and Reader-mode persistence keep working. With **no active set**, task-28005's browse-row traversal is unchanged — the set *supersedes*, it doesn't replace.
- **Auto-mark on advance:** stepping forward marks the item you leave done (a forward press on the last item is the completion gesture); **Prev never marks**; **`m`** explicitly toggles the current item's mark (un-mark a skimmed item, or mark the last one).
- **Reader footer** shows progress — `12 of 40 · 7 reviewed` / `All N reviewed` — relabels `]`/`[` as "in set", and adds **`R` to exit review** (deactivates the set but keeps it resumable), distinct from **Escape** (leaves the Reader, set stays active).
- **Liveness** is resolved in **one batched Media-DB query** per keypress (`id IN (…) AND deleted = 0 AND is_trash = 0`); tombstoned items are skipped so the count never inflates.

## Design

- Pure `plan_walk` (in `review_set_state.py`) decides each step on a **single live snapshot** — the resolve, the step, and the mark can't disagree if liveness flips mid-call.
- New `R`/`m` bindings are gated in `check_action` (the binding-audit passes; the sole failure is the pre-existing `focus_previous_workbench_pane` baseline).
- Added `ReviewSetService.deactivate_active()` (Exit-review backend — deactivate without deleting).

## Tests

- `Tests/UI/test_review_set_walker.py` (12) — forward/back walk, tombstone skip, last-item completion, no-set fall-through, progress line, exit-review, toggle-reviewed — via a fake screen over the **real** service.
- `Tests/Library/test_review_set_state.py` — `plan_walk` + `format_review_progress` (single-snapshot, mark semantics).
- Preflight (diagnostic inventory, index pins, CSS bundle, backlog IDs) green; the one added `logger.debug` is in the regenerated inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the media Reader walk an active review set instead of the browse rows (task-28241 AC1–3). `]`/`[` now step through the whole pinned set, auto-marking the item you leave done on forward advance, and the footer shows progress plus an exit-review key. AC4 (auto-loading the cursor item on entry) is split to task-28245; the set state already resumes at its saved cursor.

**Behavior**

- `]`/`[` walk the whole active set page-independently via the existing reader-row actuator; with no set active, browse-row traversal is unchanged.
- Steps advance from the item the Reader is actually showing, so `]` can't mark an unseen item; when the Reader is off the set, the first step resumes at the cursor and marks nothing.
- Forward advance marks the item you leave done (last item = completion gesture); Prev never marks; `m` toggles the current item's mark.
- Footer shows `X of M · N reviewed` / `All N reviewed`, relabels `]`/`[` as "in set", and adds `R` to exit review (deactivates but keeps the set resumable); Escape leaves the Reader with the set active.
- Liveness is resolved in batched Media-DB queries (≤900 ids each); tombstoned items are skipped.

**Testing**

- Adds UI walker tests using a fake screen over the real service, plus `plan_walk` and progress formatting unit tests, and a real Media-DB test for liveness filtering.
- New `R`/`m` bindings are gated in `check_action`; the binding audit passes except the pre-existing `focus_previous_workbench_pane` baseline.

<sup>Written for commit b5042db3a96558e74addee447e0284895fd1dedf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

