### PR TITLE
perf(personas): demand-mount heavy center views

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2847,8 +2847,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 187,
-      "diagnostic_digest": "236781455c4b3ee0de45",
+      "call_count": 188,
+      "diagnostic_digest": "da71be6b580f5c508134",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/personas_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11304,6 +11304,6 @@
     "path_privacy_candidate_calls": 714,
     "persistent_sink_files": 10,
     "task_492_calls": 1337,
-    "task_494_calls": 7567
+    "task_494_calls": 7568
   }
 }

--- a/Docs/superpowers/plans/2026-09-03-personas-demand-mounted-center-views.md
+++ b/Docs/superpowers/plans/2026-09-03-personas-demand-mounted-center-views.md
@@ -1,0 +1,486 @@
+# Personas Demand-Mounted Center Views Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Personas settle into its usable default Characters surface without constructing four inactive heavy center views, then mount and cache each view only when its workflow first needs it.
+
+**Architecture:** `PersonasScreen` composes four hidden, zero-demand slot containers in the historical center-stack order. A screen-owned async `_ensure_center_view()` population boundary constructs, mounts, hydrates, and caches one requested body with per-view concurrency and lifecycle-generation guards; workflow admission points await that boundary before touching editor/detail state.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, asyncio, pytest/pytest-asyncio
+
+**Spec:** `Docs/superpowers/specs/2026-09-03-personas-demand-mounted-center-views-design.md`
+
+## Global Constraints
+
+- Preserve the four existing heavy root IDs: `ccp-character-editor-view`, `ccp-persona-editor-view`, `personas-dictionary-detail`, and `personas-lore-detail`.
+- The initial Characters card, library, preview, inspector, attachments, conversation, and Try-It chrome remain eager.
+- Switching modes alone must not mount a heavy view.
+- Mounted views remain cached until the `PersonasScreen` instance unmounts; never recompose them on mode switches.
+- Apply selection/editor state only after the requested body is mounted and the screen lifecycle generation is current.
+- A transient mount failure must remain retryable and must not crash the application.
+- Event-loop gaps while opening Personas under the production CSS bundle must stay below 250 ms.
+- No storage, provider/runtime, Console-handoff, information-architecture, or dependency changes.
+- Use targeted verification only; do not run the full repository suite without explicit user opt-in.
+- ADR required: yes.
+- ADR path: `backlog/decisions/115-personas-demand-mounted-center-views.md`.
+- Reason: the change defines the long-lived lifecycle and restore/admission contract shared by the Personas screen and its four authoring widgets.
+
+---
+
+### Task 1: Pin the initial-load and first-use lifecycle
+
+**Files:**
+
+- Modify: `Tests/UI/test_personas_deferred_center_views.py`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py:600-625`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py:1146-1215`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py:1396-1445`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py:1681-1735`
+
+**Interfaces:**
+
+- Consumes: existing heavy widget constructors and `_show_center(visible_id: str | None) -> None`.
+- Produces: `_ensure_center_view(view_key: str) -> Widget | None`, stable slot IDs, and per-screen cached body identity used by later tasks.
+
+- [ ] **Step 1: Replace the old after-load batch assertion with a failing settled-load contract**
+
+  Update `Tests/UI/test_personas_deferred_center_views.py` so a real settled load expects all heavy roots to remain absent while the direct children of `#personas-detail-stack` contain the four slots in historical order:
+
+  ```python
+  _HEAVY_VIEW_IDS = (
+      "ccp-character-editor-view",
+      "ccp-persona-editor-view",
+      "personas-dictionary-detail",
+      "personas-lore-detail",
+  )
+
+  _EXPECTED_STACK_ORDER = [
+      "ccp-character-card-view",
+      "personas-character-editor-slot",
+      "personas-character-attachments",
+      "ccp-persona-card-view",
+      "personas-persona-editor-slot",
+      "personas-conversation-actions",
+      "personas-dictionary-detail-slot",
+      "personas-lore-detail-slot",
+      "personas-conversation-transcript-view",
+      "personas-mode-placeholder",
+      "personas-characters-empty",
+  ]
+
+  async def test_settled_initial_load_keeps_heavy_views_unmounted():
+      # Push the real screen and drain its initial worker.
+      assert all(not list(screen.query(f"#{view_id}")) for view_id in _HEAVY_VIEW_IDS)
+      stack = screen.query_one("#personas-detail-stack")
+      assert [child.id for child in stack.children] == _EXPECTED_STACK_ORDER
+  ```
+
+- [ ] **Step 2: Run the settled-load test and confirm the current batch mount fails it**
+
+  Run:
+
+  ```bash
+  python -m pytest -q Tests/UI/test_personas_deferred_center_views.py::test_settled_initial_load_keeps_heavy_views_unmounted --tb=short
+  ```
+
+  Expected: FAIL because `_load_after_mount()` currently calls `_mount_deferred_center_views()` and all four roots exist after settle.
+
+- [ ] **Step 3: Add failing first-use cache and isolation tests**
+
+  Add a mounted test that calls the new boundary directly, records the returned character editor, edits `#personas-char-editor-name`, switches through a second call, and proves only that root exists and the same object/value returns:
+
+  ```python
+  async def test_first_use_mounts_only_requested_view_and_caches_it():
+      first = await screen._ensure_center_view("character-editor")
+      assert isinstance(first, PersonasCharacterEditorWidget)
+      first.query_one("#personas-char-editor-name", Input).value = "Keep me"
+      second = await screen._ensure_center_view("character-editor")
+      assert second is first
+      assert second.query_one("#personas-char-editor-name", Input).value == "Keep me"
+      assert not list(screen.query(PersonaProfileEditorWidget))
+      assert not list(screen.query(PersonasDictionaryDetailWidget))
+      assert not list(screen.query(PersonasLoreDetailWidget))
+  ```
+
+- [ ] **Step 4: Run the first-use test and confirm the boundary is absent**
+
+  Run:
+
+  ```bash
+  python -m pytest -q Tests/UI/test_personas_deferred_center_views.py::test_first_use_mounts_only_requested_view_and_caches_it --tb=short
+  ```
+
+  Expected: FAIL with `AttributeError` for `_ensure_center_view`.
+
+- [ ] **Step 5: Implement stable slots and the minimal population boundary**
+
+  In `personas_screen.py`, import `Widget` from `textual.widget`, define the four view/slot identities near `_CENTER_VIEW_IDS`, initialize a lifecycle generation and one `asyncio.Lock` per key, and replace `_mount_deferred_center_views()` with the first-use boundary:
+
+  ```python
+  _CENTER_VIEW_ROOTS = {
+      "character-editor": "#ccp-character-editor-view",
+      "persona-editor": "#ccp-persona-editor-view",
+      "dictionary-detail": "#personas-dictionary-detail",
+      "lore-detail": "#personas-lore-detail",
+  }
+
+  _CENTER_VIEW_SLOTS = {
+      "character-editor": "#personas-character-editor-slot",
+      "persona-editor": "#personas-persona-editor-slot",
+      "dictionary-detail": "#personas-dictionary-detail-slot",
+      "lore-detail": "#personas-lore-detail-slot",
+  }
+  ```
+
+  Compose each slot as a `Vertical` with `display = False`, `height = "auto"`, and `width = "100%"`. Implement the factory as a total key match and implement:
+
+  ```python
+  async def _ensure_center_view(self, view_key: str) -> Widget | None:
+      selector = _CENTER_VIEW_ROOTS.get(view_key)
+      if selector is None:
+          raise ValueError(f"Unknown Personas center view: {view_key}")
+      existing = self.query(selector).first(None)
+      if existing is not None:
+          return existing
+      async with self._center_view_mount_locks[view_key]:
+          existing = self.query(selector).first(None)
+          if existing is not None:
+              return existing
+          generation = self._center_view_lifecycle_generation
+          body = self._build_center_view(view_key)
+          body.display = False
+          try:
+              slot = self.query_one(_CENTER_VIEW_SLOTS[view_key], Vertical)
+              await slot.mount(body)
+              if generation != self._center_view_lifecycle_generation or not self.is_mounted:
+                  await body.remove()
+                  return None
+              self._hydrate_center_view(view_key, body)
+              slot.display = True
+              return body
+          except Exception:
+              if body.is_mounted:
+                  await body.remove()
+              logger.opt(exception=True).warning(
+                  "Personas center view mount failed (view_key={}).", view_key
+              )
+              self._notify("Couldn't open this Personas view. Try again.", "error")
+              return None
+  ```
+
+  `_hydrate_center_view()` calls `set_runtime_source()` only for a mounted `PersonaProfileEditorWidget`. Remove the batch mount call from `_load_after_mount()` and update comments/docstrings to describe first-use mounting.
+
+- [ ] **Step 6: Run the lifecycle tests and make them pass**
+
+  Run:
+
+  ```bash
+  python -m pytest -q Tests/UI/test_personas_deferred_center_views.py --tb=short
+  ```
+
+  Expected: PASS for initial absence, slot order, first-use isolation, and cached identity.
+
+- [ ] **Step 7: Commit the lifecycle seam**
+
+  ```bash
+  git add Tests/UI/test_personas_deferred_center_views.py tldw_chatbook/UI/Screens/personas_screen.py
+  git commit -m "perf(personas): add first-use center view lifecycle"
+  ```
+
+---
+
+### Task 2: Admit every editor/detail workflow through the boundary
+
+**Files:**
+
+- Modify: `Tests/UI/test_personas_deferred_center_views.py`
+- Modify: `Tests/UI/test_personas_workbench_state.py:500-590`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py:4662-4930`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py:6996-7860`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py:9520-9605`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py:14540-14920`
+
+**Interfaces:**
+
+- Consumes: `_ensure_center_view(view_key: str) -> Widget | None` from Task 1.
+- Produces: exact workflow admission for character/persona create/edit and dictionary/lore select/create/edit/restore.
+
+- [ ] **Step 1: Add failing mounted admission tests for all four bodies**
+
+  Parameterize the existing production-screen harness so each real entry path starts from a settled screen, triggers one action, and asserts the requested root exists while the other three remain absent. Cover:
+
+  ```python
+  (
+      ("characters", PersonaActionRequested("create"), "ccp-character-editor-view"),
+      ("personas", PersonaActionRequested("create"), "ccp-persona-editor-view"),
+      ("dictionaries", dictionary_row_selection, "personas-dictionary-detail"),
+      ("lore", lore_row_selection, "personas-lore-detail"),
+  )
+  ```
+
+  Reuse the service fakes already present in `test_personas_workbench.py`,
+  `test_personas_dictionaries.py`, and `test_personas_lore.py`; do not introduce a
+  surrogate screen.
+
+- [ ] **Step 2: Run each new admission case and confirm direct queries fail**
+
+  Run:
+
+  ```bash
+  python -m pytest -q Tests/UI/test_personas_deferred_center_views.py -k "workflow_mounts_only" --tb=short
+  ```
+
+  Expected: FAIL with `NoMatches` at the first direct editor/detail query because the batch mount was removed in Task 1.
+
+- [ ] **Step 3: Gate selection and create paths before state mutation**
+
+  At the beginning of the body-dependent portions of these async methods, await the exact key and return when it is unavailable:
+
+  ```python
+  detail = await self._ensure_center_view("dictionary-detail")
+  if not isinstance(detail, PersonasDictionaryDetailWidget):
+      return
+  ```
+
+  Apply the pattern to:
+
+  - `_select_dictionary` and `_select_lore_entry`, after service data succeeds but before `state.select_entity()`;
+  - `_begin_create_character` and `_begin_create_profile`, before clearing selection/edit state;
+  - `_begin_create_dictionary` and `_begin_create_lore`, before clearing selection/edit state.
+
+  Use the returned typed widget instead of immediately querying it again.
+
+- [ ] **Step 4: Gate character/persona edit paths and reuse returned widgets**
+
+  Update the two production edit handlers (`EditCharacterRequested` and
+  `EditPersonaProfileRequested`) to await `character-editor` or `persona-editor`
+  before advancing editor generations, clearing state, loading record data, or
+  starting visual-identity workers. Abort cleanly on `None`.
+
+- [ ] **Step 5: Preserve dictionary/lore restore ordering**
+
+  Extend the existing round-trip restore test in `test_personas_workbench_state.py`:
+
+  ```python
+  assert screen2.query_one("#personas-dictionary-detail").display is True
+  assert not list(screen2.query("#ccp-character-editor-view"))
+  assert not list(screen2.query("#ccp-persona-editor-view"))
+  assert not list(screen2.query("#personas-lore-detail"))
+  assert screen2.state.selected_entity_id == saved_dictionary_id
+  ```
+
+  Add the symmetric lore case. The existing `_apply_pending_restore()` dispatch remains the owner; its `_select_dictionary()` / `_select_lore_entry()` call now awaits body readiness before applying the exact saved record.
+
+- [ ] **Step 6: Run focused workflow and restore tests**
+
+  Run:
+
+  ```bash
+  python -m pytest -q \
+    Tests/UI/test_personas_deferred_center_views.py \
+    Tests/UI/test_personas_workbench_state.py \
+    Tests/UI/test_personas_editor_save_in_place.py \
+    Tests/UI/test_actor_pack_creation_workflow.py \
+    Tests/UI/test_personas_dictionaries.py \
+    Tests/UI/test_personas_lore.py \
+    --tb=short
+  ```
+
+  Expected: PASS with each workflow mounting only its requested heavy body.
+
+- [ ] **Step 7: Commit workflow admission**
+
+  ```bash
+  git add Tests/UI/test_personas_deferred_center_views.py Tests/UI/test_personas_workbench_state.py tldw_chatbook/UI/Screens/personas_screen.py
+  git commit -m "fix(personas): admit heavy workflows through lazy views"
+  ```
+
+---
+
+### Task 3: Prove concurrency, retry, teardown, and responsiveness
+
+**Files:**
+
+- Modify: `Tests/UI/test_personas_deferred_center_views.py`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py:1146-1215`
+- Modify: `tldw_chatbook/UI/Screens/personas_screen.py:1681-1765`
+
+**Interfaces:**
+
+- Consumes: `_ensure_center_view(view_key: str) -> Widget | None`, `_build_center_view(view_key: str) -> Widget`, and `_hydrate_center_view(view_key: str, body: Widget) -> None`.
+- Produces: deterministic failure/retry and lifecycle-generation behavior plus the 250 ms responsiveness gate.
+
+- [ ] **Step 1: Add a failing concurrent first-use test**
+
+  Instrument `_build_center_view` while running two calls together:
+
+  ```python
+  first, second = await asyncio.gather(
+      screen._ensure_center_view("character-editor"),
+      screen._ensure_center_view("character-editor"),
+  )
+  assert first is second
+  assert build_count == 1
+  assert len(list(screen.query(PersonasCharacterEditorWidget))) == 1
+  ```
+
+- [ ] **Step 2: Add a failing transient mount retry test**
+
+  Patch the character slot's `mount` method to raise once, then delegate to the
+  real bound method. Assert the first ensure returns `None`, the second returns a
+  mounted editor, one bounded notification was emitted, and only one editor remains.
+
+- [ ] **Step 3: Add a failing teardown-generation test**
+
+  Gate the slot mount with two `asyncio.Event` objects. Start ensure, wait until
+  the fake mount reaches its controlled await, increment the screen lifecycle via
+  `on_unmount`, release the mount, and assert the method returns `None`, performs no
+  persona runtime hydration/focus, and leaves no mounted heavy root attached to the
+  retired screen.
+
+- [ ] **Step 4: Run the concurrency/retry/teardown tests and confirm the missing guards**
+
+  Run:
+
+  ```bash
+  python -m pytest -q Tests/UI/test_personas_deferred_center_views.py -k "concurrent or retry or teardown" --tb=short
+  ```
+
+  Expected: at least one FAIL before the final guards, with duplicate construction,
+  consumed failure state, or stale post-mount hydration.
+
+- [ ] **Step 5: Complete lifecycle invalidation and cleanup**
+
+  Increment `_center_view_lifecycle_generation` at the start of `on_unmount()`.
+  Ensure the population boundary double-checks the mounted root inside its per-view
+  lock, marks no separate ready state before mount/hydration succeeds, hides slots
+  until success, and removes a partially mounted body on failure or stale generation.
+  Catch cancellation separately and re-raise it after cleanup:
+
+  ```python
+  except asyncio.CancelledError:
+      if body.is_mounted:
+          await body.remove()
+      raise
+  ```
+
+- [ ] **Step 6: Add and run the production-CSS heartbeat regression**
+
+  Patch `PersonasCharacterEditorWidget.compose` to `time.sleep(0.35)` before
+  yielding a `Static`, run a 5 ms heartbeat while pushing a real `PersonasScreen`,
+  settle the initial worker, and assert the default card is mounted, the editor is
+  absent, and `max(gaps) < 0.25`:
+
+  ```python
+  def blocking_character_editor_compose(self):
+      time.sleep(0.35)
+      yield Static("deliberately slow inactive editor")
+
+  assert screen.query_one("#ccp-character-card-view").is_mounted
+  assert not list(screen.query("#ccp-character-editor-view"))
+  assert max(gaps) < 0.25
+  ```
+
+  Run:
+
+  ```bash
+  python -m pytest -q Tests/UI/test_personas_deferred_center_views.py::test_inactive_editor_compose_cannot_stall_personas_navigation --tb=short
+  ```
+
+  Expected: PASS only when initial load never constructs the inactive editor.
+
+- [ ] **Step 7: Run the complete lifecycle module**
+
+  ```bash
+  python -m pytest -q Tests/UI/test_personas_deferred_center_views.py --tb=short
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 8: Commit hardening and responsiveness coverage**
+
+  ```bash
+  git add Tests/UI/test_personas_deferred_center_views.py tldw_chatbook/UI/Screens/personas_screen.py
+  git commit -m "test(personas): harden lazy view lifecycle"
+  ```
+
+---
+
+### Task 4: Verify the affected Personas surface and close TASK-31215
+
+**Files:**
+
+- Modify: `backlog/tasks/task-31215 - Personas-mount-heavy-center-views-on-first-use.md`
+- Modify only if the implementation exposed a generalizable incident: `backlog/docs/lessons-testing-evidence.md`
+
+**Interfaces:**
+
+- Consumes: all Task 1-3 behavior.
+- Produces: focused verification evidence, completed acceptance criteria, and concise implementation notes.
+
+- [ ] **Step 1: Run the focused Personas regression set**
+
+  ```bash
+  python -m pytest -q \
+    Tests/UI/test_personas_deferred_center_views.py \
+    Tests/UI/test_personas_workbench.py \
+    Tests/UI/test_personas_workbench_state.py \
+    Tests/UI/test_personas_editor_save_in_place.py \
+    Tests/UI/test_actor_pack_creation_workflow.py \
+    Tests/UI/test_personas_dictionaries.py \
+    Tests/UI/test_personas_lore.py \
+    Tests/UI/test_personas_inspector_pane.py \
+    --tb=short
+  ```
+
+  Expected: PASS. Do not broaden to the full suite without user opt-in.
+
+- [ ] **Step 2: Run the architectural message-pump guard**
+
+  ```bash
+  python -m pytest -q Tests/Architecture/test_no_blocking_io_on_message_pump.py --tb=short
+  ```
+
+  Expected: PASS.
+
+- [ ] **Step 3: Run scoped static and diff checks**
+
+  ```bash
+  python -m compileall -q tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_deferred_center_views.py
+  ruff check tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_deferred_center_views.py
+  ruff format --check tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_deferred_center_views.py
+  git diff --check origin/dev...HEAD
+  ```
+
+  Expected: all commands exit 0.
+
+- [ ] **Step 4: Review the diff against the approved spec**
+
+  Confirm the diff changes no storage/provider/Console contract, retains every
+  existing heavy root ID, introduces no body unmount-on-switch path, and contains no
+  direct initial-load call that populates a heavy view. Search explicitly:
+
+  ```bash
+  rg -n "_mount_deferred_center_views|_ensure_center_view|personas-.*-slot" \
+    tldw_chatbook/UI/Screens/personas_screen.py Tests/UI/test_personas_deferred_center_views.py
+  ```
+
+- [ ] **Step 5: Update the Backlog task through the CLI**
+
+  Check all five acceptance criteria, add implementation notes with measured widget
+  and heartbeat evidence, list targeted test counts, record any plan deviation, and
+  set TASK-31215 to Done only after every Definition-of-Done requirement is met:
+
+  ```bash
+  backlog task edit 31215 \
+    --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --check-ac 5 \
+    --notes "Implemented screen-owned first-use mounting for all four heavy Personas center views; verification evidence recorded here." \
+    --status Done --plain
+  ```
+
+- [ ] **Step 6: Commit the closeout records**
+
+  ```bash
+  git add 'backlog/tasks/task-31215 - Personas-mount-heavy-center-views-on-first-use.md' backlog/docs/lessons-testing-evidence.md
+  git commit -m "docs(personas): close demand-mounted view task"
+  ```

--- a/Docs/superpowers/plans/2026-09-03-personas-demand-mounted-center-views.md
+++ b/Docs/superpowers/plans/2026-09-03-personas-demand-mounted-center-views.md
@@ -132,7 +132,10 @@
   }
   ```
 
-  Compose each slot as a `Vertical` with `display = False`, `height = "auto"`, and `width = "100%"`. Implement the factory as a total key match and implement:
+  Compose each slot as a `Vertical` with `display = False`, natural container
+  height, and `width = "100%"`. Do not force `height = "auto"`: the editor roots
+  own `height = "100%"`, and the wrapper must preserve their full-height layout and
+  hit-testing. Implement the factory as a total key match and implement:
 
   ```python
   async def _ensure_center_view(self, view_key: str) -> Widget | None:

--- a/Docs/superpowers/specs/2026-09-03-personas-demand-mounted-center-views-design.md
+++ b/Docs/superpowers/specs/2026-09-03-personas-demand-mounted-center-views-design.md
@@ -1,9 +1,9 @@
 # Personas demand-mounted center views — design
 
 - **Date:** 2026-09-03
-- **Status:** Draft — awaiting owner review
+- **Status:** Approved
 - **Scope:** TASK-31215, Personas/Roleplay presentation lifecycle only
-- **Decision record:** Proposed [ADR-115](../../../backlog/decisions/115-personas-demand-mounted-center-views.md)
+- **Decision record:** Accepted [ADR-115](../../../backlog/decisions/115-personas-demand-mounted-center-views.md)
 
 ## 1. Problem and evidence
 

--- a/Docs/superpowers/specs/2026-09-03-personas-demand-mounted-center-views-design.md
+++ b/Docs/superpowers/specs/2026-09-03-personas-demand-mounted-center-views-design.md
@@ -1,0 +1,203 @@
+# Personas demand-mounted center views — design
+
+- **Date:** 2026-09-03
+- **Status:** Draft — awaiting owner review
+- **Scope:** TASK-31215, Personas/Roleplay presentation lifecycle only
+- **Decision record:** Proposed [ADR-115](../../../backlog/decisions/115-personas-demand-mounted-center-views.md)
+
+## 1. Problem and evidence
+
+TASK-2725 removed the four heaviest hidden Personas views from `compose`, but its
+post-first-paint loader still mounts all four before it restores selection or
+finishes the initial library load. The user sees the first frame, then the message
+pump performs the same large CSS/mount workload regardless of which workflow is
+needed.
+
+A scratch-profile mounted census on current `dev` found 574 descendants after
+settle, 458 effectively hidden. The four deferred roots contribute 350 hidden
+descendants:
+
+| Heavy view | Hidden subtree descendants |
+| --- | ---: |
+| `PersonasCharacterEditorWidget` | 140 |
+| `PersonaProfileEditorWidget` | 83 |
+| `PersonasDictionaryDetailWidget` | 67 |
+| `PersonasLoreDetailWidget` | 60 |
+
+This is the same failure shape fixed for Lab > Models by TASK-31002: painting a
+small active route is followed by constructing unrelated inactive routes. Personas
+has more restore and editor state than Models, so the fix needs one explicit
+screen-owned lifecycle rather than scattered `QueryError` tolerance.
+
+## 2. Goals
+
+1. Let Personas settle into an interactive default Characters surface without
+   mounting any of the four heavy inactive bodies.
+2. Mount only the body required by the user's first selection/create/edit action.
+3. Cache each mounted body for the screen lifetime so unsaved input, focus, and
+   presentation state survive mode switching.
+4. Preserve restore, runtime-source, actor-pack, visual-identity, dictionary/lore,
+   and Console-handoff behavior.
+5. Make concurrent first use, mount failure, and teardown ordering deterministic.
+6. Pin responsiveness under the production CSS bundle.
+
+## 3. Non-goals
+
+- Changing Personas information architecture, labels, or visible layout.
+- Deferring the default character card, library pane, inspector, preview, character
+  attachments, conversation transcript, or Try-It chrome.
+- Unmounting a body after first use or shrinking steady-state memory during a long
+  Personas visit.
+- Refactoring the character/persona services, storage, Console handoff contract, or
+  the individual editor widget implementations.
+- Fixing the separate Library rendered-Markdown hang or applying the pattern to
+  Schedules in this change.
+
+## 4. Chosen design
+
+### 4.1 Stable slots and identities
+
+`#personas-detail-stack` keeps the historical document order but replaces the
+four absent-body anchor gaps with empty lightweight slots:
+
+```text
+character card
+character editor slot          -> mounts #ccp-character-editor-view
+character attachments
+persona card
+persona editor slot            -> mounts #ccp-persona-editor-view
+conversation actions
+dictionary detail slot         -> mounts #personas-dictionary-detail
+lore detail slot               -> mounts #personas-lore-detail
+conversation transcript
+placeholder / empty guidance
+```
+
+The slots have internal IDs and no user-visible content. The heavy roots retain
+their existing IDs, types, and CSS classes. An empty slot has zero content demand;
+after population, the existing root continues to own its own visibility and
+layout. This preserves the query and styling contract without remounting siblings
+or using fragile `after=` anchors during a user action.
+
+### 4.2 One screen-owned first-use boundary
+
+`PersonasScreen` owns an immutable view definition map:
+
+```text
+view key -> root selector, slot selector, factory, post-mount hydrator
+```
+
+An async `_ensure_center_view(view_key)` method is the only population path. It:
+
+1. validates the requested key;
+2. returns the already-mounted root immediately;
+3. acquires the per-view async lock and checks again, coalescing concurrent first
+   requests without creating an unowned background task;
+4. constructs the body only inside the successful attempt;
+5. mounts it hidden into its stable slot;
+6. checks the screen lifecycle generation and mounted ownership;
+7. applies view-specific retained state; and
+8. records readiness only after all steps succeed.
+
+Failure leaves no readiness marker. Any partial body is detached when possible,
+and the next explicit workflow action makes a fresh attempt. The caller receives a
+bounded recoverable error through the existing guarded action path; raw exception
+payloads are logged only under existing diagnostic policy.
+
+The cache lasts only for this `PersonasScreen` instance. Navigating away still
+disposes the entire screen as it does today.
+
+### 4.3 Workflow admission points
+
+Only operations that require a heavy body cross the boundary:
+
+| View | Admission paths |
+| --- | --- |
+| Character editor | Create character/actor pack; edit selected character |
+| Persona editor | Create persona/actor pack; edit selected persona |
+| Dictionary detail/editor | Select/restore dictionary; create or edit dictionary |
+| Lore detail/editor | Select/restore lore book; create or edit lore book |
+
+The admission occurs before the workflow mutates selection, edit mode, dirty state,
+or starts body-owned workers. Once admitted, the existing deeper handlers may keep
+their direct widget queries because the workflow now owns a mounted body. Save,
+cancel, media, policy, and visual-identity messages originate from a mounted editor
+and therefore do not need an additional population call.
+
+Merely switching among Characters, Personas, Dictionaries, Lore, and Prompts does
+not populate a heavy body. Dictionary/lore row selection populates the corresponding
+detail; character/persona selection continues to use the eager read-only card.
+
+### 4.4 Restore and retained state
+
+`restore_state` remains pre-mount and data-only. `_load_after_mount` no longer batch
+mounts the four views. It loads the active library and calls
+`_apply_pending_restore`; the selected-kind path then admits exactly the required
+body before applying its record.
+
+Character and persona read-only restores use their eager cards and mount no editor.
+Dictionary and lore restores await their detail body. Pending restore data remains
+screen-owned until replay succeeds or the existing stale/deleted-record handling
+classifies it terminal.
+
+The persona editor hydrator applies the latest normalized local/server runtime
+source before the admitting create/edit function writes editor data. Other bodies
+receive record data only from their existing selection/create/edit functions after
+mount. A body is never populated from a snapshot belonging to another active mode,
+entity, runtime source, or screen generation.
+
+### 4.5 Concurrency and teardown
+
+Each view has an independent lock so unrelated first-use requests do not share a
+global latch. Textual mutation still occurs on the screen event loop. Repeated
+requests for one view converge on the same mounted root.
+
+`PersonasScreen` increments a lifecycle generation during unmount. A population
+attempt captures the generation before mounting and rechecks it before hydration
+or readiness publication. If the screen detached or the generation changed, the
+attempt removes/abandons its body and returns without applying user state. Existing
+worker-specific generations continue to protect actor-pack, visual-identity, TTS,
+and search results; the new generation protects only the view-lifecycle boundary.
+
+## 5. Error and recovery behavior
+
+- An unknown view key is a programming error and fails immediately.
+- Missing/detached slots or a Textual mount failure leave the view retryable.
+- User-triggered failures flow through `_run_guarded` and show a bounded error while
+  keeping the previous stable center view intact.
+- Initial restore does not convert a transient body-mount failure into a stale
+  entity deletion. The pending payload remains eligible for a later explicit retry.
+- Navigating away makes every late population result stale; it cannot focus fields,
+  change selection, or show an editor on another screen.
+- A failed view does not block the other three views from mounting.
+
+## 6. Verification strategy
+
+TDD starts by replacing the old "all four exist after load" assertion with mounted
+contracts that fail on current `dev`:
+
+1. after the real initial load settles, all four heavy root selectors remain absent;
+2. character card selection remains usable without mounting any editor/detail;
+3. first selection/create/edit mounts only its required root;
+4. a second request returns the same root and preserves an edited field;
+5. two concurrent ensure calls construct and mount one body;
+6. a failed first mount does not consume readiness and a second attempt succeeds;
+7. dictionary/lore restore waits for the requested detail and applies the exact
+   saved entity only after mount;
+8. unmount during a controlled population delay produces no stale hydration or
+   focus mutation;
+9. all four existing mode workflows retain their current visible results; and
+10. a production-CSS heartbeat sees no single event-loop stall above 250 ms while
+    opening Personas with inactive bodies absent.
+
+Verification remains targeted per repository policy: the deferred-center-view
+module, affected Personas workbench/editor/dictionary/lore/restore tests, blocking
+I/O architecture guard, scoped Ruff/compile checks, and `git diff --check`. A full
+repository sweep is not part of this task unless the user opts in.
+
+## 7. Documentation and rollout
+
+No user-facing guide changes are expected because labels and behavior are unchanged;
+the change is observable only as faster navigation and a one-time cost when a heavy
+workflow is first opened. TASK-31215 records measured before/after evidence and any
+deviation from this design. ADR-115 is accepted when the owner approves this spec.

--- a/Tests/UI/test_actor_pack_creation_workflow.py
+++ b/Tests/UI/test_actor_pack_creation_workflow.py
@@ -21,7 +21,7 @@ from textual.widgets._select import SelectCurrent
 from Tests.UI.test_personas_workbench import (
     PersonasTestApp,
     StyledPersonasTestApp,
-    _mounted,
+    _mounted as _workbench_mounted,
     stub_characters as _stub_characters,  # noqa: F401 - registers fixture
     stub_scope_service as _stub_scope_service,  # noqa: F401 - registers fixture
 )
@@ -36,6 +36,15 @@ from tldw_chatbook.Widgets.Persona_Widgets.personas_character_editor_widget impo
 
 
 pytestmark = pytest.mark.asyncio
+
+
+async def _mounted(pilot):
+    """Return a Personas screen after its initial loading overlay has settled."""
+
+    screen = await _workbench_mounted(pilot)
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+    return screen
 
 
 def _portrait_bytes(color: tuple[int, int, int, int] = (20, 40, 60, 255)) -> bytes:
@@ -192,7 +201,7 @@ async def test_server_persona_actor_pack_explains_local_copy_requirement(
         await screen._begin_create_actor_pack()
 
         assert notifications[-1] == ("Save a local copy first", "warning", None)
-        assert screen.query_one("#ccp-persona-editor-view").display is False
+        assert not list(screen.query("#ccp-persona-editor-view"))
 
 
 @pytest.mark.parametrize("size", [(80, 24), (160, 48)])
@@ -232,12 +241,16 @@ async def test_character_actor_pack_save_uses_atomic_creation_service_once(
     async with app.run_test() as pilot:
         screen = await _mounted(pilot)
         await pilot.click("#personas-library-new-actor-pack")
+        await pilot.pause()
         editor = screen.query_one(PersonasCharacterEditorWidget)
+        assert screen._actor_pack_session is not None
+        assert screen._edit_mode == "create"
         screen.query_one("#personas-char-editor-name", Input).value = "Pack Hero"
         screen.query_one(
             "#personas-char-editor-first-message", TextArea
         ).text = "Welcome"
         editor.set_avatar_image(_character_rows()[0]["image"])
+        await pilot.pause()
         await pilot.click("#personas-char-editor-save")
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -272,7 +285,9 @@ async def test_persona_actor_pack_save_pins_selected_portrait_identity(
         screen = await _mounted(pilot)
         await pilot.click("#personas-mode-personas")
         await pilot.click("#personas-library-new-actor-pack")
+        await pilot.pause()
         screen.query_one("#personas-editor-name", Input).value = "Pack Guide"
+        await pilot.pause()
         await pilot.click("#personas-editor-save")
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -318,9 +333,11 @@ async def test_navigation_signals_and_drains_pack_creation_before_continuing(
     async with app.run_test() as pilot:
         screen = await _mounted(pilot)
         await pilot.click("#personas-library-new-actor-pack")
+        await pilot.pause()
         editor = screen.query_one(PersonasCharacterEditorWidget)
         screen.query_one("#personas-char-editor-name", Input).value = "Cancelled"
         editor.set_avatar_image(_character_rows()[0]["image"])
+        await pilot.pause()
         await pilot.click("#personas-char-editor-save")
         for _ in range(100):
             if started.is_set():
@@ -354,6 +371,7 @@ async def test_declined_dirty_navigation_preserves_actor_pack_draft(
     async with app.run_test() as pilot:
         screen = await _mounted(pilot)
         await pilot.click("#personas-library-new-actor-pack")
+        await pilot.pause()
         session = screen._actor_pack_session
         screen.state.has_unsaved_changes = True
 
@@ -386,6 +404,7 @@ async def test_stale_editor_session_is_rejected_before_pack_service_call(
         screen = await _mounted(pilot)
         await pilot.click("#personas-mode-personas")
         await pilot.click("#personas-library-new-actor-pack")
+        await pilot.pause()
         editor = screen.query_one("#ccp-persona-editor-view")
         editor.load_persona({}, runtime_source="local")
         screen.query_one("#personas-editor-name", Input).value = "Stale"
@@ -435,9 +454,11 @@ async def test_stale_pack_result_does_not_reconcile_into_newer_editor_authority(
         refresh = AsyncMock()
         screen.character_handler.refresh_character_list = refresh
         await pilot.click("#personas-library-new-actor-pack")
+        await pilot.pause()
         editor = screen.query_one(PersonasCharacterEditorWidget)
         screen.query_one("#personas-char-editor-name", Input).value = "Stale result"
         editor.set_avatar_image(_character_rows()[0]["image"])
+        await pilot.pause()
         await pilot.click("#personas-char-editor-save")
         for _ in range(100):
             if started.is_set():
@@ -488,7 +509,7 @@ async def test_runtime_source_change_fences_inflight_portrait_inventory(
         await opening
 
         assert screen._actor_pack_session is None
-        assert screen.query_one("#ccp-persona-editor-view").display is False
+        assert not list(screen.query("#ccp-persona-editor-view"))
 
 
 async def test_cancel_signals_and_drains_owned_pack_operation(
@@ -511,9 +532,11 @@ async def test_cancel_signals_and_drains_owned_pack_operation(
     async with app.run_test() as pilot:
         screen = await _mounted(pilot)
         await pilot.click("#personas-library-new-actor-pack")
+        await pilot.pause()
         editor = screen.query_one(PersonasCharacterEditorWidget)
         screen.query_one("#personas-char-editor-name", Input).value = "Cancel me"
         editor.set_avatar_image(_character_rows()[0]["image"])
+        await pilot.pause()
         await pilot.click("#personas-char-editor-save")
         for _ in range(100):
             if started.is_set():
@@ -548,11 +571,13 @@ async def test_pack_error_copy_is_plain_text_and_path_free(
     async with app.run_test(size=(80, 24)) as pilot:
         screen = await _mounted(pilot)
         await pilot.click("#personas-library-new-actor-pack")
+        await pilot.pause()
         editor = screen.query_one(PersonasCharacterEditorWidget)
         screen.query_one("#personas-char-editor-name", Input).value = "Private"
         editor.set_avatar_image(_character_rows()[0]["image"])
         status = screen.query_one("#personas-char-editor-pack-status", Static)
         assert status.region.width > 0 and status.region.height > 0
+        await pilot.pause()
         await pilot.click("#personas-char-editor-save")
         await app.workers.wait_for_complete()
 
@@ -586,9 +611,11 @@ async def test_portrait_change_during_commit_signals_authority_and_skips_reconci
     async with app.run_test() as pilot:
         screen = await _mounted(pilot)
         await pilot.click("#personas-library-new-actor-pack")
+        await pilot.pause()
         editor = screen.query_one(PersonasCharacterEditorWidget)
         screen.query_one("#personas-char-editor-name", Input).value = "Changing"
         editor.set_avatar_image(_portrait_bytes())
+        await pilot.pause()
         await pilot.click("#personas-char-editor-save")
         for _ in range(100):
             if started.is_set():

--- a/Tests/UI/test_personas_deferred_center_views.py
+++ b/Tests/UI/test_personas_deferred_center_views.py
@@ -7,12 +7,18 @@ and mounts only the body an editor/detail workflow first requests.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+import asyncio
+import time
+from unittest.mock import AsyncMock, Mock
 
 import pytest
-from textual.widgets import Input
+from textual.containers import Vertical
+from textual.widgets import Input, Static
 
-from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
+from tldw_chatbook.UI.Screens.personas_screen import (
+    PersonasScreen,
+    _CenterViewMountUnavailable,
+)
 from tldw_chatbook.Widgets.Persona_Widgets.persona_profile_editor_widget import (
     PersonaProfileEditorWidget,
 )
@@ -56,9 +62,7 @@ async def test_first_paint_excludes_the_four_heavy_center_views(monkeypatch):
     """Compose alone must not mount the deferred views (the perf mechanism)."""
     from Tests.UI.app_factory import _build_test_app
 
-    monkeypatch.setattr(
-        PersonasScreen, "_load_after_mount", AsyncMock(), raising=True
-    )
+    monkeypatch.setattr(PersonasScreen, "_load_after_mount", AsyncMock(), raising=True)
 
     app = _build_test_app()
     async with app.run_test(size=(235, 52)) as pilot:
@@ -126,3 +130,180 @@ async def test_first_use_mounts_only_requested_view_and_caches_it():
         assert not list(screen.query(PersonaProfileEditorWidget))
         assert not list(screen.query(PersonasDictionaryDetailWidget))
         assert not list(screen.query(PersonasLoreDetailWidget))
+
+
+async def test_concurrent_first_use_builds_and_mounts_one_view(monkeypatch):
+    """Concurrent requests coalesce behind one per-view mount operation."""
+    from Tests.UI.app_factory import _build_test_app
+
+    app = _build_test_app()
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        screen = PersonasScreen(app)
+        await app.push_screen(screen)
+        await pilot.pause()
+        real_builder = screen._build_center_view
+        build_count = 0
+
+        def counted_builder(view_key: str):
+            nonlocal build_count
+            build_count += 1
+            return real_builder(view_key)
+
+        monkeypatch.setattr(screen, "_build_center_view", counted_builder)
+        first, second = await asyncio.gather(
+            screen._ensure_center_view("character-editor"),
+            screen._ensure_center_view("character-editor"),
+        )
+
+        assert first is second
+        assert build_count == 1
+        assert len(list(screen.query(PersonasCharacterEditorWidget))) == 1
+
+
+async def test_transient_mount_failure_remains_retryable(monkeypatch):
+    """A failed attempt owns no ready state and a later attempt can succeed."""
+    from Tests.UI.app_factory import _build_test_app
+
+    app = _build_test_app()
+    notifications: list[tuple[str, str]] = []
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        screen = PersonasScreen(app)
+        await app.push_screen(screen)
+        await pilot.pause()
+        slot = screen.query_one("#personas-character-editor-slot", Vertical)
+        real_mount = slot.mount
+        attempts = 0
+
+        async def fail_once(*widgets, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("transient test failure")
+            return await real_mount(*widgets, **kwargs)
+
+        monkeypatch.setattr(slot, "mount", fail_once)
+        monkeypatch.setattr(
+            screen,
+            "_notify",
+            lambda message, severity="information", **_: notifications.append(
+                (str(message), severity)
+            ),
+        )
+
+        assert await screen._ensure_center_view("character-editor") is None
+        second = await screen._ensure_center_view("character-editor")
+
+        assert isinstance(second, PersonasCharacterEditorWidget)
+        assert attempts == 2
+        assert notifications == [
+            ("Couldn't open this Personas view. Try again.", "error")
+        ]
+        assert len(list(screen.query(PersonasCharacterEditorWidget))) == 1
+
+
+async def test_unmount_during_population_blocks_stale_hydration(monkeypatch):
+    """A mount finishing after lifecycle invalidation is removed, not hydrated."""
+    from Tests.UI.app_factory import _build_test_app
+
+    app = _build_test_app()
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        screen = PersonasScreen(app)
+        await app.push_screen(screen)
+        await pilot.pause()
+        slot = screen.query_one("#personas-persona-editor-slot", Vertical)
+        real_mount = slot.mount
+        started = asyncio.Event()
+        release = asyncio.Event()
+        hydrate = Mock(wraps=screen._hydrate_center_view)
+
+        async def delayed_mount(*widgets, **kwargs):
+            started.set()
+            await release.wait()
+            return await real_mount(*widgets, **kwargs)
+
+        monkeypatch.setattr(slot, "mount", delayed_mount)
+        monkeypatch.setattr(screen, "_hydrate_center_view", hydrate)
+        population = asyncio.create_task(screen._ensure_center_view("persona-editor"))
+        await started.wait()
+        generation = screen._center_view_lifecycle_generation
+
+        await screen.on_unmount()
+        assert screen._center_view_lifecycle_generation == generation + 1
+        release.set()
+        assert await population is None
+
+        hydrate.assert_not_called()
+        assert not list(screen.query(PersonaProfileEditorWidget))
+
+
+async def test_transient_restore_mount_failure_keeps_pending_intent(monkeypatch):
+    """A view-mount failure is retryable restore state, not a deleted entity."""
+    from Tests.UI.app_factory import _build_test_app
+
+    app = _build_test_app()
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        screen = PersonasScreen(app)
+        await app.push_screen(screen)
+        await pilot.pause()
+        pending = {"kind": "dictionary", "id": "7", "name": "Terms"}
+        screen._pending_restore = pending
+        screen._restored_from_saved_state = True
+        screen.state.active_mode = "dictionaries"
+        monkeypatch.setattr(screen, "_apply_mode", AsyncMock())
+        monkeypatch.setattr(
+            screen,
+            "_select_dictionary",
+            AsyncMock(side_effect=_CenterViewMountUnavailable("dictionary-detail")),
+        )
+
+        await screen._apply_pending_restore()
+
+        assert screen._pending_restore is pending
+        assert screen._restored_from_saved_state is True
+
+
+async def test_inactive_editor_compose_cannot_stall_personas_navigation(monkeypatch):
+    """An expensive inactive editor cannot block the default screen arrival."""
+    from Tests.UI.app_factory import _build_test_app
+
+    def blocking_character_editor_compose(self):
+        time.sleep(0.35)
+        yield Static("deliberately slow inactive editor")
+
+    monkeypatch.setattr(
+        PersonasCharacterEditorWidget, "compose", blocking_character_editor_compose
+    )
+
+    app = _build_test_app()
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        gaps: list[float] = []
+        running = True
+
+        async def heartbeat() -> None:
+            loop = asyncio.get_running_loop()
+            previous = loop.time()
+            while running:
+                await asyncio.sleep(0.005)
+                now = loop.time()
+                gaps.append(now - previous)
+                previous = now
+
+        heartbeat_task = asyncio.create_task(heartbeat())
+        await asyncio.sleep(0)
+        screen = PersonasScreen(app)
+        await app.push_screen(screen)
+        for _ in range(8):
+            await pilot.pause()
+        await asyncio.sleep(0.05)
+        running = False
+        await heartbeat_task
+
+        assert screen.query_one("#ccp-character-card-view").is_mounted
+        assert not list(screen.query(PersonasCharacterEditorWidget))
+        assert gaps
+        assert max(gaps) < 0.25, f"event loop stalled for {max(gaps):.3f}s"

--- a/Tests/UI/test_personas_deferred_center_views.py
+++ b/Tests/UI/test_personas_deferred_center_views.py
@@ -1,11 +1,8 @@
-"""task-2725: the four heavy hidden center views mount after first paint.
+"""TASK-31215: heavy Personas center views mount only on first use.
 
-Profiling (task file) showed the Roleplay switch cost is widget-mount CSS
-application, with 290 of the detail stack's 358 widgets in four views that
-arrive hidden: the character editor (132), dictionary detail (67), lore
-detail (60), and persona profile editor (31). They now mount as the first
-step of `_load_after_mount` — off the click→paint critical path — instead
-of inside compose.
+TASK-2725 moved four hidden bodies past first paint, but still mounted all of
+them during the initial load. TASK-31215 keeps stable slots in document order
+and mounts only the body an editor/detail workflow first requests.
 """
 
 from __future__ import annotations
@@ -13,6 +10,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock
 
 import pytest
+from textual.widgets import Input
 
 from tldw_chatbook.UI.Screens.personas_screen import PersonasScreen
 from tldw_chatbook.Widgets.Persona_Widgets.persona_profile_editor_widget import (
@@ -37,17 +35,17 @@ _DEFERRED_TYPES = (
     PersonaProfileEditorWidget,
 )
 
-#: The stack's document order — scroll flow depends on it, so the deferred
-#: mounts must land exactly where compose used to put them.
+#: The stack's document order — scroll flow depends on it, so the lightweight
+#: slots must occupy exactly the positions their bodies historically used.
 _EXPECTED_STACK_ORDER = [
     "ccp-character-card-view",
-    "ccp-character-editor-view",
+    "personas-character-editor-slot",
     "personas-character-attachments",
     "ccp-persona-card-view",
-    "ccp-persona-editor-view",
+    "personas-persona-editor-slot",
     "personas-conversation-actions",
-    "personas-dictionary-detail",
-    "personas-lore-detail",
+    "personas-dictionary-detail-slot",
+    "personas-lore-detail-slot",
     "personas-conversation-transcript-view",
     "personas-mode-placeholder",
     "personas-characters-empty",
@@ -80,9 +78,8 @@ async def test_first_paint_excludes_the_four_heavy_center_views(monkeypatch):
         )
 
 
-async def test_load_mounts_all_four_hidden_in_document_order():
-    """After the real load, the full DOM exists exactly as compose built it
-    pre-change: every deferred view present, hidden, in historical order."""
+async def test_settled_initial_load_keeps_heavy_views_unmounted():
+    """The real load must settle without constructing inactive heavy bodies."""
     from Tests.UI.app_factory import _build_test_app
 
     app = _build_test_app()
@@ -94,12 +91,38 @@ async def test_load_mounts_all_four_hidden_in_document_order():
             await pilot.pause()
 
         for deferred_type in _DEFERRED_TYPES:
-            found = list(screen.query(deferred_type))
-            assert len(found) == 1, f"{deferred_type.__name__} missing after load"
-            assert found[0].display is False, (
-                f"{deferred_type.__name__} arrived visible — it must stay "
-                "hidden until _show_center reveals it"
+            assert not list(screen.query(deferred_type)), (
+                f"{deferred_type.__name__} mounted during initial load — "
+                "inactive bodies must wait for first use"
             )
 
         stack = screen.query_one("#personas-detail-stack")
         assert [child.id for child in stack.children] == _EXPECTED_STACK_ORDER
+
+
+async def test_first_use_mounts_only_requested_view_and_caches_it():
+    """One requested body mounts once and retains its in-screen form state."""
+    from Tests.UI.app_factory import _build_test_app
+
+    app = _build_test_app()
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        screen = PersonasScreen(app)
+        await app.push_screen(screen)
+        for _ in range(6):
+            await pilot.pause()
+
+        first = await screen._ensure_center_view("character-editor")
+        assert isinstance(first, PersonasCharacterEditorWidget)
+        name = first.query_one("#personas-char-editor-name", Input)
+        name.value = "Keep this draft"
+
+        second = await screen._ensure_center_view("character-editor")
+
+        assert second is first
+        assert second.query_one("#personas-char-editor-name", Input).value == (
+            "Keep this draft"
+        )
+        assert not list(screen.query(PersonaProfileEditorWidget))
+        assert not list(screen.query(PersonasDictionaryDetailWidget))
+        assert not list(screen.query(PersonasLoreDetailWidget))

--- a/Tests/UI/test_personas_deferred_center_views.py
+++ b/Tests/UI/test_personas_deferred_center_views.py
@@ -161,6 +161,55 @@ async def test_concurrent_first_use_builds_and_mounts_one_view(monkeypatch):
         assert len(list(screen.query(PersonasCharacterEditorWidget))) == 1
 
 
+async def test_concurrent_caller_waits_until_mounted_view_is_hydrated(monkeypatch):
+    """A queryable-but-unready body must not escape the per-view lock."""
+    from Tests.UI.app_factory import _build_test_app
+
+    app = _build_test_app()
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        screen = PersonasScreen(app)
+        await app.push_screen(screen)
+        await pilot.pause()
+        slot = screen.query_one("#personas-character-editor-slot", Vertical)
+        real_mount = slot.mount
+        real_hydrate = screen._hydrate_center_view
+        mounted = asyncio.Event()
+        release = asyncio.Event()
+        hydration_attempts = 0
+
+        async def mount_then_pause(*widgets, **kwargs):
+            result = await real_mount(*widgets, **kwargs)
+            mounted.set()
+            await release.wait()
+            return result
+
+        def fail_first_hydration(view_key: str, view):
+            nonlocal hydration_attempts
+            hydration_attempts += 1
+            if hydration_attempts == 1:
+                raise RuntimeError("first hydration failed")
+            real_hydrate(view_key, view)
+
+        monkeypatch.setattr(slot, "mount", mount_then_pause)
+        monkeypatch.setattr(screen, "_hydrate_center_view", fail_first_hydration)
+        first = asyncio.create_task(screen._ensure_center_view("character-editor"))
+        await mounted.wait()
+        second = asyncio.create_task(screen._ensure_center_view("character-editor"))
+        await asyncio.sleep(0)
+        escaped_before_hydration = second.done()
+        release.set()
+
+        assert await first is None
+        ready = await second
+
+        assert not escaped_before_hydration
+        assert isinstance(ready, PersonasCharacterEditorWidget)
+        assert ready.is_mounted
+        assert hydration_attempts == 2
+        assert len(list(screen.query(PersonasCharacterEditorWidget))) == 1
+
+
 async def test_transient_mount_failure_remains_retryable(monkeypatch):
     """A failed attempt owns no ready state and a later attempt can succeed."""
     from Tests.UI.app_factory import _build_test_app

--- a/Tests/UI/test_personas_dictionaries.py
+++ b/Tests/UI/test_personas_dictionaries.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from textual.app import App
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
@@ -1062,6 +1061,9 @@ class TestDictionarySelection:
             await pilot.pause()
             detail = screen.query_one(PersonasDictionaryDetailWidget)
             assert detail.display is True
+            assert not list(screen.query("#ccp-character-editor-view"))
+            assert not list(screen.query("#ccp-persona-editor-view"))
+            assert not list(screen.query("#personas-lore-detail"))
             assert (
                 screen.query_one("#personas-dict-name", Input).value == "Medical Abbrev"
             )

--- a/Tests/UI/test_personas_expression_generate.py
+++ b/Tests/UI/test_personas_expression_generate.py
@@ -1701,7 +1701,7 @@ async def test_style_pick_reset_on_edit_requested_reopen(
     screen._expression_generate_style = template
     screen._update_expression_style_readout()
 
-    screen._handle_edit_requested(EditCharacterRequested(str(char_id)))
+    await screen._handle_edit_requested(EditCharacterRequested(str(char_id)))
 
     assert screen._expression_generate_style is None
     editor = screen.query_one(PersonasCharacterEditorWidget)

--- a/Tests/UI/test_personas_expression_slots.py
+++ b/Tests/UI/test_personas_expression_slots.py
@@ -485,12 +485,12 @@ async def test_fresh_personas_screen_reentry_never_overlaps_sync_resolution(
     await app.push_screen(second_screen)
     for _ in range(100):
         await asyncio.sleep(0.01)
-        if second_screen.query("#personas-character-editor-tts #label"):
+        if second_screen.query("#personas-library-rows"):
             break
     else:
-        pytest.fail("second PersonasScreen descendants never finished mounting")
+        pytest.fail("second PersonasScreen shell never finished mounting")
     await second_screen._select_character(str(char_id), "Packed")
-    second_screen._handle_edit_requested(EditCharacterRequested(str(char_id)))
+    await second_screen._handle_edit_requested(EditCharacterRequested(str(char_id)))
     await app.workers.wait_for_complete()
     second_browser = second_screen.query_one(PersonasVisualIdentityPackWidget)
     original_resolve = personas_screen_module.resolve_visual_identity

--- a/Tests/UI/test_personas_lore.py
+++ b/Tests/UI/test_personas_lore.py
@@ -734,8 +734,8 @@ class TestLoreModeIntegration:
             assert (
                 screen.query_one("#personas-mode-placeholder", Static).display is False
             )
-            # The detail widget is mounted but stays hidden until a book is selected.
-            assert screen.query_one(PersonasLoreDetailWidget).display is False
+            # The heavy detail widget is not mounted until a book is selected.
+            assert not list(screen.query(PersonasLoreDetailWidget))
             rows = screen.query_one("#personas-library-rows", ListView).children
             texts = [str(s.renderable) for r in rows for s in r.query(Static).results()]
             assert "Blackreach" in texts
@@ -751,6 +751,9 @@ class TestLoreModeIntegration:
             await _select_first_lore(pilot, screen)
             detail = screen.query_one(PersonasLoreDetailWidget)
             assert detail.display is True
+            assert not list(screen.query("#ccp-character-editor-view"))
+            assert not list(screen.query("#ccp-persona-editor-view"))
+            assert not list(screen.query("#personas-dictionary-detail"))
             table = screen.query_one("#personas-lore-entries-table", DataTable)
             assert table.row_count == 1
             assert detail.settings_payload()["name"] == "Blackreach"

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -10568,6 +10568,7 @@ class TestPersonaHumanIdentityRemoval:
             stub_scope_service.list_persona_profiles = AsyncMock(
                 return_value={"items": [renamed], "total": 1}
             )
+            await screen._ensure_center_view("persona-editor")
             await screen._after_profile_save({"id": "p-1", "name": "Chronicler"})
             await pilot.pause()
             assert screen.state.selected_entity_name == "Chronicler"

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -12392,6 +12392,8 @@ async def test_character_tts_population_requires_one_generation_and_observes_off
         assert screen._character_tts_snapshot is not None
         assert screen._character_tts_snapshot.repository_generation == 7
         card_control = screen.query_one("#personas-character-card-tts")
+        assert not list(screen.query("#personas-character-editor-tts"))
+        await screen._ensure_center_view("character-editor")
         editor_control = screen.query_one("#personas-character-editor-tts")
         assert card_control.presentation_state.selected_profile_id == (
             assigned_profile.profile_id

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -1156,7 +1156,7 @@ class TestCharacterSelectionAndEdit:
             screen.post_message(EditCharacterRequested(2))
             await pilot.pause()
             assert screen._edit_mode == "view"
-            assert screen.query_one("#ccp-character-editor-view").display is False
+            assert not list(screen.query("#ccp-character-editor-view"))
 
     async def test_mode_switch_during_save_does_not_render_character_into_other_mode(
         self, mock_app_instance, stub_characters, monkeypatch
@@ -2562,8 +2562,7 @@ class TestImportExport:
             await screen._stage_character_avatar_from_path(str(avatar))
             await pilot.pause()
 
-            editor = screen.query_one(PersonasCharacterEditorWidget)
-            assert "image" not in editor.get_character_data()
+            assert not list(screen.query(PersonasCharacterEditorWidget))
             assert screen.state.has_unsaved_changes is False
             assert any("Open a character editor" in msg for msg, _ in notifications)
 

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -6135,6 +6135,7 @@ class TestConsoleActions:
                 screen.character_handler, "load_character", load_character
             )
 
+            await screen._ensure_center_view("character-editor")
             await screen._after_character_save("1", "Detective Sam")
             await pilot.pause()
 
@@ -6170,6 +6171,7 @@ class TestConsoleActions:
 
             monkeypatch.setattr(screen, "_render_profile_rows", observe_render_rows)
 
+            await screen._ensure_center_view("persona-editor")
             await screen._after_profile_save({"id": "p-1", "name": "Archivist"})
             await pilot.pause()
 

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -5544,14 +5544,14 @@ class TestConversationsPanel:
             )
             resume = screen.query_one("#personas-conversation-resume", Button)
 
-            await pilot.click("#personas-conversation-resume")
+            resume.press()
             await pilot.pause()
             assert len(callbacks) == 1
             callbacks[0]()
             assert resume.disabled is False
             await pilot.pause()
 
-            await pilot.click("#personas-conversation-resume")
+            resume.press()
             await pilot.pause()
             assert len(callbacks) == 2
             callbacks[0]()

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -927,6 +927,9 @@ class TestCharacterSelectionAndEdit:
             assert screen._edit_mode == "create"
             editor = screen.query_one("#ccp-character-editor-view")
             assert editor.display is True
+            assert not list(screen.query("#ccp-persona-editor-view"))
+            assert not list(screen.query("#personas-dictionary-detail"))
+            assert not list(screen.query("#personas-lore-detail"))
             selected_name = str(
                 screen.query_one("#personas-selected-name", Static).renderable
             )
@@ -1346,6 +1349,9 @@ class TestPersonasMode:
             # read-only card).
             assert screen._edit_mode == "edit"
             assert screen.query_one("#ccp-persona-editor-view").display is True
+            assert not list(screen.query("#ccp-character-editor-view"))
+            assert not list(screen.query("#personas-dictionary-detail"))
+            assert not list(screen.query("#personas-lore-detail"))
 
     async def test_profile_save_refresh_failure_updates_purpose_line_and_recovery(
         self, mock_app_instance, stub_characters, stub_scope_service
@@ -6871,7 +6877,7 @@ class TestServerCharacterSourceIsolation:
             save_worker = Mock()
             screen._full_character_record = full_record
             screen._save_character_worker = save_worker
-            screen._handle_edit_requested(EditCharacterRequested("7"))
+            await screen._handle_edit_requested(EditCharacterRequested("7"))
             screen._handle_save_requested(
                 CharacterSaveRequested({"name": "Must stay remote"})
             )

--- a/Tests/UI/test_personas_workbench_state.py
+++ b/Tests/UI/test_personas_workbench_state.py
@@ -560,6 +560,9 @@ class TestNonCharacterModeRestore:
             assert (
                 screen2.query_one("#personas-dictionary-detail").display is True
             )
+            assert not list(screen2.query("#ccp-character-editor-view"))
+            assert not list(screen2.query("#ccp-persona-editor-view"))
+            assert not list(screen2.query("#personas-lore-detail"))
 
     async def test_saved_personas_mode_restores_mode_and_selection(
         self, mock_app_instance, stub_characters
@@ -601,6 +604,10 @@ class TestNonCharacterModeRestore:
             assert screen2.state.selected_entity_kind == "persona"
             assert screen2._pending_restore is None
             assert screen2.query_one("#ccp-persona-card-view").display is True
+            assert not list(screen2.query("#ccp-character-editor-view"))
+            assert not list(screen2.query("#ccp-persona-editor-view"))
+            assert not list(screen2.query("#personas-dictionary-detail"))
+            assert not list(screen2.query("#personas-lore-detail"))
 
 
 class TestInvalidRestoreStillAutoSelects:

--- a/backlog/decisions/115-personas-demand-mounted-center-views.md
+++ b/backlog/decisions/115-personas-demand-mounted-center-views.md
@@ -1,0 +1,105 @@
+# ADR-115: Demand-mount heavy Personas center views
+
+Status: Proposed
+Date: 2026-09-03
+Related Task: TASK-31215
+Extends: ADR-007
+
+## Decision
+
+The Personas destination will compose four stable, lightweight center-view slots
+but will not construct or mount their heavy bodies during initial load:
+
+- character editor;
+- persona profile editor;
+- dictionary detail/editor; and
+- lore detail/editor.
+
+`PersonasScreen` owns a single asynchronous first-use boundary that maps each
+heavy view identity to its slot and widget factory. The boundary mounts at most
+one instance of a requested view, coalesces concurrent requests for that view,
+and keeps the mounted widget cached for the remainder of the screen lifetime.
+A failed mount does not mark the view ready and a later user action may retry it.
+
+The initial Characters card, library rail, preview, inspector, attachments, and
+conversation surfaces remain eager because they form the usable default route.
+Switching modes alone does not mount an editor or detail body. A body is requested
+only by a workflow that needs it: character/persona create or edit, or
+dictionary/lore selection, create, edit, or restore.
+
+Existing public widget IDs remain on the heavy widget roots. The new slot IDs are
+internal layout anchors. Existing workflow code may continue querying a heavy
+widget only after its owning async entry point has crossed the first-use boundary.
+The mount boundary applies view-specific retained state, such as the current
+persona runtime source, before returning the widget to the caller.
+
+Restore and handoff inputs remain screen-owned while a view is absent. The owning
+workflow first validates that its requested body is mounted and still belongs to
+the current screen generation, then applies selection/editor state. Unmounting
+invalidates the generation so late mount or hydration continuations cannot mutate
+a detached or replacement screen.
+
+## Context
+
+TASK-2725 established that Roleplay/Personas latency is dominated by Textual
+widget mounting and CSS application, not database I/O. It moved four heavy views
+past first paint, reducing the visible navigation delay, but `_load_after_mount`
+still mounts all four before restoring or selecting data. A current mounted census
+found 574 descendants at settle and 458 effectively hidden. The four deferred
+roots account for 350 hidden descendants: 140 in the character editor, 83 in the
+persona editor, 67 in dictionary detail, and 60 in lore detail.
+
+The same first-use strategy removed the apparent Lab > Models freeze in
+TASK-31002. Personas has additional selection, restore, runtime-source, and
+Console-handoff state, so its lifecycle must be explicit rather than implemented
+as an uncoordinated set of missing-widget catches.
+
+ADR-007 makes the top-level Personas route the durable owner of these workflows.
+This decision stays within that destination while defining when its expensive
+presentation bodies exist.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Keep mounting all four bodies immediately after first paint | It preserves every historical query assumption but still blocks the post-paint load worker on hundreds of hidden descendants and reproduces the freeze-like arrival. |
+| Schedule the existing batch mount after an idle delay | It merely moves the same mount storm later, can interrupt the user's first interaction, and still constructs views the user may never open. |
+| Add defensive `query_one` handling at every current call site | More than 80 queries would each encode lifecycle policy, making restore, retry, and teardown ordering inconsistent and difficult to review. |
+| Recompose and discard a body whenever its mode changes | It lowers steady widget count but destroys unsaved editor state, focus, results, and worker presentation; repeated switching also repays the mount cost. |
+| Use `textual.lazy.Lazy` without a screen-owned boundary | It does not define when restore and action handlers may safely query descendants and does not provide the required retry and generation-fencing behavior. |
+
+## Consequences
+
+- Initial Personas navigation pays only for the usable default route rather than
+  every authoring surface.
+- First use of a heavy workflow pays that view's one-time mount cost; later uses
+  preserve widget identity and unsaved in-screen state.
+- Async workflow entry points become the lifecycle boundary. Direct calls that
+  bypass them are unsupported and should be caught by focused tests.
+- Stable slots add four lightweight widgets and one internal mapping, but avoid
+  layout-anchor churn and preserve the established center-view order.
+- A mount failure is recoverable and isolated to the requested workflow; it does
+  not crash the application or consume readiness state.
+- No storage schema, provider/runtime contract, or user-visible information
+  architecture changes.
+
+## Verification Contract
+
+The implementation must prove:
+
+1. initial load settles with none of the four heavy bodies mounted;
+2. first use mounts only the requested body and repeated/concurrent requests reuse
+   the same widget;
+3. all character, persona, dictionary, and lore entry paths cross the boundary
+   before querying their heavy view;
+4. restore/deep-link state is applied only after the required body is ready;
+5. transient failure can retry and teardown invalidates late work; and
+6. a production-CSS heartbeat records no event-loop stall above the repository's
+   250 ms threshold while opening Personas.
+
+## Links
+
+- [TASK-31215](../tasks/task-31215%20-%20Personas-mount-heavy-center-views-on-first-use.md)
+- [TASK-2725](../tasks/task-2725%20-%20Roleplay%20screen%20switch%20takes%202s%20where%20every%20other%20screen%20takes%20under%201s.md)
+- [TASK-31002](../tasks/task-31002%20-%20Models-mount-only-the-active-provider-view.md)
+- [Design specification](../../Docs/superpowers/specs/2026-09-03-personas-demand-mounted-center-views-design.md)

--- a/backlog/decisions/115-personas-demand-mounted-center-views.md
+++ b/backlog/decisions/115-personas-demand-mounted-center-views.md
@@ -31,7 +31,8 @@ Existing public widget IDs remain on the heavy widget roots. The new slot IDs ar
 internal layout anchors. Existing workflow code may continue querying a heavy
 widget only after its owning async entry point has crossed the first-use boundary.
 The mount boundary applies view-specific retained state, such as the current
-persona runtime source, before returning the widget to the caller.
+persona runtime source and character TTS presentation, before returning the widget
+to the caller.
 
 Restore and handoff inputs remain screen-owned while a view is absent. The owning
 workflow first validates that its requested body is mounted and still belongs to

--- a/backlog/decisions/115-personas-demand-mounted-center-views.md
+++ b/backlog/decisions/115-personas-demand-mounted-center-views.md
@@ -1,6 +1,6 @@
 # ADR-115: Demand-mount heavy Personas center views
 
-Status: Proposed
+Status: Accepted
 Date: 2026-09-03
 Related Task: TASK-31215
 Extends: ADR-007

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -10967,3 +10967,17 @@ budget collapse, not flake — reproduce by calling
 `build_first_request_schema_plan` directly and printing `used` vs the
 reserve before dismissing or "fixing" the test. Structural fix tracked in
 TASK-31212.
+
+## A painted Textual editor can still be outside its hit-testable layout
+
+Incident (TASK-31215, 2026-09-03): demand-mounted Personas editors initially
+used auto-height wrapper slots around editor roots that own `height: 100%`.
+Widget queries and paint-based assertions passed, but real actor-pack button
+clicks were ignored because the controls were outside the wrapper's effective
+hit-testable geometry. Giving the stable slot its natural container height
+restored both full-height layout and pointer dispatch.
+
+Rule: when introducing a wrapper around an existing full-height Textual view,
+verify it with a real pointer-driven workflow, not only widget queries,
+visibility flags, or screenshots. Painted descendants do not prove their
+ancestor geometry participates in hit testing.

--- a/backlog/tasks/task-31215 - Personas-mount-heavy-center-views-on-first-use.md
+++ b/backlog/tasks/task-31215 - Personas-mount-heavy-center-views-on-first-use.md
@@ -1,0 +1,36 @@
+---
+id: TASK-31215
+title: Personas mount heavy center views on first use
+status: To Do
+assignee: []
+created_date: '2026-09-04 00:23'
+updated_date: '2026-09-04 00:26'
+labels:
+  - roleplay
+  - performance
+dependencies: []
+references:
+  - >-
+    backlog/tasks/task-2725 - Roleplay screen switch takes 2s where every other
+    screen takes under 1s.md
+  - backlog/tasks/task-31002 - Models-mount-only-the-active-provider-view.md
+  - backlog/decisions/115-personas-demand-mounted-center-views.md
+  - >-
+    Docs/superpowers/specs/2026-09-03-personas-demand-mounted-center-views-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Remove the remaining Roleplay navigation stall by keeping the four heavy inactive center views out of the post-first-paint load path and mounting each only when its workflow is first activated, without losing restore, selection, editor, or Console-handoff state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Opening Personas reaches a usable initial Characters surface without mounting any inactive heavy center view.
+- [ ] #2 First use mounts only the requested heavy view and revisiting reuses the same widget state.
+- [ ] #3 Restore and deep-link intents replay after the required view is ready without applying stale state to another view.
+- [ ] #4 Transient mount failures remain retryable and leaving the screen prevents stale callbacks from mutating detached UI.
+- [ ] #5 Targeted Personas lifecycle and four-mode workflow tests pass, and a production-CSS responsiveness regression stays under the 250 ms event-loop-stall threshold.
+<!-- AC:END -->

--- a/backlog/tasks/task-31215 - Personas-mount-heavy-center-views-on-first-use.md
+++ b/backlog/tasks/task-31215 - Personas-mount-heavy-center-views-on-first-use.md
@@ -4,7 +4,7 @@ title: Personas mount heavy center views on first use
 status: Done
 assignee: []
 created_date: '2026-09-04 00:23'
-updated_date: '2026-09-04 02:34'
+updated_date: '2026-09-04 02:50'
 labels:
   - roleplay
   - performance
@@ -56,4 +56,6 @@ Reason: the change defines the long-lived lifecycle and restore/admission contra
 Implemented screen-owned, first-use mounting for the character editor, persona editor, dictionary manager, and lore manager. Stable lightweight slots preserve document order while per-view locks, cached instances, retryable mount failures, and lifecycle-generation checks protect concurrent activation and teardown. Character/persona creation and editing, actor packs, dictionary/lore workflows, restore intents, runtime-source hydration, and character TTS presentation now cross the exact view admission boundary before mutating widget state. A natural-height slot replaced the planned auto-height wrapper after real pointer testing exposed painted but non-hit-testable controls. Verification: 378 Personas Workbench tests, 246 other affected Personas tests, and 6 architecture checks passed (630 targeted tests total); the production-CSS heartbeat regression enforces a sub-250 ms event-loop stall; compileall, Ruff lint/format checks, and git diff whitespace checks passed. The full repository suite was not run, per the repository targeted-test policy.
 
 PR #2364 review follow-up: verified Qodo's concurrency finding with a red-first regression that pauses after DOM mount but before hydration. Replaced queryability-based reuse with an explicit ready-view cache published only after hydration and cleared on unmount, so concurrent callers remain behind the per-view lock and a failed hydration is retried safely. Added the required on_unmount lifecycle docstring. Post-fix verification: 247 affected workflow/lifecycle tests and 378 Workbench tests passed (625 total); compileall, Ruff lint/format, and git diff whitespace checks passed.
+
+CI follow-up: the Derived Artifacts gate correctly detected the intentional new bounded mount-failure warning in personas_screen.py. The statement-level diagnostic audit confirmed the call interpolates only the internal allowlisted view key and contains no user content, secret, path, or URL. Regenerated Docs/security/production-diagnostic-inventory.json; the inventory checker passes with 568 owners, 1,337 TASK-492 calls, 7,568 TASK-494 calls, and 10 sink files.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31215 - Personas-mount-heavy-center-views-on-first-use.md
+++ b/backlog/tasks/task-31215 - Personas-mount-heavy-center-views-on-first-use.md
@@ -4,7 +4,7 @@ title: Personas mount heavy center views on first use
 status: Done
 assignee: []
 created_date: '2026-09-04 00:23'
-updated_date: '2026-09-04 01:56'
+updated_date: '2026-09-04 02:34'
 labels:
   - roleplay
   - performance
@@ -54,4 +54,6 @@ Reason: the change defines the long-lived lifecycle and restore/admission contra
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented screen-owned, first-use mounting for the character editor, persona editor, dictionary manager, and lore manager. Stable lightweight slots preserve document order while per-view locks, cached instances, retryable mount failures, and lifecycle-generation checks protect concurrent activation and teardown. Character/persona creation and editing, actor packs, dictionary/lore workflows, restore intents, runtime-source hydration, and character TTS presentation now cross the exact view admission boundary before mutating widget state. A natural-height slot replaced the planned auto-height wrapper after real pointer testing exposed painted but non-hit-testable controls. Verification: 378 Personas Workbench tests, 246 other affected Personas tests, and 6 architecture checks passed (630 targeted tests total); the production-CSS heartbeat regression enforces a sub-250 ms event-loop stall; compileall, Ruff lint/format checks, and git diff whitespace checks passed. The full repository suite was not run, per the repository targeted-test policy.
+
+PR #2364 review follow-up: verified Qodo's concurrency finding with a red-first regression that pauses after DOM mount but before hydration. Replaced queryability-based reuse with an explicit ready-view cache published only after hydration and cleared on unmount, so concurrent callers remain behind the per-view lock and a failed hydration is retried safely. Added the required on_unmount lifecycle docstring. Post-fix verification: 247 affected workflow/lifecycle tests and 378 Workbench tests passed (625 total); compileall, Ruff lint/format, and git diff whitespace checks passed.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31215 - Personas-mount-heavy-center-views-on-first-use.md
+++ b/backlog/tasks/task-31215 - Personas-mount-heavy-center-views-on-first-use.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-31215
 title: Personas mount heavy center views on first use
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-04 00:23'
-updated_date: '2026-09-04 00:49'
+updated_date: '2026-09-04 01:56'
 labels:
   - roleplay
   - performance
@@ -29,11 +29,11 @@ Remove the remaining Roleplay navigation stall by keeping the four heavy inactiv
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Opening Personas reaches a usable initial Characters surface without mounting any inactive heavy center view.
-- [ ] #2 First use mounts only the requested heavy view and revisiting reuses the same widget state.
-- [ ] #3 Restore and deep-link intents replay after the required view is ready without applying stale state to another view.
-- [ ] #4 Transient mount failures remain retryable and leaving the screen prevents stale callbacks from mutating detached UI.
-- [ ] #5 Targeted Personas lifecycle and four-mode workflow tests pass, and a production-CSS responsiveness regression stays under the 250 ms event-loop-stall threshold.
+- [x] #1 Opening Personas reaches a usable initial Characters surface without mounting any inactive heavy center view.
+- [x] #2 First use mounts only the requested heavy view and revisiting reuses the same widget state.
+- [x] #3 Restore and deep-link intents replay after the required view is ready without applying stale state to another view.
+- [x] #4 Transient mount failures remain retryable and leaving the screen prevents stale callbacks from mutating detached UI.
+- [x] #5 Targeted Personas lifecycle and four-mode workflow tests pass, and a production-CSS responsiveness regression stays under the 250 ms event-loop-stall threshold.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -49,3 +49,9 @@ ADR required: yes
 ADR path: backlog/decisions/115-personas-demand-mounted-center-views.md
 Reason: the change defines the long-lived lifecycle and restore/admission contract shared by the Personas screen and its four authoring widgets.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented screen-owned, first-use mounting for the character editor, persona editor, dictionary manager, and lore manager. Stable lightweight slots preserve document order while per-view locks, cached instances, retryable mount failures, and lifecycle-generation checks protect concurrent activation and teardown. Character/persona creation and editing, actor packs, dictionary/lore workflows, restore intents, runtime-source hydration, and character TTS presentation now cross the exact view admission boundary before mutating widget state. A natural-height slot replaced the planned auto-height wrapper after real pointer testing exposed painted but non-hit-testable controls. Verification: 378 Personas Workbench tests, 246 other affected Personas tests, and 6 architecture checks passed (630 targeted tests total); the production-CSS heartbeat regression enforces a sub-250 ms event-loop stall; compileall, Ruff lint/format checks, and git diff whitespace checks passed. The full repository suite was not run, per the repository targeted-test policy.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31215 - Personas-mount-heavy-center-views-on-first-use.md
+++ b/backlog/tasks/task-31215 - Personas-mount-heavy-center-views-on-first-use.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-31215
 title: Personas mount heavy center views on first use
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-09-04 00:23'
-updated_date: '2026-09-04 00:26'
+updated_date: '2026-09-04 00:49'
 labels:
   - roleplay
   - performance
@@ -17,6 +17,7 @@ references:
   - backlog/decisions/115-personas-demand-mounted-center-views.md
   - >-
     Docs/superpowers/specs/2026-09-03-personas-demand-mounted-center-views-design.md
+  - Docs/superpowers/plans/2026-09-03-personas-demand-mounted-center-views.md
 priority: high
 ---
 
@@ -34,3 +35,17 @@ Remove the remaining Roleplay navigation stall by keeping the four heavy inactiv
 - [ ] #4 Transient mount failures remain retryable and leaving the screen prevents stale callbacks from mutating detached UI.
 - [ ] #5 Targeted Personas lifecycle and four-mode workflow tests pass, and a production-CSS responsiveness regression stays under the 250 ms event-loop-stall threshold.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add red-first mounted tests proving real initial load leaves all four heavy roots absent and stable slots preserve document order.
+2. Implement screen-owned first-use construction, mount, cache, hydration, retry, and lifecycle-generation behavior.
+3. Add red-first workflow tests and route character/persona create/edit plus dictionary/lore select/create/edit/restore through the exact view admission boundary.
+4. Add concurrency, transient-failure, teardown, and production-CSS 250 ms heartbeat regressions.
+5. Run focused Personas and architecture verification, scoped static checks, self-review, and close the task with measured evidence.
+
+ADR required: yes
+ADR path: backlog/decisions/115-personas-demand-mounted-center-views.md
+Reason: the change defines the long-lived lifecycle and restore/admission contract shared by the Personas screen and its four authoring widgets.
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -25,6 +25,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.css.query import QueryError
 from textual.timer import Timer
+from textual.widget import Widget
 from textual.worker import Worker
 from textual.widgets import (
     Button,
@@ -622,6 +623,22 @@ _CENTER_VIEW_IDS: tuple[str, ...] = (
     "#personas-characters-empty",
 )
 
+# TASK-31215: the four expensive center bodies keep their established root IDs,
+# while these stable lightweight slots preserve the detail stack's document
+# order before a workflow first needs them.
+_DEMAND_CENTER_VIEW_ROOTS: dict[str, str] = {
+    "character-editor": "#ccp-character-editor-view",
+    "persona-editor": "#ccp-persona-editor-view",
+    "dictionary-detail": "#personas-dictionary-detail",
+    "lore-detail": "#personas-lore-detail",
+}
+_DEMAND_CENTER_VIEW_SLOTS: dict[str, str] = {
+    "character-editor": "#personas-character-editor-slot",
+    "persona-editor": "#personas-persona-editor-slot",
+    "dictionary-detail": "#personas-dictionary-detail-slot",
+    "lore-detail": "#personas-lore-detail-slot",
+}
+
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class _CharacterVisualIdentityLoadSnapshot:
@@ -1159,6 +1176,10 @@ class PersonasScreen(BaseAppScreen):
         self._pending_restore: dict | None = None
         self._edit_mode: str = "view"
         self._guard_active: bool = False
+        self._center_view_lifecycle_generation = 0
+        self._center_view_mount_locks = {
+            view_key: asyncio.Lock() for view_key in _DEMAND_CENTER_VIEW_ROOTS
+        }
         # Refuse-reentry flag for the import/export file dialogs. Cancelling
         # an in-flight dialog worker (exclusive=True) would orphan a modal
         # pushed via push_screen_wait, whose dismissal then calls
@@ -1393,21 +1414,27 @@ class PersonasScreen(BaseAppScreen):
                     # the old bottom-docked wrapper, which let the two
                     # empty panels displace the card at 100x30 and left a
                     # dead void between them at 170x50.)
-                    # task-2725: the four heavy hidden center views (character
-                    # editor, persona editor, dictionary/lore detail — 290 of
-                    # this screen's ~494 widgets) are NOT composed here. They
-                    # mount hidden, order-anchored, as the first step of
-                    # `_load_after_mount` (`_mount_deferred_center_views`),
-                    # taking their CSS-application cost off the click→paint
-                    # critical path. `_show_center` skips absent selectors and
-                    # `_editor_or_none` returns None, so the compose→load
-                    # window is tolerated by design.
+                    # TASK-31215: stable, zero-demand slots preserve the
+                    # historical document order while their four expensive
+                    # bodies remain absent until a workflow first needs one.
                     with VerticalScroll(id="personas-detail-stack"):
                         yield PersonasCharacterCardWidget()
+                        character_editor_slot = Vertical(
+                            id="personas-character-editor-slot"
+                        )
+                        character_editor_slot.display = False
+                        character_editor_slot.styles.height = "auto"
+                        character_editor_slot.styles.width = "100%"
+                        yield character_editor_slot
                         with Vertical(id="personas-character-attachments"):
                             yield PersonasCharacterDictionariesWidget()
                             yield PersonasCharacterWorldBooksWidget()
                         yield PersonaProfileCardWidget()
+                        persona_editor_slot = Vertical(id="personas-persona-editor-slot")
+                        persona_editor_slot.display = False
+                        persona_editor_slot.styles.height = "auto"
+                        persona_editor_slot.styles.width = "100%"
+                        yield persona_editor_slot
                         with Vertical(id="personas-conversation-actions"):
                             yield Button(
                                 "Resume chat",
@@ -1435,6 +1462,18 @@ class PersonasScreen(BaseAppScreen):
                                     id="personas-conversation-open-library",
                                     classes="console-action-subdued",
                                 )
+                        dictionary_detail_slot = Vertical(
+                            id="personas-dictionary-detail-slot"
+                        )
+                        dictionary_detail_slot.display = False
+                        dictionary_detail_slot.styles.height = "auto"
+                        dictionary_detail_slot.styles.width = "100%"
+                        yield dictionary_detail_slot
+                        lore_detail_slot = Vertical(id="personas-lore-detail-slot")
+                        lore_detail_slot.display = False
+                        lore_detail_slot.styles.height = "auto"
+                        lore_detail_slot.styles.width = "100%"
+                        yield lore_detail_slot
                         yield PersonasConversationTranscriptWidget()
                         yield Static(
                             self._mode_placeholder_text("prompts"),
@@ -1678,41 +1717,83 @@ class PersonasScreen(BaseAppScreen):
             exclusive=True,
         )
 
-    async def _mount_deferred_center_views(self) -> None:
-        """Mount the four heavy hidden center views after first paint.
+    @staticmethod
+    def _build_center_view(view_key: str) -> Widget:
+        """Construct one heavy Personas center body for first-use mounting."""
+        if view_key == "character-editor":
+            return PersonasCharacterEditorWidget()
+        if view_key == "persona-editor":
+            return PersonaProfileEditorWidget()
+        if view_key == "dictionary-detail":
+            return PersonasDictionaryDetailWidget(id="personas-dictionary-detail")
+        if view_key == "lore-detail":
+            return PersonasLoreDetailWidget(id="personas-lore-detail")
+        raise ValueError(f"Unknown Personas center view: {view_key}")
 
-        task-2725: profiling showed the Roleplay switch cost is widget-mount
-        CSS application, and 290 of the detail stack's 358 widgets sit in
-        views that arrive hidden (`display: False`) anyway. Mounting them
-        here — as `_load_after_mount`'s first step, before
-        `_apply_pending_restore` and auto-select — keeps every downstream
-        query site valid while taking them off the click→paint critical
-        path. Each mounts hidden and order-anchored so the stack's document
-        (scroll) order is exactly what compose used to produce; `_show_
-        center` owns visibility from then on. Idempotent: a re-entered load
-        (e.g. runtime-source switch re-running `_load_after_mount`) skips
-        mounting.
-        """
+    def _mounted_center_view(self, view_key: str) -> Widget | None:
+        """Return a requested heavy root when it is already mounted."""
+        selector = _DEMAND_CENTER_VIEW_ROOTS.get(view_key)
+        if selector is None:
+            raise ValueError(f"Unknown Personas center view: {view_key}")
         try:
-            stack = self.query_one("#personas-detail-stack", VerticalScroll)
+            return self.query_one(selector)
         except QueryError:
-            return
-        if self.query(PersonasCharacterEditorWidget):
-            return
+            return None
 
-        character_editor = PersonasCharacterEditorWidget()
-        persona_editor = PersonaProfileEditorWidget()
-        dictionary_detail = PersonasDictionaryDetailWidget(
-            id="personas-dictionary-detail"
-        )
-        lore_detail = PersonasLoreDetailWidget(id="personas-lore-detail")
-        for view in (character_editor, persona_editor, dictionary_detail, lore_detail):
-            view.display = False
+    def _hydrate_center_view(self, view_key: str, view: Widget) -> None:
+        """Apply screen-owned retained state before a new body is used."""
+        if view_key == "persona-editor" and isinstance(
+            view, PersonaProfileEditorWidget
+        ):
+            view.set_runtime_source(self.persona_handler.current_mode())
 
-        await stack.mount(character_editor, after="#ccp-character-card-view")
-        await stack.mount(persona_editor, after="#ccp-persona-card-view")
-        await stack.mount(dictionary_detail, after="#personas-conversation-actions")
-        await stack.mount(lore_detail, after="#personas-dictionary-detail")
+    async def _ensure_center_view(self, view_key: str) -> Widget | None:
+        """Mount, hydrate, and cache one heavy center view on first use.
+
+        Concurrent requests for one body serialize through its lock and reuse
+        the first successful widget. Failures leave no readiness marker, so a
+        later user action can retry. A lifecycle-generation check prevents a
+        mount that finishes during teardown from hydrating detached UI.
+        """
+        if view_key not in _DEMAND_CENTER_VIEW_ROOTS:
+            raise ValueError(f"Unknown Personas center view: {view_key}")
+        existing = self._mounted_center_view(view_key)
+        if existing is not None:
+            return existing
+
+        async with self._center_view_mount_locks[view_key]:
+            existing = self._mounted_center_view(view_key)
+            if existing is not None:
+                return existing
+
+            generation = self._center_view_lifecycle_generation
+            body = self._build_center_view(view_key)
+            body.display = False
+            try:
+                slot = self.query_one(_DEMAND_CENTER_VIEW_SLOTS[view_key], Vertical)
+                await slot.mount(body)
+                if (
+                    generation != self._center_view_lifecycle_generation
+                    or not self.is_mounted
+                ):
+                    if body.is_mounted:
+                        await body.remove()
+                    return None
+                self._hydrate_center_view(view_key, body)
+                slot.display = True
+                return body
+            except asyncio.CancelledError:
+                if body.is_mounted:
+                    await body.remove()
+                raise
+            except Exception:
+                if body.is_mounted:
+                    await body.remove()
+                logger.opt(exception=True).warning(
+                    "Personas center view mount failed (view_key={}).", view_key
+                )
+                self._notify("Couldn't open this Personas view. Try again.", "error")
+                return None
 
     async def _load_after_mount(self) -> None:
         """Load the character library once the screen is already on screen."""
@@ -1727,9 +1808,6 @@ class PersonasScreen(BaseAppScreen):
             )
             if callable(ensure_recovery):
                 await asyncio.to_thread(ensure_recovery)
-            # Must precede everything below: `_apply_pending_restore` and the
-            # selection sync assume the full center-view DOM (task-2725).
-            await self._mount_deferred_center_views()
             loading_manager = getattr(self, "loading_manager", None)
             setup_loading = getattr(loading_manager, "setup", None)
             if callable(setup_loading):

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1760,6 +1760,11 @@ class PersonasScreen(BaseAppScreen):
 
     def _hydrate_center_view(self, view_key: str, view: Widget) -> None:
         """Apply screen-owned retained state before a new body is used."""
+        if view_key == "character-editor" and isinstance(
+            view, PersonasCharacterEditorWidget
+        ):
+            for control in view.query(PersonasCharacterTTSWidget):
+                control.apply_state(self._character_tts_presentation)
         if view_key == "persona-editor" and isinstance(
             view, PersonaProfileEditorWidget
         ):

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -1184,6 +1184,7 @@ class PersonasScreen(BaseAppScreen):
         self._center_view_mount_locks = {
             view_key: asyncio.Lock() for view_key in _DEMAND_CENTER_VIEW_ROOTS
         }
+        self._ready_center_views: dict[str, Widget] = {}
         # Refuse-reentry flag for the import/export file dialogs. Cancelling
         # an in-flight dialog worker (exclusive=True) would orphan a modal
         # pushed via push_screen_wait, whose dismissal then calls
@@ -1748,15 +1749,15 @@ class PersonasScreen(BaseAppScreen):
             return PersonasLoreDetailWidget(id="personas-lore-detail")
         raise ValueError(f"Unknown Personas center view: {view_key}")
 
-    def _mounted_center_view(self, view_key: str) -> Widget | None:
-        """Return a requested heavy root when it is already mounted."""
-        selector = _DEMAND_CENTER_VIEW_ROOTS.get(view_key)
-        if selector is None:
+    def _ready_center_view(self, view_key: str) -> Widget | None:
+        """Return a requested heavy root only after successful hydration."""
+        if view_key not in _DEMAND_CENTER_VIEW_ROOTS:
             raise ValueError(f"Unknown Personas center view: {view_key}")
-        try:
-            return self.query_one(selector)
-        except QueryError:
-            return None
+        existing = self._ready_center_views.get(view_key)
+        if existing is not None and existing.is_mounted:
+            return existing
+        self._ready_center_views.pop(view_key, None)
+        return None
 
     def _hydrate_center_view(self, view_key: str, view: Widget) -> None:
         """Apply screen-owned retained state before a new body is used."""
@@ -1780,12 +1781,12 @@ class PersonasScreen(BaseAppScreen):
         """
         if view_key not in _DEMAND_CENTER_VIEW_ROOTS:
             raise ValueError(f"Unknown Personas center view: {view_key}")
-        existing = self._mounted_center_view(view_key)
+        existing = self._ready_center_view(view_key)
         if existing is not None:
             return existing
 
         async with self._center_view_mount_locks[view_key]:
-            existing = self._mounted_center_view(view_key)
+            existing = self._ready_center_view(view_key)
             if existing is not None:
                 return existing
 
@@ -1804,6 +1805,7 @@ class PersonasScreen(BaseAppScreen):
                     return None
                 self._hydrate_center_view(view_key, body)
                 slot.display = True
+                self._ready_center_views[view_key] = body
                 return body
             except asyncio.CancelledError:
                 if body.is_mounted:
@@ -1906,7 +1908,9 @@ class PersonasScreen(BaseAppScreen):
             self._sync_title_and_console_actions()
 
     async def on_unmount(self) -> None:
+        """Invalidate deferred Personas work before releasing screen resources."""
         self._center_view_lifecycle_generation += 1
+        self._ready_center_views.clear()
         self._advance_persona_buddy_session()
         self._cancel_actor_pack_export()
         self._cancel_actor_pack_import()

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -640,6 +640,10 @@ _DEMAND_CENTER_VIEW_SLOTS: dict[str, str] = {
 }
 
 
+class _CenterViewMountUnavailable(RuntimeError):
+    """Signal that a restore should retain its intent after a transient mount failure."""
+
+
 @dataclasses.dataclass(frozen=True, slots=True)
 class _CharacterVisualIdentityLoadSnapshot:
     """Authority captured before an editor pack-metadata worker starts."""
@@ -1423,16 +1427,16 @@ class PersonasScreen(BaseAppScreen):
                             id="personas-character-editor-slot"
                         )
                         character_editor_slot.display = False
-                        character_editor_slot.styles.height = "auto"
                         character_editor_slot.styles.width = "100%"
                         yield character_editor_slot
                         with Vertical(id="personas-character-attachments"):
                             yield PersonasCharacterDictionariesWidget()
                             yield PersonasCharacterWorldBooksWidget()
                         yield PersonaProfileCardWidget()
-                        persona_editor_slot = Vertical(id="personas-persona-editor-slot")
+                        persona_editor_slot = Vertical(
+                            id="personas-persona-editor-slot"
+                        )
                         persona_editor_slot.display = False
-                        persona_editor_slot.styles.height = "auto"
                         persona_editor_slot.styles.width = "100%"
                         yield persona_editor_slot
                         with Vertical(id="personas-conversation-actions"):
@@ -1466,12 +1470,10 @@ class PersonasScreen(BaseAppScreen):
                             id="personas-dictionary-detail-slot"
                         )
                         dictionary_detail_slot.display = False
-                        dictionary_detail_slot.styles.height = "auto"
                         dictionary_detail_slot.styles.width = "100%"
                         yield dictionary_detail_slot
                         lore_detail_slot = Vertical(id="personas-lore-detail-slot")
                         lore_detail_slot.display = False
-                        lore_detail_slot.styles.height = "auto"
                         lore_detail_slot.styles.width = "100%"
                         yield lore_detail_slot
                         yield PersonasConversationTranscriptWidget()
@@ -1596,7 +1598,6 @@ class PersonasScreen(BaseAppScreen):
     async def _apply_pending_restore(self) -> None:
         """Re-apply a selection saved before a navigation round-trip (task-434)."""
         pending = getattr(self, "_pending_restore", None)
-        self._pending_restore = None
         if not pending or not pending.get("id"):
             return
         kind = pending.get("kind")
@@ -1617,10 +1618,22 @@ class PersonasScreen(BaseAppScreen):
             elif kind == "persona":
                 await self._select_profile(entity_id, name)
             elif kind == "dictionary":
-                await self._select_dictionary(entity_id, name)
+                await self._select_dictionary(
+                    entity_id, name, raise_on_mount_failure=True
+                )
             elif kind == "lore":
-                await self._select_lore_entry(entity_id, name)
+                await self._select_lore_entry(
+                    entity_id, name, raise_on_mount_failure=True
+                )
+            self._pending_restore = None
+        except _CenterViewMountUnavailable:
+            # A missing record is terminal in the existing selection paths,
+            # but a failed Textual mount is transient. Keep the exact payload
+            # so an explicit retry can replay it instead of misclassifying the
+            # entity as deleted.
+            return
         except Exception:
+            self._pending_restore = None
             # A stale/deleted entity must degrade to a fully cleared selection,
             # not just a blank center: leaving self.state's selection populated
             # would let _console_action_allowed() keep attach/Start-Chat wrongly
@@ -1660,6 +1673,11 @@ class PersonasScreen(BaseAppScreen):
         if self._character_tts_profile_suggestion is not None:
             return
         if self.state.selected_entity_id:
+            return
+        # A fast user can start authoring while the initial library worker is
+        # still settling. Never let its onboarding auto-selection replace that
+        # newer editor session (demand mounting makes this race easier to hit).
+        if self._edit_mode != "view":
             return
         if self.state.active_mode != "characters":
             return
@@ -1883,6 +1901,7 @@ class PersonasScreen(BaseAppScreen):
             self._sync_title_and_console_actions()
 
     async def on_unmount(self) -> None:
+        self._center_view_lifecycle_generation += 1
         self._advance_persona_buddy_session()
         self._cancel_actor_pack_export()
         self._cancel_actor_pack_import()
@@ -4667,6 +4686,9 @@ class PersonasScreen(BaseAppScreen):
     @on(PersonaEntitySelected)
     async def _handle_entity_selected(self, message: PersonaEntitySelected) -> None:
         message.stop()
+        # Explicit user intent supersedes a restore payload retained after a
+        # transient view-mount failure.
+        self._pending_restore = None
         if message.entity_kind == "character":
             await self._run_guarded(
                 lambda: self._select_character(message.entity_id, message.entity_name)
@@ -4880,7 +4902,13 @@ class PersonasScreen(BaseAppScreen):
             session_generation=session_generation,
         )
 
-    async def _select_dictionary(self, entity_id: str, entity_name: str) -> None:
+    async def _select_dictionary(
+        self,
+        entity_id: str,
+        entity_name: str,
+        *,
+        raise_on_mount_failure: bool = False,
+    ) -> None:
         """Load one dictionary into the center detail; inspector shows the selection."""
         self._advance_persona_buddy_session()
         service = self._dictionary_scope_service()
@@ -4895,6 +4923,11 @@ class PersonasScreen(BaseAppScreen):
             )
             self._notify(f"Could not load dictionary: {exc}", "error")
             return
+        detail = await self._ensure_center_view("dictionary-detail")
+        if not isinstance(detail, PersonasDictionaryDetailWidget):
+            if raise_on_mount_failure:
+                raise _CenterViewMountUnavailable("dictionary-detail")
+            return
         self._edit_mode = "view"
         self.state.has_unsaved_changes = False
         raw_version = record.get("version")
@@ -4904,7 +4937,6 @@ class PersonasScreen(BaseAppScreen):
         self.state.select_entity(
             entity_kind="dictionary", entity_id=entity_id, entity_name=entity_name
         )
-        detail = self.query_one(PersonasDictionaryDetailWidget)
         detail.load_dictionary(record)
         detail.load_statistics(
             self._dictionary_statistics(record, entity_id),
@@ -4954,7 +4986,13 @@ class PersonasScreen(BaseAppScreen):
         entries = manager.get_world_book_entries(book_id)
         return record, entries
 
-    async def _select_lore_entry(self, entity_id: str, entity_name: str) -> None:
+    async def _select_lore_entry(
+        self,
+        entity_id: str,
+        entity_name: str,
+        *,
+        raise_on_mount_failure: bool = False,
+    ) -> None:
         self._advance_persona_buddy_session()
         """Load one lore/world book into the center detail; inspector shows the selection."""
         manager = self._lore_manager()
@@ -4974,6 +5012,11 @@ class PersonasScreen(BaseAppScreen):
         if record is None:
             self._notify("Lore book not found.", "error")
             return
+        detail = await self._ensure_center_view("lore-detail")
+        if not isinstance(detail, PersonasLoreDetailWidget):
+            if raise_on_mount_failure:
+                raise _CenterViewMountUnavailable("lore-detail")
+            return
         self._edit_mode = "view"
         self.state.has_unsaved_changes = False
         raw_version = record.get("version")
@@ -4985,7 +5028,6 @@ class PersonasScreen(BaseAppScreen):
         self.state.select_entity(
             entity_kind="lore", entity_id=entity_id, entity_name=entity_name
         )
-        detail = self.query_one(PersonasLoreDetailWidget)
         detail.load_book({**record, "entries": entries})
         self._show_center("#personas-lore-detail")
         library = self.query_one(PersonasLibraryPane)
@@ -7074,6 +7116,9 @@ class PersonasScreen(BaseAppScreen):
     async def _begin_create_character(self, *, actor_pack: bool = False) -> None:
         if not self._local_character_actions_allowed():
             return
+        editor = await self._ensure_center_view("character-editor")
+        if not isinstance(editor, PersonasCharacterEditorWidget):
+            return
         self._advance_persona_buddy_session()
         self._discard_visual_identity_authoring()
         self._character_editor_generation += 1
@@ -7089,7 +7134,6 @@ class PersonasScreen(BaseAppScreen):
         self._character_save_inflight = False
         # Change-based dirty tracking: the session starts clean; the editor
         # posts EditorContentChanged on the first real modification.
-        editor = self.query_one(PersonasCharacterEditorWidget)
         editor.new_character(actor_pack=actor_pack)
         if actor_pack:
             self._actor_pack_generation += 1
@@ -7120,6 +7164,9 @@ class PersonasScreen(BaseAppScreen):
         self.call_after_refresh(self._focus_editor_name)
 
     async def _begin_create_profile(self) -> None:
+        editor = await self._ensure_center_view("persona-editor")
+        if not isinstance(editor, PersonaProfileEditorWidget):
+            return
         self._invalidate_actor_pack_session()
         self._advance_persona_buddy_session()
         await self._drain_persona_shared_visual_identity_authoring()
@@ -7135,9 +7182,7 @@ class PersonasScreen(BaseAppScreen):
         self._profile_save_operation_inflight = False
         # Change-based dirty tracking: the session starts clean (see
         # _begin_create_character).
-        self.query_one(PersonaProfileEditorWidget).new_persona(
-            runtime_source=self.persona_handler.current_mode()
-        )
+        editor.new_persona(runtime_source=self.persona_handler.current_mode())
         self._show_center("#ccp-persona-editor-view")
         inspector = self.query_one(PersonasInspectorPane)
         # Same identity reset as _begin_create_character: no stale selection.
@@ -7205,6 +7250,9 @@ class PersonasScreen(BaseAppScreen):
         if not choices:
             self._notify("No eligible local portrait Character.", "warning")
             return
+        editor = await self._ensure_center_view("persona-editor")
+        if not isinstance(editor, PersonaProfileEditorWidget):
+            return
         self._advance_persona_buddy_session()
         await self._drain_persona_shared_visual_identity_authoring()
         self._persona_shared_visual_identity_authority = None
@@ -7214,7 +7262,6 @@ class PersonasScreen(BaseAppScreen):
         self.state.clear_selection()
         self._profile_save_inflight = False
         self._profile_save_operation_inflight = False
-        editor = self.query_one(PersonaProfileEditorWidget)
         editor.begin_actor_pack_creation(
             tuple((choice.name, choice.character_id) for choice in choices)
         )
@@ -7567,6 +7614,9 @@ class PersonasScreen(BaseAppScreen):
         if service is None:
             self._notify("Dictionaries service is not configured.", "error")
             return
+        detail = await self._ensure_center_view("dictionary-detail")
+        if not isinstance(detail, PersonasDictionaryDetailWidget):
+            return
         name = self._unique_dictionary_name("Untitled dictionary")
         try:
             record = await service.create_dictionary({"name": name}, mode="local")
@@ -7764,6 +7814,9 @@ class PersonasScreen(BaseAppScreen):
                 "Lore is not configured: the database is unavailable.", "error"
             )
             return
+        detail = await self._ensure_center_view("lore-detail")
+        if not isinstance(detail, PersonasLoreDetailWidget):
+            return
         name = self._unique_lore_name("Untitled world book")
         try:
             book_id = await asyncio.to_thread(manager.create_world_book, name)
@@ -7877,6 +7930,9 @@ class PersonasScreen(BaseAppScreen):
             return
         self._advance_persona_buddy_session()
         record = await self._fetch_profile_record(str(message.persona_id))
+        editor = await self._ensure_center_view("persona-editor")
+        if not isinstance(editor, PersonaProfileEditorWidget):
+            return
         self._edit_mode = "edit"
         # A new session starts unclaimed (see _begin_create_profile).
         self._profile_save_inflight = False
@@ -7887,7 +7943,6 @@ class PersonasScreen(BaseAppScreen):
         self._persona_shared_visual_identity_authority = None
         await self._discard_persona_visual_authoring_async()
         self._persona_visual_generation += 1
-        editor = self.query_one(PersonaProfileEditorWidget)
         editor.load_persona(
             record,
             runtime_source=self.persona_handler.current_mode(),
@@ -9606,7 +9661,7 @@ class PersonasScreen(BaseAppScreen):
         )
 
     @on(EditCharacterRequested)
-    def _handle_edit_requested(self, message: EditCharacterRequested) -> None:
+    async def _handle_edit_requested(self, message: EditCharacterRequested) -> None:
         message.stop()
         if not self._local_character_actions_allowed():
             return
@@ -9616,6 +9671,9 @@ class PersonasScreen(BaseAppScreen):
         record = self._full_character_record(str(message.character_id))
         if record is None:
             self._notify("Character data is not loaded yet.", severity="warning")
+            return
+        editor = await self._ensure_center_view("character-editor")
+        if not isinstance(editor, PersonasCharacterEditorWidget):
             return
         self._discard_visual_identity_authoring()
         self._character_editor_generation += 1
@@ -9628,7 +9686,6 @@ class PersonasScreen(BaseAppScreen):
         self._character_save_inflight = False
         # Change-based dirty tracking: the session starts clean; the editor
         # posts EditorContentChanged on the first real modification.
-        editor = self.query_one(PersonasCharacterEditorWidget)
         editor.load_character(record, visual_identity_pending=True)
         # Read only active-pack metadata first. Bound characters mount the
         # lazy pack browser; unbound characters take the legacy three-slot
@@ -14722,9 +14779,7 @@ class PersonasScreen(BaseAppScreen):
         message.stop()
         rules = [dict(rule) for rule in (message.rules or [])]
         if self.persona_handler.current_mode() != "local":
-            self._notify(
-                "Tool policy rules apply to local personas only.", "warning"
-            )
+            self._notify("Tool policy rules apply to local personas only.", "warning")
             return
         editor = self.query_one(PersonaProfileEditorWidget)
         persona_id = editor.persona_id


### PR DESCRIPTION
## Summary
- keep the four inactive Personas center workflows out of initial composition
- mount, hydrate, and cache each editor or manager only on first use
- preserve restore, deep-link, concurrent activation, retry, teardown, TTS, and runtime-source behavior
- add lifecycle, workflow, real-pointer, and production-CSS responsiveness regressions

## Verification
- 378 passed: Tests/UI/test_personas_workbench.py
- 246 passed: affected Personas lifecycle/workflow modules
- 6 architecture checks passed before rebase; upstream changes were confined to Library/docs
- compileall passed
- Ruff lint and format checks passed
- git diff --check passed

Full repository suite not run per targeted-test policy.

Closes TASK-31215.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Demand-mounts the four heavy Personas center views so the initial Characters surface loads without constructing the character editor, persona editor, dictionary detail, or lore detail. Each body mounts only when its workflow first needs it and stays cached for the screen lifetime.

**Behavior**
- Restore and deep-link intents replay after the requested view is ready.
- A view is published as ready only after hydration; concurrent first requests wait on one mount, and failed hydration stays retryable.
- Leaving the screen invalidates in-flight mounts and clears the ready cache so late work can't mutate detached UI.
- No storage, provider, or user-visible information architecture changes.

Closes TASK-31215.

<sup>Written for commit 976943af2b4771ece970b5e311fbe4bcd8d8efb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

