### PR TITLE
feat(scheduling): detail-pane regrammar — DetailValueRow groups (redesign PR-1)

### DIFF
--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -93,19 +93,27 @@ duplicating it locally. The existing missed-fire accounting is unchanged.
 
 ## Task Detail — grouped fields
 
-A reminder's Task Detail pane shows its fields as three labeled groups
-instead of a flat list, matching the same label-left/value-right row style
-used throughout the pane:
+A reminder's Task Detail pane shows its body text in a card, then its
+fields as three labeled groups instead of a flat list, matching the same
+label-left/value-right row style used throughout the pane (a reminder with
+no body text shows no card):
 
-- **Details** — `Runs on` (the owner, "This device" or "Server (\<id\>)",
-  with the transfer badge text appended while a move is in flight, e.g.
-  "This device (Moving to server…)").
+- **Details** — `Runs on` (the owner: "This device" for a reminder this
+  device runs, or the server's own id for one the server runs, with the
+  transfer badge text appended while a move is in flight, e.g.
+  "This device (Moving to server…)"). The Automations tab's detail pane
+  words this row exactly the same way.
 - **Frequency** — `Repeat`, `At`, `Timezone`, and `Notifications` (always
   "Inbox + toast" — every reminder dispatch writes an inbox row and
   attempts a toast; there is no per-reminder channel setting).
 - **History** (collapsed by default — click its title to expand) —
-  `Last fire` (the last run's time and outcome) and a pointer row to the
-  **Recent runs** list, which stays exactly where it was below.
+  `Last fire` (the last run's time and outcome) and a `Run history`
+  pointer row to the **Recent runs** list, which stays exactly where it
+  was below.
+
+Each group's title is keyboard-focusable: Tab reaches it and Enter
+toggles the group, so collapsing and expanding never needs the mouse.
+That does put three focus stops ahead of the pane's action buttons.
 
 A watchlist or briefing projection (not a reminder) still shows the older
 Type/Schedule rows unchanged — the grouped layout is reminder-specific.
@@ -434,13 +442,18 @@ grouped-row layout as the reminder detail pane:
   reminder pane), `Model` (the pinned `provider/model`, or `auto` when
   the definition pins nothing), `Generation` (always/only-new/never),
   `Finding policy` (the preset name), and `Sources` (the selected library
-  sources, or "All searchable library" for the default scope).
+  sources, or "All searchable library" for the default scope). A row the
+  definition does not carry a value for reads **"Not set"** — a
+  definition authored on the server often carries none of these, and the
+  pane never fills the gap in with the create form's defaults.
 - **Frequency** — the schedule summary (repeat/at/timezone, or the raw
-  cron expression for a custom schedule).
+  cron expression for a custom schedule) and `Notifications`.
 - **History** (collapsed by default) — the last run's outcome, total run
-  count, unread results count, and a pointer to the Results tab. A
-  server-owned definition honestly shows no local run count or last run
-  here, since only the server holds that definition's execution history.
+  count, unread results count, and a pointer to the Results tab. Those
+  counts are this device's own execution record, so a server-owned
+  definition reads "Kept on the server — see Run history" instead: only
+  the server holds that definition's execution history, and the run
+  history pane beside it is already showing it.
 
 The detail pane hides at narrow terminal widths, the same responsive rule
 the Queue tab's own detail pane already uses.
@@ -529,13 +542,16 @@ The default bound is `handler_timeout_seconds` under `[scheduling]` in
 bound entirely — every handler may then run as long as it likes, and a
 wedged handler will wedge the scheduler, which is why the default is on.
 
-*Verified against 98810b90e — 2026-09-02 (schedules redesign PR-1 task 5,
-docs pass against shipped code/tests, live check pending the redesign
-program's later PRs per spec §14: the reminder Task Detail pane's grouped
-Details/Frequency/History rows, and the Automations tab's new definition
-detail pane — question card, Details/Frequency/History rows incl.
-Model/Generation/Finding policy/Sources, and the History group's run/
-unread counts). Verified against a running tldw_server — 2026-09-02 (schedules-handoff
+*Verified against the schedules redesign PR-1 fix wave — 2026-09-02
+(docs pass against shipped code/tests, live check pending the redesign
+program's later PRs per spec §14: the reminder Task Detail pane's body
+card and grouped Details/Frequency/History rows, and the Automations
+tab's definition detail pane — question card, Details/Frequency/History
+rows incl. Model/Generation/Finding policy/Sources/Notifications, and the
+History group's owner-honest run/unread counts. The owner vocabulary,
+"Not set" placeholders and server-owned History copy documented above are
+each pinned by a test in `Tests/UI/test_schedules_workbench.py` /
+`test_schedules_automations_tab.py`). Verified against a running tldw_server — 2026-09-02 (schedules-handoff
 PR-6 task 6, the program's §10 live gate: real TUI in tmux against
 tldw_server `origin/dev` 25fb0eca59 on a local single-user profile.
 Verified live: authoring a local recurring question, transferring it to

--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -91,6 +91,25 @@ recoverable rather than overwritten. History is capped per task (the newest
 keep their history server-authoritative (per ADR-077) rather than
 duplicating it locally. The existing missed-fire accounting is unchanged.
 
+## Task Detail — grouped fields
+
+A reminder's Task Detail pane shows its fields as three labeled groups
+instead of a flat list, matching the same label-left/value-right row style
+used throughout the pane:
+
+- **Details** — `Runs on` (the owner, "This device" or "Server (\<id\>)",
+  with the transfer badge text appended while a move is in flight, e.g.
+  "This device (Moving to server…)").
+- **Frequency** — `Repeat`, `At`, `Timezone`, and `Notifications` (always
+  "Inbox + toast" — every reminder dispatch writes an inbox row and
+  attempts a toast; there is no per-reminder channel setting).
+- **History** (collapsed by default — click its title to expand) —
+  `Last fire` (the last run's time and outcome) and a pointer row to the
+  **Recent runs** list, which stays exactly where it was below.
+
+A watchlist or briefing projection (not a reminder) still shows the older
+Type/Schedule rows unchanged — the grouped layout is reminder-specific.
+
 ## Creating a scheduled task
 
 Press **c**, or click **+ New** in the Queue tab's pane header, to open
@@ -404,6 +423,28 @@ showing an empty server-shaped trail; every execution still leaves its
 trail here for server automations: queued, succeeded, failed, timed out,
 skipped, the same events the server records for reconciliation.
 
+### Automations tab — definition detail pane
+
+Highlighting a definition row opens a read-only detail pane alongside the
+list and its run history — the Automations tab's first per-row detail
+view. It shows the question text in a card at the top, then the same
+grouped-row layout as the reminder detail pane:
+
+- **Details** — `Runs on` (owner + transfer badge, same wording as the
+  reminder pane), `Model` (the pinned `provider/model`, or `auto` when
+  the definition pins nothing), `Generation` (always/only-new/never),
+  `Finding policy` (the preset name), and `Sources` (the selected library
+  sources, or "All searchable library" for the default scope).
+- **Frequency** — the schedule summary (repeat/at/timezone, or the raw
+  cron expression for a custom schedule).
+- **History** (collapsed by default) — the last run's outcome, total run
+  count, unread results count, and a pointer to the Results tab. A
+  server-owned definition honestly shows no local run count or last run
+  here, since only the server holds that definition's execution history.
+
+The detail pane hides at narrow terminal widths, the same responsive rule
+the Queue tab's own detail pane already uses.
+
 ## Results tab — the automation findings inbox
 
 The **Results** tab lists the `automation_results` rows a recurring
@@ -488,7 +529,13 @@ The default bound is `handler_timeout_seconds` under `[scheduling]` in
 bound entirely — every handler may then run as long as it likes, and a
 wedged handler will wedge the scheduler, which is why the default is on.
 
-*Verified against a running tldw_server — 2026-09-02 (schedules-handoff
+*Verified against 98810b90e — 2026-09-02 (schedules redesign PR-1 task 5,
+docs pass against shipped code/tests, live check pending the redesign
+program's later PRs per spec §14: the reminder Task Detail pane's grouped
+Details/Frequency/History rows, and the Automations tab's new definition
+detail pane — question card, Details/Frequency/History rows incl.
+Model/Generation/Finding policy/Sources, and the History group's run/
+unread counts). Verified against a running tldw_server — 2026-09-02 (schedules-handoff
 PR-6 task 6, the program's §10 live gate: real TUI in tmux against
 tldw_server `origin/dev` 25fb0eca59 on a local single-user profile.
 Verified live: authoring a local recurring question, transferring it to

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2868,8 +2868,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 25,
-      "diagnostic_digest": "baa714cb950acfe4337b",
+      "call_count": 26,
+      "diagnostic_digest": "a426ac0b3afb8946aa94",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11271,6 +11271,6 @@
     "path_privacy_candidate_calls": 714,
     "persistent_sink_files": 10,
     "task_492_calls": 1337,
-    "task_494_calls": 7556
+    "task_494_calls": 7557
   }
 }

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -1528,6 +1528,27 @@ def test_count_automation_runs_filters_by_definition(tmp_path):
     assert db.count_automation_runs("unknown-definition") == 0
 
 
+def test_count_automation_runs_can_scope_to_one_owner(tmp_path):
+    """schedules-redesign PR-1 final review F11: the count is scopable the
+    same way `list_automation_runs` already scopes its read.
+
+    The detail pane shows "Run count" and "Last run" in one group, and
+    `convert_row_to_server_mirror`'s "converted" path rewrites a row's
+    `owner_id` while keeping its local id -- an unscoped count beside a
+    scoped last-run rendered "Run count: 3" next to "Last run: Never run".
+    """
+    db = _mk_db(tmp_path)
+    db.create_automation_run("local", "d1", 1, "manual", status="running")
+    db.create_automation_run("server:srv-1", "d1", 1, "scheduled", status="completed")
+
+    assert db.count_automation_runs("d1") == 2, "unscoped still counts every owner"
+    assert db.count_automation_runs("d1", "local") == 1
+    assert db.count_automation_runs("d1", "server:srv-1") == 1
+    assert db.count_automation_runs("d1", "server:other") == 0
+    # Agrees with the sibling read the pane calls beside it.
+    assert len(db.list_automation_runs("local", definition_id="d1")) == 1
+
+
 # ----------------------------------------------------------------------
 # Automation results
 # ----------------------------------------------------------------------

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -1517,6 +1517,17 @@ def test_reconcile_marks_stale_running_as_interrupted(tmp_path):
     assert row["failure_reason"] == {"code": "interrupted"}
 
 
+def test_count_automation_runs_filters_by_definition(tmp_path):
+    db = _mk_db(tmp_path)
+    db.create_automation_run("local", "d1", 1, "manual", status="running")
+    db.create_automation_run("local", "d1", 1, "scheduled", status="completed")
+    db.create_automation_run("local", "d2", 1, "manual", status="running")
+
+    assert db.count_automation_runs("d1") == 2
+    assert db.count_automation_runs("d2") == 1
+    assert db.count_automation_runs("unknown-definition") == 0
+
+
 # ----------------------------------------------------------------------
 # Automation results
 # ----------------------------------------------------------------------
@@ -2424,6 +2435,18 @@ def test_count_unread_results_owner_none_spans_all_owners(tmp_path):
     db.update_result_review(rid, "read")
     assert db.count_unread_results(None) == 1
     assert db.count_unread_results("owner-b") == 1
+
+
+def test_count_unread_results_filters_by_definition_id_across_owners(tmp_path):
+    db = _mk_db(tmp_path)
+    db.create_automation_result("owner-a", "d1", "r1", "finding", "A", "S", "key-a")
+    db.create_automation_result("owner-b", "d1", "r2", "finding", "B", "S", "key-b")
+    db.create_automation_result("owner-a", "d2", "r3", "finding", "C", "S", "key-c")
+
+    assert db.count_unread_results(None, definition_id="d1") == 2
+    assert db.count_unread_results(None, definition_id="d2") == 1
+    assert db.count_unread_results("owner-a", definition_id="d1") == 1
+    assert db.count_unread_results(None, definition_id="unknown-definition") == 0
 
 
 def test_list_automation_results_orders_mixed_offset_timestamps_correctly(tmp_path):

--- a/Tests/UI/schedules_test_helpers.py
+++ b/Tests/UI/schedules_test_helpers.py
@@ -32,6 +32,7 @@ class MockSchedulingDB:
         conflicts: list | None = None,
         automation_definitions: list[dict] | None = None,
         automation_results: list[dict] | None = None,
+        automation_runs: list[dict] | None = None,
     ) -> None:
         self._sync_state = sync_state or {}
         self._conflicts = conflicts or []
@@ -45,6 +46,11 @@ class MockSchedulingDB:
         #: EVERY existing SchedulesWorkbench test built on this fake needs
         #: these even when a test never touches the Results tab.
         self._automation_results = list(automation_results or [])
+        #: schedules-redesign PR-1, Task 4: `automation_runs` rows this DB
+        #: "contains" -- the definitions detail pane's "Last run"/"Run
+        #: count" rows read these (`count_automation_runs`/
+        #: `list_automation_runs`).
+        self._automation_runs = list(automation_runs or [])
 
     def get_sync_state(self, owner_id: str):
         return dict(self._sync_state)
@@ -110,25 +116,68 @@ class MockSchedulingDB:
         return rows[offset : offset + limit]
 
     def count_automation_results(
-        self, owner_id: str | None, review_state: str | None = None
+        self,
+        owner_id: str | None,
+        review_state: str | None = None,
+        definition_id: str | None = None,
     ) -> int:
         """Stub: mirrors the real `count_automation_results` -- the "of N"
         denominator for the capped inbox listing. `_refresh_results_tab`
         calls it unconditionally, so every workbench test built on this
-        fake needs it even when it never opens the Results tab."""
+        fake needs it even when it never opens the Results tab.
+
+        `definition_id` (Task 2 seam) added for the definitions detail
+        pane's per-definition unread-count row (schedules-redesign PR-1,
+        Task 4) -- matched exactly as given, same as the real DB."""
         return len(
             [
                 row
                 for row in self._automation_results
                 if (review_state is None or row.get("review_state") == review_state)
                 and (owner_id is None or row.get("owner_id") == owner_id)
+                and (definition_id is None or row.get("definition_id") == definition_id)
             ]
         )
 
-    def count_unread_results(self, owner_id: str | None) -> int:
+    def count_unread_results(
+        self, owner_id: str | None, definition_id: str | None = None
+    ) -> int:
         """Stub: mirrors the real `count_unread_results` (Results tab
-        badge, schedules-handoff PR-6 task 3)."""
-        return self.count_automation_results(owner_id, review_state="unread")
+        badge, schedules-handoff PR-6 task 3; `definition_id` filter added
+        Task 2/used by Task 4's detail pane)."""
+        return self.count_automation_results(
+            owner_id, review_state="unread", definition_id=definition_id
+        )
+
+    def list_automation_runs(
+        self,
+        owner_id: str,
+        definition_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict]:
+        """Stub: mirrors the real `list_automation_runs` (schedules-
+        redesign PR-1, Task 4's "Last run" row), newest first by
+        `created_at`."""
+        rows = [
+            dict(row)
+            for row in self._automation_runs
+            if row.get("owner_id") == owner_id
+            and (definition_id is None or row.get("definition_id") == definition_id)
+        ]
+        rows.sort(key=lambda row: row.get("created_at") or "", reverse=True)
+        return rows[offset : offset + limit]
+
+    def count_automation_runs(self, definition_id: str) -> int:
+        """Stub: mirrors the real `count_automation_runs` (schedules-
+        redesign PR-1, Task 4's "Run count" row)."""
+        return len(
+            [
+                row
+                for row in self._automation_runs
+                if row.get("definition_id") == definition_id
+            ]
+        )
 
     def upsert_automation_definitions_from_server(self, owner_id: str, items: list[dict]):
         inserted = 0

--- a/Tests/UI/schedules_test_helpers.py
+++ b/Tests/UI/schedules_test_helpers.py
@@ -168,14 +168,18 @@ class MockSchedulingDB:
         rows.sort(key=lambda row: row.get("created_at") or "", reverse=True)
         return rows[offset : offset + limit]
 
-    def count_automation_runs(self, definition_id: str) -> int:
+    def count_automation_runs(
+        self, definition_id: str, owner_id: str | None = None
+    ) -> int:
         """Stub: mirrors the real `count_automation_runs` (schedules-
-        redesign PR-1, Task 4's "Run count" row)."""
+        redesign PR-1, Task 4's "Run count" row), including the optional
+        owner scope the final review's F11 added."""
         return len(
             [
                 row
                 for row in self._automation_runs
                 if row.get("definition_id") == definition_id
+                and (owner_id is None or row.get("owner_id") == owner_id)
             ]
         )
 

--- a/Tests/UI/test_automation_definition_form.py
+++ b/Tests/UI/test_automation_definition_form.py
@@ -725,3 +725,53 @@ async def test_preview_renders_junk_occurrences_instead_of_crashing(local_servic
         assert "Valid." in str(
             screen.query_one("#automation-preview-text", Static).render()
         )
+
+
+@pytest.mark.asyncio
+async def test_edit_mode_prefills_a_server_shaped_cron_schedule(local_service):
+    """Final review F1 carry-forward: the wire's `schedule.expression`.
+
+    `_prefill_from_row` read `schedule["cron"]` only -- the key THIS
+    client's own writer emits. A definition authored on the server sends
+    `expression` instead, so editing a mirrored server-only definition
+    fell through to the form's one-time/blank default, and saving would
+    then write that default OVER the server's real schedule. That is a
+    silent overwrite, not a cosmetic gap, which is why it rides this PR.
+
+    Fed the repo's own RECORDED server payload rather than a hand-written
+    dict -- client-shaped fixtures are exactly what hid this.
+    """
+    import json
+    from pathlib import Path
+
+    row = json.loads(
+        (
+            Path(__file__).resolve().parents[1]
+            / "Scheduling/fixtures/server_responses/automation_definition_list.json"
+        ).read_text()
+    )["items"][0]
+    # Assert the PREMISE: if the recorded payload ever grows a `cron` key,
+    # this test silently stops testing what it claims to.
+    assert row["schedule"] == {
+        "kind": "cron",
+        "expression": "0 9 * * 1-5",
+        "timezone": "UTC",
+    }
+    assert "cron" not in row["schedule"]
+
+    app = _FormHost(
+        local_service,
+        definition_row=row,
+        definition_id=row["id"],
+        available_owners=[("This device", "local")],
+        default_owner="local",
+    )
+    async with app.run_test(size=(120, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen
+
+        assert (
+            screen.query_one("#automation-schedule-kind", Select).value == "recurring"
+        ), "a server-shaped cron schedule must not land on the one-time default"
+        assert screen.query_one("#automation-cron", Input).value == "0 9 * * 1-5"
+        assert screen.query_one("#automation-timezone", Select).value == "UTC"

--- a/Tests/UI/test_detail_value_row.py
+++ b/Tests/UI/test_detail_value_row.py
@@ -35,17 +35,33 @@ def _painted_color(app: App, widget) -> object:
     raise AssertionError(f"no painted glyphs inside {widget.region!r}")
 
 
+def _relative_luminance(color) -> float:
+    """WCAG relative luminance of a compositor-painted colour (0=black,
+    1=white) -- same formula as `Tests/UI/test_model_artifact_widgets.py`'s
+    contrast helper. Lower means visually dimmer."""
+    triplet = color.get_truecolor()
+
+    def channel(value: int) -> float:
+        srgb = value / 255
+        return srgb / 12.92 if srgb <= 0.04045 else ((srgb + 0.055) / 1.055) ** 2.4
+
+    return (
+        0.2126 * channel(triplet.red)
+        + 0.7152 * channel(triplet.green)
+        + 0.0722 * channel(triplet.blue)
+    )
+
+
 class _RowHarness(ConsolidatedCSSApp):
     """Hosts one or more rows directly, mirroring the standalone-component
     harness pattern in `test_console_inspector_section.py`.
 
     `CSS_PATH` adds the app bundle (not just the screen sheets
-    `ConsolidatedCSSApp` loads by default) because `DetailValueRow`'s own
-    `BUNDLED_CSS` references `$ds-*` design tokens, which are only defined
-    inside `tldw_cli_modular.tcss` (`css/core/_variables.tcss`, concatenated
-    in first) -- Textual pools `$variable` definitions across every source
-    feeding one `Stylesheet`, so the token source and its usage must share
-    a harness. `ConsolidatedCSSApp.__init__` re-merges the screen sheets
+    `ConsolidatedCSSApp` loads by default) because `DetailValueRow`'s
+    styling lives in `css/features/_scheduling.tcss`, which is only part of
+    the app bundle (`tldw_cli_modular.tcss`, via `build_css.py`'s
+    `CSS_MODULES`) -- not the two screen sheets `ConsolidatedCSSApp` loads
+    on its own. `ConsolidatedCSSApp.__init__` re-merges the screen sheets
     around whatever `CSS_PATH` a subclass supplies.
     """
 
@@ -60,7 +76,8 @@ class _RowHarness(ConsolidatedCSSApp):
 
 
 class _GroupHarness(ConsolidatedCSSApp):
-    """See `_RowHarness` -- `DetailGroup`'s `BUNDLED_CSS` also uses `$ds-*`."""
+    """See `_RowHarness` -- `DetailGroup`'s styling lives in the same
+    `_scheduling.tcss` block."""
 
     CSS_PATH = str(BUNDLED_STYLESHEET)
 
@@ -97,9 +114,12 @@ async def test_affordance_glyph_is_painted_and_dimmer_than_the_value():
         affordance = with_affordance.query_one(".detail-value-row-affordance")
         value = with_affordance.query_one(".detail-value-row-value")
         assert affordance.render_line(0).text.strip() == "▾"
-        assert _painted_color(app, affordance) != _painted_color(app, value), (
-            "affordance glyph must be visually dimmer than the value it sits "
-            "beside, not the same colour"
+        affordance_luminance = _relative_luminance(_painted_color(app, affordance))
+        value_luminance = _relative_luminance(_painted_color(app, value))
+        assert affordance_luminance < value_luminance, (
+            "affordance glyph must be visually dimmer (lower luminance) than "
+            f"the value it sits beside: affordance={affordance_luminance:.3f} "
+            f"value={value_luminance:.3f}"
         )
         assert len(without_affordance.query(".detail-value-row-affordance")) == 0
 

--- a/Tests/UI/test_detail_value_row.py
+++ b/Tests/UI/test_detail_value_row.py
@@ -121,7 +121,13 @@ async def test_affordance_glyph_is_painted_and_dimmer_than_the_value():
             f"the value it sits beside: affordance={affordance_luminance:.3f} "
             f"value={value_luminance:.3f}"
         )
-        assert len(without_affordance.query(".detail-value-row-affordance")) == 0
+        # The glyph is always MOUNTED (final review F13.1 made
+        # `affordance` a settable property, so PR-3 can flip a row
+        # without a remount) -- what a row without one must not do is
+        # PAINT it.
+        hidden = without_affordance.query_one(".detail-value-row-affordance")
+        assert hidden.region.width == 0
+        assert hidden.display is False
 
 
 @pytest.mark.asyncio
@@ -223,3 +229,50 @@ async def test_group_starts_collapsed_when_requested():
     async with app.run_test(size=(40, 10)):
         assert group.collapsed is True
         assert child.region.height == 0
+
+
+@pytest.mark.asyncio
+async def test_affordance_can_be_flipped_after_mount_without_a_remount():
+    """Final review F13.1: PR-3 flips a row between read-only and editable
+    per state, and both consumers hold hard refs to rows assigned inside
+    their own `compose()` -- rebuilding the row would mean a remount."""
+    row = DetailValueRow("Repeat", "Weekly", id="row")
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 6)) as pilot:
+        value = row.query_one(".detail-value-row-value")
+        glyph = row.query_one(".detail-value-row-affordance")
+        assert row.affordance is False
+        assert glyph.region.width == 0
+
+        row.affordance = True
+        await pilot.pause()
+        assert glyph.region.width > 0
+        assert glyph.render_line(0).text.strip() == "▾"
+        # Same mounted widgets throughout -- no recompose, so the painted
+        # value survives the flip.
+        assert row.query_one(".detail-value-row-value") is value
+        assert value.render_line(0).text.strip() == "Weekly"
+
+        row.affordance = False
+        await pilot.pause()
+        assert row.affordance is False
+        assert glyph.region.width == 0
+
+
+@pytest.mark.asyncio
+async def test_row_carries_its_own_identity_and_focusability():
+    """Final review F13.2/F13.3: PR-3 addresses the ROW (open its editor,
+    route its error) and spec §12 wants Up/Down row traversal -- neither
+    should need `static.parent.parent` or a subclass."""
+    plain = DetailValueRow("Repeat", "Weekly", id="plain")
+    keyed = DetailValueRow(
+        "Repeat", "Weekly", row_key="schedule.cron", can_focus=True, id="keyed"
+    )
+    app = _RowHarness(plain, keyed)
+    async with app.run_test(size=(40, 8)):
+        assert plain.row_key is None
+        assert plain.can_focus is False, "PR-1 rows stay read-only by default"
+        assert keyed.row_key == "schedule.cron"
+        assert keyed.can_focus is True
+        keyed.focus()
+        assert app.focused is keyed

--- a/Tests/UI/test_detail_value_row.py
+++ b/Tests/UI/test_detail_value_row.py
@@ -1,0 +1,205 @@
+"""Tests for `DetailValueRow` / `DetailGroup` (schedules-redesign PR-1, Task 1).
+
+Rendered (painted) output only, never a stored attribute the widget might
+ignore -- last program's lesson. Text content and single-line-ness come from
+`Widget.render_line(0)` (the exact Strip Textual paints for that row, after
+CSS text-align/text-overflow/wrap is applied); colour comes from the
+compositor's own painted segments (`app.screen._compositor.render_strips`),
+mirroring the precedent in `Tests/UI/test_model_artifact_widgets.py`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from rich.text import Text
+from textual.app import App, ComposeResult
+from textual.widgets._collapsible import CollapsibleTitle
+
+from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
+from tldw_chatbook.Widgets.detail_value_row import DetailGroup, DetailValueRow
+
+
+def _painted_color(app: App, widget) -> object:
+    """Return the foreground colour of the first non-blank glyph painted
+    inside `widget`'s own region, read from the compositor's own output."""
+    for y in range(widget.region.y, widget.region.bottom):
+        cursor = 0
+        for segment in app.screen._compositor.render_strips()[y]:
+            next_cursor = cursor + segment.cell_length
+            overlaps = cursor < widget.region.right and next_cursor > widget.region.x
+            if overlaps and segment.text.strip() and segment.style is not None:
+                color = segment.style.color
+                if color is not None:
+                    return color
+            cursor = next_cursor
+    raise AssertionError(f"no painted glyphs inside {widget.region!r}")
+
+
+class _RowHarness(ConsolidatedCSSApp):
+    """Hosts one or more rows directly, mirroring the standalone-component
+    harness pattern in `test_console_inspector_section.py`.
+
+    `CSS_PATH` adds the app bundle (not just the screen sheets
+    `ConsolidatedCSSApp` loads by default) because `DetailValueRow`'s own
+    `BUNDLED_CSS` references `$ds-*` design tokens, which are only defined
+    inside `tldw_cli_modular.tcss` (`css/core/_variables.tcss`, concatenated
+    in first) -- Textual pools `$variable` definitions across every source
+    feeding one `Stylesheet`, so the token source and its usage must share
+    a harness. `ConsolidatedCSSApp.__init__` re-merges the screen sheets
+    around whatever `CSS_PATH` a subclass supplies.
+    """
+
+    CSS_PATH = str(BUNDLED_STYLESHEET)
+
+    def __init__(self, *rows: DetailValueRow) -> None:
+        super().__init__()
+        self._rows = rows
+
+    def compose(self) -> ComposeResult:
+        yield from self._rows
+
+
+class _GroupHarness(ConsolidatedCSSApp):
+    """See `_RowHarness` -- `DetailGroup`'s `BUNDLED_CSS` also uses `$ds-*`."""
+
+    CSS_PATH = str(BUNDLED_STYLESHEET)
+
+    def __init__(self, group: DetailGroup) -> None:
+        super().__init__()
+        self._group = group
+
+    def compose(self) -> ComposeResult:
+        yield self._group
+
+
+@pytest.mark.asyncio
+async def test_label_and_value_are_painted_with_value_right_aligned():
+    row = DetailValueRow("Status", "Waiting", id="row")
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 5)):
+        label = row.query_one(".detail-value-row-label")
+        value = row.query_one(".detail-value-row-value")
+        assert label.render_line(0).text.strip() == "Status"
+        painted_value = value.render_line(0).text
+        # Right-aligned: the value's own glyphs sit flush against the
+        # right edge of its box, not the left (padded with spaces on the
+        # left instead of the right).
+        assert painted_value.rstrip() == painted_value
+        assert painted_value.strip() == "Waiting"
+
+
+@pytest.mark.asyncio
+async def test_affordance_glyph_is_painted_and_dimmer_than_the_value():
+    with_affordance = DetailValueRow("Repeat", "Weekly", affordance=True, id="a")
+    without_affordance = DetailValueRow("Repeat", "Weekly", id="b")
+    app = _RowHarness(with_affordance, without_affordance)
+    async with app.run_test(size=(40, 6)):
+        affordance = with_affordance.query_one(".detail-value-row-affordance")
+        value = with_affordance.query_one(".detail-value-row-value")
+        assert affordance.render_line(0).text.strip() == "▾"
+        assert _painted_color(app, affordance) != _painted_color(app, value), (
+            "affordance glyph must be visually dimmer than the value it sits "
+            "beside, not the same colour"
+        )
+        assert len(without_affordance.query(".detail-value-row-affordance")) == 0
+
+
+@pytest.mark.asyncio
+async def test_update_value_refreshes_the_same_widget_in_place():
+    row = DetailValueRow("Status", "Waiting", id="row")
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 5)) as pilot:
+        value = row.query_one(".detail-value-row-value")
+        row.update_value("Running")
+        await pilot.pause()
+        # Same mounted widget instance -- no recompose -- now painting the
+        # new text.
+        assert row.query_one(".detail-value-row-value") is value
+        assert value.render_line(0).text.strip() == "Running"
+
+
+@pytest.mark.asyncio
+async def test_error_slot_hidden_by_default_then_shown_and_cleared():
+    row = DetailValueRow("Schedule", "Every Monday", value_id="row-schedule")
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 6)) as pilot:
+        error = row.query_one("#row-schedule-error")
+        assert error.region.height == 0, "error slot must start painted-hidden"
+
+        row.show_error("Invalid cron expression")
+        await pilot.pause()
+        error = row.query_one("#row-schedule-error")
+        assert error.region.height > 0
+        assert "Invalid cron expression" in error.render_line(0).text
+
+        row.clear_error()
+        await pilot.pause()
+        error = row.query_one("#row-schedule-error")
+        assert error.region.height == 0, "clear_error must re-hide the slot"
+
+
+@pytest.mark.asyncio
+async def test_str_value_renders_literally_not_as_rich_markup():
+    row = DetailValueRow("Title", "[bold]Weekly sync[/bold]", id="row")
+    app = _RowHarness(row)
+    async with app.run_test(size=(50, 5)):
+        value = row.query_one(".detail-value-row-value")
+        painted = value.render_line(0).text.strip()
+        assert painted == "[bold]Weekly sync[/bold]", (
+            "a plain str value must never be interpreted as Rich markup -- "
+            f"got {painted!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_text_value_is_accepted_and_rendered():
+    row = DetailValueRow("Owner", Text("server", style="bold"), id="row")
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 5)):
+        value = row.query_one(".detail-value-row-value")
+        assert value.render_line(0).text.strip() == "server"
+
+
+@pytest.mark.asyncio
+async def test_long_value_ellipsizes_and_never_wraps_the_row():
+    long_value = "A" * 200
+    row = DetailValueRow("Title", long_value, id="row")
+    app = _RowHarness(row)
+    async with app.run_test(size=(30, 5)):
+        assert row.region.height == 1, "an overlong value must not wrap the row"
+        value = row.query_one(".detail-value-row-value")
+        painted = value.render_line(0).text
+        assert painted.strip().endswith("…"), (
+            f"expected an ellipsis marker, got {painted!r}"
+        )
+        assert long_value not in painted
+
+
+@pytest.mark.asyncio
+async def test_group_collapse_toggle_hides_and_reveals_the_row():
+    child = DetailValueRow("Status", "Waiting", id="child-row")
+    group = DetailGroup(child, title="Reminder", id="group")
+    app = _GroupHarness(group)
+    async with app.run_test(size=(40, 10)) as pilot:
+        assert group.collapsed is False
+        assert child.region.height > 0, "group starts open (collapsed=False)"
+
+        await pilot.click(CollapsibleTitle)
+        await pilot.pause()
+        assert group.collapsed is True
+        assert child.region.height == 0, "collapsing must hide the body row"
+
+        await pilot.click(CollapsibleTitle)
+        await pilot.pause()
+        assert group.collapsed is False
+        assert child.region.height > 0, "expanding again must repaint the row"
+
+
+@pytest.mark.asyncio
+async def test_group_starts_collapsed_when_requested():
+    child = DetailValueRow("Status", "Waiting", id="child-row")
+    group = DetailGroup(child, title="Reminder", collapsed=True, id="group")
+    app = _GroupHarness(group)
+    async with app.run_test(size=(40, 10)):
+        assert group.collapsed is True
+        assert child.region.height == 0

--- a/Tests/UI/test_schedules_automations_tab.py
+++ b/Tests/UI/test_schedules_automations_tab.py
@@ -922,6 +922,26 @@ async def test_definition_detail_renders_every_details_and_frequency_value():
 
 
 @pytest.mark.asyncio
+async def test_definition_detail_runs_on_shows_transfer_badge_when_in_flight():
+    """'Runs on' appends the existing in-flight transfer badge text to the
+    owner label -- same wording as the reminder detail pane's own suffix
+    (mirrors `test_schedules_workbench.py`'s
+    `test_task_detail_runs_on_shows_transfer_badge_when_in_flight`; fix
+    round 1 finding 1: this case had no dedicated test)."""
+    async with _BareDefinitionDetailApp().run_test() as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(
+            _frequency_definition(transfer_state="to_server_pending")
+        )
+        await pilot.pause()
+
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-runs-on")
+            == "This device (Moving to server\u2026)"
+        )
+
+
+@pytest.mark.asyncio
 async def test_definition_detail_renders_one_time_schedule_and_defaults():
     """A one-time schedule renders through the same rows; a definition
     with no `config`/`finding_policy` at all degrades to the create/edit

--- a/Tests/UI/test_schedules_automations_tab.py
+++ b/Tests/UI/test_schedules_automations_tab.py
@@ -7,13 +7,14 @@ round, this device's own local-owned `recurring_question` definitions
 instead -- never the server client, and never both).
 """
 
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from textual.widgets import DataTable, Input, Select, TabbedContent
+from textual.widgets import DataTable, Input, Select, Static, TabbedContent
 
-from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
 from Tests.UI.schedules_test_helpers import (
     MockSchedulingDB,
     MockSchedulingServiceMixin,
@@ -23,6 +24,7 @@ from Tests.UI.schedules_test_helpers import (
 from tldw_chatbook.Scheduling.services.server_client import (
     ServerClientValidationError,
 )
+from tldw_chatbook.UI.Screens.scheduling.definition_detail import DefinitionDetail
 from tldw_chatbook.UI.Screens.scheduling.forms.automation_definition_form import (
     AutomationDefinitionForm,
 )
@@ -104,10 +106,20 @@ class AutomationsServerClient:
 class AutomationsMockService(MockSchedulingServiceMixin):
     """Scheduling service whose server client knows automations."""
 
-    def __init__(self, server_client, local_definitions=None) -> None:
+    def __init__(
+        self,
+        server_client,
+        local_definitions=None,
+        automation_runs=None,
+        automation_results=None,
+    ) -> None:
         self.owner_id = "local"
         self.server_client = server_client
-        self.db = MockSchedulingDB(automation_definitions=local_definitions or [])
+        self.db = MockSchedulingDB(
+            automation_definitions=local_definitions or [],
+            automation_runs=automation_runs or [],
+            automation_results=automation_results or [],
+        )
         self.sync_engine = None
         # task-5 fix round: the PR-2 local run-now seam
         # (SchedulingService.run_automation_now) -- overridable per test.
@@ -809,3 +821,377 @@ async def test_edit_save_reports_updated_not_created():
         notifications = list(pilot.app._notifications)
         assert any(n.message == "Automation updated." for n in notifications)
         assert not any(n.message == "Automation created." for n in notifications)
+
+
+# --- Definitions detail pane (schedules-redesign PR-1, Task 4) ------------
+#
+# `DefinitionDetail.set_definition` is a pure paint method (no I/O), so
+# most field-value coverage lives in bare-widget unit tests that call it
+# directly -- same shape as `test_schedules_workbench.py`'s
+# `_BareTaskDetailApp`/`_frequency_reminder` precedent for Task 3's
+# `TaskDetail` regrammar. The remaining tests drive a real row highlight
+# through `SchedulesWorkbench` to prove the wiring end to end: both owner
+# labels, the Task 2 count seams, and the off-thread read discipline.
+
+
+class _BareDefinitionDetailApp(ConsolidatedCSSApp):
+    """Bare app mounting one `DefinitionDetail`, matching
+    `test_schedules_workbench.py`'s `_BareTaskDetailApp` pattern. `CSS_PATH`
+    is pinned to the app bundle so `DetailValueRow`/`DetailGroup`'s real
+    `css/features/_scheduling.tcss` styling resolves.
+    """
+
+    CSS_PATH = str(BUNDLED_STYLESHEET)
+
+    def compose(self):
+        yield DefinitionDetail()
+
+
+def _frequency_definition(**overrides) -> dict:
+    """A representative local `recurring_question` definition covering
+    every Details/Frequency row: a cron schedule, a non-UTC timezone, an
+    explicit source scope, and a non-default generation mode/finding
+    policy."""
+    row = {
+        "id": "def-freq",
+        "owner_id": "local",
+        "name": "Weekly digest",
+        "family": "recurring_question",
+        "lifecycle": "configured",
+        "health": "ready",
+        "input": {
+            "question": "What changed this week?",
+            "provider": "openai",
+            "model": "gpt-5",
+        },
+        "schedule": {
+            "kind": "cron",
+            "cron": "0 9 * * 1",
+            "timezone": "America/New_York",
+        },
+        "config": {
+            "scope": {"mode": "sources", "sources": ["media_db", "notes"]},
+            "generation_mode": "required",
+        },
+        "finding_policy": {"preset": "high_confidence_only"},
+    }
+    row.update(overrides)
+    return row
+
+
+def _detail_text(detail: DefinitionDetail, widget_id: str) -> str:
+    return detail.query_one(f"#{widget_id}", Static).render_line(0).text.strip()
+
+
+@pytest.mark.asyncio
+async def test_definition_detail_renders_every_details_and_frequency_value():
+    """Every Details/Frequency value paints through the grouped rows for a
+    representative recurring definition (task-4 brief AC)."""
+    async with _BareDefinitionDetailApp().run_test() as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_frequency_definition())
+        await pilot.pause()
+
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-question")
+            == "What changed this week?"
+        )
+        assert _detail_text(detail, "scheduling-automation-detail-runs-on") == "This device"
+        assert _detail_text(detail, "scheduling-automation-detail-model") == "openai/gpt-5"
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-generation")
+            == "Always generate a draft"
+        )
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-finding-policy")
+            == "High confidence only"
+        )
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-sources")
+            == "Media, Notes"
+        )
+        assert _detail_text(detail, "scheduling-automation-detail-repeat") == "Recurring"
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-at")
+            == "Weekly on Monday at 09:00 America/New_York"
+        )
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-timezone")
+            == "America/New_York"
+        )
+
+
+@pytest.mark.asyncio
+async def test_definition_detail_renders_one_time_schedule_and_defaults():
+    """A one-time schedule renders through the same rows; a definition
+    with no `config`/`finding_policy` at all degrades to the create/edit
+    form's own defaults rather than a blank or a crash."""
+    async with _BareDefinitionDetailApp().run_test() as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(
+            {
+                "id": "def-one-time",
+                "owner_id": "local",
+                "name": "One-off check",
+                "input": {"question": "Did the migration finish?"},
+                "schedule": {"kind": "one_time", "run_at": "2026-09-10T14:30:00+00:00"},
+            }
+        )
+        await pilot.pause()
+
+        assert _detail_text(detail, "scheduling-automation-detail-repeat") == "One-time"
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-at")
+            == "One-time at 2026-09-10 14:30 UTC"
+        )
+        assert _detail_text(detail, "scheduling-automation-detail-timezone") == "UTC"
+        assert _detail_text(detail, "scheduling-automation-detail-model") == "auto"
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-generation")
+            == "Only when something new is found"
+        )
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-finding-policy")
+            == "Balanced findings"
+        )
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-sources")
+            == "All searchable library"
+        )
+
+
+@pytest.mark.asyncio
+async def test_definition_detail_question_card_renders_brackets_literally():
+    """A bracket-bearing question must never be interpreted as Rich markup
+    (task-4 brief: escape discipline, bracket-bearing test required)."""
+    async with _BareDefinitionDetailApp().run_test() as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(
+            _frequency_definition(input={"question": "What's the [bold] status?"})
+        )
+        await pilot.pause()
+
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-question")
+            == "What's the [bold] status?"
+        )
+
+
+@pytest.mark.asyncio
+async def test_definition_detail_shows_counts_and_last_run_outcome():
+    """Run count / unread-results count / last-run outcome paint from the
+    Task 2 seams, and the History group starts collapsed."""
+    async with _BareDefinitionDetailApp().run_test() as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(
+            _frequency_definition(),
+            run_count=2,
+            last_run={
+                "status": "failed",
+                "started_at": "2026-08-20T09:00:00+00:00",
+                "ended_at": "2026-08-20T09:00:05+00:00",
+            },
+            unread_count=3,
+        )
+        await pilot.pause()
+
+        history_group = detail.query_one("#scheduling-automation-detail-group-history")
+        assert history_group.collapsed is True
+        history_group.collapsed = False
+        await pilot.pause()
+
+        assert _detail_text(detail, "scheduling-automation-detail-run-count") == "2"
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-unread-results") == "3"
+        )
+        last_run_text = _detail_text(detail, "scheduling-automation-detail-last-run")
+        assert "failed" in last_run_text
+        assert "2026-08-20 09:00" in last_run_text
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-view-results")
+            == "See Results tab"
+        )
+
+
+@pytest.mark.asyncio
+async def test_definition_detail_clears_to_empty_state_for_none():
+    async with _BareDefinitionDetailApp().run_test() as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_frequency_definition())
+        await pilot.pause()
+        body = detail.query_one("#scheduling-automation-detail-body")
+        assert body.display is True
+
+        detail.set_definition(None)
+        await pilot.pause()
+        assert body.display is False
+        empty_state = detail.query_one(
+            "#scheduling-automation-detail-empty-state", Static
+        )
+        assert empty_state.display is True
+
+
+@pytest.mark.asyncio
+async def test_selecting_a_local_definition_paints_its_details_and_counts():
+    """Integration path: a real row highlight through `SchedulesWorkbench`
+    feeds the detail pane, off-thread reads included (task-4 brief AC)."""
+    server_client = AutomationsServerClient()
+    definition = _frequency_definition(id="local-def-freq")
+    app = AutomationsTestApp(
+        AutomationsMockService(
+            server_client,
+            local_definitions=[definition],
+            automation_runs=[
+                {
+                    "id": "run-1",
+                    "owner_id": "local",
+                    "definition_id": "local-def-freq",
+                    "status": "succeeded",
+                    "created_at": "2026-08-20T09:00:00+00:00",
+                    "ended_at": "2026-08-20T09:00:05+00:00",
+                },
+                {
+                    "id": "run-2",
+                    "owner_id": "local",
+                    "definition_id": "local-def-freq",
+                    "status": "failed",
+                    "created_at": "2026-08-13T09:00:00+00:00",
+                    "ended_at": "2026-08-13T09:00:05+00:00",
+                },
+            ],
+            automation_results=[
+                {
+                    "id": "res-1",
+                    "owner_id": "local",
+                    "definition_id": "local-def-freq",
+                    "review_state": "unread",
+                    "created_at": "2026-08-20T09:00:10+00:00",
+                },
+            ],
+        )
+    )
+    # Wide terminal (task-4 fix round): an inactive `TabPane`'s content
+    # paints at a zero region -- `render_line(0)` legitimately blanks
+    # there (proven empty, not a stored-attribute false pass: `.content`
+    # still reads correctly, only the PAINT is absent -- see
+    # `test_detail_value_row.py`'s own painted-not-stored discipline), so
+    # this switches to the Automations tab before asserting, same as
+    # `test_run_now_on_automations_tab_dispatches_server_side` above.
+    async with app.run_test(size=(200, 50)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
+        tabs.active = "scheduling-automations-tab"
+        table = workbench.query_one("#scheduling-automations-table", DataTable)
+        detail = workbench.query_one("#scheduling-automation-detail", DefinitionDetail)
+
+        row_index = next(
+            i
+            for i, row in enumerate(workbench._automations)
+            if row["id"] == "local-def-freq"
+        )
+        table.cursor_coordinate = (row_index, 0)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert _detail_text(detail, "scheduling-automation-detail-runs-on") == "This device"
+        assert _detail_text(detail, "scheduling-automation-detail-model") == "openai/gpt-5"
+
+        # History starts collapsed (spec §5) -- its rows paint at zero
+        # region until expanded, same discipline Task 3's own
+        # `last_fire_row` assertion required.
+        history_group = detail.query_one("#scheduling-automation-detail-group-history")
+        history_group.collapsed = False
+        await pilot.pause()
+        assert _detail_text(detail, "scheduling-automation-detail-run-count") == "2"
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-unread-results") == "1"
+        )
+        assert "succeeded" in _detail_text(detail, "scheduling-automation-detail-last-run")
+
+
+@pytest.mark.asyncio
+async def test_selecting_a_server_definition_shows_its_server_owner_label():
+    """A server-mirrored row's 'Runs on' shows the SERVER's owner label
+    (task-4 brief AC), and never claims local run history it cannot have
+    (`automation_runs` is local-only)."""
+    server_client = AutomationsServerClient()
+    server_client.list_automation_definitions = AsyncMock(
+        return_value={
+            "items": [
+                {
+                    "id": "def-server-freq",
+                    "owner_id": "1",
+                    "name": "Server digest",
+                    "family": "recurring_question",
+                    "lifecycle": "configured",
+                    "health": "ready",
+                    "input": {
+                        "question": "What shipped?",
+                        "provider": "anthropic",
+                        "model": "claude",
+                    },
+                    "schedule": {"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+                    "config": {"scope": {"mode": "all_searchable_library"}},
+                },
+            ],
+            "total": 1,
+        }
+    )
+    app = AutomationsTestApp(AutomationsMockService(server_client))
+    # Wide terminal + active tab -- see the local-definition test above.
+    async with app.run_test(size=(200, 50)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
+        tabs.active = "scheduling-automations-tab"
+        table = workbench.query_one("#scheduling-automations-table", DataTable)
+        detail = workbench.query_one("#scheduling-automation-detail", DefinitionDetail)
+
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert _detail_text(detail, "scheduling-automation-detail-runs-on") == "server-1"
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-model")
+            == "anthropic/claude"
+        )
+
+        # History starts collapsed -- expand before reading its rows.
+        history_group = detail.query_one("#scheduling-automation-detail-group-history")
+        history_group.collapsed = False
+        await pilot.pause()
+        assert _detail_text(detail, "scheduling-automation-detail-run-count") == "0"
+
+
+@pytest.mark.asyncio
+async def test_definition_detail_counts_are_read_off_the_event_loop():
+    """schedules-redesign PR-1, task-4 AC: the pane's DB reads go through
+    `asyncio.to_thread`, the same discipline `_load_local_automations`
+    already uses for a `service.db.*` call made from inside a worker
+    coroutine.
+
+    `DataTable` auto-highlights row 0 the moment rows land under its
+    default (0, 0) cursor, so the FIRST detail load happens during the
+    initial mount/`load_automations()` pass -- the patch must wrap that
+    pass, not a later re-assignment of the same coordinate (which is a
+    no-op: `_on_automations_row_highlighted` skips an unchanged id).
+    """
+    server_client = AutomationsServerClient()
+    definition = _frequency_definition(id="local-def-freq")
+    app = AutomationsTestApp(
+        AutomationsMockService(server_client, local_definitions=[definition])
+    )
+    async with app.run_test() as pilot:
+        with patch(
+            "tldw_chatbook.UI.Screens.scheduling.schedules_workbench.asyncio.to_thread",
+            wraps=asyncio.to_thread,
+        ) as spy:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.pause()
+
+        spy.assert_awaited()

--- a/Tests/UI/test_schedules_automations_tab.py
+++ b/Tests/UI/test_schedules_automations_tab.py
@@ -874,6 +874,10 @@ def _frequency_definition(**overrides) -> dict:
             "generation_mode": "required",
         },
         "finding_policy": {"preset": "high_confidence_only"},
+        # This client's writer emits booleans from the form's one "Notify
+        # me about results" checkbox; the server sends per-outcome channel
+        # strings instead (see the fixture-shaped test below).
+        "notification_policy": {"on_success": True, "on_failure": True},
     }
     row.update(overrides)
     return row
@@ -919,6 +923,10 @@ async def test_definition_detail_renders_every_details_and_frequency_value():
             _detail_text(detail, "scheduling-automation-detail-timezone")
             == "America/New_York"
         )
+        # Final review F8: spec §5 gives BOTH columns this Frequency row.
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-notifications") == "On"
+        )
 
 
 @pytest.mark.asyncio
@@ -942,10 +950,11 @@ async def test_definition_detail_runs_on_shows_transfer_badge_when_in_flight():
 
 
 @pytest.mark.asyncio
-async def test_definition_detail_renders_one_time_schedule_and_defaults():
+async def test_definition_detail_renders_one_time_schedule_and_absent_keys():
     """A one-time schedule renders through the same rows; a definition
-    with no `config`/`finding_policy` at all degrades to the create/edit
-    form's own defaults rather than a blank or a crash."""
+    with no `config`/`finding_policy`/`notification_policy` at all says
+    so rather than blanking, crashing, or (final review F2) presenting
+    the create/edit form's DEFAULTS as if they were readings."""
     async with _BareDefinitionDetailApp().run_test() as pilot:
         detail = pilot.app.query_one(DefinitionDetail)
         detail.set_definition(
@@ -967,16 +976,16 @@ async def test_definition_detail_renders_one_time_schedule_and_defaults():
         assert _detail_text(detail, "scheduling-automation-detail-timezone") == "UTC"
         assert _detail_text(detail, "scheduling-automation-detail-model") == "auto"
         assert (
-            _detail_text(detail, "scheduling-automation-detail-generation")
-            == "Only when something new is found"
+            _detail_text(detail, "scheduling-automation-detail-generation") == "Not set"
         )
         assert (
             _detail_text(detail, "scheduling-automation-detail-finding-policy")
-            == "Balanced findings"
+            == "Not set"
         )
+        assert _detail_text(detail, "scheduling-automation-detail-sources") == "Not set"
         assert (
-            _detail_text(detail, "scheduling-automation-detail-sources")
-            == "All searchable library"
+            _detail_text(detail, "scheduling-automation-detail-notifications")
+            == "Not set"
         )
 
 
@@ -1152,7 +1161,16 @@ async def test_selecting_a_server_definition_shows_its_server_owner_label():
                         "provider": "anthropic",
                         "model": "claude",
                     },
-                    "schedule": {"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+                    # WIRE shape: the real server sends `expression`, not
+                    # `cron` (final review F1, recorded fixture
+                    # `automation_definition_list.json`). Do not "fix"
+                    # this to the client's own key -- that drift is what
+                    # let `At: -` ship for every server definition.
+                    "schedule": {
+                        "kind": "cron",
+                        "expression": "0 9 * * 1",
+                        "timezone": "UTC",
+                    },
                     "config": {"scope": {"mode": "all_searchable_library"}},
                 },
             ],
@@ -1179,12 +1197,28 @@ async def test_selecting_a_server_definition_shows_its_server_owner_label():
             _detail_text(detail, "scheduling-automation-detail-model")
             == "anthropic/claude"
         )
+        # Final review F1: the wire's `expression` key reaches the At row.
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-at")
+            == "Weekly on Monday at 09:00 UTC"
+        )
 
         # History starts collapsed -- expand before reading its rows.
         history_group = detail.query_one("#scheduling-automation-detail-group-history")
         history_group.collapsed = False
         await pilot.pause()
-        assert _detail_text(detail, "scheduling-automation-detail-run-count") == "0"
+        # Final review F3: `automation_runs` is local-only, so a server
+        # row has no local counts to report -- and "Never run"/"0" here
+        # contradicted the run-history pane beside it, which was listing
+        # that same definition's server audit trail.
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-run-count")
+            == "Kept on the server"
+        )
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-last-run")
+            == "Kept on the server — see Run history"
+        )
 
 
 @pytest.mark.asyncio
@@ -1215,3 +1249,278 @@ async def test_definition_detail_counts_are_read_off_the_event_loop():
             await pilot.pause()
 
         spy.assert_awaited()
+
+
+def _recorded_server_definition() -> dict:
+    """Item 0 of this repo's own RECORDED real-server definition list,
+    scoped the way `_load_server_automations` scopes it (`owner_id`
+    stamped from the connection, everything else passed through raw).
+
+    Hand-written dicts are what hid final review F1/F2 for a whole task:
+    every branch test wrote the CLIENT's payload shape (`schedule.cron`,
+    a full `config`), so the pane looked correct against a payload the
+    server never sends.
+    """
+    import json
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "Scheduling/fixtures/server_responses/automation_definition_list.json"
+    )
+    definition = json.loads(path.read_text())["items"][0]
+    definition["owner_id"] = "server:server-1"
+    return definition
+
+
+@pytest.mark.asyncio
+async def test_definition_detail_reads_the_recorded_server_payload_honestly():
+    """Final review F1 + F2, against the recorded fixture rather than a
+    hand-written dict.
+
+    F1: the server sends `schedule.expression`; reading only `cron`
+    rendered `At: -` for EVERY server-owned definition.
+    F2: the server's `config` carries none of the create-form's keys, and
+    substituting that form's defaults presented a guess as a reading --
+    a definition actually configured `high_confidence_only` would have
+    rendered "Finding policy: Balanced findings".
+    """
+    definition = _recorded_server_definition()
+    # Guard the premise: if the recorded payload ever grows these keys,
+    # this test is no longer testing what it claims to.
+    assert definition["schedule"]["expression"] == "0 9 * * 1-5"
+    assert "cron" not in definition["schedule"]
+    assert "generation_mode" not in definition["config"]
+    assert "scope" not in definition["config"]
+    assert "finding_policy" not in definition
+
+    async with _BareDefinitionDetailApp().run_test() as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(definition)
+        await pilot.pause()
+
+        assert _detail_text(detail, "scheduling-automation-detail-repeat") == "Recurring"
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-at")
+            == "Weekdays at 09:00 UTC"
+        )
+        assert _detail_text(detail, "scheduling-automation-detail-timezone") == "UTC"
+        # The server's per-outcome channel strings, not this client's bools.
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-notifications")
+            == "silent on success · toast on failure"
+        )
+        for row_id in ("generation", "finding-policy", "sources"):
+            assert (
+                _detail_text(detail, f"scheduling-automation-detail-{row_id}")
+                == "Not set"
+            ), row_id
+
+
+@pytest.mark.asyncio
+async def test_definition_detail_history_is_owner_honest():
+    """Final review F3: local counts are the truth only for a LOCAL row.
+
+    `automation_runs` has one writer (local dispatch) and no server
+    mirror, so a server-owned definition's local counts are structurally
+    zero -- "Never run"/"0" was a claim, not a reading, and it sat beside
+    a run-history pane showing the server's real audit trail.
+    """
+    async with _BareDefinitionDetailApp().run_test() as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        # History starts collapsed (spec §5) and its rows paint at a zero
+        # region until expanded -- the same discipline every other History
+        # assertion in this file follows.
+        detail.query_one(
+            "#scheduling-automation-detail-group-history"
+        ).collapsed = False
+
+        detail.set_definition(_frequency_definition(), run_count=0, last_run=None)
+        await pilot.pause()
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-last-run") == "Never run"
+        )
+        assert _detail_text(detail, "scheduling-automation-detail-run-count") == "0"
+
+        detail.set_definition(
+            _frequency_definition(owner_id="server:server-1"),
+            run_count=0,
+            last_run=None,
+        )
+        await pilot.pause()
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-last-run")
+            == "Kept on the server — see Run history"
+        )
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-run-count")
+            == "Kept on the server"
+        )
+
+        # Authored offline against the server scope: the server has never
+        # heard of it, so it has no history there either.
+        detail.set_definition(
+            _frequency_definition(owner_id="server:server-1", pending_sync=True),
+            run_count=0,
+            last_run=None,
+        )
+        await pilot.pause()
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-last-run")
+            == "Not synced to the server yet"
+        )
+
+
+@pytest.mark.asyncio
+async def test_definition_detail_says_so_when_the_history_read_failed():
+    """Final review F14: a failed count read must not be indistinguishable
+    from a genuinely empty history."""
+    async with _BareDefinitionDetailApp().run_test() as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.query_one(
+            "#scheduling-automation-detail-group-history"
+        ).collapsed = False
+        detail.set_definition(_frequency_definition(), history_error=True)
+        await pilot.pause()
+
+        for row_id in ("last-run", "run-count", "unread-results"):
+            assert (
+                _detail_text(detail, f"scheduling-automation-detail-{row_id}")
+                == "Couldn't load — see the log"
+            ), row_id
+
+
+@pytest.mark.asyncio
+async def test_a_failed_count_read_paints_the_error_not_zeros():
+    """Same as above, driven through `SchedulesWorkbench`'s own read path
+    (the `except` branch of `_load_automation_detail`)."""
+    server_client = AutomationsServerClient()
+    definition = _frequency_definition(id="local-def-freq")
+    service = AutomationsMockService(server_client, local_definitions=[definition])
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("sqlite is unhappy")
+
+    service.db.count_automation_runs = _boom
+    app = AutomationsTestApp(service)
+    async with app.run_test(size=(200, 50)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+            "scheduling-automations-tab"
+        )
+        detail = workbench.query_one("#scheduling-automation-detail", DefinitionDetail)
+        table = workbench.query_one("#scheduling-automations-table", DataTable)
+        row_index = next(
+            i
+            for i, row in enumerate(workbench._automations)
+            if row["id"] == "local-def-freq"
+        )
+        table.cursor_coordinate = (row_index, 0)
+        await pilot.pause()
+        await pilot.pause()
+
+        history_group = detail.query_one("#scheduling-automation-detail-group-history")
+        history_group.collapsed = False
+        await pilot.pause()
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-run-count")
+            == "Couldn't load — see the log"
+        )
+
+
+@pytest.mark.asyncio
+async def test_editing_the_selected_definition_refreshes_the_detail_pane():
+    """Final review F4: a table refresh that lands on the SAME row id must
+    still re-feed the detail pane -- the row's DATA may have changed.
+
+    The `RowHighlighted` handler early-returns on an unchanged id, so
+    after an edit-save the table cell updated while the pane beside it
+    kept painting the pre-edit model.
+    """
+    server_client = AutomationsServerClient()
+    definition = _frequency_definition(id="local-def-freq")
+    service = AutomationsMockService(server_client, local_definitions=[definition])
+    app = AutomationsTestApp(service)
+    async with app.run_test(size=(200, 50)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+            "scheduling-automations-tab"
+        )
+        detail = workbench.query_one("#scheduling-automation-detail", DefinitionDetail)
+        table = workbench.query_one("#scheduling-automations-table", DataTable)
+        row_index = next(
+            i
+            for i, row in enumerate(workbench._automations)
+            if row["id"] == "local-def-freq"
+        )
+        table.cursor_coordinate = (row_index, 0)
+        await pilot.pause()
+        await pilot.pause()
+        assert _detail_text(detail, "scheduling-automation-detail-model") == "openai/gpt-5"
+
+        # Edit-and-save shape: the stored row changes, the id does not.
+        service.db._automation_definitions[0]["input"] = {
+            "question": "What changed this week?",
+            "provider": "anthropic",
+            "model": "claude-x",
+        }
+        await workbench.load_automations()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-model")
+            == "anthropic/claude-x"
+        )
+
+
+@pytest.mark.asyncio
+async def test_automations_panes_stay_on_screen_across_the_detail_hide_boundary():
+    """Final review F5: three panes x min-width 30 could not fit the 84-89
+    band, and Textual's fr layout then laid the detail and history panes
+    out entirely off-screen (the split has `overflow: hidden`, so nothing
+    hinted at it).
+
+    84 is the width at which the detail pane is still shown -- the same
+    `hide_detail` threshold the Queue tab uses.
+    """
+
+    class _CssApp(AutomationsTestApp):
+        # The default harness does not load `_scheduling.tcss`, so
+        # geometry assertions there measure NOTHING (this exact trap made
+        # the reviewer's first probe read clean when it was not).
+        CSS_PATH = str(BUNDLED_STYLESHEET)
+
+    app = _CssApp(AutomationsMockService(AutomationsServerClient()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+            "scheduling-automations-tab"
+        )
+        await pilot.pause()
+
+        for width in (84, 90):
+            await pilot.resize_terminal(width, 40)
+            await pilot.pause()
+            await pilot.pause()
+            panes = [
+                workbench.query_one(f"#{pane_id}")
+                for pane_id in (
+                    "scheduling-automations-pane",
+                    "scheduling-automations-detail-pane",
+                    "scheduling-automation-history-pane",
+                )
+            ]
+            for pane in panes:
+                assert not pane.has_class("pane-hidden"), (width, pane.id)
+                assert pane.region.width > 0, (width, pane.id)
+                assert pane.region.right <= width, (
+                    f"W={width}: {pane.id} runs off-screen "
+                    f"(x={pane.region.x}, width={pane.region.width})"
+                )

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -9,9 +9,10 @@ import pytest
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
-from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
 from textual.containers import Horizontal
 from textual.widgets import Button, DataTable, Input, Select, Static
+from textual.widgets._collapsible import CollapsibleTitle
 
 from tldw_chatbook.Scheduling.events import (
     DeleteTaskRequested,
@@ -237,9 +238,7 @@ async def test_task_detail_renders_selected_task():
 
         detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
         title = detail.query_one("#scheduling-task-detail-title", Static)
-        kind = detail.query_one("#scheduling-task-detail-type", Static)
         status_badge = detail.query_one("#scheduling-task-status-badge", Static)
-        schedule = detail.query_one("#scheduling-task-detail-schedule", Static)
         next_run = detail.query_one("#scheduling-task-detail-next-run", Static)
         enable_button = detail.query_one("#scheduling-enable-task", Button)
         disable_button = detail.query_one("#scheduling-disable-task", Button)
@@ -247,14 +246,128 @@ async def test_task_detail_renders_selected_task():
         follow_button = detail.query_one("#schedules-follow-in-console", Button)
 
         assert "Test" in title.visual.plain
-        assert "One-time" in kind.visual.plain
         assert "Waiting" in status_badge.visual.plain
-        assert "One-time at" in schedule.visual.plain
         assert "UTC" in next_run.visual.plain
         assert enable_button.label.plain == "Enable"
         assert disable_button.label.plain == "Disable"
         assert delete_button.label.plain == "Delete"
         assert follow_button.label.plain == "Follow 'Test' in Console"
+
+        # schedules-redesign PR-1, task 3: the old combined Type/Schedule
+        # rows are hidden for a reminder now (they only remain visible for
+        # a `ScheduledTask` projection); the same "One-time"/"One-time at"
+        # facts render through the new Frequency group's Repeat/At rows
+        # instead -- painted-output assertions, not stored-attribute ones
+        # (last program's lesson), since a hidden widget's stored text
+        # would pass even if nothing were actually on screen.
+        legacy_fields = detail.query_one("#scheduling-task-detail-legacy-fields")
+        groups = detail.query_one("#scheduling-task-detail-groups")
+        assert legacy_fields.display is False
+        assert groups.display is True
+        repeat_value = detail.query_one("#scheduling-detail-repeat", Static)
+        at_value = detail.query_one("#scheduling-detail-at", Static)
+        assert "One-time" in repeat_value.render_line(0).text
+        assert "One-time at" in at_value.render_line(0).text
+
+
+class _BareTaskDetailApp(ConsolidatedCSSApp):
+    """Bare app mounting one `TaskDetail` (schedules-redesign PR-1, task 3),
+    matching `test_schedules_missed_notice.py`'s `_DetailHarnessApp`
+    pattern. `CSS_PATH` is pinned to the app bundle (not just the screen
+    sheets `ConsolidatedCSSApp` loads by default) so `DetailValueRow`/
+    `DetailGroup`'s real `css/features/_scheduling.tcss` styling resolves
+    -- Task 1's own harness precedent (`test_detail_value_row.py`).
+    """
+
+    CSS_PATH = str(BUNDLED_STYLESHEET)
+
+    def compose(self):
+        yield TaskDetail()
+
+
+def _frequency_reminder(**kwargs) -> ReminderTask:
+    """A representative recurring reminder covering every §5 Frequency/
+    Details/History value: weekly cadence, a non-UTC timezone, and a
+    recorded last dispatch."""
+    defaults = dict(
+        id="task-freq",
+        title="Weekly digest",
+        schedule_kind=ScheduleKind.RECURRING,
+        cron="0 9 * * 1",
+        timezone="America/New_York",
+        last_run_at=datetime(2026, 8, 24, 9, 0, tzinfo=timezone.utc),
+        last_status=TaskStatus.COMPLETED,
+    )
+    defaults.update(kwargs)
+    return ReminderTask(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_task_detail_groups_render_every_frequency_and_details_value():
+    """Every §5 reminder-column value paints through the new grouped rows
+    for a representative recurring reminder (task-3 brief AC)."""
+    async with _BareTaskDetailApp().run_test() as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(_frequency_reminder())
+        await pilot.pause()
+
+        def _text(widget_id: str) -> str:
+            return detail.query_one(f"#{widget_id}", Static).render_line(0).text.strip()
+
+        assert _text("scheduling-detail-runs-on") == "local"
+        assert _text("scheduling-detail-repeat") == "Recurring"
+        assert _text("scheduling-detail-at") == "Weekly on Monday at 09:00 America/New_York"
+        assert _text("scheduling-detail-timezone") == "America/New_York"
+        assert _text("scheduling-detail-notifications") == "Inbox + toast"
+
+        # The History group starts collapsed (spec §5); expand it to read
+        # the painted "Last fire" value.
+        history_group = detail.query_one("#scheduling-detail-group-history")
+        assert history_group.collapsed is True
+        history_group.collapsed = False
+        await pilot.pause()
+        assert _text("scheduling-detail-last-fire") == "2026-08-24 09:00 UTC — Completed"
+        assert _text("scheduling-detail-history-link") == "See below"
+
+
+@pytest.mark.asyncio
+async def test_task_detail_history_group_starts_collapsed_and_expands_on_click():
+    """The collapsed History group hides its rows; a real click on its
+    title expands it and repaints them (task-3 brief AC)."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(_frequency_reminder())
+        await pilot.pause()
+
+        history_group = detail.query_one("#scheduling-detail-group-history")
+        last_fire_row = detail.query_one("#scheduling-detail-last-fire", Static)
+        assert history_group.collapsed is True
+        assert last_fire_row.region.height == 0
+
+        await pilot.click(history_group.query_one(CollapsibleTitle))
+        await pilot.pause()
+        assert history_group.collapsed is False
+        assert last_fire_row.region.height > 0
+        assert "Completed" in last_fire_row.render_line(0).text
+
+        await pilot.click(history_group.query_one(CollapsibleTitle))
+        await pilot.pause()
+        assert history_group.collapsed is True
+        assert last_fire_row.region.height == 0
+
+
+@pytest.mark.asyncio
+async def test_task_detail_runs_on_shows_transfer_badge_when_in_flight():
+    """'Runs on' appends the existing in-flight transfer badge text to the
+    owner label, same wording as the queue row's transfer suffix
+    (task-3 brief: 'the existing badge text joins the value')."""
+    async with _BareTaskDetailApp().run_test() as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(_frequency_reminder(transfer_state="to_server_pending"))
+        await pilot.pause()
+
+        runs_on = detail.query_one("#scheduling-detail-runs-on", Static)
+        assert runs_on.render_line(0).text.strip() == "local (Moving to server…)"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -26,6 +26,9 @@ from tldw_chatbook.Scheduling.models import (
     TaskStatus,
 )
 from tldw_chatbook.UI.Screens.scheduling.conflicts_tab import ConflictsTab
+from tldw_chatbook.UI.Screens.scheduling.definition_detail import (
+    _definition_owner_label,
+)
 from tldw_chatbook.UI.Screens.scheduling.forms.reminder_form import ReminderForm
 from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import SchedulesWorkbench
 from tldw_chatbook.UI.Screens.scheduling.sync_status_widget import SyncStatusWidget
@@ -314,7 +317,10 @@ async def test_task_detail_groups_render_every_frequency_and_details_value():
         def _text(widget_id: str) -> str:
             return detail.query_one(f"#{widget_id}", Static).render_line(0).text.strip()
 
-        assert _text("scheduling-detail-runs-on") == "local"
+        # Final review F6/F7: the prose owner vocabulary, shared with the
+        # definitions pane (`owner_display_label`) -- not the raw metadata
+        # string this row used to render.
+        assert _text("scheduling-detail-runs-on") == "This device"
         assert _text("scheduling-detail-repeat") == "Recurring"
         assert _text("scheduling-detail-at") == "Weekly on Monday at 09:00 America/New_York"
         assert _text("scheduling-detail-timezone") == "America/New_York"
@@ -327,7 +333,7 @@ async def test_task_detail_groups_render_every_frequency_and_details_value():
         history_group.collapsed = False
         await pilot.pause()
         assert _text("scheduling-detail-last-fire") == "2026-08-24 09:00 UTC — Completed"
-        assert _text("scheduling-detail-history-link") == "See below"
+        assert _text("scheduling-detail-history-link") == "See list below"
 
 
 @pytest.mark.asyncio
@@ -367,7 +373,61 @@ async def test_task_detail_runs_on_shows_transfer_badge_when_in_flight():
         await pilot.pause()
 
         runs_on = detail.query_one("#scheduling-detail-runs-on", Static)
-        assert runs_on.render_line(0).text.strip() == "local (Moving to server…)"
+        assert (
+            runs_on.render_line(0).text.strip()
+            == "This device (Moving to server\u2026)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_task_detail_runs_on_speaks_the_definitions_pane_vocabulary():
+    """Final review F6/F7: one owner vocabulary across BOTH detail panes.
+
+    The reminder pane rendered the raw metadata string (`local`,
+    `server:1 / server <id>`) while the definitions pane rendered
+    `This device` / the bare server id -- two dialects for the flagship
+    row of the redesign, and the User Guide described only the second.
+    Both now go through `task_detail.owner_display_label`; this pins the
+    reminder side against the definitions side's own helper.
+    """
+    async with _BareTaskDetailApp().run_test() as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+
+        detail.set_task(
+            _frequency_reminder(owner_id="server:srv-9", server_id="remote-42")
+        )
+        await pilot.pause()
+        runs_on = detail.query_one("#scheduling-detail-runs-on", Static)
+        assert runs_on.render_line(0).text.strip() == "srv-9"
+        assert runs_on.render_line(0).text.strip() == _definition_owner_label(
+            {"owner_id": "server:srv-9"}
+        )
+
+        detail.set_task(_frequency_reminder(owner_id="local"))
+        await pilot.pause()
+        assert runs_on.render_line(0).text.strip() == _definition_owner_label(
+            {"owner_id": "local"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_task_detail_shows_the_reminder_body_card():
+    """Final review F10: spec §5 wants the body text in a card above the
+    groups (the definitions pane has had one all along); `ReminderTask.
+    body` was rendered nowhere. Brackets stay literal, and a body-less
+    reminder shows no empty card."""
+    async with _BareTaskDetailApp().run_test() as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(_frequency_reminder(body="Ship the [bold] digest"))
+        await pilot.pause()
+
+        card = detail.query_one("#scheduling-task-detail-body-card", Static)
+        assert card.display is True
+        assert card.render_line(0).text.strip() == "Ship the [bold] digest"
+
+        detail.set_task(_frequency_reminder(body=None))
+        await pilot.pause()
+        assert card.display is False
 
 
 @pytest.mark.asyncio

--- a/backlog/docs/spec-2026-09-02-schedules-screen-redesign.md
+++ b/backlog/docs/spec-2026-09-02-schedules-screen-redesign.md
@@ -1,0 +1,242 @@
+# Spec: Schedules screen redesign — unified list + inspector-style detail pane
+
+Status: Draft (user-approved design 2026-09-02; implementation queued
+behind the schedules-handoff program's PR-5/PR-6)
+Reference visuals: two ChatGPT scheduled-tasks screenshots (user-provided
+2026-09-02) — filter-chip rail + grouped key-value detail pane with
+in-place dropdown editing.
+
+## 1. Purpose
+
+Rebuild the Schedules workbench's layout to the reference design: one
+unified task list with filter chips on the left, and an inspector-style
+detail pane on the right whose grouped key-value rows are directly
+editable. The redesign absorbs the handoff program's surfaces (owner,
+transfer, results) instead of bolting them onto the old tab IA.
+
+## 2. Locked decisions (user-approved)
+
+1. **Editing = hybrid.** In-pane quick edits for single-value rows; the
+   modal survives for create, for multi-field surgery ("Edit in full…"),
+   and as the narrow-width fallback. Ships as an ADR-099 amendment (§10).
+2. **List = unified schedulables.** Reminders + `recurring_question`
+   definitions (+ `agent_task` later), both owners mixed. Briefing and
+   watchlist projections stay out. Conflicts, run history, and the
+   results inbox become secondary surfaces (§8).
+3. **Chips = clone + map.** `All · Active · Paused · Completed` exactly
+   as the reference; transfer states are row badges, never chips.
+4. **Owner row = dropdown + confirm.** "Runs on" renders like every
+   other row; picking the other owner runs the transfer refusal check,
+   then the PR-5 confirm dialog, then the in-flight badge.
+5. **Create ▾ = by task type.** "Reminder" / "Recurring question";
+   `agent_task` joins later disabled-with-reason.
+
+## 3. Chrome and information architecture
+
+The Queue / Automations / Conflicts tab bar is retired. The screen is a
+two-pane workbench:
+
+- **Rail (left, ~40%)**: chip row (`All Active Paused Completed`) +
+  `Create ▾`; search input; `✓ Mark all as read` (rendered only while
+  unread results exist); the unified list; a slim bottom status strip
+  carrying the sync-status widget (compacted), the owner-scope
+  indicator, and a conflicts badge chip ("2 conflicts") that opens the
+  existing conflicts view as an overlay.
+- **Detail pane (right)**: §5.
+
+Chip → row-set mapping:
+
+| Chip | Rows |
+|---|---|
+| All | Active + Paused (Completed rows excluded -- archived stays out of the default view) |
+| Active | armed rows: enabled reminders + `configured` definitions, **including** `to_server_pending`/`to_server_failed` (they still execute locally) |
+| Paused | disabled reminders + `paused` definitions |
+| Completed | fired one-time reminders + `archived` definitions |
+
+Finding resolution (`solved`) is a **results** property and never a chip
+— it lives in the History group and the results surface. Archived
+definitions become visible under Completed (a deliberate change from
+"archived mirrors hidden by default" — reachable now, but only via the
+Completed chip, so the default view stays uncluttered).
+
+**Verification item (spec-time unknown):** whether fired one-time
+reminders persist in a queryable state. If they are deleted/disabled
+without a distinguishable marker, the Completed chip covers definitions
+only and the copy says so; do not fabricate a fired-state column without
+a program decision.
+
+## 4. The unified list
+
+One row type serves both primitives:
+
+- Status glyph: `○` recurring · `▶` active one-shot/monitor · `⏸`
+  paused · `✓` completed.
+- Title; subtitle = schedule summary + `· Next run in 2h` (relative,
+  from `next_run_at`, both primitives carry it).
+- Owner suffix only when non-default: dim `⇅ server` on server-owned
+  rows.
+- Transfer badges exactly as PR-5 defines them ("Moving to server…",
+  "Waiting for server release", "Transfer failed — retry/cancel").
+- Unread-results dot, right-aligned (blue, the reference's affordance).
+- Sort: next-run ascending within Active; most-recent-first elsewhere.
+- Relative-time ticker: ONE 60-second timer refreshing visible rows
+  only, suspended while the screen is inactive (no per-second ticks —
+  performance-audit rule).
+- Search: in-memory filter over title + question/body of loaded rows
+  (bounded, human-authored counts; no pagination v1 — same ruling as
+  PR #2302's declined finding).
+
+**Data-layer implication (named task):** the list spans owners. The
+Automations side already merges local + server rows (PR-4); reminders'
+`list_tasks` is active-owner-scoped and needs a spans-owners listing
+seam. This also dissolves the "created for another owner, invisible
+after save" wart from PR #2302's Qodo round.
+
+## 5. Detail pane
+
+Header: status word in accent color ("Active"), title, top-right icon
+actions — pause/resume toggle, kebab, close. Kebab: Run now · Duplicate
+· View runs · View results · Edit in full… · Delete/Archive (§9 copy
+rule).
+
+Body: the prompt/question (reminders: body text) in a rounded card, then
+grouped key-value rows. Every row is the same widget —
+**`DetailValueRow`**: label left, value right, `▾` affordance;
+Enter/click opens an inline Select or the appropriate mini-editor;
+field-addressed errors render inline under the row. One new reusable
+widget + a group container is most of the reference look.
+
+Per-family row table (implementers do not improvise rows):
+
+| Group | Recurring question | Reminder |
+|---|---|---|
+| Details | Runs on · Model (pinned/"Provider default") · Generation (required/optional) · Finding policy · Sources (Media/Notes/Chats) | Runs on |
+| Frequency | Repeat · At · Timezone · Notifications | Repeat · At · Timezone · Notifications |
+| History (collapsed) | last run outcome · run count · link to run history · unread results inline w/ read/dismiss | last fire · link to history |
+
+Server-owned rows render the same table; rows whose value the server
+owns exclusively and we cannot push (none today — lifecycle, model,
+schedule, notifications all have push paths post-PR-5) would render
+read-only with a reason.
+
+## 6. Editing model (ADR-099 amendment)
+
+- In-pane quick edits cover single-value rows only. Each row commit goes
+  through the existing seams immediately — `save_definition(definition_id=…)`
+  (merge-on-edit choke point preserves unexposed fields) /
+  `update_reminder` — with the row flashing the saved value or showing
+  the field-addressed error inline. No debounce machinery: successive
+  offline edits already coalesce per-record in the mutation table.
+- Multi-field surgery (question text, scope rework, custom cron) and all
+  creation stay in the modals ("Edit in full…" from the kebab).
+- Narrow widths: Enter on a list row opens the modal as today. This IS
+  the two-code-path cost ADR-099 warned about, accepted deliberately:
+  the pane rows and the modal share the same facade seams and
+  validators, so the second path is thin. The amendment (§10) names
+  this.
+- **Server-owned pause/lifecycle needs a pull guard (named task):**
+  `upsert_automation_definitions_from_server` is server-wins on
+  everything except `transfer_state`, so an optimistic local pause with
+  a queued lifecycle mutation would flicker back on a pull that lands
+  before the replay. Extend the upsert with the PR-3 results pattern:
+  skip lifecycle fields when a pending lifecycle mutation exists for the
+  row. Small DB change, no migration.
+
+## 7. Owner row = the transfer machine
+
+`Runs on` is a dropdown. Choosing the other owner:
+
+1. `transfer_refusal` check — a refused target renders the refusal
+   reason as an inline error line under the row (Textual Selects cannot
+   disable individual options; do not try).
+2. Allowed → the PR-5 confirm dialog (warnings: imminent `run_at`,
+   non-transferring fields).
+3. Confirmed → `begin_transfer_*`; the row shows the in-flight badge
+   until conversion lands; Cancel lives on the badge per the §6.3 cancel
+   table. Badge state refreshes off the existing sync/mutation
+   reload-notify — no new event plumbing.
+
+## 8. Secondary surfaces
+
+- **Conflicts**: badge chip on the rail status strip → existing
+  conflicts view as overlay.
+- **Run history**: kebab + History-group link → existing run-history
+  surface.
+- **Results**: unread dots + Mark-all-read in the rail; per-result
+  read/dismiss inline in the History group; the PR-6 Results *tab* is
+  trimmed to its minimal honest version (§11) and later retired.
+- **Mark all as read** fans out one pending review mutation per
+  server-owned unread result (per-id replay; no bulk endpoint; bounded
+  by the newest-200 window). Stated so nobody "optimizes" it into a
+  local-only lie.
+
+## 9. Copy and honesty rules
+
+- Server-owned definitions get **Archive**, never Delete (the server
+  exposes no definition delete). Delete appears only where a true
+  delete path exists (local rows, reminder tombstones).
+- A `to_server_pending` row's detail says it still runs on this device
+  until the server accepts it (§6.1.1 copy, carried over from PR-5).
+- Every disabled control carries its reason (UX-073 idiom).
+
+## 10. ADRs
+
+- **New ADR (number ≥112, swept against origin/dev at merge time —
+  110/111 claimed 2026-09-02):** "Schedules unified workbench" — the
+  one-list IA, chip vocabulary, inspector-pane grammar, and the
+  retirement of the tab bar.
+- **ADR-099 amendment** (same PR): hybrid editing — in-pane single-value
+  rows + modal for create/full-edit/narrow fallback; names the accepted
+  two-path cost and the shared-seam rationale.
+- **Errata:** dev carries an ADR-099 filename collision
+  (`099-schedule-editor-shape.md` vs
+  `099-persistent-terminal-session-runtime-boundary.md`); this program
+  cites by FILENAME, and renumbering is deliberately left to the
+  in-flight `docs/lesson-adr-number-collisions` branch.
+
+## 11. Sequencing
+
+After the handoff program:
+
+- PR-5 (transfer machine) — in flight, unchanged.
+- PR-6 — results sync/notification halves unchanged; the Results tab
+  ships minimal-honest (table + read/dismiss + unread count). PR-6's
+  acceptance criteria are preserved under the trim: results visible and
+  reviewable, unread count surfaced, notification-triggered pull, live
+  E2E.
+- Then the redesign program, ~4 PRs:
+  1. `DetailValueRow` + detail-pane regrammar (read-only rows first,
+     per-family table, History group).
+  2. Unified list + chips + rail chrome + cross-owner reminder listing
+     seam + relative-time ticker.
+  3. In-pane editing + owner-row transfer + lifecycle pull-guard +
+     ADR-099 amendment + new ADR.
+  4. Responsive floor (pushed detail Screen — same widget class,
+     fresh instance, NOT reparenting), keyboard map, retire old tabs +
+     the trimmed Results tab, polish + live verification.
+
+## 12. Keyboard map (v1)
+
+`1-4` or `f` cycle chips · `/` search · `n` create · Enter open/edit ·
+`p` pause/resume · `m` move owner · `r` mark read · Esc back/close ·
+Up/Down traverse detail rows when the pane has focus. Footer-visible key
+hints extend ADR-099's parity requirement to the pane.
+
+## 13. Out of scope
+
+- `agent_task` rows beyond the disabled Create entry.
+- Briefing/watchlist projections in the list.
+- Bulk operations beyond Mark-all-read.
+- Any schema migration (none required; the lifecycle pull-guard is
+  code-only).
+
+## 14. Verification
+
+- Widget tests per component (`DetailValueRow` grammar incl. error
+  rendering; chip mapping; badge states).
+- The 80×24 floor: every operation reachable via pushed view or modal —
+  pinned by tests at both widths.
+- Live verification per lessons-live-verification at program end: drive
+  the real TUI (tmux recipe), including one real transfer via the owner
+  row against a real server.
+- UI PRs update `Docs/User_Guide/` schedules page per CLAUDE.md.

--- a/backlog/docs/spec-2026-09-02-schedules-screen-redesign.md
+++ b/backlog/docs/spec-2026-09-02-schedules-screen-redesign.md
@@ -181,18 +181,22 @@ read-only with a reason.
 
 ## 10. ADRs
 
-- **New ADR (number ≥112, swept against origin/dev at merge time —
-  110/111 claimed 2026-09-02):** "Schedules unified workbench" — the
+- **New ADR (number ≥113, swept against origin/dev at merge time —
+  110/111/112 claimed as of 2026-09-02):** "Schedules unified workbench" — the
   one-list IA, chip vocabulary, inspector-pane grammar, and the
   retirement of the tab bar.
 - **ADR-099 amendment** (same PR): hybrid editing — in-pane single-value
   rows + modal for create/full-edit/narrow fallback; names the accepted
   two-path cost and the shared-seam rationale.
-- **Errata:** dev carries an ADR-099 filename collision
+- **Errata:** dev carries ADR filename collisions on `099`
   (`099-schedule-editor-shape.md` vs
-  `099-persistent-terminal-session-runtime-boundary.md`); this program
-  cites by FILENAME, and renumbering is deliberately left to the
-  in-flight `docs/lesson-adr-number-collisions` branch.
+  `099-persistent-terminal-session-runtime-boundary.md`), and the same on
+  `098`, `102` and `104`; this program cites by FILENAME, and renumbering
+  is deliberately left to the in-flight `docs/lesson-adr-number-collisions`
+  branch. The "≥113" above was written as "≥112" until the final review
+  caught that `112-per-task-schedule-ownership-transfer.md` already
+  existed at this branch's own base — re-sweep the range at merge time
+  rather than trusting the number in this file.
 
 ## 11. Sequencing
 

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -2294,6 +2294,28 @@ class ScheduledTasksDB(BaseDB):
                 cursor.fetchall(), json_fields=self._AUTOMATION_RUN_JSON_FIELDS
             )
 
+    def count_automation_runs(self, definition_id: str) -> int:
+        """Count automation runs for one definition.
+
+        ``automation_runs`` is a local-only table (never synced from the
+        server), so unlike ``count_automation_results`` there is no
+        cross-id-space ambiguity here -- ``definition_id`` is always the
+        LOCAL definition id.
+
+        Args:
+            definition_id: The definition's local id.
+
+        Returns:
+            The number of ``automation_runs`` rows for that definition.
+        """
+        with closing(self._get_connection()) as conn:
+            cursor = conn.execute(
+                "SELECT COUNT(*) FROM automation_runs WHERE definition_id = ?",
+                (definition_id,),
+            )
+            row = cursor.fetchone()
+            return int(row[0]) if row else 0
+
     def reconcile_stale_automation_runs(self, older_than_seconds: float) -> int:
         """Mark queued/running runs older than the cutoff as interrupted.
 
@@ -2468,7 +2490,10 @@ class ScheduledTasksDB(BaseDB):
             )
 
     def count_automation_results(
-        self, owner_id: str | None, review_state: str | None = None
+        self,
+        owner_id: str | None,
+        review_state: str | None = None,
+        definition_id: str | None = None,
     ) -> int:
         """Count automation results matching ``list_automation_results``.
 
@@ -2480,6 +2505,17 @@ class ScheduledTasksDB(BaseDB):
             owner_id: Owner to scope to, or ``None`` for every owner.
             review_state: Optional ``review_state`` equality filter --
                 ``None`` counts every state.
+            definition_id: Optional ``definition_id`` equality filter,
+                matched exactly as given -- NOT translated across id
+                spaces. A result's ``definition_id`` is whatever id the
+                side that produced it used: a locally-created result
+                carries the LOCAL definition id, while a result mirrored
+                from the server carries the SERVER's id (see
+                ``UI/Screens/scheduling/results_tab.py``'s
+                ``index_definitions_by_id`` for how a caller resolves
+                which space a given definition row lives in). Pass the
+                id in whichever space applies to the rows you expect to
+                count; ``None`` counts every space.
 
         Returns:
             The number of matching ``automation_results`` rows.
@@ -2492,6 +2528,9 @@ class ScheduledTasksDB(BaseDB):
         if owner_id is not None:
             conditions.append("owner_id = ?")
             params.append(owner_id)
+        if definition_id is not None:
+            conditions.append("definition_id = ?")
+            params.append(definition_id)
         where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
         with closing(self._get_connection()) as conn:
             cursor = conn.execute(
@@ -2501,7 +2540,9 @@ class ScheduledTasksDB(BaseDB):
             row = cursor.fetchone()
             return int(row[0]) if row else 0
 
-    def count_unread_results(self, owner_id: str | None) -> int:
+    def count_unread_results(
+        self, owner_id: str | None, definition_id: str | None = None
+    ) -> int:
         """Count unread results (spec §4's inbox badge).
 
         ``owner_id=None`` counts across every owner, matching
@@ -2509,11 +2550,15 @@ class ScheduledTasksDB(BaseDB):
 
         Args:
             owner_id: Owner to scope to, or ``None`` for every owner.
+            definition_id: Optional ``definition_id`` equality filter --
+                see ``count_automation_results`` for the id-space caveat.
 
         Returns:
             The number of ``review_state='unread'`` rows.
         """
-        return self.count_automation_results(owner_id, review_state="unread")
+        return self.count_automation_results(
+            owner_id, review_state="unread", definition_id=definition_id
+        )
 
     def get_automation_result(self, result_id: str) -> Optional[dict[str, Any]]:
         """Fetch an automation result by local id.

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -2294,7 +2294,9 @@ class ScheduledTasksDB(BaseDB):
                 cursor.fetchall(), json_fields=self._AUTOMATION_RUN_JSON_FIELDS
             )
 
-    def count_automation_runs(self, definition_id: str) -> int:
+    def count_automation_runs(
+        self, definition_id: str, owner_id: Optional[str] = None
+    ) -> int:
         """Count automation runs for one definition.
 
         ``automation_runs`` is a local-only table (never synced from the
@@ -2302,16 +2304,33 @@ class ScheduledTasksDB(BaseDB):
         cross-id-space ambiguity here -- ``definition_id`` is always the
         LOCAL definition id.
 
+        ``owner_id`` scopes the count the way ``list_automation_runs``
+        already scopes its read (schedules-redesign PR-1 final review
+        F11): the detail pane shows both in one group, and
+        ``convert_row_to_server_mirror``'s "converted" path rewrites a
+        row's ``owner_id`` while keeping its local id -- so an unscoped
+        count beside a scoped last-run could contradict itself on screen
+        ("Run count: 3" next to "Last run: Never run"). The parameter is
+        optional because the existing callers count across owners.
+
         Args:
             definition_id: The definition's local id.
+            owner_id: Optional owner scope; ``None`` counts every owner's
+                runs for that definition.
 
         Returns:
             The number of ``automation_runs`` rows for that definition.
         """
+        conditions = ["definition_id = ?"]
+        params: list[Any] = [definition_id]
+        if owner_id is not None:
+            conditions.append("owner_id = ?")
+            params.append(owner_id)
         with closing(self._get_connection()) as conn:
             cursor = conn.execute(
-                "SELECT COUNT(*) FROM automation_runs WHERE definition_id = ?",
-                (definition_id,),
+                "SELECT COUNT(*) FROM automation_runs "
+                f"WHERE {' AND '.join(conditions)}",
+                params,
             )
             row = cursor.fetchone()
             return int(row[0]) if row else 0

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -404,7 +404,7 @@ class DefinitionDetail(Vertical):
     the DB-derived counts/last-run already fetched off the event loop.
     """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs: object) -> None:
         super().__init__(*args, **kwargs)
         self._question_static: Static | None = None
         self._runs_on_row: DetailValueRow | None = None
@@ -421,6 +421,11 @@ class DefinitionDetail(Vertical):
         self._unread_row: DetailValueRow | None = None
 
     def compose(self) -> ComposeResult:
+        """Compose the empty pane skeleton (populated by `set_definition`).
+
+        Returns:
+            The static children; value rows are mounted per definition.
+        """
         yield Static(
             "Definition Detail",
             id="scheduling-automation-detail-header",
@@ -530,6 +535,15 @@ class DefinitionDetail(Vertical):
         no I/O of its own. `history_error` says that fetch FAILED, so the
         History rows say so rather than painting a zero the read never
         proved (final review F14).
+
+        Args:
+            definition: The definition row dict, or ``None`` for the empty
+                state.
+            run_count: Pre-fetched local run count for the History group.
+            last_run: Pre-fetched most-recent local run row, if any.
+            unread_count: Pre-fetched unread-results count.
+            history_error: True when the history fetch failed -- the rows
+                render "couldn't load" copy instead of unproven zeros.
         """
         empty_state = self.query_one(
             "#scheduling-automation-detail-empty-state", Static

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -71,6 +71,7 @@ from .task_detail import (
     _TRANSFER_STATE_ROW_LABELS,
     _format_timezone,
     _humanize_cron,
+    definition_cron_expression,
     owner_display_label,
 )
 
@@ -311,20 +312,6 @@ def _definition_repeat_label(schedule: dict[str, Any]) -> str:
     return "-"
 
 
-def _definition_cron_expression(schedule: dict[str, Any]) -> Any:
-    """The cron string, under either key the two writers use.
-
-    Final review F1: this read `schedule["cron"]` only -- the key THIS
-    client's writer emits (`automation_definition_form.py`) -- so every
-    server-owned definition rendered `At: -`. The real server sends
-    `schedule.expression` (recorded fixture
-    `Tests/Scheduling/fixtures/server_responses/
-    automation_definition_list.json`), and `_load_server_automations`
-    passes the payload through raw, stamping only `owner_id`.
-    """
-    return schedule.get("cron") or schedule.get("expression")
-
-
 def _definition_at_label(schedule: dict[str, Any]) -> str:
     """'At' row value (Frequency group): the full schedule summary, reusing
     `_humanize_cron` for a cron-kind schedule -- the same formatter
@@ -335,7 +322,7 @@ def _definition_at_label(schedule: dict[str, Any]) -> str:
     kind = schedule.get("kind")
     if kind == "cron":
         return _humanize_cron(
-            _definition_cron_expression(schedule), schedule.get("timezone")
+            definition_cron_expression(schedule), schedule.get("timezone")
         )
     if kind == "one_time":
         run_at = schedule.get("run_at")

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -31,13 +31,18 @@ Values are drawn from BOTH the local `automation_definitions` table
 (client-authored, `schedule.cron`/`config.scope`/etc. per
 `automation_definition_form.py`'s own payload shape) and the server's raw
 list-response dicts (`_load_server_automations` never runs these through
-a JSON round-trip, so any camelCase/renamed field a live server used
-would need translating separately -- out of this task's scope, matching
-`AutomationDefinitionForm._prefill_from_row`'s own documented precedent
-of leaving an un-recognized schedule shape at its default rather than
-guessing). Every formatter here reads with `.get()`/`isinstance` guards
-and degrades to an honest placeholder instead of raising, the same
-defensive-read idiom `automation_execution_target_label` already used.
+a JSON round-trip, stamping only `owner_id`). The two shapes genuinely
+differ, and the final review proved the cost of assuming otherwise: the
+server sends `schedule.expression` where this client writes
+`schedule.cron`, so every server definition rendered `At: -`, and the
+config keys the server simply does not carry (`generation_mode`,
+`scope`, `finding_policy`) were being filled in from the CREATE FORM's
+defaults and presented as readings. Both are fixed: the cron read accepts
+either key, and an absent key renders "Not set". Every formatter here
+reads with `.get()`/`isinstance` guards and degrades to an honest
+placeholder instead of raising, the same defensive-read idiom
+`automation_execution_target_label` already used -- honest meaning "we
+have no value", never a plausible guess.
 
 Escape discipline: every `DetailValueRow` value is safe by construction
 (Task 1: the row's `Static` is built with `markup=False` and the value is
@@ -62,7 +67,35 @@ from .forms.automation_definition_form import (
     _GENERATION_MODE_OPTIONS,
     _SCOPE_SOURCE_CHECKBOXES,
 )
-from .task_detail import _TRANSFER_STATE_ROW_LABELS, _format_timezone, _humanize_cron
+from .task_detail import (
+    _TRANSFER_STATE_ROW_LABELS,
+    _format_timezone,
+    _humanize_cron,
+    owner_display_label,
+)
+
+#: Absent key -> honest placeholder (final review F2). A definition this
+#: client did not author carries none of the create-form's config keys,
+#: and substituting that form's DEFAULTS here presented a guess as a
+#: reading: a server definition configured `high_confidence_only`
+#: rendered "Finding policy: Balanced findings" in a read-only pane the
+#: user has no reason to distrust. Defaults belong to the create path.
+_NOT_SET = "Not set"
+
+#: History rows for a server-owned definition (final review F3).
+#: `automation_runs` is a local-only table with exactly one writer (local
+#: dispatch, `scheduler/handlers/automation_handler.py`), so its counts
+#: are structurally zero for a server row -- and "Never run"/"0" sat
+#: beside a run-history pane listing the server's real audit trail.
+#: Mirrors `_load_automation_history`'s own honest local-gap copy.
+_SERVER_LAST_RUN = "Kept on the server — see Run history"
+_SERVER_RUN_COUNT = "Kept on the server"
+_PENDING_SYNC_HISTORY = "Not synced to the server yet"
+
+#: History rows after a failed count read (final review F14): a DB error
+#: must not be indistinguishable from a genuinely empty history. Same
+#: wording shape as `_load_automation_history`'s read-failure notice.
+_HISTORY_READ_FAILED = "Couldn't load — see the log"
 
 #: value -> label reverse lookups, reusing the SAME vocabulary the
 #: create/edit form already presents (`automation_definition_form.py`)
@@ -125,14 +158,13 @@ def _definition_owner_label(definition: dict[str, Any]) -> str:
     `automation_name_cell` wraps into its Name-cell prefix, factored out
     here so the detail pane's "Runs on" row and the table cell can never
     drift apart.
-    """
-    from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
 
-    owner_id = str(definition.get("owner_id") or "local")
-    if not is_server_scoped_owner(owner_id):
-        return "This device"
-    label = owner_id.split(":", 1)[1] if ":" in owner_id else owner_id
-    if definition.get("pending_sync"):
+    The owner half is `task_detail.owner_display_label`, shared with the
+    reminder pane's own "Runs on" row (final review F6/F7); only the
+    definition-dict read and the pending-sync suffix live here.
+    """
+    label = owner_display_label(definition.get("owner_id") or "local")
+    if definition.get("pending_sync") and label != "This device":
         label = f"{label} · pending sync"
     return label
 
@@ -191,10 +223,13 @@ def _definition_question_text(definition: dict[str, Any]) -> str:
 
 def _definition_generation_label(config: dict[str, Any]) -> str:
     """'Generation' row value (Details group): `config.generation_mode`,
-    labeled with the same wording the create/edit form's Select uses.
-    Defaults to "optional" (the form's own default) when absent."""
+    labeled with the same wording the create/edit form's Select uses;
+    `"Not set"` when the payload carries no `generation_mode` at all
+    (final review F2 -- this used to substitute the form's own default)."""
     mode = config.get("generation_mode") if isinstance(config, dict) else None
-    mode = str(mode) if mode else "optional"
+    if not mode:
+        return _NOT_SET
+    mode = str(mode)
     return _GENERATION_MODE_LABELS.get(mode, mode)
 
 
@@ -202,27 +237,55 @@ def _definition_finding_policy_label(definition: dict[str, Any]) -> str:
     """'Finding policy' row value (Details group): the top-level
     `finding_policy.preset` column (survey §4's authoritative source --
     distinct from the create/edit payload's `config.finding_policy`,
-    which the service copies into this column at save time). Defaults to
-    "balanced_findings" (the `AutomationDefinition` model's own default)
-    when absent."""
+    which the service copies into this column at save time); `"Not set"`
+    when absent (final review F2)."""
     finding_policy = definition.get("finding_policy")
-    preset = (
-        finding_policy.get("preset") if isinstance(finding_policy, dict) else None
-    ) or "balanced_findings"
+    preset = finding_policy.get("preset") if isinstance(finding_policy, dict) else None
+    if not preset:
+        return _NOT_SET
     return _FINDING_POLICY_LABELS.get(preset, str(preset))
 
 
 def _definition_sources_label(config: dict[str, Any]) -> str:
     """'Sources' row value (Details group): `config.scope`, joined plurals
     for an explicit source list, or the all-library sentence for the
-    default scope mode."""
+    default scope mode; `"Not set"` when the payload carries no `scope`
+    at all (final review F2 -- a server definition's config has no
+    `scope`, and claiming "All searchable library" for it was a guess)."""
     scope = config.get("scope") if isinstance(config, dict) else None
-    scope = scope if isinstance(scope, dict) else {}
+    if not isinstance(scope, dict) or not scope:
+        return _NOT_SET
     if scope.get("mode") != "sources":
         return "All searchable library"
     sources = scope.get("sources") or []
     labels = [_SCOPE_SOURCE_LABELS.get(str(item), str(item)) for item in sources]
     return ", ".join(labels) if labels else "None selected"
+
+
+def _definition_notifications_label(definition: dict[str, Any]) -> str:
+    """'Notifications' row value (Frequency group), spec §5's fourth
+    Frequency row -- missing until final review F8.
+
+    Reads `notification_policy`, which arrives in two shapes: this
+    client's writer emits booleans from the form's one "Notify me about
+    results" checkbox (`automation_definition_form.py`), while the real
+    server fixture returns per-outcome channel strings
+    (`{"on_success": "silent", "on_failure": "toast"}`). Both render;
+    an absent policy says so instead of guessing.
+    """
+    policy = definition.get("notification_policy")
+    if not isinstance(policy, dict) or not policy:
+        return _NOT_SET
+    on_success = policy.get("on_success")
+    on_failure = policy.get("on_failure")
+    if isinstance(on_success, bool) or isinstance(on_failure, bool):
+        return "On" if (on_success or on_failure) else "Off"
+    parts = [
+        f"{value} on {outcome}"
+        for outcome, value in (("success", on_success), ("failure", on_failure))
+        if value
+    ]
+    return " · ".join(parts) if parts else _NOT_SET
 
 
 def _parse_iso(value: Any) -> datetime | None:
@@ -248,6 +311,20 @@ def _definition_repeat_label(schedule: dict[str, Any]) -> str:
     return "-"
 
 
+def _definition_cron_expression(schedule: dict[str, Any]) -> Any:
+    """The cron string, under either key the two writers use.
+
+    Final review F1: this read `schedule["cron"]` only -- the key THIS
+    client's writer emits (`automation_definition_form.py`) -- so every
+    server-owned definition rendered `At: -`. The real server sends
+    `schedule.expression` (recorded fixture
+    `Tests/Scheduling/fixtures/server_responses/
+    automation_definition_list.json`), and `_load_server_automations`
+    passes the payload through raw, stamping only `owner_id`.
+    """
+    return schedule.get("cron") or schedule.get("expression")
+
+
 def _definition_at_label(schedule: dict[str, Any]) -> str:
     """'At' row value (Frequency group): the full schedule summary, reusing
     `_humanize_cron` for a cron-kind schedule -- the same formatter
@@ -257,7 +334,9 @@ def _definition_at_label(schedule: dict[str, Any]) -> str:
         return "-"
     kind = schedule.get("kind")
     if kind == "cron":
-        return _humanize_cron(schedule.get("cron"), schedule.get("timezone"))
+        return _humanize_cron(
+            _definition_cron_expression(schedule), schedule.get("timezone")
+        )
     if kind == "one_time":
         run_at = schedule.get("run_at")
         dt = _parse_iso(run_at) if run_at else None
@@ -280,6 +359,34 @@ def _definition_timezone_label(schedule: dict[str, Any]) -> str:
         dt = _parse_iso(run_at) if run_at else None
         return _format_timezone(dt) if dt is not None else "UTC"
     return "UTC"
+
+
+def _definition_history_labels(
+    definition: dict[str, Any],
+    *,
+    run_count: int,
+    last_run: dict[str, Any] | None,
+    history_error: bool,
+) -> tuple[str, str]:
+    """(Last run, Run count) values -- honest for every owner (F3/F14).
+
+    `automation_runs` is local-only: it has exactly one writer (local
+    dispatch) and no server mirror, so a server-owned definition's local
+    counts are structurally zero. Rendering them as `Never run` / `0`
+    contradicted the run-history pane beside it, which was listing that
+    same definition's server audit trail at the time -- and contradicted
+    the User Guide, which already claimed the honest behaviour.
+    """
+    from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
+
+    if is_server_scoped_owner(definition.get("owner_id")):
+        if definition.get("pending_sync"):
+            # Never reached the server, and never ran locally either.
+            return _PENDING_SYNC_HISTORY, _PENDING_SYNC_HISTORY
+        return _SERVER_LAST_RUN, _SERVER_RUN_COUNT
+    if history_error:
+        return _HISTORY_READ_FAILED, _HISTORY_READ_FAILED
+    return _definition_last_run_label(last_run), str(run_count)
 
 
 def _definition_last_run_label(last_run: dict[str, Any] | None) -> str:
@@ -321,6 +428,7 @@ class DefinitionDetail(Vertical):
         self._repeat_row: DetailValueRow | None = None
         self._at_row: DetailValueRow | None = None
         self._timezone_row: DetailValueRow | None = None
+        self._notifications_row: DetailValueRow | None = None
         self._last_run_row: DetailValueRow | None = None
         self._run_count_row: DetailValueRow | None = None
         self._unread_row: DetailValueRow | None = None
@@ -377,10 +485,18 @@ class DefinitionDetail(Vertical):
             self._timezone_row = DetailValueRow(
                 "Timezone", "-", value_id="scheduling-automation-detail-timezone"
             )
+            # Spec §5 gives BOTH columns a Frequency `Notifications` row;
+            # the plan's Task 4 text quietly dropped it (final review F8).
+            self._notifications_row = DetailValueRow(
+                "Notifications",
+                "-",
+                value_id="scheduling-automation-detail-notifications",
+            )
             yield DetailGroup(
                 self._repeat_row,
                 self._at_row,
                 self._timezone_row,
+                self._notifications_row,
                 title="Frequency",
                 id="scheduling-automation-detail-group-frequency",
             )
@@ -418,12 +534,15 @@ class DefinitionDetail(Vertical):
         run_count: int = 0,
         last_run: dict[str, Any] | None = None,
         unread_count: int = 0,
+        history_error: bool = False,
     ) -> None:
         """Paint the pane for `definition` (or the empty state for `None`).
 
         Pure render -- `run_count`/`last_run`/`unread_count` are already
         fetched (off the event loop) by the caller; this method performs
-        no I/O of its own.
+        no I/O of its own. `history_error` says that fetch FAILED, so the
+        History rows say so rather than painting a zero the read never
+        proved (final review F14).
         """
         empty_state = self.query_one(
             "#scheduling-automation-detail-empty-state", Static
@@ -462,7 +581,18 @@ class DefinitionDetail(Vertical):
         self._repeat_row.update_value(_definition_repeat_label(schedule))
         self._at_row.update_value(_definition_at_label(schedule))
         self._timezone_row.update_value(_definition_timezone_label(schedule))
+        self._notifications_row.update_value(
+            _definition_notifications_label(definition)
+        )
 
-        self._last_run_row.update_value(_definition_last_run_label(last_run))
-        self._run_count_row.update_value(str(run_count))
-        self._unread_row.update_value(str(unread_count))
+        last_run_label, run_count_label = _definition_history_labels(
+            definition,
+            run_count=run_count,
+            last_run=last_run,
+            history_error=history_error,
+        )
+        self._last_run_row.update_value(last_run_label)
+        self._run_count_row.update_value(run_count_label)
+        self._unread_row.update_value(
+            _HISTORY_READ_FAILED if history_error else str(unread_count)
+        )

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -1,0 +1,468 @@
+"""Automations tab per-definition detail pane (schedules-redesign PR-1, Task 4).
+
+The Automations tab's FIRST per-row detail widget -- until now the tab
+had no field-level rendering of a selected `automation_definition` at all
+(only the definitions `DataTable`'s five columns and the audit-trail
+history pane; see `redesign-pr1-survey.md` section 1's "no per-row detail
+widget" finding). `DefinitionDetail` fills that gap using the same
+`DetailValueRow`/`DetailGroup` row grammar Task 3 used to regrammar the
+Queue tab's `TaskDetail` -- Details/Frequency/History groups, read-only
+(plan ruling 1: every row's `affordance` stays at its `False` default, no
+new bindings/actions).
+
+Like `task_detail.py` and `results_tab.py`, this is a leaf module:
+`schedules_workbench.py` imports FROM here (`DefinitionDetail`, plus
+`automation_execution_target_label`/`automation_name_cell`, moved here
+from `schedules_workbench.py` so this module's own formatters can reuse
+their owner-label logic without a circular import -- `schedules_workbench`
+re-exports both names so its own DataTable render call site and the
+pre-existing `test_execution_target_label_matrix` test, which imports
+`automation_execution_target_label` from `schedules_workbench`, both keep
+working unchanged).
+
+`DefinitionDetail.set_definition` is a pure "paint what I'm given" method,
+mirroring `TaskDetail.set_task`'s data-only feed shape: it performs no
+I/O. `schedules_workbench.py` does the DB reads (off the event loop, via
+`asyncio.to_thread`, same discipline `_load_local_automations` already
+established for a `service.db.*` call made from inside a worker
+coroutine) and passes the results in.
+
+Values are drawn from BOTH the local `automation_definitions` table
+(client-authored, `schedule.cron`/`config.scope`/etc. per
+`automation_definition_form.py`'s own payload shape) and the server's raw
+list-response dicts (`_load_server_automations` never runs these through
+a JSON round-trip, so any camelCase/renamed field a live server used
+would need translating separately -- out of this task's scope, matching
+`AutomationDefinitionForm._prefill_from_row`'s own documented precedent
+of leaving an un-recognized schedule shape at its default rather than
+guessing). Every formatter here reads with `.get()`/`isinstance` guards
+and degrades to an honest placeholder instead of raising, the same
+defensive-read idiom `automation_execution_target_label` already used.
+
+Escape discipline: every `DetailValueRow` value is safe by construction
+(Task 1: the row's `Static` is built with `markup=False` and the value is
+wrapped in a literal `rich.text.Text`, proven never to interpret
+markup). The one field NOT going through `DetailValueRow` -- the question
+card, a plain `Static` -- is built with `markup=False` here too, for the
+same reason.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Static
+
+from ....Widgets.detail_value_row import DetailGroup, DetailValueRow
+from .forms.automation_definition_form import (
+    _FINDING_POLICY_OPTIONS,
+    _GENERATION_MODE_OPTIONS,
+    _SCOPE_SOURCE_CHECKBOXES,
+)
+from .task_detail import _TRANSFER_STATE_ROW_LABELS, _format_timezone, _humanize_cron
+
+#: value -> label reverse lookups, reusing the SAME vocabulary the
+#: create/edit form already presents (`automation_definition_form.py`)
+#: rather than inventing a second wording for the same underlying value.
+_GENERATION_MODE_LABELS: dict[str, str] = {
+    value: label for label, value in _GENERATION_MODE_OPTIONS
+}
+_FINDING_POLICY_LABELS: dict[str, str] = {
+    value: label for label, value in _FINDING_POLICY_OPTIONS
+}
+_SCOPE_SOURCE_LABELS: dict[str, str] = {
+    value: label for label, value in _SCOPE_SOURCE_CHECKBOXES
+}
+
+
+def automation_execution_target_label(definition: dict[str, Any]) -> str:
+    """Render one definition's per-task execution target (ADR-077 AC#7).
+
+    Moved here from `schedules_workbench.py` (Task 4) so this module's
+    own "Model" row can call it without a circular import;
+    `schedules_workbench` re-exports the name for its DataTable render
+    call site and the pre-existing test that imports it from there.
+
+    ``input.provider``/``input.model`` ride the definition payload and the
+    server executor honors them. The column shows what was PINNED here:
+    when neither key is set the label is ``auto`` -- the definition pins
+    nothing, and the server resolves the run target from its own
+    automation-config executor defaults (``[Scheduled_Tasks_Automation]
+    executor_provider``/``executor_model``) falling back to the server
+    default. Those layers live in server config, not the payload, so
+    ``auto`` is the honest client-side rendering, not a claim about which
+    server layer actually won.
+
+    Args:
+        definition: One row from the server's definition list, as the raw
+            dict the scheduling server client returns.
+
+    Returns:
+        A short cell label: ``provider/model``, either part alone, or
+        ``auto`` when neither is set.
+    """
+    source = definition.get("input") if isinstance(definition.get("input"), dict) else {}
+    provider = str(source.get("provider") or "").strip()
+    model = str(source.get("model") or "").strip()
+    if provider and model:
+        return f"{provider}/{model}"
+    if provider:
+        return provider
+    if model:
+        return model
+    return "auto"
+
+
+def _definition_owner_label(definition: dict[str, Any]) -> str:
+    """Owner label for a definition row.
+
+    ``"This device"`` for a local row, the server id for a server-scoped
+    one, and ``"<server id> · pending sync"`` for one authored offline
+    that has not reached the server yet -- the same vocabulary
+    `automation_name_cell` wraps into its Name-cell prefix, factored out
+    here so the detail pane's "Runs on" row and the table cell can never
+    drift apart.
+    """
+    from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
+
+    owner_id = str(definition.get("owner_id") or "local")
+    if not is_server_scoped_owner(owner_id):
+        return "This device"
+    label = owner_id.split(":", 1)[1] if ":" in owner_id else owner_id
+    if definition.get("pending_sync"):
+        label = f"{label} · pending sync"
+    return label
+
+
+def automation_name_cell(definition: dict[str, Any]) -> str:
+    """Name cell for the merged local+server Automations list (task-5 fix round).
+
+    Moved here from `schedules_workbench.py` (Task 4) alongside
+    `_definition_owner_label`, which this now delegates to; behavior is
+    unchanged. `schedules_workbench` re-exports the name for its own
+    DataTable render call site.
+
+    Args:
+        definition: One merged row (local DB dict or server API dict --
+            both carry `owner_id` and `name`, confirmed against the real
+            server fixture `automation_definition_list.json`).
+
+    Returns:
+        `"[This device] <name>"` for a local row, `"[<server id>] <name>"`
+        for a server-scoped one, and `"[<server id> · pending sync]
+        <name>"` for one authored offline that has not reached the server
+        yet.
+    """
+    name = str(definition.get("name") or definition.get("id") or "")
+    return f"[{_definition_owner_label(definition)}] {name}"
+
+
+def _definition_transfer_suffix(definition: dict[str, Any]) -> str:
+    """Definition-dict counterpart of `task_detail._transfer_row_suffix`.
+
+    Reuses the SAME state->label vocabulary (`_TRANSFER_STATE_ROW_LABELS`)
+    since a definition's `transfer_state` column shares the schedules-
+    handoff spec §6 transfer state machine with a reminder's -- only the
+    read (attribute vs. dict key) differs, so the label table itself is
+    imported rather than duplicated.
+    """
+    label = _TRANSFER_STATE_ROW_LABELS.get(definition.get("transfer_state") or "")
+    return f" ({label})" if label else ""
+
+
+def _definition_question_text(definition: dict[str, Any]) -> str:
+    """Question-card text: the recurring question, or a fallback for a
+    definition that has none (a non-`recurring_question` family, or a
+    row from an older/foreign server payload shape)."""
+    input_fields = (
+        definition.get("input") if isinstance(definition.get("input"), dict) else {}
+    )
+    question = str(input_fields.get("question") or "").strip()
+    if question:
+        return question
+    description = str(definition.get("description") or "").strip()
+    if description:
+        return description
+    return str(definition.get("name") or "Untitled automation")
+
+
+def _definition_generation_label(config: dict[str, Any]) -> str:
+    """'Generation' row value (Details group): `config.generation_mode`,
+    labeled with the same wording the create/edit form's Select uses.
+    Defaults to "optional" (the form's own default) when absent."""
+    mode = config.get("generation_mode") if isinstance(config, dict) else None
+    mode = str(mode) if mode else "optional"
+    return _GENERATION_MODE_LABELS.get(mode, mode)
+
+
+def _definition_finding_policy_label(definition: dict[str, Any]) -> str:
+    """'Finding policy' row value (Details group): the top-level
+    `finding_policy.preset` column (survey §4's authoritative source --
+    distinct from the create/edit payload's `config.finding_policy`,
+    which the service copies into this column at save time). Defaults to
+    "balanced_findings" (the `AutomationDefinition` model's own default)
+    when absent."""
+    finding_policy = definition.get("finding_policy")
+    preset = (
+        finding_policy.get("preset") if isinstance(finding_policy, dict) else None
+    ) or "balanced_findings"
+    return _FINDING_POLICY_LABELS.get(preset, str(preset))
+
+
+def _definition_sources_label(config: dict[str, Any]) -> str:
+    """'Sources' row value (Details group): `config.scope`, joined plurals
+    for an explicit source list, or the all-library sentence for the
+    default scope mode."""
+    scope = config.get("scope") if isinstance(config, dict) else None
+    scope = scope if isinstance(scope, dict) else {}
+    if scope.get("mode") != "sources":
+        return "All searchable library"
+    sources = scope.get("sources") or []
+    labels = [_SCOPE_SOURCE_LABELS.get(str(item), str(item)) for item in sources]
+    return ", ".join(labels) if labels else "None selected"
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    """Best-effort ISO-8601 parse; ``None`` for anything else, never raises."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _definition_repeat_label(schedule: dict[str, Any]) -> str:
+    """'Repeat' row value (Frequency group): "Recurring" or "One-time" --
+    the definition-schedule counterpart of `task_detail._humanize_schedule_
+    kind`, which reads a `ReminderTask`'s `ScheduleKind` enum a definition's
+    plain `schedule["kind"]` string (`"cron"`/`"one_time"`) does not share."""
+    kind = schedule.get("kind") if isinstance(schedule, dict) else None
+    if kind == "cron":
+        return "Recurring"
+    if kind == "one_time":
+        return "One-time"
+    return "-"
+
+
+def _definition_at_label(schedule: dict[str, Any]) -> str:
+    """'At' row value (Frequency group): the full schedule summary, reusing
+    `_humanize_cron` for a cron-kind schedule -- the same formatter
+    `task_detail._humanize_schedule`/`reminder_form.py`'s live cron preview
+    already reuse -- rather than re-deriving cron-cadence prose."""
+    if not isinstance(schedule, dict):
+        return "-"
+    kind = schedule.get("kind")
+    if kind == "cron":
+        return _humanize_cron(schedule.get("cron"), schedule.get("timezone"))
+    if kind == "one_time":
+        run_at = schedule.get("run_at")
+        dt = _parse_iso(run_at) if run_at else None
+        if dt is None:
+            return f"One-time at {run_at}" if run_at else "One-time"
+        return f"One-time at {dt.strftime('%Y-%m-%d %H:%M')} {_format_timezone(dt)}"
+    return "-"
+
+
+def _definition_timezone_label(schedule: dict[str, Any]) -> str:
+    """'Timezone' row value (Frequency group), reusing `_format_timezone`
+    for the same per-kind timezone source `_definition_at_label` reads."""
+    if not isinstance(schedule, dict):
+        return "UTC"
+    kind = schedule.get("kind")
+    if kind == "cron":
+        return schedule.get("timezone") or "UTC"
+    if kind == "one_time":
+        run_at = schedule.get("run_at")
+        dt = _parse_iso(run_at) if run_at else None
+        return _format_timezone(dt) if dt is not None else "UTC"
+    return "UTC"
+
+
+def _definition_last_run_label(last_run: dict[str, Any] | None) -> str:
+    """'Last run' row value (History group): the most recent
+    `automation_runs` row's status plus its timestamp -- the same compact
+    slice-and-replace timestamp idiom `task_detail.format_run_history`
+    uses for a reminder's run history."""
+    if not last_run:
+        return "Never run"
+    status = str(last_run.get("status") or last_run.get("outcome") or "?")
+    when = str(
+        last_run.get("ended_at")
+        or last_run.get("started_at")
+        or last_run.get("created_at")
+        or ""
+    )
+    when = when[:16].replace("T", " ") if when else "?"
+    return f"{status} — {when}"
+
+
+class DefinitionDetail(Vertical):
+    """Automations tab per-definition detail pane.
+
+    Read-only (plan ruling 1): every `DetailValueRow` here uses the
+    `affordance` default of `False`; no new bindings or actions.
+    `set_definition` is the single feed point -- called by
+    `SchedulesWorkbench` after a definitions-table row highlight, with
+    the DB-derived counts/last-run already fetched off the event loop.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._question_static: Static | None = None
+        self._runs_on_row: DetailValueRow | None = None
+        self._model_row: DetailValueRow | None = None
+        self._generation_row: DetailValueRow | None = None
+        self._finding_policy_row: DetailValueRow | None = None
+        self._sources_row: DetailValueRow | None = None
+        self._repeat_row: DetailValueRow | None = None
+        self._at_row: DetailValueRow | None = None
+        self._timezone_row: DetailValueRow | None = None
+        self._last_run_row: DetailValueRow | None = None
+        self._run_count_row: DetailValueRow | None = None
+        self._unread_row: DetailValueRow | None = None
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "Definition Detail",
+            id="scheduling-automation-detail-header",
+            classes="scheduling-column-title",
+        )
+        yield Static(
+            "Select an automation to see its details.",
+            id="scheduling-automation-detail-empty-state",
+        )
+        with Vertical(id="scheduling-automation-detail-body"):
+            self._question_static = Static(
+                "", id="scheduling-automation-detail-question", markup=False
+            )
+            yield self._question_static
+
+            self._runs_on_row = DetailValueRow(
+                "Runs on", "-", value_id="scheduling-automation-detail-runs-on"
+            )
+            self._model_row = DetailValueRow(
+                "Model", "-", value_id="scheduling-automation-detail-model"
+            )
+            self._generation_row = DetailValueRow(
+                "Generation", "-", value_id="scheduling-automation-detail-generation"
+            )
+            self._finding_policy_row = DetailValueRow(
+                "Finding policy",
+                "-",
+                value_id="scheduling-automation-detail-finding-policy",
+            )
+            self._sources_row = DetailValueRow(
+                "Sources", "-", value_id="scheduling-automation-detail-sources"
+            )
+            yield DetailGroup(
+                self._runs_on_row,
+                self._model_row,
+                self._generation_row,
+                self._finding_policy_row,
+                self._sources_row,
+                title="Details",
+                id="scheduling-automation-detail-group-details",
+            )
+
+            self._repeat_row = DetailValueRow(
+                "Repeat", "-", value_id="scheduling-automation-detail-repeat"
+            )
+            self._at_row = DetailValueRow(
+                "At", "-", value_id="scheduling-automation-detail-at"
+            )
+            self._timezone_row = DetailValueRow(
+                "Timezone", "-", value_id="scheduling-automation-detail-timezone"
+            )
+            yield DetailGroup(
+                self._repeat_row,
+                self._at_row,
+                self._timezone_row,
+                title="Frequency",
+                id="scheduling-automation-detail-group-frequency",
+            )
+
+            self._last_run_row = DetailValueRow(
+                "Last run", "-", value_id="scheduling-automation-detail-last-run"
+            )
+            self._run_count_row = DetailValueRow(
+                "Run count", "-", value_id="scheduling-automation-detail-run-count"
+            )
+            self._unread_row = DetailValueRow(
+                "Unread results",
+                "-",
+                value_id="scheduling-automation-detail-unread-results",
+            )
+            view_results_row = DetailValueRow(
+                "Results",
+                "See Results tab",
+                value_id="scheduling-automation-detail-view-results",
+            )
+            yield DetailGroup(
+                self._last_run_row,
+                self._run_count_row,
+                self._unread_row,
+                view_results_row,
+                title="History",
+                collapsed=True,
+                id="scheduling-automation-detail-group-history",
+            )
+
+    def set_definition(
+        self,
+        definition: dict[str, Any] | None,
+        *,
+        run_count: int = 0,
+        last_run: dict[str, Any] | None = None,
+        unread_count: int = 0,
+    ) -> None:
+        """Paint the pane for `definition` (or the empty state for `None`).
+
+        Pure render -- `run_count`/`last_run`/`unread_count` are already
+        fetched (off the event loop) by the caller; this method performs
+        no I/O of its own.
+        """
+        empty_state = self.query_one(
+            "#scheduling-automation-detail-empty-state", Static
+        )
+        body = self.query_one("#scheduling-automation-detail-body", Vertical)
+        if definition is None:
+            empty_state.display = True
+            body.display = False
+            return
+        empty_state.display = False
+        body.display = True
+
+        assert self._question_static is not None, "set_definition called before mount"
+        self._question_static.update(_definition_question_text(definition))
+
+        schedule = (
+            definition.get("schedule")
+            if isinstance(definition.get("schedule"), dict)
+            else {}
+        )
+        config = (
+            definition.get("config") if isinstance(definition.get("config"), dict) else {}
+        )
+
+        assert self._runs_on_row is not None, "set_definition called before mount"
+        self._runs_on_row.update_value(
+            _definition_owner_label(definition) + _definition_transfer_suffix(definition)
+        )
+        self._model_row.update_value(automation_execution_target_label(definition))
+        self._generation_row.update_value(_definition_generation_label(config))
+        self._finding_policy_row.update_value(
+            _definition_finding_policy_label(definition)
+        )
+        self._sources_row.update_value(_definition_sources_label(config))
+
+        self._repeat_row.update_value(_definition_repeat_label(schedule))
+        self._at_row.update_value(_definition_at_label(schedule))
+        self._timezone_row.update_value(_definition_timezone_label(schedule))
+
+        self._last_run_row.update_value(_definition_last_run_label(last_run))
+        self._run_count_row.update_value(str(run_count))
+        self._unread_row.update_value(str(unread_count))

--- a/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
@@ -36,6 +36,8 @@ from textual.widgets import Button, Checkbox, Input, Label, Select, Static, Text
 
 from tldw_chatbook.Scheduling.models import PreviewStatus, ScheduleKind
 
+from ..task_detail import definition_cron_expression
+
 from .reminder_form import (
     _CURATED_TIMEZONES,
     _DEFAULT_TIMEZONE,
@@ -497,11 +499,15 @@ class AutomationDefinitionForm(ModalScreen):
             )
             self.query_one("#automation-run-at", Input).value = str(schedule["run_at"])
             self._update_schedule_field_visibility(ScheduleKind.ONE_TIME.value)
-        elif kind == "cron" and schedule.get("cron"):
+        # `cron` OR `expression` (final review F1 carry-forward): the
+        # server sends the second key, so a cron-only read left a mirrored
+        # server-only definition on the form's DEFAULT preset -- and saving
+        # then wrote that default over the server's real schedule.
+        elif kind == "cron" and definition_cron_expression(schedule):
             self.query_one("#automation-schedule-kind", Select).value = (
                 ScheduleKind.RECURRING.value
             )
-            cron_value = str(schedule["cron"])
+            cron_value = str(definition_cron_expression(schedule))
             self.query_one("#automation-cron", Input).value = cron_value
             preset_key, time_text = cron_to_preset(cron_value)
             self.query_one("#automation-cron-preset", Select).value = preset_key

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -64,6 +64,18 @@ from ....UI.Screens.scheduling.results_tab import (
 )
 from ....UI.Screens.scheduling.sync_status_widget import SyncStatusWidget
 from ....Widgets.confirmation_dialog import ConfirmationDialog
+# schedules-redesign PR-1, Task 4: `automation_execution_target_label`/
+# `automation_name_cell` moved to `definition_detail.py` (that leaf
+# module's own "Model"/"Runs on" row formatters need them and importing
+# them back from here would be circular) -- re-exported via this import
+# so the DataTable render call site below and the pre-existing
+# `test_execution_target_label_matrix` test (which imports
+# `automation_execution_target_label` from THIS module) keep working.
+from .definition_detail import (
+    DefinitionDetail,
+    automation_execution_target_label,
+    automation_name_cell,
+)
 from .forms.automation_definition_form import AutomationDefinitionForm
 from .forms.new_task_choice_modal import NewTaskChoiceModal
 from .forms.reminder_form import ReminderForm
@@ -138,76 +150,6 @@ _NOTIFICATION_OBSERVER_MAX_RECONNECTS = 5
 #: a rare outer-level restart). Interrupted immediately by unmount via
 #: `cancel_event`, never a blind sleep.
 _NOTIFICATION_OBSERVER_RESTART_DELAY_SECONDS = 5.0
-
-
-def automation_execution_target_label(definition: dict[str, Any]) -> str:
-    """Render one definition's per-task execution target (ADR-077 AC#7).
-
-    ``input.provider``/``input.model`` ride the definition payload and the
-    server executor honors them. The column shows what was PINNED here:
-    when neither key is set the label is ``auto`` -- the definition pins
-    nothing, and the server resolves the run target from its own
-    automation-config executor defaults (``[Scheduled_Tasks_Automation]
-    executor_provider``/``executor_model``) falling back to the server
-    default. Those layers live in server config, not the payload, so
-    ``auto`` is the honest client-side rendering, not a claim about which
-    server layer actually won.
-
-    Args:
-        definition: One row from the server's definition list, as the raw
-            dict the scheduling server client returns.
-
-    Returns:
-        A short cell label: ``provider/model``, either part alone, or
-        ``auto`` when neither is set.
-    """
-    source = definition.get("input") if isinstance(definition.get("input"), dict) else {}
-    provider = str(source.get("provider") or "").strip()
-    model = str(source.get("model") or "").strip()
-    if provider and model:
-        return f"{provider}/{model}"
-    if provider:
-        return provider
-    if model:
-        return model
-    return "auto"
-
-
-def automation_name_cell(definition: dict[str, Any]) -> str:
-    """Name cell for the merged local+server Automations list (task-5 fix round).
-
-    The tab now mixes local-owned rows into what used to be a server-only
-    list, so every row needs a visible owner distinction or a local save
-    reads as indistinguishable from a server one. A prefix on the existing
-    Name cell is the smallest honest rendering -- no new column, no CSS
-    changes -- since the table's own `key=` already disambiguates rows for
-    everything that acts on them; this prefix is purely for the human
-    reading the table.
-
-    Args:
-        definition: One merged row (local DB dict or server API dict --
-            both carry `owner_id` and `name`, confirmed against the real
-            server fixture `automation_definition_list.json`).
-
-    Returns:
-        `"[This device] <name>"` for a local row, `"[<server id>] <name>"`
-        for a server-scoped one, and `"[<server id> · pending sync]
-        <name>"` for one authored offline that has not reached the server
-        yet (`pending_sync`, stamped by `_load_local_automations`) -- that
-        row is only on this device, and saying "server" flat would claim a
-        definition the server has never heard of (final review I5).
-    """
-    from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
-
-    owner_id = str(definition.get("owner_id") or "local")
-    name = str(definition.get("name") or definition.get("id") or "")
-    if is_server_scoped_owner(owner_id):
-        label = owner_id.split(":", 1)[1] if ":" in owner_id else owner_id
-        if definition.get("pending_sync"):
-            label = f"{label} · pending sync"
-    else:
-        label = "This device"
-    return f"[{label}] {name}"
 
 
 def _cancel_toast_text(name: str) -> str:
@@ -429,6 +371,14 @@ class SchedulesWorkbench(BaseAppScreen):
                                 id="scheduling-automations-table", cursor_type="row"
                             )
                             yield Static("", id="scheduling-automations-notice")
+                        # schedules-redesign PR-1, Task 4: the definitions
+                        # detail pane -- the first per-row detail widget the
+                        # Automations tab has had (see redesign-pr1-survey.md
+                        # section 1's "no per-row detail widget" finding).
+                        # Third pane alongside list|history, matching the
+                        # Queue tab's list|detail|inspector idiom.
+                        with Vertical(id="scheduling-automations-detail-pane"):
+                            yield DefinitionDetail(id="scheduling-automation-detail")
                         with Vertical(id="scheduling-automation-history-pane"):
                             yield Static(
                                 "Run history",
@@ -1869,6 +1819,9 @@ class SchedulesWorkbench(BaseAppScreen):
             self._clear_automation_history(
                 "Run history needs a connected server."
             )
+            self.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            ).set_definition(None)
             return
 
         # task-15476 discipline: a rebuild must reconcile the selection by
@@ -1932,6 +1885,9 @@ class SchedulesWorkbench(BaseAppScreen):
         else:
             self._selected_automation_id = None
             self._clear_automation_history("Select an automation to see its history.")
+            self.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            ).set_definition(None)
 
         notice_text = self._automations_notice_text(
             local_items, server_items, server_available, total_server, server_error
@@ -2170,11 +2126,76 @@ class SchedulesWorkbench(BaseAppScreen):
             else "No recorded events for this automation yet.",
         )
 
+    def _request_automation_detail(self, definition_id: str) -> None:
+        """Schedule the definitions detail pane's DB reads through their
+        own exclusive worker group (schedules-redesign PR-1, Task 4): the
+        pane's counts are local-only sqlite reads, taken off the event
+        loop the same way `_load_local_automations` already reads
+        `service.db.*` from inside a worker coroutine."""
+        # run_worker takes no worker arguments in Textual 8.x -- bind the id
+        # in a closure (same shape as _request_automation_history's _load).
+        async def _load() -> None:
+            await self._load_automation_detail(definition_id)
+
+        self.run_worker(
+            _load,
+            exclusive=True,
+            group="schedules-load-automation-detail",
+        )  # type: ignore[arg-type]
+
+    async def _load_automation_detail(self, definition_id: str) -> None:
+        """Paint the definitions detail pane for `definition_id`.
+
+        `DefinitionDetail.set_definition` performs no I/O itself; this
+        method fetches the Task 2 count seams off the event loop
+        (`asyncio.to_thread`) and passes the results in.
+        """
+        detail = self.query_one("#scheduling-automation-detail", DefinitionDetail)
+        definition = self._selected_automation()
+        # A newer selection may have won the race with this worker; render
+        # nothing for a stale definition id (same guard `_load_automation_
+        # history` uses).
+        if definition is None or definition_id != self._selected_automation_id:
+            return
+        service = self._scheduling_service
+        if service is None:
+            detail.set_definition(
+                definition, run_count=0, last_run=None, unread_count=0
+            )
+            return
+
+        def _read_counts() -> tuple[int, dict[str, Any] | None, int]:
+            owner_id = str(definition.get("owner_id") or "local")
+            run_count = service.db.count_automation_runs(definition_id)
+            runs = service.db.list_automation_runs(owner_id, definition_id, limit=1)
+            unread_count = service.db.count_unread_results(
+                owner_id=None, definition_id=definition_id
+            )
+            return run_count, (runs[0] if runs else None), unread_count
+
+        try:
+            run_count, last_run, unread_count = await asyncio.to_thread(_read_counts)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Failed to load automation detail counts (definition_id={})",
+                definition_id,
+            )
+            run_count, last_run, unread_count = 0, None, 0
+        if definition_id != self._selected_automation_id:
+            return
+        detail.set_definition(
+            definition,
+            run_count=run_count,
+            last_run=last_run,
+            unread_count=unread_count,
+        )
+
     @on(DataTable.RowHighlighted, "#scheduling-automations-table")
     def _on_automations_row_highlighted(
         self, event: DataTable.RowHighlighted
     ) -> None:
-        """Track the highlighted definition for Run-now and its history pane."""
+        """Track the highlighted definition for Run-now, its history pane,
+        and its detail pane (schedules-redesign PR-1, Task 4)."""
         new_id = (
             str(event.row_key.value) if event.row_key and event.row_key.value else None
         )
@@ -2183,8 +2204,12 @@ class SchedulesWorkbench(BaseAppScreen):
         self._selected_automation_id = new_id
         if new_id is None:
             self._clear_automation_history("Select an automation to see its history.")
+            self.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            ).set_definition(None)
         else:
             self._request_automation_history(new_id)
+            self._request_automation_detail(new_id)
 
     def _selected_automation(self) -> dict[str, Any] | None:
         """Return the highlighted automation definition, if any."""
@@ -2957,6 +2982,16 @@ class SchedulesWorkbench(BaseAppScreen):
         else:
             self._resize_notice = ""
         self._update_pane_notice()
+        # schedules-redesign PR-1, Task 4: the Automations tab's detail
+        # pane hides at the same width the Queue tab's own detail pane
+        # does -- same mechanism (`pane-hidden`), separate try/except so a
+        # missing pane here (e.g. before the Automations TabPane mounts)
+        # never short-circuits the Queue-pane handling above.
+        try:
+            automations_detail = self.query_one("#scheduling-automations-detail-pane")
+        except Exception:  # noqa: BLE001 - pane not mounted yet
+            return
+        automations_detail.set_class(hide_detail, "pane-hidden")
 
     def _update_pane_notice(self) -> None:
         """Compose the queue-pane notice: hidden panes, marks, glyph legend.

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -1882,6 +1882,16 @@ class SchedulesWorkbench(BaseAppScreen):
             # Restoring the cursor fires RowHighlighted, which re-records
             # the same id -- belt and braces, set both explicitly.
             table.cursor_coordinate = (row_keys.index(previous_selection), 0)
+            # ...and that RowHighlighted hits the unchanged-id early
+            # return, so the pane would keep painting the PRE-refresh row
+            # (final review F4: edit a definition's model/cron/sources and
+            # save -- the table cell updated, the detail pane beside it
+            # did not, until the user selected another row and came back).
+            # The row DATA changed even though its id did not, so re-feed
+            # the pane explicitly. The detail worker is exclusive within
+            # its own group, so repeated refreshes are latest-wins, never
+            # a pile-up.
+            self._request_automation_detail(previous_selection)
         else:
             self._selected_automation_id = None
             self._clear_automation_history("Select an automation to see its history.")
@@ -2165,14 +2175,20 @@ class SchedulesWorkbench(BaseAppScreen):
             return
 
         def _read_counts() -> tuple[int, dict[str, Any] | None, int]:
+            # Both run reads are owner-scoped (final review F11): they sit
+            # in one group on screen, and `convert_row_to_server_mirror`'s
+            # "converted" path rewrites `owner_id` while keeping the local
+            # id -- an unscoped count beside a scoped last-run rendered
+            # "Run count: 3" next to "Last run: Never run".
             owner_id = str(definition.get("owner_id") or "local")
-            run_count = service.db.count_automation_runs(definition_id)
+            run_count = service.db.count_automation_runs(definition_id, owner_id)
             runs = service.db.list_automation_runs(owner_id, definition_id, limit=1)
             unread_count = service.db.count_unread_results(
                 owner_id=None, definition_id=definition_id
             )
             return run_count, (runs[0] if runs else None), unread_count
 
+        history_error = False
         try:
             run_count, last_run, unread_count = await asyncio.to_thread(_read_counts)
         except Exception:  # noqa: BLE001
@@ -2180,7 +2196,10 @@ class SchedulesWorkbench(BaseAppScreen):
                 "Failed to load automation detail counts (definition_id={})",
                 definition_id,
             )
-            run_count, last_run, unread_count = 0, None, 0
+            # Never paint 0/Never run off a read that blew up (F14): the
+            # pane says the read failed, matching how `_load_automation_
+            # history` reports its own read failure.
+            run_count, last_run, unread_count, history_error = 0, None, 0, True
         if definition_id != self._selected_automation_id:
             return
         detail.set_definition(
@@ -2188,6 +2207,7 @@ class SchedulesWorkbench(BaseAppScreen):
             run_count=run_count,
             last_run=last_run,
             unread_count=unread_count,
+            history_error=history_error,
         )
 
     @on(DataTable.RowHighlighted, "#scheduling-automations-table")

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -391,6 +391,34 @@ def _task_sync_label(task: ReminderTask | ScheduledTask) -> str:
     return "local (read-only projection)"
 
 
+def definition_cron_expression(schedule: dict[str, Any]) -> Any:
+    """An automation definition's cron string, under EITHER key.
+
+    The two writers disagree: this client writes `schedule["cron"]`
+    (`AutomationDefinitionForm`'s save payload), the real server sends
+    `schedule["expression"]` (recorded fixture
+    `Tests/Scheduling/fixtures/server_responses/
+    automation_definition_list.json`), and `_load_server_automations`
+    passes the payload through raw, stamping only `owner_id`.
+
+    Both readers of that field go through here (final review F1 + its
+    carry-forward), and it lives in this leaf module because the two are
+    in packages that cannot import each other: `definition_detail`'s "At"
+    row -- where a cron-only read rendered `At: -` for EVERY server-owned
+    definition -- and `AutomationDefinitionForm._prefill_from_row`, where
+    the same read was worse than cosmetic: editing a mirrored server-only
+    definition fell through to the form's default preset, so a save wrote
+    that default OVER the server's real schedule.
+
+    Args:
+        schedule: A definition's `schedule` dict, from either source.
+
+    Returns:
+        The cron string, or ``None``/empty when neither key carries one.
+    """
+    return schedule.get("cron") or schedule.get("expression")
+
+
 def owner_display_label(owner_id: Any) -> str:
     """Prose owner label shared by BOTH detail panes (final review F6/F7).
 

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -391,8 +391,44 @@ def _task_sync_label(task: ReminderTask | ScheduledTask) -> str:
     return "local (read-only projection)"
 
 
+def owner_display_label(owner_id: Any) -> str:
+    """Prose owner label shared by BOTH detail panes (final review F6/F7).
+
+    ``"This device"`` for a locally-owned row, the server's own id for a
+    server-scoped one (``"server:srv-1"`` -> ``"srv-1"``) -- the
+    vocabulary the spec, the User Guide and the Automations table's own
+    Name-cell prefix already use. The reminder pane's `Runs on` row used
+    to render the raw metadata string instead (``local``, ``server:1 /
+    server <id>``), so the two panes spoke two dialects for the flagship
+    row of the redesign. One helper, one vocabulary -- settled before
+    PR-3 turns this row into the transfer dropdown.
+
+    `TaskInspector`'s Owner row deliberately keeps `_task_owner_label`'s
+    raw value: that pane is the metadata inspector, where the unprettied
+    owner/server ids are the point.
+
+    Args:
+        owner_id: A row's ``owner_id`` (any type tolerated -- anything
+            that is not a server-scoped string reads as local).
+
+    Returns:
+        ``"This device"``, or the server's own id.
+    """
+    # ADR-097: scheduler.queue stays off the boot census -- function-local
+    # import, same as `_queue_owner_suffix` below.
+    from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
+
+    if not is_server_scoped_owner(owner_id):
+        return "This device"
+    owner_id = str(owner_id)
+    return owner_id.split(":", 1)[1] if ":" in owner_id else owner_id
+
+
 def _task_owner_label(task: ReminderTask | ScheduledTask) -> str:
-    """Return an owner label for the task."""
+    """Return the RAW owner label for the task (TaskInspector's Owner row).
+
+    Prose-rendered surfaces use `owner_display_label` instead.
+    """
     owner = task.owner_id or "local"
     if isinstance(task, ReminderTask) and task.server_id:
         owner += f" / server {task.server_id}"
@@ -476,10 +512,16 @@ _REMINDER_NOTIFICATIONS_LABEL = "Inbox + toast"
 
 
 def _reminder_runs_on_label(task: ReminderTask) -> str:
-    """'Runs on' row value (spec §5 Details group): owner label plus the
-    existing in-flight transfer badge text, when a transfer is running.
+    """'Runs on' row value (spec §5 Details group): the shared prose owner
+    label plus the existing in-flight transfer badge text, when a transfer
+    is running.
+
+    Final review F6/F7: this used to render `_task_owner_label`'s raw
+    metadata string (``local``), which neither matched the definitions
+    pane's ``This device`` nor the User Guide's own description of this
+    very row. Both panes now go through `owner_display_label`.
     """
-    return _task_owner_label(task) + _transfer_row_suffix(task)
+    return owner_display_label(task.owner_id) + _transfer_row_suffix(task)
 
 
 def _reminder_repeat_label(task: ReminderTask) -> str:
@@ -583,6 +625,7 @@ class TaskDetail(Vertical):
         self._at_row: DetailValueRow | None = None
         self._timezone_row: DetailValueRow | None = None
         self._last_fire_row: DetailValueRow | None = None
+        self._body_card: Static | None = None
 
     def compose(self) -> ComposeResult:
         yield Static(
@@ -652,6 +695,17 @@ class TaskDetail(Vertical):
             # `ReminderTask`; a `ScheduledTask` projection keeps the
             # legacy Type/Schedule rows above instead.
             with Vertical(id="scheduling-task-detail-groups"):
+                # Spec §5 wants the body text in a rounded card above the
+                # groups, exactly like the definitions pane's question
+                # card -- final review F10: it was never built, and
+                # `ReminderTask.body` was rendered nowhere. Same
+                # `markup=False` escape discipline (reminder bodies are
+                # user text); hidden entirely for a body-less reminder
+                # rather than showing an empty bordered box.
+                self._body_card = Static(
+                    "", id="scheduling-task-detail-body-card", markup=False
+                )
+                yield self._body_card
                 self._runs_on_row = DetailValueRow(
                     "Runs on", "-", value_id="scheduling-detail-runs-on"
                 )
@@ -685,9 +739,12 @@ class TaskDetail(Vertical):
                 self._last_fire_row = DetailValueRow(
                     "Last fire", "-", value_id="scheduling-detail-last-fire"
                 )
+                # Final review N2: labelled "Recent runs" pointing at a
+                # section whose own label is also "Recent runs" -- one of
+                # the two had to be renamed.
                 history_link_row = DetailValueRow(
-                    "Recent runs",
-                    "See below",
+                    "Run history",
+                    "See list below",
                     value_id="scheduling-detail-history-link",
                 )
                 yield DetailGroup(
@@ -993,6 +1050,9 @@ class TaskDetail(Vertical):
         )
         if is_reminder:
             assert self._runs_on_row is not None, "set_task called before mount"
+            body = (task.body or "").strip()
+            self._body_card.update(body)
+            self._body_card.display = bool(body)
             self._runs_on_row.update_value(_reminder_runs_on_label(task))
             self._repeat_row.update_value(_reminder_repeat_label(task))
             self._at_row.update_value(_reminder_at_label(task))

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -24,6 +24,7 @@ from ....Scheduling.events import (
 )
 from ....Scheduling.models import ReminderTask, ScheduledTask, ScheduleKind, TaskStatus
 from ....Widgets.delete_confirmation_dialog import DeleteConfirmationDialog
+from ....Widgets.detail_value_row import DetailGroup, DetailValueRow
 from ..destination_recovery import DestinationRecoveryState
 
 
@@ -465,6 +466,62 @@ def _queue_owner_suffix(task: ReminderTask | ScheduledTask, *, compact: bool) ->
     return f" (server: {label})"
 
 
+#: spec §5's Frequency-group "Notifications" row (schedules-redesign PR-1,
+#: task 3). A reminder dispatch always writes an inbox notification and
+#: attempts a transient toast (`ReminderHandler.handle` ->
+#: `NotificationDispatchService.dispatch`, `Scheduling/scheduler/handlers/
+#: reminder_handler.py`) -- there is no per-reminder notification-channel
+#: config to read (survey §4), so this is a fixed label, never derived.
+_REMINDER_NOTIFICATIONS_LABEL = "Inbox + toast"
+
+
+def _reminder_runs_on_label(task: ReminderTask) -> str:
+    """'Runs on' row value (spec §5 Details group): owner label plus the
+    existing in-flight transfer badge text, when a transfer is running.
+    """
+    return _task_owner_label(task) + _transfer_row_suffix(task)
+
+
+def _reminder_repeat_label(task: ReminderTask) -> str:
+    """'Repeat' row value (Frequency group): the schedule kind -- the same
+    content the old Type row showed for a reminder, via the same helper
+    (`_humanize_schedule_kind`, unchanged).
+    """
+    return _humanize_schedule_kind(task.schedule_kind)
+
+
+def _reminder_at_label(task: ReminderTask) -> str:
+    """'At' row value (Frequency group): the full schedule summary -- the
+    same content the old Schedule row showed, via the same helper
+    (`_humanize_schedule`, unchanged). The task-3 brief requires reusing
+    the current field-formatting helpers verbatim rather than re-deriving
+    a cadence-only or time-only string from the cron.
+    """
+    return _humanize_schedule(task)
+
+
+def _reminder_timezone_label(task: ReminderTask) -> str:
+    """'Timezone' row value (Frequency group), reusing the same per-kind
+    timezone source `_humanize_schedule`'s own formatting already reads
+    from: `run_at`'s zone for one-time, the stored cron timezone for
+    recurring.
+    """
+    if task.schedule_kind == ScheduleKind.ONE_TIME:
+        return _format_timezone(task.run_at) if task.run_at is not None else "UTC"
+    return task.timezone or "UTC"
+
+
+def _reminder_last_fire_label(task: ReminderTask) -> str:
+    """'Last fire' row value (History group): last_run_at plus the recorded
+    outcome. Uses the underlying status (task-23101 review F5), not the
+    enabled-overlaid display status, so a disabled reminder's last real
+    outcome still shows here -- same discipline as `_update_missed_notice`.
+    """
+    if task.last_run_at is None:
+        return _format_last_run(task)  # "Never run"
+    return f"{_format_last_run(task)} — {_humanize_status(_underlying_status(task))}"
+
+
 def status_badge_text(status: TaskStatus) -> Text:
     """Return a styled Rich Text badge for use in a DataTable cell."""
     label = _humanize_status(status)
@@ -518,6 +575,14 @@ class TaskDetail(Vertical):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._current_task: ReminderTask | ScheduledTask | None = None
+        # schedules-redesign PR-1, task 3: reminder-only DetailValueRow
+        # refs, captured in compose() and refreshed in place by set_task
+        # (no recompose). None until first compose().
+        self._runs_on_row: DetailValueRow | None = None
+        self._repeat_row: DetailValueRow | None = None
+        self._at_row: DetailValueRow | None = None
+        self._timezone_row: DetailValueRow | None = None
+        self._last_fire_row: DetailValueRow | None = None
 
     def compose(self) -> ComposeResult:
         yield Static(
@@ -538,22 +603,28 @@ class TaskDetail(Vertical):
                     classes="scheduling-detail-value",
                 ),
             )
-            yield Horizontal(
-                Static("Type:", classes="scheduling-detail-label"),
-                Static(
-                    "-",
-                    id="scheduling-task-detail-type",
-                    classes="scheduling-detail-value",
-                ),
-            )
-            yield Horizontal(
-                Static("Schedule:", classes="scheduling-detail-label"),
-                Static(
-                    "-",
-                    id="scheduling-task-detail-schedule",
-                    classes="scheduling-detail-value",
-                ),
-            )
+            # task-3 brief: the old combined Type/Schedule rows only apply
+            # to a `ScheduledTask` projection (watchlist_job/briefing_job)
+            # now -- reminders render Repeat/At/Timezone/Notifications
+            # through the Frequency `DetailGroup` below instead. `set_task`
+            # toggles this container's `.display` per task type.
+            with Vertical(id="scheduling-task-detail-legacy-fields"):
+                yield Horizontal(
+                    Static("Type:", classes="scheduling-detail-label"),
+                    Static(
+                        "-",
+                        id="scheduling-task-detail-type",
+                        classes="scheduling-detail-value",
+                    ),
+                )
+                yield Horizontal(
+                    Static("Schedule:", classes="scheduling-detail-label"),
+                    Static(
+                        "-",
+                        id="scheduling-task-detail-schedule",
+                        classes="scheduling-detail-value",
+                    ),
+                )
             yield Horizontal(
                 Static("Status:", classes="scheduling-detail-label"),
                 Static("-", id="scheduling-task-status-badge"),
@@ -574,6 +645,58 @@ class TaskDetail(Vertical):
                 id="scheduling-task-detail-missed",
                 classes="scheduling-detail-missed",
             )
+            # schedules-redesign PR-1, task 3 (spec §5 reminder column):
+            # Details/Frequency/History groups. Rows are read-only in this
+            # PR (plan ruling 1: `affordance` stays at its False default,
+            # no new bindings). `set_task` shows this container only for a
+            # `ReminderTask`; a `ScheduledTask` projection keeps the
+            # legacy Type/Schedule rows above instead.
+            with Vertical(id="scheduling-task-detail-groups"):
+                self._runs_on_row = DetailValueRow(
+                    "Runs on", "-", value_id="scheduling-detail-runs-on"
+                )
+                yield DetailGroup(
+                    self._runs_on_row,
+                    title="Details",
+                    id="scheduling-detail-group-details",
+                )
+                self._repeat_row = DetailValueRow(
+                    "Repeat", "-", value_id="scheduling-detail-repeat"
+                )
+                self._at_row = DetailValueRow(
+                    "At", "-", value_id="scheduling-detail-at"
+                )
+                self._timezone_row = DetailValueRow(
+                    "Timezone", "-", value_id="scheduling-detail-timezone"
+                )
+                notifications_row = DetailValueRow(
+                    "Notifications",
+                    _REMINDER_NOTIFICATIONS_LABEL,
+                    value_id="scheduling-detail-notifications",
+                )
+                yield DetailGroup(
+                    self._repeat_row,
+                    self._at_row,
+                    self._timezone_row,
+                    notifications_row,
+                    title="Frequency",
+                    id="scheduling-detail-group-frequency",
+                )
+                self._last_fire_row = DetailValueRow(
+                    "Last fire", "-", value_id="scheduling-detail-last-fire"
+                )
+                history_link_row = DetailValueRow(
+                    "Recent runs",
+                    "See below",
+                    value_id="scheduling-detail-history-link",
+                )
+                yield DetailGroup(
+                    self._last_fire_row,
+                    history_link_row,
+                    title="History",
+                    collapsed=True,
+                    id="scheduling-detail-group-history",
+                )
             # TASK-26026: durable per-dispatch run history -- the whole
             # point is that run N-1 is recoverable, not just the latest.
             yield Static(
@@ -855,6 +978,27 @@ class TaskDetail(Vertical):
         metadata.display = True
         lifecycle.display = isinstance(task, ReminderTask)
         transfer_row.display = isinstance(task, ReminderTask)
+
+        # schedules-redesign PR-1, task 3: the Details/Frequency/History
+        # groups are reminder-only (spec §5's reminder column); a
+        # `ScheduledTask` projection (watchlist_job/briefing_job) keeps the
+        # legacy Type/Schedule rows instead, since this regrammar does not
+        # touch projection rendering.
+        is_reminder = isinstance(task, ReminderTask)
+        self.query_one("#scheduling-task-detail-legacy-fields", Vertical).display = (
+            not is_reminder
+        )
+        self.query_one("#scheduling-task-detail-groups", Vertical).display = (
+            is_reminder
+        )
+        if is_reminder:
+            assert self._runs_on_row is not None, "set_task called before mount"
+            self._runs_on_row.update_value(_reminder_runs_on_label(task))
+            self._repeat_row.update_value(_reminder_repeat_label(task))
+            self._at_row.update_value(_reminder_at_label(task))
+            self._timezone_row.update_value(_reminder_timezone_label(task))
+            self._last_fire_row.update_value(_reminder_last_fire_label(task))
+
         if isinstance(task, ReminderTask):
             # Structural visibility only (spec §6, PR-5 task 7): Move to
             # server on any local row, Move to local on any server mirror,

--- a/tldw_chatbook/Widgets/detail_value_row.py
+++ b/tldw_chatbook/Widgets/detail_value_row.py
@@ -10,6 +10,15 @@ focusable. A hidden error-line slot below the row is implemented and tested
 (``show_error``/``clear_error``) but unused by any PR-1 caller; PR-3 wires a
 caller to it.
 
+Three PR-3 seams are dormant in PR-1 (final review F13, fixed while the row
+had only two consumers): ``affordance`` is a settable property, not a
+construction-only flag (the glyph is always mounted and toggled with
+``display``, so flipping a row read-only<->editable never means a remount);
+``row_key`` gives the row an identity of its own to carry on whatever
+message PR-3 posts; and ``can_focus`` is a constructor flag (default
+``False``, as every PR-1 caller leaves it) so spec §12's Up/Down row
+traversal needs no subclass.
+
 ``DetailGroup`` is a thin ``Collapsible`` subclass (the house idiom already
 used directly across this codebase -- see
 ``redesign-pr1-survey.md`` section 3 -- rather than a bespoke toggle-button
@@ -63,6 +72,8 @@ class DetailValueRow(Vertical):
         *,
         affordance: bool = False,
         value_id: str | None = None,
+        row_key: str | None = None,
+        can_focus: bool = False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -73,6 +84,15 @@ class DetailValueRow(Vertical):
         self._error_id = f"{value_id}-error" if value_id else None
         self._value_static: Static | None = None
         self._error_static: Static | None = None
+        self._affordance_static: Static | None = None
+        #: Stable field identity for the row itself (final-review F13.2).
+        #: PR-3 addresses the ROW (open its editor, route its error) and
+        #: must not reach through `static.parent.parent` to find it.
+        self.row_key = row_key
+        #: Focusable-ready (final-review F13.3): spec §12 wants Up/Down
+        #: traversal of detail rows. `Vertical.can_focus` is False and
+        #: every PR-1 caller leaves it there; PR-3 flips it per row.
+        self.can_focus = can_focus
 
     def compose(self) -> ComposeResult:
         with Horizontal(classes="detail-value-row-line"):
@@ -84,15 +104,36 @@ class DetailValueRow(Vertical):
                 id=self._value_id,
             )
             yield self._value_static
-            if self._affordance:
-                yield Static(
-                    "▾", classes="detail-value-row-affordance", markup=False
-                )
+            # Always mounted, shown/hidden by the `affordance` property
+            # (final-review F13.1): PR-3 flips a row between read-only and
+            # editable in place, and rebuilding the row would mean a
+            # remount -- both consumers hold hard refs assigned in their
+            # own `compose()`.
+            self._affordance_static = Static(
+                "▾", classes="detail-value-row-affordance", markup=False
+            )
+            self._affordance_static.styles.display = (
+                "block" if self._affordance else "none"
+            )
+            yield self._affordance_static
         self._error_static = Static(
             "", classes="detail-value-row-error", markup=False, id=self._error_id
         )
         self._error_static.styles.display = "none"
         yield self._error_static
+
+    @property
+    def affordance(self) -> bool:
+        """Whether the ``▾`` affordance glyph is showing."""
+        return self._affordance
+
+    @affordance.setter
+    def affordance(self, value: bool) -> None:
+        self._affordance = bool(value)
+        if self._affordance_static is not None:
+            self._affordance_static.styles.display = (
+                "block" if self._affordance else "none"
+            )
 
     def update_value(self, value: str | Text) -> None:
         """Refresh the painted value in place -- no recompose."""

--- a/tldw_chatbook/Widgets/detail_value_row.py
+++ b/tldw_chatbook/Widgets/detail_value_row.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
+from textual.widget import Widget
 from textual.widgets import Collapsible, Static
 
 
@@ -174,5 +175,5 @@ class DetailGroup(Collapsible):
     way).
     """
 
-    def __init__(self, *children, title: str, collapsed: bool = False, **kwargs) -> None:
+    def __init__(self, *children: Widget, title: str, collapsed: bool = False, **kwargs: object) -> None:
         super().__init__(*children, title=title, collapsed=collapsed, **kwargs)

--- a/tldw_chatbook/Widgets/detail_value_row.py
+++ b/tldw_chatbook/Widgets/detail_value_row.py
@@ -22,14 +22,22 @@ literally: a ``str`` is never interpreted as Rich markup. Callers that want
 markup build their own ``Text`` and pass it in (last program's escaping
 lesson -- server/user-derived strings must never be treated as markup).
 
-CSS lives as ``BUNDLED_CSS`` on these classes rather than a ``.tcss``
-source file: reusable, non-screen-specific ``Widgets/`` components style
-themselves this way in this codebase (``TaskDetail``'s own label/value rows
-are the precedent). Run ``python tldw_chatbook/css/build_css.py`` after
-editing either class's ``BUNDLED_CSS`` block and commit the regenerated
-``css/widget_defaults_self.tcss`` / ``css/widget_defaults_scoped.tcss``
-alongside the source -- the app only ever reads those generated files, not
-the class attribute directly (`Tests/UI/consolidated_css.py`).
+CSS for both classes lives in ``css/features/_scheduling.tcss`` (fix round
+1: not ``BUNDLED_CSS`` on the class, as first shipped), per the brief's
+file list, with plain type/class selectors (``DetailValueRow``,
+``DetailGroup``, ``.detail-value-row-*``) rather than a
+``scheduling-``-prefixed ones, so the widgets stay reusable outside
+Scheduling -- graduate them to a shared features file if/when a
+non-scheduling consumer appears. That module is concatenated into the
+app's boot-loaded CSS bundle (``tldw_cli_modular.tcss``, via
+``build_css.py``'s ``CSS_MODULES``) in the same parse pass as
+``css/core/_variables.tcss``, so ``$ds-*`` design tokens resolve directly
+there with no alias workaround (the widget-defaults ``BUNDLED_CSS`` tier
+this widget used at first is parsed as a separate stylesheet source,
+*before* ``_variables.tcss`` -- a bare ``$ds-*`` reference there is an
+unresolved-variable error). Run ``python tldw_chatbook/css/build_css.py``
+after editing ``_scheduling.tcss`` and commit the regenerated
+``tldw_cli_modular.tcss`` alongside the source.
 """
 
 from __future__ import annotations
@@ -40,7 +48,7 @@ from textual.containers import Horizontal, Vertical
 from textual.widgets import Collapsible, Static
 
 
-def _literal(value: "str | Text") -> Text:
+def _literal(value: str | Text) -> Text:
     """Return ``value`` as a ``Text`` that will render with no markup parsing."""
     return value if isinstance(value, Text) else Text(str(value))
 
@@ -48,71 +56,10 @@ def _literal(value: "str | Text") -> Text:
 class DetailValueRow(Vertical):
     """One label/value detail-pane field, plus a dormant affordance and error slot."""
 
-    BUNDLED_CSS = """
-    /* Local pass-through of the $ds-* tokens this block uses, aliased to
-       the exact same underlying values `css/core/_variables.tcss` defines.
-       The widget-defaults CSS tier (BUNDLED_CSS, TASK-15450) is parsed as
-       its own stylesheet source before the app bundle that defines the
-       real $ds-* tokens, so a bare reference is an unresolved-variable
-       parse error in *any* host, including the real app -- see
-       `TldwCli.CSS_PATH`'s own comment on this exact hazard. Not a
-       distinct palette (contrast `PromptBlockEditor`'s intentionally
-       shadowed one); keep these identical to their source of truth. */
-    $ds-text-muted: $text-muted;
-    $ds-text-primary: $text;
-    $ds-text-disabled-readable: #8a8a8a;
-    $ds-status-error-readable: #ff8fa3;
-
-    DetailValueRow {
-        height: auto;
-        min-height: 0;
-    }
-
-    DetailValueRow .detail-value-row-line {
-        height: 1;
-        min-height: 1;
-    }
-
-    DetailValueRow .detail-value-row-label {
-        color: $ds-text-muted;
-        width: auto;
-        min-width: 0;
-        height: 1;
-        padding: 0 1 0 0;
-    }
-
-    DetailValueRow .detail-value-row-value {
-        color: $ds-text-primary;
-        width: 1fr;
-        min-width: 0;
-        height: 1;
-        text-align: right;
-        text-wrap: nowrap;
-        text-overflow: ellipsis;
-    }
-
-    DetailValueRow .detail-value-row-affordance {
-        color: $ds-text-disabled-readable;
-        width: 2;
-        min-width: 2;
-        height: 1;
-        text-align: right;
-        padding: 0 0 0 1;
-    }
-
-    DetailValueRow .detail-value-row-error {
-        color: $ds-status-error-readable;
-        width: 1fr;
-        height: 1;
-        text-wrap: nowrap;
-        text-overflow: ellipsis;
-    }
-    """
-
     def __init__(
         self,
         label: str,
-        value: "str | Text",
+        value: str | Text,
         *,
         affordance: bool = False,
         value_id: str | None = None,
@@ -147,7 +94,7 @@ class DetailValueRow(Vertical):
         self._error_static.styles.display = "none"
         yield self._error_static
 
-    def update_value(self, value: "str | Text") -> None:
+    def update_value(self, value: str | Text) -> None:
         """Refresh the painted value in place -- no recompose."""
         assert self._value_static is not None, "update_value called before mount"
         self._value_static.update(_literal(value))
@@ -169,22 +116,22 @@ class DetailGroup(Collapsible):
     """Titled, collapsible container composing ``DetailValueRow`` children.
 
     A thin subclass of Textual's own ``Collapsible`` -- click the title (or
-    press Enter while it has focus) to toggle. Pass rows as constructor
-    children, e.g. ``DetailGroup(DetailValueRow(...), title="Schedule")``,
-    or with the ``with``-block compose idiom.
-    """
+    press Enter while it has focus) to toggle; the chevron and ``.collapsed``
+    reactive come for free from the base class.
 
-    BUNDLED_CSS = """
-    /* Local pass-through fallback -- see `DetailValueRow.BUNDLED_CSS`. */
-    $ds-surface-panel: $panel;
-    $ds-grid-line: $surface-lighten-1;
-
-    DetailGroup {
-        background: $ds-surface-panel;
-        border-top: hkey $ds-grid-line;
-    }
+    **``title`` is keyword-only** (``DetailGroup(*children, title, collapsed
+    = False)``), unlike the brief's originally-drafted fully-positional
+    ``DetailGroup(title, *, collapsed=False)`` -- a direct, unavoidable
+    consequence of subclassing ``Collapsible``, whose own ``__init__`` is
+    ``(*children, title="Toggle", collapsed=True, ...)``: with ``*children``
+    first, ``title`` cannot also be positional. Call it as
+    ``DetailGroup(row_1, row_2, title="Schedule")``, never
+    ``DetailGroup("Schedule", row_1)`` -- the latter is accepted by the
+    signature but silently treats the title string as a child widget
+    instead. Rows may also be added with the ``with``-block compose idiom
+    (``Collapsible.compose_add_child`` routes them into the body either
+    way).
     """
 
     def __init__(self, *children, title: str, collapsed: bool = False, **kwargs) -> None:
         super().__init__(*children, title=title, collapsed=collapsed, **kwargs)
-        self.add_class("detail-group")

--- a/tldw_chatbook/Widgets/detail_value_row.py
+++ b/tldw_chatbook/Widgets/detail_value_row.py
@@ -1,0 +1,190 @@
+"""DetailValueRow + DetailGroup: reusable label/value detail-pane row grammar.
+
+schedules-redesign PR-1, Task 1 (`.superpowers/sdd/plan-2026-09-03-
+schedules-redesign-pr1/task-1-brief.md`, the approved spec's section 5 row
+grammar). A row renders one field as ``label`` (muted, left) and ``value``
+(right-aligned, ellipsized rather than wrapped when it overflows). An
+optional dimmed ``▾`` affordance glyph marks a row whose value will become
+interactive in a later PR -- it is purely decorative here, not clickable or
+focusable. A hidden error-line slot below the row is implemented and tested
+(``show_error``/``clear_error``) but unused by any PR-1 caller; PR-3 wires a
+caller to it.
+
+``DetailGroup`` is a thin ``Collapsible`` subclass (the house idiom already
+used directly across this codebase -- see
+``redesign-pr1-survey.md`` section 3 -- rather than a bespoke toggle-button
+section like ``ConsoleInspectorSection``, which exists for a different row
+shape). It gains click/Enter-to-toggle and the chevron for free from
+``Collapsible`` itself.
+
+Values may be a plain ``str`` or a pre-built ``rich.text.Text``. Both render
+literally: a ``str`` is never interpreted as Rich markup. Callers that want
+markup build their own ``Text`` and pass it in (last program's escaping
+lesson -- server/user-derived strings must never be treated as markup).
+
+CSS lives as ``BUNDLED_CSS`` on these classes rather than a ``.tcss``
+source file: reusable, non-screen-specific ``Widgets/`` components style
+themselves this way in this codebase (``TaskDetail``'s own label/value rows
+are the precedent). Run ``python tldw_chatbook/css/build_css.py`` after
+editing either class's ``BUNDLED_CSS`` block and commit the regenerated
+``css/widget_defaults_self.tcss`` / ``css/widget_defaults_scoped.tcss``
+alongside the source -- the app only ever reads those generated files, not
+the class attribute directly (`Tests/UI/consolidated_css.py`).
+"""
+
+from __future__ import annotations
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Collapsible, Static
+
+
+def _literal(value: "str | Text") -> Text:
+    """Return ``value`` as a ``Text`` that will render with no markup parsing."""
+    return value if isinstance(value, Text) else Text(str(value))
+
+
+class DetailValueRow(Vertical):
+    """One label/value detail-pane field, plus a dormant affordance and error slot."""
+
+    BUNDLED_CSS = """
+    /* Local pass-through of the $ds-* tokens this block uses, aliased to
+       the exact same underlying values `css/core/_variables.tcss` defines.
+       The widget-defaults CSS tier (BUNDLED_CSS, TASK-15450) is parsed as
+       its own stylesheet source before the app bundle that defines the
+       real $ds-* tokens, so a bare reference is an unresolved-variable
+       parse error in *any* host, including the real app -- see
+       `TldwCli.CSS_PATH`'s own comment on this exact hazard. Not a
+       distinct palette (contrast `PromptBlockEditor`'s intentionally
+       shadowed one); keep these identical to their source of truth. */
+    $ds-text-muted: $text-muted;
+    $ds-text-primary: $text;
+    $ds-text-disabled-readable: #8a8a8a;
+    $ds-status-error-readable: #ff8fa3;
+
+    DetailValueRow {
+        height: auto;
+        min-height: 0;
+    }
+
+    DetailValueRow .detail-value-row-line {
+        height: 1;
+        min-height: 1;
+    }
+
+    DetailValueRow .detail-value-row-label {
+        color: $ds-text-muted;
+        width: auto;
+        min-width: 0;
+        height: 1;
+        padding: 0 1 0 0;
+    }
+
+    DetailValueRow .detail-value-row-value {
+        color: $ds-text-primary;
+        width: 1fr;
+        min-width: 0;
+        height: 1;
+        text-align: right;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    DetailValueRow .detail-value-row-affordance {
+        color: $ds-text-disabled-readable;
+        width: 2;
+        min-width: 2;
+        height: 1;
+        text-align: right;
+        padding: 0 0 0 1;
+    }
+
+    DetailValueRow .detail-value-row-error {
+        color: $ds-status-error-readable;
+        width: 1fr;
+        height: 1;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+    }
+    """
+
+    def __init__(
+        self,
+        label: str,
+        value: "str | Text",
+        *,
+        affordance: bool = False,
+        value_id: str | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._label = label
+        self._initial_value = value
+        self._affordance = affordance
+        self._value_id = value_id
+        self._error_id = f"{value_id}-error" if value_id else None
+        self._value_static: Static | None = None
+        self._error_static: Static | None = None
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(classes="detail-value-row-line"):
+            yield Static(self._label, classes="detail-value-row-label", markup=False)
+            self._value_static = Static(
+                _literal(self._initial_value),
+                classes="detail-value-row-value",
+                markup=False,
+                id=self._value_id,
+            )
+            yield self._value_static
+            if self._affordance:
+                yield Static(
+                    "▾", classes="detail-value-row-affordance", markup=False
+                )
+        self._error_static = Static(
+            "", classes="detail-value-row-error", markup=False, id=self._error_id
+        )
+        self._error_static.styles.display = "none"
+        yield self._error_static
+
+    def update_value(self, value: "str | Text") -> None:
+        """Refresh the painted value in place -- no recompose."""
+        assert self._value_static is not None, "update_value called before mount"
+        self._value_static.update(_literal(value))
+
+    def show_error(self, msg: str) -> None:
+        """Reveal the hidden error-line slot with ``msg``, rendered literally."""
+        assert self._error_static is not None, "show_error called before mount"
+        self._error_static.update(_literal(msg))
+        self._error_static.styles.display = "block"
+
+    def clear_error(self) -> None:
+        """Hide the error-line slot again and drop its text."""
+        assert self._error_static is not None, "clear_error called before mount"
+        self._error_static.styles.display = "none"
+        self._error_static.update("")
+
+
+class DetailGroup(Collapsible):
+    """Titled, collapsible container composing ``DetailValueRow`` children.
+
+    A thin subclass of Textual's own ``Collapsible`` -- click the title (or
+    press Enter while it has focus) to toggle. Pass rows as constructor
+    children, e.g. ``DetailGroup(DetailValueRow(...), title="Schedule")``,
+    or with the ``with``-block compose idiom.
+    """
+
+    BUNDLED_CSS = """
+    /* Local pass-through fallback -- see `DetailValueRow.BUNDLED_CSS`. */
+    $ds-surface-panel: $panel;
+    $ds-grid-line: $surface-lighten-1;
+
+    DetailGroup {
+        background: $ds-surface-panel;
+        border-top: hkey $ds-grid-line;
+    }
+    """
+
+    def __init__(self, *children, title: str, collapsed: bool = False, **kwargs) -> None:
+        super().__init__(*children, title=title, collapsed=collapsed, **kwargs)
+        self.add_class("detail-group")

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -297,3 +297,63 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
 #scheduling-workbench.compact #scheduling-list-header {
     display: none;
 }
+
+/* schedules-redesign PR-1, Task 1 (fix round 1): DetailValueRow /
+ * DetailGroup (`Widgets/detail_value_row.py`) live here per the task-1
+ * brief's file list rather than as BUNDLED_CSS on the widget classes --
+ * this module is concatenated into the boot-loaded app bundle in the same
+ * parse pass as core/_variables.tcss, so $ds-* tokens resolve directly,
+ * with no local alias workaround. Selectors are plain type/class
+ * (not scheduling-prefixed): the widgets are reusable beyond Scheduling,
+ * and this is just where the first consumer's CSS happens to ship;
+ * graduate to a shared features file if/when a non-scheduling consumer
+ * appears. */
+DetailValueRow {
+    height: auto;
+    min-height: 0;
+}
+
+DetailValueRow .detail-value-row-line {
+    height: 1;
+    min-height: 1;
+}
+
+DetailValueRow .detail-value-row-label {
+    color: $ds-text-muted;
+    width: auto;
+    min-width: 0;
+    height: 1;
+    padding: 0 1 0 0;
+}
+
+DetailValueRow .detail-value-row-value {
+    color: $ds-text-primary;
+    width: 1fr;
+    min-width: 0;
+    height: 1;
+    text-align: right;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+DetailValueRow .detail-value-row-affordance {
+    color: $ds-text-disabled-readable;
+    width: 2;
+    min-width: 2;
+    height: 1;
+    text-align: right;
+    padding: 0 0 0 1;
+}
+
+DetailValueRow .detail-value-row-error {
+    color: $ds-status-error-readable;
+    width: 1fr;
+    height: 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+DetailGroup {
+    background: $ds-surface-panel;
+    border-top: hkey $ds-grid-line;
+}

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -76,10 +76,20 @@ SchedulesWorkbench TabbedContent TabPane {
 
 /* schedules-redesign PR-1, Task 4: the Automations tab's third pane --
  * the definitions detail widget (DefinitionDetail), the same list|detail|
- * inspector idiom as the Queue tab's three panes above. */
+ * inspector idiom as the Queue tab's three panes above.
+ *
+ * min-width 22, not 30 (final review F5): the three panes' min-widths must
+ * SUM to no more than the narrowest width at which all three are still
+ * shown -- 84, the same `hide_detail` threshold the Queue tab's own detail
+ * pane uses. At 30+30+30 = 90 the 84-89 band could not satisfy that, and
+ * Textual's fr layout then gave EVERY pane the full container width,
+ * laying the detail and history panes out entirely off-screen; the split
+ * has overflow: hidden, so not even a scrollbar hinted at it. 30+30+22 =
+ * 82 fits 84 with slack. This floor only ever binds inside that band -- at
+ * any wider width the 1fr share is larger anyway. */
 #scheduling-automations-detail-pane {
     width: 1fr;
-    min-width: 30;
+    min-width: 22;
     height: 1fr;
     min-height: 0;
     padding: 1;
@@ -92,7 +102,10 @@ SchedulesWorkbench TabbedContent TabPane {
     padding: 3 1;
 }
 
-#scheduling-automation-detail-question {
+/* The two detail panes' body cards: the definitions pane's question and
+ * (final review F10) the reminder pane's body text, same card. */
+#scheduling-automation-detail-question,
+#scheduling-task-detail-body-card {
     height: auto;
     padding: 1;
     margin-bottom: 1;

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -74,6 +74,33 @@ SchedulesWorkbench TabbedContent TabPane {
     border: solid $ds-grid-line;
 }
 
+/* schedules-redesign PR-1, Task 4: the Automations tab's third pane --
+ * the definitions detail widget (DefinitionDetail), the same list|detail|
+ * inspector idiom as the Queue tab's three panes above. */
+#scheduling-automations-detail-pane {
+    width: 1fr;
+    min-width: 30;
+    height: 1fr;
+    min-height: 0;
+    padding: 1;
+    border: solid $ds-grid-line;
+}
+
+#scheduling-automation-detail-empty-state {
+    color: $text-muted;
+    text-align: center;
+    padding: 3 1;
+}
+
+#scheduling-automation-detail-question {
+    height: auto;
+    padding: 1;
+    margin-bottom: 1;
+    border: solid $ds-grid-line;
+    background: $ds-surface-panel;
+    color: $text;
+}
+
 #scheduling-automations-table {
     height: 1fr;
 }
@@ -123,7 +150,8 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
 /* Pane headers */
 #scheduling-list-title,
 #scheduling-task-detail-header,
-#scheduling-task-inspector-header {
+#scheduling-task-inspector-header,
+#scheduling-automation-detail-header {
     text-style: bold;
     color: $text;
     padding: 0 0 0 0;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13663,6 +13663,33 @@ SchedulesWorkbench TabbedContent TabPane {
     border: solid $ds-grid-line;
 }
 
+/* schedules-redesign PR-1, Task 4: the Automations tab's third pane --
+ * the definitions detail widget (DefinitionDetail), the same list|detail|
+ * inspector idiom as the Queue tab's three panes above. */
+#scheduling-automations-detail-pane {
+    width: 1fr;
+    min-width: 30;
+    height: 1fr;
+    min-height: 0;
+    padding: 1;
+    border: solid $ds-grid-line;
+}
+
+#scheduling-automation-detail-empty-state {
+    color: $text-muted;
+    text-align: center;
+    padding: 3 1;
+}
+
+#scheduling-automation-detail-question {
+    height: auto;
+    padding: 1;
+    margin-bottom: 1;
+    border: solid $ds-grid-line;
+    background: $ds-surface-panel;
+    color: $text;
+}
+
 #scheduling-automations-table {
     height: 1fr;
 }
@@ -13712,7 +13739,8 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
 /* Pane headers */
 #scheduling-list-title,
 #scheduling-task-detail-header,
-#scheduling-task-inspector-header {
+#scheduling-task-inspector-header,
+#scheduling-automation-detail-header {
     text-style: bold;
     color: $text;
     padding: 0 0 0 0;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13665,10 +13665,20 @@ SchedulesWorkbench TabbedContent TabPane {
 
 /* schedules-redesign PR-1, Task 4: the Automations tab's third pane --
  * the definitions detail widget (DefinitionDetail), the same list|detail|
- * inspector idiom as the Queue tab's three panes above. */
+ * inspector idiom as the Queue tab's three panes above.
+ *
+ * min-width 22, not 30 (final review F5): the three panes' min-widths must
+ * SUM to no more than the narrowest width at which all three are still
+ * shown -- 84, the same `hide_detail` threshold the Queue tab's own detail
+ * pane uses. At 30+30+30 = 90 the 84-89 band could not satisfy that, and
+ * Textual's fr layout then gave EVERY pane the full container width,
+ * laying the detail and history panes out entirely off-screen; the split
+ * has overflow: hidden, so not even a scrollbar hinted at it. 30+30+22 =
+ * 82 fits 84 with slack. This floor only ever binds inside that band -- at
+ * any wider width the 1fr share is larger anyway. */
 #scheduling-automations-detail-pane {
     width: 1fr;
-    min-width: 30;
+    min-width: 22;
     height: 1fr;
     min-height: 0;
     padding: 1;
@@ -13681,7 +13691,10 @@ SchedulesWorkbench TabbedContent TabPane {
     padding: 3 1;
 }
 
-#scheduling-automation-detail-question {
+/* The two detail panes' body cards: the definitions pane's question and
+ * (final review F10) the reminder pane's body text, same card. */
+#scheduling-automation-detail-question,
+#scheduling-task-detail-body-card {
     height: auto;
     padding: 1;
     margin-bottom: 1;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13887,6 +13887,66 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     display: none;
 }
 
+/* schedules-redesign PR-1, Task 1 (fix round 1): DetailValueRow /
+ * DetailGroup (`Widgets/detail_value_row.py`) live here per the task-1
+ * brief's file list rather than as BUNDLED_CSS on the widget classes --
+ * this module is concatenated into the boot-loaded app bundle in the same
+ * parse pass as core/_variables.tcss, so $ds-* tokens resolve directly,
+ * with no local alias workaround. Selectors are plain type/class
+ * (not scheduling-prefixed): the widgets are reusable beyond Scheduling,
+ * and this is just where the first consumer's CSS happens to ship;
+ * graduate to a shared features file if/when a non-scheduling consumer
+ * appears. */
+DetailValueRow {
+    height: auto;
+    min-height: 0;
+}
+
+DetailValueRow .detail-value-row-line {
+    height: 1;
+    min-height: 1;
+}
+
+DetailValueRow .detail-value-row-label {
+    color: $ds-text-muted;
+    width: auto;
+    min-width: 0;
+    height: 1;
+    padding: 0 1 0 0;
+}
+
+DetailValueRow .detail-value-row-value {
+    color: $ds-text-primary;
+    width: 1fr;
+    min-width: 0;
+    height: 1;
+    text-align: right;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+DetailValueRow .detail-value-row-affordance {
+    color: $ds-text-disabled-readable;
+    width: 2;
+    min-width: 2;
+    height: 1;
+    text-align: right;
+    padding: 0 0 0 1;
+}
+
+DetailValueRow .detail-value-row-error {
+    color: $ds-status-error-readable;
+    width: 1fr;
+    height: 1;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
+}
+
+DetailGroup {
+    background: $ds-surface-panel;
+    border-top: hkey $ds-grid-line;
+}
+
 /* ===== MODULE: features/_code_repo.tcss ===== */
 /* ========================================
  * Code Repository Copy/Paste Feature Styles

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -3069,6 +3069,44 @@
 
 
 
+/* ===== WIDGET: DetailValueRow (Widgets/detail_value_row.py) ===== */
+
+    /* Local pass-through of the $ds-* tokens this block uses, aliased to
+       the exact same underlying values `css/core/_variables.tcss` defines.
+       The widget-defaults CSS tier (BUNDLED_CSS, TASK-15450) is parsed as
+       its own stylesheet source before the app bundle that defines the
+       real $ds-* tokens, so a bare reference is an unresolved-variable
+       parse error in *any* host, including the real app -- see
+       `TldwCli.CSS_PATH`'s own comment on this exact hazard. Not a
+       distinct palette (contrast `PromptBlockEditor`'s intentionally
+       shadowed one); keep these identical to their source of truth. */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+/* ===== WIDGET: DetailGroup (Widgets/detail_value_row.py) ===== */
+
+    /* Local pass-through fallback -- see `DetailValueRow.BUNDLED_CSS`. */
+
+
+
+
+
+
 /* ===== WIDGET: ProjectSkillsImportModal (Widgets/project_skills_import_modal.py) ===== */
 
 

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -3069,44 +3069,6 @@
 
 
 
-/* ===== WIDGET: DetailValueRow (Widgets/detail_value_row.py) ===== */
-
-    /* Local pass-through of the $ds-* tokens this block uses, aliased to
-       the exact same underlying values `css/core/_variables.tcss` defines.
-       The widget-defaults CSS tier (BUNDLED_CSS, TASK-15450) is parsed as
-       its own stylesheet source before the app bundle that defines the
-       real $ds-* tokens, so a bare reference is an unresolved-variable
-       parse error in *any* host, including the real app -- see
-       `TldwCli.CSS_PATH`'s own comment on this exact hazard. Not a
-       distinct palette (contrast `PromptBlockEditor`'s intentionally
-       shadowed one); keep these identical to their source of truth. */
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-/* ===== WIDGET: DetailGroup (Widgets/detail_value_row.py) ===== */
-
-    /* Local pass-through fallback -- see `DetailValueRow.BUNDLED_CSS`. */
-
-
-
-
-
-
 /* ===== WIDGET: ProjectSkillsImportModal (Widgets/project_skills_import_modal.py) ===== */
 
 


### PR DESCRIPTION
First slice of the approved schedules-screen redesign (spec: backlog/docs/spec-2026-09-02-schedules-screen-redesign.md, committed here with its ADR-099-filename-collision errata; plan: backlog/docs/plan-2026-09-03-schedules-redesign-pr1.md). Read-only by design — in-pane editing is the program's PR-3.

## What ships
- **`DetailValueRow` + `DetailGroup`** (`Widgets/detail_value_row.py`): the redesign's foundational grammar — label left, right-aligned value, dormant affordance + error slot activated by the editing slice; PR-3-ready surface (reactive `affordance`, `row_key` identity, focus-ready). Styled via `$ds-*` tokens in `_scheduling.tcss` (the BUNDLED_CSS token-resolution hazard was adjudicated away by moving styles to the features file).
- **Reminder detail regrammar** (`task_detail.py`): the spec §5 grouped rows (Details / Frequency / History-collapsed) with strict behavior preservation — actions, transfer wiring, incidents, shortcuts untouched (whole-diff audited; one handler hit = the sanctioned worker).
- **The Automations tab's first definitions detail pane** (`definition_detail.py`): question card, Model/Generation/Finding-policy/Sources/Notifications rows, owner + in-flight transfer badge, History counts via two new per-definition count seams — off-thread, latest-wins on rapid highlight.
- **One vocabulary, honest values**: shared `owner_display_label` across both panes ("This device" / server label); absent config keys render "Not set", never form defaults presented as fact; server-owned rows say their history lives on the server instead of showing local zeros; error paths say "couldn't load" instead of fake counts.
- **Wire-shape fixes caught by our own recorded fixtures**: the server sends `schedule.expression` where local rows carry `cron` — the detail pane AND the PR-4-era authoring-form prefill (a silent server-overwrite risk on editing a mirrored definition) now share one `definition_cron_expression` helper, both pinned premise-first against the recorded fixture.
- Width-band fix (the third pane no longer clips at 84–89 cols), User Guide updates. Three new focus stops from the collapsible group titles are deliberate (keyboard-reachable collapse beats fewer stops) and documented.

## Review trail
5 SDD tasks, each reviewed (Task 1's CSS adjudication moved styles to the features file; Task 3's behavior-preservation gate passed with a single justified assertion update). Final whole-branch review (opus): 0 Critical, 6 Important — all probed (fixture-caught wire drift, defaults-as-fact, local-zeros-for-server-rows, stale-pane-on-unchanged-id, the width band, dialect split) — all fixed in one wave + a round-2 carry-forward closure, scoped re-review ALL RESOLVED. 923 Scheduling + 313 schedules-UI tests green; census 969-970/972 across runs; diagnostics pin clean; CSS bundle byte-identical.

## Deferred (ledgered)
Post-transfer history counts (a transferred definition's pre-transfer local runs don't join the new id — follow-up when the redesign's later slices touch history); a normalizing ingestion boundary for wire-key divergences (worth it only on a third occurrence); the harness trap now documented: geometry assertions need `CSS_PATH = BUNDLED_STYLESHEET` or they measure nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WocisXw6SEEG6nb1aKFHtv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the first read-only slice of the schedules detail-pane redesign and commits its user-approved spec. It replaces the reminder detail list with grouped rows and adds a per-definition inspector to Automations, while preserving existing actions, transfers, incidents, and in-pane editing remains deferred.

**New Features**
- Adds reusable `DetailValueRow` and `DetailGroup` widgets with right-aligned values, ellipsis overflow, collapsible groups, and dormant editing/error slots.
- Shows automation questions, configuration, owner and transfer state, plus definition-scoped run history counts loaded asynchronously with latest-selection handling.
- Documents the new layouts and keeps scheduled-task projections on their existing Type/Schedule display.

**Bug Fixes**
- Missing configuration values now show "Not set"; server-owned and pending definitions explain where history lives instead of showing misleading local counts.
- Reads cron schedules from either `cron` or the server's `expression` key in both detail rendering and form prefill, preventing an edit from overwriting a mirrored server schedule.
- Refreshes a selected pane after same-ID updates, aligns owner labels across panes, and prevents the three-pane Automations layout from clipping at narrow widths.

<sup>Written for commit 0e3e60d06c4cae5cb23da4e575d39e52e0df51a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

