### PR TITLE
chore(packaging): prepare trusted PyPI publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -95,7 +95,7 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev' && github.ref_protected
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,140 @@
+name: Publish Python package
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and check distributions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install build and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "setuptools>=77.0"
+          python -m pip install -e ".[dev]"
+
+      - name: Build distributions
+        run: |
+          rm -rf dist
+          python -m build --sdist --wheel --no-isolation --outdir dist
+
+      - name: Verify release version
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+          import tomllib
+
+          with Path("pyproject.toml").open("rb") as handle:
+              project_version = tomllib.load(handle)["project"]["version"]
+
+          dist = Path("dist")
+          sdists = sorted(dist.glob("*.tar.gz"))
+          wheels = sorted(dist.glob("*.whl"))
+          if len(sdists) != 1 or len(wheels) != 1:
+              raise SystemExit("expected exactly one sdist and one wheel")
+
+          wheel_version = next(
+              part
+              for part in wheels[0].name.split("-")
+              if part and part[0].isdigit()
+          )
+          sdist_stem = sdists[0].name.removesuffix(".tar.gz")
+          sdist_version = sdist_stem.rsplit("-", 1)[1]
+          if project_version != wheel_version:
+              raise SystemExit(f"wheel version {wheel_version} != project version {project_version}")
+          if project_version != sdist_version:
+              raise SystemExit(f"sdist version {sdist_version} != project version {project_version}")
+
+          if os.environ.get("GITHUB_REF_TYPE") == "tag":
+              expected_tag = f"v{project_version}"
+              actual_tag = os.environ.get("GITHUB_REF_NAME")
+              if actual_tag != expected_tag:
+                  raise SystemExit(f"tag {actual_tag} != expected release tag {expected_tag}")
+
+          print(f"project_version={project_version}")
+          print(f"wheel={wheels[0].name}")
+          print(f"sdist={sdists[0].name}")
+          PY
+
+      - name: Check package metadata
+        run: python -m twine check dist/*
+
+      - name: Check artifact contents
+        run: python Packaging/check_manifest.py dist
+
+      - name: Run release metadata tests
+        run: python -m pytest Tests/Packaging/test_release_metadata.py -q
+
+      - name: Run installed distribution regression
+        run: python -m pytest Tests/Packaging/test_installed_distribution.py -m integration -q -p no:cacheprovider
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/*
+          if-no-files-found: error
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    if: github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/tldw-chatbook/
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Publish distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.ref_protected
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/tldw-chatbook/
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/Packaging/PACKAGING_CHECKLIST.md
+++ b/Packaging/PACKAGING_CHECKLIST.md
@@ -8,6 +8,8 @@ must start from a fresh output directory; do not treat an existing checkout
 
 - [x] `pyproject.toml` is the source of truth for dependencies and entry points.
 - [x] `tldw-cli` and `tldw-serve` are declared in `[project.scripts]`.
+- [x] `Packaging/common/version.py` derives its release version from
+  `pyproject.toml`.
 - [x] `[tool.setuptools.package-data]` explicitly owns wheel runtime data.
 - [x] `include-package-data = false` keeps sdist-only files out of wheels.
 - [x] Asset directories that grow are matched by pattern, never enumerated.
@@ -57,9 +59,12 @@ fails closed: from the `.sql` files in the checkout beside it, and from the
 `.sql` names the artifact's own `ChaChaNotes_DB.py` opens. It names every
 missing script, not just the first.
 
-Run the isolated installed-wheel regression:
+Run the focused release metadata gate and installed-wheel regression:
 
 ```bash
+python -m pytest \
+  Tests/Packaging/test_release_metadata.py \
+  -q
 python -m pytest \
   Tests/Packaging/test_installed_distribution.py \
   -m integration -q -p no:cacheprovider

--- a/Packaging/PYPI_README.md
+++ b/Packaging/PYPI_README.md
@@ -28,8 +28,8 @@ Use `tldw-cli --help` and `tldw-serve --help` for installation smoke tests.
 
 Normal publishing is done by `.github/workflows/publish-pypi.yml`:
 
-- Manual workflow dispatch publishes to TestPyPI through the `testpypi`
-  environment.
+- Manual workflow dispatch from protected `dev` publishes to TestPyPI through
+  the `testpypi` environment.
 - Protected `v*` tags publish to PyPI through the `pypi` environment after the
   tag version matches `pyproject.toml`.
 

--- a/Packaging/PYPI_README.md
+++ b/Packaging/PYPI_README.md
@@ -1,105 +1,36 @@
 # PyPI Distribution Notes for tldw_chatbook
 
-This document contains notes for maintainers about the PyPI distribution process.
+`Packaging/PYPI_RELEASE.md` is the release runbook. This file is the short
+maintainer checklist.
 
-## Pre-release Checklist
-
-1. **Update Version Number**
-   - Update version in `pyproject.toml`
-   - Update version in `tldw_chatbook/__init__.py`
-   - Update CHANGELOG.md with release notes
-
-2. **Test Installation**
-   ```bash
-   # Create a fresh virtual environment
-   python -m venv test_env
-   source test_env/bin/activate  # Windows: test_env\Scripts\activate
-   
-   # Install in development mode
-   pip install -e .
-   
-   # Run import tests
-   python test_import.py
-   
-   # Test the CLI
-   tldw-cli --help
-   ```
-
-3. **Run Full Test Suite**
-   ```bash
-   pytest
-   ```
-
-4. **Build Distribution**
-   ```bash
-   ./build_dist.sh
-   ```
-
-5. **Test Distribution Locally**
-   ```bash
-   # Create another fresh environment
-   python -m venv dist_test
-   source dist_test/bin/activate
-   
-   # Install from wheel
-   pip install dist/tldw_chatbook-*.whl
-   
-   # Run import tests
-   python test_import.py
-   
-   # Test CLI
-   tldw-cli --help
-   ```
-
-## Upload to TestPyPI First
-
-1. **Configure .pypirc** (if not already done)
-   - Copy `.pypirc.template` to `~/.pypirc`
-   - Add your PyPI tokens
-
-2. **Upload to TestPyPI**
-   ```bash
-   python -m twine upload --repository testpypi dist/*
-   ```
-
-3. **Test from TestPyPI**
-   ```bash
-   pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ tldw_chatbook
-   ```
-
-## Upload to PyPI
-
-Once testing is complete:
+## Required Gates
 
 ```bash
-python -m twine upload dist/*
+python -m pip install "setuptools>=77.0" build twine wheel
+Packaging/build_dist.sh
+python -m pytest Tests/Packaging/test_release_metadata.py -q
+python -m pytest Tests/Packaging/test_installed_distribution.py -m integration -q -p no:cacheprovider
 ```
 
-## Post-release
+`Packaging/build_dist.sh` builds a fresh sdist and wheel, runs `twine check`,
+and verifies both artifacts with `Packaging/check_manifest.py`.
 
-1. Create a git tag:
-   ```bash
-   git tag -a v0.1.0 -m "Release version 0.1.0"
-   git push origin v0.1.0
-   ```
+## Entry Points
 
-2. Create a GitHub release with the changelog
+The PyPI package installs these console scripts:
 
-3. Update version in `pyproject.toml` and `__init__.py` to next development version (e.g., 0.2.0.dev0)
+- `tldw-cli`
+- `tldw-serve`
 
-## Package Structure Verification
+Use `tldw-cli --help` and `tldw-serve --help` for installation smoke tests.
 
-The distribution should include:
-- All Python modules under `tldw_chatbook/`
-- CSS files (*.tcss) in `tldw_chatbook/css/`
-- Theme files in `tldw_chatbook/css/Themes/`
-- JSON templates in `tldw_chatbook/Config_Files/`
-- LICENSE file
-- README.md
+## Publishing
 
-## Common Issues
+Normal publishing is done by `.github/workflows/publish-pypi.yml`:
 
-1. **Missing Data Files**: Check MANIFEST.in and pyproject.toml package-data
-2. **Import Errors**: Ensure all __init__.py files are present
-3. **Entry Point Not Working**: Verify the console_scripts configuration
-4. **Dependencies Missing**: Compare pyproject.toml with requirements.txt
+- Manual workflow dispatch publishes to TestPyPI through the `testpypi`
+  environment.
+- Protected `v*` tags publish to PyPI through the `pypi` environment after the
+  tag version matches `pyproject.toml`.
+
+Do not use `.pypirc` or long-lived API tokens for routine releases.

--- a/Packaging/PYPI_RELEASE.md
+++ b/Packaging/PYPI_RELEASE.md
@@ -35,9 +35,11 @@ For PyPI:
 If the project does not exist yet, create a pending trusted publisher for the
 same owner, repository, workflow, and environment.
 
-Protect the `pypi` GitHub environment and the production `v*` tag pattern before
-allowing production publishing. The publish job only downloads built artifacts
-and requests the PyPI OIDC token.
+Protect the `dev` branch, the `testpypi` and `pypi` GitHub environments, and
+the production `v*` tag pattern before allowing publishing. The TestPyPI job
+only runs for manual dispatch from protected `dev`; the PyPI job only runs for
+protected matching version tags. Publish jobs only download built artifacts and
+request the PyPI OIDC token.
 
 ## Local Release Gates
 
@@ -77,7 +79,7 @@ Run the full suite only when the release manager explicitly wants a full sweep.
 ## Publish to TestPyPI
 
 1. Open the `Publish Python package` workflow in GitHub Actions.
-2. Run it manually from the intended release branch.
+2. Run it manually from the protected `dev` branch.
 3. The workflow builds, checks, uploads artifacts, and publishes to TestPyPI
    through the `testpypi` environment.
 4. Test installation from TestPyPI:

--- a/Packaging/PYPI_RELEASE.md
+++ b/Packaging/PYPI_RELEASE.md
@@ -1,156 +1,129 @@
 # PyPI Release Guide for tldw_chatbook
 
-This guide outlines the process for building and releasing tldw_chatbook to PyPI.
+Use GitHub Actions trusted publishing for normal releases. Do not upload with a
+long-lived PyPI token unless the trusted-publishing path is unavailable.
 
-## Prerequisites
+## Package Identity
 
-1. Ensure you have the necessary tools installed:
+- Source distribution name: `tldw_chatbook`
+- Normalized PyPI name: `tldw-chatbook`
+- Install command: `pip install tldw_chatbook`
+- Console scripts: `tldw-cli`, `tldw-serve`
+- Version source of truth: `pyproject.toml`
+- Package runtime version: `tldw_chatbook/__init__.py`
+- Native packaging version helper: `Packaging/common/version.py`, derived from
+  `pyproject.toml`
+
+## One-Time PyPI Setup
+
+Create trusted publishers on TestPyPI and PyPI before the first workflow upload.
+
+For TestPyPI:
+
+- Owner: `rmusser01`
+- Repository: `tldw_chatbook`
+- Workflow: `publish-pypi.yml`
+- Environment: `testpypi`
+
+For PyPI:
+
+- Owner: `rmusser01`
+- Repository: `tldw_chatbook`
+- Workflow: `publish-pypi.yml`
+- Environment: `pypi`
+
+If the project does not exist yet, create a pending trusted publisher for the
+same owner, repository, workflow, and environment.
+
+Protect the `pypi` GitHub environment and the production `v*` tag pattern before
+allowing production publishing. The publish job only downloads built artifacts
+and requests the PyPI OIDC token.
+
+## Local Release Gates
+
+1. Update `pyproject.toml`, `tldw_chatbook/__init__.py`, and `CHANGELOG.md`.
+2. Install release tools in the active environment:
+
    ```bash
-   pip install build twine
+   python -m pip install "setuptools>=77.0" build twine wheel
    ```
 
-2. Create PyPI account at https://pypi.org/account/register/
+3. Build fresh artifacts:
 
-3. Create API token at https://pypi.org/manage/account/token/
-   - Save the token securely
-   - You'll use it as your password when uploading
-
-4. (Optional) Create TestPyPI account at https://test.pypi.org/account/register/
-   - Recommended for testing releases before publishing to production PyPI
-
-## Pre-Release Checklist
-
-- [ ] Update version in `pyproject.toml`
-- [ ] Update version in `tldw_chatbook/__init__.py`
-- [ ] Update `CHANGELOG.md` with release notes
-- [ ] Run all tests: `pytest`
-- [ ] Review and update documentation if needed
-- [ ] Commit all changes
-- [ ] Create git tag: `git tag v0.1.0`
-
-## Building the Distribution
-
-1. Clean previous builds:
    ```bash
-   rm -rf dist/ build/ *.egg-info
+   Packaging/build_dist.sh
    ```
 
-2. Build source distribution and wheel:
+4. Run the focused metadata and installed-distribution gates:
+
    ```bash
-   python -m build
+   python -m pytest Tests/Packaging/test_release_metadata.py -q
+   python -m pytest Tests/Packaging/test_installed_distribution.py -m integration -q -p no:cacheprovider
    ```
 
-   This creates:
-   - `dist/tldw_chatbook-0.1.0.tar.gz` (source distribution)
-   - `dist/tldw_chatbook-0.1.0-py3-none-any.whl` (wheel)
+5. Smoke-test the wheel in a disposable environment:
 
-3. Verify the distributions:
-   ```bash
-   twine check dist/*
-   ```
-
-## Testing the Package
-
-1. Create a test virtual environment:
    ```bash
    python -m venv test_env
-   source test_env/bin/activate  # On Windows: test_env\Scripts\activate
-   ```
-
-2. Install from built wheel:
-   ```bash
-   pip install dist/tldw_chatbook-0.1.0-py3-none-any.whl
-   ```
-
-3. Test the installation:
-   ```bash
-   tldw-chatbook --version
-   ```
-
-4. Test with optional dependencies:
-   ```bash
-   pip install dist/tldw_chatbook-0.1.0-py3-none-any.whl[embeddings_rag,websearch]
-   ```
-
-5. Deactivate and clean up:
-   ```bash
+   source test_env/bin/activate
+   pip install dist/tldw_chatbook-*.whl
+   tldw-cli --help
+   tldw-serve --help
    deactivate
-   rm -rf test_env
    ```
 
-## Uploading to TestPyPI (Recommended First)
+Run the full suite only when the release manager explicitly wants a full sweep.
 
-1. Upload to TestPyPI:
+## Publish to TestPyPI
+
+1. Open the `Publish Python package` workflow in GitHub Actions.
+2. Run it manually from the intended release branch.
+3. The workflow builds, checks, uploads artifacts, and publishes to TestPyPI
+   through the `testpypi` environment.
+4. Test installation from TestPyPI:
+
    ```bash
-   twine upload --repository testpypi dist/*
+   python -m venv testpypi_env
+   source testpypi_env/bin/activate
+   pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "tldw_chatbook==<version>"
+   tldw-cli --help
+   tldw-serve --help
+   deactivate
    ```
 
-2. Test installation from TestPyPI:
+## Publish to PyPI
+
+1. Confirm the same commit passed the local gates and TestPyPI smoke test.
+2. Create and push a protected production tag:
+
    ```bash
-   pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ tldw_chatbook
+   git tag -a v<version> -m "Release v<version>"
+   git push origin v<version>
    ```
 
-   Note: The `--extra-index-url` is needed because TestPyPI doesn't have all dependencies.
+3. The `Publish Python package` workflow publishes the checked artifacts to PyPI
+   only when the `v<version>` tag is protected and matches the package version.
+   Publishing still goes through the protected `pypi` environment.
+4. Verify:
 
-## Uploading to PyPI
-
-1. Upload to PyPI:
    ```bash
-   twine upload dist/*
+   python -m venv pypi_env
+   source pypi_env/bin/activate
+   pip install "tldw_chatbook==<version>"
+   tldw-cli --help
+   tldw-serve --help
+   deactivate
    ```
 
-   When prompted:
-   - Username: `__token__`
-   - Password: Your PyPI API token (including the `pypi-` prefix)
+## Emergency Manual Upload
 
-2. Verify the package at: https://pypi.org/project/tldw_chatbook/
+Use this only if trusted publishing is unavailable and the same `dist/` artifacts
+passed the local gates:
 
-3. Test installation:
-   ```bash
-   pip install tldw_chatbook
-   ```
+```bash
+python -m twine upload --repository testpypi dist/*
+python -m twine upload dist/*
+```
 
-## Post-Release
-
-1. Push the git tag:
-   ```bash
-   git push origin v0.1.0
-   ```
-
-2. Create GitHub release:
-   - Go to https://github.com/rmusser01/tldw_chatbook/releases
-   - Click "Create a new release"
-   - Select the tag
-   - Copy release notes from CHANGELOG.md
-   - Attach the built distributions from `dist/`
-
-3. Update version for next development:
-   - Increment version in `pyproject.toml` (e.g., to 0.2.0.dev0)
-   - Update `tldw_chatbook/__init__.py`
-   - Add new "Unreleased" section to CHANGELOG.md
-   - Commit with message: "Bump version for development"
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Authentication failed**: Ensure you're using `__token__` as username and your full API token as password
-
-2. **Package name already taken**: The name might be too similar to existing packages. Consider a unique name.
-
-3. **Missing files in distribution**: Check MANIFEST.in and ensure all necessary files are included
-
-4. **Import errors after installation**: Verify all dependencies are listed in pyproject.toml
-
-### Useful Commands
-
-- View package contents: `tar -tzf dist/tldw_chatbook-0.1.0.tar.gz`
-- View wheel contents: `unzip -l dist/tldw_chatbook-0.1.0-py3-none-any.whl`
-- Check package metadata: `twine check dist/*`
-
-## Security Notes
-
-- Never commit PyPI tokens to version control
-- Use environment variables or keyring for token storage
-- Consider using GitHub Actions for automated releases
-- Review all included files before uploading
+Manual uploads require an account or project-scoped PyPI token. Never commit
+tokens, `.pypirc`, or upload logs containing credentials.

--- a/Packaging/build_dist.sh
+++ b/Packaging/build_dist.sh
@@ -10,18 +10,21 @@ cd "$(dirname "$0")/.."
 
 REPO_ROOT="$(pwd -P)"
 
-if [[ -z "$DIST_DIR" || "$DIST_DIR" == "." || "$DIST_DIR" == "/" ]]; then
-    echo "Refusing unsafe DIST_DIR: ${DIST_DIR:-<empty>}" >&2
-    exit 1
-fi
+DIST_DIR_REAL=$("$PYTHON" - "$DIST_DIR" "$REPO_ROOT" <<'PY'
+from pathlib import Path
+import sys
 
-if [[ "$DIST_DIR" = /* || "$DIST_DIR" == ".." || "$DIST_DIR" == ../* || "$DIST_DIR" == */.. || "$DIST_DIR" == */../* ]]; then
-    echo "Refusing DIST_DIR outside repository root: $DIST_DIR" >&2
+from Packaging.common.dist_path import resolve_dist_dir
+
+try:
+    print(resolve_dist_dir(sys.argv[1], Path(sys.argv[2])))
+except ValueError as exc:
+    raise SystemExit(f"Refusing unsafe DIST_DIR: {exc}")
+PY
+) || {
     echo "Use python -m build directly for external artifact directories." >&2
     exit 1
-fi
-
-DIST_DIR_REAL="${REPO_ROOT}/${DIST_DIR#./}"
+}
 
 echo "Building tldw_chatbook distribution into ${DIST_DIR_REAL}..."
 

--- a/Packaging/build_dist.sh
+++ b/Packaging/build_dist.sh
@@ -1,46 +1,50 @@
-#!/bin/bash
-# Build script for tldw_chatbook PyPI distribution
+#!/usr/bin/env bash
+# Build a fresh tldw_chatbook PyPI distribution.
 
-set -e  # Exit on error
+set -euo pipefail
 
-echo "🚀 Building tldw_chatbook distribution..."
+PYTHON="${PYTHON:-python}"
+DIST_DIR="${DIST_DIR:-dist}"
 
-# Navigate to project root
 cd "$(dirname "$0")/.."
 
-# Clean Python artifacts
-echo "🧹 Cleaning Python artifacts..."
-find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
-find . -name "*.pyc" -o -name "*.pyo" -exec rm -f {} + 2>/dev/null || true
-find . -name ".DS_Store" -exec rm -f {} + 2>/dev/null || true
+REPO_ROOT="$(pwd -P)"
 
-# Clean previous builds
-echo "🧹 Cleaning previous builds..."
-rm -rf dist/ build/ *.egg-info
+if [[ -z "$DIST_DIR" || "$DIST_DIR" == "." || "$DIST_DIR" == "/" ]]; then
+    echo "Refusing unsafe DIST_DIR: ${DIST_DIR:-<empty>}" >&2
+    exit 1
+fi
 
-# Build source distribution and wheel
-echo "🔨 Building source and wheel distributions..."
-python -m build
+if [[ "$DIST_DIR" = /* || "$DIST_DIR" == ".." || "$DIST_DIR" == ../* || "$DIST_DIR" == */.. || "$DIST_DIR" == */../* ]]; then
+    echo "Refusing DIST_DIR outside repository root: $DIST_DIR" >&2
+    echo "Use python -m build directly for external artifact directories." >&2
+    exit 1
+fi
 
-# Check the distributions
-echo "✅ Checking distributions with twine..."
-python -m twine check dist/*
+DIST_DIR_REAL="${REPO_ROOT}/${DIST_DIR#./}"
 
-# Verify manifest
-echo "📋 Verifying distribution contents..."
-python Packaging/check_manifest.py
+echo "Building tldw_chatbook distribution into ${DIST_DIR_REAL}..."
 
-echo ""
-echo "✨ Build complete!"
-echo ""
-echo "📦 Distribution files created in ./dist/"
-ls -la dist/
-echo ""
-echo "📤 To upload to TestPyPI (for testing):"
-echo "  python -m twine upload --repository testpypi dist/*"
-echo ""
-echo "📤 To upload to PyPI (production):"
-echo "  python -m twine upload dist/*"
-echo ""
-echo "🧪 To test installation from wheel:"
-echo "  pip install dist/tldw_chatbook-*.whl"
+"$PYTHON" -c "import build, setuptools, twine, wheel" || {
+    echo "Install release tools with: $PYTHON -m pip install 'setuptools>=77.0' build twine wheel" >&2
+    exit 1
+}
+
+rm -rf "$DIST_DIR_REAL" build ./*.egg-info
+mkdir -p "$DIST_DIR_REAL"
+
+echo "Building source and wheel distributions..."
+"$PYTHON" -m build --sdist --wheel --no-isolation --outdir "$DIST_DIR_REAL"
+
+echo "Checking package metadata..."
+"$PYTHON" -m twine check "$DIST_DIR_REAL"/*
+
+echo "Verifying distribution contents..."
+"$PYTHON" Packaging/check_manifest.py "$DIST_DIR_REAL"
+
+echo
+echo "Build complete. Distribution files:"
+ls -la "$DIST_DIR_REAL"
+echo
+echo "Installed-wheel regression:"
+echo "  $PYTHON -m pytest Tests/Packaging/test_installed_distribution.py -m integration -q -p no:cacheprovider"

--- a/Packaging/build_release.sh
+++ b/Packaging/build_release.sh
@@ -1,56 +1,30 @@
-#!/bin/bash
-# Build script for tldw_chatbook PyPI release
+#!/usr/bin/env bash
+# Release build wrapper for tldw_chatbook PyPI artifacts.
 
-set -e  # Exit on error
+set -euo pipefail
 
-echo "🚀 Building tldw_chatbook for PyPI release..."
+PYTHON="${PYTHON:-python}"
 
-# Check if we're in the right directory
 if [ ! -f "pyproject.toml" ]; then
-    echo "❌ Error: pyproject.toml not found. Run this script from the project root."
+    echo "Error: pyproject.toml not found. Run this script from the project root." >&2
     exit 1
 fi
 
-# Check for required tools
-for tool in python pip build twine; do
-    if ! command -v $tool &> /dev/null; then
-        echo "❌ Error: $tool is not installed."
-        echo "Install with: pip install build twine"
-        exit 1
-    fi
-done
+if ! "$PYTHON" -c "import build, setuptools, twine, wheel" >/dev/null 2>&1; then
+    echo "Error: release build modules are not installed." >&2
+    echo "Install release tools with: $PYTHON -m pip install 'setuptools>=77.0' build twine wheel" >&2
+    exit 1
+fi
 
-# Get version from pyproject.toml
-VERSION=$(python -c "
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib
-with open('pyproject.toml', 'rb') as f:
-    data = tomllib.load(f)
-    print(data['project']['version'])
-")
-echo "📦 Building version: $VERSION"
+VERSION=$("$PYTHON" -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
 
-# Clean previous builds
-echo "🧹 Cleaning previous builds..."
-rm -rf dist/ build/ *.egg-info
+echo "Building tldw_chatbook ${VERSION} for PyPI release..."
+PYTHON="$PYTHON" Packaging/build_dist.sh
 
-# Build the distribution
-echo "🔨 Building source distribution and wheel..."
-python -m build
-
-# Check the distributions
-echo "✅ Checking distributions..."
-twine check dist/*
-
-echo "📁 Built files:"
-ls -la dist/
-
-echo ""
-echo "✨ Build complete! Next steps:"
-echo "1. Test the package: pip install dist/tldw_chatbook-${VERSION}-py3-none-any.whl"
-echo "2. Upload to TestPyPI: twine upload --repository testpypi dist/*"
-echo "3. Upload to PyPI: twine upload dist/*"
-echo ""
-echo "📚 See PYPI_RELEASE.md for detailed instructions."
+echo
+echo "Next steps:"
+echo "1. Run the installed-wheel regression printed above."
+echo "2. Use the publish-pypi GitHub Actions workflow for TestPyPI."
+echo "3. Publish production PyPI from a protected v${VERSION} tag."
+echo
+echo "See Packaging/PYPI_RELEASE.md for detailed instructions."

--- a/Packaging/common/dist_path.py
+++ b/Packaging/common/dist_path.py
@@ -1,0 +1,19 @@
+"""Distribution output path validation for release scripts."""
+
+from pathlib import Path
+
+from tldw_chatbook.Utils.path_validation import validate_path
+
+
+def resolve_dist_dir(dist_dir: str, repo_root: Path) -> Path:
+    """Return a validated repository-contained distribution directory."""
+    if not dist_dir:
+        raise ValueError("DIST_DIR cannot be empty")
+
+    root = repo_root.resolve()
+    destination = validate_path(dist_dir, root, redact_paths=True)
+    relative = destination.relative_to(root)
+    if not relative.parts:
+        raise ValueError("DIST_DIR must be a repository subdirectory")
+
+    return destination

--- a/Packaging/common/version.py
+++ b/Packaging/common/version.py
@@ -1,10 +1,29 @@
-"""
-Shared version information for packaging
-"""
+"""Shared version information for packaging."""
 
-# Version info - should match pyproject.toml
-VERSION = "0.1.6.2"
-VERSION_TUPLE = (0, 1, 6, 2)
+import re
+import tomllib
+from pathlib import Path
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_project_version() -> str:
+    with (_PROJECT_ROOT / "pyproject.toml").open("rb") as stream:
+        return str(tomllib.load(stream)["project"]["version"])
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    release = re.match(r"^\d+(?:\.\d+)*", version)
+    if release is None:
+        raise ValueError(
+            f"Project version must start with a numeric release: {version!r}"
+        )
+    return tuple(int(part) for part in release.group(0).split("."))
+
+
+VERSION = _read_project_version()
+VERSION_TUPLE = _version_tuple(VERSION)
 
 # Company/Product info
 COMPANY_NAME = "TLDW Project"

--- a/Packaging/macos/scripts/package_dmg.sh
+++ b/Packaging/macos/scripts/package_dmg.sh
@@ -6,17 +6,27 @@ set -e
 # Configuration
 APP_NAME="tldw chatbook"
 DMG_NAME="tldw-chatbook"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Get version from command line argument or read from version.py
+# Get version from command line argument or pyproject.toml.
 if [ -n "$1" ]; then
     VERSION="$1"
 else
-    # Try to read from version.py
-    VERSION_PY="${BASH_SOURCE%/*}/../../common/version.py"
-    if [ -f "$VERSION_PY" ]; then
-        VERSION=$(python3 -c "exec(open('$VERSION_PY').read()); print(VERSION)")
+    PYPROJECT_TOML="${SCRIPT_DIR}/../../../pyproject.toml"
+    if [ -f "$PYPROJECT_TOML" ]; then
+        VERSION=$(python3 - "$PYPROJECT_TOML" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+match = re.search(r'(?m)^version = "([^"]+)"', Path(sys.argv[1]).read_text())
+if match is None:
+    raise SystemExit("project.version not found")
+print(match.group(1))
+PY
+)
     else
-        echo "Error: No version specified and version.py not found"
+        echo "Error: No version specified and pyproject.toml not found"
         echo "Usage: $0 [VERSION]"
         exit 1
     fi
@@ -27,7 +37,6 @@ VOLUME_NAME="tldw chatbook ${VERSION}"
 echo "Building DMG for version: ${VERSION}"
 
 # Paths
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BUILD_DIR="${SCRIPT_DIR}/../dist"
 APP_PATH="${BUILD_DIR}/${APP_NAME}.app"
 DMG_DIR="${BUILD_DIR}/dmg"

--- a/Packaging/windows/installer.nsi
+++ b/Packaging/windows/installer.nsi
@@ -8,7 +8,7 @@
 ; Constants
 !define PRODUCT_NAME "tldw chatbook"
 !ifndef PRODUCT_VERSION
-  !define PRODUCT_VERSION "0.1.6.2"
+  !error "PRODUCT_VERSION must be provided by Packaging/windows/build_windows.py"
 !endif
 !ifndef PRODUCT_PUBLISHER
   !define PRODUCT_PUBLISHER "TLDW Project"

--- a/Tests/Packaging/test_release_metadata.py
+++ b/Tests/Packaging/test_release_metadata.py
@@ -4,6 +4,9 @@ import ast
 import tomllib
 from pathlib import Path
 
+import pytest
+
+from Packaging.common.dist_path import resolve_dist_dir
 from Packaging.common import version as packaging_version
 
 
@@ -49,3 +52,43 @@ def test_pypi_release_scripts_match_packaged_entry_points() -> None:
         "tldw-cli": "tldw_chatbook.cli:main_cli_runner",
         "tldw-serve": "tldw_chatbook.Web_Server.serve:main",
     }
+
+
+def test_distribution_output_path_must_be_strictly_inside_repo(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    external = tmp_path / "external"
+    external.mkdir()
+
+    assert resolve_dist_dir("dist", repo_root) == repo_root / "dist"
+    assert resolve_dist_dir("./dist", repo_root) == repo_root / "dist"
+
+    unsafe_paths = ("", ".", "./", "..", "../dist", "dist/..", "./dist/..", str(external))
+    for unsafe in unsafe_paths:
+        with pytest.raises(ValueError):
+            resolve_dist_dir(unsafe, repo_root)
+
+
+def test_distribution_output_path_rejects_symlink_escape(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    external = tmp_path / "external"
+    external.mkdir()
+    link = repo_root / "linked-external"
+
+    try:
+        link.symlink_to(external, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    with pytest.raises(ValueError):
+        resolve_dist_dir("linked-external/dist", repo_root)
+
+
+def test_testpypi_publish_requires_protected_dev_ref() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "publish-pypi.yml").read_text()
+
+    assert (
+        "if: github.event_name == 'workflow_dispatch' && "
+        "github.ref == 'refs/heads/dev' && github.ref_protected"
+    ) in workflow

--- a/Tests/Packaging/test_release_metadata.py
+++ b/Tests/Packaging/test_release_metadata.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import ast
+import tomllib
+from pathlib import Path
+
+from Packaging.common import version as packaging_version
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _package_version_metadata() -> tuple[str, tuple[int, ...]]:
+    tree = ast.parse((REPO_ROOT / "tldw_chatbook" / "__init__.py").read_text())
+    assignments: dict[str, object] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id in {
+                "__version__",
+                "VERSION_TUPLE",
+            }:
+                assignments[target.id] = ast.literal_eval(node.value)
+
+    package_version_tuple = assignments["VERSION_TUPLE"]
+    assert isinstance(package_version_tuple, tuple)
+
+    return (str(assignments["__version__"]), package_version_tuple)
+
+
+def test_release_version_metadata_stays_in_lockstep() -> None:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as stream:
+        project = tomllib.load(stream)["project"]
+
+    project_version = project["version"]
+    package_version, package_version_tuple = _package_version_metadata()
+
+    assert package_version == project_version
+    assert packaging_version.VERSION == project_version
+    assert packaging_version.VERSION_TUPLE == package_version_tuple
+
+
+def test_pypi_release_scripts_match_packaged_entry_points() -> None:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as stream:
+        scripts = tomllib.load(stream)["project"]["scripts"]
+
+    assert scripts == {
+        "tldw-cli": "tldw_chatbook.cli:main_cli_runner",
+        "tldw-serve": "tldw_chatbook.Web_Server.serve:main",
+    }

--- a/backlog/tasks/task-21506 - Prepare-PyPI-publishing-workflow.md
+++ b/backlog/tasks/task-21506 - Prepare-PyPI-publishing-workflow.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-08-24 05:42'
-updated_date: '2026-08-24 06:05'
+updated_date: '2026-09-03 06:45'
 labels:
   - packaging
   - release
@@ -54,10 +54,11 @@ installed-distribution contract from ADR-032.
   `tldw_chatbook/__init__.py`, packaging helper metadata, and the real
   `tldw-cli`/`tldw-serve` scripts.
 - Added `.github/workflows/publish-pypi.yml` with a build/check artifact job,
-  manual TestPyPI publishing through the `testpypi` environment, and PyPI
-  publishing from protected `v*` tags through the `pypi` environment. The build
-  job fails if artifact versions drift from `pyproject.toml` or a tag does not
-  match `v<project-version>`. Only publish jobs receive `id-token: write`.
+  manual TestPyPI publishing through the `testpypi` environment only from the
+  protected `dev` branch, and PyPI publishing from protected `v*` tags through
+  the `pypi` environment. The build job fails if artifact versions drift from
+  `pyproject.toml` or a tag does not match `v<project-version>`. Only publish
+  jobs receive `id-token: write`.
 - Reworked `Packaging/PYPI_RELEASE.md`, `Packaging/PYPI_README.md`,
   `Packaging/build_dist.sh`, `Packaging/build_release.sh`, and
   `Packaging/PACKAGING_CHECKLIST.md` around fresh artifacts, trusted
@@ -70,16 +71,21 @@ installed-distribution contract from ADR-032.
   migrations ship via `migrations/*.sql`, while `Packaging/check_manifest.py`
   and the installed-distribution regression derive the required migration set
   from source/runtime reads instead of hand-maintained lists.
+- Addressed Qodo review follow-up by routing `Packaging/build_dist.sh`
+  `DIST_DIR` cleanup validation through `Packaging.common.dist_path` and the
+  central `tldw_chatbook.Utils.path_validation.validate_path` helper, rejecting
+  root/dot spellings, traversal, absolute external paths, and symlink escapes
+  before removing any artifact directory.
 - Reused the existing `backlog/docs/lessons-testing-evidence.md` packaging
   lesson that now covers the TASK-21506 migration-package-data incident.
 
 Verification:
 
 - Red metadata test first failed on stale `Packaging.common.version.VERSION`
-  (`0.1.6.2` vs `0.1.8.0`); after the fix,
+  (`0.1.6.2` vs `0.1.8.0`); after the fix and Qodo hardening,
   `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_release_metadata.py -q`
-  passed on the clean `dev`-based branch: 2 passed, 1 environment warning in
-  1.08s.
+  passed on the clean `dev`-based branch: 5 passed, 1 environment warning in
+  0.49s.
 - `PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Packaging/build_dist.sh`
   passed on the clean `dev`-based branch, building
   `tldw_chatbook-0.1.8.0.tar.gz` and
@@ -89,11 +95,13 @@ Verification:
   first failed on the missing v40-to-v41 migration; after rebasing onto current
   `dev`'s generalized migration packaging and artifact-derived checks,
   `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_installed_distribution.py -m integration -q -p no:cacheprovider`
-  passed on the clean `dev`-based branch: 163 passed, 1 environment warning in
-  558.64s after rebasing onto current `dev`.
-- `DIST_DIR=/private/tmp/tldw-should-refuse Packaging/build_dist.sh` failed
-  closed with `Refusing DIST_DIR outside repository root`, confirming the
-  cleanup script no longer deletes arbitrary external artifact directories.
+  passed on the clean `dev`-based branch before review and again after Qodo
+  hardening: 163 passed, 1 environment warning in 544.57s.
+- `DIST_DIR=./ PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Packaging/build_dist.sh`
+  failed closed with `Refusing unsafe DIST_DIR: DIST_DIR must be a repository
+  subdirectory`; `DIST_DIR=/private/tmp/tldw-should-refuse` failed closed with
+  `Refusing unsafe DIST_DIR: Path is outside the allowed directory`, confirming
+  cleanup cannot target the checkout root or external directories.
 - `bash -n Packaging/build_dist.sh`, `bash -n Packaging/build_release.sh`,
   `bash -n Packaging/macos/scripts/package_dmg.sh`, workflow YAML parse,
   host-Python macOS version extraction, and targeted `git diff --check` passed.

--- a/backlog/tasks/task-21506 - Prepare-PyPI-publishing-workflow.md
+++ b/backlog/tasks/task-21506 - Prepare-PyPI-publishing-workflow.md
@@ -66,30 +66,31 @@ installed-distribution contract from ADR-032.
   reads the root `pyproject.toml` without importing release helpers, and the
   Windows NSIS installer fails unless `Packaging/windows/build_windows.py`
   provides `PRODUCT_VERSION`.
-- Fixed a release-blocking package-data gap caught by the installed-wheel gate:
-  the v40-to-v41 and v41-to-v42 ChaChaNotes runtime SQL migrations are now
-  packaged and required by `Packaging/check_manifest.py` and the installed
-  distribution regression.
-- Updated `backlog/docs/lessons-testing-evidence.md` with the repeated
-  migration-package-data incident.
+- Kept the current `dev` migration packaging hardening: ChaChaNotes SQL
+  migrations ship via `migrations/*.sql`, while `Packaging/check_manifest.py`
+  and the installed-distribution regression derive the required migration set
+  from source/runtime reads instead of hand-maintained lists.
+- Reused the existing `backlog/docs/lessons-testing-evidence.md` packaging
+  lesson that now covers the TASK-21506 migration-package-data incident.
 
 Verification:
 
 - Red metadata test first failed on stale `Packaging.common.version.VERSION`
   (`0.1.6.2` vs `0.1.8.0`); after the fix,
-  `/private/tmp/tldw-chatbook-pypi-runner-21506/bin/python -m pytest Tests/Packaging/test_release_metadata.py -q`
-  passed: 2 passed in 0.72s.
-- Fresh build into `/private/tmp/tldw-chatbook-pypi-dist-21506-fixed.Hay9eV`
-  succeeded; `twine check` passed for the sdist and wheel; `Packaging/check_manifest.py`
-  validated both artifacts.
+  `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_release_metadata.py -q`
+  passed on the clean `dev`-based branch: 2 passed, 1 environment warning in
+  1.08s.
+- `PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Packaging/build_dist.sh`
+  passed on the clean `dev`-based branch, building
+  `tldw_chatbook-0.1.8.0.tar.gz` and
+  `tldw_chatbook-0.1.8.0-py3-none-any.whl`; `twine check` passed for both
+  artifacts and `Packaging/check_manifest.py` validated both artifacts.
 - Installed-distribution regression in an outside-checkout Python 3.12 runner
-  first failed on the missing v40-to-v41 migration; after packaging both new
-  migrations,
-  `/private/tmp/tldw-chatbook-pypi-runner-21506/bin/python -m pytest Tests/Packaging/test_installed_distribution.py -m integration -q -p no:cacheprovider`
-  passed: 41 passed in 127.11s.
-- `PYTHON=/private/tmp/tldw-chatbook-pypi-runner-21506/bin/python Packaging/build_dist.sh`
-  passed end to end with the default ignored `dist/` output, including
-  `twine check` and `Packaging/check_manifest.py`.
+  first failed on the missing v40-to-v41 migration; after rebasing onto current
+  `dev`'s generalized migration packaging and artifact-derived checks,
+  `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_installed_distribution.py -m integration -q -p no:cacheprovider`
+  passed on the clean `dev`-based branch: 163 passed, 1 environment warning in
+  558.64s after rebasing onto current `dev`.
 - `DIST_DIR=/private/tmp/tldw-should-refuse Packaging/build_dist.sh` failed
   closed with `Refusing DIST_DIR outside repository root`, confirming the
   cleanup script no longer deletes arbitrary external artifact directories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -468,7 +468,7 @@ all-tools = [
 "Source Code" = "https://github.com/rmusser01/tldw_chatbook"
 "Changelog" = "https://github.com/rmusser01/tldw_chatbook/blob/main/CHANGELOG.md"
 
-# This creates a command-line script called 'tldw-chatbook'
+# Console scripts installed by the PyPI package.
 [project.scripts]
 # Loads the full app only when the command is invoked.
 tldw-cli = "tldw_chatbook.cli:main_cli_runner"


### PR DESCRIPTION
## Summary
- Add a trusted-publishing GitHub Actions workflow for checked TestPyPI and PyPI releases.
- Align PyPI release docs and build scripts around fresh artifacts, real console scripts, and trusted publishing.
- Derive packaging helper version metadata from pyproject.toml and add a release metadata regression.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_release_metadata.py -q`
- `PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Packaging/build_dist.sh`
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_installed_distribution.py -m integration -q -p no:cacheprovider`
- `bash -n Packaging/build_dist.sh`
- `bash -n Packaging/build_release.sh`
- `bash -n Packaging/macos/scripts/package_dmg.sh`
- workflow YAML parse
- `git diff --check`

Full suite was not run per repo guidance to use targeted verification unless requested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds trusted PyPI publishing through GitHub Actions: manual runs from protected `dev` publish checked artifacts to TestPyPI, while protected `v*` tags publish to PyPI only when the tag matches `pyproject.toml`. This replaces routine token-based uploads and requires configured PyPI environments and trusted publishers.

**Release safeguards**

- Builds fresh sdist and wheel artifacts, then checks metadata, contents, versions, and installed entry points.
- Hardens the build script's output cleanup so `DIST_DIR` can't target the repo root or escape it.
- Adds regression coverage for synchronized version metadata and the `tldw-cli` and `tldw-serve` console scripts.
- Updates release scripts and documentation to use `pyproject.toml` as the packaging version source.

**Migration**

- Configure the `testpypi` and `pypi` trusted publishers and protect `dev`, the production `v*` tag pattern, and both environments before publishing.

<sup>Written for commit 3fc54cf01b4fc3ae2e6782d6a0bdf5b0a071ff1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

