### PR TITLE
Fix main PyPI build manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,40 @@
+# Include license and documentation
+include LICENSE
+include README.md
+include CLAUDE.md
+include CHANGELOG.md
+include MANIFEST.in
+include pyproject.toml
+
+# Include requirements file for reference
+include requirements.txt
+
+# Include all JSON template files and markdown guides
+recursive-include tldw_chatbook/Config_Files *.json *.md
+
+# Include all CSS theme files
+recursive-include tldw_chatbook/css *.tcss
+
+# Include Third Party files with their licenses
+recursive-include tldw_chatbook/Third_Party *.py *.txt *.md
+
+# Exclude test files and development artifacts
+recursive-exclude Tests *
+recursive-exclude STests *
+exclude .gitignore
+exclude .env
+exclude .env.example
+exclude .pypirc.template
+prune .venv
+prune .git
+prune __pycache__
+prune *.egg-info
+
+# Exclude OS-specific files
+exclude .DS_Store
+recursive-exclude * .DS_Store
+
+# Exclude Python artifacts
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__


### PR DESCRIPTION
## Summary
- add the root MANIFEST.in that setuptools reads during source distribution builds
- include the documentation, requirements, package data, CSS, and third-party license files already expected by Packaging/check_manifest.py
- unblock the main-only PyPI workflow before the stale-version release gate runs

## Verification
- PYTHON=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Packaging/build_dist.sh
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m build --sdist --wheel --no-isolation --outdir dist
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m twine check dist/*
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Packaging/check_manifest.py dist
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_release_metadata.py -q
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the root `MANIFEST.in` so setuptools includes the documentation, requirements, package data, CSS, and third-party license files already expected by the packaging checks. This unblocks the main-only PyPI build before the stale-version release gate runs.

**Verification**
- Local sdist and wheel builds pass, along with `twine check`, the manifest check, and release metadata tests.

<sup>Written for commit 66518824954becf2edc444cd6d9b666d6b81c8c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

