### PR TITLE
fix(library): sort chooser shows every option; Reader fills its pane, Find collapses, dead pager dropped

### DIFF
--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -137,7 +137,8 @@ restoring it.
 |---|---|
 | "Filter media" / "Clear filter" | Searches the complete local Media source before paging; it is separate from Find in item. Clearing restores the unfiltered selection when it is still available. |
 | "type: All types" | Opens one bounded keyboard list containing the complete type set, with ✓ on the active choice. "All types" means no filter; a stored type literally named "All" remains a separate selectable value. Press Escape (or pick the current choice) to cancel. |
-| "Previous" / "Next" | Moves through exact 20-item pages after the active query, type, and sort are applied. The final page may contain fewer rows; disabled buttons explain why they cannot move. |
+| "sort: Newest" | Opens the same kind of bounded keyboard list with all four orders (Newest, Oldest, Title A-Z, Title Z-A) fully visible and ✓ on the active one. Escape cancels. |
+| "Previous" / "Next" | Moves through exact 20-item pages after the active query, type, and sort are applied. The final page may contain fewer rows; disabled buttons explain why they cannot move. With only one page, the controls do not render at all — just the item range. |
 | "Retry" | Repeats a failed page request. If retained rows may be out of date, unsafe row and bulk actions stay disabled until recovery succeeds. |
 | "Export…" / "Select" | The shared grammar above; Export… is scoped to the active type filter. |
 | "Trash" | Opens the Trash view — every deleted media item, restorable per item (see "Media Trash" above). Hidden while selecting, like "Export…". |
@@ -203,7 +204,7 @@ item-specific empty state; it does not silently switch modes.
 
 | Button | What it does |
 |---|---|
-| "Find" | Opens Find in item for the loaded representation; this never filters Items. |
+| "Find" | Opens the in-item search bar (collapsed until then) focused and ready to type; this never filters Items. Escape closes the bar again. |
 | "Use in Console" | Stages this item as context for your next Console message. |
 | "Read later" ↔ "Remove later" | Toggles the loaded item's persisted reading-list state. |
 | "More" | Keeps secondary actions reachable: Edit metadata, Open original when available, Open manager, and Move to trash. Narrow layouts retain these actions here rather than hiding them. |

--- a/Tests/UI/test_library_media_reader_flow.py
+++ b/Tests/UI/test_library_media_reader_flow.py
@@ -1094,7 +1094,22 @@ def test_external_server_detail_does_not_use_local_progress_seam():
     assert queried == []
 
 
-def _escape_fake(*, region: str, more_open: bool = False):
+def _escape_fake_query_one(shell, find, *, mounted):
+    from textual.css.query import NoMatches
+
+    def query_one(selector, *_args):
+        if selector == "#library-media-reader-shell":
+            return shell
+        if selector == "#library-media-content-search-controls" and not mounted:
+            raise NoMatches(selector)
+        return find
+
+    return query_one
+
+
+def _escape_fake(
+    *, region: str, more_open: bool = False, find_mounted: bool | None = None
+):
     layout = SimpleNamespace(items_open=True, library_open=True)
     library = SimpleNamespace(role="library", ancestors=())
     items = SimpleNamespace(role="items", ancestors=())
@@ -1122,10 +1137,13 @@ def _escape_fake(*, region: str, more_open: bool = False):
         _library_media_reader_session=LibraryMediaReaderSessionState(
             more_open=more_open
         ),
-        query_one=lambda selector, *_args: (
-            shell
-            if selector == "#library-media-reader-shell"
-            else find
+        query_one=_escape_fake_query_one(
+            shell,
+            find,
+            # task-31237: the bar is collapsed by default, so the fake
+            # mounts it only when the test's region IS the find bar (or
+            # explicitly requested).
+            mounted=(region == "find") if find_mounted is None else find_mounted,
         ),
         _sync_library_media_viewer_or_recompose=lambda: calls.append("sync"),
         _focus_library_control=lambda selector: calls.append(("focus", selector)),
@@ -1171,6 +1189,33 @@ def test_escape_closes_more_find_confirmation_before_leaving_reader():
     LibraryScreen.action_library_media_viewer_back(fake)
     assert fake._library_media_editing_analysis is False
     assert calls == ["sync"]
+
+
+def test_escape_closes_an_open_find_bar_from_anywhere_in_the_reader():
+    """Qodo on #2367: an open Find bar is a reader substate, focus-agnostic.
+
+    F6 to the content pane must not leave the bar stranded — Escape from
+    any reader-region focus closes it first (one press), and only the next
+    Escape graduates panes. Items/Library-pane Escapes are unaffected.
+    """
+    fake, calls, _shell, _find = _escape_fake(region="reader", find_mounted=True)
+    LibraryScreen.action_library_media_viewer_back(fake)
+    assert fake._library_media_content_query == ""
+    assert fake._library_media_find_open is False
+    assert calls == ["sync", ("focus", "#library-media-reader-find")]
+
+    # An Items-pane Escape never consumes the reader's find bar.
+    fake, calls, shell, _find = _escape_fake(region="items", find_mounted=True)
+    LibraryScreen.action_library_media_viewer_back(fake)
+    assert calls == [("rail", "#library-search-input")]
+
+
+def test_escape_label_names_close_find_while_the_bar_is_open():
+    """The footer label matches the widened close (Qodo #2367 finding 4)."""
+    fake, _calls, _shell, _find = _escape_fake(
+        region="reader", find_mounted=True
+    )
+    assert LibraryScreen._library_media_escape_label(fake) == "close find"
 
 
 def test_escape_moves_reader_to_items_then_library_then_screen_back():

--- a/Tests/UI/test_library_media_reader_flow.py
+++ b/Tests/UI/test_library_media_reader_flow.py
@@ -1135,6 +1135,10 @@ def _escape_fake(*, region: str, more_open: bool = False):
         _register_footer_shortcuts=lambda: calls.append("footer"),
         call_after_refresh=lambda callback, *args: callback(*args),
     )
+    # task-31237: Escape's find branch routes through the shared close seam.
+    fake._close_library_media_find = MethodType(
+        LibraryScreen._close_library_media_find, fake
+    )
     return fake, calls, shell, find
 
 
@@ -1427,6 +1431,10 @@ def test_find_from_analysis_clears_the_search_before_reading_the_transcript():
     )
     fake._reset_library_media_search_on_mode_change = MethodType(
         LibraryScreen._reset_library_media_search_on_mode_change, fake
+    )
+    # task-31237: the reset seam routes through the shared find-close helper.
+    fake._close_library_media_find = MethodType(
+        LibraryScreen._close_library_media_find, fake
     )
 
     LibraryScreen.handle_library_media_reader_find(

--- a/Tests/UI/test_library_media_reader_match_nav_t22209.py
+++ b/Tests/UI/test_library_media_reader_match_nav_t22209.py
@@ -171,7 +171,18 @@ async def _traverse_to_row(screen, pilot, service, *, from_index: int, to_index:
 
 
 async def _submit_query(screen, pilot, query: str) -> None:
-    """Type ``query`` into the mounted content search box and press Enter."""
+    """Type ``query`` into the content search box and press Enter.
+
+    task-31237: the Find bar is collapsed until the Find action opens it,
+    so the helper presses Find first when the input is not yet mounted.
+    """
+    if not screen.query("#library-media-content-search"):
+        screen.query_one("#library-media-reader-find", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: bool(screen.query("#library-media-content-search")),
+            message="Find never mounted the search input.",
+        )
     search_input = screen.query_one("#library-media-content-search", Input)
     search_input.focus()
     await pilot.pause()

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -170,3 +170,17 @@ async def test_find_bar_collapsed_until_find_and_escape_recollapses():
         await pilot.pause()
         await pilot.pause()
         assert not screen.query("#library-media-content-search-controls")
+
+        # Qodo on #2367: the bar is a reader substate, focus-agnostic —
+        # moving focus OUT of the bar (to the content body) must not
+        # strand it; Escape still closes it first.
+        screen.query_one("#library-media-reader-find", Button).press()
+        await _wait_for_selector(
+            screen, pilot, "#library-media-content-search-controls"
+        )
+        screen.query_one("#library-media-viewer-content").focus()
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.pause()
+        assert not screen.query("#library-media-content-search-controls")

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -74,28 +74,99 @@ async def test_type_chooser_paints_every_option():
 
 
 @pytest.mark.asyncio
-async def test_reader_content_takes_the_pane_not_an_18_row_box():
-    """No 1fr blank band; content height scales with the terminal."""
+async def test_sort_chooser_paints_every_option():
+    """task-31235: all four sort options render, as a vertical OptionList.
+
+    Critique #3 P1: the horizontal choice strip clipped "Title A-Z" and
+    rendered "Title Z-A" nowhere at the items pane's real width, while
+    keyboard selection could still pick the invisible option — an option
+    you can't see doesn't exist. Painted text on purpose (the 31221
+    lesson): geometry-only assertions are blind to clipping and to
+    focus-outline paint-over alike.
+    """
+    host = _host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        screen.query_one("#library-media-sort", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-sort-choices")
+        await pilot.pause()
+        await pilot.pause()
+        chooser = screen.query_one("#library-media-sort-choices", OptionList)
+        assert chooser.option_count == 4
+        assert chooser.has_focus  # the screen focuses the chooser on open
+        painted = _painted(host, chooser.region)
+        for label in ("Newest", "Oldest", "Title A-Z", "Title Z-A"):
+            assert label in painted, painted
+
+
+async def _open_first_reader_row(screen, pilot):
+    screen.query_one("#library-media-row-0", Button).press()
+    await _wait_for_condition(
+        pilot,
+        lambda: (
+            screen._library_media_reader_session.pending_request is None
+            and screen._library_media_reader_session.loaded_id is not None
+        ),
+        message="Reader detail never settled.",
+    )
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_reader_content_fills_the_remaining_pane():
+    """task-31237 (evolves task-31222's scaled cap into a true fill):
+    the content box takes the pane's remaining height exactly — no
+    stranded band below it, and the viewer itself never scrolls (chrome
+    stays pinned; overflow belongs to the content box's own scroll)."""
     host = _host()
     async with host.run_test(size=(170, 48)) as pilot:
         screen = await _open_media_list(host, pilot)
-        screen.query_one("#library-media-row-0", Button).press()
-        await _wait_for_condition(
-            pilot,
-            lambda: (
-                screen._library_media_reader_session.pending_request is None
-                and screen._library_media_reader_session.loaded_id is not None
-            ),
-            message="Reader detail never settled.",
-        )
-        await pilot.pause()
+        await _open_first_reader_row(screen, pilot)
         mode_read = screen.query_one("#library-media-reader-mode-read")
         # Heading (+ optional toggle) only — never a 1fr blank band.
         assert mode_read.region.height <= 4, mode_read.region
+        viewer = screen.query_one("#library-media-viewer")
         content = screen.query_one("#library-media-viewer-content")
-        # The box may stay compact for short content, but its ceiling must
-        # scale with the pane instead of a fixed 18 rows.
-        max_height = content.styles.max_height
-        assert max_height is not None and str(max_height.value) != "18", (
-            max_height
+        # Fill: the box's bottom reaches the pane bottom (1-row margin).
+        assert content.region.bottom >= viewer.region.bottom - 2, (
+            content.region,
+            viewer.region,
         )
+        # No outer scroll: the viewer's virtual height fits its container.
+        assert viewer.virtual_size.height <= viewer.container_size.height, (
+            viewer.virtual_size,
+            viewer.container_size,
+        )
+
+
+@pytest.mark.asyncio
+async def test_find_bar_collapsed_until_find_and_escape_recollapses():
+    """task-31237: the content Find bar mounts only on the Find action.
+
+    A permanently open "Search content…" input duplicated the Find button
+    and spent 3 rows on every fresh item; Escape must collapse it again
+    (the old behavior cleared the query but left the bar).
+    """
+    host = _host()
+    async with host.run_test(size=(170, 48)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _open_first_reader_row(screen, pilot)
+        assert not screen.query("#library-media-content-search-controls")
+
+        screen.query_one("#library-media-reader-find", Button).press()
+        await _wait_for_selector(
+            screen, pilot, "#library-media-content-search-controls"
+        )
+        search_input = await _wait_for_selector(
+            screen, pilot, "#library-media-content-search"
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: search_input.has_focus,
+            message="Find never focused the search input.",
+        )
+
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.pause()
+        assert not screen.query("#library-media-content-search-controls")

--- a/Tests/UI/test_library_media_side_by_side.py
+++ b/Tests/UI/test_library_media_side_by_side.py
@@ -1293,8 +1293,10 @@ async def test_compact_media_pager_receipt_and_empty_states_remain_contained() -
 async def test_single_page_media_list_drops_pager_boundary_noise() -> None:
     # task-28016: one page of results has nowhere to page to, so the
     # "Page 1 of 1" counter and the boundary reasons ("Already on the first
-    # page.", "No more results.") are suppressed; the item range stays and the
-    # (disabled) controls remain so nothing shifts once a second page exists.
+    # page.", "No more results.") are suppressed. task-31237 (critique #3,
+    # supersedes 28016's keep-the-disabled-controls choice): the two dead
+    # "○ Previous ○ Next" forms are dropped entirely -- the item range
+    # stays, and the controls return the moment a second page exists.
     app = _build_media_test_app()
     _seed_conversations(app, _two_conversations(), media=_many_media_items(3))
     host = LibraryProductionCSSHarness(app)
@@ -1306,8 +1308,24 @@ async def test_single_page_media_list_drops_pager_boundary_noise() -> None:
         )
         assert str(status.renderable) == "1-3 of 3"
         assert not screen.query("#library-media-disabled-reason")
-        assert screen.query_one("#library-media-next", Button).disabled is True
-        assert screen.query_one("#library-media-previous", Button).disabled is True
+        assert not screen.query("#library-media-next")
+        assert not screen.query("#library-media-previous")
+
+
+@pytest.mark.asyncio
+async def test_multi_page_media_list_keeps_pager_controls() -> None:
+    """A second page brings Previous/Next back (task-31237 negative control)."""
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_many_media_items(45))
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=WIDE_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _wait_for_selector(screen, pilot, "#library-media-next")
+        assert screen.query_one("#library-media-next", Button).disabled is False
+        assert (
+            screen.query_one("#library-media-previous", Button).disabled is True
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/UI/test_library_per_click_recompose_t21116.py
+++ b/Tests/UI/test_library_per_click_recompose_t21116.py
@@ -99,7 +99,7 @@ async def test_media_row_open_and_detail_arrival_are_canvas_scoped() -> None:
         calls, spy = _screen_recompose_spy()
         with patch.object(BaseAppScreen, "refresh", spy):
             screen.query_one("#library-media-row-0", Button).press()
-            await _wait_for_selector(screen, pilot, "#library-media-content-search")
+            await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
         assert calls == []
         assert screen.query_one("#library-rail") is rail_before
         assert screen.query_one("#library-media-viewer", LibraryMediaViewer)
@@ -112,7 +112,7 @@ async def test_media_viewer_back_is_canvas_scoped_and_restores_list_focus() -> N
     async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
         screen = await _boot_media_library(host, pilot)
         screen.query_one("#library-media-row-0", Button).press()
-        await _wait_for_selector(screen, pilot, "#library-media-content-search")
+        await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
         rail_before = screen.query_one("#library-rail")
         calls, spy = _screen_recompose_spy()
         with patch.object(BaseAppScreen, "refresh", spy):
@@ -179,7 +179,7 @@ async def test_open_item_by_id_media_is_canvas_scoped() -> None:
         calls, spy = _screen_recompose_spy()
         with patch.object(BaseAppScreen, "refresh", spy):
             await screen._open_library_item_by_id("media", "media-1")
-            await _wait_for_selector(screen, pilot, "#library-media-content-search")
+            await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
         assert calls == []
         assert screen.query_one("#library-rail") is rail_before
         assert screen._library_selected_row_id == LIBRARY_ROW_BROWSE_MEDIA
@@ -347,7 +347,7 @@ async def test_media_row_open_latency_probe() -> None:
         for _ in range(12):
             started = perf_counter()
             screen.query_one("#library-media-row-0", Button).press()
-            await _wait_for_selector(screen, pilot, "#library-media-content-search")
+            await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
             samples.append((perf_counter() - started) * 1000.0)
             screen.query_one("#library-media-back", Button).press()
             await _wait_for_selector(screen, pilot, "#library-media-row-0")

--- a/Tests/UI/test_library_review_round_t21116.py
+++ b/Tests/UI/test_library_review_round_t21116.py
@@ -78,7 +78,7 @@ async def test_late_media_detail_arrival_cannot_clobber_the_trash_view() -> None
         # leave it -- the worker whose continuation we fire below is the
         # one this open started.
         screen.query_one("#library-media-row-0", Button).press()
-        await _wait_for_selector(screen, pilot, "#library-media-content-search")
+        await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
         screen.query_one("#library-media-back", Button).press()
         await _wait_for_selector(screen, pilot, "#library-media-trash-open")
 
@@ -216,7 +216,7 @@ async def test_slow_canvas_swap_is_not_raced_by_the_media_browse_sync() -> None:
     async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
         screen = await _boot_media_library(host, pilot)
         screen.query_one("#library-media-row-0", Button).press()
-        await _wait_for_selector(screen, pilot, "#library-media-content-search")
+        await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
 
         fired: list[str] = []
 
@@ -254,7 +254,7 @@ async def test_routine_snapshot_midswap_still_runs_the_projection_follow_up() ->
     async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
         screen = await _boot_media_library(host, pilot)
         screen.query_one("#library-media-row-0", Button).press()
-        await _wait_for_selector(screen, pilot, "#library-media-content-search")
+        await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
 
         armed: list[object] = []
         original_arm = screen._arm_library_list_entry_focus

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -10636,11 +10636,15 @@ def _large_markdown_media_item():
 
 
 async def _open_media_viewer(screen, pilot):
-    """Navigate to the media list and open the first row's viewer."""
+    """Navigate to the media list and open the first row's viewer.
+
+    task-31237: the content Find bar no longer mounts until the Find
+    action opens it, so the viewer-loaded sentinel is the content body.
+    """
     screen.query_one("#library-row-browse-media").press()
     await _wait_for_selector(screen, pilot, "#library-media-row-1")
     screen.query_one("#library-media-row-1").press()
-    await _wait_for_selector(screen, pilot, "#library-media-content-search")
+    await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
 
 
 @pytest.mark.asyncio
@@ -10658,14 +10662,23 @@ async def test_library_media_sort_chooser_applies_the_selected_order():
         await _wait_for_selector(screen, pilot, "#library-media-sort")
         service = app.media_reading_scope_service
 
-        # Open the sort chooser; its direct-pick strip replaces the toolbar.
+        # Open the sort chooser; its vertical OptionList replaces the
+        # toolbar (task-31235: the horizontal strip clipped options).
         screen.query_one("#library-media-sort", Button).press()
-        await _wait_for_selector(screen, pilot, ".library-media-sort-choice")
+        chooser = await _wait_for_selector(
+            screen, pilot, "#library-media-sort-choices"
+        )
+        assert isinstance(chooser, OptionList)
         assert screen._library_media_sort_choices_visible is True
 
-        # Pick "Title A-Z" -> the strip closes and a page-one fetch runs
+        # Pick "Title A-Z" -> the chooser closes and a page-one fetch runs
         # under sort_by=title_asc.
-        screen.query_one("#library-media-sort-title_asc", Button).press()
+        chooser.highlighted = next(
+            index
+            for index, option in enumerate(chooser.options)
+            if getattr(option, "choice_value", None) == "title_asc"
+        )
+        chooser.action_select()
         for _ in range(150):
             if service.search_calls and service.search_calls[-1].get(
                 "sort_by"
@@ -10700,24 +10713,33 @@ async def test_library_media_sort_and_type_choosers_are_mutually_exclusive():
         screen.query_one("#library-media-type-filter", Button).press()
         await _wait_for_selector(screen, pilot, "#library-media-type-choices")
         screen.query_one("#library-media-sort", Button).press()
-        await _wait_for_selector(screen, pilot, ".library-media-sort-choice")
+        await _wait_for_selector(screen, pilot, "#library-media-sort-choices")
         assert screen._library_media_sort_choices_visible is True
         assert screen._library_media_type_choices_visible is False
 
-        # The open strip advertises its own footer keys through the shared seam.
+        # The open chooser advertises its own footer keys through the shared seam.
         footer = screen._library_footer_shortcuts_for_current_state()
         assert ("enter", "choose sort") in footer
         assert ("esc", "cancel") in footer
 
-        # Escape closes the strip.
+        # Escape closes the chooser.
         await pilot.press("escape")
         await pilot.pause()
         assert screen._library_media_sort_choices_visible is False
-        assert not screen.query(".library-media-sort-choice")
+        assert not screen.query("#library-media-sort-choices")
 
 
 async def _submit_content_search_query(screen, pilot, query):
-    """Type ``query`` into the open viewer's content search box and press Enter."""
+    """Type ``query`` into the open viewer's content search box and press Enter.
+
+    task-31237: the Find bar is collapsed until the Find action opens it,
+    so the helper presses Find first when the input is not yet mounted.
+    """
+    if not screen.query("#library-media-content-search"):
+        screen.query_one("#library-media-reader-find", Button).press()
+        await _wait_for_selector(
+            screen, pilot, "#library-media-content-search"
+        )
     search_input = screen.query_one("#library-media-content-search", Input)
     search_input.value = query
     search_input.focus()
@@ -10748,10 +10770,15 @@ async def test_library_shell_media_content_search_no_query_hides_status_and_nav(
 
         await _open_media_viewer(screen, pilot)
 
-        assert screen.query_one("#library-media-content-search")
-        # task-28002: the status line and the prev/next nav container persist
-        # display-gated (tearing them down recomposed away the focused Input)
-        # -- with no active query they are hidden, not removed.
+        # task-31237: a fresh item renders NO find bar at all -- it mounts
+        # when the Find action opens it.
+        assert not screen.query("#library-media-content-search")
+        screen.query_one("#library-media-reader-find", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-content-search")
+        # task-28002: once open, the status line and the prev/next nav
+        # container persist display-gated (tearing them down recomposed away
+        # the focused Input) -- with no active query they are hidden, not
+        # removed.
         assert not screen.query_one("#library-media-content-search-status").display
         assert not screen.query_one("#library-media-content-search-nav").display
 
@@ -12019,7 +12046,11 @@ async def test_library_shell_media_content_search_placeholder_states_raw_text_fo
         await _wait_for_library_shell(screen, pilot)
         await _open_media_viewer(screen, pilot)
 
-        search_input = screen.query_one("#library-media-content-search", Input)
+        # task-31237: the Find bar mounts on the Find action.
+        screen.query_one("#library-media-reader-find", Button).press()
+        search_input = await _wait_for_selector(
+            screen, pilot, "#library-media-content-search"
+        )
         assert search_input.placeholder == "Search content (raw text)…"
 
 

--- a/backlog/tasks/task-31235 - Sort-chooser-renders-every-option.md
+++ b/backlog/tasks/task-31235 - Sort-chooser-renders-every-option.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-31235
 title: Sort chooser renders every option
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-04 01:50'
+updated_date: '2026-09-04 04:21'
 labels:
   - library
   - media-ux
@@ -19,7 +20,22 @@ Critique #3 P1: the sort chooser renders "✓ Newest  Oldest  Title A-" in the ~
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 All four MEDIA_SORT_CHOICES options are fully visible when the sort chooser is open at the shell's narrow pane width
-- [ ] #2 The active option keeps its ✓ marker and keyboard selection works over the visible list
-- [ ] #3 A test pins that every sort option's label renders (painted-text or equivalent, not just presence in the DOM)
+- [x] #1 All four MEDIA_SORT_CHOICES options are fully visible when the sort chooser is open at the shell's narrow pane width
+- [x] #2 The active option keeps its ✓ marker and keyboard selection works over the visible list
+- [x] #3 A test pins that every sort option's label renders (painted-text or equivalent, not just presence in the DOM)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: painted-text test that every MEDIA_SORT_CHOICES label renders at the shell's narrow pane width
+2. GREEN: replace the horizontal choice strip with the type chooser's vertical OptionList twin; move the handler to OptionList.OptionSelected
+3. Suppress the app-tier *:focus outline for the new id (31221 family) and pin it
+4. Live tmux verify at 200x52
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Sort chooser is now the type chooser's vertical OptionList twin (library_media_canvas.py): all four MEDIA_SORT_CHOICES render with ✓ on the active option, pre-highlighted. Handler moved from the strip's Button.Pressed to OptionList.OptionSelected with identical validation (allow-list derived from MEDIA_SORT_CHOICES) and close-on-same-value semantics; open-focus rides _sync_library_canvas's then hook because a bare call_after_refresh has no ordering against the canvas-scoped recompose (test caught it). The app-global *:focus outline overwrote 'Newest' and 'Title Z-A' at option-count height — suppressed at app tier for the new id and pinned with a painted-text test (region assertions are blind to paint-over). Live-verified at 200x52: four options vertical, picking 'Title A-Z' re-sorts and closes. Shipped in PR #2367 with task-31237.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31237 - Reader-uses-its-vertical-space.md
+++ b/backlog/tasks/task-31237 - Reader-uses-its-vertical-space.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-31237
 title: Reader uses its vertical space
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-04 01:50'
+updated_date: '2026-09-04 04:21'
 labels:
   - library
   - media-ux
@@ -19,8 +20,23 @@ Critique #3 P2: at 52 terminal rows the Reader's content box ends near row 39 (#
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The Reader content area grows to fill the remaining pane height at tall terminal sizes (no stranded band below the box)
-- [ ] #2 The content find input is collapsed until Find is invoked, and Escape re-collapses it
-- [ ] #3 The pager row is hidden when there is only one page
-- [ ] #4 The task-31222 regression (fixed 18-row cap under an unstyled 1fr band) stays fixed at small sizes
+- [x] #1 The Reader content area grows to fill the remaining pane height at tall terminal sizes (no stranded band below the box)
+- [x] #2 The content find input is collapsed until Find is invoked, and Escape re-collapses it
+- [x] #3 The pager row is hidden when there is only one page
+- [x] #4 The task-31222 regression (fixed 18-row cap under an unstyled 1fr band) stays fixed at small sizes
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: fill contract (content box ends at pane bottom, virtual height == container), Find round trip (collapsed → open → Escape collapses), single-page pager absence + multi-page negative control
+2. GREEN: #library-media-viewer-content 75vh cap → height:1fr; find_open state + one _close_library_media_find() seam; _compose_pager drops controls on single_page
+3. Convert test helpers that typed into the always-open bar to press Find first
+4. Live tmux verify at 200x52 and confirm 31222's small-size fix holds
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Three parts. Fill: #library-media-viewer-content goes from the 75vh cap to height:1fr — at 200x52 with a 300-line document the box ends at the pane bottom and the viewer's virtual height equals its container (no stranded band, no double scroll). The old '1fr balloons the pane' CSS note predated task-31222's height:auto wrappers; with them in place 1fr resolves against the viewer remainder, and the 31222 small-size fix still holds. Find collapse: the 'Search content…' bar no longer renders permanently; new find_open state with one _close_library_media_find() seam replacing all 8 query-reset pairs (item open, external open, viewer exit, rail switch, delete, mode change, Escape, entry guard), threaded through the viewer constructor AND the in-place _sync_library_media_viewer_state compare/assign. Focus is taken by the bar's own post-mount hook (three screen-level call_after_refresh variants lost the race against the nested recompose-mount). Qodo round: an open Find bar is a reader substate — Escape closes it first from any reader-region focus incl. after F6, and the footer says 'esc close find'. Dead pager: a single-page list renders no Previous/Next controls (supersedes task-28016's keep-disabled-controls choice per the critique ruling); the range Static stays; controls return with a second page; Retry still renders on a failed single-page fetch. Test helpers now press Find before typing. Live-verified at 200x52. Shipped in PR #2367 with task-31235.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -24038,6 +24038,9 @@ class LibraryScreen(BaseAppScreen):
         width. Picking the already-active sort only closes the chooser --
         no service request. Any other value re-fetches page one under the
         new order.
+
+        Args:
+            event: Selection event emitted by the bounded sort chooser.
         """
         event.stop()
         if self._library_media_bulk_delete_in_flight:
@@ -38660,6 +38663,19 @@ class LibraryScreen(BaseAppScreen):
         ):
             self._exit_library_media_viewer()
             return
+        # Qodo on #2367: an open Find bar is a reader substate regardless
+        # of where focus sits INSIDE the reader region (F6 to the content
+        # pane must not leave the bar stranded) -- Escape closes it first,
+        # and _library_media_escape_label advertises exactly that. The
+        # items/library-pane branches above stay untouched: their Escape
+        # never consumes the reader's find state.
+        if find_controls is not None:
+            self._close_library_media_find()
+            self._sync_library_media_viewer_or_recompose()
+            self.call_after_refresh(
+                self._focus_library_control, "#library-media-reader-find"
+            )
+            return
         if layout.items_open:
             self._focus_library_media_items_pane()
         elif layout.library_open:
@@ -39686,6 +39702,11 @@ class LibraryScreen(BaseAppScreen):
             focused is shell.library or shell.library in focused.ancestors
         ):
             return "back"
+        # Qodo on #2367: with the Find bar open, a reader-region Escape
+        # closes it first (see action_library_media_viewer_back) -- the
+        # label says so even when focus has left the bar (F6 to content).
+        if find_controls is not None:
+            return "close find"
         if shell.effective_layout.items_open:
             return "focus Items"
         if shell.effective_layout.library_open:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -2695,6 +2695,10 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_generating_analysis: bool = False
         self._library_media_content_query: str = ""
         self._library_media_content_match_index: int = 0
+        # task-31237: the content Find bar is collapsed until the Find
+        # action opens it -- a permanently open "Search content…" input
+        # duplicated the Find button and spent 3 rows on every fresh item.
+        self._library_media_find_open: bool = False
         # task-22209: in-content match list for the open item, memoized on
         # (detail object identity, query). Both the query submit and every
         # Prev/Next click need it, and deriving it costs a full content
@@ -23494,8 +23498,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_confirming_delete = False
         self._library_media_highlights = []
         self._library_media_editing_analysis = False
-        self._library_media_content_query = ""
-        self._library_media_content_match_index = 0
+        self._close_library_media_find()
         self._library_media_content_mode = "raw"
         self._library_notes_filter = ""
         self._library_notes_filter_records = None
@@ -24003,30 +24006,43 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_sort_choices_visible = (
             not self._library_media_sort_choices_visible
         )
-        _sync_library_canvas(self, "media")
-        if self._library_media_sort_choices_visible:
-            current = self._library_media_browse_controller.mutation_refresh_scope.sort_by
-            self.call_after_refresh(
-                self._focus_library_choice_strip_active,
-                ".library-media-sort-choice",
-                current,
-            )
-        else:
-            self.call_after_refresh(
-                self._focus_library_control, "#library-media-sort"
-            )
+        # task-31235: the chooser is a vertical OptionList (like the type
+        # chooser) with the active value pre-highlighted at compose time,
+        # so focusing the list is enough. The focus rides the sync's
+        # ``then`` hook -- ``call_after_refresh`` has no ordering against
+        # a canvas-scoped recompose (see ``_sync_library_canvas``).
+        def focus_open_chooser() -> None:
+            self._focus_library_control("#library-media-sort-choices")
 
-    @on(Button.Pressed, ".library-media-sort-choice")
-    def handle_library_media_sort_choice(self, event: Button.Pressed) -> None:
-        """Apply the exact sort value carried by one strip choice (task-28013).
+        def focus_sort_opener() -> None:
+            self._focus_library_control("#library-media-sort")
 
-        Picking the already-active sort only closes the strip -- no service
-        request. Any other value re-fetches page one under the new order.
+        _sync_library_canvas(
+            self,
+            "media",
+            then=(
+                focus_open_chooser
+                if self._library_media_sort_choices_visible
+                else focus_sort_opener
+            ),
+        )
+
+    @on(OptionList.OptionSelected, "#library-media-sort-choices")
+    def handle_library_media_sort_choice(
+        self, event: OptionList.OptionSelected
+    ) -> None:
+        """Apply the exact sort value carried by one chooser option.
+
+        task-31235: the horizontal strip (task-28013) became a vertical
+        OptionList -- it clipped options off-pane at the items pane's real
+        width. Picking the already-active sort only closes the chooser --
+        no service request. Any other value re-fetches page one under the
+        new order.
         """
         event.stop()
         if self._library_media_bulk_delete_in_flight:
             return
-        requested = str(getattr(event.button, "choice_value", "") or "")
+        requested = str(getattr(event.option, "choice_value", "") or "")
         self._library_media_sort_choices_visible = False
         current = self._library_media_browse_controller.mutation_refresh_scope.sort_by
         valid = {value for value, _ in MEDIA_SORT_CHOICES}
@@ -25354,8 +25370,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_confirming_delete = False
         self._library_media_highlights = []
         self._library_media_editing_analysis = False
-        self._library_media_content_query = ""
-        self._library_media_content_match_index = 0
+        self._close_library_media_find()
         self._library_media_content_mode = "raw"
         self._sync_library_media_viewer_or_recompose()
 
@@ -25370,8 +25385,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_highlights = []
         self._library_media_editing = False
         self._library_media_editing_analysis = False
-        self._library_media_content_query = ""
-        self._library_media_content_match_index = 0
+        self._close_library_media_find()
         self._library_media_content_mode = "raw"
         self._library_media_view = "viewer"
         self._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
@@ -38543,8 +38557,7 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_editing = False
         self._library_media_confirming_delete = False
         self._library_media_editing_analysis = False
-        self._library_media_content_query = ""
-        self._library_media_content_match_index = 0
+        self._close_library_media_find()
         self._library_media_content_mode = "raw"
         self._load_library_media_list_if_needed()
         # task-21116: the exit is a canvas-child swap (viewer -> list), not
@@ -38611,8 +38624,7 @@ class LibraryScreen(BaseAppScreen):
             and focused is not None
             and (focused is find_controls or find_controls in focused.ancestors)
         ):
-            self._library_media_content_query = ""
-            self._library_media_content_match_index = 0
+            self._close_library_media_find()
             self._sync_library_media_viewer_or_recompose()
             self.call_after_refresh(
                 self._focus_library_control, "#library-media-reader-find"
@@ -40052,8 +40064,7 @@ class LibraryScreen(BaseAppScreen):
                 self._library_media_composed_detail = None
                 self._library_media_highlights = []
                 self._library_media_editing_analysis = False
-                self._library_media_content_query = ""
-                self._library_media_content_match_index = 0
+                self._close_library_media_find()
                 self._library_media_content_mode = "raw"
                 if adjacent is None:
                     self._selected_media_id = ""
@@ -40358,6 +40369,7 @@ class LibraryScreen(BaseAppScreen):
             content_query=self._library_media_content_query,
             content_match_index=self._library_media_content_match_index,
             content_mode=self._library_media_content_mode,
+            find_open=self._library_media_find_open,
             loading=(
                 self._library_media_reader_session.pending_request is not None
                 and self._library_media_reader_session.error is None
@@ -40601,6 +40613,7 @@ class LibraryScreen(BaseAppScreen):
             and viewer.content_query == self._library_media_content_query
             and viewer.content_match_index == self._library_media_content_match_index
             and viewer.content_mode == self._library_media_content_mode
+            and viewer.find_open == self._library_media_find_open
             and viewer.error_message == (self._library_media_reader_session.error or "")
             and viewer.reader_mode == self._library_media_reader_session.mode
             and viewer.more_open == self._library_media_reader_session.more_open
@@ -40645,6 +40658,7 @@ class LibraryScreen(BaseAppScreen):
             viewer.content_query = self._library_media_content_query
             viewer.content_match_index = self._library_media_content_match_index
             viewer.content_mode = self._library_media_content_mode
+            viewer.find_open = self._library_media_find_open
             viewer.loading = loading
             viewer.loading_message = loading_message
             viewer.error_message = self._library_media_reader_session.error or ""
@@ -40774,8 +40788,7 @@ class LibraryScreen(BaseAppScreen):
             new_mode: The Reader mode being switched to.
         """
         if new_mode != self._library_media_reader_session.mode:
-            self._library_media_content_query = ""
-            self._library_media_content_match_index = 0
+            self._close_library_media_find()
             self._library_media_content_match_memo = None
 
     def _capture_library_media_loaded_progress(self) -> None:
@@ -40926,6 +40939,18 @@ class LibraryScreen(BaseAppScreen):
             return
         body.scroller.scroll_to(x=offset[0], y=offset[1], animate=False, force=True)
 
+    def _close_library_media_find(self) -> None:
+        """Reset the content Find bar: collapsed, no query, first match.
+
+        task-31237: one seam for every reset path (item open, viewer exit,
+        rail switch, delete, mode change, Escape) so a stale ``find_open``
+        can never hold the bar open across a context the query reset
+        already abandoned.
+        """
+        self._library_media_find_open = False
+        self._library_media_content_query = ""
+        self._library_media_content_match_index = 0
+
     @on(Button.Pressed, "#library-media-reader-find")
     def handle_library_media_reader_find(self, event: Button.Pressed) -> None:
         """Take Find to the loaded item's content body.
@@ -40938,6 +40963,9 @@ class LibraryScreen(BaseAppScreen):
         # clears any active analysis search before focusing the transcript
         # find bar -- the same reset the Reader mode buttons apply.
         self._reset_library_media_search_on_mode_change("read")
+        # task-31237: the bar is collapsed until this gesture opens it
+        # (AFTER the reset above, which closes it as part of the mode seam).
+        self._library_media_find_open = True
         self._library_media_reader_session = set_mode(
             self._library_media_reader_session, "read"
         )
@@ -41014,12 +41042,27 @@ class LibraryScreen(BaseAppScreen):
         except (NoMatches, QueryError):
             return None
 
-    def _focus_library_media_content_search_input(self) -> None:
-        """Focus the mounted content search box after controls synchronize."""
+    def _focus_library_media_content_search_input(
+        self, *, _retries: int = 4
+    ) -> None:
+        """Focus the mounted content search box after controls synchronize.
+
+        task-31237: the input now MOUNTS during the viewer's recompose
+        (the bar is collapsed until Find opens it), and screen-level
+        ``call_after_refresh`` callbacks can flush before the widget-level
+        recompose lands its children -- a short bounded re-defer chain
+        covers the mount latency instead of silently losing the focus.
+        """
         try:
             self.query_one("#library-media-content-search", Input).focus()
         except (NoMatches, QueryError):
-            pass
+            if _retries > 0:
+                self.call_after_refresh(
+                    partial(
+                        self._focus_library_media_content_search_input,
+                        _retries=_retries - 1,
+                    )
+                )
 
     @on(Button.Pressed, "#library-media-content-mode-rendered")
     async def handle_library_media_content_mode_rendered(
@@ -42535,8 +42578,7 @@ class LibraryScreen(BaseAppScreen):
             self._library_media_confirming_delete = False
             self._library_media_highlights = []
             self._library_media_editing_analysis = False
-            self._library_media_content_query = ""
-            self._library_media_content_match_index = 0
+            self._close_library_media_find()
             self._library_media_content_mode = "raw"
             self.run_worker(
                 self._refresh_library_media_detail(

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -20,9 +20,6 @@ from tldw_chatbook.Library.library_media_state import (
     LibraryMediaCanvasState,
     MEDIA_SORT_CHOICES,
 )
-from tldw_chatbook.Widgets.Library.library_choice_strip import (
-    compose_library_choice_strip,
-)
 from tldw_chatbook.Library.library_shell_state import (
     LIBRARY_DELETE_SELECTED_DISABLED_TOOLTIP,
     LIBRARY_DELETE_SELECTED_TOOLTIP,
@@ -688,17 +685,31 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             choices.styles.height = min(8, max(1, len(options)))
             yield choices
         if sort_choices_visible:
-            # task-28013: the sort chooser's direct-pick strip, replacing the
-            # toolbar row exactly like the type chooser (shared helper).
-            yield from compose_library_choice_strip(
-                strip_id="library-media-sort-choices",
-                choice_class="library-media-sort-choice",
-                options=tuple(
-                    (f"library-media-sort-{value}", value, label)
-                    for value, label in MEDIA_SORT_CHOICES
-                ),
-                active_value=current_sort,
+            # task-31235 (critique #3 P1): a vertical OptionList exactly like
+            # the type chooser above -- the horizontal choice strip clipped
+            # "Title A-Z" and rendered "Title Z-A" nowhere at the items
+            # pane's real width, while keyboard selection could still pick
+            # the invisible option.
+            sort_options: list[Option] = []
+            sort_highlighted = 0
+            for index, (value, label) in enumerate(MEDIA_SORT_CHOICES):
+                option = Option(
+                    f"✓ {label}" if value == current_sort else label,
+                    id=f"library-media-sort-option-{index}",
+                )
+                option.choice_value = value
+                sort_options.append(option)
+                if value == current_sort:
+                    sort_highlighted = index
+            sort_choices = OptionList(
+                *sort_options,
+                id="library-media-sort-choices",
+                compact=True,
+                markup=False,
             )
+            sort_choices.highlighted = sort_highlighted
+            sort_choices.styles.height = min(8, max(1, len(sort_options)))
+            yield sort_choices
         confirming_bulk_delete = getattr(self.canvas, "confirming_bulk_delete", False)
         if select_mode:
             if confirming_bulk_delete:
@@ -1009,6 +1020,14 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                     classes="library-source-pager-status",
                     markup=False,
                 )
+            # task-31237 (supersedes task-28016's keep-the-disabled-controls
+            # choice, critique #3 ruling): a single-page result renders NO
+            # pager controls -- two dead "○ Previous ○ Next" forms under
+            # every short list were pure noise. The range Static above
+            # stays; the controls return the moment a second page exists.
+            # A failed fetch still needs its Retry even on one page.
+            if pager.single_page and not pager.retry_visible:
+                return
             with Horizontal(classes="library-source-pager-controls"):
                 previous = Button(
                     library_disabled_action_label(

--- a/tldw_chatbook/Widgets/Library/library_media_content.py
+++ b/tldw_chatbook/Widgets/Library/library_media_content.py
@@ -5,6 +5,7 @@ import asyncio
 from typing import Any
 
 from textual.app import ComposeResult
+from textual.css.query import NoMatches
 from textual.containers import (
     Container,
     Horizontal,
@@ -346,6 +347,25 @@ class LibraryMediaContentSearchControls(Vertical):
         self.matches = matches
         self.match_index = match_index
         self.set_class(bool(self.query), self.ACTIVE_SEARCH_CLASS)
+
+    def on_mount(self) -> None:
+        """Take focus into the input on the Find-gesture mount (task-31237).
+
+        The bar now mounts only when the Find action opens it (or a query
+        is already applied). On the gesture mount -- empty query -- the
+        input takes focus from THIS widget's own post-refresh hook (its
+        children exist by then), because no screen-level defer can order
+        itself after a nested recompose-mount; an active-query remount
+        (match navigation, mode flips) never steals focus.
+        """
+        if not self.query:
+            self.call_after_refresh(self._focus_search_input)
+
+    def _focus_search_input(self) -> None:
+        try:
+            self.query_one("#library-media-content-search", Input).focus()
+        except NoMatches:
+            pass
 
     def compose(self) -> ComposeResult:
         """Compose the persistent, display-gated content-search controls.

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -81,6 +81,7 @@ class LibraryMediaViewer(Vertical):
         content_query: str = "",
         content_match_index: int = 0,
         content_mode: str = "raw",
+        find_open: bool = False,
         loading: bool = False,
         loading_message: str = "Loading media…",
         error_message: str = "",
@@ -100,6 +101,9 @@ class LibraryMediaViewer(Vertical):
 
         Args:
             viewer: Pure display state for the loaded item.
+            find_open: Whether the content Find bar renders (task-31237:
+                collapsed until the Find action opens it -- a permanently
+                open input duplicated Find and spent 3 rows per item).
             review_banner: One-line active review-set banner ("Reviewing:
                 <name> — X of M · N reviewed · ✓ reviewed"), or "" when no
                 set is active (task-30045). Rendered as literal text (set
@@ -115,6 +119,7 @@ class LibraryMediaViewer(Vertical):
         self.content_query = content_query
         self.content_match_index = content_match_index
         self.content_mode = content_mode
+        self.find_open = find_open
         self.loading = loading
         self.loading_message = loading_message
         self.error_message = error_message
@@ -328,14 +333,21 @@ class LibraryMediaViewer(Vertical):
             # the scrolling Reader. Textual docks relative to the immediate
             # container, so nesting these under the mode marker pins an active
             # Find bar below the Reader header instead of at the viewport top.
-            matches = find_content_matches(self.viewer.content, self.content_query)
-            yield LibraryMediaContentSearchControls(
-                is_markdown=self.viewer.is_markdown,
-                query=self.content_query,
-                matches=matches,
-                match_index=self.content_match_index,
-                id="library-media-content-search-controls",
-            )
+            # task-31237: the Find bar is collapsed until the Find action
+            # opens it (or a query is applied); a permanently open
+            # "Search content…" input duplicated Find and spent 3 rows on
+            # every fresh item.
+            if self.find_open or self.content_query:
+                matches = find_content_matches(
+                    self.viewer.content, self.content_query
+                )
+                yield LibraryMediaContentSearchControls(
+                    is_markdown=self.viewer.is_markdown,
+                    query=self.content_query,
+                    matches=matches,
+                    match_index=self.content_match_index,
+                    id="library-media-content-search-controls",
+                )
             yield LibraryMediaContentBody(
                 content=self.viewer.content,
                 is_markdown=self.viewer.is_markdown,

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -3476,6 +3476,14 @@ with stray left-edge border fragments), and padding 0 1 so the full
     outline: none;
 }
 
+/* task-31235: the sort chooser became the type chooser's OptionList twin
+   (its horizontal strip clipped options off-pane), so it inherits the same
+   focus-outline suppression -- at option-count height the outline's
+   top+bottom rows would overwrite "Newest" and "Title Z-A". */
+#library-media-sort-choices:focus {
+    outline: none;
+}
+
 /* task-31222: the Read-mode wrapper held only a heading yet defaulted to
    1fr, inserting a blank band above the Find bar while the content sat in
    a fixed 18-row box below -- the Reader's product got ~1/3 of its pane. */
@@ -3484,13 +3492,17 @@ with stray left-edge border fragments), and padding 0 1 so the full
 }
 
 #library-media-viewer-content {
-    /* Bounded so short content stays compact and long content scrolls inside
-       this region; height:1fr here ballooned the pane and split the sections.
-       task-31222: the bound scales with the terminal instead of a fixed 18
-       rows, so a tall window reads tall (only long content engages the
-       inner scroll). */
-    height: auto;
-    max-height: 75vh;
+    /* task-31237 (evolves task-31222's 75vh cap into a true fill): the
+       content box takes exactly the pane's remaining height -- 75vh could
+       overrun the remainder (double scroll: viewer AND box) or undershoot
+       it (a stranded blank band below the reading surface, critique #3
+       P2). With the 31222 height:auto wrappers above it in place, 1fr now
+       resolves against the viewer's viewport remainder, so chrome stays
+       pinned and overflow belongs to this box's own scroll (measured:
+       viewer virtual == container at 200x52 with a 300-line document; the
+       pre-31222 balloon came from the then-unstyled 1fr mode wrapper, not
+       from 1fr here). */
+    height: 1fr;
     min-height: 3;
     margin: 0 0 1 0;
     border: solid $ds-grid-line;

--- a/tldw_chatbook/css/screen_agentic_library.tcss
+++ b/tldw_chatbook/css/screen_agentic_library.tcss
@@ -2352,6 +2352,14 @@ with stray left-edge border fragments), and padding 0 1 so the full
     outline: none;
 }
 
+/* task-31235: the sort chooser became the type chooser's OptionList twin
+   (its horizontal strip clipped options off-pane), so it inherits the same
+   focus-outline suppression -- at option-count height the outline's
+   top+bottom rows would overwrite "Newest" and "Title Z-A". */
+#library-media-sort-choices:focus {
+    outline: none;
+}
+
 /* task-31222: the Read-mode wrapper held only a heading yet defaulted to
    1fr, inserting a blank band above the Find bar while the content sat in
    a fixed 18-row box below -- the Reader's product got ~1/3 of its pane. */
@@ -2360,13 +2368,17 @@ with stray left-edge border fragments), and padding 0 1 so the full
 }
 
 #library-media-viewer-content {
-    /* Bounded so short content stays compact and long content scrolls inside
-       this region; height:1fr here ballooned the pane and split the sections.
-       task-31222: the bound scales with the terminal instead of a fixed 18
-       rows, so a tall window reads tall (only long content engages the
-       inner scroll). */
-    height: auto;
-    max-height: 75vh;
+    /* task-31237 (evolves task-31222's 75vh cap into a true fill): the
+       content box takes exactly the pane's remaining height -- 75vh could
+       overrun the remainder (double scroll: viewer AND box) or undershoot
+       it (a stranded blank band below the reading surface, critique #3
+       P2). With the 31222 height:auto wrappers above it in place, 1fr now
+       resolves against the viewer's viewport remainder, so chrome stays
+       pinned and overflow belongs to this box's own scroll (measured:
+       viewer virtual == container at 200x52 with a 300-line document; the
+       pre-31222 balloon came from the then-unstyled 1fr mode wrapper, not
+       from 1fr here). */
+    height: 1fr;
     min-height: 3;
     margin: 0 0 1 0;
     border: solid $ds-grid-line;


### PR DESCRIPTION
Second fix PR from critique #3 of Library ▸ Media (parallel to #2366). Tasks 31235 + 31237 — the sort-chooser P1 and the Reader vertical-space P2.

## task-31235 — the sort chooser renders every option

The horizontal choice strip rendered "✓ Newest  Oldest  Title A-" in the ~38-col items pane: "Title A-Z" truncated, "Title Z-A" entirely invisible with no overflow cue — yet a keyboard user could arrow to and select the unrendered option. The chooser is now the type chooser's vertical OptionList twin (✓-prefixed active option pre-highlighted); the handler moved from the strip's Button.Pressed to OptionList.OptionSelected with identical validation and close-on-same-value semantics, and the open-focus rides `_sync_library_canvas`'s `then` hook (a bare `call_after_refresh` has no ordering against a canvas-scoped recompose — a test caught it). The 31221-family `*:focus` outline struck again — at option-count height it overwrote "Newest" and "Title Z-A" outright — pinned with a painted-text test and suppressed at app tier for the new id.

## task-31237 — the Reader uses its vertical space

Three parts, all critique-verified live:

- **Fill**: `#library-media-viewer-content` goes from the 75vh cap to `height: 1fr` — measured at 200x52 with a 300-line document, the box ends exactly at the pane bottom and the viewer's virtual height equals its container: no stranded blank band, no double scroll, chrome pinned, overflow owned by the box's own scroll. (The old "1fr balloons the pane" note predated task-31222's height:auto wrappers; with them in place 1fr resolves correctly against the viewer remainder.)
- **Find collapse**: the "Search content…" bar no longer renders permanently (it duplicated the Find button and spent 3 rows on every fresh item). New `find_open` state with one `_close_library_media_find()` seam replacing all 8 query-reset pairs (item open, external open, viewer exit, rail switch, delete, mode change, Escape, entry guard); threaded through the viewer constructor AND the in-place `_sync_library_media_viewer_state` compare/assign (the #2351 trap). Focus is taken by the bar's own post-mount hook — three screen-level `call_after_refresh` variants provably lost the race against the nested recompose-mount, and an empty-query mount is by construction the Find gesture (active-query remounts never steal focus).
- **Dead pager**: a single-page list renders no "○ Previous ○ Next" (supersedes task-28016's keep-the-disabled-controls choice per the critique ruling); the range Static stays, the controls return with a second page, and Retry still renders on a failed single-page fetch.

## Tests

New/updated: painted-text sort-options test + fill contract + Find round trip (render-fixes), pager absence + multi-page negative control (side-by-side), OptionList driving + collapsed-bar contract (shell), helper conversions in reader-flow/match-nav/per-click/review-round (the collapsed bar means helpers press Find before typing). **5 failures confirmed pre-existing on clean dev** (stash-verified): `test_media_type_strip_works_in_both_layouts` (compact class at 100x30) and 4 `#library-media-edit`/substate tests across review-round and per-click — possibly related to the just-landed #2364 demand-mount change, not this PR. Preflight clean.

## Live verification (tmux 200x52, seeded, cleaned up)

Sort chooser: all four options render vertically with ✓ on the active one; picking "Title A-Z" re-sorts and closes. Fresh item: no find bar, content box runs to the pane edge, pager shows "1-2 of 2" with zero controls. Find press: bar mounts and the footer flips to "typing in field | esc close find" (focus proven by the typing-context footer itself); "long" → "Match 1 of 200 matches"; Escape collapses the bar and restores the viewer footer.

Note: backlog tasks 31235/31237 are filed on #2366's branch; their Done statuses + implementation notes land in a follow-up commit here once #2366 merges and this branch rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGaR5sbP3iuynBGbthzAZ1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Library media viewer problems: the sort chooser shows every option, the Reader fills its pane, the Find bar collapses until opened, and single-page lists drop dead pager controls.

- The sort chooser is now a vertical OptionList showing all four orders with ✓ on the active one; the old horizontal strip hid "Title A-Z" and "Title Z-A" while keyboard users could still select them.
- The content box fills the remaining pane height instead of capping at 75vh, eliminating the blank band and double scroll.
- The Find bar is collapsed until the Find action opens it; one close seam replaces all 8 query-reset paths.
- Single-page lists render no Previous/Next controls; the controls return once a second page exists.
- An open Find bar is a reader substate: Escape closes it first from any reader-region focus, including after F6 moves focus to the content pane, and the footer label says "close find" while it is open.
- Tasks 31235 and 31237 are marked Done with implementation notes in the backlog.

<sup>Written for commit a542ec16a65e37e96975058b5fcd880ca62d91ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

