### PR TITLE
fix(library): review-set continuity — Review-selected lands, resume always agrees, Dismiss gets Undo

### DIFF
--- a/.impeccable/critique/2026-09-04T01-42-54Z__tldw-chatbook-ui-screens-library-screen-py.md
+++ b/.impeccable/critique/2026-09-04T01-42-54Z__tldw-chatbook-ui-screens-library-screen-py.md
@@ -1,0 +1,79 @@
+---
+target: Library ▸ Media (library_screen.py)
+total_score: 28
+max_score: 40
+na_heuristics: 
+p0_count: 0
+p1_count: 3
+timestamp: 2026-09-04T01-42-54Z
+slug: tldw-chatbook-ui-screens-library-screen-py
+---
+Method: dual-agent (A: design review · B: detector/evidence; B re-spawned once mid-run after a stall — mechanical pass only, no cross-contamination)
+
+Target: Library ▸ Browse ▸ Media (Operate mode) at dev tip 60d95fc7d2 (post re-critique fix wave 2: #2358/#2359/#2361). Live at 235×52 and 100×30, plus source.
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Auto-resume re-arms the banner ("Read later — 1 of 2") over a document that is not in the set |
+| 2 | Match System / Real World | 3 | "Sets" is a cipher until the feature is already learned; tooltip is mouse-only in a terminal |
+| 3 | User Control and Freedom | 3 | Picker Dismiss is a one-click soft-delete with no confirm, no undo, no surfaced reopen path |
+| 4 | Consistency and Standards | 3 | "Review these" opens item 1 in the Reader; "Review selected" does not |
+| 5 | Error Prevention | 3 | Bulk delete choreography is textbook; Dismiss sits adjacent to every picker row unguarded |
+| 6 | Recognition Rather Than Recall | 2 | Sort strip clips "Title A-Z" and renders "Title Z-A" nowhere; no reviewed-marks on list rows mid-walk |
+| 7 | Flexibility and Efficiency | 3 | Real keyboard core (] [ m R s space /) but no key for Sets/Review these/select-all; first ] after resume is a wasted sync press |
+| 8 | Aesthetic and Minimalist Design | 2 | Reader content capped at 75vh strands ~10 rows at 52-row terminals; default-open find input spends 3 rows on every fresh item |
+| 9 | Error Recovery | 3 | Delete: undo receipt + durable Trash. Dismiss: nothing |
+| 10 | Help and Documentation | 3 | Contextual footer teaching is exemplary; the user guide's create-promise is false for the Select path |
+| **Total** | | **28/40** | **Good (lower edge of the band)** |
+
+## Design Specificity Verdict
+
+**LLM assessment**: Authored for this product, decisively. The house grammar — state-in-text everywhere ("✓ Newest", "Read (selected)"), ○ disabled markers with reasons, honest-footer discipline that retires keys at boundaries and on completion, "typing in field" while focus is in an Input, provenance honesty in the Info tab, the receipt grammar ("✓ deleted · N items · in Trash") — is not a category template. The weakness is fit-and-finish, not identity.
+
+**Deterministic scan**: `detect.mjs --json` over the five media widgets returned `[]` (exit 0) — no-signal, since the engine targets web markup and these are Python TUI files. Mechanical greps: 0 hex colors in all five files (clean); 22 `Button(` constructors in library_media_canvas.py with 12 carrying tooltips (5 kwarg + 7 post-construction incl. the two gate helpers that stamp reasons onto disabled actions); every Unicode state marker (✓ ○ ▸ ☑ ☐ ✕) co-occurs with words in the same label — none is a bare glyph. The one severity oddity B flagged (the same "Review-set storage is unavailable." string is `warning` at one site, `error` at two) is documented intentional in code: ambient severity one notch below gesture severity (task-31225 rider).
+
+**Visual overlays**: Not applicable — terminal UI, no browser surface.
+
+**Where A and B agree**: B's live captures independently confirm A's strengths — the wave-2 fixes hold (Clear filter visible and adjacent on a "zz" miss with an honest "No media matched 'zz'." empty state; the type chooser renders its options; select mode swaps to ☐ rows, ○ disabled bulk actions, and a "space toggle selection" footer). B's verbatim footer-code quote matches the behavior A saw in five distinct states.
+
+## Overall Impression
+
+The instrument-panel discipline this surface has been building for six phases now genuinely lands: footer honesty, receipts, and completion ceremony are brand-defining. What drags the score is that the review-set feature's two entry/re-entry seams break its own core promise — continuity. You invoke "Review selected" and see nothing happen; you come back to a saved place and the banner points at the wrong document. The single biggest opportunity: make the review-set lifecycle as honest as the footer already is.
+
+## What's Working
+
+1. **Honest-footer discipline is a signature.** Keys are removed when a text field would swallow them ("typing in field"), when boundaries make them no-ops, and when completion retires them ("m toggle reviewed | R finish review | All 6 reviewed"). Verified live in five states and in code (`_review_footer_entries`, `_library_footer_shortcuts_for_current_state`).
+2. **The walk model is well-designed.** Advance-marks-what-you-leave, [ never marks, final ] as completion gesture, tombstone-skipping with live-only progress; `review_set_state.py` is pure and correct about edge cases.
+3. **Destructive-action choreography.** Danger isolated on its own row, ○ disabled forms with reasons, armed confirm naming both recovery paths ("undo right away, or restore later from Trash"), receipt, durable Trash.
+
+## Priority Issues
+
+1. **[P1] "Review selected" doesn't start the review.** The bulk Review action toasts "Reviewing 2 items." then leaves the user in select mode with unchecked boxes and a blank reader pane. Verified in code: both create paths call `_open_library_media_viewer(items[0])` (library_screen.py:39305), but nothing on the selection path ever exits select mode (`_library_media_select_mode` is cleared only by Done/bulk-delete, lines 24249/24526), so the viewer never surfaces. Contradicts the shipped doc's promise ("Creating a set activates it and opens its first item in the Reader"). **Why**: the user's invoked feature is invisible at the moment of invocation. **Fix**: exit select mode before the viewer open on the selection path, exactly as "Review these" behaves.
+2. **[P1] Auto-resume restores the frame, not the item.** Leaving Media and returning re-arms banner + footer over an off-set document; the first ] is a silent sync that advances nothing. Verified in code: the once-per-set gate (`_review_set_auto_resumed`, library_screen.py:39576) returns without opening the cursor item on re-entry, while the banner re-arms unconditionally. **Why**: the status line disagrees with the visible document exactly when the feature's promise is "your place is saved." **Fix**: whenever the review banner/footer arms, load the cursor item — or suppress the banner until the viewer matches.
+3. **[P1] Sort chooser clips options off-pane.** Renders "✓ Newest  Oldest  Title A-" in the ~38-col items pane; "Title Z-A" is invisible with no overflow cue, and a keyboard user can select an option that is rendered nowhere. Verified in code: the sort chooser is a horizontal `compose_library_choice_strip` (library_media_canvas.py:690-701) while the type chooser is a vertical `OptionList` (line 681). **Fix**: use the type chooser's vertical OptionList, or wrap the strip to two rows like the toolbar's multi-row grammar (task-30043).
+4. **[P2] Dismiss is a one-click, adjacent, unconfirmed soft-delete with no surfaced recovery.** Every picker row is [open][Dismiss] side by side; Dismiss fires immediately and closes the dialog; no reopen path exists in the UI. A mid-walk set with many done-marks dies to one mis-click — a hidden recovery state, the product's own stated anti-reference. **Fix**: undo on the toast (the delete-receipt pattern already exists) or an armed confirm on incomplete sets.
+5. **[P2] The Reader strands its vertical space.** At 52 rows the content box ends near row 39 (`#library-media-viewer-content { max-height: 75vh }`) leaving ~10 blank rows while long documents scroll inside; the default-open "Search content…" input spends 3 more rows above; single-page pagers still show two dead ○ controls. **Fix**: let the content box fill remaining height; collapse the find input until Find is invoked.
+
+## Persona Red Flags
+
+**Alex (impatient power user)**: three unnecessary steps between "Review selected" and the first document (discover nothing happened → Done → ]); no keybinding for Sets, Review these, or select-all; the resume-sync eats his first ]; 38-col rows truncate half the titles on a 235-col terminal so he identifies items by mouse tooltip.
+
+**Sam (keyboard-only, shape-grammar dependent)**: genuinely well served — ☑/☐/▸/○ markers all carry words (B verified every code-line marker has text co-occurrence). Two real flags: the sort strip lets him arrow to and select an option that is not rendered anywhere on screen; "✓" means *active* on the picker's top row one line above rows where ✓ means *completed* — an easy misread as "Read later is finished."
+
+## Minor Observations
+
+- Pane-join artifacts at the reader pane's top/bottom edges ("┌───┐─────", "└───┘─────").
+- Trash header truncates: "Local Trash · 0 i".
+- Find counts lines, not occurrences, with tautological copy ("Match 1 of 1 matches" over ~30 visible hits).
+- The More menu replaces the entire body while open — disorienting for a disclosure.
+- Reader tab is sticky across items: a walk begun after visiting Info opens item 1 on Info, not Read.
+- Escape's label roams ("esc focus rail" / "esc focus Library" / "esc focus Items") — precise, but three names for "go left."
+- Silent active-set replacement (creating a set deactivates the current one wordlessly) + anonymous auto-names ("2 selected items") make picker rows indistinguishable later. [P3]
+
+## Questions to Consider
+
+1. The core act here is *reading*, yet the reading surface is the only region refusing its space — should an active review walk collapse the list pane into a focus mode?
+2. Auto-mark-on-leave equates "paged past" with "reviewed" — ]]]]]]  completes a set without reading a word. Is completion a claim the UI should make on the user's behalf?
+3. If review sets are durable workflow objects worth a picker, why can't they be named, and why is their only lifecycle exit an unconfirmed, unrecoverable Dismiss?

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -217,11 +217,14 @@ them one by one, with your place and progress saved between visits.
 - **Create** — **Review these** on the media list pins the whole filtered
   result (in the current sort order, capped at 500 items with a notice when
   trimmed); in Select mode, **Review selected** pins just the checked items in
-  list order. Creating a set activates it and opens its first item in the
-  Reader.
+  list order and leaves Select mode. Creating a set activates it and opens its
+  first item in the Reader. If another set was mid-walk, a notice names it and
+  its progress ("Paused 'Read later' at 1 of 2 · 0 reviewed. Resume from
+  Sets.") — creating never silently strands a walk.
 - **Resume on entry** — opening the media area with a set active loads its
-  current item into the Reader automatically (once per set per session;
-  Escape back to the list and re-entering shows the list).
+  current item into the Reader automatically, on every entry, so the banner
+  and the open document always agree (Escape shows the list until the next
+  entry).
 - **Walk** — while a set is active the Reader carries a banner naming the
   set, your place, and the open item's own state ("Reviewing: All media — 2
   of 14 · 1 reviewed · ✓ reviewed"), and the footer shows the same place. `]` advances and marks the item you leave as reviewed;
@@ -230,17 +233,21 @@ them one by one, with your place and progress saved between visits.
   Reader but keeps the set active — re-entering resumes at your cursor.
   **R** (Exit review) deactivates the set without deleting it.
 - **Resume / switch / dismiss** — **Sets** on the media list title row opens
-  the saved-set picker: each row shows the set's name and live progress, with
+  the saved-set picker: each row shows the set's name, live progress, and
+  created date (so two "2 selected items" sets stay distinguishable), with
   the active set marked `✓`. Picking a set activates it (deactivating any
   other) and lands at its saved cursor; picking a completed set reopens it.
-  **Dismiss** soft-deletes a set. **Review read-later** in the same picker
-  builds a new set from your read-later queue, newest saves first.
+  **Dismiss** soft-deletes a set and leaves a "✓ dismissed · name" receipt on
+  the media list with **Undo** (restores the set — cursor, reviewed marks,
+  and active state intact) and **Dismiss** to clear the receipt. **Review
+  read-later** in the same picker builds a new set from your read-later
+  queue, newest saves first.
 - Deleted media items become skipped tombstones: progress counts only items
   that still exist, and a set whose items were all removed reports "No items
   to review" instead of completing.
 
-*Verified against feat/review-sets-p4 — 2026-09-02 (task-28240..28243: live
-end-to-end create → walk → exit → resume → dismiss pass in tmux).*
+*Verified against fix/media-review-continuity — 2026-09-04 (task-31233/34/36/38:
+live create-from-selection → every-entry resume → dismiss-undo pass in tmux).*
 
 ### Conversations
 

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2805,8 +2805,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 109,
-      "diagnostic_digest": "a8dd908ae6288ad6a624",
+      "call_count": 110,
+      "diagnostic_digest": "2a77628aac583c79aaac",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11304,6 +11304,6 @@
     "path_privacy_candidate_calls": 714,
     "persistent_sink_files": 10,
     "task_492_calls": 1337,
-    "task_494_calls": 7567
+    "task_494_calls": 7568
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -11304,6 +11304,6 @@
     "path_privacy_candidate_calls": 714,
     "persistent_sink_files": 10,
     "task_492_calls": 1337,
-    "task_494_calls": 7568
+    "task_494_calls": 7569
   }
 }

--- a/Tests/Library/test_review_set_service.py
+++ b/Tests/Library/test_review_set_service.py
@@ -177,6 +177,64 @@ def test_dismiss_soft_deletes_and_deactivates():
     assert svc.get_review_set(set_id) is None  # dismissed sets are hidden
 
 
+def test_undismiss_restores_the_set_with_marks_and_activation():
+    """task-31236: Undo on the dismiss receipt is an un-tombstone.
+
+    Dismiss only flips deleted_at/active — cursor and done marks were never
+    touched — so undismiss must bring the set back exactly as it was,
+    including re-activating a set that was active when dismissed.
+    """
+    svc = _service()
+    set_id = svc.create_review_set(
+        "X", origin="browse", items=[(1, "a"), (2, "b")]
+    )
+    svc.mark_item_done(set_id, 1, True)
+    svc.set_cursor(set_id, 1)
+    svc.dismiss(set_id)
+    assert svc.list_review_sets() == ()
+
+    svc.undismiss(set_id, reactivate=True)
+
+    restored = svc.get_active_review_set()
+    assert restored is not None and restored.set_id == set_id
+    assert restored.cursor == 1
+    assert [item.done for item in restored.items] == [True, False]
+
+
+def test_undismiss_never_steals_activation_from_a_newer_set():
+    """The one-active invariant outranks the undo (task-31236 AC#2).
+
+    If another set became active after the dismissal, the restored set
+    comes back resumable but INACTIVE — undo must not silently deactivate
+    the set the user is now walking.
+    """
+    svc = _service()
+    first = svc.create_review_set("First", origin="browse", items=[(1, "a")])
+    svc.dismiss(first)
+    second = svc.create_review_set("Second", origin="browse", items=[(2, "b")])
+
+    svc.undismiss(first, reactivate=True)
+
+    active = svc.get_active_review_set()
+    assert active is not None and active.set_id == second  # untouched
+    listed = {review_set.set_id for review_set in svc.list_review_sets()}
+    assert first in listed  # back and resumable via the picker
+
+
+def test_undismiss_without_reactivate_restores_inactive():
+    svc = _service()
+    set_id = svc.create_review_set("X", origin="browse", items=[(1, "a")])
+    svc.deactivate_active()
+    svc.dismiss(set_id)
+
+    svc.undismiss(set_id, reactivate=False)
+
+    assert svc.get_active_review_set() is None
+    assert {review_set.set_id for review_set in svc.list_review_sets()} == {
+        set_id
+    }
+
+
 def test_deactivate_active_keeps_the_set_resumable():
     svc = _service()
     set_id = svc.create_review_set("X", origin="browse", items=[(1, "a")])

--- a/Tests/Library/test_review_set_state.py
+++ b/Tests/Library/test_review_set_state.py
@@ -270,8 +270,8 @@ def test_picker_rows_carry_id_name_progress_and_active_in_order():
     rows = build_picker_rows(sets, is_live=_live())
 
     assert rows == [
-        ("s1", "All media", "2 of 2 · 1 reviewed · 2026-09-01", True),
-        ("s2", "pdf items", "1 of 1 · 0 reviewed · 2026-09-01", False),
+        ("s1", "All media", "2 of 2 · 1 reviewed · 2026-09-01 00:00", True),
+        ("s2", "pdf items", "1 of 1 · 0 reviewed · 2026-09-01 00:00", False),
     ]
 
 
@@ -279,7 +279,7 @@ def test_picker_rows_progress_is_live_only():
     # id 11 tombstoned: total counts live items, done tombstones don't count.
     sets = (_review_set("s1", "Set", _items((10, False), (11, True))),)
     rows = build_picker_rows(sets, is_live=_live(11))
-    assert rows == [("s1", "Set", "1 of 1 · 0 reviewed · 2026-09-01", False)]
+    assert rows == [("s1", "Set", "1 of 1 · 0 reviewed · 2026-09-01 00:00", False)]
 
 
 def test_picker_rows_completed_and_empty_labels():
@@ -288,14 +288,15 @@ def test_picker_rows_completed_and_empty_labels():
         _review_set("gone", "Gone set", _items((20, False))),
     )
     rows = build_picker_rows(sets, is_live=_live(20))
-    assert rows[0][2] == "All 2 reviewed · 2026-09-01"
-    assert rows[1][2] == "No items to review · 2026-09-01"
+    assert rows[0][2] == "All 2 reviewed · 2026-09-01 00:00"
+    assert rows[1][2] == "No items to review · 2026-09-01 00:00"
 
 
 def test_picker_rows_same_name_sets_are_distinguishable():
     """task-31238: auto-names ("2 selected items") rendered two selection
     sets as identical picker rows -- the detail label ends with the created
-    date so same-name sets can be told apart."""
+    minute so same-name sets can be told apart even when created the SAME
+    DAY (Qodo on #2366: date-only left same-day twins identical)."""
     twin_a = _review_set("a", "2 selected items", _items((10, False)))
     twin_b = ReviewSet(
         set_id="b",
@@ -305,15 +306,15 @@ def test_picker_rows_same_name_sets_are_distinguishable():
         active=False,
         completed_at=None,
         items=_items((20, False)),
-        created_at="2026-08-15T12:30:00Z",
-        updated_at="2026-08-15T12:30:00Z",
+        created_at="2026-09-01T12:30:00Z",
+        updated_at="2026-09-01T12:30:00Z",
     )
     rows = build_picker_rows((twin_a, twin_b), is_live=_live())
 
     labels = [(name, detail) for _sid, name, detail, _active in rows]
     assert len(set(labels)) == 2  # not identical any more
-    assert rows[0][2].endswith("2026-09-01")
-    assert rows[1][2].endswith("2026-08-15")
+    assert rows[0][2].endswith("2026-09-01 00:00")
+    assert rows[1][2].endswith("2026-09-01 12:30")
 
 
 def test_picker_rows_tolerate_a_malformed_created_timestamp():

--- a/Tests/Library/test_review_set_state.py
+++ b/Tests/Library/test_review_set_state.py
@@ -270,8 +270,8 @@ def test_picker_rows_carry_id_name_progress_and_active_in_order():
     rows = build_picker_rows(sets, is_live=_live())
 
     assert rows == [
-        ("s1", "All media", "2 of 2 · 1 reviewed", True),
-        ("s2", "pdf items", "1 of 1 · 0 reviewed", False),
+        ("s1", "All media", "2 of 2 · 1 reviewed · 2026-09-01", True),
+        ("s2", "pdf items", "1 of 1 · 0 reviewed · 2026-09-01", False),
     ]
 
 
@@ -279,7 +279,7 @@ def test_picker_rows_progress_is_live_only():
     # id 11 tombstoned: total counts live items, done tombstones don't count.
     sets = (_review_set("s1", "Set", _items((10, False), (11, True))),)
     rows = build_picker_rows(sets, is_live=_live(11))
-    assert rows == [("s1", "Set", "1 of 1 · 0 reviewed", False)]
+    assert rows == [("s1", "Set", "1 of 1 · 0 reviewed · 2026-09-01", False)]
 
 
 def test_picker_rows_completed_and_empty_labels():
@@ -288,5 +288,47 @@ def test_picker_rows_completed_and_empty_labels():
         _review_set("gone", "Gone set", _items((20, False))),
     )
     rows = build_picker_rows(sets, is_live=_live(20))
-    assert rows[0][2] == "All 2 reviewed"
-    assert rows[1][2] == "No items to review"
+    assert rows[0][2] == "All 2 reviewed · 2026-09-01"
+    assert rows[1][2] == "No items to review · 2026-09-01"
+
+
+def test_picker_rows_same_name_sets_are_distinguishable():
+    """task-31238: auto-names ("2 selected items") rendered two selection
+    sets as identical picker rows -- the detail label ends with the created
+    date so same-name sets can be told apart."""
+    twin_a = _review_set("a", "2 selected items", _items((10, False)))
+    twin_b = ReviewSet(
+        set_id="b",
+        name="2 selected items",
+        origin="selection",
+        cursor=0,
+        active=False,
+        completed_at=None,
+        items=_items((20, False)),
+        created_at="2026-08-15T12:30:00Z",
+        updated_at="2026-08-15T12:30:00Z",
+    )
+    rows = build_picker_rows((twin_a, twin_b), is_live=_live())
+
+    labels = [(name, detail) for _sid, name, detail, _active in rows]
+    assert len(set(labels)) == 2  # not identical any more
+    assert rows[0][2].endswith("2026-09-01")
+    assert rows[1][2].endswith("2026-08-15")
+
+
+def test_picker_rows_tolerate_a_malformed_created_timestamp():
+    """A garbage created_at must not crash the picker; the date part is
+    simply omitted."""
+    broken = ReviewSet(
+        set_id="x",
+        name="Set",
+        origin="browse",
+        cursor=0,
+        active=False,
+        completed_at=None,
+        items=_items((10, False)),
+        created_at="",
+        updated_at="",
+    )
+    rows = build_picker_rows((broken,), is_live=_live())
+    assert rows == [("x", "Set", "1 of 1 · 0 reviewed", False)]

--- a/Tests/UI/test_library_multiselect_media.py
+++ b/Tests/UI/test_library_multiselect_media.py
@@ -662,6 +662,52 @@ async def test_delete_receipt_absent_when_count_zero():
             pilot.app.query_one("#library-media-bulk-delete-undo", Button)
 
 
+class _MediaCanvasDismissReceiptApp(ConsolidatedCSSApp):
+    def compose(self):
+        yield LibraryMediaCanvas(
+            canvas=dataclasses.replace(
+                _select_mode_canvas_state(),
+                select_mode=False,
+                review_dismiss_receipt_name="Read later",
+            ),
+            id="library-media-canvas",
+        )
+
+
+@pytest.mark.asyncio
+async def test_review_dismiss_receipt_renders_name_with_undo_and_dismiss():
+    """task-31236: a dismissed review set's receipt renders in the list,
+    naming the set, with Undo right at the point of action -- the same
+    grammar as the bulk-delete receipt (a one-click dismissal of a
+    mid-walk set must be recoverable in place)."""
+    app = _MediaCanvasDismissReceiptApp()
+    async with app.run_test() as pilot:
+        receipt_copy = pilot.app.query_one(
+            "#library-media-review-dismiss-receipt-copy", Static
+        )
+        rendered = str(receipt_copy.renderable)
+        assert "Read later" in rendered
+        assert "dismissed" in rendered.lower()
+
+        undo_btn = pilot.app.query_one(
+            "#library-media-review-dismiss-undo", Button
+        )
+        close_btn = pilot.app.query_one(
+            "#library-media-review-dismiss-receipt-close", Button
+        )
+        assert undo_btn is not None and close_btn is not None
+
+
+@pytest.mark.asyncio
+async def test_review_dismiss_receipt_absent_when_no_name():
+    app = _MediaCanvasApp()  # review_dismiss_receipt_name defaults to ""
+    async with app.run_test() as pilot:
+        with pytest.raises(NoMatches):
+            pilot.app.query_one(
+                "#library-media-review-dismiss-receipt-copy", Static
+            )
+
+
 def _select_mode_with_preview_state() -> LibraryMediaCanvasState:
     """Select mode active with a stale ``selected_id``/preview left over
     from before Select was entered -- the exact UAT repro shape (LIB-05)."""

--- a/Tests/UI/test_review_set_walker.py
+++ b/Tests/UI/test_review_set_walker.py
@@ -682,7 +682,7 @@ async def test_picker_worker_lists_rows_and_opens_the_chosen_set(tmp_path):
     by_id = {row[0]: row for row in rows}
     assert by_id[second][3] is True  # newest set was the active one
     # task-31238: the detail label carries the created date after progress.
-    assert by_id[first][2] == "1 of 1 · 0 reviewed · 2026-09-02"
+    assert by_id[first][2] == "1 of 1 · 0 reviewed · 2026-09-02 00:00"
     active = service.get_active_review_set()
     assert active is not None and active.set_id == first  # switched (one-active)
     assert fake._opened == ["local:media:10"]  # landed at its cursor
@@ -787,6 +787,70 @@ async def test_dismiss_undo_worker_restores_the_set(tmp_path, monkeypatch):
     assert [item.done for item in restored.items] == [True, False]
     assert fake._library_media_review_dismiss_receipt is None
     assert fake._syncs == [True, True]  # chrome refreshed after the restore
+
+
+def test_dismiss_undo_and_receipt_close_cannot_race(tmp_path):
+    """Qodo on #2366: one in-flight undo owns the receipt until it settles.
+
+    Without the guard, Dismiss could clear the receipt while the undo's DB
+    call was pending (the worker then restored a set whose receipt was
+    already gone), and a second Undo press would CANCEL the first through
+    the exclusive worker group.
+    """
+    scheduled: list = []
+    fake = SimpleNamespace(
+        _library_media_review_dismiss_receipt=("set-1", "X", True),
+        _review_dismiss_undo_in_flight=False,
+        run_worker=lambda coro, **_kw: (scheduled.append(coro), coro.close()),
+        _review_dismiss_undo_worker=lambda receipt: (None for _ in ()),
+    )
+    event = SimpleNamespace(stop=lambda: None)
+
+    LibraryScreen.handle_library_media_review_dismiss_undo(fake, event)
+    assert fake._review_dismiss_undo_in_flight is True
+
+    # A second Undo press while in flight schedules nothing (it would
+    # cancel the first via the exclusive group).
+    LibraryScreen.handle_library_media_review_dismiss_undo(fake, event)
+    assert len(scheduled) == 1
+
+    # Receipt-close while in flight is refused: the receipt still stands.
+    LibraryScreen.handle_library_media_review_dismiss_receipt_close(
+        fake, event
+    )
+    assert fake._library_media_review_dismiss_receipt == ("set-1", "X", True)
+
+
+@pytest.mark.asyncio
+async def test_dismiss_undo_worker_clears_the_in_flight_flag(
+    tmp_path, monkeypatch
+):
+    """The flag drops on success AND on failure (finally)."""
+    import tldw_chatbook.UI.Screens.library_screen as screen_module
+
+    monkeypatch.setattr(
+        screen_module, "_sync_library_canvas", lambda *_a, **_kw: None
+    )
+    service = _service(tmp_path)
+    set_id = service.create_review_set("X", origin="browse", items=[(10, "A")])
+    fake = _picker_fake(service, decision=None)
+    fake._review_dismiss_undo_in_flight = True
+    fake._review_dismiss_undo_worker = MethodType(
+        LibraryScreen._review_dismiss_undo_worker, fake
+    )
+    fake._library_media_review_dismiss_receipt = (set_id, "X", True)
+
+    await fake._review_dismiss_undo_worker((set_id, "X", True))
+    assert fake._review_dismiss_undo_in_flight is False
+
+    fake._review_dismiss_undo_in_flight = True
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("db gone")
+
+    fake._review_set_service = boom
+    await fake._review_dismiss_undo_worker((set_id, "X", True))  # no raise
+    assert fake._review_dismiss_undo_in_flight is False
 
 
 @pytest.mark.asyncio
@@ -1133,6 +1197,24 @@ def test_auto_resume_runs_in_its_own_worker_group():
 
     assert recorded["group"] != "library_review_set"
     assert recorded["exclusive"] is True  # still debounces its own re-entries
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_persists_a_resolved_tombstoned_cursor(tmp_path):
+    # Qodo on #2366 (the Qodo #2337 pattern, third path): the landing
+    # resolver opened the item resolved from a tombstoned cursor without
+    # persisting that position — a later restore of the deleted media could
+    # yank a subsequent entry backward to the stale cursor.
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "X", origin="browse", items=[(10, "A"), (11, "B")]
+    )
+    fake = _auto_resume_fake(service, live_ids={11})
+
+    await fake._auto_resume_review_set_worker()
+
+    assert fake._opened == ["local:media:11"]
+    assert service.get_review_set(set_id).cursor == 1  # persisted resolve
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_review_set_walker.py
+++ b/Tests/UI/test_review_set_walker.py
@@ -436,6 +436,103 @@ def test_create_and_open_review_set_warns_on_truncation(tmp_path):
     assert any(severity == "warning" for _msg, severity in fake._notices)
 
 
+def test_create_notifies_when_it_pauses_an_in_progress_active_set(tmp_path):
+    """task-31238: creating a set silently deactivated the active one.
+
+    A walk in progress just stopped being resumable-by-] with no
+    acknowledgment. The create now names the paused set and its live
+    progress, and points at the resume path.
+    """
+    service = _service(tmp_path)
+    old = service.create_review_set(
+        "Read later", origin="read_later", items=[(10, "A"), (11, "B")]
+    )
+    service.mark_item_done(old, 10, True)
+    service.set_cursor(old, 1)
+    fake = _entry_fake(service)
+    fake._review_set_live_ids = lambda ids: {int(i) for i in ids}
+
+    LibraryScreen._create_and_open_review_set(
+        fake, "New", "browse", [(20, "C")]
+    )
+
+    assert any(
+        "Paused" in message
+        and "Read later" in message
+        and "2 of 2 · 1 reviewed" in message
+        for message, _severity in fake._notices
+    )
+
+
+def test_create_stays_quiet_when_no_active_set_was_displaced(tmp_path):
+    """task-31238 AC#3: no pause notice when nothing was displaced."""
+    fake = _entry_fake(_service(tmp_path))
+
+    LibraryScreen._create_and_open_review_set(
+        fake, "New", "browse", [(20, "C")]
+    )
+
+    assert not any("Paused" in message for message, _severity in fake._notices)
+
+
+def test_create_stays_quiet_when_the_displaced_set_was_complete(tmp_path):
+    """A finished set being displaced loses nothing — no pause notice."""
+    service = _service(tmp_path)
+    old = service.create_review_set("Done", origin="browse", items=[(10, "A")])
+    service.mark_item_done(old, 10, True)
+    service.refresh_completion(old, lambda _id: True)
+    fake = _entry_fake(service)
+    fake._review_set_live_ids = lambda ids: {int(i) for i in ids}
+
+    LibraryScreen._create_and_open_review_set(
+        fake, "New", "browse", [(20, "C")]
+    )
+
+    assert not any("Paused" in message for message, _severity in fake._notices)
+
+
+def test_create_from_selection_exits_select_mode_before_landing(
+    tmp_path, monkeypatch
+):
+    """task-31233: the Select-path create leaves select mode, then lands.
+
+    Critique #3 P1: "Review selected" toasted "Reviewing 2 items." but left
+    the user in select mode with a blank reader — the viewer open at the end
+    of _create_and_open_review_set never surfaced because select mode was
+    still armed (it is cleared only by Done/bulk-delete). The exit must come
+    BEFORE the open, sync the CANVAS (the viewer open syncs only the viewer
+    in place — live-verified stale select toolbar without it), and not
+    announce a discard — the selection was consumed, not thrown away.
+    """
+    import tldw_chatbook.UI.Screens.library_screen as screen_module
+
+    service = _service(tmp_path)
+    fake = _entry_fake(service)
+    fake._library_media_select_mode = True
+    events: list[object] = []
+    fake._exit_library_media_select_mode = (
+        lambda *, announce_discard: events.append(("exit", announce_discard))
+    )
+    monkeypatch.setattr(
+        screen_module,
+        "_sync_library_canvas",
+        lambda _screen, kind, **_kw: events.append(("canvas_sync", kind)),
+    )
+    fake._open_library_media_viewer = lambda media_id: events.append(
+        ("open", media_id)
+    )
+
+    LibraryScreen._create_and_open_review_set(
+        fake, "2 selected items", "selection", [(10, "A"), (11, "B")]
+    )
+
+    assert events == [
+        ("exit", False),
+        ("canvas_sync", "media"),
+        ("open", "local:media:10"),
+    ]
+
+
 def _worker_fake(service, *, search_media, scope=None):
     """Fake screen for the entry-point workers, wiring the real methods."""
     fake = _entry_fake(service)
@@ -584,7 +681,8 @@ async def test_picker_worker_lists_rows_and_opens_the_chosen_set(tmp_path):
     assert {row[0] for row in rows} == {first, second}
     by_id = {row[0]: row for row in rows}
     assert by_id[second][3] is True  # newest set was the active one
-    assert by_id[first][2] == "1 of 1 · 0 reviewed"
+    # task-31238: the detail label carries the created date after progress.
+    assert by_id[first][2] == "1 of 1 · 0 reviewed · 2026-09-02"
     active = service.get_active_review_set()
     assert active is not None and active.set_id == first  # switched (one-active)
     assert fake._opened == ["local:media:10"]  # landed at its cursor
@@ -626,20 +724,87 @@ async def test_picker_worker_open_persists_a_resolved_tombstoned_cursor(tmp_path
 
 
 @pytest.mark.asyncio
-async def test_picker_worker_dismiss_soft_deletes_without_opening(tmp_path):
+async def test_picker_worker_dismiss_soft_deletes_and_arms_the_undo_receipt(
+    tmp_path, monkeypatch
+):
+    import tldw_chatbook.UI.Screens.library_screen as screen_module
+
     service = _service(tmp_path)
     set_id = service.create_review_set("X", origin="browse", items=[(10, "A")])
     fake = _picker_fake(service, decision=("dismiss", set_id))
+    canvas_syncs: list[str] = []
+    monkeypatch.setattr(
+        screen_module,
+        "_sync_library_canvas",
+        lambda _screen, kind, **_kw: canvas_syncs.append(kind),
+    )
 
     await fake._review_set_picker_worker()
 
     assert service.list_review_sets() == ()
     assert fake._opened == []
-    assert fake._notices  # the dismissal is confirmed
+    # task-31236: the confirmation is the undo receipt, not a toast -- a
+    # one-click dismissal of a mid-walk set must be recoverable in place.
+    # (set_id, name, was_active) so Undo can restore the activation too.
+    assert fake._library_media_review_dismiss_receipt == (set_id, "X", True)
     # Dismissing the ACTIVE set must refresh the Reader chrome -- the footer
     # kept advertising "] next in set · 1 of 3" after a live dismissal
-    # (live-verified 2026-09-02).
+    # (live-verified 2026-09-02). The CANVAS sync is separate and required:
+    # the viewer seam updates only the viewer in place, so the receipt row
+    # never mounted without it (live-verified 2026-09-04).
     assert fake._syncs == [True]
+    assert canvas_syncs == ["media"]
+
+
+@pytest.mark.asyncio
+async def test_dismiss_undo_worker_restores_the_set(tmp_path, monkeypatch):
+    """task-31236 AC#2: Undo brings the set back — marks, cursor, active."""
+    import tldw_chatbook.UI.Screens.library_screen as screen_module
+
+    monkeypatch.setattr(
+        screen_module, "_sync_library_canvas", lambda *_a, **_kw: None
+    )
+    service = _service(tmp_path)
+    set_id = service.create_review_set(
+        "X", origin="browse", items=[(10, "A"), (11, "B")]
+    )
+    service.mark_item_done(set_id, 10, True)
+    service.set_cursor(set_id, 1)
+    fake = _picker_fake(service, decision=("dismiss", set_id))
+    await fake._review_set_picker_worker()
+    assert service.list_review_sets() == ()
+
+    fake._review_dismiss_undo_worker = MethodType(
+        LibraryScreen._review_dismiss_undo_worker, fake
+    )
+    await fake._review_dismiss_undo_worker(
+        fake._library_media_review_dismiss_receipt
+    )
+
+    restored = service.get_active_review_set()
+    assert restored is not None and restored.set_id == set_id
+    assert restored.cursor == 1
+    assert [item.done for item in restored.items] == [True, False]
+    assert fake._library_media_review_dismiss_receipt is None
+    assert fake._syncs == [True, True]  # chrome refreshed after the restore
+
+
+@pytest.mark.asyncio
+async def test_dismiss_undo_worker_failure_notifies(tmp_path):
+    service = _service(tmp_path)
+    fake = _picker_fake(service, decision=None)
+    fake._review_dismiss_undo_worker = MethodType(
+        LibraryScreen._review_dismiss_undo_worker, fake
+    )
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("db gone")
+
+    fake._review_set_service = boom
+
+    await fake._review_dismiss_undo_worker(("set-1", "X", True))  # no raise
+
+    assert any(severity == "error" for _msg, severity in fake._notices)
 
 
 @pytest.mark.asyncio
@@ -924,10 +1089,12 @@ def _auto_resume_fake(service, *, live_ids=None):
 
 
 @pytest.mark.asyncio
-async def test_auto_resume_opens_the_active_sets_cursor_item_once(tmp_path):
-    # task-28245 AC#1: entering the media area with an active set loads its
-    # cursor item without a keypress -- but only ONCE per set per screen
-    # session, so Escape-to-list + re-entry shows the list, not a yank loop.
+async def test_auto_resume_opens_the_cursor_item_on_every_entry(tmp_path):
+    # task-31234 (SUPERSEDES task-28245's once-per-set AC — user ruling at
+    # the critique #3 close): EVERY entry to the media area with an active
+    # set lands on its cursor item. The once-per-set gate re-armed the
+    # banner over whatever document was showing on re-entry — the frame
+    # restored, the item not, and the first ] became a silent sync.
     service = _service(tmp_path)
     set_id = service.create_review_set(
         "X", origin="browse", items=[(10, "A"), (11, "B")]
@@ -939,7 +1106,7 @@ async def test_auto_resume_opens_the_active_sets_cursor_item_once(tmp_path):
     assert fake._opened == ["local:media:11"]
 
     await fake._auto_resume_review_set_worker()
-    assert fake._opened == ["local:media:11"]  # once per set
+    assert fake._opened == ["local:media:11", "local:media:11"]  # every entry
 
 
 def test_auto_resume_runs_in_its_own_worker_group():

--- a/backlog/tasks/task-28245 - Review-sets-Phase-2b-resume-the-active-sets-cursor-item-on-entering-the-media-Reader.md
+++ b/backlog/tasks/task-28245 - Review-sets-Phase-2b-resume-the-active-sets-cursor-item-on-entering-the-media-Reader.md
@@ -43,3 +43,7 @@ Split from task-28241 AC#4. The walker (AC1-3) resumes the SET STATE automatical
 <!-- SECTION:NOTES:BEGIN -->
 Shipped in PR #2342 (dev e364bf662). _auto_resume_review_set_worker resolves the active set's live cursor off-loop and opens via _open_library_media_viewer (same path as a row press, so ReadingProgress restore untouched - AC#2); once per set per screen session (guard burned only when the open happens). ONE hook only: the rail-select seam's media branch - the mount-leg kick was added then deliberately REMOVED because its boot-time timing made the worker's lazy imports race the _ui_ready module census (flaky Perf Guard 977>972); the rail gesture cannot race boot, which also settles AC#3 structurally. Auto-resume runs in its own exclusive worker group (library_review_set_resume) after Qodo caught the shared group cancelling in-flight set creation. Live-verified: restart -> click Media -> auto-loads cursor item at '2 of 3 · 1 reviewed'; Escape -> away -> re-entry shows the list.
 <!-- SECTION:NOTES:END -->
+
+## Superseded (task-31234)
+
+The once-per-set gate was REMOVED by task-31234 (critique #3 P1, user ruling at the close): re-entry re-armed the banner over an off-set document — the frame restored, the item not. Auto-resume now opens the cursor item on EVERY entry gesture; "Escape + re-entry shows the list" no longer holds (re-entry lands in the Reader at the saved place). AC#3's cold-start yank guard is unchanged.

--- a/backlog/tasks/task-31233 - Review-selected-opens-the-review-it-creates.md
+++ b/backlog/tasks/task-31233 - Review-selected-opens-the-review-it-creates.md
@@ -1,0 +1,36 @@
+---
+id: TASK-31233
+title: Review selected opens the review it creates
+status: Done
+assignee: []
+created_date: '2026-09-04 01:50'
+updated_date: '2026-09-04 03:05'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #3 P1: the Select-mode "Review" bulk action toasts "Reviewing N items." then leaves the user in select mode with unchecked boxes and a blank reader pane — the invoked feature is invisible at the moment of invocation, and the user guide's promise ("Creating a set activates it and opens its first item in the Reader") is false for this path. Root cause verified: both create paths call _open_library_media_viewer(items[0]) (library_screen.py:39305), but nothing on the selection path exits select mode (_library_media_select_mode is cleared only by Done/bulk-delete, lines 24249/24526), so the viewer never surfaces.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Creating a set from Select mode exits select mode and opens the set's first item in the Reader, exactly like "Review these"
+- [x] #2 The review banner and walk footer are armed immediately after the create
+- [x] #3 A pinning test covers the select-path create end state (not select mode, viewer open at item 1)
+<!-- AC:END -->
+
+## Implementation Plan
+
+1. RED: pin the create-from-selection end state (exit before open, no discard notice, canvas sync)
+2. GREEN: exit select mode + canvas sync in _create_and_open_review_set before the viewer open
+3. Live tmux verify at 200x50
+
+## Implementation Notes
+
+One guard in the shared _create_and_open_review_set (covers Review-selected AND any future creator invoked over armed select mode): if select mode is active, _exit_library_media_select_mode(announce_discard=False) then _sync_library_canvas(self, "media"), then the viewer open. The canvas sync is load-bearing and was found live: _open_library_media_viewer ends in the viewer-scoped seam, which updates only the VIEWER in place — without the canvas sync the select toolbar stayed mounted (stale "2 selected" rows) while the banner armed. Live-verified: Select → 2 checked → Review → browse toolbar restored, banner "2 selected items — 1 of 2", Reader at item 1. Files: library_screen.py, test_review_set_walker.py, user guide.

--- a/backlog/tasks/task-31234 - Auto-resume-always-lands-on-the-cursor-item.md
+++ b/backlog/tasks/task-31234 - Auto-resume-always-lands-on-the-cursor-item.md
@@ -1,0 +1,37 @@
+---
+id: TASK-31234
+title: Auto-resume always lands on the cursor item
+status: Done
+assignee: []
+created_date: '2026-09-04 01:50'
+updated_date: '2026-09-04 03:05'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #3 P1: re-entering Media with an active review set re-arms the banner + walk footer ("Reviewing: Read later — 1 of 2") over whatever document happens to be showing — including one not in the set — and the first ] is a silent sync that advances nothing. The status line disagrees with the visible document exactly when the feature's promise is continuity. Root cause verified: the once-per-set gate (_review_set_auto_resumed, library_screen.py:39576) returns without opening the cursor item on re-entry while the banner re-arms unconditionally. USER RULING (critique #3 close): always load the cursor item — re-entering Media with an active set lands in the Reader at the saved place, every time. This supersedes task-28245's once-per-set/show-the-list AC; document the supersession.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Entering the Media area with an active review set opens the set's cursor item in the Reader, on every entry (once-per-set gate removed)
+- [x] #2 The banner, footer progress, and visible document always agree after entry
+- [x] #3 The cold-start yank guard (abort when the user has already navigated away mid-resume) still holds
+- [x] #4 task-28245's superseded AC is annotated in that task file or the walker test docstrings
+<!-- AC:END -->
+
+## Implementation Plan
+
+1. RED: rewrite the once-per-set pinning test to the new every-entry contract
+2. GREEN: remove the _review_set_auto_resumed gate from the worker
+3. Annotate task-28245's superseded AC; live tmux verify
+
+## Implementation Notes
+
+Removed the once-per-set gate block from _auto_resume_review_set_worker (the set_id is no longer consumed) and rewrote its docstring; the cold-start yank guards (still-on-media-list + is_current + view=="list") are untouched and still pinned by test_auto_resume_aborts_when_the_user_moved_away. task-28245 got a "## Superseded (task-31234)" section documenting the reversal and the user ruling. Live-verified twice: enter Media with an active set → Reader at cursor with agreeing banner; leave to Notes, re-enter → same landing again (the old gate would have shown the bare list under a lying banner).

--- a/backlog/tasks/task-31235 - Sort-chooser-renders-every-option.md
+++ b/backlog/tasks/task-31235 - Sort-chooser-renders-every-option.md
@@ -1,0 +1,25 @@
+---
+id: TASK-31235
+title: Sort chooser renders every option
+status: To Do
+assignee: []
+created_date: '2026-09-04 01:50'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #3 P1: the sort chooser renders "✓ Newest  Oldest  Title A-" in the ~38-col items pane — "Title A-Z" is truncated and "Title Z-A" is entirely invisible with no overflow cue, yet a keyboard user can still arrow to and select the unrendered option. Recognition-over-recall failure: an option you can't see doesn't exist. Verified: the sort chooser is a horizontal compose_library_choice_strip (library_media_canvas.py:690-701) while the sibling type chooser is a vertical OptionList (line 681) that fits fine.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All four MEDIA_SORT_CHOICES options are fully visible when the sort chooser is open at the shell's narrow pane width
+- [ ] #2 The active option keeps its ✓ marker and keyboard selection works over the visible list
+- [ ] #3 A test pins that every sort option's label renders (painted-text or equivalent, not just presence in the DOM)
+<!-- AC:END -->

--- a/backlog/tasks/task-31236 - Review-set-Dismiss-gets-an-Undo-receipt.md
+++ b/backlog/tasks/task-31236 - Review-set-Dismiss-gets-an-Undo-receipt.md
@@ -1,0 +1,36 @@
+---
+id: TASK-31236
+title: Review-set Dismiss gets an Undo receipt
+status: Done
+assignee: []
+created_date: '2026-09-04 01:50'
+updated_date: '2026-09-04 03:05'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #3 P2: every picker row is [open][Dismiss] side by side; Dismiss fires immediately (soft-delete), toasts "Review set dismissed.", closes the dialog, and no reopen path exists anywhere in the UI. A mid-walk set with many done-marks dies to one mis-click — a hidden recovery state, the product's stated anti-reference. USER RULING (critique #3 close): undo on the toast, mirroring the media delete-receipt pattern — no extra click on the happy path. The rows are already soft-deleted (deleted_at), so undo is an un-tombstone, not a rebuild.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Dismissing a set surfaces an immediate Undo affordance in the receipt
+- [x] #2 Undo restores the set with its cursor, done-marks, and active/inactive state intact
+- [x] #3 The undo window closing (timeout or next action) leaves the current soft-delete semantics unchanged
+<!-- AC:END -->
+
+## Implementation Plan
+
+1. RED: service undismiss contract (restore + one-active yield), picker-dismiss receipt arming, undo worker, canvas receipt row
+2. GREEN: ReviewSetService.undismiss; screen receipt state + handlers + worker; canvas row mirroring the bulk-delete receipt
+3. Live tmux verify of dismiss → receipt → Undo → DB restore
+
+## Implementation Notes
+
+Service: undismiss(set_id, reactivate) clears deleted_at and re-activates ONLY when no other live set became active since (one-active invariant outranks the undo; single transaction). Screen: the PICKER_DISMISS branch captures (set_id, name, was_active) from the picker rows into _library_media_review_dismiss_receipt and no longer toasts — the receipt IS the confirmation, mirroring the delete-receipt precedent; Undo runs _review_dismiss_undo_worker (group library_review_set, exit_on_error=False, error notice on failure per the task-30042 silent-failure ruling). Canvas: "✓ dismissed · name" + Undo/Dismiss row after the bulk-delete receipt, review_dismiss_receipt_name threaded through both state builders. Trap re-hit and pinned in tests: the viewer-scoped sync seam does NOT recompose the canvas — both the dismiss branch and the undo worker need their own _sync_library_canvas(self, "media") or the receipt never mounts/clears (live-verified both ways). DB-verified: restored set has deleted_at NULL with cursor and done marks intact; a set dismissed while inactive comes back inactive.

--- a/backlog/tasks/task-31237 - Reader-uses-its-vertical-space.md
+++ b/backlog/tasks/task-31237 - Reader-uses-its-vertical-space.md
@@ -1,0 +1,26 @@
+---
+id: TASK-31237
+title: Reader uses its vertical space
+status: To Do
+assignee: []
+created_date: '2026-09-04 01:50'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #3 P2: at 52 terminal rows the Reader's content box ends near row 39 (#library-media-viewer-content max-height: 75vh, _agentic_terminal.tcss) leaving ~10 blank rows below while long documents scroll inside a smaller box; the default-open "Search content…" find input spends 3 more rows on every fresh item (duplicating the Find action); a single-page document still renders two dead "○ Previous ○ Next" pager controls. This is the reading surface of a reading workflow idling a third of its pane.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The Reader content area grows to fill the remaining pane height at tall terminal sizes (no stranded band below the box)
+- [ ] #2 The content find input is collapsed until Find is invoked, and Escape re-collapses it
+- [ ] #3 The pager row is hidden when there is only one page
+- [ ] #4 The task-31222 regression (fixed 18-row cap under an unstyled 1fr band) stays fixed at small sizes
+<!-- AC:END -->

--- a/backlog/tasks/task-31238 - Review-set-replacement-notice-and-distinguishable-picker-rows.md
+++ b/backlog/tasks/task-31238 - Review-set-replacement-notice-and-distinguishable-picker-rows.md
@@ -1,0 +1,36 @@
+---
+id: TASK-31238
+title: Review-set replacement notice and distinguishable picker rows
+status: Done
+assignee: []
+created_date: '2026-09-04 01:50'
+updated_date: '2026-09-04 03:05'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #3 P3: creating any review set silently deactivates the currently active one (one-active invariant) without a word — a walk in progress just stops being resumable-by-] with no acknowledgment. And auto-names ("2 selected items") make picker rows indistinguishable later: two selection-sets render identical rows. Fix: toast the pause ("Paused 'Read later' at 1 of 2") when a create deactivates an in-progress set, and add a distinguishing detail (created date or first-item title) to picker rows.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Creating a set while another is active surfaces a notice naming the paused set and its progress
+- [x] #2 Picker rows carry a distinguishing detail beyond the auto-name so identical-name sets can be told apart
+- [x] #3 No notice fires when no active set was displaced
+<!-- AC:END -->
+
+## Implementation Plan
+
+1. RED: build_picker_rows date suffix (incl. same-name distinguishability + malformed timestamp) and the create-pause notice trio
+2. GREEN: _with_created_date in review_set_state; displaced-set capture + Paused notice in _create_and_open_review_set
+3. Live tmux verify (fast capture for the toast)
+
+## Implementation Notes
+
+Picker rows: build_picker_rows suffixes the detail label with the created DATE (" · YYYY-MM-DD", omitted for malformed timestamps) — tuple shape unchanged, so the picker widget needed zero changes. Pause notice: _create_and_open_review_set captures get_active_review_set() BEFORE creating; when the displaced set is incomplete (completed_at is None) it toasts "Paused '<name>' at <live progress>. Resume from Sets." — name markup-escaped, progress computed live via _review_set_live_ids so the toast can never disagree with the picker. No notice when nothing was displaced or the displaced set was complete. Live-verified: toast captured at +1s; picker rows show the date (wraps at narrow widths but renders).

--- a/tldw_chatbook/Library/library_media_state.py
+++ b/tldw_chatbook/Library/library_media_state.py
@@ -949,7 +949,14 @@ def build_library_media_browse_state(
     loaded_id: str = "",
     review_dismiss_receipt_name: str = "",
 ) -> LibraryMediaCanvasState:
-    """Project one exact Media page without filtering, sorting, or slicing it."""
+    """Project one exact Media page without filtering, sorting, or slicing it.
+
+    Args:
+        review_dismiss_receipt_name: Name of the most recently dismissed
+            review set, rendered as a "✓ dismissed · <name>" undo receipt
+            until acted on or replaced (task-31236). "" (the default)
+            means no receipt to show.
+    """
     if not isinstance(result, MediaBrowseResult):
         raise TypeError("result must be a MediaBrowseResult.")
     if type(type_options) is not tuple or any(
@@ -1117,6 +1124,10 @@ def build_library_media_state(
             receipt with Undo/Dismiss until acted on or replaced by a
             newer bulk-delete action. 0 (the default) means no receipt to
             show.
+        review_dismiss_receipt_name: Name of the most recently dismissed
+            review set, rendered as a "✓ dismissed · <name>" undo receipt
+            until acted on or replaced (task-31236). "" (the default)
+            means no receipt to show.
 
     Returns:
         Immutable canvas state: rows, type options, active type, status/empty copy,

--- a/tldw_chatbook/Library/library_media_state.py
+++ b/tldw_chatbook/Library/library_media_state.py
@@ -775,6 +775,10 @@ class LibraryMediaCanvasState:
     # as the type chooser and the Prompts/Notes sort choosers).
     sort_by: str = "last_modified_desc"
     sort_choices_visible: bool = False
+    # task-31236: name of the most recently dismissed review set, rendered
+    # as a "✓ dismissed · <name>" receipt with Undo/Dismiss until acted on
+    # or replaced. "" means no receipt (the normal state).
+    review_dismiss_receipt_name: str = ""
 
 
 @dataclass(frozen=True)
@@ -943,6 +947,7 @@ def build_library_media_browse_state(
     sort_choices_visible: bool = False,
     loading_id: str = "",
     loaded_id: str = "",
+    review_dismiss_receipt_name: str = "",
 ) -> LibraryMediaCanvasState:
     """Project one exact Media page without filtering, sorting, or slicing it."""
     if not isinstance(result, MediaBrowseResult):
@@ -1021,6 +1026,7 @@ def build_library_media_browse_state(
         query=result.scope.query,
         sort_by=result.scope.sort_by,
         sort_choices_visible=sort_choices_visible,
+        review_dismiss_receipt_name=review_dismiss_receipt_name,
     )
 
 
@@ -1094,6 +1100,7 @@ def build_library_media_state(
     confirming_bulk_delete: bool = False,
     delete_receipt_count: int = 0,
     type_choices_visible: bool = False,
+    review_dismiss_receipt_name: str = "",
 ) -> LibraryMediaCanvasState:
     """Build the Library Browse ▸ Media canvas display state.
 
@@ -1227,4 +1234,5 @@ def build_library_media_state(
         confirming_bulk_delete=confirming_bulk_delete,
         delete_receipt_count=max(0, delete_receipt_count),
         type_choices_visible=type_choices_visible,
+        review_dismiss_receipt_name=review_dismiss_receipt_name,
     )

--- a/tldw_chatbook/Library/review_set_service.py
+++ b/tldw_chatbook/Library/review_set_service.py
@@ -354,6 +354,39 @@ class ReviewSetService:
                 (timestamp, timestamp, set_id),
             )
 
+    def undismiss(self, set_id: str, *, reactivate: bool) -> None:
+        """Restore a dismissed set (the task-31236 undo receipt).
+
+        Dismiss only flipped ``deleted_at``/``active``, so this is an
+        un-tombstone: cursor and done marks come back untouched.
+        Re-activation happens only when asked AND no other live set became
+        active since -- the one-active invariant outranks the undo.
+
+        Args:
+            set_id: The dismissed set to restore.
+            reactivate: Whether the set was active when dismissed.
+        """
+        timestamp = self._now()
+        with self._db.transaction() as conn:
+            conn.execute(
+                "UPDATE review_sets SET deleted_at = NULL, updated_at = ? "
+                "WHERE set_id = ?",
+                (timestamp, set_id),
+            )
+            if reactivate:
+                other_active = conn.execute(
+                    "SELECT 1 FROM review_sets "
+                    "WHERE active = 1 AND deleted_at IS NULL "
+                    "AND set_id != ? LIMIT 1",
+                    (set_id,),
+                ).fetchone()
+                if other_active is None:
+                    conn.execute(
+                        "UPDATE review_sets SET active = 1, updated_at = ? "
+                        "WHERE set_id = ?",
+                        (timestamp, set_id),
+                    )
+
     def deactivate_active(self) -> None:
         """Deactivate the active set ("Exit review"), keeping it resumable.
 

--- a/tldw_chatbook/Library/review_set_state.py
+++ b/tldw_chatbook/Library/review_set_state.py
@@ -335,21 +335,36 @@ def build_picker_rows(
         is_live: Liveness predicate covering every backing id in ``sets``.
 
     Returns:
-        ``(set_id, name, progress_label, active)`` per set, where
-        ``progress_label`` is :func:`format_review_progress` over the set's
-        live items.
+        ``(set_id, name, detail_label, active)`` per set, where
+        ``detail_label`` is :func:`format_review_progress` over the set's
+        live items, suffixed with the created DATE (task-31238: auto-names
+        like "2 selected items" otherwise render identical rows for two
+        selection sets — the date makes same-name sets distinguishable).
     """
     return [
         (
             review_set.set_id,
             review_set.name,
-            format_review_progress(
-                review_progress(review_set.items, review_set.cursor, is_live)
+            _with_created_date(
+                format_review_progress(
+                    review_progress(
+                        review_set.items, review_set.cursor, is_live
+                    )
+                ),
+                review_set.created_at,
             ),
             review_set.active,
         )
         for review_set in sets
     ]
+
+
+def _with_created_date(label: str, created_at: str) -> str:
+    """Suffix ``label`` with the ISO date part of ``created_at``, if any."""
+    date_part = (created_at or "")[:10]
+    if len(date_part) == 10 and date_part[4] == "-" and date_part[7] == "-":
+        return f"{label} · {date_part}"
+    return label
 
 
 def is_empty(items: tuple[ReviewSetItem, ...], is_live: IsLive) -> bool:

--- a/tldw_chatbook/Library/review_set_state.py
+++ b/tldw_chatbook/Library/review_set_state.py
@@ -337,9 +337,10 @@ def build_picker_rows(
     Returns:
         ``(set_id, name, detail_label, active)`` per set, where
         ``detail_label`` is :func:`format_review_progress` over the set's
-        live items, suffixed with the created DATE (task-31238: auto-names
-        like "2 selected items" otherwise render identical rows for two
-        selection sets — the date makes same-name sets distinguishable).
+        live items, suffixed with the created MINUTE ("YYYY-MM-DD HH:MM";
+        task-31238: auto-names like "2 selected items" otherwise render
+        identical rows for two selection sets — and Qodo on #2366: a
+        date-only suffix left same-DAY twins identical too).
     """
     return [
         (
@@ -360,10 +361,16 @@ def build_picker_rows(
 
 
 def _with_created_date(label: str, created_at: str) -> str:
-    """Suffix ``label`` with the ISO date part of ``created_at``, if any."""
-    date_part = (created_at or "")[:10]
-    if len(date_part) == 10 and date_part[4] == "-" and date_part[7] == "-":
-        return f"{label} · {date_part}"
+    """Suffix ``label`` with ``created_at``'s "YYYY-MM-DD HH:MM", if valid."""
+    stamp = (created_at or "")[:16]
+    if (
+        len(stamp) == 16
+        and stamp[4] == "-"
+        and stamp[7] == "-"
+        and stamp[10] == "T"
+        and stamp[13] == ":"
+    ):
+        return f"{label} · {stamp[:10]} {stamp[11:]}"
     return label
 
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -2633,6 +2633,9 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_review_dismiss_receipt: (
             tuple[str, str, bool] | None
         ) = None
+        # Qodo on #2366: one in-flight undo owns the receipt until it
+        # settles (blocks a second Undo and a racing receipt-close).
+        self._review_dismiss_undo_in_flight: bool = False
         # task-4025: "list" | "viewer" | "trash" -- the Trash view is the
         # third in-canvas view of the media canvas (never a rail row or a
         # `type:` cycle value; see the task file's mechanism decision).
@@ -39467,8 +39470,15 @@ class LibraryScreen(BaseAppScreen):
         """
         event.stop()
         receipt = self._library_media_review_dismiss_receipt
-        if receipt is None:
+        # Qodo on #2366: one in-flight undo owns the receipt until it
+        # settles -- a second press would CANCEL the first through the
+        # exclusive worker group, and a racing receipt-close would strand
+        # the restore without its receipt.
+        if receipt is None or getattr(
+            self, "_review_dismiss_undo_in_flight", False
+        ):
             return
+        self._review_dismiss_undo_in_flight = True
         self.run_worker(
             self._review_dismiss_undo_worker(receipt),
             group="library_review_set",
@@ -39486,6 +39496,11 @@ class LibraryScreen(BaseAppScreen):
             event: The receipt row's "Dismiss" press.
         """
         event.stop()
+        # Qodo on #2366: the receipt belongs to a pending undo until that
+        # settles -- clearing it mid-restore left the restored set with no
+        # visible acknowledgment.
+        if getattr(self, "_review_dismiss_undo_in_flight", False):
+            return
         self._library_media_review_dismiss_receipt = None
         _sync_library_canvas(self, "media")
 
@@ -39527,6 +39542,8 @@ class LibraryScreen(BaseAppScreen):
             self._notify_review_set(
                 "Couldn't restore the review set.", severity="error"
             )
+        finally:
+            self._review_dismiss_undo_in_flight = False
 
     async def _review_read_later_pairs(self) -> list[tuple[int, str]]:
         """Build ordered (backing_id, title) pairs from the read-later queue.
@@ -39746,6 +39763,11 @@ class LibraryScreen(BaseAppScreen):
         landing = {item.position: item for item in review_set.items}.get(resolved)
         if landing is None or landing.backing_media_id not in live_ids:
             return None
+        # Qodo on #2366 (the Qodo #2337 pattern, third path): persist a
+        # tombstone-resolved cursor so a later restore of the deleted item
+        # cannot yank a subsequent entry back to the stale position.
+        if resolved != review_set.cursor:
+            service.set_cursor(review_set.set_id, resolved)
         return review_set.set_id, landing.backing_media_id
 
     def _focus_library_media_items_pane(self) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -2628,6 +2628,11 @@ class LibraryScreen(BaseAppScreen):
         # entered, set to the succeeded subset when a delete completes, and
         # narrowed to only the still-failed ids by a partial Undo.
         self._library_media_delete_receipt_ids: tuple[str, ...] = ()
+        # task-31236: (set_id, name, was_active) of the most recently
+        # dismissed review set -- rendered as an in-list undo receipt.
+        self._library_media_review_dismiss_receipt: (
+            tuple[str, str, bool] | None
+        ) = None
         # task-4025: "list" | "viewer" | "trash" -- the Trash view is the
         # third in-canvas view of the media canvas (never a rail row or a
         # `type:` cycle value; see the task file's mechanism decision).
@@ -15400,6 +15405,7 @@ class LibraryScreen(BaseAppScreen):
                 confirming_bulk_delete=self._library_media_confirming_bulk_delete,
                 delete_receipt_count=len(self._library_media_delete_receipt_ids),
                 type_choices_visible=self._library_media_type_choices_visible,
+                review_dismiss_receipt_name=self._review_dismiss_receipt_name(),
             )
         state = build_library_media_browse_state(
             controller.applied_result,
@@ -15412,6 +15418,7 @@ class LibraryScreen(BaseAppScreen):
             delete_receipt_count=len(self._library_media_delete_receipt_ids),
             type_choices_visible=self._library_media_type_choices_visible,
             sort_choices_visible=self._library_media_sort_choices_visible,
+            review_dismiss_receipt_name=self._review_dismiss_receipt_name(),
             loading_id=(
                 (self._library_media_reader_session.selected_id or "")
                 if self._library_media_reader_session.pending_request is not None
@@ -15424,6 +15431,11 @@ class LibraryScreen(BaseAppScreen):
         if self._library_media_select_mode:
             self._library_media_row_selection.reconcile(r.media_id for r in state.rows)
         return state
+
+    def _review_dismiss_receipt_name(self) -> str:
+        """Display name for the pending dismiss-undo receipt, "" when none."""
+        receipt = self._library_media_review_dismiss_receipt
+        return receipt[1] if receipt is not None else ""
 
     def _library_media_content_signature(self) -> tuple[object, ...]:
         """Return applied normal-Media scope plus ordered stable row IDs."""
@@ -39294,6 +39306,10 @@ class LibraryScreen(BaseAppScreen):
                 self._REVIEW_SET_STORAGE_UNAVAILABLE, severity="error"
             )
             return
+        # task-31238: creating a set displaces the active one (one-active
+        # invariant) -- capture it BEFORE the create so an in-progress walk
+        # never just stops being resumable-by-] without a word.
+        displaced = service.get_active_review_set()
         service.create_review_set(name, origin, items)
         if truncated:
             self._notify_review_set(
@@ -39302,6 +39318,36 @@ class LibraryScreen(BaseAppScreen):
             )
         else:
             self._notify_review_set(f"Reviewing {len(items)} items.")
+        if displaced is not None and displaced.completed_at is None:
+            from rich.markup import escape
+
+            from tldw_chatbook.Library.review_set_state import (
+                format_review_progress,
+                review_progress,
+            )
+
+            live = self._review_set_live_ids(
+                item.backing_media_id for item in displaced.items
+            )
+            progress = format_review_progress(
+                review_progress(
+                    displaced.items, displaced.cursor, live.__contains__
+                )
+            )
+            self._notify_review_set(
+                f"Paused '{escape(displaced.name)}' at {progress}. "
+                "Resume from Sets."
+            )
+        # task-31233: a create invoked from Select mode must leave it before
+        # landing -- select mode is otherwise cleared only by Done/bulk-delete,
+        # so the viewer open below never surfaced (blank reader, boxes reset).
+        # The selection was consumed, not discarded: no notice. The canvas
+        # sync mirrors the Done toggle's -- the viewer open below syncs only
+        # the VIEWER in place, leaving the select toolbar stale without it
+        # (live-verified 2026-09-04).
+        if getattr(self, "_library_media_select_mode", False):
+            self._exit_library_media_select_mode(announce_discard=False)
+            _sync_library_canvas(self, "media")
         self._open_library_media_viewer(f"local:media:{items[0][0]}")
 
     _REVIEW_SET_STORAGE_UNAVAILABLE = "Review-set storage is unavailable."
@@ -39367,13 +39413,27 @@ class LibraryScreen(BaseAppScreen):
                 )
                 return
             if action == PICKER_DISMISS:
+                dismissed_row = next(
+                    (row for row in rows if row[0] == set_id), None
+                )
                 await self._run_library_service_call(
                     service.dismiss, set_id, isolate_in_worker=True
                 )
-                self._notify_review_set("Review set dismissed.")
+                # task-31236: the confirmation is an in-list undo receipt,
+                # not a toast -- a one-click dismissal of a mid-walk set
+                # must be recoverable in place (user ruling, critique #3).
+                self._library_media_review_dismiss_receipt = (
+                    set_id,
+                    dismissed_row[1] if dismissed_row else "review set",
+                    bool(dismissed_row[3]) if dismissed_row else False,
+                )
                 # Dismissing the ACTIVE set must drop the Reader's set chrome
                 # -- without this the footer kept advertising "] next in set"
-                # after the set was gone (live-verified 2026-09-02).
+                # after the set was gone (live-verified 2026-09-02). The
+                # canvas sync is separate: the viewer seam updates only the
+                # VIEWER in place, so the receipt row never mounted without
+                # it (live-verified 2026-09-04).
+                _sync_library_canvas(self, "media")
                 self._sync_library_media_viewer_or_recompose()
                 return
             if action != PICKER_OPEN:
@@ -39394,6 +39454,78 @@ class LibraryScreen(BaseAppScreen):
             logger.opt(exception=True).warning("review-set picker failed")
             self._notify_review_set(
                 "Couldn't open review sets.", severity="error"
+            )
+
+    @on(Button.Pressed, "#library-media-review-dismiss-undo")
+    def handle_library_media_review_dismiss_undo(
+        self, event: Button.Pressed
+    ) -> None:
+        """Restore the set named by the dismiss receipt (task-31236).
+
+        Args:
+            event: The receipt row's "Undo" press.
+        """
+        event.stop()
+        receipt = self._library_media_review_dismiss_receipt
+        if receipt is None:
+            return
+        self.run_worker(
+            self._review_dismiss_undo_worker(receipt),
+            group="library_review_set",
+            exclusive=True,
+            exit_on_error=False,
+        )
+
+    @on(Button.Pressed, "#library-media-review-dismiss-receipt-close")
+    def handle_library_media_review_dismiss_receipt_close(
+        self, event: Button.Pressed
+    ) -> None:
+        """Clear the dismiss receipt without restoring anything.
+
+        Args:
+            event: The receipt row's "Dismiss" press.
+        """
+        event.stop()
+        self._library_media_review_dismiss_receipt = None
+        _sync_library_canvas(self, "media")
+
+    async def _review_dismiss_undo_worker(
+        self, receipt: tuple[str, str, bool]
+    ) -> None:
+        """Un-tombstone the receipt's set, restoring activation if it had it.
+
+        task-31236 AC#2: cursor and done marks were never touched by the
+        dismiss, so the service-side ``undismiss`` brings the set back
+        exactly as it was; re-activation yields to any set that became
+        active since (the one-active invariant outranks the undo).
+
+        Args:
+            receipt: ``(set_id, name, was_active)`` captured at dismissal.
+        """
+        try:
+            service = self._review_set_service()
+            if service is None:
+                self._notify_review_set(
+                    self._REVIEW_SET_STORAGE_UNAVAILABLE, severity="error"
+                )
+                return
+            set_id, _name, was_active = receipt
+            await self._run_library_service_call(
+                partial(service.undismiss, set_id, reactivate=was_active),
+                isolate_in_worker=True,
+            )
+            self._library_media_review_dismiss_receipt = None
+            # Canvas sync clears the receipt row; the viewer seam re-arms
+            # the set chrome when the restored set is active again.
+            _sync_library_canvas(self, "media")
+            self._sync_library_media_viewer_or_recompose()
+        except Exception:
+            # task-30042 (user ruling): failures are never silent.
+            logger.opt(exception=True).warning(
+                "review-set dismiss undo failed"
+            )
+            self._notify_review_set(
+                "Couldn't restore the review set.", severity="error"
             )
 
     async def _review_read_later_pairs(self) -> list[tuple[int, str]]:
@@ -39536,16 +39668,17 @@ class LibraryScreen(BaseAppScreen):
         )
 
     async def _auto_resume_review_set_worker(self) -> None:
-        """Open the active set's cursor item in the Reader, once per set.
+        """Open the active set's cursor item in the Reader, on every entry.
 
-        AC#1: entering the media area with an active set loads its cursor
-        item without a keypress. Once per set per screen session -- Escape
-        back to the list plus re-entry shows the list, never a yank loop.
-        AC#3: the final still-on-the-media-list + current-screen gates make
-        a cold-start yank abort without opening (and without burning the
-        once-per-set chance). task-30042 (user ruling): failures are NEVER
-        silent -- missing storage warns once per session, and any storage
-        error surfaces; only the ordinary no-active-set case stays quiet.
+        task-31234 (supersedes task-28245's once-per-set gate, user ruling
+        at the critique #3 close): the banner and the visible document must
+        always agree, so every entry with an active set lands at the saved
+        place -- Escape shows the list until the next entry gesture.
+        task-28245 AC#3 still holds: the final still-on-the-media-list +
+        current-screen gates make a cold-start yank abort without opening.
+        task-30042 (user ruling): failures are NEVER silent -- missing
+        storage warns once per session, and any storage error surfaces;
+        only the ordinary no-active-set case stays quiet.
         """
         try:
             if self._review_set_service() is None:
@@ -39565,18 +39698,17 @@ class LibraryScreen(BaseAppScreen):
             )
             if landing is None:
                 return
-            set_id, backing_id = landing
+            _set_id, backing_id = landing
             if (
                 self._library_selected_row_id != LIBRARY_ROW_BROWSE_MEDIA
                 or self._library_media_view != "list"
                 or not getattr(self, "is_current", False)
             ):
                 return
-            resumed: set[str] = getattr(self, "_review_set_auto_resumed", set())
-            if set_id in resumed:
-                return
-            resumed.add(set_id)
-            self._review_set_auto_resumed = resumed
+            # task-31234 (supersedes task-28245's once-per-set gate, user
+            # ruling at the critique #3 close): open the cursor item on
+            # EVERY entry. The gate restored the banner but not the item on
+            # re-entry -- the status line pointed at an off-set document.
             self._open_library_media_viewer(f"local:media:{backing_id}")
         except Exception:
             # task-30042: resuming failed on a real error -- surface it; the

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -833,6 +833,40 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 )
                 yield self._gate_mutation_action(dismiss, "Dismiss")
 
+        # task-31236: a dismissed review set's undo receipt -- the same
+        # grammar as the bulk-delete receipt above, because a one-click
+        # dismissal of a mid-walk set (with its done-marks) must be
+        # recoverable right where the user lands after the picker closes.
+        dismissed_set_name = getattr(
+            self.canvas, "review_dismiss_receipt_name", ""
+        )
+        if dismissed_set_name:
+            dismiss_receipt_row = Horizontal(
+                classes="ds-toolbar", id="library-media-review-dismiss-receipt"
+            )
+            dismiss_receipt_row.styles.height = "auto"
+            with dismiss_receipt_row:
+                yield Static(
+                    f"✓ dismissed · {dismissed_set_name}",
+                    id="library-media-review-dismiss-receipt-copy",
+                    classes="library-toolbar-count",
+                    markup=False,
+                )
+                undo_set = Button(
+                    "Undo",
+                    id="library-media-review-dismiss-undo",
+                    classes="library-canvas-action",
+                    compact=True,
+                )
+                yield self._gate_stale_action(undo_set, "Undo")
+                close_receipt = Button(
+                    "Dismiss",
+                    id="library-media-review-dismiss-receipt-close",
+                    classes="library-canvas-action",
+                    compact=True,
+                )
+                yield self._gate_mutation_action(close_receipt, "Dismiss")
+
         status_text = (
             self.pager.status_copy
             if self.pager is not None and self.pager.status_copy


### PR DESCRIPTION
First fix PR from critique #3 of Library ▸ Media (28/40, first Good-band score). Tasks 31233 + 31234 + 31236 + 31238 — both review-set continuity P1s, the Dismiss-recovery P2, and the set-identity P3. User rulings at the critique close: fix everything incl. P3; Dismiss = undo on the receipt; resume = always load the cursor item.

## task-31233 — "Review selected" opens the review it creates

The Select-mode bulk Review toasted "Reviewing 2 items." then left the user in select mode with unchecked boxes and a blank reader — the shared create path opens item 1 (39305), but nothing on the selection path ever exited select mode (cleared only by Done/bulk-delete). The create now exits select mode (no discard notice — the selection was consumed) and syncs the CANVAS before the viewer open. The canvas sync is load-bearing and was found live: the viewer-scoped sync seam updates only the viewer in place, so without it the select toolbar stayed mounted under an armed banner.

## task-31234 — auto-resume always lands on the cursor item

Re-entry re-armed the banner ("Read later — 1 of 2") over whatever document was showing — including one not in the set — because the once-per-set gate returned without opening while the banner re-armed unconditionally; the first `]` was a silent sync. The gate is removed: every entry to Media with an active set lands in the Reader at the saved place, so the banner and the visible document always agree. Supersedes task-28245's show-the-list AC (documented in that task file); the cold-start yank guards are untouched.

## task-31236 — Dismiss gets an Undo receipt

A picker row's Dismiss was a one-click soft-delete with no confirm, no undo, and no surfaced reopen path — a mid-walk set with its done-marks died to one mis-click. Dismiss now leaves a "✓ dismissed · name" receipt on the media list (the bulk-delete receipt grammar) with Undo. New `ReviewSetService.undismiss(set_id, reactivate)` clears the tombstone in one transaction and re-activates only when no other live set became active since — the one-active invariant outranks the undo. Cursor and reviewed marks come back untouched (dismiss never touched them). Failure paths notify per the task-30042 no-silent-failures ruling.

## task-31238 — replacement notice + distinguishable picker rows

Creating any set silently deactivated the active one; auto-names ("2 selected items") made two selection sets render identical picker rows. The create now toasts "Paused '<name>' at <live progress>. Resume from Sets." when it displaces an in-progress set (quiet when nothing was displaced or the displaced set was complete; name markup-escaped; progress computed live so the toast can't disagree with the picker). Picker detail labels end with the created date — same tuple shape, zero picker-widget changes.

## Tests

15 new/updated across `test_review_set_walker.py` (create/exit ordering incl. the canvas sync, every-entry resume, dismiss-receipt arming, undo worker + failure, pause-notice trio), `test_review_set_service.py` (undismiss restore / one-active yield / inactive restore), `test_review_set_state.py` (date suffix, same-name distinguishability, malformed timestamp), `test_library_multiselect_media.py` (receipt row renders / absent). 330 green across all touched suites; preflight clean (diagnostic inventory regenerated for the one new failure-notice logger).

## Live verification (tmux, seeded, cleaned up)

Select → 2 checked → Review: select mode exits, browse toolbar returns, banner "2 selected items — 1 of 2", Reader at item 1. Leave to Notes and re-enter Media twice: Reader lands at the cursor item both times with an agreeing banner. Sets → Dismiss: "✓ dismissed · All media Undo" receipt; Undo restores the set (DB: deleted_at NULL, cursor + marks intact, activation yielded correctly). "Review these" over an in-progress set: "Paused 'All media' at 1 of 3 · 0 reviewed. Resume from Sets." captured at +1s; picker rows show created dates.

Also included: critique #3 snapshot (`.impeccable/critique/`), PR-B tasks 31235/31237 filed (sort-chooser clipping, reader vertical space — separate branch), task-28245 supersession note, user-guide updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGaR5sbP3iuynBGbthzAZ1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four review-set continuity issues from critique #3 of Library ▸ Media: Review-selected now opens the review it creates, auto-resume always lands on the saved cursor item, Dismiss is recoverable via an Undo receipt, and creating a set no longer silently displaces an in-progress walk.

**Bug Fixes**
- Creating a set from Select mode exits select mode and opens the set's first item in the Reader, matching the "Review these" path.
- Auto-resume opens the active set's cursor item on every entry into Media, so the banner and visible document always agree; this supersedes task-28245's once-per-set behavior. Tombstone-resolved cursor positions are persisted so a restored item can't yank a later entry backward.
- Dismissing a review set leaves a "✓ dismissed · name" receipt on the media list with Undo, restoring the set's cursor, done-marks, and active state; restoration yields activation to any newer active set, and an in-flight undo refuses a second Undo or a racing receipt-close.
- Creating a set over an in-progress one toasts "Paused '<name>' at <live progress>. Resume from Sets." instead of deactivating it silently.
- Picker rows now append the created minute, so same-auto-named sets like "2 selected items" stay distinguishable even when made the same day.

<sup>Written for commit b55d6b12f01461295d07b5938ca3c3cb28c7939e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

