### PR TITLE
fix(library): honest footer under typing focus and at completion; filter-miss recovery (task-31223..31225)

### DIFF
--- a/Tests/UI/test_library_footer_focus.py
+++ b/Tests/UI/test_library_footer_focus.py
@@ -1,0 +1,97 @@
+"""The footer never advertises keys a focused text field will swallow.
+
+Re-critique 2026-09-03 P1 (task-31223): the footer branch keyed off screen
+state, not focus — with focus in the rail search it advertised
+"] next in set | m | R" while those keystrokes were inserted as text (a
+stray "]" corrupted the filter into a zero-match list). Keyboard-first
+brand: the footer is the instrument and must not lie.
+"""
+
+from __future__ import annotations
+
+from types import MethodType, SimpleNamespace
+
+from textual.widgets import Button, Input, TextArea
+
+from tldw_chatbook.Library.library_rail_state import LibraryLifecycle
+from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+
+_ROUTE = (
+    ("/", "focus search"),
+    ("F6", "next pane"),
+    ("]", "next in set"),
+    ("[", "prev in set"),
+    ("m", "toggle reviewed"),
+    ("R", "exit review"),
+    ("", "2 of 6 · 1 reviewed"),
+    ("esc", "focus Library"),
+)
+
+
+def _fake(focused) -> SimpleNamespace:
+    fake = SimpleNamespace(
+        _library_route_shortcuts_for_current_state=lambda: _ROUTE,
+        _library_emergency_return_eligibility=lambda: SimpleNamespace(
+            enabled=False
+        ),
+        _library_lifecycle=LibraryLifecycle.GRADUATED,
+        focused=focused,
+    )
+    fake._library_footer_shortcuts_for_current_state = MethodType(
+        LibraryScreen._library_footer_shortcuts_for_current_state, fake
+    )
+    return fake
+
+
+def test_typing_focus_drops_swallowed_printable_keys():
+    shortcuts = _fake(Input())._library_footer_shortcuts_for_current_state()
+    keys = [key for key, _ in shortcuts]
+    # Single printable keys are inserted as text while typing — never shown.
+    assert "]" not in keys and "[" not in keys
+    assert "m" not in keys and "R" not in keys and "/" not in keys
+    # Keys that still work stay, and so does the informational progress chip.
+    assert "esc" in keys and "F6" in keys
+    assert ("", "2 of 6 · 1 reviewed") in shortcuts
+    # The swap announces itself instead of silently thinning.
+    assert any("typing" in label for _key, label in shortcuts)
+
+
+def test_text_area_focus_gets_the_same_honesty():
+    shortcuts = _fake(TextArea())._library_footer_shortcuts_for_current_state()
+    keys = [key for key, _ in shortcuts]
+    assert "]" not in keys and "m" not in keys
+
+
+def test_non_typing_focus_keeps_the_full_set():
+    shortcuts = _fake(Button())._library_footer_shortcuts_for_current_state()
+    assert ("]", "next in set") in shortcuts
+    assert ("m", "toggle reviewed") in shortcuts
+    assert not any("typing" in label for _key, label in shortcuts)
+
+
+def test_no_focus_keeps_the_full_set():
+    shortcuts = _fake(None)._library_footer_shortcuts_for_current_state()
+    assert ("]", "next in set") in shortcuts
+
+
+def test_completed_set_footer_drops_walk_keys_and_offers_the_finish():
+    """After 'All N reviewed' the footer stops advertising ] (task-31225).
+
+    The final ] is an idempotent no-op on a complete set — advertising it
+    violates the honest-footer rule (task-28005); R becomes the named next
+    step, and m stays so un-marking can resume the walk.
+    """
+    entries = LibraryScreen._review_footer_entries("All 6 reviewed")
+    keys = [key for key, _ in entries]
+    assert "]" not in keys and "[" not in keys
+    assert ("m", "toggle reviewed") in entries
+    assert ("R", "finish review") in entries
+    assert ("", "All 6 reviewed") in entries
+
+
+def test_in_progress_set_footer_keeps_the_walk_keys():
+    entries = LibraryScreen._review_footer_entries("2 of 6 · 1 reviewed")
+    assert ("]", "next in set") in entries
+    assert ("[", "prev in set") in entries
+    assert ("R", "exit review") in entries
+    assert ("", "2 of 6 · 1 reviewed") in entries

--- a/Tests/UI/test_library_footer_focus.py
+++ b/Tests/UI/test_library_footer_focus.py
@@ -44,6 +44,7 @@ def _fake(focused) -> SimpleNamespace:
 
 
 def test_typing_focus_drops_swallowed_printable_keys():
+    """Input focus removes every single-printable-key advertisement."""
     shortcuts = _fake(Input())._library_footer_shortcuts_for_current_state()
     keys = [key for key, _ in shortcuts]
     # Single printable keys are inserted as text while typing — never shown.
@@ -57,12 +58,14 @@ def test_typing_focus_drops_swallowed_printable_keys():
 
 
 def test_text_area_focus_gets_the_same_honesty():
+    """TextArea focus is a typing context exactly like Input."""
     shortcuts = _fake(TextArea())._library_footer_shortcuts_for_current_state()
     keys = [key for key, _ in shortcuts]
     assert "]" not in keys and "m" not in keys
 
 
 def test_non_typing_focus_keeps_the_full_set():
+    """A focused Button leaves the advertised set untouched."""
     shortcuts = _fake(Button())._library_footer_shortcuts_for_current_state()
     assert ("]", "next in set") in shortcuts
     assert ("m", "toggle reviewed") in shortcuts
@@ -70,6 +73,7 @@ def test_non_typing_focus_keeps_the_full_set():
 
 
 def test_no_focus_keeps_the_full_set():
+    """No focus at all leaves the advertised set untouched."""
     shortcuts = _fake(None)._library_footer_shortcuts_for_current_state()
     assert ("]", "next in set") in shortcuts
 
@@ -90,8 +94,34 @@ def test_completed_set_footer_drops_walk_keys_and_offers_the_finish():
 
 
 def test_in_progress_set_footer_keeps_the_walk_keys():
+    """An in-progress set keeps ]/[/m/R and the progress chip."""
     entries = LibraryScreen._review_footer_entries("2 of 6 · 1 reviewed")
     assert ("]", "next in set") in entries
     assert ("[", "prev in set") in entries
     assert ("R", "exit review") in entries
     assert ("", "2 of 6 · 1 reviewed") in entries
+
+
+def test_typing_flip_routes_through_the_notes_aware_dispatcher():
+    """A focus flip must re-apply the CONTEXT footer, not the generic one.
+
+    Qodo #2359: _apply_library_notes_footer_context dispatches to the Notes
+    region tiers when that workflow is active and falls back to the generic
+    (typing-filtered) set otherwise — calling the generic registration
+    directly overwrote the Notes editor's footer on focus flips.
+    """
+    calls: list[str] = []
+    fake = SimpleNamespace(
+        _library_footer_typing_context=False,
+        _apply_library_notes_footer_context=lambda: calls.append("dispatch"),
+    )
+    fake._refresh_footer_typing_context = MethodType(
+        LibraryScreen._refresh_footer_typing_context, fake
+    )
+
+    fake._refresh_footer_typing_context(Input())  # flip: False -> True
+    assert calls == ["dispatch"]
+    fake._refresh_footer_typing_context(Input())  # same context: no churn
+    assert calls == ["dispatch"]
+    fake._refresh_footer_typing_context(Button())  # flip back
+    assert calls == ["dispatch", "dispatch"]

--- a/Tests/UI/test_library_media_toolbar_adapt.py
+++ b/Tests/UI/test_library_media_toolbar_adapt.py
@@ -76,12 +76,15 @@ def _select_state(
 
 
 class _CanvasApp(ConsolidatedCSSApp):
-    def __init__(self, state: LibraryMediaCanvasState) -> None:
+    def __init__(self, state: LibraryMediaCanvasState, pager=None) -> None:
         super().__init__()
         self._state = state
+        self._pager = pager
 
     def compose(self):
-        yield LibraryMediaCanvas(canvas=self._state, id="library-media-canvas")
+        yield LibraryMediaCanvas(
+            canvas=self._state, pager=self._pager, id="library-media-canvas"
+        )
 
 
 @pytest.mark.asyncio
@@ -242,3 +245,48 @@ def test_wide_row_prefixes_are_short_so_titles_survive():
         "Quarterly metrics narrative", "document · 3m", compact=False
     )
     assert plain.startswith(" Quarterly")
+
+
+@pytest.mark.asyncio
+async def test_filter_miss_offers_clear_filter_not_import():
+    """A zero-match ACTIVE-query page must not pin Import media (task-31224).
+
+    The honest recovery is clearing the filter; the query-echoing status
+    copy is already right, and the Clear control must actually render.
+    """
+    import dataclasses
+
+    state = dataclasses.replace(
+        _browse_state(),
+        rows=(),
+        count=0,
+        query="]",
+        empty_copy="No media matched ']'.",
+    )
+    from tldw_chatbook.Library.library_pager_state import (
+        build_library_pager_display,
+    )
+
+    pager = build_library_pager_display(
+        applied_page=1,
+        requested_page=1,
+        page_size=20,
+        row_count=0,
+        total=0,
+        freshness="fresh",
+        loading=False,
+    )
+    app = _CanvasApp(state, pager=pager)
+    async with app.run_test(size=(50, 34)) as pilot:
+        await pilot.pause()
+        # No import suggestion for a filter miss...
+        assert not app.query("#library-media-empty-import")
+        # ...and the Clear control is genuinely on screen and enabled.
+        clear = app.query_one("#library-media-filter-clear", Button)
+        assert clear.disabled is False
+        canvas = app.query_one("#library-media-canvas", LibraryMediaCanvas)
+        assert clear.region.width > 0
+        assert (
+            clear.region.x + clear.region.width
+            <= canvas.region.x + canvas.region.width
+        )

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -1882,3 +1882,34 @@ release from that) — and treat "the click closes the dialog but the action
 didn't happen" as a coordinates smell, not an app bug, whenever the row
 contains any non-ASCII glyph. Verify a suspected hit-region bug with the
 widget's own oracle (DB row, `pilot.click`) before touching app code.
+
+## Region assertions are blind to paint-over — the `*:focus` outline family (media type chooser, task-31221, 2026-09-03)
+
+**What happened.** The Library media type chooser rendered live as an empty
+bordered band with its options invisible, while every harness test on it
+passed. Two hypotheses died on evidence (the OptionList height math; a
+compact-variant focus border) before compositor painted-text probes showed
+the truth: the app-global `*:focus { outline: solid }` fallback
+(core/_reset.tcss) PAINTS OVER a widget's outermost rows without costing
+geometry, and the screen focuses the option-count-height chooser on open —
+with a two-option catalogue the outline's top and bottom rows covered every
+option. Every geometry assertion (`region`, `scrollable_content_region`)
+measured *correct* the whole time, because outlines do not participate in
+layout. This was the THIRD widget bitten by that reset (TASK-1160 DataTable,
+TASK-2300 SelectOverlay — whose block literally predicts "a bare box with
+nothing in it" for two-option compacts).
+
+**What to do.** When a widget looks empty or clipped live but its regions
+measure fine, suspect paint-over (outline, overlay, ANSI layer) before
+layout, and assert on **compositor painted text**
+(`screen._compositor.render_strips()` cropped to the region — see
+`_painted_text_in_region` in test_library_media_reader_shell.py) rather
+than on geometry. Check the TASK-1160/TASK-2300 blocks in
+components/_lists.tcss first: any focusable widget whose outermost rows
+carry content needs the same `outline: none` + content-safe-cue opt-out.
+Two auxiliary traps from the same hunt: widget-tier CSS (BUNDLED_CSS /
+DEFAULT_CSS) loses to app-tier rules regardless of specificity, so an
+opt-out fighting an app-tier reset must live at app tier; and a sentinel
+edit used to test code provenance MUST be verified to have landed
+(`assert old in s` before replace) — an unverified no-op replace produced a
+false "app runs foreign code" scare mid-hunt.

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -3677,6 +3677,24 @@ class LibraryScreen(BaseAppScreen):
             return self.LIBRARY_LIST_SHORTCUTS
         return self.LIBRARY_GENERAL_SHORTCUTS
 
+    def _refresh_footer_typing_context(self, focused) -> None:
+        """Re-apply the footer when the typing context flips (task-31223).
+
+        Routes through ``_apply_library_notes_footer_context`` -- the
+        context dispatcher that applies the Notes region tiers when that
+        workflow is active and falls back to the generic (typing-filtered)
+        set otherwise (Qodo #2359: calling the generic registration
+        directly overwrote the Notes editor footer). Flip-gated so
+        ordinary focus moves cause zero footer churn.
+
+        Args:
+            focused: The newly focused widget.
+        """
+        typing = isinstance(focused, (Input, TextArea))
+        if typing != getattr(self, "_library_footer_typing_context", False):
+            self._library_footer_typing_context = typing
+            self._apply_library_notes_footer_context()
+
     @staticmethod
     def _review_footer_entries(progress: str) -> tuple[tuple[str, str], ...]:
         """The Reader footer's review-set segment for one progress line.
@@ -10572,12 +10590,7 @@ class LibraryScreen(BaseAppScreen):
             return
         # task-31223: the footer's typing-context swap (drop keys a text
         # field will swallow) must follow focus, not just route changes.
-        # Re-register only on a context FLIP so ordinary focus moves stay
-        # free of footer churn.
-        typing = isinstance(focused, (Input, TextArea))
-        if typing != getattr(self, "_library_footer_typing_context", False):
-            self._library_footer_typing_context = typing
-            self._register_footer_shortcuts()
+        self._refresh_footer_typing_context(focused)
         self._remember_library_notes_authority_focus(focused)
         target_restore = self._library_notes_programmatic_focus_target is focused
         pending_receipt = self._library_pending_list_entry_media_return

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -3634,11 +3634,7 @@ class LibraryScreen(BaseAppScreen):
                         # task-28241: in a review set, ] / [ walk the pinned set
                         # (whole thing, not the page), and the footer carries
                         # the progress plus an exit-review key.
-                        shortcuts.append(("]", "next in set"))
-                        shortcuts.append(("[", "prev in set"))
-                        shortcuts.append(("m", "toggle reviewed"))
-                        shortcuts.append(("R", "exit review"))
-                        shortcuts.append(("", progress))
+                        shortcuts.extend(self._review_footer_entries(progress))
                     else:
                         if self._library_media_adjacent_row(1) is not None:
                             shortcuts.append(("]", "next item"))
@@ -3681,11 +3677,54 @@ class LibraryScreen(BaseAppScreen):
             return self.LIBRARY_LIST_SHORTCUTS
         return self.LIBRARY_GENERAL_SHORTCUTS
 
+    @staticmethod
+    def _review_footer_entries(progress: str) -> tuple[tuple[str, str], ...]:
+        """The Reader footer's review-set segment for one progress line.
+
+        task-31225 (re-critique P2): on a COMPLETE set the final ``]`` is an
+        idempotent no-op, so advertising it violates the honest-footer rule
+        (task-28005). Completion keeps ``m`` (un-marking resumes the walk)
+        and names ``R`` as the next step. The completion check reads the
+        canonical ``format_review_progress`` "All N reviewed" form.
+
+        Args:
+            progress: The formatted live progress line.
+
+        Returns:
+            ``(key, label)`` entries for the footer.
+        """
+        if progress.startswith("All "):
+            return (
+                ("m", "toggle reviewed"),
+                ("R", "finish review"),
+                ("", progress),
+            )
+        return (
+            ("]", "next in set"),
+            ("[", "prev in set"),
+            ("m", "toggle reviewed"),
+            ("R", "exit review"),
+            ("", progress),
+        )
+
     def _library_footer_shortcuts_for_current_state(
         self,
     ) -> tuple[tuple[str, str], ...]:
         """Hide rail-search hints while the compact rail has no search box."""
         shortcuts = self._library_route_shortcuts_for_current_state()
+        # task-31223 (re-critique P1): while a text field holds focus, every
+        # single printable key is INSERTED AS TEXT, so advertising "] next
+        # in set" or "s select" is the footer lying -- live, a stray "]"
+        # went into the filter and produced a zero-match list. Drop the
+        # swallowed keys, keep the ones that still work (esc / enter /
+        # F-keys) and the informational chips, and announce the swap.
+        focused = self.focused
+        if isinstance(focused, (Input, TextArea)):
+            shortcuts = (("", "typing in field"),) + tuple(
+                pair
+                for pair in shortcuts
+                if not (len(pair[0]) == 1 and pair[0].isprintable())
+            )
         emergency = self._library_emergency_return_eligibility()
         if emergency.enabled:
             shortcuts = tuple(pair for pair in shortcuts if pair[0] != "esc") + (
@@ -10531,6 +10570,14 @@ class LibraryScreen(BaseAppScreen):
             if self._library_notes_programmatic_focus_target is focused:
                 self._library_notes_programmatic_focus_target = None
             return
+        # task-31223: the footer's typing-context swap (drop keys a text
+        # field will swallow) must follow focus, not just route changes.
+        # Re-register only on a context FLIP so ordinary focus moves stay
+        # free of footer churn.
+        typing = isinstance(focused, (Input, TextArea))
+        if typing != getattr(self, "_library_footer_typing_context", False):
+            self._library_footer_typing_context = typing
+            self._register_footer_shortcuts()
         self._remember_library_notes_authority_focus(focused)
         target_restore = self._library_notes_programmatic_focus_target is focused
         pending_receipt = self._library_pending_list_entry_media_return
@@ -39487,6 +39534,10 @@ class LibraryScreen(BaseAppScreen):
             if self._review_set_service() is None:
                 if not getattr(self, "_review_set_storage_warned", False):
                     self._review_set_storage_warned = True
+                    # Deliberately WARNING where the explicit gestures use
+                    # ERROR (task-31225 rider): this fires ambiently on
+                    # media entry, not in answer to a press -- ambient
+                    # severity stays a notch below gesture severity.
                     self._notify_review_set(
                         self._REVIEW_SET_STORAGE_UNAVAILABLE,
                         severity="warning",

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -158,6 +158,17 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         width: auto;
         min-width: 0;
     }
+    /* task-31224: Textual Input defaults to width 100%, which consumed the
+     * whole filter row and pushed "Clear filter" off-screen -- the one
+     * honest recovery for a filter miss was invisible (live: it never
+     * rendered at any width). Share the row instead. */
+    #library-media-filter {
+        width: 1fr;
+    }
+    #library-media-filter-clear {
+        width: auto;
+        min-width: 0;
+    }
     """
 
     def __init__(
@@ -479,6 +490,12 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 id="library-media-status",
                 markup=False,
             )
+            # task-31224: a FILTER miss must not suggest importing -- the
+            # query-echoing status copy plus the (now visible) Clear filter
+            # control above are the honest recovery. Import/Show-all stay
+            # the recovery for a genuinely empty source only.
+            if self.canvas.query:
+                return
             if self.canvas.active_type is None:
                 yield Button(
                     "Import media",

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -2841,6 +2841,17 @@
         width: auto;
         min-width: 0;
     }
+    /* task-31224: Textual Input defaults to width 100%, which consumed the
+     * whole filter row and pushed "Clear filter" off-screen -- the one
+     * honest recovery for a filter miss was invisible (live: it never
+     * rendered at any width). Share the row instead. */
+    LibraryMediaCanvas #library-media-filter {
+        width: 1fr;
+    }
+    LibraryMediaCanvas #library-media-filter-clear {
+        width: auto;
+        min-width: 0;
+    }
 
 
 /* ===== WIDGET: LibraryNoteFolderNameDialog (Widgets/Library/library_note_folder_dialog.py) ===== */

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -2338,6 +2338,12 @@
      * is what keeps task-28025's fit contract true. Baseline geometry lives
      * here so harnesses without the app bundle lay out like the app. */
 
+    /* task-31224: Textual Input defaults to width 100%, which consumed the
+     * whole filter row and pushed "Clear filter" off-screen -- the one
+     * honest recovery for a filter miss was invisible (live: it never
+     * rendered at any width). Share the row instead. */
+
+
 
 
 /* ===== WIDGET: LibraryNoteFolderNameDialog (Widgets/Library/library_note_folder_dialog.py) ===== */


### PR DESCRIPTION
Second fix PR from the 2026-09-03 re-critique of Library ▸ Media (parallel to #2358). Tasks 31223 + 31224 + 31225 — the footer-honesty P1 and both recovery P2s.

## task-31223 — the footer never lies about typing focus

With focus in any Input/TextArea, every single printable key is inserted as text — yet the footer kept advertising `] next in set | m | R` (live: a stray `]` corrupted the filter into a zero-match list; "s select" typed an "s" into the rail search). The footer now swaps to a typing context: swallowed printable keys drop, keys that still work (esc / enter / F-keys) and informational chips stay, and the swap announces itself (`typing in field`). Re-registered from `on_descendant_focus` on context **flips** only, so ordinary focus moves cause zero footer churn.

## task-31224 — filter-miss recovery is the right one, and visible

A zero-match *active-query* page pinned **Import media** as its recovery (`fresh_zero` never checked `canvas.query`) while the actual recovery — **Clear filter** — never rendered anywhere: Textual `Input` defaults to `width: 100%` and consumed the whole filter row, pushing the button off-screen at every width. The Input now shares its row (`1fr`), Clear is visible and enabled whenever a query is applied, and the Import/Show-all suggestions are gated to genuinely-empty sources.

## task-31225 — completion stops advertising a dead key

After "All N reviewed" the footer kept advertising `] next in set` — an idempotent no-op, violating the same honest-footer rule (task-28005) that trims Prev/Next at list ends. On a complete set the segment is now `m toggle reviewed | R finish review | All N reviewed`; un-marking with `m` restores the walk keys (live-verified round trip). Extracted `_review_footer_entries` so the segment is unit-testable. Rider: documented why the ambient storage warning is `warning` while gesture failures are `error` (the severity inconsistency Assessment B flagged).

## Tests

6 in the new `test_library_footer_focus.py` (typing-context transform incl. TextArea, pass-through cases, completion/in-progress segments) + the filter-miss recovery contract in the adapt suite (no Import on query miss; Clear rendered inside the pane). 125 green across footer/walker/toolbar/multiselect suites; preflight clean; no schema, no logger.

## Live verification (tmux, seeded, cleaned up)

Focusing the rail search mid-review swaps the footer to `typing in field | F6 next pane | 1 of 2 · 0 reviewed | esc back`; Escape restores the full set. Completing a 2-doc set shows `m toggle reviewed | R finish review | All 2 reviewed` with no `]`; pressing `m` resumes the walk keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2gSzBnVrjf37m4bPU3BCn

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Library footer so it stops advertising keys a focused text field swallows, stops advertising a dead key at review completion, and makes filter-miss recovery actually show "Clear filter."

**Bug Fixes**
- With focus in an Input or TextArea, the footer drops printable keys that would be inserted as text, keeps working keys like esc and F6, and announces "typing in field."
- The typing-context swap routes through the Notes-aware dispatcher so it no longer overwrites the Notes editor's region-specific footer on focus flips.
- On a complete review set, the footer no longer advertises `]` (a no-op); it now shows `m toggle reviewed | R finish review | All N reviewed` instead.
- A zero-match filter page no longer suggests "Import media"; the "Clear filter" button is now visible and enabled since the filter Input shares its row instead of consuming full width.
- Adds a lessons doc on paint-over bugs being invisible to region assertions, from the task-31221 investigation.

<sup>Written for commit a0280b5ea5f449bd29b4bec72ac4f1eb230ed93e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

