### PR TITLE
Activate main-only PyPI publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,8 +3,12 @@ name: Publish Python package
 on:
   workflow_dispatch:
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -13,6 +17,8 @@ jobs:
   build:
     name: Build and check distributions
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release-version.outputs.version }}
 
     steps:
       - name: Check out source
@@ -36,11 +42,13 @@ jobs:
           python -m build --sdist --wheel --no-isolation --outdir dist
 
       - name: Verify release version
+        id: release-version
         run: |
           python - <<'PY'
-          import os
           from pathlib import Path
           import tomllib
+
+          from Packaging.check_pypi_release import write_github_output
 
           with Path("pyproject.toml").open("rb") as handle:
               project_version = tomllib.load(handle)["project"]["version"]
@@ -63,11 +71,7 @@ jobs:
           if project_version != sdist_version:
               raise SystemExit(f"sdist version {sdist_version} != project version {project_version}")
 
-          if os.environ.get("GITHUB_REF_TYPE") == "tag":
-              expected_tag = f"v{project_version}"
-              actual_tag = os.environ.get("GITHUB_REF_NAME")
-              if actual_tag != expected_tag:
-                  raise SystemExit(f"tag {actual_tag} != expected release tag {expected_tag}")
+          write_github_output("version", project_version)
 
           print(f"project_version={project_version}")
           print(f"wheel={wheels[0].name}")
@@ -82,9 +86,6 @@ jobs:
 
       - name: Run release metadata tests
         run: python -m pytest Tests/Packaging/test_release_metadata.py -q
-
-      - name: Run installed distribution regression
-        run: python -m pytest Tests/Packaging/test_installed_distribution.py -m integration -q -p no:cacheprovider
 
       - name: Upload distributions
         uses: actions/upload-artifact@v4
@@ -117,10 +118,41 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
 
+  check_pypi_release:
+    name: Check PyPI release status
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    outputs:
+      release_exists: ${{ steps.check.outputs.release_exists }}
+      latest_version: ${{ steps.check.outputs.latest_version }}
+      publish_release: ${{ steps.check.outputs.publish_release }}
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install output path validation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install loguru packaging psutil pydantic
+
+      - name: Check whether version should be published to PyPI
+        id: check
+        env:
+          RELEASE_VERSION: ${{ needs.build.outputs.version }}
+        run: python Packaging/check_pypi_release.py "$RELEASE_VERSION"
+
   publish-pypi:
     name: Publish to PyPI
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.ref_protected
-    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.ref_protected && needs.check_pypi_release.outputs.publish_release == 'true'
+    needs: [build, check_pypi_release]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/Packaging/PYPI_README.md
+++ b/Packaging/PYPI_README.md
@@ -1,105 +1,36 @@
 # PyPI Distribution Notes for tldw_chatbook
 
-This document contains notes for maintainers about the PyPI distribution process.
+`Packaging/PYPI_RELEASE.md` is the release runbook. This file is the short
+maintainer checklist.
 
-## Pre-release Checklist
-
-1. **Update Version Number**
-   - Update version in `pyproject.toml`
-   - Update version in `tldw_chatbook/__init__.py`
-   - Update CHANGELOG.md with release notes
-
-2. **Test Installation**
-   ```bash
-   # Create a fresh virtual environment
-   python -m venv test_env
-   source test_env/bin/activate  # Windows: test_env\Scripts\activate
-   
-   # Install in development mode
-   pip install -e .
-   
-   # Run import tests
-   python test_import.py
-   
-   # Test the CLI
-   tldw-cli --help
-   ```
-
-3. **Run Full Test Suite**
-   ```bash
-   pytest
-   ```
-
-4. **Build Distribution**
-   ```bash
-   ./build_dist.sh
-   ```
-
-5. **Test Distribution Locally**
-   ```bash
-   # Create another fresh environment
-   python -m venv dist_test
-   source dist_test/bin/activate
-   
-   # Install from wheel
-   pip install dist/tldw_chatbook-*.whl
-   
-   # Run import tests
-   python test_import.py
-   
-   # Test CLI
-   tldw-cli --help
-   ```
-
-## Upload to TestPyPI First
-
-1. **Configure .pypirc** (if not already done)
-   - Copy `.pypirc.template` to `~/.pypirc`
-   - Add your PyPI tokens
-
-2. **Upload to TestPyPI**
-   ```bash
-   python -m twine upload --repository testpypi dist/*
-   ```
-
-3. **Test from TestPyPI**
-   ```bash
-   pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ tldw_chatbook
-   ```
-
-## Upload to PyPI
-
-Once testing is complete:
+## Required Gates
 
 ```bash
-python -m twine upload dist/*
+python -m pip install "setuptools>=77.0" build twine wheel
+Packaging/build_dist.sh
+python -m pytest Tests/Packaging/test_release_metadata.py -q
 ```
 
-## Post-release
+`Packaging/build_dist.sh` builds a fresh sdist and wheel, runs `twine check`,
+and verifies both artifacts with `Packaging/check_manifest.py`.
 
-1. Create a git tag:
-   ```bash
-   git tag -a v0.1.0 -m "Release version 0.1.0"
-   git push origin v0.1.0
-   ```
+## Entry Points
 
-2. Create a GitHub release with the changelog
+The PyPI package installs these console scripts:
 
-3. Update version in `pyproject.toml` and `__init__.py` to next development version (e.g., 0.2.0.dev0)
+- `tldw-cli`
+- `tldw-serve`
 
-## Package Structure Verification
+Use `tldw-cli --help` and `tldw-serve --help` for installation smoke tests.
 
-The distribution should include:
-- All Python modules under `tldw_chatbook/`
-- CSS files (*.tcss) in `tldw_chatbook/css/`
-- Theme files in `tldw_chatbook/css/Themes/`
-- JSON templates in `tldw_chatbook/Config_Files/`
-- LICENSE file
-- README.md
+## Publishing
 
-## Common Issues
+Normal publishing is done by `.github/workflows/publish-pypi.yml`:
 
-1. **Missing Data Files**: Check MANIFEST.in and pyproject.toml package-data
-2. **Import Errors**: Ensure all __init__.py files are present
-3. **Entry Point Not Working**: Verify the console_scripts configuration
-4. **Dependencies Missing**: Compare pyproject.toml with requirements.txt
+- Manual workflow dispatch from protected `dev` publishes to TestPyPI through
+  the `testpypi` environment.
+- Protected `main` pushes publish to PyPI through the `pypi` environment only
+  when the built version is absent and newer than the latest PyPI release. Tag
+  pushes do not publish.
+
+Do not use `.pypirc` or long-lived API tokens for routine releases.

--- a/Packaging/PYPI_RELEASE.md
+++ b/Packaging/PYPI_RELEASE.md
@@ -1,156 +1,136 @@
 # PyPI Release Guide for tldw_chatbook
 
-This guide outlines the process for building and releasing tldw_chatbook to PyPI.
+Use GitHub Actions trusted publishing for normal releases. Do not upload with a
+long-lived PyPI token unless the trusted-publishing path is unavailable.
 
-## Prerequisites
+## Package Identity
 
-1. Ensure you have the necessary tools installed:
+- Source distribution name: `tldw_chatbook`
+- Normalized PyPI name: `tldw-chatbook`
+- Install command: `pip install tldw_chatbook`
+- Console scripts: `tldw-cli`, `tldw-serve`
+- Version source of truth: `pyproject.toml`
+- Package runtime version: `tldw_chatbook/__init__.py`
+- Native packaging version helper: `Packaging/common/version.py`, derived from
+  `pyproject.toml`
+
+## One-Time PyPI Setup
+
+Create trusted publishers on TestPyPI and PyPI before the first workflow upload.
+
+For TestPyPI:
+
+- Owner: `rmusser01`
+- Repository: `tldw_chatbook`
+- Workflow: `publish-pypi.yml`
+- Environment: `testpypi`
+
+For PyPI:
+
+- Owner: `rmusser01`
+- Repository: `tldw_chatbook`
+- Workflow: `publish-pypi.yml`
+- Environment: `pypi`
+
+If the project does not exist yet, create a pending trusted publisher for the
+same owner, repository, workflow, and environment.
+
+Protect the `dev` and `main` branches and the `testpypi` and `pypi` GitHub
+environments before allowing publishing. The TestPyPI job only runs for manual
+dispatch from protected `dev`; the PyPI job only runs for protected `main`
+branch pushes, and it skips the upload when the built version already exists on
+PyPI or is older than the latest published version. Publish jobs only download
+built artifacts and request the PyPI OIDC token.
+
+## Local Release Gates
+
+1. Update `pyproject.toml`, `tldw_chatbook/__init__.py`, and `CHANGELOG.md`.
+2. Install release tools in the active environment:
+
    ```bash
-   pip install build twine
+   python -m pip install "setuptools>=77.0" build twine wheel
    ```
 
-2. Create PyPI account at https://pypi.org/account/register/
+3. Build fresh artifacts:
 
-3. Create API token at https://pypi.org/manage/account/token/
-   - Save the token securely
-   - You'll use it as your password when uploading
-
-4. (Optional) Create TestPyPI account at https://test.pypi.org/account/register/
-   - Recommended for testing releases before publishing to production PyPI
-
-## Pre-Release Checklist
-
-- [ ] Update version in `pyproject.toml`
-- [ ] Update version in `tldw_chatbook/__init__.py`
-- [ ] Update `CHANGELOG.md` with release notes
-- [ ] Run all tests: `pytest`
-- [ ] Review and update documentation if needed
-- [ ] Commit all changes
-- [ ] Create git tag: `git tag v0.1.0`
-
-## Building the Distribution
-
-1. Clean previous builds:
    ```bash
-   rm -rf dist/ build/ *.egg-info
+   Packaging/build_dist.sh
    ```
 
-2. Build source distribution and wheel:
+4. Run the focused metadata gate:
+
    ```bash
-   python -m build
+   python -m pytest Tests/Packaging/test_release_metadata.py -q
    ```
 
-   This creates:
-   - `dist/tldw_chatbook-0.1.0.tar.gz` (source distribution)
-   - `dist/tldw_chatbook-0.1.0-py3-none-any.whl` (wheel)
+5. Smoke-test the wheel in a disposable environment:
 
-3. Verify the distributions:
-   ```bash
-   twine check dist/*
-   ```
-
-## Testing the Package
-
-1. Create a test virtual environment:
    ```bash
    python -m venv test_env
-   source test_env/bin/activate  # On Windows: test_env\Scripts\activate
-   ```
-
-2. Install from built wheel:
-   ```bash
-   pip install dist/tldw_chatbook-0.1.0-py3-none-any.whl
-   ```
-
-3. Test the installation:
-   ```bash
-   tldw-chatbook --version
-   ```
-
-4. Test with optional dependencies:
-   ```bash
-   pip install dist/tldw_chatbook-0.1.0-py3-none-any.whl[embeddings_rag,websearch]
-   ```
-
-5. Deactivate and clean up:
-   ```bash
+   source test_env/bin/activate
+   pip install dist/tldw_chatbook-*.whl
+   tldw-cli --help
+   tldw-serve --help
    deactivate
-   rm -rf test_env
    ```
 
-## Uploading to TestPyPI (Recommended First)
+Run the full suite only when the release manager explicitly wants a full sweep.
 
-1. Upload to TestPyPI:
+## Publish to TestPyPI
+
+1. Open the `Publish Python package` workflow in GitHub Actions.
+2. Run it manually from the protected `dev` branch.
+3. The workflow builds, checks, uploads artifacts, and publishes to TestPyPI
+   through the `testpypi` environment.
+4. Test installation from TestPyPI:
+
    ```bash
-   twine upload --repository testpypi dist/*
+   python -m venv testpypi_env
+   source testpypi_env/bin/activate
+   pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ "tldw_chatbook==<version>"
+   tldw-cli --help
+   tldw-serve --help
+   deactivate
    ```
 
-2. Test installation from TestPyPI:
+## Publish to PyPI
+
+1. Confirm the same commit passed the local gates and TestPyPI smoke test.
+2. Merge the approved release commit to the protected `main` branch. Do not
+   publish by pushing a tag; tag pushes are intentionally ignored by the PyPI
+   workflow.
+3. The `Publish Python package` workflow builds and checks the artifacts from
+   `main`, verifies whether the version is publishable on PyPI, and publishes
+   through the protected `pypi` environment only when the version is absent and
+   newer than the latest published version.
+4. After PyPI is verified, create and push the annotated source tag at the
+   `main` release commit for provenance:
+
    ```bash
-   pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ tldw_chatbook
+   git tag -a v<version> -m "Release v<version>"
+   git push origin v<version>
    ```
 
-   Note: The `--extra-index-url` is needed because TestPyPI doesn't have all dependencies.
+5. Verify:
 
-## Uploading to PyPI
-
-1. Upload to PyPI:
    ```bash
-   twine upload dist/*
+   python -m venv pypi_env
+   source pypi_env/bin/activate
+   pip install "tldw_chatbook==<version>"
+   tldw-cli --help
+   tldw-serve --help
+   deactivate
    ```
 
-   When prompted:
-   - Username: `__token__`
-   - Password: Your PyPI API token (including the `pypi-` prefix)
+## Emergency Manual Upload
 
-2. Verify the package at: https://pypi.org/project/tldw_chatbook/
+Use this only if trusted publishing is unavailable and the same `dist/` artifacts
+passed the local gates:
 
-3. Test installation:
-   ```bash
-   pip install tldw_chatbook
-   ```
+```bash
+python -m twine upload --repository testpypi dist/*
+python -m twine upload dist/*
+```
 
-## Post-Release
-
-1. Push the git tag:
-   ```bash
-   git push origin v0.1.0
-   ```
-
-2. Create GitHub release:
-   - Go to https://github.com/rmusser01/tldw_chatbook/releases
-   - Click "Create a new release"
-   - Select the tag
-   - Copy release notes from CHANGELOG.md
-   - Attach the built distributions from `dist/`
-
-3. Update version for next development:
-   - Increment version in `pyproject.toml` (e.g., to 0.2.0.dev0)
-   - Update `tldw_chatbook/__init__.py`
-   - Add new "Unreleased" section to CHANGELOG.md
-   - Commit with message: "Bump version for development"
-
-## Troubleshooting
-
-### Common Issues
-
-1. **Authentication failed**: Ensure you're using `__token__` as username and your full API token as password
-
-2. **Package name already taken**: The name might be too similar to existing packages. Consider a unique name.
-
-3. **Missing files in distribution**: Check MANIFEST.in and ensure all necessary files are included
-
-4. **Import errors after installation**: Verify all dependencies are listed in pyproject.toml
-
-### Useful Commands
-
-- View package contents: `tar -tzf dist/tldw_chatbook-0.1.0.tar.gz`
-- View wheel contents: `unzip -l dist/tldw_chatbook-0.1.0-py3-none-any.whl`
-- Check package metadata: `twine check dist/*`
-
-## Security Notes
-
-- Never commit PyPI tokens to version control
-- Use environment variables or keyring for token storage
-- Consider using GitHub Actions for automated releases
-- Review all included files before uploading
+Manual uploads require an account or project-scoped PyPI token. Never commit
+tokens, `.pypirc`, or upload logs containing credentials.

--- a/Packaging/build_dist.sh
+++ b/Packaging/build_dist.sh
@@ -1,7 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build script for tldw_chatbook PyPI distribution
 
-set -e  # Exit on error
+set -euo pipefail
+
+PYTHON="${PYTHON:-python}"
 
 echo "🚀 Building tldw_chatbook distribution..."
 
@@ -20,15 +22,15 @@ rm -rf dist/ build/ *.egg-info
 
 # Build source distribution and wheel
 echo "🔨 Building source and wheel distributions..."
-python -m build
+"$PYTHON" -m build
 
 # Check the distributions
 echo "✅ Checking distributions with twine..."
-python -m twine check dist/*
+"$PYTHON" -m twine check dist/*
 
 # Verify manifest
 echo "📋 Verifying distribution contents..."
-python Packaging/check_manifest.py
+"$PYTHON" Packaging/check_manifest.py
 
 echo ""
 echo "✨ Build complete!"
@@ -37,10 +39,10 @@ echo "📦 Distribution files created in ./dist/"
 ls -la dist/
 echo ""
 echo "📤 To upload to TestPyPI (for testing):"
-echo "  python -m twine upload --repository testpypi dist/*"
+echo "  $PYTHON -m twine upload --repository testpypi dist/*"
 echo ""
 echo "📤 To upload to PyPI (production):"
-echo "  python -m twine upload dist/*"
+echo "  $PYTHON -m twine upload dist/*"
 echo ""
 echo "🧪 To test installation from wheel:"
 echo "  pip install dist/tldw_chatbook-*.whl"

--- a/Packaging/build_release.sh
+++ b/Packaging/build_release.sh
@@ -1,56 +1,37 @@
-#!/bin/bash
-# Build script for tldw_chatbook PyPI release
+#!/usr/bin/env bash
+# Release build wrapper for tldw_chatbook PyPI artifacts.
 
-set -e  # Exit on error
+set -euo pipefail
 
-echo "🚀 Building tldw_chatbook for PyPI release..."
+PYTHON="${PYTHON:-python}"
 
-# Check if we're in the right directory
 if [ ! -f "pyproject.toml" ]; then
-    echo "❌ Error: pyproject.toml not found. Run this script from the project root."
+    echo "Error: pyproject.toml not found. Run this script from the project root." >&2
     exit 1
 fi
 
-# Check for required tools
-for tool in python pip build twine; do
-    if ! command -v $tool &> /dev/null; then
-        echo "❌ Error: $tool is not installed."
-        echo "Install with: pip install build twine"
-        exit 1
-    fi
-done
+if ! "$PYTHON" -c "import build, setuptools, twine, wheel" >/dev/null 2>&1; then
+    echo "Error: release build modules are not installed." >&2
+    echo "Install release tools with: $PYTHON -m pip install 'setuptools>=77.0' build twine wheel" >&2
+    exit 1
+fi
 
-# Get version from pyproject.toml
-VERSION=$(python -c "
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib
-with open('pyproject.toml', 'rb') as f:
-    data = tomllib.load(f)
-    print(data['project']['version'])
-")
-echo "📦 Building version: $VERSION"
+VERSION=$("$PYTHON" - <<'PY'
+from pathlib import Path
+import tomllib
 
-# Clean previous builds
-echo "🧹 Cleaning previous builds..."
-rm -rf dist/ build/ *.egg-info
+with Path("pyproject.toml").open("rb") as stream:
+    print(tomllib.load(stream)["project"]["version"])
+PY
+)
 
-# Build the distribution
-echo "🔨 Building source distribution and wheel..."
-python -m build
+echo "Building tldw_chatbook ${VERSION} for PyPI release..."
+PYTHON="$PYTHON" Packaging/build_dist.sh
 
-# Check the distributions
-echo "✅ Checking distributions..."
-twine check dist/*
-
-echo "📁 Built files:"
-ls -la dist/
-
-echo ""
-echo "✨ Build complete! Next steps:"
-echo "1. Test the package: pip install dist/tldw_chatbook-${VERSION}-py3-none-any.whl"
-echo "2. Upload to TestPyPI: twine upload --repository testpypi dist/*"
-echo "3. Upload to PyPI: twine upload dist/*"
-echo ""
-echo "📚 See PYPI_RELEASE.md for detailed instructions."
+echo
+echo "Next steps:"
+echo "1. Smoke-test the built wheel in a disposable environment."
+echo "2. Use the publish-pypi GitHub Actions workflow for TestPyPI."
+echo "3. Merge the approved release commit to protected main for production PyPI."
+echo
+echo "See Packaging/PYPI_RELEASE.md for detailed instructions."

--- a/Packaging/check_pypi_release.py
+++ b/Packaging/check_pypi_release.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Check whether a package version already exists on PyPI."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from inspect import signature
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Protocol
+
+from packaging.version import InvalidVersion, Version
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+)
+
+from tldw_chatbook.Utils.input_validation import (
+    validate_github_actions_output_name as shared_validate_github_actions_output_name,
+    validate_pypi_package_name as shared_validate_pypi_package_name,
+    validate_python_package_version as shared_validate_python_package_version,
+    validate_url as shared_validate_url,
+)
+from tldw_chatbook.Utils.path_validation import validate_path
+
+
+PYPI_JSON_BASE_URL = "https://pypi.org/pypi"
+PYPI_REQUEST_TIMEOUT_SECONDS = 30
+DEFAULT_PACKAGE_NAME = "tldw-chatbook"
+DEFAULT_OUTPUT_NAME = "publish_release"
+FIXED_OUTPUT_NAMES = frozenset(("release_exists", "latest_version"))
+VALIDATE_PATH_PARAMETERS = signature(validate_path).parameters
+
+
+@dataclass(frozen=True)
+class ReleaseDecision:
+    """PyPI publication decision for a candidate package version."""
+
+    release_exists: bool
+    latest_version: str | None
+    publish_release: bool
+
+
+class HttpResponse(Protocol):
+    def __enter__(self) -> "HttpResponse": ...
+
+    def __exit__(self, *_args: object) -> None: ...
+
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class UrlOpen(Protocol):
+    def __call__(self, url: str, timeout: int) -> HttpResponse: ...
+
+
+class PypiProjectResponse(BaseModel):
+    """Validated subset of the PyPI project JSON response."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    releases: dict[str, object] = Field(default_factory=dict)
+
+
+class ReleaseCheckInput(BaseModel):
+    """Validated command-line inputs for the PyPI release check."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    package_name: str = Field(default=DEFAULT_PACKAGE_NAME, min_length=1)
+    version: str = Field(min_length=1)
+    base_url: str = Field(default=PYPI_JSON_BASE_URL, min_length=1)
+    output_name: str = Field(default=DEFAULT_OUTPUT_NAME, min_length=1)
+
+    @field_validator("package_name")
+    @classmethod
+    def validate_package_name(cls, value: str) -> str:
+        return validate_package_name(value)
+
+    @field_validator("version")
+    @classmethod
+    def validate_version(cls, value: str) -> str:
+        return validate_version(value)
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, value: str) -> str:
+        return validate_base_url(value)
+
+    @field_validator("output_name")
+    @classmethod
+    def validate_output_name(cls, value: str) -> str:
+        return validate_custom_output_name(value)
+
+
+def validate_package_name(package_name: str) -> str:
+    """Return a validated PyPI package name.
+
+    Args:
+        package_name: Candidate PyPI project name.
+
+    Returns:
+        The original package name when it satisfies the shared input policy.
+
+    Raises:
+        ValueError: If the package name is empty or invalid.
+    """
+    if not package_name:
+        raise ValueError("package name cannot be empty")
+    if not shared_validate_pypi_package_name(package_name):
+        raise ValueError("package name is invalid")
+    return package_name
+
+
+def validate_version(version: str) -> str:
+    """Return a validated PEP 440 package version.
+
+    Args:
+        version: Candidate package version.
+
+    Returns:
+        The original version string when it satisfies the shared input policy.
+
+    Raises:
+        ValueError: If the version is empty or invalid.
+    """
+    if not version:
+        raise ValueError("version cannot be empty")
+    if not shared_validate_python_package_version(version):
+        raise ValueError("version is invalid")
+    return version
+
+
+def validate_base_url(base_url: str) -> str:
+    """Return a validated HTTP(S) PyPI JSON API base URL.
+
+    Args:
+        base_url: Candidate PyPI-compatible JSON API base URL.
+
+    Returns:
+        The URL without trailing slashes.
+
+    Raises:
+        ValueError: If the URL is empty, malformed, or not HTTP(S).
+    """
+    if not base_url:
+        raise ValueError("base URL cannot be empty")
+    if not shared_validate_url(base_url):
+        raise ValueError("base URL is invalid")
+    parsed = urllib.parse.urlsplit(base_url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("base URL must use http or https")
+    return base_url.rstrip("/")
+
+
+def validate_github_output_name(name: str) -> str:
+    """Return a GitHub Actions output name that is safe to write.
+
+    Args:
+        name: Candidate GitHub Actions output name.
+
+    Returns:
+        The original output name when it satisfies the shared input policy.
+
+    Raises:
+        ValueError: If the output name is empty or can inject an assignment.
+    """
+    if not shared_validate_github_actions_output_name(name):
+        raise ValueError("GitHub output name is invalid")
+    return name
+
+
+def validate_custom_output_name(name: str) -> str:
+    """Return a custom output name that cannot overwrite fixed metadata.
+
+    Args:
+        name: Candidate caller-controlled output name.
+
+    Returns:
+        The original output name when it is safe and not reserved.
+
+    Raises:
+        ValueError: If the output name is unsafe or reserved by this script.
+    """
+    validate_github_output_name(name)
+    if name in FIXED_OUTPUT_NAMES:
+        raise ValueError("custom output name cannot overwrite fixed release metadata")
+    return name
+
+
+def validate_action_output_path(
+    output_path: str | os.PathLike[str],
+    runner_temp: str | os.PathLike[str],
+) -> Path:
+    """Return a validated GitHub output path across supported release branches.
+
+    Args:
+        output_path: Candidate ``GITHUB_OUTPUT`` file path.
+        runner_temp: Current GitHub Actions ``RUNNER_TEMP`` directory.
+
+    Returns:
+        The validated path.
+
+    Raises:
+        ValueError: If the output path escapes ``runner_temp``.
+    """
+    kwargs: dict[str, bool] = {}
+    if "redact_paths" in VALIDATE_PATH_PARAMETERS:
+        kwargs["redact_paths"] = True
+    if "allow_hidden" in VALIDATE_PATH_PARAMETERS:
+        kwargs["allow_hidden"] = True
+    return validate_path(output_path, runner_temp, **kwargs)
+
+
+def release_exists(
+    package_name: str,
+    version: str,
+    *,
+    base_url: str = PYPI_JSON_BASE_URL,
+    urlopen: UrlOpen = urllib.request.urlopen,
+) -> bool:
+    """Return whether the package version already exists in the PyPI JSON API.
+
+    Args:
+        package_name: PyPI project name to query.
+        version: Exact version to check.
+        base_url: Base URL for the PyPI-compatible JSON API.
+        urlopen: URL opener compatible with ``urllib.request.urlopen``.
+
+    Returns:
+        True when the exact release version exists, otherwise False.
+
+    Raises:
+        ValueError: If any input value is invalid.
+        urllib.error.HTTPError: If the API returns a non-404 HTTP error.
+    """
+    package_name = validate_package_name(package_name)
+    version = validate_version(version)
+    base_url = validate_base_url(base_url)
+
+    package = urllib.parse.quote(package_name, safe="")
+    quoted_version = urllib.parse.quote(version, safe="")
+    url = f"{base_url}/{package}/{quoted_version}/json"
+
+    try:
+        with urlopen(url, timeout=PYPI_REQUEST_TIMEOUT_SECONDS) as response:
+            response.read(1)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return False
+        raise
+
+    return True
+
+
+def latest_release_version(
+    package_name: str,
+    *,
+    base_url: str = PYPI_JSON_BASE_URL,
+    urlopen: UrlOpen = urllib.request.urlopen,
+) -> str | None:
+    """Return the latest valid package version from the PyPI JSON API.
+
+    Args:
+        package_name: PyPI project name to query.
+        base_url: Base URL for the PyPI-compatible JSON API.
+        urlopen: URL opener compatible with ``urllib.request.urlopen``.
+
+    Returns:
+        The newest valid release version string, or ``None`` when the project
+        does not exist or has no valid release versions.
+
+    Raises:
+        ValueError: If ``package_name`` or ``base_url`` is invalid.
+        ValidationError: If the PyPI JSON response has an unexpected shape.
+        urllib.error.HTTPError: If the API returns a non-404 HTTP error.
+    """
+    package_name = validate_package_name(package_name)
+    base_url = validate_base_url(base_url)
+
+    package = urllib.parse.quote(package_name, safe="")
+    url = f"{base_url}/{package}/json"
+
+    try:
+        with urlopen(url, timeout=PYPI_REQUEST_TIMEOUT_SECONDS) as response:
+            payload = PypiProjectResponse.model_validate_json(response.read())
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+
+    versions: list[Version] = []
+    for version_text in payload.releases:
+        try:
+            versions.append(Version(version_text))
+        except InvalidVersion:
+            continue
+
+    if not versions:
+        return None
+
+    return str(max(versions))
+
+
+def release_decision(
+    package_name: str,
+    version: str,
+    *,
+    base_url: str = PYPI_JSON_BASE_URL,
+    urlopen: UrlOpen = urllib.request.urlopen,
+) -> ReleaseDecision:
+    """Return whether a candidate package version should be published.
+
+    Args:
+        package_name: PyPI project name to query.
+        version: Candidate package version.
+        base_url: Base URL for the PyPI-compatible JSON API.
+        urlopen: URL opener compatible with ``urllib.request.urlopen``.
+
+    Returns:
+        A release decision containing exact-version existence, the latest PyPI
+        release, and whether publication should proceed.
+
+    Raises:
+        ValueError: If any input value is invalid.
+        ValidationError: If the PyPI project JSON response has an unexpected
+            shape.
+        urllib.error.HTTPError: If the API returns a non-404 HTTP error.
+    """
+    package_name = validate_package_name(package_name)
+    version = validate_version(version)
+    base_url = validate_base_url(base_url)
+    candidate_version = Version(version)
+    exists = release_exists(package_name, version, base_url=base_url, urlopen=urlopen)
+    latest_version = latest_release_version(
+        package_name,
+        base_url=base_url,
+        urlopen=urlopen,
+    )
+
+    if exists:
+        return ReleaseDecision(
+            release_exists=True,
+            latest_version=latest_version or version,
+            publish_release=False,
+        )
+
+    if latest_version is None:
+        return ReleaseDecision(
+            release_exists=False,
+            latest_version=None,
+            publish_release=True,
+        )
+
+    return ReleaseDecision(
+        release_exists=False,
+        latest_version=latest_version,
+        publish_release=candidate_version > Version(latest_version),
+    )
+
+
+def resolve_github_output_path(
+    output_path: str | os.PathLike[str] | None = None,
+    *,
+    runner_temp: str | os.PathLike[str] | None = None,
+) -> Path | None:
+    """Return a validated GitHub output file path, or ``None`` outside Actions.
+
+    Args:
+        output_path: Explicit output path override. Defaults to ``GITHUB_OUTPUT``.
+        runner_temp: Explicit runner-temp override. Defaults to ``RUNNER_TEMP``.
+
+    Returns:
+        A validated output path, or ``None`` when no output file is configured.
+
+    Raises:
+        ValueError: If an output path is configured without a runner-temp root
+            or if the output path escapes that root.
+    """
+    raw_output_path = output_path or os.environ.get("GITHUB_OUTPUT")
+    if not raw_output_path:
+        return None
+
+    raw_runner_temp = runner_temp or os.environ.get("RUNNER_TEMP")
+    if not raw_runner_temp:
+        raise ValueError("RUNNER_TEMP is required when GITHUB_OUTPUT is set")
+
+    return validate_action_output_path(raw_output_path, raw_runner_temp)
+
+
+def write_github_output(
+    name: str,
+    value: str,
+    *,
+    output_path: str | os.PathLike[str] | None = None,
+    runner_temp: str | os.PathLike[str] | None = None,
+) -> None:
+    """Append a single GitHub Actions output assignment after path validation.
+
+    Args:
+        name: GitHub Actions output name.
+        value: Single-line output value.
+        output_path: Explicit output path override. Defaults to ``GITHUB_OUTPUT``.
+        runner_temp: Explicit runner-temp override. Defaults to ``RUNNER_TEMP``.
+
+    Raises:
+        ValueError: If the output name, value, or output path is unsafe.
+    """
+    validate_github_output_name(name)
+    if any(char in value for char in "\r\n"):
+        raise ValueError("GitHub output value cannot contain newlines")
+
+    path = resolve_github_output_path(output_path, runner_temp=runner_temp)
+    if path is None:
+        return
+
+    with path.open("a", encoding="utf-8") as output:
+        output.write(f"{name}={value}\n")
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    urlopen: UrlOpen = urllib.request.urlopen,
+) -> int:
+    """Run the PyPI version-existence check for GitHub Actions.
+
+    Args:
+        argv: Command-line arguments without the program name.
+        urlopen: URL opener compatible with ``urllib.request.urlopen``.
+
+    Returns:
+        Process exit code.
+
+    Raises:
+        urllib.error.HTTPError: If the PyPI-compatible API returns a non-404
+            HTTP error.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="Project version to check on PyPI.")
+    parser.add_argument(
+        "--package",
+        default=DEFAULT_PACKAGE_NAME,
+        help=f"Normalized PyPI package name. Default: {DEFAULT_PACKAGE_NAME}",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=PYPI_JSON_BASE_URL,
+        help=f"PyPI JSON API base URL. Default: {PYPI_JSON_BASE_URL}",
+    )
+    parser.add_argument(
+        "--output-name",
+        default=DEFAULT_OUTPUT_NAME,
+        help=f"GitHub Actions output name. Default: {DEFAULT_OUTPUT_NAME}",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        check_input = ReleaseCheckInput(
+            package_name=args.package,
+            version=args.version,
+            base_url=args.base_url,
+            output_name=args.output_name,
+        )
+    except ValidationError as exc:
+        parser.error(str(exc))
+
+    decision = release_decision(
+        check_input.package_name,
+        check_input.version,
+        base_url=check_input.base_url,
+        urlopen=urlopen,
+    )
+    outputs = (
+        ("release_exists", str(decision.release_exists).lower()),
+        ("latest_version", decision.latest_version or ""),
+        (check_input.output_name, str(decision.publish_release).lower()),
+    )
+    for name, value in outputs:
+        write_github_output(name, value)
+        print(f"{name}={value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Packaging/common/dist_path.py
+++ b/Packaging/common/dist_path.py
@@ -1,0 +1,38 @@
+"""Distribution output path validation for release scripts."""
+
+from inspect import signature
+from pathlib import Path
+
+from tldw_chatbook.Utils.path_validation import validate_path
+
+
+_VALIDATE_PATH_PARAMETERS = signature(validate_path).parameters
+
+
+def resolve_dist_dir(dist_dir: str, repo_root: Path) -> Path:
+    """Return a validated repository-contained distribution directory.
+
+    Args:
+        dist_dir: Candidate distribution output directory.
+        repo_root: Repository root that must contain the output directory.
+
+    Returns:
+        The resolved distribution directory path.
+
+    Raises:
+        ValueError: If the output path is empty, points at the repository root,
+            or escapes the repository root.
+    """
+    if not dist_dir:
+        raise ValueError("DIST_DIR cannot be empty")
+
+    root = repo_root.resolve()
+    kwargs: dict[str, bool] = {}
+    if "redact_paths" in _VALIDATE_PATH_PARAMETERS:
+        kwargs["redact_paths"] = True
+    destination = validate_path(dist_dir, root, **kwargs)
+    relative = destination.relative_to(root)
+    if not relative.parts:
+        raise ValueError("DIST_DIR must be a repository subdirectory")
+
+    return destination

--- a/Packaging/common/version.py
+++ b/Packaging/common/version.py
@@ -1,10 +1,29 @@
-"""
-Shared version information for packaging
-"""
+"""Shared version information for packaging."""
 
-# Version info - should match pyproject.toml
-VERSION = "0.1.6.2"
-VERSION_TUPLE = (0, 1, 6, 2)
+import re
+import tomllib
+from pathlib import Path
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_project_version() -> str:
+    with (_PROJECT_ROOT / "pyproject.toml").open("rb") as stream:
+        return str(tomllib.load(stream)["project"]["version"])
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    release = re.match(r"^\d+(?:\.\d+)*", version)
+    if release is None:
+        raise ValueError(
+            f"Project version must start with a numeric release: {version!r}"
+        )
+    return tuple(int(part) for part in release.group(0).split("."))
+
+
+VERSION = _read_project_version()
+VERSION_TUPLE = _version_tuple(VERSION)
 
 # Company/Product info
 COMPANY_NAME = "TLDW Project"

--- a/Tests/Packaging/test_release_metadata.py
+++ b/Tests/Packaging/test_release_metadata.py
@@ -1,0 +1,593 @@
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import tomllib
+import urllib.error
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from Packaging.common.dist_path import resolve_dist_dir
+from Packaging.common import version as packaging_version
+from Packaging import check_pypi_release
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class _PypiJsonResponse:
+    def __init__(self, payload: bytes = b"{") -> None:
+        self.payload = payload
+
+    def __enter__(self) -> "_PypiJsonResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, _size: int = -1) -> bytes:
+        return self.payload
+
+
+class _PypiJsonHandler(BaseHTTPRequestHandler):
+    releases = {"1.2.3": []}
+    request_paths: list[str] = []
+
+    def do_GET(self) -> None:
+        type(self).request_paths.append(self.path)
+        if self.path == "/pypi/tldw-chatbook/json":
+            self._send_json({"releases": self.releases})
+            return
+
+        prefix = "/pypi/tldw-chatbook/"
+        suffix = "/json"
+        if self.path.startswith(prefix) and self.path.endswith(suffix):
+            version = self.path.removeprefix(prefix).removesuffix(suffix)
+            if version in self.releases:
+                self._send_json({"info": {"version": version}})
+                return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    def _send_json(self, payload: object) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def _package_version_metadata() -> tuple[str, tuple[int, ...]]:
+    tree = ast.parse((REPO_ROOT / "tldw_chatbook" / "__init__.py").read_text())
+    assignments: dict[str, object] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id in {
+                "__version__",
+                "VERSION_TUPLE",
+            }:
+                assignments[target.id] = ast.literal_eval(node.value)
+
+    package_version_tuple = assignments["VERSION_TUPLE"]
+    assert isinstance(package_version_tuple, tuple)
+
+    return (str(assignments["__version__"]), package_version_tuple)
+
+
+def test_release_version_metadata_stays_in_lockstep() -> None:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as stream:
+        project = tomllib.load(stream)["project"]
+
+    project_version = project["version"]
+    package_version, package_version_tuple = _package_version_metadata()
+
+    assert package_version == project_version
+    assert packaging_version.VERSION == project_version
+    assert packaging_version.VERSION_TUPLE == package_version_tuple
+
+
+def test_pypi_release_scripts_match_packaged_entry_points() -> None:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as stream:
+        scripts = tomllib.load(stream)["project"]["scripts"]
+
+    assert scripts == {
+        "tldw-cli": "tldw_chatbook.app:main_cli_runner",
+        "tldw-serve": "tldw_chatbook.Web_Server.serve:main",
+    }
+
+
+def test_distribution_output_path_must_be_strictly_inside_repo(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    external = tmp_path / "external"
+    external.mkdir()
+
+    assert resolve_dist_dir("dist", repo_root) == repo_root / "dist"
+    assert resolve_dist_dir("./dist", repo_root) == repo_root / "dist"
+
+    unsafe_paths = ("", ".", "./", "..", "../dist", "dist/..", "./dist/..", str(external))
+    for unsafe in unsafe_paths:
+        with pytest.raises(ValueError):
+            resolve_dist_dir(unsafe, repo_root)
+
+
+def test_distribution_output_path_rejects_symlink_escape(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    external = tmp_path / "external"
+    external.mkdir()
+    link = repo_root / "linked-external"
+
+    try:
+        link.symlink_to(external, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    with pytest.raises(ValueError):
+        resolve_dist_dir("linked-external/dist", repo_root)
+
+
+def test_pypi_release_exists_returns_true_for_existing_version() -> None:
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return _PypiJsonResponse()
+
+    assert check_pypi_release.release_exists(
+        "tldw-chatbook",
+        "1.2.3",
+        base_url="https://example.test/pypi/",
+        urlopen=fake_urlopen,
+    )
+    assert captured == {
+        "url": "https://example.test/pypi/tldw-chatbook/1.2.3/json",
+        "timeout": 30,
+    }
+
+
+def test_pypi_release_exists_returns_false_for_missing_version() -> None:
+    def fake_urlopen(url: str, timeout: int) -> object:
+        raise urllib.error.HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+
+    assert not check_pypi_release.release_exists(
+        "tldw-chatbook",
+        "9.9.9",
+        urlopen=fake_urlopen,
+    )
+
+
+def test_pypi_release_exists_reraises_unexpected_http_errors() -> None:
+    def fake_urlopen(url: str, timeout: int) -> object:
+        raise urllib.error.HTTPError(url, 503, "Unavailable", hdrs=None, fp=None)
+
+    with pytest.raises(urllib.error.HTTPError):
+        check_pypi_release.release_exists(
+            "tldw-chatbook",
+            "1.2.3",
+            urlopen=fake_urlopen,
+        )
+
+
+def test_pypi_release_decision_allows_absent_version_newer_than_latest() -> None:
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        if url.endswith("/tldw-chatbook/1.2.4/json"):
+            raise urllib.error.HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+        if url.endswith("/tldw-chatbook/json"):
+            return _PypiJsonResponse(b'{"releases": {"1.2.3": [], "not-version": []}}')
+        raise AssertionError(url)
+
+    decision = check_pypi_release.release_decision(
+        "tldw-chatbook",
+        "1.2.4",
+        base_url="https://example.test/pypi",
+        urlopen=fake_urlopen,
+    )
+
+    assert not decision.release_exists
+    assert decision.latest_version == "1.2.3"
+    assert decision.publish_release
+
+
+def test_pypi_release_decision_skips_existing_version() -> None:
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        if url.endswith("/tldw-chatbook/1.2.3/json"):
+            return _PypiJsonResponse()
+        if url.endswith("/tldw-chatbook/json"):
+            return _PypiJsonResponse(b'{"releases": {"1.2.3": []}}')
+        raise AssertionError(url)
+
+    decision = check_pypi_release.release_decision(
+        "tldw-chatbook",
+        "1.2.3",
+        base_url="https://example.test/pypi",
+        urlopen=fake_urlopen,
+    )
+
+    assert decision.release_exists
+    assert decision.latest_version == "1.2.3"
+    assert not decision.publish_release
+
+
+def test_pypi_release_decision_reports_real_latest_for_existing_stale_candidate() -> None:
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        if url.endswith("/tldw-chatbook/1.2.3/json"):
+            return _PypiJsonResponse()
+        if url.endswith("/tldw-chatbook/json"):
+            return _PypiJsonResponse(b'{"releases": {"1.2.3": [], "1.2.4": []}}')
+        raise AssertionError(url)
+
+    decision = check_pypi_release.release_decision(
+        "tldw-chatbook",
+        "1.2.3",
+        base_url="https://example.test/pypi",
+        urlopen=fake_urlopen,
+    )
+
+    assert decision.release_exists
+    assert decision.latest_version == "1.2.4"
+    assert not decision.publish_release
+
+
+def test_pypi_release_decision_skips_absent_version_older_than_latest() -> None:
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        if url.endswith("/tldw-chatbook/1.2.2/json"):
+            raise urllib.error.HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+        if url.endswith("/tldw-chatbook/json"):
+            return _PypiJsonResponse(b'{"releases": {"1.2.3": []}}')
+        raise AssertionError(url)
+
+    decision = check_pypi_release.release_decision(
+        "tldw-chatbook",
+        "1.2.2",
+        base_url="https://example.test/pypi",
+        urlopen=fake_urlopen,
+    )
+
+    assert not decision.release_exists
+    assert decision.latest_version == "1.2.3"
+    assert not decision.publish_release
+
+
+def test_pypi_release_decision_allows_first_release_for_missing_package() -> None:
+    def fake_urlopen(url: str, timeout: int) -> object:
+        raise urllib.error.HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+
+    decision = check_pypi_release.release_decision(
+        "tldw-chatbook",
+        "0.1.0",
+        base_url="https://example.test/pypi",
+        urlopen=fake_urlopen,
+    )
+
+    assert not decision.release_exists
+    assert decision.latest_version is None
+    assert decision.publish_release
+
+
+def test_pypi_release_payload_shape_is_validated() -> None:
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        return _PypiJsonResponse(b'{"releases": []}')
+
+    with pytest.raises(ValidationError):
+        check_pypi_release.latest_release_version(
+            "tldw-chatbook",
+            base_url="https://example.test/pypi",
+            urlopen=fake_urlopen,
+        )
+
+
+def test_github_output_path_is_validated_against_runner_temp(tmp_path: Path) -> None:
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    output_path = runner_temp / "_runner_file_commands" / "set_output"
+    output_path.parent.mkdir()
+    output_path.touch()
+    outside_path = tmp_path / "outside_output"
+    outside_path.touch()
+
+    check_pypi_release.write_github_output(
+        "release_exists",
+        "false",
+        output_path=output_path,
+        runner_temp=runner_temp,
+    )
+    assert output_path.read_text() == "release_exists=false\n"
+
+    with pytest.raises(ValueError):
+        check_pypi_release.write_github_output(
+            "release_exists",
+            "false",
+            output_path=outside_path,
+            runner_temp=runner_temp,
+        )
+
+
+def test_check_pypi_release_cli_uses_workflow_arguments_and_emits_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    captured: list[tuple[str, int]] = []
+
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        captured.append((url, timeout))
+        if url.endswith("/tldw-chatbook/1.2.3/json"):
+            return _PypiJsonResponse()
+        if url.endswith("/tldw-chatbook/json"):
+            return _PypiJsonResponse(b'{"releases": {"1.2.3": []}}')
+        raise AssertionError(url)
+
+    output_path = tmp_path / "_runner_file_commands" / "set_output"
+    output_path.parent.mkdir()
+    output_path.touch()
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+
+    assert (
+        check_pypi_release.main(
+            ["1.2.3", "--base-url", "https://example.test/pypi"],
+            urlopen=fake_urlopen,
+        )
+        == 0
+    )
+
+    assert captured == [
+        (
+            "https://example.test/pypi/tldw-chatbook/1.2.3/json",
+            check_pypi_release.PYPI_REQUEST_TIMEOUT_SECONDS,
+        ),
+        (
+            "https://example.test/pypi/tldw-chatbook/json",
+            check_pypi_release.PYPI_REQUEST_TIMEOUT_SECONDS,
+        ),
+    ]
+    assert output_path.read_text() == (
+        "release_exists=true\n"
+        "latest_version=1.2.3\n"
+        "publish_release=false\n"
+    )
+    output = capsys.readouterr().out
+    assert "release_exists=true" in output
+    assert "publish_release=false" in output
+
+
+def test_check_pypi_release_cli_skips_stale_version_and_emits_outputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        if url.endswith("/tldw-chatbook/1.2.2/json"):
+            raise urllib.error.HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+        if url.endswith("/tldw-chatbook/json"):
+            return _PypiJsonResponse(b'{"releases": {"1.2.3": []}}')
+        raise AssertionError(url)
+
+    output_path = tmp_path / "_runner_file_commands" / "set_output"
+    output_path.parent.mkdir()
+    output_path.touch()
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+    monkeypatch.setenv("RUNNER_TEMP", str(tmp_path))
+
+    assert (
+        check_pypi_release.main(
+            ["1.2.2", "--base-url", "https://example.test/pypi"],
+            urlopen=fake_urlopen,
+        )
+        == 0
+    )
+
+    assert output_path.read_text() == (
+        "release_exists=false\n"
+        "latest_version=1.2.3\n"
+        "publish_release=false\n"
+    )
+    output = capsys.readouterr().out
+    assert "release_exists=false" in output
+    assert "latest_version=1.2.3" in output
+    assert "publish_release=false" in output
+
+
+def test_check_pypi_release_cli_integrates_http_and_github_output(
+    tmp_path: Path,
+) -> None:
+    _PypiJsonHandler.request_paths = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _PypiJsonHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        base_url = f"http://127.0.0.1:{server.server_port}/pypi"
+        cases = (
+            (
+                "1.2.4",
+                "release_exists=false\nlatest_version=1.2.3\npublish_release=true\n",
+            ),
+            (
+                "1.2.2",
+                "release_exists=false\nlatest_version=1.2.3\npublish_release=false\n",
+            ),
+        )
+
+        for candidate, expected_output in cases:
+            run_dir = tmp_path / candidate
+            output_path = run_dir / "_runner_file_commands" / "set_output"
+            output_path.parent.mkdir(parents=True)
+            output_path.touch()
+            env = os.environ.copy()
+            existing_pythonpath = env.get("PYTHONPATH")
+            env.update(
+                {
+                    "GITHUB_OUTPUT": str(output_path),
+                    "RUNNER_TEMP": str(run_dir),
+                    "PYTHONPATH": (
+                        str(REPO_ROOT)
+                        if not existing_pythonpath
+                        else f"{REPO_ROOT}{os.pathsep}{existing_pythonpath}"
+                    ),
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO_ROOT / "Packaging" / "check_pypi_release.py"),
+                    candidate,
+                    "--base-url",
+                    base_url,
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            assert result.returncode == 0, result.stderr
+            assert output_path.read_text() == expected_output
+            assert expected_output.strip() in result.stdout
+
+        assert "/pypi/tldw-chatbook/1.2.4/json" in _PypiJsonHandler.request_paths
+        assert "/pypi/tldw-chatbook/1.2.2/json" in _PypiJsonHandler.request_paths
+        assert _PypiJsonHandler.request_paths.count("/pypi/tldw-chatbook/json") == 2
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_check_pypi_release_cli_rejects_invalid_version() -> None:
+    called = False
+
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        nonlocal called
+        called = True
+        return _PypiJsonResponse()
+
+    with pytest.raises(SystemExit) as excinfo:
+        check_pypi_release.main(["not-a-version"], urlopen=fake_urlopen)
+
+    assert excinfo.value.code == 2
+    assert not called
+
+
+def test_check_pypi_release_cli_rejects_reserved_output_names() -> None:
+    called = False
+
+    def fake_urlopen(url: str, timeout: int) -> _PypiJsonResponse:
+        nonlocal called
+        called = True
+        return _PypiJsonResponse()
+
+    with pytest.raises(SystemExit) as excinfo:
+        check_pypi_release.main(
+            ["1.2.3", "--output-name", "release_exists"],
+            urlopen=fake_urlopen,
+        )
+
+    assert excinfo.value.code == 2
+    assert not called
+
+
+def test_testpypi_publish_requires_protected_dev_ref() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "publish-pypi.yml").read_text()
+
+    assert (
+        "if: github.event_name == 'workflow_dispatch' && "
+        "github.ref == 'refs/heads/dev' && github.ref_protected"
+    ) in workflow
+
+
+def _publish_workflow_text() -> str:
+    return (REPO_ROOT / ".github" / "workflows" / "publish-pypi.yml").read_text()
+
+
+def _workflow_job_block(workflow: str, job_name: str) -> str:
+    match = re.search(
+        rf"^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [\w-]+:\n|\Z)",
+        workflow,
+        re.M | re.S,
+    )
+    assert match is not None, f"{job_name} job not found"
+    return match.group("body")
+
+
+def test_production_pypi_publish_requires_protected_main_push() -> None:
+    workflow = _publish_workflow_text()
+    trigger_block = workflow.split("\npermissions:", maxsplit=1)[0]
+    publish_job = _workflow_job_block(workflow, "publish-pypi")
+
+    assert "push:\n    branches:\n      - main" in trigger_block
+    assert "tags:" not in trigger_block
+    assert "github.event_name == 'push'" in publish_job
+    assert "github.ref == 'refs/heads/main'" in publish_job
+    assert "github.ref_protected" in publish_job
+    assert "refs/tags" not in publish_job
+    assert "refs/heads/dev" not in publish_job
+
+
+def test_production_pypi_publish_checks_version_before_upload() -> None:
+    workflow = _publish_workflow_text()
+    check_job = _workflow_job_block(workflow, "check_pypi_release")
+    publish_job = _workflow_job_block(workflow, "publish-pypi")
+
+    assert 'run: python Packaging/check_pypi_release.py "$RELEASE_VERSION"' in check_job
+    assert "Install output path validation dependencies" in check_job
+    assert "python -m pip install loguru packaging psutil pydantic" in check_job
+    assert "needs: [build, check_pypi_release]" in publish_job
+    assert "needs.check_pypi_release.outputs.publish_release == 'true'" in publish_job
+
+
+def test_release_workflow_serializes_same_ref_runs() -> None:
+    workflow = _publish_workflow_text()
+
+    assert (
+        "concurrency:\n"
+        "  group: ${{ github.workflow }}-${{ github.ref }}\n"
+        "  cancel-in-progress: false"
+    ) in workflow
+
+
+def test_release_workflow_uses_validated_github_output_writes() -> None:
+    workflow = _publish_workflow_text()
+    build_job = _workflow_job_block(workflow, "build")
+
+    assert "version: ${{ steps.release-version.outputs.version }}" in build_job
+    assert "from Packaging.check_pypi_release import write_github_output" in build_job
+    assert 'write_github_output("version", project_version)' in build_job
+    assert "GITHUB_OUTPUT" not in workflow
+
+
+def test_release_instructions_do_not_publish_production_pypi_from_tags() -> None:
+    checked_paths = (
+        REPO_ROOT / "Packaging" / "PYPI_README.md",
+        REPO_ROOT / "Packaging" / "PYPI_RELEASE.md",
+        REPO_ROOT / "Packaging" / "build_release.sh",
+    )
+    forbidden_lines = (
+        "Protected `v*` tags publish to PyPI",
+        "PyPI job only runs for protected matching version tags",
+        "Publish production PyPI from a protected v",
+    )
+
+    for path in checked_paths:
+        text = path.read_text()
+        for forbidden_line in forbidden_lines:
+            assert forbidden_line not in text

--- a/backlog/tasks/task-31213 - Restrict-production-PyPI-publishing-to-main.md
+++ b/backlog/tasks/task-31213 - Restrict-production-PyPI-publishing-to-main.md
@@ -1,0 +1,62 @@
+---
+id: TASK-31213
+title: Restrict production PyPI publishing to main
+status: Done
+assignee: []
+created_date: '2026-09-03 22:34'
+updated_date: '2026-09-03 22:40'
+labels:
+  - packaging
+  - ci
+  - release
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure production PyPI publishing cannot be triggered from dev or release tags, and only runs from protected main branch pushes when the built version is not already on PyPI.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Production PyPI publishing is triggered only by pushes to main.
+- [x] #2 The production publish job requires refs/heads/main and a protected ref.
+- [x] #3 Tag pushes do not trigger production PyPI publishing.
+- [x] #4 A version-exists guard prevents duplicate production uploads on main pushes.
+- [x] #5 The GitHub pypi environment deployment policy permits main only.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add workflow policy regression tests for the PyPI trigger and publish job guards.
+2. Change .github/workflows/publish-pypi.yml to trigger production on protected main pushes instead of v* tag pushes.
+3. Add a PyPI version-exists check before the production publish job so ordinary main pushes do not attempt duplicate uploads.
+4. Verify the live GitHub pypi environment policy allows only the main branch.
+5. Run targeted packaging tests and diff checks.
+
+ADR required: no
+ADR path: N/A
+Reason: This is CI/release policy wiring for an existing packaging workflow, not a storage, runtime, API, or architectural boundary change.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Changed the PyPI workflow so production publishing is triggered by protected `main` branch pushes instead of `v*` tag pushes. The build job now exports the project version through a validated GitHub Actions output writer, a separate PyPI status job checks whether that version already exists, and the production publish job runs only when that check reports a new version. TestPyPI remains a manual dispatch from protected `dev`.
+
+Extracted the PyPI version-exists guard into `Packaging/check_pypi_release.py`, added executable coverage for existing releases, missing releases, unexpected HTTP errors, validated output-path writes, workflow-facing output emission, and serialized same-ref workflow runs. Updated PyPI release documentation and the release build wrapper output so maintainers no longer follow the old tag-driven production path. Verified the live GitHub `pypi` environment deployment policy now permits only the `main` branch.
+
+Main activation note: this branch keeps `main`'s current `tldw-cli` entry point expectation and removes the nonfunctional installed-distribution workflow step that referenced `Tests/Packaging/test_installed_distribution.py`, which is not present on `main`. The release metadata tests now cover the production trigger, publish guard, output wiring, and stale-version behavior that this PR changes.
+
+Verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_release_metadata.py -q` -> 24 passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile Packaging/check_pypi_release.py Tests/Packaging/test_release_metadata.py` -> passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check Packaging/check_pypi_release.py Tests/Packaging/test_release_metadata.py` -> passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "from pathlib import Path; import yaml; yaml.safe_load(Path('.github/workflows/publish-pypi.yml').read_text()); print('yaml ok')"` -> yaml ok
+- `bash -n Packaging/build_release.sh` -> passed
+- `git diff --check` -> passed
+- `gh api repos/rmusser01/tldw_chatbook/environments/pypi/deployment-branch-policies` -> only `main` branch policy
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31214 - Prevent-main-PyPI-workflow-from-publishing-stale-versions.md
+++ b/backlog/tasks/task-31214 - Prevent-main-PyPI-workflow-from-publishing-stale-versions.md
@@ -1,0 +1,62 @@
+---
+id: TASK-31214
+title: Prevent main PyPI workflow from publishing stale versions
+status: Done
+assignee: []
+created_date: '2026-09-03 23:11'
+updated_date: '2026-09-03 23:14'
+labels:
+  - packaging
+  - ci
+  - release
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Ensure the main-driven PyPI workflow cannot publish an older package version that is absent from PyPI but lower than the latest published release.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The PyPI release-status helper reports the latest published version.
+- [x] #2 Production publishing is allowed only when the candidate version is absent and newer than the latest published version.
+- [x] #3 A stale lower version on main skips production upload instead of publishing.
+- [x] #4 Focused executable tests cover latest-version comparison and stale-version skip behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Extend the PyPI release-status helper to read the package-level PyPI JSON and identify the latest valid published version.
+2. Emit a publish_release output that is true only for absent versions newer than the latest published release.
+3. Change the workflow publish condition to use publish_release rather than release_exists alone.
+4. Add targeted tests for newer, existing, missing-package, and stale lower-version behavior.
+5. Run focused tests, lint, syntax checks, and environment-policy verification.
+
+ADR required: no
+ADR path: N/A
+Reason: This is a defensive CI release guard inside the existing packaging workflow, not a new architecture or release boundary.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Extended `Packaging/check_pypi_release.py` so it checks both exact candidate-version existence and the latest package-level PyPI release. The workflow now consumes `publish_release`, which is true only when the candidate version is absent and greater than the latest valid published version. This prevents a stale `main` checkout at `0.1.8.0` from publishing after `0.1.8.1` already exists.
+
+Updated PyPI release docs to state that protected `main` publishes only absent versions newer than the latest PyPI release. Added focused tests for newer absent versions, existing versions, stale lower versions, missing-project first releases, workflow output wiring, and a subprocess CLI run against a local PyPI-shaped HTTP server. Addressed review feedback by validating CLI inputs with Pydantic through the shared input-validation module, validating the PyPI JSON response shape, centralizing the PyPI request timeout, reporting the real latest release for existing stale candidates, rejecting custom output names that would overwrite fixed metadata, and keeping the selected Python interpreter consistent through the local release scripts.
+
+Verification:
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_release_metadata.py -q` -> 25 passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Web_Scraping/test_input_validation.py -q` -> 9 passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile Packaging/check_pypi_release.py Packaging/common/dist_path.py Packaging/common/version.py Tests/Packaging/test_release_metadata.py tldw_chatbook/Utils/input_validation.py` -> passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check Packaging/check_pypi_release.py Packaging/common/dist_path.py Packaging/common/version.py Tests/Packaging/test_release_metadata.py tldw_chatbook/Utils/input_validation.py` -> passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -c "from pathlib import Path; import yaml; yaml.safe_load(Path('.github/workflows/publish-pypi.yml').read_text()); print('yaml ok')"` -> yaml ok
+- `bash -n Packaging/build_release.sh` -> passed
+- `bash -n Packaging/build_dist.sh` -> passed
+- `git diff --check` -> passed
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Packaging/check_pypi_release.py 0.1.8.0` -> `release_exists=false`, `latest_version=0.1.8.1`, `publish_release=false`
+- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Packaging/check_pypi_release.py 0.1.8.2` -> `release_exists=false`, `latest_version=0.1.8.1`, `publish_release=true`
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Utils/input_validation.py
+++ b/tldw_chatbook/Utils/input_validation.py
@@ -5,11 +5,14 @@ import re
 import ipaddress
 import time
 from typing import Union, Optional
-from pathlib import Path
+from packaging.version import InvalidVersion, Version
 from ..Metrics.metrics_logger import log_counter, log_histogram
 
 
 PROVIDER_API_KEY_MAX_LENGTH = 4096
+PYPI_PACKAGE_NAME_PATTERN = re.compile(
+    r"^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9._-]*[A-Za-z0-9])$"
+)
 
 
 def validate_email(email: str) -> bool:
@@ -132,6 +135,50 @@ def validate_url(url: str) -> bool:
     log_histogram("input_validation_url_length", len(url))
     
     return result
+
+
+def validate_pypi_package_name(package_name: str) -> bool:
+    """Validate a PyPI project name.
+
+    Args:
+        package_name: Candidate project name.
+
+    Returns:
+        True when the value matches PyPI's permitted project-name characters
+        and boundary rules.
+    """
+    return bool(package_name and PYPI_PACKAGE_NAME_PATTERN.fullmatch(package_name))
+
+
+def validate_python_package_version(version: str) -> bool:
+    """Validate a Python package version using PEP 440 parsing.
+
+    Args:
+        version: Candidate package version.
+
+    Returns:
+        True when the value is non-empty and accepted by
+        ``packaging.version.Version``.
+    """
+    if not version:
+        return False
+    try:
+        Version(version)
+    except InvalidVersion:
+        return False
+    return True
+
+
+def validate_github_actions_output_name(name: str) -> bool:
+    """Validate a GitHub Actions output name for file-command writes.
+
+    Args:
+        name: Candidate output name.
+
+    Returns:
+        True when the value cannot inject another output assignment or line.
+    """
+    return bool(name and not any(char in name for char in "=\r\n"))
 
 
 def validate_filename(filename: str) -> bool:


### PR DESCRIPTION
## Summary
- change the production PyPI workflow trigger from `v*` tag pushes to protected `main` branch pushes
- add a PyPI release-status gate so `main` only uploads absent versions newer than the current PyPI latest
- keep TestPyPI manual dispatch on protected `dev`
- add focused release metadata tests and main-compatible packaging helpers
- remove the nonfunctional main workflow step that referenced missing `Tests/Packaging/test_installed_distribution.py`

## Verification
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_release_metadata.py -q` -> 24 passed
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile Packaging/check_pypi_release.py Packaging/common/dist_path.py Packaging/common/version.py Tests/Packaging/test_release_metadata.py` -> passed
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m ruff check Packaging/check_pypi_release.py Packaging/common/dist_path.py Packaging/common/version.py Tests/Packaging/test_release_metadata.py` -> All checks passed
- workflow YAML parse -> yaml ok
- `bash -n Packaging/build_release.sh` -> passed
- `git diff --check` -> passed
- live PyPI `0.1.8.0` -> `release_exists=false`, `latest_version=0.1.8.1`, `publish_release=false`
- live PyPI `0.1.8.2` -> `release_exists=false`, `latest_version=0.1.8.1`, `publish_release=true`
- GitHub `pypi` environment deployment branch policies -> only `main` branch policy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates production PyPI publishing on protected `main` pushes instead of `v*` tag pushes, so releases only publish versions that are absent and newer than the latest published PyPI release.

**Changes**
- The workflow triggers on protected `main` pushes; tag pushes no longer publish.
- A new `Packaging/check_pypi_release.py` queries PyPI and emits `publish_release` only when the candidate version is new and greater than the latest published release.
- TestPyPI publishing remains a manual workflow dispatch from protected `dev`.
- Removed the workflow step that referenced a missing `Tests/Packaging/test_installed_distribution.py`.
- Added release metadata tests, shared input-validation helpers, and updated packaging docs and build scripts.
- The live `pypi` environment deployment policy is now restricted to `main`.

<sup>Written for commit 2f81cfcb018d6c5786fbdf4443efcea484db65c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

