### PR TITLE
Skip stale PyPI release versions

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -128,6 +128,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_exists: ${{ steps.check.outputs.release_exists }}
+      latest_version: ${{ steps.check.outputs.latest_version }}
+      publish_release: ${{ steps.check.outputs.publish_release }}
 
     steps:
       - name: Check out source
@@ -142,9 +144,9 @@ jobs:
       - name: Install output path validation dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install loguru psutil
+          python -m pip install loguru packaging psutil pydantic
 
-      - name: Check whether version already exists on PyPI
+      - name: Check whether version should be published to PyPI
         id: check
         env:
           RELEASE_VERSION: ${{ needs.build.outputs.version }}
@@ -152,7 +154,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.ref_protected && needs.check_pypi_release.outputs.release_exists == 'false'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.ref_protected && needs.check_pypi_release.outputs.publish_release == 'true'
     needs: [build, check_pypi_release]
     runs-on: ubuntu-latest
     environment:

--- a/Packaging/PYPI_README.md
+++ b/Packaging/PYPI_README.md
@@ -31,7 +31,7 @@ Normal publishing is done by `.github/workflows/publish-pypi.yml`:
 - Manual workflow dispatch from protected `dev` publishes to TestPyPI through
   the `testpypi` environment.
 - Protected `main` pushes publish to PyPI through the `pypi` environment only
-  when the built version does not already exist on PyPI. Tag pushes do not
-  publish.
+  when the built version is absent and newer than the latest PyPI release. Tag
+  pushes do not publish.
 
 Do not use `.pypirc` or long-lived API tokens for routine releases.

--- a/Packaging/PYPI_RELEASE.md
+++ b/Packaging/PYPI_RELEASE.md
@@ -39,8 +39,8 @@ Protect the `dev` and `main` branches and the `testpypi` and `pypi` GitHub
 environments before allowing publishing. The TestPyPI job only runs for manual
 dispatch from protected `dev`; the PyPI job only runs for protected `main`
 branch pushes, and it skips the upload when the built version already exists on
-PyPI. Publish jobs only download built artifacts and request the PyPI OIDC
-token.
+PyPI or is older than the latest published version. Publish jobs only download
+built artifacts and request the PyPI OIDC token.
 
 ## Local Release Gates
 
@@ -101,8 +101,9 @@ Run the full suite only when the release manager explicitly wants a full sweep.
    publish by pushing a tag; tag pushes are intentionally ignored by the PyPI
    workflow.
 3. The `Publish Python package` workflow builds and checks the artifacts from
-   `main`, verifies whether the version already exists on PyPI, and publishes
-   through the protected `pypi` environment only when the version is new.
+   `main`, verifies whether the version is publishable on PyPI, and publishes
+   through the protected `pypi` environment only when the version is absent and
+   newer than the latest published version.
 4. After PyPI is verified, create and push the annotated source tag at the
    `main` release commit for provenance:
 

--- a/Packaging/check_pypi_release.py
+++ b/Packaging/check_pypi_release.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import os
+import re
 import sys
 import urllib.error
 import urllib.parse
@@ -12,12 +14,38 @@ import urllib.request
 from pathlib import Path
 from typing import Protocol
 
+from packaging.version import InvalidVersion, Version
+from pydantic import (
+    AnyUrl,
+    BaseModel,
+    ConfigDict,
+    Field,
+    TypeAdapter,
+    ValidationError,
+    field_validator,
+)
+
 from tldw_chatbook.Utils.path_validation import validate_path
 
 
 PYPI_JSON_BASE_URL = "https://pypi.org/pypi"
+PYPI_REQUEST_TIMEOUT_SECONDS = 30
 DEFAULT_PACKAGE_NAME = "tldw-chatbook"
-DEFAULT_OUTPUT_NAME = "release_exists"
+DEFAULT_OUTPUT_NAME = "publish_release"
+FIXED_OUTPUT_NAMES = frozenset(("release_exists", "latest_version"))
+PACKAGE_NAME_PATTERN = re.compile(
+    r"^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9._-]*[A-Za-z0-9])$"
+)
+URL_ADAPTER = TypeAdapter(AnyUrl)
+
+
+@dataclass(frozen=True)
+class ReleaseDecision:
+    """PyPI publication decision for a candidate package version."""
+
+    release_exists: bool
+    latest_version: str | None
+    publish_release: bool
 
 
 class HttpResponse(Protocol):
@@ -25,11 +53,95 @@ class HttpResponse(Protocol):
 
     def __exit__(self, *_args: object) -> None: ...
 
-    def read(self, size: int) -> bytes: ...
+    def read(self, size: int = -1) -> bytes: ...
 
 
 class UrlOpen(Protocol):
     def __call__(self, url: str, timeout: int) -> HttpResponse: ...
+
+
+class PypiProjectResponse(BaseModel):
+    """Validated subset of the PyPI project JSON response."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    releases: dict[str, object] = Field(default_factory=dict)
+
+
+class ReleaseCheckInput(BaseModel):
+    """Validated command-line inputs for the PyPI release check."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    package_name: str = Field(default=DEFAULT_PACKAGE_NAME, min_length=1)
+    version: str = Field(min_length=1)
+    base_url: str = Field(default=PYPI_JSON_BASE_URL, min_length=1)
+    output_name: str = Field(default=DEFAULT_OUTPUT_NAME, min_length=1)
+
+    @field_validator("package_name")
+    @classmethod
+    def validate_package_name(cls, value: str) -> str:
+        return validate_package_name(value)
+
+    @field_validator("version")
+    @classmethod
+    def validate_version(cls, value: str) -> str:
+        return validate_version(value)
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, value: str) -> str:
+        return validate_base_url(value)
+
+    @field_validator("output_name")
+    @classmethod
+    def validate_output_name(cls, value: str) -> str:
+        return validate_custom_output_name(value)
+
+
+def validate_package_name(package_name: str) -> str:
+    """Return a validated PyPI package name."""
+    if not package_name:
+        raise ValueError("package name cannot be empty")
+    if not PACKAGE_NAME_PATTERN.fullmatch(package_name):
+        raise ValueError("package name is invalid")
+    return package_name
+
+
+def validate_version(version: str) -> str:
+    """Return a validated PEP 440 package version."""
+    if not version:
+        raise ValueError("version cannot be empty")
+    try:
+        Version(version)
+    except InvalidVersion as exc:
+        raise ValueError("version is invalid") from exc
+    return version
+
+
+def validate_base_url(base_url: str) -> str:
+    """Return a validated HTTP(S) PyPI JSON API base URL."""
+    if not base_url:
+        raise ValueError("base URL cannot be empty")
+    parsed = URL_ADAPTER.validate_python(base_url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("base URL must use http or https")
+    return str(parsed).rstrip("/")
+
+
+def validate_github_output_name(name: str) -> str:
+    """Return a GitHub Actions output name that is safe to write."""
+    if not name or any(char in name for char in "=\r\n"):
+        raise ValueError("GitHub output name is invalid")
+    return name
+
+
+def validate_custom_output_name(name: str) -> str:
+    """Return a custom output name that cannot overwrite fixed metadata."""
+    validate_github_output_name(name)
+    if name in FIXED_OUTPUT_NAMES:
+        raise ValueError("custom output name cannot overwrite fixed release metadata")
+    return name
 
 
 def release_exists(
@@ -40,17 +152,16 @@ def release_exists(
     urlopen: UrlOpen = urllib.request.urlopen,
 ) -> bool:
     """Return whether the package version already exists in the PyPI JSON API."""
-    if not package_name:
-        raise ValueError("package name cannot be empty")
-    if not version:
-        raise ValueError("version cannot be empty")
+    package_name = validate_package_name(package_name)
+    version = validate_version(version)
+    base_url = validate_base_url(base_url)
 
     package = urllib.parse.quote(package_name, safe="")
     quoted_version = urllib.parse.quote(version, safe="")
-    url = f"{base_url.rstrip('/')}/{package}/{quoted_version}/json"
+    url = f"{base_url}/{package}/{quoted_version}/json"
 
     try:
-        with urlopen(url, timeout=30) as response:
+        with urlopen(url, timeout=PYPI_REQUEST_TIMEOUT_SECONDS) as response:
             response.read(1)
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
@@ -58,6 +169,112 @@ def release_exists(
         raise
 
     return True
+
+
+def latest_release_version(
+    package_name: str,
+    *,
+    base_url: str = PYPI_JSON_BASE_URL,
+    urlopen: UrlOpen = urllib.request.urlopen,
+) -> str | None:
+    """Return the latest valid package version from the PyPI JSON API.
+
+    Args:
+        package_name: PyPI project name to query.
+        base_url: Base URL for the PyPI-compatible JSON API.
+        urlopen: URL opener compatible with ``urllib.request.urlopen``.
+
+    Returns:
+        The newest valid release version string, or ``None`` when the project
+        does not exist or has no valid release versions.
+
+    Raises:
+        ValueError: If ``package_name`` or ``base_url`` is invalid.
+        ValidationError: If the PyPI JSON response has an unexpected shape.
+        urllib.error.HTTPError: If the API returns a non-404 HTTP error.
+    """
+    package_name = validate_package_name(package_name)
+    base_url = validate_base_url(base_url)
+
+    package = urllib.parse.quote(package_name, safe="")
+    url = f"{base_url}/{package}/json"
+
+    try:
+        with urlopen(url, timeout=PYPI_REQUEST_TIMEOUT_SECONDS) as response:
+            payload = PypiProjectResponse.model_validate_json(response.read())
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+
+    versions: list[Version] = []
+    for version_text in payload.releases:
+        try:
+            versions.append(Version(version_text))
+        except InvalidVersion:
+            continue
+
+    if not versions:
+        return None
+
+    return str(max(versions))
+
+
+def release_decision(
+    package_name: str,
+    version: str,
+    *,
+    base_url: str = PYPI_JSON_BASE_URL,
+    urlopen: UrlOpen = urllib.request.urlopen,
+) -> ReleaseDecision:
+    """Return whether a candidate package version should be published.
+
+    Args:
+        package_name: PyPI project name to query.
+        version: Candidate package version.
+        base_url: Base URL for the PyPI-compatible JSON API.
+        urlopen: URL opener compatible with ``urllib.request.urlopen``.
+
+    Returns:
+        A release decision containing exact-version existence, the latest PyPI
+        release, and whether publication should proceed.
+
+    Raises:
+        ValueError: If any input value is invalid.
+        ValidationError: If the PyPI project JSON response has an unexpected
+            shape.
+        urllib.error.HTTPError: If the API returns a non-404 HTTP error.
+    """
+    package_name = validate_package_name(package_name)
+    version = validate_version(version)
+    base_url = validate_base_url(base_url)
+    candidate_version = Version(version)
+    exists = release_exists(package_name, version, base_url=base_url, urlopen=urlopen)
+    latest_version = latest_release_version(
+        package_name,
+        base_url=base_url,
+        urlopen=urlopen,
+    )
+
+    if exists:
+        return ReleaseDecision(
+            release_exists=True,
+            latest_version=latest_version or version,
+            publish_release=False,
+        )
+
+    if latest_version is None:
+        return ReleaseDecision(
+            release_exists=False,
+            latest_version=None,
+            publish_release=True,
+        )
+
+    return ReleaseDecision(
+        release_exists=False,
+        latest_version=latest_version,
+        publish_release=candidate_version > Version(latest_version),
+    )
 
 
 def resolve_github_output_path(
@@ -90,8 +307,7 @@ def write_github_output(
     runner_temp: str | os.PathLike[str] | None = None,
 ) -> None:
     """Append a single GitHub Actions output assignment after path validation."""
-    if not name or any(char in name for char in "=\r\n"):
-        raise ValueError("GitHub output name is invalid")
+    validate_github_output_name(name)
     if any(char in value for char in "\r\n"):
         raise ValueError("GitHub output value cannot contain newlines")
 
@@ -128,18 +344,30 @@ def main(
     )
     args = parser.parse_args(argv)
 
-    exists = (
-        "true"
-        if release_exists(
-            args.package,
-            args.version,
+    try:
+        check_input = ReleaseCheckInput(
+            package_name=args.package,
+            version=args.version,
             base_url=args.base_url,
-            urlopen=urlopen,
+            output_name=args.output_name,
         )
-        else "false"
+    except ValidationError as exc:
+        parser.error(str(exc))
+
+    decision = release_decision(
+        check_input.package_name,
+        check_input.version,
+        base_url=check_input.base_url,
+        urlopen=urlopen,
     )
-    write_github_output(args.output_name, exists)
-    print(f"{args.output_name}={exists}")
+    outputs = (
+        ("release_exists", str(decision.release_exists).lower()),
+        ("latest_version", decision.latest_version or ""),
+        (check_input.output_name, str(decision.publish_release).lower()),
+    )
+    for name, value in outputs:
+        write_github_output(name, value)
+        print(f"{name}={value}")
     return 0
 
 

--- a/Tests/Packaging/test_release_metadata.py
+++ b/Tests/Packaging/test_release_metadata.py
@@ -7,6 +7,7 @@ import urllib.error
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from Packaging.common.dist_path import resolve_dist_dir
 from Packaging.common import version as packaging_version
@@ -17,14 +18,17 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class _PypiJsonResponse:
+    def __init__(self, payload: bytes = b"{") -> None:
+        self.payload = payload
+
     def __enter__(self) -> "_PypiJsonResponse":
         return self
 
     def __exit__(self, *_args: object) -> None:
         return None
 
-    def read(self, _size: int) -> bytes:
-        return b"{"
+    def read(self, _size: int = -1) -> bytes:
+        return self.payload
 
 
 def _package_version_metadata() -> tuple[str, tuple[int, ...]]:
@@ -142,6 +146,114 @@ def test_pypi_release_exists_reraises_unexpected_http_errors() -> None:
         )
 
 
+def test_pypi_release_decision_allows_absent_version_newer_than_latest() -> None:
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        if url.endswith("/tldw-chatbook/1.2.4/json"):
+            raise urllib.error.HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+        if url.endswith("/tldw-chatbook/json"):
+            return _PypiJsonResponse(b'{"releases": {"1.2.3": [], "not-version": []}}')
+        raise AssertionError(url)
+
+    decision = check_pypi_release.release_decision(
+        "tldw-chatbook",
+        "1.2.4",
+        base_url="https://example.test/pypi",
+        urlopen=fake_urlopen,
+    )
+
+    assert not decision.release_exists
+    assert decision.latest_version == "1.2.3"
+    assert decision.publish_release
+
+
+def test_pypi_release_decision_skips_existing_version() -> None:
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        if url.endswith("/tldw-chatbook/1.2.3/json"):
+            return _PypiJsonResponse()
+        if url.endswith("/tldw-chatbook/json"):
+            return _PypiJsonResponse(b'{"releases": {"1.2.3": []}}')
+        raise AssertionError(url)
+
+    decision = check_pypi_release.release_decision(
+        "tldw-chatbook",
+        "1.2.3",
+        base_url="https://example.test/pypi",
+        urlopen=fake_urlopen,
+    )
+
+    assert decision.release_exists
+    assert decision.latest_version == "1.2.3"
+    assert not decision.publish_release
+
+
+def test_pypi_release_decision_reports_real_latest_for_existing_stale_candidate() -> None:
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        if url.endswith("/tldw-chatbook/1.2.3/json"):
+            return _PypiJsonResponse()
+        if url.endswith("/tldw-chatbook/json"):
+            return _PypiJsonResponse(b'{"releases": {"1.2.3": [], "1.2.4": []}}')
+        raise AssertionError(url)
+
+    decision = check_pypi_release.release_decision(
+        "tldw-chatbook",
+        "1.2.3",
+        base_url="https://example.test/pypi",
+        urlopen=fake_urlopen,
+    )
+
+    assert decision.release_exists
+    assert decision.latest_version == "1.2.4"
+    assert not decision.publish_release
+
+
+def test_pypi_release_decision_skips_absent_version_older_than_latest() -> None:
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        if url.endswith("/tldw-chatbook/1.2.2/json"):
+            raise urllib.error.HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+        if url.endswith("/tldw-chatbook/json"):
+            return _PypiJsonResponse(b'{"releases": {"1.2.3": []}}')
+        raise AssertionError(url)
+
+    decision = check_pypi_release.release_decision(
+        "tldw-chatbook",
+        "1.2.2",
+        base_url="https://example.test/pypi",
+        urlopen=fake_urlopen,
+    )
+
+    assert not decision.release_exists
+    assert decision.latest_version == "1.2.3"
+    assert not decision.publish_release
+
+
+def test_pypi_release_decision_allows_first_release_for_missing_package() -> None:
+    def fake_urlopen(url: str, timeout: int) -> object:
+        raise urllib.error.HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+
+    decision = check_pypi_release.release_decision(
+        "tldw-chatbook",
+        "0.1.0",
+        base_url="https://example.test/pypi",
+        urlopen=fake_urlopen,
+    )
+
+    assert not decision.release_exists
+    assert decision.latest_version is None
+    assert decision.publish_release
+
+
+def test_pypi_release_payload_shape_is_validated() -> None:
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        return _PypiJsonResponse(b'{"releases": []}')
+
+    with pytest.raises(ValidationError):
+        check_pypi_release.latest_release_version(
+            "tldw-chatbook",
+            base_url="https://example.test/pypi",
+            urlopen=fake_urlopen,
+        )
+
+
 def test_github_output_path_is_validated_against_runner_temp(tmp_path: Path) -> None:
     runner_temp = tmp_path / "runner-temp"
     runner_temp.mkdir()
@@ -173,12 +285,15 @@ def test_check_pypi_release_cli_uses_workflow_arguments_and_emits_output(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: list[tuple[str, int]] = []
 
     def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
-        captured["url"] = url
-        captured["timeout"] = timeout
-        return _PypiJsonResponse()
+        captured.append((url, timeout))
+        if url.endswith("/tldw-chatbook/1.2.3/json"):
+            return _PypiJsonResponse()
+        if url.endswith("/tldw-chatbook/json"):
+            return _PypiJsonResponse(b'{"releases": {"1.2.3": []}}')
+        raise AssertionError(url)
 
     output_path = tmp_path / "_runner_file_commands" / "set_output"
     output_path.parent.mkdir()
@@ -194,12 +309,94 @@ def test_check_pypi_release_cli_uses_workflow_arguments_and_emits_output(
         == 0
     )
 
-    assert captured == {
-        "url": "https://example.test/pypi/tldw-chatbook/1.2.3/json",
-        "timeout": 30,
-    }
-    assert output_path.read_text() == "release_exists=true\n"
-    assert "release_exists=true" in capsys.readouterr().out
+    assert captured == [
+        (
+            "https://example.test/pypi/tldw-chatbook/1.2.3/json",
+            check_pypi_release.PYPI_REQUEST_TIMEOUT_SECONDS,
+        ),
+        (
+            "https://example.test/pypi/tldw-chatbook/json",
+            check_pypi_release.PYPI_REQUEST_TIMEOUT_SECONDS,
+        ),
+    ]
+    assert output_path.read_text() == (
+        "release_exists=true\n"
+        "latest_version=1.2.3\n"
+        "publish_release=false\n"
+    )
+    output = capsys.readouterr().out
+    assert "release_exists=true" in output
+    assert "publish_release=false" in output
+
+
+def test_check_pypi_release_cli_skips_stale_version_and_emits_outputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        if url.endswith("/tldw-chatbook/1.2.2/json"):
+            raise urllib.error.HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+        if url.endswith("/tldw-chatbook/json"):
+            return _PypiJsonResponse(b'{"releases": {"1.2.3": []}}')
+        raise AssertionError(url)
+
+    output_path = tmp_path / "_runner_file_commands" / "set_output"
+    output_path.parent.mkdir()
+    output_path.touch()
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+
+    assert (
+        check_pypi_release.main(
+            ["1.2.2", "--base-url", "https://example.test/pypi"],
+            urlopen=fake_urlopen,
+        )
+        == 0
+    )
+
+    assert output_path.read_text() == (
+        "release_exists=false\n"
+        "latest_version=1.2.3\n"
+        "publish_release=false\n"
+    )
+    output = capsys.readouterr().out
+    assert "release_exists=false" in output
+    assert "latest_version=1.2.3" in output
+    assert "publish_release=false" in output
+
+
+def test_check_pypi_release_cli_rejects_invalid_version() -> None:
+    called = False
+
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        nonlocal called
+        called = True
+        return _PypiJsonResponse()
+
+    with pytest.raises(SystemExit) as excinfo:
+        check_pypi_release.main(["not-a-version"], urlopen=fake_urlopen)
+
+    assert excinfo.value.code == 2
+    assert not called
+
+
+def test_check_pypi_release_cli_rejects_reserved_output_names() -> None:
+    called = False
+
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        nonlocal called
+        called = True
+        return _PypiJsonResponse()
+
+    with pytest.raises(SystemExit) as excinfo:
+        check_pypi_release.main(
+            ["1.2.3", "--output-name", "release_exists"],
+            urlopen=fake_urlopen,
+        )
+
+    assert excinfo.value.code == 2
+    assert not called
 
 
 def test_testpypi_publish_requires_protected_dev_ref() -> None:
@@ -246,9 +443,9 @@ def test_production_pypi_publish_checks_version_before_upload() -> None:
 
     assert 'run: python Packaging/check_pypi_release.py "$RELEASE_VERSION"' in check_job
     assert "Install output path validation dependencies" in check_job
-    assert "python -m pip install loguru psutil" in check_job
+    assert "python -m pip install loguru packaging psutil pydantic" in check_job
     assert "needs: [build, check_pypi_release]" in publish_job
-    assert "needs.check_pypi_release.outputs.release_exists == 'false'" in publish_job
+    assert "needs.check_pypi_release.outputs.publish_release == 'true'" in publish_job
 
 
 def test_release_workflow_serializes_same_ref_runs() -> None:

--- a/backlog/tasks/task-31214 - Prevent-main-PyPI-workflow-from-publishing-stale-versions.md
+++ b/backlog/tasks/task-31214 - Prevent-main-PyPI-workflow-from-publishing-stale-versions.md
@@ -1,0 +1,60 @@
+---
+id: TASK-31214
+title: Prevent main PyPI workflow from publishing stale versions
+status: Done
+assignee: []
+created_date: '2026-09-03 23:11'
+updated_date: '2026-09-03 23:14'
+labels:
+  - packaging
+  - ci
+  - release
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure the main-driven PyPI workflow cannot publish an older package version that is absent from PyPI but lower than the latest published release.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The PyPI release-status helper reports the latest published version.
+- [x] #2 Production publishing is allowed only when the candidate version is absent and newer than the latest published version.
+- [x] #3 A stale lower version on main skips production upload instead of publishing.
+- [x] #4 Focused executable tests cover latest-version comparison and stale-version skip behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Extend the PyPI release-status helper to read the package-level PyPI JSON and identify the latest valid published version.
+2. Emit a publish_release output that is true only for absent versions newer than the latest published release.
+3. Change the workflow publish condition to use publish_release rather than release_exists alone.
+4. Add targeted tests for newer, existing, missing-package, and stale lower-version behavior.
+5. Run focused tests, lint, syntax checks, and environment-policy verification.
+
+ADR required: no
+ADR path: N/A
+Reason: This is a defensive CI release guard inside the existing packaging workflow, not a new architecture or release boundary.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Extended `Packaging/check_pypi_release.py` so it checks both exact candidate-version existence and the latest package-level PyPI release. The workflow now consumes `publish_release`, which is true only when the candidate version is absent and greater than the latest valid published version. This prevents a stale `main` checkout at `0.1.8.0` from publishing after `0.1.8.1` already exists.
+
+Updated PyPI release docs to state that protected `main` publishes only absent versions newer than the latest PyPI release. Added focused tests for newer absent versions, existing versions, stale lower versions, missing-project first releases, and workflow output wiring. Addressed review feedback by validating CLI inputs with Pydantic, validating the PyPI JSON response shape, centralizing the PyPI request timeout, reporting the real latest release for existing stale candidates, and rejecting custom output names that would overwrite fixed metadata.
+
+Verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_release_metadata.py -q` -> 24 passed, 1 existing dependency warning
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile Packaging/check_pypi_release.py Tests/Packaging/test_release_metadata.py` -> passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check Packaging/check_pypi_release.py Tests/Packaging/test_release_metadata.py` -> passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "from pathlib import Path; import yaml; yaml.safe_load(Path('.github/workflows/publish-pypi.yml').read_text()); print('yaml ok')"` -> yaml ok
+- `bash -n Packaging/build_release.sh` -> passed
+- `git diff --check` -> passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Packaging/check_pypi_release.py 0.1.8.0` -> `release_exists=false`, `latest_version=0.1.8.1`, `publish_release=false`
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Packaging/check_pypi_release.py 0.1.8.2` -> `release_exists=false`, `latest_version=0.1.8.1`, `publish_release=true`
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- Add latest-version awareness to the PyPI release-status helper.
- Emit `publish_release=true` only when the candidate version is absent and newer than the latest PyPI release.
- Switch the production workflow condition to `publish_release`, preventing stale main versions from uploading.
- Update release docs to describe duplicate and stale-version skips.

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_release_metadata.py -q` -> 19 passed, 1 existing dependency warning
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile Packaging/check_pypi_release.py Tests/Packaging/test_release_metadata.py` -> passed
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check Packaging/check_pypi_release.py Tests/Packaging/test_release_metadata.py` -> passed
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "from pathlib import Path; import yaml; yaml.safe_load(Path('.github/workflows/publish-pypi.yml').read_text()); print('yaml ok')"` -> yaml ok
- `bash -n Packaging/build_release.sh` -> passed
- `git diff --check` -> passed
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Packaging/check_pypi_release.py 0.1.8.0` -> `publish_release=false` against latest `0.1.8.1`
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Packaging/check_pypi_release.py 0.1.8.2` -> `publish_release=true` against latest `0.1.8.1`

Backlog: TASK-31214

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the main-branch PyPI workflow from publishing a stale version that is absent from PyPI but older than the latest published release.

The release check now compares the candidate version against the latest PyPI release, and the workflow publishes only when the candidate is absent and newer. Previously, any absent version was published, which could overwrite a newer release with an older one.

**Migration**
- Workflow consumers must now read the `publish_release` output instead of `release_exists`; `release_exists` and `latest_version` remain available as additional outputs.

This addresses TASK-31214 acceptance criteria #1–#4.

<sup>Written for commit 3d2d5403e2994a717674f6f6e0217cc41c1c6e26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

