### PR TITLE
Fix PyPI release-check import path

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -146,6 +146,7 @@ jobs:
       - name: Check whether version should be published to PyPI
         id: check
         env:
+          PYTHONPATH: ${{ github.workspace }}
           RELEASE_VERSION: ${{ needs.build.outputs.version }}
         run: python Packaging/check_pypi_release.py "$RELEASE_VERSION"
 

--- a/Tests/Packaging/test_release_metadata.py
+++ b/Tests/Packaging/test_release_metadata.py
@@ -551,6 +551,7 @@ def test_production_pypi_publish_checks_version_before_upload() -> None:
     assert 'run: python Packaging/check_pypi_release.py "$RELEASE_VERSION"' in check_job
     assert "Install output path validation dependencies" in check_job
     assert "python -m pip install loguru packaging psutil pydantic" in check_job
+    assert "PYTHONPATH: ${{ github.workspace }}" in check_job
     assert "needs: [build, check_pypi_release]" in publish_job
     assert "needs.check_pypi_release.outputs.publish_release == 'true'" in publish_job
 


### PR DESCRIPTION
## Summary
- expose the repository root through PYTHONPATH for the PyPI release-check job
- keep the release checker using shared tldw_chatbook.Utils validation without requiring a package install in that job
- add a workflow regression assertion so the clean-runner import path is preserved

## Verification
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_release_metadata.py::test_production_pypi_publish_checks_version_before_upload -q (failed before workflow fix for missing PYTHONPATH)
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Packaging/test_release_metadata.py -q
- PYTHONPATH=/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/codex-pypi-main-workflow-activation /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python Packaging/check_pypi_release.py 0.1.8.0
- /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile Packaging/check_pypi_release.py Tests/Packaging/test_release_metadata.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the PyPI release-check job failing because `Packaging/check_pypi_release.py` could not import `tldw_chatbook.Utils` without the repository root on `PYTHONPATH`.

- Sets `PYTHONPATH` to `${{ github.workspace }}` in the workflow so the release checker can use the shared module without a package install.
- Adds a regression assertion in `Tests/Packaging/test_release_metadata.py` to keep the `PYTHONPATH` entry in the job definition.

<sup>Written for commit 943a0ef1f43cb2afff0f49a9274cb83de9443f69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

