### PR TITLE
docs: close out the 2026-09-03 critique-fix tasks (30044, 30045)

### DIFF
--- a/backlog/tasks/task-30044 - Reader-image-preview-failure-chrome-only-when-an-image-was-expected-row-prefixes-stop-displacing-titles.md
+++ b/backlog/tasks/task-30044 - Reader-image-preview-failure-chrome-only-when-an-image-was-expected-row-prefixes-stop-displacing-titles.md
@@ -3,11 +3,11 @@ id: TASK-30044
 title: >-
   Reader - image-preview failure chrome only when an image was expected; row
   prefixes stop displacing titles
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-09-03 13:06'
-updated_date: '2026-09-03 13:59'
+updated_date: '2026-09-03 16:46'
 labels:
   - library
   - media-ux
@@ -23,9 +23,9 @@ Critique 2026-09-03 P2: every plain document's Read tab leads with 'Image previe
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A plain document with no image type hint shows no preview-unavailable status and no Retry preview button
-- [ ] #2 An item whose type indicates an image keeps the status and retry path
-- [ ] #3 List rows keep their titles legible while carrying loading/loaded state
+- [x] #1 A plain document with no image type hint shows no preview-unavailable status and no Retry preview button
+- [x] #2 An item whose type indicates an image keeps the status and retry path
+- [x] #3 List rows keep their titles legible while carrying loading/loaded state
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -33,3 +33,9 @@ Critique 2026-09-03 P2: every plain document's Read tab leads with 'Image previe
 <!-- SECTION:PLAN:BEGIN -->
 1. image_preview_eligibility callers: stamp the unavailable status ONLY when an image was expected (type hint / image media_type) - TDD\n2. Row prefixes: wide-mode 'Loaded in Reader'/'Selected · loading preview' 28-cell prefixes become the compact short grammar so titles survive - TDD\n3. Live verify: plain document shows no failure chrome; loaded row keeps its title
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Shipped in PR #2351 (dev 72474d391). image_preview_expected (MIME hint or media_type/type == image) gates the unavailable status: plain documents show no failure chrome or Retry button (AC1); image-typed items keep the status/retry path (AC2, truth-table pinned); an item that STOPS being image-expected sheds any previously stamped status (Qodo round). Row prefixes: both densities use 'Loaded · '/'Loading · ' so titles survive (AC3). Live-verified.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-30045 - Review-sets-set-identity-and-per-item-state-in-the-Reader-chrome.md
+++ b/backlog/tasks/task-30045 - Review-sets-set-identity-and-per-item-state-in-the-Reader-chrome.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-30045
 title: Review sets - set identity and per-item state in the Reader chrome
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-09-03 13:06'
-updated_date: '2026-09-03 14:03'
+updated_date: '2026-09-03 16:46'
 labels:
   - library
   - media-ux
@@ -21,9 +21,9 @@ Critique 2026-09-03 P2 + user ruling on Q2: the review set is a workflow object 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 While a set is active the Reader shows the set's name and progress in its chrome
-- [ ] #2 The current item's reviewed state is visible at a glance and updates when m toggles it
-- [ ] #3 The chrome disappears when no set is active
+- [x] #1 While a set is active the Reader shows the set's name and progress in its chrome
+- [x] #2 The current item's reviewed state is visible at a glance and updates when m toggles it
+- [x] #3 The chrome disappears when no set is active
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -31,3 +31,9 @@ Critique 2026-09-03 P2 + user ruling on Q2: the review set is a workflow object 
 <!-- SECTION:PLAN:BEGIN -->
 1. Screen helper _active_review_set_banner: 'Reviewing: <name> - X of M · N reviewed · ✓ reviewed / · not yet reviewed' over one live snapshot; None when inactive - TDD via walker fakes\n2. LibraryMediaViewer gains review_banner param; composes a markup-safe one-line header when set (id library-media-review-banner); screen threads it from _build_library_media_reader\n3. m/walk already sync the viewer, so the banner updates in place - live verify
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Shipped in PR #2351 (dev 72474d391). Reader banner 'Reviewing: <name> - X of M · N reviewed · ✓ reviewed': _active_review_set_banner (one live snapshot; per-item state only for LIVE items after Qodo caught tombstones claiming state; fails closed w/ logged warning) + LibraryMediaViewer.review_banner (markup-safe Static; absent when empty). Key finding: the in-place _sync_library_media_viewer_state seam services m/walk keystrokes, so the banner had to join its compare-and-assign inputs - without that it went stale/absent (found live). Live-verified: appears on create, m flips state in place, ] advances the ordinal, disappears with no active set.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
Backlog closure for the final PR of the critique-fix train: tasks 30044 + 30045 marked Done with ticked ACs and implementation notes (PR #2351 merged as 72474d391). Tasks 30041-30043 were closed in their own trains (#2346, #2350).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2gSzBnVrjf37m4bPU3BCn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes backlog tasks 30044 and 30045 by marking their acceptance criteria complete and documenting the shipped Reader fixes.

- Task 30044 records image-only preview failure states and compact row prefixes that keep titles visible.
- Task 30045 records the review-set banner, progress, and live per-item reviewed state.
- Both task files now include verification results and edge-case notes.

<sup>Written for commit 035b275df476eec5289bcd832e18059373b37a9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

