### PR TITLE
fix(library): review-set finish line + no silent failures (task-30041, task-30042)

### DIFF
--- a/.impeccable/critique/2026-09-03T12-58-19Z__tldw-chatbook-ui-screens-library-screen-py.md
+++ b/.impeccable/critique/2026-09-03T12-58-19Z__tldw-chatbook-ui-screens-library-screen-py.md
@@ -1,0 +1,71 @@
+---
+target: Library ▸ Media surface (post review-sets program)
+total_score: 24
+max_score: 40
+na_heuristics: 
+p0_count: 0
+p1_count: 3
+timestamp: 2026-09-03T12-58-19Z
+slug: tldw-chatbook-ui-screens-library-screen-py
+---
+Method: dual-agent (A: live design review sub-agent · B: detector/evidence sub-agent)
+
+Target: Library ▸ Browse ▸ Media (list, toolbar, select mode, Reader, Trash, review sets) — live tmux at 235×52 + 100×30, seeded 6-item profile. Session caveat: a second app instance from another worktree shared the user profile during Assessment A; findings that depend on persistence are attributed accordingly.
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 2 | Footer goes stale at the set-completion moment; list view gives no hint a set is active; "Loaded in Reader" marker persisted after the Reader emptied |
+| 2 | Match System / Real World | 3 | "Remove later" reads as deferred removal; "Open manager" jargon; "Match 1 of 1 matches" counts blocks, not occurrences |
+| 3 | User Control and Freedom | 3 | "Review set dismissed." has no Undo (bulk delete does); no keyboard route back to a paused set |
+| 4 | Consistency and Standards | 3 | Same width: Conversations stacks its toolbar readably, Media chops horizontally; `]`/`[` silently change meaning browse↔set |
+| 5 | Error Prevention | 3 | Armed confirm + danger placement strong; undermined by `Tr`/`R` mystery-meat buttons two cells apart |
+| 6 | Recognition Rather Than Recall | 1 | Resting toolbar renders `t so E Tr R Se`; select-mode actions render as bare `○ ○ ○`; reviewed state of the current item shown nowhere; set name never shown |
+| 7 | Flexibility and Efficiency | 3 | Walking is keyboard-first, but no key creates a set or opens the picker; `]` dies at the last item |
+| 8 | Aesthetic and Minimalist Design | 2 | "Image preview unavailable" + "Retry preview" failure chrome atop every plain document; verbose state prefixes displace row titles to "Quart"/"SQLit" |
+| 9 | Error Recovery | 2 | Delete has receipts + Trash; the review-set subsystem fails silently end-to-end by design (`service is None → return`, silent auto-resume) |
+| 10 | Help and Documentation | 2 | Footer teaching + stamped user guide, but the guide promises a completion gesture and auto-resume the product doesn't deliver |
+| **Total** | | **24/40** | **Acceptable** |
+
+## Design Specificity Verdict
+
+**LLM assessment (A):** Authored at the model layer, category-generic-to-broken at the presentation layer. The interaction model is unmistakably this product's: a footer that re-teaches itself per mode with honest escape labels, and review-set semantics (advance-marks-what-you-leave, tombstones, live-only progress, title snapshots surviving deletion) that no template produces. But the rendered resting state betrays it: at 235×52 the six-button toolbar renders as `t so E Tr R Se`, select-mode actions as three bare `○`, and delete-confirm safety copy clips mid-word.
+
+**Deterministic scan (B):** The bundled detector targets web markup: the five Python widget files scanned clean as plain text (exit 0, zero findings — "unscannable-by-design", not "clean"). A TCSS fallback scan found 2 advisory findings (`#6f7782` border, `rgb(245,245,245)`) — both in Console styling sources, outside this surface. Mechanical greps agree with A's strengths: 0 hardcoded hex in the media widgets, every unicode state marker (`✓ ○ ▸ ☑ ☐`) is text-paired in code, notice copy inventory is clean and specific, all 14 inline `styles.` assignments are sizing-only. B's independent 100×30 capture reproduced the toolbar fragmentation (`ty so Ex Tr Re Sel`) and a clipped Reader action row — the legibility failure is not width-specific, it is the pane's grammar.
+
+**Visual overlays:** not applicable (terminal UI, no browser target).
+
+## Overall Impression
+
+A genuinely well-modeled surface wearing the wrong clothes at rest. The safety grammar (armed confirms, receipts, Trash) and the review-set data model are better than most shipping products; the footer-as-contract is the brand executed correctly. But the two moments that define the surface — glancing at the toolbar to act, and finishing a review set — are respectively illegible and dead. Fix the finish line and the resting toolbar and this jumps a band.
+
+## What's Working
+
+1. **The footer as a live contract** — keys appear only when they work, escape labels state their true effect per focus context, and set progress rides in the same line. Recognition-over-recall done the terminal-native way.
+2. **Delete-safety grammar** — count-naming armed confirm, danger button at the far end, `✓ deleted · N items · in Trash` receipt with Undo, honest Trash empty copy. Layered and recoverable.
+3. **The review-set data model** — tombstones, live-only progress, title snapshots for deleted items, cap-with-notice. Deletion-honest design most products get wrong.
+
+## Priority Issues
+
+- **[P1] The documented completion gesture is dead, and the footer lies at the finish.** `check_action` for `library_media_next_item/prev_item` gates `]`/`[` on browse-row adjacency and never consults the active review set (confirmed at `library_screen.py:30772`), so at the last row `]` is disabled while the footer still advertises "] next in set" — reproduced live (footer pinned at "6 of 6 · 5 reviewed"; the final mark never lands). It also misfires whenever set order ≠ browse order (filtered/selection sets). Separately, the walk's clamp branch marks + refreshes completion but skips the viewer sync, so even a working final step would leave the footer stale. **Why:** the single moment the feature builds toward is a silent no-op; the doc promises it. **Fix:** `check_action` returns True for these actions whenever `_review_set_active()`; add the viewer sync on the no-target branch; give completion an actual moment (e.g. "All 6 reviewed" notice + offer to dismiss). **Suggested command:** /impeccable harden
+- **[P1] The Items-pane toolbar is illegible in the resting 3-pane layout.** At the pane's 40-col floor all six compact buttons chop to `t so E Tr R Se`; select mode renders `0/selec/ted` + three bare `○`; the armed-confirm safety copy clips to "You can und / restore later from Tr". Tooltips are mouse-only. B reproduced independently at 100×30. **Why:** the actions the surface exists for are unrecognizable in its default state; the accessibility markers become the entire label. **Fix:** below a measured width, switch to the stacked one-action-per-row grammar the Conversations canvas already uses, or overflow into a single "Actions ▸" chooser strip (machinery exists). **Suggested command:** /impeccable adapt
+- **[P1] Review-set failures are silent end-to-end.** Every failure path is a deliberate silent return (`service is None → return`; auto-resume "any failure is silent"). During Assessment A the Sets button produced no response across three activations — likely environmental (a second app instance shared the profile and collections writes stopped landing), but that is exactly the point: a wedged storage path is indistinguishable from the feature not existing, and "progress saved between visits" can silently be false. **Why:** the product's own anti-reference is "hidden recovery states". **Fix:** the picker button always responds (a `service is None` press says storage is unavailable); surface a health notice when the collections DB cannot be opened/written. **Suggested command:** /impeccable harden
+- **[P2] The current item's reviewed state — and the set's name — are displayed nowhere.** `m`'s only feedback is the aggregate counter changing; landing mid-set you must toggle twice to learn the state. **Fix:** a per-item glyph in the footer segment or a one-line set header ("Reviewing: All media — 3 of 6 · ✓") above the Reader. **Suggested command:** /impeccable polish
+- **[P2] Failure chrome on the primary reading surface.** Every plain document's Read tab leads with "Image preview unavailable — showing complete stored text" + a persistent "Retry preview" button above the content, and the wide-mode row prefix "Loaded in Reader" consumes ~28 of ~35 label cells, leaving "Quart"/"SQLit". **Fix:** surface preview status only when an image was expected; use the compact prefix grammar (exists) or a leading glyph in narrow layouts. **Suggested command:** /impeccable distill
+
+## Persona Red Flags
+
+**Alex (impatient power user):** cannot start a review set from the keyboard (footer offers `/ F6 s esc`; "Review these" is a click-only button currently labeled `R`, two cells from `Tr`); his `]` rhythm dies at the last item with the footer still advertising it — he presses it three times, doubts himself, leaves the set uncompleted; after R-exit, resuming means mousing to "Sets".
+
+**Sam (keyboard-only / no color-only meaning):** the non-color vocabulary is strong on paper (`☐/☑`, `▸`, `✓`, focus boxes) — but in the resting layout the `○` disabled markers ARE the labels for the three bulk actions, and the reason tooltips are hover-only, so Sam can never read what a control is or why it's off; the clipped confirm copy means arming a destructive action whose safety sentence reads "You can und / restore later from Tr".
+
+## Minor Observations
+
+"Match 1 of 1 matches" double-counts the word and counts blocks; duplicate "All media" sets can be created back-to-back (picker rows differ only by progress); `R` the key exits review while `R` the chopped button creates one; "Open manager" unexplained; pager disabled-reason itself truncates; Reader keeps showing the prior item while browsing Trash; two advisory TCSS color literals (Console-scoped) are outside DESIGN.md's palette.
+
+## Questions to Consider
+
+1. If the resting 3-pane layout cannot render six labeled buttons, is a toolbar the wrong grammar for this pane — should list actions live in one chooser strip and the pane spend its columns on titles?
+2. A review set is the product's first real "workflow object" — why is its entire runtime UI a footer string? Would a one-line set header above the Reader solve name-invisibility, per-item state, and list-level awareness at once?
+3. For a persistence feature, is the silent-failure doctrine ever acceptable when the write path is down — what would the brand's own "no hidden recovery states" commitment call this?

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2777,8 +2777,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 118,
-      "diagnostic_digest": "f53c03f37eb09a5fb154",
+      "call_count": 123,
+      "diagnostic_digest": "ebb31e5800450e3a742a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11271,6 +11271,6 @@
     "path_privacy_candidate_calls": 714,
     "persistent_sink_files": 10,
     "task_492_calls": 1337,
-    "task_494_calls": 7557
+    "task_494_calls": 7562
   }
 }

--- a/Tests/UI/test_review_set_walker.py
+++ b/Tests/UI/test_review_set_walker.py
@@ -37,6 +37,8 @@ def _walker_fake(
     the walk marks/advances from the DISPLAYED item, not the persisted cursor).
     """
     calls: list[tuple[str, str]] = []
+    notices: list[tuple[str, str]] = []
+    syncs: list[bool] = []
     fake = SimpleNamespace(
         _review_set_service=lambda: service,
         _review_set_live_ids=(
@@ -48,8 +50,21 @@ def _walker_fake(
             lambda media_id, title, **_kwargs: calls.append((media_id, title))
         ),
         _library_media_reader_session=SimpleNamespace(loaded_backing_id=loaded),
+        _notify_review_set=(
+            lambda message, severity="information": notices.append(
+                (message, severity)
+            )
+        ),
+        _sync_library_media_viewer_or_recompose=lambda: syncs.append(True),
     )
     fake._select_calls = calls
+    fake._notices = notices
+    fake._syncs = syncs
+    for name in (
+        "_walk_active_review_set_unguarded",
+        "_toggle_reviewed_unguarded",
+    ):
+        setattr(fake, name, MethodType(getattr(LibraryScreen, name), fake))
     return fake
 
 
@@ -136,6 +151,110 @@ def test_walk_resumes_at_cursor_without_marking_when_reader_is_off_set(tmp_path)
     assert all(item.done is False for item in review_set.items)  # nothing marked
     assert fake._select_calls == [("local:media:11", "B")]  # loaded the cursor item
     assert review_set.cursor == 1  # unchanged (already a live position)
+
+
+# --- the finish line (task-30041, critique 2026-09-03) -----------------------
+
+
+def test_check_action_enables_walk_keys_whenever_a_set_is_active(tmp_path):
+    """]/[ must gate on the ACTIVE SET, not browse-row adjacency.
+
+    Critique P1: at the last browse row _library_media_adjacent_row returns
+    None, which disabled the documented final-] completion gesture at the
+    binding layer (and misfired whenever set order diverged from browse
+    order). With a set active the walk clamps safely, so the keys stay live.
+    """
+    fake = SimpleNamespace(
+        _library_media_item_traversal_active=lambda: True,
+        _review_set_active=lambda: True,
+        _library_media_adjacent_row=lambda direction: None,  # last browse row
+    )
+    assert (
+        LibraryScreen.check_action(fake, "library_media_next_item", ()) is True
+    )
+    assert (
+        LibraryScreen.check_action(fake, "library_media_prev_item", ()) is True
+    )
+
+    fake._review_set_active = lambda: False
+    assert (
+        LibraryScreen.check_action(fake, "library_media_next_item", ()) is False
+    )
+
+
+def test_walk_final_forward_syncs_the_footer_and_notifies_completion(tmp_path):
+    """The completion gesture refreshes the chrome and gets a real moment.
+
+    Critique P1: the clamp branch marked the last item and refreshed
+    completion but skipped the viewer sync, so the footer stayed stale at
+    exactly the finish; and completing a set had no acknowledgment at all.
+    """
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "X", origin="browse", items=[(10, "A"), (11, "B")]
+    )
+    service.mark_item_done(set_id, backing_media_id=10, done=True)
+    service.set_cursor(set_id, 1)
+    fake = _walker_fake(service, loaded=11)
+
+    LibraryScreen._walk_active_review_set(fake, 1)
+
+    review_set = service.get_review_set(set_id)
+    assert review_set.completed_at is not None
+    assert fake._syncs == [True]  # footer refreshed at the finish
+    assert any("All 2 reviewed" in message for message, _sev in fake._notices)
+
+
+def test_walk_completion_notice_fires_only_on_the_completing_walk(tmp_path):
+    """A ] pressed after completion must not re-announce."""
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "X", origin="browse", items=[(10, "A"), (11, "B")]
+    )
+    service.mark_item_done(set_id, backing_media_id=10, done=True)
+    service.set_cursor(set_id, 1)
+    fake = _walker_fake(service, loaded=11)
+
+    LibraryScreen._walk_active_review_set(fake, 1)  # completes
+    LibraryScreen._walk_active_review_set(fake, 1)  # idempotent extra press
+
+    completion_notices = [
+        message for message, _sev in fake._notices if "All 2 reviewed" in message
+    ]
+    assert len(completion_notices) == 1
+
+
+# --- no silent failures (task-30042, critique 2026-09-03) --------------------
+
+
+def test_walk_failure_notifies_and_consumes_instead_of_raising(tmp_path):
+    """Storage exploding mid-walk surfaces an error, never a crash."""
+
+    class _Boom:
+        def get_active_review_set(self):
+            raise RuntimeError("db gone")
+
+    fake = _walker_fake(_service(tmp_path))
+    fake._review_set_service = lambda: _Boom()
+
+    handled = LibraryScreen._walk_active_review_set(fake, 1)
+
+    assert handled is True  # consumed; no browse fallback double-action
+    assert any(severity == "error" for _msg, severity in fake._notices)
+
+
+def test_toggle_reviewed_failure_notifies(tmp_path):
+    class _Boom:
+        def get_active_review_set(self):
+            raise RuntimeError("db gone")
+
+    fake = _walker_fake(_service(tmp_path))
+    fake._review_set_service = lambda: _Boom()
+    fake._library_media_item_traversal_active = lambda: True
+
+    LibraryScreen.action_library_media_toggle_reviewed(fake)  # must not raise
+
+    assert any(severity == "error" for _msg, severity in fake._notices)
 
 
 def test_walk_returns_false_when_no_set_is_active(tmp_path):
@@ -666,6 +785,75 @@ async def test_read_later_pairs_run_against_the_real_media_db(tmp_path):
         ids[0],
     ]
     assert fake._opened == [f"local:media:{ids[2]}"]
+
+
+@pytest.mark.asyncio
+async def test_picker_press_with_unavailable_storage_notifies(tmp_path):
+    """Pressing Sets with no storage must say so, never silently no-op.
+
+    task-30042 (critique P1 + user ruling: silent failure is never
+    acceptable): a dead button is indistinguishable from the feature not
+    existing.
+    """
+    fake = _picker_fake(_service(tmp_path), decision=None)
+    fake._review_set_service = lambda: None
+
+    await fake._review_set_picker_worker()
+
+    assert any(
+        "storage" in message.lower() and severity == "error"
+        for message, severity in fake._notices
+    )
+
+
+def test_create_with_unavailable_storage_notifies(tmp_path):
+    """A build that resolved items but has no storage must not vanish."""
+    fake = _entry_fake(_service(tmp_path))
+    fake._review_set_service = lambda: None
+
+    LibraryScreen._create_and_open_review_set(
+        fake, "Talks", "browse", [(10, "A")]
+    )
+
+    assert fake._opened == []
+    assert any(
+        "storage" in message.lower() and severity == "error"
+        for message, severity in fake._notices
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_failure_notifies(tmp_path):
+    """Auto-resume exceptions surface an error instead of the old silence."""
+    service = _service(tmp_path)
+    service.create_review_set("X", origin="browse", items=[(10, "A")])
+    fake = _auto_resume_fake(service)
+
+    def boom():
+        raise RuntimeError("db gone")
+
+    fake._resolve_active_review_set_landing = boom
+
+    await fake._auto_resume_review_set_worker()  # must not raise
+
+    assert any(severity == "error" for _msg, severity in fake._notices)
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_with_unavailable_storage_warns_once(tmp_path):
+    """Missing storage on media entry warns once per session, not per visit."""
+    fake = _auto_resume_fake(_service(tmp_path))
+    fake._review_set_service = lambda: None
+
+    await fake._auto_resume_review_set_worker()
+    await fake._auto_resume_review_set_worker()
+
+    warnings = [
+        message
+        for message, severity in fake._notices
+        if severity == "warning" and "storage" in message.lower()
+    ]
+    assert len(warnings) == 1
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_review_set_walker.py
+++ b/Tests/UI/test_review_set_walker.py
@@ -182,6 +182,30 @@ def test_check_action_enables_walk_keys_whenever_a_set_is_active(tmp_path):
     )
 
 
+def test_check_action_fails_closed_when_storage_errors(tmp_path):
+    """A storage error in the binding gate degrades to browse, never crashes.
+
+    Qodo #2346: check_action runs on every key resolution and footer render,
+    so an exception here would crash-loop the screen. The gate fails closed
+    (browse adjacency), and the explicit gesture paths carry the notices.
+    """
+
+    class _Boom:
+        def get_active_review_set(self):
+            raise RuntimeError("db gone")
+
+    fake = SimpleNamespace(
+        _library_media_item_traversal_active=lambda: True,
+        _review_set_service=lambda: _Boom(),
+        _library_media_adjacent_row=lambda direction: None,
+    )
+    fake._review_set_active = MethodType(LibraryScreen._review_set_active, fake)
+
+    assert (
+        LibraryScreen.check_action(fake, "library_media_next_item", ()) is False
+    )
+
+
 def test_walk_final_forward_syncs_the_footer_and_notifies_completion(tmp_path):
     """The completion gesture refreshes the chrome and gets a real moment.
 
@@ -365,6 +389,9 @@ def _entry_fake(service):
     )
     fake._notify_review_set = MethodType(
         LibraryScreen._notify_review_set, fake
+    )
+    fake._REVIEW_SET_STORAGE_UNAVAILABLE = (
+        LibraryScreen._REVIEW_SET_STORAGE_UNAVAILABLE
     )
     fake._opened = opened
     fake._notices = notices

--- a/backlog/tasks/task-30041 - Review-sets-fix-the-dead-completion-gesture-and-stale-finish-footer.md
+++ b/backlog/tasks/task-30041 - Review-sets-fix-the-dead-completion-gesture-and-stale-finish-footer.md
@@ -1,0 +1,34 @@
+---
+id: TASK-30041
+title: Review sets - fix the dead completion gesture and stale finish footer
+status: In Progress
+assignee:
+  - '@claude'
+created_date: '2026-09-03 13:04'
+updated_date: '2026-09-03 13:07'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique 2026-09-03 P1: check_action for library_media_next_item/prev_item gates ]/[ on browse-row adjacency and never consults the active review set, so the documented final-] completion gesture is disabled at the last browse row (and the gate misfires whenever set order diverges from browse order). The walk's clamp branch also skips the viewer sync, leaving the footer stale at the completion moment. Reproduced live; docs promise the gesture.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 With an active review set, ] and [ are enabled wherever the set can move or mark, regardless of browse-row adjacency
+- [ ] #2 The final ] on the last live item marks it done and the footer updates to the all-reviewed state in the same interaction
+- [ ] #3 Completing a set surfaces an explicit completion notice
+- [ ] #4 Walking a selection-origin set whose order differs from browse order works end to end
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. check_action ]/[ branch: enabled whenever _review_set_active() (walk clamps safely), else browse adjacency - TDD via fake\n2. Walk clamp branch: viewer sync so the footer updates at the finish - TDD\n3. Completion notice: walk that marks and flips the set to complete notifies 'All N reviewed.' - TDD\n4. Live verify: 6-item set, walk to final ], footer flips + notice
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-30042 - Review-sets-no-silent-failures-every-gesture-responds-storage-health-surfaces.md
+++ b/backlog/tasks/task-30042 - Review-sets-no-silent-failures-every-gesture-responds-storage-health-surfaces.md
@@ -1,0 +1,35 @@
+---
+id: TASK-30042
+title: >-
+  Review sets - no silent failures: every gesture responds, storage health
+  surfaces
+status: In Progress
+assignee:
+  - '@claude'
+created_date: '2026-09-03 13:05'
+updated_date: '2026-09-03 13:07'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique 2026-09-03 P1 + explicit user ruling: silent failure is never acceptable. Today service-is-None paths return silently (picker press, create, walk), auto-resume swallows all exceptions, and a wedged collections DB is indistinguishable from the feature not existing - against the product's own no-hidden-recovery-states commitment.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Pressing Sets always responds: with unavailable storage it says so instead of doing nothing
+- [ ] #2 Create/walk/toggle/exit/picker/auto-resume surface an error notice on any failure instead of returning silently
+- [ ] #3 No review-set code path swallows an exception without user-visible feedback
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Explicit gestures (Sets press, Review these/selected create) notify 'Review-set storage is unavailable.' when service is None - TDD\n2. walk/toggle/exit wrapped: exceptions notify instead of propagating/silent - TDD\n3. Auto-resume + liveness failures notify once per session (guarded) - TDD\n4. Live spot-check
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-30043 - Media-items-pane-legible-action-grammar-at-the-narrow-pane-width.md
+++ b/backlog/tasks/task-30043 - Media-items-pane-legible-action-grammar-at-the-narrow-pane-width.md
@@ -1,0 +1,26 @@
+---
+id: TASK-30043
+title: Media items pane - legible action grammar at the narrow pane width
+status: To Do
+assignee: []
+created_date: '2026-09-03 13:05'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique 2026-09-03 P1: at the items pane's 40-col floor the six-button toolbar chops to 't so E Tr R Se', select-mode actions render as bare disabled markers, and the armed-confirm safety copy clips mid-word; tooltips are mouse-only. User ruling on the critique's Q1: yes - the horizontal toolbar is the wrong grammar for this pane.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 At the narrow pane width every list action shows a readable text label (no chopped fragments, no marker-only buttons)
+- [ ] #2 Select-mode actions and the selected-count remain readable at the narrow width
+- [ ] #3 The armed bulk-delete confirmation copy wraps instead of clipping
+- [ ] #4 The wide layout keeps its current single-row presentation
+<!-- AC:END -->

--- a/backlog/tasks/task-30044 - Reader-image-preview-failure-chrome-only-when-an-image-was-expected-row-prefixes-stop-displacing-titles.md
+++ b/backlog/tasks/task-30044 - Reader-image-preview-failure-chrome-only-when-an-image-was-expected-row-prefixes-stop-displacing-titles.md
@@ -1,0 +1,27 @@
+---
+id: TASK-30044
+title: >-
+  Reader - image-preview failure chrome only when an image was expected; row
+  prefixes stop displacing titles
+status: To Do
+assignee: []
+created_date: '2026-09-03 13:06'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique 2026-09-03 P2: every plain document's Read tab leads with 'Image preview unavailable - showing complete stored text' plus a persistent Retry preview button above the content (the unavailable reason stamps the status even with no image type hint), and the wide-mode row prefix 'Loaded in Reader' consumes ~28 of ~35 label cells leaving titles as 'Quart'/'SQLit'.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A plain document with no image type hint shows no preview-unavailable status and no Retry preview button
+- [ ] #2 An item whose type indicates an image keeps the status and retry path
+- [ ] #3 List rows keep their titles legible while carrying loading/loaded state
+<!-- AC:END -->

--- a/backlog/tasks/task-30045 - Review-sets-set-identity-and-per-item-state-in-the-Reader-chrome.md
+++ b/backlog/tasks/task-30045 - Review-sets-set-identity-and-per-item-state-in-the-Reader-chrome.md
@@ -1,0 +1,25 @@
+---
+id: TASK-30045
+title: Review sets - set identity and per-item state in the Reader chrome
+status: To Do
+assignee: []
+created_date: '2026-09-03 13:06'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique 2026-09-03 P2 + user ruling on Q2: the review set is a workflow object and deserves a real runtime surface, not only a footer string. Today the set's name never appears while walking and the current item's reviewed state is displayed nowhere (m's only feedback is the aggregate counter changing).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 While a set is active the Reader shows the set's name and progress in its chrome
+- [ ] #2 The current item's reviewed state is visible at a glance and updates when m toggles it
+- [ ] #3 The chrome disappears when no set is active
+<!-- AC:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -41868,6 +41868,7 @@ class LibraryScreen(BaseAppScreen):
         try:
             return self._walk_active_review_set_unguarded(service, direction)
         except Exception:
+            logger.opt(exception=True).warning("review-set walk failed")
             self._notify_review_set(
                 "Couldn't walk the review set — storage error.",
                 severity="error",
@@ -41979,9 +41980,23 @@ class LibraryScreen(BaseAppScreen):
         )
 
     def _review_set_active(self) -> bool:
-        """True when a review set is active (drives the Reader footer + gating)."""
+        """True when a review set is active (drives the Reader footer + gating).
+
+        Fails CLOSED on a storage error (Qodo #2346): this runs on every key
+        resolution and footer render, so raising here would crash-loop the
+        screen and a notice here would toast-storm. The keys degrade to
+        browse traversal; the explicit gesture paths carry the notices.
+        """
         service = self._review_set_service()
-        return service is not None and service.get_active_review_set() is not None
+        if service is None:
+            return False
+        try:
+            return service.get_active_review_set() is not None
+        except Exception:
+            logger.opt(exception=True).warning(
+                "review-set active-check failed; gating fails closed"
+            )
+            return False
 
     def action_library_media_exit_review(self) -> None:
         """Exit review mode: deactivate the active set, keeping it resumable.
@@ -42001,6 +42016,7 @@ class LibraryScreen(BaseAppScreen):
                 return
             service.deactivate_active()
         except Exception:
+            logger.opt(exception=True).warning("review-set exit failed")
             self._notify_review_set(
                 "Couldn't exit review — storage error.", severity="error"
             )
@@ -42025,6 +42041,7 @@ class LibraryScreen(BaseAppScreen):
         try:
             self._toggle_reviewed_unguarded(service)
         except Exception:
+            logger.opt(exception=True).warning("review-set toggle failed")
             self._notify_review_set(
                 "Couldn't update the reviewed mark — storage error.",
                 severity="error",
@@ -42262,7 +42279,7 @@ class LibraryScreen(BaseAppScreen):
             # task-30042: the items resolved but there is nowhere to pin
             # them -- say so instead of silently discarding the gesture.
             self._notify_review_set(
-                "Review-set storage is unavailable.", severity="error"
+                self._REVIEW_SET_STORAGE_UNAVAILABLE, severity="error"
             )
             return
         service.create_review_set(name, origin, items)
@@ -42274,6 +42291,8 @@ class LibraryScreen(BaseAppScreen):
         else:
             self._notify_review_set(f"Reviewing {len(items)} items.")
         self._open_library_media_viewer(f"local:media:{items[0][0]}")
+
+    _REVIEW_SET_STORAGE_UNAVAILABLE = "Review-set storage is unavailable."
 
     def _notify_review_set(
         self, message: str, *, severity: str = "information"
@@ -42313,7 +42332,7 @@ class LibraryScreen(BaseAppScreen):
                 # task-30042: a dead button is indistinguishable from the
                 # feature not existing -- the press always responds.
                 self._notify_review_set(
-                    "Review-set storage is unavailable.", severity="error"
+                    self._REVIEW_SET_STORAGE_UNAVAILABLE, severity="error"
                 )
                 return
             rows = await self._run_library_service_call(
@@ -42517,7 +42536,7 @@ class LibraryScreen(BaseAppScreen):
                 if not getattr(self, "_review_set_storage_warned", False):
                     self._review_set_storage_warned = True
                     self._notify_review_set(
-                        "Review-set storage is unavailable.",
+                        self._REVIEW_SET_STORAGE_UNAVAILABLE,
                         severity="warning",
                     )
                 return
@@ -42542,6 +42561,7 @@ class LibraryScreen(BaseAppScreen):
         except Exception:
             # task-30042: resuming failed on a real error -- surface it; the
             # user has an active set they can no longer see.
+            logger.opt(exception=True).warning("review-set auto-resume failed")
             self._notify_review_set(
                 "Couldn't resume the review set — storage error.",
                 severity="error",

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -30776,6 +30776,14 @@ class LibraryScreen(BaseAppScreen):
             # the boundary. A focused Input still consumes "[" / "]" first.
             if not self._library_media_item_traversal_active():
                 return False
+            # task-30041 (critique P1): with an active review set the keys
+            # walk the PINNED SET, so browse-row adjacency is the wrong
+            # gate -- it disabled the documented final-] completion gesture
+            # at the last browse row and misfired whenever set order
+            # diverged from browse order. The walk clamps safely at the
+            # set's ends.
+            if self._review_set_active():
+                return True
             direction = 1 if action == "library_media_next_item" else -1
             return self._library_media_adjacent_row(direction) is not None
         if action in (
@@ -41853,6 +41861,21 @@ class LibraryScreen(BaseAppScreen):
         service = self._review_set_service()
         if service is None:
             return False
+        # task-30042 (user ruling: silent failure is never acceptable): a
+        # storage error mid-walk surfaces and consumes the key -- falling
+        # through to browse traversal would stack a second action on top of
+        # an error the user hasn't seen yet.
+        try:
+            return self._walk_active_review_set_unguarded(service, direction)
+        except Exception:
+            self._notify_review_set(
+                "Couldn't walk the review set — storage error.",
+                severity="error",
+            )
+            return True
+
+    def _walk_active_review_set_unguarded(self, service, direction: int) -> bool:
+        """The walk body; storage exceptions are the caller's to surface."""
         review_set = service.get_active_review_set()
         if review_set is None:
             return False
@@ -41899,19 +41922,31 @@ class LibraryScreen(BaseAppScreen):
         outcome = plan_walk(
             review_set.items, displayed_position, direction, is_live
         )
+        was_complete = review_set.completed_at is not None
         if outcome.mark_done_backing_id is not None:
             service.mark_item_done(
                 review_set.set_id, outcome.mark_done_backing_id, True
             )
         if outcome.new_cursor != review_set.cursor:
             service.set_cursor(review_set.set_id, outcome.new_cursor)
-        service.refresh_completion(review_set.set_id, is_live)
+        complete = service.refresh_completion(review_set.set_id, is_live)
         if outcome.target is not None:
             self._select_library_media_reader_row(
                 f"local:media:{outcome.target.backing_media_id}",
                 outcome.target.title_snapshot,
                 immediate=True,
             )
+        else:
+            # task-30041 (critique P1): the clamp step -- including the
+            # final-] completion gesture -- changes marks/completion without
+            # loading a new item, so the Reader chrome must refresh here or
+            # the footer stays stale at exactly the finish.
+            self._sync_library_media_viewer_or_recompose()
+        if complete and not was_complete and outcome.mark_done_backing_id is not None:
+            live_count = sum(
+                1 for item in review_set.items if is_live(item.backing_media_id)
+            )
+            self._notify_review_set(f"All {live_count} reviewed.")
         return True
 
     def _active_review_set_progress(self) -> str | None:
@@ -41958,9 +41993,18 @@ class LibraryScreen(BaseAppScreen):
         if not self._library_media_item_traversal_active():
             return
         service = self._review_set_service()
-        if service is None or service.get_active_review_set() is None:
+        if service is None:
             return
-        service.deactivate_active()
+        # task-30042: surface a storage error instead of crashing the action.
+        try:
+            if service.get_active_review_set() is None:
+                return
+            service.deactivate_active()
+        except Exception:
+            self._notify_review_set(
+                "Couldn't exit review — storage error.", severity="error"
+            )
+            return
         self._sync_library_media_viewer_or_recompose()
 
     def action_library_media_toggle_reviewed(self) -> None:
@@ -41976,6 +42020,18 @@ class LibraryScreen(BaseAppScreen):
         service = self._review_set_service()
         if service is None:
             return
+        # task-30042: a storage error on an explicit mark gesture surfaces
+        # instead of crashing the action or silently dropping the mark.
+        try:
+            self._toggle_reviewed_unguarded(service)
+        except Exception:
+            self._notify_review_set(
+                "Couldn't update the reviewed mark — storage error.",
+                severity="error",
+            )
+
+    def _toggle_reviewed_unguarded(self, service) -> None:
+        """The toggle body; storage exceptions are the caller's to surface."""
         review_set = service.get_active_review_set()
         if review_set is None:
             return
@@ -42203,6 +42259,11 @@ class LibraryScreen(BaseAppScreen):
             return
         service = self._review_set_service()
         if service is None:
+            # task-30042: the items resolved but there is nowhere to pin
+            # them -- say so instead of silently discarding the gesture.
+            self._notify_review_set(
+                "Review-set storage is unavailable.", severity="error"
+            )
             return
         service.create_review_set(name, origin, items)
         if truncated:
@@ -42249,6 +42310,11 @@ class LibraryScreen(BaseAppScreen):
         try:
             service = self._review_set_service()
             if service is None:
+                # task-30042: a dead button is indistinguishable from the
+                # feature not existing -- the press always responds.
+                self._notify_review_set(
+                    "Review-set storage is unavailable.", severity="error"
+                )
                 return
             rows = await self._run_library_service_call(
                 self._collect_review_set_picker_rows, isolate_in_worker=True
@@ -42442,10 +42508,19 @@ class LibraryScreen(BaseAppScreen):
         back to the list plus re-entry shows the list, never a yank loop.
         AC#3: the final still-on-the-media-list + current-screen gates make
         a cold-start yank abort without opening (and without burning the
-        once-per-set chance). Auto-resume is a convenience: any failure is
-        silent, never a notice or a crash.
+        once-per-set chance). task-30042 (user ruling): failures are NEVER
+        silent -- missing storage warns once per session, and any storage
+        error surfaces; only the ordinary no-active-set case stays quiet.
         """
         try:
+            if self._review_set_service() is None:
+                if not getattr(self, "_review_set_storage_warned", False):
+                    self._review_set_storage_warned = True
+                    self._notify_review_set(
+                        "Review-set storage is unavailable.",
+                        severity="warning",
+                    )
+                return
             landing = await self._run_library_service_call(
                 self._resolve_active_review_set_landing, isolate_in_worker=True
             )
@@ -42465,7 +42540,12 @@ class LibraryScreen(BaseAppScreen):
             self._review_set_auto_resumed = resumed
             self._open_library_media_viewer(f"local:media:{backing_id}")
         except Exception:
-            return
+            # task-30042: resuming failed on a real error -- surface it; the
+            # user has an active set they can no longer see.
+            self._notify_review_set(
+                "Couldn't resume the review set — storage error.",
+                severity="error",
+            )
 
     def _resolve_active_review_set_landing(self) -> tuple[str, int] | None:
         """Resolve the active set's live cursor item (runs off the loop).


### PR DESCRIPTION
First of four fix PRs from the 2026-09-03 design critique of Library ▸ Media (dual-agent, 24/40; snapshot in `.impeccable/critique/`). Covers the two review-set P1s — tasks 30041 + 30042 — under the explicit ruling that **silent failure is never acceptable**.

## task-30041 — the finish line works

- `check_action` for `]`/`[` gated on **browse-row adjacency**, so the documented final-`]` completion gesture was disabled at the binding layer on the last browse row (footer still advertising it), and the gate misfired whenever set order ≠ browse order (selection/filtered sets). With an active set the keys now gate on `_review_set_active()` — the walk clamps safely at the set's ends.
- The walk's clamp branch (which the completion gesture rides) marked the item and refreshed completion but never synced the Reader chrome — the footer stayed stale at exactly the finish. It syncs now.
- Completing a set gets a real moment: the walk that flips the set to complete fires **"All N reviewed."** once (later idempotent presses don't re-announce).

## task-30042 — no silent failures

- Pressing **Sets** or landing a create with unavailable storage now says **"Review-set storage is unavailable."** instead of silently returning — a dead button was indistinguishable from the feature not existing.
- `walk` / `toggle reviewed` / `exit review` wrap storage errors into error notices; the walk **consumes** the key on error rather than stacking a browse fallback on top of an unseen failure.
- Auto-resume surfaces storage errors ("Couldn't resume the review set — storage error.") and warns once per session when storage is missing; only the ordinary no-active-set case stays quiet.

## Tests

9 new (all watched fail first): the `check_action` set-gate, clamp-branch sync + completion notice + once-only, walk/toggle failure notices, Sets-press and create storage notices, auto-resume failure notice + once-per-session storage warning. 98 green across the review-set battery.

## Live verification (tmux, seeded, cleaned up)

3-item set → `]` `]` → "3 of 3 · 2 reviewed" on the last item → final `]` flips the footer to **"All 3 reviewed"** in the same interaction with the completion toast visible. Before this change the same final press was a silent no-op with the footer pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2gSzBnVrjf37m4bPU3BCn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Review-set navigation now completes reliably (TASK-30041): `[`/`]` follow the active set instead of browse-row adjacency, and the final mark refreshes the Reader chrome and announces completion. Review-set storage failures now surface notices instead of being silently ignored (TASK-30042).

**Bug Fixes**

- Storage errors in walking, toggling, exiting, creating, and resuming review sets produce user-visible feedback; failed walks consume the key instead of falling through to browse navigation.
- The set-active gate fails closed on storage errors so key resolution and footer renders can't crash-loop the screen, and each error path logs its traceback before notifying.
- Missing storage warns once per session during auto-resume, while the ordinary no-active-set case remains quiet.
- Added regression coverage for finish-line behavior, idempotent completion notices, action gating, and storage failures.

<sup>Written for commit 32a28183032e8f16ff732c15e626aa0ab64f6e18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

