### PR TITLE
feat(library): review sets phase 2b - auto-resume on media entry (task-28245)

### DIFF
--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -219,6 +219,9 @@ them one by one, with your place and progress saved between visits.
   trimmed); in Select mode, **Review selected** pins just the checked items in
   list order. Creating a set activates it and opens its first item in the
   Reader.
+- **Resume on entry** — opening the media area with a set active loads its
+  current item into the Reader automatically (once per set per session;
+  Escape back to the list and re-entering shows the list).
 - **Walk** — while a set is active the Reader footer shows your place ("2 of
   14 · 1 reviewed"). `]` advances and marks the item you leave as reviewed;
   `[` goes back without marking; `m` toggles the loaded item's reviewed mark;

--- a/Tests/UI/test_review_set_walker.py
+++ b/Tests/UI/test_review_set_walker.py
@@ -683,6 +683,80 @@ async def test_picker_worker_failure_notifies(tmp_path):
     assert any(severity == "error" for _msg, severity in fake._notices)
 
 
+def _auto_resume_fake(service, *, live_ids=None):
+    """Fake screen for the auto-resume worker (task-28245)."""
+    fake = _entry_fake(service)
+    fake._review_set_live_ids = (
+        (lambda ids: {int(i) for i in ids})
+        if live_ids is None
+        else (lambda ids: set(live_ids))
+    )
+
+    async def run_call(call, *args, isolate_in_worker=False, **kwargs):
+        result = call(*args, **kwargs)
+        return await result if hasattr(result, "__await__") else result
+
+    fake._run_library_service_call = run_call
+    fake._library_selected_row_id = "browse-media"
+    fake._library_media_view = "list"
+    fake.is_current = True
+    for name in (
+        "_auto_resume_review_set_worker",
+        "_resolve_active_review_set_landing",
+    ):
+        setattr(fake, name, MethodType(getattr(LibraryScreen, name), fake))
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_opens_the_active_sets_cursor_item_once(tmp_path):
+    # task-28245 AC#1: entering the media area with an active set loads its
+    # cursor item without a keypress -- but only ONCE per set per screen
+    # session, so Escape-to-list + re-entry shows the list, not a yank loop.
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "X", origin="browse", items=[(10, "A"), (11, "B")]
+    )
+    service.set_cursor(set_id, 1)
+    fake = _auto_resume_fake(service)
+
+    await fake._auto_resume_review_set_worker()
+    assert fake._opened == ["local:media:11"]
+
+    await fake._auto_resume_review_set_worker()
+    assert fake._opened == ["local:media:11"]  # once per set
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_is_a_no_op_without_an_active_set(tmp_path):
+    fake = _auto_resume_fake(_service(tmp_path))
+    await fake._auto_resume_review_set_worker()
+    assert fake._opened == [] and fake._notices == []
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_aborts_when_the_user_moved_away(tmp_path):
+    # task-28245 AC#3: if the initial-tab switch (or the user) yanked the
+    # screen off the media list before the resolve finished, do not open.
+    service = _service(tmp_path)
+    service.create_review_set("X", origin="browse", items=[(10, "A")])
+    fake = _auto_resume_fake(service)
+    fake._library_media_view = "viewer"
+
+    await fake._auto_resume_review_set_worker()
+    assert fake._opened == []
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_skips_an_all_tombstoned_set_quietly(tmp_path):
+    service = _service(tmp_path)
+    service.create_review_set("X", origin="browse", items=[(10, "A")])
+    fake = _auto_resume_fake(service, live_ids=set())
+
+    await fake._auto_resume_review_set_worker()
+    assert fake._opened == [] and fake._notices == []  # convenience, no nag
+
+
 def test_review_these_name_from_scope():
     assert (
         LibraryScreen._review_these_name(

--- a/Tests/UI/test_review_set_walker.py
+++ b/Tests/UI/test_review_set_walker.py
@@ -727,6 +727,32 @@ async def test_auto_resume_opens_the_active_sets_cursor_item_once(tmp_path):
     assert fake._opened == ["local:media:11"]  # once per set
 
 
+def test_auto_resume_runs_in_its_own_worker_group():
+    """Auto-resume must not share the exclusive creation group (Qodo #2342).
+
+    ``library_review_set`` is the exclusive group the entry-point build
+    workers run in; if auto-resume joined it, clicking the Media rail while
+    "Review these" was still paging would CANCEL the set creation.
+    """
+
+    async def noop():
+        return None
+
+    recorded: dict = {}
+
+    def run_worker(coro, **kwargs):
+        recorded.update(kwargs)
+        coro.close()
+
+    fake = SimpleNamespace(
+        run_worker=run_worker, _auto_resume_review_set_worker=noop
+    )
+    LibraryScreen._maybe_auto_resume_review_set(fake)
+
+    assert recorded["group"] != "library_review_set"
+    assert recorded["exclusive"] is True  # still debounces its own re-entries
+
+
 @pytest.mark.asyncio
 async def test_auto_resume_is_a_no_op_without_an_active_set(tmp_path):
     fake = _auto_resume_fake(_service(tmp_path))

--- a/backlog/tasks/task-28244 - Review-sets-Phase-5-optional-read-later-source-and-28009-bridge.md
+++ b/backlog/tasks/task-28244 - Review-sets-Phase-5-optional-read-later-source-and-28009-bridge.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-28244
 title: 'Review sets - Phase 5 (optional): read-later source and 28009 bridge'
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-09-02 22:29'
-updated_date: '2026-09-03 05:03'
+updated_date: '2026-09-03 06:37'
 labels:
   - library
   - media-ux
@@ -23,7 +23,7 @@ Optional: build a review set from the read-later queue, and bridge done-marks to
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A 'Review read-later' entry builds a set from list_read_it_later_media_ids() (already ordered saved_at DESC)
+- [x] #1 A 'Review read-later' entry builds a set from list_read_it_later_media_ids() (already ordered saved_at DESC)
 - [ ] #2 If/when task-28009 adds a global media read marker, completing an item in a set optionally flips it; until then done-marks stay set-local
 <!-- AC:END -->
 
@@ -35,3 +35,9 @@ Optional: build a review set from the read-later queue, and bridge done-marks to
 3. AC#2 contingent on 28009 (not built): done-marks stay set-local - no code
 4. Docs stamp + live spot-check
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Shipped in PR #2340 (dev b8179f059). 'Review read-later' action in the set picker builds a set from list_read_it_later_media_ids (saved_at DESC, bounded by new limit param at REVIEW_SET_CAP+1), titles via the bounded id_allowlist query reordered client-side to the saved order, shared create+land path. AC#2 intentionally unchecked: contingent on task-28009's global read marker, which does not exist - done-marks stay set-local per design.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-28245 - Review-sets-Phase-2b-resume-the-active-sets-cursor-item-on-entering-the-media-Reader.md
+++ b/backlog/tasks/task-28245 - Review-sets-Phase-2b-resume-the-active-sets-cursor-item-on-entering-the-media-Reader.md
@@ -3,9 +3,11 @@ id: TASK-28245
 title: >-
   Review sets - Phase 2b: resume the active set's cursor item on entering the
   media Reader
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-09-03 01:47'
+updated_date: '2026-09-03 05:59'
 labels:
   - library
   - media-ux
@@ -26,3 +28,12 @@ Split from task-28241 AC#4. The walker (AC1-3) resumes the SET STATE automatical
 - [ ] #2 Per-item scroll resume (ReadingProgress) still restores within the loaded item
 - [ ] #3 Does not fire during cold-start tab switching or fight the initial-tab navigation
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. _maybe_auto_resume_review_set: worker (group library_review_set) resolving the active set's cursor off-loop; opens the Reader at it ONCE per set (screen-session guard), only if still on the media list and the screen is current - TDD via fakes
+2. Hooks: end of the rail-select seam (media row) + on_mount's media-list branch
+3. AC#2: loading goes through _open_library_media_viewer = same path as a row press, ReadingProgress untouched
+4. AC#3: worker's final still-on-media-list + is_current gates make a cold-start yank abort; live tmux verify incl. restart
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -42419,10 +42419,14 @@ class LibraryScreen(BaseAppScreen):
         Called on explicit media-area entry (rail select, screen mount). The
         worker re-checks the surface right before opening, so an entry that
         gets yanked away (cold-start initial-tab switch) aborts cleanly.
+
+        Its OWN exclusive group, not ``library_review_set`` -- joining the
+        entry-point builders' group would CANCEL an in-flight "Review these"
+        build when the user clicks the Media rail mid-build (Qodo #2342).
         """
         self.run_worker(
             self._auto_resume_review_set_worker(),
-            group="library_review_set",
+            group="library_review_set_resume",
             exclusive=True,
             exit_on_error=False,
         )

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -10793,6 +10793,11 @@ class LibraryScreen(BaseAppScreen):
                 focus_identity=None,
             )
             self._request_library_media_facets()
+            # task-28245: a screen mount that lands on the media list with an
+            # active review set resumes it at its cursor. The worker's final
+            # still-on-the-media-list + current-screen gates make a cold-start
+            # initial-tab yank abort without opening (AC#3).
+            self.call_after_refresh(self._maybe_auto_resume_review_set)
         if (
             self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
             and self._library_media_view == "trash"
@@ -26440,6 +26445,9 @@ class LibraryScreen(BaseAppScreen):
                 focus_identity="#library-media-row-0",
             )
             self._request_library_media_facets()
+            # task-28245: entering the media area with an active review set
+            # resumes it at its cursor without a keypress (once per set).
+            self._maybe_auto_resume_review_set()
         # task-2856 AC1: a rail-row press landing on one of the four list
         # canvases focuses its primary list's first row -- the entry-point
         # half of the same seam ``_exit_library_skill_editor_guarded`` /
@@ -42402,6 +42410,84 @@ class LibraryScreen(BaseAppScreen):
             # subsequent resume back to the stale cursor (Qodo #2337).
             service.set_cursor(set_id, resolved)
         return landing.backing_media_id
+
+    # -- auto-resume on media entry (task-28245) ------------------------------
+
+    def _maybe_auto_resume_review_set(self) -> None:
+        """Kick the once-per-set auto-resume of an active review set.
+
+        Called on explicit media-area entry (rail select, screen mount). The
+        worker re-checks the surface right before opening, so an entry that
+        gets yanked away (cold-start initial-tab switch) aborts cleanly.
+        """
+        self.run_worker(
+            self._auto_resume_review_set_worker(),
+            group="library_review_set",
+            exclusive=True,
+            exit_on_error=False,
+        )
+
+    async def _auto_resume_review_set_worker(self) -> None:
+        """Open the active set's cursor item in the Reader, once per set.
+
+        AC#1: entering the media area with an active set loads its cursor
+        item without a keypress. Once per set per screen session -- Escape
+        back to the list plus re-entry shows the list, never a yank loop.
+        AC#3: the final still-on-the-media-list + current-screen gates make
+        a cold-start yank abort without opening (and without burning the
+        once-per-set chance). Auto-resume is a convenience: any failure is
+        silent, never a notice or a crash.
+        """
+        try:
+            landing = await self._run_library_service_call(
+                self._resolve_active_review_set_landing, isolate_in_worker=True
+            )
+            if landing is None:
+                return
+            set_id, backing_id = landing
+            if (
+                self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
+                or self._library_media_view != "list"
+                or not getattr(self, "is_current", False)
+            ):
+                return
+            resumed: set[str] = getattr(self, "_review_set_auto_resumed", set())
+            if set_id in resumed:
+                return
+            resumed.add(set_id)
+            self._review_set_auto_resumed = resumed
+            self._open_library_media_viewer(f"local:media:{backing_id}")
+        except Exception:
+            return
+
+    def _resolve_active_review_set_landing(self) -> tuple[str, int] | None:
+        """Resolve the active set's live cursor item (runs off the loop).
+
+        Returns:
+            ``(set_id, backing_media_id)`` for the item the Reader should
+            resume at, or ``None`` when no set is active or every pinned
+            item is a tombstone.
+        """
+        from tldw_chatbook.Library.review_set_state import resolve_cursor
+
+        service = self._review_set_service()
+        if service is None:
+            return None
+        review_set = service.get_active_review_set()
+        if review_set is None:
+            return None
+        live_ids = self._review_set_live_ids(
+            item.backing_media_id for item in review_set.items
+        )
+        resolved = resolve_cursor(
+            review_set.items,
+            review_set.cursor,
+            lambda candidate: candidate in live_ids,
+        )
+        landing = {item.position: item for item in review_set.items}.get(resolved)
+        if landing is None or landing.backing_media_id not in live_ids:
+            return None
+        return review_set.set_id, landing.backing_media_id
 
     def _focus_library_media_items_pane(self) -> None:
         """Focus the Items pane at its most useful control (task-28004).

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -10793,11 +10793,12 @@ class LibraryScreen(BaseAppScreen):
                 focus_identity=None,
             )
             self._request_library_media_facets()
-            # task-28245: a screen mount that lands on the media list with an
-            # active review set resumes it at its cursor. The worker's final
-            # still-on-the-media-list + current-screen gates make a cold-start
-            # initial-tab yank abort without opening (AC#3).
-            self.call_after_refresh(self._maybe_auto_resume_review_set)
+            # task-28245: NO auto-resume kick here, deliberately. The mount
+            # leg runs during boot, and the worker's lazy review-set imports
+            # raced the _ui_ready module census on slow runners (977 > 972,
+            # flaky Perf Guard). The rail-select seam is the explicit
+            # user gesture that resumes a set (AC#3's cold-start concern is
+            # structurally avoided there).
         if (
             self._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
             and self._library_media_view == "trash"
@@ -42416,9 +42417,11 @@ class LibraryScreen(BaseAppScreen):
     def _maybe_auto_resume_review_set(self) -> None:
         """Kick the once-per-set auto-resume of an active review set.
 
-        Called on explicit media-area entry (rail select, screen mount). The
-        worker re-checks the surface right before opening, so an entry that
-        gets yanked away (cold-start initial-tab switch) aborts cleanly.
+        Called ONLY from the rail-select seam (an explicit user gesture) --
+        never from the mount leg, whose boot-time timing made the worker's
+        lazy imports race the _ui_ready module census (flaky Perf Guard).
+        The worker still re-checks the surface right before opening, so an
+        entry that gets yanked away aborts cleanly.
 
         Its OWN exclusive group, not ``library_review_set`` -- joining the
         entry-point builders' group would CANCEL an in-flight "Review these"


### PR DESCRIPTION
Phase 2b — the **final phase** of the review-sets program (design: `backlog/docs/design-library-review-sets.md`, task-28245, split from task-28241 AC#4; phases 1-5 = #2323 / #2333 / #2335 / #2337 / #2340): opening the media area with an active review set loads its cursor item into the Reader **without a keypress**.

## What's here

- **`_auto_resume_review_set_worker`**: resolves the active set's live cursor off the event loop (`_resolve_active_review_set_landing`: active set → chunked liveness → `resolve_cursor`), then opens via `_open_library_media_viewer` — the **same path as a row press**, so per-item `ReadingProgress` scroll restore is untouched (AC#2).
- **Once per set per screen session**: Escape back to the list plus re-entry shows the list — never a yank loop. The guard is only burned when the open actually happens.
- **Two hooks**: the rail-select seam's media branch, and `on_mount`'s media-list branch (`call_after_refresh`). The worker's final gates — still on the media list, screen is current — make a cold-start initial-tab yank abort without opening (AC#3). All failures are silent: auto-resume is a convenience, not a feature gate.

## Tests

4 new worker tests over a real tmp service DB: opens-the-cursor-item-once (with the once-guard re-run), no-active-set no-op, moved-away abort (AC#3), all-tombstoned quiet skip. 152 green across the review-set battery + multiselect suite; preflight clean; no CSS, no schema, no new logger.

## Live verification (tmux, seeded media, cleaned up after)

Create set → walk to item 2 ("2 of 3 · 1 reviewed") → **quit the app** → relaunch → Library → click **Media** → the Reader auto-loads item 2 at "2 of 3 · 1 reviewed" with no further keypress. Then Escape → Conversations → Media again shows the **list** (once-guard holds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2gSzBnVrjf37m4bPU3BCn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens an active review set's cursor item in the Reader when the Media rail is clicked, without a keypress. Previously entering media always showed the list; now with a set active, the Reader loads at the current item, but only once per set per session—escaping back to the list and re-entering shows the list again.

**New Features**
- Kicks off only from the rail-select media branch; the mount-leg kick was dropped because its boot-time timing raced the `_ui_ready` module census and flaked the Perf Guard.
- Resolves the live cursor off the event loop and opens through the same path as a row press, preserving per-item scroll restore; final gates abort a cold-start yank without opening.
- All failures are silent; updates the user guide.

**Bug Fixes**
- Runs in its own exclusive worker group, so clicking the Media rail during an in-flight "Review these" build no longer cancels the build.

<sup>Written for commit f49b819f4b7d3e7bd36ea669bb3a4732309dd42e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

