### PR TITLE
fix(console): repair context fixtures and format modules

### DIFF
--- a/Docs/superpowers/plans/2026-09-03-task-26945-ruff-chat-console-context.md
+++ b/Docs/superpowers/plans/2026-09-03-task-26945-ruff-chat-console-context.md
@@ -1,0 +1,71 @@
+# TASK-26945 Ruff Chat Console Context Cleanup Implementation Plan
+
+> **For Codex:** Use `superpowers:verification-before-completion` and `superpowers:requesting-code-review` before closeout.
+
+**Goal:** Apply Ruff 0.15.22's formatter to the exact twelve TASK-26000 Console context paths while proving Python semantics, comments, and formatter directives are unchanged.
+
+**Architecture:** Treat TASK-26000's batch manifest as the ownership boundary. Reconcile every recorded path against current `origin/dev`, capture Python 3.12.11 structural evidence after the separately committed TASK-30040 baseline-test repair, run Ruff only on those twelve paths, compare the same evidence after formatting, and use the recorded eight-module focused suite as behavioral evidence.
+
+**Tech Stack:** Python 3.12.11, Ruff 0.15.22, pytest, standard-library `ast` and `tokenize`, Git, Backlog.md.
+
+**Spec:** `Docs/superpowers/specs/2026-08-30-task-26000-ruff-formatter-debt-design.md`
+
+## Global Constraints
+
+- The assigned path set is exact; do not format or change any unassigned Python path.
+- Normalize only `ast.TypeIgnore.lineno` when comparing AST dumps.
+- Preserve ordered comment tokens, inline directive anchors, standalone Ruff directive adjacency, and `# fmt: off` / `# fmt: on` enclosed-node intervals.
+- Do not make handwritten production behavior changes.
+- TASK-30040 is a separate committed test-fixture repair; TASK-26945's formatter baseline begins after that commit.
+- Use the exact focused test modules owned by this batch. Do not run the full suite without user opt-in.
+
+## Task 1: Reconcile Ownership and Capture the Baseline
+
+**Files:**
+
+- Inspect: `backlog/tasks/task-26945 - Clean-Ruff-formatter-debt-for-ruff-chat-console-context.md`
+- Inspect: `Docs/superpowers/reviews/evidence/task-26000/ruff-formatter-debt.json`
+- Inspect: all twelve Assigned Paths in TASK-26945
+
+1. Verify the branch merge-base is the fetched current `origin/dev` and record both current and TASK-26000 pinned commits.
+2. Confirm all twelve paths exist and inspect history for deletions, renames, upstream modifications, or already-formatted files.
+3. Record that four paths changed between the TASK-26000 pin and current `origin/dev`, with no assigned-path rename or deletion.
+4. Record TASK-30040's separate repair/format commit for `Tests/Chat/test_console_memory_selection.py`; keep the path in the batch and include it in every guard and Ruff command.
+5. Capture AST, ordered comments, directive anchors, and formatter-range evidence for all twelve paths using Python 3.12.11.
+
+## Task 2: Format Only the Assigned Paths
+
+**Files:**
+
+- Modify: the exact twelve Assigned Paths, when Ruff changes them
+
+1. Run Ruff 0.15.22 `format` with the twelve paths supplied explicitly.
+2. Assert the Python diff outside the twelve-path allowlist is empty.
+3. Compare post-format structural evidence against the baseline and stop on any mismatch.
+
+## Task 3: Run Focused and Governance Verification
+
+**Files:**
+
+- Verify: the exact twelve Assigned Paths
+- Verify: the eight assigned test modules
+
+1. Run Ruff 0.15.22 lint and format checks on all twelve paths.
+2. Run the eight assigned Console context test modules in one Python 3.12.11 pytest command.
+3. Run `Tests/CI/test_backlog_task_id_uniqueness.py` and `git diff --check`.
+4. Confirm no unassigned Python path changed and inspect the formatter diff for behavioral edits.
+
+## Task 4: Commit, Review, and Close TASK-26945
+
+**Files:**
+
+- Modify: `backlog/tasks/task-26945 - Clean-Ruff-formatter-debt-for-ruff-chat-console-context.md`
+
+1. Commit only the formatter-owned Python changes.
+2. Request an independent review of the formatting commit and address every Critical or Important finding.
+3. Add exact drift, structural, Ruff, focused-test, and governance results to Implementation Notes.
+4. Check all acceptance criteria, set TASK-26945 to Done, and commit only the closeout record.
+
+ADR required: no
+ADR path: N/A
+Reason: This is mechanical formatter cleanup under TASK-26000's accepted contract and introduces no architectural, persistence, security, dependency, or long-lived UX decision.

--- a/Docs/superpowers/plans/2026-09-03-task-30040-console-memory-selection-fixture-guards.md
+++ b/Docs/superpowers/plans/2026-09-03-task-30040-console-memory-selection-fixture-guards.md
@@ -1,0 +1,57 @@
+# TASK-30040 Console Memory-Selection Fixture Guard Repair Implementation Plan
+
+> **For Codex:** Use `superpowers:test-driven-development` for the existing red regression and `superpowers:verification-before-completion` before closeout.
+
+**Goal:** Restore the Console memory-selection regression module after ADR-097's fail-closed semantic mutation guard made four deliberate raw-row corruption fixtures invalid.
+
+**Architecture:** Keep the production persistence boundary unchanged. Add one test-local helper that borrows the database's existing connection-scoped coordinator capability, authorizes only `message_update` for one named message inside a managed transaction, and executes one deliberate fixture mutation. Route only the guarded raw updates through that helper; leave ordinary test behavior and unguarded visibility/version setup unchanged.
+
+**Tech Stack:** Python 3.12.11, pytest, SQLite, Ruff 0.15.22.
+
+**Spec:** `backlog/tasks/task-30040 - Repair-Console-memory-selection-corruption-fixtures-for-semantic-guards.md`
+
+## Global Constraints
+
+- No production code or mutation-trigger changes.
+- Keep authorization test-only, transaction-scoped, message-specific, and limited to `message_update`.
+- Do not replace the real SQLite guard callback or install a blanket allow-all function.
+- Verify only the affected module and repository-required governance checks; do not run the full suite without user opt-in.
+- Preserve TASK-26945's formatter-only AST-equivalence baseline by landing this repair separately first.
+
+## Task 1: Preserve the Red Regression Evidence
+
+**Files:**
+
+- Inspect: `Tests/Chat/test_console_memory_selection.py`
+- Inspect: `tldw_chatbook/DB/base_db.py`
+- Inspect: `tldw_chatbook/DB/migrations/chachanotes_v56_to_v57_semantic_mutation_guard.sql`
+
+1. Run the assigned Console memory-selection module on current `origin/dev`.
+2. Confirm the four failures occur at deliberate raw updates of referenced semantic message columns and raise the semantic-mutation authorization error.
+3. Confirm the test file predates the ADR-097 mutation guard and that no open PR already owns the repair.
+
+## Task 2: Add the Narrow Test-Only Mutation Helper
+
+**Files:**
+
+- Modify: `Tests/Chat/test_console_memory_selection.py`
+
+1. Add a typed helper that accepts the database, message ID, SQL, and parameters.
+2. Inside `db.transaction()`, obtain the exact connection's private coordinator capability and authorize only `{\"message_update\"}` for the supplied message ID.
+3. Execute the caller's single mutation through the managed cursor.
+4. Replace only the four failing guarded fixture writes with helper calls.
+
+## Task 3: Verify and Close the Repair
+
+**Files:**
+
+- Modify: `backlog/tasks/task-30040 - Repair-Console-memory-selection-corruption-fixtures-for-semantic-guards.md`
+
+1. Run `pytest -q Tests/Chat/test_console_memory_selection.py` with Python 3.12.11 and record the exact result.
+2. Run Ruff 0.15.22 lint and format checks on the touched Python file.
+3. Run `pytest -q Tests/CI/test_backlog_task_id_uniqueness.py` and `git diff --check`.
+4. Self-review the diff, mark every acceptance criterion complete, add concise implementation notes, and set TASK-30040 to Done.
+
+ADR required: no
+ADR path: N/A
+Reason: This is a test-fixture compatibility repair under the existing ADR-097 mutation boundary and changes no persistence architecture or product behavior.

--- a/Tests/Chat/test_console_context_compaction.py
+++ b/Tests/Chat/test_console_context_compaction.py
@@ -814,10 +814,7 @@ def _range_semantic(
 
 def _semantic_unit_for_test(unit: DurableConversationUnit) -> ConsoleConversationUnit:
     return ConsoleConversationUnit(
-        tuple(
-            {"role": row.role, "content": row.content}
-            for row in unit.messages
-        )
+        tuple({"role": row.role, "content": row.content} for row in unit.messages)
     )
 
 
@@ -860,9 +857,11 @@ def test_range_to_prefix_orders_early_memory_and_largest_later_prefix() -> None:
     ).plan
 
     assert planned is not None
-    assert [
-        unit.messages[0].message_id for unit in planned.selected_units
-    ] == ["u0", "u2", "u3"]
+    assert [unit.messages[0].message_id for unit in planned.selected_units] == [
+        "u0",
+        "u2",
+        "u3",
+    ]
     assert planned.boundary_message_id == "a3"
     envelope = planned.auxiliary_messages[1]["content"]
     assert envelope.index("UNIT-0-USER") < envelope.index("SEALED-RANGE-MEMORY")
@@ -979,9 +978,9 @@ def test_range_to_prefix_sends_mandatory_early_visual_in_effective_order() -> No
     assert prepared_auxiliary
     content = planned.auxiliary_messages[1]["content"]
     assert isinstance(content, (list, tuple))
-    expected_url = units[0].messages[0].visual_attachments[0].provider_part()[
-        "image_url"
-    ]["url"]
+    expected_url = (
+        units[0].messages[0].visual_attachments[0].provider_part()["image_url"]["url"]
+    )
     early_index = next(
         index
         for index, part in enumerate(content)
@@ -996,14 +995,12 @@ def test_range_to_prefix_sends_mandatory_early_visual_in_effective_order() -> No
     assistant_index = next(
         index
         for index, part in enumerate(content)
-        if part.get("type") == "text"
-        and "early answer" in part.get("text", "")
+        if part.get("type") == "text" and "early answer" in part.get("text", "")
     )
     marker_index = next(
         index
         for index, part in enumerate(content)
-        if part.get("type") == "text"
-        and "SEALED-RANGE-MEMORY" in part.get("text", "")
+        if part.get("type") == "text" and "SEALED-RANGE-MEMORY" in part.get("text", "")
     )
     assert early_index < image_index < assistant_index
     assert assistant_index == marker_index
@@ -1020,9 +1017,7 @@ def test_range_to_prefix_sends_mandatory_early_visual_in_effective_order() -> No
 def test_range_to_prefix_frames_one_tool_bearing_multimodal_unit() -> None:
     tool_unit = DurableConversationUnit(
         (
-            _visual_user_message(
-                "u2", "VISUAL-TOOL-USER " + "x " * 80, image_count=2
-            ),
+            _visual_user_message("u2", "VISUAL-TOOL-USER " + "x " * 80, image_count=2),
             DurableMessageSnapshot(
                 message_id="a2-call",
                 version=1,
@@ -1155,14 +1150,13 @@ def test_ordinary_automatic_compaction_sends_selected_visual() -> None:
     assert planned is not None
     content = planned.auxiliary_messages[1]["content"]
     assert isinstance(content, (list, tuple))
-    expected_url = units[0].messages[0].visual_attachments[0].provider_part()[
-        "image_url"
-    ]["url"]
+    expected_url = (
+        units[0].messages[0].visual_attachments[0].provider_part()["image_url"]["url"]
+    )
     user_index = next(
         index
         for index, part in enumerate(content)
-        if part.get("type") == "text"
-        and "VISUAL-ORDINARY" in part.get("text", "")
+        if part.get("type") == "text" and "VISUAL-ORDINARY" in part.get("text", "")
     )
     image_index = next(
         index
@@ -1253,9 +1247,7 @@ def test_range_to_prefix_refuses_mandatory_visuals_before_auxiliary_preparation(
     units = (
         DurableConversationUnit(
             (
-                _visual_user_message(
-                    "u0", "visual early " + "x " * 80, image_count=2
-                ),
+                _visual_user_message("u0", "visual early " + "x " * 80, image_count=2),
                 _message("a0", "assistant", "early answer " + "y " * 80),
             )
         ),
@@ -1563,9 +1555,7 @@ class _Gateway:
             await self.release.wait()
         scripted = getattr(self, "texts", None)
         text = (
-            scripted[min(self.calls - 1, len(scripted) - 1)]
-            if scripted
-            else self.text
+            scripted[min(self.calls - 1, len(scripted) - 1)] if scripted else self.text
         )
         return AuxiliaryCompletionResult(
             provider="openai",
@@ -1798,9 +1788,7 @@ def _canonical_automatic_body_tokens(plan, summary: str) -> int:
         memory=(tagged_memory_message(summary),),
     )
     after = _prepare(candidate)
-    empty_memory = _prepare(
-        replace(candidate, memory=(tagged_memory_message(""),))
-    )
+    empty_memory = _prepare(replace(candidate, memory=(tagged_memory_message(""),)))
     return max(
         0,
         after.accounting.memory_tokens - empty_memory.accounting.memory_tokens,
@@ -1808,7 +1796,9 @@ def _canonical_automatic_body_tokens(plan, summary: str) -> int:
 
 
 @pytest.mark.asyncio
-async def test_automatic_compaction_commits_prefix_scope_selection_and_provenance() -> None:
+async def test_automatic_compaction_commits_prefix_scope_selection_and_provenance() -> (
+    None
+):
     repository = _Repository()
     service = ConsoleCompactionService(repository, _Gateway(text="New prefix memory."))
     plan, prompt, prefix, admission, _commit = _transaction_inputs()
@@ -2131,7 +2121,9 @@ async def test_range_compaction_progress_counts_active_thinking_candidate() -> N
     assert repository.commits == []
 
 
-def _manual_transaction_inputs(focus: str = "") -> tuple[
+def _manual_transaction_inputs(
+    focus: str = "",
+) -> tuple[
     ManualMemoryPlan,
     CompactionPromptSnapshot,
     BranchMemoryCommit,
@@ -2168,9 +2160,7 @@ def _manual_transaction_inputs(focus: str = "") -> tuple[
     lineage = tuple(
         PersistedLineageFenceRow(
             message_id=row.message_id,
-            parent_message_id=(
-                snapshots[index - 1].message_id if index else None
-            ),
+            parent_message_id=(snapshots[index - 1].message_id if index else None),
             version=1,
             deleted=False,
             content_digest=f"digest-{row.message_id}",
@@ -2246,7 +2236,9 @@ def _canonical_manual_body_tokens(plan: ManualMemoryPlan, summary: str) -> int:
 
 
 @pytest.mark.asyncio
-async def test_manual_transaction_rejects_mismatched_plan_before_call_or_ledger() -> None:
+async def test_manual_transaction_rejects_mismatched_plan_before_call_or_ledger() -> (
+    None
+):
     repository = _Repository()
     gateway = _Gateway()
     service = ConsoleCompactionService(repository, gateway)
@@ -2272,7 +2264,9 @@ async def test_manual_transaction_rejects_mismatched_plan_before_call_or_ledger(
 
 
 @pytest.mark.asyncio
-async def test_manual_transaction_rejects_non_suppressing_selection_before_call_or_ledger() -> None:
+async def test_manual_transaction_rejects_non_suppressing_selection_before_call_or_ledger() -> (
+    None
+):
     repository = _Repository()
     gateway = _Gateway()
     service = ConsoleCompactionService(repository, gateway)
@@ -3081,9 +3075,7 @@ class _ControllerRepository(_Repository):
         selection_id,
         expected_revision,
     ):
-        self.undo_calls.append(
-            (conversation_id, selection_id, expected_revision)
-        )
+        self.undo_calls.append((conversation_id, selection_id, expected_revision))
         if (
             not self.reset_selections
             or self.reset_selections[-1].selection_id != selection_id
@@ -3288,9 +3280,7 @@ def _insert_real_prefix_memory(
             conversation_id=conversation_id,
             boundary_message_id=boundary_message_id,
             captured_leaf_message_id=activation_message_id,
-            lineage_json=json.dumps(
-                [boundary_message_id, activation_message_id]
-            ),
+            lineage_json=json.dumps([boundary_message_id, activation_message_id]),
             summary_text=f"Summary for {memory_id}.",
             provider="openai",
             model="gpt-test",
@@ -3412,8 +3402,7 @@ def test_effective_memory_crosses_sibling_event_and_memory_pages(tmp_path) -> No
         for selection in repository.list_active_memory_selections(conversation_id)
     }
     assert "current-memory" not in {
-        memory.memory_id
-        for memory in repository.list_active_memories(conversation_id)
+        memory.memory_id for memory in repository.list_active_memories(conversation_id)
     }
 
     effective = controller._select_session_effective_memory(
@@ -3744,9 +3733,7 @@ async def test_automatic_preflight_uses_active_model_visual_limit(monkeypatch) -
         captured_plan_arguments.update(kwargs)
         return real_plan_compaction(**kwargs)
 
-    monkeypatch.setattr(
-        controller_module, "plan_compaction", capture_plan_arguments
-    )
+    monkeypatch.setattr(controller_module, "plan_compaction", capture_plan_arguments)
     snapshots = controller._durable_context_snapshots(session.id)
     assert snapshots is not None
     assert len(snapshots[0].visual_attachments) == 1
@@ -3814,9 +3801,7 @@ async def test_automatic_preflight_refuses_selected_non_image_attachment_before_
 
 
 @pytest.mark.asyncio
-async def test_bounded_budget_without_older_units_does_not_block_fitting_send() -> (
-    None
-):
+async def test_bounded_budget_without_older_units_does_not_block_fitting_send() -> None:
     """Allow a fitting bounded send when no older unit remains to compact."""
     controller, _store, session, assistant, gateway, provider_messages = (
         _controller_preflight_fixture(
@@ -4166,7 +4151,9 @@ def test_reset_all_invalidates_an_outstanding_exact_undo_token() -> None:
 
 
 @pytest.mark.asyncio
-async def test_hung_auxiliary_call_times_out_distinctly_and_leaves_memory_intact() -> None:
+async def test_hung_auxiliary_call_times_out_distinctly_and_leaves_memory_intact() -> (
+    None
+):
     """TASK-26016: the auxiliary call was unbounded -- a hung summarizer
     blocked the send that triggered it forever. The timeout must finish the
     ledger as TIMED_OUT (not FAILED-as-model-error, not CANCELLED), return
@@ -4243,8 +4230,7 @@ def test_auxiliary_timeout_coercion_never_goes_unbounded() -> None:
             repository, gateway, auxiliary_timeout_seconds=bad
         )
         assert (
-            service._auxiliary_timeout
-            == DEFAULT_COMPACTION_AUXILIARY_TIMEOUT_SECONDS
+            service._auxiliary_timeout == DEFAULT_COMPACTION_AUXILIARY_TIMEOUT_SECONDS
         )
     service = ConsoleCompactionService(
         repository, gateway, auxiliary_timeout_seconds=45
@@ -4639,9 +4625,9 @@ async def test_native_failure_falls_back_to_the_local_path() -> None:
     assert gateway.calls == 1
     assert result.memory.summary_text == "Local summary."
     provenance = json.loads(result.memory.selected_units_json)
-    assert not any(
-        row.get("kind") == "compaction_engine" for row in provenance
-    ), "a fallback commit must not claim the native engine"
+    assert not any(row.get("kind") == "compaction_engine" for row in provenance), (
+        "a fallback commit must not claim the native engine"
+    )
 
 
 @pytest.mark.asyncio

--- a/Tests/Chat/test_console_context_policy.py
+++ b/Tests/Chat/test_console_context_policy.py
@@ -44,13 +44,9 @@ def test_policy_precedence_is_field_by_field() -> None:
     assert policy.compaction_representation is ContextCompactionRepresentation.HYBRID
     assert policy.trigger_ratio == 0.85
     assert policy.target_ratio == 0.60
+    assert policy.failure_behavior is CompactionFailureBehavior.OMIT_OLDER_CONTEXT
     assert (
-        policy.failure_behavior
-        is CompactionFailureBehavior.OMIT_OLDER_CONTEXT
-    )
-    assert (
-        policy.carry_forward_mode
-        is ContextCarryForwardMode.MEMORY_WITH_LATEST_EXCHANGE
+        policy.carry_forward_mode is ContextCarryForwardMode.MEMORY_WITH_LATEST_EXCHANGE
     )
     assert policy.summary_max_tokens == 1024
 
@@ -178,9 +174,7 @@ def test_sparse_serialization_round_trip_rejects_boolean_integer() -> None:
     assert ConsoleContextPolicyOverrides.from_mapping(original.to_dict()) == original
 
     with pytest.raises(ContextPolicyError, match="integer"):
-        ConsoleContextPolicyOverrides.from_mapping(
-            {"custom_budget_tokens": True}
-        )
+        ConsoleContextPolicyOverrides.from_mapping({"custom_budget_tokens": True})
 
     with pytest.raises(ContextPolicyError, match="ContextBudgetMode"):
         ConsoleContextPolicyOverrides(budget_mode="custom")  # type: ignore[arg-type]

--- a/Tests/Chat/test_console_context_policy_cas.py
+++ b/Tests/Chat/test_console_context_policy_cas.py
@@ -91,7 +91,9 @@ def test_chat_persistence_service_exposes_revision_guard_without_breaking_legacy
         first = ConsoleContextPolicyOverrides(
             compaction_mode=ContextCompactionMode.AUTOMATIC
         )
-        second = ConsoleContextPolicyOverrides(compaction_mode=ContextCompactionMode.OFF)
+        second = ConsoleContextPolicyOverrides(
+            compaction_mode=ContextCompactionMode.OFF
+        )
 
         revision = service.update_conversation_context_policy(
             conversation_id=conversation_id,

--- a/Tests/Chat/test_console_manual_memory_planning.py
+++ b/Tests/Chat/test_console_manual_memory_planning.py
@@ -96,9 +96,10 @@ def test_complete_durable_units_accept_only_closed_user_led_exchanges(
 
     units = helper(messages)
 
-    assert tuple(
-        tuple(message.message_id for message in unit.messages) for unit in units
-    ) == expected_units
+    assert (
+        tuple(tuple(message.message_id for message in unit.messages) for unit in units)
+        == expected_units
+    )
 
 
 @pytest.mark.parametrize(
@@ -486,16 +487,20 @@ def test_manual_planners_select_exact_units_and_canonical_idle_projections(
     assert result.plan is not None
     plan = result.plan
     assert plan.coverage_kind.value == coverage
-    assert tuple(
-        row.message_id for unit in plan.selected_units for row in unit.messages
-    ) == selected_ids
-    assert tuple(
-        row.message_id for unit in plan.retained_units for row in unit.messages
-    ) == retained_ids
+    assert (
+        tuple(row.message_id for unit in plan.selected_units for row in unit.messages)
+        == selected_ids
+    )
+    assert (
+        tuple(row.message_id for unit in plan.retained_units for row in unit.messages)
+        == retained_ids
+    )
     assert plan.selection_anchor_message_id == kwargs["selected_prompt_message_id"]
     assert plan.start_message_id == start
     assert plan.boundary_message_id == boundary
-    assert plan.before_projection.semantic.system == plan.after_projection.semantic.system
+    assert (
+        plan.before_projection.semantic.system == plan.after_projection.semantic.system
+    )
     assert plan.before_projection.semantic.memory == ()
     assert plan.after_projection.semantic.memory
     assert plan.before_projection.semantic.active_request == (IDLE_REQUEST_SENTINEL,)

--- a/Tests/Chat/test_console_memory_selection.py
+++ b/Tests/Chat/test_console_memory_selection.py
@@ -137,19 +137,26 @@ def test_generated_prefix_requires_a_live_boundary_and_matching_digest() -> None
     valid = _memory("prefix")
     head = _selection(1, "prefix")
 
-    assert _select(
-        memories=(valid,), scopes=(_scope("prefix"),), selections=(head,)
-    ).kind is EffectiveMemoryKind.GENERATED_PREFIX
-    assert _select(
-        memories=(replace(valid, boundary_message_id="sibling"),),
-        scopes=(_scope("prefix"),),
-        selections=(head,),
-    ).kind is EffectiveMemoryKind.RAW
-    assert _select(
-        memories=(replace(valid, summarized_prefix_digest="0" * 64),),
-        scopes=(_scope("prefix"),),
-        selections=(head,),
-    ).kind is EffectiveMemoryKind.RAW
+    assert (
+        _select(memories=(valid,), scopes=(_scope("prefix"),), selections=(head,)).kind
+        is EffectiveMemoryKind.GENERATED_PREFIX
+    )
+    assert (
+        _select(
+            memories=(replace(valid, boundary_message_id="sibling"),),
+            scopes=(_scope("prefix"),),
+            selections=(head,),
+        ).kind
+        is EffectiveMemoryKind.RAW
+    )
+    assert (
+        _select(
+            memories=(replace(valid, summarized_prefix_digest="0" * 64),),
+            scopes=(_scope("prefix"),),
+            selections=(head,),
+        ).kind
+        is EffectiveMemoryKind.RAW
+    )
 
 
 def test_generated_range_requires_both_ordered_anchors_and_prefix_digest() -> None:
@@ -162,9 +169,7 @@ def test_generated_range_requires_both_ordered_anchors_and_prefix_digest() -> No
         anchor="u2",
     )
 
-    result = _select(
-        memories=(memory,), scopes=(valid_scope,), selections=(head,)
-    )
+    result = _select(memories=(memory,), scopes=(valid_scope,), selections=(head,))
     assert result.kind is EffectiveMemoryKind.GENERATED_RANGE
     assert result.memory == memory
     assert result.branch_head == head
@@ -255,7 +260,10 @@ def test_valid_legacy_wins_without_a_suppressing_branch_head(with_head: bool) ->
 @pytest.mark.parametrize(
     ("head", "expected"),
     [
-        (_selection(1, "generated", suppresses_legacy=True), EffectiveMemoryKind.GENERATED_PREFIX),
+        (
+            _selection(1, "generated", suppresses_legacy=True),
+            EffectiveMemoryKind.GENERATED_PREFIX,
+        ),
         (_selection(1, None, suppresses_legacy=True), EffectiveMemoryKind.RAW),
     ],
 )
@@ -434,6 +442,25 @@ def _repository_database(_tmp_path, name: str):
     return db, ConsoleContextRepository(db), conversation_id, root_id, leaf_id
 
 
+def _raw_semantic_corruption(
+    db: CharactersRAGDB,
+    message_id: str,
+    sql: str,
+    params: tuple[object, ...] = (),
+) -> None:
+    """Authorize one deliberate inconsistent-row fixture write only."""
+
+    with db.transaction() as cursor:
+        authorization = db._semantic_mutation_authorization_for_coordinator(
+            cursor.connection
+        )
+        with authorization._authorize(
+            message_id=message_id,
+            operations={"message_update"},
+        ):
+            cursor.execute(sql, params)
+
+
 def _persisted_lineage(
     root_id: str,
     leaf_id: str,
@@ -508,9 +535,7 @@ def _branch_commit(
         prompt_revision=1,
         prompt_digest="p" * 64,
         selected_units_json="[]",
-        summarized_prefix_digest=_prefix_digest(
-            root_id, leaf_id, through_leaf=manual
-        ),
+        summarized_prefix_digest=_prefix_digest(root_id, leaf_id, through_leaf=manual),
         input_tokens=20,
         output_tokens=5,
         before_tokens=100,
@@ -595,7 +620,9 @@ def _derived_row_snapshot(db: CharactersRAGDB, conversation_id: str):
     )
 
 
-def test_two_jobs_admitted_without_memory_allow_only_one_atomic_commit(tmp_path) -> None:
+def test_two_jobs_admitted_without_memory_allow_only_one_atomic_commit(
+    tmp_path,
+) -> None:
     db, repository, conversation_id, root_id, leaf_id = _repository_database(
         tmp_path, "no-memory-race"
     )
@@ -622,9 +649,9 @@ def test_two_jobs_admitted_without_memory_allow_only_one_atomic_commit(tmp_path)
         (("memory-first", "prefix", "automatic"),),
         (("selection-first", 1, 1),),
     )
-    assert not repository.list_active_memory_selections(
-        conversation_id
-    )[0].suppresses_legacy
+    assert not repository.list_active_memory_selections(conversation_id)[
+        0
+    ].suppresses_legacy
 
 
 def test_manual_selection_forces_legacy_suppression_without_clearing_legacy(
@@ -694,9 +721,7 @@ def test_automatic_replacement_inherits_suppression_and_ignores_hidden_legacy(
         )
     )
     current = repository.list_active_memory_selections(conversation_id)[0]
-    effective, head = _generated_fences(
-        current, effective_kind="generated_range"
-    )
+    effective, head = _generated_fences(current, effective_kind="generated_range")
     replacement = _branch_commit(
         conversation_id,
         root_id,
@@ -794,9 +819,7 @@ def test_exact_legacy_boundary_and_summary_digest_mismatch_is_stale(
         expected_effective=legacy,
     )
     if legacy_mutation == "boundary":
-        db.set_conversation_context_summary(
-            conversation_id, "Legacy facts.", leaf_id
-        )
+        db.set_conversation_context_summary(conversation_id, "Legacy facts.", leaf_id)
     else:
         db.set_conversation_context_summary(
             conversation_id, "Changed legacy facts.", root_id
@@ -834,11 +857,12 @@ def test_changed_persisted_cursor_leaf_or_parent_rejects_without_writes(
             before_message_id=root_id,
         )
     else:
-        db.get_connection().execute(
+        _raw_semantic_corruption(
+            db,
+            leaf_id,
             "UPDATE messages SET parent_message_id = NULL WHERE id = ?",
             (leaf_id,),
         )
-        db.get_connection().commit()
 
     assert not repository.commit_memory_selection_if_current(stale)
     assert _derived_row_snapshot(db, conversation_id) == ((), (), ())
@@ -876,12 +900,12 @@ def test_selected_variant_image_is_fenced_from_the_persisted_variant_row(
         root_id, "selected variant content", is_selected=True
     )
     assert variant_id is not None
-    connection = db.get_connection()
-    connection.execute(
+    _raw_semantic_corruption(
+        db,
+        variant_id,
         "UPDATE messages SET image_data = ?, image_mime_type = ? WHERE id = ?",
         (b"variant image", "image/png", variant_id),
     )
-    connection.commit()
     image_digest = persisted_attachment_digest(
         position=0,
         mime_type="image/png",
@@ -933,14 +957,18 @@ def test_non_fork_position_zero_runtime_label_normalizes_to_persisted_facts(
         tmp_path, "ordinary-position-zero-label"
     )
     connection = db.get_connection()
-    connection.execute(
+    _raw_semantic_corruption(
+        db,
+        root_id,
         "UPDATE messages SET image_data = ?, image_mime_type = ? WHERE id = ?",
         (b"ordinary image", "image/png", root_id),
     )
-    connection.commit()
-    assert connection.execute(
-        "SELECT metadata_json FROM messages WHERE id = ?", (root_id,)
-    ).fetchone()["metadata_json"] is None
+    assert (
+        connection.execute(
+            "SELECT metadata_json FROM messages WHERE id = ?", (root_id,)
+        ).fetchone()["metadata_json"]
+        is None
+    )
 
     runtime_digest = persisted_attachment_digest(
         position=0,
@@ -1022,11 +1050,12 @@ def test_changed_durable_message_fact_rejects_without_partial_insert(
         durable_lineage=durable_lineage,
     )
     if durable_mutation == "content":
-        db.get_connection().execute(
+        _raw_semantic_corruption(
+            db,
+            root_id,
             "UPDATE messages SET content = 'changed content' WHERE id = ?",
             (root_id,),
         )
-        db.get_connection().commit()
     elif durable_mutation == "version":
         db.get_connection().execute(
             "UPDATE messages SET version = 2 WHERE id = ?",
@@ -1040,9 +1069,7 @@ def test_changed_durable_message_fact_rejects_without_partial_insert(
         )
         db.get_connection().commit()
     elif durable_mutation == "variant":
-        assert db.create_message_variant(
-            root_id, "selected variant", is_selected=True
-        )
+        assert db.create_message_variant(root_id, "selected variant", is_selected=True)
     else:
         db.set_message_attachments(
             root_id,
@@ -1149,9 +1176,7 @@ def _manual_memory_with_legacy(tmp_path, name: str):
         )
     )
     current = repository.list_active_memory_selections(conversation_id)[0]
-    effective, head = _generated_fences(
-        current, effective_kind="generated_range"
-    )
+    effective, head = _generated_fences(current, effective_kind="generated_range")
     return (
         db,
         repository,
@@ -1196,15 +1221,18 @@ def test_current_reset_appends_exact_tombstone_without_mutating_memory_or_legacy
     )
 
     assert token == ("current-reset-tombstone", 1)
-    assert tuple(
-        db.get_connection()
-        .execute(
-            "SELECT id, active, revision, reset_at FROM "
-            "console_conversation_memories WHERE conversation_id = ?",
-            (conversation_id,),
+    assert (
+        tuple(
+            db.get_connection()
+            .execute(
+                "SELECT id, active, revision, reset_at FROM "
+                "console_conversation_memories WHERE conversation_id = ?",
+                (conversation_id,),
+            )
+            .fetchone()
         )
-        .fetchone()
-    ) == before_memory
+        == before_memory
+    )
     assert db.get_conversation_context_summary(conversation_id) == (
         "Legacy facts.",
         root_id,
@@ -1250,20 +1278,28 @@ def test_undo_deactivates_only_exact_current_tombstone_at_expected_revision(
         expected_revision=token[1],
     )
 
-    rows = db.get_connection().execute(
-        "SELECT selection_id, active, revision FROM "
-        "console_conversation_memory_selections WHERE conversation_id = ? "
-        "ORDER BY sequence",
-        (conversation_id,),
-    ).fetchall()
+    rows = (
+        db.get_connection()
+        .execute(
+            "SELECT selection_id, active, revision FROM "
+            "console_conversation_memory_selections WHERE conversation_id = ? "
+            "ORDER BY sequence",
+            (conversation_id,),
+        )
+        .fetchall()
+    )
     assert [tuple(row) for row in rows] == [
         ("manual-current-selection", 1, 1),
         ("undo-tombstone", 0, 2),
     ]
-    memory = db.get_connection().execute(
-        "SELECT active, revision FROM console_conversation_memories "
-        "WHERE id = 'manual-current-memory'"
-    ).fetchone()
+    memory = (
+        db.get_connection()
+        .execute(
+            "SELECT active, revision FROM console_conversation_memories "
+            "WHERE id = 'manual-current-memory'"
+        )
+        .fetchone()
+    )
     assert tuple(memory) == (1, 1)
 
 
@@ -1282,9 +1318,7 @@ def test_later_applicable_select_or_reset_expires_undo_token(
         head,
     ) = _manual_memory_with_legacy(tmp_path, f"undo-expiry-{later_event_kind}")
     token = repository.append_current_branch_reset_if_current(
-        _reset_selection(
-            conversation_id, leaf_id, selection_id="expiring-tombstone"
-        ),
+        _reset_selection(conversation_id, leaf_id, selection_id="expiring-tombstone"),
         expected_effective=effective,
         expected_branch_head=head,
         expected_cursor=(leaf_id, None),
@@ -1304,9 +1338,7 @@ def test_later_applicable_select_or_reset_expires_undo_token(
                 created_at="2026-08-28T00:00:03Z",
             )
             if later_event_kind == "select"
-            else _reset_selection(
-                conversation_id, leaf_id, selection_id="later-reset"
-            )
+            else _reset_selection(conversation_id, leaf_id, selection_id="later-reset")
         )
     )
 
@@ -1315,9 +1347,13 @@ def test_later_applicable_select_or_reset_expires_undo_token(
         selection_id=token[0],
         expected_revision=token[1],
     )
-    expired = db.get_connection().execute(
-        "SELECT active, revision FROM console_conversation_memory_selections "
-        "WHERE selection_id = ?",
-        (token[0],),
-    ).fetchone()
+    expired = (
+        db.get_connection()
+        .execute(
+            "SELECT active, revision FROM console_conversation_memory_selections "
+            "WHERE selection_id = ?",
+            (token[0],),
+        )
+        .fetchone()
+    )
     assert tuple(expired) == (1, 1)

--- a/Tests/Chat/test_console_prefill.py
+++ b/Tests/Chat/test_console_prefill.py
@@ -40,11 +40,13 @@ class TestParsePrefillArgs:
 
     def test_pin_word_prefix_is_one_shot(self):
         result = parse_prefill_args("pinch of salt")
-        assert result == PrefillCommandAction(kind=ACTION_ONE_SHOT, text="pinch of salt")
+        assert result == PrefillCommandAction(
+            kind=ACTION_ONE_SHOT, text="pinch of salt"
+        )
 
     def test_plain_text_is_one_shot_stripped(self):
-        result = parse_prefill_args("  {\"answer\":  ")
-        assert result == PrefillCommandAction(kind=ACTION_ONE_SHOT, text="{\"answer\":")
+        result = parse_prefill_args('  {"answer":  ')
+        assert result == PrefillCommandAction(kind=ACTION_ONE_SHOT, text='{"answer":')
 
     def test_over_length_is_error(self):
         result = parse_prefill_args("x" * (PREFILL_MAX_CHARS + 1))

--- a/Tests/Chat/test_console_prepared_request.py
+++ b/Tests/Chat/test_console_prepared_request.py
@@ -324,15 +324,11 @@ def test_memory_wire_projection_is_unique_owned_and_private_anchor_free(
         apply_safety_window=False,
     )
 
-    wire = "\n".join(
-        str(row.get("content", "")) for row in prepared.messages_payload
-    )
+    wire = "\n".join(str(row.get("content", "")) for row in prepared.messages_payload)
     if prepared.system_message:
         wire = prepared.system_message + "\n" + wire
     assert wire.count("PROJECTED-MEMORY-CANARY") == 1
-    assert wire.index("ORIGINAL-SYSTEM-CANARY") < wire.index(
-        "PROJECTED-MEMORY-CANARY"
-    )
+    assert wire.index("ORIGINAL-SYSTEM-CANARY") < wire.index("PROJECTED-MEMORY-CANARY")
     assert all(
         prepared_request.PERSISTED_MESSAGE_ID_KEY not in row
         and prepared_request.PERSISTED_CONVERSATION_ID_KEY not in row
@@ -930,9 +926,7 @@ def test_tool_schemas_split_out_of_mandatory_by_construction() -> None:
         }
     ]
     with_tools = prepare_provider_request(
-        build_console_request(
-            [{"role": "user", "content": "describe"}], tools=tools
-        ),
+        build_console_request([{"role": "user", "content": "describe"}], tools=tools),
         wire_style="distinct_roles",
         model="gpt-4o",
         capacity=_capacity(None),

--- a/Tests/Chat/test_console_world_info_application.py
+++ b/Tests/Chat/test_console_world_info_application.py
@@ -117,9 +117,7 @@ async def test_apply_world_info_multimodal_history_and_message():
 async def test_apply_world_info_command_message_skipped():
     controller, store = _controller(_stub_wi)
     session = _session_with_conv(store)
-    messages = [
-        {"role": ConsoleMessageRole.USER.value, "content": "/do a thing"}
-    ]
+    messages = [{"role": ConsoleMessageRole.USER.value, "content": "/do a thing"}]
     out = await controller._apply_world_info(messages, session.id)
     assert out[-1]["content"] == "/do a thing"
 

--- a/backlog/tasks/task-26945 - Clean Ruff formatter debt for ruff-chat-console-context.md
+++ b/backlog/tasks/task-26945 - Clean Ruff formatter debt for ruff-chat-console-context.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-26945
 title: Clean Ruff formatter debt for ruff-chat-console-context
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-31 18:31'
-updated_date: '2026-09-03 04:14'
+updated_date: '2026-09-03 04:25'
 labels:
   - maintenance
   - formatting
@@ -50,14 +50,14 @@ Clean the `ruff-chat-console-context` Ruff formatter batch at the owner boundary
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 After rebasing onto current `origin/dev`, reproduce and reconcile every TASK-26000 assigned path; if upstream deleted, renamed, modified, or already formatted it, record that lineage and amend ownership mechanically without silently dropping it or absorbing an unassigned path. <!-- TASK-26000-CONTRACT: rebase-reconcile --><!-- TASK-26000-CONTRACT: drift-reconciliation -->
-- [ ] #2 Run Ruff 0.15.22 formatting on only the assigned paths, with no unassigned Python path changed. <!-- TASK-26000-CONTRACT: assigned-paths-only -->
-- [ ] #3 Before and after formatting, parse each assigned file on Python 3.12.11 with `ast.parse(..., type_comments=True)`, normalize only `TypeIgnore.lineno`, and require equal `ast.dump(..., include_attributes=False)`. <!-- TASK-26000-CONTRACT: ast-type-comments -->
-- [ ] #4 Preserve ordered comment-token text; anchor inline `# noqa`, `# type: ignore`, and single-target Ruff directives to the same deepest AST-node path and significant-token position, preserve standalone file directives between the same adjacent statement paths, and require each `# fmt: off` / `# fmt: on` range to enclose the same ordered AST-node interval. <!-- TASK-26000-CONTRACT: comment-directives -->
-- [ ] #5 Ruff lint and `ruff format --check` pass on every touched Python path. <!-- TASK-26000-CONTRACT: ruff-checks -->
-- [ ] #6 Implementation Notes record the focused-test rationale and every exact test command/result. <!-- TASK-26000-CONTRACT: focused-tests -->
-- [ ] #7 `git diff --check` and `Tests/CI/test_backlog_task_id_uniqueness.py` pass. <!-- TASK-26000-CONTRACT: governance -->
-- [ ] #8 The diff contains no hand-written production behavior change. <!-- TASK-26000-CONTRACT: no-handwritten-behavior -->
+- [x] #1 After rebasing onto current `origin/dev`, reproduce and reconcile every TASK-26000 assigned path; if upstream deleted, renamed, modified, or already formatted it, record that lineage and amend ownership mechanically without silently dropping it or absorbing an unassigned path. <!-- TASK-26000-CONTRACT: rebase-reconcile --><!-- TASK-26000-CONTRACT: drift-reconciliation -->
+- [x] #2 Run Ruff 0.15.22 formatting on only the assigned paths, with no unassigned Python path changed. <!-- TASK-26000-CONTRACT: assigned-paths-only -->
+- [x] #3 Before and after formatting, parse each assigned file on Python 3.12.11 with `ast.parse(..., type_comments=True)`, normalize only `TypeIgnore.lineno`, and require equal `ast.dump(..., include_attributes=False)`. <!-- TASK-26000-CONTRACT: ast-type-comments -->
+- [x] #4 Preserve ordered comment-token text; anchor inline `# noqa`, `# type: ignore`, and single-target Ruff directives to the same deepest AST-node path and significant-token position, preserve standalone file directives between the same adjacent statement paths, and require each `# fmt: off` / `# fmt: on` range to enclose the same ordered AST-node interval. <!-- TASK-26000-CONTRACT: comment-directives -->
+- [x] #5 Ruff lint and `ruff format --check` pass on every touched Python path. <!-- TASK-26000-CONTRACT: ruff-checks -->
+- [x] #6 Implementation Notes record the focused-test rationale and every exact test command/result. <!-- TASK-26000-CONTRACT: focused-tests -->
+- [x] #7 `git diff --check` and `Tests/CI/test_backlog_task_id_uniqueness.py` pass. <!-- TASK-26000-CONTRACT: governance -->
+- [x] #8 The diff contains no hand-written production behavior change. <!-- TASK-26000-CONTRACT: no-handwritten-behavior -->
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -74,3 +74,25 @@ Reason: Mechanical formatter cleanup under TASK-26000 introduces no architectura
 
 Detailed plan: Docs/superpowers/plans/2026-09-03-task-26945-ruff-chat-console-context.md
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Applied Ruff 0.15.22 to the exact twelve-path ruff-chat-console-context allowlist. Ruff reformatted eleven files and left Tests/Chat/test_console_memory_selection.py unchanged because the separately reviewed TASK-30040 prerequisite had already repaired and formatted that assigned path. The formatter commit contains only the expected eleven Python paths; Ruff replay from each parent blob reproduced every resulting file byte-for-byte.
+
+Drift reconciliation: work began from fetched origin/dev de52e8f1e736b54e0cc2b11342e7f60662d106a2, then origin/dev advanced and the branch was rebased onto e76915ccf38a8557f203977f2ebeecc1645afeca before structural capture or batch formatting. Relative to TASK-26000 pin e555df102c950c29beed5e7119f433d35eee1f3c, four assigned paths had upstream modifications and were retained: Tests/Chat/test_console_context_compaction.py and tldw_chatbook/Chat/console_context_compaction.py at 7685a16d21998aa73ec16ab813b6c007703caa2b; Tests/Chat/test_console_prepared_request.py at bf852436ec41c6e0f19a5428324c22696da3c0f1; tldw_chatbook/Chat/console_context_repository.py at a157d87cfaddd884f5a4d5d26ac0d20238f44be6. No assigned path was renamed or deleted. The canonical sorted path digest remained 11a85c1a0bd495783743a97a47f2b5f0da359158fcdd22b86532a22c229797bd.
+
+Structural evidence: Python 3.12.11 parsed all twelve files before and after formatting with type_comments=True; only TypeIgnore.lineno was normalized, and AST dumps matched. Ordered comments, inline directive anchors plus significant-token positions, standalone Ruff directive adjacency, and fmt-range enclosed-node intervals matched. One pre-existing tied deepest-node case was resolved by deterministically anchoring the rightmost deepest AST node completed before the inline directive; capture and compare then covered all twelve paths. Ruff check reported All checks passed; Ruff format --check reported 12 files already formatted; git diff --check passed. Independent review found no Critical, Important, or Minor issue and confirmed exact scope, parent-blob Ruff replay, structural equality, and no behavior, security, or performance change.
+
+Focused-test rationale: the batch owns Console context, memory selection, policy, prefill, prepared-request, and world-info behavior, so the eight assigned modules exercise every changed production owner and its adjacent regression surface without an unrelated full-suite sweep. Exact command: /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_context_compaction.py Tests/Chat/test_console_context_policy.py Tests/Chat/test_console_context_policy_cas.py Tests/Chat/test_console_manual_memory_planning.py Tests/Chat/test_console_memory_selection.py Tests/Chat/test_console_prefill.py Tests/Chat/test_console_prepared_request.py Tests/Chat/test_console_world_info_application.py. Before formatting, after TASK-30040 and the final rebase, it reported 280 passed, 1 warning in 19.45s; after formatting it reported 280 passed, 1 warning in 20.19s; the final closeout replay reported 280 passed, 1 warning in 21.06s. The warning is the environment RequestsDependencyWarning; successful runs also emitted unrelated pre-existing pytest temporary-directory cleanup warnings after the summary. Exact governance command /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/CI/test_backlog_task_id_uniqueness.py reported 3 passed, 1 warning in 1.02s and 3 passed, 1 warning in 1.05s on final closeout replay. No full suite was run under repository policy.
+
+Modified Python files: Tests/Chat/test_console_context_compaction.py; Tests/Chat/test_console_context_policy.py; Tests/Chat/test_console_context_policy_cas.py; Tests/Chat/test_console_manual_memory_planning.py; Tests/Chat/test_console_prefill.py; Tests/Chat/test_console_prepared_request.py; Tests/Chat/test_console_world_info_application.py; tldw_chatbook/Chat/console_context_compaction.py; tldw_chatbook/Chat/console_context_policy.py; tldw_chatbook/Chat/console_context_repository.py; tldw_chatbook/Chat/console_prefill.py. Added Docs/superpowers/plans/2026-09-03-task-26945-ruff-chat-console-context.md and updated this task record.
+
+ADR required: no. This is mechanical formatter cleanup under TASK-26000 and introduces no architectural, persistence, security, dependency, or long-lived UX decision.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Formatted the exact twelve-path Console context batch with Ruff 0.15.22, preserving Python semantics and directive/comment structure, with 280 focused tests and all scoped governance checks passing.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-26945 - Clean Ruff formatter debt for ruff-chat-console-context.md
+++ b/backlog/tasks/task-26945 - Clean Ruff formatter debt for ruff-chat-console-context.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-26945
 title: Clean Ruff formatter debt for ruff-chat-console-context
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-08-31 18:31'
-updated_date: '2026-08-31 18:31'
+updated_date: '2026-09-03 04:14'
 labels:
   - maintenance
   - formatting
@@ -14,18 +15,19 @@ dependencies:
 references:
   - Docs/superpowers/specs/2026-08-30-task-26000-ruff-formatter-debt-design.md
   - Docs/superpowers/reviews/evidence/task-26000/ruff-formatter-debt.json
+  - Docs/superpowers/plans/2026-09-03-task-26945-ruff-chat-console-context.md
 priority: medium
 ---
-
-<!-- TASK-26000-BATCH: ruff-chat-console-context -->
-<!-- TASK-26000-PATHS-SHA256: 11a85c1a0bd495783743a97a47f2b5f0da359158fcdd22b86532a22c229797bd -->
-<!-- TASK-26000-FINAL: false -->
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
 Clean the `ruff-chat-console-context` Ruff formatter batch at the owner boundary recorded as: Console context, memory, prepared-request, and RAG state services.. The focused test surface recorded by TASK-26000 is `["Tests/Chat"]`.
 <!-- SECTION:DESCRIPTION:END -->
+
+<!-- TASK-26000-BATCH: ruff-chat-console-context -->
+<!-- TASK-26000-PATHS-SHA256: 11a85c1a0bd495783743a97a47f2b5f0da359158fcdd22b86532a22c229797bd -->
+<!-- TASK-26000-FINAL: false -->
 
 ## Assigned Paths
 
@@ -48,12 +50,27 @@ Clean the `ruff-chat-console-context` Ruff formatter batch at the owner boundary
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] After rebasing onto current `origin/dev`, reproduce and reconcile every TASK-26000 assigned path; if upstream deleted, renamed, modified, or already formatted it, record that lineage and amend ownership mechanically without silently dropping it or absorbing an unassigned path. <!-- TASK-26000-CONTRACT: rebase-reconcile --><!-- TASK-26000-CONTRACT: drift-reconciliation -->
-- [ ] Run Ruff 0.15.22 formatting on only the assigned paths, with no unassigned Python path changed. <!-- TASK-26000-CONTRACT: assigned-paths-only -->
-- [ ] Before and after formatting, parse each assigned file on Python 3.12.11 with `ast.parse(..., type_comments=True)`, normalize only `TypeIgnore.lineno`, and require equal `ast.dump(..., include_attributes=False)`. <!-- TASK-26000-CONTRACT: ast-type-comments -->
-- [ ] Preserve ordered comment-token text; anchor inline `# noqa`, `# type: ignore`, and single-target Ruff directives to the same deepest AST-node path and significant-token position, preserve standalone file directives between the same adjacent statement paths, and require each `# fmt: off` / `# fmt: on` range to enclose the same ordered AST-node interval. <!-- TASK-26000-CONTRACT: comment-directives -->
-- [ ] Ruff lint and `ruff format --check` pass on every touched Python path. <!-- TASK-26000-CONTRACT: ruff-checks -->
-- [ ] Implementation Notes record the focused-test rationale and every exact test command/result. <!-- TASK-26000-CONTRACT: focused-tests -->
-- [ ] `git diff --check` and `Tests/CI/test_backlog_task_id_uniqueness.py` pass. <!-- TASK-26000-CONTRACT: governance -->
-- [ ] The diff contains no hand-written production behavior change. <!-- TASK-26000-CONTRACT: no-handwritten-behavior -->
+- [ ] #1 After rebasing onto current `origin/dev`, reproduce and reconcile every TASK-26000 assigned path; if upstream deleted, renamed, modified, or already formatted it, record that lineage and amend ownership mechanically without silently dropping it or absorbing an unassigned path. <!-- TASK-26000-CONTRACT: rebase-reconcile --><!-- TASK-26000-CONTRACT: drift-reconciliation -->
+- [ ] #2 Run Ruff 0.15.22 formatting on only the assigned paths, with no unassigned Python path changed. <!-- TASK-26000-CONTRACT: assigned-paths-only -->
+- [ ] #3 Before and after formatting, parse each assigned file on Python 3.12.11 with `ast.parse(..., type_comments=True)`, normalize only `TypeIgnore.lineno`, and require equal `ast.dump(..., include_attributes=False)`. <!-- TASK-26000-CONTRACT: ast-type-comments -->
+- [ ] #4 Preserve ordered comment-token text; anchor inline `# noqa`, `# type: ignore`, and single-target Ruff directives to the same deepest AST-node path and significant-token position, preserve standalone file directives between the same adjacent statement paths, and require each `# fmt: off` / `# fmt: on` range to enclose the same ordered AST-node interval. <!-- TASK-26000-CONTRACT: comment-directives -->
+- [ ] #5 Ruff lint and `ruff format --check` pass on every touched Python path. <!-- TASK-26000-CONTRACT: ruff-checks -->
+- [ ] #6 Implementation Notes record the focused-test rationale and every exact test command/result. <!-- TASK-26000-CONTRACT: focused-tests -->
+- [ ] #7 `git diff --check` and `Tests/CI/test_backlog_task_id_uniqueness.py` pass. <!-- TASK-26000-CONTRACT: governance -->
+- [ ] #8 The diff contains no hand-written production behavior change. <!-- TASK-26000-CONTRACT: no-handwritten-behavior -->
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reconcile all twelve TASK-26000 assigned paths against current origin/dev, record drift and the separate TASK-30040 test repair, and capture Python 3.12.11 AST/comment/directive evidence.
+2. Run Ruff 0.15.22 format with all twelve paths supplied explicitly, reject any unassigned Python diff, and require the structural comparison to match.
+3. Run Ruff lint/format checks, the eight assigned Console context test modules, backlog task-ID uniqueness, and git diff --check.
+4. Commit only formatter-owned Python changes, request independent review, then record exact evidence and close TASK-26945 in a task-only commit.
+
+ADR required: no
+ADR path: N/A
+Reason: Mechanical formatter cleanup under TASK-26000 introduces no architectural, persistence, security, dependency, or long-lived UX decision.
+
+Detailed plan: Docs/superpowers/plans/2026-09-03-task-26945-ruff-chat-console-context.md
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-30040 - Repair-Console-memory-selection-corruption-fixtures-for-semantic-guards.md
+++ b/backlog/tasks/task-30040 - Repair-Console-memory-selection-corruption-fixtures-for-semantic-guards.md
@@ -1,0 +1,46 @@
+---
+id: TASK-30040
+title: Repair Console memory-selection corruption fixtures for semantic guards
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-09-03 04:03'
+updated_date: '2026-09-03 04:04'
+labels:
+  - console
+  - testing
+  - bug
+dependencies: []
+references:
+  - backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Restore the Console memory-selection regression suite on current dev by keeping deliberate persisted-row corruption fixtures compatible with the fail-closed semantic mutation boundary, without weakening production guards or changing Console behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All current-dev failures in Tests/Chat/test_console_memory_selection.py caused by direct guarded fixture mutations pass.
+- [ ] #2 Deliberate fixture corruption is authorized only for the exact message and message_update operation inside a managed transaction.
+- [ ] #3 Production semantic mutation guards and Console behavior are unchanged.
+- [ ] #4 Focused tests, Ruff checks on touched Python paths, git diff --check, and backlog task-ID uniqueness pass.
+- [ ] #5 ADR required: no; this is a test-fixture compatibility repair under existing ADR-097.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Preserve the four current-dev red failures and confirm they are stale direct fixture mutations blocked by ADR-097.
+2. Add one test-local, transaction-scoped helper that authorizes only message_update for the exact message, then route only the four guarded corruption writes through it.
+3. Run the affected pytest module, Ruff 0.15.22 checks, backlog ID uniqueness, and git diff --check; self-review and close the task.
+
+ADR required: no
+ADR path: N/A
+Reason: This is a test-fixture compatibility repair under existing ADR-097 and changes no production architecture or behavior.
+
+Detailed plan: Docs/superpowers/plans/2026-09-03-task-30040-console-memory-selection-fixture-guards.md
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-30040 - Repair-Console-memory-selection-corruption-fixtures-for-semantic-guards.md
+++ b/backlog/tasks/task-30040 - Repair-Console-memory-selection-corruption-fixtures-for-semantic-guards.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-30040
 title: Repair Console memory-selection corruption fixtures for semantic guards
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-03 04:03'
-updated_date: '2026-09-03 04:04'
+updated_date: '2026-09-03 04:13'
 labels:
   - console
   - testing
@@ -24,11 +24,11 @@ Restore the Console memory-selection regression suite on current dev by keeping 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All current-dev failures in Tests/Chat/test_console_memory_selection.py caused by direct guarded fixture mutations pass.
-- [ ] #2 Deliberate fixture corruption is authorized only for the exact message and message_update operation inside a managed transaction.
-- [ ] #3 Production semantic mutation guards and Console behavior are unchanged.
-- [ ] #4 Focused tests, Ruff checks on touched Python paths, git diff --check, and backlog task-ID uniqueness pass.
-- [ ] #5 ADR required: no; this is a test-fixture compatibility repair under existing ADR-097.
+- [x] #1 All current-dev failures in Tests/Chat/test_console_memory_selection.py caused by direct guarded fixture mutations pass.
+- [x] #2 Deliberate fixture corruption is authorized only for the exact message and message_update operation inside a managed transaction.
+- [x] #3 Production semantic mutation guards and Console behavior are unchanged.
+- [x] #4 Focused tests, Ruff checks on touched Python paths, git diff --check, and backlog task-ID uniqueness pass.
+- [x] #5 ADR required: no; this is a test-fixture compatibility repair under existing ADR-097.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -44,3 +44,15 @@ Reason: This is a test-fixture compatibility repair under existing ADR-097 and c
 
 Detailed plan: Docs/superpowers/plans/2026-09-03-task-30040-console-memory-selection-fixture-guards.md
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Restored the current-dev Console memory-selection suite without changing production behavior or weakening ADR-097. Added one test-local helper that uses the exact database connection's coordinator capability inside a managed transaction and authorizes only message_update for the supplied message ID; only the four deliberate guarded corruption writes use it.
+
+TDD evidence: before the repair, /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q Tests/Chat/test_console_memory_selection.py reported 4 failed and 32 passed because the guarded raw updates raised semantic mutation authorization required. After the repair and formatting, the same command reported 36 passed with one dependency warning; the successful process also emitted unrelated pre-existing pytest temporary-directory cleanup warnings. Ruff 0.15.22 check passed and format --check reported one file already formatted. The Python 3.12.11 AST/comment/directive guard matched before and after Ruff formatting. Tests/CI/test_backlog_task_id_uniqueness.py reported 3 passed with one warning, and git diff --check passed.
+
+Files: Tests/Chat/test_console_memory_selection.py; Docs/superpowers/plans/2026-09-03-task-30040-console-memory-selection-fixture-guards.md; this task record. Independent review found no Critical or Minor issues and no implementation issue; its sole Important closeout finding is addressed by these notes and the completed checklist.
+
+ADR required: no. Existing backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md governs the mutation boundary; this repair changes only test-fixture setup.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_context_compaction.py
+++ b/tldw_chatbook/Chat/console_context_compaction.py
@@ -139,7 +139,10 @@ class LegacyMemorySnapshot:
             raise ValueError("legacy conversation_id must be non-empty")
         if not isinstance(self.summary_text, str) or not self.summary_text.strip():
             raise ValueError("legacy summary_text must be non-empty")
-        if not isinstance(self.boundary_message_id, str) or not self.boundary_message_id:
+        if (
+            not isinstance(self.boundary_message_id, str)
+            or not self.boundary_message_id
+        ):
             raise ValueError("legacy boundary_message_id must be non-empty")
 
 
@@ -184,9 +187,10 @@ class DurableVisualAttachment:
             or self.position < 0
         ):
             raise ValueError("Durable visual position must be a non-negative integer.")
-        if not isinstance(self.digest, str) or re.fullmatch(
-            r"[0-9a-f]{64}", self.digest
-        ) is None:
+        if (
+            not isinstance(self.digest, str)
+            or re.fullmatch(r"[0-9a-f]{64}", self.digest) is None
+        ):
             raise ValueError("Durable visual digest must be a SHA-256 identity fence.")
         if not isinstance(self.mime_type, str) or not self.mime_type.startswith(
             "image/"
@@ -282,8 +286,7 @@ class DurableMessageSnapshot:
         payload["content_digest"] = _digest_json(payload.pop("content"))
         tool_calls = payload.pop("tool_calls")
         payload["tool_call_ids"] = [
-            call.get("id") if isinstance(call, Mapping) else None
-            for call in tool_calls
+            call.get("id") if isinstance(call, Mapping) else None for call in tool_calls
         ]
         payload["tool_calls_digest"] = _digest_json(tool_calls)
         return payload
@@ -384,9 +387,9 @@ class ManualMemoryPlan:
     # and the unsteered messages the transaction retries with when the
     # steered summary comes back unusable (AC#5).
     focus_topic: str = ""
-    fallback_auxiliary_messages: (
-        tuple[Mapping[str, Any], ...] | None
-    ) = field(default=None, repr=False)
+    fallback_auxiliary_messages: tuple[Mapping[str, Any], ...] | None = field(
+        default=None, repr=False
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -569,7 +572,9 @@ def complete_durable_units(
     )
     if first_user is None:
         return ()
-    if any(message.role not in {"system", "assistant"} for message in rows[:first_user]):
+    if any(
+        message.role not in {"system", "assistant"} for message in rows[:first_user]
+    ):
         return ()
 
     units: list[DurableConversationUnit] = []
@@ -780,12 +785,16 @@ def select_effective_memory(
         ),
         None,
     )
-    if memory is None or scope is None or not _generated_memory_is_valid(
-        memory,
-        scope,
-        branch_head,
-        active_messages,
-        positions,
+    if (
+        memory is None
+        or scope is None
+        or not _generated_memory_is_valid(
+            memory,
+            scope,
+            branch_head,
+            active_messages,
+            positions,
+        )
     ):
         return EffectiveMemoryResult(
             EffectiveMemoryKind.RAW,
@@ -1054,9 +1063,7 @@ def _append_range_unit_parts(
             json.dumps(
                 {
                     "kind": "raw_unit",
-                    "messages": [
-                        message.digest_payload() for message in unit.messages
-                    ],
+                    "messages": [message.digest_payload() for message in unit.messages],
                 },
                 ensure_ascii=False,
                 sort_keys=True,
@@ -1128,9 +1135,7 @@ def _build_range_compaction_messages(
                 **marker,
                 "summary_text": memory.summary_text,
                 "provenance": {
-                    "selected_units_digest": _digest_json(
-                        memory.selected_units_json
-                    ),
+                    "selected_units_digest": _digest_json(memory.selected_units_json),
                     "summarized_prefix_digest": memory.summarized_prefix_digest,
                     "prompt_id": memory.prompt_id,
                     "prompt_revision": memory.prompt_revision,
@@ -1376,8 +1381,7 @@ def _plan_manual_memory(
 
     covered_raw_tokens = max(
         0,
-        before.accounting.compactable_tokens
-        - after.accounting.compactable_tokens,
+        before.accounting.compactable_tokens - after.accounting.compactable_tokens,
     )
     memory_tokens = after.accounting.memory_tokens
     ceiling = after.capacity.effective_input_ceiling_tokens
@@ -1473,9 +1477,7 @@ def _automatic_visual_input_reason(
     ):
         return "automatic_visual_input_unsupported"
     visual_count = sum(
-        len(message.visual_attachments)
-        for unit in units
-        for message in unit.messages
+        len(message.visual_attachments) for unit in units for message in unit.messages
     )
     if not visual_count:
         return None
@@ -1686,19 +1688,17 @@ def _plan_range_to_prefix_compaction(
             unit.messages[0].message_id == scope.selection_anchor_message_id
             for unit in units
         )
-        or not any(unit.boundary_message_id == memory.boundary_message_id for unit in units)
+        or not any(
+            unit.boundary_message_id == memory.boundary_message_id for unit in units
+        )
     ):
         return CompactionPlanResult(None, "invalid_effective_range_anchors")
 
     early = tuple(
-        unit
-        for unit in units
-        if positions[unit.boundary_message_id] < start_index
+        unit for unit in units if positions[unit.boundary_message_id] < start_index
     )
     later = tuple(
-        unit
-        for unit in units
-        if positions[unit.messages[0].message_id] > end_index
+        unit for unit in units if positions[unit.messages[0].message_id] > end_index
     )
     retained_count = len(early) + len(later)
     if retained_count > len(semantic.compactable):
@@ -1775,10 +1775,10 @@ def _plan_range_to_prefix_compaction(
             or auxiliary.accounting.total_input_tokens > ceiling
         ):
             continue
-        provenance = tuple(
-            unit.provenance_payload() for unit in early
-        ) + (marker,) + tuple(
-            unit.provenance_payload() for unit in selected_later
+        provenance = (
+            tuple(unit.provenance_payload() for unit in early)
+            + (marker,)
+            + tuple(unit.provenance_payload() for unit in selected_later)
         )
         boundary = (
             selected_later[-1].boundary_message_id
@@ -1852,9 +1852,7 @@ class ConsoleCompactionService:
         resolution: ConsoleProviderResolution,
         prompt: CompactionPromptSnapshot,
         current_admission: Callable[[], BranchMemoryCommit | None],
-        prepare_projection: Callable[
-            [PreparedConsoleRequest], PreparedProviderRequest
-        ],
+        prepare_projection: Callable[[PreparedConsoleRequest], PreparedProviderRequest],
     ) -> CompactionTransactionResult:
         """Execute one exact manual prefix/range summary and guarded commit."""
         if not _manual_admission_matches(
@@ -1958,10 +1956,7 @@ class ConsoleCompactionService:
             reported_output = (
                 completion.usage.output if completion.usage is not None else None
             )
-            if (
-                not summary
-                or _contains_reserved_envelope(summary)
-            ):
+            if not summary or _contains_reserved_envelope(summary):
                 self._finish(
                     operation_id,
                     AuxiliaryAttemptStatus.FAILED,
@@ -2102,9 +2097,7 @@ class ConsoleCompactionService:
             )
             commit = replace(admission, memory=memory)
             try:
-                committed = self._repository.commit_memory_selection_if_current(
-                    commit
-                )
+                committed = self._repository.commit_memory_selection_if_current(commit)
             except Exception as exc:
                 self._finish(
                     operation_id,
@@ -2308,8 +2301,7 @@ class ConsoleCompactionService:
                         reason="invalid_summary_output",
                     )
                 after_conversation = (
-                    after.accounting.memory_tokens
-                    + after.accounting.compactable_tokens
+                    after.accounting.memory_tokens + after.accounting.compactable_tokens
                 )
             except Exception as exc:
                 self._finish(
@@ -2373,9 +2365,7 @@ class ConsoleCompactionService:
             )
             commit = replace(branch_commit, memory=record)
             try:
-                committed = self._repository.commit_memory_selection_if_current(
-                    commit
-                )
+                committed = self._repository.commit_memory_selection_if_current(commit)
             except Exception:
                 self._finish(
                     operation_id,
@@ -2582,7 +2572,8 @@ def _automatic_admission_matches(
         and resolution.ready
         and admission.conversation_id == memory.conversation_id
         and admission.captured_leaf_message_id == memory.captured_leaf_message_id
-        and admission.lineage == tuple(row.message_id for row in branch_commit.durable_lineage)
+        and admission.lineage
+        == tuple(row.message_id for row in branch_commit.durable_lineage)
         and prefix_ids == admission.lineage[: len(prefix_ids)]
         and resolution.provider == memory.provider == admission.provider
         and (resolution.model or "") == memory.model == admission.model
@@ -2604,6 +2595,8 @@ def _automatic_admission_matches(
         and branch_commit.expected_cursor[0] == memory.captured_leaf_message_id
         and plan.requested_output_cap > 0
     )
+
+
 def _digest_json(value: Any) -> str:
     encoded = json.dumps(
         value,

--- a/tldw_chatbook/Chat/console_context_policy.py
+++ b/tldw_chatbook/Chat/console_context_policy.py
@@ -62,9 +62,7 @@ class ConsoleContextPolicyDefaults:
     trigger_ratio: float = DEFAULT_COMPACTION_TRIGGER_RATIO
     target_ratio: float = DEFAULT_COMPACTION_TARGET_RATIO
     summary_max_tokens: int = DEFAULT_SUMMARY_MAX_TOKENS
-    failure_behavior: CompactionFailureBehavior = (
-        CompactionFailureBehavior.STOP_AND_ASK
-    )
+    failure_behavior: CompactionFailureBehavior = CompactionFailureBehavior.STOP_AND_ASK
     carry_forward_mode: ContextCarryForwardMode = (
         ContextCarryForwardMode.MEMORY_WITH_RECENT_TURNS
     )
@@ -143,9 +141,7 @@ class ConsoleContextPolicyOverrides:
         if not isinstance(source, Mapping):
             raise ContextPolicyError("Context policy overrides must be a mapping.")
         return cls(
-            budget_mode=_optional_enum(
-                source, "budget_mode", ContextBudgetMode
-            ),
+            budget_mode=_optional_enum(source, "budget_mode", ContextBudgetMode),
             custom_budget_tokens=_optional_int(source, "custom_budget_tokens"),
             compaction_mode=_optional_enum(
                 source, "compaction_mode", ContextCompactionMode
@@ -320,9 +316,7 @@ def resolve_context_policy(
         else None
     )
     if available_capacity is not None and available_capacity <= 0:
-        errors.append(
-            "Mandatory request material leaves no conversation capacity."
-        )
+        errors.append("Mandatory request material leaves no conversation capacity.")
         available_capacity = 0
 
     effective_budget: int | None
@@ -370,9 +364,7 @@ def resolve_context_policy(
 
 def _validate_complete_policy(policy: ConsoleContextPolicyDefaults) -> None:
     _validate_enum("budget_mode", policy.budget_mode, ContextBudgetMode)
-    _validate_enum(
-        "compaction_mode", policy.compaction_mode, ContextCompactionMode
-    )
+    _validate_enum("compaction_mode", policy.compaction_mode, ContextCompactionMode)
     _validate_enum(
         "compaction_representation",
         policy.compaction_representation,
@@ -386,9 +378,7 @@ def _validate_complete_policy(policy: ConsoleContextPolicyDefaults) -> None:
         policy.carry_forward_mode,
         ContextCarryForwardMode,
     )
-    _validate_optional_positive_int(
-        "custom_budget_tokens", policy.custom_budget_tokens
-    )
+    _validate_optional_positive_int("custom_budget_tokens", policy.custom_budget_tokens)
     _validate_positive_int("summary_max_tokens", policy.summary_max_tokens)
     _validate_ratio("trigger_ratio", policy.trigger_ratio)
     _validate_ratio("target_ratio", policy.target_ratio)

--- a/tldw_chatbook/Chat/console_context_repository.py
+++ b/tldw_chatbook/Chat/console_context_repository.py
@@ -276,9 +276,7 @@ class ConsoleMemorySelectionRecord:
         if self.event_kind is MemorySelectionKind.SELECT:
             if self.selected_memory_id is None:
                 raise ValueError("select event requires a selected memory")
-            _validate_bounded_text(
-                "selected_memory_id", self.selected_memory_id, 200
-            )
+            _validate_bounded_text("selected_memory_id", self.selected_memory_id, 200)
         else:
             if self.selected_memory_id is not None:
                 raise ValueError("reset event cannot carry a selected memory")
@@ -320,9 +318,7 @@ class MemorySelectionFence:
             self.selection_id,
             self.selection_revision,
         )
-        _validate_optional_revision_pair(
-            "memory", self.memory_id, self.memory_revision
-        )
+        _validate_optional_revision_pair("memory", self.memory_id, self.memory_revision)
 
 
 @dataclass(frozen=True, slots=True)
@@ -341,24 +337,18 @@ class PersistedLineageFenceRow:
     def __post_init__(self) -> None:
         _validate_bounded_text("message_id", self.message_id, 200)
         if self.parent_message_id is not None:
-            _validate_bounded_text(
-                "parent_message_id", self.parent_message_id, 200
-            )
+            _validate_bounded_text("parent_message_id", self.parent_message_id, 200)
         if type(self.version) is not int or self.version <= 0:
             raise ValueError("version must be a positive integer")
         if type(self.deleted) is not bool:
             raise ValueError("deleted must be a boolean")
         _validate_bounded_text("content_digest", self.content_digest, 256)
-        if (self.selected_variant_id is None) != (
-            self.selected_variant_index is None
-        ):
+        if (self.selected_variant_id is None) != (self.selected_variant_index is None):
             raise ValueError(
                 "selected variant id and index must both be present or absent"
             )
         if self.selected_variant_id is not None:
-            _validate_bounded_text(
-                "selected_variant_id", self.selected_variant_id, 200
-            )
+            _validate_bounded_text("selected_variant_id", self.selected_variant_id, 200)
             if (
                 type(self.selected_variant_index) is not int
                 or self.selected_variant_index < 0
@@ -400,9 +390,7 @@ class BranchMemoryCommit:
             or len(self.expected_cursor) != 2
         ):
             raise ValueError("expected_cursor must be a two-item tuple")
-        _validate_bounded_text(
-            "expected active leaf", self.expected_cursor[0], 200
-        )
+        _validate_bounded_text("expected active leaf", self.expected_cursor[0], 200)
         if self.expected_cursor[1] is not None:
             _validate_bounded_text(
                 "expected before message", self.expected_cursor[1], 200
@@ -707,9 +695,7 @@ class ConsoleContextRepository:
             _insert_memory(cursor, record)
         return True
 
-    def commit_memory_selection_if_current(
-        self, commit: BranchMemoryCommit
-    ) -> bool:
+    def commit_memory_selection_if_current(self, commit: BranchMemoryCommit) -> bool:
         """Atomically append memory, scope, and selection if every fence matches.
 
         Args:
@@ -739,8 +725,7 @@ class ConsoleContextRepository:
             if tuple(state.fence for state in lineage) != commit.durable_lineage:
                 return False
             positions = {
-                state.fence.message_id: index
-                for index, state in enumerate(lineage)
+                state.fence.message_id: index for index, state in enumerate(lineage)
             }
             boundary_index = positions.get(commit.memory.boundary_message_id)
             if (
@@ -772,9 +757,7 @@ class ConsoleContextRepository:
                 True
                 if commit.scope.origin_kind is MemoryOriginKind.MANUAL_REWIND
                 else (
-                    branch_head.suppresses_legacy
-                    if branch_head is not None
-                    else False
+                    branch_head.suppresses_legacy if branch_head is not None else False
                 )
             )
             selection = ConsoleMemorySelectionRecord(
@@ -812,9 +795,7 @@ class ConsoleContextRepository:
             durable_lineage=durable_lineage,
         )
         with self.db.transaction(immediate=True) as cursor:
-            persisted = _load_persisted_branch_state(
-                cursor, reset.conversation_id
-            )
+            persisted = _load_persisted_branch_state(cursor, reset.conversation_id)
             if persisted is None:
                 return None
             cursor_pair, conversation_row, lineage = persisted
@@ -932,9 +913,7 @@ class ConsoleContextRepository:
         with self.db.transaction() as cursor:
             _insert_memory_scope(cursor, record)
 
-    def load_memory_scope(
-        self, memory_id: str
-    ) -> ConsoleMemoryScopeRecord | None:
+    def load_memory_scope(self, memory_id: str) -> ConsoleMemoryScopeRecord | None:
         """Read one scope; corrupt derived metadata is ineligible."""
         _validate_bounded_text("memory_id", memory_id, 200)
         with self.db.transaction() as cursor:
@@ -1264,9 +1243,7 @@ def _validate_branch_memory_commit_ownership(commit: BranchMemoryCommit) -> None
     scope = commit.scope
     selection = commit.selection
     if not (
-        memory.conversation_id
-        == scope.conversation_id
-        == selection.conversation_id
+        memory.conversation_id == scope.conversation_id == selection.conversation_id
     ):
         raise ValueError("memory, scope, and selection must share a conversation")
     if scope.memory_id != memory.memory_id:
@@ -1353,12 +1330,8 @@ def _validate_branch_reset_input(
         _validate_bounded_text("expected before message", expected_cursor[1], 200)
     if not isinstance(durable_lineage, tuple) or not durable_lineage:
         raise ValueError("durable_lineage must be a non-empty tuple")
-    if any(
-        not isinstance(row, PersistedLineageFenceRow) for row in durable_lineage
-    ):
-        raise TypeError(
-            "durable_lineage must contain PersistedLineageFenceRow values"
-        )
+    if any(not isinstance(row, PersistedLineageFenceRow) for row in durable_lineage):
+        raise TypeError("durable_lineage must contain PersistedLineageFenceRow values")
     if (
         reset.activation_message_id != expected_cursor[0]
         or durable_lineage[-1].message_id != expected_cursor[0]
@@ -1369,11 +1342,14 @@ def _validate_branch_reset_input(
 def _load_persisted_branch_state(
     cursor: Any,
     conversation_id: str,
-) -> tuple[
-    tuple[str, str | None],
-    Mapping[str, Any],
-    tuple[_PersistedLineageState, ...],
-] | None:
+) -> (
+    tuple[
+        tuple[str, str | None],
+        Mapping[str, Any],
+        tuple[_PersistedLineageState, ...],
+    ]
+    | None
+):
     conversation = cursor.execute(
         """
         SELECT active_leaf_message_id, active_leaf_before_message_id,
@@ -1416,9 +1392,7 @@ def _load_persisted_branch_state(
             return None
         reversed_lineage.append(state)
         message_id = (
-            None
-            if row["parent_message_id"] is None
-            else str(row["parent_message_id"])
+            None if row["parent_message_id"] is None else str(row["parent_message_id"])
         )
     return (
         (leaf_id, before_message_id),
@@ -1600,9 +1574,7 @@ def _effective_memory_fence(
     branch_head: ConsoleMemorySelectionRecord | None,
     branch_head_fence: MemorySelectionFence,
 ) -> MemorySelectionFence:
-    positions = {
-        state.fence.message_id: index for index, state in enumerate(lineage)
-    }
+    positions = {state.fence.message_id: index for index, state in enumerate(lineage)}
     legacy_summary = conversation["context_summary"]
     legacy_boundary = conversation["summary_boundary_message_id"]
     valid_legacy = (
@@ -1611,9 +1583,7 @@ def _effective_memory_fence(
         and isinstance(legacy_boundary, str)
         and legacy_boundary in positions
     )
-    if valid_legacy and (
-        branch_head is None or not branch_head.suppresses_legacy
-    ):
+    if valid_legacy and (branch_head is None or not branch_head.suppresses_legacy):
         return MemorySelectionFence(
             effective_kind="legacy_prefix",
             legacy_boundary_message_id=legacy_boundary,
@@ -1673,16 +1643,17 @@ def _persisted_memory_is_valid(
     if (
         int(memory["active"]) != 1
         or memory["source_kind"] != "generated"
-        or memory["coverage_kind"] not in {
+        or memory["coverage_kind"]
+        not in {
             MemoryCoverageKind.PREFIX.value,
             MemoryCoverageKind.RANGE.value,
         }
-        or memory["origin_kind"] not in {
+        or memory["origin_kind"]
+        not in {
             MemoryOriginKind.AUTOMATIC.value,
             MemoryOriginKind.MANUAL_REWIND.value,
         }
-        or memory["captured_leaf_message_id"]
-        != branch_head.activation_message_id
+        or memory["captured_leaf_message_id"] != branch_head.activation_message_id
     ):
         return False
     boundary_index = positions.get(str(memory["boundary_message_id"]))
@@ -1878,9 +1849,7 @@ def _insert_memory_scope(cursor: Any, record: ConsoleMemoryScopeRecord) -> None:
     )
 
 
-def _insert_memory_selection(
-    cursor: Any, record: ConsoleMemorySelectionRecord
-) -> int:
+def _insert_memory_selection(cursor: Any, record: ConsoleMemorySelectionRecord) -> int:
     result = cursor.execute(
         """
         INSERT INTO console_conversation_memory_selections(
@@ -1914,9 +1883,7 @@ def _digest_json(value: Any) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _validate_optional_pair(
-    name: str, first: str | None, second: str | None
-) -> None:
+def _validate_optional_pair(name: str, first: str | None, second: str | None) -> None:
     if (first is None) != (second is None):
         raise ValueError(f"{name} fields must both be present or absent")
     if first is not None:

--- a/tldw_chatbook/Chat/console_prefill.py
+++ b/tldw_chatbook/Chat/console_prefill.py
@@ -51,9 +51,7 @@ class PrefillCommandAction:
 
 def _validated(kind: str, text: str) -> PrefillCommandAction:
     if not text:
-        return PrefillCommandAction(
-            kind=ACTION_ERROR, error="Prefill text is empty."
-        )
+        return PrefillCommandAction(kind=ACTION_ERROR, error="Prefill text is empty.")
     if len(text) > PREFILL_MAX_CHARS:
         return PrefillCommandAction(
             kind=ACTION_ERROR,


### PR DESCRIPTION
## Summary

- repair four stale Console memory-selection corruption fixtures using the existing exact-message, transaction-scoped semantic-mutation authorization without changing production guards
- apply Ruff 0.15.22 formatting to the exact twelve-path TASK-26945 Console-context batch (eleven changed; the repaired test was already clean)
- preserve Python 3.12.11 ASTs, ordered comments, directive anchors, and formatter-range structure; close TASK-30040 and TASK-26945

## Verification

- focused Console context suite: 280 passed, 1 environment dependency warning
- TASK-30040 focused module: 36 passed, 1 environment dependency warning
- Ruff 0.15.22 lint: pass
- Ruff format check: 12 files already formatted
- structural AST/comment/directive comparison: 12 paths match
- parent-blob Ruff replay: 12 paths reproduce byte-for-byte
- backlog task-ID uniqueness: 3 passed, 1 environment warning
- git diff --check: pass
- independent reviews: no remaining Critical, Important, or Minor findings

A full-suite sweep was not run under repository policy; the exact owner-aligned focused surface is recorded in TASK-26945.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs four Console memory-selection corruption fixtures that ADR-097's fail-closed semantic mutation guard now blocks, and applies Ruff 0.15.22 formatting to the twelve-path Console context batch. Closes TASK-30040 and TASK-26945. No production behavior changes.

**Bug Fixes**
- The four guarded raw fixture writes now go through a test-local helper that authorizes only `message_update` for the exact message inside a managed transaction.
- Production semantic mutation guards and Console behavior are unchanged.

**Refactors**
- Eleven Console context test and production files are reformatted; the repaired test file was already clean.
- AST, ordered comments, directive anchors, and formatter ranges are preserved across all twelve paths.
- Adds the implementation plans and task closeout records for both tasks.

<sup>Written for commit 18c9307647419061ad5ed91198f516b9fb27fcdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

