### PR TITLE
chore(release): bump PyPI version to 0.1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to Some kind of Versioning
     
-## [Unreleased (placeholder for copy/paste)]
+## [0.1.8.1] - 2026-09-03
 
 ### Added
 - Initial features pending documentation

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ machine by default.
 
 ## Alpha status
 
-tldw_chatbook is **Alpha** software. The current package version is `0.1.8.0`.
+tldw_chatbook is **Alpha** software. The current package version is `0.1.8.1`.
 The core application is usable, but the project is moving quickly: interfaces
 can change, advanced integrations vary in maturity, and older data may
 occasionally need migration or recovery.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tldw_chatbook"
-version = "0.1.8.0"
+version = "0.1.8.1"
 authors = [
   { name="Robert Musser", email="contact@rmusser.net" },
 ]

--- a/tldw_chatbook/__init__.py
+++ b/tldw_chatbook/__init__.py
@@ -91,13 +91,13 @@ def _install_textual_compatibility_shims() -> None:
 
 _install_textual_compatibility_shims()
 
-__version__ = "0.1.8.0"
+__version__ = "0.1.8.1"
 __author__ = "Robert Musser"
 __email__ = "contact@rmusser.net"
 __license__ = "AGPLv3+"
 
 # Version tuple for programmatic comparison
-VERSION_TUPLE = (0, 1, 8, 0)
+VERSION_TUPLE = (0, 1, 8, 1)
 
 # Export key components when package is imported
 __all__ = [


### PR DESCRIPTION
## Summary

- Bump package metadata from `0.1.8.0` to `0.1.8.1`
- Update README alpha-version text and changelog release heading
- Preserve the existing historical `v0.1.8.0` GitHub tag instead of moving it

## Why

TestPyPI successfully published and installed `0.1.8.0`, but production PyPI release cannot safely use the same version because the repository already has an older annotated `v0.1.8.0` tag. This patch moves the PyPI release target to `0.1.8.1` so the production tag can point at current `dev` without rewriting existing release history.

## Verification

- `git diff --check`
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_release_metadata.py -q`
- `env PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Packaging/build_dist.sh`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the package version from `0.1.8.0` to `0.1.8.1` so production PyPI can publish without reusing the existing `v0.1.8.0` tag. Updates the README alpha version text, the changelog release heading, and the package version tuple to match. This is release metadata only; no runtime behavior changes.

<sup>Written for commit 2c893cfc8d51effc41fd1b45b41a36da694de6d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

