### PR TITLE
feat(scheduling): unified schedules list + filter chips + rail (redesign PR-2)

### DIFF
--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -43,7 +43,10 @@ reminder or a `configured` automation, including one mid-transfer to the
 server — it keeps running locally until the server actually accepts
 it); **Paused** is anything disabled or explicitly paused; **Completed**
 is a fired one-time reminder or an archived automation, kept out of the
-default **All** view so it stays uncluttered. Each row shows a status
+default **All** view so it stays uncluttered (a one-time reminder that
+has already fired stays under **Completed** even if you re-enable it —
+re-enabling gives it no new run time; edit its schedule to arm it
+again). Each row shows a status
 glyph (`○` recurring, `▶` one-shot, `⏸` paused, `✓` completed), the
 title with the same owner/transfer-badge suffixes described below, and
 a subtitle line (the schedule summary plus a relative next-run time, or
@@ -53,7 +56,10 @@ with unread results carries a bold unread dot after its title.
 Automation-definition rows are **view-only from the Queue tab** —
 highlighting one opens the same read-only detail pane the Automations
 tab uses, but editing, running, transferring, or deleting a recurring
-question still happens from the **Automations** tab. Every reminder
+question still happens from the **Automations** tab. Pressing a
+reminder key (**e**, **r**, **x**, **space**, **d**) on a definition row
+says so ("This automation is managed on the Automations tab for now")
+rather than doing nothing. Every reminder
 action described in the rest of this page (edit, run now, delete, mark,
 enable/disable, move between owners) is unchanged and still reachable
 from the Queue tab exactly as before.
@@ -77,8 +83,13 @@ The Queue tab's pane header is a rail: **Create ▾** opens the chooser
 described below; **Mark all read** appears only once an automation
 result somewhere in the queue is unread, and clears every one of them
 in one press (the same action as pressing **a**, without needing to be
-on the Results tab first). Below the chip row, the filter box narrows
-the list by title or body text as you type.
+on the Results tab first). It — and the per-row unread dots — track
+results as they change: a result arriving from the server makes them
+appear without switching tabs, and marking everything read from the
+Results tab clears them here too. Below the chip row, the filter box
+narrows the list by title or question/body text as you type — not by
+status words like `missed`, which the unified list dropped along with
+the Status/Type columns.
 
 ## Status strip
 
@@ -609,6 +620,21 @@ The default bound is `handler_timeout_seconds` under `[scheduling]` in
 `config.toml` (**300** seconds). Set it to `0` (or negative) to disable the
 bound entirely — every handler may then run as long as it likes, and a
 wedged handler will wedge the scheduler, which is why the default is on.
+
+*Verified against the schedules redesign PR-2 final fix wave —
+2026-09-03 (docs pass against shipped code/tests, live check pending the
+redesign program's later PRs per spec §14: an automation created from
+the Queue rail's **Create ▾** now appears in the list immediately; a
+definition moved to the server keeps its earlier unread results in the
+Queue's count, so the unread dots and **Mark all read** agree with the
+Results tab's badge; results pulled from the server (or marked read
+anywhere) refresh both surfaces; reminder enable/disable and delete act
+under the row's OWN owner, so a server-owned row's change is pushed
+instead of silently reverted by the next sync; and the reminder keys
+answer honestly on a definition row. Pinned by
+`Tests/UI/test_schedules_unified_list.py`,
+`Tests/Scheduling/test_unified_rows.py`, and
+`Tests/Scheduling/test_scheduling_service.py`.)*
 
 *Verified against the schedules redesign PR-2 Task 4 fix wave —
 2026-09-03 (docs pass against shipped code/tests, live check pending the

--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -30,6 +30,33 @@ Server, last pull/push) above **Queue**, **Automations**, **Conflicts**,
 and **Results** tabs, with panels for the Schedule Queue, Task Detail, and
 Inspector.
 
+## The unified Queue list
+
+The Queue tab's Schedule Queue lists **both** reminders and recurring-
+question automation definitions in one table, spanning both owners
+(this device and any connected server) — no need to check the
+Automations tab separately just to see whether something is scheduled.
+A chip row above the table (**All · Active · Paused · Completed**)
+narrows it: **Active** is everything still armed to run (an enabled
+reminder or a `configured` automation, including one mid-transfer to the
+server — it keeps running locally until the server actually accepts
+it); **Paused** is anything disabled or explicitly paused; **Completed**
+is a fired one-time reminder or an archived automation, kept out of the
+default **All** view so it stays uncluttered. Each row shows a status
+glyph (`○` recurring, `▶` one-shot, `⏸` paused, `✓` completed), the
+title with the same owner/transfer-badge suffixes described below, and
+a subtitle line (the schedule summary plus a relative next-run time, or
+"— (paused)"/"— (disabled)" when nothing will fire). An automation row
+with unread results carries a bold unread dot after its title.
+
+Automation-definition rows are **view-only from the Queue tab** —
+highlighting one opens the same read-only detail pane the Automations
+tab uses, but editing, running, transferring, or deleting a recurring
+question still happens from the **Automations** tab. Every reminder
+action described in the rest of this page (edit, run now, delete, mark,
+enable/disable, move between owners) is unchanged and still reachable
+from the Queue tab exactly as before.
+
 ## Getting there
 
 - Press **Ctrl+7**, click **⌃7 Schedules** in the nav bar, or press
@@ -176,13 +203,17 @@ carries it.
 
 Press **space** on a highlighted task (or the **Disable** button in the
 detail pane) to disable it. A disabled task shows the text status
-**Disabled** in both the queue row and the detail badge, and its Next Run
-reads **— (disabled)** instead of a concrete time it will not honor.
+**Disabled** in the detail badge, the `⏸` glyph in the queue row (the
+unified list conveys status via glyph, not a separate Status column),
+and its Next Run reads **— (disabled)** instead of a concrete time it
+will not honor, in both the detail pane and the queue row's subtitle.
 Enabling it restores the recorded last outcome and the real next run.
 
 This covers a one-time reminder that has already fired: running it
-disables it and clears its next run, so it reads **Disabled** with a Next
-Run of **— (disabled)** — the same as a task you disabled by hand.
+disables it and clears its next run, so it reads **Disabled** in the
+detail badge with a Next Run of **— (disabled)** — the same as a task
+you disabled by hand. A fired one-time reminder shows the `✓` glyph in
+the queue and moves under the **Completed** chip.
 
 ## Ran late — what happens to overdue reminders
 
@@ -212,9 +243,11 @@ not running at the scheduled time.
   time, not from where it left off. Skipped occurrences are counted and
   surfaced, never re-run.
 - **The queue marks late tasks with a ◇ glyph** before the title, so a
-  glance at the Queue tab shows what fell behind. Typing `missed` into the
-  queue filter finds them (it also matches tasks whose last dispatch
-  *failed*, which is a different thing — see below).
+  glance at the Queue tab shows what fell behind. The queue filter
+  searches title and body text only (it no longer matches status words
+  like `missed` — the unified list dropped the old status/type keyword
+  search along with the Status/Type columns); search for the task's own
+  title to find it, or scan for the ◇ glyph.
 
 This state describes the **last** dispatch and heals itself: the next
 on-time firing clears the marker and the notice.
@@ -541,6 +574,19 @@ The default bound is `handler_timeout_seconds` under `[scheduling]` in
 `config.toml` (**300** seconds). Set it to `0` (or negative) to disable the
 bound entirely — every handler may then run as long as it likes, and a
 wedged handler will wedge the scheduler, which is why the default is on.
+
+*Verified against the schedules redesign PR-2 Task 2 fix wave —
+2026-09-03 (docs pass against shipped code/tests, live check pending the
+redesign program's later PRs per spec §14: the Queue tab's unified list
+— reminders + automation definitions spanning both owners in one table,
+the All/Active/Paused/Completed chip row, per-row status glyphs, the
+combined schedule-summary-plus-next-run subtitle line replacing the old
+Type/Status/Next-Run columns, the unread dot on a definition row, and
+detail-pane routing between the reminder and definition detail panes on
+highlight. Automation-definition rows stay view-only from the Queue tab
+in this PR; every reminder action is unchanged. Pinned by
+`Tests/UI/test_schedules_unified_list.py` and the updated assertions in
+`Tests/UI/test_schedules_workbench.py`.)*
 
 *Verified against the schedules redesign PR-1 fix wave — 2026-09-02
 (docs pass against shipped code/tests, live check pending the redesign

--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -25,10 +25,11 @@ If creation is accepted but no completed briefing appears, inspect the exact bri
 ## What this screen is for
 
 Schedules controls when jobs, watchlists, and workflows run. The screen
-has no single on-screen title; it opens on a sync status bar (Local /
-Server, last pull/push) above **Queue**, **Automations**, **Conflicts**,
-and **Results** tabs, with panels for the Schedule Queue, Task Detail, and
-Inspector.
+has no single on-screen title; a one-line scheduler-liveness indicator
+sits above **Queue**, **Automations**, **Conflicts**, and **Results**
+tabs, with panels for the Schedule Queue, Task Detail, and Inspector. A
+status strip (sync bar + Conflicts count) runs along the bottom of the
+whole screen, shared across every tab — see "Status strip", below.
 
 ## The unified Queue list
 
@@ -56,6 +57,40 @@ question still happens from the **Automations** tab. Every reminder
 action described in the rest of this page (edit, run now, delete, mark,
 enable/disable, move between owners) is unchanged and still reachable
 from the Queue tab exactly as before.
+
+Watchlist checks and briefings are not in this list — they have their
+own home in Watchlists' **Sources** pane, whose **Next check** column
+shows the same "when will this run again" signal the Queue used to
+project for them (see the [Watchlists guide](watchlists.md)).
+
+Every row's relative next-run text ("in 25m", "overdue 2h") stays
+current on its own: the visible Queue rows repaint once a minute
+without reloading the list, so a bucket a row was in a minute ago
+("in 1h") reads correctly once it crosses into the next one ("in 59m")
+even if you never touch the screen. Switching away to another tab in
+the app pauses that repaint; coming back refreshes it immediately so
+nothing is left stale from the time it was hidden.
+
+## Queue rail
+
+The Queue tab's pane header is a rail: **Create ▾** opens the chooser
+described below; **Mark all read** appears only once an automation
+result somewhere in the queue is unread, and clears every one of them
+in one press (the same action as pressing **a**, without needing to be
+on the Results tab first). Below the chip row, the filter box narrows
+the list by title or body text as you type.
+
+## Status strip
+
+A status strip runs along the bottom of the screen, below the tabs and
+shared by all of them: the sync bar (Local/Server, last pull/push —
+see "Sync bar honesty", below) on the left, and a **Conflicts** button
+on the right showing the current owner's scheduled-task conflict count
+("Conflicts (2)", or plain "Conflicts" with none). Clicking it switches
+to the Conflicts tab. At narrow terminal widths the sync bar's
+timestamps drop to save space, the same compacting the side panes
+already do; the owner buttons and any sync error stay visible either
+way.
 
 ## Getting there
 
@@ -147,13 +182,13 @@ Type/Schedule rows unchanged — the grouped layout is reminder-specific.
 
 ## Creating a scheduled task
 
-Press **c**, or click **+ New** in the Queue tab's pane header, to open
-the create form. Clicking **+ New** first asks which kind of task you
-want — **Reminder…** or **Recurring question…** — since a recurring
-question is a different kind of definition, not just another schedule
-shape; **c** always opens the reminder form directly. The form scrolls
-when the terminal is short; the live "Runs: …" preview, validation, and
-Save/Cancel stay pinned at the bottom while you edit.
+Press **c**, or click **Create ▾** in the Queue tab's rail header, to
+open the create form. Clicking **Create ▾** first asks which kind of
+task you want — **Reminder…** or **Recurring question…** — since a
+recurring question is a different kind of definition, not just another
+schedule shape; **c** always opens the reminder form directly. The form
+scrolls when the terminal is short; the live "Runs: …" preview,
+validation, and Save/Cancel stay pinned at the bottom while you edit.
 
 Every create/edit form also has a **Runs on** selector — **This device**
 or **Server (\<id\>)** when a scheduling server is connected — defaulting
@@ -400,8 +435,8 @@ toast.
 
 A recurring question runs a scoped search on a schedule and reports what
 it finds — a different kind of task than a reminder. Open its create
-form from the Queue tab's **+ New** chooser ("Recurring question…") or
-the Automations tab's own **+ New** button. Its v1 fields: a name, the
+form from the Queue tab's **Create ▾** chooser ("Recurring question…")
+or the Automations tab's own **+ New** button. Its v1 fields: a name, the
 question itself, which sources to search (all readable library sources,
 or a specific choice of Media / Notes / Chats — collections, tags, and
 saved searches are not offered yet), the schedule (the same one-time/
@@ -574,6 +609,20 @@ The default bound is `handler_timeout_seconds` under `[scheduling]` in
 `config.toml` (**300** seconds). Set it to `0` (or negative) to disable the
 bound entirely — every handler may then run as long as it likes, and a
 wedged handler will wedge the scheduler, which is why the default is on.
+
+*Verified against the schedules redesign PR-2 Task 4 fix wave —
+2026-09-03 (docs pass against shipped code/tests, live check pending the
+redesign program's later PRs per spec §14: the Queue rail's **Create ▾**
+relabel (was "+ New") and **Mark all read** button, the bottom status
+strip's relocation of the sync bar plus its new **Conflicts** count
+button, the Watchlists Sources pane's restored **Next check** column
+and its cross-reference here, and the 60-second relative-next-run
+ticker — repaints the visible Queue rows in place, pauses while another
+screen covers Schedules, and refreshes immediately on return, never
+reloading data. Pinned by `Tests/UI/test_schedules_next_run_relative.py`
+(tick/suspend/resume), `Tests/UI/test_schedules_workbench.py` (rail +
+status strip), `Tests/UI/test_schedules_new_button.py` (Create ▾), and
+`Tests/Watchlists/test_watchlists_sources_pane.py` (Next check).)*
 
 *Verified against the schedules redesign PR-2 Task 2 fix wave —
 2026-09-03 (docs pass against shipped code/tests, live check pending the

--- a/Docs/User_Guide/watchlists.md
+++ b/Docs/User_Guide/watchlists.md
@@ -69,6 +69,13 @@ reports both the total selected count and how many are hidden by filters.
 These shortcuts appear in Help and the command palette only while the Sources
 table owns focus.
 
+The table's **Next check** column shows when a local subscription's next
+scheduled check falls due (its last check, or creation time if it has
+never been checked, plus its check frequency) — this is where that
+signal lives; the Schedules screen's Queue no longer projects watchlist
+checks into its own list. A server-backed source has no check-frequency
+equivalent to compute from, so this column reads "-" for those rows.
+
 ## Checking a source while a check is already running
 
 One check of a given page runs at a time. If you press **Check now** for a

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1875,7 +1875,7 @@
     },
     {
       "call_count": 30,
-      "diagnostic_digest": "85faf1dd88102c6d707d",
+      "diagnostic_digest": "6590cf0ec2798004ac25",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/services/scheduling_service.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2896,8 +2896,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 26,
-      "diagnostic_digest": "a426ac0b3afb8946aa94",
+      "call_count": 28,
+      "diagnostic_digest": "d95d225ae19609a110d2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11304,6 +11304,6 @@
     "path_privacy_candidate_calls": 714,
     "persistent_sink_files": 10,
     "task_492_calls": 1337,
-    "task_494_calls": 7563
+    "task_494_calls": 7565
   }
 }

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -381,6 +381,106 @@ async def test_delete_reminder_server_falls_back_to_tombstone_on_generic_error(d
     assert tombstone is not None
 
 
+# ---------------------------------------------------------------------------
+# Cross-owner writes (final review F4): redesign PR-2's Queue lists
+# reminders across owners, so "the row under the cursor" is no longer
+# guaranteed to be the service's ACTIVE owner. Every reminder write now
+# takes the ROW's owner, the same `owner_id=` thread `create_reminder`
+# established -- without it a `server:` row's toggle/delete took the
+# local-only branch: no server call, no pending mutation, no tombstone,
+# and the next pull silently undid the user's action.
+# ---------------------------------------------------------------------------
+
+
+async def _server_owned_row(db, server_client):
+    """A local row owned by `server:1`, created while `local` is active."""
+    svc = SchedulingService(db=db, server_client=server_client, runtime_source="local")
+    server_client.create_reminder.side_effect = ServerUnavailableError("offline")
+    task = await svc.create_reminder(
+        _reminder_payload("Server row"), owner_id="server:1"
+    )
+    db.update_reminder_task(task.id, server_id="srv-1")
+    db.delete_pending_mutation_for_record(task.id, "reminder_task", "server:1")
+    server_client.create_reminder.side_effect = None
+    assert svc.owner_id == "local"
+    return svc, task
+
+
+@pytest.mark.asyncio
+async def test_update_reminder_for_server_row_reaches_the_server_while_local_active(db):
+    server_client = AsyncMock()
+    svc, task = await _server_owned_row(db, server_client)
+    server_client.update_reminder.return_value = {
+        "id": "srv-1",
+        "title": "Server row",
+        "schedule_kind": "one_time",
+        "run_at": "2026-07-20T14:00:00+00:00",
+        "enabled": False,
+    }
+
+    await svc.update_reminder(task.id, {"enabled": False}, owner_id=task.owner_id)
+
+    server_client.update_reminder.assert_awaited_once()
+    assert server_client.update_reminder.await_args.args[0] == "srv-1"
+
+
+@pytest.mark.asyncio
+async def test_update_reminder_for_server_row_records_mutation_when_offline(db):
+    server_client = AsyncMock()
+    svc, task = await _server_owned_row(db, server_client)
+    server_client.update_reminder.side_effect = ServerUnavailableError("offline")
+
+    await svc.update_reminder(task.id, {"enabled": False}, owner_id=task.owner_id)
+
+    pending = db.get_pending_mutations("server:1", primitive="reminder_task")
+    assert [row["payload"]["action"] for row in pending] == ["update"]
+    assert db.get_reminder_task(task.id)["enabled"] == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_reminder_for_server_row_reaches_the_server_while_local_active(db):
+    server_client = AsyncMock()
+    svc, task = await _server_owned_row(db, server_client)
+    server_client.delete_reminder.return_value = {"deleted": True}
+
+    assert await svc.delete_reminder(task.id, owner_id=task.owner_id) is True
+
+    server_client.delete_reminder.assert_awaited_once_with("srv-1")
+    assert await svc.get_reminder(task.id) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_reminder_for_server_row_records_tombstone_when_offline(db):
+    server_client = AsyncMock()
+    svc, task = await _server_owned_row(db, server_client)
+    server_client.delete_reminder.side_effect = ServerUnavailableError("offline")
+
+    assert await svc.delete_reminder(task.id, owner_id=task.owner_id) is True
+
+    assert await svc.get_reminder(task.id) is None
+    assert db.get_tombstone(task.id, "reminder_task", "server:1") is not None
+
+
+@pytest.mark.asyncio
+async def test_local_row_writes_record_nothing_while_a_server_owner_is_active(db):
+    """The inverse guard: threading the ROW's owner must not start
+    recording server mutations for LOCAL rows just because the active
+    owner happens to be a server."""
+    server_client = AsyncMock()
+    svc = SchedulingService(db=db, server_client=server_client, runtime_source="local")
+    task = await svc.create_reminder(_reminder_payload("Local row"))
+    svc.set_owner("server:1")
+
+    await svc.update_reminder(task.id, {"enabled": False}, owner_id=task.owner_id)
+    assert db.get_pending_mutations("local", primitive="reminder_task") == []
+    assert db.get_pending_mutations("server:1", primitive="reminder_task") == []
+    server_client.update_reminder.assert_not_awaited()
+
+    assert await svc.delete_reminder(task.id, owner_id=task.owner_id) is True
+    server_client.delete_reminder.assert_not_awaited()
+    assert db.get_tombstone(task.id, "reminder_task", "local") is None
+
+
 @pytest.mark.asyncio
 async def test_delete_reminder_returns_false_for_missing_id(db):
     svc = SchedulingService(db=db, runtime_source="local")

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -461,6 +461,102 @@ async def test_list_tasks_filters_watchlist_by_owner(db):
     projection.list_jobs.assert_called_once_with(owner_id="server:1")
 
 
+# --- spans-owners `owner_id` parameter (schedules-redesign PR-2, Task 1) ---
+#
+# `list_tasks()` (zero args, the default `...` sentinel) must keep behaving
+# EXACTLY as every test above pins it -- these add the new opt-in shape
+# without touching that default path.
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_default_still_scopes_to_current_owner(db):
+    """Byte-for-byte preservation: calling with no argument at all must
+    still scope reminders to `self.owner_id`, same as before this
+    parameter existed."""
+    svc = SchedulingService(db=db, runtime_source="local")
+    db.create_reminder_task(
+        owner_id="local",
+        title="Local reminder",
+        schedule_kind="one_time",
+        run_at="2026-07-20T14:00:00+00:00",
+    )
+    db.create_reminder_task(
+        owner_id="server:9",
+        title="Server reminder",
+        schedule_kind="one_time",
+        run_at="2026-07-21T14:00:00+00:00",
+    )
+
+    tasks = await svc.list_tasks()
+
+    assert [t.title for t in tasks] == ["Local reminder"]
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_owner_id_none_spans_every_owner(db):
+    """The new spans-owners seam: `owner_id=None` returns reminders from
+    EVERY owner, not just `self.owner_id` -- the redesign's unified Queue
+    list (plan ruling, survey SS2's cross-owner listing gap)."""
+    svc = SchedulingService(db=db, runtime_source="local")
+    db.create_reminder_task(
+        owner_id="local",
+        title="Local reminder",
+        schedule_kind="one_time",
+        run_at="2026-07-20T14:00:00+00:00",
+    )
+    db.create_reminder_task(
+        owner_id="server:9",
+        title="Server reminder",
+        schedule_kind="one_time",
+        run_at="2026-07-21T14:00:00+00:00",
+    )
+
+    tasks = await svc.list_tasks(owner_id=None)
+
+    assert {t.title for t in tasks} == {"Local reminder", "Server reminder"}
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_owner_id_explicit_string_scopes_to_that_owner(db):
+    """A specific owner id (not the service's current one) scopes
+    reminders to just that owner."""
+    svc = SchedulingService(db=db, runtime_source="local")
+    db.create_reminder_task(
+        owner_id="local",
+        title="Local reminder",
+        schedule_kind="one_time",
+        run_at="2026-07-20T14:00:00+00:00",
+    )
+    db.create_reminder_task(
+        owner_id="server:9",
+        title="Server reminder",
+        schedule_kind="one_time",
+        run_at="2026-07-21T14:00:00+00:00",
+    )
+
+    tasks = await svc.list_tasks(owner_id="server:9")
+
+    assert [t.title for t in tasks] == ["Server reminder"]
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_spans_owners_keeps_projections_scoped_to_current_owner(db):
+    """Watchlist/briefing `list_jobs` only STAMP the owner id onto every
+    row (their underlying read has no per-owner filter) -- passing them
+    `owner_id=None` would fail their `ScheduledTask.owner_id: str` field.
+    A spans-owners reminder listing must not do that: projections stay
+    scoped to `self.owner_id` regardless of the reminder-side argument."""
+    svc = SchedulingService(db=db, runtime_source="local")
+    projection = MagicMock(spec=WatchlistProjection)
+    projection.list_jobs.return_value = []
+    svc.watchlist_projection = projection
+
+    tasks = await svc.list_tasks(owner_id=None)
+
+    assert tasks == []
+    projection.list_jobs.assert_called_once_with(owner_id="local")
+
+
 # --- briefing projection (task-1810): scheduled briefings on the unified list ---
 #
 # Mirrors the watchlist-projection tests immediately above -- same shape,

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -663,6 +663,33 @@ async def test_list_tasks_includes_both_watchlist_and_briefing_projections(db):
 
 
 @pytest.mark.asyncio
+async def test_list_tasks_include_projections_false_skips_the_projection_reads(db):
+    """redesign PR-2 Task 2 review, finding 2: the unified Queue's
+    `load_tasks` immediately discards every `ScheduledTask` row, so
+    `include_projections=False` must stop `list_tasks` from calling
+    `list_jobs` on either projection at all -- not just from returning
+    their rows. `list_jobs.assert_not_called()` is the counting-fake pin
+    the review asked for; the DEFAULT (`include_projections=True`, the
+    existing tests above) must keep calling both.
+    """
+    svc = SchedulingService(db=db, runtime_source="local")
+    await svc.create_reminder(_reminder_payload("Reminder"))
+
+    watchlist_projection = MagicMock(spec=WatchlistProjection)
+    briefing_projection = MagicMock(spec=BriefingProjection)
+    svc.watchlist_projection = watchlist_projection
+    svc.briefing_projection = briefing_projection
+
+    tasks = await svc.list_tasks(include_projections=False)
+
+    watchlist_projection.list_jobs.assert_not_called()
+    briefing_projection.list_jobs.assert_not_called()
+    assert len(tasks) == 1
+    assert isinstance(tasks[0], ReminderTask)
+    assert tasks[0].title == "Reminder"
+
+
+@pytest.mark.asyncio
 async def test_list_tasks_includes_a_cadenced_briefing_schedule_ac1(db, tmp_path):
     """AC #1: a watchlist with a non-NULL briefing_cadence_seconds shows up
     as a scheduled task on the unified list, alongside reminders and

--- a/Tests/Scheduling/test_unified_rows.py
+++ b/Tests/Scheduling/test_unified_rows.py
@@ -118,23 +118,65 @@ class TestReminderHasFired:
 
 
 @pytest.mark.parametrize(
-    "transfer_state",
-    [
-        None,
-        "to_server_pending",
-        "to_server_failed",
-        "to_server_sent",
-        "from_server_pending",
-    ],
+    "transfer_state", [None, "to_server_pending", "to_server_failed"]
 )
-def test_enabled_reminder_stays_active_regardless_of_transfer_state(transfer_state):
-    """spec SS3 / plan ruling 2: enabled reminders are Active, full stop --
-    a reminder's Active bucket does not gate on transfer_state at all
-    (unlike a definition's -- see `definition_is_armed` below). Every
-    dormant/in-flight transfer state must still stay Active."""
+def test_enabled_reminder_stays_active_when_not_dormant(transfer_state):
+    """spec SS3: Active "includ[es] to_server_pending/to_server_failed...
+    they still execute locally" -- these are NOT in DORMANT_TRANSFER_STATES
+    and keep arming, same as the definition side (`definition_is_armed`)."""
     task = _reminder(enabled=True, transfer_state=transfer_state)
     rows = build_unified_rows([task], [], [])
     assert rows[0].bucket == "active"
+
+
+@pytest.mark.parametrize("transfer_state", ["to_server_sent", "from_server_pending"])
+def test_enabled_reminder_parks_under_paused_when_dormant(transfer_state):
+    """Review round 1, finding 1: `_reminder_bucket` must mirror
+    `_definition_bucket`'s dormant fallback (see
+    `test_configured_definition_parks_under_paused_when_dormant` below) --
+    `PriorityQueue.load()` excludes a dormant transfer_state for BOTH
+    primitives (`scheduler/queue.py:96-108`), and
+    `list_reminder_tasks(armable_only=True)`/`reminders_due_before`
+    already apply the same exclusion on the reminder side. An enabled
+    reminder sitting out a dormant transfer is not "armed" -- it does not
+    still execute locally -- so it parks under Paused, not Active;
+    `transfer_state` still carries the raw dormant value for the badge."""
+    task = _reminder(enabled=True, transfer_state=transfer_state)
+    rows = build_unified_rows([task], [], [])
+    assert rows[0].bucket == "paused"
+    assert rows[0].transfer_state == transfer_state
+
+
+def _bucket_for(kind: str, transfer_state: str | None) -> str:
+    """Build one armed (enabled/configured) row of ``kind`` and return its bucket."""
+    if kind == "reminder":
+        rows = build_unified_rows(
+            [_reminder(enabled=True, transfer_state=transfer_state)], [], []
+        )
+    else:
+        definition = _definition(lifecycle="configured", transfer_state=transfer_state)
+        rows = build_unified_rows([], [definition], [])
+    return rows[0].bucket
+
+
+@pytest.mark.parametrize("kind", ["reminder", "definition"])
+@pytest.mark.parametrize(
+    "transfer_state", [None, "to_server_pending", "to_server_failed"]
+)
+def test_both_primitives_stay_active_when_not_dormant(kind, transfer_state):
+    """Pins the symmetry itself (review round 1, finding 2): reminders and
+    definitions must agree on which transfer states still count as
+    "armed" -- neither primitive gets its own rule."""
+    assert _bucket_for(kind, transfer_state) == "active"
+
+
+@pytest.mark.parametrize("kind", ["reminder", "definition"])
+@pytest.mark.parametrize("transfer_state", ["to_server_sent", "from_server_pending"])
+def test_both_primitives_park_under_paused_when_dormant(kind, transfer_state):
+    """Pins the symmetry itself (review round 1, finding 2): a dormant
+    transfer state excludes a row from Active on BOTH primitives, not
+    just definitions."""
+    assert _bucket_for(kind, transfer_state) == "paused"
 
 
 def test_disabled_unfired_reminder_is_paused():

--- a/Tests/Scheduling/test_unified_rows.py
+++ b/Tests/Scheduling/test_unified_rows.py
@@ -1,0 +1,495 @@
+"""Tests for the pure unified-row adapter (schedules redesign PR-2, Task 1).
+
+Covers the bucket table (every chip x both primitives x transfer states),
+the dual local/server id-space unread resolution (the survey's warning --
+a server-mirrored definition's results must still be counted), sort
+orders, and search. No Textual, no DB, no asyncio -- `unified_rows.py` is
+pure, so these are plain function-call tests.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tldw_chatbook.Scheduling.models import ReminderTask, ScheduleKind
+from tldw_chatbook.UI.Screens.scheduling.unified_rows import (
+    UnifiedRow,
+    build_unified_rows,
+    definition_is_armed,
+    filter_rows,
+    reminder_has_fired,
+    sort_rows,
+)
+
+
+def _reminder(**overrides) -> ReminderTask:
+    defaults = dict(
+        id="rem-1",
+        owner_id="local",
+        title="Recurring Reminder",
+        body="Reminder body text",
+        schedule_kind=ScheduleKind.RECURRING,
+        cron="0 9 * * *",
+        timezone="UTC",
+        enabled=True,
+        next_run_at=datetime(2026, 9, 5, 9, 0, tzinfo=timezone.utc),
+        last_run_at=None,
+        transfer_state=None,
+    )
+    defaults.update(overrides)
+    return ReminderTask(**defaults)
+
+
+def _one_time_reminder(**overrides) -> ReminderTask:
+    defaults = dict(
+        schedule_kind=ScheduleKind.ONE_TIME,
+        run_at=datetime(2026, 9, 5, 9, 0, tzinfo=timezone.utc),
+        cron=None,
+        timezone=None,
+    )
+    defaults.update(overrides)
+    return _reminder(**defaults)
+
+
+def _definition(**overrides) -> dict:
+    defaults = dict(
+        id="def-1",
+        server_id=None,
+        owner_id="local",
+        name="A Definition",
+        lifecycle="configured",
+        transfer_state=None,
+        schedule={"kind": "cron", "cron": "0 9 * * *", "timezone": "UTC"},
+        next_run_at="2026-09-05T09:00:00+00:00",
+        updated_at="2026-09-01T00:00:00+00:00",
+        input={"question": "What changed?"},
+    )
+    defaults.update(overrides)
+    return defaults
+
+
+def _result(**overrides) -> dict:
+    defaults = dict(
+        id="res-1",
+        definition_id="def-1",
+        owner_id="local",
+        review_state="unread",
+        kind="finding",
+    )
+    defaults.update(overrides)
+    return defaults
+
+
+# ---------------------------------------------------------------------------
+# Bucket table -- reminders
+# ---------------------------------------------------------------------------
+
+
+class TestReminderHasFired:
+    def test_fired_when_disabled_no_next_run_but_has_run(self):
+        task = _reminder(
+            enabled=False,
+            next_run_at=None,
+            last_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
+        )
+        assert reminder_has_fired(task) is True
+
+    def test_not_fired_when_never_run(self):
+        task = _reminder(enabled=False, next_run_at=None, last_run_at=None)
+        assert reminder_has_fired(task) is False
+
+    def test_not_fired_when_enabled(self):
+        task = _reminder(
+            enabled=True,
+            next_run_at=None,
+            last_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
+        )
+        assert reminder_has_fired(task) is False
+
+    def test_not_fired_when_next_run_still_set(self):
+        task = _reminder(
+            enabled=False,
+            next_run_at=datetime(2026, 9, 5, tzinfo=timezone.utc),
+            last_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
+        )
+        assert reminder_has_fired(task) is False
+
+
+@pytest.mark.parametrize(
+    "transfer_state",
+    [
+        None,
+        "to_server_pending",
+        "to_server_failed",
+        "to_server_sent",
+        "from_server_pending",
+    ],
+)
+def test_enabled_reminder_stays_active_regardless_of_transfer_state(transfer_state):
+    """spec SS3 / plan ruling 2: enabled reminders are Active, full stop --
+    a reminder's Active bucket does not gate on transfer_state at all
+    (unlike a definition's -- see `definition_is_armed` below). Every
+    dormant/in-flight transfer state must still stay Active."""
+    task = _reminder(enabled=True, transfer_state=transfer_state)
+    rows = build_unified_rows([task], [], [])
+    assert rows[0].bucket == "active"
+
+
+def test_disabled_unfired_reminder_is_paused():
+    task = _reminder(
+        enabled=False, next_run_at=datetime(2026, 9, 5, tzinfo=timezone.utc)
+    )
+    rows = build_unified_rows([task], [], [])
+    assert rows[0].bucket == "paused"
+
+
+def test_fired_reminder_is_completed():
+    task = _reminder(
+        enabled=False,
+        next_run_at=None,
+        last_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+    rows = build_unified_rows([task], [], [])
+    assert rows[0].bucket == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Bucket table -- definitions
+# ---------------------------------------------------------------------------
+
+
+class TestDefinitionIsArmed:
+    @pytest.mark.parametrize(
+        "transfer_state", [None, "to_server_pending", "to_server_failed"]
+    )
+    def test_armed_when_configured_and_not_dormant(self, transfer_state):
+        assert definition_is_armed(_definition(transfer_state=transfer_state)) is True
+
+    @pytest.mark.parametrize(
+        "transfer_state", ["to_server_sent", "from_server_pending"]
+    )
+    def test_not_armed_when_dormant(self, transfer_state):
+        assert definition_is_armed(_definition(transfer_state=transfer_state)) is False
+
+    @pytest.mark.parametrize("lifecycle", ["paused", "archived", "disabled"])
+    def test_not_armed_when_not_configured(self, lifecycle):
+        assert definition_is_armed(_definition(lifecycle=lifecycle)) is False
+
+
+@pytest.mark.parametrize(
+    "transfer_state", [None, "to_server_pending", "to_server_failed"]
+)
+def test_configured_definition_stays_active_when_not_dormant(transfer_state):
+    definition = _definition(lifecycle="configured", transfer_state=transfer_state)
+    rows = build_unified_rows([], [definition], [])
+    assert rows[0].bucket == "active"
+
+
+@pytest.mark.parametrize("transfer_state", ["to_server_sent", "from_server_pending"])
+def test_configured_definition_parks_under_paused_when_dormant(transfer_state):
+    """Judgment call (documented in unified_rows._definition_bucket): a
+    `configured` definition sitting out a dormant transfer is not counted
+    Active (mirrors `list_armable_automation_definitions`'s own gate), and
+    `UnifiedRow.bucket` has no 4th "in transfer" state -- it is parked
+    under Paused so it still appears under the All chip. `transfer_state`
+    still carries the raw dormant value for the caller's own badge."""
+    definition = _definition(lifecycle="configured", transfer_state=transfer_state)
+    rows = build_unified_rows([], [definition], [])
+    assert rows[0].bucket == "paused"
+    assert rows[0].transfer_state == transfer_state
+
+
+def test_paused_lifecycle_definition_is_paused():
+    rows = build_unified_rows([], [_definition(lifecycle="paused")], [])
+    assert rows[0].bucket == "paused"
+
+
+def test_disabled_lifecycle_definition_is_paused():
+    """Plan ruling 2's explicit trailing sentence: disabled-lifecycle
+    definitions bucket as Paused."""
+    rows = build_unified_rows([], [_definition(lifecycle="disabled")], [])
+    assert rows[0].bucket == "paused"
+
+
+def test_archived_lifecycle_definition_is_completed():
+    rows = build_unified_rows([], [_definition(lifecycle="archived")], [])
+    assert rows[0].bucket == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Glyphs (spec SS4)
+# ---------------------------------------------------------------------------
+
+
+def test_recurring_active_reminder_glyph_is_circle():
+    rows = build_unified_rows([_reminder(schedule_kind=ScheduleKind.RECURRING)], [], [])
+    assert rows[0].glyph == "○"
+
+
+def test_one_time_active_reminder_glyph_is_triangle():
+    rows = build_unified_rows([_one_time_reminder()], [], [])
+    assert rows[0].glyph == "▶"
+
+
+def test_paused_reminder_glyph_is_pause_bar():
+    rows = build_unified_rows([_reminder(enabled=False)], [], [])
+    assert rows[0].glyph == "⏸"
+
+
+def test_completed_reminder_glyph_is_check():
+    rows = build_unified_rows(
+        [
+            _reminder(
+                enabled=False,
+                next_run_at=None,
+                last_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
+            )
+        ],
+        [],
+        [],
+    )
+    assert rows[0].glyph == "✓"
+
+
+def test_cron_definition_glyph_is_circle():
+    rows = build_unified_rows([], [_definition()], [])
+    assert rows[0].glyph == "○"
+
+
+def test_one_time_definition_glyph_is_triangle():
+    schedule = {"kind": "one_time", "run_at": "2026-09-05T09:00:00+00:00"}
+    rows = build_unified_rows([], [_definition(schedule=schedule)], [])
+    assert rows[0].glyph == "▶"
+
+
+def test_archived_definition_glyph_is_check_not_circle():
+    rows = build_unified_rows([], [_definition(lifecycle="archived")], [])
+    assert rows[0].glyph == "✓"
+
+
+# ---------------------------------------------------------------------------
+# Unread resolution across both id spaces (plan ruling 3 / survey warning)
+# ---------------------------------------------------------------------------
+
+
+def test_unread_count_resolves_across_local_and_server_id_spaces():
+    """The survey's warning IS the test: a server-mirrored definition's
+    results must be counted even though ONE of the two results below
+    carries the SERVER's id (not the definition's own local `id`)."""
+    definition = _definition(id="def-local-1", server_id="srv-77")
+    results = [
+        _result(definition_id="srv-77", review_state="unread"),  # server id space
+        _result(definition_id="def-local-1", review_state="unread"),  # local id space
+        _result(definition_id="srv-77", review_state="read"),  # not unread -- excluded
+        _result(definition_id="unrelated-id", review_state="unread"),  # matches nothing
+    ]
+    rows = build_unified_rows([], [definition], results)
+    assert rows[0].unread_count == 2
+
+
+def test_reminder_rows_never_carry_unread_count():
+    rows = build_unified_rows([_reminder()], [], [_result(definition_id="rem-1")])
+    assert rows[0].unread_count == 0
+
+
+def test_zero_unread_when_no_matching_results():
+    rows = build_unified_rows(
+        [], [_definition()], [_result(definition_id="def-1", review_state="read")]
+    )
+    assert rows[0].unread_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Filter (chip + search)
+# ---------------------------------------------------------------------------
+
+
+def _mixed_rows() -> list[UnifiedRow]:
+    return build_unified_rows(
+        reminders=[
+            _reminder(id="active-rem", title="Ping the server"),
+            _reminder(
+                id="paused-rem",
+                title="Weekly check",
+                enabled=False,
+                next_run_at=datetime(2026, 9, 5, tzinfo=timezone.utc),
+            ),
+            _reminder(
+                id="done-rem",
+                title="Old one-shot",
+                enabled=False,
+                next_run_at=None,
+                last_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
+            ),
+        ],
+        definitions=[
+            _definition(
+                id="active-def", name="Daily digest", input={"question": "Any outages?"}
+            ),
+            _definition(id="paused-def", name="Held automation", lifecycle="paused"),
+            _definition(
+                id="archived-def", name="Retired automation", lifecycle="archived"
+            ),
+        ],
+        results=[],
+    )
+
+
+def test_chip_all_excludes_completed():
+    rows = filter_rows(_mixed_rows(), chip="all", query="")
+    buckets = {row.bucket for row in rows}
+    assert buckets == {"active", "paused"}
+    assert len(rows) == 4
+
+
+def test_chip_active_only():
+    rows = filter_rows(_mixed_rows(), chip="active", query="")
+    assert {row.row_id for row in rows} == {
+        "reminder:active-rem",
+        "definition:active-def",
+    }
+
+
+def test_chip_paused_only():
+    rows = filter_rows(_mixed_rows(), chip="paused", query="")
+    assert {row.row_id for row in rows} == {
+        "reminder:paused-rem",
+        "definition:paused-def",
+    }
+
+
+def test_chip_completed_only():
+    rows = filter_rows(_mixed_rows(), chip="completed", query="")
+    assert {row.row_id for row in rows} == {
+        "reminder:done-rem",
+        "definition:archived-def",
+    }
+
+
+def test_search_matches_title_case_insensitively():
+    rows = filter_rows(_mixed_rows(), chip="all", query="DIGEST")
+    assert {row.row_id for row in rows} == {"definition:active-def"}
+
+
+def test_search_matches_question_body_not_just_title():
+    rows = filter_rows(_mixed_rows(), chip="all", query="outages")
+    assert {row.row_id for row in rows} == {"definition:active-def"}
+
+
+def test_blank_search_matches_everything_in_chip():
+    rows = filter_rows(_mixed_rows(), chip="all", query="   ")
+    assert len(rows) == 4
+
+
+def test_search_with_no_match_returns_empty():
+    rows = filter_rows(_mixed_rows(), chip="all", query="nonexistent-xyz")
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Sort (plan ruling 5)
+# ---------------------------------------------------------------------------
+
+
+def test_active_sorts_by_next_run_ascending_none_last():
+    soon = _reminder(id="soon", next_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc))
+    later = _reminder(
+        id="later", next_run_at=datetime(2026, 9, 10, tzinfo=timezone.utc)
+    )
+    unscheduled = _reminder(
+        id="unscheduled", next_run_at=None, cron="0 9 * * *", timezone="UTC"
+    )
+    rows = build_unified_rows([later, unscheduled, soon], [], [])
+    ordered = sort_rows(rows, "active")
+    assert [row.row_id for row in ordered] == [
+        "reminder:soon",
+        "reminder:later",
+        "reminder:unscheduled",
+    ]
+
+
+def test_paused_sorts_by_recency_descending_none_last():
+    recent = _reminder(
+        id="recent",
+        enabled=False,
+        next_run_at=datetime(2026, 9, 5, tzinfo=timezone.utc),
+        last_run_at=datetime(2026, 9, 2, tzinfo=timezone.utc),
+    )
+    older = _reminder(
+        id="older",
+        enabled=False,
+        next_run_at=datetime(2026, 9, 5, tzinfo=timezone.utc),
+        last_run_at=datetime(2026, 8, 1, tzinfo=timezone.utc),
+    )
+    never_run = _reminder(
+        id="never-run",
+        enabled=False,
+        next_run_at=datetime(2026, 9, 5, tzinfo=timezone.utc),
+        last_run_at=None,
+    )
+    rows = build_unified_rows([older, never_run, recent], [], [])
+    ordered = sort_rows(rows, "paused")
+    assert [row.row_id for row in ordered] == [
+        "reminder:recent",
+        "reminder:older",
+        "reminder:never-run",
+    ]
+
+
+def test_completed_sorts_definitions_by_updated_at_descending():
+    newer = _definition(
+        id="newer", lifecycle="archived", updated_at="2026-09-05T00:00:00+00:00"
+    )
+    older = _definition(
+        id="older", lifecycle="archived", updated_at="2026-09-01T00:00:00+00:00"
+    )
+    rows = build_unified_rows([], [newer, older], [])
+    ordered = sort_rows(rows, "completed")
+    assert [row.row_id for row in ordered] == ["definition:newer", "definition:older"]
+
+
+def test_all_chip_puts_active_rows_first_then_paused_by_recency():
+    active_far = _reminder(
+        id="active-far", next_run_at=datetime(2026, 9, 20, tzinfo=timezone.utc)
+    )
+    active_near = _reminder(
+        id="active-near", next_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc)
+    )
+    paused_recent = _reminder(
+        id="paused-recent",
+        enabled=False,
+        next_run_at=datetime(2026, 9, 5, tzinfo=timezone.utc),
+        last_run_at=datetime(2026, 9, 3, tzinfo=timezone.utc),
+    )
+    rows = build_unified_rows([active_far, paused_recent, active_near], [], [])
+    ordered = sort_rows(rows, "all")
+    assert [row.row_id for row in ordered] == [
+        "reminder:active-near",
+        "reminder:active-far",
+        "reminder:paused-recent",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Row shape sanity
+# ---------------------------------------------------------------------------
+
+
+def test_row_id_is_namespaced_by_kind():
+    rows = build_unified_rows(
+        [_reminder(id="shared-id")], [_definition(id="shared-id")], []
+    )
+    ids = {row.row_id for row in rows}
+    assert ids == {"reminder:shared-id", "definition:shared-id"}
+
+
+def test_owner_label_this_device_for_local():
+    rows = build_unified_rows([_reminder(owner_id="local")], [], [])
+    assert rows[0].owner_label == "This device"
+
+
+def test_owner_label_server_id_for_server_scoped():
+    rows = build_unified_rows([_reminder(owner_id="server:srv-9")], [], [])
+    assert rows[0].owner_label == "srv-9"

--- a/Tests/Scheduling/test_unified_rows.py
+++ b/Tests/Scheduling/test_unified_rows.py
@@ -100,13 +100,17 @@ class TestReminderHasFired:
         task = _reminder(enabled=False, next_run_at=None, last_run_at=None)
         assert reminder_has_fired(task) is False
 
-    def test_not_fired_when_enabled(self):
+    def test_fired_when_re_enabled_after_firing(self):
+        """Final review F9 (ruled): re-enabling a fired one-time reminder
+        gives it no future run -- only a SCHEDULE edit recomputes
+        `next_run_at`, and the due query filters `next_run_at IS NOT
+        NULL`. `enabled` is therefore not part of the predicate."""
         task = _reminder(
             enabled=True,
             next_run_at=None,
             last_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
         )
-        assert reminder_has_fired(task) is False
+        assert reminder_has_fired(task) is True
 
     def test_not_fired_when_next_run_still_set(self):
         task = _reminder(
@@ -185,6 +189,24 @@ def test_disabled_unfired_reminder_is_paused():
     )
     rows = build_unified_rows([task], [], [])
     assert rows[0].bucket == "paused"
+
+
+def test_re_enabled_fired_reminder_is_completed_not_active():
+    """Final review F9 (ruled): re-enabling a fired one-time reminder
+    (space, or the detail pane's Enable) gives it no future run --
+    `_set_reminder_enabled` sends only `{"enabled": ...}`, `update_
+    reminder` recomputes `next_run_at` only for a SCHEDULE change, and
+    the due query filters `next_run_at IS NOT NULL`. It buckets
+    Completed; an Active chip would advertise armed status the scheduler
+    will never honour."""
+    task = _one_time_reminder(
+        enabled=True,
+        next_run_at=None,
+        last_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+    rows = build_unified_rows([task], [], [])
+    assert rows[0].bucket == "completed"
+    assert rows[0].glyph == "✓"
 
 
 def test_fired_reminder_is_completed():
@@ -329,6 +351,44 @@ def test_unread_count_resolves_across_local_and_server_id_spaces():
     ]
     rows = build_unified_rows([], [definition], results)
     assert rows[0].unread_count == 2
+
+
+def test_transferred_definition_keeps_its_pre_transfer_unread_results():
+    """Final review F2, the review's own repro: a definition moved to the
+    server is carried in the DISPLAY list as the raw server payload
+    (`id` IS the server id) and is EXCLUDED from the local half of the
+    merge (which drops every `server_id`-bearing row). Its pre-transfer,
+    locally-produced results carry the LOCAL uuid, so without the full
+    local table they resolve to nothing and the count silently reads 0 --
+    hiding the rail's `Mark all read` button while the Results tab's
+    badge still counts them."""
+    local_table_row = _definition(id="def-local-1", server_id="srv-77")
+    display_row = _definition(id="srv-77", name="A Definition")
+    display_row.pop("server_id")  # a raw server payload carries no server_id
+    results = [
+        _result(id="res-a", definition_id="def-local-1", review_state="unread"),
+        _result(id="res-b", definition_id="def-local-1", review_state="unread"),
+    ]
+
+    stale = build_unified_rows([], [display_row], results)
+    assert stale[0].unread_count == 0, "the pre-fix behaviour this pins against"
+
+    rows = build_unified_rows([], [display_row], results, [local_table_row])
+    assert rows[0].unread_count == 2, (
+        "the Queue's unread count must match the Results tab's badge for "
+        "the same DB"
+    )
+
+
+def test_server_only_definition_still_resolves_with_a_local_table():
+    """The full local table is ADDED to the resolution index, not
+    substituted for it: a server definition with no local mirror row is
+    absent from that table, and its results must still be counted."""
+    results = [_result(definition_id="srv-99", review_state="unread")]
+    rows = build_unified_rows(
+        [], [_definition(id="srv-99")], results, [_definition(id="def-other")]
+    )
+    assert rows[0].unread_count == 1
 
 
 def test_reminder_rows_never_carry_unread_count():

--- a/Tests/Scheduling/test_unified_rows.py
+++ b/Tests/Scheduling/test_unified_rows.py
@@ -59,6 +59,11 @@ def _definition(**overrides) -> dict:
         server_id=None,
         owner_id="local",
         name="A Definition",
+        # Qodo MEDIUM: `build_unified_rows` now filters definitions to
+        # `family == "recurring_question"` (unknown/agent_task families
+        # must not render as pseudo-recurring rows) -- every real
+        # definition row carries a family, so the helper must too.
+        family="recurring_question",
         lifecycle="configured",
         transfer_state=None,
         schedule={"kind": "cron", "cron": "0 9 * * *", "timezone": "UTC"},
@@ -89,7 +94,7 @@ def _result(**overrides) -> dict:
 
 class TestReminderHasFired:
     def test_fired_when_disabled_no_next_run_but_has_run(self):
-        task = _reminder(
+        task = _one_time_reminder(
             enabled=False,
             next_run_at=None,
             last_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
@@ -105,12 +110,30 @@ class TestReminderHasFired:
         gives it no future run -- only a SCHEDULE edit recomputes
         `next_run_at`, and the due query filters `next_run_at IS NOT
         NULL`. `enabled` is therefore not part of the predicate."""
-        task = _reminder(
+        task = _one_time_reminder(
             enabled=True,
             next_run_at=None,
             last_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
         )
         assert reminder_has_fired(task) is True
+
+    def test_recurring_never_fires_even_with_the_same_no_next_run_shape(self):
+        """Qodo MEDIUM: `reminder_has_fired` now REQUIRES the ONE_TIME
+        schedule kind. A recurring reminder can land in the exact same
+        `next_run_at is None, last_run_at is not None` shape -- an
+        exhausted cron (end-date-passed) or an anomalous row -- but
+        `mark_reminder_dispatched` never disables it the way it does a
+        one-time reminder, so treating that shape as "fired" for a
+        recurring row was a false Completed. See
+        `test_recurring_reminder_with_no_next_run_is_paused_not_completed`
+        below for the ruled bucket (Paused, not Completed)."""
+        task = _reminder(
+            schedule_kind=ScheduleKind.RECURRING,
+            enabled=False,
+            next_run_at=None,
+            last_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
+        )
+        assert reminder_has_fired(task) is False
 
     def test_not_fired_when_next_run_still_set(self):
         task = _reminder(
@@ -210,13 +233,32 @@ def test_re_enabled_fired_reminder_is_completed_not_active():
 
 
 def test_fired_reminder_is_completed():
-    task = _reminder(
+    task = _one_time_reminder(
         enabled=False,
         next_run_at=None,
         last_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
     )
     rows = build_unified_rows([task], [], [])
     assert rows[0].bucket == "completed"
+
+
+def test_recurring_reminder_with_no_next_run_is_paused_not_completed():
+    """Ruled (Qodo MEDIUM): a RECURRING reminder with `last_run_at` set
+    and `next_run_at` NULL (exhausted cron / anomalous row) is
+    disabled-not-finished, not Completed -- recurring never "completes"
+    the way a one-time reminder does. It is also not caught by
+    `_reminder_bucket`'s `enabled` check when the row is still enabled
+    (`mark_reminder_dispatched` never flips `enabled` on the recurring
+    branch), so it needs its own route to Paused rather than falling
+    through to Active with nothing left armed to run."""
+    task = _reminder(
+        schedule_kind=ScheduleKind.RECURRING,
+        enabled=True,
+        next_run_at=None,
+        last_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+    rows = build_unified_rows([task], [], [])
+    assert rows[0].bucket == "paused"
 
 
 # ---------------------------------------------------------------------------
@@ -282,6 +324,23 @@ def test_archived_lifecycle_definition_is_completed():
     assert rows[0].bucket == "completed"
 
 
+def test_agent_task_definition_yields_no_unified_row():
+    """Qodo MEDIUM: `definitions` is never family-filtered upstream (the
+    server can return `agent_task` rows too), so `build_unified_rows`
+    itself must drop anything that is not `recurring_question` -- an
+    `agent_task` row has no recurring semantics behind it and would
+    otherwise render as a pseudo-recurring Queue entry. It stays visible
+    on the Automations tab, which is family-agnostic and unaffected by
+    this filter."""
+    rows = build_unified_rows([], [_definition(family="agent_task")], [])
+    assert rows == []
+
+
+def test_unknown_family_definition_yields_no_unified_row():
+    rows = build_unified_rows([], [_definition(family="something_new")], [])
+    assert rows == []
+
+
 # ---------------------------------------------------------------------------
 # Glyphs (spec SS4)
 # ---------------------------------------------------------------------------
@@ -305,7 +364,7 @@ def test_paused_reminder_glyph_is_pause_bar():
 def test_completed_reminder_glyph_is_check():
     rows = build_unified_rows(
         [
-            _reminder(
+            _one_time_reminder(
                 enabled=False,
                 next_run_at=None,
                 last_run_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
@@ -418,7 +477,7 @@ def _mixed_rows() -> list[UnifiedRow]:
                 enabled=False,
                 next_run_at=datetime(2026, 9, 5, tzinfo=timezone.utc),
             ),
-            _reminder(
+            _one_time_reminder(
                 id="done-rem",
                 title="Old one-shot",
                 enabled=False,

--- a/Tests/UI/test_destination_visual_parity_correction.py
+++ b/Tests/UI/test_destination_visual_parity_correction.py
@@ -1585,7 +1585,14 @@ async def test_watchlists_right_rail_does_not_clip_action_labels(size):
         (
             "schedules",
             "#scheduling-workbench",
-            ("Schedule Queue", "Task Detail", "Inspector"),
+            # redesign PR-2, Task 2 added `DefinitionDetail` as a sibling of
+            # `TaskDetail` (toggled via the `pane-hidden` class, not removed
+            # from the DOM) -- `_visible_workbench_pane_titles` checks each
+            # `.column-title` Static's OWN `.display`, which Textual never
+            # derives from an ancestor's `display: none` (`Widget.display`
+            # only reads `self.styles.display`), so the hidden pane's title
+            # still shows up here even while its content is invisible.
+            ("Schedule Queue", "Task Detail", "Definition Detail", "Inspector"),
         ),
         (
             "workflows",
@@ -2091,7 +2098,7 @@ async def test_operational_loading_states_preserve_workbench_geometry(
         load_started = asyncio.Event()
         load_cancelled = asyncio.Event()
 
-        async def hold_initial_load(self):
+        async def hold_initial_load(self, *, refresh_definitions: bool = True):
             load_started.set()
             try:
                 await asyncio.Event().wait()

--- a/Tests/UI/test_schedules_automations_tab.py
+++ b/Tests/UI/test_schedules_automations_tab.py
@@ -127,7 +127,7 @@ class AutomationsMockService(MockSchedulingServiceMixin):
             return_value={"run_id": "run-local-1", "deduped": False}
         )
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         return []
 
 
@@ -192,7 +192,12 @@ async def test_automations_tab_loads_server_definitions():
         table = workbench.query_one("#scheduling-automations-table", DataTable)
         notice = workbench.query_one("#scheduling-automations-notice")
 
-        server_client.list_automation_definitions.assert_awaited_once()
+        # redesign PR-2, Task 2: `load_tasks` (the Queue tab's own unified
+        # loader) now ALSO fetches both definition halves on every mount
+        # (its own separate cadence, per the brief -- not a shared cache
+        # with this tab's `load_automations`), so the server fetch is
+        # awaited twice, not once, at mount.
+        assert server_client.list_automation_definitions.await_count == 2
         assert table.row_count == 2
         assert "2 automations on the server" in str(notice.content)
         # Highlighting a row records the selection Run-now will act on.

--- a/Tests/UI/test_schedules_automations_tab.py
+++ b/Tests/UI/test_schedules_automations_tab.py
@@ -127,7 +127,7 @@ class AutomationsMockService(MockSchedulingServiceMixin):
             return_value={"run_id": "run-local-1", "deduped": False}
         )
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return []
 
 

--- a/Tests/UI/test_schedules_disabled_state.py
+++ b/Tests/UI/test_schedules_disabled_state.py
@@ -229,7 +229,7 @@ class _DisabledTaskService(MockSchedulingServiceMixin):
     def __init__(self) -> None:
         self.enabled = False
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return [_reminder(enabled=self.enabled)]
 
     async def update_reminder(self, task_id, fields):
@@ -288,7 +288,7 @@ async def test_disabled_row_and_badge_read_disabled_and_survive_refresh():
 class _DisabledMissedService(MockSchedulingServiceMixin):
     """One disabled task whose last dispatch failed, one with a conflict."""
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return [
             _reminder_with(
                 "task-m", "Failed backup", TaskStatus.MISSED, enabled=False

--- a/Tests/UI/test_schedules_disabled_state.py
+++ b/Tests/UI/test_schedules_disabled_state.py
@@ -229,7 +229,7 @@ class _DisabledTaskService(MockSchedulingServiceMixin):
     def __init__(self) -> None:
         self.enabled = False
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         return [_reminder(enabled=self.enabled)]
 
     async def update_reminder(self, task_id, fields):
@@ -252,12 +252,20 @@ async def test_disabled_row_and_badge_read_disabled_and_survive_refresh():
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
 
+        # redesign PR-2, Task 2: glyph/title/subtitle (spec S4) replaces
+        # the old Title/Type/Status/Next-Run columns -- "Disabled" is now
+        # conveyed by the paused glyph, not a separate Status cell. The
+        # subtitle's schedule-summary half legitimately still names the
+        # configured 2099 date (descriptive, unaffected by enabled state
+        # -- same as the create/edit form would show); the "no concrete
+        # future time" promise-avoidance rule (task-23101) applies only
+        # to the next-run half, after the "·" separator.
         table = workbench.query_one("#scheduling-task-table", DataTable)
         row = table.get_row_at(0)
-        # Queue row: text says Disabled, and no concrete future time.
-        assert "Disabled" in str(row[2])
-        assert "2099" not in str(row[3])
-        assert "disabled" in str(row[3]).lower()
+        assert str(row[0]) == "⏸"
+        next_run_text = str(row[2]).rsplit("·", 1)[-1]
+        assert "2099" not in next_run_text
+        assert "disabled" in next_run_text.lower()
 
         badge = workbench.query_one("#scheduling-task-status-badge", Static)
         assert "Disabled" in str(badge.render())
@@ -271,7 +279,7 @@ async def test_disabled_row_and_badge_read_disabled_and_survive_refresh():
         await workbench.load_tasks()
         await pilot.pause()
         row = table.get_row_at(0)
-        assert "Disabled" in str(row[2])
+        assert str(row[0]) == "⏸"
 
 
 # --- review F5: mounted consumers of the underlying status ----------------
@@ -280,7 +288,7 @@ async def test_disabled_row_and_badge_read_disabled_and_survive_refresh():
 class _DisabledMissedService(MockSchedulingServiceMixin):
     """One disabled task whose last dispatch failed, one with a conflict."""
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         return [
             _reminder_with(
                 "task-m", "Failed backup", TaskStatus.MISSED, enabled=False
@@ -342,13 +350,27 @@ async def test_disabled_missed_task_keeps_the_retry_affordance():
 
 @pytest.mark.asyncio
 async def test_missed_filter_matches_a_disabled_missed_task():
+    """redesign PR-2, Task 2: the old ad hoc queue filter substring-
+    matched status/type vocabulary too, so typing "missed" found a row
+    whose `_was_missed_while_away` flag was set regardless of its title
+    -- that was the old single-primitive table's own filter shape. Spec
+    S4's unified search is explicitly title + question/body only (ruling
+    5, `unified_rows.filter_rows`), so a bare status keyword no longer
+    narrows the list; a title search still does.
+    """
     app = _MissedApp()
     async with app.run_test(size=(160, 48)) as pilot:
         workbench = await _mounted_missed_workbench(pilot)
+
         workbench._filter_text = "missed"
         workbench._render_table()
         await pilot.pause()
+        titles = [task.title for task in workbench._visible_tasks]
+        assert "Failed backup" not in titles, titles
 
+        workbench._filter_text = "Failed backup"
+        workbench._render_table()
+        await pilot.pause()
         titles = [task.title for task in workbench._visible_tasks]
         assert "Failed backup" in titles, titles
 

--- a/Tests/UI/test_schedules_disabled_state.py
+++ b/Tests/UI/test_schedules_disabled_state.py
@@ -232,7 +232,7 @@ class _DisabledTaskService(MockSchedulingServiceMixin):
     async def list_tasks(self, owner_id=None, include_projections=True):
         return [_reminder(enabled=self.enabled)]
 
-    async def update_reminder(self, task_id, fields):
+    async def update_reminder(self, task_id, fields, *, owner_id=None):
         self.enabled = fields.get("enabled", self.enabled)
 
 

--- a/Tests/UI/test_schedules_marks_legend.py
+++ b/Tests/UI/test_schedules_marks_legend.py
@@ -17,14 +17,14 @@ from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import (
 )
 
 
-from Tests.UI.schedules_test_helpers import MockSchedulingServiceMixin
+from Tests.UI.schedules_test_helpers import MockSchedulingDB, MockSchedulingServiceMixin
 
 
 class _Service(MockSchedulingServiceMixin):
     def __init__(self, *, with_missed: bool = False) -> None:
         self._with_missed = with_missed
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         tasks = [
             ReminderTask(
                 id="task-1",
@@ -144,27 +144,40 @@ async def test_resize_notice_and_mark_legend_coexist():
 
 
 class _MixedService(MockSchedulingServiceMixin):
-    """One reminder plus one read-only watchlist projection."""
+    """One reminder plus one read-only automation-definition row.
+
+    redesign PR-2, Task 2: used to be a reminder + a watchlist
+    projection, but projections no longer enter the unified Queue list
+    at all (spec S2 locked decision 2) -- a definition row is the
+    actual "second, non-markable row kind" the unified list now has.
+    """
 
     def __init__(self) -> None:
         self.updated: list = []
+        self.db = MockSchedulingDB(
+            automation_definitions=[
+                {
+                    "id": "def-1",
+                    "server_id": None,
+                    "owner_id": "local",
+                    "name": "Definition Title",
+                    "lifecycle": "configured",
+                    "schedule": {
+                        "kind": "one_time",
+                        "run_at": "2099-01-02T00:00:00+00:00",
+                    },
+                    "input": {"question": "What changed?"},
+                }
+            ]
+        )
 
-    async def list_tasks(self):
-        from tldw_chatbook.Scheduling.models import ScheduledTask, TaskStatus
-
+    async def list_tasks(self, owner_id=None):
         return [
             ReminderTask(
                 id="task-1",
                 title="First",
                 schedule_kind=ScheduleKind.ONE_TIME,
                 run_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
-            ),
-            ScheduledTask(
-                id="watchlist:1",
-                title="Watchlist Title",
-                type="watchlist_job",
-                status=TaskStatus.WAITING,
-                next_run_at=datetime(2099, 1, 2, tzinfo=timezone.utc),
             ),
         ]
 
@@ -173,12 +186,18 @@ class _MixedService(MockSchedulingServiceMixin):
 
 
 @pytest.mark.asyncio
-async def test_projection_rows_are_not_markable():
+async def test_definition_rows_are_not_markable():
+    """redesign PR-2, Task 2: definition rows expose no actions in this
+    PR (plan ruling 1) -- marking one must not-op, same as the
+    since-retired projection-row case this test used to cover (a
+    watchlist projection can no longer even enter the Queue list, spec
+    S2 locked decision 2)."""
     app = _App(_MixedService())
     async with app.run_test(size=(160, 48)) as pilot:
         workbench = await _mounted(pilot)
         table = workbench.query_one("#scheduling-task-table", DataTable)
-        table.move_cursor(row=1)  # the projection
+        assert workbench._visible_rows[1].kind == "definition"
+        table.move_cursor(row=1)  # the definition
         await pilot.pause()
 
         workbench.action_mark_task()
@@ -187,7 +206,7 @@ async def test_projection_rows_are_not_markable():
         assert not workbench._marked_ids
         assert "marked" not in _notice_text(workbench)
         messages = [n.message for n in pilot.app._notifications]
-        assert any("Managed by Watchlists" in m for m in messages), messages
+        assert any("select a task first" in m.lower() for m in messages), messages
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_marks_legend.py
+++ b/Tests/UI/test_schedules_marks_legend.py
@@ -161,6 +161,12 @@ class _MixedService(MockSchedulingServiceMixin):
                     "server_id": None,
                     "owner_id": "local",
                     "name": "Definition Title",
+                    # Qodo MEDIUM (schedules-redesign PR-2):
+                    # `build_unified_rows` filters definitions to
+                    # `family == "recurring_question"` -- every real
+                    # definition row carries a family, so this fixture
+                    # must too.
+                    "family": "recurring_question",
                     "lifecycle": "configured",
                     "schedule": {
                         "kind": "one_time",

--- a/Tests/UI/test_schedules_marks_legend.py
+++ b/Tests/UI/test_schedules_marks_legend.py
@@ -181,7 +181,7 @@ class _MixedService(MockSchedulingServiceMixin):
             ),
         ]
 
-    async def update_reminder(self, task_id, fields):
+    async def update_reminder(self, task_id, fields, *, owner_id=None):
         self.updated.append((task_id, fields))
 
 
@@ -206,7 +206,9 @@ async def test_definition_rows_are_not_markable():
         assert not workbench._marked_ids
         assert "marked" not in _notice_text(workbench)
         messages = [n.message for n in pilot.app._notifications]
-        assert any("select a task first" in m.lower() for m in messages), messages
+        # Final review F8: a definition row IS selected, so the refusal
+        # says where the action lives instead of "select a task first".
+        assert any("Automations tab" in m for m in messages), messages
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_marks_legend.py
+++ b/Tests/UI/test_schedules_marks_legend.py
@@ -24,7 +24,7 @@ class _Service(MockSchedulingServiceMixin):
     def __init__(self, *, with_missed: bool = False) -> None:
         self._with_missed = with_missed
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         tasks = [
             ReminderTask(
                 id="task-1",
@@ -171,7 +171,7 @@ class _MixedService(MockSchedulingServiceMixin):
             ]
         )
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return [
             ReminderTask(
                 id="task-1",

--- a/Tests/UI/test_schedules_new_button.py
+++ b/Tests/UI/test_schedules_new_button.py
@@ -1,10 +1,12 @@
-"""Visible New button in the Schedule Queue pane (UX F-07).
+"""Visible Create button in the Schedule Queue rail (UX F-07).
 
 The only create affordance used to be the `c` key in the footer. This adds
-a primary button beside the "Schedule Queue" pane title. Task 5 upgrades
+a primary button beside the "Schedule Queue" pane title. Task 5 upgraded
 its behavior from a direct reminder-form push to a two-item chooser
 (Reminder / Recurring question) -- the `c` key binding is unchanged and
-still opens the reminder form directly.
+still opens the reminder form directly. Redesign PR-2, Task 3 relabels it
+`Create ▾` and repositions it in the rail header alongside the new
+`Mark all read` button -- same id/handler/chooser, unchanged.
 """
 
 from __future__ import annotations
@@ -13,6 +15,13 @@ import pytest
 from textual.widgets import Button
 
 from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
+from Tests.UI.schedules_test_helpers import (
+    MockSchedulingDB,
+    MockSchedulingServiceMixin,
+)
+from tldw_chatbook.UI.Screens.scheduling.forms.automation_definition_form import (
+    AutomationDefinitionForm,
+)
 from tldw_chatbook.UI.Screens.scheduling.forms.new_task_choice_modal import (
     NewTaskChoiceModal,
 )
@@ -24,6 +33,24 @@ from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import (
 
 class LocalOnlyTestApp(ConsolidatedCSSApp):
     scheduling_service = None
+
+
+class _EmptyService(MockSchedulingServiceMixin):
+    """A service is required for the recurring-question path -- unlike the
+    reminder path, `action_create_automation` refuses without one."""
+
+    def __init__(self) -> None:
+        self.owner_id = "local"
+        self.db = MockSchedulingDB()
+
+    async def list_tasks(self, owner_id=None, include_projections=True):
+        return []
+
+
+class ServiceBackedTestApp(ConsolidatedCSSApp):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.scheduling_service = _EmptyService()
 
 
 class LocalOnlyBundledCSSTestApp(LocalOnlyTestApp):
@@ -40,7 +67,8 @@ class LocalOnlyBundledCSSTestApp(LocalOnlyTestApp):
 
 @pytest.mark.asyncio
 async def test_new_button_exists_and_opens_choice_chooser():
-    """task-5: the button now offers Reminder / Recurring question."""
+    """Redesign PR-2, Task 3: `Create ▾` (relabeled from `+ New`) still
+    opens the same chooser via the same id/handler."""
     app = LocalOnlyTestApp()
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
@@ -48,7 +76,7 @@ async def test_new_button_exists_and_opens_choice_chooser():
         workbench = pilot.app.screen
 
         button = workbench.query_one("#scheduling-new-task", Button)
-        assert "New" in str(button.label)
+        assert "Create" in str(button.label)
 
         pushed: list = []
         workbench.app.push_screen = lambda screen, callback=None: pushed.append(screen)
@@ -75,6 +103,27 @@ async def test_new_button_chooser_reminder_choice_opens_reminder_form():
         await pilot.pause()
 
         assert isinstance(pilot.app.screen, ReminderForm)
+
+
+@pytest.mark.asyncio
+async def test_new_button_chooser_recurring_choice_opens_automation_form():
+    """Picking "Recurring question…" opens the automation-definition form
+    -- the rail's `Create ▾` button's OTHER path (redesign PR-2, Task 3:
+    "both create paths still open their modals")."""
+    app = ServiceBackedTestApp()
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        workbench.query_one("#scheduling-new-task", Button).press()
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, NewTaskChoiceModal)
+
+        await pilot.click("#new-task-choice-automation")
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, AutomationDefinitionForm)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_next_run_relative.py
+++ b/Tests/UI/test_schedules_next_run_relative.py
@@ -7,6 +7,7 @@ and the queue a shorter "2026-08-28 09:00 (in 14h)". All tests inject
 """
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
 
 import pytest
 from textual.widgets import DataTable, Static
@@ -215,3 +216,77 @@ async def test_refresh_timer_exists_and_skips_when_not_current():
         # And the suspend handler paused the cadence timer outright.
         assert workbench._next_run_refresh_timer is not None
         workbench._render_table = real_render  # type: ignore[assignment]
+
+
+# --- redesign PR-2, Task 4: ticker pinned against the unified rows --------
+#
+# The ticker itself is unchanged from dev (survey: the ONLY set_interval
+# under UI/Screens/**, adapted to `_visible_rows` in Task 2 -- see the
+# guard comment on `_refresh_next_run_rendering`). These three tests pin
+# the exact contract the task-4 brief calls out: a tick never reloads data,
+# suspend pauses the cadence, and resume both resumes it and repaints
+# immediately so nothing sits stale.
+
+
+@pytest.mark.asyncio
+async def test_tick_rerenders_without_reloading_data():
+    """A tick must repaint the cached rows' relative text, never re-fetch
+    from the service (brief: 'no reload, no DB')."""
+    app = _FixedApp()
+    async with app.run_test(size=(160, 48)) as pilot:
+        workbench = SchedulesWorkbench(app_instance=pilot.app)
+        await pilot.app.push_screen(workbench)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        reload_calls: list[bool] = []
+        workbench._request_tasks_refresh = (  # type: ignore[assignment]
+            lambda **kw: reload_calls.append(True)
+        )
+        render_calls: list[bool] = []
+        workbench._render_table = lambda **kw: render_calls.append(True)  # type: ignore[assignment]
+
+        workbench._refresh_next_run_rendering()
+
+        assert render_calls, "a tick must re-render the relative-time text"
+        assert not reload_calls, "a tick must never re-fetch data (no reload, no DB)"
+
+
+@pytest.mark.asyncio
+async def test_on_screen_suspend_pauses_the_ticker():
+    app = _FixedApp()
+    async with app.run_test(size=(160, 48)) as pilot:
+        workbench = SchedulesWorkbench(app_instance=pilot.app)
+        await pilot.app.push_screen(workbench)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        mock_timer = Mock()
+        workbench._next_run_refresh_timer = mock_timer
+
+        workbench.on_screen_suspend()
+
+        mock_timer.pause.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_on_screen_resume_resumes_and_ticks_immediately():
+    app = _FixedApp()
+    async with app.run_test(size=(160, 48)) as pilot:
+        workbench = SchedulesWorkbench(app_instance=pilot.app)
+        await pilot.app.push_screen(workbench)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        mock_timer = Mock()
+        workbench._next_run_refresh_timer = mock_timer
+        render_calls: list[bool] = []
+        workbench._render_table = lambda **kw: render_calls.append(True)  # type: ignore[assignment]
+
+        workbench.on_screen_resume()
+
+        mock_timer.resume.assert_called_once()
+        assert render_calls, "resume must repaint immediately -- nothing stays stale"

--- a/Tests/UI/test_schedules_next_run_relative.py
+++ b/Tests/UI/test_schedules_next_run_relative.py
@@ -86,7 +86,7 @@ from Tests.UI.schedules_test_helpers import MockSchedulingServiceMixin
 
 
 class _Service(MockSchedulingServiceMixin):
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         return [
             ReminderTask(
                 id="task-1",
@@ -115,7 +115,10 @@ async def test_queue_cell_and_detail_pane_agree_on_the_relative_form():
         await pilot.pause()
 
         table = workbench.query_one("#scheduling-task-table", DataTable)
-        cell = str(table.get_row_at(0)[3])
+        # redesign PR-2, Task 2: column 2 is now the subtitle (schedule
+        # summary + relative next-run), replacing the old standalone
+        # Next-Run column at index 3.
+        cell = str(table.get_row_at(0)[2])
         detail = str(
             workbench.query_one(
                 "#scheduling-task-detail-next-run", Static
@@ -135,7 +138,7 @@ class _FixedTaskService(_Service):
 
     RUN_AT = datetime(2026, 8, 28, 9, 0, tzinfo=timezone.utc)
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         return [
             ReminderTask(
                 id="task-1",
@@ -169,10 +172,10 @@ async def test_render_table_uses_one_injectable_now():
         run_at = _FixedTaskService.RUN_AT
 
         workbench._render_table(now=run_at - timedelta(hours=14))
-        assert "(in 14h)" in str(table.get_row_at(0)[3])
+        assert "(in 14h)" in str(table.get_row_at(0)[2])
 
         workbench._render_table(now=run_at - timedelta(minutes=25))
-        assert "(in 25m)" in str(table.get_row_at(0)[3])
+        assert "(in 25m)" in str(table.get_row_at(0)[2])
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_next_run_relative.py
+++ b/Tests/UI/test_schedules_next_run_relative.py
@@ -86,7 +86,7 @@ from Tests.UI.schedules_test_helpers import MockSchedulingServiceMixin
 
 
 class _Service(MockSchedulingServiceMixin):
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return [
             ReminderTask(
                 id="task-1",
@@ -138,7 +138,7 @@ class _FixedTaskService(_Service):
 
     RUN_AT = datetime(2026, 8, 28, 9, 0, tzinfo=timezone.utc)
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return [
             ReminderTask(
                 id="task-1",

--- a/Tests/UI/test_schedules_notification_observer.py
+++ b/Tests/UI/test_schedules_notification_observer.py
@@ -78,7 +78,7 @@ class _OwnerSuffixService(MockSchedulingServiceMixin):
             )
         ]
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         return await self.list_reminders()
 
 
@@ -94,7 +94,9 @@ async def test_queue_owner_suffix_shown_at_wide_width():
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
         table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
-        assert "(server: 1)" in str(table.get_cell_at((0, 0)))
+        # redesign PR-2, Task 2: column 0 is now the glyph, column 1 the
+        # title (old single-primitive shape was Title/Type/Status/Next Run).
+        assert "(server: 1)" in str(table.get_cell_at((0, 1)))
 
 
 @pytest.mark.asyncio
@@ -103,8 +105,8 @@ async def test_queue_owner_suffix_hidden_at_compact_width():
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
         table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
-        assert "(server: 1)" not in str(table.get_cell_at((0, 0)))
-        assert "Nightly digest" in str(table.get_cell_at((0, 0)))
+        assert "(server: 1)" not in str(table.get_cell_at((0, 1)))
+        assert "Nightly digest" in str(table.get_cell_at((0, 1)))
 
 
 class _BracketTitleService(MockSchedulingServiceMixin):
@@ -122,7 +124,7 @@ class _BracketTitleService(MockSchedulingServiceMixin):
             )
         ]
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         return await self.list_reminders()
 
 
@@ -145,7 +147,9 @@ async def test_queue_title_renders_brackets_literally():
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
         table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
-        assert rendered_row_cells(table, 0)[0] == "Nightly [bold] digest (server: 1)"
+        # redesign PR-2, Task 2: column 0 is now the glyph, column 1 the
+        # title.
+        assert rendered_row_cells(table, 0)[1] == "Nightly [bold] digest (server: 1)"
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/UI/test_schedules_notification_observer.py
+++ b/Tests/UI/test_schedules_notification_observer.py
@@ -78,7 +78,7 @@ class _OwnerSuffixService(MockSchedulingServiceMixin):
             )
         ]
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return await self.list_reminders()
 
 
@@ -124,7 +124,7 @@ class _BracketTitleService(MockSchedulingServiceMixin):
             )
         ]
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return await self.list_reminders()
 
 

--- a/Tests/UI/test_schedules_results_tab.py
+++ b/Tests/UI/test_schedules_results_tab.py
@@ -21,7 +21,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from textual.widgets import DataTable, TabbedContent
+from textual.widgets import Button, DataTable, TabbedContent
 
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from Tests.UI.schedules_test_helpers import rendered_row_cells
@@ -667,6 +667,47 @@ async def test_mark_all_read_fans_out_per_row(results_db):
         assert db.get_automation_result(r3)["review_state"] == "read"
         notifications = list(pilot.app._notifications)
         assert any("Marked 2 result" in n.message for n in notifications)
+
+
+@pytest.mark.asyncio
+async def test_rail_mark_all_read_button_fans_out_without_switching_tabs(results_db):
+    """redesign PR-2, Task 3: unlike the `a` keybinding (Results-tab-only,
+    see `test_results_actions_refuse_off_the_results_tab`), the rail's
+    `Mark all read` button on the Queue tab reuses the SAME per-row
+    fan-out (`_dispatch_mark_all_results_read`) without a tab switch
+    first, then refreshes the Queue's own unread dots so the button hides
+    itself again once nothing is unread."""
+    db = results_db
+    definition_id = _seed_definition(db)
+    r1 = _seed_result(db, definition_id=definition_id, dedupe_key="d1")
+    r2 = _seed_result(db, definition_id=definition_id, dedupe_key="d2")
+
+    app = ResultsWorkbenchTestApp(db)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        # Still on the Queue tab -- the `a` keybinding would refuse here.
+        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
+        assert tabs.active == "scheduling-queue-tab"
+
+        button = workbench.query_one("#scheduling-mark-all-read", Button)
+        assert button.display is True
+
+        button.press()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert db.get_automation_result(r1)["review_state"] == "read"
+        assert db.get_automation_result(r2)["review_state"] == "read"
+        notifications = list(pilot.app._notifications)
+        assert any("Marked 2 result" in n.message for n in notifications)
+
+        assert button.display is False
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_results_tab.py
+++ b/Tests/UI/test_schedules_results_tab.py
@@ -670,6 +670,73 @@ async def test_mark_all_read_fans_out_per_row(results_db):
 
 
 @pytest.mark.asyncio
+async def test_mark_all_read_reaches_unread_rows_beyond_the_inbox_window(
+    results_db,
+):
+    """HIGH (Qodo): `_unread_result_ids` used to read the Results tab's
+    own CAPPED listing (`RESULTS_INBOX_LIMIT`, 200 newest rows) instead
+    of querying the DB directly, so an older unread result outside that
+    window survived a mark-all-read -- while the rail button's
+    visibility is gated on the FULL-table `count_unread_results` (final
+    review F2), so it could hide with unread work still sitting there.
+    Seeds one old server-mirrored unread result first (oldest, so it
+    falls outside the newest-`RESULTS_INBOX_LIMIT` window once
+    `RESULTS_INBOX_LIMIT` more local ones are seeded after it), then
+    proves mark-all-read reaches it anyway AND still queues its server
+    pushback mutation.
+    """
+    db = results_db
+    server_definition_id = _seed_definition(
+        db, owner_id="server:1", server_id="srv-def-1"
+    )
+    old_result_id = _seed_result(
+        db,
+        definition_id=server_definition_id,
+        owner_id="server:1",
+        server_id="srv-res-old",
+        dedupe_key="old",
+    )
+    local_definition_id = _seed_definition(db)
+    for index in range(RESULTS_INBOX_LIMIT):
+        _seed_result(db, definition_id=local_definition_id, dedupe_key=f"d{index}")
+    total_unread = RESULTS_INBOX_LIMIT + 1
+    assert db.count_unread_results(owner_id=None) == total_unread
+
+    app = ResultsWorkbenchTestApp(db)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = await _open_results_tab(pilot)
+
+        # Sanity: the loaded table window is capped, so the old result is
+        # not among the currently-rendered rows -- this is the exact
+        # shape that used to leave it unreached.
+        table = workbench.query_one("#scheduling-results-table", DataTable)
+        assert table.row_count == RESULTS_INBOX_LIMIT
+
+        workbench.action_mark_all_results_read()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert db.count_unread_results(owner_id=None) == 0
+        assert db.get_automation_result(old_result_id)["review_state"] == "read"
+        notifications = list(pilot.app._notifications)
+        assert any(
+            f"Marked {total_unread} result" in n.message for n in notifications
+        )
+
+        mutations = db.get_pending_mutations(
+            owner_id="server:1", primitive="automation_result_review"
+        )
+        assert any(
+            mutation["payload"].get("server_result_id") == "srv-res-old"
+            and mutation["payload"].get("review_state") == "read"
+            for mutation in mutations
+        )
+
+
+@pytest.mark.asyncio
 async def test_rail_mark_all_read_button_fans_out_without_switching_tabs(results_db):
     """redesign PR-2, Task 3: unlike the `a` keybinding (Results-tab-only,
     see `test_results_actions_refuse_off_the_results_tab`), the rail's

--- a/Tests/UI/test_schedules_sync_surface.py
+++ b/Tests/UI/test_schedules_sync_surface.py
@@ -274,3 +274,40 @@ async def test_clear_is_hidden_until_an_error_exists():
         bar.update_status(None, None, [])
         await pilot.pause()
         assert not clear.display
+
+
+# --- redesign PR-2, Task 3: width-triggered compact path -------------------
+
+
+@pytest.mark.asyncio
+async def test_set_compact_hides_timestamps_but_keeps_owner_and_error_visible():
+    """`set_compact` is additive and independent of `_apply_collapse`'s
+    own owner/server-based collapse: with a live server (so the owner
+    buttons render normally), compact hides only the last-pull/last-push
+    timestamps -- the owner indicator (plan ruling 4's "(b)") and the
+    error/Clear pair stay visible, same honesty-over-compactness carve-out
+    `_apply_collapse` already documents."""
+    app = _BarHarness(
+        current_owner="local",
+        active_server_id="http://127.0.0.1:8000",
+        server_available=True,
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        bar = app.query_one(SyncStatusWidget)
+        bar.update_status(None, None, [{"message": "boom"}])
+        await pilot.pause()
+
+        bar.set_compact(True)
+        await pilot.pause()
+        assert not app.query_one("#scheduling-last-pull", Static).display
+        assert not app.query_one("#scheduling-last-push", Static).display
+        assert app.query_one("#scheduling-owner-local", Button).display
+        assert app.query_one("#scheduling-owner-server", Button).display
+        assert app.query_one("#scheduling-sync-error", Static).display
+        assert app.query_one("#scheduling-clear-error", Button).display
+
+        bar.set_compact(False)
+        await pilot.pause()
+        assert app.query_one("#scheduling-last-pull", Static).display
+        assert app.query_one("#scheduling-last-push", Static).display

--- a/Tests/UI/test_schedules_sync_surface.py
+++ b/Tests/UI/test_schedules_sync_surface.py
@@ -42,7 +42,7 @@ class _SyncService(MockSchedulingServiceMixin):
         self._outcome = outcome
         self.db = MockSchedulingDB()
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return [
             ReminderTask(
                 id="task-1",

--- a/Tests/UI/test_schedules_sync_surface.py
+++ b/Tests/UI/test_schedules_sync_surface.py
@@ -42,7 +42,7 @@ class _SyncService(MockSchedulingServiceMixin):
         self._outcome = outcome
         self.db = MockSchedulingDB()
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         return [
             ReminderTask(
                 id="task-1",

--- a/Tests/UI/test_schedules_terminology.py
+++ b/Tests/UI/test_schedules_terminology.py
@@ -55,7 +55,7 @@ class _MixedService(MockSchedulingServiceMixin):
     def __init__(self) -> None:
         self.created: list[dict] = []
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return [
             ReminderTask(
                 id="task-1",

--- a/Tests/UI/test_schedules_terminology.py
+++ b/Tests/UI/test_schedules_terminology.py
@@ -9,7 +9,6 @@ to edit them instead of exposing the internal "reminder" noun.
 from datetime import datetime, timezone
 
 import pytest
-from textual.widgets import DataTable, Input, Static
 
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from tldw_chatbook.Scheduling.models import (
@@ -56,7 +55,7 @@ class _MixedService(MockSchedulingServiceMixin):
     def __init__(self) -> None:
         self.created: list[dict] = []
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         return [
             ReminderTask(
                 id="task-1",
@@ -87,59 +86,22 @@ async def _mounted_workbench(pilot):
     return workbench
 
 
-@pytest.mark.asyncio
-async def test_edit_guard_on_projection_names_the_owner_not_reminders():
-    app = _App()
-    async with app.run_test(size=(160, 48)) as pilot:
-        workbench = await _mounted_workbench(pilot)
-        table = workbench.query_one("#scheduling-task-table", DataTable)
-        table.move_cursor(row=1)  # the watchlist projection
-        await pilot.pause()
-
-        workbench.action_edit_task()
-        await pilot.pause()
-
-        messages = [n.message for n in pilot.app._notifications]
-        assert any("Managed by Watchlists" in m for m in messages), messages
-        assert not any("reminder" in m.lower() for m in messages), messages
-
-
-@pytest.mark.asyncio
-async def test_toggle_guard_on_projection_names_the_owner_not_reminders():
-    app = _App()
-    async with app.run_test(size=(160, 48)) as pilot:
-        workbench = await _mounted_workbench(pilot)
-        table = workbench.query_one("#scheduling-task-table", DataTable)
-        table.move_cursor(row=1)
-        await pilot.pause()
-
-        workbench.action_toggle_enabled()
-        await pilot.pause()
-
-        messages = [n.message for n in pilot.app._notifications]
-        assert any("Managed by Watchlists" in m for m in messages), messages
-        assert not any("reminder" in m.lower() for m in messages), messages
-
-
-@pytest.mark.asyncio
-async def test_detail_pane_states_projection_ownership():
-    app = _App()
-    async with app.run_test(size=(160, 48)) as pilot:
-        workbench = await _mounted_workbench(pilot)
-        table = workbench.query_one("#scheduling-task-table", DataTable)
-        table.move_cursor(row=1)
-        await pilot.pause()
-
-        managed = workbench.query_one(
-            "#scheduling-task-detail-managed", Static
-        )
-        assert managed.display
-        assert "Managed by Watchlists" in str(managed.render())
-
-        # Selecting the reminder row hides the ownership line again.
-        table.move_cursor(row=0)
-        await pilot.pause()
-        assert not managed.display
+# redesign PR-2, Task 2: the three tests that used to live here (edit
+# guard / toggle guard / detail-pane ownership line, all triggered by
+# selecting a watchlist projection AT ROW 1 of the queue table) pinned a
+# scenario the redesign retires -- watchlist/briefing projections no
+# longer enter the unified Queue list at all (spec S2 locked decision 2,
+# Task 1's report), so there is no longer a route to reach the
+# `_managed_elsewhere_notice` guard FROM this table with a projection.
+# The guard's own copy generation stays covered by
+# `test_managed_elsewhere_notice_names_the_owning_screen` above (a
+# direct, workbench-free unit test of `_managed_elsewhere_notice` itself);
+# `TaskDetail.set_task`'s "#scheduling-task-detail-managed" ownership-line
+# RENDERING for a `ScheduledTask` has no dedicated test anywhere else in
+# the suite and genuinely loses coverage here -- the code path is now
+# unreachable from this screen (a `ScheduledTask` is never fed to
+# `TaskDetail` from the Queue table any more) but is left in place,
+# unmodified, in case another future caller needs it.
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_transfer_actions.py
+++ b/Tests/UI/test_schedules_transfer_actions.py
@@ -414,13 +414,22 @@ async def test_cancel_on_dormant_copy_uses_the_copys_own_id(transfer_db):
         assert copy_id is not None
         assert copy_id != mirror_id
 
-        # The device view (owner_id="local", the service's default) is
-        # what the copy lives under -- reload the queue and select it.
+        # redesign PR-2, Task 2: the Queue list is now spans-owners, so
+        # BOTH the local dormant copy AND the server-owned mirror show up
+        # (was 1 -- only the current-owner-scoped reminder listing --
+        # before the unified list). Select the copy row explicitly by id
+        # rather than assuming it lands at index 0.
         await pilot.app.screen.load_tasks()
         await pilot.pause()
         table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
-        assert table.row_count == 1  # only the dormant copy is local-owned
-        await _select_row(pilot)
+        assert table.row_count == 2
+        workbench = pilot.app.screen
+        copy_index = next(
+            index
+            for index, row in enumerate(workbench._visible_rows)
+            if row.kind == "reminder" and row.source_row.id == copy_id
+        )
+        await _select_row(pilot, copy_index)
 
         cancel_button = pilot.app.screen.query_one(
             "#scheduling-cancel-transfer", Button
@@ -547,7 +556,9 @@ async def test_queue_row_shows_transfer_badge_suffix(transfer_db):
 
         table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
         row = table.get_row_at(0)
-        assert "Moving to server" in str(row[0])
+        # redesign PR-2, Task 2: column 0 is now the glyph, column 1 the
+        # title (old single-primitive shape was Title/Type/Status/Next Run).
+        assert "Moving to server" in str(row[1])
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/UI/test_schedules_unified_list.py
+++ b/Tests/UI/test_schedules_unified_list.py
@@ -16,10 +16,14 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from textual.widgets import Button, DataTable, Static, TabbedContent
+from textual.widgets import Button, DataTable, Input, Static, TabbedContent
 
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from Tests.UI.schedules_test_helpers import MockSchedulingDB, MockSchedulingServiceMixin
+from tldw_chatbook.Scheduling.events import (
+    AcknowledgeIncidentRequested,
+    DeleteTaskRequested,
+)
 from tldw_chatbook.Scheduling.models import ReminderTask, ScheduleKind
 from tldw_chatbook.UI.Screens.scheduling.definition_detail import DefinitionDetail
 from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import SchedulesWorkbench
@@ -506,11 +510,13 @@ def _counting_definitions_service() -> tuple[_MixedService, list]:
 
 
 @pytest.mark.asyncio
-async def test_automations_edit_save_then_reminder_toggle_refetches_once():
-    """redesign PR-2 Task 2 review round 2: an Automations-tab edit-save
-    marks the Queue's definitions cache stale; the NEXT reminder-only
-    refresh must upgrade to exactly one full definitions fetch -- not
-    zero (stale would go unnoticed) and not more than one."""
+async def test_automations_edit_save_refetches_definitions_immediately():
+    """Round 2 pinned that a save marks the cache stale and the NEXT
+    reminder-only refresh upgrades to one full fetch. Final review F1
+    moved that fetch forward: the save's own path refreshes the Queue
+    (its create entry point is the Queue rail, which never fires
+    `TabActivated`), so the flag is consumed at the save -- exactly one
+    definitions fetch then, and none owed to the next reminder action."""
     service, calls = _counting_definitions_service()
 
     class _CountingApp(ConsolidatedCSSApp):
@@ -520,6 +526,7 @@ async def test_automations_edit_save_then_reminder_toggle_refetches_once():
 
     async with _CountingApp().run_test(size=(160, 48)) as pilot:
         workbench = await _mounted(pilot)
+        calls_before_save = len(calls)
 
         workbench._on_automation_form_result(
             SimpleNamespace(status="saved"), was_edit=True
@@ -527,7 +534,11 @@ async def test_automations_edit_save_then_reminder_toggle_refetches_once():
         await pilot.pause()
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
-        assert workbench._definitions_stale is True
+        assert workbench._definitions_stale is False
+        assert len(calls) == calls_before_save + 2, (
+            "the save refreshes the Automations list AND the Queue, one "
+            "definitions fetch each"
+        )
         calls_after_save = len(calls)
 
         task = next(
@@ -541,8 +552,8 @@ async def test_automations_edit_save_then_reminder_toggle_refetches_once():
         await pilot.pause()
 
         assert workbench._definitions_stale is False
-        assert len(calls) == calls_after_save + 1, (
-            "a stale-triggered upgrade must fetch definitions exactly once"
+        assert len(calls) == calls_after_save, (
+            "nothing is owed once the save itself refetched"
         )
 
 
@@ -619,3 +630,559 @@ async def test_no_mutation_reminder_toggle_still_skips_the_refetch():
 
         assert workbench._definitions_stale is False
         assert len(calls) == calls_after_mount
+
+
+# ---------------------------------------------------------------------------
+# Final review fix wave (F1-F12). One test per finding, each driving the
+# real workbench wiring rather than the pure adapter (Task 1's own suite
+# covers the math).
+# ---------------------------------------------------------------------------
+
+
+class _RuntimeState:
+    active_server_id = "server-1"
+
+
+class _RuntimePolicy:
+    state = _RuntimeState()
+
+
+def _app_for(service, *, with_server: bool = False):
+    """A `ConsolidatedCSSApp` wired to ``service`` (and, optionally, to a
+    runtime policy naming an active server so `_server_available` is
+    true and the Queue loader fetches the server half too)."""
+
+    class _ServiceApp(ConsolidatedCSSApp):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.scheduling_service = service
+            if with_server:
+                self.runtime_policy = _RuntimePolicy()
+
+    return _ServiceApp()
+
+
+def _toasts(app) -> list[str]:
+    return [n.message for n in app._notifications]
+
+
+# --- F1: a rail Create ▾ save paints its row without leaving the tab -------
+
+
+@pytest.mark.asyncio
+async def test_rail_create_recurring_question_paints_the_new_row():
+    """Final review F1: Task 3 moved definition-create onto the Queue
+    rail, so the save never fires `TabActivated` -- the only consumer of
+    `_definitions_stale`. The automation the user just created has to
+    appear on the surface it was created from, with no tab switch."""
+    service = _MixedService()
+    async with _app_for(service).run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        assert "def-new" not in _row_ids(workbench, "definition")
+
+        # The form wrote the row; the modal's callback is what the rail
+        # path actually reaches.
+        service.db._automation_definitions.append(
+            _definition("def-new", "Just created")
+        )
+        workbench._on_automation_form_result(SimpleNamespace(status="saved"))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert "def-new" in _row_ids(workbench, "definition")
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        painted = [str(table.get_row_at(i)[1]) for i in range(table.row_count)]
+        assert any("Just created" in cell for cell in painted)
+
+
+# --- F2: a transferred definition keeps its pre-transfer unread count -----
+
+
+_TRANSFERRED_LOCAL_ROW = {
+    "id": "def-local-1",
+    "server_id": "srv-1",
+    "owner_id": "server:server-1",
+    "family": "recurring_question",
+    "name": "Moved to the server",
+    "lifecycle": "configured",
+    "schedule": {"kind": "one_time", "run_at": "2099-01-01T00:00:00+00:00"},
+    "input": {"question": "What changed?"},
+    "updated_at": "2026-08-01T00:00:00+00:00",
+}
+
+
+class _TransferredService(MockSchedulingServiceMixin):
+    """One definition that has been transferred to the server, plus the two
+    unread results it produced BEFORE the transfer (local id space)."""
+
+    def __init__(self) -> None:
+        self.server_client = SimpleNamespace(
+            notifications_service=object(),
+            list_automation_definitions=AsyncMock(
+                return_value={
+                    "items": [
+                        {
+                            "id": "srv-1",
+                            "owner_id": "1",
+                            "name": "Moved to the server",
+                            "family": "recurring_question",
+                            "lifecycle": "configured",
+                            "health": "ready",
+                            "schedule": {
+                                "kind": "one_time",
+                                "run_at": "2099-01-01T00:00:00+00:00",
+                            },
+                            "input": {"question": "What changed?"},
+                            "updated_at": "2026-08-01T00:00:00+00:00",
+                        }
+                    ],
+                    "total": 1,
+                }
+            ),
+        )
+        self.db = MockSchedulingDB(
+            automation_definitions=[dict(_TRANSFERRED_LOCAL_ROW)],
+            automation_results=[
+                {
+                    "id": f"result-{index}",
+                    "definition_id": "def-local-1",
+                    "owner_id": "local",
+                    "review_state": "unread",
+                    "kind": "finding",
+                    "created_at": "2026-08-20T00:00:00+00:00",
+                }
+                for index in (1, 2)
+            ],
+        )
+
+    async def list_tasks(self, owner_id=None, include_projections=True):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_transferred_definition_unread_matches_the_results_badge():
+    """Final review F2, the review's own repro: the Results tab badge read
+    2 while the Queue counted 0 (and hid the rail button) for the same DB,
+    because the Queue indexed the DISPLAY merge -- which drops every local
+    row carrying a `server_id`."""
+    service = _TransferredService()
+    async with _app_for(service, with_server=True).run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+
+        queue_unread = sum(row.unread_count for row in workbench._all_rows)
+        badge = str(
+            workbench.query_one("#scheduling-tabs", TabbedContent)
+            .get_tab("scheduling-results-tab")
+            .label
+        )
+        assert "Results (2)" in badge
+        assert queue_unread == 2, (
+            "the Queue's unread count must equal the Results badge for the "
+            f"same DB; badge={badge!r}"
+        )
+        assert workbench.query_one("#scheduling-mark-all-read", Button).display is True
+
+
+# --- F3: incident ack routes by row id, not by a reminder-list index ------
+
+
+class _IncidentDB(MockSchedulingDB):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.acked: list[int] = []
+
+    def list_task_incidents(self, key, limit=10):
+        if key == "task-late":
+            return [
+                {
+                    "id": 7,
+                    "task_id": "task-late",
+                    "kind": "handler_failed",
+                    "message": "Handler failed",
+                    "created_at": "2026-08-27T11:00:00+00:00",
+                    "acknowledged_at": None,
+                }
+            ]
+        return []
+
+    def acknowledge_incident(self, incident_id, when) -> None:
+        self.acked.append(int(incident_id))
+
+
+class _DefinitionAboveReminderService(MockSchedulingServiceMixin):
+    """A definition row that sorts ABOVE the incident-carrying reminder --
+    the exact divergence between `_visible_rows` and `_visible_tasks`."""
+
+    def __init__(self) -> None:
+        self.db = _IncidentDB(
+            automation_definitions=[
+                {
+                    **_definition("def-first", "Sorts first"),
+                    "next_run_at": "2026-08-27T12:30:00+00:00",
+                }
+            ]
+        )
+
+    async def list_tasks(self, owner_id=None, include_projections=True):
+        return [
+            _reminder("task-late", "Failing reminder", next_run_at=_NOW + timedelta(hours=5))
+        ]
+
+
+@pytest.mark.asyncio
+async def test_acknowledge_incident_keeps_the_selected_reminder_showing():
+    """Final review F3: `_update_detail_for_index` takes a `_visible_rows`
+    index. Feeding it a `_visible_tasks` index rendered the row ABOVE the
+    highlighted one -- flipping the pane to a definition and moving
+    `_selected_row_id` with it, silently, while the cursor stayed put."""
+    service = _DefinitionAboveReminderService()
+    async with _app_for(service).run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        kinds = [row.kind for row in workbench._visible_rows]
+        assert kinds == ["definition", "reminder"], kinds
+
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        table.move_cursor(row=1)
+        await pilot.pause()
+        assert workbench._selected_row_id == "reminder:task-late"
+
+        workbench.post_message(AcknowledgeIncidentRequested(7))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert service.db.acked == [7]
+        assert workbench._selected_row_id == "reminder:task-late"
+        assert workbench._selected_task_id == "task-late"
+        task_detail = workbench.query_one("#scheduling-task-detail", TaskDetail)
+        assert not _pane_hidden(task_detail)
+
+
+# --- F4: reminder writes key off the ROW's owner, not the active one ------
+
+
+class _OwnerRecordingService(MockSchedulingServiceMixin):
+    """Active owner is `local`; the queue also lists a `server:` row."""
+
+    def __init__(self) -> None:
+        self.owner_id = "local"
+        self.db = MockSchedulingDB()
+        self.updated: list[tuple] = []
+        self.deleted: list[tuple] = []
+
+    async def list_tasks(self, owner_id=None, include_projections=True):
+        local_row = _reminder("task-local", "Local reminder")
+        server_row = _reminder("task-server", "Server reminder")
+        server_row.owner_id = "server:srv-1"
+        return [local_row, server_row]
+
+    async def update_reminder(self, task_id, fields, *, owner_id=None):
+        self.updated.append((task_id, fields, owner_id))
+        return None
+
+    async def delete_reminder(self, task_id, *, owner_id=None):
+        self.deleted.append((task_id, owner_id))
+        return True
+
+
+@pytest.mark.asyncio
+async def test_reminder_writes_thread_the_rows_own_owner():
+    """Final review F4: the list spans owners since Task 1 but the writes
+    still read `service.owner_id`, so toggling/deleting a `server:` row
+    while "This device" was active wrote the local mirror with no pending
+    mutation and no tombstone -- the next pull undid it."""
+    service = _OwnerRecordingService()
+    async with _app_for(service).run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        rows = {row.row_id: row.source_row for row in workbench._visible_rows}
+        server_task = rows["reminder:task-server"]
+        local_task = rows["reminder:task-local"]
+
+        # One at a time: `_set_reminder_enabled` runs in an exclusive
+        # worker group, so a second call would cancel the first.
+        workbench._set_reminder_enabled(server_task, False)
+        workbench.post_message(DeleteTaskRequested(server_task))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench._set_reminder_enabled(local_task, False)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert ("task-server", {"enabled": False}, "server:srv-1") in service.updated
+        assert ("task-server", "server:srv-1") in service.deleted
+        # The local row is untouched by the change: still its own owner,
+        # never the active one by accident.
+        assert ("task-local", {"enabled": False}, "local") in service.updated
+
+
+# --- F5: a results pull reveals the rail button with no tab switch --------
+
+
+class _PullService(MockSchedulingServiceMixin):
+    """No unread results until `_pull_results` runs."""
+
+    def __init__(self) -> None:
+        self.db = MockSchedulingDB(
+            automation_definitions=[_definition("def-1", "Watched question")]
+        )
+
+        async def _run_phase(owner_id, label, phase):
+            self.db._automation_results.append(
+                {
+                    "id": "result-pulled",
+                    "definition_id": "def-1",
+                    "owner_id": "local",
+                    "review_state": "unread",
+                    "kind": "finding",
+                    "created_at": "2026-08-28T00:00:00+00:00",
+                }
+            )
+
+        self.sync_engine = SimpleNamespace(
+            _run_phase=_run_phase, _pull_results=object()
+        )
+
+    async def list_tasks(self, owner_id=None, include_projections=True):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_results_pull_reveals_the_rail_mark_all_read_button():
+    """Final review F5: an SSE-triggered pull only refreshed the Results
+    tab, so the Queue's unread dots and the rail button (gated on
+    `sum(row.unread_count) > 0`) stayed absent for exactly the event they
+    were built for -- with no periodic reload to correct them."""
+    service = _PullService()
+    async with _app_for(service).run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        button = workbench.query_one("#scheduling-mark-all-read", Button)
+        assert button.display is False
+
+        await workbench._pull_results_worker()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert button.display is True
+        assert sum(row.unread_count for row in workbench._all_rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_marking_all_read_from_the_results_tab_clears_the_queue_dots():
+    """The inverse half of F5: `a` on the Results tab shares the fan-out,
+    so the Queue's dots and the rail button must drop with it."""
+    service = _MixedService()
+    async with _app_for(service).run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        button = workbench.query_one("#scheduling-mark-all-read", Button)
+        assert button.display is True
+
+        async def _review(result_id, review_state):
+            for row in service.db._automation_results:
+                if row["id"] == result_id:
+                    row["review_state"] = review_state
+            return True
+
+        service.review_automation_result = _review
+        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
+        tabs.active = "scheduling-results-tab"
+        await pilot.pause()
+        workbench.action_mark_all_results_read()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert sum(row.unread_count for row in workbench._all_rows) == 0
+        assert button.display is False
+
+
+# --- F6: the placeholder matches what search actually matches -------------
+
+
+@pytest.mark.asyncio
+async def test_filter_placeholder_names_title_and_question():
+    """Final review F6: the placeholder still promised type and status
+    after ruling 5 narrowed search to title + question/body and the
+    Type/Status columns were removed."""
+    async with _App().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        placeholder = workbench.query_one("#scheduling-queue-filter", Input).placeholder
+        assert "question" in placeholder.lower()
+        assert "status" not in placeholder.lower()
+        assert "type" not in placeholder.lower()
+
+
+# --- F8: definition rows answer the reminder keys honestly ----------------
+
+
+@pytest.mark.asyncio
+async def test_definition_row_keys_say_where_the_action_lives():
+    """Final review F8: `r` was swallowed in silence and the other keys
+    answered "select a task first" while a row was plainly selected."""
+    async with _App().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        definition_index = next(
+            i
+            for i, row in enumerate(workbench._visible_rows)
+            if row.kind == "definition"
+        )
+        table.move_cursor(row=definition_index)
+        await pilot.pause()
+
+        for action in (
+            workbench.action_run_task_now,
+            workbench.action_edit_task,
+            workbench.action_mark_task,
+            workbench.action_toggle_enabled,
+            workbench.action_delete,
+        ):
+            before = len(_toasts(pilot.app))
+            action()
+            await pilot.pause()
+            new = _toasts(pilot.app)[before:]
+            assert new, f"{action.__name__} answered nothing at all"
+            assert any("Automations tab" in message for message in new), (
+                f"{action.__name__} said {new!r}"
+            )
+
+        # d must not reach TaskDetail.request_delete, which would open a
+        # confirmation for whatever reminder the pane last held.
+        assert isinstance(pilot.app.screen, SchedulesWorkbench)
+
+
+# --- F10: empty-state copy at widths where the chips are hidden -----------
+
+
+class _ActiveOnlyService(MockSchedulingServiceMixin):
+    def __init__(self) -> None:
+        self.db = MockSchedulingDB()
+
+    async def list_tasks(self, owner_id=None, include_projections=True):
+        return [_reminder("task-active", "Active reminder", next_run_at=_NOW)]
+
+
+async def _completed_chip_notice(size) -> str:
+    service = _ActiveOnlyService()
+    async with _app_for(service).run_test(size=size) as pilot:
+        workbench = await _mounted(pilot)
+        workbench._set_queue_chip("completed")
+        await pilot.pause()
+        assert not workbench._visible_rows
+        return workbench.query_one(
+            "#scheduling-task-detail-empty-state", Static
+        ).visual.plain
+
+
+@pytest.mark.asyncio
+async def test_empty_view_copy_drops_the_chip_hint_when_chips_are_hidden():
+    """Final review F10: below width 84 the chip row is hidden while the
+    selected chip persists, so "Choose a different chip" pointed at a
+    control that is not on screen."""
+    wide = await _completed_chip_notice((160, 48))
+    assert "No tasks in this view" in wide
+    assert "Choose a different chip" in wide
+
+    narrow = await _completed_chip_notice((80, 40))
+    assert "No tasks in this view" in narrow
+    assert "chip" not in narrow.lower()
+
+
+# --- F11: a server run-now marks the definitions cache stale --------------
+
+
+class _ServerRunNowService(MockSchedulingServiceMixin):
+    def __init__(self) -> None:
+        self.server_client = SimpleNamespace(
+            notifications_service=object(),
+            list_automation_definitions=AsyncMock(
+                return_value={"items": [], "total": 0}
+            ),
+            run_automation_definition_now=AsyncMock(
+                return_value={"run_slot_utc": "slot-1", "deduped": False}
+            ),
+            list_automation_definition_audit=AsyncMock(
+                return_value={"items": [], "total": 0}
+            ),
+        )
+        self.db = MockSchedulingDB()
+
+    async def list_tasks(self, owner_id=None, include_projections=True):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_server_run_now_marks_definitions_stale():
+    """Final review F11: the branch's own rule is "mark staleness at each
+    genuine mutation call site"; only the local twin did."""
+    service = _ServerRunNowService()
+    async with _app_for(service, with_server=True).run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        assert workbench._definitions_stale is False
+
+        workbench._run_automation_now(
+            {
+                "id": "srv-1",
+                "name": "Server automation",
+                "owner_id": "server:server-1",
+                "family": "recurring_question",
+                "lifecycle": "configured",
+            }
+        )
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        service.server_client.run_automation_definition_now.assert_awaited_once()
+        assert workbench._definitions_stale is True
+
+
+# --- F12: the ticker does not re-read the definition detail ---------------
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_the_definition_detail_read_for_an_unchanged_row():
+    """Final review F12: the ticker re-ran 3 DB reads a minute for a row
+    that had not moved, against its own "no reload/DB on tick" contract.
+    A refresh-driven render still re-feeds -- data can change while the
+    selection stands still (PR-1's own F4 lesson)."""
+    service = _MixedService()
+    reads: list[tuple] = []
+    real_count = service.db.count_automation_runs
+
+    def _counting(*args, **kwargs):
+        reads.append((args, kwargs))
+        return real_count(*args, **kwargs)
+
+    service.db.count_automation_runs = _counting
+
+    async with _app_for(service).run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        definition_index = next(
+            i
+            for i, row in enumerate(workbench._visible_rows)
+            if row.kind == "definition"
+        )
+        table.move_cursor(row=definition_index)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        after_selection = len(reads)
+        assert after_selection > 0
+
+        workbench._refresh_next_run_rendering()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert len(reads) == after_selection, "a tick must not re-read the DB"
+
+        # A refresh-driven render still re-feeds the pane.
+        workbench._render_table()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert len(reads) == after_selection + 1

--- a/Tests/UI/test_schedules_unified_list.py
+++ b/Tests/UI/test_schedules_unified_list.py
@@ -59,6 +59,11 @@ def _definition(def_id: str, name: str, *, lifecycle: str = "configured") -> dic
         "server_id": None,
         "owner_id": "local",
         "name": name,
+        # Qodo MEDIUM (schedules-redesign PR-2): `build_unified_rows`
+        # filters definitions to `family == "recurring_question"` --
+        # every real definition row carries a family, so this fixture
+        # must too.
+        "family": "recurring_question",
         "lifecycle": lifecycle,
         "schedule": {"kind": "one_time", "run_at": "2099-01-01T00:00:00+00:00"},
         "input": {"question": f"Question for {name}?"},

--- a/Tests/UI/test_schedules_unified_list.py
+++ b/Tests/UI/test_schedules_unified_list.py
@@ -12,9 +12,11 @@ the workbench's wiring, not re-proving Task 1's own math.
 """
 
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
-from textual.widgets import Button, DataTable, Static
+from textual.widgets import Button, DataTable, Static, TabbedContent
 
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from Tests.UI.schedules_test_helpers import MockSchedulingDB, MockSchedulingServiceMixin
@@ -478,3 +480,142 @@ async def test_search_narrows_a_mixed_reminder_and_definition_list():
         await pilot.pause()
         kinds = {row.kind for row in workbench._visible_rows}
         assert kinds == {"reminder", "definition"}
+
+
+# ---------------------------------------------------------------------------
+# Fix round 2 (task-2 review addendum): an Automations-tab definition
+# mutation must not leave the Queue's cached definitions stale for the
+# rest of the session -- a reminder-only refresh upgrades to one full
+# fetch, and so does switching to the Queue tab while stale.
+# ---------------------------------------------------------------------------
+
+
+def _counting_definitions_service() -> tuple[_MixedService, list]:
+    """A `_MixedService` whose `db.list_automation_definitions` records
+    every call, for the staleness pins below."""
+    service = _MixedService()
+    calls: list[tuple] = []
+    real = service.db.list_automation_definitions
+
+    def _counting(*args, **kwargs):
+        calls.append((args, kwargs))
+        return real(*args, **kwargs)
+
+    service.db.list_automation_definitions = _counting
+    return service, calls
+
+
+@pytest.mark.asyncio
+async def test_automations_edit_save_then_reminder_toggle_refetches_once():
+    """redesign PR-2 Task 2 review round 2: an Automations-tab edit-save
+    marks the Queue's definitions cache stale; the NEXT reminder-only
+    refresh must upgrade to exactly one full definitions fetch -- not
+    zero (stale would go unnoticed) and not more than one."""
+    service, calls = _counting_definitions_service()
+
+    class _CountingApp(ConsolidatedCSSApp):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.scheduling_service = service
+
+    async with _CountingApp().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+
+        workbench._on_automation_form_result(
+            SimpleNamespace(status="saved"), was_edit=True
+        )
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert workbench._definitions_stale is True
+        calls_after_save = len(calls)
+
+        task = next(
+            row.source_row
+            for row in workbench._visible_rows
+            if row.kind == "reminder" and row.source_row.id == "task-active"
+        )
+        workbench._set_reminder_enabled(task, False)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert workbench._definitions_stale is False
+        assert len(calls) == calls_after_save + 1, (
+            "a stale-triggered upgrade must fetch definitions exactly once"
+        )
+
+
+@pytest.mark.asyncio
+async def test_automations_run_now_then_tab_switch_to_queue_refreshes():
+    """An Automations-tab run-now marks the cache stale; switching to
+    the Queue tab while stale upgrades the next refresh to a full one,
+    even with no reminder action in between."""
+    service, calls = _counting_definitions_service()
+    service.run_automation_now = AsyncMock(
+        return_value={"run_id": "run-1", "deduped": False}
+    )
+
+    class _CountingApp(ConsolidatedCSSApp):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.scheduling_service = service
+
+    async with _CountingApp().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        definition = next(
+            row.source_row
+            for row in workbench._visible_rows
+            if row.kind == "definition" and row.source_row["id"] == "def-active"
+        )
+        workbench._run_automation_now(definition)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert workbench._definitions_stale is True
+        calls_after_run = len(calls)
+
+        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
+        tabs.active = "scheduling-automations-tab"
+        await pilot.pause()
+        tabs.active = "scheduling-queue-tab"
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert workbench._definitions_stale is False
+        assert len(calls) == calls_after_run + 1, (
+            "arriving on the Queue tab while stale must fetch definitions"
+            " exactly once"
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_mutation_reminder_toggle_still_skips_the_refetch():
+    """Round-1 pin, re-asserted here explicitly: with no Automations
+    mutation in play, `_definitions_stale` never gets set, so a
+    reminder-only refresh still reuses the cached definitions."""
+    service, calls = _counting_definitions_service()
+
+    class _CountingApp(ConsolidatedCSSApp):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.scheduling_service = service
+
+    async with _CountingApp().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        assert workbench._definitions_stale is False
+        calls_after_mount = len(calls)
+
+        task = next(
+            row.source_row
+            for row in workbench._visible_rows
+            if row.kind == "reminder" and row.source_row.id == "task-active"
+        )
+        workbench._set_reminder_enabled(task, False)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert workbench._definitions_stale is False
+        assert len(calls) == calls_after_mount

--- a/Tests/UI/test_schedules_unified_list.py
+++ b/Tests/UI/test_schedules_unified_list.py
@@ -1,0 +1,391 @@
+"""Tests for the unified Schedules Queue list (redesign PR-2, Task 2).
+
+Covers what `Tests/UI/test_schedules_workbench.py` does not: a MIXED
+listing (reminders + automation definitions, both id-spaces), each
+chip's bucket (including the fired-one-time-reminder-under-Completed and
+to_server_pending-stays-Active cases the brief calls out by name),
+detail routing both directions, a reminder-action preservation smoke
+test, and definition rows exposing no actions. `Tests/Scheduling/
+test_unified_rows.py` (Task 1) already exhaustively covers the bucket/
+sort/filter PURE functions this file builds on -- these tests are about
+the workbench's wiring, not re-proving Task 1's own math.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from textual.widgets import Button, DataTable, Static
+
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from Tests.UI.schedules_test_helpers import MockSchedulingDB, MockSchedulingServiceMixin
+from tldw_chatbook.Scheduling.models import ReminderTask, ScheduleKind
+from tldw_chatbook.UI.Screens.scheduling.definition_detail import DefinitionDetail
+from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import SchedulesWorkbench
+from tldw_chatbook.UI.Screens.scheduling.task_detail import TaskDetail
+
+_NOW = datetime(2026, 8, 27, 12, 0, tzinfo=timezone.utc)
+
+
+def _reminder(
+    task_id: str,
+    title: str,
+    *,
+    enabled: bool = True,
+    next_run_at: datetime | None = None,
+    last_run_at: datetime | None = None,
+    transfer_state: str | None = None,
+) -> ReminderTask:
+    return ReminderTask(
+        id=task_id,
+        title=title,
+        schedule_kind=ScheduleKind.ONE_TIME,
+        run_at=next_run_at or (_NOW + timedelta(hours=1)),
+        next_run_at=next_run_at,
+        enabled=enabled,
+        last_run_at=last_run_at,
+        transfer_state=transfer_state,
+    )
+
+
+def _definition(def_id: str, name: str, *, lifecycle: str = "configured") -> dict:
+    return {
+        "id": def_id,
+        "server_id": None,
+        "owner_id": "local",
+        "name": name,
+        "lifecycle": lifecycle,
+        "schedule": {"kind": "one_time", "run_at": "2099-01-01T00:00:00+00:00"},
+        "input": {"question": f"Question for {name}?"},
+        "updated_at": "2026-08-01T00:00:00+00:00",
+    }
+
+
+class _MixedService(MockSchedulingServiceMixin):
+    """Reminders + automation definitions spanning every chip bucket.
+
+    Reminder side: `task-active` (armed), `task-pending` (`enabled` with
+    `transfer_state="to_server_pending"` -- spec S3: stays Active, "they
+    still execute locally"), `task-paused` (disabled, not fired),
+    `task-fired` (disabled, `next_run_at=None`, `last_run_at` set -- the
+    fired-one-time predicate, `reminder_has_fired`).
+
+    Definition side: `def-active` (configured), `def-paused` (paused
+    lifecycle), `def-archived` (archived lifecycle), `def-unread` (
+    configured, with one UNREAD `automation_results` row so the title
+    cell's unread dot has something to paint).
+    """
+
+    def __init__(self) -> None:
+        self.updated: list = []
+        self.db = MockSchedulingDB(
+            automation_definitions=[
+                _definition("def-active", "Active definition"),
+                _definition("def-paused", "Paused definition", lifecycle="paused"),
+                _definition(
+                    "def-archived", "Archived definition", lifecycle="archived"
+                ),
+                _definition("def-unread", "Unread definition"),
+            ],
+            automation_results=[
+                {
+                    "id": "result-1",
+                    "definition_id": "def-unread",
+                    "owner_id": "local",
+                    "review_state": "unread",
+                    "kind": "finding",
+                    "created_at": "2026-08-20T00:00:00+00:00",
+                }
+            ],
+        )
+
+    async def list_tasks(self, owner_id=None):
+        return [
+            _reminder(
+                "task-active", "Active reminder", next_run_at=_NOW + timedelta(hours=2)
+            ),
+            _reminder(
+                "task-pending",
+                "Pending-transfer reminder",
+                next_run_at=_NOW + timedelta(hours=3),
+                transfer_state="to_server_pending",
+            ),
+            _reminder(
+                "task-paused",
+                "Paused reminder",
+                enabled=False,
+                next_run_at=_NOW + timedelta(hours=4),
+            ),
+            _reminder(
+                "task-fired",
+                "Fired reminder",
+                enabled=False,
+                next_run_at=None,
+                last_run_at=_NOW - timedelta(hours=1),
+            ),
+        ]
+
+    async def update_reminder(self, task_id, fields, *, owner_id=None):
+        self.updated.append((task_id, fields))
+        return None
+
+
+class _App(ConsolidatedCSSApp):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.scheduling_service = _MixedService()
+
+
+async def _mounted(pilot):
+    workbench = SchedulesWorkbench(app_instance=pilot.app)
+    await pilot.app.push_screen(workbench)
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+    return workbench
+
+
+def _row_ids(workbench, kind: str | None = None) -> set[str]:
+    return {
+        row.row_id.split(":", 1)[1]
+        for row in workbench._visible_rows
+        if kind is None or row.kind == kind
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mixed rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mixed_listing_renders_both_kinds_painted():
+    """Reminders and definitions both render, each with a real glyph and
+    the title/subtitle content the spec names (painted, not the stored
+    object -- D8)."""
+    async with _App().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+
+        kinds = {row.row_id.split(":", 1)[0] for row in workbench._visible_rows}
+        assert kinds == {"reminder", "definition"}
+        # Default chip is "all" (Active+Paused) -- Completed rows (the
+        # fired reminder, the archived definition) are excluded by design.
+        assert "task-fired" not in _row_ids(workbench)
+        assert "def-archived" not in _row_ids(workbench)
+
+        for index, row in enumerate(workbench._visible_rows):
+            painted = table.get_row_at(index)
+            assert str(painted[0]) == row.glyph
+            # `row.title` is the bare title for both kinds -- a definition
+            # cell wraps it in the automation_name_cell owner-prefix
+            # ("[This device] <name>"), checked precisely below.
+            assert row.title in str(painted[1])
+
+        # The definition row's title carries the automation_name_cell
+        # owner-prefix rendering (reused verbatim, per the brief).
+        def_index = next(
+            i
+            for i, row in enumerate(workbench._visible_rows)
+            if row.kind == "definition"
+        )
+        assert "[This device]" in str(table.get_row_at(def_index)[1])
+
+        # The unread definition's title carries the bold unread dot.
+        unread_index = next(
+            i
+            for i, row in enumerate(workbench._visible_rows)
+            if row.kind == "definition" and row.source_row.get("id") == "def-unread"
+        )
+        assert "●" in str(table.get_row_at(unread_index)[1])
+
+
+# ---------------------------------------------------------------------------
+# Chip buckets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_active_chip_includes_to_server_pending_reminder():
+    """spec S3: `to_server_pending` stays Active -- "they still execute
+    locally" -- not dropped into Paused with the dormant transfer states."""
+    async with _App().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        workbench._set_queue_chip("active")
+        await pilot.pause()
+
+        reminder_ids = _row_ids(workbench, "reminder")
+        assert reminder_ids == {"task-active", "task-pending"}
+        definition_ids = _row_ids(workbench, "definition")
+        assert definition_ids == {"def-active", "def-unread"}
+
+
+@pytest.mark.asyncio
+async def test_paused_chip_includes_disabled_reminder_and_paused_definition():
+    async with _App().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        workbench._set_queue_chip("paused")
+        await pilot.pause()
+
+        assert _row_ids(workbench, "reminder") == {"task-paused"}
+        assert _row_ids(workbench, "definition") == {"def-paused"}
+
+
+@pytest.mark.asyncio
+async def test_completed_chip_includes_fired_reminder_and_archived_definition():
+    """The brief's own two named cases: a fired one-time reminder AND an
+    archived definition both surface only under Completed."""
+    async with _App().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        workbench._set_queue_chip("completed")
+        await pilot.pause()
+
+        assert _row_ids(workbench, "reminder") == {"task-fired"}
+        assert _row_ids(workbench, "definition") == {"def-archived"}
+
+
+@pytest.mark.asyncio
+async def test_all_chip_excludes_completed_rows():
+    async with _App().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        workbench._set_queue_chip("all")
+        await pilot.pause()
+
+        assert "task-fired" not in _row_ids(workbench, "reminder")
+        assert "def-archived" not in _row_ids(workbench, "definition")
+
+
+@pytest.mark.asyncio
+async def test_chip_button_press_switches_the_active_chip():
+    """The chip row is real buttons, not just the pure `_set_queue_chip`
+    seam -- pressing one drives the same narrowing."""
+    async with _App().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        completed_button = workbench.query_one("#scheduling-chip-completed", Button)
+        completed_button.press()
+        await pilot.pause()
+
+        assert workbench._chip == "completed"
+        assert str(completed_button.variant) == "primary"
+        all_button = workbench.query_one("#scheduling-chip-all", Button)
+        assert str(all_button.variant) == "default"
+        assert _row_ids(workbench, "reminder") == {"task-fired"}
+
+
+# ---------------------------------------------------------------------------
+# Detail routing, both directions
+# ---------------------------------------------------------------------------
+
+
+def _pane_hidden(widget) -> bool:
+    return "pane-hidden" in widget.classes
+
+
+@pytest.mark.asyncio
+async def test_highlighting_routes_to_the_matching_detail_pane_both_directions():
+    async with _App().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        task_detail = workbench.query_one("#scheduling-task-detail", TaskDetail)
+        definition_detail = workbench.query_one(
+            "#scheduling-queue-definition-detail", DefinitionDetail
+        )
+
+        reminder_index = next(
+            i for i, row in enumerate(workbench._visible_rows) if row.kind == "reminder"
+        )
+        definition_index = next(
+            i
+            for i, row in enumerate(workbench._visible_rows)
+            if row.kind == "definition"
+        )
+
+        # Reminder -> definition.
+        table.move_cursor(row=reminder_index)
+        await pilot.pause()
+        assert not _pane_hidden(task_detail)
+        assert _pane_hidden(definition_detail)
+
+        table.move_cursor(row=definition_index)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert _pane_hidden(task_detail)
+        assert not _pane_hidden(definition_detail)
+        assert (
+            definition_detail.query_one(
+                "#scheduling-automation-detail-empty-state", Static
+            ).display
+            is False
+        )
+
+        # Definition -> reminder, back again.
+        table.move_cursor(row=reminder_index)
+        await pilot.pause()
+        assert not _pane_hidden(task_detail)
+        assert _pane_hidden(definition_detail)
+
+
+# ---------------------------------------------------------------------------
+# Preservation gate: reminder actions still fire amid a mixed list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reminder_actions_still_fire_amid_a_mixed_list():
+    """Smoke test: edit/mark/toggle on a REMINDER row still work exactly
+    as before, even though the table now also contains definition rows.
+    """
+    async with _App().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        reminder_index = next(
+            i
+            for i, row in enumerate(workbench._visible_rows)
+            if row.kind == "reminder" and row.source_row.id == "task-active"
+        )
+        table.move_cursor(row=reminder_index)
+        await pilot.pause()
+
+        workbench.action_mark_task()
+        await pilot.pause()
+        assert workbench._marked_ids == {"task-active"}
+
+        workbench.action_clear_marks()
+        await pilot.pause()
+        assert not workbench._marked_ids
+
+
+# ---------------------------------------------------------------------------
+# Definition rows: no actions in this PR
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_definition_rows_expose_no_actions():
+    """Edit/mark/toggle/delete on a definition row must no-op -- plan
+    ruling 1: definition rows are viewable + detail only until PR-4."""
+    async with _App().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        definition_index = next(
+            i
+            for i, row in enumerate(workbench._visible_rows)
+            if row.kind == "definition"
+        )
+        table.move_cursor(row=definition_index)
+        await pilot.pause()
+
+        assert workbench._selected_task_id is None
+        assert workbench._selected_task() is None
+
+        workbench.action_mark_task()
+        await pilot.pause()
+        assert not workbench._marked_ids
+
+        workbench.action_edit_task()
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, SchedulesWorkbench)  # no form pushed
+
+        workbench.action_toggle_enabled()
+        await pilot.pause()
+        assert workbench._scheduling_service.updated == []

--- a/Tests/UI/test_schedules_unified_list.py
+++ b/Tests/UI/test_schedules_unified_list.py
@@ -98,7 +98,7 @@ class _MixedService(MockSchedulingServiceMixin):
             ],
         )
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return [
             _reminder(
                 "task-active", "Active reminder", next_run_at=_NOW + timedelta(hours=2)
@@ -389,3 +389,92 @@ async def test_definition_rows_expose_no_actions():
         workbench.action_toggle_enabled()
         await pilot.pause()
         assert workbench._scheduling_service.updated == []
+
+
+# ---------------------------------------------------------------------------
+# Fix round 1 (task-2 review): reminder-only refreshes must not re-fetch
+# automation definitions (finding 3), and the filter seam must narrow a
+# MIXED reminder+definition list (finding 4, the brief's own "search
+# narrows" AC item, previously untested at the integration level).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reminder_toggle_triggers_no_new_definitions_fetch():
+    """redesign PR-2 Task 2 review, finding 3: a reminder-only action
+    (`_request_tasks_refresh(refresh_definitions=False)`) must reuse the
+    definitions already in `self._all_rows` rather than re-running
+    `_load_local_automations`'s `service.db.list_automation_definitions`
+    scan. Counting fake, per the review's own suggested pin shape."""
+    service = _MixedService()
+    calls: list[tuple] = []
+    real_list_automation_definitions = service.db.list_automation_definitions
+
+    def _counting_list_automation_definitions(*args, **kwargs):
+        calls.append((args, kwargs))
+        return real_list_automation_definitions(*args, **kwargs)
+
+    service.db.list_automation_definitions = _counting_list_automation_definitions
+
+    class _CountingApp(ConsolidatedCSSApp):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.scheduling_service = service
+
+    async with _CountingApp().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        # Mount runs the FULL Queue loader (load_tasks's own definitions
+        # fetch) AND the Automations tab's own load_automations -- both
+        # call list_automation_definitions once each. That baseline is
+        # not what this test pins; only whether a reminder toggle adds
+        # to it.
+        calls_after_mount = len(calls)
+        assert calls_after_mount > 0
+
+        task = next(
+            row.source_row
+            for row in workbench._visible_rows
+            if row.kind == "reminder" and row.source_row.id == "task-active"
+        )
+        workbench._set_reminder_enabled(task, False)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert service.updated == [("task-active", {"enabled": False})]
+        assert len(calls) == calls_after_mount, (
+            "a reminder-only refresh must not re-fetch automation definitions"
+        )
+
+
+@pytest.mark.asyncio
+async def test_search_narrows_a_mixed_reminder_and_definition_list():
+    """The brief's own named AC ("search narrows") for the mixed list --
+    the pure `filter_rows` function is exhaustively covered in Task 1's
+    suite; this pins the workbench's own wiring
+    (`_filter_text` -> `_render_table` -> `filter_rows(self._all_rows,
+    ...)`) against a set with BOTH row kinds, including a definition
+    matched only by its question/body text."""
+    async with _App().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+
+        # A reminder title match narrows to just that reminder.
+        workbench._filter_text = "Active reminder"
+        workbench._render_table()
+        await pilot.pause()
+        assert _row_ids(workbench) == {"task-active"}
+
+        # A definition's question/body text (not its title) also matches
+        # -- `search_blob` is title + question/body (Task 1, ruling 5).
+        workbench._filter_text = "Question for Active definition"
+        workbench._render_table()
+        await pilot.pause()
+        assert _row_ids(workbench, "definition") == {"def-active"}
+        assert _row_ids(workbench, "reminder") == set()
+
+        # Clearing the filter restores the full (chip-narrowed) mixed set.
+        workbench._filter_text = ""
+        workbench._render_table()
+        await pilot.pause()
+        kinds = {row.kind for row in workbench._visible_rows}
+        assert kinds == {"reminder", "definition"}

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -78,6 +78,7 @@ class MockSchedulingService(_MockSchedulingServiceMixin):
         # flip), so a cross-owner save is observable here.
         self.created_owners: list[str | None] = []
         self.updated_owners: list[str | None] = []
+        self.deleted_owners: list[str | None] = []
 
     async def list_reminders(self):
         return [
@@ -109,8 +110,9 @@ class MockSchedulingService(_MockSchedulingServiceMixin):
             setattr(task, key, value)
         return task
 
-    async def delete_reminder(self, task_id: str):
+    async def delete_reminder(self, task_id: str, *, owner_id: str | None = None):
         self.deleted_ids.append(task_id)
+        self.deleted_owners.append(owner_id)
         return True
 
 
@@ -819,7 +821,7 @@ class RecordingMockSchedulingService(_MockSchedulingServiceMixin):
     async def list_tasks(self, owner_id=None, include_projections=True):
         return await self.list_reminders()
 
-    async def delete_reminder(self, task_id: str) -> None:
+    async def delete_reminder(self, task_id: str, *, owner_id: str | None = None) -> None:
         if self.fail_delete:
             raise RuntimeError("delete failed")
         self.deleted_ids.append(task_id)
@@ -890,11 +892,15 @@ class ControlledRefreshSchedulingService(_MockSchedulingServiceMixin):
             return [self.newest_task]
         raise AssertionError(f"Unexpected list_tasks call {self._list_calls}")
 
-    async def delete_reminder(self, task_id: str) -> None:
+    async def delete_reminder(
+        self, task_id: str, *, owner_id: str | None = None
+    ) -> None:
         """Record completion of the controlled delete.
 
         Args:
             task_id: Identifier of the deleted reminder.
+            owner_id: The row's own owner, threaded by the workbench
+                (final review F4); recorded only, not acted on.
         """
         self.deleted_ids.append(task_id)
         self.delete_completed.set()
@@ -1176,10 +1182,14 @@ async def test_create_reminder_for_a_different_runs_on_owner_queues_a_mutation(
 
             toasts = [n.message for n in pilot.app._notifications]
             assert any(
-                "Server (example.com)" in message
-                and "switch to that owner" in message
-                for message in toasts
+                "Server (example.com)" in message for message in toasts
             ), f"the toast must name the owner it was created for; got {toasts}"
+            # Final review F7: the queue spans owners since redesign PR-2
+            # Task 1, so the old "switch to that owner to see it"
+            # instruction told the user to do something unnecessary.
+            assert not any("switch to that owner" in m for m in toasts), (
+                f"the cross-owner instruction must be gone; got {toasts}"
+            )
 
         assert service.owner_id == "local"  # never repointed by the save
         assert service.sync_engine.owner_id == "local"

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -1550,6 +1550,11 @@ def _definition_row(
         "server_id": None,
         "owner_id": "local",
         "name": name,
+        # Qodo MEDIUM (schedules-redesign PR-2): `build_unified_rows`
+        # filters definitions to `family == "recurring_question"` --
+        # every real definition row carries a family, so this fixture
+        # must too.
+        "family": "recurring_question",
         "lifecycle": lifecycle,
         "schedule": {"kind": "one_time", "run_at": "2099-01-01T00:00:00+00:00"},
         "input": {"question": "What changed?"},

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -10,7 +10,7 @@ import pytest
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
 from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
-from textual.widgets import Button, DataTable, Input, Select, Static
+from textual.widgets import Button, DataTable, Input, Select, Static, TabbedContent
 from textual.widgets._collapsible import CollapsibleTitle
 
 from tldw_chatbook.Scheduling.events import (
@@ -1527,3 +1527,152 @@ async def test_sync_strip_fields_do_not_abut():
         assert push.region.right < error.region.x, (
             f"push {push.region} abuts error {error.region}"
         )
+
+
+# --- redesign PR-2, Task 3: rail chrome + bottom status strip --------------
+
+
+def _definition_row(
+    def_id: str, *, name: str = "Digest", lifecycle: str = "configured"
+) -> dict:
+    return {
+        "id": def_id,
+        "server_id": None,
+        "owner_id": "local",
+        "name": name,
+        "lifecycle": lifecycle,
+        "schedule": {"kind": "one_time", "run_at": "2099-01-01T00:00:00+00:00"},
+        "input": {"question": "What changed?"},
+        "updated_at": "2026-08-01T00:00:00+00:00",
+    }
+
+
+class _RailService(_MockSchedulingServiceMixin):
+    """One definition, optionally carrying an unread result -- drives the
+    rail's `Mark all read` visibility (redesign PR-2, Task 3)."""
+
+    def __init__(self, *, unread: bool = False, conflicts: list | None = None) -> None:
+        self.owner_id = "local"
+        self.db = _MockSchedulingDB(
+            conflicts=conflicts,
+            automation_definitions=[_definition_row("def-1")],
+            automation_results=(
+                [
+                    {
+                        "id": "result-1",
+                        "definition_id": "def-1",
+                        "owner_id": "local",
+                        "review_state": "unread",
+                        "kind": "finding",
+                        "created_at": "2026-08-20T00:00:00+00:00",
+                    }
+                ]
+                if unread
+                else []
+            ),
+        )
+
+    async def list_tasks(self, owner_id=None, include_projections=True):
+        return []
+
+
+class _RailTestApp(ConsolidatedCSSApp):
+    def __init__(self, service: _RailService, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.scheduling_service = service
+
+
+@pytest.mark.asyncio
+async def test_mark_all_read_hidden_when_nothing_unread():
+    app = _RailTestApp(_RailService(unread=False))
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        button = pilot.app.screen.query_one("#scheduling-mark-all-read", Button)
+        assert button.display is False
+
+
+@pytest.mark.asyncio
+async def test_mark_all_read_visible_when_a_definition_has_unread_results():
+    """redesign PR-2, Task 3: the rail action is shown only once the
+    unified rows' total unread count is > 0 -- summed across
+    `UnifiedRow.unread_count`, not a new query."""
+    app = _RailTestApp(_RailService(unread=True))
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        button = pilot.app.screen.query_one("#scheduling-mark-all-read", Button)
+        assert button.display is True
+
+
+@pytest.mark.asyncio
+async def test_conflicts_badge_shows_count_and_switches_to_conflicts_tab():
+    """redesign PR-2, Task 3, plan ruling 4: the status strip's conflicts
+    badge mirrors `_refresh_conflicts_tab`'s own existing count (no new
+    query) and switches to the Conflicts tab on click -- no overlay."""
+    app = _RailTestApp(
+        _RailService(conflicts=[{"id": "c1"}, {"id": "c2"}])
+    )
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        badge = workbench.query_one("#scheduling-conflicts-badge", Button)
+        assert str(badge.label) == "Conflicts (2)"
+        assert "scheduled task" in str(badge.tooltip).lower()
+
+        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
+        assert tabs.active != "scheduling-conflicts-tab"
+
+        badge.press()
+        await pilot.pause()
+
+        assert tabs.active == "scheduling-conflicts-tab"
+
+
+@pytest.mark.asyncio
+async def test_conflicts_badge_defaults_to_no_count():
+    app = _RailTestApp(_RailService())
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+
+        badge = pilot.app.screen.query_one("#scheduling-conflicts-badge", Button)
+        assert str(badge.label) == "Conflicts"
+
+
+@pytest.mark.asyncio
+async def test_status_strip_sync_widget_is_compact_at_narrow_width():
+    """redesign PR-2, Task 3: the strip's width-triggered compact path --
+    the default (80, 24) test size is well under `SCHEDULES_COMPACT_
+    WORKBENCH_MAX_WIDTH` (120), so `_sync_responsive_workbench` (run at
+    `on_mount`) should already have applied it."""
+    app = _RailTestApp(_RailService())
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+
+        sync_status = pilot.app.screen.query_one(
+            "#scheduling-sync-status", SyncStatusWidget
+        )
+        assert "compact" in sync_status.classes
+
+
+@pytest.mark.asyncio
+async def test_status_strip_sync_widget_is_not_compact_at_wide_width():
+    app = _RailTestApp(_RailService())
+    async with app.run_test(size=(200, 40)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+
+        sync_status = pilot.app.screen.query_one(
+            "#scheduling-sync-status", SyncStatusWidget
+        )
+        assert "compact" not in sync_status.classes

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -10,7 +10,6 @@ import pytest
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
 from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
-from textual.containers import Horizontal
 from textual.widgets import Button, DataTable, Input, Select, Static
 from textual.widgets._collapsible import CollapsibleTitle
 
@@ -91,7 +90,7 @@ class MockSchedulingService(_MockSchedulingServiceMixin):
             )
         ]
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         return await self.list_reminders()
 
     async def create_reminder(self, payload: dict, *, owner_id: str | None = None):
@@ -137,7 +136,7 @@ class MockSchedulingServiceWithWatchlist(_MockSchedulingServiceMixin):
             )
         ]
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         reminder_tasks = await self.list_reminders()
         return reminder_tasks + [
             ScheduledTask(
@@ -463,7 +462,7 @@ class EmptyMockSchedulingService(_MockSchedulingServiceMixin):
     async def list_reminders(self):
         return []
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         return await self.list_reminders()
 
 
@@ -486,7 +485,7 @@ class DistinctMetadataMockSchedulingService(_MockSchedulingServiceMixin):
             )
         ]
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         return await self.list_reminders()
 
 
@@ -496,7 +495,7 @@ class FailingMockSchedulingService(_MockSchedulingServiceMixin):
     async def list_reminders(self):
         raise RuntimeError("service unavailable")
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         raise RuntimeError("service unavailable")
 
 
@@ -635,7 +634,7 @@ async def test_conflict_card_shows_for_conflict_status():
                 )
             ]
 
-        async def list_tasks(self):
+        async def list_tasks(self, owner_id=None):
             return await self.list_reminders()
 
     class WorkbenchTestAppWithConflict(ConsolidatedCSSApp):
@@ -693,84 +692,37 @@ async def test_load_tasks_service_error_notifies_and_uses_empty_state():
         assert "No scheduled tasks yet" in empty_state.visual.plain
 
 
+# redesign PR-2, Task 2: the four watchlist-row tests that used to live
+# here (renders/selects/inspects/hides-lifecycle for a watchlist
+# projection AT ROW 1 of the queue table) pinned the OLD single-primitive
+# table's shape -- a flat reminder+projection list with Title/Type/
+# Status/Next-Run columns. Spec S2 locked decision 2 ("Briefing and
+# watchlist projections stay out") and Task 1's own report ("Task 2 is
+# expected to filter list_tasks' spans-owners result down to real
+# ReminderTask instances") retire that: the unified Queue list is
+# reminders + automation definitions only. Replaced by the single
+# exclusion test below; the detail-pane/inspector rendering for a
+# `ScheduledTask` projection stays covered directly by `task_detail.py`'s
+# own unit tests (`TaskDetail.set_task`/`TaskInspector.set_task` are
+# still general-purpose, just no longer reachable with a projection FROM
+# this table).
 @pytest.mark.asyncio
-async def test_workbench_renders_watchlist_job_row():
-    """The workbench renders both reminders and watchlist projection rows."""
+async def test_watchlist_projection_excluded_from_unified_queue():
+    """A watchlist projection never appears in the unified Queue list."""
     async with WorkbenchTestAppWithMixedService().run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
 
-        table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
-        assert table.row_count == 2
-
-        watchlist_row = table.get_row_at(1)
-        assert "Watchlist Title" in str(watchlist_row[0])
-        assert "Watchlist Job" in str(watchlist_row[1])
-        assert "Waiting" in str(watchlist_row[2])
-        # task-23111: the queue column drops the TZ token and appends a
-        # relative form ("2026-07-20 11:00 (overdue 39d)").
-        assert "2026-07-20 11:00" in str(watchlist_row[3])
-
-
-@pytest.mark.asyncio
-async def test_select_watchlist_task_updates_detail():
-    """Selecting a watchlist row updates the detail pane with projection metadata."""
-    async with WorkbenchTestAppWithMixedService().run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-
-        table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
-        table.cursor_coordinate = (1, 0)
-        pilot.app.screen._update_detail_for_index(1)
-        await pilot.pause()
-
-        detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
-        type_label = detail.query_one("#scheduling-task-detail-type", Static)
-        schedule = detail.query_one("#scheduling-task-detail-schedule", Static)
-
-        assert "Watchlist Job" in type_label.visual.plain
-        assert "Every 1h" in schedule.visual.plain
-
-
-@pytest.mark.asyncio
-async def test_inspector_shows_read_only_projection_for_watchlist():
-    """The inspector surfaces the read-only projection state for watchlist jobs."""
-    async with WorkbenchTestAppWithMixedService().run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-
-        table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
-        table.cursor_coordinate = (1, 0)
-        pilot.app.screen._update_detail_for_index(1)
-        await pilot.pause()
-
-        inspector = pilot.app.screen.query_one(
-            "#scheduling-task-inspector", TaskInspector
-        )
-        sync = inspector.query_one("#scheduling-inspector-sync", Static)
-        last_run = inspector.query_one("#scheduling-inspector-last-run", Static)
-        owner = inspector.query_one("#scheduling-inspector-owner", Static)
-
-        assert "local (read-only projection)" in sync.visual.plain
-        assert "-" == last_run.visual.plain.strip()
-        assert "local" in owner.visual.plain
-
-
-@pytest.mark.asyncio
-async def test_watchlist_task_hides_lifecycle_actions():
-    """Watchlist projections do not expose reminder lifecycle buttons."""
-    async with WorkbenchTestAppWithMixedService().run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-
-        table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
-        table.cursor_coordinate = (1, 0)
-        pilot.app.screen._update_detail_for_index(1)
-        await pilot.pause()
-
-        detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
-        lifecycle = detail.query_one("#scheduling-task-detail-lifecycle", Horizontal)
-        assert lifecycle.display is False
+        workbench = pilot.app.screen
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        assert table.row_count == 1
+        assert "Reminder" in str(table.get_row_at(0)[1])
+        assert not any(
+            row.kind != "reminder" for row in workbench._visible_rows
+        ), "only reminder rows are unified-list eligible until definitions exist"
+        assert all(
+            task.id != "watchlist:1" for task in workbench._tasks
+        ), "the projection must never enter the reminder-only _tasks list"
 
 
 def test_humanize_cron_daily_pattern():
@@ -812,7 +764,7 @@ class ToggleFailingMockSchedulingService(_MockSchedulingServiceMixin):
             )
         ]
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         return await self.list_reminders()
 
 
@@ -864,7 +816,7 @@ class RecordingMockSchedulingService(_MockSchedulingServiceMixin):
             )
         ]
 
-    async def list_tasks(self):
+    async def list_tasks(self, owner_id=None):
         return await self.list_reminders()
 
     async def delete_reminder(self, task_id: str) -> None:
@@ -916,7 +868,7 @@ class ControlledRefreshSchedulingService(_MockSchedulingServiceMixin):
             next_run_at=timestamp,
         )
 
-    async def list_tasks(self) -> list[ReminderTask]:
+    async def list_tasks(self, owner_id=None) -> list[ReminderTask]:
         """Return the next controlled task snapshot.
 
         Returns:
@@ -1039,7 +991,9 @@ async def test_delete_mutation_refresh_cannot_repaint_after_newer_user_refresh()
         assert [task.id for task in workbench._tasks] == ["newest-task"]
         table = workbench.query_one("#scheduling-task-table", DataTable)
         assert table.row_count == 1
-        assert "Newest user snapshot" in str(table.get_row_at(0)[0])
+        # redesign PR-2, Task 2: column 0 is now the glyph, column 1 the
+        # title (old single-primitive shape was Title/Type/Status/Next Run).
+        assert "Newest user snapshot" in str(table.get_row_at(0)[1])
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -90,7 +90,7 @@ class MockSchedulingService(_MockSchedulingServiceMixin):
             )
         ]
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return await self.list_reminders()
 
     async def create_reminder(self, payload: dict, *, owner_id: str | None = None):
@@ -136,7 +136,7 @@ class MockSchedulingServiceWithWatchlist(_MockSchedulingServiceMixin):
             )
         ]
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         reminder_tasks = await self.list_reminders()
         return reminder_tasks + [
             ScheduledTask(
@@ -462,7 +462,7 @@ class EmptyMockSchedulingService(_MockSchedulingServiceMixin):
     async def list_reminders(self):
         return []
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return await self.list_reminders()
 
 
@@ -485,7 +485,7 @@ class DistinctMetadataMockSchedulingService(_MockSchedulingServiceMixin):
             )
         ]
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return await self.list_reminders()
 
 
@@ -495,7 +495,7 @@ class FailingMockSchedulingService(_MockSchedulingServiceMixin):
     async def list_reminders(self):
         raise RuntimeError("service unavailable")
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         raise RuntimeError("service unavailable")
 
 
@@ -634,7 +634,7 @@ async def test_conflict_card_shows_for_conflict_status():
                 )
             ]
 
-        async def list_tasks(self, owner_id=None):
+        async def list_tasks(self, owner_id=None, include_projections=True):
             return await self.list_reminders()
 
     class WorkbenchTestAppWithConflict(ConsolidatedCSSApp):
@@ -764,7 +764,7 @@ class ToggleFailingMockSchedulingService(_MockSchedulingServiceMixin):
             )
         ]
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return await self.list_reminders()
 
 
@@ -816,7 +816,7 @@ class RecordingMockSchedulingService(_MockSchedulingServiceMixin):
             )
         ]
 
-    async def list_tasks(self, owner_id=None):
+    async def list_tasks(self, owner_id=None, include_projections=True):
         return await self.list_reminders()
 
     async def delete_reminder(self, task_id: str) -> None:
@@ -868,7 +868,7 @@ class ControlledRefreshSchedulingService(_MockSchedulingServiceMixin):
             next_run_at=timestamp,
         )
 
-    async def list_tasks(self, owner_id=None) -> list[ReminderTask]:
+    async def list_tasks(self, owner_id=None, include_projections=True) -> list[ReminderTask]:
         """Return the next controlled task snapshot.
 
         Returns:

--- a/Tests/UI/test_ux_batch7.py
+++ b/Tests/UI/test_ux_batch7.py
@@ -154,7 +154,9 @@ async def test_bulk_mark_and_toggle() -> None:
         from textual.widgets import DataTable
 
         table = screen.query_one("#scheduling-task-table", DataTable)
-        first_title = str(table.get_row_at(0)[0])
+        # redesign PR-2, Task 2: column 0 is now the glyph, column 1 the
+        # title (old single-primitive shape was Title/Type/Status/Next Run).
+        first_title = str(table.get_row_at(0)[1])
         assert first_title.startswith("● ")
 
         screen.action_toggle_enabled()

--- a/Tests/Watchlists/test_watchlists_sources_pane.py
+++ b/Tests/Watchlists/test_watchlists_sources_pane.py
@@ -1406,3 +1406,90 @@ def test_source_row_name_strips_control_characters():
     )
     assert "\x9b" not in cells[0].plain
     assert "Evil" in cells[0].plain and "31mFeed" in cells[0].plain
+
+
+# ---------------------------------------------------------------------------
+# "Next check" column (redesign PR-2 Task 2 review, finding 1): the
+# Schedules Queue used to project a watchlist subscription's next-check
+# time; Task 2 dropped watchlist projections from that unified list, which
+# orphaned the only surviving "when will this run again" signal for
+# Watchlists. This restores it in the Sources table, computed the same way
+# (`WatchlistProjection._compute_next_run`), rendered through this pane's
+# own `humane_timestamp` idiom.
+# ---------------------------------------------------------------------------
+
+
+def test_source_next_check_text_computes_from_check_frequency():
+    """last_checked + check_frequency, far enough in the past to render as
+    an absolute date (avoids a Today/Yesterday-relative flake). Compared
+    against `humane_timestamp` directly rather than a hardcoded string --
+    `humane_timestamp` renders in the VIEWER'S local zone, so a fixed
+    UTC-string expectation would be flaky across timezones."""
+    from datetime import datetime, timedelta, timezone
+
+    from tldw_chatbook.UI.Watchlists_Modules.humane_time import humane_timestamp
+
+    last_checked = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    source = {
+        "last_checked_or_scraped_at": last_checked.isoformat(),
+        "settings": {"check_frequency": 3600},  # 1 hour
+    }
+    expected = humane_timestamp(last_checked + timedelta(hours=1))
+    assert SourcesPane.source_next_check_text(source) == expected
+
+
+def test_source_next_check_text_falls_back_to_created_at_before_first_check():
+    from datetime import datetime, timedelta, timezone
+
+    from tldw_chatbook.UI.Watchlists_Modules.humane_time import humane_timestamp
+
+    created_at = datetime(2020, 6, 15, tzinfo=timezone.utc)
+    source = {
+        "created_at": created_at.isoformat(),
+        "settings": {"check_frequency": 86400},  # 1 day
+    }
+    expected = humane_timestamp(created_at + timedelta(days=1))
+    assert SourcesPane.source_next_check_text(source) == expected
+
+
+def test_source_next_check_text_is_dash_without_check_frequency():
+    """A server-backed watchlist source's normalizer never publishes a
+    check_frequency equivalent -- honest "-", the same as the removed
+    Queue projection (WatchlistProjection is local-Subscriptions_DB-only)."""
+    assert SourcesPane.source_next_check_text(
+        {"last_checked_or_scraped_at": "2020-01-01T00:00:00+00:00"}
+    ) == "-"
+    assert SourcesPane.source_next_check_text({}) == "-"
+
+
+@pytest.mark.asyncio
+async def test_sources_table_paints_a_next_check_column():
+    from datetime import datetime, timedelta, timezone
+
+    from tldw_chatbook.UI.Watchlists_Modules.humane_time import humane_timestamp
+
+    last_checked = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    expected = humane_timestamp(last_checked + timedelta(hours=1))
+
+    app = SourcesPaneHarness()
+    async with app.run_test(size=(140, 40)) as pilot:
+        pane = app.query_one(SourcesPane)
+        pane.sources = [
+            {
+                "id": "source-1",
+                "name": "AI News RSS",
+                "source_type": "rss",
+                "status": "ok",
+                "last_checked_or_scraped_at": last_checked.isoformat(),
+                "settings": {"check_frequency": 3600},
+                "active": True,
+            }
+        ]
+        await pilot.pause()
+
+        table = pane.query_one("#sources-table", DataTable)
+        assert [
+            str(column.label) for column in table.columns.values()
+        ] == ["Name", "Type", "Status", "Last checked", "Next check", "Active"]
+        row = table.get_row_at(0)
+        assert str(row[4]) == expected

--- a/backlog/docs/plan-2026-09-03-schedules-redesign-pr2.md
+++ b/backlog/docs/plan-2026-09-03-schedules-redesign-pr2.md
@@ -1,0 +1,66 @@
+# Schedules Redesign — PR-2: Unified list, filter chips, rail chrome
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The Queue tab becomes the redesign's unified surface: one list of reminders AND recurring-question definitions across both owners, filtered by the four chips, searched in-memory, ticked every 60s, with the rail chrome (Create ▾, Mark-all-read, bottom status strip) around it. Read-mostly: definition rows are viewable with the PR-1 detail pane; their actions stay on the Automations tab until PR-4 retires it.
+
+**Architecture:** A pure row-adapter module (`unified_rows.py`) turns reminder + definition rows into one `UnifiedRow` shape — status bucket (the chip predicates, including the verified fired-one-time predicate and PR-5's transfer-arming semantics), glyph, schedule summary, relative next-run, owner, unread count (derived in Python from ONE all-owners results listing routed through the dual local/server id-space resolution — never N queries, never a naive join). The Queue `DataTable` renders those rows; highlight routes between the two PR-1 detail panes by toggling the existing `pane-hidden` class (they become siblings in the Queue detail area). The cross-owner reminder seam is one parameter thread (the DB layer already supports `owner_id=None`, unused). The rail relocates the existing Create chooser, adds search + Mark-all-read, and a bottom strip hosting the sync widget (new width-compact path) + a conflicts badge that switches to the Conflicts tab (the overlay is PR-4 polish). The 60s ticker clones the file's own `set_interval` pause/resume idiom with `on_screen_suspend`/`on_screen_resume`.
+
+**Tech Stack:** Python ≥3.11, Textual 8.x, SQLite, pytest.
+
+**Spec:** `backlog/docs/spec-2026-09-02-schedules-screen-redesign.md` §3/§4 (tracked on dev since PR-1). Planning rulings (binding):
+1. **Morph-in-place**: the Queue tab IS the unified surface; Automations/Conflicts/Results tabs coexist untouched until PR-4. Definition rows in the unified list are viewable (highlight → PR-1's `DefinitionDetail`); NO new definition-action wiring in PR-2 — reminder rows keep every existing behavior verbatim.
+2. **Chip mapping** (spec §3 + PR-5 semantics): Active = enabled reminders + `configured` definitions, INCLUDING `to_server_pending`/`to_server_failed` rows (reuse the armable-filter semantics — `DORMANT_TRANSFER_STATES` is the authority, do not restate the state list); Paused = disabled-but-not-fired reminders + `paused` definitions; Completed = fired one-time reminders (`enabled=0 AND next_run_at IS NULL AND last_run_at IS NOT NULL` — name it `reminder_has_fired(row)` where the bucket logic lives) + `archived` definitions; All = Active + Paused. `disabled`-lifecycle definitions bucket as Paused with their lock reason preserved for the detail pane.
+3. **Unread derivation**: one all-owners `list_automation_results` call per refresh; counts grouped in Python and resolved through the SAME dual id-space logic as `results_tab.py`'s `index_definitions_by_id`/`definition_for_result` — hoist those helpers to a shared module if importing them would cycle (check direction first). A definition row's dot shows when its resolved unread count > 0.
+4. **Status strip minimalism**: the strip hosts the EXISTING `SyncStatusWidget` under a new compact styling path + the owner indicator it already contains + a conflicts badge chip (existing count semantics — single-owner reminder conflicts — with the count's scope stated in the tooltip) that SWITCHES to the Conflicts tab. No overlay, no new conflict queries.
+5. **Sort**: `next_run_at` ascending (None last) within Active; most-recent-first (`last_run_at`/`updated_at` desc) for Paused/Completed; the All chip keeps Active's order for armed rows then appends Paused by recency. Search = case-insensitive substring over title + question/body, in-memory.
+
+## Global Constraints
+
+- Worktree `/Users/macbook-dev/Documents/GitHub/tldw_chatbook-redesign-pr2`, branch `feat/schedules-unified-list` off current `origin/dev`. Never the main checkout; NEVER `git stash`; no pkill beyond own PIDs; `git --no-pager`; FOREGROUND pytest only; tmp_path DBs.
+- NO schema migration; NO sync/action behavior changes — listing, filtering, rendering, routing only (plus the one service parameter thread).
+- Survey with exact seams: `redesign-pr2-survey.md` in the SDD workspace.
+- Diagnostics pin is a SCRIPT (`scripts/check_persistent_diagnostic_inventory.py --write` + commit JSON) on any logger change. Census merge bar = COUNT parity with dev's CI (watch new imports on the workbench path). CSS via the build flow, `$ds-*` tokens, source+bundle together. Geometry/paint tests need `CSS_PATH = BUNDLED_STYLESHEET` (documented trap). Painted-output assertions only. `DetailGroup(title=...)` is keyword-only.
+- UI change ⇒ `Docs/User_Guide/` schedules page update.
+- Commit trailer on every commit:
+
+```
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01WocisXw6SEEG6nb1aKFHtv
+```
+
+---
+
+### Task 1: Row adapter + cross-owner seam (pure core)
+
+**Files:** Create `tldw_chatbook/UI/Screens/scheduling/unified_rows.py` (pure — no Textual imports). Modify `tldw_chatbook/Scheduling/services/scheduling_service.py` (`list_tasks` gains `owner_id: str | None | EllipsisType`-style opt-in spans-owners parameter — read the current signature and pick the least-invasive shape; default preserves every caller), and hoist the id-space helpers if ruling 3's cycle check demands it. Tests: `Tests/Scheduling/test_unified_rows.py` (new), `test_scheduling_service.py`.
+
+**Interfaces (produced; Task 2 consumes):**
+- `@dataclass UnifiedRow`: `kind` ("reminder"|"definition"), `row_id`, `title`, `schedule_summary`, `next_run_at`, `owner_id`, `owner_label`, `transfer_state`, `bucket` ("active"|"paused"|"completed"), `glyph`, `unread_count`, `search_blob`, `source_row` (the original dict/task).
+- `build_unified_rows(reminders: list, definitions: list[dict], results: list[dict]) -> list[UnifiedRow]` — buckets per ruling 2 (`reminder_has_fired` defined here; definition arming defers to `DORMANT_TRANSFER_STATES` + lifecycle), glyphs per spec §4 (`○` recurring, `▶` one-shot/monitor, `⏸` paused, `✓` completed), schedule summaries via the EXISTING formatting helpers (import, don't re-derive), owner labels via `owner_display_label`, unread via ruling 3's Python grouping.
+- `filter_rows(rows, *, chip: str, query: str) -> list[UnifiedRow]` and `sort_rows(rows, chip)` per ruling 5.
+
+- [ ] TDD: bucket table (every chip × both primitives × transfer states incl. pending/failed-stay-active and the fired predicate); unread resolution across BOTH id spaces (a server-mirrored definition's results counted — the survey's warning is the test); sort orders; search; spans-owners `list_tasks` (existing callers pinned unchanged). FAIL → implement → PASS → commit `feat(scheduling): unified row adapter + cross-owner listing`.
+
+### Task 2: The unified Queue surface
+
+**Files:** Modify `tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py` (Queue tab: chips row above the table; the DataTable renders `UnifiedRow`s — glyph/title/subtitle columns per spec §4 with the existing owner-suffix and transfer-badge rendering preserved; unread dot; chip + search filtering; `load_tasks` becomes the unified loader calling Task 1 with the three listings — reminders spans-owners, both definition halves via the existing merge precedent, one results listing; detail routing: compose `DefinitionDetail` as a sibling of `TaskDetail` in the Queue detail area, toggle via the `pane-hidden` class on highlight by row kind; reminder-row behavior byte-preserved — every existing binding/action/test), CSS as needed. Tests: `Tests/UI/test_schedules_workbench.py` + a new `Tests/UI/test_schedules_unified_list.py`.
+
+- [ ] TDD: mixed listing renders both kinds (painted); chips filter (each chip's bucket, incl. a fired reminder under Completed and a to_server_pending row under Active); search narrows; highlight routes to the right detail pane both directions; reminder actions all still fire (the existing test suite is the preservation gate — zero unrelated assertion changes allowed); definition rows expose NO actions. FAIL → implement → PASS → commit `feat(scheduling): unified queue list with filter chips`.
+
+### Task 3: Rail chrome + status strip
+
+**Files:** Modify `schedules_workbench.py` (rail header: relocate the existing "+ New" chooser as `Create ▾`; search input wiring; `Mark all as read` action visible only when total unread > 0, reusing the Results tab's per-row mutation fan-out; bottom status strip: the existing `SyncStatusWidget` restyled compact for the strip (new width-compact CSS path — the survey says one compact path exists for local-only; add the width-triggered one), conflicts badge chip (existing count, scope in tooltip, click switches to the Conflicts tab)), `sync_status_widget.py` (the compact path), CSS. Tests: workbench + a small sync-widget compact test.
+
+- [ ] TDD: chooser reachable from the rail (both create paths still open their modals); Mark-all-read visibility + action; strip renders compact; badge switches tabs. FAIL → implement → PASS → commit `feat(scheduling): rail chrome and status strip`.
+
+### Task 4: Ticker + docs + gates
+
+**Files:** Modify `schedules_workbench.py` (60s `set_interval` cloning the file's own pause/resume-with-immediate-refresh idiom — the survey's line refs; suspend on `on_screen_suspend`, resume+refresh on `on_screen_resume`; tick updates ONLY the visible rows' relative next-run text, no full reload), `Docs/User_Guide/` schedules page (unified list, chips, rail). Gates.
+
+- [ ] TDD: tick updates relative text without a reload (fake clock or injected now — read how schedule_compute tests inject time); suspend/resume behavior; then FULL gates — `Tests/Scheduling/ -q`, all schedules UI files, census (count parity vs dev CI), pin script, ruff, bundle byte-identical. Commit `feat(scheduling): relative-time ticker + docs`.
+
+---
+
+## After the tasks
+Final whole-branch review (opus; preservation + bucket-correctness + id-space lenses) → one fix wave → PR `feat(scheduling): unified schedules list + filter chips + rail (redesign PR-2)` → paged bot read → adjudicate → rebase-watch with `gh pr merge` INSIDE the 30s loop on CLEAN (auto-merge is disabled repo-wide; exit-then-merge loses the race).

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -12,6 +12,7 @@ import asyncio
 from dataclasses import dataclass
 from dataclasses import field as _dataclass_field
 from datetime import datetime, timedelta, timezone
+from types import EllipsisType
 from typing import Any, Callable
 from zoneinfo import ZoneInfo
 
@@ -425,9 +426,38 @@ class SchedulingService:
         rows = self.db.list_reminder_tasks(owner_id=self.owner_id)
         return [self._row_to_reminder(row) for row in rows]
 
-    async def list_tasks(self) -> list[ReminderTask | ScheduledTask]:
-        """Return reminders plus watchlist/briefing projections for the current owner."""
-        tasks: list[ReminderTask | ScheduledTask] = list(await self.list_reminders())
+    async def list_tasks(
+        self, owner_id: str | None | EllipsisType = ...
+    ) -> list[ReminderTask | ScheduledTask]:
+        """Return reminders plus watchlist/briefing projections.
+
+        Args:
+            owner_id: Reminder owner scope. The default (``...``, i.e. the
+                parameter is left unset) preserves every existing caller
+                byte-for-byte: reminders scope to ``self.owner_id``, same
+                as before this parameter existed. Pass ``None`` for a
+                spans-owners listing -- every owner's reminders, via
+                `ScheduledTasksDB.list_reminder_tasks`'s own
+                ``owner_id=None`` "no WHERE clause" behavior (redesign
+                PR-2's unified Queue list) -- or a specific owner id
+                string to scope reminders to that one owner.
+                Watchlist/briefing projections always stay scoped to
+                ``self.owner_id`` regardless of this argument: their
+                `list_jobs` only STAMPS the given owner id onto every row
+                (their underlying read has no per-owner filter at all),
+                so a ``None`` owner would fail their `ScheduledTask.
+                owner_id: str` field instead of "spanning owners".
+
+        Returns:
+            Reminders (in the requested owner scope) plus this device's
+            watchlist/briefing projections, sorted by ``next_run_at``
+            ascending (``None`` last).
+        """
+        reminder_owner_id = self.owner_id if owner_id is ... else owner_id
+        rows = self.db.list_reminder_tasks(owner_id=reminder_owner_id)
+        tasks: list[ReminderTask | ScheduledTask] = [
+            self._row_to_reminder(row) for row in rows
+        ]
         if self.watchlist_projection is not None:
             tasks.extend(self.watchlist_projection.list_jobs(owner_id=self.owner_id))
         if self.briefing_projection is not None:

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -582,12 +582,27 @@ class SchedulingService:
         assert row is not None
         return self._row_to_reminder(row)
 
-    async def delete_reminder(self, task_id: str) -> bool:
+    async def delete_reminder(
+        self, task_id: str, *, owner_id: str | None = None
+    ) -> bool:
         """Delete a reminder locally and on the server when connected.
 
         If the server is unavailable or returns an error, a tombstone is recorded
         so the delete can be pushed later.
+
+        Args:
+            task_id: The local reminder row to delete.
+            owner_id: The owner this delete belongs to; defaults to
+                `self.owner_id`. Same rationale (and same `_owner_uses_
+                server` seam) as `create_reminder`/`update_reminder`'s --
+                redesign PR-2's Queue lists reminders across owners, so
+                "the row under the cursor" is no longer guaranteed to be
+                the service's active owner. Deleting a `server:` row
+                while the active owner was local previously took the
+                local-only branch: no server call, no tombstone, and the
+                row came back on the next pull (final review F4).
         """
+        owner_id = owner_id or self.owner_id
         row = self.db.get_reminder_task(task_id)
         if row is None:
             return False
@@ -605,7 +620,7 @@ class SchedulingService:
             )
             return False
 
-        use_server = self._use_server()
+        use_server = self._owner_uses_server(owner_id)
         if use_server:
             assert self.server_client is not None
             server_id = row.get("server_id")
@@ -613,32 +628,32 @@ class SchedulingService:
                 if server_id:
                     await self.server_client.delete_reminder(server_id)
                 self.db.delete_reminder_task(task_id)
-                self.db.delete_sync_mapping(task_id, _REMINDER_PRIMITIVE, self.owner_id)
+                self.db.delete_sync_mapping(task_id, _REMINDER_PRIMITIVE, owner_id)
                 self.db.delete_pending_mutation_for_record(
-                    task_id, _REMINDER_PRIMITIVE, self.owner_id
+                    task_id, _REMINDER_PRIMITIVE, owner_id
                 )
                 self._notify_queue_changed()
                 return True
             except ServerUnavailableError:
                 logger.warning(
-                    f"Server unavailable while deleting reminder {task_id} for {self.owner_id}"
+                    f"Server unavailable while deleting reminder {task_id} for {owner_id}"
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.exception(
-                    f"Server delete_reminder failed for {task_id} ({self.owner_id}): {exc}"
+                    f"Server delete_reminder failed for {task_id} ({owner_id}): {exc}"
                 )
 
             if server_id is None:
                 # No server copy exists; drop any stale pending mutation and
                 # fall back to a local-only delete.
                 self.db.delete_pending_mutation_for_record(
-                    task_id, _REMINDER_PRIMITIVE, self.owner_id
+                    task_id, _REMINDER_PRIMITIVE, owner_id
                 )
 
-            self.db.record_tombstone(task_id, _REMINDER_PRIMITIVE, self.owner_id)
+            self.db.record_tombstone(task_id, _REMINDER_PRIMITIVE, owner_id)
             self.db.delete_reminder_task(task_id)
             self.db.delete_pending_mutation_for_record(
-                task_id, _REMINDER_PRIMITIVE, self.owner_id
+                task_id, _REMINDER_PRIMITIVE, owner_id
             )
             self._notify_queue_changed()
             return True

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -427,9 +427,12 @@ class SchedulingService:
         return [self._row_to_reminder(row) for row in rows]
 
     async def list_tasks(
-        self, owner_id: str | None | EllipsisType = ...
+        self,
+        owner_id: str | None | EllipsisType = ...,
+        *,
+        include_projections: bool = True,
     ) -> list[ReminderTask | ScheduledTask]:
-        """Return reminders plus watchlist/briefing projections.
+        """Return reminders plus (optionally) watchlist/briefing projections.
 
         Args:
             owner_id: Reminder owner scope. The default (``...``, i.e. the
@@ -447,21 +450,36 @@ class SchedulingService:
                 (their underlying read has no per-owner filter at all),
                 so a ``None`` owner would fail their `ScheduledTask.
                 owner_id: str` field instead of "spanning owners".
+            include_projections: Default ``True`` preserves every existing
+                caller byte-for-byte. ``False`` skips both `list_jobs`
+                calls entirely -- redesign PR-2 Task 2's review, finding
+                2: the unified Queue's `load_tasks` immediately filters
+                every `ScheduledTask` row back out, so building AND
+                sorting them was pure waste on that path (a full
+                `Subscriptions_DB.get_all_subscriptions` scan plus a
+                comparable briefing read, on every Queue refresh). The
+                Queue passes ``include_projections=False``.
 
         Returns:
-            Reminders (in the requested owner scope) plus this device's
-            watchlist/briefing projections, sorted by ``next_run_at``
-            ascending (``None`` last).
+            Reminders (in the requested owner scope) plus, when
+            ``include_projections`` is true, this device's watchlist/
+            briefing projections -- sorted by ``next_run_at`` ascending
+            (``None`` last).
         """
         reminder_owner_id = self.owner_id if owner_id is ... else owner_id
         rows = self.db.list_reminder_tasks(owner_id=reminder_owner_id)
         tasks: list[ReminderTask | ScheduledTask] = [
             self._row_to_reminder(row) for row in rows
         ]
-        if self.watchlist_projection is not None:
-            tasks.extend(self.watchlist_projection.list_jobs(owner_id=self.owner_id))
-        if self.briefing_projection is not None:
-            tasks.extend(self.briefing_projection.list_jobs(owner_id=self.owner_id))
+        if include_projections:
+            if self.watchlist_projection is not None:
+                tasks.extend(
+                    self.watchlist_projection.list_jobs(owner_id=self.owner_id)
+                )
+            if self.briefing_projection is not None:
+                tasks.extend(
+                    self.briefing_projection.list_jobs(owner_id=self.owner_id)
+                )
         # Sort by next_run_at (None sorts last)
         tasks.sort(
             key=lambda t: t.next_run_at or datetime.max.replace(tzinfo=timezone.utc)

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -54,7 +54,6 @@ same reason.
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any
 
 from textual.app import ComposeResult
@@ -70,10 +69,13 @@ from .forms.automation_definition_form import (
 from .task_detail import (
     _TRANSFER_STATE_ROW_LABELS,
     _format_timezone,
-    _humanize_cron,
-    definition_cron_expression,
     owner_display_label,
 )
+# `_definition_at_label`/`_definition_question_text`/`_parse_iso` moved to
+# `unified_rows.py` (redesign PR-2 Task 1 -- that pure module needs them
+# too and cannot import a Textual-heavy module without dragging Textual in
+# as a side effect); imported back here unchanged.
+from .unified_rows import _definition_at_label, _definition_question_text, _parse_iso
 
 #: Absent key -> honest placeholder (final review F2). A definition this
 #: client did not author carries none of the create-form's config keys,
@@ -206,22 +208,6 @@ def _definition_transfer_suffix(definition: dict[str, Any]) -> str:
     return f" ({label})" if label else ""
 
 
-def _definition_question_text(definition: dict[str, Any]) -> str:
-    """Question-card text: the recurring question, or a fallback for a
-    definition that has none (a non-`recurring_question` family, or a
-    row from an older/foreign server payload shape)."""
-    input_fields = (
-        definition.get("input") if isinstance(definition.get("input"), dict) else {}
-    )
-    question = str(input_fields.get("question") or "").strip()
-    if question:
-        return question
-    description = str(definition.get("description") or "").strip()
-    if description:
-        return description
-    return str(definition.get("name") or "Untitled automation")
-
-
 def _definition_generation_label(config: dict[str, Any]) -> str:
     """'Generation' row value (Details group): `config.generation_mode`,
     labeled with the same wording the create/edit form's Select uses;
@@ -289,16 +275,6 @@ def _definition_notifications_label(definition: dict[str, Any]) -> str:
     return " · ".join(parts) if parts else _NOT_SET
 
 
-def _parse_iso(value: Any) -> datetime | None:
-    """Best-effort ISO-8601 parse; ``None`` for anything else, never raises."""
-    if not isinstance(value, str) or not value:
-        return None
-    try:
-        return datetime.fromisoformat(value)
-    except ValueError:
-        return None
-
-
 def _definition_repeat_label(schedule: dict[str, Any]) -> str:
     """'Repeat' row value (Frequency group): "Recurring" or "One-time" --
     the definition-schedule counterpart of `task_detail._humanize_schedule_
@@ -309,27 +285,6 @@ def _definition_repeat_label(schedule: dict[str, Any]) -> str:
         return "Recurring"
     if kind == "one_time":
         return "One-time"
-    return "-"
-
-
-def _definition_at_label(schedule: dict[str, Any]) -> str:
-    """'At' row value (Frequency group): the full schedule summary, reusing
-    `_humanize_cron` for a cron-kind schedule -- the same formatter
-    `task_detail._humanize_schedule`/`reminder_form.py`'s live cron preview
-    already reuse -- rather than re-deriving cron-cadence prose."""
-    if not isinstance(schedule, dict):
-        return "-"
-    kind = schedule.get("kind")
-    if kind == "cron":
-        return _humanize_cron(
-            definition_cron_expression(schedule), schedule.get("timezone")
-        )
-    if kind == "one_time":
-        run_at = schedule.get("run_at")
-        dt = _parse_iso(run_at) if run_at else None
-        if dt is None:
-            return f"One-time at {run_at}" if run_at else "One-time"
-        return f"One-time at {dt.strftime('%Y-%m-%d %H:%M')} {_format_timezone(dt)}"
     return "-"
 
 

--- a/tldw_chatbook/UI/Screens/scheduling/results_tab.py
+++ b/tldw_chatbook/UI/Screens/scheduling/results_tab.py
@@ -24,6 +24,16 @@ from textual.app import ComposeResult
 from textual.containers import Vertical
 from textual.widgets import DataTable, Static
 
+# `index_definitions_by_id`/`definition_for_result` moved to
+# `unified_rows.py` (redesign PR-2 Task 1 -- that pure module resolves
+# results across the same dual local/server id space and cannot import a
+# Textual-heavy module without dragging Textual in as a side effect);
+# imported back here unchanged so every existing call site keeps working.
+from .unified_rows import (
+    definition_for_result,
+    index_definitions_by_id,  # noqa: F401  (re-export: schedules_workbench.py imports this from here)
+)
+
 _KIND_GLYPHS = {"finding": "●", "failure": "✕"}  # ● / ✕
 
 #: The tab's heading when every stored result fits in the listing.
@@ -131,62 +141,6 @@ def _review_state_cell(review_state: str) -> Text:
     if review_state == "unread":
         return Text(f"● {review_state}", style="bold")
     return Text(review_state or "-")
-
-
-def index_definitions_by_id(
-    rows: list[dict[str, Any]],
-) -> dict[str, dict[str, Any]]:
-    """Index definition rows under BOTH id spaces they are referred to by.
-
-    A result's `definition_id` is whatever the side that produced it
-    calls the definition: a locally-created result carries the LOCAL row
-    id, while a result mirrored down from the server carries the
-    SERVER's id (`upsert_automation_results_from_server` copies
-    `definition_id` verbatim -- it has no local id to translate it to).
-    Indexing by `row["id"]` alone therefore missed every synced result,
-    so mark-solved refused with "definition could not be found" on
-    exactly the rows the feature exists for (live verification task 6,
-    D3). Local ids are UUID4 and server ids are the server's own opaque
-    ids, so the two key spaces do not collide in practice; the local id
-    is written first regardless, so a pathological clash still resolves
-    to a row this device owns.
-
-    Args:
-        rows: Definition rows from
-            `ScheduledTasksDB.list_automation_definitions`.
-
-    Returns:
-        Each row keyed by its local ``id`` and, when present, by its
-        ``server_id`` too.
-    """
-    index: dict[str, dict[str, Any]] = {}
-    for row in rows:
-        index[str(row["id"])] = row
-    for row in rows:
-        server_id = row.get("server_id")
-        if server_id:
-            index.setdefault(str(server_id), row)
-    return index
-
-
-def definition_for_result(
-    result: dict[str, Any], definitions_by_id: dict[str, dict[str, Any]]
-) -> dict[str, Any] | None:
-    """The definition row a result belongs to, across both id spaces.
-
-    Pairs with `index_definitions_by_id`; the one lookup both the
-    eligibility gate and the mark-solved action route through, so they
-    can never disagree about which definition a row resolves to.
-
-    Args:
-        result: An ``automation_results`` row.
-        definitions_by_id: The index built by `index_definitions_by_id`.
-
-    Returns:
-        The owning definition row, or ``None`` when the result's
-        ``definition_id`` matches neither id space.
-    """
-    return definitions_by_id.get(str(result.get("definition_id") or ""))
 
 
 def solved_eligibility(

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -308,6 +308,16 @@ class SchedulesWorkbench(BaseAppScreen):
         self._visible_tasks: list[ReminderTask] = []
         self._all_rows: list[UnifiedRow] = []
         self._visible_rows: list[UnifiedRow] = []
+        # redesign PR-2, Task 2 review round 2: any Automations-tab
+        # mutation of a definition (create/edit save, run-now, transfer
+        # begin/cancel -- everything that funnels through
+        # `_request_automations_refresh`) sets this; a reminder-only
+        # refresh (`refresh_definitions=False`) upgrades to a full one
+        # and clears it, and switching TO the Queue tab while stale does
+        # the same. Without this, the Queue's cached definition rows
+        # could go stale for the whole session -- reminder-only actions
+        # deliberately stopped self-healing it (finding 3's own fix).
+        self._definitions_stale = False
         self._chip: Chip = "all"
         self._filter_text = ""
         self._filter_debounce_timer: Timer | None = None
@@ -919,6 +929,14 @@ class SchedulesWorkbench(BaseAppScreen):
         """
         return [row.source_row for row in self._all_rows if row.kind == "definition"]
 
+    @on(TabbedContent.TabActivated, pane="#scheduling-queue-tab")
+    def _on_queue_tab_activated(self, event: TabbedContent.TabActivated) -> None:
+        """Arriving on the Queue tab while definitions are stale (review
+        round 2) upgrades the next refresh to a full one, rather than
+        waiting for a reminder action to (maybe never) trigger one."""
+        if self._definitions_stale:
+            self._request_tasks_refresh()
+
     async def load_tasks(self, *, refresh_definitions: bool = True) -> None:
         """Fetch reminders + automation definitions and build the unified
         Queue rows (redesign PR-2, Task 2).
@@ -932,12 +950,18 @@ class SchedulesWorkbench(BaseAppScreen):
         since this call site discarded every one of them anyway), both
         definition halves (the Automations tab's existing local+server
         merge, reused verbatim -- or, when ``refresh_definitions`` is
-        False, the definitions already in `self._all_rows` from the last
-        full load, review finding 3), and one all-owners results listing
-        (unread-count derivation only). The results read + row build are
-        pushed off the event loop (`asyncio.to_thread`), the same "local
-        DB read, off-thread" discipline `_load_local_automations`
-        already uses.
+        False AND nothing marked the cache stale, the definitions
+        already in `self._all_rows` from the last full load, review
+        finding 3), and one all-owners results listing (unread-count
+        derivation only). The results read + row build are pushed off
+        the event loop (`asyncio.to_thread`), the same "local DB read,
+        off-thread" discipline `_load_local_automations` already uses.
+
+        `self._definitions_stale` (review round 2): an Automations-tab
+        mutation upgrades the NEXT call here to a full definitions fetch
+        even when the caller only asked for `refresh_definitions=False`
+        -- a reminder-only refresh must not keep painting a definitions
+        snapshot a since-edited/transferred/run automation has outgrown.
         """
         service = self._scheduling_service
         if service is None:
@@ -952,11 +976,14 @@ class SchedulesWorkbench(BaseAppScreen):
             # Defensive, not load-bearing: `include_projections=False`
             # already guarantees every row is a `ReminderTask`.
             reminders = [task for task in combined if isinstance(task, ReminderTask)]
+            do_full_definitions_fetch = refresh_definitions or self._definitions_stale
             definitions = (
                 await self._load_queue_definitions(service)
-                if refresh_definitions
+                if do_full_definitions_fetch
                 else self._current_definitions()
             )
+            if do_full_definitions_fetch:
+                self._definitions_stale = False
 
             def _build_rows() -> list[UnifiedRow]:
                 results = service.db.list_automation_results(
@@ -1842,6 +1869,9 @@ class SchedulesWorkbench(BaseAppScreen):
         """
         if outcome is None:
             return
+        # redesign PR-2 Task 2 review round 2: a real definition save --
+        # the Queue's cached definitions rows may now be outdated.
+        self._definitions_stale = True
         status = getattr(outcome, "status", None)
         verb = "updated" if was_edit else "created"
         if status == "saved":
@@ -2078,7 +2108,21 @@ class SchedulesWorkbench(BaseAppScreen):
         )  # type: ignore[arg-type]
 
     def _request_automations_refresh(self) -> None:
-        """Schedule the automations loader through its exclusive worker group."""
+        """Schedule the automations loader through its exclusive worker group.
+
+        NOTE: this alone must NOT set `self._definitions_stale` -- it is
+        also called at mount and from sync-completed/failed
+        (`schedules-load-automations` fires concurrently with the
+        Queue's own mount-time full refresh), and doing so here caused a
+        real regression (round 2 fix-round-1 draft): the Queue tab's
+        `TabbedContent.TabActivated` fires for the INITIAL default-active
+        tab too, so a stale flag set by mount's own automations refresh
+        was immediately consumed by the tab-activation handler, forcing
+        a SECOND full Queue reload on every mount. Staleness is instead
+        marked at each genuine mutation call site (create/edit save,
+        run-now, transfer begin/cancel) -- see their own `self.
+        _definitions_stale = True` lines.
+        """
         self.run_worker(
             self.load_automations,
             exclusive=True,
@@ -2662,6 +2706,9 @@ class SchedulesWorkbench(BaseAppScreen):
             self.app_instance.notify(
                 f"'{name}' ran now{deduped}.", severity="information"
             )
+            # redesign PR-2 Task 2 review round 2: a real local run --
+            # the Queue's cached definitions rows may now be outdated.
+            self._definitions_stale = True
             self._request_automations_refresh()
 
         self.run_worker(
@@ -2949,6 +2996,13 @@ class SchedulesWorkbench(BaseAppScreen):
             return
 
         async def _resolve_and_begin() -> None:
+            # redesign PR-2 Task 2 review round 2: a genuine user-
+            # triggered transfer attempt (m/M/y) -- the Queue's cached
+            # definitions rows may now be outdated regardless of which
+            # branch below this lands on (refused/pending/not_found all
+            # still touch the local mirror row via `_resolve_local_
+            # definition_id`).
+            self._definitions_stale = True
             local_id = await self._resolve_local_definition_id(service, definition)
             if local_id is None:
                 self.app_instance.notify(
@@ -3051,6 +3105,10 @@ class SchedulesWorkbench(BaseAppScreen):
             return
 
         async def _resolve_and_cancel() -> None:
+            # redesign PR-2 Task 2 review round 2: a genuine user-
+            # triggered cancel (k) -- see `_resolve_and_begin`'s matching
+            # comment for why this is marked unconditionally.
+            self._definitions_stale = True
             local_id = await self._resolve_local_definition_id(service, definition)
             if local_id is None:
                 self.app_instance.notify(

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -887,28 +887,57 @@ class SchedulesWorkbench(BaseAppScreen):
             "schedules-workbench-compact",
         )
 
-    def _request_tasks_refresh(self) -> None:
-        """Schedule the task loader through its exclusive worker group."""
+    def _request_tasks_refresh(self, *, refresh_definitions: bool = True) -> None:
+        """Schedule the task loader through its exclusive worker group.
+
+        Args:
+            refresh_definitions: Passed through to `load_tasks`. Default
+                ``True`` preserves every call site's prior behavior (full
+                reload). Reminder-only actions (delete/edit/mark/toggle/
+                transfer/bulk-*, owner switch) pass ``False`` -- redesign
+                PR-2 Task 2 review, finding 3: none of them can change
+                which automation definitions exist, so re-running the
+                full local+server definitions fetch on each one was pure
+                waste on the hot refresh path. Mount and sync-completed/
+                failed keep the default: sync can genuinely pull/push
+                definitions, and mount has no prior snapshot to reuse.
+        """
+
+        async def _load() -> None:
+            await self.load_tasks(refresh_definitions=refresh_definitions)
+
         self.run_worker(
-            self.load_tasks,
+            _load,
             exclusive=True,
             group="schedules-load-tasks",
         )  # type: ignore[arg-type]
 
-    async def load_tasks(self) -> None:
+    def _current_definitions(self) -> list[dict[str, Any]]:
+        """The automation-definition dicts already sitting in the last-
+        built unified rows -- reused by a reminder-only refresh instead
+        of re-fetching them (redesign PR-2 Task 2 review, finding 3).
+        """
+        return [row.source_row for row in self._all_rows if row.kind == "definition"]
+
+    async def load_tasks(self, *, refresh_definitions: bool = True) -> None:
         """Fetch reminders + automation definitions and build the unified
         Queue rows (redesign PR-2, Task 2).
 
         Three listings feed Task 1's `build_unified_rows`: reminders
-        spans-owners (`SchedulingService.list_tasks(owner_id=None)`,
-        filtered to real `ReminderTask` rows -- watchlist/briefing
-        projections stay out per spec S2 locked decision 2 and Task 1's
-        own report), both definition halves (the Automations tab's
-        existing local+server merge, reused verbatim), and one
-        all-owners results listing (unread-count derivation only). The
-        results read + row build are pushed off the event loop
-        (`asyncio.to_thread`), the same "local DB read, off-thread"
-        discipline `_load_local_automations` already uses.
+        spans-owners (`SchedulingService.list_tasks(owner_id=None,
+        include_projections=False)` -- watchlist/briefing projections
+        stay out per spec S2 locked decision 2 and Task 1's own report,
+        and `include_projections=False` (Task 2 review finding 2) stops
+        `list_tasks` from building AND sorting them in the first place,
+        since this call site discarded every one of them anyway), both
+        definition halves (the Automations tab's existing local+server
+        merge, reused verbatim -- or, when ``refresh_definitions`` is
+        False, the definitions already in `self._all_rows` from the last
+        full load, review finding 3), and one all-owners results listing
+        (unread-count derivation only). The results read + row build are
+        pushed off the event loop (`asyncio.to_thread`), the same "local
+        DB read, off-thread" discipline `_load_local_automations`
+        already uses.
         """
         service = self._scheduling_service
         if service is None:
@@ -917,9 +946,17 @@ class SchedulesWorkbench(BaseAppScreen):
             return
 
         try:
-            combined = await service.list_tasks(owner_id=None)
+            combined = await service.list_tasks(
+                owner_id=None, include_projections=False
+            )
+            # Defensive, not load-bearing: `include_projections=False`
+            # already guarantees every row is a `ReminderTask`.
             reminders = [task for task in combined if isinstance(task, ReminderTask)]
-            definitions = await self._load_queue_definitions(service)
+            definitions = (
+                await self._load_queue_definitions(service)
+                if refresh_definitions
+                else self._current_definitions()
+            )
 
             def _build_rows() -> list[UnifiedRow]:
                 results = service.db.list_automation_results(
@@ -1466,7 +1503,7 @@ class SchedulesWorkbench(BaseAppScreen):
                     f"Deleted '{event.task.title}'.",
                     severity="information",
                 )
-            self._request_tasks_refresh()
+            self._request_tasks_refresh(refresh_definitions=False)
 
         self.run_worker(
             _delete_and_refresh,
@@ -1590,10 +1627,10 @@ class SchedulesWorkbench(BaseAppScreen):
                     f"Failed to start the transfer for '{task.title}'.",
                     severity="error",
                 )
-                self._request_tasks_refresh()
+                self._request_tasks_refresh(refresh_definitions=False)
                 return
             self._notify_transfer_outcome(task, direction, outcome)
-            self._request_tasks_refresh()
+            self._request_tasks_refresh(refresh_definitions=False)
 
         self.run_worker(
             _confirm_and_begin,
@@ -1651,7 +1688,7 @@ class SchedulesWorkbench(BaseAppScreen):
                     f"Failed to cancel the transfer for '{task.title}'.",
                     severity="error",
                 )
-                self._request_tasks_refresh()
+                self._request_tasks_refresh(refresh_definitions=False)
                 return
             if outcome.status == "cancelled":
                 self.app_instance.notify(
@@ -1664,7 +1701,7 @@ class SchedulesWorkbench(BaseAppScreen):
                     or f"Could not cancel the transfer for '{task.title}'.",
                     severity="warning",
                 )
-            self._request_tasks_refresh()
+            self._request_tasks_refresh(refresh_definitions=False)
 
         self.run_worker(
             _cancel_and_refresh,
@@ -1875,7 +1912,7 @@ class SchedulesWorkbench(BaseAppScreen):
                     "Failed to save the scheduled task. Check the form values and try again.",
                     severity="error",
                 )
-            self._request_tasks_refresh()
+            self._request_tasks_refresh(refresh_definitions=False)
 
         self.run_worker(
             _save_and_refresh,
@@ -2032,7 +2069,7 @@ class SchedulesWorkbench(BaseAppScreen):
                     f"Failed to run '{task.title}'.",
                     severity="error",
                 )
-            self._request_tasks_refresh()
+            self._request_tasks_refresh(refresh_definitions=False)
 
         self.run_worker(
             _run_and_refresh,
@@ -3233,7 +3270,7 @@ class SchedulesWorkbench(BaseAppScreen):
                     f"Failed to update '{task.title}'.",
                     severity="error",
                 )
-            self._request_tasks_refresh()
+            self._request_tasks_refresh(refresh_definitions=False)
 
         self.run_worker(
             _update_and_refresh,
@@ -3395,7 +3432,7 @@ class SchedulesWorkbench(BaseAppScreen):
             app_config=self.app_instance.app_config,
         )
         self._refresh_owner_select()
-        self._request_tasks_refresh()
+        self._request_tasks_refresh(refresh_definitions=False)
         self._refresh_conflicts_tab()
 
     @on(Button.Pressed, "#scheduling-clear-error")
@@ -3444,7 +3481,7 @@ class SchedulesWorkbench(BaseAppScreen):
 
     @on(ConflictsTab.ConflictResolved)
     def _on_conflict_resolved(self, event: ConflictsTab.ConflictResolved) -> None:
-        self._request_tasks_refresh()
+        self._request_tasks_refresh(refresh_definitions=False)
         self._refresh_conflicts_tab()
 
     def _refresh_conflicts_tab(self) -> None:
@@ -3603,7 +3640,7 @@ class SchedulesWorkbench(BaseAppScreen):
                 severity="information" if not errors else "warning",
             )
             self._marked_ids.clear()
-            self._request_tasks_refresh()
+            self._request_tasks_refresh(refresh_definitions=False)
 
         self.run_worker(
             _bulk_delete,
@@ -3778,7 +3815,7 @@ class SchedulesWorkbench(BaseAppScreen):
                 severity="information" if not errors else "warning",
             )
             self._marked_ids.clear()
-            self._request_tasks_refresh()
+            self._request_tasks_refresh(refresh_definitions=False)
 
         self.run_worker(
             _bulk_toggle,

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -1118,7 +1118,16 @@ class SchedulesWorkbench(BaseAppScreen):
         try:
             local_rows = await asyncio.to_thread(service.db.list_automation_definitions)
         except Exception:  # noqa: BLE001
-            logger.exception("Failed to load local automation definitions")
+            # `owner_id`/"Queue list" context only (Qodo LOW) -- never
+            # payload content. This is the sibling of the identical
+            # message `_load_local_automations` logs for the Automations
+            # tab's own refresh; without a call-site tag the two were
+            # indistinguishable in the log.
+            logger.exception(
+                "Failed to load local automation definitions for the "
+                "Queue list (owner_id={})",
+                service.owner_id,
+            )
             local_rows = []
         self._queue_local_definitions = local_rows
         local_items = self._device_only_automations(local_rows)
@@ -3473,15 +3482,22 @@ class SchedulesWorkbench(BaseAppScreen):
             _mark_solved, exclusive=True, group="schedules-mark-solved"
         )  # type: ignore[arg-type]
 
-    def _unread_result_ids(self) -> list[str]:
-        """Currently-loaded unread result ids, Results-tab's own listing
-        (already refreshed independently of which tab is active)."""
-        results_tab = self.query_one("#scheduling-results", ResultsTab)
-        return [
-            result["id"]
-            for result in results_tab.results()
-            if result.get("review_state") == "unread"
-        ]
+    def _unread_result_ids(self, service: "SchedulingService") -> list[str]:
+        """Every unread result id across the FULL table, read straight
+        from the DB -- not the Results tab's own listing, which is capped
+        at `RESULTS_INBOX_LIMIT` (200) rows. The rail button's visibility
+        already sums the full-table unread count (`_refresh_results_tab`'s
+        `count_unread_results`); mark-all-read has to clear that same set
+        or an unread row older than the loaded window survives while the
+        button hides itself as if nothing were left (Qodo HIGH).
+        """
+        unread_total = service.db.count_unread_results(owner_id=None)
+        if not unread_total:
+            return []
+        results = service.db.list_automation_results(
+            owner_id=None, review_state="unread", limit=unread_total
+        )
+        return [result["id"] for result in results]
 
     async def _dispatch_mark_all_results_read(
         self, service: "SchedulingService", unread_ids: list[str]
@@ -3527,7 +3543,7 @@ class SchedulesWorkbench(BaseAppScreen):
                 "Scheduling service is unavailable.", severity="warning"
             )
             return
-        unread_ids = self._unread_result_ids()
+        unread_ids = self._unread_result_ids(service)
         if not unread_ids:
             self.app_instance.notify("Nothing unread.", severity="information")
             return
@@ -3553,7 +3569,7 @@ class SchedulesWorkbench(BaseAppScreen):
                 "Scheduling service is unavailable.", severity="warning"
             )
             return
-        unread_ids = self._unread_result_ids()
+        unread_ids = self._unread_result_ids(service)
         if not unread_ids:
             self.app_instance.notify("Nothing unread.", severity="information")
             return

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -73,6 +73,7 @@ from ....Widgets.confirmation_dialog import ConfirmationDialog
 # `automation_execution_target_label` from THIS module) keep working.
 from .definition_detail import (
     DefinitionDetail,
+    _definition_transfer_suffix,
     automation_execution_target_label,
     automation_name_cell,
 )
@@ -84,15 +85,22 @@ from .task_detail import (
     TaskDetail,
     TaskInspector,
     _format_next_run,
+    _format_relative,
     _managed_elsewhere_notice,
     _queue_owner_suffix,
-    _task_status,
-    _task_type_label,
     _transfer_row_suffix,
-    _underlying_status,
     _was_missed_while_away,
-    status_badge_text,
     transfer_row_dict,
+)
+# schedules-redesign PR-2, Task 2: the pure row adapter -- see that
+# module's docstring for why it is a standalone, Textual-free file.
+from .unified_rows import (
+    Chip,
+    RowKind,
+    UnifiedRow,
+    build_unified_rows,
+    filter_rows,
+    sort_rows,
 )
 
 if TYPE_CHECKING:
@@ -175,6 +183,64 @@ def _cancel_toast_text(name: str) -> str:
 AUTOMATION_HISTORY_FOLLOWUP_SECONDS = 5.0
 
 
+def _row_title_cell(
+    row: UnifiedRow, *, marked_ids: set[str], compact_owner_suffix: bool
+) -> Text:
+    """Queue-row title cell for one `UnifiedRow` (redesign PR-2, spec S4).
+
+    Each primitive keeps its OWN existing title-suffix/prefix rendering
+    verbatim -- a reminder row is byte-identical to the pre-redesign
+    Title column (`_transfer_row_suffix`/`_queue_owner_suffix`), a
+    definition row reuses the Automations tab's own Name-cell rendering
+    (`automation_name_cell`/`_definition_transfer_suffix`) -- rather than
+    inventing one shared format neither primitive used before.
+    """
+    if row.kind == "reminder":
+        task = row.source_row
+        assert isinstance(task, ReminderTask)
+        text = Text(
+            ("● " if task.id in marked_ids else "")
+            + ("◇ " if _was_missed_while_away(task) else "")
+            + task.title
+            + _transfer_row_suffix(task)
+            + _queue_owner_suffix(task, compact=compact_owner_suffix)
+        )
+    else:
+        definition = row.source_row
+        assert isinstance(definition, dict)
+        text = Text(
+            automation_name_cell(definition) + _definition_transfer_suffix(definition)
+        )
+    if row.unread_count > 0:
+        # Same "bold leading dot" idiom `results_tab._review_state_cell`
+        # uses for an unread result -- reused rather than inventing a
+        # second unread affordance.
+        text.append(" ●", style="bold")
+    return text
+
+
+def _row_subtitle(row: UnifiedRow, now: datetime) -> str:
+    """Queue-row subtitle: schedule summary + relative next-run (spec S4).
+
+    A reminder row reuses `_format_next_run` verbatim (the exact text the
+    pre-redesign Next-Run column showed). A definition row has no
+    existing per-row relative-time formatter to reuse (`_format_next_run`
+    is typed for `ReminderTask | ScheduledTask`), so this derives the
+    same "absolute (relative)" shape from `UnifiedRow`'s own
+    already-normalized `next_run_at` + `bucket`.
+    """
+    if row.kind == "reminder":
+        next_text = _format_next_run(row.source_row, now=now, compact=True)
+    elif row.bucket == "paused":
+        next_text = "— (paused)"
+    elif row.next_run_at is None:
+        next_text = "-"
+    else:
+        absolute = row.next_run_at.strftime("%Y-%m-%d %H:%M")
+        next_text = f"{absolute} ({_format_relative(row.next_run_at, now)})"
+    return f"{row.schedule_summary} · {next_text}"
+
+
 class SchedulesWorkbench(BaseAppScreen):
     """Main workbench for managing scheduled runs, reminders, and jobs."""
 
@@ -230,8 +296,19 @@ class SchedulesWorkbench(BaseAppScreen):
     ):
         super().__init__(app_instance, screen_name, **kwargs)
         self._scheduling_service = getattr(app_instance, "scheduling_service", None)
-        self._tasks: list[ReminderTask | ScheduledTask] = []
-        self._visible_tasks: list[ReminderTask | ScheduledTask] = []
+        # redesign PR-2, Task 2: `self._tasks`/`self._visible_tasks` stay
+        # reminder-only (never watchlist/briefing `ScheduledTask`
+        # projections -- spec S2 locked decision 2, Task 1's report) so
+        # EVERY existing reminder action (`_selected_task`, mark/toggle/
+        # edit/delete, the timezone/marks-legend helpers below) keeps
+        # reading them unchanged. `self._all_rows`/`self._visible_rows`
+        # are the NEW unified source of truth the DataTable itself
+        # renders from (reminders + automation definitions, spans owners).
+        self._tasks: list[ReminderTask] = []
+        self._visible_tasks: list[ReminderTask] = []
+        self._all_rows: list[UnifiedRow] = []
+        self._visible_rows: list[UnifiedRow] = []
+        self._chip: Chip = "all"
         self._filter_text = ""
         self._filter_debounce_timer: Timer | None = None
         self._next_run_refresh_timer: Timer | None = None
@@ -239,6 +316,12 @@ class SchedulesWorkbench(BaseAppScreen):
         # panes, tracked independently of row index so a filter keystroke
         # can restore the same selection instead of always jumping to row 0.
         self._selected_task_id: str | None = None
+        # redesign PR-2, Task 2: the highlighted UnifiedRow's own id
+        # (`"reminder:<id>"`/`"definition:<id>"`), the general cursor-
+        # restoration key `_render_table` uses across BOTH kinds --
+        # `_selected_task_id` above stays reminder-only for the existing
+        # action code that reads it directly.
+        self._selected_row_id: str | None = None
         self._marked_ids: set[str] = set()
         #: The current hidden-panes notice from on_resize; combined with
         #: the marks/glyph legend in _update_pane_notice (task-23107).
@@ -340,6 +423,32 @@ class SchedulesWorkbench(BaseAppScreen):
                                     variant="primary",
                                     tooltip="Schedule a new task (c).",
                                 )
+                            # redesign PR-2, Task 2: the chip row (spec S3)
+                            # -- one of the four buttons always carries
+                            # variant="primary" for "current", the same
+                            # idiom `SyncStatusWidget`'s owner toggle uses.
+                            with Horizontal(id="scheduling-queue-chips"):
+                                yield Button(
+                                    "All",
+                                    id="scheduling-chip-all",
+                                    variant="primary",
+                                    classes="scheduling-queue-chip",
+                                )
+                                yield Button(
+                                    "Active",
+                                    id="scheduling-chip-active",
+                                    classes="scheduling-queue-chip",
+                                )
+                                yield Button(
+                                    "Paused",
+                                    id="scheduling-chip-paused",
+                                    classes="scheduling-queue-chip",
+                                )
+                                yield Button(
+                                    "Completed",
+                                    id="scheduling-chip-completed",
+                                    classes="scheduling-queue-chip",
+                                )
                             yield Input(
                                 placeholder="Filter: title, type, or status…",
                                 id="scheduling-queue-filter",
@@ -350,6 +459,16 @@ class SchedulesWorkbench(BaseAppScreen):
                             yield Static("", id="scheduling-pane-notice")
                         with Vertical(id="scheduling-detail-pane"):
                             yield TaskDetail(id="scheduling-task-detail")
+                            # redesign PR-2, Task 2: a sibling of TaskDetail
+                            # in the SAME pane -- highlight routes between
+                            # the two via the `pane-hidden` class (survey
+                            # section 3's recipe), never both visible.
+                            # Definition rows are viewable + detail-only
+                            # here (no actions until PR-4).
+                            yield DefinitionDetail(
+                                id="scheduling-queue-definition-detail",
+                                classes="pane-hidden",
+                            )
                         with Vertical(id="scheduling-inspector-pane"):
                             yield TaskInspector(id="scheduling-task-inspector")
                 with TabPane("Automations", id="scheduling-automations-tab"):
@@ -419,8 +538,11 @@ class SchedulesWorkbench(BaseAppScreen):
         self._refresh_owner_select()
         self._refresh_conflicts_tab()
         self._refresh_results_tab()
+        # redesign PR-2, Task 2: glyph/title/subtitle (spec S4) replaces
+        # the old Title/Type/Status/Next-Run shape -- a single primitive's
+        # column set no longer fits a mixed reminder+definition list.
         table = self.query_one("#scheduling-task-table", DataTable)
-        table.add_columns("Title", "Type", "Status", "Next Run")
+        table.add_columns("", "Title", "Details")
         automations_table = self.query_one("#scheduling-automations-table", DataTable)
         automations_table.add_columns(
             "Name", "Family", "Lifecycle", "Health", "Model"
@@ -731,7 +853,10 @@ class SchedulesWorkbench(BaseAppScreen):
         # TASK-26025: refresh liveness even on an empty queue -- a stall
         # with nothing queued is exactly the case AC#2 must distinguish.
         self._refresh_scheduler_liveness()
-        if not self._visible_tasks:
+        # redesign PR-2, Task 2: `_visible_rows`, not the reminder-only
+        # `_visible_tasks` -- a Queue showing only definition rows still
+        # has relative next-run text that must not go stale.
+        if not self._visible_rows:
             return
         self._render_table()
 
@@ -771,7 +896,20 @@ class SchedulesWorkbench(BaseAppScreen):
         )  # type: ignore[arg-type]
 
     async def load_tasks(self) -> None:
-        """Fetch reminders from the scheduling service and populate the table."""
+        """Fetch reminders + automation definitions and build the unified
+        Queue rows (redesign PR-2, Task 2).
+
+        Three listings feed Task 1's `build_unified_rows`: reminders
+        spans-owners (`SchedulingService.list_tasks(owner_id=None)`,
+        filtered to real `ReminderTask` rows -- watchlist/briefing
+        projections stay out per spec S2 locked decision 2 and Task 1's
+        own report), both definition halves (the Automations tab's
+        existing local+server merge, reused verbatim), and one
+        all-owners results listing (unread-count derivation only). The
+        results read + row build are pushed off the event loop
+        (`asyncio.to_thread`), the same "local DB read, off-thread"
+        discipline `_load_local_automations` already uses.
+        """
         service = self._scheduling_service
         if service is None:
             logger.debug("No scheduling_service available; cannot load tasks")
@@ -779,7 +917,17 @@ class SchedulesWorkbench(BaseAppScreen):
             return
 
         try:
-            tasks = await service.list_tasks()
+            combined = await service.list_tasks(owner_id=None)
+            reminders = [task for task in combined if isinstance(task, ReminderTask)]
+            definitions = await self._load_queue_definitions(service)
+
+            def _build_rows() -> list[UnifiedRow]:
+                results = service.db.list_automation_results(
+                    owner_id=None, limit=RESULTS_INBOX_LIMIT
+                )
+                return build_unified_rows(reminders, definitions, results)
+
+            all_rows = await asyncio.to_thread(_build_rows)
         except Exception:  # noqa: BLE001
             logger.exception("Failed to load tasks")
             self.app_instance.notify(
@@ -787,30 +935,72 @@ class SchedulesWorkbench(BaseAppScreen):
                 severity="error",
             )
             self._tasks = []
+            self._all_rows = []
             table = self.query_one("#scheduling-task-table", DataTable)
             table.clear()
             self.query_one("#scheduling-task-detail", TaskDetail).set_task(
                 None, queue_empty=True
             )
             self.query_one("#scheduling-task-inspector", TaskInspector).set_task(None)
+            self.query_one(
+                "#scheduling-queue-definition-detail", DefinitionDetail
+            ).set_definition(None)
             await self._refresh_console_context()
             return
 
-        self._tasks = list(tasks)
+        self._tasks = reminders
         # Marks must always refer to rows that still exist (task-23107
         # review F1): a task deleted or filtered out of existence must not
         # linger as an invisible mark a bulk verb would act on.
         self._marked_ids.intersection_update({task.id for task in self._tasks})
+        self._all_rows = all_rows
         self._render_table()
         await self._refresh_console_context()
 
-    def _render_table(self, now: datetime | None = None) -> None:
-        """Rebuild the queue rows from the current tasks + filter text.
+    async def _load_queue_definitions(
+        self, service: "SchedulingService"
+    ) -> list[dict[str, Any]]:
+        """Local + server automation-definition rows for the unified list.
 
-        Restores the previously selected task's row (by id) when it is
-        still visible after the filter narrows, instead of always jumping
-        the detail/inspector panes back to row 0 (task-15476): a filter
-        keystroke must not discard what the user was looking at.
+        Reuses the Automations tab's own both-owners merge precedent
+        (`_load_local_automations` + `_load_server_automations`) rather
+        than a third fetch shape -- this is a SEPARATE fetch from
+        `load_automations`'s own cadence (own tab, own refresh triggers),
+        not a shared cache.
+        """
+        local_items = await self._load_local_automations(service)
+        server_client = getattr(service, "server_client", None)
+        server_available = server_client is not None and self._server_available(
+            service, self._active_server_id()
+        )
+        if not server_available:
+            return local_items
+        try:
+            server_items, _total = await self._load_server_automations(server_client)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Failed to load server automations for the Queue list (server_id={})",
+                self._active_server_id(),
+            )
+            return local_items
+        return local_items + server_items
+
+    def _render_table(self, now: datetime | None = None) -> None:
+        """Rebuild the unified queue rows from `self._all_rows` + the
+        current chip + filter text (redesign PR-2, Task 2).
+
+        Chip + search narrowing and ordering are Task 1's own pure
+        functions (`filter_rows`/`sort_rows`) -- never re-derived here.
+        `self._visible_rows` becomes the new 1:1 source of truth for the
+        `DataTable`'s row index; `self._visible_tasks` is DERIVED from it
+        (reminder rows only, in table order) purely so every existing
+        reminder-action helper below keeps reading an unchanged shape.
+
+        Restores the previously selected row (by its `UnifiedRow.row_id`,
+        stable across BOTH kinds) when it is still visible after the
+        chip/filter narrows, instead of always jumping back to row 0
+        (task-15476): a filter keystroke or chip switch must not discard
+        what the user was looking at.
 
         ``now`` is one shared reference for every row's relative
         next-run rendering (review F9: per-row ``datetime.now()`` let a
@@ -818,83 +1008,90 @@ class SchedulesWorkbench(BaseAppScreen):
         deterministic tests.
         """
         render_now = now if now is not None else datetime.now(timezone.utc)
-        previous_selected_id = self._selected_task_id
-        text = self._filter_text.strip().lower()
+        previous_selected_row_id = self._selected_row_id
+        self._visible_rows = sort_rows(
+            filter_rows(self._all_rows, chip=self._chip, query=self._filter_text),
+            self._chip,
+        )
         self._visible_tasks = [
-            task
-            for task in self._tasks
-            if not text
-            or text in task.title.lower()
-            or text in _task_type_label(task).lower()
-            or text in _task_status(task).value.lower().replace("_", " ")
-            or text in _task_status(task).value.lower()
-            # Underlying status too (review F5): a disabled task whose
-            # last dispatch failed must still answer a "missed" filter.
-            or text in _underlying_status(task).value.lower().replace("_", " ")
-            or text in _underlying_status(task).value.lower()
-            # task-18937: filtering for "missed" finds late-dispatch rows too,
-            # not just handler-failure ones -- both are honest matches for a
-            # user asking "what went wrong while I wasn't looking".
-            or (_was_missed_while_away(task) and "missed" in text)
+            row.source_row for row in self._visible_rows if row.kind == "reminder"
         ]
         # Owner suffix (plan ruling 4): hidden at compact width, evaluated
         # once per render pass -- `_sync_responsive_workbench` (on_mount/
         # on_resize) always runs before this, so `self.size` is current.
         compact_owner_suffix = self.size.width <= SCHEDULES_COMPACT_WORKBENCH_MAX_WIDTH
-        rows: list[tuple[Text, str, Text, str]] = [
-            (
-                # `Text`: the title is user-authored, so it must never be
-                # re-parsed as markup by the DataTable cell formatter
-                # (D8's class -- the owner suffix here happens to use
-                # parens and survived live, but `[bold]` in a reminder
-                # title would not have). The other two str cells are built
-                # from this module's own vocabulary, not outside text.
-                Text(
-                    ("● " if task.id in self._marked_ids else "")
-                    + ("◇ " if _was_missed_while_away(task) else "")
-                    + task.title
-                    + _transfer_row_suffix(task)
-                    + _queue_owner_suffix(task, compact=compact_owner_suffix)
-                ),
-                _task_type_label(task),
-                status_badge_text(_task_status(task)),
-                # Compact: same relative form as the detail pane, without
-                # the timezone token (task-23111); one shared `now` for
-                # every row (review F9).
-                _format_next_run(task, now=render_now, compact=True),
-            )
-            for task in self._visible_tasks
-        ]
 
         table = self.query_one("#scheduling-task-table", DataTable)
         table.clear()
-        for row in rows:
-            table.add_row(*row)
+        for row in self._visible_rows:
+            # Every cell is `Text`, never `str` (D8: `DataTable` runs a
+            # `str` cell through `Text.from_markup`, which eats
+            # user-authored `[...]` tokens -- the reminder title's own
+            # bracket-safety precedent, reused for definition rows too).
+            table.add_row(
+                Text(row.glyph),
+                _row_title_cell(
+                    row,
+                    marked_ids=self._marked_ids,
+                    compact_owner_suffix=compact_owner_suffix,
+                ),
+                Text(_row_subtitle(row, render_now)),
+                key=row.row_id,
+            )
         self._update_pane_notice()
 
-        if rows:
+        if self._visible_rows:
             target_index = 0
-            if previous_selected_id is not None:
-                for index, task in enumerate(self._visible_tasks):
-                    if task.id == previous_selected_id:
+            if previous_selected_row_id is not None:
+                for index, row in enumerate(self._visible_rows):
+                    if row.row_id == previous_selected_row_id:
                         target_index = index
                         break
             if table.row_count:
                 table.move_cursor(row=target_index)
             self._update_detail_for_index(target_index)
         else:
+            self._selected_row_id = None
             self._selected_task_id = None
             self.query_one("#scheduling-task-detail", TaskDetail).set_task(
                 None, queue_empty=not self._tasks
             )
             self.query_one("#scheduling-task-inspector", TaskInspector).set_task(None)
-            if self._tasks and self._filter_text.strip():
+            self.query_one(
+                "#scheduling-queue-definition-detail", DefinitionDetail
+            ).set_definition(None)
+            self._show_queue_detail_pane("reminder")
+            if self._all_rows and (self._filter_text.strip() or self._chip != "all"):
                 # Everything filtered out: say so instead of "select a task".
+                filter_text = self._filter_text.strip()
+                notice = (
+                    f"No tasks match '{filter_text}'. "
+                    "Clear the filter to see the queue."
+                    if filter_text
+                    else "No tasks in this view. Choose a different chip "
+                    "to see the queue."
+                )
                 self._update_static_content(
                     self.query_one("#scheduling-task-detail-empty-state", Static),
-                    f"No tasks match '{self._filter_text.strip()}'. "
-                    "Clear the filter to see the queue.",
+                    notice,
                 )
+
+    def _show_queue_detail_pane(self, kind: RowKind) -> None:
+        """Toggle which Queue detail widget is visible (redesign PR-2,
+        Task 2): `TaskDetail` for a reminder row, `DefinitionDetail` for a
+        definition row -- via the `pane-hidden` class, the SAME mechanism
+        `on_resize` already uses for width-based hiding of independent
+        panes (survey section 3's routing recipe). Orthogonal to that
+        width-based hide: this only ever runs while `#scheduling-detail-
+        pane` itself is shown.
+        """
+        is_reminder = kind == "reminder"
+        self.query_one("#scheduling-task-detail", TaskDetail).set_class(
+            not is_reminder, "pane-hidden"
+        )
+        self.query_one(
+            "#scheduling-queue-definition-detail", DefinitionDetail
+        ).set_class(is_reminder, "pane-hidden")
 
     @on(Input.Changed, "#scheduling-queue-filter")
     def _on_queue_filter_changed(self, event: Input.Changed) -> None:
@@ -912,6 +1109,33 @@ class SchedulesWorkbench(BaseAppScreen):
 
     def _apply_queue_filter_debounced(self) -> None:
         self._filter_debounce_timer = None
+        self._render_table()
+
+    #: redesign PR-2, Task 2: chip button id -> `Chip` value.
+    _CHIP_BY_BUTTON_ID: dict[str, Chip] = {
+        "scheduling-chip-all": "all",
+        "scheduling-chip-active": "active",
+        "scheduling-chip-paused": "paused",
+        "scheduling-chip-completed": "completed",
+    }
+
+    @on(Button.Pressed, ".scheduling-queue-chip")
+    def _on_queue_chip_pressed(self, event: Button.Pressed) -> None:
+        """Switch the Queue's active chip (spec S3: All/Active/Paused/
+        Completed) -- one handler for all four buttons, matched by id."""
+        event.stop()
+        chip = self._CHIP_BY_BUTTON_ID.get(event.button.id or "")
+        if chip is not None:
+            self._set_queue_chip(chip)
+
+    def _set_queue_chip(self, chip: Chip) -> None:
+        if chip == self._chip:
+            return
+        self._chip = chip
+        for button_id, candidate in self._CHIP_BY_BUTTON_ID.items():
+            self.query_one(f"#{button_id}", Button).variant = (
+                "primary" if candidate == chip else "default"
+            )
         self._render_table()
 
     @on(DataTable.RowHighlighted)
@@ -955,25 +1179,51 @@ class SchedulesWorkbench(BaseAppScreen):
             return []
 
     def _update_detail_for_index(self, index: int) -> None:
-        """Render task details in the detail and inspector panes."""
-        if not (0 <= index < len(self._visible_tasks)):
+        """Render the highlighted Queue row's detail, routed by kind
+        (redesign PR-2, Task 2). ``index`` is a `self._visible_rows`
+        index (the table's own row index), NOT a `self._visible_tasks`
+        one -- the two lists diverge whenever a definition row precedes
+        the highlighted one.
+        """
+        if not (0 <= index < len(self._visible_rows)):
+            self._selected_row_id = None
             self._selected_task_id = None
             self.query_one("#scheduling-task-detail", TaskDetail).set_task(
                 None, queue_empty=not self._tasks
             )
             self.query_one("#scheduling-task-inspector", TaskInspector).set_task(None)
+            self.query_one(
+                "#scheduling-queue-definition-detail", DefinitionDetail
+            ).set_definition(None)
             return
 
-        task = self._visible_tasks[index]
-        self._selected_task_id = task.id
-        task_detail = self.query_one("#scheduling-task-detail", TaskDetail)
-        task_detail.set_task(
-            task,
-            run_history=self._run_history_for(task.id),
-            incidents=self._incidents_for(task.id),
-        )
-        self._update_transfer_actions(task_detail, task)
-        self.query_one("#scheduling-task-inspector", TaskInspector).set_task(task)
+        row = self._visible_rows[index]
+        self._selected_row_id = row.row_id
+        if row.kind == "reminder":
+            task = row.source_row
+            assert isinstance(task, ReminderTask)
+            self._selected_task_id = task.id
+            self._show_queue_detail_pane("reminder")
+            task_detail = self.query_one("#scheduling-task-detail", TaskDetail)
+            task_detail.set_task(
+                task,
+                run_history=self._run_history_for(task.id),
+                incidents=self._incidents_for(task.id),
+            )
+            self._update_transfer_actions(task_detail, task)
+            self.query_one("#scheduling-task-inspector", TaskInspector).set_task(task)
+        else:
+            # Definition rows expose no actions in this PR (viewable +
+            # detail only, plan ruling 1) -- `_selected_task_id = None`
+            # means every existing reminder action (`_selected_task`,
+            # edit/mark/toggle/delete) already no-ops gracefully here,
+            # with no new guard branches needed.
+            self._selected_task_id = None
+            self._show_queue_detail_pane("definition")
+            self.query_one("#scheduling-task-inspector", TaskInspector).set_task(None)
+            definition = row.source_row
+            assert isinstance(definition, dict)
+            self._request_queue_definition_detail(row.row_id, definition)
 
     def _update_transfer_actions(
         self, task_detail: TaskDetail, task: ReminderTask | ScheduledTask
@@ -2174,6 +2424,35 @@ class SchedulesWorkbench(BaseAppScreen):
             )
             return
 
+        run_count, last_run, unread_count, history_error = (
+            await self._fetch_definition_detail_counts(
+                service, definition, definition_id
+            )
+        )
+        if definition_id != self._selected_automation_id:
+            return
+        detail.set_definition(
+            definition,
+            run_count=run_count,
+            last_run=last_run,
+            unread_count=unread_count,
+            history_error=history_error,
+        )
+
+    async def _fetch_definition_detail_counts(
+        self,
+        service: "SchedulingService",
+        definition: dict[str, Any],
+        definition_id: str,
+    ) -> tuple[int, dict[str, Any] | None, int, bool]:
+        """Off-thread run_count/last_run/unread_count read for one
+        definition -- shared by the Automations tab's own detail pane
+        (`_load_automation_detail`) and the Queue tab's definition-row
+        routing (redesign PR-2, Task 2: `_load_queue_definition_detail`),
+        same DB reads, same owner-scoping (final review F11), same
+        never-paint-0-off-a-failed-read guard (F14).
+        """
+
         def _read_counts() -> tuple[int, dict[str, Any] | None, int]:
             # Both run reads are owner-scoped (final review F11): they sit
             # in one group on screen, and `convert_row_to_server_mirror`'s
@@ -2188,9 +2467,9 @@ class SchedulesWorkbench(BaseAppScreen):
             )
             return run_count, (runs[0] if runs else None), unread_count
 
-        history_error = False
         try:
             run_count, last_run, unread_count = await asyncio.to_thread(_read_counts)
+            return run_count, last_run, unread_count, False
         except Exception:  # noqa: BLE001
             logger.exception(
                 "Failed to load automation detail counts (definition_id={})",
@@ -2199,8 +2478,52 @@ class SchedulesWorkbench(BaseAppScreen):
             # Never paint 0/Never run off a read that blew up (F14): the
             # pane says the read failed, matching how `_load_automation_
             # history` reports its own read failure.
-            run_count, last_run, unread_count, history_error = 0, None, 0, True
-        if definition_id != self._selected_automation_id:
+            return 0, None, 0, True
+
+    def _request_queue_definition_detail(
+        self, row_id: str, definition: dict[str, Any]
+    ) -> None:
+        """Schedule the Queue tab's definition-detail counts through their
+        own exclusive worker group (redesign PR-2, Task 2) -- mirrors
+        `_request_automation_detail`'s shape, separate group so a Queue
+        selection and an Automations-tab selection can never contend."""
+
+        async def _load() -> None:
+            await self._load_queue_definition_detail(row_id, definition)
+
+        self.run_worker(
+            _load,
+            exclusive=True,
+            group="schedules-load-queue-definition-detail",
+        )  # type: ignore[arg-type]
+
+    async def _load_queue_definition_detail(
+        self, row_id: str, definition: dict[str, Any]
+    ) -> None:
+        """Paint the Queue tab's `DefinitionDetail` sibling for the
+        highlighted definition row (redesign PR-2, Task 2). Reuses how
+        the Automations tab loads its own detail pane's counts, off the
+        event loop.
+        """
+        detail = self.query_one(
+            "#scheduling-queue-definition-detail", DefinitionDetail
+        )
+        definition_id = str(definition.get("id") or "")
+        service = self._scheduling_service
+        if service is None:
+            if row_id == self._selected_row_id:
+                detail.set_definition(
+                    definition, run_count=0, last_run=None, unread_count=0
+                )
+            return
+        run_count, last_run, unread_count, history_error = (
+            await self._fetch_definition_detail_counts(
+                service, definition, definition_id
+            )
+        )
+        # A newer selection may have won the race with this worker; render
+        # nothing for a stale row (same guard `_load_automation_detail` uses).
+        if row_id != self._selected_row_id:
             return
         detail.set_definition(
             definition,
@@ -3288,15 +3611,27 @@ class SchedulesWorkbench(BaseAppScreen):
             group="schedules-bulk-delete",
         )  # type: ignore[arg-type]
 
-    def _selected_task(self) -> ReminderTask | ScheduledTask | None:
-        """Return the task under the queue cursor, if any."""
-        if not self._visible_tasks:
+    def _selected_task(self) -> ReminderTask | None:
+        """Return the reminder under the queue cursor, if any.
+
+        redesign PR-2, Task 2: routes through `self._visible_rows` (the
+        table's own 1:1 row index) rather than `self._visible_tasks`
+        directly -- the two diverge whenever a definition row precedes
+        the cursor. A definition row under the cursor returns ``None``,
+        the same "nothing to act on" result every caller (`action_edit_
+        task`/`action_mark_task`/`action_toggle_enabled`/`action_delete`)
+        already handles -- definition rows expose no actions in this PR.
+        """
+        if not self._visible_rows:
             return None
         table = self.query_one("#scheduling-task-table", DataTable)
-        row = table.cursor_row
-        if row is None or not (0 <= row < len(self._visible_tasks)):
+        row_index = table.cursor_row
+        if row_index is None or not (0 <= row_index < len(self._visible_rows)):
             return None
-        return self._visible_tasks[row]
+        row = self._visible_rows[row_index]
+        if row.kind != "reminder":
+            return None
+        return row.source_row
 
     def action_edit_task(self) -> None:
         """Open the highlighted task/definition in its edit form (e key).

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -308,6 +308,12 @@ class SchedulesWorkbench(BaseAppScreen):
         self._visible_tasks: list[ReminderTask] = []
         self._all_rows: list[UnifiedRow] = []
         self._visible_rows: list[UnifiedRow] = []
+        # Final review F2: the UNFILTERED local definitions table from the
+        # last full definitions fetch, for unread-count resolution only
+        # (never a source of rows). The display merge above excludes every
+        # row that has a `server_id`, so a transferred definition's
+        # pre-transfer results have no key to resolve through without it.
+        self._queue_local_definitions: list[dict[str, Any]] = []
         # redesign PR-2, Task 2 review round 2: any Automations-tab
         # mutation of a definition (create/edit save, run-now, transfer
         # begin/cancel -- everything that funnels through
@@ -467,7 +473,13 @@ class SchedulesWorkbench(BaseAppScreen):
                                     classes="scheduling-queue-chip",
                                 )
                             yield Input(
-                                placeholder="Filter: title, type, or status…",
+                                # Says what ruling 5's search actually
+                                # matches -- title + question/body (final
+                                # review F6: the Type/Status columns are
+                                # gone and status words like "missed" no
+                                # longer match, which the user guide
+                                # already documents).
+                                placeholder="Filter: title or question…",
                                 id="scheduling-queue-filter",
                             )
                             yield DataTable(
@@ -839,7 +851,9 @@ class SchedulesWorkbench(BaseAppScreen):
                         service.sync_engine._pull_results,
                     )
                     self._refresh_owner_select()
-                    self._refresh_results_tab()
+                    # A pull is exactly the event the Queue's unread dots
+                    # and rail button exist for (final review F5).
+                    self._refresh_results_surfaces()
                 if not self._results_pull_rerun_requested:
                     return
                 self._results_pull_rerun_requested = False
@@ -902,7 +916,7 @@ class SchedulesWorkbench(BaseAppScreen):
         # has relative next-run text that must not go stale.
         if not self._visible_rows:
             return
-        self._render_table()
+        self._render_table(tick=True)
 
     def on_screen_suspend(self) -> None:
         """Stop the relative-time refresh while another screen covers this.
@@ -1043,7 +1057,12 @@ class SchedulesWorkbench(BaseAppScreen):
                 results = service.db.list_automation_results(
                     owner_id=None, limit=RESULTS_INBOX_LIMIT
                 )
-                return build_unified_rows(reminders, definitions, results)
+                return build_unified_rows(
+                    reminders,
+                    definitions,
+                    results,
+                    self._queue_local_definitions,
+                )
 
             all_rows = await asyncio.to_thread(_build_rows)
         except Exception:  # noqa: BLE001
@@ -1087,8 +1106,22 @@ class SchedulesWorkbench(BaseAppScreen):
         than a third fetch shape -- this is a SEPARATE fetch from
         `load_automations`'s own cadence (own tab, own refresh triggers),
         not a shared cache.
+
+        Also stashes the UNFILTERED local listing in
+        `self._queue_local_definitions` for `build_unified_rows`'s
+        unread-count resolution (final review F2): the display merge
+        above drops every local row that has a `server_id`, so a
+        transferred definition's pre-transfer results resolved to
+        nothing. Same single `list_automation_definitions` call -- the
+        rows were already read and then filtered away.
         """
-        local_items = await self._load_local_automations(service)
+        try:
+            local_rows = await asyncio.to_thread(service.db.list_automation_definitions)
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to load local automation definitions")
+            local_rows = []
+        self._queue_local_definitions = local_rows
+        local_items = self._device_only_automations(local_rows)
         server_client = getattr(service, "server_client", None)
         server_available = server_client is not None and self._server_available(
             service, self._active_server_id()
@@ -1105,9 +1138,16 @@ class SchedulesWorkbench(BaseAppScreen):
             return local_items
         return local_items + server_items
 
-    def _render_table(self, now: datetime | None = None) -> None:
+    def _render_table(self, now: datetime | None = None, *, tick: bool = False) -> None:
         """Rebuild the unified queue rows from `self._all_rows` + the
         current chip + filter text (redesign PR-2, Task 2).
+
+        ``tick`` marks the relative-time ticker's own re-render (the only
+        caller that re-renders WITHOUT new data): it suppresses the
+        definition-detail re-read for an unchanged selection (final
+        review F12). Every other caller leaves it False, because data
+        genuinely can change without the selection changing -- the
+        PR-1 F4 lesson: a refresh-driven re-feed must still re-feed.
 
         Chip + search narrowing and ordering are Task 1's own pure
         functions (`filter_rows`/`sort_rows`) -- never re-derived here.
@@ -1169,7 +1209,7 @@ class SchedulesWorkbench(BaseAppScreen):
                         break
             if table.row_count:
                 table.move_cursor(row=target_index)
-            self._update_detail_for_index(target_index)
+            self._update_detail_for_index(target_index, from_tick=tick)
         else:
             self._selected_row_id = None
             self._selected_task_id = None
@@ -1184,17 +1224,33 @@ class SchedulesWorkbench(BaseAppScreen):
             if self._all_rows and (self._filter_text.strip() or self._chip != "all"):
                 # Everything filtered out: say so instead of "select a task".
                 filter_text = self._filter_text.strip()
-                notice = (
-                    f"No tasks match '{filter_text}'. "
-                    "Clear the filter to see the queue."
-                    if filter_text
-                    else "No tasks in this view. Choose a different chip "
-                    "to see the queue."
-                )
+                if filter_text:
+                    notice = (
+                        f"No tasks match '{filter_text}'. "
+                        "Clear the filter to see the queue."
+                    )
+                else:
+                    # The chip row is hidden below width 84 (the `compact`
+                    # class this same threshold sets), while the selected
+                    # chip persists -- so don't point at a control that is
+                    # not on screen (final review F10).
+                    notice = "No tasks in this view."
+                    if not self._chips_hidden():
+                        notice += " Choose a different chip to see the queue."
                 self._update_static_content(
                     self.query_one("#scheduling-task-detail-empty-state", Static),
                     notice,
                 )
+
+    def _chips_hidden(self) -> bool:
+        """True when the chip row is off screen (`_scheduling.tcss`:
+        `#scheduling-workbench.compact #scheduling-queue-chips { display:
+        none }`). Reads the class `on_resize` actually set rather than
+        re-deriving its width threshold here."""
+        try:
+            return self.query_one("#scheduling-workbench").has_class("compact")
+        except Exception:  # noqa: BLE001 - not mounted yet
+            return False
 
     def _show_queue_detail_pane(self, kind: RowKind) -> None:
         """Toggle which Queue detail widget is visible (redesign PR-2,
@@ -1260,7 +1316,28 @@ class SchedulesWorkbench(BaseAppScreen):
 
     @on(DataTable.RowHighlighted)
     def _on_task_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
-        """Update the detail pane when the user highlights a task row."""
+        """Update the detail pane when the user highlights a task row.
+
+        Both guards below suppress `_render_table`'s own ECHOES, not any
+        real cursor move (final review F12 -- the same unchanged-selection
+        discipline `_on_automations_row_highlighted` has):
+
+        1. `DataTable.clear()` posts a RowHighlighted for row 0 before
+           the rows are re-added, so every render re-rendered row 0's
+           detail (clobbering `_selected_row_id` on the way) before the
+           restored row won it back. That event is stale by the time it
+           is processed -- the table's live cursor has already moved on.
+        2. `move_cursor` back to the restored row posts an echo for a row
+           `_render_table` just called `_update_detail_for_index` with
+           directly. A refresh's re-feed is that DIRECT call; repeating
+           it here is pure duplication.
+        """
+        if event.cursor_row != event.data_table.cursor_row:
+            return
+        if not (0 <= event.cursor_row < len(self._visible_rows)):
+            return
+        if self._visible_rows[event.cursor_row].row_id == self._selected_row_id:
+            return
         self._update_detail_for_index(event.cursor_row)
 
     def _incidents_for(self, task_id) -> list:
@@ -1298,13 +1375,22 @@ class SchedulesWorkbench(BaseAppScreen):
         except Exception:  # noqa: BLE001 -- history read never breaks the pane
             return []
 
-    def _update_detail_for_index(self, index: int) -> None:
+    def _update_detail_for_index(self, index: int, *, from_tick: bool = False) -> None:
         """Render the highlighted Queue row's detail, routed by kind
         (redesign PR-2, Task 2). ``index`` is a `self._visible_rows`
         index (the table's own row index), NOT a `self._visible_tasks`
         one -- the two lists diverge whenever a definition row precedes
         the highlighted one.
+
+        ``from_tick`` is set only by the relative-time ticker's own
+        re-render: it skips the definition-detail worker when the
+        selection has not changed (final review F12 -- 3 DB reads a
+        minute for a row that did not move, against the ticker's own
+        "no reload/DB on tick" contract). Deliberately NOT applied to
+        refresh-driven calls: those re-feed on purpose, because the
+        DATA can change while the selection stands still.
         """
+        previously_selected_row_id = self._selected_row_id
         if not (0 <= index < len(self._visible_rows)):
             self._selected_row_id = None
             self._selected_task_id = None
@@ -1343,6 +1429,11 @@ class SchedulesWorkbench(BaseAppScreen):
             self.query_one("#scheduling-task-inspector", TaskInspector).set_task(None)
             definition = row.source_row
             assert isinstance(definition, dict)
+            if from_tick and row.row_id == previously_selected_row_id:
+                # Same row, no new data (F12): the pane already shows
+                # this definition's counts. Mirrors `_on_automations_row_
+                # highlighted`'s own unchanged-selection guard.
+                return
             self._request_queue_definition_detail(row.row_id, definition)
 
     def _update_transfer_actions(
@@ -1574,7 +1665,13 @@ class SchedulesWorkbench(BaseAppScreen):
 
         async def _delete_and_refresh() -> None:
             try:
-                await service.delete_reminder(event.task.id)
+                # The ROW's owner (final review F4): deleting a `server:`
+                # row while "This device" is active took the local-only
+                # branch -- no server call, no tombstone -- and the row
+                # came back on the next pull.
+                await service.delete_reminder(
+                    event.task.id, owner_id=event.task.owner_id
+                )
             except Exception:  # noqa: BLE001
                 logger.exception("Failed to delete reminder {}", event.task.id)
                 self.app_instance.notify(
@@ -1939,6 +2036,15 @@ class SchedulesWorkbench(BaseAppScreen):
         `was_edit` only changes the toast wording ("updated" vs
         "created") -- an edit reusing the create-mode "created" copy
         would misreport what actually happened.
+
+        Refreshes the QUEUE too, not just the Automations list (final
+        review F1): Task 3 moved the create entry point onto the Queue
+        rail (`Create ▾` -> "Recurring question…"), so this save's
+        flagship path never leaves the Queue tab -- `TabActivated`, the
+        only consumer of `_definitions_stale`, never fires, and the
+        automation the user just created stayed invisible on the surface
+        it was created from. Symmetric with the reminder half
+        (`_on_reminder_form_result`), which has always refreshed here.
         """
         if outcome is None:
             return
@@ -1957,6 +2063,10 @@ class SchedulesWorkbench(BaseAppScreen):
                 severity="information",
             )
         self._request_automations_refresh()
+        # Full refresh (definitions included): `_definitions_stale` is set
+        # above, so a `refresh_definitions=False` call would upgrade
+        # itself anyway -- ask for what this actually needs.
+        self._request_tasks_refresh()
 
     def _on_reminder_form_result(
         self, form_data: dict[str, Any] | None, task_id: str | None = None
@@ -1978,18 +2088,20 @@ class SchedulesWorkbench(BaseAppScreen):
         # so a form built before this selector existed (or a caller that
         # omits it) behaves exactly as before.
         target_owner = form_data.pop("owner_id", None) or service.owner_id
-        # This list is owner-scoped, so a save aimed elsewhere cannot appear
-        # in it -- say where it went instead of a bare "created" that reads
-        # as a lost save. Label, not raw id: same vocabulary as the "Runs on"
-        # selector the owner was picked from.
+        # Name the owner it was created for (label, not raw id: same
+        # vocabulary as the "Runs on" selector the owner was picked from).
+        # The old copy also told the user to "switch to that owner to see
+        # it" -- true when this list was owner-scoped, wrong since Task 1
+        # made it span owners (final review F7, spec §4: the cross-owner
+        # list "dissolves" that wart). The row appears here immediately
+        # whatever owner it was created under.
         owner_label = {
             value: label for label, value in self._runs_on_options()[0]
         }.get(target_owner, target_owner)
         created_message = (
             "Scheduled task created."
             if target_owner == service.owner_id
-            else f"Scheduled task created for {owner_label} — switch to that "
-            "owner to see it."
+            else f"Scheduled task created for {owner_label}."
         )
 
         async def _save_and_refresh() -> None:
@@ -2039,10 +2151,16 @@ class SchedulesWorkbench(BaseAppScreen):
             logger.debug("acknowledge_incident failed")
             return
         # re-render the detail so the acked incident drops out of the
-        # alerting set and the button hides.
-        if self._selected_task_id is not None:
-            for index, task in enumerate(self._visible_tasks):
-                if task.id == self._selected_task_id:
+        # alerting set and the button hides. Indexed over `_visible_rows`,
+        # NOT `_visible_tasks` (final review F3): `_update_detail_for_
+        # index` takes the table's own row index, and the two lists
+        # diverge the moment a definition row sorts above the highlighted
+        # reminder -- the old code then rendered a DIFFERENT row's detail
+        # and moved the selection with it, silently, while the cursor
+        # stayed put.
+        if self._selected_row_id is not None:
+            for index, row in enumerate(self._visible_rows):
+                if row.row_id == self._selected_row_id:
                     self._update_detail_for_index(index)
                     break
 
@@ -2104,8 +2222,14 @@ class SchedulesWorkbench(BaseAppScreen):
             self._review_selected_result("read")
             return
         task = self._selected_reminder_task()
-        if task is not None:
-            self._run_reminder_now(task)
+        if task is None:
+            # Never swallow the key silently (final review F8): on a
+            # definition row `r` did nothing at all, with no message.
+            self.app_instance.notify(
+                self._no_task_notice("run"), severity="warning"
+            )
+            return
+        self._run_reminder_now(task)
 
     def _selected_reminder_task(self) -> ReminderTask | None:
         """Return the highlighted task when it is a reminder (not a projection)."""
@@ -2333,13 +2457,25 @@ class SchedulesWorkbench(BaseAppScreen):
         create-time placeholder (`execution_unavailable`) as if it were
         live.
         """
-        from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
-
         try:
             all_rows = await asyncio.to_thread(service.db.list_automation_definitions)
         except Exception:  # noqa: BLE001
             logger.exception("Failed to load local automation definitions")
             return []
+        return self._device_only_automations(all_rows)
+
+    def _device_only_automations(
+        self, all_rows: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """The device-only half of a local definitions listing, decorated.
+
+        Split out of `_load_local_automations` (final review F2) so the
+        Queue loader can keep the UNFILTERED listing for its unread-count
+        resolution while still deriving the same display half from it --
+        one `list_automation_definitions` call per refresh either way.
+        """
+        from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
+
         rows = [row for row in all_rows if not row.get("server_id")]
         for row in rows:
             if is_server_scoped_owner(row.get("owner_id")):
@@ -2835,6 +2971,11 @@ class SchedulesWorkbench(BaseAppScreen):
                 "The result arrives as a notification.",
                 severity="information",
             )
+            # Same rule as the local twin (final review F11): mark
+            # staleness at each genuine mutation call site. A server
+            # run-now can change what the next `_load_server_automations`
+            # returns (next_run_at, health, last-run state).
+            self._definitions_stale = True
             # The dispatch returns when the run is ENQUEUED, not finished:
             # the terminal audit event lands only after the server executes
             # (an LLM call -- seconds). One immediate fetch catches the
@@ -3265,7 +3406,7 @@ class SchedulesWorkbench(BaseAppScreen):
                     "Could not update this result — see the log.",
                     severity="error",
                 )
-            self._refresh_results_tab()
+            self._refresh_results_surfaces()
 
         self.run_worker(
             _review, exclusive=True, group="schedules-review-result"
@@ -3326,7 +3467,7 @@ class SchedulesWorkbench(BaseAppScreen):
                     outcome.reason or "Could not mark this result solved.",
                     severity="warning",
                 )
-            self._refresh_results_tab()
+            self._refresh_results_surfaces()
 
         self.run_worker(
             _mark_solved, exclusive=True, group="schedules-mark-solved"
@@ -3349,7 +3490,12 @@ class SchedulesWorkbench(BaseAppScreen):
         result ids -- there is no bulk DB primitive for this (spec's
         documented fan-out, mirroring `_on_bulk_delete_confirmed`'s
         loop-and-count shape). Shared by the Results tab's `a` keybinding
-        and the rail's `Mark all read` button (redesign PR-2, Task 3).
+        and the rail's `Mark all read` button (redesign PR-2, Task 3) --
+        the Queue refresh included, which used to sit in the rail
+        button's own wrapper as if it were a rail-specific nicety (final
+        review F5): pressing `a` on the Results tab left the Queue's
+        unread dots painted and its rail button visible, and pressing
+        that button then reported "Nothing unread."
         """
         errors = 0
         for result_id in unread_ids:
@@ -3362,7 +3508,7 @@ class SchedulesWorkbench(BaseAppScreen):
             + ".",
             severity="information" if not errors else "warning",
         )
-        self._refresh_results_tab()
+        self._refresh_results_surfaces()
 
     def action_mark_all_results_read(self) -> None:
         """a key: mark every currently-loaded unread result read,
@@ -3397,12 +3543,9 @@ class SchedulesWorkbench(BaseAppScreen):
         """Rail `Mark all read` (redesign PR-2, Task 3): reuses the exact
         same per-row fan-out as the `a` keybinding above, but reachable
         without switching to the Results tab first -- the whole point of
-        a rail-level affordance for it. Also refreshes the Queue's own
-        unified rows afterward so the per-row unread dots and this
-        button's own visibility drop immediately (`refresh_definitions=
-        False`: definitions did not change, only result review state
-        did -- results are always re-fetched regardless, same reminder-
-        only-refresh shape Task 2 review established).
+        a rail-level affordance for it. The Queue refresh that used to
+        live here moved INTO that shared fan-out (final review F5): it
+        was never rail-specific.
         """
         service = self._service()
         if service is None:
@@ -3417,7 +3560,6 @@ class SchedulesWorkbench(BaseAppScreen):
 
         async def _mark_all() -> None:
             await self._dispatch_mark_all_results_read(service, unread_ids)
-            self._request_tasks_refresh(refresh_definitions=False)
 
         self.run_worker(
             _mark_all, exclusive=True, group="schedules-mark-all-read"
@@ -3435,7 +3577,16 @@ class SchedulesWorkbench(BaseAppScreen):
 
         async def _update_and_refresh() -> None:
             try:
-                await service.update_reminder(task.id, {"enabled": enabled})
+                # The ROW's owner, never the service's active one (final
+                # review F4): this list spans owners since Task 1, so
+                # toggling a `server:` row while "This device" is active
+                # used to write the local mirror with NO pending mutation
+                # -- the server kept firing it and the next pull undid the
+                # toggle. Same `owner_id=` thread PR-5 established for
+                # `create_reminder`.
+                await service.update_reminder(
+                    task.id, {"enabled": enabled}, owner_id=task.owner_id
+                )
                 status = "enabled" if enabled else "disabled"
                 self.app_instance.notify(
                     f"'{task.title}' {status}.", severity="information"
@@ -3732,6 +3883,25 @@ class SchedulesWorkbench(BaseAppScreen):
             f"Results ({unread})" if unread else "Results",
         )
 
+    def _refresh_results_surfaces(self) -> None:
+        """Every surface a results MUTATION moves: the Results tab and the
+        Queue's own unread dots + rail `Mark all read` visibility.
+
+        Final review F5: the unread affordances Task 3 added to the Queue
+        derive from `UnifiedRow.unread_count`, which is only recomputed by
+        `load_tasks` -- so an SSE-triggered pull, a read/dismiss, a
+        mark-solved or a mark-all-read updated the Results tab and left
+        the Queue's dots (and the rail button, gated on
+        `sum(row.unread_count) > 0`) stale in both directions: hidden
+        while unread work existed, or visible with nothing left to mark.
+        `refresh_definitions=False` -- results never change which
+        definitions exist, and results are re-read on every load anyway.
+        Called from the mutation paths only, never from the mount/reload
+        paths that already run their own `_request_tasks_refresh`.
+        """
+        self._refresh_results_tab()
+        self._request_tasks_refresh(refresh_definitions=False)
+
     def action_delete(self) -> None:
         """Delete marked tasks in bulk, else the selected one (confirmed).
 
@@ -3783,7 +3953,19 @@ class SchedulesWorkbench(BaseAppScreen):
                 severity="warning",
             )
             return
-        if self._refuse_if_transfer_locked(self._selected_task(), "delete this task"):
+        task = self._selected_task()
+        if task is None:
+            # `TaskDetail.request_delete` deletes the task the pane last
+            # HELD, and the definition branch of `_update_detail_for_
+            # index` only hides that pane -- it never clears it. Pressing
+            # `d` on a definition row therefore opened a confirmation for
+            # whichever reminder was highlighted before it (final review
+            # F8's silent-refusal finding, in its sharpest form).
+            self.app_instance.notify(
+                self._no_task_notice("delete"), severity="warning"
+            )
+            return
+        if self._refuse_if_transfer_locked(task, "delete this task"):
             return
         self.query_one("#scheduling-task-detail", TaskDetail).request_delete()
 
@@ -3806,8 +3988,11 @@ class SchedulesWorkbench(BaseAppScreen):
                     # A False return is a refusal, not a crash (e.g. the
                     # transfer read-only guard, final review I7) -- count
                     # it, so the toast never claims a delete that the
-                    # facade declined.
-                    if not await service.delete_reminder(task.id):
+                    # facade declined. `owner_id` is the ROW's own (final
+                    # review F4), same as the single-row delete.
+                    if not await service.delete_reminder(
+                        task.id, owner_id=task.owner_id
+                    ):
                         errors += 1
                 except Exception:  # noqa: BLE001
                     logger.exception("Failed to delete reminder {}", task.id)
@@ -3850,6 +4035,23 @@ class SchedulesWorkbench(BaseAppScreen):
             return None
         return row.source_row
 
+    def _no_task_notice(self, verb: str) -> str:
+        """Copy for a reminder verb that found no reminder to act on.
+
+        A definition row IS selected and highlighted when the cursor sits
+        on one, so "select a task first" reads as a bug (final review
+        F8). Say where the action lives instead -- the same "managed
+        elsewhere" vocabulary `_managed_elsewhere_notice` established for
+        projection rows. Definition rows stay action-free here per plan
+        ruling 1; this only fixes how the refusal is REPORTED.
+        """
+        if (self._selected_row_id or "").startswith("definition:"):
+            return (
+                "This automation is managed on the Automations tab for "
+                f"now — {verb} it there."
+            )
+        return f"Nothing to {verb} — select a task first."
+
     def action_edit_task(self) -> None:
         """Open the highlighted task/definition in its edit form (e key).
 
@@ -3868,7 +4070,7 @@ class SchedulesWorkbench(BaseAppScreen):
         task = self._selected_task()
         if task is None:
             self.app_instance.notify(
-                "Nothing to edit — select a task first.",
+                self._no_task_notice("edit"),
                 severity="warning",
             )
             return
@@ -3895,7 +4097,7 @@ class SchedulesWorkbench(BaseAppScreen):
         task = self._selected_task()
         if task is None:
             self.app_instance.notify(
-                "Nothing to mark — select a task first.",
+                self._no_task_notice("mark"),
                 severity="warning",
             )
             return
@@ -3948,7 +4150,7 @@ class SchedulesWorkbench(BaseAppScreen):
         task = self._selected_task()
         if task is None:
             self.app_instance.notify(
-                "Nothing to toggle — select a task first.",
+                self._no_task_notice("enable or disable"),
                 severity="warning",
             )
             return
@@ -3979,9 +4181,11 @@ class SchedulesWorkbench(BaseAppScreen):
             for task in marked:
                 try:
                     # A None return is a refusal, not a crash -- same
-                    # reasoning as the bulk delete above.
+                    # reasoning as the bulk delete above. `owner_id` is
+                    # the ROW's own (final review F4), same as the
+                    # single-row toggle.
                     if await service.update_reminder(
-                        task.id, {"enabled": not task.enabled}
+                        task.id, {"enabled": not task.enabled}, owner_id=task.owner_id
                     ) is None:
                         errors += 1
                 except Exception:  # noqa: BLE001

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -408,12 +408,6 @@ class SchedulesWorkbench(BaseAppScreen):
                 id="scheduling-recovery",
             )
         with Vertical(id="schedules-shell"):
-            yield SyncStatusWidget(
-                id="scheduling-sync-status",
-                current_owner=owner_id,
-                active_server_id=active_server_id,
-                server_available=server_available,
-            )
             # TASK-26025: scheduler liveness -- a stale heartbeat reads
             # distinctly from an empty queue and a never-started loop.
             yield Static("", id="scheduling-liveness")
@@ -421,6 +415,14 @@ class SchedulesWorkbench(BaseAppScreen):
                 with TabPane("Queue", id="scheduling-queue-tab"):
                     with Horizontal(id="scheduling-workbench"):
                         with Vertical(id="scheduling-list-pane"):
+                            # redesign PR-2, Task 3: the rail header --
+                            # `Create ▾` is the pre-existing 2-choice
+                            # chooser button (`scheduling-new-task`,
+                            # unchanged id/handler, relabeled/repositioned
+                            # here); `Mark all read` is new, and only shown
+                            # once `_update_mark_all_read_visibility` finds
+                            # unread rows (default hidden below, mirrors
+                            # `SyncStatusWidget`'s own Clear-button idiom).
                             with Horizontal(id="scheduling-list-header"):
                                 yield Static(
                                     "Schedule Queue",
@@ -428,10 +430,15 @@ class SchedulesWorkbench(BaseAppScreen):
                                     classes="scheduling-column-title",
                                 )
                                 yield Button(
-                                    "+ New",
+                                    "Create ▾",
                                     id="scheduling-new-task",
                                     variant="primary",
                                     tooltip="Schedule a new task (c).",
+                                )
+                                yield Button(
+                                    "Mark all read",
+                                    id="scheduling-mark-all-read",
+                                    tooltip="Mark every unread automation result read (a).",
                                 )
                             # redesign PR-2, Task 2: the chip row (spec S3)
                             # -- one of the four buttons always carries
@@ -529,6 +536,29 @@ class SchedulesWorkbench(BaseAppScreen):
                     )
                 with TabPane("Results", id="scheduling-results-tab"):
                     yield ResultsTab(id="scheduling-results")
+            # redesign PR-2, Task 3: the bottom status strip (plan ruling
+            # 4) -- shared across every tab (not Queue-specific, so it
+            # sits below the TabbedContent rather than inside one
+            # TabPane), hosting the existing `SyncStatusWidget` (owner
+            # indicator + sync health, now with a width-compact styling
+            # path -- see `_sync_responsive_workbench`) and a conflicts
+            # badge chip that switches to the Conflicts tab.
+            with Horizontal(id="scheduling-status-strip"):
+                yield SyncStatusWidget(
+                    id="scheduling-sync-status",
+                    current_owner=owner_id,
+                    active_server_id=active_server_id,
+                    server_available=server_available,
+                )
+                yield Button(
+                    "Conflicts",
+                    id="scheduling-conflicts-badge",
+                    classes="scheduling-queue-chip",
+                    tooltip=(
+                        "Sync conflicts for the current owner's scheduled "
+                        "tasks only. Click to open the Conflicts tab."
+                    ),
+                )
 
     def _service(self) -> "SchedulingService | None":
         """Return the app's scheduling service, if available."""
@@ -548,6 +578,10 @@ class SchedulesWorkbench(BaseAppScreen):
         self._refresh_owner_select()
         self._refresh_conflicts_tab()
         self._refresh_results_tab()
+        # redesign PR-2, Task 3: hidden until `load_tasks` finds unread
+        # rows (mirrors `SyncStatusWidget`'s own Clear-button idiom of
+        # starting hidden rather than flashing visible-then-hidden).
+        self.query_one("#scheduling-mark-all-read", Button).display = False
         # redesign PR-2, Task 2: glyph/title/subtitle (spec S4) replaces
         # the old Title/Type/Status/Next-Run shape -- a single primitive's
         # column set no longer fits a mixed reminder+definition list.
@@ -892,10 +926,18 @@ class SchedulesWorkbench(BaseAppScreen):
 
     def _sync_responsive_workbench(self) -> None:
         """Keep the primary queue and detail action visible at narrow widths."""
-        self.set_class(
-            self.size.width <= SCHEDULES_COMPACT_WORKBENCH_MAX_WIDTH,
-            "schedules-workbench-compact",
-        )
+        compact = self.size.width <= SCHEDULES_COMPACT_WORKBENCH_MAX_WIDTH
+        self.set_class(compact, "schedules-workbench-compact")
+        # redesign PR-2, Task 3: the strip's own width-triggered compact
+        # path -- additive, independent of `_apply_collapse`'s owner/
+        # server-based collapse; reuses this same threshold rather than
+        # inventing a second one.
+        try:
+            self.query_one("#scheduling-sync-status", SyncStatusWidget).set_compact(
+                compact
+            )
+        except Exception:  # noqa: BLE001 - not mounted yet
+            pass
 
     def _request_tasks_refresh(self, *, refresh_definitions: bool = True) -> None:
         """Schedule the task loader through its exclusive worker group.
@@ -928,6 +970,18 @@ class SchedulesWorkbench(BaseAppScreen):
         of re-fetching them (redesign PR-2 Task 2 review, finding 3).
         """
         return [row.source_row for row in self._all_rows if row.kind == "definition"]
+
+    def _update_mark_all_read_visibility(self) -> None:
+        """Rail `Mark all read` visibility (redesign PR-2, Task 3): shown
+        only when the unified rows carry unread automation results in
+        total. `UnifiedRow.unread_count` is always 0 for a reminder row
+        (reminders never produce results) so this sum is effectively the
+        definitions' own unread total -- no separate query."""
+        try:
+            button = self.query_one("#scheduling-mark-all-read", Button)
+        except Exception:  # noqa: BLE001 - not mounted yet
+            return
+        button.display = sum(row.unread_count for row in self._all_rows) > 0
 
     @on(TabbedContent.TabActivated, pane="#scheduling-queue-tab")
     def _on_queue_tab_activated(self, event: TabbedContent.TabActivated) -> None:
@@ -1000,6 +1054,7 @@ class SchedulesWorkbench(BaseAppScreen):
             )
             self._tasks = []
             self._all_rows = []
+            self._update_mark_all_read_visibility()
             table = self.query_one("#scheduling-task-table", DataTable)
             table.clear()
             self.query_one("#scheduling-task-detail", TaskDetail).set_task(
@@ -1018,6 +1073,7 @@ class SchedulesWorkbench(BaseAppScreen):
         # linger as an invisible mark a bulk verb would act on.
         self._marked_ids.intersection_update({task.id for task in self._tasks})
         self._all_rows = all_rows
+        self._update_mark_all_read_visibility()
         self._render_table()
         await self._refresh_console_context()
 
@@ -1745,6 +1801,23 @@ class SchedulesWorkbench(BaseAppScreen):
     def _on_new_automation_pressed(self, event: Button.Pressed) -> None:
         event.stop()
         self.action_create_automation()
+
+    @on(Button.Pressed, "#scheduling-mark-all-read")
+    def _on_mark_all_read_pressed(self, event: Button.Pressed) -> None:
+        """Rail `Mark all read` (redesign PR-2, Task 3) -- reachable from
+        the Queue tab, unlike the `a` keybinding which requires the
+        Results tab active."""
+        event.stop()
+        self._rail_mark_all_read()
+
+    @on(Button.Pressed, "#scheduling-conflicts-badge")
+    def _on_conflicts_badge_pressed(self, event: Button.Pressed) -> None:
+        """Status-strip conflicts badge (redesign PR-2, Task 3, plan
+        ruling 4) -- switches to the Conflicts tab, no overlay."""
+        event.stop()
+        self.query_one("#scheduling-tabs", TabbedContent).active = (
+            "scheduling-conflicts-tab"
+        )
 
     @on(Button.Pressed, "#schedules-follow-in-console")
     def follow_latest_schedule_run_in_console(self, event: Button.Pressed) -> None:
@@ -3259,11 +3332,42 @@ class SchedulesWorkbench(BaseAppScreen):
             _mark_solved, exclusive=True, group="schedules-mark-solved"
         )  # type: ignore[arg-type]
 
+    def _unread_result_ids(self) -> list[str]:
+        """Currently-loaded unread result ids, Results-tab's own listing
+        (already refreshed independently of which tab is active)."""
+        results_tab = self.query_one("#scheduling-results", ResultsTab)
+        return [
+            result["id"]
+            for result in results_tab.results()
+            if result.get("review_state") == "unread"
+        ]
+
+    async def _dispatch_mark_all_results_read(
+        self, service: "SchedulingService", unread_ids: list[str]
+    ) -> None:
+        """Per-row `review_automation_result` fan-out for a batch of
+        result ids -- there is no bulk DB primitive for this (spec's
+        documented fan-out, mirroring `_on_bulk_delete_confirmed`'s
+        loop-and-count shape). Shared by the Results tab's `a` keybinding
+        and the rail's `Mark all read` button (redesign PR-2, Task 3).
+        """
+        errors = 0
+        for result_id in unread_ids:
+            if not await service.review_automation_result(result_id, "read"):
+                errors += 1
+        count = len(unread_ids) - errors
+        self.app_instance.notify(
+            f"Marked {count} result{'s' if count != 1 else ''} read"
+            + (f" ({errors} failed)" if errors else "")
+            + ".",
+            severity="information" if not errors else "warning",
+        )
+        self._refresh_results_tab()
+
     def action_mark_all_results_read(self) -> None:
         """a key: mark every currently-loaded unread result read,
-        Results-tab only. Per-row `review_automation_result` calls -- there
-        is no bulk DB primitive for this (spec's documented fan-out),
-        mirroring `_on_bulk_delete_confirmed`'s loop-and-count shape.
+        Results-tab only (the rail's `Mark all read` button reaches the
+        same fan-out from the Queue tab, see `_rail_mark_all_read`).
         """
         if not self._is_results_tab_active():
             self.app_instance.notify(
@@ -3277,29 +3381,43 @@ class SchedulesWorkbench(BaseAppScreen):
                 "Scheduling service is unavailable.", severity="warning"
             )
             return
-        results_tab = self.query_one("#scheduling-results", ResultsTab)
-        unread_ids = [
-            result["id"]
-            for result in results_tab.results()
-            if result.get("review_state") == "unread"
-        ]
+        unread_ids = self._unread_result_ids()
         if not unread_ids:
             self.app_instance.notify("Nothing unread.", severity="information")
             return
 
         async def _mark_all() -> None:
-            errors = 0
-            for result_id in unread_ids:
-                if not await service.review_automation_result(result_id, "read"):
-                    errors += 1
-            count = len(unread_ids) - errors
+            await self._dispatch_mark_all_results_read(service, unread_ids)
+
+        self.run_worker(
+            _mark_all, exclusive=True, group="schedules-mark-all-read"
+        )  # type: ignore[arg-type]
+
+    def _rail_mark_all_read(self) -> None:
+        """Rail `Mark all read` (redesign PR-2, Task 3): reuses the exact
+        same per-row fan-out as the `a` keybinding above, but reachable
+        without switching to the Results tab first -- the whole point of
+        a rail-level affordance for it. Also refreshes the Queue's own
+        unified rows afterward so the per-row unread dots and this
+        button's own visibility drop immediately (`refresh_definitions=
+        False`: definitions did not change, only result review state
+        did -- results are always re-fetched regardless, same reminder-
+        only-refresh shape Task 2 review established).
+        """
+        service = self._service()
+        if service is None:
             self.app_instance.notify(
-                f"Marked {count} result{'s' if count != 1 else ''} read"
-                + (f" ({errors} failed)" if errors else "")
-                + ".",
-                severity="information" if not errors else "warning",
+                "Scheduling service is unavailable.", severity="warning"
             )
-            self._refresh_results_tab()
+            return
+        unread_ids = self._unread_result_ids()
+        if not unread_ids:
+            self.app_instance.notify("Nothing unread.", severity="information")
+            return
+
+        async def _mark_all() -> None:
+            await self._dispatch_mark_all_results_read(service, unread_ids)
+            self._request_tasks_refresh(refresh_definitions=False)
 
         self.run_worker(
             _mark_all, exclusive=True, group="schedules-mark-all-read"
@@ -3551,11 +3669,15 @@ class SchedulesWorkbench(BaseAppScreen):
             service.owner_id, primitive="reminder_task"
         )
         conflicts_tab.populate(conflicts)
+        label = f"Conflicts ({len(conflicts)})" if conflicts else "Conflicts"
         # Surface the conflict count on the tab label itself (UX-063).
-        self._set_tab_label(
-            "scheduling-conflicts-tab",
-            f"Conflicts ({len(conflicts)})" if conflicts else "Conflicts",
-        )
+        self._set_tab_label("scheduling-conflicts-tab", label)
+        # redesign PR-2, Task 3: same count, mirrored onto the status
+        # strip's badge (plan ruling 4) -- no new query.
+        try:
+            self.query_one("#scheduling-conflicts-badge", Button).label = label
+        except Exception:  # noqa: BLE001 - strip not mounted yet
+            pass
 
     def _set_tab_label(self, pane_id: str, label: str) -> None:
         """Relabel one tab in the workbench's `TabbedContent`.

--- a/tldw_chatbook/UI/Screens/scheduling/sync_status_widget.py
+++ b/tldw_chatbook/UI/Screens/scheduling/sync_status_widget.py
@@ -141,6 +141,10 @@ class SyncStatusWidget(Horizontal):
         that one method rather than fighting over the same two Statics'
         `.display` -- `_apply_collapse`'s own owner/server-based collapse
         decision (and the owner-button/note halves of it) are unchanged.
+
+        Args:
+            compact: Whether the host rail is narrow enough to hide the
+                last-pull/last-push timestamps.
         """
         self.set_class(compact, "compact")
         self._apply_collapse()

--- a/tldw_chatbook/UI/Screens/scheduling/sync_status_widget.py
+++ b/tldw_chatbook/UI/Screens/scheduling/sync_status_widget.py
@@ -105,15 +105,26 @@ class SyncStatusWidget(Horizontal):
         persisted sync error from a since-removed server must stay
         visible and clearable on a now-local-only profile, so collapsed
         mode shows local note + error + Clear whenever an error exists.
+
+        redesign PR-2, Task 3: the width-triggered compact path
+        (`set_compact`/`self.has_class("compact")`) ALSO hides the
+        timestamps, folded into this same write rather than a second
+        independent one -- Textual widgets resolve `.display` from
+        whichever code last set it imperatively (inline styles beat
+        stylesheet rules), so a plain CSS `.compact { display: none }`
+        rule here would silently lose to this method's own explicit
+        `display = not collapsed` on every owner/server-state refresh.
+        Folding both triggers into one write keeps there being exactly
+        one place these two Statics' visibility is decided. The
+        owner-button collapse stays gated on `collapsed` alone -- compact
+        must not hide the owner indicator (plan ruling 4's "(b)").
         """
         collapsed = self.current_owner == "local" and not self.server_available
-        for selector in (
-            "#scheduling-owner-local",
-            "#scheduling-owner-server",
-            "#scheduling-last-pull",
-            "#scheduling-last-push",
-        ):
+        for selector in ("#scheduling-owner-local", "#scheduling-owner-server"):
             self.query_one(selector).display = not collapsed
+        hide_timestamps = collapsed or self.has_class("compact")
+        for selector in ("#scheduling-last-pull", "#scheduling-last-push"):
+            self.query_one(selector).display = not hide_timestamps
         note = self.query_one("#scheduling-sync-local-note", Static)
         note.display = collapsed
         note.update(
@@ -121,6 +132,18 @@ class SyncStatusWidget(Horizontal):
             if collapsed
             else ""
         )
+
+    def set_compact(self, compact: bool) -> None:
+        """Width-triggered compact styling path (redesign PR-2, Task 3).
+
+        Additive: stores the trigger as a CSS class (`.compact`) and
+        re-runs `_apply_collapse` so the two triggers combine through
+        that one method rather than fighting over the same two Statics'
+        `.display` -- `_apply_collapse`'s own owner/server-based collapse
+        decision (and the owner-button/note halves of it) are unchanged.
+        """
+        self.set_class(compact, "compact")
+        self._apply_collapse()
 
     def set_owner_state(
         self,

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -26,6 +26,16 @@ from ....Scheduling.models import ReminderTask, ScheduledTask, ScheduleKind, Tas
 from ....Widgets.delete_confirmation_dialog import DeleteConfirmationDialog
 from ....Widgets.detail_value_row import DetailGroup, DetailValueRow
 from ..destination_recovery import DestinationRecoveryState
+# Hoisted to `unified_rows.py` (redesign PR-2 Task 1) so that pure module can
+# reuse them without pulling Textual in as an import side effect; re-exported
+# here unchanged so every existing call site/test import keeps working.
+from .unified_rows import (
+    _format_timezone,
+    _humanize_cron,  # noqa: F401  (re-export: definition_detail.py + tests import this from here)
+    _humanize_schedule,
+    definition_cron_expression,  # noqa: F401  (re-export: definition_detail.py imports this from here)
+    owner_display_label,
+)
 
 
 SCHEDULES_EMPTY_CONSOLE_RECOVERY = DestinationRecoveryState(
@@ -39,16 +49,6 @@ SCHEDULES_EMPTY_CONSOLE_RECOVERY = DestinationRecoveryState(
     disabled_tooltip="Start or select a schedule run to enable Console follow.",
 )
 
-
-_WEEKDAYS = [
-    "Sunday",
-    "Monday",
-    "Tuesday",
-    "Wednesday",
-    "Thursday",
-    "Friday",
-    "Saturday",
-]
 
 _STATUS_LABELS: dict[TaskStatus, str] = {
     TaskStatus.WAITING: "Waiting",
@@ -106,13 +106,6 @@ def _humanize_status(status: TaskStatus) -> str:
 def _humanize_schedule_kind(kind: ScheduleKind) -> str:
     """Return 'Recurring' or 'One-time' for a schedule kind."""
     return "Recurring" if kind == ScheduleKind.RECURRING else "One-time"
-
-
-def _format_timezone(dt) -> str:
-    """Return a timezone label for a datetime, defaulting to UTC."""
-    if dt.tzinfo is None:
-        return "UTC"
-    return dt.tzname() or "UTC"
 
 
 def _format_relative(next_run_at: datetime, now: datetime) -> str:
@@ -233,75 +226,6 @@ def format_incidents(incidents) -> str:
     return "\n".join(lines)
 
 
-def _humanize_cron(cron: str | None, timezone: str | None = None) -> str:
-    """Summarize a cron expression in plain English."""
-    if not cron:
-        return "-"
-    parts = cron.split()
-    if len(parts) != 5:
-        return cron
-    minute, hour, dom, month, dow = parts
-    tz = f" {timezone}" if timezone else " UTC"
-
-    def _is_wildcard(value: str) -> bool:
-        return value == "*"
-
-    def _is_digit(value: str) -> bool:
-        # ASCII only: '²'.isdigit() is True but int('²') raises, and this
-        # runs on every detail render of a synced cron (review F14).
-        return bool(value) and value.isascii() and value.isdigit()
-
-    if (
-        _is_digit(minute)
-        and _is_digit(hour)
-        and _is_wildcard(dom)
-        and _is_wildcard(month)
-        and _is_wildcard(dow)
-    ):
-        return f"Daily at {int(hour):02d}:{int(minute):02d}{tz}"
-
-    if (
-        _is_digit(minute)
-        and _is_digit(hour)
-        and _is_wildcard(dom)
-        and _is_wildcard(month)
-        and dow == "1-5"
-    ):
-        # The "Every weekday at..." preset (task-23102).
-        return f"Weekdays at {int(hour):02d}:{int(minute):02d}{tz}"
-
-    if (
-        _is_digit(minute)
-        and _is_digit(hour)
-        and _is_wildcard(dom)
-        and _is_wildcard(month)
-        and _is_digit(dow)
-    ):
-        day_index = int(dow)
-        if 0 <= day_index <= 6:
-            return f"Weekly on {_WEEKDAYS[day_index]} at {int(hour):02d}:{int(minute):02d}{tz}"
-
-    if (
-        _is_digit(minute)
-        and _is_digit(hour)
-        and _is_digit(dom)
-        and _is_wildcard(month)
-        and _is_wildcard(dow)
-    ):
-        return f"Monthly on the {int(dom)} at {int(hour):02d}:{int(minute):02d}{tz}"
-
-    return f"cron: {cron}{tz}"
-
-
-def _humanize_schedule(task: ReminderTask) -> str:
-    """Return a human-readable schedule summary for the task."""
-    if task.schedule_kind == ScheduleKind.ONE_TIME:
-        if task.run_at is None:
-            return "One-time"
-        return f"One-time at {task.run_at.strftime('%Y-%m-%d %H:%M')} {_format_timezone(task.run_at)}"
-    return _humanize_cron(task.cron, task.timezone)
-
-
 def _underlying_status(task: ReminderTask | ScheduledTask) -> TaskStatus:
     """The recorded dispatch status, without the enabled-state overlay.
 
@@ -389,67 +313,6 @@ def _task_sync_label(task: ReminderTask | ScheduledTask) -> str:
             sync_status += " (local)"
         return sync_status
     return "local (read-only projection)"
-
-
-def definition_cron_expression(schedule: dict[str, Any]) -> Any:
-    """An automation definition's cron string, under EITHER key.
-
-    The two writers disagree: this client writes `schedule["cron"]`
-    (`AutomationDefinitionForm`'s save payload), the real server sends
-    `schedule["expression"]` (recorded fixture
-    `Tests/Scheduling/fixtures/server_responses/
-    automation_definition_list.json`), and `_load_server_automations`
-    passes the payload through raw, stamping only `owner_id`.
-
-    Both readers of that field go through here (final review F1 + its
-    carry-forward), and it lives in this leaf module because the two are
-    in packages that cannot import each other: `definition_detail`'s "At"
-    row -- where a cron-only read rendered `At: -` for EVERY server-owned
-    definition -- and `AutomationDefinitionForm._prefill_from_row`, where
-    the same read was worse than cosmetic: editing a mirrored server-only
-    definition fell through to the form's default preset, so a save wrote
-    that default OVER the server's real schedule.
-
-    Args:
-        schedule: A definition's `schedule` dict, from either source.
-
-    Returns:
-        The cron string, or ``None``/empty when neither key carries one.
-    """
-    return schedule.get("cron") or schedule.get("expression")
-
-
-def owner_display_label(owner_id: Any) -> str:
-    """Prose owner label shared by BOTH detail panes (final review F6/F7).
-
-    ``"This device"`` for a locally-owned row, the server's own id for a
-    server-scoped one (``"server:srv-1"`` -> ``"srv-1"``) -- the
-    vocabulary the spec, the User Guide and the Automations table's own
-    Name-cell prefix already use. The reminder pane's `Runs on` row used
-    to render the raw metadata string instead (``local``, ``server:1 /
-    server <id>``), so the two panes spoke two dialects for the flagship
-    row of the redesign. One helper, one vocabulary -- settled before
-    PR-3 turns this row into the transfer dropdown.
-
-    `TaskInspector`'s Owner row deliberately keeps `_task_owner_label`'s
-    raw value: that pane is the metadata inspector, where the unprettied
-    owner/server ids are the point.
-
-    Args:
-        owner_id: A row's ``owner_id`` (any type tolerated -- anything
-            that is not a server-scoped string reads as local).
-
-    Returns:
-        ``"This device"``, or the server's own id.
-    """
-    # ADR-097: scheduler.queue stays off the boot census -- function-local
-    # import, same as `_queue_owner_suffix` below.
-    from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
-
-    if not is_server_scoped_owner(owner_id):
-        return "This device"
-    owner_id = str(owner_id)
-    return owner_id.split(":", 1)[1] if ":" in owner_id else owner_id
 
 
 def _task_owner_label(task: ReminderTask | ScheduledTask) -> str:

--- a/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
+++ b/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
@@ -410,9 +410,18 @@ def reminder_has_fired(task: ReminderTask) -> bool:
     """True for a fired one-time reminder (survey SS6, task_detail.py:163-167).
 
     Dispatching a one-time reminder disables it AND clears
-    ``next_run_at`` -- this triple (disabled, no next run, but has run at
-    least once) is the only way an ``enabled=0`` reminder also carries a
-    ``last_run_at``, distinguishing "fired" from a user-initiated pause.
+    ``next_run_at``; "has run at least once, has no next run" is what
+    distinguishes "fired" from a user-initiated pause (which keeps its
+    ``next_run_at``) and from a reminder that never ran (no
+    ``last_run_at``).
+
+    ``enabled`` is deliberately NOT part of the predicate (final review
+    F9, ruled): re-enabling a fired one-time reminder does not give it a
+    future run -- `_set_reminder_enabled` sends only ``{"enabled": ...}``
+    and `SchedulingService.update_reminder` recomputes ``next_run_at``
+    only when a SCHEDULE key is in the payload, while the due query
+    filters ``next_run_at IS NOT NULL``. Bucketing that row Active would
+    advertise armed status the scheduler will never honour.
 
     Args:
         task: The reminder to check.
@@ -420,9 +429,7 @@ def reminder_has_fired(task: ReminderTask) -> bool:
     Returns:
         ``True`` when the reminder has fired its one-time schedule.
     """
-    return (
-        not task.enabled and task.next_run_at is None and task.last_run_at is not None
-    )
+    return task.next_run_at is None and task.last_run_at is not None
 
 
 def definition_is_armed(definition: dict[str, Any]) -> bool:
@@ -512,16 +519,29 @@ def _definition_glyph(definition: dict[str, Any], bucket: RowBucket) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _unread_counts_by_local_id(
+def _unread_row_key(definition: dict[str, Any]) -> str:
+    """The key a definition's unread count is stored and looked up under.
+
+    ``server_id or id`` (final review F2): the DISPLAY list carries a
+    transferred definition as the raw server payload (whose ``id`` IS the
+    server id), while the local table carries the same definition as a
+    row with a local uuid ``id`` and that server id in ``server_id``.
+    Keying on ``server_id or id`` is the one expression both shapes agree
+    on; a purely local row has no ``server_id`` and keeps its own id.
+    """
+    return str(definition.get("server_id") or definition.get("id") or "")
+
+
+def _unread_counts_by_row_key(
     results: list[dict[str, Any]], definitions_by_id: dict[str, dict[str, Any]]
 ) -> dict[str, int]:
-    """Group unread results by their resolved definition's LOCAL id.
+    """Group unread results by their resolved definition's row key.
 
     Routes every result through `definition_for_result` (the same dual
     local/server id-space resolution `results_tab.py` uses) BEFORE
-    grouping, so a server-mirrored definition's results are counted
-    under that definition's own local ``id`` even though the result row
-    itself may carry the server's id verbatim (plan ruling 3).
+    grouping, so a server-mirrored definition's results are counted for
+    that definition even though the result row itself may carry the
+    server's id verbatim (plan ruling 3).
 
     Args:
         results: All-owners `automation_results` rows (one
@@ -529,8 +549,8 @@ def _unread_counts_by_local_id(
         definitions_by_id: The index built by `index_definitions_by_id`.
 
     Returns:
-        ``{definition_local_id: unread_count}``, omitting definitions
-        with zero unread results.
+        ``{_unread_row_key(definition): unread_count}``, omitting
+        definitions with zero unread results.
     """
     counts: dict[str, int] = defaultdict(int)
     for result in results:
@@ -539,7 +559,7 @@ def _unread_counts_by_local_id(
         definition = definition_for_result(result, definitions_by_id)
         if definition is None:
             continue
-        counts[str(definition.get("id") or "")] += 1
+        counts[_unread_row_key(definition)] += 1
     return dict(counts)
 
 
@@ -563,7 +583,7 @@ def _reminder_row(task: ReminderTask) -> UnifiedRow:
 
 
 def _definition_row(
-    definition: dict[str, Any], unread_by_local_id: dict[str, int]
+    definition: dict[str, Any], unread_by_row_key: dict[str, int]
 ) -> UnifiedRow:
     bucket = _definition_bucket(definition)
     local_id = str(definition.get("id") or "")
@@ -580,7 +600,7 @@ def _definition_row(
         transfer_state=definition.get("transfer_state"),
         bucket=bucket,
         glyph=_definition_glyph(definition, bucket),
-        unread_count=unread_by_local_id.get(local_id, 0),
+        unread_count=unread_by_row_key.get(_unread_row_key(definition), 0),
         search_blob=f"{name}\n{_definition_question_text(definition)}",
         source_row=definition,
     )
@@ -590,6 +610,7 @@ def build_unified_rows(
     reminders: list[ReminderTask],
     definitions: list[dict[str, Any]],
     results: list[dict[str, Any]],
+    local_definitions: list[dict[str, Any]] | None = None,
 ) -> list[UnifiedRow]:
     """Adapt reminders + automation definitions into one unified row list.
 
@@ -603,15 +624,34 @@ def build_unified_rows(
             precedent: `_load_local_automations` + `_load_server_automations`).
         results: One all-owners `list_automation_results(owner_id=None)`
             listing, used only to derive `UnifiedRow.unread_count`.
+        local_definitions: The FULL local definitions table
+            (`list_automation_definitions(owner_id=None)`, the same input
+            the Results tab's own index uses), for result->definition
+            resolution ONLY -- never a source of rows. Final review F2:
+            the display merge above deliberately EXCLUDES every local row
+            that carries a ``server_id``, so a definition transferred to
+            the server is a key in NEITHER of the merge's two id spaces;
+            its pre-transfer, locally-produced results resolved to
+            nothing and dropped out of the unread count, hiding the
+            rail's `Mark all read` button while the Results tab's badge
+            still counted them. Resolution indexes these rows AND the
+            display rows, since a server definition with no local mirror
+            row is absent from the local table. Defaults to
+            ``definitions`` -- every caller with no separate local
+            listing behaves exactly as before.
 
     Returns:
         One `UnifiedRow` per reminder and per definition, unsorted and
         unfiltered (`filter_rows`/`sort_rows` do that).
     """
-    definitions_by_id = index_definitions_by_id(definitions)
-    unread_by_local_id = _unread_counts_by_local_id(results, definitions_by_id)
+    definitions_by_id = index_definitions_by_id(
+        [*local_definitions, *definitions]
+        if local_definitions is not None
+        else definitions
+    )
+    unread_by_row_key = _unread_counts_by_row_key(results, definitions_by_id)
     rows = [_reminder_row(task) for task in reminders]
-    rows.extend(_definition_row(d, unread_by_local_id) for d in definitions)
+    rows.extend(_definition_row(d, unread_by_row_key) for d in definitions)
     return rows
 
 

--- a/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
+++ b/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
@@ -1,0 +1,668 @@
+"""Pure row adapter for the unified Schedules Queue list (redesign PR-2, Task 1).
+
+Turns reminders (`ReminderTask` model instances) and automation-definition
+rows (raw dicts, local and server-mirrored alike) into one `UnifiedRow`
+shape the Queue tab renders, filters by chip, and searches -- spanning
+both primitives and both owners (spec
+`backlog/docs/spec-2026-09-02-schedules-screen-redesign.md` SS3/SS4, plan
+`backlog/docs/plan-2026-09-03-schedules-redesign-pr2.md` ruling 2).
+
+Deliberately Textual-free (no `import textual` anywhere in this file, nor
+in anything it imports) so it stays cheap to import -- and unit-testable
+without a Textual harness -- regardless of what pulls it in later.
+`task_detail.py`, `definition_detail.py`, and `results_tab.py` each used
+to define a handful of small, genuinely pure formatters this module also
+needs (schedule-summary prose, the owner label, the dual local/server
+id-space result->definition resolver). Importing them FROM those modules
+would execute those modules' own top-level `textual` imports as a side
+effect -- so they are HOISTED here instead, and those three modules now
+import the names back (`from .unified_rows import ...`), keeping every
+existing call site, test import, and docstring cross-reference unchanged.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from tldw_chatbook.Scheduling.db.scheduled_tasks_db import DORMANT_TRANSFER_STATES
+from tldw_chatbook.Scheduling.models import ReminderTask, ScheduleKind
+
+RowKind = Literal["reminder", "definition"]
+RowBucket = Literal["active", "paused", "completed"]
+Chip = Literal["all", "active", "paused", "completed"]
+
+_CHIP_BUCKETS: dict[str, tuple[RowBucket, ...]] = {
+    "all": ("active", "paused"),
+    "active": ("active",),
+    "paused": ("paused",),
+    "completed": ("completed",),
+}
+
+
+@dataclass
+class UnifiedRow:
+    """One reminder or automation-definition row, shaped for the unified list.
+
+    Attributes:
+        kind: ``"reminder"`` or ``"definition"``.
+        row_id: A stable, cross-kind-collision-safe list key
+            (``f"{kind}:{local_id}"``).
+        title: The row's display title (``ReminderTask.title`` /
+            ``definition["name"]``).
+        schedule_summary: Humanized cadence prose ("Daily at 09:00 UTC",
+            "One-time at 2026-09-03 09:00 UTC"), via the existing
+            formatters -- never re-derived.
+        next_run_at: The row's next scheduled fire time, normalized to a
+            real ``datetime`` for both primitives (a definition's
+            ``next_run_at`` is a raw ISO string at the DB layer).
+        owner_id: The row's raw owner id (``"local"`` / ``"server:<id>"``).
+        owner_label: The prose owner label (`owner_display_label`).
+        transfer_state: The row's raw transfer-state column value, passed
+            through for the caller's own badge rendering -- this module
+            never renders badges.
+        bucket: Which of the three chip buckets the row currently lives
+            in (`filter_rows`/`sort_rows` consume this).
+        glyph: The one-character status glyph (spec SS4).
+        unread_count: Unread `automation_results` rows resolved to this
+            definition (always ``0`` for a reminder row -- reminders
+            never produce results).
+        search_blob: ``title`` + body/question text, for `filter_rows`'s
+            case-insensitive substring search.
+        source_row: The original `ReminderTask` or definition ``dict``,
+            for a caller that needs a field this adapter does not expose.
+    """
+
+    kind: RowKind
+    row_id: str
+    title: str
+    schedule_summary: str
+    next_run_at: datetime | None
+    owner_id: str
+    owner_label: str
+    transfer_state: str | None
+    bucket: RowBucket
+    glyph: str
+    unread_count: int
+    search_blob: str
+    source_row: ReminderTask | dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Hoisted formatters (moved from task_detail.py / definition_detail.py /
+# results_tab.py -- see module docstring for why). Each keeps its ORIGINAL
+# name and behavior; the donor modules now import these back.
+# ---------------------------------------------------------------------------
+
+#: Weekday names for `_humanize_cron`'s single-weekday preset (index 0-6,
+#: Sunday-first -- matches `croniter`'s day-of-week numbering).
+_WEEKDAYS = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+]
+
+
+def _format_timezone(dt) -> str:
+    """Return a timezone label for a datetime, defaulting to UTC.
+
+    Args:
+        dt: A ``datetime`` (naive or aware).
+
+    Returns:
+        The datetime's ``tzname()``, or ``"UTC"`` for a naive value or one
+        whose ``tzname()`` is falsy.
+    """
+    if dt.tzinfo is None:
+        return "UTC"
+    return dt.tzname() or "UTC"
+
+
+def _humanize_cron(cron: str | None, timezone: str | None = None) -> str:
+    """Summarize a cron expression in plain English.
+
+    Args:
+        cron: A 5-field cron string, or ``None``.
+        timezone: The cron's timezone label; defaults to ``"UTC"``.
+
+    Returns:
+        A human-readable cadence summary, or ``"-"``/the raw string when
+        the expression is empty/not a recognized 5-field preset.
+    """
+    if not cron:
+        return "-"
+    parts = cron.split()
+    if len(parts) != 5:
+        return cron
+    minute, hour, dom, month, dow = parts
+    tz = f" {timezone}" if timezone else " UTC"
+
+    def _is_wildcard(value: str) -> bool:
+        return value == "*"
+
+    def _is_digit(value: str) -> bool:
+        # ASCII only: '²'.isdigit() is True but int('²') raises, and this
+        # runs on every detail render of a synced cron (review F14).
+        return bool(value) and value.isascii() and value.isdigit()
+
+    if (
+        _is_digit(minute)
+        and _is_digit(hour)
+        and _is_wildcard(dom)
+        and _is_wildcard(month)
+        and _is_wildcard(dow)
+    ):
+        return f"Daily at {int(hour):02d}:{int(minute):02d}{tz}"
+
+    if (
+        _is_digit(minute)
+        and _is_digit(hour)
+        and _is_wildcard(dom)
+        and _is_wildcard(month)
+        and dow == "1-5"
+    ):
+        # The "Every weekday at..." preset (task-23102).
+        return f"Weekdays at {int(hour):02d}:{int(minute):02d}{tz}"
+
+    if (
+        _is_digit(minute)
+        and _is_digit(hour)
+        and _is_wildcard(dom)
+        and _is_wildcard(month)
+        and _is_digit(dow)
+    ):
+        day_index = int(dow)
+        if 0 <= day_index <= 6:
+            return f"Weekly on {_WEEKDAYS[day_index]} at {int(hour):02d}:{int(minute):02d}{tz}"
+
+    if (
+        _is_digit(minute)
+        and _is_digit(hour)
+        and _is_digit(dom)
+        and _is_wildcard(month)
+        and _is_wildcard(dow)
+    ):
+        return f"Monthly on the {int(dom)} at {int(hour):02d}:{int(minute):02d}{tz}"
+
+    return f"cron: {cron}{tz}"
+
+
+def _humanize_schedule(task: ReminderTask) -> str:
+    """Return a human-readable schedule summary for a reminder.
+
+    Args:
+        task: The reminder to summarize.
+
+    Returns:
+        "One-time" prose for a one-time reminder, or the humanized cron
+        for a recurring one.
+    """
+    if task.schedule_kind == ScheduleKind.ONE_TIME:
+        if task.run_at is None:
+            return "One-time"
+        return f"One-time at {task.run_at.strftime('%Y-%m-%d %H:%M')} {_format_timezone(task.run_at)}"
+    return _humanize_cron(task.cron, task.timezone)
+
+
+def definition_cron_expression(schedule: dict[str, Any]) -> Any:
+    """An automation definition's cron string, under EITHER key.
+
+    The two writers disagree: this client writes ``schedule["cron"]``
+    (`AutomationDefinitionForm`'s save payload), the real server sends
+    ``schedule["expression"]``.
+
+    Args:
+        schedule: A definition's ``schedule`` dict, from either source.
+
+    Returns:
+        The cron string, or ``None``/empty when neither key carries one.
+    """
+    return schedule.get("cron") or schedule.get("expression")
+
+
+def owner_display_label(owner_id: Any) -> str:
+    """Prose owner label shared by every schedules surface.
+
+    ``"This device"`` for a locally-owned row, the server's own id for a
+    server-scoped one (``"server:srv-1"`` -> ``"srv-1"``).
+
+    Args:
+        owner_id: A row's ``owner_id`` (any type tolerated -- anything
+            that is not a server-scoped string reads as local).
+
+    Returns:
+        ``"This device"``, or the server's own id.
+    """
+    # ADR-097: scheduler.queue stays off the boot census -- function-local
+    # import, matching the original call site this was hoisted from.
+    from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
+
+    if not is_server_scoped_owner(owner_id):
+        return "This device"
+    owner_id = str(owner_id)
+    return owner_id.split(":", 1)[1] if ":" in owner_id else owner_id
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    """Best-effort ISO-8601 parse; ``None`` for anything else, never raises.
+
+    Args:
+        value: A candidate ISO-8601 timestamp string.
+
+    Returns:
+        The parsed ``datetime``, or ``None`` when ``value`` is not a
+        parseable string.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _definition_at_label(schedule: dict[str, Any]) -> str:
+    """The full schedule summary for a definition's ``schedule`` dict.
+
+    The definition-side counterpart of `_humanize_schedule`, reusing
+    `_humanize_cron` for a cron-kind schedule rather than re-deriving
+    cron-cadence prose.
+
+    Args:
+        schedule: A definition's ``schedule`` dict (``kind`` is
+            ``"cron"``/``"one_time"``).
+
+    Returns:
+        A human-readable schedule summary, or ``"-"`` for an
+        unrecognized/absent schedule shape.
+    """
+    if not isinstance(schedule, dict):
+        return "-"
+    kind = schedule.get("kind")
+    if kind == "cron":
+        return _humanize_cron(
+            definition_cron_expression(schedule), schedule.get("timezone")
+        )
+    if kind == "one_time":
+        run_at = schedule.get("run_at")
+        dt = _parse_iso(run_at) if run_at else None
+        if dt is None:
+            return f"One-time at {run_at}" if run_at else "One-time"
+        return f"One-time at {dt.strftime('%Y-%m-%d %H:%M')} {_format_timezone(dt)}"
+    return "-"
+
+
+def _definition_question_text(definition: dict[str, Any]) -> str:
+    """The recurring question/body text for search + question-card display.
+
+    Args:
+        definition: An automation-definition row (dict).
+
+    Returns:
+        The definition's ``input.question``, falling back to its
+        ``description``, then its ``name``, then ``"Untitled automation"``.
+    """
+    input_fields = (
+        definition.get("input") if isinstance(definition.get("input"), dict) else {}
+    )
+    question = str(input_fields.get("question") or "").strip()
+    if question:
+        return question
+    description = str(definition.get("description") or "").strip()
+    if description:
+        return description
+    return str(definition.get("name") or "Untitled automation")
+
+
+def index_definitions_by_id(
+    rows: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Index definition rows under BOTH id spaces they are referred to by.
+
+    A result's ``definition_id`` is whatever the side that produced it
+    calls the definition: a locally-created result carries the LOCAL row
+    id, while a result mirrored down from the server carries the
+    SERVER's id (`upsert_automation_results_from_server` copies
+    ``definition_id`` verbatim -- it has no local id to translate it to).
+    Indexing by ``row["id"]`` alone therefore misses every synced result.
+    Local ids are UUID4 and server ids are the server's own opaque ids,
+    so the two key spaces do not collide in practice; the local id is
+    written first regardless, so a pathological clash still resolves to
+    a row this device owns.
+
+    Args:
+        rows: Definition rows from
+            `ScheduledTasksDB.list_automation_definitions` (or the
+            server-mirrored equivalent).
+
+    Returns:
+        Each row keyed by its local ``id`` and, when present, by its
+        ``server_id`` too.
+    """
+    index: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        index[str(row["id"])] = row
+    for row in rows:
+        server_id = row.get("server_id")
+        if server_id:
+            index.setdefault(str(server_id), row)
+    return index
+
+
+def definition_for_result(
+    result: dict[str, Any], definitions_by_id: dict[str, dict[str, Any]]
+) -> dict[str, Any] | None:
+    """The definition row a result belongs to, across both id spaces.
+
+    Pairs with `index_definitions_by_id`.
+
+    Args:
+        result: An ``automation_results`` row.
+        definitions_by_id: The index built by `index_definitions_by_id`.
+
+    Returns:
+        The owning definition row, or ``None`` when the result's
+        ``definition_id`` matches neither id space.
+    """
+    return definitions_by_id.get(str(result.get("definition_id") or ""))
+
+
+# ---------------------------------------------------------------------------
+# Bucket predicates (plan ruling 2)
+# ---------------------------------------------------------------------------
+
+
+def reminder_has_fired(task: ReminderTask) -> bool:
+    """True for a fired one-time reminder (survey SS6, task_detail.py:163-167).
+
+    Dispatching a one-time reminder disables it AND clears
+    ``next_run_at`` -- this triple (disabled, no next run, but has run at
+    least once) is the only way an ``enabled=0`` reminder also carries a
+    ``last_run_at``, distinguishing "fired" from a user-initiated pause.
+
+    Args:
+        task: The reminder to check.
+
+    Returns:
+        ``True`` when the reminder has fired its one-time schedule.
+    """
+    return (
+        not task.enabled and task.next_run_at is None and task.last_run_at is not None
+    )
+
+
+def definition_is_armed(definition: dict[str, Any]) -> bool:
+    """True when a ``configured`` definition is not sitting out a dormant transfer.
+
+    Mirrors `ScheduledTasksDB.list_armable_automation_definitions`'s own
+    lifecycle + `DORMANT_TRANSFER_STATES` gate (imported, never
+    restated): a definition whose ``transfer_state`` is
+    ``to_server_sent``/``from_server_pending`` has left this device's
+    control until the transfer settles, so it does not count as the
+    Active chip's "still runs here" claim. ``to_server_pending``/
+    ``to_server_failed`` are NOT dormant and keep arming (spec SS3:
+    Active "includ[es] to_server_pending/to_server_failed... they still
+    execute locally").
+
+    Args:
+        definition: An automation-definition row (dict).
+
+    Returns:
+        ``True`` when the definition is configured and not dormant.
+    """
+    return (
+        definition.get("lifecycle") == "configured"
+        and definition.get("transfer_state") not in DORMANT_TRANSFER_STATES
+    )
+
+
+def _reminder_bucket(task: ReminderTask) -> RowBucket:
+    if reminder_has_fired(task):
+        return "completed"
+    if not task.enabled:
+        return "paused"
+    return "active"
+
+
+def _definition_bucket(definition: dict[str, Any]) -> RowBucket:
+    lifecycle = definition.get("lifecycle")
+    if lifecycle == "archived":
+        return "completed"
+    if lifecycle in ("paused", "disabled"):
+        return "paused"
+    if definition_is_armed(definition):
+        return "active"
+    # A `configured` definition sitting out a dormant transfer (or an
+    # unrecognized lifecycle value) is still a real, visible row -- park
+    # it under Paused rather than silently dropping it from every chip.
+    # `UnifiedRow.bucket` has no 4th "in transfer" state; its
+    # `transfer_state` field still carries the raw value for the
+    # caller's own badge.
+    return "paused"
+
+
+# ---------------------------------------------------------------------------
+# Glyphs (spec SS4)
+# ---------------------------------------------------------------------------
+
+
+def _reminder_glyph(task: ReminderTask, bucket: RowBucket) -> str:
+    if bucket == "paused":
+        return "⏸"
+    if bucket == "completed":
+        return "✓"
+    return "○" if task.schedule_kind == ScheduleKind.RECURRING else "▶"
+
+
+def _definition_glyph(definition: dict[str, Any], bucket: RowBucket) -> str:
+    if bucket == "paused":
+        return "⏸"
+    if bucket == "completed":
+        return "✓"
+    schedule = definition.get("schedule")
+    kind = schedule.get("kind") if isinstance(schedule, dict) else None
+    return "○" if kind == "cron" else "▶"
+
+
+# ---------------------------------------------------------------------------
+# Row construction
+# ---------------------------------------------------------------------------
+
+
+def _unread_counts_by_local_id(
+    results: list[dict[str, Any]], definitions_by_id: dict[str, dict[str, Any]]
+) -> dict[str, int]:
+    """Group unread results by their resolved definition's LOCAL id.
+
+    Routes every result through `definition_for_result` (the same dual
+    local/server id-space resolution `results_tab.py` uses) BEFORE
+    grouping, so a server-mirrored definition's results are counted
+    under that definition's own local ``id`` even though the result row
+    itself may carry the server's id verbatim (plan ruling 3).
+
+    Args:
+        results: All-owners `automation_results` rows (one
+            `list_automation_results(owner_id=None)` call per refresh).
+        definitions_by_id: The index built by `index_definitions_by_id`.
+
+    Returns:
+        ``{definition_local_id: unread_count}``, omitting definitions
+        with zero unread results.
+    """
+    counts: dict[str, int] = defaultdict(int)
+    for result in results:
+        if result.get("review_state") != "unread":
+            continue
+        definition = definition_for_result(result, definitions_by_id)
+        if definition is None:
+            continue
+        counts[str(definition.get("id") or "")] += 1
+    return dict(counts)
+
+
+def _reminder_row(task: ReminderTask) -> UnifiedRow:
+    bucket = _reminder_bucket(task)
+    return UnifiedRow(
+        kind="reminder",
+        row_id=f"reminder:{task.id}",
+        title=task.title,
+        schedule_summary=_humanize_schedule(task),
+        next_run_at=task.next_run_at,
+        owner_id=task.owner_id,
+        owner_label=owner_display_label(task.owner_id),
+        transfer_state=task.transfer_state,
+        bucket=bucket,
+        glyph=_reminder_glyph(task, bucket),
+        unread_count=0,
+        search_blob=f"{task.title}\n{task.body or ''}",
+        source_row=task,
+    )
+
+
+def _definition_row(
+    definition: dict[str, Any], unread_by_local_id: dict[str, int]
+) -> UnifiedRow:
+    bucket = _definition_bucket(definition)
+    local_id = str(definition.get("id") or "")
+    owner_id = str(definition.get("owner_id") or "local")
+    name = str(definition.get("name") or local_id)
+    return UnifiedRow(
+        kind="definition",
+        row_id=f"definition:{local_id}",
+        title=name,
+        schedule_summary=_definition_at_label(definition.get("schedule") or {}),
+        next_run_at=_parse_iso(definition.get("next_run_at")),
+        owner_id=owner_id,
+        owner_label=owner_display_label(owner_id),
+        transfer_state=definition.get("transfer_state"),
+        bucket=bucket,
+        glyph=_definition_glyph(definition, bucket),
+        unread_count=unread_by_local_id.get(local_id, 0),
+        search_blob=f"{name}\n{_definition_question_text(definition)}",
+        source_row=definition,
+    )
+
+
+def build_unified_rows(
+    reminders: list[ReminderTask],
+    definitions: list[dict[str, Any]],
+    results: list[dict[str, Any]],
+) -> list[UnifiedRow]:
+    """Adapt reminders + automation definitions into one unified row list.
+
+    Args:
+        reminders: Every owner's reminders (e.g. from
+            ``SchedulingService.list_tasks(owner_id=None)``, filtered to
+            real `ReminderTask` rows -- briefing/watchlist projections
+            stay out of the unified list per plan ruling 1).
+        definitions: Local + server-mirrored ``recurring_question``
+            definition rows (the existing Automations-tab merge
+            precedent: `_load_local_automations` + `_load_server_automations`).
+        results: One all-owners `list_automation_results(owner_id=None)`
+            listing, used only to derive `UnifiedRow.unread_count`.
+
+    Returns:
+        One `UnifiedRow` per reminder and per definition, unsorted and
+        unfiltered (`filter_rows`/`sort_rows` do that).
+    """
+    definitions_by_id = index_definitions_by_id(definitions)
+    unread_by_local_id = _unread_counts_by_local_id(results, definitions_by_id)
+    rows = [_reminder_row(task) for task in reminders]
+    rows.extend(_definition_row(d, unread_by_local_id) for d in definitions)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Filter + sort (plan ruling 5)
+# ---------------------------------------------------------------------------
+
+
+def filter_rows(rows: list[UnifiedRow], *, chip: Chip, query: str) -> list[UnifiedRow]:
+    """Narrow ``rows`` to one chip's bucket set, then an in-memory search.
+
+    Args:
+        rows: The full unified row list (any order).
+        chip: ``"all"`` (Active + Paused; Completed excluded by design --
+            spec SS3), ``"active"``, ``"paused"``, or ``"completed"``.
+        query: Case-insensitive substring matched against each row's
+            ``search_blob`` (title + question/body). Blank/whitespace-only
+            matches everything.
+
+    Returns:
+        The matching rows, in their input order.
+    """
+    buckets = _CHIP_BUCKETS.get(chip, _CHIP_BUCKETS["all"])
+    needle = query.strip().lower()
+    return [
+        row
+        for row in rows
+        if row.bucket in buckets and (not needle or needle in row.search_blob.lower())
+    ]
+
+
+def _as_utc(dt: datetime) -> datetime:
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+_FAR_FUTURE = datetime.max.replace(tzinfo=timezone.utc)
+_FAR_PAST = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _next_run_sort_key(row: UnifiedRow) -> datetime:
+    return _as_utc(row.next_run_at) if row.next_run_at is not None else _FAR_FUTURE
+
+
+def _recency_of(row: UnifiedRow) -> datetime | None:
+    """The "last activity" timestamp `sort_rows` uses for Paused/Completed.
+
+    Ruling 5 names ``last_run_at``/``updated_at`` -- the reminder and
+    definition field that carries the same meaning on each primitive.
+    """
+    if row.kind == "reminder":
+        task = row.source_row
+        assert isinstance(task, ReminderTask)
+        return task.last_run_at
+    definition = row.source_row
+    assert isinstance(definition, dict)
+    return _parse_iso(definition.get("updated_at"))
+
+
+def _recency_sort_key(row: UnifiedRow) -> datetime:
+    recency = _recency_of(row)
+    return _as_utc(recency) if recency is not None else _FAR_PAST
+
+
+def sort_rows(rows: list[UnifiedRow], chip: Chip) -> list[UnifiedRow]:
+    """Order ``rows`` per plan ruling 5.
+
+    Args:
+        rows: Rows already narrowed to one chip (`filter_rows`'s output),
+            though any row list is accepted.
+        chip: Which chip's order to apply. ``"active"`` sorts by
+            ``next_run_at`` ascending (``None`` last). ``"paused"``/
+            ``"completed"`` sort by recency descending (most-recent-first,
+            ``None`` last). ``"all"`` keeps Active rows first in Active's
+            own order, then appends Paused rows in Paused's own order.
+
+    Returns:
+        A new, ordered list (input list is not mutated).
+    """
+    if chip == "active":
+        return sorted(rows, key=_next_run_sort_key)
+    if chip in ("paused", "completed"):
+        return sorted(rows, key=_recency_sort_key, reverse=True)
+    active_rows = sorted(
+        (row for row in rows if row.bucket == "active"), key=_next_run_sort_key
+    )
+    paused_rows = sorted(
+        (row for row in rows if row.bucket == "paused"),
+        key=_recency_sort_key,
+        reverse=True,
+    )
+    return active_rows + paused_rows

--- a/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
+++ b/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
@@ -415,6 +415,16 @@ def reminder_has_fired(task: ReminderTask) -> bool:
     ``next_run_at``) and from a reminder that never ran (no
     ``last_run_at``).
 
+    ``schedule_kind == ScheduleKind.ONE_TIME`` is REQUIRED (Qodo MEDIUM):
+    only a one-time reminder's dispatch clears ``next_run_at`` for good.
+    A recurring reminder can land in that same shape too -- ``cron``
+    exhausted (end-date-passed) or an anomalous row -- and
+    `mark_reminder_dispatched` never touches ``enabled`` on the recurring
+    branch, so without this guard such a row read as "fired" and bucketed
+    Completed despite still being armed to re-enable. `_reminder_bucket`
+    routes that shape to Paused instead (disabled-not-finished, not
+    finished-for-good).
+
     ``enabled`` is deliberately NOT part of the predicate (final review
     F9, ruled): re-enabling a fired one-time reminder does not give it a
     future run -- `_set_reminder_enabled` sends only ``{"enabled": ...}``
@@ -429,7 +439,11 @@ def reminder_has_fired(task: ReminderTask) -> bool:
     Returns:
         ``True`` when the reminder has fired its one-time schedule.
     """
-    return task.next_run_at is None and task.last_run_at is not None
+    return (
+        task.schedule_kind == ScheduleKind.ONE_TIME
+        and task.next_run_at is None
+        and task.last_run_at is not None
+    )
 
 
 def definition_is_armed(definition: dict[str, Any]) -> bool:
@@ -461,6 +475,16 @@ def _reminder_bucket(task: ReminderTask) -> RowBucket:
     if reminder_has_fired(task):
         return "completed"
     if not task.enabled:
+        return "paused"
+    if task.schedule_kind == ScheduleKind.RECURRING and task.next_run_at is None:
+        # Ruled (Qodo MEDIUM, paired with `reminder_has_fired`'s ONE_TIME
+        # guard): a recurring reminder with no next occurrence (exhausted
+        # cron / anomalous row) is disabled-not-finished, not Completed --
+        # recurring never "completes" the way a one-time reminder does.
+        # It also is not caught by the `enabled` check above (`enabled`
+        # is untouched on the recurring dispatch branch), so it needs its
+        # own route to Paused rather than falling through to Active with
+        # nothing left armed to run.
         return "paused"
     if task.transfer_state in DORMANT_TRANSFER_STATES:
         # Mirrors `_definition_bucket`'s dormant fallback (review round
@@ -651,7 +675,23 @@ def build_unified_rows(
     )
     unread_by_row_key = _unread_counts_by_row_key(results, definitions_by_id)
     rows = [_reminder_row(task) for task in reminders]
-    rows.extend(_definition_row(d, unread_by_row_key) for d in definitions)
+    # `family == "recurring_question"` only (Qodo MEDIUM): `definitions`
+    # is never family-filtered upstream (`list_automation_definitions`'s
+    # `family=` default, and a server page can return `agent_task` rows
+    # too -- same guard `_definition_row` for the plain Automations
+    # listing has no equivalent of, since that tab is family-agnostic by
+    # design). An `agent_task`/unknown-family row rendered here would be
+    # a pseudo-recurring Queue entry with no recurring semantics behind
+    # it. Definitions of every family stay visible on the Automations
+    # tab -- still the all-families home until PR-4 retires it (plan
+    # ruling: "their actions stay on the Automations tab until PR-4
+    # retires it") -- PR-4 MUST revisit this filter when that tab goes
+    # away, or agent_task definitions lose their only remaining surface.
+    rows.extend(
+        _definition_row(d, unread_by_row_key)
+        for d in definitions
+        if d.get("family") == "recurring_question"
+    )
     return rows
 
 

--- a/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
+++ b/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
@@ -8,8 +8,15 @@ both primitives and both owners (spec
 `backlog/docs/plan-2026-09-03-schedules-redesign-pr2.md` ruling 2).
 
 Deliberately Textual-free (no `import textual` anywhere in this file, nor
-in anything it imports) so it stays cheap to import -- and unit-testable
-without a Textual harness -- regardless of what pulls it in later.
+in anything it imports): this module's OWN dependency chain never needs
+Textual, so its logic can be exercised with plain function calls, no
+Textual harness required. That claim is scoped to this file's own
+imports, not to importing its dotted package path in general -- `import
+tldw_chatbook.UI.Screens.scheduling.unified_rows` still runs
+`.../scheduling/__init__.py` first, which already eagerly imports
+`SchedulesWorkbench` (Textual) regardless of what this module needs;
+Textual is a hard dependency present in every real run/test environment
+anyway, so that pre-existing package-init cost is harmless in practice.
 `task_detail.py`, `definition_detail.py`, and `results_tab.py` each used
 to define a handful of small, genuinely pure formatters this module also
 needs (schedule-summary prose, the owner label, the dual local/server
@@ -215,7 +222,19 @@ def definition_cron_expression(schedule: dict[str, Any]) -> Any:
 
     The two writers disagree: this client writes ``schedule["cron"]``
     (`AutomationDefinitionForm`'s save payload), the real server sends
-    ``schedule["expression"]``.
+    ``schedule["expression"]`` (recorded fixture
+    ``Tests/Scheduling/fixtures/server_responses/
+    automation_definition_list.json``), and ``_load_server_automations``
+    passes the payload through raw, stamping only ``owner_id``.
+
+    Both readers of that field go through here (final review F1 + its
+    carry-forward, originally in `task_detail.py` before this hoist):
+    `definition_detail`'s "At" row -- where a cron-only read rendered
+    ``At: -`` for EVERY server-owned definition -- and
+    ``AutomationDefinitionForm._prefill_from_row``, where the same read
+    was worse than cosmetic: editing a mirrored server-only definition
+    fell through to the form's default preset, so a save wrote that
+    default OVER the server's real schedule.
 
     Args:
         schedule: A definition's ``schedule`` dict, from either source.
@@ -227,10 +246,19 @@ def definition_cron_expression(schedule: dict[str, Any]) -> Any:
 
 
 def owner_display_label(owner_id: Any) -> str:
-    """Prose owner label shared by every schedules surface.
+    """Prose owner label shared by every schedules surface (final review F6/F7).
 
     ``"This device"`` for a locally-owned row, the server's own id for a
-    server-scoped one (``"server:srv-1"`` -> ``"srv-1"``).
+    server-scoped one (``"server:srv-1"`` -> ``"srv-1"``) -- the
+    vocabulary the spec, the User Guide, and the Automations table's own
+    Name-cell prefix already use. The reminder pane's `Runs on` row used
+    to render the raw metadata string instead (``local``, ``server:1``/
+    ``server <id>``), so the two panes spoke two dialects for the
+    flagship row of the redesign; one helper, one vocabulary.
+
+    `TaskInspector`'s Owner row deliberately keeps `_task_owner_label`'s
+    raw value instead: that pane is the metadata inspector, where the
+    unprettied owner/server ids are the point.
 
     Args:
         owner_id: A row's ``owner_id`` (any type tolerated -- anything
@@ -426,6 +454,15 @@ def _reminder_bucket(task: ReminderTask) -> RowBucket:
     if reminder_has_fired(task):
         return "completed"
     if not task.enabled:
+        return "paused"
+    if task.transfer_state in DORMANT_TRANSFER_STATES:
+        # Mirrors `_definition_bucket`'s dormant fallback (review round
+        # 1, finding 1): `PriorityQueue.load()` excludes a dormant
+        # transfer_state for BOTH primitives (`scheduler/queue.py:96-108`),
+        # and `list_reminder_tasks(armable_only=True)`/
+        # `reminders_due_before` already apply the same exclusion on the
+        # reminder side. "Armed" (spec SS3) is one shared concept across
+        # reminders and definitions, not two independently-scoped rules.
         return "paused"
     return "active"
 

--- a/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/sources_pane.py
@@ -774,7 +774,13 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         # button here and on the Inspector, toasts like "It will be
         # checked on its normal schedule."); this column was the one
         # holdout still saying "scraped".
-        table.add_columns("Name", "Type", "Status", "Last checked", "Active")
+        # redesign PR-2 Task 2 review finding 1: "Next check" restores the
+        # next-check-due visibility the Schedules Queue used to carry for
+        # watchlist sources before that projection was dropped from the
+        # unified list -- see `source_next_check_text`.
+        table.add_columns(
+            "Name", "Type", "Status", "Last checked", "Next check", "Active"
+        )
         self._populate_table(table)
         yield table
 
@@ -957,6 +963,61 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
         )
 
     @staticmethod
+    def source_next_check_text(source: dict[str, Any]) -> str:
+        """What the Next check column says.
+
+        Redesign PR-2 Task 2's review (finding 1): the Schedules Queue
+        used to project every local watchlist subscription's next-check
+        time (`WatchlistProjection._compute_next_run` = `last_checked (or
+        created_at) + check_frequency`) into a queue row; Task 2 dropped
+        watchlist projections from that unified list per the locked
+        product decision that they "have their own home" -- except they
+        did not have one anywhere in Watchlists, so that removal orphaned
+        this pane's only surviving "when will this run again" signal.
+        This column restores it, computed the SAME way, rendered through
+        this pane's own `humane_timestamp` idiom (not the Queue's old
+        "(overdue Nd)" annotation -- this pane has no other row that uses
+        that vocabulary).
+
+        `check_frequency` rides `source["settings"]`
+        (`watchlist_normalizers._local_source_settings` already publishes
+        it there for a local subscription). A server-backed watchlist
+        source's normalizer never receives a check_frequency equivalent
+        (grepped: the field is Subscriptions_DB-only, no server model
+        carries it) -- those rows honestly read `"-"`, exactly as they
+        did in the now-removed Queue projection (`WatchlistProjection`
+        only ever read from the local `Subscriptions_DB`).
+
+        Args:
+            source: A normalized source dict.
+
+        Returns:
+            `humane_timestamp` of the computed next-check time, or `"-"`
+            when there is not enough data (no check_frequency, or never
+            checked and never created).
+        """
+        # Function-local import: `Scheduling.services` eagerly imports the
+        # full `SchedulingService`/`SchedulingServerClient` stack on
+        # package init (same ADR-097 "keep it off the boot census"
+        # reasoning already used throughout `schedules_workbench.py` for
+        # `scheduler.queue` imports) -- this pane should not pay that
+        # weight just to reuse two pure functions.
+        from ...Scheduling.services.watchlist_projection import _compute_next_run
+
+        settings = source.get("settings")
+        check_frequency = (
+            settings.get("check_frequency") if isinstance(settings, dict) else None
+        )
+        next_run = _compute_next_run(
+            source.get("last_checked_or_scraped_at"),
+            check_frequency,
+            source.get("created_at"),
+        )
+        if next_run is None:
+            return "-"
+        return humane_timestamp(next_run)
+
+    @staticmethod
     def _source_row_cells(
         source: dict[str, Any], highlighted: bool, checked: bool = False
     ) -> tuple[Text, ...]:
@@ -988,6 +1049,7 @@ class SourcesPane(RecomposeCaptureGuard, Vertical):
             Text(str(source.get("source_type") or "-"), style=style),
             Text(SourcesPane.source_status_text(source), style=style),
             Text(SourcesPane.source_last_scraped_text(source), style=style),
+            Text(SourcesPane.source_next_check_text(source), style=style),
             Text("Yes" if source.get("active") else "No", style=style),
         )
 

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -4,9 +4,10 @@
  * Scheduling workbench specific styles
  * ======================================== */
 
-/* The destination header + sync bar above the tabs are auto-height siblings;
- * without an explicit 1fr the auto-height TabbedContent measures its fr
- * children against the whole content area and overflows past the footer. */
+/* The liveness Static + bottom status strip are auto-height siblings of
+ * the TabbedContent; without an explicit 1fr the auto-height TabbedContent
+ * measures its fr children against the whole content area and overflows
+ * past the footer. */
 #schedules-shell {
     height: 1fr;
     min-height: 0;
@@ -14,6 +15,23 @@
 
 #scheduling-tabs {
     height: 1fr;
+}
+
+/* redesign PR-2, Task 3: the bottom status strip (plan ruling 4) -- shared
+ * across every tab (not Queue-specific), hosting the existing
+ * SyncStatusWidget (owner indicator + sync health) and a conflicts badge
+ * that switches to the Conflicts tab. SyncStatusWidget takes the
+ * remaining width so the badge sits flush right; `align` centers the
+ * badge (height:1, from .scheduling-queue-chip) against the taller
+ * padded SyncStatusWidget row. */
+#scheduling-status-strip {
+    height: auto;
+    border-top: solid $ds-grid-line;
+    align: left middle;
+}
+
+#scheduling-status-strip > SyncStatusWidget {
+    width: 1fr;
 }
 
 SchedulesWorkbench TabbedContent,
@@ -206,6 +224,15 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
 #scheduling-new-task {
     width: auto;
     min-width: 9;
+}
+
+/* redesign PR-2, Task 3: the rail's Mark-all-read button -- hidden by
+ * default (see SchedulesWorkbench.on_mount / _update_mark_all_read_
+ * visibility), same height:auto row as Create above it. */
+#scheduling-mark-all-read {
+    width: auto;
+    min-width: 9;
+    margin-left: 1;
 }
 
 /* Automations tab header (task-5): same title+button row shape as the

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -135,10 +135,33 @@ SchedulesWorkbench TabbedContent TabPane {
     background: $surface-darken-1;
 }
 
+/* redesign PR-2, Task 2: the chip row (spec S3) -- compact single-row
+ * buttons, same height:1/border:none idiom the filter Input above uses,
+ * so the row costs one line rather than a full 3-row Button box. */
+#scheduling-queue-chips {
+    height: 1;
+    margin: 0 0 1 0;
+}
+
+#scheduling-queue-chips .scheduling-queue-chip {
+    height: 1;
+    border: none;
+    min-width: 8;
+    margin-right: 1;
+    background: $surface-darken-1;
+}
+
 /* Compact mode: the filter's margin row goes to the table (80x24 has
- * exactly one spare row; without this the queue shows only the filter). */
+ * exactly one spare row; without this the queue shows only the filter).
+ * The chip row is hidden outright at this width rather than squeezed
+ * further -- it is a filter convenience, not a required affordance, and
+ * the narrow-width floor already prioritizes the table + detail pane. */
 #scheduling-workbench.compact #scheduling-queue-filter {
     margin: 0;
+}
+
+#scheduling-workbench.compact #scheduling-queue-chips {
+    display: none;
 }
 
 SchedulesWorkbench.schedules-workbench-compact #scheduling-workbench {

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13740,10 +13740,33 @@ SchedulesWorkbench TabbedContent TabPane {
     background: $surface-darken-1;
 }
 
+/* redesign PR-2, Task 2: the chip row (spec S3) -- compact single-row
+ * buttons, same height:1/border:none idiom the filter Input above uses,
+ * so the row costs one line rather than a full 3-row Button box. */
+#scheduling-queue-chips {
+    height: 1;
+    margin: 0 0 1 0;
+}
+
+#scheduling-queue-chips .scheduling-queue-chip {
+    height: 1;
+    border: none;
+    min-width: 8;
+    margin-right: 1;
+    background: $surface-darken-1;
+}
+
 /* Compact mode: the filter's margin row goes to the table (80x24 has
- * exactly one spare row; without this the queue shows only the filter). */
+ * exactly one spare row; without this the queue shows only the filter).
+ * The chip row is hidden outright at this width rather than squeezed
+ * further -- it is a filter convenience, not a required affordance, and
+ * the narrow-width floor already prioritizes the table + detail pane. */
 #scheduling-workbench.compact #scheduling-queue-filter {
     margin: 0;
+}
+
+#scheduling-workbench.compact #scheduling-queue-chips {
+    display: none;
 }
 
 SchedulesWorkbench.schedules-workbench-compact #scheduling-workbench {

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13609,9 +13609,10 @@ Button.error:hover {
  * Scheduling workbench specific styles
  * ======================================== */
 
-/* The destination header + sync bar above the tabs are auto-height siblings;
- * without an explicit 1fr the auto-height TabbedContent measures its fr
- * children against the whole content area and overflows past the footer. */
+/* The liveness Static + bottom status strip are auto-height siblings of
+ * the TabbedContent; without an explicit 1fr the auto-height TabbedContent
+ * measures its fr children against the whole content area and overflows
+ * past the footer. */
 #schedules-shell {
     height: 1fr;
     min-height: 0;
@@ -13619,6 +13620,23 @@ Button.error:hover {
 
 #scheduling-tabs {
     height: 1fr;
+}
+
+/* redesign PR-2, Task 3: the bottom status strip (plan ruling 4) -- shared
+ * across every tab (not Queue-specific), hosting the existing
+ * SyncStatusWidget (owner indicator + sync health) and a conflicts badge
+ * that switches to the Conflicts tab. SyncStatusWidget takes the
+ * remaining width so the badge sits flush right; `align` centers the
+ * badge (height:1, from .scheduling-queue-chip) against the taller
+ * padded SyncStatusWidget row. */
+#scheduling-status-strip {
+    height: auto;
+    border-top: solid $ds-grid-line;
+    align: left middle;
+}
+
+#scheduling-status-strip > SyncStatusWidget {
+    width: 1fr;
 }
 
 SchedulesWorkbench TabbedContent,
@@ -13811,6 +13829,15 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
 #scheduling-new-task {
     width: auto;
     min-width: 9;
+}
+
+/* redesign PR-2, Task 3: the rail's Mark-all-read button -- hidden by
+ * default (see SchedulesWorkbench.on_mount / _update_mark_all_read_
+ * visibility), same height:auto row as Create above it. */
+#scheduling-mark-all-read {
+    width: auto;
+    min-width: 9;
+    margin-left: 1;
 }
 
 /* Automations tab header (task-5): same title+button row shape as the


### PR DESCRIPTION
Second slice of the approved schedules-screen redesign (spec §3/§4; plan: backlog/docs/plan-2026-09-03-schedules-redesign-pr2.md). The Queue tab becomes the redesign's unified surface.

## What ships
- **One list, both primitives, both owners**: reminders and recurring-question definitions render as unified rows (glyph, title, schedule summary · relative next-run, owner suffix, transfer badges, unread dots) via a pure row adapter whose buckets are SYMMETRIC across primitives and defer to the transfer machine's `DORMANT_TRANSFER_STATES` authority; the fired-one-time predicate is now a named helper.
- **Filter chips** (`All Active Paused Completed`) + in-memory search + per-chip sort; highlight routes between the PR-1 detail panes by row kind.
- **Rail chrome**: the create chooser relocated as `Create ▾`, Mark-all-read (the real per-row mutation fan-out, visible only with unread work), and a bottom status strip — compact sync widget + conflicts badge that switches tabs.
- **Cross-owner honesty, root-fixed**: listing across owners forced the write side to follow — reminder update/toggle/delete now record mutations under the ROW's owner (the fifth and final occurrence of this program's owner-scope defect class), so acting on a mirrored row syncs instead of silently lying.
- **Watchlists "Next check" restored**: the unified list drops projections per the spec's locked decision; review verified the premise half-true (briefings had a home, watchlists didn't) — so the Watchlists sources pane gained the next-check column the queue removal orphaned, fed by the same projection math.
- **Refresh discipline**: definitions load once per cycle (shared loader + `include_projections` skip), reminder-only actions reuse the snapshot, a cross-tab staleness flag upgrades to a full refresh on Automations-tab mutations/tab-arrival, SSE results-pulls now refresh the Queue's unread state, and the 60s ticker updates visible relative-times with zero DB work — including a `RowHighlighted` echo guard that also stopped every render double-painting row 0's detail.
- Review-caught along the way: a wrong-row destructive delete (`d` on a definition row confirmed deletion of the previously-held reminder — guarded), an unread index that missed transferred definitions' results (now built from the full local table, matching the Results badge), and an incident-ack index-space crossover.

## Review trail
4 SDD tasks, each reviewed (Task 1's asymmetric dormant bucketing ruled against and inverted; Task 2's projection-removal premise verified and repaired; Task 2's snapshot staleness bounded via the invalidation hook after a re-review trace). Final whole-branch review (opus): 5 Important + 7 Minor, all probed — one wave fixed all 12 (revert-checked per fix), scoped re-review ALL RESOLVED. Assembled gate: 1512 passed / 11 dev-baseline failures name-for-name (attributed via read-only worktree diff against dev's own run); census stable; diagnostics pin exact; CSS bundle byte-identical.

## Deferred (ledgered)
Post-transfer HISTORY counts (distinct from the fixed unread gap); dead single-primitive branches + the unreachable managed-by rendering (PR-4's retirement sweep); the reminder detail's remaining per-tick sync reads (PR-4 rider).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WocisXw6SEEG6nb1aKFHtv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the owner-scoped Schedules Queue, which mixed reminders with watchlist and briefing projections, with a unified cross-owner list of reminders and recurring-question definitions. It adds chip filters, search, rail actions, and shared sync/conflict status while moving watchlist next-check visibility to Watchlists Sources.

**Behavior**

- Definition rows open the existing detail view but remain view-only; reminder actions use each row’s owner.
- `Create ▾` keeps the reminder and recurring-question chooser, while `Mark all read` resolves every unread result and hides when none remain.
- Transfer-aware buckets place dormant rows in Paused, reserve Completed for fired one-time reminders, and exclude non-`recurring_question` definitions from the Queue.
- Reminder-only refreshes reuse definition snapshots; Queue-created definitions refresh immediately, and Automations changes invalidate the snapshot before the next Queue load.
- A 60-second ticker updates relative next-run labels without database reads, while compact layouts retain sync ownership and errors.

**Validation**

- Adds adapter, service, UI, and Watchlists coverage for mixed owners, transfer states, unread resolution, routing, rail actions, refreshes, and ticker behavior; updates both user guides.
- The assembled schedules gate matches the `dev` baseline with no new failures.

<sup>Written for commit 938e452414dc5138740859730bcfb298157ef5c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

