### PR TITLE
feat(library): legible multi-row action grammar for the media items pane (task-30043)

### DIFF
--- a/Tests/UI/test_library_media_toolbar_adapt.py
+++ b/Tests/UI/test_library_media_toolbar_adapt.py
@@ -1,0 +1,187 @@
+"""The media canvas's multi-row action grammar (task-30043).
+
+Critique 2026-09-03 P1: the items pane sits at ~40-44 cols in every real
+shell layout, so the old single six-button row chopped to ``t so E Tr R Se``
+and select mode's bulk actions rendered as bare ``○ ○ ○``. The multi-row
+grammar is THE grammar — every row's label budget (including the "○ "
+disabled forms) fits the pane's 40-col floor, so labels are always words.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Library.library_media_state import (
+    LibraryMediaCanvasState,
+    LibraryMediaRow,
+)
+from tldw_chatbook.Widgets.Library.library_media_canvas import LibraryMediaCanvas
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+
+
+def _browse_state() -> LibraryMediaCanvasState:
+    rows = (
+        LibraryMediaRow(
+            media_id="1",
+            title="First item",
+            media_type="document",
+            secondary="document · today",
+        ),
+    )
+    return LibraryMediaCanvasState(
+        rows=rows,
+        type_options=(None, "document"),
+        active_type=None,
+        status_copy="",
+        empty_copy="No media yet.",
+        selected_id="",
+        preview_lines=(),
+        count=1,
+    )
+
+
+def _select_state(
+    *, selected_count: int = 0, confirming: bool = False
+) -> LibraryMediaCanvasState:
+    rows = (
+        LibraryMediaRow(
+            media_id="1",
+            title="First item",
+            media_type="document",
+            secondary="document · today",
+            checked=selected_count > 0,
+        ),
+        LibraryMediaRow(
+            media_id="2",
+            title="Second item",
+            media_type="document",
+            secondary="document · today",
+            checked=False,
+        ),
+    )
+    return LibraryMediaCanvasState(
+        rows=rows,
+        type_options=(None, "document"),
+        active_type=None,
+        status_copy="",
+        empty_copy="No media yet.",
+        selected_id="",
+        preview_lines=(),
+        count=2,
+        select_mode=True,
+        selected_count=selected_count,
+        confirming_bulk_delete=confirming,
+    )
+
+
+class _CanvasApp(ConsolidatedCSSApp):
+    def __init__(self, state: LibraryMediaCanvasState) -> None:
+        super().__init__()
+        self._state = state
+
+    def compose(self):
+        yield LibraryMediaCanvas(canvas=self._state, id="library-media-canvas")
+
+
+@pytest.mark.asyncio
+async def test_browse_actions_split_into_labeled_rows():
+    """Choosers / plain actions / Review these each get a fitting row."""
+    app = _CanvasApp(_browse_state())
+    async with app.run_test(size=(50, 34)) as pilot:
+        await pilot.pause()
+        assert app.query("#library-media-toolbar-choosers")
+        assert app.query("#library-media-toolbar-actions")
+        assert app.query("#library-media-toolbar-review")
+        # Full labels survive: no chopped fragments.
+        assert str(app.query_one("#library-media-review", Button).label) == (
+            "Review these"
+        )
+        assert str(app.query_one("#library-media-export", Button).label) == (
+            "Export…"
+        )
+        assert str(
+            app.query_one("#library-media-trash-open", Button).label
+        ) == "Trash"
+        assert str(
+            app.query_one("#library-media-select-toggle", Button).label
+        ) == "Select"
+
+
+@pytest.mark.asyncio
+async def test_browse_action_rows_fit_the_pane_floor():
+    """At 40 cols every action stays inside the canvas — no clipped buttons."""
+    app = _CanvasApp(_browse_state())
+    async with app.run_test(size=(40, 34)) as pilot:
+        await pilot.pause()
+        canvas = app.query_one("#library-media-canvas", LibraryMediaCanvas)
+        right = canvas.region.x + canvas.region.width
+        for selector in (
+            "#library-media-type-filter",
+            "#library-media-sort",
+            "#library-media-export",
+            "#library-media-trash-open",
+            "#library-media-review",
+            "#library-media-select-toggle",
+        ):
+            button = app.query_one(selector, Button)
+            assert button.region.width > 0, selector
+            assert button.region.x + button.region.width <= right, selector
+
+
+@pytest.mark.asyncio
+async def test_select_mode_bulk_actions_are_words_not_markers():
+    """Disabled bulk actions read '○ Export', never a bare '○'."""
+    app = _CanvasApp(_select_state(selected_count=0))
+    async with app.run_test(size=(50, 34)) as pilot:
+        await pilot.pause()
+        export = app.query_one("#library-media-export-selected", Button)
+        review = app.query_one("#library-media-review-selected", Button)
+        delete = app.query_one("#library-media-delete-selected", Button)
+        assert str(export.label) == "○ Export"
+        assert str(review.label) == "○ Review"
+        assert str(delete.label) == "○ Delete"
+        # The in-place count-crossing patch rebuilds from the same short base.
+        assert export._library_disabled_marker_base == "Export"
+        # The full meaning still rides on the F-018 tooltip.
+        assert "Select one or more items" in str(export.tooltip)
+        # Summary keeps the full Select-all sentence.
+        assert str(app.query_one("#library-media-select-all", Button).label) == (
+            "Select all 2 shown"
+        )
+        # Delete is isolated on its own danger row, never adjacent to another
+        # action (task-2853's rule, upgraded).
+        danger_row = app.query_one("#library-media-select-danger")
+        assert len(danger_row.query(Button)) == 1
+        actions_row = app.query_one("#library-media-select-actions")
+        assert len(actions_row.query(Button)) == 3  # Clear, Export, Review
+
+
+@pytest.mark.asyncio
+async def test_select_mode_rows_fit_the_pane_floor():
+    app = _CanvasApp(_select_state(selected_count=1))
+    async with app.run_test(size=(40, 34)) as pilot:
+        await pilot.pause()
+        canvas = app.query_one("#library-media-canvas", LibraryMediaCanvas)
+        right = canvas.region.x + canvas.region.width
+        for selector in (
+            "#library-media-select-all",
+            "#library-media-select-clear",
+            "#library-media-export-selected",
+            "#library-media-review-selected",
+            "#library-media-delete-selected",
+        ):
+            button = app.query_one(selector, Button)
+            assert button.region.width > 0, selector
+            assert button.region.x + button.region.width <= right, selector
+
+
+@pytest.mark.asyncio
+async def test_confirm_copy_wraps_inside_the_pane():
+    app = _CanvasApp(_select_state(selected_count=2, confirming=True))
+    async with app.run_test(size=(50, 34)) as pilot:
+        await pilot.pause()
+        copy = app.query_one("#library-media-bulk-delete-confirm-copy", Static)
+        canvas = app.query_one("#library-media-canvas", LibraryMediaCanvas)
+        assert copy.region.width <= canvas.region.width
+        assert copy.region.height >= 2  # the safety sentence wrapped, not clipped

--- a/Tests/UI/test_library_media_toolbar_adapt.py
+++ b/Tests/UI/test_library_media_toolbar_adapt.py
@@ -185,3 +185,34 @@ async def test_confirm_copy_wraps_inside_the_pane():
         canvas = app.query_one("#library-media-canvas", LibraryMediaCanvas)
         assert copy.region.width <= canvas.region.width
         assert copy.region.height >= 2  # the safety sentence wrapped, not clipped
+
+
+@pytest.mark.asyncio
+async def test_long_type_values_are_capped_in_the_chooser_label():
+    """A long stored media type must not re-overflow the chooser row.
+
+    Qodo #2350: type values are data; "type: presentation" + "sort: Title
+    A-Z" exceeded the pane's ~34 usable cells. The LABEL caps the value
+    (full value stays in the tooltip and in the chooser strip itself).
+    """
+    state = _browse_state()
+    import dataclasses
+
+    state = dataclasses.replace(
+        state,
+        type_options=(None, "presentation-deck"),
+        active_type="presentation-deck",
+    )
+    app = _CanvasApp(state)
+    async with app.run_test(size=(40, 34)) as pilot:
+        await pilot.pause()
+        type_button = app.query_one("#library-media-type-filter", Button)
+        label = str(type_button.label)
+        assert "presentation-deck" not in label  # capped in the label...
+        assert label.endswith("…")
+        assert "presentation-deck" in str(type_button.tooltip)  # ...not the tooltip
+        canvas = app.query_one("#library-media-canvas", LibraryMediaCanvas)
+        right = canvas.region.x + canvas.region.width
+        sort_button = app.query_one("#library-media-sort", Button)
+        for button in (type_button, sort_button):
+            assert button.region.x + button.region.width <= right

--- a/backlog/tasks/task-30043 - Media-items-pane-legible-action-grammar-at-the-narrow-pane-width.md
+++ b/backlog/tasks/task-30043 - Media-items-pane-legible-action-grammar-at-the-narrow-pane-width.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-30043
 title: Media items pane - legible action grammar at the narrow pane width
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-09-03 13:05'
+updated_date: '2026-09-03 13:13'
 labels:
   - library
   - media-ux
@@ -24,3 +26,9 @@ Critique 2026-09-03 P1: at the items pane's 40-col floor the six-button toolbar 
 - [ ] #3 The armed bulk-delete confirmation copy wraps instead of clipping
 - [ ] #4 The wide layout keeps its current single-row presentation
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Screen threads the measured items-pane width into the canvas (LibraryMediaRowGeometryChanged already delivers it) as narrow_actions bool\n2. Narrow grammar: toolbar splits into two auto-height rows with short REAL labels (type/sort/Export | Trash/Review/Select); select mode splits count+select-all+clear / three bulk actions; wide keeps one row\n3. Armed-confirm copy Static wraps (height auto) instead of clipping\n4. Live verify at the 40-col pane + wide
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -102,6 +102,20 @@ class LibraryMediaRowScroll(VerticalScroll):
         self.post_message(LibraryMediaRowGeometryChanged(self, geometry))
 
 
+def _capped_choice_value(value: str, cap: int = 8) -> str:
+    """Bound a data-derived chooser value for its opener label (task-30043).
+
+    Args:
+        value: The stored value (e.g. a media type).
+        cap: Maximum characters to show before an ellipsis.
+
+    Returns:
+        The value, or its first ``cap - 1`` characters plus ``…``.
+    """
+    value = str(value)
+    return value if len(value) <= cap else value[: cap - 1] + "…"
+
+
 def _media_row_label_rest(
     title: str,
     secondary: str,
@@ -505,11 +519,14 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         type_filter = Button(
             # task-14902: a chooser-opener, no longer a cycler -- press
             # opens the direct-pick strip below instead of advancing.
+            # Qodo #2350: the VALUE is data and can be long; the label caps
+            # it so the chooser row's budget holds (the tooltip and the
+            # chooser strip itself carry the full value).
             library_choice_label(
                 "type",
                 "All types"
                 if self.canvas.active_type is None
-                else self.canvas.active_type,
+                else _capped_choice_value(self.canvas.active_type),
             ),
             id="library-media-type-filter",
             classes="library-canvas-action",

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -45,6 +45,14 @@ from tldw_chatbook.Widgets.recompose_capture_guard import RecomposeCaptureGuard
 _MEDIA_ROW_COMPACT_HEIGHT = 1
 _MEDIA_ROW_WIDE_HEIGHT = 2
 
+# task-30043 (critique 2026-09-03 P1): the items pane sits at ~40-44 cols in
+# EVERY real shell layout (3-pane reading shell AND the compact stage), so a
+# single six-button row can never render its labels there -- live capture
+# showed ``t so E Tr R Se`` and select mode's bulk actions as bare ``○ ○ ○``.
+# The multi-row grammar below is therefore THE grammar, not a responsive
+# variant: every row's label sum (including the "○ "-prefixed disabled
+# forms) is budgeted to fit the pane's 40-col floor.
+
 
 @dataclass(frozen=True)
 class LibraryMediaRowGeometry:
@@ -125,6 +133,19 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         canvas: Current media canvas display state.
     """
 
+    BUNDLED_CSS = """
+    /* task-30043: the multi-row action grammar needs CONTENT-width buttons.
+     * Textual Button's 16-cell min-width floor alone would overflow the
+     * pane's 40-col floor (six floors = 96 cells); each row's label budget
+     * is what keeps task-28025's fit contract true. Baseline geometry lives
+     * here so harnesses without the app bundle lay out like the app. */
+    .ds-toolbar > .library-canvas-action,
+    .ds-toolbar > .library-toolbar-count {
+        width: auto;
+        min-width: 0;
+    }
+    """
+
     def __init__(
         self,
         canvas: LibraryMediaCanvasState,
@@ -156,7 +177,13 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         # divide the REAL width, so the canvas must be bounded like the
         # viewer already is.
         self.styles.width = "1fr"
-        self.styles.min_width = 40
+        # task-30043: 36, not 40 -- the 3-pane shell actually allots this
+        # pane ~37 visible cells, so a 40-cell floor overflowed the slot and
+        # silently clipped the rightmost ~3 cells of every child (live: the
+        # armed-confirm copy wrapped at 40 and rendered "restore later from
+        # Tr"). The floor only exists to bound the 13fr resolution trap
+        # below; 36 keeps that while letting the canvas fit its real slot.
+        self.styles.min_width = 36
 
     def sync_state(
         self,
@@ -274,6 +301,92 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             button.tooltip = reason
         return button
 
+    def _select_all_button(self, rendered_count: int) -> Button:
+        """Build the Select-all bulk action (summary-row sibling of the count)."""
+        label = f"Select all {rendered_count} shown"
+        select_all = Button(
+            label,
+            id="library-media-select-all",
+            classes="library-canvas-action",
+            compact=True,
+        )
+        return self._gate_stale_action(select_all, label)
+
+    def _clear_selection_button(self) -> Button:
+        """Build the Clear bulk action."""
+        clear = Button(
+            "Clear",
+            id="library-media-select-clear",
+            classes="library-canvas-action",
+            compact=True,
+        )
+        return self._gate_stale_action(clear, "Clear")
+
+    def _bulk_action_button(
+        self,
+        base: str,
+        widget_id: str,
+        disabled_tooltip: str,
+        enabled_tooltip: str,
+        *,
+        danger: bool = False,
+    ) -> Button:
+        """Build one Export/Review/Delete bulk action (task-30043).
+
+        Short REAL words ("Export" / "Review" / "Delete") -- the mode and the
+        adjacent count make them unambiguous, the F-018 tooltips carry the
+        full sentences, and a disabled action can never collapse to a bare
+        "○" marker the way the full labels did at the pane's 40-col floor.
+
+        task-4023 AC#1 (RC-07): "○" disabled marker -- these are the very
+        buttons the user entered Select mode looking for, previously
+        colour-only at a measured 1.39:1. The base label is stashed so
+        `_apply_library_row_toggle`'s in-place patch can rebuild it when
+        the selection count crosses 0.
+        """
+        bulk_disabled = self.canvas.selected_count == 0
+        classes = "library-canvas-action"
+        if danger:
+            classes += " library-media-action-danger"
+        button = Button(
+            library_disabled_action_label(base, bulk_disabled),
+            id=widget_id,
+            classes=classes,
+            compact=True,
+        )
+        button._library_disabled_marker_base = base
+        button.disabled = bulk_disabled
+        # F-018: a disabled action says why.
+        button.tooltip = disabled_tooltip if bulk_disabled else enabled_tooltip
+        return self._gate_stale_action(button, base)
+
+    def _select_mode_bulk_buttons(self) -> ComposeResult:
+        """Yield the Export and Review bulk actions (Delete rides its own row)."""
+        yield self._bulk_action_button(
+            "Export",
+            "library-media-export-selected",
+            LIBRARY_EXPORT_SELECTED_DISABLED_TOOLTIP,
+            LIBRARY_EXPORT_SELECTED_TOOLTIP,
+        )
+        # task-28242: "Review selected" pins the selection as an ordered
+        # review set.
+        yield self._bulk_action_button(
+            "Review",
+            "library-media-review-selected",
+            LIBRARY_REVIEW_SELECTED_DISABLED_TOOLTIP,
+            LIBRARY_REVIEW_SELECTED_TOOLTIP,
+        )
+
+    def _delete_selected_button(self) -> Button:
+        """Build the isolated danger action (task-2853's far-end rule, upgraded)."""
+        return self._bulk_action_button(
+            "Delete",
+            "library-media-delete-selected",
+            LIBRARY_DELETE_SELECTED_DISABLED_TOOLTIP,
+            LIBRARY_DELETE_SELECTED_TOOLTIP,
+            danger=True,
+        )
+
     def _gate_mutation_action(self, button: Button, base_label: str) -> Button:
         """Disable even recovery controls only while a write is unsettled."""
         if self.mutation_action_reason:
@@ -381,112 +494,143 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         # horizontal ``ds-toolbar`` rows. Same render-safe shape as those
         # canvases: fixed-width compact Buttons only, never mixed with a
         # 1fr sibling.
-        toolbar = Horizontal(classes="ds-toolbar")
-        toolbar.styles.height = "auto"
         # task-14902: while the type choice strip is open it REPLACES this
         # toolbar row (the Notes Sort precedent -- browse actions hide while
         # the chooser is showing), keeping the vertical budget flat.
         type_choices_visible = getattr(self.canvas, "type_choices_visible", False)
         sort_choices_visible = getattr(self.canvas, "sort_choices_visible", False)
-        toolbar.display = not (type_choices_visible or sort_choices_visible)
+        toolbar_visible = not (type_choices_visible or sort_choices_visible)
         sort_labels = dict(MEDIA_SORT_CHOICES)
         current_sort = getattr(self.canvas, "sort_by", "last_modified_desc")
-        with toolbar:
-            type_filter = Button(
-                # task-14902: a chooser-opener, no longer a cycler -- press
-                # opens the direct-pick strip below instead of advancing.
-                library_choice_label(
-                    "type",
-                    "All types"
-                    if self.canvas.active_type is None
-                    else self.canvas.active_type,
+        type_filter = Button(
+            # task-14902: a chooser-opener, no longer a cycler -- press
+            # opens the direct-pick strip below instead of advancing.
+            library_choice_label(
+                "type",
+                "All types"
+                if self.canvas.active_type is None
+                else self.canvas.active_type,
+            ),
+            id="library-media-type-filter",
+            classes="library-canvas-action",
+            compact=True,
+            tooltip=library_choice_tooltip(
+                "media type",
+                tuple(
+                    "All types" if value is None else value
+                    for value in self.type_options
                 ),
-                id="library-media-type-filter",
-                classes="library-canvas-action",
-                compact=True,
-                tooltip=library_choice_tooltip(
-                    "media type",
-                    tuple(
-                        "All types" if value is None else value
-                        for value in self.type_options
+            ),
+        )
+        self._gate_mutation_action(type_filter, str(type_filter.label))
+        # task-28013: sort chooser opener -- hidden in select mode like
+        # Export/Trash (Select's toolbar acts on the selection).
+        sort_btn = Button(
+            library_choice_label(
+                "sort", sort_labels.get(current_sort, "Newest")
+            ),
+            id="library-media-sort",
+            classes="library-canvas-action",
+            compact=True,
+            tooltip=library_choice_tooltip(
+                "the sort order", tuple(label for _, label in MEDIA_SORT_CHOICES)
+            ),
+        )
+        sort_btn.display = not select_mode
+        self._gate_stale_action(sort_btn, str(sort_btn.label))
+        export_btn = Button(
+            "Export…",
+            id="library-media-export",
+            classes="library-canvas-action",
+            compact=True,
+        )
+        export_btn.display = not select_mode
+        self._gate_stale_action(export_btn, "Export…")
+        # task-4025: the browsable Trash surface's entry point -- a
+        # plain navigation action (never a `type:` cycle value: `type:`
+        # cycles CONTENT types derived from the records, and trash is a
+        # STATE). Always enabled: the trash count isn't known until its
+        # view fetches, and an empty Trash shows its honest empty copy
+        # rather than this button lying disabled. Hidden in select mode
+        # like "Export…" -- Select's toolbar is for acting on the
+        # selection, not navigating away from it.
+        trash_btn = Button(
+            "Trash",
+            id="library-media-trash-open",
+            classes="library-canvas-action",
+            compact=True,
+            tooltip="Browse and restore deleted media.",
+        )
+        trash_btn.display = not select_mode
+        # task-28242: "Review these" pins the WHOLE filtered result as an
+        # ordered review set and walks it in the Reader. A list-level
+        # action, hidden in select mode like Export/Trash.
+        review_btn = Button(
+            "Review these",
+            id="library-media-review",
+            classes="library-canvas-action",
+            compact=True,
+            tooltip="Review every item in this list, one by one.",
+        )
+        review_btn.display = not select_mode
+        self._gate_stale_action(review_btn, "Review these")
+        # Disable only when there's nothing to select AND we're not
+        # already in select mode -- in select mode the button is "Done"
+        # and must always be pressable so the user can exit even if the
+        # rows dropped to zero (e.g. a background snapshot refresh
+        # emptied the list).
+        select_disabled = rendered_count == 0 and not select_mode
+        select_btn = Button(
+            # task-4023 AC#1 (RC-07): disabled carries the non-colour
+            # "○" marker; the F-018 reason tooltip below says why.
+            library_disabled_action_label(
+                "Done" if select_mode else "Select", select_disabled
+            ),
+            id="library-media-select-toggle",
+            classes="library-canvas-action",
+            compact=True,
+        )
+        select_btn.disabled = select_disabled
+        if select_disabled:
+            select_btn.tooltip = LIBRARY_SELECT_TOGGLE_DISABLED_TOOLTIP
+        self._gate_stale_action(
+            select_btn, "Done" if select_mode else "Select"
+        )
+        # task-30043 (critique P1): at the items pane's ~40-col real width
+        # one Horizontal cannot render six labels (live capture: ``t so E Tr
+        # R Se``), so the browse actions split into rows of readable labels.
+        # In select mode most of these hide (only type + Done remain), so
+        # its single row always fits and the vertical budget stays flat.
+        if not select_mode:
+            toolbar_rows: tuple[tuple[str, tuple[Button, ...]], ...] = (
+                ("library-media-toolbar-choosers", (type_filter, sort_btn)),
+                (
+                    "library-media-toolbar-actions",
+                    (export_btn, trash_btn, select_btn),
+                ),
+                ("library-media-toolbar-review", (review_btn,)),
+            )
+        else:
+            toolbar_rows = (
+                (
+                    "library-media-toolbar",
+                    (
+                        type_filter,
+                        sort_btn,
+                        export_btn,
+                        trash_btn,
+                        review_btn,
+                        select_btn,
                     ),
                 ),
             )
-            yield self._gate_mutation_action(type_filter, str(type_filter.label))
-            # task-28013: sort chooser opener -- hidden in select mode like
-            # Export/Trash (Select's toolbar acts on the selection).
-            sort_btn = Button(
-                library_choice_label(
-                    "sort", sort_labels.get(current_sort, "Newest")
-                ),
-                id="library-media-sort",
-                classes="library-canvas-action",
-                compact=True,
-                tooltip=library_choice_tooltip(
-                    "the sort order", tuple(label for _, label in MEDIA_SORT_CHOICES)
-                ),
-            )
-            sort_btn.display = not select_mode
-            yield self._gate_stale_action(sort_btn, str(sort_btn.label))
-            export_btn = Button(
-                "Export…",
-                id="library-media-export",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            export_btn.display = not select_mode
-            yield self._gate_stale_action(export_btn, "Export…")
-            # task-4025: the browsable Trash surface's entry point -- a
-            # plain navigation action (never a `type:` cycle value: `type:`
-            # cycles CONTENT types derived from the records, and trash is a
-            # STATE). Always enabled: the trash count isn't known until its
-            # view fetches, and an empty Trash shows its honest empty copy
-            # rather than this button lying disabled. Hidden in select mode
-            # like "Export…" -- Select's toolbar is for acting on the
-            # selection, not navigating away from it.
-            trash_btn = Button(
-                "Trash",
-                id="library-media-trash-open",
-                classes="library-canvas-action",
-                compact=True,
-                tooltip="Browse and restore deleted media.",
-            )
-            trash_btn.display = not select_mode
-            yield trash_btn
-            # task-28242: "Review these" pins the WHOLE filtered result as an
-            # ordered review set and walks it in the Reader. A list-level
-            # action, hidden in select mode like Export/Trash.
-            review_btn = Button(
-                "Review these",
-                id="library-media-review",
-                classes="library-canvas-action",
-                compact=True,
-                tooltip="Review every item in this list, one by one.",
-            )
-            review_btn.display = not select_mode
-            yield self._gate_stale_action(review_btn, "Review these")
-            # Disable only when there's nothing to select AND we're not
-            # already in select mode -- in select mode the button is "Done"
-            # and must always be pressable so the user can exit even if the
-            # rows dropped to zero (e.g. a background snapshot refresh
-            # emptied the list).
-            select_disabled = rendered_count == 0 and not select_mode
-            select_btn = Button(
-                # task-4023 AC#1 (RC-07): disabled carries the non-colour
-                # "○" marker; the F-018 reason tooltip below says why.
-                library_disabled_action_label(
-                    "Done" if select_mode else "Select", select_disabled
-                ),
-                id="library-media-select-toggle",
-                classes="library-canvas-action",
-                compact=True,
-            )
-            select_btn.disabled = select_disabled
-            if select_disabled:
-                select_btn.tooltip = LIBRARY_SELECT_TOGGLE_DISABLED_TOOLTIP
-            yield self._gate_stale_action(
-                select_btn, "Done" if select_mode else "Select"
-            )
+        for row_id, row_buttons in toolbar_rows:
+            row = Horizontal(id=row_id, classes="ds-toolbar")
+            row.styles.height = "auto"
+            row.display = toolbar_visible
+            with row:
+                for button in row_buttons:
+                    yield button
         if type_choices_visible:
             options: list[Option] = []
             highlighted = 0
@@ -538,12 +682,18 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 # AC3's honest "there's no Trash view" copy, which was
                 # true only until this surface existed.
                 item_word = "item" if self.canvas.selected_count == 1 else "items"
-                yield Static(
+                confirm_copy = Static(
                     f"Delete {self.canvas.selected_count} selected {item_word}? "
                     "You can undo right away, or restore later from Trash.",
                     id="library-media-bulk-delete-confirm-copy",
                     markup=False,
                 )
+                # task-30043: bound the copy to the pane so the safety
+                # sentence WRAPS -- unbounded, it clipped mid-word ("You can
+                # und / restore later from Tr") at the narrow pane width.
+                confirm_copy.styles.width = "1fr"
+                confirm_copy.styles.height = "auto"
+                yield confirm_copy
             action_row = Horizontal(classes="ds-toolbar")
             action_row.styles.height = "auto"
             with action_row:
@@ -584,100 +734,26 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                     )
                     yield self._gate_mutation_action(cancel, "Cancel")
                 else:
-                    select_all = Button(
-                        f"Select all {rendered_count} shown",
-                        id="library-media-select-all",
-                        classes="library-canvas-action",
-                        compact=True,
-                    )
-                    yield self._gate_stale_action(
-                        select_all, f"Select all {rendered_count} shown"
-                    )
-                    clear = Button(
-                        "Clear",
-                        id="library-media-select-clear",
-                        classes="library-canvas-action",
-                        compact=True,
-                    )
-                    yield self._gate_stale_action(clear, "Clear")
-                    export_disabled = self.canvas.selected_count == 0
-                    export_selected = Button(
-                        # task-4023 AC#1 (RC-07): "○" disabled marker --
-                        # these are the very buttons the user entered
-                        # Select mode looking for, previously colour-only
-                        # at a measured 1.39:1. The base label is stashed
-                        # so `_apply_library_row_toggle`'s in-place patch
-                        # can rebuild it when the selection count crosses 0.
-                        library_disabled_action_label(
-                            "Export selected", export_disabled
-                        ),
-                        id="library-media-export-selected",
-                        classes="library-canvas-action",
-                        compact=True,
-                    )
-                    export_selected._library_disabled_marker_base = (
-                        "Export selected"
-                    )
-                    export_selected.disabled = export_disabled
-                    # F-018: a disabled action says why.
-                    export_selected.tooltip = (
-                        LIBRARY_EXPORT_SELECTED_DISABLED_TOOLTIP
-                        if export_selected.disabled
-                        else LIBRARY_EXPORT_SELECTED_TOOLTIP
-                    )
-                    yield self._gate_stale_action(
-                        export_selected, "Export selected"
-                    )
-                    # task-28242: the third real bulk action -- "Review
-                    # selected" -- pins the selection as an ordered review set.
-                    # Sits between Export and the far-end danger Delete.
-                    review_disabled = self.canvas.selected_count == 0
-                    review_selected = Button(
-                        library_disabled_action_label(
-                            "Review selected", review_disabled
-                        ),
-                        id="library-media-review-selected",
-                        classes="library-canvas-action",
-                        compact=True,
-                    )
-                    review_selected._library_disabled_marker_base = (
-                        "Review selected"
-                    )
-                    review_selected.disabled = review_disabled
-                    review_selected.tooltip = (
-                        LIBRARY_REVIEW_SELECTED_DISABLED_TOOLTIP
-                        if review_disabled
-                        else LIBRARY_REVIEW_SELECTED_TOOLTIP
-                    )
-                    yield self._gate_stale_action(
-                        review_selected, "Review selected"
-                    )
-                    # task-2853: the second real bulk action -- "Delete
-                    # selected" -- pushed to the far end (CSS margin, same
-                    # library-media-action-danger idiom the single-item
-                    # viewer's own Delete uses) so it is never adjacent to
-                    # Export selected.
-                    delete_disabled = self.canvas.selected_count == 0
-                    delete_selected = Button(
-                        library_disabled_action_label(
-                            "Delete selected", delete_disabled
-                        ),
-                        id="library-media-delete-selected",
-                        classes="library-canvas-action library-media-action-danger",
-                        compact=True,
-                    )
-                    delete_selected._library_disabled_marker_base = (
-                        "Delete selected"
-                    )
-                    delete_selected.disabled = delete_disabled
-                    delete_selected.tooltip = (
-                        LIBRARY_DELETE_SELECTED_DISABLED_TOOLTIP
-                        if delete_selected.disabled
-                        else LIBRARY_DELETE_SELECTED_TOOLTIP
-                    )
-                    yield self._gate_stale_action(
-                        delete_selected, "Delete selected"
-                    )
+                    yield self._select_all_button(rendered_count)
+            if not confirming_bulk_delete:
+                # task-30043: the bulk actions get their own row of short
+                # REAL words ("○ Export", never a bare marker) -- one shared
+                # row rendered them as ``○ ○ ○`` at the pane's 40-col floor.
+                actions_row = Horizontal(
+                    id="library-media-select-actions", classes="ds-toolbar"
+                )
+                actions_row.styles.height = "auto"
+                with actions_row:
+                    yield self._clear_selection_button()
+                    yield from self._select_mode_bulk_buttons()
+                # task-2853's danger-isolation rule, upgraded: Delete gets a
+                # whole row, so it is never adjacent to any other action.
+                danger_row = Horizontal(
+                    id="library-media-select-danger", classes="ds-toolbar"
+                )
+                danger_row.styles.height = "auto"
+                with danger_row:
+                    yield self._delete_selected_button()
 
         # task-4022 AC2: a completed bulk delete's receipt, naming the
         # count with an Undo affordance right at the point of action --

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -3233,9 +3233,19 @@ with stray left-edge border fragments), and padding 0 1 so the full
     max-width: 100%;
 }
 
+/* task-30043 (critique 2026-09-03 P1) supersedes task-28025's 1fr squeeze:
+   sharing the row width chopped every label to fragments (``t so E Tr R
+   Se``) and collapsed disabled bulk actions to bare "○" markers at the
+   pane's 40-col floor. The canvas now switches to a multi-row grammar
+   below its measured narrow threshold (library_media_canvas.py's
+   _resolve_narrow_actions), so buttons keep their CONTENT width (auto,
+   with min-width 0 lifting Textual Button's 16-cell floor -- six floors
+   alone would overflow any pane under 96 cols) and every label stays a
+   readable word; each row's label sum is budgeted to fit the 40-col
+   floor, which is what keeps task-28025's fit contract true. */
 #library-media-canvas > .ds-toolbar > .library-canvas-action,
 #library-media-canvas > .ds-toolbar > .library-toolbar-count {
-    width: 1fr;
+    width: auto;
     min-width: 0;
 }
 

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -2925,9 +2925,19 @@ LibraryFileNotesGitPanel #file-notes-git-commit-body:focus {
     max-width: 100%;
 }
 
+/* task-30043 (critique 2026-09-03 P1) supersedes task-28025's 1fr squeeze:
+   sharing the row width chopped every label to fragments (``t so E Tr R
+   Se``) and collapsed disabled bulk actions to bare "○" markers at the
+   pane's 40-col floor. The canvas now switches to a multi-row grammar
+   below its measured narrow threshold (library_media_canvas.py's
+   _resolve_narrow_actions), so buttons keep their CONTENT width (auto,
+   with min-width 0 lifting Textual Button's 16-cell floor -- six floors
+   alone would overflow any pane under 96 cols) and every label stays a
+   readable word; each row's label sum is budgeted to fit the 40-col
+   floor, which is what keeps task-28025's fit contract true. */
 #library-media-canvas > .ds-toolbar > .library-canvas-action,
 #library-media-canvas > .ds-toolbar > .library-toolbar-count {
-    width: 1fr;
+    width: auto;
     min-width: 0;
 }
 

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -2829,6 +2829,20 @@
     }
 
 
+/* ===== WIDGET: LibraryMediaCanvas (Widgets/Library/library_media_canvas.py) ===== */
+
+    /* task-30043: the multi-row action grammar needs CONTENT-width buttons.
+     * Textual Button's 16-cell min-width floor alone would overflow the
+     * pane's 40-col floor (six floors = 96 cells); each row's label budget
+     * is what keeps task-28025's fit contract true. Baseline geometry lives
+     * here so harnesses without the app bundle lay out like the app. */
+    LibraryMediaCanvas .ds-toolbar > .library-canvas-action,
+    LibraryMediaCanvas .ds-toolbar > .library-toolbar-count {
+        width: auto;
+        min-width: 0;
+    }
+
+
 /* ===== WIDGET: LibraryNoteFolderNameDialog (Widgets/Library/library_note_folder_dialog.py) ===== */
 
 

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -2330,6 +2330,16 @@
     }
 
 
+/* ===== WIDGET: LibraryMediaCanvas (Widgets/Library/library_media_canvas.py) ===== */
+
+    /* task-30043: the multi-row action grammar needs CONTENT-width buttons.
+     * Textual Button's 16-cell min-width floor alone would overflow the
+     * pane's 40-col floor (six floors = 96 cells); each row's label budget
+     * is what keeps task-28025's fit contract true. Baseline geometry lives
+     * here so harnesses without the app bundle lay out like the app. */
+
+
+
 /* ===== WIDGET: LibraryNoteFolderNameDialog (Widgets/Library/library_note_folder_dialog.py) ===== */
 
     LibraryNoteFolderNameDialog { align: center middle; }


### PR DESCRIPTION
Second of four fix PRs from the 2026-09-03 design critique of Library ▸ Media (task-30043; #2346 shipped the review-set hardening). Fixes the critique's other P1: the items pane's action toolbar was illegible in its resting state.

## The problem (live captures in the critique snapshot)

The items pane sits at **~40-44 columns in every real shell layout** (the 3-pane reading shell and the compact stage alike). Six compact buttons sharing one row rendered as `t so E Tr R Se`; entering select mode showed the bulk actions as bare `○ ○ ○` disabled markers — for a keyboard/screen-reader user the accessibility markers *were* the labels; the armed bulk-delete safety copy clipped mid-word ("You can und / restore later from Tr").

## The fix — multi-row is THE grammar

- **Browse**: three budgeted rows — `[type, sort]`, `[Export…, Trash, Select]`, `[Review these]`. Full labels always. (In select mode most of these hide, so its single row keeps fitting.)
- **Select mode**: summary row `[N selected, Select all N shown]`; bulk row `[Clear, Export, Review]` — short REAL words (the mode and the adjacent count make them unambiguous; the F-018 tooltips carry the full sentences; the `○` disabled marker always rides WITH its word); **Delete isolated on its own danger row** — task-2853's far-end rule, upgraded. The `_apply_library_row_toggle` in-place patch keeps working via the stashed short bases.
- **Content-width buttons**: a canvas `BUNDLED_CSS` block lifts Textual Button's 16-cell min-width floor (six floors = 96 cells could never fit) — this **supersedes task-28025's `1fr` squeeze**, whose equal shares were what chopped the labels. Every row's label budget (including the `○ `-prefixed disabled forms) fits the pane floor, which is what keeps 28025's fit contract true — its pinning test still passes.
- **The confirm copy wraps whole**: the canvas claimed `min-width: 40` while the shell allots ~37, so children laid out 3 cells wider than visible and the safety sentence clipped. The floor drops to 36 (it only exists to bound the 13fr resolution trap), and the copy Static is bounded to the pane.
- **No width machinery**: an earlier draft made this a responsive variant driven by `on_resize` + recompose; that mount-time recompose raced the viewer-return settlement (8 side-by-side tests) and was deleted rather than tuned — the pane is never wide enough for the single row in any shipped layout.

CSS bundle + widget-defaults regenerated and committed (BUNDLED_CSS change).

## Tests

5 in the new `test_library_media_toolbar_adapt.py` (row structure, word-not-marker labels, 40-col fit for browse and select rows via region assertions, confirm-copy wrap) + the full multiselect (64) and side-by-side (31, incl. task-28025's fit contract) suites green — 100 total.

## Live verification (tmux, seeded, cleaned up)

At the real pane: `type: All types / sort: Newest`, `Export… Trash Select`, `Review these` all as words; select mode reads `0 selected · Select all 3 shown / Clear ○ Export ○ Review / ○ Delete`; checking a row flips the labels in place; the armed confirm shows the complete sentence "Delete 1 selected item? You can undo right away, or restore later from Trash."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2gSzBnVrjf37m4bPU3BCn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements task-30043 by replacing the media items pane's single six-button toolbar with a multi-row action grammar, so actions read as full words instead of fragments like `t so E Tr R Se` at the pane's ~40-column width.

- Browse mode uses three rows: `[type, sort]`, `[Export…, Trash, Select]`, and `[Review these]`.
- Select mode shows a summary row, a bulk row (`Clear`, `Export`, `Review`), and Delete isolated on its own danger row.
- Disabled bulk actions keep the `○` marker attached to their word, so they render as `○ Export` rather than a bare `○`.
- Toolbar buttons now size to their content, superseding the `1fr` squeeze that chopped labels.
- The bulk-delete confirmation copy now wraps inside the pane; the canvas `min-width` floor drops from 40 to 36 to fit the shell's ~37-column allotment.
- Long stored type values are capped at 8 characters plus ellipsis in the chooser label, with the full value kept in the tooltip.
- Adds 6 UI tests covering row structure, word-not-marker labels, 40-column fit, confirmation-copy wrapping, and the type-label cap.

<sup>Written for commit 8ff9a3961ba99c45d5fce87f5ed301c41cbc75b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

