### PR TITLE
Restrict production PyPI publishing to main

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,8 +3,12 @@ name: Publish Python package
 on:
   workflow_dispatch:
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -13,6 +17,8 @@ jobs:
   build:
     name: Build and check distributions
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release-version.outputs.version }}
 
     steps:
       - name: Check out source
@@ -36,11 +42,13 @@ jobs:
           python -m build --sdist --wheel --no-isolation --outdir dist
 
       - name: Verify release version
+        id: release-version
         run: |
           python - <<'PY'
-          import os
           from pathlib import Path
           import tomllib
+
+          from Packaging.check_pypi_release import write_github_output
 
           with Path("pyproject.toml").open("rb") as handle:
               project_version = tomllib.load(handle)["project"]["version"]
@@ -63,11 +71,7 @@ jobs:
           if project_version != sdist_version:
               raise SystemExit(f"sdist version {sdist_version} != project version {project_version}")
 
-          if os.environ.get("GITHUB_REF_TYPE") == "tag":
-              expected_tag = f"v{project_version}"
-              actual_tag = os.environ.get("GITHUB_REF_NAME")
-              if actual_tag != expected_tag:
-                  raise SystemExit(f"tag {actual_tag} != expected release tag {expected_tag}")
+          write_github_output("version", project_version)
 
           print(f"project_version={project_version}")
           print(f"wheel={wheels[0].name}")
@@ -117,10 +121,39 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
 
+  check_pypi_release:
+    name: Check PyPI release status
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    outputs:
+      release_exists: ${{ steps.check.outputs.release_exists }}
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install output path validation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install loguru psutil
+
+      - name: Check whether version already exists on PyPI
+        id: check
+        env:
+          RELEASE_VERSION: ${{ needs.build.outputs.version }}
+        run: python Packaging/check_pypi_release.py "$RELEASE_VERSION"
+
   publish-pypi:
     name: Publish to PyPI
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.ref_protected
-    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.ref_protected && needs.check_pypi_release.outputs.release_exists == 'false'
+    needs: [build, check_pypi_release]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/Packaging/PYPI_README.md
+++ b/Packaging/PYPI_README.md
@@ -30,7 +30,8 @@ Normal publishing is done by `.github/workflows/publish-pypi.yml`:
 
 - Manual workflow dispatch from protected `dev` publishes to TestPyPI through
   the `testpypi` environment.
-- Protected `v*` tags publish to PyPI through the `pypi` environment after the
-  tag version matches `pyproject.toml`.
+- Protected `main` pushes publish to PyPI through the `pypi` environment only
+  when the built version does not already exist on PyPI. Tag pushes do not
+  publish.
 
 Do not use `.pypirc` or long-lived API tokens for routine releases.

--- a/Packaging/PYPI_RELEASE.md
+++ b/Packaging/PYPI_RELEASE.md
@@ -35,11 +35,12 @@ For PyPI:
 If the project does not exist yet, create a pending trusted publisher for the
 same owner, repository, workflow, and environment.
 
-Protect the `dev` branch, the `testpypi` and `pypi` GitHub environments, and
-the production `v*` tag pattern before allowing publishing. The TestPyPI job
-only runs for manual dispatch from protected `dev`; the PyPI job only runs for
-protected matching version tags. Publish jobs only download built artifacts and
-request the PyPI OIDC token.
+Protect the `dev` and `main` branches and the `testpypi` and `pypi` GitHub
+environments before allowing publishing. The TestPyPI job only runs for manual
+dispatch from protected `dev`; the PyPI job only runs for protected `main`
+branch pushes, and it skips the upload when the built version already exists on
+PyPI. Publish jobs only download built artifacts and request the PyPI OIDC
+token.
 
 ## Local Release Gates
 
@@ -96,17 +97,21 @@ Run the full suite only when the release manager explicitly wants a full sweep.
 ## Publish to PyPI
 
 1. Confirm the same commit passed the local gates and TestPyPI smoke test.
-2. Create and push a protected production tag:
+2. Merge the approved release commit to the protected `main` branch. Do not
+   publish by pushing a tag; tag pushes are intentionally ignored by the PyPI
+   workflow.
+3. The `Publish Python package` workflow builds and checks the artifacts from
+   `main`, verifies whether the version already exists on PyPI, and publishes
+   through the protected `pypi` environment only when the version is new.
+4. After PyPI is verified, create and push the annotated source tag at the
+   `main` release commit for provenance:
 
    ```bash
    git tag -a v<version> -m "Release v<version>"
    git push origin v<version>
    ```
 
-3. The `Publish Python package` workflow publishes the checked artifacts to PyPI
-   only when the `v<version>` tag is protected and matches the package version.
-   Publishing still goes through the protected `pypi` environment.
-4. Verify:
+5. Verify:
 
    ```bash
    python -m venv pypi_env

--- a/Packaging/build_release.sh
+++ b/Packaging/build_release.sh
@@ -25,6 +25,6 @@ echo
 echo "Next steps:"
 echo "1. Run the installed-wheel regression printed above."
 echo "2. Use the publish-pypi GitHub Actions workflow for TestPyPI."
-echo "3. Publish production PyPI from a protected v${VERSION} tag."
+echo "3. Merge the approved release commit to protected main for production PyPI."
 echo
 echo "See Packaging/PYPI_RELEASE.md for detailed instructions."

--- a/Packaging/check_pypi_release.py
+++ b/Packaging/check_pypi_release.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Check whether a package version already exists on PyPI."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Protocol
+
+from tldw_chatbook.Utils.path_validation import validate_path
+
+
+PYPI_JSON_BASE_URL = "https://pypi.org/pypi"
+DEFAULT_PACKAGE_NAME = "tldw-chatbook"
+DEFAULT_OUTPUT_NAME = "release_exists"
+
+
+class HttpResponse(Protocol):
+    def __enter__(self) -> "HttpResponse": ...
+
+    def __exit__(self, *_args: object) -> None: ...
+
+    def read(self, size: int) -> bytes: ...
+
+
+class UrlOpen(Protocol):
+    def __call__(self, url: str, timeout: int) -> HttpResponse: ...
+
+
+def release_exists(
+    package_name: str,
+    version: str,
+    *,
+    base_url: str = PYPI_JSON_BASE_URL,
+    urlopen: UrlOpen = urllib.request.urlopen,
+) -> bool:
+    """Return whether the package version already exists in the PyPI JSON API."""
+    if not package_name:
+        raise ValueError("package name cannot be empty")
+    if not version:
+        raise ValueError("version cannot be empty")
+
+    package = urllib.parse.quote(package_name, safe="")
+    quoted_version = urllib.parse.quote(version, safe="")
+    url = f"{base_url.rstrip('/')}/{package}/{quoted_version}/json"
+
+    try:
+        with urlopen(url, timeout=30) as response:
+            response.read(1)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return False
+        raise
+
+    return True
+
+
+def resolve_github_output_path(
+    output_path: str | os.PathLike[str] | None = None,
+    *,
+    runner_temp: str | os.PathLike[str] | None = None,
+) -> Path | None:
+    """Return a validated GitHub output file path, or ``None`` outside Actions."""
+    raw_output_path = output_path or os.environ.get("GITHUB_OUTPUT")
+    if not raw_output_path:
+        return None
+
+    raw_runner_temp = runner_temp or os.environ.get("RUNNER_TEMP")
+    if not raw_runner_temp:
+        raise ValueError("RUNNER_TEMP is required when GITHUB_OUTPUT is set")
+
+    return validate_path(
+        raw_output_path,
+        raw_runner_temp,
+        redact_paths=True,
+        allow_hidden=True,
+    )
+
+
+def write_github_output(
+    name: str,
+    value: str,
+    *,
+    output_path: str | os.PathLike[str] | None = None,
+    runner_temp: str | os.PathLike[str] | None = None,
+) -> None:
+    """Append a single GitHub Actions output assignment after path validation."""
+    if not name or any(char in name for char in "=\r\n"):
+        raise ValueError("GitHub output name is invalid")
+    if any(char in value for char in "\r\n"):
+        raise ValueError("GitHub output value cannot contain newlines")
+
+    path = resolve_github_output_path(output_path, runner_temp=runner_temp)
+    if path is None:
+        return
+
+    with path.open("a", encoding="utf-8") as output:
+        output.write(f"{name}={value}\n")
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    urlopen: UrlOpen = urllib.request.urlopen,
+) -> int:
+    """Run the PyPI version-existence check for GitHub Actions."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="Project version to check on PyPI.")
+    parser.add_argument(
+        "--package",
+        default=DEFAULT_PACKAGE_NAME,
+        help=f"Normalized PyPI package name. Default: {DEFAULT_PACKAGE_NAME}",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=PYPI_JSON_BASE_URL,
+        help=f"PyPI JSON API base URL. Default: {PYPI_JSON_BASE_URL}",
+    )
+    parser.add_argument(
+        "--output-name",
+        default=DEFAULT_OUTPUT_NAME,
+        help=f"GitHub Actions output name. Default: {DEFAULT_OUTPUT_NAME}",
+    )
+    args = parser.parse_args(argv)
+
+    exists = (
+        "true"
+        if release_exists(
+            args.package,
+            args.version,
+            base_url=args.base_url,
+            urlopen=urlopen,
+        )
+        else "false"
+    )
+    write_github_output(args.output_name, exists)
+    print(f"{args.output_name}={exists}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Tests/Packaging/test_release_metadata.py
+++ b/Tests/Packaging/test_release_metadata.py
@@ -1,16 +1,30 @@
 from __future__ import annotations
 
 import ast
+import re
 import tomllib
+import urllib.error
 from pathlib import Path
 
 import pytest
 
 from Packaging.common.dist_path import resolve_dist_dir
 from Packaging.common import version as packaging_version
+from Packaging import check_pypi_release
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _PypiJsonResponse:
+    def __enter__(self) -> "_PypiJsonResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, _size: int) -> bytes:
+        return b"{"
 
 
 def _package_version_metadata() -> tuple[str, tuple[int, ...]]:
@@ -85,6 +99,109 @@ def test_distribution_output_path_rejects_symlink_escape(tmp_path: Path) -> None
         resolve_dist_dir("linked-external/dist", repo_root)
 
 
+def test_pypi_release_exists_returns_true_for_existing_version() -> None:
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return _PypiJsonResponse()
+
+    assert check_pypi_release.release_exists(
+        "tldw-chatbook",
+        "1.2.3",
+        base_url="https://example.test/pypi/",
+        urlopen=fake_urlopen,
+    )
+    assert captured == {
+        "url": "https://example.test/pypi/tldw-chatbook/1.2.3/json",
+        "timeout": 30,
+    }
+
+
+def test_pypi_release_exists_returns_false_for_missing_version() -> None:
+    def fake_urlopen(url: str, timeout: int) -> object:
+        raise urllib.error.HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+
+    assert not check_pypi_release.release_exists(
+        "tldw-chatbook",
+        "9.9.9",
+        urlopen=fake_urlopen,
+    )
+
+
+def test_pypi_release_exists_reraises_unexpected_http_errors() -> None:
+    def fake_urlopen(url: str, timeout: int) -> object:
+        raise urllib.error.HTTPError(url, 503, "Unavailable", hdrs=None, fp=None)
+
+    with pytest.raises(urllib.error.HTTPError):
+        check_pypi_release.release_exists(
+            "tldw-chatbook",
+            "1.2.3",
+            urlopen=fake_urlopen,
+        )
+
+
+def test_github_output_path_is_validated_against_runner_temp(tmp_path: Path) -> None:
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    output_path = runner_temp / "_runner_file_commands" / "set_output"
+    output_path.parent.mkdir()
+    output_path.touch()
+    outside_path = tmp_path / "outside_output"
+    outside_path.touch()
+
+    check_pypi_release.write_github_output(
+        "release_exists",
+        "false",
+        output_path=output_path,
+        runner_temp=runner_temp,
+    )
+    assert output_path.read_text() == "release_exists=false\n"
+
+    with pytest.raises(ValueError):
+        check_pypi_release.write_github_output(
+            "release_exists",
+            "false",
+            output_path=outside_path,
+            runner_temp=runner_temp,
+        )
+
+
+def test_check_pypi_release_cli_uses_workflow_arguments_and_emits_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return _PypiJsonResponse()
+
+    output_path = tmp_path / "_runner_file_commands" / "set_output"
+    output_path.parent.mkdir()
+    output_path.touch()
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+
+    assert (
+        check_pypi_release.main(
+            ["1.2.3", "--base-url", "https://example.test/pypi"],
+            urlopen=fake_urlopen,
+        )
+        == 0
+    )
+
+    assert captured == {
+        "url": "https://example.test/pypi/tldw-chatbook/1.2.3/json",
+        "timeout": 30,
+    }
+    assert output_path.read_text() == "release_exists=true\n"
+    assert "release_exists=true" in capsys.readouterr().out
+
+
 def test_testpypi_publish_requires_protected_dev_ref() -> None:
     workflow = (REPO_ROOT / ".github" / "workflows" / "publish-pypi.yml").read_text()
 
@@ -92,3 +209,81 @@ def test_testpypi_publish_requires_protected_dev_ref() -> None:
         "if: github.event_name == 'workflow_dispatch' && "
         "github.ref == 'refs/heads/dev' && github.ref_protected"
     ) in workflow
+
+
+def _publish_workflow_text() -> str:
+    return (REPO_ROOT / ".github" / "workflows" / "publish-pypi.yml").read_text()
+
+
+def _workflow_job_block(workflow: str, job_name: str) -> str:
+    match = re.search(
+        rf"^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [\w-]+:\n|\Z)",
+        workflow,
+        re.M | re.S,
+    )
+    assert match is not None, f"{job_name} job not found"
+    return match.group("body")
+
+
+def test_production_pypi_publish_requires_protected_main_push() -> None:
+    workflow = _publish_workflow_text()
+    trigger_block = workflow.split("\npermissions:", maxsplit=1)[0]
+    publish_job = _workflow_job_block(workflow, "publish-pypi")
+
+    assert "push:\n    branches:\n      - main" in trigger_block
+    assert "tags:" not in trigger_block
+    assert "github.event_name == 'push'" in publish_job
+    assert "github.ref == 'refs/heads/main'" in publish_job
+    assert "github.ref_protected" in publish_job
+    assert "refs/tags" not in publish_job
+    assert "refs/heads/dev" not in publish_job
+
+
+def test_production_pypi_publish_checks_version_before_upload() -> None:
+    workflow = _publish_workflow_text()
+    check_job = _workflow_job_block(workflow, "check_pypi_release")
+    publish_job = _workflow_job_block(workflow, "publish-pypi")
+
+    assert 'run: python Packaging/check_pypi_release.py "$RELEASE_VERSION"' in check_job
+    assert "Install output path validation dependencies" in check_job
+    assert "python -m pip install loguru psutil" in check_job
+    assert "needs: [build, check_pypi_release]" in publish_job
+    assert "needs.check_pypi_release.outputs.release_exists == 'false'" in publish_job
+
+
+def test_release_workflow_serializes_same_ref_runs() -> None:
+    workflow = _publish_workflow_text()
+
+    assert (
+        "concurrency:\n"
+        "  group: ${{ github.workflow }}-${{ github.ref }}\n"
+        "  cancel-in-progress: false"
+    ) in workflow
+
+
+def test_release_workflow_uses_validated_github_output_writes() -> None:
+    workflow = _publish_workflow_text()
+    build_job = _workflow_job_block(workflow, "build")
+
+    assert "version: ${{ steps.release-version.outputs.version }}" in build_job
+    assert "from Packaging.check_pypi_release import write_github_output" in build_job
+    assert 'write_github_output("version", project_version)' in build_job
+    assert "GITHUB_OUTPUT" not in workflow
+
+
+def test_release_instructions_do_not_publish_production_pypi_from_tags() -> None:
+    checked_paths = (
+        REPO_ROOT / "Packaging" / "PYPI_README.md",
+        REPO_ROOT / "Packaging" / "PYPI_RELEASE.md",
+        REPO_ROOT / "Packaging" / "build_release.sh",
+    )
+    forbidden_lines = (
+        "Protected `v*` tags publish to PyPI",
+        "PyPI job only runs for protected matching version tags",
+        "Publish production PyPI from a protected v",
+    )
+
+    for path in checked_paths:
+        text = path.read_text()
+        for forbidden_line in forbidden_lines:
+            assert forbidden_line not in text

--- a/backlog/tasks/task-31213 - Restrict-production-PyPI-publishing-to-main.md
+++ b/backlog/tasks/task-31213 - Restrict-production-PyPI-publishing-to-main.md
@@ -1,0 +1,60 @@
+---
+id: TASK-31213
+title: Restrict production PyPI publishing to main
+status: Done
+assignee: []
+created_date: '2026-09-03 22:34'
+updated_date: '2026-09-03 22:40'
+labels:
+  - packaging
+  - ci
+  - release
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure production PyPI publishing cannot be triggered from dev or release tags, and only runs from protected main branch pushes when the built version is not already on PyPI.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Production PyPI publishing is triggered only by pushes to main.
+- [x] #2 The production publish job requires refs/heads/main and a protected ref.
+- [x] #3 Tag pushes do not trigger production PyPI publishing.
+- [x] #4 A version-exists guard prevents duplicate production uploads on main pushes.
+- [x] #5 The GitHub pypi environment deployment policy permits main only.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add workflow policy regression tests for the PyPI trigger and publish job guards.
+2. Change .github/workflows/publish-pypi.yml to trigger production on protected main pushes instead of v* tag pushes.
+3. Add a PyPI version-exists check before the production publish job so ordinary main pushes do not attempt duplicate uploads.
+4. Verify the live GitHub pypi environment policy allows only the main branch.
+5. Run targeted packaging tests and diff checks.
+
+ADR required: no
+ADR path: N/A
+Reason: This is CI/release policy wiring for an existing packaging workflow, not a storage, runtime, API, or architectural boundary change.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Changed the PyPI workflow so production publishing is triggered by protected `main` branch pushes instead of `v*` tag pushes. The build job now exports the project version through a validated GitHub Actions output writer, a separate PyPI status job checks whether that version already exists, and the production publish job runs only when that check reports a new version. TestPyPI remains a manual dispatch from protected `dev`.
+
+Extracted the PyPI version-exists guard into `Packaging/check_pypi_release.py`, added executable coverage for existing releases, missing releases, unexpected HTTP errors, validated output-path writes, workflow-facing output emission, and serialized same-ref workflow runs. Updated PyPI release documentation and the release build wrapper output so maintainers no longer follow the old tag-driven production path. Verified the live GitHub `pypi` environment deployment policy now permits only the `main` branch.
+
+Verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_release_metadata.py -q` -> 15 passed, 1 existing dependency warning
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile Packaging/check_pypi_release.py Tests/Packaging/test_release_metadata.py` -> passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check Packaging/check_pypi_release.py Tests/Packaging/test_release_metadata.py` -> passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "from pathlib import Path; import yaml; yaml.safe_load(Path('.github/workflows/publish-pypi.yml').read_text()); print('yaml ok')"` -> yaml ok
+- `bash -n Packaging/build_release.sh` -> passed
+- `git diff --check` -> passed
+- `gh api repos/rmusser01/tldw_chatbook/environments/pypi/deployment-branch-policies` -> only `main` branch policy
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- Change production PyPI publishing from protected `v*` tag pushes to protected `main` branch pushes.
- Add workflow concurrency so same-ref main publish runs serialize instead of racing duplicate uploads.
- Extract PyPI version-exists and GitHub output-writing logic into `Packaging/check_pypi_release.py`.
- Validate `GITHUB_OUTPUT` against `RUNNER_TEMP` before writing workflow outputs.
- Keep TestPyPI as manual dispatch from protected `dev`.
- Update release docs and release wrapper next-step text away from the old tag-driven production path.
- Verified the live GitHub `pypi` environment deployment policy now permits only the `main` branch.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_release_metadata.py -q` -> 15 passed, 1 existing dependency warning
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile Packaging/check_pypi_release.py Tests/Packaging/test_release_metadata.py` -> passed
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check Packaging/check_pypi_release.py Tests/Packaging/test_release_metadata.py` -> passed
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "from pathlib import Path; import yaml; yaml.safe_load(Path('.github/workflows/publish-pypi.yml').read_text()); print('yaml ok')"` -> yaml ok
- `bash -n Packaging/build_release.sh` -> passed
- `git diff --check` -> passed
- `gh api repos/rmusser01/tldw_chatbook/environments/pypi/deployment-branch-policies` -> only `main` branch policy

Backlog: TASK-31213