### PR TITLE
feat(library): review sets phase 4 - set picker (task-28243)

### DIFF
--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -209,6 +209,34 @@ item-specific empty state; it does not silently switch modes.
 | "More" | Keeps secondary actions reachable: Edit metadata, Open original when available, Open manager, and Move to trash. Narrow layouts retain these actions here rather than hiding them. |
 | "Move to trash" | Two-step, title-specific confirmation. Success selects the adjacent item and leaves a bounded Undo receipt; Trash remains the durable recovery path. |
 
+### Review sets
+
+A review set pins an ordered snapshot of media items so you can work through
+them one by one, with your place and progress saved between visits.
+
+- **Create** — **Review these** on the media list pins the whole filtered
+  result (in the current sort order, capped at 500 items with a notice when
+  trimmed); in Select mode, **Review selected** pins just the checked items in
+  list order. Creating a set activates it and opens its first item in the
+  Reader.
+- **Walk** — while a set is active the Reader footer shows your place ("2 of
+  14 · 1 reviewed"). `]` advances and marks the item you leave as reviewed;
+  `[` goes back without marking; `m` toggles the loaded item's reviewed mark;
+  a final `]` on the last item marks it done in place. **Escape** leaves the
+  Reader but keeps the set active — re-entering resumes at your cursor.
+  **R** (Exit review) deactivates the set without deleting it.
+- **Resume / switch / dismiss** — **Sets** on the media list title row opens
+  the saved-set picker: each row shows the set's name and live progress, with
+  the active set marked `✓`. Picking a set activates it (deactivating any
+  other) and lands at its saved cursor; picking a completed set reopens it.
+  **Dismiss** soft-deletes a set.
+- Deleted media items become skipped tombstones: progress counts only items
+  that still exist, and a set whose items were all removed reports "No items
+  to review" instead of completing.
+
+*Verified against feat/review-sets-p4 — 2026-09-02 (task-28240..28243: live
+end-to-end create → walk → exit → resume → dismiss pass in tmux).*
+
 ### Conversations
 
 Conversations use a fixed **20-item page**. The row list scrolls independently
@@ -307,7 +335,10 @@ The Media type chooser supports **Up/Down**, **Home/End**, and **Enter**;
 The Media grips accept **Enter** and **Space**. Arrow-key traversal moves the
 Items selection with a short settle delay; **Enter** loads immediately.
 **Escape** closes transient Reader state before moving outward through Items
-and Library. **Enter** submits the "Filter conversations… (Enter)", **Filter
+and Library. While a review set is active, the Reader adds **]** (next in
+set, marking the item you leave), **[** (previous, never marks), **m**
+(toggle reviewed), and **R** (exit review, keeping the set resumable); the
+footer shows these alongside your "X of M · N reviewed" progress. **Enter** submits the "Filter conversations… (Enter)", **Filter
 media**, and "Search content…" boxes. Global
 navigation keys live in the [guide index](../index.md).
 

--- a/Tests/Library/test_review_set_state.py
+++ b/Tests/Library/test_review_set_state.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 from tldw_chatbook.Library.review_set_state import (
     ReviewProgress,
+    ReviewSet,
     ReviewSetItem,
     advance_cursor,
+    build_picker_rows,
     build_pinned_items,
     format_review_progress,
     is_complete,
@@ -232,3 +234,59 @@ def test_build_pinned_items_dups_past_cap_do_not_flag_truncation():
 def test_build_pinned_items_coerces_types():
     items, _ = build_pinned_items([("10", 42)])
     assert items == [(10, "42")]
+
+
+# --- picker rows (set picker, task-28243) ------------------------------------
+
+
+def _review_set(
+    set_id: str,
+    name: str,
+    items: tuple[ReviewSetItem, ...],
+    *,
+    cursor: int = 0,
+    active: bool = False,
+) -> ReviewSet:
+    return ReviewSet(
+        set_id=set_id,
+        name=name,
+        origin="browse",
+        cursor=cursor,
+        active=active,
+        completed_at=None,
+        items=items,
+        created_at="2026-09-01T00:00:00Z",
+        updated_at="2026-09-01T00:00:00Z",
+    )
+
+
+def test_picker_rows_carry_id_name_progress_and_active_in_order():
+    sets = (
+        _review_set(
+            "s1", "All media", _items((10, True), (11, False)), cursor=1, active=True
+        ),
+        _review_set("s2", "pdf items", _items((20, False))),
+    )
+    rows = build_picker_rows(sets, is_live=_live())
+
+    assert rows == [
+        ("s1", "All media", "2 of 2 · 1 reviewed", True),
+        ("s2", "pdf items", "1 of 1 · 0 reviewed", False),
+    ]
+
+
+def test_picker_rows_progress_is_live_only():
+    # id 11 tombstoned: total counts live items, done tombstones don't count.
+    sets = (_review_set("s1", "Set", _items((10, False), (11, True))),)
+    rows = build_picker_rows(sets, is_live=_live(11))
+    assert rows == [("s1", "Set", "1 of 1 · 0 reviewed", False)]
+
+
+def test_picker_rows_completed_and_empty_labels():
+    sets = (
+        _review_set("done", "Done set", _items((10, True), (11, True))),
+        _review_set("gone", "Gone set", _items((20, False))),
+    )
+    rows = build_picker_rows(sets, is_live=_live(20))
+    assert rows[0][2] == "All 2 reviewed"
+    assert rows[1][2] == "No items to review"

--- a/Tests/UI/test_review_set_picker_dialog.py
+++ b/Tests/UI/test_review_set_picker_dialog.py
@@ -1,0 +1,125 @@
+"""Contract tests for the Library review-set picker dialog (task-28243).
+
+The dialog is dumb: it renders pre-computed ``(set_id, name, progress_label,
+active)`` rows (built by ``build_picker_rows``) and dismisses with an
+``(action, set_id)`` decision -- ``("open", id)`` to resume/switch,
+``("dismiss", id)`` to soft-delete, or ``None`` on cancel. All service work
+happens in the screen's worker, never here.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Widgets.Library.library_review_set_picker import (
+    LibraryReviewSetPickerDialog,
+)
+
+ROWS = [
+    ("s1", "All media", "2 of 5 · 1 reviewed", True),
+    ("s2", "pdf items", "All 3 reviewed", False),
+]
+
+
+class ModalHarness(App[None]):
+    """Minimal host capturing the picker's typed dismissal result."""
+
+    def __init__(self, rows: list[tuple[str, str, str, bool]]) -> None:
+        super().__init__()
+        self.rows = rows
+        self.results: list[tuple[str, str] | None] = []
+
+    def compose(self) -> ComposeResult:
+        yield Static("Library")
+
+    def show(self) -> None:
+        self.push_screen(
+            LibraryReviewSetPickerDialog(self.rows),
+            callback=self.results.append,
+        )
+
+
+@pytest.mark.asyncio
+async def test_rows_render_name_progress_and_active_marker() -> None:
+    app = ModalHarness(ROWS)
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.show()
+        await pilot.pause()
+        opens = list(app.screen.query(".library-review-set-open"))
+        labels = [str(button.label) for button in opens]
+
+        assert len(opens) == 2
+        assert "All media" in labels[0] and "2 of 5 · 1 reviewed" in labels[0]
+        assert labels[0].startswith("✓")  # the active set carries the marker
+        assert "pdf items" in labels[1] and not labels[1].startswith("✓")
+
+
+@pytest.mark.asyncio
+async def test_picking_a_set_dismisses_with_open_decision() -> None:
+    app = ModalHarness(ROWS)
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.show()
+        await pilot.pause()
+        opens = list(app.screen.query(".library-review-set-open"))
+        opens[1].press()
+        await pilot.pause()
+
+        assert app.results == [("open", "s2")]
+
+
+@pytest.mark.asyncio
+async def test_dismiss_button_dismisses_with_dismiss_decision() -> None:
+    app = ModalHarness(ROWS)
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.show()
+        await pilot.pause()
+        dismisses = list(app.screen.query(".library-review-set-dismiss"))
+        assert len(dismisses) == 2
+        dismisses[0].press()
+        await pilot.pause()
+
+        assert app.results == [("dismiss", "s1")]
+
+
+@pytest.mark.asyncio
+async def test_empty_rows_show_empty_copy_and_close_returns_none() -> None:
+    app = ModalHarness([])
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.show()
+        await pilot.pause()
+        copy = str(
+            app.screen.query_one("#library-review-set-picker-empty", Static).renderable
+        )
+        assert "No saved review sets" in copy
+        assert not list(app.screen.query(".library-review-set-open"))
+
+        app.screen.query_one("#library-review-set-picker-close", Button).press()
+        await pilot.pause()
+        assert app.results == [None]
+
+
+@pytest.mark.asyncio
+async def test_escape_cancels_with_none() -> None:
+    app = ModalHarness(ROWS)
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.show()
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert app.results == [None]
+
+
+@pytest.mark.asyncio
+async def test_markup_in_set_names_renders_literally() -> None:
+    # Set names derive from user search queries -- hostile markup must not
+    # style the label or crash compose (home/library escape_markup lesson).
+    app = ModalHarness([("s1", "[red]evil[/red]", "1 of 1 · 0 reviewed", False)])
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.show()
+        await pilot.pause()
+        button = app.screen.query_one(".library-review-set-open", Button)
+
+        assert "[red]evil[/red]" in str(button.label)

--- a/Tests/UI/test_review_set_picker_dialog.py
+++ b/Tests/UI/test_review_set_picker_dialog.py
@@ -113,6 +113,29 @@ async def test_escape_cancels_with_none() -> None:
 
 
 @pytest.mark.asyncio
+async def test_many_rows_scroll_and_close_stays_reachable() -> None:
+    # Qodo #2337: rows must live in a scrolling region so a long set list
+    # cannot push lower rows and the Close action past the modal's height cap.
+    rows = [
+        (f"s{n}", f"Set {n}", "1 of 1 · 0 reviewed", False) for n in range(40)
+    ]
+    app = ModalHarness(rows)
+    async with app.run_test(size=(100, 30)) as pilot:
+        app.show()
+        await pilot.pause()
+        modal = app.screen
+        scroll = modal.query_one("#library-review-set-picker-rows")
+        assert len(scroll.query(".library-review-set-row")) == 40
+        actions = modal.query_one("#library-review-set-picker-actions")
+        assert scroll not in actions.ancestors  # Close is outside the scroll
+
+        close = modal.query_one("#library-review-set-picker-close", Button)
+        close.press()
+        await pilot.pause()
+        assert app.results == [None]
+
+
+@pytest.mark.asyncio
 async def test_markup_in_set_names_renders_literally() -> None:
     # Set names derive from user search queries -- hostile markup must not
     # style the label or crash compose (home/library escape_markup lesson).

--- a/Tests/UI/test_review_set_walker.py
+++ b/Tests/UI/test_review_set_walker.py
@@ -411,6 +411,9 @@ def _picker_fake(service, *, decision, live_ids=None):
 
     fake._push_review_set_picker = push
     fake._pushed = pushed
+    syncs: list[bool] = []
+    fake._sync_library_media_viewer_or_recompose = lambda: syncs.append(True)
+    fake._syncs = syncs
     for name in (
         "_review_set_picker_worker",
         "_collect_review_set_picker_rows",
@@ -469,6 +472,10 @@ async def test_picker_worker_dismiss_soft_deletes_without_opening(tmp_path):
     assert service.list_review_sets() == ()
     assert fake._opened == []
     assert fake._notices  # the dismissal is confirmed
+    # Dismissing the ACTIVE set must refresh the Reader chrome -- the footer
+    # kept advertising "] next in set · 1 of 3" after a live dismissal
+    # (live-verified 2026-09-02).
+    assert fake._syncs == [True]
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_review_set_walker.py
+++ b/Tests/UI/test_review_set_walker.py
@@ -385,6 +385,137 @@ async def test_review_these_worker_notifies_on_failure(tmp_path):
     assert any(severity == "error" for _msg, severity in fake._notices)
 
 
+def _picker_fake(service, *, decision, live_ids=None):
+    """Fake screen for the set-picker worker (task-28243).
+
+    ``decision`` is what the (stubbed) modal resolves to; the real service,
+    row collector, and activation run against the tmp DB.
+    """
+    fake = _entry_fake(service)
+    fake._review_set_live_ids = (
+        (lambda ids: {int(i) for i in ids})
+        if live_ids is None
+        else (lambda ids: set(live_ids))
+    )
+
+    async def run_call(call, *args, isolate_in_worker=False, **kwargs):
+        result = call(*args, **kwargs)
+        return await result if hasattr(result, "__await__") else result
+
+    fake._run_library_service_call = run_call
+    pushed: list = []
+
+    async def push(rows):
+        pushed.append(rows)
+        return decision
+
+    fake._push_review_set_picker = push
+    fake._pushed = pushed
+    for name in (
+        "_review_set_picker_worker",
+        "_collect_review_set_picker_rows",
+        "_activate_review_set",
+    ):
+        setattr(fake, name, MethodType(getattr(LibraryScreen, name), fake))
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_picker_worker_lists_rows_and_opens_the_chosen_set(tmp_path):
+    service = _service(tmp_path)
+    first = service.create_review_set("First", origin="browse", items=[(10, "A")])
+    second = service.create_review_set(
+        "Second", origin="browse", items=[(20, "B"), (21, "C")]
+    )
+    fake = _picker_fake(service, decision=("open", first))
+
+    await fake._review_set_picker_worker()
+
+    rows = fake._pushed[0]
+    assert {row[0] for row in rows} == {first, second}
+    by_id = {row[0]: row for row in rows}
+    assert by_id[second][3] is True  # newest set was the active one
+    assert by_id[first][2] == "1 of 1 · 0 reviewed"
+    active = service.get_active_review_set()
+    assert active is not None and active.set_id == first  # switched (one-active)
+    assert fake._opened == ["local:media:10"]  # landed at its cursor
+
+
+@pytest.mark.asyncio
+async def test_picker_worker_open_reopens_a_completed_set(tmp_path):
+    service = _service(tmp_path)
+    done_set = service.create_review_set("Done", origin="browse", items=[(10, "A")])
+    service.mark_item_done(done_set, 10, True)
+    service.refresh_completion(done_set, lambda _id: True)
+    service.create_review_set("Other", origin="browse", items=[(20, "B")])
+    fake = _picker_fake(service, decision=("open", done_set))
+
+    await fake._review_set_picker_worker()
+
+    reopened = service.get_review_set(done_set)
+    assert reopened.completed_at is None  # AC#2: reopened
+    assert reopened.active is True
+    assert fake._opened == ["local:media:10"]
+
+
+@pytest.mark.asyncio
+async def test_picker_worker_dismiss_soft_deletes_without_opening(tmp_path):
+    service = _service(tmp_path)
+    set_id = service.create_review_set("X", origin="browse", items=[(10, "A")])
+    fake = _picker_fake(service, decision=("dismiss", set_id))
+
+    await fake._review_set_picker_worker()
+
+    assert service.list_review_sets() == ()
+    assert fake._opened == []
+    assert fake._notices  # the dismissal is confirmed
+
+
+@pytest.mark.asyncio
+async def test_picker_worker_cancel_changes_nothing(tmp_path):
+    service = _service(tmp_path)
+    set_id = service.create_review_set("X", origin="browse", items=[(10, "A")])
+    fake = _picker_fake(service, decision=None)
+
+    await fake._review_set_picker_worker()
+
+    active = service.get_active_review_set()
+    assert active is not None and active.set_id == set_id
+    assert fake._opened == [] and fake._notices == []
+
+
+@pytest.mark.asyncio
+async def test_picker_worker_open_all_tombstoned_notifies_without_activating(
+    tmp_path,
+):
+    service = _service(tmp_path)
+    gone = service.create_review_set("Gone", origin="browse", items=[(10, "A")])
+    keep = service.create_review_set("Keep", origin="browse", items=[(20, "B")])
+    fake = _picker_fake(service, decision=("open", gone), live_ids={20})
+
+    await fake._review_set_picker_worker()
+
+    active = service.get_active_review_set()
+    assert active is not None and active.set_id == keep  # unchanged
+    assert fake._opened == []
+    assert any(severity == "warning" for _msg, severity in fake._notices)
+
+
+@pytest.mark.asyncio
+async def test_picker_worker_failure_notifies(tmp_path):
+    service = _service(tmp_path)
+    fake = _picker_fake(service, decision=None)
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("db exploded")
+
+    fake._collect_review_set_picker_rows = boom
+
+    await fake._review_set_picker_worker()  # must not raise
+
+    assert any(severity == "error" for _msg, severity in fake._notices)
+
+
 def test_review_these_name_from_scope():
     assert (
         LibraryScreen._review_these_name(

--- a/Tests/UI/test_review_set_walker.py
+++ b/Tests/UI/test_review_set_walker.py
@@ -462,6 +462,24 @@ async def test_picker_worker_open_reopens_a_completed_set(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_picker_worker_open_persists_a_resolved_tombstoned_cursor(tmp_path):
+    # Qodo #2337: the cursor sat on a tombstone; opening resolves to the next
+    # live item AND persists that position, so a later restore of the deleted
+    # item cannot yank a subsequent resume back to the stale cursor.
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "X", origin="browse", items=[(10, "A"), (11, "B")]
+    )
+    service.create_review_set("Other", origin="browse", items=[(20, "C")])
+    fake = _picker_fake(service, decision=("open", set_id), live_ids={11, 20})
+
+    await fake._review_set_picker_worker()
+
+    assert fake._opened == ["local:media:11"]
+    assert service.get_review_set(set_id).cursor == 1  # persisted resolve
+
+
+@pytest.mark.asyncio
 async def test_picker_worker_dismiss_soft_deletes_without_opening(tmp_path):
     service = _service(tmp_path)
     set_id = service.create_review_set("X", origin="browse", items=[(10, "A")])

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -1859,3 +1859,26 @@ caught it either.
 string is safe; "this particular example survives" is not the same as "this surface is escaped". Be
 especially suspicious of generated prefixes — URLs, ids, scope labels — because whether they trip a
 markup parser depends on their first character, which is data, not code.
+
+## tmux SGR click columns must be counted in CELLS — BSD `awk index()`/`cut -c` count BYTES (review-set picker, task-28243, 2026-09-02)
+
+**What happened.** Live-verifying the review-set picker, clicks computed from
+`capture-pane` output via `awk '{ print index($0, "Dismiss") }'` (and slices
+via `cut -c`) reliably "missed": the modal closed but the DB showed the set
+never dismissed, three rounds in a row, while the same button worked via
+keyboard and `pilot.click`. That read as an app-side hit-region bug and burned
+a debugging round with region probes and app-log archaeology. The real cause:
+macOS/BSD `awk index()` and `cut -c` count **bytes**, and every multi-byte
+glyph earlier in the captured line (`▊` `✓` `—` `·` = 2–3 bytes each) inflated
+the computed column, so the SGR click (which addresses screen **cells**)
+landed ~6 cells right of the target — on the neighbouring 1fr button, whose
+"open" action closed the modal and made the state look untouched. A DB-oracle
+column bisect (`col=154` no, `col=150` fired) pinned it.
+
+**What to do.** Compute click columns with a character-aware tool — e.g. pipe
+the captured line through python `line.find(needle)` (see
+`scratchpad/click.sh` pattern: find by char index, then emit the SGR press +
+release from that) — and treat "the click closes the dialog but the action
+didn't happen" as a coordinates smell, not an app bug, whenever the row
+contains any non-ASCII glyph. Verify a suspected hit-region bug with the
+widget's own oracle (DB row, `pilot.click`) before touching app code.

--- a/backlog/tasks/task-28243 - Review-sets-Phase-4-set-picker-resume-switch-dismiss.md
+++ b/backlog/tasks/task-28243 - Review-sets-Phase-4-set-picker-resume-switch-dismiss.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-09-02 22:29'
-updated_date: '2026-09-03 04:48'
+updated_date: '2026-09-03 04:57'
 labels:
   - library
   - media-ux
@@ -23,9 +23,9 @@ A lightweight picker to resume, switch between, or dismiss saved review sets (de
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A picker opened from the media list lists saved sets with name + progress (X of M, reviewed N); selecting one activates it and loads at its cursor
-- [ ] #2 The picker can dismiss (soft-delete) a set and reopen a completed one; activating a set deactivates the previously active one (one-active invariant)
-- [ ] #3 Reuses the Library choice-strip / picker idioms; no new rail row required for v1
+- [x] #1 A picker opened from the media list lists saved sets with name + progress (X of M, reviewed N); selecting one activates it and loads at its cursor
+- [x] #2 The picker can dismiss (soft-delete) a set and reopen a completed one; activating a set deactivates the previously active one (one-active invariant)
+- [x] #3 Reuses the Library choice-strip / picker idioms; no new rail row required for v1
 <!-- AC:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-28243 - Review-sets-Phase-4-set-picker-resume-switch-dismiss.md
+++ b/backlog/tasks/task-28243 - Review-sets-Phase-4-set-picker-resume-switch-dismiss.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@claude'
 created_date: '2026-09-02 22:29'
-updated_date: '2026-09-03 04:21'
+updated_date: '2026-09-03 04:48'
 labels:
   - library
   - media-ux
@@ -37,3 +37,9 @@ A lightweight picker to resume, switch between, or dismiss saved review sets (de
 4. 'Sets' toolbar button on the media list (no rail row, hidden in select mode)
 5. Live tmux verify + docs stamp
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented on feat/review-sets-p4 (stacked on p3 #2335). build_picker_rows pure rows (review_set_state) over ONE union liveness snapshot; dumb LibraryReviewSetPickerDialog (SafeModalDismissMixin, decision tuple, literal-Text labels, esc/Close cancel); screen worker collects rows off-loop, push_screen_wait, applies decision off-loop (open = reopen-if-completed + activate + land at resolved cursor; all-tombstoned never activated; dismiss = soft-delete + notice + viewer sync). 'Sets' opener on the media list TITLE row - the action toolbar overflows the narrow Items pane (28025) and one more button crashed rich chop_cells at width 2 (live-verified); not composed on the fresh-empty page (pins ONE recovery action). Live tmux end-to-end pass: create -> walk -> exit -> picker resume at cursor -> dismiss drops footer chrome. Docs: media-and-conversations.md Review sets section. Traps: byte-vs-cell tmux column arithmetic (BSD awk/cut count bytes) gave false negative clicks; Static defaults to 1fr in Horizontal and swallowed the title row.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28243 - Review-sets-Phase-4-set-picker-resume-switch-dismiss.md
+++ b/backlog/tasks/task-28243 - Review-sets-Phase-4-set-picker-resume-switch-dismiss.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-28243
 title: 'Review sets - Phase 4: set picker (resume / switch / dismiss)'
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-09-02 22:29'
+updated_date: '2026-09-03 04:21'
 labels:
   - library
   - media-ux
@@ -25,3 +27,13 @@ A lightweight picker to resume, switch between, or dismiss saved review sets (de
 - [ ] #2 The picker can dismiss (soft-delete) a set and reopen a completed one; activating a set deactivates the previously active one (one-active invariant)
 - [ ] #3 Reuses the Library choice-strip / picker idioms; no new rail row required for v1
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Pure build_picker_rows in review_set_state (rows = id/name/live-progress/active) - TDD
+2. Dumb modal LibraryReviewSetPickerDialog (SafeModalDismissMixin, decision tuple open/dismiss/None) - TDD via ModalHarness
+3. Screen worker: collect rows off-loop (one union liveness resolve), push_screen_wait, apply decision (reopen-if-completed + activate + land at resolved cursor; dismiss + notice; empty set = notice, never activated)
+4. 'Sets' toolbar button on the media list (no rail row, hidden in select mode)
+5. Live tmux verify + docs stamp
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/Library/review_set_state.py
+++ b/tldw_chatbook/Library/review_set_state.py
@@ -324,6 +324,34 @@ def build_pinned_items(
     return items, truncated
 
 
+def build_picker_rows(
+    sets: "Iterable[ReviewSet]", is_live: IsLive
+) -> list[tuple[str, str, str, bool]]:
+    """Build the set-picker's display rows (task-28243).
+
+    Args:
+        sets: Review sets in display order (the service lists newest-activity
+            first).
+        is_live: Liveness predicate covering every backing id in ``sets``.
+
+    Returns:
+        ``(set_id, name, progress_label, active)`` per set, where
+        ``progress_label`` is :func:`format_review_progress` over the set's
+        live items.
+    """
+    return [
+        (
+            review_set.set_id,
+            review_set.name,
+            format_review_progress(
+                review_progress(review_set.items, review_set.cursor, is_live)
+            ),
+            review_set.active,
+        )
+        for review_set in sets
+    ]
+
+
 def is_empty(items: tuple[ReviewSetItem, ...], is_live: IsLive) -> bool:
     """True when the set has no live items (every pinned item is a tombstone).
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -42253,6 +42253,10 @@ class LibraryScreen(BaseAppScreen):
                     service.dismiss, set_id, isolate_in_worker=True
                 )
                 self._notify_review_set("Review set dismissed.")
+                # Dismissing the ACTIVE set must drop the Reader's set chrome
+                # -- without this the footer kept advertising "] next in set"
+                # after the set was gone (live-verified 2026-09-02).
+                self._sync_library_media_viewer_or_recompose()
                 return
             if action != "open":
                 return

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -42247,8 +42247,13 @@ class LibraryScreen(BaseAppScreen):
             decision = await self._push_review_set_picker(rows)
             if decision is None:
                 return
+            from tldw_chatbook.Widgets.Library.library_review_set_picker import (
+                PICKER_DISMISS,
+                PICKER_OPEN,
+            )
+
             action, set_id = decision
-            if action == "dismiss":
+            if action == PICKER_DISMISS:
                 await self._run_library_service_call(
                     service.dismiss, set_id, isolate_in_worker=True
                 )
@@ -42258,7 +42263,7 @@ class LibraryScreen(BaseAppScreen):
                 # after the set was gone (live-verified 2026-09-02).
                 self._sync_library_media_viewer_or_recompose()
                 return
-            if action != "open":
+            if action != PICKER_OPEN:
                 return
             landing = await self._run_library_service_call(
                 self._activate_review_set, set_id, isolate_in_worker=True
@@ -42346,6 +42351,11 @@ class LibraryScreen(BaseAppScreen):
         if review_set.completed_at is not None:
             service.reopen(set_id)
         service.activate(set_id)
+        if resolved != review_set.cursor:
+            # Persist the tombstone resolve (the walker does the same on
+            # resume) so a later restore of the deleted item cannot yank a
+            # subsequent resume back to the stale cursor (Qodo #2337).
+            service.set_cursor(set_id, resolved)
         return landing.backing_media_id
 
     def _focus_library_media_items_pane(self) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -42212,6 +42212,138 @@ class LibraryScreen(BaseAppScreen):
         if callable(notify):
             notify(message, severity=severity)
 
+    # -- review-set picker (task-28243) ---------------------------------------
+
+    @on(Button.Pressed, "#library-media-review-sets")
+    def handle_library_media_review_sets(self, event: Button.Pressed) -> None:
+        """Open the saved review-set picker (resume / switch / dismiss).
+
+        Args:
+            event: The "Sets" toolbar button press.
+        """
+        event.stop()
+        self.run_worker(
+            self._review_set_picker_worker(),
+            group="library_review_set",
+            exclusive=True,
+            exit_on_error=False,
+        )
+
+    async def _review_set_picker_worker(self) -> None:
+        """List saved sets, await one picker decision, and apply it.
+
+        One decision per open (lean v1): resume/switch loads the chosen set at
+        its cursor, dismiss soft-deletes it. Wrapped so a DB failure surfaces a
+        notice instead of a silent no-op (the worker runs with
+        ``exit_on_error=False``).
+        """
+        try:
+            service = self._review_set_service()
+            if service is None:
+                return
+            rows = await self._run_library_service_call(
+                self._collect_review_set_picker_rows, isolate_in_worker=True
+            )
+            decision = await self._push_review_set_picker(rows)
+            if decision is None:
+                return
+            action, set_id = decision
+            if action == "dismiss":
+                await self._run_library_service_call(
+                    service.dismiss, set_id, isolate_in_worker=True
+                )
+                self._notify_review_set("Review set dismissed.")
+                return
+            if action != "open":
+                return
+            landing = await self._run_library_service_call(
+                self._activate_review_set, set_id, isolate_in_worker=True
+            )
+            if landing is None:
+                self._notify_review_set(
+                    "All items in this set were removed.", severity="warning"
+                )
+                return
+            self._open_library_media_viewer(f"local:media:{landing}")
+        except Exception:
+            self._notify_review_set(
+                "Couldn't open review sets.", severity="error"
+            )
+
+    def _collect_review_set_picker_rows(
+        self,
+    ) -> list[tuple[str, str, str, bool]]:
+        """Build the picker's display rows with live progress (off the loop).
+
+        One liveness resolve covers the union of every listed set's backing
+        ids, so per-set progress shares a single chunked Media-DB query.
+        """
+        from tldw_chatbook.Library.review_set_state import build_picker_rows
+
+        service = self._review_set_service()
+        if service is None:
+            return []
+        sets = service.list_review_sets()
+        live_ids = self._review_set_live_ids(
+            item.backing_media_id
+            for review_set in sets
+            for item in review_set.items
+        )
+        return build_picker_rows(sets, lambda candidate: candidate in live_ids)
+
+    async def _push_review_set_picker(
+        self, rows: list[tuple[str, str, str, bool]]
+    ) -> tuple[str, str] | None:
+        """Push the picker modal and await its decision.
+
+        Returns:
+            ``("open", set_id)`` | ``("dismiss", set_id)``, or ``None`` on
+            cancel (or when the host cannot push modals).
+        """
+        push_screen_wait = getattr(self.app, "push_screen_wait", None)
+        if not callable(push_screen_wait):
+            return None
+        from tldw_chatbook.Widgets.Library.library_review_set_picker import (
+            LibraryReviewSetPickerDialog,
+        )
+
+        return await push_screen_wait(LibraryReviewSetPickerDialog(rows))
+
+    def _activate_review_set(self, set_id: str) -> int | None:
+        """Activate ``set_id`` and return its landing backing id (off-loop).
+
+        Reopens a completed set first (AC#2); activation deactivates any other
+        active set (the service's one-active invariant). An all-tombstoned set
+        is NOT activated -- the caller shows the empty notice instead (design
+        §7: an empty set is empty, never resumable).
+
+        Returns:
+            The live backing id at the set's resolved cursor, or ``None``.
+        """
+        from tldw_chatbook.Library.review_set_state import resolve_cursor
+
+        service = self._review_set_service()
+        if service is None:
+            return None
+        review_set = service.get_review_set(set_id)
+        if review_set is None:
+            return None
+        live_ids = self._review_set_live_ids(
+            item.backing_media_id for item in review_set.items
+        )
+        resolved = resolve_cursor(
+            review_set.items,
+            review_set.cursor,
+            lambda candidate: candidate in live_ids,
+        )
+        landing = {item.position: item for item in review_set.items}.get(resolved)
+        if landing is None or landing.backing_media_id not in live_ids:
+            return None
+        if review_set.completed_at is not None:
+            service.reopen(set_id)
+        service.activate(set_id)
+        return landing.backing_media_id
+
     def _focus_library_media_items_pane(self) -> None:
         """Focus the Items pane at its most useful control (task-28004).
 

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -436,6 +436,19 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             )
             review_btn.display = not select_mode
             yield self._gate_stale_action(review_btn, "Review these")
+            # task-28243: "Sets" opens the saved review-set picker (resume /
+            # switch / dismiss). Read-only until a pick, so it needs no
+            # stale-page gate; hidden in select mode like the other
+            # list-level actions.
+            sets_btn = Button(
+                "Sets",
+                id="library-media-review-sets",
+                classes="library-canvas-action",
+                compact=True,
+                tooltip="Resume, switch, or dismiss saved review sets.",
+            )
+            sets_btn.display = not select_mode
+            yield sets_btn
             # Disable only when there's nothing to select AND we're not
             # already in select mode -- in select mode the button is "Done"
             # and must always be pressable so the user can exit even if the

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -290,7 +290,47 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         """
         title_count = self.pager.title_count if self.pager is not None else self.canvas.count
         title = "Media" if title_count is None else f"Media ({title_count})"
-        yield Static(title, id="library-media-title")
+        select_mode = getattr(self.canvas, "select_mode", False)
+        fresh_zero = (
+            self.pager is not None
+            and title_count == 0
+            and not self.canvas.rows
+            and not select_mode
+            and not self.canvas.delete_receipt_count
+            and not self.stale_action_reason
+            and not self.mutation_action_reason
+            and not self.pager.status_copy
+            and not self.pager.retry_visible
+        )
+        # task-28243: the "Sets" picker opener lives on the TITLE row, not the
+        # action toolbar -- that toolbar already overflows the narrow items
+        # pane (task-28025) and one more button pushed a squeezed Button into
+        # rich's zero-width chop_cells crash (live-verified 2026-09-02). The
+        # title row carries ~9 chars in a min-width-40 pane, so both widgets
+        # always render at full width. Auto-width Static + fixed compact
+        # Button only (task-4023's render-safe grammar: no 1fr sibling).
+        # Hidden in select mode like the other list-level actions; on the
+        # fresh-empty page it is not composed at all -- that page pins
+        # exactly ONE recovery action (and display:none still matches DOM
+        # queries).
+        title_row = Horizontal(id="library-media-title-row")
+        title_row.styles.height = "auto"
+        with title_row:
+            title_static = Static(title, id="library-media-title")
+            # A Static defaults to 1fr inside a Horizontal and would swallow
+            # the whole row, pushing the button out of view (live-verified).
+            title_static.styles.width = "auto"
+            yield title_static
+            if not fresh_zero:
+                sets_btn = Button(
+                    "Sets",
+                    id="library-media-review-sets",
+                    classes="library-canvas-action",
+                    compact=True,
+                    tooltip="Resume, switch, or dismiss saved review sets.",
+                )
+                sets_btn.display = not select_mode
+                yield sets_btn
         filter_row = Horizontal(classes="ds-toolbar")
         filter_row.styles.height = "auto"
         with filter_row:
@@ -306,18 +346,7 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             )
             clear_filter.disabled = not bool(self.canvas.query)
             yield clear_filter
-        select_mode = getattr(self.canvas, "select_mode", False)
-        if (
-            self.pager is not None
-            and title_count == 0
-            and not self.canvas.rows
-            and not select_mode
-            and not self.canvas.delete_receipt_count
-            and not self.stale_action_reason
-            and not self.mutation_action_reason
-            and not self.pager.status_copy
-            and not self.pager.retry_visible
-        ):
+        if fresh_zero:
             yield Static(
                 self.canvas.empty_copy,
                 id="library-media-status",
@@ -436,19 +465,6 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             )
             review_btn.display = not select_mode
             yield self._gate_stale_action(review_btn, "Review these")
-            # task-28243: "Sets" opens the saved review-set picker (resume /
-            # switch / dismiss). Read-only until a pick, so it needs no
-            # stale-page gate; hidden in select mode like the other
-            # list-level actions.
-            sets_btn = Button(
-                "Sets",
-                id="library-media-review-sets",
-                classes="library-canvas-action",
-                compact=True,
-                tooltip="Resume, switch, or dismiss saved review sets.",
-            )
-            sets_btn.display = not select_mode
-            yield sets_btn
             # Disable only when there's nothing to select AND we're not
             # already in select mode -- in select mode the button is "Done"
             # and must always be pressable so the user can exit even if the

--- a/tldw_chatbook/Widgets/Library/library_review_set_picker.py
+++ b/tldw_chatbook/Widgets/Library/library_review_set_picker.py
@@ -43,7 +43,9 @@ class LibraryReviewSetPickerDialog(
 
     BUNDLED_CSS = """
     LibraryReviewSetPickerDialog { align: center middle; }
-    LibraryReviewSetPickerDialog > Vertical {
+    /* ID subject, not `... > Vertical`: an ancestor-scoped bare-type rule
+     * would trip the CSS fast-path ratchet (275 > 274, UI latency CI). */
+    #library-review-set-picker-dialog {
         width: 72; max-height: 80%; height: auto; padding: 1 2;
         border: tall $accent; background: $surface;
     }

--- a/tldw_chatbook/Widgets/Library/library_review_set_picker.py
+++ b/tldw_chatbook/Widgets/Library/library_review_set_picker.py
@@ -3,8 +3,9 @@
 A dumb modal: it renders pre-computed ``(set_id, name, progress_label,
 active)`` rows -- built by ``review_set_state.build_picker_rows`` in the
 screen's worker -- and dismisses with one ``(action, set_id)`` decision:
-``("open", id)`` to resume/switch, ``("dismiss", id)`` to soft-delete, or
-``None`` on cancel. All service and liveness work stays in the screen.
+``(PICKER_OPEN, id)`` to resume/switch, ``(PICKER_DISMISS, id)`` to
+soft-delete, or ``None`` on cancel. All service and liveness work stays in
+the screen.
 """
 
 from __future__ import annotations
@@ -15,16 +16,21 @@ from rich.text import Text
 from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Button, Static
 
 from tldw_chatbook.Library.library_shell_state import LIBRARY_CHOICE_ACTIVE_MARKER
+from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
 
-from ..modal_dismissal import SafeModalDismissMixin
+PICKER_OPEN = "open"
+"""Decision action: activate the chosen set and resume at its cursor."""
+
+PICKER_DISMISS = "dismiss"
+"""Decision action: soft-delete the chosen set."""
 
 PickerDecision = tuple[str, str] | None
-"""``("open", set_id)`` | ``("dismiss", set_id)`` | ``None`` (cancel)."""
+"""``(PICKER_OPEN, set_id)`` | ``(PICKER_DISMISS, set_id)`` | ``None``."""
 
 
 class LibraryReviewSetPickerDialog(
@@ -41,21 +47,33 @@ class LibraryReviewSetPickerDialog(
         width: 72; max-height: 80%; height: auto; padding: 1 2;
         border: tall $accent; background: $surface;
     }
+    #library-review-set-picker-rows { height: auto; max-height: 20; }
     .library-review-set-row { height: auto; }
     .library-review-set-open { width: 1fr; }
     #library-review-set-picker-actions { height: auto; align-horizontal: right; }
     """
 
     def __init__(self, rows: Sequence[tuple[str, str, str, bool]]) -> None:
-        """Args:
-        rows: ``(set_id, name, progress_label, active)`` per saved set, in
-            display order. Names derive from user input and are rendered as
-            literal text (never markup).
+        """Hold the pre-computed picker rows for compose.
+
+        Args:
+            rows: ``(set_id, name, progress_label, active)`` per saved set, in
+                display order. Names derive from user input and are rendered
+                as literal text (never markup).
         """
         super().__init__()
         self._rows = tuple(rows)
 
     def compose(self) -> ComposeResult:
+        """Render the title, the scrollable set rows, and the Close action.
+
+        The rows live in their own scrolling region so a long saved-set list
+        cannot push lower rows or the Close action past the dialog's height
+        cap (Qodo #2337).
+
+        Returns:
+            ComposeResult for the dialog.
+        """
         with Vertical(id="library-review-set-picker-dialog"):
             yield Static(
                 "Review sets",
@@ -68,41 +86,59 @@ class LibraryReviewSetPickerDialog(
                     "media list to start one.",
                     id="library-review-set-picker-empty",
                 )
-            for index, (set_id, name, progress, active) in enumerate(self._rows):
-                marker = (
-                    f"{LIBRARY_CHOICE_ACTIVE_MARKER} " if active else ""
-                )
-                with Horizontal(classes="library-review-set-row"):
-                    open_button = Button(
-                        Text(f"{marker}{name} — {progress}"),
-                        id=f"library-review-set-open-{index}",
-                        classes="library-review-set-open",
-                        compact=True,
+            with VerticalScroll(id="library-review-set-picker-rows"):
+                for index, (set_id, name, progress, active) in enumerate(
+                    self._rows
+                ):
+                    marker = (
+                        f"{LIBRARY_CHOICE_ACTIVE_MARKER} " if active else ""
                     )
-                    open_button.review_set_id = set_id
-                    yield open_button
-                    dismiss_button = Button(
-                        "Dismiss",
-                        id=f"library-review-set-dismiss-{index}",
-                        classes="library-review-set-dismiss",
-                        compact=True,
-                    )
-                    dismiss_button.review_set_id = set_id
-                    yield dismiss_button
+                    with Horizontal(classes="library-review-set-row"):
+                        open_button = Button(
+                            Text(f"{marker}{name} — {progress}"),
+                            id=f"library-review-set-open-{index}",
+                            classes="library-review-set-open",
+                            compact=True,
+                        )
+                        open_button.review_set_id = set_id
+                        yield open_button
+                        dismiss_button = Button(
+                            "Dismiss",
+                            id=f"library-review-set-dismiss-{index}",
+                            classes="library-review-set-dismiss",
+                            compact=True,
+                        )
+                        dismiss_button.review_set_id = set_id
+                        yield dismiss_button
             with Horizontal(id="library-review-set-picker-actions"):
                 yield Button("Close", id="library-review-set-picker-close")
 
     @on(Button.Pressed, ".library-review-set-open")
     def _open(self, event: Button.Pressed) -> None:
+        """Dismiss with the open decision for the pressed row's set.
+
+        Args:
+            event: The row's open Button press.
+        """
         event.stop()
-        self.dismiss(("open", str(event.button.review_set_id)))
+        self.dismiss((PICKER_OPEN, str(event.button.review_set_id)))
 
     @on(Button.Pressed, ".library-review-set-dismiss")
     def _dismiss_set(self, event: Button.Pressed) -> None:
+        """Dismiss with the soft-delete decision for the pressed row's set.
+
+        Args:
+            event: The row's Dismiss Button press.
+        """
         event.stop()
-        self.dismiss(("dismiss", str(event.button.review_set_id)))
+        self.dismiss((PICKER_DISMISS, str(event.button.review_set_id)))
 
     @on(Button.Pressed, "#library-review-set-picker-close")
     async def _close(self, event: Button.Pressed) -> None:
+        """Cancel the picker without a decision.
+
+        Args:
+            event: The Close Button press.
+        """
         event.stop()
         await self.request_safe_cancel(source="visible")

--- a/tldw_chatbook/Widgets/Library/library_review_set_picker.py
+++ b/tldw_chatbook/Widgets/Library/library_review_set_picker.py
@@ -1,0 +1,108 @@
+"""The Library review-set picker dialog (task-28243).
+
+A dumb modal: it renders pre-computed ``(set_id, name, progress_label,
+active)`` rows -- built by ``review_set_state.build_picker_rows`` in the
+screen's worker -- and dismisses with one ``(action, set_id)`` decision:
+``("open", id)`` to resume/switch, ``("dismiss", id)`` to soft-delete, or
+``None`` on cancel. All service and liveness work stays in the screen.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from rich.text import Text
+from textual import on
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Library.library_shell_state import LIBRARY_CHOICE_ACTIVE_MARKER
+
+from ..modal_dismissal import SafeModalDismissMixin
+
+PickerDecision = tuple[str, str] | None
+"""``("open", set_id)`` | ``("dismiss", set_id)`` | ``None`` (cancel)."""
+
+
+class LibraryReviewSetPickerDialog(
+    SafeModalDismissMixin, ModalScreen[PickerDecision]
+):
+    """List saved review sets with resume-or-dismiss actions per row."""
+
+    BINDINGS = (Binding("escape", "request_safe_cancel", "Cancel", show=False),)
+    SAFE_MODAL_CONTENT = "#library-review-set-picker-dialog"
+
+    BUNDLED_CSS = """
+    LibraryReviewSetPickerDialog { align: center middle; }
+    LibraryReviewSetPickerDialog > Vertical {
+        width: 72; max-height: 80%; height: auto; padding: 1 2;
+        border: tall $accent; background: $surface;
+    }
+    .library-review-set-row { height: auto; }
+    .library-review-set-open { width: 1fr; }
+    #library-review-set-picker-actions { height: auto; align-horizontal: right; }
+    """
+
+    def __init__(self, rows: Sequence[tuple[str, str, str, bool]]) -> None:
+        """Args:
+        rows: ``(set_id, name, progress_label, active)`` per saved set, in
+            display order. Names derive from user input and are rendered as
+            literal text (never markup).
+        """
+        super().__init__()
+        self._rows = tuple(rows)
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="library-review-set-picker-dialog"):
+            yield Static(
+                "Review sets",
+                id="library-review-set-picker-title",
+                classes="destination-section",
+            )
+            if not self._rows:
+                yield Static(
+                    "No saved review sets. Use “Review these” on the "
+                    "media list to start one.",
+                    id="library-review-set-picker-empty",
+                )
+            for index, (set_id, name, progress, active) in enumerate(self._rows):
+                marker = (
+                    f"{LIBRARY_CHOICE_ACTIVE_MARKER} " if active else ""
+                )
+                with Horizontal(classes="library-review-set-row"):
+                    open_button = Button(
+                        Text(f"{marker}{name} — {progress}"),
+                        id=f"library-review-set-open-{index}",
+                        classes="library-review-set-open",
+                        compact=True,
+                    )
+                    open_button.review_set_id = set_id
+                    yield open_button
+                    dismiss_button = Button(
+                        "Dismiss",
+                        id=f"library-review-set-dismiss-{index}",
+                        classes="library-review-set-dismiss",
+                        compact=True,
+                    )
+                    dismiss_button.review_set_id = set_id
+                    yield dismiss_button
+            with Horizontal(id="library-review-set-picker-actions"):
+                yield Button("Close", id="library-review-set-picker-close")
+
+    @on(Button.Pressed, ".library-review-set-open")
+    def _open(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(("open", str(event.button.review_set_id)))
+
+    @on(Button.Pressed, ".library-review-set-dismiss")
+    def _dismiss_set(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(("dismiss", str(event.button.review_set_id)))
+
+    @on(Button.Pressed, "#library-review-set-picker-close")
+    async def _close(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self.request_safe_cancel(source="visible")

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -2846,7 +2846,13 @@
 /* ===== WIDGET: LibraryReviewSetPickerDialog (Widgets/Library/library_review_set_picker.py) ===== */
 
 
-
+    /* ID subject, not `... > Vertical`: an ancestor-scoped bare-type rule
+     * would trip the CSS fast-path ratchet (275 > 274, UI latency CI). */
+    LibraryReviewSetPickerDialog #library-review-set-picker-dialog {
+        width: 72; max-height: 80%; height: auto; padding: 1 2;
+        border: tall $accent; background: $surface;
+    }
+    LibraryReviewSetPickerDialog #library-review-set-picker-rows { height: auto; max-height: 20; }
     LibraryReviewSetPickerDialog .library-review-set-row { height: auto; }
     LibraryReviewSetPickerDialog .library-review-set-open { width: 1fr; }
     LibraryReviewSetPickerDialog #library-review-set-picker-actions { height: auto; align-horizontal: right; }

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -2843,6 +2843,15 @@
     LibraryNoteFolderTargetDialog #library-note-folder-target-actions { height: auto; align-horizontal: right; }
 
 
+/* ===== WIDGET: LibraryReviewSetPickerDialog (Widgets/Library/library_review_set_picker.py) ===== */
+
+
+
+    LibraryReviewSetPickerDialog .library-review-set-row { height: auto; }
+    LibraryReviewSetPickerDialog .library-review-set-open { width: 1fr; }
+    LibraryReviewSetPickerDialog #library-review-set-picker-actions { height: auto; align-horizontal: right; }
+
+
 /* ===== WIDGET: PersonaProfileEditorWidget (Widgets/Persona_Widgets/persona_profile_editor_widget.py) ===== */
 
 

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -2398,6 +2398,18 @@
     }
 
 
+/* ===== WIDGET: LibraryReviewSetPickerDialog (Widgets/Library/library_review_set_picker.py) ===== */
+
+    LibraryReviewSetPickerDialog { align: center middle; }
+    LibraryReviewSetPickerDialog > Vertical {
+        width: 72; max-height: 80%; height: auto; padding: 1 2;
+        border: tall $accent; background: $surface;
+    }
+
+
+
+
+
 /* ===== WIDGET: ModelInstallProgress (Widgets/ModelArtifacts/install_progress.py) ===== */
 
     ModelInstallProgress {

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -2401,10 +2401,10 @@
 /* ===== WIDGET: LibraryReviewSetPickerDialog (Widgets/Library/library_review_set_picker.py) ===== */
 
     LibraryReviewSetPickerDialog { align: center middle; }
-    LibraryReviewSetPickerDialog > Vertical {
-        width: 72; max-height: 80%; height: auto; padding: 1 2;
-        border: tall $accent; background: $surface;
-    }
+    /* ID subject, not `... > Vertical`: an ancestor-scoped bare-type rule
+     * would trip the CSS fast-path ratchet (275 > 274, UI latency CI). */
+
+
 
 
 


### PR DESCRIPTION
Phase 4 of the review-sets program (design: `backlog/docs/design-library-review-sets.md`, task-28243; phases 1-3 = #2323 / #2333 / #2335): a picker to **resume, switch between, or dismiss** saved review sets, opened from the media list.

## What's here

- **`build_picker_rows`** (`Library/review_set_state.py`): pure `(set_id, name, progress_label, active)` rows — progress via the existing `format_review_progress` over one live snapshot.
- **`LibraryReviewSetPickerDialog`** (`Widgets/Library/library_review_set_picker.py`): a dumb modal on the `SafeModalDismissMixin` idiom. Renders pre-computed rows (active set carries the `✓` marker; names are user-derived and render as literal `Text`, never markup) and dismisses with one typed decision: `("open", id)`, `("dismiss", id)`, or `None`.
- **Screen worker** (`_review_set_picker_worker`): collects rows off the event loop with ONE chunked liveness resolve across every listed set, awaits the modal, then applies the decision off-loop:
  - **open** → reopens a completed set (AC#2), activates it (service's one-active invariant deactivates the previous), and lands the Reader at the set's resolved cursor. An all-tombstoned set is **never** activated (design §7) — notice instead.
  - **dismiss** → soft-delete + confirmation notice + a Reader-chrome sync (without it the footer kept advertising "] next in set · 1 of 3" after a live dismissal).
- **"Sets" opener on the media list TITLE row** — deliberately NOT the action toolbar: that toolbar already overflows the narrow Items pane (task-28025), and adding one more button pushed a squeezed Button into rich's zero-width `chop_cells` `ValueError`, crashing the app on Media open (live-verified, then relocated). The title row carries ~9 chars in a min-width-40 pane. Not composed on the fresh-empty page, which pins exactly one recovery action.
- Docs: `Docs/User_Guide/library/media-and-conversations.md` gains a **Review sets** section covering the whole feature (entry points, walk keys, picker) + keyboard entries; plus a lessons entry (tmux SGR click columns are cells; BSD awk/cut count bytes).

## Tests

15 new: `build_picker_rows` (3), dialog contract incl. markup-literal labels and Escape-cancel (6), worker end-to-end over a real tmp service DB (6: open/switch, reopen-completed, dismiss+sync, cancel, all-tombstoned, failure-notice). 141 green across the review-set battery + multiselect toolbar suite. No new logger (diagnostic inventory untouched); no schema change; preflight clean.

Two failures that predate this branch (reproduced on dev without these commits): `test_generated_stylesheet_includes_library_media_rules` (dev's e435052ad left `#library-media-title` out of the bundle) and `test_library_note_media_route_switch_updates_contextual_chrome`.

## Live verification (tmux, seeded media, cleaned up after)

Create via "Review these" → walk `]` ("2 of 3 · 1 reviewed") → `R` exit → **Sets** lists "All media — 2 of 3 · 1 reviewed" → picking it resumes at the cursor item with set chrome restored → **Dismiss** soft-deletes and the footer drops the set keys immediately. Empty picker state verified before any set existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2gSzBnVrjf37m4bPU3BCn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a set picker to the media list so saved review sets can be resumed, switched between, or dismissed. Previously sets could only be walked while active; now a "Sets" button on the media list title row opens a picker showing each set's live progress, with the active set marked.

**Behavior**
- Picking a set activates it (deactivating any other), reopens it if completed, and lands the Reader at its saved cursor; a cursor resolved past a deleted item is persisted.
- Dismiss soft-deletes with a confirmation; dismissing the active set also clears the Reader footer's set keys immediately.
- All-tombstoned sets are never activated — a warning shows instead.
- Set names are user-derived and render as literal text, never markup.
- The picker rows scroll so a long set list can't push lower rows or Close past the modal's height cap.
- The "Sets" button sits on the title row rather than the action toolbar, which already overflows the narrow Items pane and crashed on an extra button; it's hidden in select mode and omitted on the fresh-empty page.
- The picker dialog's CSS targets the dialog by ID to stay under the CSS fast-path ratchet; the regenerated CSS bundles are committed.

<sup>Written for commit 4dd2684e1ee59b58b59ca9f9f17325548fd82e28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

