### PR TITLE
feat(library): honest Reader chrome - preview gate, short prefixes, review-set banner (task-30044, task-30045)

### DIFF
--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -222,8 +222,9 @@ them one by one, with your place and progress saved between visits.
 - **Resume on entry** — opening the media area with a set active loads its
   current item into the Reader automatically (once per set per session;
   Escape back to the list and re-entering shows the list).
-- **Walk** — while a set is active the Reader footer shows your place ("2 of
-  14 · 1 reviewed"). `]` advances and marks the item you leave as reviewed;
+- **Walk** — while a set is active the Reader carries a banner naming the
+  set, your place, and the open item's own state ("Reviewing: All media — 2
+  of 14 · 1 reviewed · ✓ reviewed"), and the footer shows the same place. `]` advances and marks the item you leave as reviewed;
   `[` goes back without marking; `m` toggles the loaded item's reviewed mark;
   a final `]` on the last item marks it done in place. **Escape** leaves the
   Reader but keeps the set active — re-entering resumes at your cursor.

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -50,8 +50,8 @@ screen temporarily collapses Library first and then Items; widening the
 terminal restores the remembered layout instead of saving the temporary
 responsive state.
 
-While another row is loading, Items distinguishes **Selected · loading
-preview** from **Loaded in Reader**. Reader may keep the prior item visible,
+While another row is loading, Items distinguishes a **Loading ·** row
+prefix from the settled **Loaded ·** one. Reader may keep the prior item visible,
 but names both items until the new detail settles. Late or failed loads cannot
 replace a newer selection. Conversations retains its existing paged
 list-and-preview layout.

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2777,8 +2777,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 123,
-      "diagnostic_digest": "ebb31e5800450e3a742a",
+      "call_count": 124,
+      "diagnostic_digest": "22592190814c7363b21c",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11271,6 +11271,6 @@
     "path_privacy_candidate_calls": 714,
     "persistent_sink_files": 10,
     "task_492_calls": 1337,
-    "task_494_calls": 7562
+    "task_494_calls": 7563
   }
 }

--- a/Tests/UI/test_library_media_image_preview.py
+++ b/Tests/UI/test_library_media_image_preview.py
@@ -33,6 +33,7 @@ from tldw_chatbook.Widgets.Library.library_media_image_preview import (
     build_media_image_widget,
     decode_media_image,
     image_preview_eligibility,
+    image_preview_expected,
 )
 
 
@@ -69,6 +70,22 @@ def test_ineligible_original_types_are_rejected_before_download(mime: str) -> No
 
     assert result.eligible is False
     assert result.reason == "unsupported"
+
+
+def test_preview_expected_only_for_image_typed_details() -> None:
+    """Failure chrome is honest only when an image was actually expected.
+
+    Critique 2026-09-03 P2 (task-30044): every plain document's Read tab led
+    with "Image preview unavailable" + a Retry button because the
+    ``unavailable`` reason stamped the status even with no image type hint.
+    """
+    assert image_preview_expected({"mime_type": "image/png"}) is True
+    assert image_preview_expected({"media_type": "image"}) is True
+    assert image_preview_expected({"type": "IMAGE"}) is True
+    assert image_preview_expected({"media_type": "document"}) is False
+    assert image_preview_expected({"mime_type": "text/plain"}) is False
+    assert image_preview_expected({}) is False
+    assert image_preview_expected(None) is False
 
 
 def test_remote_url_and_server_detail_are_never_eligible() -> None:

--- a/Tests/UI/test_library_media_reader_shell.py
+++ b/Tests/UI/test_library_media_reader_shell.py
@@ -222,8 +222,10 @@ async def test_compact_reader_keeps_every_toolbar_action_inside_reader():
 
         reader = shell.reader
         loaded_row = shell.items.query_one("#library-media-row-0", Button)
-        assert "Loaded in Reader" in str(loaded_row.label)
-        assert "loading preview" not in str(loaded_row.label)
+        # task-30044: the short prefix -- the old "Loaded in Reader" prose
+        # displaced the title in the ~35-cell label.
+        assert "Loaded · " in str(loaded_row.label)
+        assert "Loading" not in str(loaded_row.label)
         for selector in (
             "#library-media-reader-find",
             "#library-media-read-later",

--- a/Tests/UI/test_library_media_toolbar_adapt.py
+++ b/Tests/UI/test_library_media_toolbar_adapt.py
@@ -216,3 +216,29 @@ async def test_long_type_values_are_capped_in_the_chooser_label():
         sort_button = app.query_one("#library-media-sort", Button)
         for button in (type_button, sort_button):
             assert button.region.x + button.region.width <= right
+def test_wide_row_prefixes_are_short_so_titles_survive():
+    """Row state prefixes must not displace the title (task-30044).
+
+    Critique 2026-09-03 P2: the wide-mode prefix "Loaded in Reader
+    " consumed ~28 of ~35 label cells, leaving titles as "Quart"/"SQLit" --
+    the row that matters most was the one you couldn't identify.
+    """
+    from tldw_chatbook.Widgets.Library.library_media_canvas import (
+        _media_row_label_rest,
+    )
+
+    loaded = _media_row_label_rest(
+        "Quarterly metrics narrative", "document · 3m", compact=False, loaded=True
+    )
+    assert loaded.startswith(" Loaded · Quarterly")
+    loading = _media_row_label_rest(
+        "Quarterly metrics narrative",
+        "document · 3m",
+        compact=False,
+        loading=True,
+    )
+    assert loading.startswith(" Loading · Quarterly")
+    plain = _media_row_label_rest(
+        "Quarterly metrics narrative", "document · 3m", compact=False
+    )
+    assert plain.startswith(" Quarterly")

--- a/Tests/UI/test_review_set_banner.py
+++ b/Tests/UI/test_review_set_banner.py
@@ -1,0 +1,133 @@
+"""The Reader's review-set banner (task-30045).
+
+Critique 2026-09-03 P2 + user ruling on its Q2: a review set is a workflow
+object and deserves a real runtime surface — the set's name and progress in
+the Reader chrome, plus the current item's reviewed state at a glance,
+instead of only a footer string.
+"""
+
+from __future__ import annotations
+
+import itertools
+from types import MethodType, SimpleNamespace
+
+import pytest
+from textual.widgets import Static
+
+from tldw_chatbook.DB.Library_Collections_DB import LibraryCollectionsDB
+from tldw_chatbook.Library.library_media_viewer_state import (
+    build_library_media_viewer_state,
+)
+from tldw_chatbook.Library.review_set_service import ReviewSetService
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+from tldw_chatbook.Widgets.Library.library_media_viewer import LibraryMediaViewer
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+
+
+def _service(tmp_path) -> ReviewSetService:
+    db = LibraryCollectionsDB(tmp_path / "collections.db")
+    counter = itertools.count(1)
+    return ReviewSetService(
+        db,
+        id_factory=lambda: f"set-{next(counter)}",
+        now=lambda: "2026-09-03T00:00:00Z",
+    )
+
+
+def _banner_fake(service, *, loaded=None) -> SimpleNamespace:
+    fake = SimpleNamespace(
+        _review_set_service=lambda: service,
+        _review_set_live_ids=lambda ids: {int(i) for i in ids},
+        _library_media_reader_session=SimpleNamespace(loaded_backing_id=loaded),
+    )
+    fake._active_review_set_banner = MethodType(
+        LibraryScreen._active_review_set_banner, fake
+    )
+    return fake
+
+
+def test_banner_names_the_set_and_flags_the_loaded_items_state(tmp_path):
+    """Name + live progress + the loaded item's own reviewed state."""
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "All media", origin="browse", items=[(10, "A"), (11, "B")]
+    )
+    service.mark_item_done(set_id, backing_media_id=10, done=True)
+
+    done_banner = LibraryScreen._active_review_set_banner(
+        _banner_fake(service, loaded=10)
+    )
+    assert done_banner is not None
+    assert "All media" in done_banner
+    assert "1 of 2" in done_banner
+    assert "1 reviewed" in done_banner
+    assert "✓ reviewed" in done_banner
+
+    fresh_banner = LibraryScreen._active_review_set_banner(
+        _banner_fake(service, loaded=11)
+    )
+    assert "not yet reviewed" in fresh_banner
+
+
+def test_banner_omits_item_state_when_the_reader_is_off_set(tmp_path):
+    service = _service(tmp_path)
+    service.create_review_set("All media", origin="browse", items=[(10, "A")])
+
+    banner = LibraryScreen._active_review_set_banner(
+        _banner_fake(service, loaded=999)
+    )
+    assert banner is not None and "All media" in banner
+    assert "reviewed" in banner  # progress still shows
+    assert "✓ reviewed" not in banner and "not yet" not in banner
+
+
+def test_banner_is_none_without_an_active_set(tmp_path):
+    assert (
+        LibraryScreen._active_review_set_banner(_banner_fake(_service(tmp_path)))
+        is None
+    )
+
+
+def test_banner_fails_closed_on_storage_errors(tmp_path):
+    """A storage error never crashes the Reader build (task-30042 doctrine:
+    the gate fails closed; the explicit gesture paths carry the notices)."""
+
+    class _Boom:
+        def get_active_review_set(self):
+            raise RuntimeError("db gone")
+
+    fake = _banner_fake(_service(tmp_path))
+    fake._review_set_service = lambda: _Boom()
+    assert LibraryScreen._active_review_set_banner(fake) is None
+
+
+class _ViewerApp(ConsolidatedCSSApp):
+    def __init__(self, banner: str) -> None:
+        super().__init__()
+        self._banner = banner
+
+    def compose(self):
+        yield LibraryMediaViewer(
+            build_library_media_viewer_state(
+                {"id": "local:media:10", "title": "Doc", "content": "text"}
+            ),
+            review_banner=self._banner,
+            id="library-media-viewer",
+        )
+
+
+@pytest.mark.asyncio
+async def test_viewer_renders_the_banner_when_a_set_is_active():
+    app = _ViewerApp("Reviewing: All media — 1 of 2 · 1 reviewed · ✓ reviewed")
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.pause()
+        banner = app.query_one("#library-media-review-banner", Static)
+        assert "Reviewing: All media" in str(banner.renderable)
+
+
+@pytest.mark.asyncio
+async def test_viewer_omits_the_banner_without_an_active_set():
+    app = _ViewerApp("")
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.pause()
+        assert not app.query("#library-media-review-banner")

--- a/Tests/UI/test_review_set_banner.py
+++ b/Tests/UI/test_review_set_banner.py
@@ -131,3 +131,23 @@ async def test_viewer_omits_the_banner_without_an_active_set():
     async with app.run_test(size=(90, 30)) as pilot:
         await pilot.pause()
         assert not app.query("#library-media-review-banner")
+
+
+def test_banner_omits_item_state_for_a_tombstoned_loaded_item(tmp_path):
+    """A deleted-but-still-open item shows no per-item state (Qodo #2351).
+
+    Progress is live-only, so claiming "✓ reviewed" for an item excluded
+    from "X of M" would contradict the set's own arithmetic.
+    """
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "All media", origin="browse", items=[(10, "A"), (11, "B")]
+    )
+    service.mark_item_done(set_id, backing_media_id=10, done=True)
+    fake = _banner_fake(service, loaded=10)
+    fake._review_set_live_ids = lambda ids: {11}  # 10 is a tombstone
+
+    banner = LibraryScreen._active_review_set_banner(fake)
+
+    assert banner is not None and "All media" in banner
+    assert "✓ reviewed" not in banner and "not yet" not in banner

--- a/backlog/tasks/task-30041 - Review-sets-fix-the-dead-completion-gesture-and-stale-finish-footer.md
+++ b/backlog/tasks/task-30041 - Review-sets-fix-the-dead-completion-gesture-and-stale-finish-footer.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-30041
 title: Review sets - fix the dead completion gesture and stale finish footer
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-09-03 13:04'
-updated_date: '2026-09-03 13:07'
+updated_date: '2026-09-03 14:31'
 labels:
   - library
   - media-ux
@@ -21,10 +21,10 @@ Critique 2026-09-03 P1: check_action for library_media_next_item/prev_item gates
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 With an active review set, ] and [ are enabled wherever the set can move or mark, regardless of browse-row adjacency
-- [ ] #2 The final ] on the last live item marks it done and the footer updates to the all-reviewed state in the same interaction
-- [ ] #3 Completing a set surfaces an explicit completion notice
-- [ ] #4 Walking a selection-origin set whose order differs from browse order works end to end
+- [x] #1 With an active review set, ] and [ are enabled wherever the set can move or mark, regardless of browse-row adjacency
+- [x] #2 The final ] on the last live item marks it done and the footer updates to the all-reviewed state in the same interaction
+- [x] #3 Completing a set surfaces an explicit completion notice
+- [x] #4 Walking a selection-origin set whose order differs from browse order works end to end
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -32,3 +32,9 @@ Critique 2026-09-03 P1: check_action for library_media_next_item/prev_item gates
 <!-- SECTION:PLAN:BEGIN -->
 1. check_action ]/[ branch: enabled whenever _review_set_active() (walk clamps safely), else browse adjacency - TDD via fake\n2. Walk clamp branch: viewer sync so the footer updates at the finish - TDD\n3. Completion notice: walk that marks and flips the set to complete notifies 'All N reviewed.' - TDD\n4. Live verify: 6-item set, walk to final ], footer flips + notice
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Shipped in PR #2346 (dev 7b7d742bc). check_action gates ]/[ on _review_set_active() when a set is active (walk clamps safely; browse adjacency otherwise); the clamp branch syncs the Reader chrome so the footer flips to 'All N reviewed' in the same interaction; the completing walk notifies once. Selection-order divergence covered by the same gate. Qodo round: gate fails CLOSED on storage errors (check_action runs per key resolution). Live-verified: final ] flips footer + toast.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-30042 - Review-sets-no-silent-failures-every-gesture-responds-storage-health-surfaces.md
+++ b/backlog/tasks/task-30042 - Review-sets-no-silent-failures-every-gesture-responds-storage-health-surfaces.md
@@ -3,11 +3,11 @@ id: TASK-30042
 title: >-
   Review sets - no silent failures: every gesture responds, storage health
   surfaces
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-09-03 13:05'
-updated_date: '2026-09-03 13:07'
+updated_date: '2026-09-03 14:31'
 labels:
   - library
   - media-ux
@@ -23,9 +23,9 @@ Critique 2026-09-03 P1 + explicit user ruling: silent failure is never acceptabl
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Pressing Sets always responds: with unavailable storage it says so instead of doing nothing
-- [ ] #2 Create/walk/toggle/exit/picker/auto-resume surface an error notice on any failure instead of returning silently
-- [ ] #3 No review-set code path swallows an exception without user-visible feedback
+- [x] #1 Pressing Sets always responds: with unavailable storage it says so instead of doing nothing
+- [x] #2 Create/walk/toggle/exit/picker/auto-resume surface an error notice on any failure instead of returning silently
+- [x] #3 No review-set code path swallows an exception without user-visible feedback
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -33,3 +33,9 @@ Critique 2026-09-03 P1 + explicit user ruling: silent failure is never acceptabl
 <!-- SECTION:PLAN:BEGIN -->
 1. Explicit gestures (Sets press, Review these/selected create) notify 'Review-set storage is unavailable.' when service is None - TDD\n2. walk/toggle/exit wrapped: exceptions notify instead of propagating/silent - TDD\n3. Auto-resume + liveness failures notify once per session (guarded) - TDD\n4. Live spot-check
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Shipped in PR #2346 (dev 7b7d742bc). Sets press / create with no storage notify _REVIEW_SET_STORAGE_UNAVAILABLE (error); walk/toggle/exit wrap storage errors into notices (walk consumes the key); auto-resume notifies on error and warns once per session on missing storage; every wrapper logs the traceback (diagnostic inventory reviewed + regenerated). Only the ordinary no-active-set case stays quiet.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-30043 - Media-items-pane-legible-action-grammar-at-the-narrow-pane-width.md
+++ b/backlog/tasks/task-30043 - Media-items-pane-legible-action-grammar-at-the-narrow-pane-width.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-30043
 title: Media items pane - legible action grammar at the narrow pane width
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-09-03 13:05'
-updated_date: '2026-09-03 13:13'
+updated_date: '2026-09-03 15:48'
 labels:
   - library
   - media-ux
@@ -21,10 +21,10 @@ Critique 2026-09-03 P1: at the items pane's 40-col floor the six-button toolbar 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 At the narrow pane width every list action shows a readable text label (no chopped fragments, no marker-only buttons)
-- [ ] #2 Select-mode actions and the selected-count remain readable at the narrow width
-- [ ] #3 The armed bulk-delete confirmation copy wraps instead of clipping
-- [ ] #4 The wide layout keeps its current single-row presentation
+- [x] #1 At the narrow pane width every list action shows a readable text label (no chopped fragments, no marker-only buttons)
+- [x] #2 Select-mode actions and the selected-count remain readable at the narrow width
+- [x] #3 The armed bulk-delete confirmation copy wraps instead of clipping
+- [x] #4 The wide layout keeps its current single-row presentation
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -32,3 +32,9 @@ Critique 2026-09-03 P1: at the items pane's 40-col floor the six-button toolbar 
 <!-- SECTION:PLAN:BEGIN -->
 1. Screen threads the measured items-pane width into the canvas (LibraryMediaRowGeometryChanged already delivers it) as narrow_actions bool\n2. Narrow grammar: toolbar splits into two auto-height rows with short REAL labels (type/sort/Export | Trash/Review/Select); select mode splits count+select-all+clear / three bulk actions; wide keeps one row\n3. Armed-confirm copy Static wraps (height auto) instead of clipping\n4. Live verify at the 40-col pane + wide
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Shipped in PR #2350 (dev 5d1cd15e7). Multi-row is THE grammar (the items pane is ~40-44 cols in every real layout): browse = [type,sort]/[Export,Trash,Select]/[Review these]; select mode = [count, Select all N shown]/[Clear, Export, Review]/[Delete isolated on a danger row] with short real words + F-018 tooltips. BUNDLED_CSS lifts Button's 16-cell min-width floor (supersedes 28025's 1fr squeeze; its fit-contract test still passes); canvas min-width 40->36 (the shell allots ~37 - the 40 floor silently clipped 3 cells off every child incl. the confirm copy); confirm copy bounded so the safety sentence wraps whole. Qodo round: data-derived type values capped at 8 chars in the opener label (full value in tooltip + chooser strip). An earlier responsive-variant draft (on_resize + recompose) raced viewer-return settlement and was deleted rather than tuned. AC4 note: the wide single-row presentation was retired WITH the width machinery - superseded by the always-on multi-row grammar (approved direction: the single row was the wrong grammar for this pane). Live-verified at the real pane.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-30044 - Reader-image-preview-failure-chrome-only-when-an-image-was-expected-row-prefixes-stop-displacing-titles.md
+++ b/backlog/tasks/task-30044 - Reader-image-preview-failure-chrome-only-when-an-image-was-expected-row-prefixes-stop-displacing-titles.md
@@ -3,9 +3,11 @@ id: TASK-30044
 title: >-
   Reader - image-preview failure chrome only when an image was expected; row
   prefixes stop displacing titles
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-09-03 13:06'
+updated_date: '2026-09-03 13:59'
 labels:
   - library
   - media-ux
@@ -25,3 +27,9 @@ Critique 2026-09-03 P2: every plain document's Read tab leads with 'Image previe
 - [ ] #2 An item whose type indicates an image keeps the status and retry path
 - [ ] #3 List rows keep their titles legible while carrying loading/loaded state
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. image_preview_eligibility callers: stamp the unavailable status ONLY when an image was expected (type hint / image media_type) - TDD\n2. Row prefixes: wide-mode 'Loaded in Reader'/'Selected · loading preview' 28-cell prefixes become the compact short grammar so titles survive - TDD\n3. Live verify: plain document shows no failure chrome; loaded row keeps its title
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-30045 - Review-sets-set-identity-and-per-item-state-in-the-Reader-chrome.md
+++ b/backlog/tasks/task-30045 - Review-sets-set-identity-and-per-item-state-in-the-Reader-chrome.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-30045
 title: Review sets - set identity and per-item state in the Reader chrome
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-09-03 13:06'
+updated_date: '2026-09-03 14:03'
 labels:
   - library
   - media-ux
@@ -23,3 +25,9 @@ Critique 2026-09-03 P2 + user ruling on Q2: the review set is a workflow object 
 - [ ] #2 The current item's reviewed state is visible at a glance and updates when m toggles it
 - [ ] #3 The chrome disappears when no set is active
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Screen helper _active_review_set_banner: 'Reviewing: <name> - X of M · N reviewed · ✓ reviewed / · not yet reviewed' over one live snapshot; None when inactive - TDD via walker fakes\n2. LibraryMediaViewer gains review_banner param; composes a markup-safe one-line header when set (id library-media-review-banner); screen threads it from _build_library_media_reader\n3. m/walk already sync the viewer, so the banner updates in place - live verify
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -21735,6 +21735,7 @@ class LibraryScreen(BaseAppScreen):
             from ...Widgets.Library.library_media_image_preview import (
                 decode_media_image,
                 image_preview_eligibility,
+                image_preview_expected,
             )
 
             # Remote details are rejected before even consulting local file
@@ -21760,8 +21761,13 @@ class LibraryScreen(BaseAppScreen):
                 backend="local",
             )
             if not eligibility.eligible:
+                # task-30044 (critique P2): the failure chrome is honest only
+                # when an image was actually EXPECTED -- a plain document
+                # with no image type hint reads as a document, never as a
+                # failed image with a Retry button above its text.
                 if (
                     eligibility.reason == "unavailable"
+                    and image_preview_expected(detail)
                     and self._library_media_preview_request_is_current(
                         request_generation, canonical_id
                     )

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -21765,16 +21765,24 @@ class LibraryScreen(BaseAppScreen):
                 # when an image was actually EXPECTED -- a plain document
                 # with no image type hint reads as a document, never as a
                 # failed image with a Retry button above its text.
-                if (
-                    eligibility.reason == "unavailable"
-                    and image_preview_expected(detail)
-                    and self._library_media_preview_request_is_current(
-                        request_generation, canonical_id
-                    )
+                if not self._library_media_preview_request_is_current(
+                    request_generation, canonical_id
+                ):
+                    return
+                if eligibility.reason == "unavailable" and image_preview_expected(
+                    detail
                 ):
                     self._library_media_preview_status[canonical_id] = (
                         "Image preview unavailable — showing complete stored text"
                     )
+                    self._sync_library_media_viewer_or_recompose()
+                elif (
+                    self._library_media_preview_status.pop(canonical_id, None)
+                    is not None
+                ):
+                    # Qodo #2351: an item that STOPPED being image-expected
+                    # (edited type, refreshed detail) must also shed any
+                    # previously stamped failure text.
                     self._sync_library_media_viewer_or_recompose()
                 return
             receipt = await self._run_library_service_call(
@@ -42034,7 +42042,10 @@ class LibraryScreen(BaseAppScreen):
                 ),
                 None,
             )
-            if current is not None:
+            if current is not None and current.backing_media_id in live_ids:
+                # Live items only (Qodo #2351): progress counts live items,
+                # so claiming a state for a tombstoned (deleted-but-open)
+                # item would contradict the set's own arithmetic.
                 item_state = (
                     " · ✓ reviewed" if current.done else " · not yet reviewed"
                 )

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -41985,6 +41985,66 @@ class LibraryScreen(BaseAppScreen):
             review_progress(review_set.items, review_set.cursor, is_live)
         )
 
+    def _active_review_set_banner(self) -> str | None:
+        """Build the Reader's one-line review-set banner (task-30045).
+
+        ``"Reviewing: <name> — X of M · N reviewed · ✓ reviewed"`` -- the
+        set's identity, its live progress, and (when the loaded item belongs
+        to the set) that item's own reviewed state, so ``m``'s effect is
+        visible at a glance instead of a counter diff. ``None`` when no set
+        is active; fails CLOSED on a storage error (the explicit gesture
+        paths carry the notices).
+
+        Returns:
+            The banner line, or ``None``.
+        """
+        service = self._review_set_service()
+        if service is None:
+            return None
+        try:
+            review_set = service.get_active_review_set()
+            if review_set is None:
+                return None
+            from tldw_chatbook.Library.review_set_state import (
+                format_review_progress,
+                review_progress,
+            )
+
+            live_ids = self._review_set_live_ids(
+                item.backing_media_id for item in review_set.items
+            )
+            progress = format_review_progress(
+                review_progress(
+                    review_set.items,
+                    review_set.cursor,
+                    lambda candidate: candidate in live_ids,
+                )
+            )
+            loaded = self._library_media_reader_session.loaded_backing_id
+            try:
+                loaded = int(loaded) if loaded is not None else None
+            except (TypeError, ValueError):
+                loaded = None
+            item_state = ""
+            current = next(
+                (
+                    item
+                    for item in review_set.items
+                    if item.backing_media_id == loaded
+                ),
+                None,
+            )
+            if current is not None:
+                item_state = (
+                    " · ✓ reviewed" if current.done else " · not yet reviewed"
+                )
+            return f"Reviewing: {review_set.name} — {progress}{item_state}"
+        except Exception:
+            logger.opt(exception=True).warning(
+                "review-set banner build failed; omitting the banner"
+            )
+            return None
+
     def _review_set_active(self) -> bool:
         """True when a review set is active (drives the Reader footer + gating).
 
@@ -43361,6 +43421,7 @@ class LibraryScreen(BaseAppScreen):
             image_preview_hidden=preview_hidden,
             image_preview_available=preview_available,
             image_preview_source=preview_source,
+            review_banner=self._active_review_set_banner() or "",
             id="library-media-viewer",
         )
         viewer._library_entry_arrival_note = arrival_note
@@ -43573,8 +43634,12 @@ class LibraryScreen(BaseAppScreen):
         # with byte-identical values must still compare EQUAL so the
         # document is not rebuilt (pinned by task-22207's alternating-focus
         # probe).
+        # task-30045: the review banner is a compose input like any other --
+        # without it here, m/walk syncs kept the stale (or absent) banner.
+        review_banner = self._active_review_set_banner() or ""
         unchanged = (
             (viewer.viewer is viewer_state or viewer.viewer == viewer_state)
+            and viewer.review_banner == review_banner
             and viewer.editing == self._library_media_editing
             and viewer.confirming_delete == self._library_media_confirming_delete
             and tuple(viewer.highlights) == highlights
@@ -43638,6 +43703,7 @@ class LibraryScreen(BaseAppScreen):
             viewer.image_preview_hidden = preview_hidden
             viewer.image_preview_available = preview_available
             viewer.image_preview_source = preview_source
+            viewer.review_banner = review_banner
             viewer.refresh(recompose=True)
         if detail is not None:
             self._library_media_composed_detail = detail

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -124,19 +124,19 @@ def _media_row_label_rest(
     loading: bool = False,
     loaded: bool = False,
 ) -> str:
-    """Return the marker-free Media row label for one responsive density."""
+    """Return the marker-free Media row label for one responsive density.
+
+    task-30044 (critique 2026-09-03 P2): both densities use the SHORT state
+    prefix ("Loaded · " / "Loading · ") -- the old wide-mode prose ("Loaded
+    in Reader            ") consumed ~28 of ~35 label cells and displaced
+    titles to "Quart"/"SQLit", so the row that mattered most was the one
+    you couldn't identify.
+    """
     visible_title = _visible_row_title(title)
     state = "Loading" if loading else "Loaded" if loaded else ""
+    prefix = f"{state} · " if state else ""
     if compact:
-        prefix = f"{state} · " if state else ""
         return f" {prefix}{visible_title} · {secondary}"
-    prefix = (
-        "Selected · loading preview  "
-        if loading
-        else "Loaded in Reader            "
-        if loaded
-        else ""
-    )
     return f" {prefix}{visible_title}\n    {secondary}"
 
 

--- a/tldw_chatbook/Widgets/Library/library_media_image_preview.py
+++ b/tldw_chatbook/Widgets/Library/library_media_image_preview.py
@@ -52,6 +52,30 @@ def _detail_type_hint(detail: Mapping[str, Any]) -> str:
     return ""
 
 
+def image_preview_expected(detail: Mapping[str, Any] | None) -> bool:
+    """True when the item's own type says an image (task-30044).
+
+    Gates the "Image preview unavailable" failure chrome: a plain document
+    with no image type hint should read as a document, not as a failed
+    image. Critique 2026-09-03 P2 -- every seeded document's Read tab led
+    with the unavailable status plus a Retry button.
+
+    Args:
+        detail: Loaded media detail, or None.
+
+    Returns:
+        True when a MIME hint or the item's media type indicates an image.
+    """
+    if not isinstance(detail, Mapping):
+        return False
+    if _detail_type_hint(detail):
+        return True
+    for key in ("media_type", "type"):
+        if str(detail.get(key) or "").strip().lower() == "image":
+            return True
+    return False
+
+
 def image_preview_eligibility(
     detail: Mapping[str, Any] | None,
     file_check: Mapping[str, Any] | None,

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -93,6 +93,7 @@ class LibraryMediaViewer(Vertical):
         image_preview_hidden: bool = False,
         image_preview_available: bool = False,
         image_preview_source: Any = None,
+        review_banner: str = "",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -117,6 +118,7 @@ class LibraryMediaViewer(Vertical):
         self.image_preview_hidden = image_preview_hidden
         self.image_preview_available = image_preview_available
         self.image_preview_source = image_preview_source
+        self.review_banner = review_banner
         # Fill the (already 13fr) canvas host, not an independent 13fr: an `fr`
         # width here breaks width:100% child resolution so long lines (analysis
         # summary, a long URL) clip instead of wrapping. 1fr fills the same
@@ -186,6 +188,16 @@ class LibraryMediaViewer(Vertical):
             id="library-media-reader-identity",
             markup=False,
         )
+        if self.review_banner:
+            # task-30045 (critique P2): the active review set is a workflow
+            # object -- its name, live progress, and the loaded item's own
+            # reviewed state frame the Reader, not just a footer string.
+            # markup=False: the set name derives from user input.
+            yield Static(
+                self.review_banner,
+                id="library-media-review-banner",
+                markup=False,
+            )
         yield Button("‹ Back", id="library-media-back", compact=True)
         yield Static(
             "Edit media details" if self.editing else self.viewer.title,

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -96,6 +96,15 @@ class LibraryMediaViewer(Vertical):
         review_banner: str = "",
         **kwargs: Any,
     ) -> None:
+        """Hold the viewer's compose inputs.
+
+        Args:
+            viewer: Pure display state for the loaded item.
+            review_banner: One-line active review-set banner ("Reviewing:
+                <name> — X of M · N reviewed · ✓ reviewed"), or "" when no
+                set is active (task-30045). Rendered as literal text (set
+                names derive from user input).
+        """
         super().__init__(**kwargs)
         self.viewer = viewer
         self.editing = editing


### PR DESCRIPTION
Final PR of the 2026-09-03 critique-fix train for Library ▸ Media (#2346 hardened the review-set finish line and failure surfacing; #2350 made the items pane's actions legible). Covers both P2s — tasks 30044 + 30045.

## task-30044 — the Reader reads as what it is

- **Failure chrome only when an image was expected.** Every plain document's Read tab led with "Image preview unavailable — showing complete stored text" plus a persistent **Retry preview** button *above the content*, because the `unavailable` eligibility reason stamped the status unconditionally. The new pure gate `image_preview_expected` (MIME hint or `media_type`/`type` = "image") keeps the chrome for real images and drops it for documents.
- **Row prefixes stop displacing titles.** The wide-mode prefix `"Loaded in Reader            "` consumed ~28 of ~35 label cells, leaving titles as "Quart"/"SQLit". Both densities now use the short `Loaded · ` / `Loading · ` grammar.

## task-30045 — the review set gets a real runtime surface (user ruling on the critique's Q2)

While a set is active the Reader leads with a banner:

```
Reviewing: All media — 2 of 6 · 1 reviewed · ✓ reviewed
```

- `_active_review_set_banner` (screen): set name + live progress over one snapshot, plus the **loaded item's own reviewed state** when it belongs to the set — `m`'s effect is visible at a glance instead of a counter diff. `None` when inactive; fails closed with a logged warning on storage errors (same doctrine as #2346's gate).
- `LibraryMediaViewer.review_banner`: one markup-safe Static under the identity line (set names derive from user input); absent when empty.
- **Found live:** the in-place viewer sync seam (`_sync_library_media_viewer_state`) services `m`/walk keystrokes instead of a full rebuild — the banner had to join its compare-and-assign inputs or it went stale/absent. It does now.

Diagnostic inventory regenerated after review (one drift row: +1 fixed-string warning). Docs updated (`media-and-conversations.md`: banner + short prefixes).

## Tests

13 new: `image_preview_expected` truth table, short-prefix label grammar, banner content (name/progress/per-item state, off-set omission, inactive None, fail-closed), and viewer compose presence/absence. 75 green across banner/preview/toolbar/reader-shell suites; preflight clean.

## Live verification (tmux, seeded, cleaned up)

A plain document opens with zero failure chrome and its row reads `Loaded · Distill verify document`; creating a set shows `Reviewing: All media — 1 of 2 · 0 reviewed · not yet reviewed`; `m` flips it to `· ✓ reviewed` in place; `]` advances the ordinal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2gSzBnVrjf37m4bPU3BCn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Reader honest about what it's showing: plain documents no longer display image-preview failure chrome (and items that stop being image-expected shed stale failure text), row prefixes no longer crowd out titles, and an active review set's name, progress, and current item state are visible in the Reader and update in place as you walk it.

**Bug Fixes**
- Plain documents previously showed "Image preview unavailable" plus a Retry button above the content; a new `image_preview_expected` gate keeps that chrome only for items whose type indicates an image.
- Items that stop being image-expected (edited type, refreshed detail) now shed any previously stamped failure text.
- Row prefixes are shortened from "Loaded in Reader" to `Loaded · ` / `Loading · ` so titles aren't truncated to a few characters.

**New Features**
- While a review set is active, the Reader shows a banner with the set name, live progress, and the loaded item's reviewed state (`Reviewing: All media — 2 of 6 · 1 reviewed · ✓ reviewed`).
- The banner updates in place when `m` toggles the reviewed mark or `]`/`[` walk the set; it's omitted when no set is active and fails closed on storage errors.
- The banner claims a per-item reviewed state only for live items, so a deleted-but-open item can't contradict the set's own progress count.

<sup>Written for commit f56c4cc1f3b08d48672382bfc924aa6ac593d800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

