### PR TITLE
docs: define llama.cpp Lab-to-Console connection contract

### DIFF
--- a/Docs/superpowers/plans/2026-09-03-task-31200-llamacpp-lab-console-contract.md
+++ b/Docs/superpowers/plans/2026-09-03-task-31200-llamacpp-lab-console-contract.md
@@ -4,7 +4,7 @@
 
 **Goal:** Establish and accept the architectural contract that lets Lab verify a llama.cpp destination and hand it to the active Console session without conflating process liveness, API readiness, session adoption, or durable defaults.
 
-**Architecture:** Create ADR-114 as a documentation-only decision. It extends the existing endpoint normalization, managed/external GGUF authority, and Console settings ownership decisions; it selects `http://127.0.0.1:8080` as the absent-value llama.cpp default, defines a sanitized cross-surface connection descriptor, and assigns each lifecycle and persistence transition to one existing owner. No production behavior changes in TASK-31200.
+**Architecture:** Create ADR-114 as a documentation-only decision. It extends the existing endpoint normalization, managed/external GGUF authority, and Console settings ownership decisions; it selects `http://127.0.0.1:8080` as the absent-value llama.cpp default, reserves `chatbook-llamacpp` as the safe API model alias for Lab-owned launches, defines a sanitized cross-surface connection descriptor, and assigns each lifecycle and persistence transition to one existing owner. Existing servers with path-identifying model IDs fail closed before handoff. No production behavior changes in TASK-31200.
 
 **Tech Stack:** Markdown ADRs, Backlog.md, Python 3.11 application contracts, Textual 8.x UI terminology, OpenAI-compatible llama.cpp HTTP endpoints.
 
@@ -20,6 +20,9 @@
 - Preserve ADR-095: ordinary Console session Apply does not persist endpoints; only the explicit full Settings default action may persist an explicitly edited checked endpoint.
 - Preserve TASK-16476 behavior: adopting a local server never silently overwrites a different configured endpoint.
 - Credentials, executable paths, GGUF paths, query strings, fragments, and raw logs never enter the cross-surface descriptor or conversation metadata.
+- Lab-owned launch construction emits exactly one `--alias chatbook-llamacpp`; raw/expert arguments cannot replace or duplicate it.
+- Existing-server model IDs with unambiguous filesystem markers fail closed without display, logging, or copy; an interior `/` alone remains valid for namespace-style IDs.
+- The narrow cross-surface display allowlist does not prevent Lab from owning and rendering its executable/GGUF selection, PID, expert configuration, redacted command/arguments, or bounded sanitized diagnostics.
 - Existing explicit user endpoints remain authoritative; the canonical `8080` choice applies only when no explicit or configured value exists.
 - Keep this contract llama.cpp-specific until TASK-31201 proves it; do not introduce a universal local-runtime framework.
 
@@ -96,6 +99,7 @@ In Context, cite the exact current divergence:
 - configured provider and local discovery default: `8080` in `config.py` and `local_server_discovery.py`.
 - Console direct-path fallback: `9099` in `console_session_settings.py`.
 - subprocess liveness currently drives running presentation while stdout and stderr are discarded.
+- the Lab command builder supplies `--model` without a reserved `--alias`, so llama.cpp's default `/v1/models` ID is the selected filesystem path.
 - Console detected-server adoption already has safe session application and configured-endpoint preservation, but its default-persistence behavior is not the Lab handoff contract.
 - TASK-16473 already requires a warning when an active Console endpoint will not survive restart; Lab handoff must retain that session-only truth rather than imply persistence.
 - TASK-26837 records a provider-setup path that can report success without a durable `api_settings` entry; Make default must not inherit or normalize that false-success behavior.
@@ -108,7 +112,7 @@ Put this normative shape in the Decision section:
 LlamaCppConnectionTarget
   provider_key: canonical llama_cpp identity
   base_url: canonical credential-free persisted endpoint root
-  model_id: exact model ID returned by the verified endpoint
+  model_id: exact non-path-identifying model ID returned by the verified endpoint
   runtime_owner: lab_process | external_server
   verification_generation: process-local opaque generation
 ```
@@ -117,9 +121,13 @@ State explicitly:
 
 - `base_url` is produced by `resolve_provider_endpoint`; the descriptor never carries a chat-completions suffix.
 - `model_id` is endpoint-reported identity, not a GGUF path, managed artifact path, or filename-derived global identity.
+- every Lab-owned launch emits the stable reserved `--alias chatbook-llamacpp`, and readiness requires the endpoint to report that exact alias.
+- raw arguments reject every separated or equals-attached `-a` and `--alias` form so they cannot replace or duplicate the reserved alias.
+- existing-server IDs are rejected as path-identifying only for unambiguous filesystem markers: file URIs; absolute, explicit-relative, home-relative, drive-root, or UNC prefixes; backslashes; dot path segments; or a final `.gguf` component. An interior forward slash alone remains valid for `owner/model` identities.
+- a rejected existing-server ID fails before selector, descriptor, display, copy, log, or adoption and produces only generic recovery to configure `llama-server --alias`.
 - `runtime_owner` is informational lifecycle provenance, not authority for Console to stop a process.
 - `verification_generation` exists only to reject stale probes and is never persisted.
-- executable path, external GGUF path, managed store path, credentials, raw command, and raw log output remain Lab-owned and are excluded.
+- executable path, external GGUF path, and managed store path remain Lab-owned; credentials, raw command, and raw log output are excluded, with Lab retention/rendering governed by the narrow observability exception.
 
 - [ ] **Step 4: Define distinct lifecycle and product states**
 
@@ -156,7 +164,7 @@ Also record:
 
 - existing explicit `8001`, `9099`, LAN, HTTPS, and reverse-proxy-prefix endpoints remain valid and are not migrated or rewritten.
 - new Lab launch defaults to loopback `127.0.0.1:8080` only when the user has not supplied a value.
-- API ready requires a successful health-compatible probe and successful `/v1/models` response containing the selected exact model ID.
+- API ready requires a successful health-compatible probe and successful `/v1/models` response containing the selected exact admissible model ID: the reserved alias for a Lab-owned launch or an accepted non-path-identifying ID for an existing server.
 - a user-entered existing-server check is an explicit, exact-endpoint exception to ADR-002's configured-provider-only discovery rule; it does not enable ambient LAN scanning or background remote discovery.
 - a port collision may offer Connect to it only after that exact endpoint passes the llama.cpp-compatible health and model checks.
 
@@ -192,9 +200,11 @@ State that every probe and handoff carries the exact verification generation. Ca
 
 Define observability:
 
-- UI may show the canonical credential-free endpoint, endpoint-reported model ID, coarse lifecycle state, and bounded failure category.
+- the narrow display allowlist applies to cross-surface UI, Console, app-global metadata, and application/unrestricted logs: canonical provider identity and credential-free endpoint, accepted endpoint model ID, coarse lifecycle state, and bounded failure category.
+- Lab may retain/render its own executable/GGUF selections, PID, expert configuration, redacted command/arguments, and bounded sanitized runtime diagnostics; user-entered arguments appear only in their owning editor and derived presentations are redacted.
 - app-global state and logs must not retain raw executable/model paths, credentials, raw command arguments, or unbounded process output.
-- TASK-31206 may add bounded sanitized diagnostics within Lab, but those diagnostics do not enter the handoff descriptor.
+- TASK-31206 diagnostics and copy remain bounded, sanitized, and Lab-local; they do not enter the handoff descriptor, Console, conversation metadata, app-global metadata, or application logs.
+- rejected path-identifying endpoint IDs are suppressed before every render, copy, or log projection.
 
 Rollback rule: disable the new Lab handoff and fall back to existing Console Settings/discovery; retain existing explicit config and do not synthesize migrations.
 
@@ -216,7 +226,7 @@ Consequences must name the follow-on work: TASK-31201 implements the app-scoped 
 Run:
 
 ```bash
-rg -n 'LlamaCppConnectionTarget|127\.0\.0\.1:8080|Use in Console|Make default|process_alive|model_available|verification_generation|ADR-002|ADR-025|ADR-095|TASK-16473|TASK-16476|TASK-26837' backlog/decisions/114-llamacpp-lab-console-connection-authority.md
+rg -n -- 'LlamaCppConnectionTarget|127\.0\.0\.1:8080|--alias|path-identifying|Use in Console|Make default|process_alive|model_available|verification_generation|ADR-002|ADR-025|ADR-095|TASK-16473|TASK-16476|TASK-26837' backlog/decisions/114-llamacpp-lab-console-connection-authority.md
 ```
 
 Expected: every required term appears in its normative section; no requirement relies only on the Context narrative.
@@ -319,6 +329,12 @@ git commit -m "docs: link llama.cpp handoff contract"
 
 - [ ] **Step 1: Add the follow-on verification matrix to ADR-114**
 
+Before the matrix, require future launch-construction tests for exact reserved-alias
+emission and raw-argument override prevention. Require existing-server tests that
+reject path-identifying IDs before selector, descriptor, display, copy, log, or
+adoption; prove the rejected sentinel is absent from every projection; and accept an
+ordinary namespace ID containing one forward slash.
+
 The `## Verification obligations` table must contain these rows:
 
 | Contract | Required future evidence |
@@ -346,7 +362,7 @@ Expected mapping:
 1. Descriptor and default policy: Decision plus Default and compatibility policy.
 2. Six distinct truth states: Ownership and state transitions.
 3. Four explicit actions and no silent overwrite: action table.
-4. Cross-surface privacy: Privacy and observability boundary.
+4. Cross-surface privacy and the narrow Lab-owned diagnostics exception: Privacy and observability boundary.
 5. Existing ADR/task reconciliation: Context, Decision, and Links.
 6. Sequence, settlement, observability, verification: Ownership, Privacy, Rollback, and Verification obligations.
 
@@ -391,7 +407,7 @@ Use Backlog.md:
 backlog task edit 31200 \
   --check-ac 1 --check-ac 2 --check-ac 3 \
   --check-ac 4 --check-ac 5 --check-ac 6 \
-  --notes "Accepted ADR-114 to separate llama.cpp process ownership, HTTP and model readiness, active Console adoption, and explicit provider-default persistence. Selected the absent-value loopback default at port 8080, defined the sanitized generation-fenced handoff target, preserved ADR-025 GGUF authority and ADR-095 settings ownership, and linked the verification obligations for TASK-31201 through TASK-31206. Modified the canonical ADR index, handoff wireframe, plan, and TASK-31200 metadata; no production code or tests changed." \
+  --notes "Accepted ADR-114 to separate llama.cpp process ownership, HTTP and model readiness, active Console adoption, and explicit provider-default persistence. Selected the absent-value loopback default at port 8080, reserved a stable path-independent alias for Lab launches, made path-identifying existing-server model IDs fail closed, and scoped the cross-surface privacy allowlist while preserving bounded Lab-local diagnostics. Preserved ADR-025 GGUF authority and ADR-095 settings ownership and linked the verification obligations for TASK-31201 through TASK-31206. Modified the canonical ADR index, handoff wireframe, plan, and TASK-31200 metadata; no production code or tests changed." \
   --plain
 ```
 
@@ -422,8 +438,9 @@ git commit -m "docs: accept llama.cpp connection contract"
 Run:
 
 ```bash
-git diff --check HEAD~3..HEAD
-git diff --name-only HEAD~3..HEAD
+base_sha=$(git merge-base origin/dev HEAD)
+git diff --check "$base_sha..HEAD"
+git diff --name-only "$base_sha..HEAD"
 ```
 
 Expected changed paths are limited to ADR-114, the decisions index, the handoff wireframe, this plan, and TASK-31200. No Python, TCSS, TOML, schema, migration, test, or generated CSS file may appear.

--- a/Docs/superpowers/plans/2026-09-03-task-31200-llamacpp-lab-console-contract.md
+++ b/Docs/superpowers/plans/2026-09-03-task-31200-llamacpp-lab-console-contract.md
@@ -1,0 +1,429 @@
+# llama.cpp Lab-to-Console Connection Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish and accept the architectural contract that lets Lab verify a llama.cpp destination and hand it to the active Console session without conflating process liveness, API readiness, session adoption, or durable defaults.
+
+**Architecture:** Create ADR-114 as a documentation-only decision. It extends the existing endpoint normalization, managed/external GGUF authority, and Console settings ownership decisions; it selects `http://127.0.0.1:8080` as the absent-value llama.cpp default, defines a sanitized cross-surface connection descriptor, and assigns each lifecycle and persistence transition to one existing owner. No production behavior changes in TASK-31200.
+
+**Tech Stack:** Markdown ADRs, Backlog.md, Python 3.11 application contracts, Textual 8.x UI terminology, OpenAI-compatible llama.cpp HTTP endpoints.
+
+**Spec:** `Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md`
+
+## Global Constraints
+
+- TASK-31200 is documentation-only; do not edit Python, TCSS, TOML defaults, schemas, or tests.
+- ADR required: yes.
+- ADR path: `backlog/decisions/114-llamacpp-lab-console-connection-authority.md`.
+- Reason: this work changes the provider/runtime boundary, cross-screen state ownership, persistence scope, privacy boundary, and long-lived setup flow.
+- Preserve ADR-025 managed/external GGUF ownership and exact process-lease lifetime.
+- Preserve ADR-095: ordinary Console session Apply does not persist endpoints; only the explicit full Settings default action may persist an explicitly edited checked endpoint.
+- Preserve TASK-16476 behavior: adopting a local server never silently overwrites a different configured endpoint.
+- Credentials, executable paths, GGUF paths, query strings, fragments, and raw logs never enter the cross-surface descriptor or conversation metadata.
+- Existing explicit user endpoints remain authoritative; the canonical `8080` choice applies only when no explicit or configured value exists.
+- Keep this contract llama.cpp-specific until TASK-31201 proves it; do not introduce a universal local-runtime framework.
+
+---
+
+### Task 1: Author ADR-114 and freeze the connection vocabulary
+
+**Files:**
+
+- Create: `backlog/decisions/114-llamacpp-lab-console-connection-authority.md`
+- Read: `backlog/decisions/002-openai-compatible-model-discovery.md`
+- Read: `backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md`
+- Read: `backlog/decisions/095-conversation-owned-console-generation-settings.md`
+- Read: `tldw_chatbook/Chat/provider_endpoint_contract.py:14-194`
+- Read: `tldw_chatbook/Event_Handlers/LLM_Management_Events/server_lifecycle.py:26-424`
+
+**Interfaces:**
+
+- Consumes: `resolve_provider_endpoint(provider: str, value: object) -> ProviderEndpointResolution`, `canonical_connection_identity(provider: str, value: object) -> tuple[str, str] | None`, ADR-025 GGUF authority, and ADR-095 Console session/default ownership.
+- Produces: the normative `LlamaCppConnectionTarget`, readiness vocabulary, ownership table, default-resolution order, handoff actions, and privacy contract consumed by TASK-31201 through TASK-31206.
+
+- [ ] **Step 1: Reconfirm that ADR number 114 is unclaimed**
+
+Run:
+
+```bash
+git for-each-ref --format='%(refname)' refs/remotes/ | while IFS= read -r ref_name; do
+  git ls-tree -r --name-only "$ref_name" backlog/decisions/
+done | rg '/114-' || true
+
+git worktree list --porcelain | sed -n 's/^worktree //p' | while IFS= read -r worktree_path; do
+  find "$worktree_path/backlog/decisions" -maxdepth 1 -type f -name '114-*.md' -print 2>/dev/null
+done
+```
+
+Expected: no matching ADR path. If another ADR-114 appears, rescan all refs and worktrees, select the next unused number, and update every path in this plan and TASK-31200 before writing.
+
+- [ ] **Step 2: Create the ADR metadata and context**
+
+Create `backlog/decisions/114-llamacpp-lab-console-connection-authority.md` with this opening structure:
+
+```markdown
+# ADR-114: Own llama.cpp process, readiness, Console adoption, and defaults separately
+
+Status: Proposed
+Date: 2026-09-03
+Related Tasks: TASK-31200 through TASK-31206
+Extends: ADR-002, ADR-025, ADR-095
+
+## Decision
+
+## Context
+
+## Ownership and state transitions
+
+## Default and compatibility policy
+
+## Privacy and observability boundary
+
+## Alternatives Considered
+
+## Consequences
+
+## Rollback plan
+
+## Verification obligations
+
+## Links
+```
+
+In Context, cite the exact current divergence:
+
+- Lab launch fallback: `8001` in `llm_management_events.py`.
+- configured provider and local discovery default: `8080` in `config.py` and `local_server_discovery.py`.
+- Console direct-path fallback: `9099` in `console_session_settings.py`.
+- subprocess liveness currently drives running presentation while stdout and stderr are discarded.
+- Console detected-server adoption already has safe session application and configured-endpoint preservation, but its default-persistence behavior is not the Lab handoff contract.
+- TASK-16473 already requires a warning when an active Console endpoint will not survive restart; Lab handoff must retain that session-only truth rather than imply persistence.
+- TASK-26837 records a provider-setup path that can report success without a durable `api_settings` entry; Make default must not inherit or normalize that false-success behavior.
+
+- [ ] **Step 3: Define the sanitized connection descriptor**
+
+Put this normative shape in the Decision section:
+
+```text
+LlamaCppConnectionTarget
+  provider_key: canonical llama_cpp identity
+  base_url: canonical credential-free persisted endpoint root
+  model_id: exact model ID returned by the verified endpoint
+  runtime_owner: lab_process | external_server
+  verification_generation: process-local opaque generation
+```
+
+State explicitly:
+
+- `base_url` is produced by `resolve_provider_endpoint`; the descriptor never carries a chat-completions suffix.
+- `model_id` is endpoint-reported identity, not a GGUF path, managed artifact path, or filename-derived global identity.
+- `runtime_owner` is informational lifecycle provenance, not authority for Console to stop a process.
+- `verification_generation` exists only to reject stale probes and is never persisted.
+- executable path, external GGUF path, managed store path, credentials, raw command, and raw log output remain Lab-owned and are excluded.
+
+- [ ] **Step 4: Define distinct lifecycle and product states**
+
+Document two layers rather than one overloaded running flag:
+
+```text
+Runtime truth: unclaimed -> reserved -> process_alive -> process_dead
+Connection truth: unchecked -> checking -> api_healthy -> model_available -> stale_or_failed
+Product state: not_configured | checking | starting | loading_model | api_ready | console_connected | needs_attention
+```
+
+Assign owners:
+
+- `server_lifecycle.py` remains the exact claim/process owner.
+- a TASK-31201 app-scoped llama.cpp connection owner will own the target plus generation-fenced HTTP/model evidence.
+- Lab projects those two owners into the product state.
+- Console owns whether the active session adopted the target.
+- Settings/config owns durable provider defaults.
+
+Specify that `process_alive` alone can render Starting or Loading model, never API ready.
+
+- [ ] **Step 5: Choose the default-resolution and readiness contract**
+
+Record this precedence:
+
+```text
+explicit user-entered or launch endpoint
+  -> exact current-session target
+  -> configured provider endpoint
+  -> canonical llama.cpp absent-value default http://127.0.0.1:8080
+```
+
+Also record:
+
+- existing explicit `8001`, `9099`, LAN, HTTPS, and reverse-proxy-prefix endpoints remain valid and are not migrated or rewritten.
+- new Lab launch defaults to loopback `127.0.0.1:8080` only when the user has not supplied a value.
+- API ready requires a successful health-compatible probe and successful `/v1/models` response containing the selected exact model ID.
+- a user-entered existing-server check is an explicit, exact-endpoint exception to ADR-002's configured-provider-only discovery rule; it does not enable ambient LAN scanning or background remote discovery.
+- a port collision may offer Connect to it only after that exact endpoint passes the llama.cpp-compatible health and model checks.
+
+- [ ] **Step 6: Define adoption and persistence actions**
+
+Put this action table in the ADR:
+
+| Action | Owner and effect | Persistence |
+|---|---|---|
+| Start on this computer | Lab reserves and owns one exact process claim | None |
+| Connect to existing server | Lab verifies one user-entered endpoint | None |
+| Use in Console | Console applies provider, exact model, and base URL to the active session | Process-local session only |
+| Make default | Full Settings commit path applies its existing checked-endpoint rules | Explicit config mutation |
+| Stop server | Lab stops only its exact owned process claim | Does not alter Console or defaults |
+
+Require that Use in Console:
+
+- never calls the detected-server path that auto-fills missing config.
+- never persists `base_url` in conversation metadata, consistent with ADR-095.
+- preserves a different configured endpoint and labels the adopted target Session only.
+- refreshes Console readiness in the same application process.
+
+Require that Make default:
+
+- opens or delegates to the full Settings commit path rather than treating Lab verification as permission to write configuration.
+- reports success only after the normalized provider endpoint is durably present in the configuration layer that restart resolution reads.
+- retains TASK-16473's distinction between session-only and restart-safe endpoints and TASK-16476's protection against silently replacing a different configured endpoint.
+- treats TASK-26837's missing-`api_settings` success state as an unresolved defect to prevent or surface, never as accepted behavior.
+
+- [ ] **Step 7: Define settlement, privacy, and rollback**
+
+State that every probe and handoff carries the exact verification generation. Cancellation, process death, target edit, model change, screen recomposition, or newer probe invalidates older evidence. A stale result cannot expose Use in Console or modify Console.
+
+Define observability:
+
+- UI may show the canonical credential-free endpoint, endpoint-reported model ID, coarse lifecycle state, and bounded failure category.
+- app-global state and logs must not retain raw executable/model paths, credentials, raw command arguments, or unbounded process output.
+- TASK-31206 may add bounded sanitized diagnostics within Lab, but those diagnostics do not enter the handoff descriptor.
+
+Rollback rule: disable the new Lab handoff and fall back to existing Console Settings/discovery; retain existing explicit config and do not synthesize migrations.
+
+- [ ] **Step 8: Record alternatives and consequences**
+
+Include and reject at least these alternatives:
+
+- treat process liveness as readiness.
+- auto-write the Lab endpoint into provider configuration.
+- reuse `_apply_detected_local_server` unchanged for Lab handoff.
+- persist the complete Lab launch command in Console conversation metadata.
+- retain three context-specific defaults.
+- generalize all local runtimes before the llama.cpp path is proven.
+
+Consequences must name the follow-on work: TASK-31201 implements the app-scoped connection owner and adoption; TASK-31202/31203 project it into onboarding; TASK-31204/31205 retain launch configuration separately; TASK-31206 adds Lab-local diagnostics.
+
+- [ ] **Step 9: Run the ADR content check**
+
+Run:
+
+```bash
+rg -n 'LlamaCppConnectionTarget|127\.0\.0\.1:8080|Use in Console|Make default|process_alive|model_available|verification_generation|ADR-002|ADR-025|ADR-095|TASK-16473|TASK-16476|TASK-26837' backlog/decisions/114-llamacpp-lab-console-connection-authority.md
+```
+
+Expected: every required term appears in its normative section; no requirement relies only on the Context narrative.
+
+- [ ] **Step 10: Commit the ADR draft**
+
+```bash
+git add backlog/decisions/114-llamacpp-lab-console-connection-authority.md
+git commit -m "docs: define llama.cpp Lab Console authority"
+```
+
+### Task 2: Index the ADR and connect every planning artifact
+
+**Files:**
+
+- Modify: `backlog/decisions/README.md`
+- Modify: `Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md`
+- Modify: `backlog/tasks/task-31200 - Define-the-llama.cpp-Lab-to-Console-connection-and-readiness-contract.md`
+
+**Interfaces:**
+
+- Consumes: proposed ADR-114 path and the existing TASK-31200 acceptance criteria.
+- Produces: discoverable canonical decision links for later task plans and reviewers.
+
+- [ ] **Step 1: Add ADR-114 to the canonical index**
+
+Add one row to `backlog/decisions/README.md`:
+
+```markdown
+| [ADR-114](114-llamacpp-lab-console-connection-authority.md) | Proposed | Keep llama.cpp process ownership, HTTP/model readiness, Console session adoption, and durable provider defaults separate behind one sanitized connection target. |
+```
+
+Place it in numeric order after ADR-113. Do not renumber or repair historical duplicate ADR IDs in this task.
+
+- [ ] **Step 2: Link the ADR from the wireframe brief**
+
+Add an `## Architecture authority` section before Backlog mapping:
+
+```markdown
+## Architecture authority
+
+- [ADR-114](../../../backlog/decisions/114-llamacpp-lab-console-connection-authority.md) owns endpoint defaults, readiness truth, cross-surface handoff, persistence scope, and privacy boundaries.
+- [ADR-025](../../../backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md) continues to own Managed versus External GGUF authority and exact process-lifetime artifact leases.
+- [ADR-095](../../../backlog/decisions/095-conversation-owned-console-generation-settings.md) continues to own Console session settings and explicit default persistence.
+```
+
+- [ ] **Step 3: Update TASK-31200 documentation metadata**
+
+Use Backlog.md rather than hand-editing frontmatter:
+
+```bash
+backlog task edit 31200 \
+  --doc backlog/decisions/114-llamacpp-lab-console-connection-authority.md \
+  --doc Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md \
+  --doc Docs/superpowers/plans/2026-09-03-task-31200-llamacpp-lab-console-contract.md \
+  --plain
+```
+
+Expected: all three documentation paths render and the existing description, acceptance criteria, status, assignee, labels, and dependency list remain unchanged.
+
+- [ ] **Step 4: Verify links and commit the index/brief update**
+
+Run:
+
+```bash
+test -f backlog/decisions/114-llamacpp-lab-console-connection-authority.md
+test -f Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md
+test -f Docs/superpowers/plans/2026-09-03-task-31200-llamacpp-lab-console-contract.md
+backlog task 31200 --plain
+git diff --check
+```
+
+Expected: every command succeeds; TASK-31200 prints all three documentation paths.
+
+```bash
+git add backlog/decisions/README.md \
+  Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md \
+  'backlog/tasks/task-31200 - Define-the-llama.cpp-Lab-to-Console-connection-and-readiness-contract.md'
+git commit -m "docs: link llama.cpp handoff contract"
+```
+
+### Task 3: Prove contract coverage and close TASK-31200
+
+**Files:**
+
+- Modify: `backlog/decisions/114-llamacpp-lab-console-connection-authority.md`
+- Modify: `backlog/decisions/README.md`
+- Modify: `backlog/tasks/task-31200 - Define-the-llama.cpp-Lab-to-Console-connection-and-readiness-contract.md`
+- Read: `backlog/tasks/task-31201 - Bridge-a-verified-Lab-llama.cpp-runtime-into-the-active-Console-session.md`
+- Read: `backlog/tasks/task-31202 - Guide-first-time-llama.cpp-setup-from-prerequisites-to-a-verified-Chatbook-response.md`
+- Read: `backlog/tasks/task-31203 - Make-the-llama.cpp-setup-flow-visible-and-keyboard-efficient-at-narrow-widths.md`
+- Read: `backlog/tasks/task-31204 - Separate-current-and-next-llama.cpp-launch-configuration-and-add-Restart-last.md`
+- Read: `backlog/tasks/task-31205 - Add-durable-named-llama.cpp-launch-profiles.md`
+- Read: `backlog/tasks/task-31206 - Add-bounded-llama.cpp-diagnostics-command-preview-and-recovery-actions.md`
+
+**Interfaces:**
+
+- Consumes: ADR-114 and all follow-on task acceptance criteria.
+- Produces: an accepted, implementation-ready contract with explicit verification obligations and a fully closed TASK-31200 record.
+
+- [ ] **Step 1: Add the follow-on verification matrix to ADR-114**
+
+The `## Verification obligations` table must contain these rows:
+
+| Contract | Required future evidence |
+|---|---|
+| Canonical endpoint | Pure normalization/default-precedence tests in `Tests/Chat/test_provider_endpoint_contract.py` and Console settings tests |
+| Process versus readiness | Lifecycle plus real loopback HTTP tests proving live-process/not-ready and model-ready transitions |
+| Stale-result fencing | Generation replacement tests for process exit, model edit, endpoint edit, cancellation, and recomposition |
+| Console adoption | Mounted Lab-to-Console test proving exact provider/base URL/model apply without restart |
+| Persistence boundary | Regression test proving Use in Console does not write config and Make default preserves unrelated or newer fields |
+| Managed model privacy | Tests proving no filesystem path enters the descriptor, rendered authority text, app-global metadata, or Console settings |
+| Compact UX | Production-stylesheet 80x24, 100x30, and 120x40 compositor/focus tests |
+| Live qualification | Scratch-profile run against a real llama-server, with default-profile fingerprints checked before cleanup |
+
+- [ ] **Step 2: Audit every TASK-31200 acceptance criterion against the ADR**
+
+Run:
+
+```bash
+backlog task 31200 --plain
+rg -n '^## |LlamaCppConnectionTarget|Runtime truth|Connection truth|Product state|Default and compatibility|Privacy and observability|Verification obligations' backlog/decisions/114-llamacpp-lab-console-connection-authority.md
+```
+
+Expected mapping:
+
+1. Descriptor and default policy: Decision plus Default and compatibility policy.
+2. Six distinct truth states: Ownership and state transitions.
+3. Four explicit actions and no silent overwrite: action table.
+4. Cross-surface privacy: Privacy and observability boundary.
+5. Existing ADR/task reconciliation: Context, Decision, and Links.
+6. Sequence, settlement, observability, verification: Ownership, Privacy, Rollback, and Verification obligations.
+
+- [ ] **Step 3: Run the documentation integrity checks**
+
+Run:
+
+```bash
+blocked_terms='T''BD|TO''DO|FIX''ME|implement lat''er|similar to Ta''sk'
+rg -n "$blocked_terms" \
+  backlog/decisions/114-llamacpp-lab-console-connection-authority.md \
+  Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md \
+  Docs/superpowers/plans/2026-09-03-task-31200-llamacpp-lab-console-contract.md
+
+rg -n '[[:blank:]]+$' \
+  backlog/decisions/114-llamacpp-lab-console-connection-authority.md \
+  Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md \
+  Docs/superpowers/plans/2026-09-03-task-31200-llamacpp-lab-console-contract.md
+
+git diff --check
+```
+
+Expected: both `rg` commands return no matches and `git diff --check` succeeds. These are documentation checks; do not run the application test suite for TASK-31200.
+
+- [ ] **Step 4: Promote the reviewed ADR from Proposed to Accepted**
+
+After the coverage and integrity checks pass, change the ADR status:
+
+```markdown
+Status: Accepted
+```
+
+and change ADR-114's index status from `Proposed` to `Accepted`. Do not alter either decision summary.
+
+Do not mark TASK-31200 Done yet.
+
+- [ ] **Step 5: Check all TASK-31200 acceptance criteria and add Implementation Notes**
+
+Use Backlog.md:
+
+```bash
+backlog task edit 31200 \
+  --check-ac 1 --check-ac 2 --check-ac 3 \
+  --check-ac 4 --check-ac 5 --check-ac 6 \
+  --notes "Accepted ADR-114 to separate llama.cpp process ownership, HTTP and model readiness, active Console adoption, and explicit provider-default persistence. Selected the absent-value loopback default at port 8080, defined the sanitized generation-fenced handoff target, preserved ADR-025 GGUF authority and ADR-095 settings ownership, and linked the verification obligations for TASK-31201 through TASK-31206. Modified the canonical ADR index, handoff wireframe, plan, and TASK-31200 metadata; no production code or tests changed." \
+  --plain
+```
+
+Expected: all six acceptance criteria are checked and the notes name the ADR decision, compatibility boundaries, modified artifacts, and documentation-only verification.
+
+- [ ] **Step 6: Mark TASK-31200 Done and verify the rendered record**
+
+```bash
+backlog task edit 31200 -s Done --plain
+backlog task 31200 --plain
+```
+
+Expected: status Done, six checked criteria, ADR-114 and both design/plan documents linked, and Implementation Notes present. If any field is missing, restore it before committing.
+
+- [ ] **Step 7: Commit closeout metadata**
+
+```bash
+git add backlog/decisions/114-llamacpp-lab-console-connection-authority.md \
+  backlog/decisions/README.md \
+  Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md \
+  Docs/superpowers/plans/2026-09-03-task-31200-llamacpp-lab-console-contract.md \
+  'backlog/tasks/task-31200 - Define-the-llama.cpp-Lab-to-Console-connection-and-readiness-contract.md'
+git commit -m "docs: accept llama.cpp connection contract"
+```
+
+- [ ] **Step 8: Final scope verification**
+
+Run:
+
+```bash
+git diff --check HEAD~3..HEAD
+git diff --name-only HEAD~3..HEAD
+```
+
+Expected changed paths are limited to ADR-114, the decisions index, the handoff wireframe, this plan, and TASK-31200. No Python, TCSS, TOML, schema, migration, test, or generated CSS file may appear.

--- a/Docs/superpowers/plans/2026-09-03-task-31200-llamacpp-lab-console-contract.md
+++ b/Docs/superpowers/plans/2026-09-03-task-31200-llamacpp-lab-console-contract.md
@@ -24,6 +24,7 @@
 - Existing-server model IDs with unambiguous filesystem markers fail closed without display, logging, or copy; an interior `/` alone remains valid for namespace-style IDs.
 - The narrow cross-surface display allowlist does not prevent Lab from owning and rendering its executable/GGUF selection, PID, expert configuration, redacted command/arguments, or bounded sanitized diagnostics.
 - Existing explicit user endpoints remain authoritative; the canonical `8080` choice applies only when no explicit or configured value exists.
+- Preserve active Console endpoint precedence: session target, `TLDW_CONSOLE_LLAMA_CPP_BASE_URL`, `[console].llama_cpp_base_url_override`, configured provider endpoint, then the absent-value default. Restart omits only the process-local session target.
 - Keep this contract llama.cpp-specific until TASK-31201 proves it; do not introduce a universal local-runtime framework.
 
 ---
@@ -151,20 +152,31 @@ Specify that `process_alive` alone can render Starting or Loading model, never A
 
 - [ ] **Step 5: Choose the default-resolution and readiness contract**
 
-Record this precedence:
+Record the context-specific precedence rather than one shortened chain:
 
 ```text
-explicit user-entered or launch endpoint
-  -> exact current-session target
+Active Console:
+exact current-session target
+  -> TLDW_CONSOLE_LLAMA_CPP_BASE_URL
+  -> [console].llama_cpp_base_url_override
+  -> configured provider endpoint
+  -> canonical llama.cpp absent-value default http://127.0.0.1:8080
+
+Console restart:
+TLDW_CONSOLE_LLAMA_CPP_BASE_URL
+  -> [console].llama_cpp_base_url_override
   -> configured provider endpoint
   -> canonical llama.cpp absent-value default http://127.0.0.1:8080
 ```
 
 Also record:
 
+- an explicit Lab check or launch endpoint is authoritative for that Lab action; Use in Console installs it as the exact current-session target.
+- a new local launch with no explicit endpoint uses loopback `127.0.0.1:8080` and never treats a remote Console override as a bind target.
 - existing explicit `8001`, `9099`, LAN, HTTPS, and reverse-proxy-prefix endpoints remain valid and are not migrated or rewritten.
 - new Lab launch defaults to loopback `127.0.0.1:8080` only when the user has not supplied a value.
 - API ready requires a successful health-compatible probe and successful `/v1/models` response containing the selected exact admissible model ID: the reserved alias for a Lab-owned launch or an accepted non-path-identifying ID for an existing server.
+- before path classification, an existing-server model ID must be 1–120 Unicode code points, canonical-whitespace-equal, printable, and free of `Cc`, `Cf`, and `Cs` Unicode categories; invalid input fails closed without cleaning, truncation, display, copy, or logging.
 - a user-entered existing-server check is an explicit, exact-endpoint exception to ADR-002's configured-provider-only discovery rule; it does not enable ambient LAN scanning or background remote discovery.
 - a port collision may offer Connect to it only after that exact endpoint passes the llama.cpp-compatible health and model checks.
 
@@ -339,7 +351,7 @@ The `## Verification obligations` table must contain these rows:
 
 | Contract | Required future evidence |
 |---|---|
-| Canonical endpoint | Pure normalization/default-precedence tests in `Tests/Chat/test_provider_endpoint_contract.py` and Console settings tests |
+| Canonical endpoint | Pure normalization and context-specific active-session/restart/Lab precedence tests, including both existing Console override layers |
 | Process versus readiness | Lifecycle plus real loopback HTTP tests proving live-process/not-ready and model-ready transitions |
 | Stale-result fencing | Generation replacement tests for process exit, model edit, endpoint edit, cancellation, and recomposition |
 | Console adoption | Mounted Lab-to-Console test proving exact provider/base URL/model apply without restart |

--- a/Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md
+++ b/Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md
@@ -1,0 +1,190 @@
+# llama.cpp Lab-to-Console handoff wireframe
+
+## Design brief
+
+- **Job and audience:** Help a first-time local-model user reach a verified Chatbook response, while giving an experienced user repeatable launch, restart, and diagnosis controls.
+- **Outcome and proof:** Success means the selected llama.cpp API is healthy, its model is discoverable, and the exact provider, endpoint, and model are active in the Console session. A live subprocess alone is not success.
+- **Direction:** Keep the terminal-native Lab workbench, but replace the flat launcher form with a four-step readiness path. Present one primary action for the current state and disclose expert configuration separately.
+- **Boundary:** Lab owns local process launch, model-path authority, and runtime output. Console owns the active conversation destination. Provider defaults remain configuration-owned and change only through an explicit Make default action.
+- **Responsive rule:** At compact widths, collapse navigation before setup content, stack all label/input/action groups, and keep the current recovery or completion action painted without horizontal panning.
+
+## Shared state language
+
+| State | Meaning | Primary action |
+|---|---|---|
+| Not configured | Required runtime, model, or endpoint is missing | Complete the current checklist item |
+| Checking | Chatbook is probing the exact endpoint | Cancel |
+| Starting | Chatbook owns a pending local process claim | Stop starting |
+| Loading model | Process is alive but the selected model is not API-ready | Stop |
+| API ready | Health and model discovery passed | Use in Console |
+| Console connected | The active Console session uses the verified destination | Open Console |
+| Needs attention | A specific preflight, process, or API check failed | Context-specific recovery |
+
+`Ready` is not used for a mounted screen or process liveness.
+
+## First-run — start on this computer
+
+```text
+┌ LAB ─ Models ─ llama.cpp                                      Not configured ┐
+│ Catalog        Set up llama.cpp                                                │
+│                Run a local GGUF model and connect it to Chatbook.              │
+│ ● llama.cpp                                                                    │
+│   Ollama       [ Start on this computer ] [ Connect to existing server ]       │
+│   vLLM                                                                         │
+│                SETUP                                                           │
+│ Models         1  Runtime       llama-server found                  [Change]   │
+│   Installed    2  Model         Not selected                        [Choose]   │
+│   Remote       3  Endpoint      127.0.0.1:8080                      [Edit]     │
+│                4  Chatbook      Waiting for steps 1–3                          │
+│                                                                                 │
+│                Choose a model                                                   │
+│                (•) Installed in Chatbook — recommended                         │
+│                    No compatible GGUF models installed                          │
+│                    [ Find a model ]  [ Import a GGUF ]                          │
+│                ( ) Existing GGUF file                                           │
+│                                                                                 │
+│                ▸ Expert launch settings                                         │
+│                                                                                 │
+│                Complete step 2 to continue.                   [ Start & check ] │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+Behavior:
+
+- Detect runs automatically once when no executable is known; Browse remains available.
+- Find a model opens Remote and preserves return intent for the exact llama.cpp setup.
+- Start & check preflights the executable, model, and endpoint; it becomes available only when the adjacent reason is satisfied.
+- Expert launch settings contains host binding, port override, context/hardware presets, raw arguments, and command preview.
+
+## First-run — connect to an existing server
+
+```text
+┌ LAB ─ Models ─ llama.cpp                                      Not configured ┐
+│                Set up llama.cpp                                                │
+│                [ Start on this computer ] [ Connect to existing server ]       │
+│                                                                                 │
+│                Server URL                                                      │
+│                [ http://127.0.0.1:8080_____________________ ] [ Check ]         │
+│                                                                                 │
+│                Checking…  Health endpoint reached                              │
+│                Model       [ gemma-3-4b-it-q4_k_m.gguf              ▾ ]         │
+│                                                                                 │
+│                This changes the current Console session only.                   │
+│                Your saved endpoint remains unchanged.                           │
+│                                                                                 │
+│                                             [ Cancel ] [ Use in Console ]        │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+This path never asks for a local executable or GGUF path.
+
+## Verified handoff
+
+```text
+┌ LAB ─ Models ─ llama.cpp                                           API ready ┐
+│                llama.cpp is ready for Chatbook                                │
+│                                                                                │
+│                Endpoint     http://127.0.0.1:8080                              │
+│                Model        gemma-3-4b-it-q4_k_m.gguf                         │
+│                Runtime      Local process · PID 4812                           │
+│                Health       API healthy · model available                      │
+│                Console      Not connected                                      │
+│                                                                                │
+│                This applies to the active Console session.                     │
+│                It will not replace a different saved endpoint.                 │
+│                                                                                │
+│                [ Stop server ] [ Make default… ] [ Use in Console ]            │
+└────────────────────────────────────────────────────────────────────────────────┘
+
+                              ↓ Use in Console
+
+┌ CONSOLE ─ New chat                                      llama.cpp · Connected ┐
+│ Model: gemma-3-4b-it-q4_k_m.gguf                                           [⌄] │
+│ Endpoint: 127.0.0.1:8080 · Session only                                      │
+│                                                                                │
+│ Try a message to verify generation.                                            │
+│ [ Say hello in one sentence.__________________________________ ] [ Send ]      │
+└────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Experienced user — current and next launch
+
+```text
+┌ LAB ─ Models ─ llama.cpp                            API ready · Console active ┐
+│ Profile  [ Coding · 8k context ▾ ]          [ Duplicate ] [ Save changes ]    │
+│                                                                                │
+│ CURRENT LAUNCH                         NEXT LAUNCH                              │
+│ Model     Qwen2.5-Coder-7B Q4          Model     Qwen2.5-Coder-14B Q4          │
+│ Endpoint  127.0.0.1:8080               Endpoint  127.0.0.1:8080                │
+│ Health    API ready                     Preflight Changes need checking          │
+│ Started   14:32 · PID 4812              Arguments --ctx-size 16384 --ngl 35     │
+│                                                                                │
+│ [ View command ] [ Server log ]         [ Check changes ] [ Restart with next ]│
+│                                                                                │
+│ Server log · last 200 sanitized lines                              [ Copy ]     │
+│ 14:32:08 model loaded · 5.1 GiB                                                │
+│ 14:32:09 listening on 127.0.0.1:8080                                           │
+│ 14:32:09 health check passed                                                    │
+│                                                                                │
+│ [ Stop server ]                                               [ Open Console ] │
+└────────────────────────────────────────────────────────────────────────────────┘
+```
+
+Current launch is immutable process truth. Next launch is an editable candidate. Restart performs preflight before stopping the current healthy process.
+
+## Compact 80-column topology
+
+```text
+┌ LAB · Models · llama.cpp ─────────────────────── Not configured ┐
+│ Set up llama.cpp                                                 │
+│ [ Start here ] [ Connect existing ]                             │
+│                                                                 │
+│ 1 Runtime                                            Incomplete │
+│ Server executable                                               │
+│ [ /opt/llama.cpp/build/bin/llama-server___________ ]            │
+│ [ Detect ] [ Browse ]                                           │
+│                                                                 │
+│ 2 Model                                              Waiting    │
+│ 3 Endpoint                                           Waiting    │
+│ 4 Chatbook                                           Waiting    │
+│                                                                 │
+│ Choose or detect a server executable.                           │
+│                                                [ Continue ]     │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+The provider catalog and Inspector collapse before the setup column. Nothing relies on horizontal scrolling. F6 enters the setup pane; a pane-local action returns to the current primary action.
+
+## Error and recovery examples
+
+| Failure | Message | Recovery |
+|---|---|---|
+| Port occupied | Port 8080 is already in use. Chatbook found a llama.cpp-compatible API there. | Connect to it, or choose another port |
+| Executable unavailable | llama-server could not be executed. Check file permission or choose another binary. | Browse, Detect again |
+| Model rejected | llama.cpp started, but could not load this model. | View sanitized log, choose another model |
+| Health timeout | The process is running, but its API did not become ready within the expected time. | Keep waiting, view log, stop |
+| Saved endpoint differs | Console is saved to 192.168.1.20:8080. Use this local server for the current session only? | Use for session, cancel, make default |
+
+## Scope boundaries
+
+- Do not auto-start a runtime on app launch.
+- Do not auto-persist discovered endpoints or models.
+- Do not copy executable or GGUF paths into Console session metadata.
+- Do not generalize the first implementation into a universal local-server framework before the llama.cpp contract is proven.
+- Do not expose unbounded or unsanitized subprocess output.
+
+## Architecture authority
+
+- [ADR-114](../../../backlog/decisions/114-llamacpp-lab-console-connection-authority.md) owns endpoint defaults, readiness truth, cross-surface handoff, persistence scope, and privacy boundaries.
+- [ADR-025](../../../backlog/decisions/025-shared-stt-artifacts-and-runtime-routing.md) continues to own Managed versus External GGUF authority and exact process-lifetime artifact leases.
+- [ADR-095](../../../backlog/decisions/095-conversation-owned-console-generation-settings.md) continues to own Console session settings and explicit default persistence.
+
+## Backlog mapping
+
+1. TASK-31200 defines the cross-surface contract and ADR.
+2. TASK-31201 implements verified readiness and Console adoption.
+3. TASK-31202 implements the first-run paths and documentation.
+4. TASK-31203 implements compact layout and keyboard behavior.
+5. TASK-31204 separates current and next launch and adds Restart last.
+6. TASK-31205 adds durable named profiles.
+7. TASK-31206 adds bounded diagnostics and recovery.

--- a/Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md
+++ b/Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md
@@ -84,6 +84,12 @@ ID is offered or copied. Recovery says to configure `llama-server --alias` and c
 again without echoing the rejected value. A forward slash by itself remains valid
 for namespace-style model IDs such as `community/gemma-3-4b-it`.
 
+Before path classification, the endpoint-provided ID must be 1–120 Unicode code
+points, already use canonical whitespace, be printable, and contain no control,
+format/bidi-control, or surrogate character. Chatbook rejects unsafe values rather
+than cleaning or truncating them, and does so before selector, display, copy, log,
+descriptor, or adoption. The recovery message never echoes the rejected value.
+
 ## Verified handoff
 
 ```text
@@ -170,6 +176,7 @@ The provider catalog and Inspector collapse before the setup column. Nothing rel
 | Model rejected | llama.cpp started, but could not load this model. | View sanitized log, choose another model |
 | Health timeout | The process is running, but its API did not become ready within the expected time. | Keep waiting, view log, stop |
 | Saved endpoint differs | Console is saved to 192.168.1.20:8080. Use this local server for the current session only? | Use for session, cancel, make default |
+| Unsafe model identity | This server did not return a model name Chatbook can safely use. | Configure `llama-server --alias`, check again |
 
 ## Scope boundaries
 

--- a/Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md
+++ b/Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md
@@ -55,6 +55,7 @@ Behavior:
 - Find a model opens Remote and preserves return intent for the exact llama.cpp setup.
 - Start & check preflights the executable, model, and endpoint; it becomes available only when the adjacent reason is satisfied.
 - Expert launch settings contains host binding, port override, context/hardware presets, raw arguments, and command preview.
+- Every Lab-owned start reserves the stable API model alias `chatbook-llamacpp`; expert arguments cannot replace or duplicate it.
 
 ## First-run — connect to an existing server
 
@@ -67,7 +68,7 @@ Behavior:
 │                [ http://127.0.0.1:8080_____________________ ] [ Check ]         │
 │                                                                                 │
 │                Checking…  Health endpoint reached                              │
-│                Model       [ gemma-3-4b-it-q4_k_m.gguf              ▾ ]         │
+│                Model       [ community/gemma-3-4b-it                 ▾ ]         │
 │                                                                                 │
 │                This changes the current Console session only.                   │
 │                Your saved endpoint remains unchanged.                           │
@@ -78,6 +79,11 @@ Behavior:
 
 This path never asks for a local executable or GGUF path.
 
+An existing server that exposes a filesystem- or GGUF-path model ID fails before the
+ID is offered or copied. Recovery says to configure `llama-server --alias` and check
+again without echoing the rejected value. A forward slash by itself remains valid
+for namespace-style model IDs such as `community/gemma-3-4b-it`.
+
 ## Verified handoff
 
 ```text
@@ -85,7 +91,7 @@ This path never asks for a local executable or GGUF path.
 │                llama.cpp is ready for Chatbook                                │
 │                                                                                │
 │                Endpoint     http://127.0.0.1:8080                              │
-│                Model        gemma-3-4b-it-q4_k_m.gguf                         │
+│                Model        chatbook-llamacpp                                  │
 │                Runtime      Local process · PID 4812                           │
 │                Health       API healthy · model available                      │
 │                Console      Not connected                                      │
@@ -99,7 +105,7 @@ This path never asks for a local executable or GGUF path.
                               ↓ Use in Console
 
 ┌ CONSOLE ─ New chat                                      llama.cpp · Connected ┐
-│ Model: gemma-3-4b-it-q4_k_m.gguf                                           [⌄] │
+│ Model: chatbook-llamacpp                                                   [⌄] │
 │ Endpoint: 127.0.0.1:8080 · Session only                                      │
 │                                                                                │
 │ Try a message to verify generation.                                            │
@@ -170,6 +176,8 @@ The provider catalog and Inspector collapse before the setup column. Nothing rel
 - Do not auto-start a runtime on app launch.
 - Do not auto-persist discovered endpoints or models.
 - Do not copy executable or GGUF paths into Console session metadata.
+- Do not project Lab-owned executable/GGUF selection, PID, expert arguments, command preview, or diagnostics into the handoff descriptor, Console, conversation metadata, or app-global metadata.
+- Do not display, log, or copy a rejected path-identifying endpoint model ID; show generic `--alias` recovery instead.
 - Do not generalize the first implementation into a universal local-server framework before the llama.cpp contract is proven.
 - Do not expose unbounded or unsanitized subprocess output.
 

--- a/backlog/decisions/114-llamacpp-lab-console-connection-authority.md
+++ b/backlog/decisions/114-llamacpp-lab-console-connection-authority.md
@@ -96,6 +96,14 @@ Ownership is split as follows:
 | Active-session adoption | Console | Whether the current Console session adopted the verified target |
 | Durable provider endpoint/defaults | Settings/config | Configuration read by restart resolution |
 
+For a managed-artifact launch, this decision preserves ADR-025's exact process-lease
+lifetime. The artifact lease is acquired before spawn, transferred atomically to the
+exact process claim, and retained until that claim proves its exact process dead. A
+cancellation request or UI stop completion is not permission to release the lease
+early. A stubborn process retains both its claim and lease, and a stale generation
+cannot detach or release either. Lease release occurs only through identity-matched
+claim settlement after confirmed process death.
+
 The Lab never collapses these owners into one running flag. Runtime state can advance
 from `unclaimed` through `reserved` and `process_alive` while connection state remains
 `unchecked` or `checking`. Only current-generation health and exact-model evidence can
@@ -159,7 +167,8 @@ durable change remains an explicit Settings action under ADR-002 and this decisi
 The UI may show only the canonical credential-free endpoint, endpoint-reported model
 ID, coarse lifecycle state, and a bounded failure category. App-global state and
 logs must not retain raw executable or model paths, credentials, raw command
-arguments, or unbounded process output.
+arguments, or unbounded process output. Query strings and fragments never enter
+`LlamaCppConnectionTarget` or Console conversation metadata.
 
 TASK-31206 may add bounded, sanitized diagnostics within Lab. Those diagnostics
 remain Lab-local and do not enter `LlamaCppConnectionTarget`, Console conversation
@@ -209,6 +218,10 @@ stop unrelated processes, alter active Console sessions, or rewrite defaults.
 - Probe settlement tests must invalidate evidence after cancellation, process death,
   target edit, model change, screen recomposition, or a newer
   `verification_generation`.
+- Managed-artifact lifecycle tests must prove lease acquisition before spawn, atomic
+  transfer to the exact process claim, retention until that claim proves the exact
+  process dead, retention for a stubborn process, and rejection of cancellation, UI
+  stop completion, or stale-generation attempts to release the lease early.
 - Adoption tests must prove **Use in Console** is session-only, does not call the
   detected-server persistence path, preserves a different configured endpoint, omits
   `base_url` from conversation metadata, and refreshes readiness in process.
@@ -217,7 +230,8 @@ stop unrelated processes, alter active Console sessions, or rewrite defaults.
   restart, while preserving TASK-16473, TASK-16476, and TASK-26837 protections.
 - Privacy tests must prove the descriptor, app-global state, logs, and Console
   metadata exclude executable/model paths, credentials, raw commands, and unbounded
-  process output.
+  process output. They must also prove that query strings and fragments never enter
+  `LlamaCppConnectionTarget` or Console conversation metadata.
 
 ## Links
 

--- a/backlog/decisions/114-llamacpp-lab-console-connection-authority.md
+++ b/backlog/decisions/114-llamacpp-lab-console-connection-authority.md
@@ -14,7 +14,7 @@ process-local descriptor:
 LlamaCppConnectionTarget
   provider_key: canonical llama_cpp identity
   base_url: canonical credential-free persisted endpoint root
-  model_id: exact model ID returned by the verified endpoint
+  model_id: exact non-path-identifying model ID returned by the verified endpoint
   runtime_owner: lab_process | external_server
   verification_generation: process-local opaque generation
 ```
@@ -24,8 +24,35 @@ a chat-completions suffix. `model_id` is endpoint-reported identity, not a GGUF
 path, managed artifact path, or filename-derived global identity. `runtime_owner`
 is informational lifecycle provenance, not authority for Console to stop a process.
 `verification_generation` exists only to reject stale probes and is never persisted.
-Executable paths, external GGUF paths, managed store paths, credentials, raw
-commands, and raw log output remain Lab-owned and are excluded from the descriptor.
+Executable paths, external GGUF paths, and managed store paths remain Lab-owned.
+Credentials, raw commands, and raw log output are also excluded from the descriptor;
+the Privacy and observability boundary below governs what Lab may retain or render.
+
+For every Lab-owned llama.cpp launch, Chatbook reserves the stable model alias
+`chatbook-llamacpp`. The launch builder emits exactly one
+`--alias chatbook-llamacpp`; the value is never derived from the selected GGUF path
+or filename. Expert/raw arguments cannot supply any `-a` or `--alias` option,
+including `-a=...` and `--alias=...` attached-value forms; they cannot replace the
+reserved value or add another model alias. A Lab-owned endpoint is model-ready only
+when `/v1/models` reports that exact reserved alias.
+
+For an existing server, Chatbook preserves an accepted selected model ID exactly,
+but first classifies it without publishing it. An ID is path-identifying only when
+its raw text, viewed with surrounding ASCII whitespace removed for classification,
+has an unambiguous filesystem marker: a case-insensitive `file:` URI; a POSIX
+absolute, explicit relative, or home-relative prefix (`/`, `./`, `../`, or `~/`); a
+Windows drive-root prefix such as `C:\` or `C:/`; a UNC prefix (`\\` or `//`);
+any backslash path separator; a `.` or `..` path segment; or a final path
+component ending in `.gguf` case-insensitively. An interior forward slash alone is
+not path-identifying, so ordinary namespace-style IDs such as `owner/model` remain
+valid.
+
+A path-identifying candidate never enters a model selector, descriptor, handoff,
+display, copy payload, or log. If the selected existing-server identity is
+path-identifying, verification fails closed before descriptor creation or adoption
+and shows only a bounded recovery message directing the user to restart or configure
+`llama-server` with a non-path `--alias`, then check again. The rejected value is
+never interpolated into that message.
 
 The descriptor uses `canonical_connection_identity` wherever a provider and endpoint
 must be compared. Its GGUF boundary remains governed by ADR-025: managed artifacts
@@ -44,9 +71,11 @@ Product state: not_configured | checking | starting | loading_model | api_ready 
 
 `process_alive` alone may project to `starting` or `loading_model`; it can never
 project to `api_ready`. API ready requires both a successful health-compatible probe
-and a successful `/v1/models` response containing the selected exact model ID. A
-port collision may offer **Connect to it** only after that exact endpoint passes the
-same llama.cpp-compatible health and model checks.
+and a successful `/v1/models` response containing the selected exact admissible
+model ID: the reserved alias for a Lab-owned launch or the non-path-identifying exact
+ID selected from an existing server. A port collision may offer **Connect to it**
+only after that exact endpoint passes the same llama.cpp-compatible health and model
+checks.
 
 Every probe and handoff carries the exact `verification_generation`. Cancellation,
 process death, target edit, model change, screen recomposition, or a newer probe
@@ -61,6 +90,12 @@ discovery defaults use port `8080` in `config.py` and `local_server_discovery.py
 and the Console direct-path fallback is port `9099` in
 `console_session_settings.py`. This makes the same absent user value resolve to
 different servers depending on the entry point.
+
+The current Lab command builder supplies the selected file through `--model` but
+does not force an alias. llama.cpp consequently reports that model path as the
+default `/v1/models` ID; its documented `--alias` option replaces the API identity.
+Without a reserved alias, requiring an exact endpoint-reported ID would copy the
+very filesystem identity this descriptor prohibits.
 
 Subprocess liveness currently drives the running presentation while stdout and
 stderr are discarded. A live process therefore supplies no evidence that the API is
@@ -164,15 +199,25 @@ durable change remains an explicit Settings action under ADR-002 and this decisi
 
 ## Privacy and observability boundary
 
-The UI may show only the canonical credential-free endpoint, endpoint-reported model
-ID, coarse lifecycle state, and a bounded failure category. App-global state and
-logs must not retain raw executable or model paths, credentials, raw command
-arguments, or unbounded process output. Query strings and fragments never enter
-`LlamaCppConnectionTarget` or Console conversation metadata.
+The narrow display allowlist governs every projection out of Lab into cross-surface
+UI, Console, app-global metadata, or application/unrestricted logs. Those projections
+may carry or show only canonical provider identity, the canonical credential-free
+endpoint, an accepted endpoint-reported model ID, coarse lifecycle state, and a
+bounded failure category. App-global state and logs must not retain raw executable
+or model paths, credentials, raw command arguments, or unbounded process output.
+Query strings and fragments never enter `LlamaCppConnectionTarget` or Console
+conversation metadata.
 
-TASK-31206 may add bounded, sanitized diagnostics within Lab. Those diagnostics
-remain Lab-local and do not enter `LlamaCppConnectionTarget`, Console conversation
-metadata, app-global connection state, or unrestricted logs.
+Lab itself may retain and render its surface-owned executable and GGUF selections,
+the owned process PID, and expert launch configuration. User-entered arguments may
+appear in their owning editor; every derived command or argument presentation is
+redacted. TASK-31206 may add a bounded, sanitized runtime diagnostic tail and
+sanitized copy action within Lab. The same bound and redaction apply before render or
+copy, including suppression of any rejected endpoint model ID.
+
+These Lab-local details never enter `LlamaCppConnectionTarget`, Console, active
+session or conversation metadata, app-global connection metadata, or application
+logs. Lab's bounded diagnostic buffer is not an unrestricted application log sink.
 
 ## Alternatives Considered
 
@@ -201,6 +246,8 @@ metadata, app-global connection state, or unrestricted logs.
   absent values, so no endpoint migration or synthesized configuration is required.
 - Readiness now requires network evidence and exact model identity, adding probe,
   cancellation, and stale-result handling to the local launch workflow.
+- Lab-owned launches now carry one stable Chatbook-reserved model alias, while an
+  existing server must expose a non-path-identifying model ID before handoff.
 
 ## Rollback plan
 
@@ -228,9 +275,18 @@ stop unrelated processes, alter active Console sessions, or rewrite defaults.
 - Persistence tests must prove **Make default** reports success only after the
   normalized endpoint exists in the durable `api_settings` layer consumed on
   restart, while preserving TASK-16473, TASK-16476, and TASK-26837 protections.
+- Lab launch-construction tests must prove starts and restarts using distinct GGUF
+  paths each emit exactly one `--alias chatbook-llamacpp`, and that separated and
+  equals-attached `-a` and `--alias` raw-argument forms are rejected before they can
+  replace or duplicate it.
+- Existing-server tests must prove path-identifying IDs fail closed before selector,
+  descriptor, display, copy, log, or adoption; the recovery names `--alias` without
+  echoing a sentinel path. The same tests must accept ordinary namespace-style IDs
+  such as `owner/model` and preserve accepted IDs exactly.
 - Privacy tests must prove the descriptor, app-global state, logs, and Console
   metadata exclude executable/model paths, credentials, raw commands, and unbounded
-  process output. They must also prove that query strings and fragments never enter
+  process output while Lab retains only its explicitly permitted bounded local
+  diagnostics. They must also prove that query strings and fragments never enter
   `LlamaCppConnectionTarget` or Console conversation metadata.
 
 | Contract | Required future evidence |
@@ -252,3 +308,4 @@ stop unrelated processes, alter active Console sessions, or rewrite defaults.
 - [TASK-16473: Warn when a Console endpoint will not survive restart](../tasks/task-16473%20-%20Console-warn-when-a-saved-provider-endpoint-will-not-survive-restart.md)
 - [TASK-16476: Preserve a configured endpoint during server adoption](../tasks/task-16476%20-%20Console-server-adoption-must-not-clobber-a-configured-endpoint.md)
 - [TASK-26837: Provider setup can omit durable API settings](../tasks/task-26837%20-%20Provider-setup-can-report-a-successful-connection-test-yet-write-no-api_settings-block.md)
+- [llama.cpp HTTP server README: model IDs and `--alias`](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md#get-v1models-openai-compatible-model-info-api)

--- a/backlog/decisions/114-llamacpp-lab-console-connection-authority.md
+++ b/backlog/decisions/114-llamacpp-lab-console-connection-authority.md
@@ -36,23 +36,30 @@ including `-a=...` and `--alias=...` attached-value forms; they cannot replace t
 reserved value or add another model alias. A Lab-owned endpoint is model-ready only
 when `/v1/models` reports that exact reserved alias.
 
-For an existing server, Chatbook preserves an accepted selected model ID exactly,
-but first classifies it without publishing it. An ID is path-identifying only when
-its raw text, viewed with surrounding ASCII whitespace removed for classification,
-has an unambiguous filesystem marker: a case-insensitive `file:` URI; a POSIX
-absolute, explicit relative, or home-relative prefix (`/`, `./`, `../`, or `~/`); a
-Windows drive-root prefix such as `C:\` or `C:/`; a UNC prefix (`\\` or `//`);
+For an existing server, Chatbook treats every endpoint-provided model ID as
+untrusted and validates it without publishing it. The candidate must be a string
+from 1 through 120 Unicode code points, equal to its own `" ".join(value.split())`
+canonical-whitespace form, be printable, and contain no character in Unicode
+categories `Cc`, `Cf`, or `Cs`. This rejects embedded controls, bidi controls,
+surrogates, line and paragraph separators, leading or trailing whitespace, and
+non-canonical whitespace. Chatbook rejects rather than cleans, collapses, or
+truncates an invalid candidate so the accepted identifier remains exact.
+
+Only a structurally safe candidate proceeds to path classification. An ID is
+path-identifying only when its raw text has an unambiguous filesystem marker: a
+case-insensitive `file:` URI; a POSIX absolute, explicit relative, or home-relative
+prefix (`/`, `./`, `../`, or `~/`); a Windows drive-root prefix such as `C:\` or
+`C:/`; a UNC prefix (`\\` or `//`);
 any backslash path separator; a `.` or `..` path segment; or a final path
 component ending in `.gguf` case-insensitively. An interior forward slash alone is
 not path-identifying, so ordinary namespace-style IDs such as `owner/model` remain
 valid.
 
-A path-identifying candidate never enters a model selector, descriptor, handoff,
-display, copy payload, or log. If the selected existing-server identity is
-path-identifying, verification fails closed before descriptor creation or adoption
-and shows only a bounded recovery message directing the user to restart or configure
-`llama-server` with a non-path `--alias`, then check again. The rejected value is
-never interpolated into that message.
+A structurally unsafe or path-identifying candidate never enters a model selector,
+descriptor, handoff, display, copy payload, or log. Verification fails closed before
+descriptor creation or adoption and shows only a bounded recovery message directing
+the user to restart or configure `llama-server` with a safe non-path `--alias`, then
+check again. The rejected value is never interpolated into that message.
 
 The descriptor uses `canonical_connection_identity` wherever a provider and endpoint
 must be compared. Its GGUF boundary remains governed by ADR-025: managed artifacts
@@ -176,17 +183,39 @@ accepted behavior.
 
 ## Default and compatibility policy
 
-Absent values resolve in this order:
+Endpoint authority is context-specific; one shortened chain must not replace these
+three orders.
+
+Active Console execution resolves:
 
 ```text
-explicit user-entered or launch endpoint
-  -> exact current-session target
+exact current-session target
+  -> TLDW_CONSOLE_LLAMA_CPP_BASE_URL
+  -> [console].llama_cpp_base_url_override
   -> configured provider endpoint
   -> canonical llama.cpp absent-value default http://127.0.0.1:8080
 ```
 
-New Lab launches default to loopback `127.0.0.1:8080` only when the user supplied no
-value. Existing explicit `8001`, `9099`, LAN, HTTPS, and reverse-proxy-prefix
+Console restart resolution omits the process-local session target but retains the
+remaining order:
+
+```text
+TLDW_CONSOLE_LLAMA_CPP_BASE_URL
+  -> [console].llama_cpp_base_url_override
+  -> configured provider endpoint
+  -> canonical llama.cpp absent-value default http://127.0.0.1:8080
+```
+
+An explicit Lab existing-server URL or launch host/port is authoritative for that
+Lab action. **Use in Console** installs the verified target as the exact current-
+session target, so it then precedes both existing override layers without mutating
+them. An empty Connect to existing server field may be suggested from the Console
+restart chain only after `resolve_provider_endpoint` accepts and canonicalizes the
+value. A new local **Start on this computer** with no explicit launch value
+uses loopback `127.0.0.1:8080`; it never reinterprets a Console environment,
+configuration, LAN, or HTTPS endpoint as a local bind instruction.
+
+Existing explicit `8001`, `9099`, LAN, HTTPS, and reverse-proxy-prefix
 endpoints remain valid and are neither migrated nor rewritten. Endpoint parsing,
 suffix removal, safe display, and equality use `resolve_provider_endpoint` and
 `canonical_connection_identity` rather than raw string comparison.
@@ -279,10 +308,18 @@ stop unrelated processes, alter active Console sessions, or rewrite defaults.
   paths each emit exactly one `--alias chatbook-llamacpp`, and that separated and
   equals-attached `-a` and `--alias` raw-argument forms are rejected before they can
   replace or duplicate it.
-- Existing-server tests must prove path-identifying IDs fail closed before selector,
-  descriptor, display, copy, log, or adoption; the recovery names `--alias` without
-  echoing a sentinel path. The same tests must accept ordinary namespace-style IDs
-  such as `owner/model` and preserve accepted IDs exactly.
+- Existing-server tests must prove empty, over-120-code-point, non-canonical-
+  whitespace, non-printable, `Cc`, `Cf`, `Cs`, line-separator, paragraph-separator,
+  and path-identifying IDs fail closed before selector, descriptor, display, copy,
+  log, or adoption; the recovery names `--alias` without echoing a sentinel value.
+  The same tests must accept ordinary namespace-style IDs such as `owner/model` and
+  preserve accepted IDs exactly.
+- Endpoint-precedence tests must separately prove active Console session target ->
+  `TLDW_CONSOLE_LLAMA_CPP_BASE_URL` ->
+  `[console].llama_cpp_base_url_override` -> configured provider endpoint -> `8080`,
+  and restart env override -> Console override -> provider endpoint -> `8080`. Lab
+  launch tests must prove an absent launch value uses local `8080` rather than
+  reinterpreting a remote Console override as a bind target.
 - Privacy tests must prove the descriptor, app-global state, logs, and Console
   metadata exclude executable/model paths, credentials, raw commands, and unbounded
   process output while Lab retains only its explicitly permitted bounded local
@@ -291,7 +328,7 @@ stop unrelated processes, alter active Console sessions, or rewrite defaults.
 
 | Contract | Required future evidence |
 |---|---|
-| Canonical endpoint | Pure normalization/default-precedence tests in `Tests/Chat/test_provider_endpoint_contract.py` and Console settings tests |
+| Canonical endpoint | Pure normalization and context-specific active-session/restart/Lab precedence tests, including both existing Console override layers |
 | Process versus readiness | Lifecycle plus real loopback HTTP tests proving live-process/not-ready and model-ready transitions |
 | Stale-result fencing | Generation replacement tests for process exit, model edit, endpoint edit, cancellation, and recomposition |
 | Console adoption | Mounted Lab-to-Console test proving exact provider/base URL/model apply without restart |

--- a/backlog/decisions/114-llamacpp-lab-console-connection-authority.md
+++ b/backlog/decisions/114-llamacpp-lab-console-connection-authority.md
@@ -1,0 +1,229 @@
+# ADR-114: Own llama.cpp process, readiness, Console adoption, and defaults separately
+
+Status: Proposed
+Date: 2026-09-03
+Related Tasks: TASK-31200 through TASK-31206
+Extends: ADR-002, ADR-025, ADR-095
+
+## Decision
+
+Chatbook will represent a verified llama.cpp connection with one sanitized,
+process-local descriptor:
+
+```text
+LlamaCppConnectionTarget
+  provider_key: canonical llama_cpp identity
+  base_url: canonical credential-free persisted endpoint root
+  model_id: exact model ID returned by the verified endpoint
+  runtime_owner: lab_process | external_server
+  verification_generation: process-local opaque generation
+```
+
+`base_url` is produced by `resolve_provider_endpoint`; the descriptor never carries
+a chat-completions suffix. `model_id` is endpoint-reported identity, not a GGUF
+path, managed artifact path, or filename-derived global identity. `runtime_owner`
+is informational lifecycle provenance, not authority for Console to stop a process.
+`verification_generation` exists only to reject stale probes and is never persisted.
+Executable paths, external GGUF paths, managed store paths, credentials, raw
+commands, and raw log output remain Lab-owned and are excluded from the descriptor.
+
+The descriptor uses `canonical_connection_identity` wherever a provider and endpoint
+must be compared. Its GGUF boundary remains governed by ADR-025: managed artifacts
+and external user-owned paths are distinct launch authorities, and neither path nor
+filename becomes model identity. Its Console boundary remains governed by ADR-095:
+provider endpoints are configuration-owned and never enter conversation generation
+metadata.
+
+Readiness is not process liveness. The contract has three distinct vocabularies:
+
+```text
+Runtime truth: unclaimed -> reserved -> process_alive -> process_dead
+Connection truth: unchecked -> checking -> api_healthy -> model_available -> stale_or_failed
+Product state: not_configured | checking | starting | loading_model | api_ready | console_connected | needs_attention
+```
+
+`process_alive` alone may project to `starting` or `loading_model`; it can never
+project to `api_ready`. API ready requires both a successful health-compatible probe
+and a successful `/v1/models` response containing the selected exact model ID. A
+port collision may offer **Connect to it** only after that exact endpoint passes the
+same llama.cpp-compatible health and model checks.
+
+Every probe and handoff carries the exact `verification_generation`. Cancellation,
+process death, target edit, model change, screen recomposition, or a newer probe
+invalidates older evidence. A stale result cannot expose **Use in Console** or modify
+Console.
+
+## Context
+
+The existing llama.cpp flow has three context-specific defaults. The Lab launch
+fallback is port `8001` in `llm_management_events.py`; configured provider and local
+discovery defaults use port `8080` in `config.py` and `local_server_discovery.py`;
+and the Console direct-path fallback is port `9099` in
+`console_session_settings.py`. This makes the same absent user value resolve to
+different servers depending on the entry point.
+
+Subprocess liveness currently drives the running presentation while stdout and
+stderr are discarded. A live process therefore supplies no evidence that the API is
+healthy or that the selected model is available.
+
+Console detected-server adoption already applies a discovered endpoint safely to
+the current session and preserves a different configured endpoint, but its behavior
+of filling missing configuration is not the Lab handoff contract. TASK-16473 already
+requires a warning when an active Console endpoint will not survive restart. Lab
+handoff must retain that session-only truth rather than imply persistence. TASK-16476
+also protects a different configured endpoint from silent replacement.
+
+TASK-26837 records a provider-setup path that can report a successful connection
+test without a durable `api_settings` entry. **Make default** must not inherit or
+normalize that false-success behavior.
+
+ADR-002 otherwise limits OpenAI-compatible discovery to configured providers and
+explicit persistence. ADR-025 owns managed and external GGUF authority, and ADR-095
+separates active Console session settings, conversation-safe metadata, and durable
+provider defaults. This decision extends those boundaries for the explicit Lab to
+Console workflow rather than introducing a competing provider, artifact, or
+conversation owner.
+
+## Ownership and state transitions
+
+Ownership is split as follows:
+
+| Concern | Owner | Authority |
+|---|---|---|
+| Exact launch reservation, process identity, and stop | `server_lifecycle.py` | The exact claim and process generation |
+| Verified connection target and readiness evidence | TASK-31201 app-scoped llama.cpp connection owner | `LlamaCppConnectionTarget` plus generation-fenced HTTP/model evidence |
+| User-facing Lab state | Lab | Projection of runtime and connection owners into product state |
+| Active-session adoption | Console | Whether the current Console session adopted the verified target |
+| Durable provider endpoint/defaults | Settings/config | Configuration read by restart resolution |
+
+The Lab never collapses these owners into one running flag. Runtime state can advance
+from `unclaimed` through `reserved` and `process_alive` while connection state remains
+`unchecked` or `checking`. Only current-generation health and exact-model evidence can
+advance connection truth through `api_healthy` to `model_available`, permitting the
+Lab to project `api_ready`. Console adoption may then project `console_connected` for
+the active session. Failure, invalidation, or process death projects
+`needs_attention` or an earlier honest state without treating prior evidence as
+current.
+
+The supported actions preserve those owners:
+
+| Action | Owner and effect | Persistence |
+|---|---|---|
+| Start on this computer | Lab reserves and owns one exact process claim | None |
+| Connect to existing server | Lab verifies one user-entered endpoint | None |
+| Use in Console | Console applies provider, exact model, and base URL to the active session | Process-local session only |
+| Make default | Full Settings commit path applies its existing checked-endpoint rules | Explicit config mutation |
+| Stop server | Lab stops only its exact owned process claim | Does not alter Console or defaults |
+
+**Use in Console** never calls the detected-server path that auto-fills missing
+configuration. It never persists `base_url` in conversation metadata, consistent
+with ADR-095. It preserves a different configured endpoint, labels the adopted
+target **Session only**, and refreshes Console readiness in the same application
+process. Console adoption grants no authority to stop the Lab process, and stopping
+the server does not rewrite the adopted session or any configured default.
+
+**Make default** opens or delegates to the full Settings commit path; Lab verification
+is not permission to write configuration. It reports success only after the
+normalized provider endpoint is durably present in the configuration layer read by
+restart resolution. The commit path retains TASK-16473's distinction between
+session-only and restart-safe endpoints and TASK-16476's protection against silently
+replacing a different configured endpoint. TASK-26837's missing-`api_settings`
+success state is an unresolved defect that the path must prevent or surface, never
+accepted behavior.
+
+## Default and compatibility policy
+
+Absent values resolve in this order:
+
+```text
+explicit user-entered or launch endpoint
+  -> exact current-session target
+  -> configured provider endpoint
+  -> canonical llama.cpp absent-value default http://127.0.0.1:8080
+```
+
+New Lab launches default to loopback `127.0.0.1:8080` only when the user supplied no
+value. Existing explicit `8001`, `9099`, LAN, HTTPS, and reverse-proxy-prefix
+endpoints remain valid and are neither migrated nor rewritten. Endpoint parsing,
+suffix removal, safe display, and equality use `resolve_provider_endpoint` and
+`canonical_connection_identity` rather than raw string comparison.
+
+A user-entered existing-server check is an explicit, exact-endpoint exception to
+ADR-002's configured-provider-only discovery rule. It authorizes only the endpoint
+the user entered; it does not enable ambient LAN scanning or background remote
+discovery. Discovery and verification do not persist model IDs or endpoints. Any
+durable change remains an explicit Settings action under ADR-002 and this decision.
+
+## Privacy and observability boundary
+
+The UI may show only the canonical credential-free endpoint, endpoint-reported model
+ID, coarse lifecycle state, and a bounded failure category. App-global state and
+logs must not retain raw executable or model paths, credentials, raw command
+arguments, or unbounded process output.
+
+TASK-31206 may add bounded, sanitized diagnostics within Lab. Those diagnostics
+remain Lab-local and do not enter `LlamaCppConnectionTarget`, Console conversation
+metadata, app-global connection state, or unrestricted logs.
+
+## Alternatives Considered
+
+| Alternative | Why rejected |
+|---|---|
+| Treat process liveness as readiness | A process can be alive while loading, bound to the wrong endpoint, unable to answer the API, or serving a different model. |
+| Auto-write the Lab endpoint into provider configuration | It confuses verification with consent, can overwrite a user's durable endpoint, and makes session-only adoption look restart-safe. |
+| Reuse `_apply_detected_local_server` unchanged for Lab handoff | That path may fill missing configuration and update defaults; Lab's **Use in Console** action is explicitly session-only. |
+| Persist the complete Lab launch command in Console conversation metadata | It leaks paths and arguments, violates ADR-095's allowlist, and makes runtime launch details conversation-owned. |
+| Retain three context-specific defaults | The same absent value would continue resolving differently across Lab, discovery, and Console. |
+| Generalize all local runtimes before the llama.cpp path is proven | Other runtimes have different lifecycle, endpoint, and model contracts; early generalization would weaken the llama.cpp contract. |
+
+## Consequences
+
+- TASK-31201 implements the app-scoped connection owner, generation-fenced
+  verification, and active Console adoption.
+- TASK-31202 and TASK-31203 project the ownership and readiness vocabulary into
+  guided onboarding and a keyboard-efficient, narrow-width Lab experience.
+- TASK-31204 and TASK-31205 retain launch configuration separately through current
+  versus next configuration, restart-last behavior, and durable named profiles.
+- TASK-31206 adds bounded, sanitized Lab-local diagnostics without expanding the
+  handoff descriptor.
+- Lab, Console, and Settings must display whether a value is runtime-only,
+  session-only, or durable instead of deriving persistence from successful probing.
+- Existing configured endpoints remain compatible; the unified default affects only
+  absent values, so no endpoint migration or synthesized configuration is required.
+- Readiness now requires network evidence and exact model identity, adding probe,
+  cancellation, and stale-result handling to the local launch workflow.
+
+## Rollback plan
+
+Disable the new Lab handoff and fall back to existing Console Settings/discovery.
+Retain every existing explicit configuration value and do not synthesize migrations.
+Disabling the handoff also disables its app-scoped connection projection; it does not
+stop unrelated processes, alter active Console sessions, or rewrite defaults.
+
+## Verification obligations
+
+- Contract tests must prove the exact default-resolution order and preserve explicit
+  `8001`, `9099`, LAN, HTTPS, and reverse-proxy-prefix endpoints.
+- Readiness tests must prove that `process_alive` without current-generation health
+  and `/v1/models` evidence cannot expose `api_ready` or **Use in Console**.
+- Probe settlement tests must invalidate evidence after cancellation, process death,
+  target edit, model change, screen recomposition, or a newer
+  `verification_generation`.
+- Adoption tests must prove **Use in Console** is session-only, does not call the
+  detected-server persistence path, preserves a different configured endpoint, omits
+  `base_url` from conversation metadata, and refreshes readiness in process.
+- Persistence tests must prove **Make default** reports success only after the
+  normalized endpoint exists in the durable `api_settings` layer consumed on
+  restart, while preserving TASK-16473, TASK-16476, and TASK-26837 protections.
+- Privacy tests must prove the descriptor, app-global state, logs, and Console
+  metadata exclude executable/model paths, credentials, raw commands, and unbounded
+  process output.
+
+## Links
+
+- [ADR-002: OpenAI-compatible model discovery](002-openai-compatible-model-discovery.md)
+- [ADR-025: Shared artifacts and runtime routing](025-shared-stt-artifacts-and-runtime-routing.md)
+- [ADR-095: Console generation settings ownership](095-conversation-owned-console-generation-settings.md)
+- [TASK-16473: Warn when a Console endpoint will not survive restart](../tasks/task-16473%20-%20Console-warn-when-a-saved-provider-endpoint-will-not-survive-restart.md)
+- [TASK-16476: Preserve a configured endpoint during server adoption](../tasks/task-16476%20-%20Console-server-adoption-must-not-clobber-a-configured-endpoint.md)
+- [TASK-26837: Provider setup can omit durable API settings](../tasks/task-26837%20-%20Provider-setup-can-report-a-successful-connection-test-yet-write-no-api_settings-block.md)

--- a/backlog/decisions/114-llamacpp-lab-console-connection-authority.md
+++ b/backlog/decisions/114-llamacpp-lab-console-connection-authority.md
@@ -1,6 +1,6 @@
 # ADR-114: Own llama.cpp process, readiness, Console adoption, and defaults separately
 
-Status: Proposed
+Status: Accepted
 Date: 2026-09-03
 Related Tasks: TASK-31200 through TASK-31206
 Extends: ADR-002, ADR-025, ADR-095
@@ -232,6 +232,17 @@ stop unrelated processes, alter active Console sessions, or rewrite defaults.
   metadata exclude executable/model paths, credentials, raw commands, and unbounded
   process output. They must also prove that query strings and fragments never enter
   `LlamaCppConnectionTarget` or Console conversation metadata.
+
+| Contract | Required future evidence |
+|---|---|
+| Canonical endpoint | Pure normalization/default-precedence tests in `Tests/Chat/test_provider_endpoint_contract.py` and Console settings tests |
+| Process versus readiness | Lifecycle plus real loopback HTTP tests proving live-process/not-ready and model-ready transitions |
+| Stale-result fencing | Generation replacement tests for process exit, model edit, endpoint edit, cancellation, and recomposition |
+| Console adoption | Mounted Lab-to-Console test proving exact provider/base URL/model apply without restart |
+| Persistence boundary | Regression test proving Use in Console does not write config and Make default preserves unrelated or newer fields |
+| Managed model privacy | Tests proving no filesystem path enters the descriptor, rendered authority text, app-global metadata, or Console settings |
+| Compact UX | Production-stylesheet 80x24, 100x30, and 120x40 compositor/focus tests |
+| Live qualification | Scratch-profile run against a real llama-server, with default-profile fingerprints checked before cleanup |
 
 ## Links
 

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -99,6 +99,7 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-106](106-human-reviewed-agent-lesson-promotion.md) | Accepted | Force foreground approval for Agent Lesson mutations and permit only exact, human-reviewed promotion through existing instruction and trust authorities. |
 | [ADR-107](107-portable-tool-use-packs.md) | Proposed | Export one flattened Tool policy profile as deterministic policy-only content; import it unbound with exact mapping, first-bind confirmation, and deny tombstones. |
 | [ADR-113](113-collections-capture-authority-and-legacy-boundary.md) | Accepted | Separate Local and Server Collections capture authority from Media and preserve obsolete generic containers as explicit read-only legacy data. |
+| [ADR-114](114-llamacpp-lab-console-connection-authority.md) | Proposed | Keep llama.cpp process ownership, HTTP/model readiness, Console session adoption, and durable provider defaults separate behind one sanitized connection target. |
 
 ## Historical Decision Material
 

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -99,7 +99,7 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-106](106-human-reviewed-agent-lesson-promotion.md) | Accepted | Force foreground approval for Agent Lesson mutations and permit only exact, human-reviewed promotion through existing instruction and trust authorities. |
 | [ADR-107](107-portable-tool-use-packs.md) | Proposed | Export one flattened Tool policy profile as deterministic policy-only content; import it unbound with exact mapping, first-bind confirmation, and deny tombstones. |
 | [ADR-113](113-collections-capture-authority-and-legacy-boundary.md) | Accepted | Separate Local and Server Collections capture authority from Media and preserve obsolete generic containers as explicit read-only legacy data. |
-| [ADR-114](114-llamacpp-lab-console-connection-authority.md) | Proposed | Keep llama.cpp process ownership, HTTP/model readiness, Console session adoption, and durable provider defaults separate behind one sanitized connection target. |
+| [ADR-114](114-llamacpp-lab-console-connection-authority.md) | Accepted | Keep llama.cpp process ownership, HTTP/model readiness, Console session adoption, and durable provider defaults separate behind one sanitized connection target. |
 
 ## Historical Decision Material
 

--- a/backlog/tasks/task-31200 - Define-the-llama.cpp-Lab-to-Console-connection-and-readiness-contract.md
+++ b/backlog/tasks/task-31200 - Define-the-llama.cpp-Lab-to-Console-connection-and-readiness-contract.md
@@ -46,7 +46,7 @@ ADR required: yes
 ADR path: backlog/decisions/114-llamacpp-lab-console-connection-authority.md
 Reason: TASK-31200 changes the provider/runtime boundary, cross-screen state ownership, persistence scope, privacy boundary, and long-lived setup flow.
 
-1. Author ADR-114 with the sanitized LlamaCppConnectionTarget, separate runtime/connection/product states, explicit action ownership, canonical absent-value port 8080 policy, compatibility rules, and verification obligations.
+1. Author ADR-114 with the sanitized LlamaCppConnectionTarget, stable path-independent Lab launch alias, fail-closed external model identity rule, separate runtime/connection/product states, explicit action ownership, canonical absent-value port 8080 policy, compatibility rules, and verification obligations.
 2. Reconcile ADR-002 exact-endpoint discovery, ADR-025 GGUF/process-lease authority, ADR-095 Console/default ownership, and TASK-16473/TASK-16476/TASK-26837 behavior.
 3. Index ADR-114 and link it from the approved handoff wireframe, this implementation plan, and TASK-31200.
 4. Self-review the contract against all six acceptance criteria, reject placeholders and ambiguous ownership, and verify documentation integrity without changing or testing production code.
@@ -56,5 +56,5 @@ Reason: TASK-31200 changes the provider/runtime boundary, cross-screen state own
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Accepted ADR-114 to separate llama.cpp process ownership, HTTP and model readiness, active Console adoption, and explicit provider-default persistence. Selected the absent-value loopback default at port 8080, defined the sanitized generation-fenced handoff target, preserved ADR-025 GGUF authority and ADR-095 settings ownership, and linked the verification obligations for TASK-31201 through TASK-31206. Modified the canonical ADR index, handoff wireframe, plan, and TASK-31200 metadata; no production code or tests changed.
+Accepted ADR-114 to separate llama.cpp process ownership, HTTP and model readiness, active Console adoption, and explicit provider-default persistence. Selected the absent-value loopback default at port 8080, reserved a stable path-independent alias for Lab launches, made path-identifying existing-server model IDs fail closed, and scoped the cross-surface privacy allowlist while preserving bounded Lab-local diagnostics. Preserved ADR-025 GGUF authority and ADR-095 settings ownership and linked the verification obligations for TASK-31201 through TASK-31206. Modified the canonical ADR index, handoff wireframe, plan, and TASK-31200 metadata; no production code or tests changed.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31200 - Define-the-llama.cpp-Lab-to-Console-connection-and-readiness-contract.md
+++ b/backlog/tasks/task-31200 - Define-the-llama.cpp-Lab-to-Console-connection-and-readiness-contract.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-31200
 title: Define the llama.cpp Lab-to-Console connection and readiness contract
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-03 12:46'
-updated_date: '2026-09-03 13:23'
+updated_date: '2026-09-03 13:30'
 labels:
   - llamacpp
   - lab
@@ -31,12 +31,12 @@ ADR required: yes. This task must author the governing ADR because it changes th
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The ADR chooses one canonical credential-free connection descriptor and one default/fallback policy shared by Lab launch, local discovery, Console readiness, and Console execution.
-- [ ] #2 The ADR distinguishes process reserved, process alive, API healthy, model available, Console session adopted, and saved default states, with one named authority for each transition.
-- [ ] #3 The contract defines Start on this computer, Connect to an existing server, Use in this Console session, and Make default as explicit actions; no action silently overwrites a different saved endpoint.
-- [ ] #4 The contract keeps credentials, executable paths, GGUF paths, and raw logs within their owning surface while permitting the sanitized endpoint, provider identity, model identity, and readiness evidence needed by Console.
-- [ ] #5 The ADR reconciles ADR-002, ADR-025, ADR-095, TASK-16473, TASK-16476, and TASK-26837 and records backward-compatible handling for existing llama.cpp configuration.
-- [ ] #6 The ADR includes the end-to-end state sequence, failure settlement rules, observability boundary, and verification strategy for real loopback HTTP and mounted Textual flows.
+- [x] #1 The ADR chooses one canonical credential-free connection descriptor and one default/fallback policy shared by Lab launch, local discovery, Console readiness, and Console execution.
+- [x] #2 The ADR distinguishes process reserved, process alive, API healthy, model available, Console session adopted, and saved default states, with one named authority for each transition.
+- [x] #3 The contract defines Start on this computer, Connect to an existing server, Use in this Console session, and Make default as explicit actions; no action silently overwrites a different saved endpoint.
+- [x] #4 The contract keeps credentials, executable paths, GGUF paths, and raw logs within their owning surface while permitting the sanitized endpoint, provider identity, model identity, and readiness evidence needed by Console.
+- [x] #5 The ADR reconciles ADR-002, ADR-025, ADR-095, TASK-16473, TASK-16476, and TASK-26837 and records backward-compatible handling for existing llama.cpp configuration.
+- [x] #6 The ADR includes the end-to-end state sequence, failure settlement rules, observability boundary, and verification strategy for real loopback HTTP and mounted Textual flows.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -52,3 +52,9 @@ Reason: TASK-31200 changes the provider/runtime boundary, cross-screen state own
 4. Self-review the contract against all six acceptance criteria, reject placeholders and ambiguous ownership, and verify documentation integrity without changing or testing production code.
 5. Accept ADR-114, complete TASK-31200 metadata, and commit only the ADR, index, wireframe, plan, and task record.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Accepted ADR-114 to separate llama.cpp process ownership, HTTP and model readiness, active Console adoption, and explicit provider-default persistence. Selected the absent-value loopback default at port 8080, defined the sanitized generation-fenced handoff target, preserved ADR-025 GGUF authority and ADR-095 settings ownership, and linked the verification obligations for TASK-31201 through TASK-31206. Modified the canonical ADR index, handoff wireframe, plan, and TASK-31200 metadata; no production code or tests changed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31200 - Define-the-llama.cpp-Lab-to-Console-connection-and-readiness-contract.md
+++ b/backlog/tasks/task-31200 - Define-the-llama.cpp-Lab-to-Console-connection-and-readiness-contract.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-03 12:46'
-updated_date: '2026-09-03 13:30'
+updated_date: '2026-09-03 14:28'
 labels:
   - llamacpp
   - lab
@@ -56,5 +56,5 @@ Reason: TASK-31200 changes the provider/runtime boundary, cross-screen state own
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Accepted ADR-114 to separate llama.cpp process ownership, HTTP and model readiness, active Console adoption, and explicit provider-default persistence. Selected the absent-value loopback default at port 8080, reserved a stable path-independent alias for Lab launches, made path-identifying existing-server model IDs fail closed, and scoped the cross-surface privacy allowlist while preserving bounded Lab-local diagnostics. Preserved ADR-025 GGUF authority and ADR-095 settings ownership and linked the verification obligations for TASK-31201 through TASK-31206. Modified the canonical ADR index, handoff wireframe, plan, and TASK-31200 metadata; no production code or tests changed.
+Accepted ADR-114 to separate llama.cpp process ownership, HTTP and model readiness, active Console adoption, and explicit provider-default persistence. Selected the absent-value loopback default at port 8080, reserved a stable path-independent alias for Lab launches, made path-identifying existing-server model IDs fail closed, and scoped the cross-surface privacy allowlist while preserving bounded Lab-local diagnostics. Review follow-up preserved active Console and restart precedence for TLDW_CONSOLE_LLAMA_CPP_BASE_URL and [console].llama_cpp_base_url_override, and required endpoint-provided model IDs to fail closed on empty, oversized, non-canonical-whitespace, non-printable, control, bidi/format-control, surrogate, line-separator, or path-identifying input before cross-surface projection. Preserved ADR-025 GGUF authority and ADR-095 settings ownership and linked the verification obligations for TASK-31201 through TASK-31206. Modified the canonical ADR index, handoff wireframe, plan, and TASK-31200 metadata; no production code or tests changed.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31200 - Define-the-llama.cpp-Lab-to-Console-connection-and-readiness-contract.md
+++ b/backlog/tasks/task-31200 - Define-the-llama.cpp-Lab-to-Console-connection-and-readiness-contract.md
@@ -1,0 +1,54 @@
+---
+id: TASK-31200
+title: Define the llama.cpp Lab-to-Console connection and readiness contract
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-09-03 12:46'
+updated_date: '2026-09-03 13:23'
+labels:
+  - llamacpp
+  - lab
+  - console
+  - ux
+  - architecture
+dependencies: []
+documentation:
+  - backlog/decisions/114-llamacpp-lab-console-connection-authority.md
+  - Docs/superpowers/specs/2026-09-03-llamacpp-lab-console-handoff-wireframe.md
+  - >-
+    Docs/superpowers/plans/2026-09-03-task-31200-llamacpp-lab-console-contract.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Establish the cross-surface contract that turns a Lab-owned llama.cpp process or an existing llama.cpp endpoint into an explicitly adopted Console destination. Resolve the current 8001, 8080, and 9099 divergence and define endpoint, model, lifecycle, persistence, privacy, and ownership truth before implementation.
+
+ADR required: yes. This task must author the governing ADR because it changes the provider/runtime boundary and long-lived application structure.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The ADR chooses one canonical credential-free connection descriptor and one default/fallback policy shared by Lab launch, local discovery, Console readiness, and Console execution.
+- [ ] #2 The ADR distinguishes process reserved, process alive, API healthy, model available, Console session adopted, and saved default states, with one named authority for each transition.
+- [ ] #3 The contract defines Start on this computer, Connect to an existing server, Use in this Console session, and Make default as explicit actions; no action silently overwrites a different saved endpoint.
+- [ ] #4 The contract keeps credentials, executable paths, GGUF paths, and raw logs within their owning surface while permitting the sanitized endpoint, provider identity, model identity, and readiness evidence needed by Console.
+- [ ] #5 The ADR reconciles ADR-002, ADR-025, ADR-095, TASK-16473, TASK-16476, and TASK-26837 and records backward-compatible handling for existing llama.cpp configuration.
+- [ ] #6 The ADR includes the end-to-end state sequence, failure settlement rules, observability boundary, and verification strategy for real loopback HTTP and mounted Textual flows.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/114-llamacpp-lab-console-connection-authority.md
+Reason: TASK-31200 changes the provider/runtime boundary, cross-screen state ownership, persistence scope, privacy boundary, and long-lived setup flow.
+
+1. Author ADR-114 with the sanitized LlamaCppConnectionTarget, separate runtime/connection/product states, explicit action ownership, canonical absent-value port 8080 policy, compatibility rules, and verification obligations.
+2. Reconcile ADR-002 exact-endpoint discovery, ADR-025 GGUF/process-lease authority, ADR-095 Console/default ownership, and TASK-16473/TASK-16476/TASK-26837 behavior.
+3. Index ADR-114 and link it from the approved handoff wireframe, this implementation plan, and TASK-31200.
+4. Self-review the contract against all six acceptance criteria, reject placeholders and ambiguous ownership, and verify documentation integrity without changing or testing production code.
+5. Accept ADR-114, complete TASK-31200 metadata, and commit only the ADR, index, wireframe, plan, and task record.
+<!-- SECTION:PLAN:END -->


### PR DESCRIPTION
## Summary

- accept ADR-114 as the llama.cpp Lab-to-Console authority for endpoint, readiness, session adoption, defaults, privacy, and lifecycle ownership
- add the first-run and power-user workflow wireframe plus its implementation plan
- close TASK-31200 with all six acceptance criteria and link the governing artifacts

## Key decisions

- use `http://127.0.0.1:8080` only when no explicit or configured endpoint exists
- distinguish process liveness, API/model readiness, Console session adoption, and durable defaults
- reserve the path-independent `chatbook-llamacpp` alias for Lab-owned launches and fail closed on path-identifying external model IDs
- keep executable/GGUF paths and bounded diagnostics Lab-local while exposing only a sanitized connection target across surfaces
- preserve ADR-025 process-lease lifetime, ADR-095 settings ownership, and existing endpoint-protection behavior

## Verification

- base-to-head `git diff --check` passed
- cumulative scope is exactly five documentation paths
- ADR-114 is Accepted and contains the eight-row future verification matrix
- TASK-31200 is Done with 6/6 acceptance criteria checked
- independent per-task reviews and final whole-branch review passed after one focused fix wave

## Tests

Not run. This change is documentation-only and does not modify application code, tests, styles, configuration, schemas, or migrations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts ADR-114, which defines how Lab hands a llama.cpp process or existing server to Console. Replaces the inconsistent 8001/8080/9099 absent-value behavior with `http://127.0.0.1:8080`; existing explicit endpoints remain unchanged, and no application behavior changes.

**Contract**

- Reserves the path-independent `chatbook-llamacpp` alias for Lab launches; existing servers must pass fail-closed model-ID validation, rejecting path-identifying, oversized, or non-printable values before display, copy, logging, or adoption.
- Separates process liveness, API/model readiness, Console session adoption, and durable defaults with explicit ownership and generation-fenced handoff rules.
- Keeps executable and GGUF paths, credentials, raw arguments, and unbounded logs Lab-local while allowing bounded sanitized diagnostics.
- Defines Start, Connect, Use in Console, Make default, and Stop actions without silently overwriting saved endpoints.
- Adds first-run and power-user wireframes plus implementation coverage for TASK-31201 through TASK-31206.

**Verification**

- Links ADR-114, the wireframe, and implementation plan from TASK-31200, which is marked Done with all six acceptance criteria checked.
- `git diff --check` passed; tests were not run because this change only modifies documentation and backlog records.

<sup>Written for commit 0e3889ac302a9c2d3d5f40423cdf8002dddaf0eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

