### PR TITLE
test(library): bind _close_library_media_find in the multiselect fake helper

### DIFF
--- a/Tests/UI/test_library_multiselect_media.py
+++ b/Tests/UI/test_library_multiselect_media.py
@@ -70,6 +70,12 @@ def _bind_media_mutation_seams(fake):
     fake._complete_library_media_mutation = types.MethodType(
         LibraryScreen._complete_library_media_mutation, fake
     )
+    # task-31237: the delete path resets the content Find bar through the
+    # one ``_close_library_media_find`` seam (collapsed, no query, first
+    # match) instead of poking the two query attributes directly.
+    fake._close_library_media_find = types.MethodType(
+        LibraryScreen._close_library_media_find, fake
+    )
     if fake._library_media_bulk_delete_in_flight:
         fake._begin_library_media_mutation()
     return fake

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -10981,3 +10981,26 @@ Rule: when introducing a wrapper around an existing full-height Textual view,
 verify it with a real pointer-driven workflow, not only widget queries,
 visibility flags, or screenshots. Painted descendants do not prove their
 ancestor geometry participates in hit testing.
+
+## A PR's green CI never ran the MERGED combination -- re-run the changed method's fake-driven tests on the merged head (task-31237, 2026-09-04)
+
+Incident (PR #2367, 2026-09-04): the branch added `_close_library_media_find()`
+and routed `_delete_library_media_item`'s query reset through it instead of
+assigning the two query attributes directly. Pre-merge CI was green. Meanwhile
+dev had merged task-14901's two single-delete tests, which drive
+`_delete_library_media_item` on a bare `SimpleNamespace` fake -- attribute
+assignment works on a SimpleNamespace, a method call does not. On the merged
+head both raised `AttributeError`; PR Fast Lane does not run
+`test_library_multiselect_media.py`, the update-branch merge commit went green,
+the landing loop admin-merged it, and dev needed follow-up PR #2369. Same shape
+on #2366 the same night: two PRs each regenerating
+`Docs/security/production-diagnostic-inventory.json` merge cleanly, but the
+summary count carries only one side.
+
+Rule: after the update-branch / merge-with-dev step and BEFORE admin-merge, grep
+`Tests/` for every production method whose body you changed
+(`grep -rn '<method_name>' Tests/`) and run those files on the merged head --
+a direct-method fake that dev added after you forked will not be in your
+branch's test list. Regenerate derived inventories on the merged head, not on
+the branch tip. A green check on the pre-merge head is evidence about the
+branch, not about dev-plus-branch.

--- a/backlog/tasks/task-31249 - Library-UI-test-debt-on-dev---six-pre-existing-failures-nobody-owns.md
+++ b/backlog/tasks/task-31249 - Library-UI-test-debt-on-dev---six-pre-existing-failures-nobody-owns.md
@@ -1,0 +1,34 @@
+---
+id: TASK-31249
+title: Library UI test debt on dev - six pre-existing failures nobody owns
+status: To Do
+assignee: []
+created_date: '2026-09-04 04:59'
+labels:
+  - library
+  - tests
+  - tech-debt
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Six Library UI tests fail identically on clean dev (verified at 59d987015d and e4652f9d37, each file run in its own process) and no open task owns them. PR #2367's body noted them as pre-existing and the wave-3 landing hit them again; every media PR touching these files now has to re-verify them by hand to tell its own breakage from the baseline, which is how a real break (fixed in PR #2369) nearly hid among them. Suspected origins, unconfirmed: #2364 (Personas demand-mount, task-31215) for the `#library-media-edit` group; an unbound `MediaReadingScopeService` fake (`active_authority`) for the deep-link test.
+
+Failures (`pytest --tb=line`, Tests/UI):
+- test_library_per_click_recompose_t21116.py::test_media_viewer_substate_escape_is_viewer_scoped -- `#library-media-edit never mounted within 30.0s` (test_library_shell.py:3686 helper)
+- test_library_per_click_recompose_t21116.py::test_open_item_by_id_media_is_canvas_scoped -- `assert [LibraryScreen()] == []` (a whole-screen recompose where a canvas-scoped one is pinned)
+- test_library_per_click_recompose_t21116.py::test_export_open_from_media_is_canvas_scoped -- LibraryRail identity changed (rail was recomposed)
+- test_library_review_round_t21116.py::test_viewer_substate_escape_refreshes_the_footer_shortcut_set -- `#library-media-edit never mounted within 30.0s`
+- test_library_shell.py::test_library_starter_deep_link_opens_hidden_collection_or_note_route -- worker `AttributeError: 'SimpleNamespace' object has no attribute 'active_authority'` in library_collections_capture_controller.adopt_active_authority
+- test_library_choice_strips.py::test_media_type_strip_works_in_both_layouts -- `compact class never reached True at (100, 30)`
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Each of the six tests passes on dev, or is rewritten/removed with the reason recorded in this task (no bare skip markers)
+- [ ] #2 The root cause of the `#library-media-edit never mounted` group is identified and recorded, whether the fix lands in production code or in the test contract
+- [ ] #3 test_library_shell.py, test_library_per_click_recompose_t21116.py, test_library_review_round_t21116.py and test_library_choice_strips.py run green in separate processes on dev
+<!-- AC:END -->


### PR DESCRIPTION
Follow-up to #2367 (task-31237). Its `_delete_library_media_item` now routes the Find reset through the new `_close_library_media_find` seam; the two task-14901 direct-method fakes in `Tests/UI/test_library_multiselect_media.py` (single-item delete arms entry focus / leaves receipt + undo) lacked that attribute once the branch merged with dev, so they raised `AttributeError`. Pre-merge CI never ran the combination and Fast Lane does not include this file.

Fix: bind the real method in `_bind_media_mutation_seams`, the helper both fakes already pass through — same `types.MethodType` idiom the reader-flow fakes use. Test-only, 6 lines.

Verified: `Tests/UI/test_library_multiselect_media.py` 66/66 locally on the merged head (2 failed before). Note this commit was pushed to `fix/media-reader-chrome` seconds after #2367's admin-merge, hence the separate PR.

Also in this PR (second commit, docs only):
- `backlog/docs/lessons-testing-evidence.md`: the merged-head lesson above (re-run the changed method's fake-driven tests on dev-plus-branch before admin-merge; regenerate derived inventories on the merged head — the #2366 inventory union-drift).
- `task-31249`: the six Library UI tests that fail identically on clean dev (per-click ×3, review-round ×1, shell deep-link, type-strip compact) with their one-line reasons, so future media PRs can tell their own breakage from the baseline. Verified against 59d987015d and e4652f9d37; no open task owned them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LebG4HPfSniVohbuXkU4n
