### PR TITLE
fix(library): chooser paints its options; Reader content takes its pane (task-31220..31222)

### DIFF
--- a/.impeccable/critique/2026-09-03T20-07-51Z__tldw-chatbook-ui-screens-library-screen-py.md
+++ b/.impeccable/critique/2026-09-03T20-07-51Z__tldw-chatbook-ui-screens-library-screen-py.md
@@ -1,0 +1,71 @@
+---
+target: "Library ▸ Media surface (re-score after critique-fix train #2346/#2350/#2351)"
+total_score: 26
+max_score: 40
+na_heuristics: 
+p0_count: 1
+p1_count: 3
+timestamp: 2026-09-03T20-07-51Z
+slug: tldw-chatbook-ui-screens-library-screen-py
+---
+Method: dual-agent (A: live design review sub-agent · B: detector/evidence sub-agent)
+
+Target: Library ▸ Browse ▸ Media (post critique-fix train #2346/#2350/#2351) — live tmux at 235×52 + 100×30, seeded 6-item profile. A's load-bearing claims re-verified against source before synthesis; no same-profile second instance this session (pgrep-checked).
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 2 | Sets picker failed twice then went silently dead; "Read later" gave zero response and persisted nothing; footer advertised walk keys while keystrokes landed in an input |
+| 2 | Match System / Real World | 3 | "Match 1 of 1 matches" is line-granular counting; "document · 1m" ambiguous units |
+| 3 | User Control and Freedom | 2 | Undo/Cancel/R-exit grammar is strong, but resume/switch/dismiss (the picker) was unreachable all session and Retry on a failed item load never recovered |
+| 4 | Consistency and Standards | 3 | Three disclosure patterns on one pane (More expander / chooser strips / modal); four differently named search inputs on one journey |
+| 5 | Error Prevention | 3 | Armed confirm + isolated danger row + cap + stale gating; nothing prevents believing a mark saved when it didn't |
+| 6 | Recognition Rather Than Recall | 2 | The type chooser renders as an EMPTY bordered box (height math ignores OptionList's 2-row chrome) — selection is blind |
+| 7 | Flexibility and Efficiency | 2 | One-press Review these + walk keys are a power dream, but printable-key shortcuts die on invisible focus drift ("s"/"]" typed into inputs) |
+| 8 | Aesthetic and Minimalist Design | 3 | Calm and dense, but the Reader caps content at 18 rows while an unstyled 1fr mode container holds ~14 blank rows above it |
+| 9 | Error Recovery | 2 | "Couldn't open review sets." has no reason/retry and its except swallows without logging; filter-miss recovery pins "Import media" while Clear filter never rendered |
+| 10 | Help and Documentation | 4 | Stamped, accurate user guide; footer micro-help; full-sentence tooltips |
+| **Total** | | **26/40** | **Acceptable (high)** |
+
+## Design Specificity Verdict
+
+**LLM assessment (A):** unmistakably authored — the walk grammar (auto-mark-on-leave, m/R, banner + footer progress), the receipt-with-Undo delete flow, ○-prefixed disabled labels with reason tooltips, "(selected)" state-in-text tabs. The armed-delete copy names both recovery paths. The betrayal is execution reliability: in one 25-minute session the same surface produced a dead Sets button, a completion that did not durably persist, an invisible type chooser, and an unresponsive Read later. Authored design, ~26/40 delivery.
+
+**Deterministic scan (B):** detector no-signal on Python (honest null); 0 hardcoded hex; every unicode state marker is word-paired in code AND in the 100×30 render ("○ Export", never bare glyphs — the prior bare-`○ ○ ○` state is confirmed gone); all 18 inline styles are sizing; the 16-notice review-set inventory is specific and severity-tagged, with one mechanical inconsistency ("Review-set storage is unavailable." ships as error twice, warning once). B independently reproduced the multi-row grammar rendering correctly at 100×30, and recorded one unattributed incident: Space in empty select mode at 100×30 blanked the canvas with a pane-grip artifact until palette navigation recovered it.
+
+## Overall Impression
+
+The three P1s and both P2s from the last critique are verifiably gone — the finish line works and announces itself, the action rows are words at every width, documents no longer wear image-failure chrome, and the set has a real banner. What the deeper session exposed underneath is the next layer: a state-dependent storage degradation that makes displayed state diverge from durable state, and two rendering bugs (blind type chooser, Reader wasting its pane) that predate this program. The design language is now consistently excellent; the running system's reliability is the frontier.
+
+## What's Working
+
+1. **The walk model** — auto-mark-on-leave, never-marking Prev, the completion gesture, tombstone-skipping pure logic, banner + footer progress. Original, keyboard-native interaction design.
+2. **Destructive-flow grammar** — ○ disabled labels with reason tooltips, danger isolation on its own row, armed confirm naming Undo AND Trash, receipt with Undo. Best-in-class terminal UX writing.
+3. **Honest empty states + documentation** — query-echoing zero-match copy, Trash's plain-language empty state, a stamped and accurate user guide.
+
+## Priority Issues
+
+- **[P0] Session-progressive silent storage degradation; displayed state diverges from durable state.** Live sequence: a 6-item set completed in the UI ("All 6 reviewed", clean R-exit) but the DB shows position 5 `done=0`, `active=1`, `completed_at=NULL`; the Sets picker then failed twice ("Couldn't open review sets.") and went silently dead; "Read later" persisted nothing across three presses; a plain row click stuck on "Media item is unavailable." with an ineffective Retry. Each control fails in a different dialect and nothing says "storage is unhealthy". Compounding: the picker worker's `except Exception` (library_screen.py:39972) is the ONE review-set wrapper without traceback logging — the app log contains no trace. No same-profile contention this session (pgrep-verified), so last run's environmental explanation is dead; the uncommitted-transaction signature (app sees its own writes, external reader doesn't) is the lead. **Fix:** log the swallowed exception; one storage-health surface; root-cause the wedged connection/worker. **Suggested command:** /impeccable harden
+- **[P1] The type chooser renders zero options.** `choices.styles.height = min(8, max(1, len(options)))` ignores OptionList's 2-row default chrome (the Console popup rule documents this exact cost), so the common 2-option case is an empty bordered band — a core decision made blind. **Fix:** budget +2 rows or strip the inner chrome as `#console-command-popup OptionList` does. **Suggested command:** /impeccable polish
+- **[P1] The Reader wastes its pane.** `#library-media-reader-mode-read` has no CSS rule → an unstyled Vertical defaults to 1fr holding ~14 blank rows above the Find bar, while `#library-media-viewer-content` is capped `max-height: 18` regardless of terminal size — content gets ~1/3 of a 45-row pane. **Fix:** `height: auto` on the mode container; let content take remaining height. **Suggested command:** /impeccable layout
+- **[P1] The footer advertises keys the focused widget will swallow.** The shortcut branch keys off screen state, not focus: with focus in the rail search the footer showed "] next in set | m | R" while keystrokes were inserted as text (a stray "]" corrupted the filter to a zero-match list). For a keyboard-first brand the footer is the instrument — it must not lie. **Fix:** focus-aware footer context or priority bindings + a visible "typing in <input>" state. **Suggested command:** /impeccable harden
+- **[P2] Zero-match filter recovery is wrong and the right one is invisible.** `fresh_zero` doesn't check `canvas.query`, so a filter miss pins "Import media"; meanwhile `#library-media-filter-clear` (no width bound on its row's Input, no shared action class) never rendered at any point live. **Fix:** gate the Import suggestion on an empty query; bound the Input so Clear renders. **Suggested command:** /impeccable onboard
+- **[P2] The completion moment has no exit.** After "All N reviewed" the footer keeps advertising "] next in set" (now a silent no-op — the same honest-footer rule, task-28005, that trims Prev/Next at list ends) and offers no next step. **Fix:** at completion swap the footer segment to "R exit review" and stop advertising ]. **Suggested command:** /impeccable polish
+
+## Persona Red Flags
+
+**Alex (impatient power user):** resuming yesterday's batch runs through the one button that failed or silently no-op'd all session; a mid-walk `/` search silently costs him the walk keys and `]` edits his filter; no per-row reviewed ✓ means "what's left" requires walking serially; content confined to an 18-row box forces constant inner scrolling on a large terminal.
+
+**Sam (keyboard-only, no color-only meaning):** genuinely well served by the text idioms ("(selected)", "○ Export", ▸/☑/☐, "✓ reviewed") — the house rule shows. Hard stops: the blank type chooser offers no visible options and no textual highlight feedback; Find's match (line-granular) has no non-color positional marker; invisible focus plus the untruthful footer breaks the one instrument a keyboard-only user navigates by; silent controls give no failure signal at all.
+
+## Minor Observations
+
+"Local Media item" is developer-ese; duplicate "Read" heading under the "Read (selected)" tab; the banner mixes set progress and item state in one line; the More expander shoves tabs+content ~18 rows down; "Open manager" unexplained; Trash header truncates ("Local Trash · 0 i"); storage-unavailable notice ships as error twice / warning once (line 40132); B's unattributed Space-in-empty-select-mode canvas blank at 100×30 (pane-grip artifact suggests Space activated a focused grip — unconfirmed); re-entry resumed the Reader on a different item than last read.
+
+## Questions to Consider
+
+1. Why does a Reader cap its text at 18 rows and spend a third of its pane on a blank band — who is that space for?
+2. Is "reviewed" a mode (banner-only) or a property of the items (per-row ✓ in the list)? The current answer forces serial recall of parallel information.
+3. Four search boxes with four names on one journey — is search one concept in this product or four?
+4. When the data layer wedges, the surface speaks four dialects of failure (toast, silence, error card, dead button). What is this product's single honest voice for "something systemic is wrong"?

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2805,8 +2805,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 108,
-      "diagnostic_digest": "91a2a19d731954e8dd84",
+      "call_count": 109,
+      "diagnostic_digest": "a8dd908ae6288ad6a624",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11304,6 +11304,6 @@
     "path_privacy_candidate_calls": 714,
     "persistent_sink_files": 10,
     "task_492_calls": 1337,
-    "task_494_calls": 7566
+    "task_494_calls": 7567
   }
 }

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -1,0 +1,101 @@
+"""Render fixes from the 2026-09-03 re-critique (tasks 31221, 31222).
+
+Two verified rendering bugs, both only reproducible on the REAL screen path
+(the library's split stylesheet loads lazily via LibraryScreen.CSS_PATH, and
+the chooser bug needs the screen's focus-on-open):
+
+- task-31221: the app-global ``*:focus`` solid outline (core/_reset.tcss)
+  paints OVER a widget's outermost rows without costing geometry; the
+  screen focuses the option-count-height type chooser on open, so with the
+  common two-option catalogue the outline covered every option — an empty
+  bordered band, selection blind. Third widget bitten after TASK-1160
+  (DataTable) and TASK-2300 (SelectOverlay).
+- task-31222: ``#library-media-reader-mode-read`` had no height rule (an
+  unstyled Vertical defaulted to 1fr, holding a blank band above the Find
+  bar) while ``#library-media-viewer-content`` was capped at 18 rows
+  regardless of terminal size.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Button, OptionList
+
+from Tests.UI.test_library_media_side_by_side import (
+    _build_media_test_app,
+    _open_media_list,
+    _two_media_items,
+)
+from Tests.UI.test_library_shell import (
+    LibraryProductionCSSHarness,
+    _seed_conversations,
+    _two_conversations,
+    _wait_for_condition,
+    _wait_for_selector,
+)
+
+
+def _host() -> LibraryProductionCSSHarness:
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    return LibraryProductionCSSHarness(app)
+
+
+def _painted(host, region) -> str:
+    strips = list(host.screen._compositor.render_strips())
+    return "\n".join(
+        strips[y].crop(region.x, region.right).text
+        for y in range(region.y, min(region.bottom, len(strips)))
+    )
+
+
+@pytest.mark.asyncio
+async def test_type_chooser_paints_every_option():
+    """Every option's TEXT is painted in the opened chooser (task-31221).
+
+    Painted text on purpose: the bug was the app-global ``*:focus`` solid
+    outline painting OVER the option rows without affecting layout, so
+    region assertions passed while the user saw an empty bordered band.
+    """
+    host = _host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        screen.query_one("#library-media-type-filter", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-type-choices")
+        await pilot.pause()
+        await pilot.pause()
+        chooser = screen.query_one("#library-media-type-choices", OptionList)
+        assert chooser.option_count >= 2
+        assert chooser.has_focus  # the screen focuses the chooser on open
+        painted = _painted(host, chooser.region)
+        assert "All types" in painted, painted
+        assert "video" in painted, painted
+        assert "audio" in painted, painted
+
+
+@pytest.mark.asyncio
+async def test_reader_content_takes_the_pane_not_an_18_row_box():
+    """No 1fr blank band; content height scales with the terminal."""
+    host = _host()
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        screen.query_one("#library-media-row-0", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_media_reader_session.pending_request is None
+                and screen._library_media_reader_session.loaded_id is not None
+            ),
+            message="Reader detail never settled.",
+        )
+        await pilot.pause()
+        mode_read = screen.query_one("#library-media-reader-mode-read")
+        # Heading (+ optional toggle) only — never a 1fr blank band.
+        assert mode_read.region.height <= 4, mode_read.region
+        content = screen.query_one("#library-media-viewer-content")
+        # The box may stay compact for short content, but its ceiling must
+        # scale with the pane instead of a fixed 18 rows.
+        max_height = content.styles.max_height
+        assert max_height is not None and str(max_height.value) != "18", (
+            max_height
+        )

--- a/backlog/tasks/task-31220 - Media-storage-root-cause-the-session-progressive-silent-degradation.md
+++ b/backlog/tasks/task-31220 - Media-storage-root-cause-the-session-progressive-silent-degradation.md
@@ -1,0 +1,45 @@
+---
+id: TASK-31220
+title: Media storage - root-cause the session-progressive silent degradation
+status: To Do
+assignee:
+  - '@claude'
+created_date: '2026-09-03 22:30'
+updated_date: '2026-09-03 22:44'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Re-critique 2026-09-03 P0 (user: full root-cause hunt): in a ~25-min live session, a completed review set never durably persisted (UI 'All 6 reviewed' but DB done=0/active=1/completed_at=NULL), the Sets picker failed twice then went silently dead, Read later persisted nothing, and a plain row click stuck on 'Media item is unavailable.' with dead Retry - spanning BOTH DBs. The picker worker's except Exception is the one review-set wrapper without traceback logging, so no trace exists. Lead: stuck DB thread w/ open transaction exhausting the asyncio.to_thread pool; CancelledError (BaseException) explains the silent-dead phase.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The picker worker's exception path logs the traceback
+- [ ] #2 The root cause of the wedge is identified with reproduction evidence
+- [ ] #3 A durable fix lands with a regression pin, and displayed state can no longer silently diverge from durable state
+- [ ] #4 One storage-health surface tells the user when local storage is unhealthy
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Instrument: log the picker worker's swallowed exception (the one wrapper #2346 missed)\n2. Reproduce: scripted long session (create/walk/complete/exit/picker/dismiss/read-later/trash/type-chooser loop) with an external DB probe between phases to catch divergence onset\n3. On wedge: kill -USR2 the app pid -> faulthandler.log all-thread stacks -> identify the stuck thread/lock\n4. Root-cause fix + regression pin + storage-health surface
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Hunt round 1 (2026-09-03): 24-round scripted repro (create->complete->picker->dismiss + read-later + trash + chooser, external RO probes every round) reproduced NOTHING - all 24 completions durably persisted (done_marks=6, completed_at stamped), every Sets press produced the modal, zero probe errors. The critique session's divergence evidence is now suspect: Assessment A ran a scratch-profile harness mid-session and its external DB dump may have read the scratch profile's collections DB (which would contain exactly the observed fresh-set shape). The in-app dead controls (Sets silent, Read later inert, media detail unavailable) remain unexplained and observed-once. AC1 SHIPPED (picker except now logs the traceback - the one wrapper 30042 missed), so the next natural occurrence self-documents in tldw_cli_app.log. AC2-4 open pending a reproducible occurrence; repro script kept at scratchpad/hunt_31202.sh (SIGUSR2 all-thread dump wired).
+<!-- SECTION:NOTES:END -->
+
+
+## Renumbering
+
+Renumbered from task-31202 on 2026-09-03: id collision with an older dev arrival (owner rule TASK-19601; older keeps the id).

--- a/backlog/tasks/task-31221 - Media-type-chooser-options-are-invisible-zero-height-OptionList.md
+++ b/backlog/tasks/task-31221 - Media-type-chooser-options-are-invisible-zero-height-OptionList.md
@@ -1,0 +1,29 @@
+---
+id: TASK-31221
+title: Media type chooser - options are invisible (zero-height OptionList)
+status: To Do
+assignee: []
+created_date: '2026-09-03 22:30'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Re-critique P1: choices.styles.height = min(8, max(1, len(options))) ignores OptionList's 2-row default chrome, so the common 2-option case renders an empty bordered band and selection is blind (verified in code; the Console popup rule documents the exact cost).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Every type option is visible for any option count
+- [ ] #2 The highlighted option is visually indicated
+<!-- AC:END -->
+
+
+## Renumbering
+
+Renumbered from task-31203 on 2026-09-03: id collision with an older dev arrival (owner rule TASK-19601; older keeps the id).

--- a/backlog/tasks/task-31222 - Reader-content-takes-the-pane-instead-of-an-18-row-box-under-a-blank-band.md
+++ b/backlog/tasks/task-31222 - Reader-content-takes-the-pane-instead-of-an-18-row-box-under-a-blank-band.md
@@ -1,0 +1,29 @@
+---
+id: TASK-31222
+title: Reader - content takes the pane instead of an 18-row box under a blank band
+status: To Do
+assignee: []
+created_date: '2026-09-03 22:31'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Re-critique P1: #library-media-reader-mode-read has no CSS rule (unstyled Vertical defaults to 1fr = ~14 blank rows above the Find bar) and #library-media-viewer-content is capped max-height 18 regardless of terminal size - content gets ~1/3 of the pane.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 No blank band above the Find bar in the Read tab
+- [ ] #2 Content height scales with the pane (long content scrolls inside; short content stays compact)
+<!-- AC:END -->
+
+
+## Renumbering
+
+Renumbered from task-31204 on 2026-09-03: id collision with an older dev arrival (owner rule TASK-19601; older keeps the id).

--- a/backlog/tasks/task-31223 - Footer-never-advertise-keys-the-focused-widget-will-swallow.md
+++ b/backlog/tasks/task-31223 - Footer-never-advertise-keys-the-focused-widget-will-swallow.md
@@ -1,0 +1,29 @@
+---
+id: TASK-31223
+title: Footer - never advertise keys the focused widget will swallow
+status: To Do
+assignee: []
+created_date: '2026-09-03 22:31'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Re-critique P1: the footer shortcut branch keys off screen state, not focus; with focus in an Input it advertised '] next in set | m | R' while keystrokes were inserted as text (a stray ] corrupted the filter to a zero-match list). Keyboard-first brand: the footer is the instrument and must not lie.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 With focus in a text input, the footer reflects typing context instead of advertising swallowed action keys
+- [ ] #2 Walk keys shown in the footer always work when shown
+<!-- AC:END -->
+
+
+## Renumbering
+
+Renumbered from task-31205 on 2026-09-03: id collision with an older dev arrival (owner rule TASK-19601; older keeps the id).

--- a/backlog/tasks/task-31224 - Media-filter-miss-recovery-suggest-Clear-filter-not-Import-media.md
+++ b/backlog/tasks/task-31224 - Media-filter-miss-recovery-suggest-Clear-filter-not-Import-media.md
@@ -1,0 +1,29 @@
+---
+id: TASK-31224
+title: 'Media filter-miss recovery - suggest Clear filter, not Import media'
+status: To Do
+assignee: []
+created_date: '2026-09-03 22:31'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Re-critique P2: fresh_zero never checks canvas.query so a filter miss pins 'Import media' as recovery; meanwhile #library-media-filter-clear never rendered live (unbounded Input swallows its row; no shared action class).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A zero-match ACTIVE-query page offers clearing the filter, not importing
+- [ ] #2 The Clear filter control is visible whenever a query is applied
+<!-- AC:END -->
+
+
+## Renumbering
+
+Renumbered from task-31206 on 2026-09-03: id collision with an older dev arrival (owner rule TASK-19601; older keeps the id).

--- a/backlog/tasks/task-31225 - Review-set-completion-honest-footer-and-a-next-step.md
+++ b/backlog/tasks/task-31225 - Review-set-completion-honest-footer-and-a-next-step.md
@@ -1,0 +1,29 @@
+---
+id: TASK-31225
+title: Review-set completion - honest footer and a next step
+status: To Do
+assignee: []
+created_date: '2026-09-03 22:31'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Re-critique P2: after 'All N reviewed' the footer keeps advertising '] next in set' (now a silent no-op, violating the task-28005 honest-footer rule) and offers no next step. Riders: the storage-unavailable notice ships error twice/warning once (normalize); investigate B's unattributed Space-in-empty-select-mode canvas blank at 100x30 (pane-grip hypothesis).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A completed set's footer stops advertising ] and keeps R (and m for un-marking)
+- [ ] #2 Completion offers a next step
+<!-- AC:END -->
+
+
+## Renumbering
+
+Renumbered from task-31207 on 2026-09-03: id collision with an older dev arrival (owner rule TASK-19601; older keeps the id).

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -39328,6 +39328,10 @@ class LibraryScreen(BaseAppScreen):
                 return
             self._open_library_media_viewer(f"local:media:{landing}")
         except Exception:
+            # task-31220: the one review-set wrapper task-30042 missed -- a
+            # live wedge left NO trace in the log because this swallowed the
+            # traceback.
+            logger.opt(exception=True).warning("review-set picker failed")
             self._notify_review_set(
                 "Couldn't open review sets.", severity="error"
             )

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -3460,13 +3460,37 @@ with stray left-edge border fragments), and padding 0 1 so the full
     margin: 0 0 1 0;
 }
 
+/* task-31221. The third widget bitten by core/_reset.tcss's
+   ``*:focus { outline: solid }`` fallback, after TASK-1160 (DataTable) and
+   TASK-2300 (SelectOverlay, components/_lists.tcss) -- read TASK-2300's
+   block for the mechanics; this is its raw-OptionList sibling. The media
+   type chooser opens at option-count height and the screen focuses it
+   immediately, so the outline's top+bottom rows overwrote the FIRST and
+   LAST options outright: with the common two-option catalogue the chooser
+   rendered as a bare box with nothing in it and selection was blind
+   (root-caused live 2026-09-03 via painted-text probes -- every REGION
+   measured correct while the paint was covered, which is why no geometry
+   assertion ever caught it). Focus stays visible the sanctioned way: the
+   highlighted-option recolour already says which option is current. */
+#library-media-type-choices:focus {
+    outline: none;
+}
+
+/* task-31222: the Read-mode wrapper held only a heading yet defaulted to
+   1fr, inserting a blank band above the Find bar while the content sat in
+   a fixed 18-row box below -- the Reader's product got ~1/3 of its pane. */
+#library-media-reader-mode-read {
+    height: auto;
+}
+
 #library-media-viewer-content {
     /* Bounded so short content stays compact and long content scrolls inside
        this region; height:1fr here ballooned the pane and split the sections.
-       max-height is generous so typical content shows in full (only long
-       transcripts engage the inner scroll), reducing nested-scroll friction. */
+       task-31222: the bound scales with the terminal instead of a fixed 18
+       rows, so a tall window reads tall (only long content engages the
+       inner scroll). */
     height: auto;
-    max-height: 18;
+    max-height: 75vh;
     min-height: 3;
     margin: 0 0 1 0;
     border: solid $ds-grid-line;

--- a/tldw_chatbook/css/screen_agentic_library.tcss
+++ b/tldw_chatbook/css/screen_agentic_library.tcss
@@ -2336,13 +2336,37 @@ with stray left-edge border fragments), and padding 0 1 so the full
     margin: 0 0 1 0;
 }
 
+/* task-31221. The third widget bitten by core/_reset.tcss's
+   ``*:focus { outline: solid }`` fallback, after TASK-1160 (DataTable) and
+   TASK-2300 (SelectOverlay, components/_lists.tcss) -- read TASK-2300's
+   block for the mechanics; this is its raw-OptionList sibling. The media
+   type chooser opens at option-count height and the screen focuses it
+   immediately, so the outline's top+bottom rows overwrote the FIRST and
+   LAST options outright: with the common two-option catalogue the chooser
+   rendered as a bare box with nothing in it and selection was blind
+   (root-caused live 2026-09-03 via painted-text probes -- every REGION
+   measured correct while the paint was covered, which is why no geometry
+   assertion ever caught it). Focus stays visible the sanctioned way: the
+   highlighted-option recolour already says which option is current. */
+#library-media-type-choices:focus {
+    outline: none;
+}
+
+/* task-31222: the Read-mode wrapper held only a heading yet defaulted to
+   1fr, inserting a blank band above the Find bar while the content sat in
+   a fixed 18-row box below -- the Reader's product got ~1/3 of its pane. */
+#library-media-reader-mode-read {
+    height: auto;
+}
+
 #library-media-viewer-content {
     /* Bounded so short content stays compact and long content scrolls inside
        this region; height:1fr here ballooned the pane and split the sections.
-       max-height is generous so typical content shows in full (only long
-       transcripts engage the inner scroll), reducing nested-scroll friction. */
+       task-31222: the bound scales with the terminal instead of a fixed 18
+       rows, so a tall window reads tall (only long content engages the
+       inner scroll). */
     height: auto;
-    max-height: 18;
+    max-height: 75vh;
     min-height: 3;
     margin: 0 0 1 0;
     border: solid $ds-grid-line;


### PR DESCRIPTION
First fix PR from the 2026-09-03 re-critique of Library ▸ Media (dual-agent, 26/40; snapshot in `.impeccable/critique/`). Covers both render P1s and the P0's instrumentation AC. (Tasks renumbered 31202-31207 → 31220-31225 after an id collision with an older dev arrival, per the TASK-19601 owner rule.)

## task-31221 — the type chooser paints its options

The chooser rendered as an **empty bordered band** and selection was blind (Down+Enter on invisible options). The root cause was *not* the height math: the app-global `*:focus { outline: solid }` fallback (core/_reset.tcss) **paints over** a widget's outermost rows without costing geometry, and the screen focuses the option-count-height chooser the moment it opens — with the common two-option catalogue the outline's top+bottom rows overwrote every option. This is the **third widget** bitten by that reset after TASK-1160 (DataTable, header/last-row) and TASK-2300 (SelectOverlay, "bare box with nothing in it" — the same words this critique used). Fixed the sanctioned way: `#library-media-type-choices:focus { outline: none }` in the library module beside TASK-2300's rationale; focus stays visible via the highlighted-option recolour.

**The pinning test asserts PAINTED text, not regions** — every geometry assertion (region, scrollable_content_region) measured *correct* while the paint was covered, which is exactly why this bug class survived region-based tests. Root-caused via compositor painted-text probes after two wrong hypotheses (height math, focus border) each died on evidence.

## task-31222 — the Reader's content takes its pane

`#library-media-reader-mode-read` had no height rule — an unstyled Vertical defaulted to 1fr, holding a ~14-row blank band between the "Read" heading and the Find bar — while `#library-media-viewer-content` was capped at `max-height: 18` regardless of terminal size, confining the Reader's product to ~⅓ of its pane. Now `height: auto` on the wrapper and `max-height: 75vh` on the content: a tall window reads tall, short content stays compact, only genuinely long content engages the inner scroll.

## task-31220 AC1 — the storage wedge self-documents next time

The review-set picker worker's `except Exception` was the one wrapper #2346 missed — a live wedge left **no trace** in the log. It now logs the traceback. The P0 hunt itself: a 24-round scripted repro (create → complete → picker → dismiss + read-later + trash + chooser, external RO probes each round, SIGUSR2 stack-camera armed) reproduced **zero** divergence — every completion persisted, every picker press worked. Evidence and the observed-once status are recorded on the task; the critique session's external DB dump is additionally suspect (the assessor ran a scratch-profile harness mid-session).

## Tests

`test_library_media_render_fixes.py`: painted-option assertion on the production harness (the only harness that loads the lazily-split library sheet AND exercises the focus-on-open path) + the Reader band/cap contract. 83 green across render/toolbar/reader-shell/side-by-side/fastpath suites (one known in-process-leak flake passes isolated); preflight clean; diagnostic inventory reviewed + regenerated (+1 fixed-string warning).

## Live verification (tmux, seeded, cleaned up)

Chooser now shows `✓ All types` / `document` with the active mark; the Read tab's heading sits directly above the Find bar and a 30-line document renders in full with no inner scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2gSzBnVrjf37m4bPU3BCn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Library Media type chooser and Reader rendering bugs, and makes the review-set picker log failures it previously swallowed.

**Bug Fixes**
- The type chooser no longer renders as an empty bordered band: the global `*:focus` outline was painting over the option rows, making selection blind.
- The Reader's content now scales with the terminal (`max-height: 75vh`) instead of a fixed 18-row box, and the blank band above the Find bar is gone.
- The review-set picker worker now logs its traceback on failure, so the observed-once storage wedge leaves a trace next time.

<sup>Written for commit 0a851c66ce7557b4cc7ebeac94328a5777b5cdc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

