### PR TITLE
feat(library): review sets phase 3 - entry points (task-28242)

### DIFF
--- a/Tests/Library/test_review_set_state.py
+++ b/Tests/Library/test_review_set_state.py
@@ -13,6 +13,7 @@ from tldw_chatbook.Library.review_set_state import (
     ReviewProgress,
     ReviewSetItem,
     advance_cursor,
+    build_pinned_items,
     format_review_progress,
     is_complete,
     is_empty,
@@ -201,3 +202,33 @@ def test_format_progress_empty_set():
         format_review_progress(ReviewProgress(index=0, total=0, reviewed=0))
         == "No items to review"
     )
+
+
+# --- building the pinned item list (entry points, task-28242) ----------------
+
+
+def test_build_pinned_items_dedupes_by_id_keeping_first():
+    items, truncated = build_pinned_items([(10, "A"), (11, "B"), (10, "A-again")])
+    assert items == [(10, "A"), (11, "B")]
+    assert truncated is False
+
+
+def test_build_pinned_items_caps_and_flags_truncation():
+    items, truncated = build_pinned_items(
+        [(index, f"t{index}") for index in range(600)], cap=500
+    )
+    assert len(items) == 500
+    assert items[0] == (0, "t0") and items[-1] == (499, "t499")
+    assert truncated is True
+
+
+def test_build_pinned_items_dups_past_cap_do_not_flag_truncation():
+    pairs = [(index, f"t{index}") for index in range(500)] + [(0, "dup")] * 50
+    items, truncated = build_pinned_items(pairs, cap=500)
+    assert len(items) == 500
+    assert truncated is False  # only duplicates followed the cap, nothing dropped
+
+
+def test_build_pinned_items_coerces_types():
+    items, _ = build_pinned_items([("10", 42)])
+    assert items == [(10, "42")]

--- a/Tests/UI/test_review_set_walker.py
+++ b/Tests/UI/test_review_set_walker.py
@@ -9,7 +9,7 @@ and the per-item actuator is recorded rather than mounting a Reader.
 from __future__ import annotations
 
 import itertools
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 
 from tldw_chatbook.DB.Library_Collections_DB import LibraryCollectionsDB
 from tldw_chatbook.Library.review_set_service import ReviewSetService
@@ -228,6 +228,85 @@ def test_review_set_live_ids_treats_ids_live_when_media_db_absent():
         _REVIEW_SET_LIVENESS_BATCH=LibraryScreen._REVIEW_SET_LIVENESS_BATCH,
     )
     assert LibraryScreen._review_set_live_ids(fake, [1, 2, 3]) == {1, 2, 3}
+
+
+def _entry_fake(service):
+    opened: list[str] = []
+    notices: list[tuple[str, str]] = []
+    fake = SimpleNamespace(
+        _review_set_service=lambda: service,
+        _open_library_media_viewer=lambda media_id: opened.append(media_id),
+        app_instance=SimpleNamespace(
+            notify=lambda message, severity="information": notices.append(
+                (message, severity)
+            )
+        ),
+    )
+    fake._notify_review_set = MethodType(
+        LibraryScreen._notify_review_set, fake
+    )
+    fake._opened = opened
+    fake._notices = notices
+    return fake
+
+
+def test_create_and_open_review_set_creates_activates_and_lands(tmp_path):
+    service = _service(tmp_path)
+    fake = _entry_fake(service)
+
+    LibraryScreen._create_and_open_review_set(
+        fake, "Talks", "browse", [(10, "A"), (11, "B")]
+    )
+
+    review_set = service.get_active_review_set()
+    assert review_set is not None
+    assert [item.backing_media_id for item in review_set.items] == [10, 11]
+    assert fake._opened == ["local:media:10"]  # landed on the first item
+
+
+def test_create_and_open_review_set_empty_notifies_and_makes_no_set(tmp_path):
+    service = _service(tmp_path)
+    fake = _entry_fake(service)
+
+    LibraryScreen._create_and_open_review_set(fake, "X", "browse", [])
+
+    assert service.get_active_review_set() is None
+    assert fake._opened == []
+    assert fake._notices and fake._notices[0][1] == "warning"
+
+
+def test_create_and_open_review_set_warns_on_truncation(tmp_path):
+    service = _service(tmp_path)
+    fake = _entry_fake(service)
+
+    LibraryScreen._create_and_open_review_set(
+        fake, "X", "browse", [(index, f"t{index}") for index in range(600)]
+    )
+
+    review_set = service.get_active_review_set()
+    assert len(review_set.items) == 500
+    assert any(severity == "warning" for _msg, severity in fake._notices)
+
+
+def test_review_these_name_from_scope():
+    assert (
+        LibraryScreen._review_these_name(
+            SimpleNamespace(query="cats", media_type=None)
+        )
+        == 'Search: "cats"'
+    )
+    assert (
+        LibraryScreen._review_these_name(
+            SimpleNamespace(query="", media_type="video")
+        )
+        == "video items"
+    )
+    assert (
+        LibraryScreen._review_these_name(
+            SimpleNamespace(query="", media_type=None)
+        )
+        == "All media"
+    )
 
 
 def test_review_set_active_reflects_the_service(tmp_path):

--- a/Tests/UI/test_review_set_walker.py
+++ b/Tests/UI/test_review_set_walker.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import itertools
 from types import MethodType, SimpleNamespace
 
+import pytest
+
 from tldw_chatbook.DB.Library_Collections_DB import LibraryCollectionsDB
 from tldw_chatbook.Library.review_set_service import ReviewSetService
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
@@ -286,6 +288,101 @@ def test_create_and_open_review_set_warns_on_truncation(tmp_path):
     review_set = service.get_active_review_set()
     assert len(review_set.items) == 500
     assert any(severity == "warning" for _msg, severity in fake._notices)
+
+
+def _worker_fake(service, *, search_media, scope=None):
+    """Fake screen for the entry-point workers, wiring the real methods."""
+    fake = _entry_fake(service)
+    fake._library_media_browse_controller = SimpleNamespace(applied_scope=scope)
+    fake.app_instance.media_reading_scope_service = SimpleNamespace(
+        search_media=search_media
+    )
+
+    async def run_call(call, *args, isolate_in_worker=False, **kwargs):
+        return await call(*args, **kwargs)
+
+    fake._run_library_service_call = run_call
+    for name in (
+        "_collect_review_pairs_from_scope",
+        "_order_selected_review_pairs",
+        "_create_and_open_review_set",
+        "_review_these_worker",
+        "_review_selected_worker",
+    ):
+        setattr(fake, name, MethodType(getattr(LibraryScreen, name), fake))
+    fake._review_these_name = LibraryScreen._review_these_name
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_review_these_worker_pages_the_whole_result_and_lands(tmp_path):
+    service = _service(tmp_path)
+    pages = {
+        0: [
+            {"backing_media_id": 10, "title": "A"},
+            {"backing_media_id": 11, "title": "B"},
+        ],
+        2: [{"backing_media_id": 12, "title": "C"}],
+    }
+
+    async def search_media(*, offset=0, **_kwargs):
+        return {"items": pages.get(offset, []), "total": 3}
+
+    scope = SimpleNamespace(
+        query="", media_type=None, sort_by="last_modified_desc", page_size=2
+    )
+    fake = _worker_fake(service, search_media=search_media, scope=scope)
+
+    await fake._review_these_worker()
+
+    review_set = service.get_active_review_set()
+    assert [item.backing_media_id for item in review_set.items] == [10, 11, 12]
+    assert review_set.origin == "browse"
+    assert fake._opened == ["local:media:10"]
+
+
+@pytest.mark.asyncio
+async def test_review_selected_worker_orders_via_the_id_allowlist(tmp_path):
+    service = _service(tmp_path)
+    seen_kwargs = {}
+
+    async def search_media(**kwargs):
+        seen_kwargs.update(kwargs)
+        # the service returns the allowlist in browse order (newest first).
+        return {
+            "items": [
+                {"backing_media_id": 30, "title": "Z"},
+                {"backing_media_id": 20, "title": "Y"},
+            ],
+            "total": 2,
+        }
+
+    fake = _worker_fake(service, search_media=search_media, scope=None)
+
+    await fake._review_selected_worker((20, 30))
+
+    review_set = service.get_active_review_set()
+    assert [item.backing_media_id for item in review_set.items] == [30, 20]
+    assert review_set.origin == "selection"
+    assert seen_kwargs["id_allowlist"] == [20, 30]  # bounded allowlist passed
+
+
+@pytest.mark.asyncio
+async def test_review_these_worker_notifies_on_failure(tmp_path):
+    service = _service(tmp_path)
+
+    async def search_media(**_kwargs):
+        raise RuntimeError("db exploded")
+
+    scope = SimpleNamespace(
+        query="", media_type=None, sort_by="last_modified_desc", page_size=2
+    )
+    fake = _worker_fake(service, search_media=search_media, scope=scope)
+
+    await fake._review_these_worker()  # must not raise
+
+    assert service.get_active_review_set() is None
+    assert any(severity == "error" for _msg, severity in fake._notices)
 
 
 def test_review_these_name_from_scope():

--- a/backlog/tasks/task-28242 - Review-sets-Phase-3-entry-points-Review-these-Review-selected.md
+++ b/backlog/tasks/task-28242 - Review-sets-Phase-3-entry-points-Review-these-Review-selected.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-28242
 title: 'Review sets - Phase 3: entry points (Review these / Review selected)'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-02 22:29'
+updated_date: '2026-09-03 03:56'
 labels:
   - library
   - media-ux
@@ -21,7 +22,19 @@ Create review sets from the media browse result and from a Select-mode selection
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A 'Review these' action on the media list pins the WHOLE filtered browse result (page through to last_page in a worker, de-dupe by id, cap 500 with pin-first-500 + warn on overflow) and opens it active at cursor 0
-- [ ] #2 A 'Review selected' third Select-mode bulk action (next to Export/Delete selected) pins the selected ids ordered by a deterministic sort-order query (NOT the mounted rows, since RowSelection is unordered and can span pages)
-- [ ] #3 Both paths land the user in the Reader walking the new set; the filter-query surface is covered by 'Review these' (no separate RAG-search integration)
+- [x] #1 A 'Review these' action on the media list pins the WHOLE filtered browse result (page through to last_page in a worker, de-dupe by id, cap 500 with pin-first-500 + warn on overflow) and opens it active at cursor 0
+- [x] #2 A 'Review selected' third Select-mode bulk action (next to Export/Delete selected) pins the selected ids ordered by a deterministic sort-order query (NOT the mounted rows, since RowSelection is unordered and can span pages)
+- [x] #3 Both paths land the user in the Reader walking the new set; the filter-query surface is covered by 'Review these' (no separate RAG-search integration)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+3a. Build the ordered pinned-item list from a browse result (pure helper): dedupe by id, cap 500, (id,title) pairs. 3b. 'Review these' action on the media list toolbar: page through the WHOLE filtered result (with_page to last_page) in a worker, build items, create_review_set(origin=browse), land in Reader at item 0. 3c. 'Review selected' Select-mode bulk action next to Export/Delete: order selected ids by a deterministic sort-order query (not mounted rows), create_review_set(origin=selection), land in Reader. 3d. Both land via _select_library_media_reader_row. TDD the pure builder + the ordering; live-verify the buttons.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Phase 3 entry points shipped + LIVE-VERIFIED end-to-end (tmux, seeded 4 media items). 'Review these' (browse toolbar #library-media-review) pages the WHOLE filtered result via search_media(library_summary=True, sort_by, media_types) in a worker, build_pinned_items (dedupe by backing id, cap 500, truncation flag), create_review_set(origin=browse), lands in Reader at item 0 via _open_library_media_viewer. 'Review selected' (select-mode #library-media-review-selected, between Export and danger Delete) orders the selection by search_media(id_allowlist=backing_ids, sort_by) -- deterministic browse order, NOT the unordered RowSelection -- then create(origin=selection) + land. Shared _create_and_open_review_set (empty->notify, truncation->warn). LIVE: clicked Review these -> set created + Reader landed on first item; footer showed '1 of 4 . 0 reviewed'; pressed ] -> advanced to item 2, footer '2 of 4 . 1 reviewed', left item auto-marked done. Cleaned up seeded data after. Pure build_pinned_items + _create_and_open_review_set unit-tested (Tests/UI/test_review_set_walker.py + test_review_set_state.py, 59 pass). NO new logger (branch doesn't touch diagnostic inventory). Files: Widgets/Library/library_media_canvas.py, UI/Screens/library_screen.py, Library/review_set_state.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/library_shell_state.py
+++ b/tldw_chatbook/Library/library_shell_state.py
@@ -75,6 +75,12 @@ LIBRARY_EXPORT_SELECTED_TOOLTIP = "Export the selected items."
 LIBRARY_DELETE_SELECTED_DISABLED_TOOLTIP = "Select one or more items to delete them."
 LIBRARY_DELETE_SELECTED_TOOLTIP = "Move the selected items to trash."
 
+# task-28242: the Media canvas's "Review selected" bulk action, same pair.
+LIBRARY_REVIEW_SELECTED_DISABLED_TOOLTIP = (
+    "Select one or more items to review them."
+)
+LIBRARY_REVIEW_SELECTED_TOOLTIP = "Review the selected items, one by one."
+
 # task-4023 AC#1 (RC-07): disabled state finally joins the product's
 # non-colour vocabulary. Every disabled Library action label carries a
 # leading "○" -- the existing ✓/○ pair's neutral glyph (ingest option

--- a/tldw_chatbook/Library/review_set_state.py
+++ b/tldw_chatbook/Library/review_set_state.py
@@ -19,6 +19,10 @@ from typing import Callable, Iterable
 IsLive = Callable[[int], bool]
 """Predicate: does this backing media id still resolve to a live item?"""
 
+REVIEW_SET_CAP = 500
+"""Max distinct items a review set pins (task-28242). One source of truth for
+the collect/build/notify/query paths so they cannot disagree."""
+
 
 @dataclass(frozen=True)
 class ReviewSetItem:
@@ -287,7 +291,7 @@ def format_review_progress(progress: ReviewProgress) -> str:
 
 
 def build_pinned_items(
-    pairs: "Iterable[tuple[int, str]]", *, cap: int = 500
+    pairs: "Iterable[tuple[int, str]]", *, cap: int = REVIEW_SET_CAP
 ) -> tuple[list[tuple[int, str]], bool]:
     """Build the pinned ``(backing_media_id, title)`` list for a new set.
 

--- a/tldw_chatbook/Library/review_set_state.py
+++ b/tldw_chatbook/Library/review_set_state.py
@@ -14,7 +14,7 @@ LIVE items only; the cursor is an absolute position that survives deletions.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, Iterable
 
 IsLive = Callable[[int], bool]
 """Predicate: does this backing media id still resolve to a live item?"""
@@ -284,6 +284,40 @@ def format_review_progress(progress: ReviewProgress) -> str:
     if progress.reviewed >= progress.total:
         return f"All {progress.total} reviewed"
     return f"{progress.index} of {progress.total} · {progress.reviewed} reviewed"
+
+
+def build_pinned_items(
+    pairs: "Iterable[tuple[int, str]]", *, cap: int = 500
+) -> tuple[list[tuple[int, str]], bool]:
+    """Build the pinned ``(backing_media_id, title)`` list for a new set.
+
+    task-28242: a set is a snapshot, so the entry points pin an ordered list at
+    creation. Duplicates by backing id are dropped keeping the first
+    occurrence, and the list is capped at ``cap`` items (a several-thousand-item
+    "review set" is not a review set). Duplicates that follow the cap are *not*
+    counted as truncation -- only distinct items actually dropped are.
+
+    Args:
+        pairs: Ordered ``(backing_media_id, title)`` pairs (order is preserved).
+        cap: Maximum distinct items to pin.
+
+    Returns:
+        ``(items, truncated)`` -- the pinned pairs, and whether the cap dropped
+        at least one distinct item.
+    """
+    seen: set[int] = set()
+    items: list[tuple[int, str]] = []
+    truncated = False
+    for backing_media_id, title in pairs:
+        bid = int(backing_media_id)
+        if bid in seen:
+            continue
+        if len(items) >= cap:
+            truncated = True
+            break
+        seen.add(bid)
+        items.append((bid, str(title)))
+    return items, truncated
 
 
 def is_empty(items: tuple[ReviewSetItem, ...], is_live: IsLive) -> bool:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -412,6 +412,8 @@ from ...Library.library_shell_state import (
     LIBRARY_EXPORT_SELECTED_DISABLED_TOOLTIP,
     LIBRARY_EXPORT_SELECTED_TOOLTIP,
     LIBRARY_EXPORT_SERVER_DISABLED_TOOLTIP,
+    LIBRARY_REVIEW_SELECTED_DISABLED_TOOLTIP,
+    LIBRARY_REVIEW_SELECTED_TOOLTIP,
     LIBRARY_ROW_BROWSE_COLLECTIONS,
     LIBRARY_ROW_BROWSE_CONVERSATIONS,
     LIBRARY_ROW_BROWSE_MEDIA,
@@ -1868,6 +1870,19 @@ def _apply_library_row_toggle(
                 else LIBRARY_DELETE_SELECTED_TOOLTIP
             )
             _patch_library_disabled_marker_label(delete_button)
+            # task-28242 (Qodo #2335): the "Review selected" bulk action flips
+            # in place too, or it stays disabled after the first row toggle
+            # until an unrelated full recompose.
+            review_button = screen.query_one(
+                "#library-media-review-selected", Button
+            )
+            review_button.disabled = selection.count == 0
+            review_button.tooltip = (
+                LIBRARY_REVIEW_SELECTED_DISABLED_TOOLTIP
+                if review_button.disabled
+                else LIBRARY_REVIEW_SELECTED_TOOLTIP
+            )
+            _patch_library_disabled_marker_label(review_button)
         elif kind == "notes":
             work_panes = screen.query("#library-note-work-pane")
             if work_panes and screen._library_note_session.snapshot is not None:
@@ -42027,21 +42042,37 @@ class LibraryScreen(BaseAppScreen):
         )
 
     async def _review_these_worker(self) -> None:
-        """Page the whole filtered result, then create + open the set."""
-        scope = getattr(self._library_media_browse_controller, "applied_scope", None)
-        if scope is None:
-            return
-        pairs = await self._collect_review_pairs_from_scope(scope)
-        self._create_and_open_review_set(
-            self._review_these_name(scope), "browse", pairs
-        )
+        """Page the whole filtered result, then create + open the set.
+
+        Wrapped so a search/DB failure surfaces a notice instead of a silent
+        no-op (Qodo #2335) -- the worker runs with ``exit_on_error=False``.
+        """
+        try:
+            scope = getattr(
+                self._library_media_browse_controller, "applied_scope", None
+            )
+            if scope is None:
+                return
+            pairs = await self._collect_review_pairs_from_scope(scope)
+            self._create_and_open_review_set(
+                self._review_these_name(scope), "browse", pairs
+            )
+        except Exception:
+            self._notify_review_set(
+                "Couldn't build the review set.", severity="error"
+            )
 
     async def _review_selected_worker(self, backing_ids: tuple[int, ...]) -> None:
         """Order the selected ids by the browse sort, then create + open."""
-        pairs = await self._order_selected_review_pairs(backing_ids)
-        self._create_and_open_review_set(
-            f"{len(backing_ids)} selected items", "selection", pairs
-        )
+        try:
+            pairs = await self._order_selected_review_pairs(backing_ids)
+            self._create_and_open_review_set(
+                f"{len(backing_ids)} selected items", "selection", pairs
+            )
+        except Exception:
+            self._notify_review_set(
+                "Couldn't build the review set.", severity="error"
+            )
 
     async def _collect_review_pairs_from_scope(
         self, scope: Any
@@ -42059,6 +42090,8 @@ class LibraryScreen(BaseAppScreen):
         )
         if not callable(search):
             return []
+        from tldw_chatbook.Library.review_set_state import REVIEW_SET_CAP
+
         pairs: list[tuple[int, str]] = []
         page = 1
         page_size = scope.page_size
@@ -42080,7 +42113,11 @@ class LibraryScreen(BaseAppScreen):
             for item in items:
                 pairs.append((int(item["backing_media_id"]), str(item["title"])))
             total = int(payload.get("total", 0)) if isinstance(payload, Mapping) else 0
-            if not items or page * page_size >= total or len(pairs) > 500:
+            if (
+                not items
+                or page * page_size >= total
+                or len(pairs) > REVIEW_SET_CAP
+            ):
                 break
             page += 1
         return pairs
@@ -42101,17 +42138,22 @@ class LibraryScreen(BaseAppScreen):
         )
         if not callable(search):
             return []
+        from tldw_chatbook.Library.review_set_state import REVIEW_SET_CAP
+
         scope = getattr(self._library_media_browse_controller, "applied_scope", None)
         sort_by = scope.sort_by if scope is not None else "last_modified_desc"
+        # Qodo #2335: bound the query to the cap (+1 to flag overflow), not the
+        # unrestricted selection size.
+        ids = list(backing_ids)[: REVIEW_SET_CAP + 1]
         payload = await self._run_library_service_call(
             search,
             mode="local",
             query="",
             library_summary=True,
             isolate_in_worker=True,
-            id_allowlist=list(backing_ids),
+            id_allowlist=ids,
             sort_by=sort_by,
-            limit=len(backing_ids),
+            limit=len(ids),
             offset=0,
         )
         items = payload.get("items", []) if isinstance(payload, Mapping) else []
@@ -42139,9 +42181,12 @@ class LibraryScreen(BaseAppScreen):
             origin: ``'browse'`` or ``'selection'``.
             pairs: Ordered ``(backing_media_id, title)`` pairs.
         """
-        from tldw_chatbook.Library.review_set_state import build_pinned_items
+        from tldw_chatbook.Library.review_set_state import (
+            REVIEW_SET_CAP,
+            build_pinned_items,
+        )
 
-        items, truncated = build_pinned_items(pairs, cap=500)
+        items, truncated = build_pinned_items(pairs, cap=REVIEW_SET_CAP)
         if not items:
             self._notify_review_set(
                 "No media items to review.", severity="warning"
@@ -42153,7 +42198,8 @@ class LibraryScreen(BaseAppScreen):
         service.create_review_set(name, origin, items)
         if truncated:
             self._notify_review_set(
-                "Review set capped at the first 500 items.", severity="warning"
+                f"Review set capped at the first {REVIEW_SET_CAP} items.",
+                severity="warning",
             )
         else:
             self._notify_review_set(f"Reviewing {len(items)} items.")

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -41981,6 +41981,191 @@ class LibraryScreen(BaseAppScreen):
         )
         self._sync_library_media_viewer_or_recompose()
 
+    # -- review-set entry points (task-28242) --------------------------------
+
+    @on(Button.Pressed, "#library-media-review")
+    def handle_library_media_review_these(self, event: Button.Pressed) -> None:
+        """Pin the WHOLE filtered list as a review set and open it.
+
+        Args:
+            event: The "Review these" button press.
+        """
+        event.stop()
+        self.run_worker(
+            self._review_these_worker(),
+            group="library_review_set",
+            exclusive=True,
+            exit_on_error=False,
+        )
+
+    @on(Button.Pressed, "#library-media-review-selected")
+    def handle_library_media_review_selected(self, event: Button.Pressed) -> None:
+        """Pin the current Select-mode selection as a review set and open it.
+
+        Args:
+            event: The "Review selected" bulk-action button press.
+        """
+        event.stop()
+        if getattr(self, "_library_media_bulk_delete_in_flight", False):
+            return
+        selection = self._library_media_row_selection
+        if not selection.count:
+            return
+        backing_ids: list[int] = []
+        for canonical_id in selection.ids:
+            try:
+                backing_ids.append(int(str(canonical_id).rsplit(":", 1)[-1]))
+            except (ValueError, TypeError):
+                continue
+        if not backing_ids:
+            return
+        self.run_worker(
+            self._review_selected_worker(tuple(backing_ids)),
+            group="library_review_set",
+            exclusive=True,
+            exit_on_error=False,
+        )
+
+    async def _review_these_worker(self) -> None:
+        """Page the whole filtered result, then create + open the set."""
+        scope = getattr(self._library_media_browse_controller, "applied_scope", None)
+        if scope is None:
+            return
+        pairs = await self._collect_review_pairs_from_scope(scope)
+        self._create_and_open_review_set(
+            self._review_these_name(scope), "browse", pairs
+        )
+
+    async def _review_selected_worker(self, backing_ids: tuple[int, ...]) -> None:
+        """Order the selected ids by the browse sort, then create + open."""
+        pairs = await self._order_selected_review_pairs(backing_ids)
+        self._create_and_open_review_set(
+            f"{len(backing_ids)} selected items", "selection", pairs
+        )
+
+    async def _collect_review_pairs_from_scope(
+        self, scope: Any
+    ) -> list[tuple[int, str]]:
+        """Page the whole filtered result into ordered (backing_id, title) pairs.
+
+        Reads the raw ``search_media`` envelope page by page (off the event
+        loop) in browse-sort order, stopping at the total, an empty page, or one
+        past the 500 cap (so ``build_pinned_items`` can flag truncation).
+        """
+        search = getattr(
+            getattr(self.app_instance, "media_reading_scope_service", None),
+            "search_media",
+            None,
+        )
+        if not callable(search):
+            return []
+        pairs: list[tuple[int, str]] = []
+        page = 1
+        page_size = scope.page_size
+        while True:
+            filters: dict[str, Any] = {"sort_by": scope.sort_by}
+            if scope.media_type:
+                filters["media_types"] = [scope.media_type]
+            payload = await self._run_library_service_call(
+                search,
+                mode="local",
+                query=scope.query,
+                limit=page_size,
+                offset=(page - 1) * page_size,
+                library_summary=True,
+                isolate_in_worker=True,
+                **filters,
+            )
+            items = payload.get("items", []) if isinstance(payload, Mapping) else []
+            for item in items:
+                pairs.append((int(item["backing_media_id"]), str(item["title"])))
+            total = int(payload.get("total", 0)) if isinstance(payload, Mapping) else 0
+            if not items or page * page_size >= total or len(pairs) > 500:
+                break
+            page += 1
+        return pairs
+
+    async def _order_selected_review_pairs(
+        self, backing_ids: tuple[int, ...]
+    ) -> list[tuple[int, str]]:
+        """Order selected backing ids by the browse sort (deterministic).
+
+        Uses ``search_media``'s ``id_allowlist`` so the selection reads in the
+        same order the user saw, regardless of which pages it spanned -- NOT the
+        unordered RowSelection set.
+        """
+        search = getattr(
+            getattr(self.app_instance, "media_reading_scope_service", None),
+            "search_media",
+            None,
+        )
+        if not callable(search):
+            return []
+        scope = getattr(self._library_media_browse_controller, "applied_scope", None)
+        sort_by = scope.sort_by if scope is not None else "last_modified_desc"
+        payload = await self._run_library_service_call(
+            search,
+            mode="local",
+            query="",
+            library_summary=True,
+            isolate_in_worker=True,
+            id_allowlist=list(backing_ids),
+            sort_by=sort_by,
+            limit=len(backing_ids),
+            offset=0,
+        )
+        items = payload.get("items", []) if isinstance(payload, Mapping) else []
+        return [(int(item["backing_media_id"]), str(item["title"])) for item in items]
+
+    @staticmethod
+    def _review_these_name(scope: Any) -> str:
+        """A human name for a browse-derived review set."""
+        if scope.query:
+            return f'Search: "{scope.query}"'
+        if scope.media_type:
+            return f"{scope.media_type} items"
+        return "All media"
+
+    def _create_and_open_review_set(
+        self, name: str, origin: str, pairs: list[tuple[int, str]]
+    ) -> None:
+        """Create the set from pinned pairs, activate it, and open it in Reader.
+
+        A no-op (with a notice) when nothing resolved; warns when the 500 cap
+        dropped items.
+
+        Args:
+            name: Human label for the set.
+            origin: ``'browse'`` or ``'selection'``.
+            pairs: Ordered ``(backing_media_id, title)`` pairs.
+        """
+        from tldw_chatbook.Library.review_set_state import build_pinned_items
+
+        items, truncated = build_pinned_items(pairs, cap=500)
+        if not items:
+            self._notify_review_set(
+                "No media items to review.", severity="warning"
+            )
+            return
+        service = self._review_set_service()
+        if service is None:
+            return
+        service.create_review_set(name, origin, items)
+        if truncated:
+            self._notify_review_set(
+                "Review set capped at the first 500 items.", severity="warning"
+            )
+        else:
+            self._notify_review_set(f"Reviewing {len(items)} items.")
+        self._open_library_media_viewer(f"local:media:{items[0][0]}")
+
+    def _notify_review_set(
+        self, message: str, *, severity: str = "information"
+    ) -> None:
+        notify = getattr(self.app_instance, "notify", None)
+        if callable(notify):
+            notify(message, severity=severity)
+
     def _focus_library_media_items_pane(self) -> None:
         """Focus the Items pane at its most useful control (task-28004).
 

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -28,6 +28,8 @@ from tldw_chatbook.Library.library_shell_state import (
     LIBRARY_DELETE_SELECTED_TOOLTIP,
     LIBRARY_EXPORT_SELECTED_DISABLED_TOOLTIP,
     LIBRARY_EXPORT_SELECTED_TOOLTIP,
+    LIBRARY_REVIEW_SELECTED_DISABLED_TOOLTIP,
+    LIBRARY_REVIEW_SELECTED_TOOLTIP,
     LIBRARY_SELECT_TOGGLE_DISABLED_TOOLTIP,
     library_choice_label,
     library_choice_tooltip,
@@ -614,9 +616,9 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                     )
                     review_selected.disabled = review_disabled
                     review_selected.tooltip = (
-                        "Select items to review them one by one."
+                        LIBRARY_REVIEW_SELECTED_DISABLED_TOOLTIP
                         if review_disabled
-                        else "Review the selected items, one by one."
+                        else LIBRARY_REVIEW_SELECTED_TOOLTIP
                     )
                     yield self._gate_stale_action(
                         review_selected, "Review selected"

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -422,6 +422,18 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             )
             trash_btn.display = not select_mode
             yield trash_btn
+            # task-28242: "Review these" pins the WHOLE filtered result as an
+            # ordered review set and walks it in the Reader. A list-level
+            # action, hidden in select mode like Export/Trash.
+            review_btn = Button(
+                "Review these",
+                id="library-media-review",
+                classes="library-canvas-action",
+                compact=True,
+                tooltip="Review every item in this list, one by one.",
+            )
+            review_btn.display = not select_mode
+            yield self._gate_stale_action(review_btn, "Review these")
             # Disable only when there's nothing to select AND we're not
             # already in select mode -- in select mode the button is "Done"
             # and must always be pressable so the user can exit even if the
@@ -584,6 +596,30 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                     )
                     yield self._gate_stale_action(
                         export_selected, "Export selected"
+                    )
+                    # task-28242: the third real bulk action -- "Review
+                    # selected" -- pins the selection as an ordered review set.
+                    # Sits between Export and the far-end danger Delete.
+                    review_disabled = self.canvas.selected_count == 0
+                    review_selected = Button(
+                        library_disabled_action_label(
+                            "Review selected", review_disabled
+                        ),
+                        id="library-media-review-selected",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                    review_selected._library_disabled_marker_base = (
+                        "Review selected"
+                    )
+                    review_selected.disabled = review_disabled
+                    review_selected.tooltip = (
+                        "Select items to review them one by one."
+                        if review_disabled
+                        else "Review the selected items, one by one."
+                    )
+                    yield self._gate_stale_action(
+                        review_selected, "Review selected"
                     )
                     # task-2853: the second real bulk action -- "Delete
                     # selected" -- pushed to the far end (CSS margin, same


### PR DESCRIPTION
## What

Phase 3 of Library review sets — **the entry points that let a user actually create a set**. Until now the walker (Phase 2) was dormant because nothing could create a set; this closes that. Closes **task-28242**.

Two ways to create one, both landing straight in the Reader walking the new set:

- **"Review these"** on the media list toolbar (between Trash and Select) pins the **whole filtered result** — it pages through `search_media` in a worker, dedupes by id, and caps at 500 (with a "first 500" warning on overflow). Covers the filter-query surface too (a filtered list *is* a browse result).
- **"Review selected"** — a third **Select-mode bulk action** between "Export selected" and the far-end danger "Delete selected" — pins the selection ordered by a **deterministic sort-order query** (`search_media(id_allowlist=…)`), not the unordered `RowSelection` (which is a set and can span pages).

## Verified end-to-end (live)

Seeded 4 media items and drove the real app in tmux:
1. Clicked **"Review these"** → the set was created and the Reader **landed on the first item**; the footer showed **`1 of 4 · 0 reviewed`**.
2. Pressed **`]`** → advanced to item 2, the item left behind was **auto-marked done**, and the footer updated to **`2 of 4 · 1 reviewed`**.

(Seeded data cleaned up afterward; the user's DB is untouched.)

## Design

- Pure `build_pinned_items(pairs, cap=500)` (in `review_set_state.py`) — dedupe-by-id + cap + truncation flag.
- Shared `_create_and_open_review_set` — builds the pinned list, creates + activates the set, lands on its first item (empty → notice, truncation → warning).
- The paging/ordering calls mirror the browse controller's existing `search_media` usage exactly; no new logger (so this branch doesn't touch the diagnostic inventory).

## Tests

`Tests/UI/test_review_set_walker.py` + `Tests/Library/test_review_set_state.py` — `build_pinned_items` (dedupe/cap/truncation/coercion), `_create_and_open_review_set` (create+activate+land, empty, truncation), and the name derivation. 59 review-set tests green; derived-artifact checks (inventory, index pins, CSS, backlog) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes task-28242: adds the two entry points that let users create review sets, so the Phase 2 walker is finally reachable from the UI. "Review these" pins the whole filtered list; "Review selected" pins the current selection — both create the set and land in the Reader walking it.

**New Features**
- `build_pinned_items` dedupes by backing id, caps at 500, and returns a truncation flag.
- "Review these" pages the whole filtered result via `search_media` in a worker and warns when the cap drops items.
- "Review selected" orders the selection with a deterministic sort query (`id_allowlist`), not the unordered `RowSelection`.
- Empty or unresolved selections notify the user and create no set.

**Bug Fixes**
- "Review selected" now enables in place when rows are toggled, like Export/Delete.
- Worker failures now surface an error notice instead of a silent no-op.

<sup>Written for commit 71e87101f85ca9ddd16187bbd9dc537b84d0526c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

