### PR TITLE
chore(backlog): add Collections follow-up tasks

### DIFF
--- a/Docs/superpowers/plans/2026-09-02-collections-followup-backlog-creation.md
+++ b/Docs/superpowers/plans/2026-09-02-collections-followup-backlog-creation.md
@@ -27,8 +27,25 @@
 2. Run `git diff --check` and inspect the final documentation diff.
 3. Commit the reviewed design and this execution plan on `codex/collections-followup-backlog`.
 4. Fetch Chatbook's `origin/dev` and rebase the Chatbook branch onto it.
-5. Fetch `origin/dev` separately in `tldw_server2`, then create an isolated Server worktree on branch `codex/collections-followup-backlog` from that refreshed ref; do not touch the dirty primary checkout.
-6. Before filing in each repository, build an occupied-ID census from every registered worktree plus every `refs/remotes/*` tree's `backlog/tasks`, `backlog/completed`, and `backlog/archive/tasks` buckets. Also search those trees for normalized title duplicates. Save the census outside the repositories, confirm the candidate branch itself passes its local duplicate-ID guard, and treat every newly allocated ID as provisional until the post-creation and pre-merge census repeats.
+5. After the rebase, repeat `git diff --check origin/dev...HEAD` and inspect the complete post-rebase documentation diff.
+6. Fetch `origin/dev` separately in `tldw_server2`, then create an isolated Server worktree on branch `codex/collections-followup-backlog` from that refreshed ref; do not touch the dirty primary checkout.
+7. Before filing in each repository, build an occupied-ID census from every registered worktree plus every `refs/remotes/*` tree's `backlog/tasks`, `backlog/completed`, and `backlog/archive/tasks` buckets. Also search those trees for normalized title duplicates. Save the census outside the repositories, confirm the candidate branch itself passes its local duplicate-ID guard, and treat every newly allocated ID as provisional until the post-creation and pre-merge census repeats.
+
+## Backlog CLI 1.44 safe filing sequence
+
+Use this sequence for every Server and Chatbook record:
+
+1. Create the record without a priority. Pass labels exactly once as one comma-separated value,
+   `-l "label-a,label-b,label-c"`, and pass only the first acceptance criterion with one `--ac`.
+2. Set priority separately with `backlog task edit <id> --priority <level>`.
+3. Append each remaining acceptance criterion with its own
+   `backlog task edit <id> --ac <criterion>` command.
+4. Use `--parent <id>` for a child task; never use the `-p` abbreviation.
+5. Read the record back with `backlog task <id> --plain` and verify its exact labels, priority,
+   parent, and acceptance-criterion count.
+
+This sequence avoids comma-joined and multi-value parsing ambiguity; correctness is established by
+the read-back counts rather than by assuming how repeated CLI flags are parsed.
 
 ## Task 2: File the six Server capability prerequisites
 
@@ -42,8 +59,12 @@
 - Create through Backlog.md CLI: `tldw_server2/backlog/tasks/task-<allocated> - Add Server-native Reading export re-import.md`
 
 1. Check the available tools for the official Backlog MCP workflow required by the Server repository. If no dedicated Backlog MCP tool is callable, record that result and use the documented Backlog.md CLI fallback.
-2. Create S1 through S5b in the design's order with status `To Do`, the exact priority and labels from the filing table, and the corresponding description and acceptance criteria from the approved design.
-3. Work around Backlog CLI 1.44's collapsed repeated-`--ac` behavior: create each record with exactly its first criterion, then append each remaining criterion with a separate `backlog task edit <id> --ac <criterion>` call. Verify the resulting criterion counts are S1=6, S2=5, S3=5, S4=6, S5a=6, and S5b=6.
+2. Create S1 through S5b in the design's order with status `To Do`, the corresponding description,
+   and exact labels from the filing table, following the safe filing sequence above: no priority on
+   create, one comma-separated `-l` value, and only the first acceptance criterion on create.
+3. Set each priority with a separate `backlog task edit <id> --priority <level>` command and append
+   one remaining criterion per `backlog task edit <id> --ac <criterion>` call. Read back and verify
+   the exact criterion counts: S1=6, S2=5, S3=5, S4=6, S5a=6, and S5b=6.
 4. Add stable textual references to `tldw_chatbook:TASK-18919` and the Chatbook design path in each description.
 5. Capture each CLI-assigned task ID immediately; make S5b depend on the actual S5a ID and do not add dependencies among the other Server tasks.
 6. Inspect every generated record with `backlog task <id> --plain`; verify title, description, acceptance criteria, labels, priority, status, and dependency.
@@ -62,11 +83,19 @@
 - Create through Backlog.md CLI: `backlog/tasks/task-<allocated> - Manage Server Reading import and export workflows.md`
 - Create through Backlog.md CLI: `backlog/tasks/task-<allocated> - Decide legacy Collections migration or retirement.md`
 
-1. Create C1, C2, and C3 with status `To Do`, exact design metadata, and `TASK-18919` as their same-repository prerequisite.
-2. Capture C3's allocated ID, then create C3a, C3b, and C3c as children of C3. Also give each child the completed `TASK-18919` prerequisite; do not make children depend on the tracking parent.
+1. Create C1, C2, and C3 with status `To Do`, exact design metadata, and `TASK-18919` as their
+   same-repository prerequisite. Follow the safe filing sequence: create without priority, pass
+   labels once as one comma-separated `-l` value, and include only the first acceptance criterion.
+   Then set priority and append each remaining criterion with separate edit commands.
+2. Capture C3's allocated ID, then create C3a, C3b, and C3c as children using
+   `--parent <C3-id>`; never use `-p`. Apply the same no-priority create, single comma-separated
+   label value, separate priority edit, and one-criterion-per-edit sequence. Also give each child
+   the completed `TASK-18919` prerequisite; do not make children depend on the tracking parent.
 3. Put the exact allocated `tldw_server:TASK-<id>` prerequisite identities in C1, C2, C3a, C3b, and C3c descriptions. Do not use same-repository dependency fields for those external tasks.
-4. Create C4 as a low-priority, decision-only task depending on `TASK-18919`; require a new ADR and prohibit production lifecycle mutation or real-user data inspection.
-5. Work around Backlog CLI 1.44's collapsed repeated-`--ac` behavior exactly as for the Server records. Verify criterion counts are C1=5, C2=5, C3=4, C3a=5, C3b=6, C3c=6, and C4=6.
+4. Create C4 as a decision-only task depending on `TASK-18919`, using the safe filing sequence;
+   set its low priority with a separate priority edit, require a new ADR, and prohibit production
+   lifecycle mutation or real-user data inspection.
+5. Read back and verify exact criterion counts: C1=5, C2=5, C3=4, C3a=5, C3b=6, C3c=6, and C4=6.
 6. Preserve the design's descriptions and acceptance criteria, reference ADR-107 and the approved design, and leave implementation plans absent while all records remain `To Do`.
 7. Inspect all seven records with `backlog task <id> --plain`; verify C3 child links, dependencies, external references, priorities, labels, and statuses.
 8. Repeat the all-remote-ref/all-worktree occupied-ID and normalized-title census. Resolve any provisional collision before commit.

--- a/Docs/superpowers/plans/2026-09-02-collections-followup-backlog-creation.md
+++ b/Docs/superpowers/plans/2026-09-02-collections-followup-backlog-creation.md
@@ -6,7 +6,7 @@
 
 **Architecture:** The Server records own additive, versioned capability contracts; Chatbook records remain fail-closed and reference the exact Server task identities without cross-repository Backlog dependencies. A Chatbook tracking parent groups the three management workflows, while the legacy lifecycle remains a decision-only ADR task. Task IDs are allocated only after rebasing both filing branches on their latest `origin/dev` state.
 
-**Tech Stack:** Backlog.md CLI, Markdown, Git
+**Tech Stack:** Backlog MCP, Backlog.md CLI, Markdown, Git
 
 ---
 
@@ -14,7 +14,9 @@
 
 - Approved design: `Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md`
 - Chatbook foundation: `TASK-18919` and `backlog/decisions/107-collections-capture-authority-and-legacy-boundary.md`
-- Filing rule: create every record with the Backlog.md CLI; do not edit generated task files manually.
+- Filing rule: use the official Backlog MCP for Server records whenever it is callable, with the
+  Backlog.md CLI only as the Server fallback. Use Chatbook's documented Backlog.md CLI workflow for
+  Chatbook records. Do not edit generated task files manually.
 
 ## Task 1: Freeze the reviewed design and refresh repository bases
 
@@ -33,7 +35,8 @@
 
 ## Backlog CLI 1.44 safe filing sequence
 
-Use this sequence for every Server and Chatbook record:
+Use this sequence for every Chatbook record and only as the Server fallback when Backlog MCP is not
+callable:
 
 1. Create the record without a priority. Pass labels exactly once as one comma-separated value,
    `-l "label-a,label-b,label-c"`, and pass only the first acceptance criterion with one `--ac`.
@@ -51,23 +54,28 @@ the read-back counts rather than by assuming how repeated CLI flags are parsed.
 
 **Files:**
 
-- Create through Backlog.md CLI: `tldw_server2/backlog/tasks/task-<allocated> - Add atomic revision-guarded hard delete for Reading items.md`
-- Create through Backlog.md CLI: `tldw_server2/backlog/tasks/task-<allocated> - Add coherent scoped tag and domain aggregates for Reading items.md`
-- Create through Backlog.md CLI: `tldw_server2/backlog/tasks/task-<allocated> - Establish safe Collections output-template ownership and deletion.md`
-- Create through Backlog.md CLI: `tldw_server2/backlog/tasks/task-<allocated> - Attest bounded Reading digest schedule and output management.md`
-- Create through Backlog.md CLI: `tldw_server2/backlog/tasks/task-<allocated> - Add complete restart-safe Reading export jobs.md`
-- Create through Backlog.md CLI: `tldw_server2/backlog/tasks/task-<allocated> - Add Server-native Reading export re-import.md`
+- Create through Backlog interface/MCP: `tldw_server2/backlog/tasks/task-<allocated> - Add atomic revision-guarded hard delete for Reading items.md`
+- Create through Backlog interface/MCP: `tldw_server2/backlog/tasks/task-<allocated> - Add coherent scoped tag and domain aggregates for Reading items.md`
+- Create through Backlog interface/MCP: `tldw_server2/backlog/tasks/task-<allocated> - Establish safe Collections output-template ownership and deletion.md`
+- Create through Backlog interface/MCP: `tldw_server2/backlog/tasks/task-<allocated> - Attest bounded Reading digest schedule and output management.md`
+- Create through Backlog interface/MCP: `tldw_server2/backlog/tasks/task-<allocated> - Add complete restart-safe Reading export jobs.md`
+- Create through Backlog interface/MCP: `tldw_server2/backlog/tasks/task-<allocated> - Add Server-native Reading export re-import.md`
 
-1. Check the available tools for the official Backlog MCP workflow required by the Server repository. If no dedicated Backlog MCP tool is callable, record that result and use the documented Backlog.md CLI fallback.
+1. Use the official Backlog MCP `task_create`, `task_edit`, and `task_view` tools when callable. If
+   those tools are unavailable at execution time, record that result and use the documented
+   Backlog.md CLI fallback only for Server filing.
 2. Create S1 through S5b in the design's order with status `To Do`, the corresponding description,
-   and exact labels from the filing table, following the safe filing sequence above: no priority on
-   create, one comma-separated `-l` value, and only the first acceptance criterion on create.
-3. Set each priority with a separate `backlog task edit <id> --priority <level>` command and append
-   one remaining criterion per `backlog task edit <id> --ac <criterion>` call. Read back and verify
-   the exact criterion counts: S1=6, S2=5, S3=5, S4=6, S5a=6, and S5b=6.
+   and exact priority and labels from the filing table through the selected Server interface.
+3. With Backlog MCP, pass the acceptance criteria as an array and read every record back with
+   `task_view` to verify exact counts. Only for the CLI fallback, use the safe sequence above: omit
+   priority on create, pass labels once as one comma-separated `-l` value, include only the first
+   criterion on create, set priority separately, and append one criterion per edit. Verify counts
+   are S1=6, S2=5, S3=5, S4=6, S5a=6, and S5b=6.
 4. Add stable textual references to `tldw_chatbook:TASK-18919` and the Chatbook design path in each description.
-5. Capture each CLI-assigned task ID immediately; make S5b depend on the actual S5a ID and do not add dependencies among the other Server tasks.
-6. Inspect every generated record with `backlog task <id> --plain`; verify title, description, acceptance criteria, labels, priority, status, and dependency.
+5. Capture each interface-assigned task ID immediately; make S5b depend on the actual S5a ID and do not add dependencies among the other Server tasks.
+6. Inspect every generated record with Backlog MCP `task_view`, or with
+   `backlog task <id> --plain` after a CLI fallback; verify title, description, acceptance criteria,
+   labels, priority, status, and dependency.
 7. Repeat the all-remote-ref/all-worktree occupied-ID and normalized-title census. If any provisional ID or title collides, renumber/recreate it before commit using the repository's documented owner rule.
 8. Run the repository's task-ID/metadata checks when present, run `git diff --check`, inspect the complete Server diff, and commit only the six generated records and any Backlog CLI index metadata.
 
@@ -103,7 +111,9 @@ the read-back counts rather than by assuming how repeated CLI flags are parsed.
 
 ## Task 4: Cross-repository closeout verification
 
-1. Re-read all thirteen records from the CLI and compare them against the approved design's filing table and acceptance criteria.
+1. Re-read the six Server records with Backlog MCP `task_view` when MCP was used, or the CLI plain
+   view after a fallback, and re-read the seven Chatbook records with `backlog task <id> --plain`.
+   Compare all thirteen against the approved design's filing table and acceptance criteria.
 2. Verify every Chatbook capability task names the correct allocated Server task, S5b depends only on S5a, the three C3 children have the correct parent, and no record references an uncreated future ID.
 3. Repeat the occupied-ID and normalized-title census against every current remote ref and registered worktree in both repositories. Record that the IDs remain provisional until this same check is run immediately before merge.
 4. Confirm both worktrees are clean after their commits and report the two branch names, thirteen task IDs/titles, dependency graph, and any intentionally deferred implementation planning.
@@ -113,7 +123,9 @@ the read-back counts rather than by assuming how repeated CLI flags are parsed.
 
 - `git diff --check` passes in both filing worktrees before commit.
 - Repository-provided Backlog duplicate-ID/metadata checks pass where available, and the broader remote-ref/worktree census finds no conflicting provisional ID or normalized title.
-- `backlog task <id> --plain` shows all thirteen tasks as `To Do`, unassigned, and without implementation plans.
+- Backlog MCP `task_view` (or CLI plain view after a Server fallback) shows the six Server records,
+  and `backlog task <id> --plain` shows the seven Chatbook records, as `To Do`, unassigned, and
+  without implementation plans.
 - The Server branch contains exactly six new capability task records; the Chatbook branch contains exactly seven new follow-up records plus the reviewed design and this plan.
 
 ## ADR check

--- a/Docs/superpowers/plans/2026-09-02-collections-followup-backlog-creation.md
+++ b/Docs/superpowers/plans/2026-09-02-collections-followup-backlog-creation.md
@@ -17,6 +17,8 @@
 - Filing rule: use the official Backlog MCP for Server records whenever it is callable, with the
   Backlog.md CLI only as the Server fallback. Use Chatbook's documented Backlog.md CLI workflow for
   Chatbook records. Do not edit generated task files manually.
+- Server MCP project: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/collections-followup-backlog`.
+  Pass this exact absolute path as the `project` argument on every Server Backlog MCP call.
 
 ## Task 1: Freeze the reviewed design and refresh repository bases
 
@@ -61,8 +63,10 @@ the read-back counts rather than by assuming how repeated CLI flags are parsed.
 - Create through Backlog interface/MCP: `tldw_server2/backlog/tasks/task-<allocated> - Add complete restart-safe Reading export jobs.md`
 - Create through Backlog interface/MCP: `tldw_server2/backlog/tasks/task-<allocated> - Add Server-native Reading export re-import.md`
 
-1. Use the official Backlog MCP `task_create`, `task_edit`, and `task_view` tools when callable. If
-   those tools are unavailable at execution time, record that result and use the documented
+1. Use the official Backlog MCP `task_create`, `task_edit`, and `task_view` tools when callable.
+   Every Server call to any of those tools must pass
+   `project=/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/collections-followup-backlog`.
+   If those tools are unavailable at execution time, record that result and use the documented
    Backlog.md CLI fallback only for Server filing.
 2. Create S1 through S5b in the design's order with status `To Do`, the corresponding description,
    and exact priority and labels from the filing table through the selected Server interface.
@@ -73,9 +77,11 @@ the read-back counts rather than by assuming how repeated CLI flags are parsed.
    are S1=6, S2=5, S3=5, S4=6, S5a=6, and S5b=6.
 4. Add stable textual references to `tldw_chatbook:TASK-18919` and the Chatbook design path in each description.
 5. Capture each interface-assigned task ID immediately; make S5b depend on the actual S5a ID and do not add dependencies among the other Server tasks.
-6. Inspect every generated record with Backlog MCP `task_view`, or with
-   `backlog task <id> --plain` after a CLI fallback; verify title, description, acceptance criteria,
-   labels, priority, status, and dependency.
+6. After every Server Backlog MCP `task_create`, `task_edit`, or `task_view` call, verify every
+   returned file path belongs to the exact Server filing worktree above; stop before another
+   mutation if any returned path is outside it. Inspect every generated record with Backlog MCP
+   `task_view`, or with `backlog task <id> --plain` after a CLI fallback; verify title, description,
+   acceptance criteria, labels, priority, status, and dependency.
 7. Repeat the all-remote-ref/all-worktree occupied-ID and normalized-title census. If any provisional ID or title collides, renumber/recreate it before commit using the repository's documented owner rule.
 8. Run the repository's task-ID/metadata checks when present, run `git diff --check`, inspect the complete Server diff, and commit only the six generated records and any Backlog CLI index metadata.
 

--- a/Docs/superpowers/plans/2026-09-02-collections-followup-backlog-creation.md
+++ b/Docs/superpowers/plans/2026-09-02-collections-followup-backlog-creation.md
@@ -1,0 +1,96 @@
+# Collections Follow-up Backlog Creation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create a reviewed, dependency-correct set of six `tldw_server` prerequisite tasks and seven `tldw_chatbook` follow-up records for the Collections work stream.
+
+**Architecture:** The Server records own additive, versioned capability contracts; Chatbook records remain fail-closed and reference the exact Server task identities without cross-repository Backlog dependencies. A Chatbook tracking parent groups the three management workflows, while the legacy lifecycle remains a decision-only ADR task. Task IDs are allocated only after rebasing both filing branches on their latest `origin/dev` state.
+
+**Tech Stack:** Backlog.md CLI, Markdown, Git
+
+---
+
+## Source design
+
+- Approved design: `Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md`
+- Chatbook foundation: `TASK-18919` and `backlog/decisions/107-collections-capture-authority-and-legacy-boundary.md`
+- Filing rule: create every record with the Backlog.md CLI; do not edit generated task files manually.
+
+## Task 1: Freeze the reviewed design and refresh repository bases
+
+**Files:**
+
+- Modify: `Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md`
+- Create: `Docs/superpowers/plans/2026-09-02-collections-followup-backlog-creation.md`
+
+1. Verify the design contains thirteen records, explicit filing metadata, measurable acceptance criteria, stable cross-repository reference rules, and no optional real-user data probe.
+2. Run `git diff --check` and inspect the final documentation diff.
+3. Commit the reviewed design and this execution plan on `codex/collections-followup-backlog`.
+4. Fetch Chatbook's `origin/dev` and rebase the Chatbook branch onto it.
+5. Fetch `origin/dev` separately in `tldw_server2`, then create an isolated Server worktree on branch `codex/collections-followup-backlog` from that refreshed ref; do not touch the dirty primary checkout.
+6. Before filing in each repository, build an occupied-ID census from every registered worktree plus every `refs/remotes/*` tree's `backlog/tasks`, `backlog/completed`, and `backlog/archive/tasks` buckets. Also search those trees for normalized title duplicates. Save the census outside the repositories, confirm the candidate branch itself passes its local duplicate-ID guard, and treat every newly allocated ID as provisional until the post-creation and pre-merge census repeats.
+
+## Task 2: File the six Server capability prerequisites
+
+**Files:**
+
+- Create through Backlog.md CLI: `tldw_server2/backlog/tasks/task-<allocated> - Add atomic revision-guarded hard delete for Reading items.md`
+- Create through Backlog.md CLI: `tldw_server2/backlog/tasks/task-<allocated> - Add coherent scoped tag and domain aggregates for Reading items.md`
+- Create through Backlog.md CLI: `tldw_server2/backlog/tasks/task-<allocated> - Establish safe Collections output-template ownership and deletion.md`
+- Create through Backlog.md CLI: `tldw_server2/backlog/tasks/task-<allocated> - Attest bounded Reading digest schedule and output management.md`
+- Create through Backlog.md CLI: `tldw_server2/backlog/tasks/task-<allocated> - Add complete restart-safe Reading export jobs.md`
+- Create through Backlog.md CLI: `tldw_server2/backlog/tasks/task-<allocated> - Add Server-native Reading export re-import.md`
+
+1. Check the available tools for the official Backlog MCP workflow required by the Server repository. If no dedicated Backlog MCP tool is callable, record that result and use the documented Backlog.md CLI fallback.
+2. Create S1 through S5b in the design's order with status `To Do`, the exact priority and labels from the filing table, and the corresponding description and acceptance criteria from the approved design.
+3. Work around Backlog CLI 1.44's collapsed repeated-`--ac` behavior: create each record with exactly its first criterion, then append each remaining criterion with a separate `backlog task edit <id> --ac <criterion>` call. Verify the resulting criterion counts are S1=6, S2=5, S3=5, S4=6, S5a=6, and S5b=6.
+4. Add stable textual references to `tldw_chatbook:TASK-18919` and the Chatbook design path in each description.
+5. Capture each CLI-assigned task ID immediately; make S5b depend on the actual S5a ID and do not add dependencies among the other Server tasks.
+6. Inspect every generated record with `backlog task <id> --plain`; verify title, description, acceptance criteria, labels, priority, status, and dependency.
+7. Repeat the all-remote-ref/all-worktree occupied-ID and normalized-title census. If any provisional ID or title collides, renumber/recreate it before commit using the repository's documented owner rule.
+8. Run the repository's task-ID/metadata checks when present, run `git diff --check`, inspect the complete Server diff, and commit only the six generated records and any Backlog CLI index metadata.
+
+## Task 3: File the seven Chatbook follow-ups
+
+**Files:**
+
+- Create through Backlog.md CLI: `backlog/tasks/task-<allocated> - Enable atomic Server capture hard delete.md`
+- Create through Backlog.md CLI: `backlog/tasks/task-<allocated> - Present complete Server capture tag and domain facets.md`
+- Create through Backlog.md CLI: `backlog/tasks/task-<allocated> - Complete Server Collections management workflows.md`
+- Create through Backlog.md CLI: `backlog/tasks/task-<allocated> - Manage Server Collections output templates.md`
+- Create through Backlog.md CLI: `backlog/tasks/task-<allocated> - Manage Server Reading digest schedules and outputs.md`
+- Create through Backlog.md CLI: `backlog/tasks/task-<allocated> - Manage Server Reading import and export workflows.md`
+- Create through Backlog.md CLI: `backlog/tasks/task-<allocated> - Decide legacy Collections migration or retirement.md`
+
+1. Create C1, C2, and C3 with status `To Do`, exact design metadata, and `TASK-18919` as their same-repository prerequisite.
+2. Capture C3's allocated ID, then create C3a, C3b, and C3c as children of C3. Also give each child the completed `TASK-18919` prerequisite; do not make children depend on the tracking parent.
+3. Put the exact allocated `tldw_server:TASK-<id>` prerequisite identities in C1, C2, C3a, C3b, and C3c descriptions. Do not use same-repository dependency fields for those external tasks.
+4. Create C4 as a low-priority, decision-only task depending on `TASK-18919`; require a new ADR and prohibit production lifecycle mutation or real-user data inspection.
+5. Work around Backlog CLI 1.44's collapsed repeated-`--ac` behavior exactly as for the Server records. Verify criterion counts are C1=5, C2=5, C3=4, C3a=5, C3b=6, C3c=6, and C4=6.
+6. Preserve the design's descriptions and acceptance criteria, reference ADR-107 and the approved design, and leave implementation plans absent while all records remain `To Do`.
+7. Inspect all seven records with `backlog task <id> --plain`; verify C3 child links, dependencies, external references, priorities, labels, and statuses.
+8. Repeat the all-remote-ref/all-worktree occupied-ID and normalized-title census. Resolve any provisional collision before commit.
+9. Run `python scripts/check_backlog_task_ids.py`, run `git diff --check`, inspect the complete Chatbook diff, and commit only the generated backlog records and Backlog CLI index metadata.
+
+## Task 4: Cross-repository closeout verification
+
+1. Re-read all thirteen records from the CLI and compare them against the approved design's filing table and acceptance criteria.
+2. Verify every Chatbook capability task names the correct allocated Server task, S5b depends only on S5a, the three C3 children have the correct parent, and no record references an uncreated future ID.
+3. Repeat the occupied-ID and normalized-title census against every current remote ref and registered worktree in both repositories. Record that the IDs remain provisional until this same check is run immediately before merge.
+4. Confirm both worktrees are clean after their commits and report the two branch names, thirteen task IDs/titles, dependency graph, and any intentionally deferred implementation planning.
+5. Do not push, open pull requests, or merge unless the user requests those repository mutations separately.
+
+## Verification
+
+- `git diff --check` passes in both filing worktrees before commit.
+- Repository-provided Backlog duplicate-ID/metadata checks pass where available, and the broader remote-ref/worktree census finds no conflicting provisional ID or normalized title.
+- `backlog task <id> --plain` shows all thirteen tasks as `To Do`, unassigned, and without implementation plans.
+- The Server branch contains exactly six new capability task records; the Chatbook branch contains exactly seven new follow-up records plus the reviewed design and this plan.
+
+## ADR check
+
+**ADR required:** no for this filing change.
+
+**ADR path:** N/A
+
+**Reason:** This plan records backlog metadata only and makes no production architecture decision. The future S1, S2, S3, S5a/S5b, and C4 records explicitly require the applicable ADR work before their implementation begins.

--- a/Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+++ b/Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-09-01
 
-**Status:** Approved for backlog creation
+**Status:** In review
 
 **Repositories:** `tldw_chatbook`, `tldw_server`
 
@@ -12,31 +12,38 @@
 
 Turn the four known post-reader opportunities into an ordered, atomic backlog without reopening
 TASK-18919 or implying that unsupported Server behavior is safe. Cross-repository capabilities are
-implemented and attested by `tldw_server` before Chatbook enables them. Broader Collections
-management is split by workflow so each implementation task can ship in one PR. The legacy
-recovery lifecycle begins with a decision task because migration and retirement have materially
-different data-loss, rollback, and compatibility consequences.
+implemented and attested by `tldw_server` before Chatbook enables them. Review of the shipped APIs
+found that the broader management workflows also need bounded capability prerequisites: output
+templates are shared and lack reference-safe deletion, digest schedule listing lacks an exact page
+envelope, and export is page-capped rather than a complete restart-safe job. Broader Collections
+management is therefore split by workflow and paired with the smallest truthful Server contract so
+each implementation task can ship in one PR. The legacy recovery lifecycle begins with a decision
+task because migration and retirement have materially different data-loss, rollback, and
+compatibility consequences.
 
 ## Approaches considered
 
 ### Selected: atomic cross-repository tasks
 
-Create two Server capability tasks, two corresponding Chatbook integration tasks, a Chatbook
-tracking parent with three workflow children, and one Chatbook ADR decision task. This produces
-nine records whose ownership and completion evidence are unambiguous.
+Create five Server capability tasks, five corresponding Chatbook workflow integrations, one
+Chatbook tracking parent, and one Chatbook ADR decision task. This produces twelve records whose
+ownership and completion evidence are unambiguous. Three Server tasks harden only the concrete
+gaps found in otherwise-shipped template, digest, and import/export contracts; they do not redesign
+those products.
 
 ### Rejected: six coarse tasks
 
 One task per requested line plus two Server prerequisites would make templates, digests, and
-import/export one multi-PR implementation unit. It would also mix the legacy lifecycle decision
-with an implementation whose desired behavior is not yet known.
+import/export one multi-PR implementation unit. It would also leave the Chatbook children with no
+truthful capability evidence and mix the legacy lifecycle decision with an implementation whose
+desired behavior is not yet known.
 
 ### Rejected: duplicate all management work in both repositories
 
 The Server already exposes output-template, Reading digest, and Reading import/export contracts.
-Creating speculative Server rewrites for those workflows would duplicate existing product surfaces.
-Chatbook tasks should consume and capability-check the existing contracts, and should create a
-Server follow-up only if implementation discovery finds a concrete contract gap.
+Replacing those surfaces would duplicate existing product work. The selected Server prerequisites
+retain those routes and address only observed blockers: shared-template ownership/deletion,
+digest-page attestation, and complete native export/re-import lifecycle.
 
 ## Task structure
 
@@ -44,88 +51,150 @@ Server follow-up only if implementation discovery finds a concrete contract gap.
 
 #### S1. Add atomic revision-guarded hard delete for Reading items
 
-The permanent-delete mutation must accept an exact expected revision or equivalent precondition and
-enforce it in the same transaction as deletion. A stale precondition returns a documented conflict
-without deleting the item. The operation remains user-scoped, removes capture-owned children, and
-does not delete linked external Media or Notes. A versioned docs-info capability is advertised only
-when this contract is active. SQLite and PostgreSQL concurrency, authorization, not-found,
-conflict, cascade, and diagnostic-privacy behavior are covered.
+Add a positive, monotonically increasing integer `revision` to persisted Reading items and every
+Reading summary/detail response. Every item-owned mutation that can change the user's deletion
+decision increments that revision, including metadata/status/tag changes and capture-owned content
+changes. The permanent-delete request accepts `expected_revision` and enforces `WHERE id = ? AND
+user_id = ? AND revision = ?` or its backend-equivalent in the same transaction as child cleanup
+and deletion. A stale precondition returns a documented 409/412 conflict without deleting the item;
+missing items remain distinct. The operation removes capture-owned children and artifacts but does
+not delete linked external Media or Notes. Docs-info advertises exact
+`hasReadingOptimisticDeletesV1=true` only when the response token and atomic mutation are active.
+SQLite/PostgreSQL migration, concurrent mutation/delete, authorization, conflict, cascade, and
+diagnostic-privacy behavior are covered.
 
 #### S2. Add coherent scoped tag and domain aggregates for Reading items
 
 Expose bounded, deterministic, fully pageable tag and domain aggregate results for an explicitly
-documented Reading scope. Aggregate rows and exact aggregate totals must be evaluated coherently
-with the accepted search/status/favorite/date/tag/domain filters; the contract must state how a
-facet's own active filter affects its values. The result is user-scoped and avoids returning private
-capture content or sensitive URL components. A versioned docs-info capability is advertised only
-when the endpoint and its SQLite/PostgreSQL snapshot guarantees are active.
+documented Reading scope. The endpoint accepts a facet-value `q` search so searching never means
+filtering only already-loaded pages. Aggregate rows and exact aggregate totals are evaluated in one
+snapshot with the accepted capture search/status/favorite/date/tag/domain filters. The contract
+uses self-excluding semantics: the requested facet ignores that facet's active filter while retaining
+all other scope filters, allowing the user to change it without losing alternatives. Normalized
+value plus stable tie-break ordering makes every matching value reachable. Results are user-scoped
+and exclude capture content and sensitive URL components. Docs-info advertises exact
+`hasReadingAggregateFacetsV1=true` only when the endpoint and its SQLite/PostgreSQL snapshot
+guarantees are active.
+
+#### S3. Establish safe ownership and capability evidence for Collections output templates
+
+Keep the existing `/outputs/templates` API but define which template types are governed by the
+Collections umbrella and expose their cross-workflow references. Update and delete remain
+user-scoped; deletion refuses a template referenced by any digest schedule or other durable Server
+workflow unless that reference is first removed or reassigned. The API returns bounded conflict
+reasons without leaking another user's objects. Docs-info advertises exact
+`hasCollectionsOutputTemplateManagementV1=true` only when bounded paging, CRUD, reference-safe
+deletion, and the documented ownership set are active. Existing template rendering remains intact.
+
+#### S4. Attest bounded Reading digest schedule and output management
+
+Retain the existing digest routes while returning exact bounded page envelopes for schedules and
+outputs, with deterministic ordering and user scoping. Preserve schedule `last_status`,
+`last_run_at`, `next_run_at`, and output history as the only run evidence; do not invent a distinct
+run-history API. Create/update/delete responses and errors are documented sufficiently for a client
+to reconcile after transport uncertainty, but no speculative optimistic revision contract is added.
+Docs-info advertises exact `hasReadingDigestManagementV1=true` only when those guarantees are
+active and the configured scheduler/worker availability is reported separately.
+
+#### S5. Add complete restart-safe Reading export and native re-import
+
+Retain Pocket JSON and Instapaper CSV admission, then add Server-native JSONL/ZIP re-import for the
+Server's own export schema. Replace page-capped pseudo-export with an asynchronous, user-scoped
+export job that evaluates one explicit filter scope coherently, writes every matching item exactly
+once to a private managed artifact, exposes bounded job status, and supports authorized download
+and cleanup. Interruption is restart-safe and never publishes a partial artifact as complete.
+Docs-info advertises exact `hasReadingImportExportManagementV1=true` only when native round-trip,
+complete-scope export, job lifecycle, and artifact retention guarantees are active.
 
 ### `tldw_chatbook` capability integrations
 
 #### C1. Enable capability-gated Server capture hard delete
 
-Reference S1 as an external prerequisite rather than using a cross-repository Backlog dependency
-identifier. Chatbook keeps Server hard delete visibly unavailable until the exact capability is
-positively established. It sends the loaded capture revision with the destructive request, preserves
-the item on conflict or unknown outcome, refreshes authoritative state, and removes the row only
-after confirmed deletion. Confirmation and cleanup semantics continue to follow ADR-055 and
-ADR-107, and linked Media or Notes are never presented as deletion targets.
+Reference S1 by its full repository-qualified URL rather than using a cross-repository Backlog
+dependency identifier. Chatbook keeps Server hard delete visibly unavailable until exact
+`hasReadingOptimisticDeletesV1=true` is positively established and refuses a response with a
+missing/invalid revision instead of using its current fallback value. It sends the loaded revision
+with the destructive request, preserves the item on conflict or unknown outcome, refreshes
+authoritative state, and removes the row only after confirmed deletion. Confirmation and cleanup
+semantics continue to follow ADR-055 and ADR-107, and linked Media or Notes are never presented as
+deletion targets.
 
 #### C2. Present complete capability-gated Server tag and domain facets
 
-Reference S2 as an external prerequisite. Until attested aggregates exist, retain the current typed
-filters and never label suggestions from returned rows as complete facets. When supported, expose
-bounded, searchable tag and domain facet values with exact counts, deterministic paging, complete-
-scope filtering, generation fencing, and explicit loading/empty/error/retry states. Source changes
-must discard prior-authority facet state, and narrow layouts must preserve the adaptive reader.
+Reference S2 by its full repository-qualified URL. Until exact
+`hasReadingAggregateFacetsV1=true` exists, retain typed filters and never label suggestions from
+returned rows as complete facets. When supported, every facet browse and value search calls the
+Server endpoint with bounded paging; Chatbook never filters a loaded prefix to claim a complete
+result. Expose exact counts, deterministic paging, complete-scope filtering, generation fencing,
+and explicit loading/empty/error/retry states. Source changes discard prior-authority facet state,
+and narrow layouts preserve the adaptive reader.
 
 ### `tldw_chatbook` Collections-management program
 
 #### C3. Tracking parent: complete Server Collections management workflows
 
-Track three independent children and close only when all three are Done. The parent describes the
-cohesive outcome but contains no implementation plan of its own.
+Track three independent children and close only when all three are Done. The parent has a
+non-implementing coordination/closeout plan: maintain child links and status, verify their combined
+navigation and capability honesty, record integrated evidence, complete its acceptance criteria,
+and close after all children. It does not own production code.
 
 #### C3a. Manage Server Collections output templates
 
-Add bounded browse, detail, create, edit, and safe delete for the Server output-template contract
-used by Collections workflows. Capability and authorization failures remain explicit; Local mode
-does not claim template parity. Validation, conflicts, pagination, and destructive confirmation are
-covered by service and mounted tests.
+Reference S3 by full repository-qualified URL and require exact
+`hasCollectionsOutputTemplateManagementV1=true`. Add bounded browse, detail, create, edit, and
+reference-safe delete only for the Server-owned Collections template types. The UI explains that a
+template may serve multiple Collections workflows and surfaces Server in-use conflicts without
+offering a destructive bypass. Create/update/delete transport uncertainty never auto-retries;
+Refresh reconciles authoritative state. Delete requires title-specific permanent confirmation.
+Local mode does not claim template parity. Validation, paging, authorization, unknown outcomes,
+and destructive confirmation are covered by service and mounted tests.
 
 #### C3b. Manage Server Reading digest schedules and outputs
 
-Add bounded schedule browse/detail/create/edit/enable-disable/delete plus output history and run
-status using the existing Reading digest contracts. Timezone and recurrence values are presented in
-human terms, destructive actions are confirmed, and unavailable worker/scheduler capabilities are
-truthful. Local mode remains unsupported unless a separate Local design is approved.
+Reference S4 by full repository-qualified URL and require exact
+`hasReadingDigestManagementV1=true`. Add exact bounded schedule browse/detail/create/edit,
+enable-disable/delete, and output history using existing Reading digest contracts. Present only
+`last_status`, `last_run_at`, `next_run_at`, and output history; do not label these as a complete run
+ledger. Timezone and recurrence values are presented in human terms. Delete is permanent and
+confirmed. Ambiguous create/update/delete outcomes never auto-retry and instead retain input plus
+offer Refresh/reconciliation; only explicit Server conflicts are called conflicts. Scheduler/worker
+unavailability remains distinct from CRUD capability. Local mode remains unsupported unless a
+separate Local design is approved.
 
 #### C3c. Manage full Server Reading import and export workflows
 
-Add bounded import admission and job progress/recovery, plus export format/scope controls and safe
-artifact delivery using the existing Reading contracts. The UI distinguishes accepted, running,
-partially successful, failed, cancelled, and unknown outcomes; it does not load unbounded files or
-leak paths. Round-trip and production-shaped mounted coverage verify Pocket/Instapaper-compatible
-workflows. Local capture import/export is not inferred from the Server contract.
+Reference S5 by full repository-qualified URL and require exact
+`hasReadingImportExportManagementV1=true`. Add bounded Pocket/Instapaper and Server-native import
+admission, import/export job history and detail, explicit export scope/format/content controls,
+authorized artifact download, and retention/cleanup presentation. The UI distinguishes accepted,
+running, partially successful, completed, failed, cancelled, interrupted, and unknown outcomes; it
+does not load unbounded files, retain private paths, or present a partial artifact as complete.
+Round-trip means Server-native export followed by Server-native import; Pocket/Instapaper are
+import-only compatibility formats. Production-shaped tests use more than one API page. Local
+capture import/export is not inferred from the Server contract.
 
 ### `tldw_chatbook` legacy lifecycle decision
 
 #### C4. Decide migration or retirement of legacy generic Collections recovery
 
-Inventory actual v1 data, recovery usage, compatibility promises, and supported downgrade paths.
-Compare at least: retained export-only recovery, explicit user-approved migration into captures,
-and retirement after a defined release/notice window. The task produces a new accepted ADR that
-defines authority mapping, identity and canonical-URL collisions, membership handling, consent,
-backup/export requirements, rollback, retention, telemetry/privacy boundaries, and removal gates.
-No legacy data is mutated or deleted in this decision task. Atomic implementation tasks are created
-only after the ADR selects an outcome.
+Inventory the v1 schema, code reachability, compatibility promises, and downgrade paths using
+repository evidence and synthetic fixtures. An optional local probe may report only aggregate row
+counts and whether recovery has been invoked for the currently selected database; it never records
+names, item text, URLs, memberships, stable identifiers, raw paths, or cross-user telemetry. The ADR
+must remain decidable without any real-user probe. Compare at least: retained export-only recovery,
+explicit user-approved migration into captures, and retirement after a defined release/notice
+window. The task produces a new accepted ADR defining authority mapping, canonical-URL collisions,
+membership handling, consent, backup/export requirements, rollback, retention, privacy boundaries,
+and removal gates. No legacy data is mutated or deleted in this decision task. Atomic
+implementation tasks are created only after the ADR selects an outcome.
 
 ## Ordering and references
 
-- S1 and S2 are independent Server tasks.
+- S1 through S5 are independent Server tasks.
 - C1 references S1 and remains blocked on its attested capability.
 - C2 references S2 and remains blocked on its attested capability.
-- C3a, C3b, and C3c are independent children of C3 and depend on completed TASK-18919 behavior.
+- C3a, C3b, and C3c are independent children of C3, depend on completed TASK-18919 behavior, and
+  reference S3, S4, and S5 respectively.
 - C4 depends on TASK-18919 and references ADR-107; it requires a new ADR but no code change.
 - Chatbook tasks reference the eventual Server task file or repository URL rather than declaring a
   same-repository dependency on a potentially colliding numeric task ID.
@@ -142,13 +211,18 @@ only after the ADR selects an outcome.
 
 ## ADR assessment
 
-- S1: a Server ADR check is required during planning because it changes a destructive API contract;
-  an existing Server ADR may be linked if it already governs the exact atomic-delete lifecycle.
+- S1: a Server ADR is required because it adds a schema revision, destructive precondition, and
+  public capability contract.
 - S2: a Server ADR check is required during planning because it adds a public aggregate contract;
   reuse an applicable existing ADR or create one then.
+- S3: a Server ADR check is required because it formalizes shared template ownership and durable
+  reference-safe deletion.
+- S4: no new Server ADR is expected because it hardens the existing digest contract's paging and
+  attestation; planning must record the check.
+- S5: a Server ADR is required because it adds managed export-job artifacts, retention, restart,
+  and native round-trip ownership.
 - C1 and C2: no new Chatbook ADR is expected because they implement ADR-107's existing fail-closed
   capability boundary; planning must still record the check.
 - C3a, C3b, and C3c: planning must assess whether existing Server ownership contracts fully govern
   the long-lived UI workflows; no storage decision is made by these backlog records.
 - C4: a new ADR is mandatory and is the task's primary deliverable.
-

--- a/Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+++ b/Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-09-01
 
-**Status:** In review
+**Status:** Independently approved; pending user review
 
 **Repositories:** `tldw_chatbook`, `tldw_server`
 
@@ -108,7 +108,9 @@ clients. Add asynchronous, user-scoped export-job routes that evaluate one expli
 coherently, write every matching item exactly once to a private managed artifact, expose bounded job
 history/detail, and support authorized download and confirmed cleanup. Interruption is restart-safe
 and never publishes a partial artifact as complete. A caller-generated export request key prevents
-duplicate artifacts after a lost create response. Docs-info advertises exact
+duplicate artifacts after a lost create response; reusing a key with a different normalized scope or
+content payload returns a bounded conflict. Each artifact carries the versioned Server-native
+portable-schema identifier and manifest consumed by S5b. Docs-info advertises exact
 `hasReadingExportJobsV1=true` only when complete-scope export, job lifecycle, artifact retention,
 and cleanup guarantees are active.
 

--- a/Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+++ b/Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
@@ -117,6 +117,11 @@ portable-schema identifier and manifest consumed by S5b. Docs-info advertises ex
 `hasReadingExportJobsV1=true` only when complete-scope export, job lifecycle, artifact retention,
 and cleanup guarantees are active.
 
+S5a is one reviewable Server PR boundary because its routes, job state, managed store,
+request-key idempotency, private artifact lifecycle, and portable manifest form one new
+Server-native export-job aggregate; none is truthful or independently useful without the others.
+It excludes re-import, generic backup, UI work, Local behavior, and additional export formats.
+
 #### S5b. Add Server-native Reading export re-import
 
 Retain Pocket JSON and Instapaper CSV import, then add Server-native JSONL/ZIP admission for
@@ -202,6 +207,10 @@ a partial artifact as complete. Round-trip means the exact S5b portable field se
 Server-native export and import; Pocket/Instapaper are import-only compatibility formats.
 Production-shaped tests use more than one API page and verify collision idempotency. Local capture
 import/export is not inferred from the Server contract.
+
+C3c is one reviewable Chatbook PR boundary over the already-shipped S5a and S5b contracts because
+it adds one management surface and its service integration. It includes no Server implementation,
+Local parity, import parser, artifact storage, portable-schema, or database-schema work.
 
 ### `tldw_chatbook` legacy lifecycle decision
 

--- a/Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+++ b/Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
@@ -25,9 +25,9 @@ compatibility consequences.
 
 ### Selected: atomic cross-repository tasks
 
-Create five Server capability tasks, five corresponding Chatbook workflow integrations, one
-Chatbook tracking parent, and one Chatbook ADR decision task. This produces twelve records whose
-ownership and completion evidence are unambiguous. Three Server tasks harden only the concrete
+Create six Server capability tasks, five corresponding Chatbook workflow integrations, one
+Chatbook tracking parent, and one Chatbook ADR decision task. This produces thirteen records whose
+ownership and completion evidence are unambiguous. Four Server tasks harden only the concrete
 gaps found in otherwise-shipped template, digest, and import/export contracts; they do not redesign
 those products.
 
@@ -66,9 +66,10 @@ diagnostic-privacy behavior are covered.
 #### S2. Add coherent scoped tag and domain aggregates for Reading items
 
 Expose bounded, deterministic, fully pageable tag and domain aggregate results for an explicitly
-documented Reading scope. The endpoint accepts a facet-value `q` search so searching never means
-filtering only already-loaded pages. Aggregate rows and exact aggregate totals are evaluated in one
-snapshot with the accepted capture search/status/favorite/date/tag/domain filters. The contract
+documented Reading scope. It uses distinct `capture_q` and `facet_q` parameters so facet-value
+search never means filtering only already-loaded pages and cannot be confused with capture search.
+Aggregate rows and exact aggregate totals are evaluated in one snapshot with the accepted capture
+search/status/favorite/date/tag/domain filters. The contract
 uses self-excluding semantics: the requested facet ignores that facet's active filter while retaining
 all other scope filters, allowing the user to change it without losing alternatives. Normalized
 value plus stable tie-break ordering makes every matching value reachable. Results are user-scoped
@@ -88,23 +89,42 @@ deletion, and the documented ownership set are active. Existing template renderi
 
 #### S4. Attest bounded Reading digest schedule and output management
 
-Retain the existing digest routes while returning exact bounded page envelopes for schedules and
-outputs, with deterministic ordering and user scoping. Preserve schedule `last_status`,
+Keep all existing digest routes and response shapes unchanged. Add an exact bounded schedule-page
+route beside the current bare-list route; the existing output-page route retains its envelope. Both
+use deterministic ordering and user scoping. Schedule creation accepts a caller-generated,
+user-scoped `client_request_id`: repeating the same key and normalized payload returns the original
+schedule, while reusing it with a different payload fails with a bounded conflict. Exact lookup by
+that key lets a client reconcile a lost create response. Preserve schedule `last_status`,
 `last_run_at`, `next_run_at`, and output history as the only run evidence; do not invent a distinct
-run-history API. Create/update/delete responses and errors are documented sufficiently for a client
-to reconcile after transport uncertainty, but no speculative optimistic revision contract is added.
-Docs-info advertises exact `hasReadingDigestManagementV1=true` only when those guarantees are
-active and the configured scheduler/worker availability is reported separately.
+run-history API. Update/delete responses remain non-optimistic and are documented for refresh-based
+reconciliation after transport uncertainty. Docs-info advertises exact
+`hasReadingDigestManagementV1=true` only when these additive guarantees are active and configured
+scheduler/worker availability is reported separately.
 
-#### S5. Add complete restart-safe Reading export and native re-import
+#### S5a. Add complete restart-safe Reading export jobs
 
-Retain Pocket JSON and Instapaper CSV admission, then add Server-native JSONL/ZIP re-import for the
-Server's own export schema. Replace page-capped pseudo-export with an asynchronous, user-scoped
-export job that evaluates one explicit filter scope coherently, writes every matching item exactly
-once to a private managed artifact, exposes bounded job status, and supports authorized download
-and cleanup. Interruption is restart-safe and never publishes a partial artifact as complete.
-Docs-info advertises exact `hasReadingImportExportManagementV1=true` only when native round-trip,
-complete-scope export, job lifecycle, and artifact retention guarantees are active.
+Keep the current page-scoped streaming `/reading/export` route and response unchanged for existing
+clients. Add asynchronous, user-scoped export-job routes that evaluate one explicit filter scope
+coherently, write every matching item exactly once to a private managed artifact, expose bounded job
+history/detail, and support authorized download and confirmed cleanup. Interruption is restart-safe
+and never publishes a partial artifact as complete. A caller-generated export request key prevents
+duplicate artifacts after a lost create response. Docs-info advertises exact
+`hasReadingExportJobsV1=true` only when complete-scope export, job lifecycle, artifact retention,
+and cleanup guarantees are active.
+
+#### S5b. Add Server-native Reading export re-import
+
+Retain Pocket JSON and Instapaper CSV import, then add Server-native JSONL/ZIP admission for
+artifacts produced by S5a. The portable schema includes submitted URL, title, summary, freeform
+note, status, favorite, tags, published/read timestamps, optional sanitized text/clean HTML, and
+capture-owned highlights. It excludes database/user IDs, authoritative created/updated timestamps,
+Media and linked-Note identities, generated audio, offline/archive files, and internal metadata.
+Import allocates new identities, recomputes canonical URLs, and records source timestamps only as
+bounded import provenance. On a canonical-URL collision it preserves existing scalar/state/content
+fields, unions tags, and adds only nonduplicate capture-owned highlights using a documented stable
+fingerprint. Importing into an empty authority reproduces every portable field; repeated import is
+idempotent and never creates another capture or highlight. Docs-info advertises exact
+`hasReadingNativeImportV1=true` only when this versioned field and collision contract is active.
 
 ### `tldw_chatbook` capability integrations
 
@@ -155,23 +175,28 @@ Reference S4 by full repository-qualified URL and require exact
 `hasReadingDigestManagementV1=true`. Add exact bounded schedule browse/detail/create/edit,
 enable-disable/delete, and output history using existing Reading digest contracts. Present only
 `last_status`, `last_run_at`, `next_run_at`, and output history; do not label these as a complete run
-ledger. Timezone and recurrence values are presented in human terms. Delete is permanent and
-confirmed. Ambiguous create/update/delete outcomes never auto-retry and instead retain input plus
-offer Refresh/reconciliation; only explicit Server conflicts are called conflicts. Scheduler/worker
+ledger. Every create submission carries one stable request key; after an unknown response, Check
+Status performs exact lookup and an explicit retry reuses that key, so it cannot duplicate the
+schedule. Timezone and recurrence values are presented in human terms. Delete is permanent and
+confirmed. Ambiguous update/delete outcomes never auto-retry and instead retain input plus offer
+Refresh/reconciliation; only explicit Server conflicts are called conflicts. Scheduler/worker
 unavailability remains distinct from CRUD capability. Local mode remains unsupported unless a
 separate Local design is approved.
 
 #### C3c. Manage full Server Reading import and export workflows
 
-Reference S5 by full repository-qualified URL and require exact
-`hasReadingImportExportManagementV1=true`. Add bounded Pocket/Instapaper and Server-native import
-admission, import/export job history and detail, explicit export scope/format/content controls,
-authorized artifact download, and retention/cleanup presentation. The UI distinguishes accepted,
-running, partially successful, completed, failed, cancelled, interrupted, and unknown outcomes; it
-does not load unbounded files, retain private paths, or present a partial artifact as complete.
-Round-trip means Server-native export followed by Server-native import; Pocket/Instapaper are
-import-only compatibility formats. Production-shaped tests use more than one API page. Local
-capture import/export is not inferred from the Server contract.
+Reference S5a and S5b by full repository-qualified URLs and require both exact
+`hasReadingExportJobsV1=true` and `hasReadingNativeImportV1=true`. Add bounded
+Pocket/Instapaper/Server-native import admission, import/export job history and detail, explicit
+export scope/format/content controls, authorized artifact download, and retention/cleanup
+presentation. Artifact cleanup is permanent and requires export-title/date confirmation; an unknown
+cleanup response preserves the row as stale until Refresh proves whether the artifact remains. The
+UI distinguishes accepted, running, partially successful, completed, failed, cancelled,
+interrupted, and unknown outcomes; it does not load unbounded files, retain private paths, or present
+a partial artifact as complete. Round-trip means the exact S5b portable field set through a
+Server-native export and import; Pocket/Instapaper are import-only compatibility formats.
+Production-shaped tests use more than one API page and verify collision idempotency. Local capture
+import/export is not inferred from the Server contract.
 
 ### `tldw_chatbook` legacy lifecycle decision
 
@@ -190,11 +215,12 @@ implementation tasks are created only after the ADR selects an outcome.
 
 ## Ordering and references
 
-- S1 through S5 are independent Server tasks.
+- S1 through S4, S5a, and S5b are Server tasks; S5b depends on S5a's versioned portable export
+  schema, while the others are independent.
 - C1 references S1 and remains blocked on its attested capability.
 - C2 references S2 and remains blocked on its attested capability.
 - C3a, C3b, and C3c are independent children of C3, depend on completed TASK-18919 behavior, and
-  reference S3, S4, and S5 respectively.
+  reference S3, S4, and both S5 tasks respectively.
 - C4 depends on TASK-18919 and references ADR-107; it requires a new ADR but no code change.
 - Chatbook tasks reference the eventual Server task file or repository URL rather than declaring a
   same-repository dependency on a potentially colliding numeric task ID.
@@ -219,8 +245,10 @@ implementation tasks are created only after the ADR selects an outcome.
   reference-safe deletion.
 - S4: no new Server ADR is expected because it hardens the existing digest contract's paging and
   attestation; planning must record the check.
-- S5: a Server ADR is required because it adds managed export-job artifacts, retention, restart,
-  and native round-trip ownership.
+- S5a: a Server ADR is required because it adds managed export-job artifacts, retention, restart,
+  and cleanup ownership.
+- S5b: the S5a ADR must govern the portable artifact; planning must amend it or create a linked ADR
+  if native re-import adds a materially different data-ownership or collision decision.
 - C1 and C2: no new Chatbook ADR is expected because they implement ADR-107's existing fail-closed
   capability boundary; planning must still record the check.
 - C3a, C3b, and C3c: planning must assess whether existing Server ownership contracts fully govern

--- a/Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+++ b/Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
@@ -1,0 +1,154 @@
+# Collections Follow-up Backlog Design
+
+**Date:** 2026-09-01
+
+**Status:** Approved for backlog creation
+
+**Repositories:** `tldw_chatbook`, `tldw_server`
+
+**Foundation:** TASK-18919 and ADR-107
+
+## Goal
+
+Turn the four known post-reader opportunities into an ordered, atomic backlog without reopening
+TASK-18919 or implying that unsupported Server behavior is safe. Cross-repository capabilities are
+implemented and attested by `tldw_server` before Chatbook enables them. Broader Collections
+management is split by workflow so each implementation task can ship in one PR. The legacy
+recovery lifecycle begins with a decision task because migration and retirement have materially
+different data-loss, rollback, and compatibility consequences.
+
+## Approaches considered
+
+### Selected: atomic cross-repository tasks
+
+Create two Server capability tasks, two corresponding Chatbook integration tasks, a Chatbook
+tracking parent with three workflow children, and one Chatbook ADR decision task. This produces
+nine records whose ownership and completion evidence are unambiguous.
+
+### Rejected: six coarse tasks
+
+One task per requested line plus two Server prerequisites would make templates, digests, and
+import/export one multi-PR implementation unit. It would also mix the legacy lifecycle decision
+with an implementation whose desired behavior is not yet known.
+
+### Rejected: duplicate all management work in both repositories
+
+The Server already exposes output-template, Reading digest, and Reading import/export contracts.
+Creating speculative Server rewrites for those workflows would duplicate existing product surfaces.
+Chatbook tasks should consume and capability-check the existing contracts, and should create a
+Server follow-up only if implementation discovery finds a concrete contract gap.
+
+## Task structure
+
+### `tldw_server` capability prerequisites
+
+#### S1. Add atomic revision-guarded hard delete for Reading items
+
+The permanent-delete mutation must accept an exact expected revision or equivalent precondition and
+enforce it in the same transaction as deletion. A stale precondition returns a documented conflict
+without deleting the item. The operation remains user-scoped, removes capture-owned children, and
+does not delete linked external Media or Notes. A versioned docs-info capability is advertised only
+when this contract is active. SQLite and PostgreSQL concurrency, authorization, not-found,
+conflict, cascade, and diagnostic-privacy behavior are covered.
+
+#### S2. Add coherent scoped tag and domain aggregates for Reading items
+
+Expose bounded, deterministic, fully pageable tag and domain aggregate results for an explicitly
+documented Reading scope. Aggregate rows and exact aggregate totals must be evaluated coherently
+with the accepted search/status/favorite/date/tag/domain filters; the contract must state how a
+facet's own active filter affects its values. The result is user-scoped and avoids returning private
+capture content or sensitive URL components. A versioned docs-info capability is advertised only
+when the endpoint and its SQLite/PostgreSQL snapshot guarantees are active.
+
+### `tldw_chatbook` capability integrations
+
+#### C1. Enable capability-gated Server capture hard delete
+
+Reference S1 as an external prerequisite rather than using a cross-repository Backlog dependency
+identifier. Chatbook keeps Server hard delete visibly unavailable until the exact capability is
+positively established. It sends the loaded capture revision with the destructive request, preserves
+the item on conflict or unknown outcome, refreshes authoritative state, and removes the row only
+after confirmed deletion. Confirmation and cleanup semantics continue to follow ADR-055 and
+ADR-107, and linked Media or Notes are never presented as deletion targets.
+
+#### C2. Present complete capability-gated Server tag and domain facets
+
+Reference S2 as an external prerequisite. Until attested aggregates exist, retain the current typed
+filters and never label suggestions from returned rows as complete facets. When supported, expose
+bounded, searchable tag and domain facet values with exact counts, deterministic paging, complete-
+scope filtering, generation fencing, and explicit loading/empty/error/retry states. Source changes
+must discard prior-authority facet state, and narrow layouts must preserve the adaptive reader.
+
+### `tldw_chatbook` Collections-management program
+
+#### C3. Tracking parent: complete Server Collections management workflows
+
+Track three independent children and close only when all three are Done. The parent describes the
+cohesive outcome but contains no implementation plan of its own.
+
+#### C3a. Manage Server Collections output templates
+
+Add bounded browse, detail, create, edit, and safe delete for the Server output-template contract
+used by Collections workflows. Capability and authorization failures remain explicit; Local mode
+does not claim template parity. Validation, conflicts, pagination, and destructive confirmation are
+covered by service and mounted tests.
+
+#### C3b. Manage Server Reading digest schedules and outputs
+
+Add bounded schedule browse/detail/create/edit/enable-disable/delete plus output history and run
+status using the existing Reading digest contracts. Timezone and recurrence values are presented in
+human terms, destructive actions are confirmed, and unavailable worker/scheduler capabilities are
+truthful. Local mode remains unsupported unless a separate Local design is approved.
+
+#### C3c. Manage full Server Reading import and export workflows
+
+Add bounded import admission and job progress/recovery, plus export format/scope controls and safe
+artifact delivery using the existing Reading contracts. The UI distinguishes accepted, running,
+partially successful, failed, cancelled, and unknown outcomes; it does not load unbounded files or
+leak paths. Round-trip and production-shaped mounted coverage verify Pocket/Instapaper-compatible
+workflows. Local capture import/export is not inferred from the Server contract.
+
+### `tldw_chatbook` legacy lifecycle decision
+
+#### C4. Decide migration or retirement of legacy generic Collections recovery
+
+Inventory actual v1 data, recovery usage, compatibility promises, and supported downgrade paths.
+Compare at least: retained export-only recovery, explicit user-approved migration into captures,
+and retirement after a defined release/notice window. The task produces a new accepted ADR that
+defines authority mapping, identity and canonical-URL collisions, membership handling, consent,
+backup/export requirements, rollback, retention, telemetry/privacy boundaries, and removal gates.
+No legacy data is mutated or deleted in this decision task. Atomic implementation tasks are created
+only after the ADR selects an outcome.
+
+## Ordering and references
+
+- S1 and S2 are independent Server tasks.
+- C1 references S1 and remains blocked on its attested capability.
+- C2 references S2 and remains blocked on its attested capability.
+- C3a, C3b, and C3c are independent children of C3 and depend on completed TASK-18919 behavior.
+- C4 depends on TASK-18919 and references ADR-107; it requires a new ADR but no code change.
+- Chatbook tasks reference the eventual Server task file or repository URL rather than declaring a
+  same-repository dependency on a potentially colliding numeric task ID.
+
+## Backlog quality rules
+
+- Each implementation record describes user-visible or externally verifiable outcomes, not a file
+  edit sequence.
+- Every task is sized for one PR; the tracking parent is explicitly non-implementing.
+- Capability tasks fail closed until positive versioned evidence exists.
+- No task claims Local/Server parity where one authority lacks the feature.
+- No task references an uncreated future task ID.
+- Implementation plans and final ADR decisions are added only when their tasks enter progress.
+
+## ADR assessment
+
+- S1: a Server ADR check is required during planning because it changes a destructive API contract;
+  an existing Server ADR may be linked if it already governs the exact atomic-delete lifecycle.
+- S2: a Server ADR check is required during planning because it adds a public aggregate contract;
+  reuse an applicable existing ADR or create one then.
+- C1 and C2: no new Chatbook ADR is expected because they implement ADR-107's existing fail-closed
+  capability boundary; planning must still record the check.
+- C3a, C3b, and C3c: planning must assess whether existing Server ownership contracts fully govern
+  the long-lived UI workflows; no storage decision is made by these backlog records.
+- C4: a new ADR is mandatory and is the task's primary deliverable.
+

--- a/Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+++ b/Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-09-01
 
-**Status:** Independently approved; pending user review
+**Status:** Approved for backlog creation after independent and practical review
 
 **Repositories:** `tldw_chatbook`, `tldw_server`
 
@@ -80,10 +80,13 @@ guarantees are active.
 #### S3. Establish safe ownership and capability evidence for Collections output templates
 
 Keep the existing `/outputs/templates` API but define which template types are governed by the
-Collections umbrella and expose their cross-workflow references. Update and delete remain
-user-scoped; deletion refuses a template referenced by any digest schedule or other durable Server
-workflow unless that reference is first removed or reassigned. The API returns bounded conflict
-reasons without leaking another user's objects. Docs-info advertises exact
+Collections umbrella and expose the current live reference owner: Reading digest schedules.
+Historical rendered outputs do not block deletion because they are self-contained. Update and
+delete remain user-scoped; deletion refuses a template referenced by a Reading digest schedule
+unless that reference is first removed or reassigned. The task records a source-level reference
+inventory at its branch base; finding another live owner requires updating the task acceptance
+criteria before implementation rather than silently expanding scope. The API returns bounded
+conflict reasons without leaking another user's objects. Docs-info advertises exact
 `hasCollectionsOutputTemplateManagementV1=true` only when bounded paging, CRUD, reference-safe
 deletion, and the documented ownership set are active. Existing template rendering remains intact.
 
@@ -132,8 +135,8 @@ idempotent and never creates another capture or highlight. Docs-info advertises 
 
 #### C1. Enable capability-gated Server capture hard delete
 
-Reference S1 by its full repository-qualified URL rather than using a cross-repository Backlog
-dependency identifier. Chatbook keeps Server hard delete visibly unavailable until exact
+Reference S1 as `tldw_server:TASK-N` rather than using a same-repository Backlog dependency or a
+pre-merge `blob/dev` URL. Chatbook keeps Server hard delete visibly unavailable until exact
 `hasReadingOptimisticDeletesV1=true` is positively established and refuses a response with a
 missing/invalid revision instead of using its current fallback value. It sends the loaded revision
 with the destructive request, preserves the item on conflict or unknown outcome, refreshes
@@ -143,7 +146,7 @@ deletion targets.
 
 #### C2. Present complete capability-gated Server tag and domain facets
 
-Reference S2 by its full repository-qualified URL. Until exact
+Reference S2 as `tldw_server:TASK-N`. Until exact
 `hasReadingAggregateFacetsV1=true` exists, retain typed filters and never label suggestions from
 returned rows as complete facets. When supported, every facet browse and value search calls the
 Server endpoint with bounded paging; Chatbook never filters a loaded prefix to claim a complete
@@ -162,7 +165,7 @@ and close after all children. It does not own production code.
 
 #### C3a. Manage Server Collections output templates
 
-Reference S3 by full repository-qualified URL and require exact
+Reference S3 as `tldw_server:TASK-N` and require exact
 `hasCollectionsOutputTemplateManagementV1=true`. Add bounded browse, detail, create, edit, and
 reference-safe delete only for the Server-owned Collections template types. The UI explains that a
 template may serve multiple Collections workflows and surfaces Server in-use conflicts without
@@ -173,7 +176,7 @@ and destructive confirmation are covered by service and mounted tests.
 
 #### C3b. Manage Server Reading digest schedules and outputs
 
-Reference S4 by full repository-qualified URL and require exact
+Reference S4 as `tldw_server:TASK-N` and require exact
 `hasReadingDigestManagementV1=true`. Add exact bounded schedule browse/detail/create/edit,
 enable-disable/delete, and output history using existing Reading digest contracts. Present only
 `last_status`, `last_run_at`, `next_run_at`, and output history; do not label these as a complete run
@@ -187,7 +190,7 @@ separate Local design is approved.
 
 #### C3c. Manage full Server Reading import and export workflows
 
-Reference S5a and S5b by full repository-qualified URLs and require both exact
+Reference S5a and S5b as `tldw_server:TASK-N` identities and require both exact
 `hasReadingExportJobsV1=true` and `hasReadingNativeImportV1=true`. Add bounded
 Pocket/Instapaper/Server-native import admission, import/export job history and detail, explicit
 export scope/format/content controls, authorized artifact download, and retention/cleanup
@@ -204,16 +207,220 @@ import/export is not inferred from the Server contract.
 
 #### C4. Decide migration or retirement of legacy generic Collections recovery
 
-Inventory the v1 schema, code reachability, compatibility promises, and downgrade paths using
-repository evidence and synthetic fixtures. An optional local probe may report only aggregate row
-counts and whether recovery has been invoked for the currently selected database; it never records
-names, item text, URLs, memberships, stable identifiers, raw paths, or cross-user telemetry. The ADR
-must remain decidable without any real-user probe. Compare at least: retained export-only recovery,
-explicit user-approved migration into captures, and retirement after a defined release/notice
-window. The task produces a new accepted ADR defining authority mapping, canonical-URL collisions,
-membership handling, consent, backup/export requirements, rollback, retention, privacy boundaries,
-and removal gates. No legacy data is mutated or deleted in this decision task. Atomic
-implementation tasks are created only after the ADR selects an outcome.
+Inventory the v1 schema, code reachability, compatibility promises, and downgrade paths using only
+repository evidence and synthetic fixtures. No real-user database, telemetry, row count, path,
+identifier, name, item text, URL, or membership is inspected or collected. Compare at least:
+retained export-only recovery, explicit user-approved migration into captures, and retirement after
+a defined release/notice window. The task produces a new accepted ADR defining authority mapping,
+canonical-URL collisions, membership handling, consent, backup/export requirements, rollback,
+retention, privacy boundaries, and removal gates. No legacy data is mutated or deleted in this
+decision task. Atomic implementation tasks are created only after the ADR selects an outcome.
+
+## Filing metadata
+
+All records are created **To Do** and unassigned. Implementation plans are intentionally absent
+until a task is moved to In Progress.
+
+| Key | Repository | Title | Priority | Labels |
+| --- | --- | --- | --- | --- |
+| S1 | `tldw_server` | Add atomic revision-guarded hard delete for Reading items | high | collections, reading-list, api, concurrency, deletion |
+| S2 | `tldw_server` | Add coherent scoped tag and domain aggregates for Reading items | medium | collections, reading-list, api, facets, pagination |
+| S3 | `tldw_server` | Establish safe Collections output-template ownership and deletion | medium | collections, output-templates, api, deletion |
+| S4 | `tldw_server` | Attest bounded Reading digest schedule and output management | medium | collections, reading-list, digests, pagination |
+| S5a | `tldw_server` | Add complete restart-safe Reading export jobs | medium | collections, reading-list, export, jobs |
+| S5b | `tldw_server` | Add Server-native Reading export re-import | medium | collections, reading-list, import-export, portability |
+| C1 | `tldw_chatbook` | Enable atomic Server capture hard delete | medium | library, collections, reading-list, deletion, server-parity |
+| C2 | `tldw_chatbook` | Present complete Server capture tag and domain facets | medium | library, collections, reading-list, facets, server-parity |
+| C3 | `tldw_chatbook` | Complete Server Collections management workflows | medium | library, collections, server-parity, tracking |
+| C3a | `tldw_chatbook` | Manage Server Collections output templates | medium | library, collections, output-templates, server-parity |
+| C3b | `tldw_chatbook` | Manage Server Reading digest schedules and outputs | medium | library, collections, reading-list, digests, server-parity |
+| C3c | `tldw_chatbook` | Manage Server Reading import and export workflows | medium | library, collections, reading-list, import-export, server-parity |
+| C4 | `tldw_chatbook` | Decide legacy Collections migration or retirement | low | library, collections, legacy, adr, decision |
+
+Server records reference `tldw_chatbook:TASK-18919` and
+`tldw_chatbook:Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md`.
+Chatbook records reference TASK-18919, ADR-107, and this design. C1, C2, C3a, C3b, and C3c also
+reference their exact `tldw_server:TASK-N` prerequisites after the Server records allocate IDs.
+
+## Draft acceptance criteria
+
+### S1 — atomic Reading hard delete
+
+- [ ] Every Reading item summary/detail exposes a positive monotonic `revision`, and every
+  item-owned change relevant to deletion advances it in SQLite and PostgreSQL.
+- [ ] Hard delete atomically requires the authenticated user's exact `expected_revision`; stale
+  requests return a documented conflict and remove nothing.
+- [ ] Confirmed hard delete removes the Reading item and capture-owned children/artifacts without
+  deleting linked external Media or Notes.
+- [ ] Schema migration, concurrent mutation/delete, wrong-user, missing-item, rollback, and cascade
+  behavior have focused SQLite/PostgreSQL regression coverage.
+- [ ] Docs-info advertises `hasReadingOptimisticDeletesV1=true` only when the complete contract is
+  active, and public API documentation describes the precondition and responses.
+- [ ] A new or applicable Server ADR records the schema, destructive precondition, and ownership
+  decision before implementation begins.
+
+### S2 — coherent Reading aggregate facets
+
+- [ ] Authenticated callers can page every tag or domain aggregate through deterministic bounded
+  results with exact aggregate totals and server-side `facet_q` search.
+- [ ] Aggregate count and rows use one SQLite/PostgreSQL snapshot and apply `capture_q` plus all
+  non-self facet filters before aggregation.
+- [ ] Self-excluding tag/domain semantics are documented and verified for combined filters,
+  concurrent writers, empty scopes, deep pages, and normalization collisions.
+- [ ] Responses reveal no capture body, note, highlight, sensitive URL component, or other user's
+  values.
+- [ ] Docs-info advertises `hasReadingAggregateFacetsV1=true` only with the complete contract, and
+  the ADR check plus focused API/database/security tests are recorded.
+
+### S3 — safe Collections template ownership
+
+- [ ] The API and documentation identify the exact output-template types governed by Collections
+  and record a branch-base inventory of live template reference owners.
+- [ ] Template listing remains bounded and user-scoped, while create/get/update/delete preserve the
+  existing rendering contract and expose bounded errors.
+- [ ] Deleting a template referenced by a Reading digest schedule is refused atomically without
+  exposing another user's objects; historical self-contained outputs do not block deletion.
+- [ ] Docs-info advertises `hasCollectionsOutputTemplateManagementV1=true` only when ownership,
+  CRUD, paging, and reference-safe deletion guarantees are active.
+- [ ] Focused database/API/security tests and the required Server ADR check pass.
+
+### S4 — bounded Reading digest management
+
+- [ ] Existing digest routes and response shapes remain compatible, and an additive schedule-page
+  route returns exact totals with deterministic bounded rows.
+- [ ] Schedule creation uses a user-scoped `client_request_id`; identical replays return the same
+  schedule, payload mismatch conflicts, and exact lookup reconciles a lost response.
+- [ ] Schedule and output reads never cross users and expose only `last_status`, `last_run_at`,
+  `next_run_at`, and bounded output history rather than claiming a complete run ledger.
+- [ ] Update/delete outcomes and scheduler/worker availability are documented separately so clients
+  can refresh after uncertainty without inventing optimistic conflicts.
+- [ ] Docs-info advertises `hasReadingDigestManagementV1=true` only when the additive paging and
+  idempotent-create contract is active.
+- [ ] Focused SQLite/PostgreSQL, API, concurrency, compatibility, and security tests pass; the ADR
+  check is recorded.
+
+### S5a — complete Reading export jobs
+
+- [ ] Existing page-scoped streaming export remains compatible, while additive authenticated job
+  routes expose bounded create/history/detail/download/cleanup behavior.
+- [ ] Each export job reads one explicit filter scope coherently and writes every matching capture
+  exactly once to a private managed artifact, including scopes larger than one API page.
+- [ ] A user-scoped request key makes identical creates idempotent and rejects a different normalized
+  payload with a bounded conflict.
+- [ ] Interrupted or failed jobs resume or terminate truthfully and never publish a partial artifact
+  as complete; retention and confirmed cleanup are restart-safe.
+- [ ] Every completed artifact includes the versioned Server-native schema identifier and manifest
+  required by S5b, and unauthorized users cannot discover or download it.
+- [ ] Docs-info advertises `hasReadingExportJobsV1=true` only with the full contract; a Server ADR
+  plus focused job/database/API/security tests are complete.
+
+### S5b — Server-native Reading re-import
+
+- [ ] Import accepts the versioned Server-native JSONL/ZIP artifacts produced by S5a while retaining
+  Pocket JSON and Instapaper CSV compatibility.
+- [ ] Empty-authority import reproduces every declared portable field and allocates fresh local
+  identities without importing user/database IDs, external links, private paths, or internal
+  metadata.
+- [ ] Canonical-URL collisions preserve existing scalar/state/content fields, union tags, and add
+  only nonduplicate capture-owned highlights using the documented stable fingerprint.
+- [ ] Re-importing the same artifact is idempotent and produces no duplicate capture or highlight;
+  malformed, future-version, oversized, and partially corrupt input fails safely.
+- [ ] Docs-info advertises `hasReadingNativeImportV1=true` only with the field/collision contract and
+  public portability documentation.
+- [ ] S5a is a same-repository dependency, and focused parser/job/database/API/security and
+  multi-page round-trip tests pass with the applicable ADR recorded or amended.
+
+### C1 — Chatbook Server hard delete
+
+- [ ] Server hard delete remains visibly disabled with a reason unless
+  `hasReadingOptimisticDeletesV1=true` is positively established for the active authority.
+- [ ] Server captures with a missing/invalid revision fail closed; no fallback revision is used for
+  destructive actions.
+- [ ] Confirmed deletion sends the loaded revision, requires title-specific permanent confirmation,
+  and removes the row only after authoritative success.
+- [ ] Conflict or unknown outcome preserves the capture, marks state stale, and offers authoritative
+  Refresh without automatic retry; external Media and Notes are never deletion targets.
+- [ ] Local behavior remains unchanged and service/controller/mounted/live regressions cover source
+  switches, late responses, narrow layouts, and ADR-055/ADR-107 semantics.
+
+### C2 — Chatbook complete Server facets
+
+- [ ] Without `hasReadingAggregateFacetsV1=true`, typed filters remain available and current-page
+  suggestions are never labelled complete facets.
+- [ ] With the capability, tag/domain browse and `facet_q` search use bounded Server pages with exact
+  totals; the client never filters a loaded prefix to claim completeness.
+- [ ] Counts and values reflect the active capture scope and documented self-excluding semantics,
+  with deterministic navigation across deep pages.
+- [ ] Authority/scope changes and unmounts fence late results; loading, empty, stale, failure, and
+  Retry states remain explicit.
+- [ ] Service/state/mounted and 160×50/120×35/100×30/80×24 regressions preserve the adaptive reader
+  and Local typed-filter behavior.
+
+### C3 — Collections management tracking parent
+
+- [ ] C3a, C3b, and C3c are linked as children with current status and external Server prerequisites.
+- [ ] The parent carries a non-implementing coordination/closeout plan after entering In Progress and
+  owns no production code.
+- [ ] Integrated navigation and fail-closed capability behavior across all three workflows have one
+  recorded production-shaped verification pass.
+- [ ] The parent closes only after every child is Done and its combined evidence and residual risks
+  are documented.
+
+### C3a — Chatbook Server template management
+
+- [ ] The surface remains disabled unless `hasCollectionsOutputTemplateManagementV1=true` is
+  positively established and exposes only the Server-declared Collections template types.
+- [ ] Users can browse exact bounded pages, inspect, create, edit, and preview templates without
+  claiming Local parity.
+- [ ] In-use deletion conflicts identify the blocking workflow without offering a destructive bypass;
+  eligible deletion requires title-specific permanent confirmation.
+- [ ] Create/update/delete uncertainty never auto-retries, retains user input where applicable, and
+  reconciles through Refresh.
+- [ ] Service/schema/controller/mounted/live tests cover validation, paging, authorization,
+  capability changes, conflicts, uncertainty, focus, and narrow layouts.
+
+### C3b — Chatbook Server digest management
+
+- [ ] The surface remains disabled unless `hasReadingDigestManagementV1=true` is positively
+  established, with scheduler/worker availability shown separately.
+- [ ] Users can browse exact bounded schedule pages, inspect/create/edit/enable-disable/delete
+  schedules, and browse bounded output history.
+- [ ] Recurrence and timezone are presented in human terms; the UI exposes only Server-proven
+  last/next/status/output evidence and never claims a complete run ledger.
+- [ ] Create uses one stable request key with Check Status and explicit idempotent retry after an
+  unknown response; it cannot duplicate a schedule.
+- [ ] Delete is permanently confirmed, while uncertain update/delete outcomes retain context and
+  reconcile through Refresh without automatic retry.
+- [ ] Service/schema/controller/mounted/live tests cover paging, validation, authority changes,
+  capability/worker states, uncertainty, focus, and narrow layouts.
+
+### C3c — Chatbook Server import/export management
+
+- [ ] The workflow remains disabled unless both `hasReadingExportJobsV1=true` and
+  `hasReadingNativeImportV1=true` are positively established.
+- [ ] Users can admit bounded Pocket/Instapaper/Server-native imports and inspect exact bounded
+  import/export job history and detail.
+- [ ] Export controls define scope, format, included portable content, retention, authorized download,
+  and permanently confirmed artifact cleanup without revealing private paths.
+- [ ] Accepted/running/partial/completed/failed/cancelled/interrupted/unknown states are distinct;
+  partial artifacts are never presented as complete and uncertain cleanup remains stale until Refresh.
+- [ ] Server-native round-trip and canonical-collision behavior match S5b; Pocket/Instapaper remain
+  import-only and Local import/export parity is not claimed.
+- [ ] Service/schema/controller/mounted/live tests use more than one API page and cover idempotency,
+  authority changes, recovery, focus, and all standard terminal geometries.
+
+### C4 — legacy Collections lifecycle ADR
+
+- [ ] Repository code/schema/recovery reachability, compatibility promises, and downgrade behavior
+  are inventoried with synthetic fixtures only; no real-user data or telemetry is inspected.
+- [ ] Retained export-only recovery, explicit user-approved capture migration, and time-bounded
+  retirement are compared with evidence and stated trade-offs.
+- [ ] A new accepted ADR selects the lifecycle and defines authority mapping, canonical collisions,
+  memberships, consent, backup/export, rollback, retention, privacy, and removal gates.
+- [ ] The decision task mutates or deletes no legacy data and changes no production lifecycle.
+- [ ] Any approved implementation is decomposed into atomic Backlog tasks only after the ADR selects
+  an outcome; those tasks do not reference uncreated future IDs.
+- [ ] Decision evidence, ADR linkage, documentation checks, and task closeout satisfy repository DoD.
 
 ## Ordering and references
 
@@ -224,8 +431,9 @@ implementation tasks are created only after the ADR selects an outcome.
 - C3a, C3b, and C3c are independent children of C3, depend on completed TASK-18919 behavior, and
   reference S3, S4, and both S5 tasks respectively.
 - C4 depends on TASK-18919 and references ADR-107; it requires a new ADR but no code change.
-- Chatbook tasks reference the eventual Server task file or repository URL rather than declaring a
-  same-repository dependency on a potentially colliding numeric task ID.
+- Chatbook tasks use stable `tldw_server:TASK-N` references rather than declaring a same-repository
+  dependency on a potentially colliding numeric task ID. Canonical `blob/dev` URLs may be added
+  after the Server task files merge, when those links can resolve.
 
 ## Backlog quality rules
 

--- a/backlog/tasks/task-30016 - Enable-atomic-Server-capture-hard-delete.md
+++ b/backlog/tasks/task-30016 - Enable-atomic-Server-capture-hard-delete.md
@@ -1,0 +1,37 @@
+---
+id: TASK-30016
+title: Enable atomic Server capture hard delete
+status: To Do
+assignee: []
+created_date: '2026-09-03 02:56'
+updated_date: '2026-09-03 02:58'
+labels:
+  - library
+  - collections
+  - reading-list
+  - deletion
+  - server-parity
+dependencies:
+  - TASK-18919
+references:
+  - TASK-18919
+  - backlog/decisions/107-collections-capture-authority-and-legacy-boundary.md
+  - Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+  - 'tldw_server:TASK-13153'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reference S1 as `tldw_server:TASK-13153` rather than using a same-repository Backlog dependency or a pre-merge `blob/dev` URL. Chatbook keeps Server hard delete visibly unavailable until exact `hasReadingOptimisticDeletesV1=true` is positively established and refuses a response with a missing/invalid revision instead of using its current fallback value. It sends the loaded revision with the destructive request, preserves the item on conflict or unknown outcome, refreshes authoritative state, and removes the row only after confirmed deletion. Confirmation and cleanup semantics continue to follow ADR-055 and ADR-107, and linked Media or Notes are never presented as deletion targets.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Server hard delete remains visibly disabled with a reason unless `hasReadingOptimisticDeletesV1=true` is positively established for the active authority.
+- [ ] #2 Server captures with a missing/invalid revision fail closed; no fallback revision is used for destructive actions.
+- [ ] #3 Confirmed deletion sends the loaded revision, requires title-specific permanent confirmation, and removes the row only after authoritative success.
+- [ ] #4 Conflict or unknown outcome preserves the capture, marks state stale, and offers authoritative Refresh without automatic retry; external Media and Notes are never deletion targets.
+- [ ] #5 Local behavior remains unchanged and service/controller/mounted/live regressions cover source switches, late responses, narrow layouts, and ADR-055/ADR-107 semantics.
+<!-- AC:END -->

--- a/backlog/tasks/task-30017 - Present-complete-Server-capture-tag-and-domain-facets.md
+++ b/backlog/tasks/task-30017 - Present-complete-Server-capture-tag-and-domain-facets.md
@@ -1,0 +1,37 @@
+---
+id: TASK-30017
+title: Present complete Server capture tag and domain facets
+status: To Do
+assignee: []
+created_date: '2026-09-03 02:58'
+updated_date: '2026-09-03 02:59'
+labels:
+  - library
+  - collections
+  - reading-list
+  - facets
+  - server-parity
+dependencies:
+  - TASK-18919
+references:
+  - TASK-18919
+  - backlog/decisions/107-collections-capture-authority-and-legacy-boundary.md
+  - Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+  - 'tldw_server:TASK-13154'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reference S2 as `tldw_server:TASK-13154`. Until exact `hasReadingAggregateFacetsV1=true` exists, retain typed filters and never label suggestions from returned rows as complete facets. When supported, every facet browse and value search calls the Server endpoint with bounded paging; Chatbook never filters a loaded prefix to claim a complete result. Expose exact counts, deterministic paging, complete-scope filtering, generation fencing, and explicit loading/empty/error/retry states. Source changes discard prior-authority facet state, and narrow layouts preserve the adaptive reader.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Without `hasReadingAggregateFacetsV1=true`, typed filters remain available and current-page suggestions are never labelled complete facets.
+- [ ] #2 With the capability, tag/domain browse and `facet_q` search use bounded Server pages with exact totals; the client never filters a loaded prefix to claim completeness.
+- [ ] #3 Counts and values reflect the active capture scope and documented self-excluding semantics, with deterministic navigation across deep pages.
+- [ ] #4 Authority/scope changes and unmounts fence late results; loading, empty, stale, failure, and Retry states remain explicit.
+- [ ] #5 Service/state/mounted and 160×50/120×35/100×30/80×24 regressions preserve the adaptive reader and Local typed-filter behavior.
+<!-- AC:END -->

--- a/backlog/tasks/task-30018 - Complete-Server-Collections-management-workflows.md
+++ b/backlog/tasks/task-30018 - Complete-Server-Collections-management-workflows.md
@@ -1,0 +1,34 @@
+---
+id: TASK-30018
+title: Complete Server Collections management workflows
+status: To Do
+assignee: []
+created_date: '2026-09-03 03:00'
+updated_date: '2026-09-03 03:00'
+labels:
+  - library
+  - collections
+  - server-parity
+  - tracking
+dependencies:
+  - TASK-18919
+references:
+  - TASK-18919
+  - backlog/decisions/107-collections-capture-authority-and-legacy-boundary.md
+  - Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Track three independent children and close only when all three are Done. The parent has a non-implementing coordination/closeout plan: maintain child links and status, verify their combined navigation and capability honesty, record integrated evidence, complete its acceptance criteria, and close after all children. It does not own production code.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 C3a, C3b, and C3c are linked as children with current status and external Server prerequisites.
+- [ ] #2 The parent carries a non-implementing coordination/closeout plan after entering In Progress and owns no production code.
+- [ ] #3 Integrated navigation and fail-closed capability behavior across all three workflows have one recorded production-shaped verification pass.
+- [ ] #4 The parent closes only after every child is Done and its combined evidence and residual risks are documented.
+<!-- AC:END -->

--- a/backlog/tasks/task-30018.1 - Manage-Server-Collections-output-templates.md
+++ b/backlog/tasks/task-30018.1 - Manage-Server-Collections-output-templates.md
@@ -1,0 +1,37 @@
+---
+id: TASK-30018.1
+title: Manage Server Collections output templates
+status: To Do
+assignee: []
+created_date: '2026-09-03 03:01'
+updated_date: '2026-09-03 03:01'
+labels:
+  - library
+  - collections
+  - output-templates
+  - server-parity
+dependencies:
+  - TASK-18919
+references:
+  - TASK-18919
+  - backlog/decisions/107-collections-capture-authority-and-legacy-boundary.md
+  - Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+  - 'tldw_server:TASK-13155'
+parent_task_id: TASK-30018
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reference S3 as `tldw_server:TASK-13155` and require exact `hasCollectionsOutputTemplateManagementV1=true`. Add bounded browse, detail, create, edit, and reference-safe delete only for the Server-owned Collections template types. The UI explains that a template may serve multiple Collections workflows and surfaces Server in-use conflicts without offering a destructive bypass. Create/update/delete transport uncertainty never auto-retries; Refresh reconciles authoritative state. Delete requires title-specific permanent confirmation. Local mode does not claim template parity. Validation, paging, authorization, unknown outcomes, and destructive confirmation are covered by service and mounted tests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The surface remains disabled unless `hasCollectionsOutputTemplateManagementV1=true` is positively established and exposes only the Server-declared Collections template types.
+- [ ] #2 Users can browse exact bounded pages, inspect, create, edit, and preview templates without claiming Local parity.
+- [ ] #3 In-use deletion conflicts identify the blocking workflow without offering a destructive bypass; eligible deletion requires title-specific permanent confirmation.
+- [ ] #4 Create/update/delete uncertainty never auto-retries, retains user input where applicable, and reconciles through Refresh.
+- [ ] #5 Service/schema/controller/mounted/live tests cover validation, paging, authorization, capability changes, conflicts, uncertainty, focus, and narrow layouts.
+<!-- AC:END -->

--- a/backlog/tasks/task-30018.2 - Manage-Server-Reading-digest-schedules-and-outputs.md
+++ b/backlog/tasks/task-30018.2 - Manage-Server-Reading-digest-schedules-and-outputs.md
@@ -1,0 +1,39 @@
+---
+id: TASK-30018.2
+title: Manage Server Reading digest schedules and outputs
+status: To Do
+assignee: []
+created_date: '2026-09-03 03:02'
+updated_date: '2026-09-03 03:02'
+labels:
+  - library
+  - collections
+  - reading-list
+  - digests
+  - server-parity
+dependencies:
+  - TASK-18919
+references:
+  - TASK-18919
+  - backlog/decisions/107-collections-capture-authority-and-legacy-boundary.md
+  - Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+  - 'tldw_server:TASK-13156'
+parent_task_id: TASK-30018
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reference S4 as `tldw_server:TASK-13156` and require exact `hasReadingDigestManagementV1=true`. Add exact bounded schedule browse/detail/create/edit, enable-disable/delete, and output history using existing Reading digest contracts. Present only `last_status`, `last_run_at`, `next_run_at`, and output history; do not label these as a complete run ledger. Every create submission carries one stable request key; after an unknown response, Check Status performs exact lookup and an explicit retry reuses that key, so it cannot duplicate the schedule. Timezone and recurrence values are presented in human terms. Delete is permanent and confirmed. Ambiguous update/delete outcomes never auto-retry and instead retain input plus offer Refresh/reconciliation; only explicit Server conflicts are called conflicts. Scheduler/worker unavailability remains distinct from CRUD capability. Local mode remains unsupported unless a separate Local design is approved.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The surface remains disabled unless `hasReadingDigestManagementV1=true` is positively established, with scheduler/worker availability shown separately.
+- [ ] #2 Users can browse exact bounded schedule pages, inspect/create/edit/enable-disable/delete schedules, and browse bounded output history.
+- [ ] #3 Recurrence and timezone are presented in human terms; the UI exposes only Server-proven last/next/status/output evidence and never claims a complete run ledger.
+- [ ] #4 Create uses one stable request key with Check Status and explicit idempotent retry after an unknown response; it cannot duplicate a schedule.
+- [ ] #5 Delete is permanently confirmed, while uncertain update/delete outcomes retain context and reconcile through Refresh without automatic retry.
+- [ ] #6 Service/schema/controller/mounted/live tests cover paging, validation, authority changes, capability/worker states, uncertainty, focus, and narrow layouts.
+<!-- AC:END -->

--- a/backlog/tasks/task-30018.3 - Manage-Server-Reading-import-and-export-workflows.md
+++ b/backlog/tasks/task-30018.3 - Manage-Server-Reading-import-and-export-workflows.md
@@ -1,0 +1,42 @@
+---
+id: TASK-30018.3
+title: Manage Server Reading import and export workflows
+status: To Do
+assignee: []
+created_date: '2026-09-03 03:03'
+updated_date: '2026-09-03 03:03'
+labels:
+  - library
+  - collections
+  - reading-list
+  - import-export
+  - server-parity
+dependencies:
+  - TASK-18919
+references:
+  - TASK-18919
+  - backlog/decisions/107-collections-capture-authority-and-legacy-boundary.md
+  - Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+  - 'tldw_server:TASK-13157'
+  - 'tldw_server:TASK-13158'
+parent_task_id: TASK-30018
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reference S5a and S5b as `tldw_server:TASK-13157` and `tldw_server:TASK-13158` identities and require both exact `hasReadingExportJobsV1=true` and `hasReadingNativeImportV1=true`. Add bounded Pocket/Instapaper/Server-native import admission, import/export job history and detail, explicit export scope/format/content controls, authorized artifact download, and retention/cleanup presentation. Artifact cleanup is permanent and requires export-title/date confirmation; an unknown cleanup response preserves the row as stale until Refresh proves whether the artifact remains. The UI distinguishes accepted, running, partially successful, completed, failed, cancelled, interrupted, and unknown outcomes; it does not load unbounded files, retain private paths, or present a partial artifact as complete. Round-trip means the exact S5b portable field set through a Server-native export and import; Pocket/Instapaper are import-only compatibility formats. Production-shaped tests use more than one API page and verify collision idempotency. Local capture import/export is not inferred from the Server contract.
+
+C3c is one reviewable Chatbook PR boundary because it integrates the already-complete S5a/S5b contract through one Collections transfer management surface and one client-service seam. It excludes Server implementation, Local parity, import parsing, artifact storage, and schema work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The workflow remains disabled unless both `hasReadingExportJobsV1=true` and `hasReadingNativeImportV1=true` are positively established.
+- [ ] #2 Users can admit bounded Pocket/Instapaper/Server-native imports and inspect exact bounded import/export job history and detail.
+- [ ] #3 Export controls define scope, format, included portable content, retention, authorized download, and permanently confirmed artifact cleanup without revealing private paths.
+- [ ] #4 Accepted/running/partial/completed/failed/cancelled/interrupted/unknown states are distinct; partial artifacts are never presented as complete and uncertain cleanup remains stale until Refresh.
+- [ ] #5 Server-native round-trip and canonical-collision behavior match S5b; Pocket/Instapaper remain import-only and Local import/export parity is not claimed.
+- [ ] #6 Service/schema/controller/mounted/live tests use more than one API page and cover idempotency, authority changes, recovery, focus, and all standard terminal geometries.
+<!-- AC:END -->

--- a/backlog/tasks/task-30018.3 - Manage-Server-Reading-import-and-export-workflows.md
+++ b/backlog/tasks/task-30018.3 - Manage-Server-Reading-import-and-export-workflows.md
@@ -4,7 +4,7 @@ title: Manage Server Reading import and export workflows
 status: To Do
 assignee: []
 created_date: '2026-09-03 03:03'
-updated_date: '2026-09-03 03:03'
+updated_date: '2026-09-03 03:27'
 labels:
   - library
   - collections
@@ -28,7 +28,7 @@ priority: medium
 <!-- SECTION:DESCRIPTION:BEGIN -->
 Reference S5a and S5b as `tldw_server:TASK-13157` and `tldw_server:TASK-13158` identities and require both exact `hasReadingExportJobsV1=true` and `hasReadingNativeImportV1=true`. Add bounded Pocket/Instapaper/Server-native import admission, import/export job history and detail, explicit export scope/format/content controls, authorized artifact download, and retention/cleanup presentation. Artifact cleanup is permanent and requires export-title/date confirmation; an unknown cleanup response preserves the row as stale until Refresh proves whether the artifact remains. The UI distinguishes accepted, running, partially successful, completed, failed, cancelled, interrupted, and unknown outcomes; it does not load unbounded files, retain private paths, or present a partial artifact as complete. Round-trip means the exact S5b portable field set through a Server-native export and import; Pocket/Instapaper are import-only compatibility formats. Production-shaped tests use more than one API page and verify collision idempotency. Local capture import/export is not inferred from the Server contract.
 
-C3c is one reviewable Chatbook PR boundary because it integrates the already-complete S5a/S5b contract through one Collections transfer management surface and one client-service seam. It excludes Server implementation, Local parity, import parsing, artifact storage, and schema work.
+C3c is one reviewable Chatbook PR boundary over the already-shipped S5a and S5b contracts because it adds one management surface and its service integration. It includes no Server implementation, Local parity, import parser, artifact storage, portable-schema, or database-schema work.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-30019 - Decide-legacy-Collections-migration-or-retirement.md
+++ b/backlog/tasks/task-30019 - Decide-legacy-Collections-migration-or-retirement.md
@@ -1,0 +1,37 @@
+---
+id: TASK-30019
+title: Decide legacy Collections migration or retirement
+status: To Do
+assignee: []
+created_date: '2026-09-03 03:04'
+updated_date: '2026-09-03 03:05'
+labels:
+  - library
+  - collections
+  - legacy
+  - adr
+  - decision
+dependencies:
+  - TASK-18919
+references:
+  - TASK-18919
+  - backlog/decisions/107-collections-capture-authority-and-legacy-boundary.md
+  - Docs/superpowers/specs/2026-09-01-collections-followup-backlog-design.md
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Inventory the v1 schema, code reachability, compatibility promises, and downgrade paths using only repository evidence and synthetic fixtures. No real-user database, telemetry, row count, path, identifier, name, item text, URL, or membership is inspected or collected. Compare at least: retained export-only recovery, explicit user-approved migration into captures, and retirement after a defined release/notice window. The task produces a new accepted ADR defining authority mapping, canonical-URL collisions, membership handling, consent, backup/export requirements, rollback, retention, privacy boundaries, and removal gates. No legacy data is mutated or deleted in this decision task. Atomic implementation tasks are created only after the ADR selects an outcome.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Repository code/schema/recovery reachability, compatibility promises, and downgrade behavior are inventoried with synthetic fixtures only; no real-user data or telemetry is inspected.
+- [ ] #2 Retained export-only recovery, explicit user-approved capture migration, and time-bounded retirement are compared with evidence and stated trade-offs.
+- [ ] #3 A new accepted ADR selects the lifecycle and defines authority mapping, canonical collisions, memberships, consent, backup/export, rollback, retention, privacy, and removal gates.
+- [ ] #4 The decision task mutates or deletes no legacy data and changes no production lifecycle.
+- [ ] #5 Any approved implementation is decomposed into atomic Backlog tasks only after the ADR selects an outcome; those tasks do not reference uncreated future IDs.
+- [ ] #6 Decision evidence, ADR linkage, documentation checks, and task closeout satisfy repository DoD.
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

- add the approved cross-repository design and executable filing plan for the Collections follow-up stream
- add capability-gated Chatbook work for atomic Server delete and complete tag/domain facets
- add a non-implementing management parent with template, digest, and import/export children, plus the legacy lifecycle ADR decision

## Backlog records

- TASK-30016 and TASK-30017: Server delete and facet integrations
- TASK-30018 with children TASK-30018.1 through TASK-30018.3: Server Collections management
- TASK-30019: decision-only legacy migration or retirement ADR
- all records depend on completed TASK-18919 and reference exact Server TASK-13153 through TASK-13158

## Companion PR

- Server prerequisite records: https://github.com/rmusser01/tldw_server/pull/2865

## Verification

- independent spec and quality reviews passed with no remaining findings
- `python3 scripts/check_backlog_task_ids.py` passed across 3,125 task files
- all-ref/all-worktree ID and normalized-title census found zero target collisions
- `git diff --check origin/dev...HEAD` passed
- branch diff contains exactly the approved two docs and seven Backlog task files

No production code changed, so runtime tests were not applicable. Task IDs remain provisional until the collision census is rerun immediately before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the approved Collections follow-up backlog design and filing plan plus seven `tldw_chatbook` task records. No production code changes; the diff contains two docs and seven Backlog task files.

**Backlog records**
- TASK-30016 and TASK-30017 gate Server hard delete and complete tag/domain facets behind capability flags.
- TASK-30018 is a non-implementing tracking parent for children TASK-30018.1 through TASK-30018.3 covering output templates, digest schedules, and import/export.
- TASK-30019 is a decision-only task requiring a new ADR for legacy migration or retirement.
- All records depend on completed TASK-18919 and reference Server prerequisites TASK-13153 through TASK-13158 in a companion `tldw_server` PR.
- Task IDs remain provisional until the collision census is rerun immediately before merge.

Verification: `python3 scripts/check_backlog_task_ids.py` passed across 3,125 task files, `git diff --check` passed, and the ID/title census found no collisions.

<sup>Written for commit cddc0bb968b706a4510697e26324cc1b9d3bfb7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

