### PR TITLE
feat(scheduling): in-pane editing + owner-row transfer (redesign PR-3)

### DIFF
--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -220,12 +220,15 @@ target and only changes through **Edit in full…** or the create form.
   and clears any inline error under it — an edit always commits against
   the row you opened it on, never against whichever row the pane happens
   to be showing by the time you press Enter.
-- An automation whose **Pause**, **Resume** or pending move has not
-  reached the server yet refuses an in-place edit and says which change
-  is waiting ("A pause is waiting to sync — edit this automation once it
-  lands."). Only one pending change per automation can be queued for the
-  server at a time, and saving the edit would throw the other one away
-  without telling you. Sync (or reconnect), then edit.
+- An automation whose pending **move** (to the server, or back to this
+  device) has not reached the server yet refuses an in-place edit and
+  says which change is waiting ("A move to the server is waiting to sync
+  — edit this automation once it lands."). An edit and a move share one
+  queue slot, so saving the edit would throw the move away without
+  telling you. Sync (or reconnect), then edit. A pending **Pause** or
+  **Resume** does *not* refuse an edit — lifecycle changes queue
+  separately, so you can pause an automation while offline, edit it, and
+  have both land on the next sync.
 - `Runs on`'s dropdown is the same transfer flow described under
   "Moving a task between this device and the server", below — picking
   the other owner runs the same refusal check and confirmation dialog,

--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -191,6 +191,41 @@ That does put three focus stops ahead of the pane's action buttons.
 A watchlist or briefing projection (not a reminder) still shows the older
 Type/Schedule rows unchanged — the grouped layout is reminder-specific.
 
+### Editing rows in place
+
+Click a row (or Tab to it and press Enter) to edit it where it sits,
+instead of opening the create/edit form. The dimmed `▾` next to a row's
+value marks it as editable; a row without one has no single-field write
+target and only changes through **Edit in full…** or the create form.
+
+- **Repeat**, **Timezone**, and `Runs on` open a dropdown pre-selected to
+  the current value; picking a new one commits immediately. **At** opens
+  a text box; press Enter to commit the typed value (the same forgiving
+  local-time parsing the create form uses).
+- **Escape** closes an open editor without saving — a plain cancel, not a
+  commit of whatever is currently showing.
+- A bad **At** value (unparseable text) commits nothing: the row shows
+  the error inline underneath and restores the last-saved value rather
+  than left holding your typo.
+- Only one of **Repeat** or **At** is ever editable at a time — a
+  one-time reminder's Repeat row and a recurring reminder's At row have
+  no sensible single-field target for the other schedule kind, so they
+  stay read-only rows until you switch kind via the full edit form.
+  `Notifications` never opens an editor for a reminder — see the
+  Frequency bullet above.
+- A row that is locked (a transfer is in flight, or the row's owner is a
+  dormant server-release copy waiting to arm) still responds to a click:
+  it shows the lock reason inline instead of silently doing nothing.
+- `Runs on`'s dropdown is the same transfer flow described under
+  "Moving a task between this device and the server", below — picking
+  the other owner runs the same refusal check and confirmation dialog,
+  just from the row itself rather than a button. Once a move is queued or
+  failed, its own **Cancel transfer** / **Retry transfer** buttons appear
+  directly under the row (the dropdown is unavailable while a move is in
+  flight — that is the locked state above). The pane's older Move/Cancel/
+  Retry buttons documented there keep working side by side with all of
+  this.
+
 ## Creating a scheduled task
 
 Press **c**, or click **Create ▾** in the Queue tab's rail header, to
@@ -364,6 +399,12 @@ already running, or, moving a `recurring_question` mirror to this
 device, the same local-health reason the Automations tab already
 surfaces.
 
+The `Runs on` row itself is a second way into the same flow: opening its
+dropdown and picking the other owner runs the same refusal check and
+confirmation dialog described below, with a refusal shown inline under
+the row instead of as a toast. Both surfaces drive the same transfer —
+use whichever is at hand.
+
 Clicking Move opens a confirmation listing anything worth knowing before
 you commit: an imminent or already-passed one-time run time ("server
 behavior this close to run time is unverified"), and, for a reminder,
@@ -512,27 +553,43 @@ skipped, the same events the server records for reconciliation.
 
 ### Automations tab — definition detail pane
 
-Highlighting a definition row opens a read-only detail pane alongside the
-list and its run history — the Automations tab's first per-row detail
-view. It shows the question text in a card at the top, then the same
+Highlighting a definition row opens a detail pane alongside the list and
+its run history — the Automations tab's first per-row detail view. A
+**Pause**/**Resume** button sits above the body, toggling the
+definition's lifecycle (Archive stays a kebab/list action, not this
+button); the pane shows the question text in a card next, then the same
 grouped-row layout as the reminder detail pane:
 
 - **Details** — `Runs on` (owner + transfer badge, same wording as the
-  reminder pane), `Model` (the pinned `provider/model`, or `auto` when
-  the definition pins nothing), `Generation` (always/only-new/never),
-  `Finding policy` (the preset name), and `Sources` (the selected library
-  sources, or "All searchable library" for the default scope). A row the
-  definition does not carry a value for reads **"Not set"** — a
-  definition authored on the server often carries none of these, and the
-  pane never fills the gap in with the create form's defaults.
+  reminder pane; its dropdown is the same transfer flow described under
+  "Moving a task between this device and the server"), `Model` (the
+  pinned `provider/model`, or `auto` when the definition pins nothing),
+  `Generation` (always/only-new/never), `Finding policy` (the preset
+  name), and `Sources` (the selected library sources, or "All searchable
+  library" for the default scope). A row the definition does not carry a
+  value for reads **"Not set"** — a definition authored on the server
+  often carries none of these, and the pane never fills the gap in with
+  the create form's defaults.
 - **Frequency** — the schedule summary (repeat/at/timezone, or the raw
-  cron expression for a custom schedule) and `Notifications`.
+  cron expression for a custom schedule) and `Notifications` (a real
+  On/Off toggle here, unlike a reminder's fixed "Inbox + toast" label).
 - **History** (collapsed by default) — the last run's outcome, total run
   count, unread results count, and a pointer to the Results tab. Those
   counts are this device's own execution record, so a server-owned
   definition reads "Kept on the server — see Run history" instead: only
   the server holds that definition's execution history, and the run
   history pane beside it is already showing it.
+
+Every Details/Frequency row except the schedule-kind mismatch (Repeat on
+a one-time definition, or At on a recurring one — same rule the reminder
+pane follows) edits in place the same way the reminder pane's rows do —
+see "Editing rows in place", above — with one addition: **Sources**
+opens three checkboxes (Media/Notes/Chats) plus an **Apply** button
+rather than a dropdown, since a checkbox has no single commit event of
+its own. Ticking every box and applying writes the explicit three-source
+selection, not "all searchable library" — pick **Edit in full…** if you
+want the scope to keep resolving to whatever sources are readable at
+each run rather than freezing today's three.
 
 The detail pane hides at narrow terminal widths, the same responsive rule
 the Queue tab's own detail pane already uses.
@@ -620,6 +677,30 @@ The default bound is `handler_timeout_seconds` under `[scheduling]` in
 `config.toml` (**300** seconds). Set it to `0` (or negative) to disable the
 bound entirely — every handler may then run as long as it likes, and a
 wedged handler will wedge the scheduler, which is why the default is on.
+
+*Verified against the schedules redesign PR-3 fix wave — 2026-09-03
+(docs pass against shipped code/tests, live check pending the redesign
+program's later PRs per spec §14: reminder Repeat/At/Timezone rows and
+recurring-question Model/Generation/Finding policy/Sources/Notifications
+rows now edit in place per "Editing rows in place" and "Automations tab
+— definition detail pane" above — commit-on-close for a Select, Enter to
+commit an Input, Escape to cancel without saving, a bad **At** value
+restoring the last-saved value with an inline error, and a locked row
+answering activation with its lock reason instead of going silent; the
+`Runs on` row's dropdown drives the same transfer_refusal → confirm
+dialog with warnings → begin_transfer flow the Move/Retry/Cancel buttons
+already used, as a second surface onto the same facade, coexisting with
+those buttons through this PR; and the definition pane's header
+Pause/Resume button is `set_definition_lifecycle`'s first UI caller,
+repainting optimistically and protected from a racing server pull by a
+lifecycle-scoped pull guard. Pinned by `Tests/UI/test_detail_value_row.py`,
+the Frequency/owner-row/lifecycle assertions added to
+`Tests/UI/test_schedules_workbench.py` and
+`Tests/UI/test_schedules_automations_tab.py`, and
+`Tests/Scheduling/test_scheduling_service.py` /
+`Tests/Scheduling/test_scheduled_tasks_db.py` /
+`Tests/Scheduling/test_sync_engine.py` for the edit bridge and pull
+guard.)*
 
 *Verified against the schedules redesign PR-2 final fix wave —
 2026-09-03 (docs pass against shipped code/tests, live check pending the

--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -216,6 +216,16 @@ target and only changes through **Edit in full…** or the create form.
 - A row that is locked (a transfer is in flight, or the row's owner is a
   dormant server-release copy waiting to arm) still responds to a click:
   it shows the lock reason inline instead of silently doing nothing.
+- Selecting a different row in the list closes any editor you left open
+  and clears any inline error under it — an edit always commits against
+  the row you opened it on, never against whichever row the pane happens
+  to be showing by the time you press Enter.
+- An automation whose **Pause**, **Resume** or pending move has not
+  reached the server yet refuses an in-place edit and says which change
+  is waiting ("A pause is waiting to sync — edit this automation once it
+  lands."). Only one pending change per automation can be queued for the
+  server at a time, and saving the edit would throw the other one away
+  without telling you. Sync (or reconnect), then edit.
 - `Runs on`'s dropdown is the same transfer flow described under
   "Moving a task between this device and the server", below — picking
   the other owner runs the same refusal check and confirmation dialog,
@@ -678,8 +688,9 @@ The default bound is `handler_timeout_seconds` under `[scheduling]` in
 bound entirely — every handler may then run as long as it likes, and a
 wedged handler will wedge the scheduler, which is why the default is on.
 
-*Verified against the schedules redesign PR-3 fix wave — 2026-09-03
-(docs pass against shipped code/tests, live check pending the redesign
+*Verified against the schedules redesign PR-3 final fix wave —
+2026-09-03 (docs pass against shipped code/tests, live check pending the
+redesign
 program's later PRs per spec §14: reminder Repeat/At/Timezone rows and
 recurring-question Model/Generation/Finding policy/Sources/Notifications
 rows now edit in place per "Editing rows in place" and "Automations tab

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1882,7 +1882,7 @@
     },
     {
       "call_count": 35,
-      "diagnostic_digest": "f4e8d6eb51cef7e9606e",
+      "diagnostic_digest": "ddee18d094a5525b4b45",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/services/sync_engine.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2896,6 +2896,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 1,
+      "diagnostic_digest": "6abd5e2a330f548a189a",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Screens/scheduling/definition_detail.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 2,
       "diagnostic_digest": "9464185b1733c0018297",
       "owner": "TASK-494",
@@ -2903,10 +2910,17 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 28,
-      "diagnostic_digest": "d95d225ae19609a110d2",
+      "call_count": 34,
+      "diagnostic_digest": "b7e7388dbb41c5b41a6f",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "ed9785733a5fff78c95a",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Screens/scheduling/task_detail.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -11307,10 +11321,10 @@
   "schema_version": 3,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 569,
+    "owner_files": 571,
     "path_privacy_candidate_calls": 714,
     "persistent_sink_files": 10,
     "task_492_calls": 1337,
-    "task_494_calls": 7588
+    "task_494_calls": 7596
   }
 }

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -1727,6 +1727,161 @@ def test_upsert_definitions_server_wins_on_update(tmp_path):
     assert rows[0]["lifecycle"] == "paused"
 
 
+def test_upsert_definitions_pending_lifecycle_mutation_blocks_lifecycle_field(tmp_path):
+    """PR-3 task 2, guard layer 1: an unpushed local pause/resume/archive
+    outranks the mirror until SyncEngine's lifecycle replay has pushed it
+    -- same TOCTOU-closing shape as the results review guard, but
+    surgical: only `lifecycle` is withheld, every other field still
+    server-wins."""
+    db = _mk_db(tmp_path)
+    db.upsert_automation_definitions_from_server("server:42", [_definition_item()])
+    local_id = db.list_automation_definitions(owner_id="server:42")[0]["id"]
+    db.record_pending_mutation(
+        local_id,
+        "automation_definition",
+        "server:42",
+        {"action": "pause", "server_definition_id": "srv-def-1"},
+    )
+
+    counts = db.upsert_automation_definitions_from_server(
+        "server:42",
+        [_definition_item(name="Renamed", lifecycle="archived")],
+    )
+
+    assert counts == {"inserted": 0, "updated": 1}
+    row = db.get_automation_definition(local_id)
+    assert row["lifecycle"] == "configured"  # withheld -- unpushed pause pending
+    assert row["name"] == "Renamed"  # every other field still server-wins
+
+
+def test_upsert_definitions_pending_non_lifecycle_mutation_does_not_block_lifecycle(
+    tmp_path,
+):
+    """`automation_definition` also carries `save_definition`'s edit-path
+    and transfer mutations under the SAME primitive -- the guard must
+    inspect `payload["action"]`, not just "a pending mutation exists",
+    or an unrelated pending edit would wrongly freeze lifecycle too."""
+    db = _mk_db(tmp_path)
+    db.upsert_automation_definitions_from_server("server:42", [_definition_item()])
+    local_id = db.list_automation_definitions(owner_id="server:42")[0]["id"]
+    db.record_pending_mutation(
+        local_id,
+        "automation_definition",
+        "server:42",
+        {"action": "update", "definition_payload": {"name": "Local edit"}},
+    )
+
+    counts = db.upsert_automation_definitions_from_server(
+        "server:42",
+        [_definition_item(lifecycle="archived")],
+    )
+
+    assert counts == {"inserted": 0, "updated": 1}
+    row = db.get_automation_definition(local_id)
+    assert row["lifecycle"] == "archived"  # not a lifecycle mutation -- server wins
+
+
+def test_upsert_definitions_skip_lifecycle_server_ids_blocks_lifecycle_field(tmp_path):
+    """PR-3 task 2, guard layer 2: the same-cycle pushed-ids skip set
+    (threaded from `SyncEngine._replay_definition_mutations`, mirroring
+    `skip_review_server_ids`) protects a row whose pending mutation is
+    ALREADY gone (replayed earlier this cycle) from a same-cycle stale
+    echo -- guard 1 alone can't see it."""
+    db = _mk_db(tmp_path)
+    db.upsert_automation_definitions_from_server("server:42", [_definition_item()])
+
+    counts = db.upsert_automation_definitions_from_server(
+        "server:42",
+        [_definition_item(name="Renamed", lifecycle="archived")],
+        skip_lifecycle_server_ids=frozenset({"srv-def-1"}),
+    )
+
+    assert counts == {"inserted": 0, "updated": 1}
+    row = db.list_automation_definitions(owner_id="server:42")[0]
+    assert row["lifecycle"] == "configured"  # withheld -- pushed this cycle
+    assert row["name"] == "Renamed"  # every other field still server-wins
+
+
+def test_upsert_definitions_pending_lifecycle_mutation_recorded_mid_loop_still_blocks(
+    tmp_path,
+):
+    """Fault-ordering, same shape as
+    `test_upsert_results_pending_mutation_recorded_mid_loop_still_blocks_update`:
+    the guard's pending-mutation SELECT must run per-row INSIDE this
+    write transaction, immediately before that row's own UPDATE -- not
+    snapshotted once before the loop starts. Proven by inserting row 2's
+    pending lifecycle mutation, via a separate real connection, DURING
+    this very upsert call, timed to land right as row 1's existence
+    check fires (strictly after any pre-loop snapshot would have been
+    taken). A snapshot-based guard would miss it; the per-row check
+    catches it."""
+    db = _mk_db(tmp_path)
+    db.upsert_automation_definitions_from_server(
+        "server:42",
+        [
+            _definition_item(id="srv-def-1", name="First"),
+            _definition_item(id="srv-def-2", name="Second"),
+        ],
+    )
+    rows_by_server_id = {
+        row["server_id"]: row["id"]
+        for row in db.list_automation_definitions(owner_id="server:42")
+    }
+    local_id_2 = rows_by_server_id["srv-def-2"]
+
+    real_get_connection = ScheduledTasksDB._get_connection
+    injected = {"done": False}
+
+    def _get_connection_with_injector(self):
+        conn = real_get_connection(self)
+
+        def _on_statement(sql):
+            if injected["done"] or "SELECT id FROM automation_definitions" not in sql:
+                return
+            injected["done"] = True
+            # Simulate a concurrent set_definition_lifecycle write landing
+            # mid-loop: a totally separate connection records row 2's
+            # pending pause mutation right now, before this upsert call
+            # has reached row 2.
+            side_conn = sqlite3.connect(str(tmp_path / "s.db"))
+            try:
+                side_conn.execute(
+                    "INSERT INTO pending_mutations "
+                    "(local_id, primitive, owner_id, payload, created_at) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (
+                        local_id_2,
+                        "automation_definition",
+                        "server:42",
+                        '{"action": "pause", "server_definition_id": "srv-def-2"}',
+                        "2026-09-01T00:00:00+00:00",
+                    ),
+                )
+                side_conn.commit()
+            finally:
+                side_conn.close()
+
+        conn.set_trace_callback(_on_statement)
+        return conn
+
+    with mock.patch.object(
+        ScheduledTasksDB, "_get_connection", _get_connection_with_injector
+    ):
+        counts = db.upsert_automation_definitions_from_server(
+            "server:42",
+            [
+                _definition_item(id="srv-def-1", name="First", lifecycle="archived"),
+                _definition_item(id="srv-def-2", name="Second", lifecycle="archived"),
+            ],
+        )
+
+    assert injected["done"], "the spy never saw the expected SELECT -- test setup is stale"
+    assert counts == {"inserted": 0, "updated": 2}
+    row_2 = db.get_automation_definition(local_id_2)
+    assert row_2["lifecycle"] == "configured"  # caught despite landing mid-loop
+    assert row_2["name"] == "Second"  # other fields still server-wins
+
+
 def test_upsert_definitions_never_clears_local_transfer_state(tmp_path):
     """spec §6 parked finding: a server payload must never clear a local
     transfer marker."""

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -1677,6 +1677,26 @@ def test_upsert_definitions_inserts_new_row(tmp_path):
     assert rows[0]["schedule"] == {"kind": "cron", "expression": "0 9 * * 1-5"}
 
 
+def test_upsert_definitions_insert_defaults_json_columns_to_empty_dict_not_null(
+    tmp_path,
+):
+    """task-4 review Finding 1: a server item that omits `input`/`config`/
+    `notification_policy` entirely (the exact `_definition_item()` default
+    shape every other test in this section already uses) used to leave
+    those THREE columns SQL NULL on insert -- unlike `family`/`name`/
+    `lifecycle`/`health`/`version`, which all get an explicit
+    `setdefault`. `SchedulingService._merge_definition_payload`'s
+    `isinstance(stored, dict)` check then skipped the merge entirely for
+    a NULL column, silently dropping whatever the untouched group held on
+    the next edit (e.g. `input.question`)."""
+    db = _mk_db(tmp_path)
+    db.upsert_automation_definitions_from_server("server:42", [_definition_item()])
+    row = db.get_automation_definition_by_server_id("server:42", "srv-def-1")
+    assert row["input"] == {}
+    assert row["config"] == {}
+    assert row["notification_policy"] == {}
+
+
 def test_upsert_definitions_strips_resolved_sources_from_scope(tmp_path):
     """Task 6 fix-round finding: a server item's `config.scope` may echo
     back `resolved_sources` (the client's own local preview does, for the

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -1758,7 +1758,7 @@ def test_upsert_definitions_pending_lifecycle_mutation_blocks_lifecycle_field(tm
     local_id = db.list_automation_definitions(owner_id="server:42")[0]["id"]
     db.record_pending_mutation(
         local_id,
-        "automation_definition",
+        "automation_lifecycle",
         "server:42",
         {"action": "pause", "server_definition_id": "srv-def-1"},
     )
@@ -1777,10 +1777,10 @@ def test_upsert_definitions_pending_lifecycle_mutation_blocks_lifecycle_field(tm
 def test_upsert_definitions_pending_non_lifecycle_mutation_does_not_block_lifecycle(
     tmp_path,
 ):
-    """`automation_definition` also carries `save_definition`'s edit-path
-    and transfer mutations under the SAME primitive -- the guard must
-    inspect `payload["action"]`, not just "a pending mutation exists",
-    or an unrelated pending edit would wrongly freeze lifecycle too."""
+    """A queued EDIT lives in the `automation_definition` slot, which the
+    guard (keyed on `automation_lifecycle` since Qodo findings 5+6) never
+    reads -- so an unrelated pending edit does not freeze `lifecycle`,
+    and the two coexist on one row instead of sharing a slot."""
     db = _mk_db(tmp_path)
     db.upsert_automation_definitions_from_server("server:42", [_definition_item()])
     local_id = db.list_automation_definitions(owner_id="server:42")[0]["id"]
@@ -1871,7 +1871,7 @@ def test_upsert_definitions_pending_lifecycle_mutation_recorded_mid_loop_still_b
                     "VALUES (?, ?, ?, ?, ?)",
                     (
                         local_id_2,
-                        "automation_definition",
+                        "automation_lifecycle",
                         "server:42",
                         '{"action": "pause", "server_definition_id": "srv-def-2"}',
                         "2026-09-01T00:00:00+00:00",
@@ -2154,7 +2154,7 @@ def test_adopt_server_definition_identity_withholds_lifecycle_under_the_guard(tm
         local_id,
         lifecycle="paused",
         pending_mutation={
-            "primitive": "automation_definition",
+            "primitive": "automation_lifecycle",
             "owner_id": "server:42",
             "payload": {"action": "pause", "server_definition_id": "srv-def-9"},
         },
@@ -2181,10 +2181,11 @@ def test_adopt_server_definition_identity_withholds_lifecycle_under_the_guard(tm
 def test_adopt_server_definition_identity_applies_lifecycle_under_an_edit_mutation(
     tmp_path,
 ):
-    """The guard is action-scoped, not "any pending mutation": the replay
-    that CALLS this method always still has its own edit mutation queued
-    (it is deleted right after), so a bare check would freeze `lifecycle`
-    on every push."""
+    """The guard is SLOT-scoped, not "any pending mutation for this row":
+    the replay that CALLS this method always still has its own edit
+    mutation queued in the `automation_definition` slot (it is deleted
+    right after), so a primitive-blind check would freeze `lifecycle` on
+    every push."""
     db = _mk_db(tmp_path)
     local_id = db.create_automation_definition(
         "server:42", "recurring_question", "Draft", lifecycle="paused"

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -2140,6 +2140,69 @@ def test_adopt_server_definition_identity_unknown_local_id_returns_false(tmp_pat
     )
 
 
+def test_adopt_server_definition_identity_withholds_lifecycle_under_the_guard(tmp_path):
+    """Redesign PR-3 final review C1's belt: the push-echo mirror now
+    carries the same `lifecycle` guard the pull mirror has. A pause queued
+    while an online save was in flight must not be reverted by the echo
+    that save comes back with -- SURGICALLY: every other echoed field,
+    `server_id` included, still writes."""
+    db = _mk_db(tmp_path)
+    local_id = db.create_automation_definition(
+        "server:42", "recurring_question", "Draft"
+    )
+    db.update_automation_definition(
+        local_id,
+        lifecycle="paused",
+        pending_mutation={
+            "primitive": "automation_definition",
+            "owner_id": "server:42",
+            "payload": {"action": "pause", "server_definition_id": "srv-def-9"},
+        },
+    )
+
+    assert (
+        db.adopt_server_definition_identity(
+            local_id,
+            {
+                "id": "srv-def-9",
+                "name": "Server-confirmed name",
+                "lifecycle": "configured",
+            },
+        )
+        is True
+    )
+
+    row = db.get_automation_definition(local_id)
+    assert row["lifecycle"] == "paused"
+    assert row["server_id"] == "srv-def-9"
+    assert row["name"] == "Server-confirmed name"
+
+
+def test_adopt_server_definition_identity_applies_lifecycle_under_an_edit_mutation(
+    tmp_path,
+):
+    """The guard is action-scoped, not "any pending mutation": the replay
+    that CALLS this method always still has its own edit mutation queued
+    (it is deleted right after), so a bare check would freeze `lifecycle`
+    on every push."""
+    db = _mk_db(tmp_path)
+    local_id = db.create_automation_definition(
+        "server:42", "recurring_question", "Draft", lifecycle="paused"
+    )
+    db.record_pending_mutation(
+        local_id,
+        "automation_definition",
+        "server:42",
+        {"action": "update", "server_definition_id": "srv-def-9"},
+    )
+
+    db.adopt_server_definition_identity(
+        local_id, {"id": "srv-def-9", "lifecycle": "configured"}
+    )
+
+    assert db.get_automation_definition(local_id)["lifecycle"] == "configured"
+
+
 # ----------------------------------------------------------------------
 # create/update_automation_definition pending_mutation +
 # get_automation_definition_by_server_id (schedules-handoff PR-4, task 4)

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -3218,6 +3218,232 @@ async def test_set_definition_lifecycle_refused_while_transferring(db):
 
 
 # ----------------------------------------------------------------------
+# Mutation-slot collision: an edit must not destroy a queued lifecycle
+# change (redesign PR-3 final review C1). Both probes from that review,
+# turned into pinned tests -- the class reintroduces easily.
+# ----------------------------------------------------------------------
+
+
+def _paused_server_definition(db):
+    """A synced, server-owned definition with a `pause` queued for sync."""
+    definition_id = db.create_automation_definition(
+        "server:1",
+        "recurring_question",
+        "Daily Q",
+        server_id="srv-def-1",
+        schedule={"kind": "interval", "every_seconds": 3600},
+        input={"question": "What happened today?"},
+        config={},
+    )
+    db.update_automation_definition(
+        definition_id,
+        lifecycle="paused",
+        pending_mutation={
+            "primitive": "automation_definition",
+            "owner_id": "server:1",
+            "payload": {"action": "pause", "server_definition_id": "srv-def-1"},
+        },
+    )
+    return definition_id
+
+
+def _assert_pause_survived(db, definition_id):
+    assert db.get_automation_definition(definition_id)["lifecycle"] == "paused"
+    pending = db.get_pending_mutations("server:1", primitive="automation_definition")
+    assert [m["payload"]["action"] for m in pending] == ["pause"]
+
+
+@pytest.mark.asyncio
+async def test_edit_refused_while_a_pause_is_queued_online(db):
+    """C1 probe 1: server reachable. The echo used to revert `lifecycle`
+    and the mirror then deleted the queued pause -- silently, both ends."""
+    definition_id = _paused_server_definition(db)
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-1",
+        "status": "valid",
+        "validation_errors": [],
+    }
+    server_client.update_automation_definition.return_value = _server_definition_echo()
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    outcome = await svc.save_definition(
+        _definition_payload(name="Edited"), "server:1", definition_id=definition_id
+    )
+
+    assert outcome.status == "error"
+    assert outcome.errors[0]["code"] == "pending_mutation"
+    assert "pause" in outcome.errors[0]["message"].lower()
+    _assert_pause_survived(db, definition_id)
+    assert db.get_automation_definition(definition_id)["name"] == "Daily Q"
+    # Refused at the entry -- the network is never reached at all.
+    server_client.preview_automation_definition.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_edit_refused_while_a_pause_is_queued_offline(db):
+    """C1 probe 2: seam unreachable. `record_pending_mutation`'s
+    `INSERT OR REPLACE` used to overwrite the queued pause with the edit."""
+    definition_id = _paused_server_definition(db)
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.side_effect = ServerUnavailableError(
+        "offline"
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    outcome = await svc.save_definition(
+        _definition_payload(name="Edited"), "server:1", definition_id=definition_id
+    )
+
+    assert outcome.status == "error"
+    assert outcome.errors[0]["code"] == "pending_mutation"
+    _assert_pause_survived(db, definition_id)
+
+
+@pytest.mark.asyncio
+async def test_edit_refused_while_a_release_transfer_is_queued(db):
+    """C1 covers the whole non-edit action class, not just lifecycle: a
+    queued `release_from_server` shares the same single slot, and the
+    mirror row carries no `transfer_state` for `transfer_lock_reason` to
+    catch."""
+    definition_id = _paused_server_definition(db)
+    db.record_pending_mutation(
+        definition_id,
+        "automation_definition",
+        "server:1",
+        {"action": "release_from_server", "server_definition_id": "srv-def-1"},
+    )
+    svc = SchedulingService(db=db, server_client=AsyncMock(), runtime_source="server:1")
+
+    outcome = await svc.save_definition(
+        _definition_payload(name="Edited"), "server:1", definition_id=definition_id
+    )
+
+    assert outcome.status == "error"
+    assert "move to this device" in outcome.errors[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_offline_edit_still_replaces_an_earlier_offline_edit(db):
+    """C1's refusal is CROSS-action only: update-over-update coalescing is
+    what `_save_definition_offline` documents and must keep working."""
+    definition_id = db.create_automation_definition(
+        "server:1",
+        "recurring_question",
+        "Original",
+        server_id="srv-def-1",
+        schedule={"kind": "interval", "every_seconds": 3600},
+        input={"question": "What happened today?"},
+        config={},
+    )
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.side_effect = ServerUnavailableError(
+        "offline"
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    first = await svc.save_definition(
+        _definition_payload(name="First"), "server:1", definition_id=definition_id
+    )
+    second = await svc.save_definition(
+        _definition_payload(name="Second"), "server:1", definition_id=definition_id
+    )
+
+    assert (first.status, second.status) == ("queued", "queued")
+    pending = db.get_pending_mutations("server:1", primitive="automation_definition")
+    assert len(pending) == 1
+    assert pending[0]["payload"]["definition_payload"]["name"] == "Second"
+
+
+@pytest.mark.asyncio
+async def test_local_row_edit_is_never_refused_by_its_retained_transfer_mutation(db):
+    """A `to_server_failed` row deliberately KEEPS its transfer mutation
+    queued and stays editable (`transfer_lock_reason`'s own docstring).
+    C1's guard is scoped to server-owned rows -- the only ones whose edits
+    touch the queue at all -- so this pins that it did not turn that
+    documented affordance into a refusal."""
+    definition_id = _make_definition(db)
+    db.record_pending_mutation(
+        definition_id,
+        "automation_definition",
+        "local",
+        {"action": "transfer_to_server", "transfer_errors": ["nope"]},
+    )
+    db.set_transfer_state(
+        "automation_definition", definition_id, "to_server_failed", expected=(None,)
+    )
+    svc = _transfer_service(db, server_client=_connected_server_client())
+
+    outcome = await svc.save_definition(
+        _definition_payload(name="Edited anyway"),
+        owner_id="local",
+        definition_id=definition_id,
+    )
+
+    assert outcome.status == "saved"
+    assert db.get_automation_definition(definition_id)["name"] == "Edited anyway"
+
+
+@pytest.mark.asyncio
+async def test_online_save_does_not_clear_a_lifecycle_mutation_queued_mid_flight(db):
+    """C1's second leg: a pause queued DURING the online round trip (the
+    entry guard read an empty slot before the network call) must survive
+    both the echo's `lifecycle` and the mirror's queue clear."""
+    definition_id = db.create_automation_definition(
+        "server:1",
+        "recurring_question",
+        "Original",
+        server_id="srv-def-1",
+        schedule={"kind": "interval", "every_seconds": 3600},
+        input={"question": "What happened today?"},
+        config={},
+    )
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-1",
+        "status": "valid",
+        "validation_errors": [],
+    }
+
+    async def _commit_then_user_pauses(*_args, **_kwargs):
+        # The user hits Pause while the PATCH is in flight.
+        db.update_automation_definition(
+            definition_id,
+            lifecycle="paused",
+            pending_mutation={
+                "primitive": "automation_definition",
+                "owner_id": "server:1",
+                "payload": {
+                    "action": "pause",
+                    "server_definition_id": "srv-def-1",
+                },
+            },
+        )
+        return _server_definition_echo(name="Edited", lifecycle="configured")
+
+    server_client.update_automation_definition.side_effect = _commit_then_user_pauses
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    outcome = await svc.save_definition(
+        _definition_payload(name="Edited"), "server:1", definition_id=definition_id
+    )
+
+    assert outcome.status == "saved"
+    row = db.get_automation_definition(definition_id)
+    # The edit landed; the pause was neither reverted nor dequeued.
+    assert row["name"] == "Edited"
+    _assert_pause_survived(db, definition_id)
+
+
+# ----------------------------------------------------------------------
 # resolve_definition (schedules-handoff PR-6, task 2)
 # ----------------------------------------------------------------------
 

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -3174,7 +3174,7 @@ async def test_set_definition_lifecycle_local_writes_without_a_mutation(db):
 
     assert outcome.status == "saved"
     assert db.get_automation_definition(definition_id)["lifecycle"] == "paused"
-    assert db.get_pending_mutations(primitive="automation_definition") == []
+    assert db.get_pending_mutations(primitive="automation_lifecycle") == []
 
 
 @pytest.mark.asyncio
@@ -3191,9 +3191,12 @@ async def test_set_definition_lifecycle_server_row_records_the_replay_mutation(d
 
     assert outcome.status == "saved"
     assert db.get_automation_definition(definition_id)["lifecycle"] == "configured"
-    mutations = db.get_pending_mutations("server:1", primitive="automation_definition")
+    mutations = db.get_pending_mutations("server:1", primitive="automation_lifecycle")
     assert [m["payload"]["action"] for m in mutations] == ["resume"]
     assert mutations[0]["payload"]["server_definition_id"] == "srv-def-1"
+    # Its OWN slot -- nothing lands in the shared definition primitive
+    # (Qodo findings 5+6), which is what leaves room for a queued edit.
+    assert db.get_pending_mutations("server:1", primitive="automation_definition") == []
 
 
 @pytest.mark.asyncio
@@ -3218,9 +3221,13 @@ async def test_set_definition_lifecycle_refused_while_transferring(db):
 
 
 # ----------------------------------------------------------------------
-# Mutation-slot collision: an edit must not destroy a queued lifecycle
-# change (redesign PR-3 final review C1). Both probes from that review,
-# turned into pinned tests -- the class reintroduces easily.
+# Mutation-slot COEXISTENCE: an edit and a lifecycle change queue in
+# different `pending_mutations` slots (`automation_definition` vs
+# `automation_lifecycle`), so neither destroys the other -- Qodo findings
+# 5+6, which reversed final review C1's cross-action refusal for the
+# lifecycle half. Both of C1's probes are kept, inverted: what used to be
+# refused now succeeds with BOTH mutations intact. The edit-vs-TRANSFER
+# refusal below still stands (those two DO share a slot).
 # ----------------------------------------------------------------------
 
 
@@ -3239,7 +3246,7 @@ def _paused_server_definition(db):
         definition_id,
         lifecycle="paused",
         pending_mutation={
-            "primitive": "automation_definition",
+            "primitive": "automation_lifecycle",
             "owner_id": "server:1",
             "payload": {"action": "pause", "server_definition_id": "srv-def-1"},
         },
@@ -3249,14 +3256,17 @@ def _paused_server_definition(db):
 
 def _assert_pause_survived(db, definition_id):
     assert db.get_automation_definition(definition_id)["lifecycle"] == "paused"
-    pending = db.get_pending_mutations("server:1", primitive="automation_definition")
+    pending = db.get_pending_mutations("server:1", primitive="automation_lifecycle")
     assert [m["payload"]["action"] for m in pending] == ["pause"]
 
 
 @pytest.mark.asyncio
-async def test_edit_refused_while_a_pause_is_queued_online(db):
-    """C1 probe 1: server reachable. The echo used to revert `lifecycle`
-    and the mirror then deleted the queued pause -- silently, both ends."""
+async def test_edit_coexists_with_a_queued_pause_online(db):
+    """C1 probe 1, inverted. The edit goes through (it no longer collides
+    with anything), the echo cannot revert `lifecycle` -- `adopt_server_
+    definition_identity`'s guard reads the lifecycle slot and sees the
+    pause -- and `_clear_stale_edit_mutation` cannot reach the pause
+    either, since it only ever clears the definition slot."""
     definition_id = _paused_server_definition(db)
     server_client = AsyncMock()
     server_client.preview_automation_definition.return_value = {
@@ -3264,7 +3274,11 @@ async def test_edit_refused_while_a_pause_is_queued_online(db):
         "status": "valid",
         "validation_errors": [],
     }
-    server_client.update_automation_definition.return_value = _server_definition_echo()
+    # The echo carries the server's PRE-pause `lifecycle` -- the exact
+    # payload that used to revert the row.
+    server_client.update_automation_definition.return_value = _server_definition_echo(
+        name="Edited", lifecycle="configured"
+    )
     svc = SchedulingService(
         db=db, server_client=server_client, runtime_source="server:1"
     )
@@ -3273,19 +3287,18 @@ async def test_edit_refused_while_a_pause_is_queued_online(db):
         _definition_payload(name="Edited"), "server:1", definition_id=definition_id
     )
 
-    assert outcome.status == "error"
-    assert outcome.errors[0]["code"] == "pending_mutation"
-    assert "pause" in outcome.errors[0]["message"].lower()
+    assert outcome.status == "saved"
+    assert db.get_automation_definition(definition_id)["name"] == "Edited"
     _assert_pause_survived(db, definition_id)
-    assert db.get_automation_definition(definition_id)["name"] == "Daily Q"
-    # Refused at the entry -- the network is never reached at all.
-    server_client.preview_automation_definition.assert_not_awaited()
+    server_client.preview_automation_definition.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_edit_refused_while_a_pause_is_queued_offline(db):
-    """C1 probe 2: seam unreachable. `record_pending_mutation`'s
-    `INSERT OR REPLACE` used to overwrite the queued pause with the edit."""
+async def test_offline_edit_coexists_with_a_queued_pause(db):
+    """C1 probe 2, inverted -- the finding-5 headline. `record_pending_
+    mutation`'s `INSERT OR REPLACE` is keyed `(local_id, primitive,
+    owner_id)`: with the pause in its own primitive, the queued edit
+    lands BESIDE it instead of overwriting it, so both replay."""
     definition_id = _paused_server_definition(db)
     server_client = AsyncMock()
     server_client.preview_automation_definition.side_effect = ServerUnavailableError(
@@ -3299,17 +3312,56 @@ async def test_edit_refused_while_a_pause_is_queued_offline(db):
         _definition_payload(name="Edited"), "server:1", definition_id=definition_id
     )
 
-    assert outcome.status == "error"
-    assert outcome.errors[0]["code"] == "pending_mutation"
+    assert outcome.status == "queued"
     _assert_pause_survived(db, definition_id)
+    queued_edits = db.get_pending_mutations(
+        "server:1", primitive="automation_definition"
+    )
+    assert [m["payload"]["action"] for m in queued_edits] == ["update"]
+    assert queued_edits[0]["payload"]["definition_payload"]["name"] == "Edited"
+
+
+@pytest.mark.asyncio
+async def test_pause_after_an_offline_edit_keeps_both_queued(db):
+    """The MIRROR direction of finding 5 (the C1 deferral this reversal
+    closes): pausing a row that already has an offline edit queued used
+    to discard that edit's push. Order must not matter."""
+    definition_id = db.create_automation_definition(
+        "server:1",
+        "recurring_question",
+        "Daily Q",
+        server_id="srv-def-1",
+        schedule={"kind": "interval", "every_seconds": 3600},
+        input={"question": "What happened today?"},
+        config={},
+    )
+    server_client = AsyncMock()
+    server_client.preview_automation_definition.side_effect = ServerUnavailableError(
+        "offline"
+    )
+    svc = SchedulingService(
+        db=db, server_client=server_client, runtime_source="server:1"
+    )
+
+    edited = await svc.save_definition(
+        _definition_payload(name="Edited"), "server:1", definition_id=definition_id
+    )
+    paused = await svc.set_definition_lifecycle(definition_id, "pause")
+
+    assert (edited.status, paused.status) == ("queued", "saved")
+    _assert_pause_survived(db, definition_id)
+    queued_edits = db.get_pending_mutations(
+        "server:1", primitive="automation_definition"
+    )
+    assert [m["payload"]["action"] for m in queued_edits] == ["update"]
 
 
 @pytest.mark.asyncio
 async def test_edit_refused_while_a_release_transfer_is_queued(db):
-    """C1 covers the whole non-edit action class, not just lifecycle: a
-    queued `release_from_server` shares the same single slot, and the
-    mirror row carries no `transfer_state` for `transfer_lock_reason` to
-    catch."""
+    """C1's TRANSFER half stands after Qodo 5+6: a queued
+    `release_from_server` still shares the `automation_definition` slot
+    an edit would take, and the mirror row carries no `transfer_state`
+    for `transfer_lock_reason` to catch."""
     definition_id = _paused_server_definition(db)
     db.record_pending_mutation(
         definition_id,
@@ -3392,9 +3444,10 @@ async def test_local_row_edit_is_never_refused_by_its_retained_transfer_mutation
 
 @pytest.mark.asyncio
 async def test_online_save_does_not_clear_a_lifecycle_mutation_queued_mid_flight(db):
-    """C1's second leg: a pause queued DURING the online round trip (the
-    entry guard read an empty slot before the network call) must survive
-    both the echo's `lifecycle` and the mirror's queue clear."""
+    """C1's second leg, still live after Qodo 5+6: a pause queued DURING
+    the online round trip must survive both the echo's `lifecycle` (the
+    adopt-identity belt withholds it) and the mirror's queue clear (which
+    only ever touches the definition slot)."""
     definition_id = db.create_automation_definition(
         "server:1",
         "recurring_question",
@@ -3417,7 +3470,7 @@ async def test_online_save_does_not_clear_a_lifecycle_mutation_queued_mid_flight
             definition_id,
             lifecycle="paused",
             pending_mutation={
-                "primitive": "automation_definition",
+                "primitive": "automation_lifecycle",
                 "owner_id": "server:1",
                 "payload": {
                     "action": "pause",

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -1751,6 +1751,53 @@ async def test_save_definition_edit_still_clears_a_field_the_payload_carries(db)
 
 
 @pytest.mark.asyncio
+async def test_save_definition_edit_merges_over_a_sql_null_json_column(db):
+    """task-4 review Finding 1: `config`/`input`/`notification_policy`
+    may be SQL NULL (Python `None`) rather than `{}` -- reachable via
+    `create_automation_definition`'s own `None -> NULL` pass-through (the
+    same shape `upsert_automation_definitions_from_server`'s INSERT path
+    used to leave before its own fix) for a definition a caller never
+    populated one of these groups on. `_merge_definition_payload`'s old
+    `isinstance(stored, dict)` gate treated NULL as "nothing to merge"
+    and skipped the branch entirely -- dropping the payload's OWN
+    incoming value for that group too, not just the (nonexistent) stored
+    one. Edits the SAME group that is NULL (`config`, via the Generation
+    row's real edit shape) to pin the exact failure mode the review
+    reproduced."""
+    def_id = db.create_automation_definition(
+        "local",
+        "recurring_question",
+        "Nully digest",
+        input={"question": "What shipped?"},
+        config=None,
+        notification_policy=None,
+        schedule={"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+    )
+    row = db.get_automation_definition(def_id)
+    assert row["config"] is None
+    assert row["notification_policy"] is None
+
+    svc = SchedulingService(db=db, runtime_source="local")
+    outcome = await svc.save_definition(
+        {
+            "family": "recurring_question",
+            "name": "Nully digest",
+            "schedule": {"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+            "config": {"generation_mode": "required"},
+            "input": {},
+            "notification_policy": {},
+        },
+        "local",
+        definition_id=def_id,
+    )
+
+    assert outcome.status == "saved", outcome.errors
+    row = db.get_automation_definition(def_id)
+    assert row["config"]["generation_mode"] == "required"
+    assert row["input"]["question"] == "What shipped?"  # untouched group preserved
+
+
+@pytest.mark.asyncio
 async def test_save_definition_server_owner_offline_invalid_writes_nothing(db):
     server_client = AsyncMock()
     server_client.preview_automation_definition.side_effect = ServerUnavailableError(

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -2939,6 +2939,150 @@ async def test_update_reminder_refused_while_transferring(db):
     assert db.get_reminder_task(reminder_id)["title"] == "Original"
 
 
+# ----------------------------------------------------------------------
+# edit_reminder_fields (redesign PR-3 task 2's reminder validation bridge)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_reminder_fields_invalid_cron_returns_field_error(db):
+    svc = SchedulingService(db=db, runtime_source="local")
+    reminder_id = _make_reminder(
+        db, schedule_kind="recurring", run_at=None, cron="0 9 * * *", timezone="UTC"
+    )
+
+    outcome = await svc.edit_reminder_fields(reminder_id, {"cron": "not a cron"})
+
+    assert outcome.status == "error"
+    assert outcome.errors == [
+        {
+            "field": "cron",
+            "code": "invalid_cron",
+            "message": "Cron expression is invalid.",
+        }
+    ]
+    assert db.get_reminder_task(reminder_id)["cron"] == "0 9 * * *"
+
+
+@pytest.mark.asyncio
+async def test_edit_reminder_fields_invalid_timezone_returns_field_error(db):
+    svc = SchedulingService(db=db, runtime_source="local")
+    reminder_id = _make_reminder(
+        db, schedule_kind="recurring", run_at=None, cron="0 9 * * *", timezone="UTC"
+    )
+
+    outcome = await svc.edit_reminder_fields(
+        reminder_id, {"timezone": "Not/A_Real_Zone"}
+    )
+
+    assert outcome.status == "error"
+    assert outcome.errors[0]["field"] == "timezone"
+    assert outcome.errors[0]["code"] == "invalid_timezone"
+    assert db.get_reminder_task(reminder_id)["timezone"] == "UTC"
+
+
+@pytest.mark.asyncio
+async def test_edit_reminder_fields_invalid_run_at_returns_field_error(db):
+    svc = SchedulingService(db=db, runtime_source="local")
+    reminder_id = _make_reminder(db, schedule_kind="one_time", run_at="2030-01-01T00:00:00+00:00")
+
+    outcome = await svc.edit_reminder_fields(reminder_id, {"run_at": "not a date"})
+
+    assert outcome.status == "error"
+    assert outcome.errors[0]["field"] == "run_at"
+    assert outcome.errors[0]["code"] == "invalid_datetime"
+
+
+@pytest.mark.asyncio
+async def test_edit_reminder_fields_valid_run_at_accepts_forgiving_local_format(db):
+    """Reuses `reminder_form.parse_forgiving_datetime` -- a naive,
+    space-separated datetime (not full ISO-8601) must parse and persist,
+    same as the create form accepts."""
+    svc = SchedulingService(db=db, runtime_source="local")
+    reminder_id = _make_reminder(db, schedule_kind="one_time", run_at="2030-01-01T00:00:00+00:00")
+
+    outcome = await svc.edit_reminder_fields(reminder_id, {"run_at": "2031-06-15 09:30"})
+
+    assert outcome.status == "saved"
+    assert outcome.task is not None
+    assert (outcome.task.run_at.year, outcome.task.run_at.month, outcome.task.run_at.day) == (
+        2031,
+        6,
+        15,
+    )
+
+
+@pytest.mark.asyncio
+async def test_edit_reminder_fields_bad_schedule_kind_returns_field_error_not_raw_exception(db):
+    """Belt-and-suspenders: a bad value the pre-checks above don't cover
+    (schedule_kind isn't cron/run_at/timezone) still routes through
+    `ReminderTask`'s own model validation inside `update_reminder` -- the
+    bridge must catch that `pydantic.ValidationError` and translate it,
+    never let it escape."""
+    svc = SchedulingService(db=db, runtime_source="local")
+    reminder_id = _make_reminder(db)
+
+    outcome = await svc.edit_reminder_fields(reminder_id, {"schedule_kind": "bogus"})
+
+    assert outcome.status == "error"
+    assert outcome.errors
+    assert outcome.errors[0]["field"] == "schedule_kind"
+
+
+@pytest.mark.asyncio
+async def test_edit_reminder_fields_locked_row_returns_row_error(db):
+    svc = _transfer_service(db, server_client=_connected_server_client())
+    reminder_id = _make_reminder(db, title="Original")
+    db.set_transfer_state(
+        "reminder_task", reminder_id, "to_server_pending", expected=(None,)
+    )
+
+    outcome = await svc.edit_reminder_fields(reminder_id, {"title": "Edited"})
+
+    assert outcome.status == "error"
+    assert outcome.errors[0]["field"] == "_row"
+    assert outcome.errors[0]["code"] == "transfer_in_progress"
+    assert db.get_reminder_task(reminder_id)["title"] == "Original"
+
+
+@pytest.mark.asyncio
+async def test_edit_reminder_fields_unknown_task_id_returns_row_not_found(db):
+    svc = SchedulingService(db=db, runtime_source="local")
+
+    outcome = await svc.edit_reminder_fields("does-not-exist", {"title": "Edited"})
+
+    assert outcome.status == "error"
+    assert outcome.errors[0]["field"] == "_row"
+    assert outcome.errors[0]["code"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_edit_reminder_fields_valid_edit_threads_the_rows_owner(db):
+    """PR-2 row-owner discipline: the row's OWN `owner_id` is threaded to
+    `update_reminder`, not the service's active `owner_id` -- the unified
+    list can show a row that belongs to a different owner than the
+    service's current one (same rationale as `delete_reminder`'s)."""
+    offline_client = AsyncMock()
+    offline_client.notifications_service = object()
+    offline_client.update_reminder.side_effect = ServerUnavailableError("offline")
+
+    svc = SchedulingService(db=db, server_client=offline_client, runtime_source="local")
+    reminder_id = _make_reminder(db, owner_id="server:1", server_id="srv-1")
+
+    outcome = await svc.edit_reminder_fields(reminder_id, {"title": "Renamed"})
+
+    assert outcome.status == "saved"
+    assert outcome.task is not None
+    assert outcome.task.title == "Renamed"
+    assert svc.owner_id == "local"  # never flipped
+    offline_client.update_reminder.assert_awaited_once()
+
+    pending = db.get_pending_mutations("server:1", primitive="reminder_task")
+    assert len(pending) == 1
+    assert pending[0]["payload"]["action"] == "update"
+    assert db.get_pending_mutations("local", primitive="reminder_task") == []
+
+
 @pytest.mark.asyncio
 async def test_delete_reminder_refused_while_transferring(db):
     """I7: deleting a dormant release copy discards the only row the

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -1680,6 +1680,55 @@ async def test_sync_now_replays_definition_archive(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_sync_now_pull_skips_stale_lifecycle_echo_pushed_same_cycle(tmp_path):
+    """PR-3 task 2, guard layer 2 end-to-end: the definitions push phase
+    (which replays the pending `pause`) runs, then deletes the mutation,
+    BEFORE the definitions pull phase runs in the same `sync_now` call.
+    If the pull's page still echoes the pre-pause lifecycle (server
+    write/read-path lag), guard 1 alone can't see it -- the mutation is
+    already gone. `skip_lifecycle_server_ids`, threaded from the push
+    phase's return value, is what stops the pull from reverting the
+    pause that was just pushed THIS cycle."""
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    local_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Daily digest", server_id="srv-def-1"
+    )
+    db.record_pending_mutation(
+        local_id,
+        "automation_definition",
+        "server:1",
+        {"action": "pause", "server_definition_id": "srv-def-1"},
+    )
+    server_client = _empty_reminders_client()
+    server_client.pause_automation_definition.return_value = {
+        "id": "srv-def-1",
+        "family": "recurring_question",
+        "name": "Daily digest",
+        "lifecycle": "paused",
+    }
+    # The same cycle's definitions-list page still echoes the PRE-pause
+    # state.
+    server_client.list_automation_definitions.return_value = _definition_page(
+        [
+            {
+                "id": "srv-def-1",
+                "family": "recurring_question",
+                "name": "Daily digest (renamed)",
+                "lifecycle": "configured",
+            }
+        ]
+    )
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    row = db.get_automation_definition(local_id)
+    assert row["lifecycle"] == "paused"  # not reverted by the same-cycle stale echo
+    assert row["name"] == "Daily digest (renamed)"  # every other field still server-wins
+
+
+@pytest.mark.asyncio
 async def test_sync_now_definition_lifecycle_not_found_clears_without_sync_error(
     tmp_path, captured_logs
 ):

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -1374,6 +1374,93 @@ async def test_sync_now_replays_definition_update(tmp_path):
     assert row["name"] == "New name"
 
 
+@pytest.mark.parametrize("pause_queued_first", [False, True])
+@pytest.mark.asyncio
+async def test_sync_now_replays_a_queued_edit_and_pause_together(
+    tmp_path, pause_queued_first
+):
+    """Qodo findings 5+6: an offline edit and an offline pause on the SAME
+    row occupy different `pending_mutations` slots, so both survive being
+    queued and both replay in one cycle -- whichever was queued first.
+
+    The convergence hinge is the echo. `_replay_definition_mutations`
+    settles the definition slot BEFORE the lifecycle slot, so when
+    `adopt_server_definition_identity` applies the PATCH response (which
+    here still reports the pre-pause `lifecycle` -- the server write/read
+    lag this whole guard family exists for), the pause is still queued,
+    and the adopt-identity belt withholds `lifecycle` on exactly that
+    basis. Without that belt the row would end the cycle `configured`
+    with nothing left to correct it."""
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    local_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Old name", server_id="srv-def-2"
+    )
+
+    def _queue_pause():
+        db.record_pending_mutation(
+            local_id,
+            "automation_lifecycle",
+            "server:1",
+            {"action": "pause", "server_definition_id": "srv-def-2"},
+        )
+
+    def _queue_edit():
+        db.record_pending_mutation(
+            local_id,
+            "automation_definition",
+            "server:1",
+            {
+                "action": "update",
+                "definition_payload": {
+                    "family": "recurring_question",
+                    "name": "New name",
+                },
+                "server_definition_id": "srv-def-2",
+            },
+        )
+
+    for step in (
+        (_queue_pause, _queue_edit)
+        if pause_queued_first
+        else (_queue_edit, _queue_pause)
+    ):
+        step()
+
+    server_client = _empty_reminders_client()
+    server_client.list_automation_definitions.return_value = _definition_page([])
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-2",
+        "status": "valid",
+        "validation_errors": [],
+    }
+    server_client.update_automation_definition.return_value = {
+        "id": "srv-def-2",
+        "name": "New name",
+        # Stale: the pause has not been pushed yet at echo time.
+        "lifecycle": "configured",
+    }
+    server_client.pause_automation_definition.return_value = {
+        "id": "srv-def-2",
+        "family": "recurring_question",
+        "name": "New name",
+        "lifecycle": "paused",
+    }
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    server_client.update_automation_definition.assert_awaited_once_with(
+        "srv-def-2", "prev-2"
+    )
+    server_client.pause_automation_definition.assert_awaited_once_with("srv-def-2")
+    assert db.get_pending_mutations("server:1", primitive="automation_definition") == []
+    assert db.get_pending_mutations("server:1", primitive="automation_lifecycle") == []
+    row = db.get_automation_definition(local_id)
+    assert row["name"] == "New name"
+    assert row["lifecycle"] == "paused"
+
+
 @pytest.mark.asyncio
 async def test_sync_now_definition_update_without_server_id_converts_to_create(
     tmp_path,
@@ -1586,7 +1673,7 @@ async def test_sync_now_replays_definition_pause_and_mirrors_echo(tmp_path):
     )
     db.record_pending_mutation(
         local_id,
-        "automation_definition",
+        "automation_lifecycle",
         "server:1",
         {"action": "pause", "server_definition_id": "srv-def-1"},
     )
@@ -1604,7 +1691,7 @@ async def test_sync_now_replays_definition_pause_and_mirrors_echo(tmp_path):
     assert outcome.status == "ok"
     server_client.pause_automation_definition.assert_awaited_once_with("srv-def-1")
     assert (
-        db.get_pending_mutations("server:1", primitive="automation_definition") == []
+        db.get_pending_mutations("server:1", primitive="automation_lifecycle") == []
     )
     row = db.get_automation_definition(local_id)
     assert row["lifecycle"] == "paused"
@@ -1622,7 +1709,7 @@ async def test_sync_now_replays_definition_resume(tmp_path):
     )
     db.record_pending_mutation(
         local_id,
-        "automation_definition",
+        "automation_lifecycle",
         "server:1",
         {"action": "resume", "server_definition_id": "srv-def-1"},
     )
@@ -1640,7 +1727,7 @@ async def test_sync_now_replays_definition_resume(tmp_path):
     assert outcome.status == "ok"
     server_client.resume_automation_definition.assert_awaited_once_with("srv-def-1")
     assert (
-        db.get_pending_mutations("server:1", primitive="automation_definition") == []
+        db.get_pending_mutations("server:1", primitive="automation_lifecycle") == []
     )
     assert db.get_automation_definition(local_id)["lifecycle"] == "configured"
 
@@ -1653,7 +1740,7 @@ async def test_sync_now_replays_definition_archive(tmp_path):
     )
     db.record_pending_mutation(
         local_id,
-        "automation_definition",
+        "automation_lifecycle",
         "server:1",
         {"action": "archive", "server_definition_id": "srv-def-1"},
     )
@@ -1672,7 +1759,7 @@ async def test_sync_now_replays_definition_archive(tmp_path):
     assert outcome.status == "ok"
     server_client.archive_automation_definition.assert_awaited_once_with("srv-def-1")
     assert (
-        db.get_pending_mutations("server:1", primitive="automation_definition") == []
+        db.get_pending_mutations("server:1", primitive="automation_lifecycle") == []
     )
     row = db.get_automation_definition(local_id)
     assert row["lifecycle"] == "archived"
@@ -1695,7 +1782,7 @@ async def test_sync_now_pull_skips_stale_lifecycle_echo_pushed_same_cycle(tmp_pa
     )
     db.record_pending_mutation(
         local_id,
-        "automation_definition",
+        "automation_lifecycle",
         "server:1",
         {"action": "pause", "server_definition_id": "srv-def-1"},
     )
@@ -1738,7 +1825,7 @@ async def test_sync_now_definition_lifecycle_not_found_clears_without_sync_error
     )
     db.record_pending_mutation(
         local_id,
-        "automation_definition",
+        "automation_lifecycle",
         "server:1",
         {"action": "archive", "server_definition_id": "srv-def-gone"},
     )
@@ -1752,7 +1839,7 @@ async def test_sync_now_definition_lifecycle_not_found_clears_without_sync_error
 
     assert outcome.status == "ok"
     assert (
-        db.get_pending_mutations("server:1", primitive="automation_definition") == []
+        db.get_pending_mutations("server:1", primitive="automation_lifecycle") == []
     ), "nothing left server-side to transition -- clear rather than retry forever"
     state = db.get_sync_state("server:1") or {}
     assert not (state.get("sync_errors") or []), "a 404 here is not a user-facing error"
@@ -1775,7 +1862,7 @@ async def test_sync_now_definition_lifecycle_validation_error_does_not_block_the
     )
     db.record_pending_mutation(
         poisoned_id,
-        "automation_definition",
+        "automation_lifecycle",
         "server:1",
         {"action": "pause", "server_definition_id": "srv-def-old"},
     )
@@ -1784,7 +1871,7 @@ async def test_sync_now_definition_lifecycle_validation_error_does_not_block_the
     )
     db.record_pending_mutation(
         healthy_id,
-        "automation_definition",
+        "automation_lifecycle",
         "server:1",
         {"action": "resume", "server_definition_id": "srv-def-healthy"},
     )
@@ -1806,7 +1893,7 @@ async def test_sync_now_definition_lifecycle_validation_error_does_not_block_the
     # The healthy resume went through despite the poisoned pause ahead of it.
     assert db.get_automation_definition(healthy_id)["lifecycle"] == "configured"
     # And the poisoned one is settled, not left to jam the queue forever.
-    assert db.get_pending_mutations("server:1", primitive="automation_definition") == []
+    assert db.get_pending_mutations("server:1", primitive="automation_lifecycle") == []
     errors = (db.get_sync_state("server:1") or {}).get("sync_errors") or []
     assert any("lifecycle_transition_invalid" in error["message"] for error in errors)
 
@@ -1819,7 +1906,7 @@ async def test_sync_now_definition_lifecycle_retryable_error_retains_mutation(tm
     )
     db.record_pending_mutation(
         local_id,
-        "automation_definition",
+        "automation_lifecycle",
         "server:1",
         {"action": "pause", "server_definition_id": "srv-def-1"},
     )
@@ -1833,7 +1920,7 @@ async def test_sync_now_definition_lifecycle_retryable_error_retains_mutation(tm
 
     assert outcome.status == "error"
     assert "offline" in (outcome.error or "")
-    pending = db.get_pending_mutations("server:1", primitive="automation_definition")
+    pending = db.get_pending_mutations("server:1", primitive="automation_lifecycle")
     assert len(pending) == 1, "the mutation must be left queued for retry"
     assert db.get_automation_definition(local_id)["lifecycle"] == "configured"
 
@@ -1851,7 +1938,7 @@ async def test_sync_now_definition_lifecycle_without_server_id_drops_mutation(tm
     )
     db.record_pending_mutation(
         local_id,
-        "automation_definition",
+        "automation_lifecycle",
         "server:1",
         {"action": "pause", "server_definition_id": None},
     )
@@ -1863,7 +1950,7 @@ async def test_sync_now_definition_lifecycle_without_server_id_drops_mutation(tm
     assert outcome.status == "ok"
     server_client.pause_automation_definition.assert_not_awaited()
     assert (
-        db.get_pending_mutations("server:1", primitive="automation_definition") == []
+        db.get_pending_mutations("server:1", primitive="automation_lifecycle") == []
     )
 
 

--- a/Tests/UI/test_detail_value_row.py
+++ b/Tests/UI/test_detail_value_row.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import pytest
 from rich.text import Text
 from textual.app import App, ComposeResult
+from textual.css.query import NoMatches
+from textual.widgets import Input
 from textual.widgets._collapsible import CollapsibleTitle
 
 from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
@@ -70,9 +72,18 @@ class _RowHarness(ConsolidatedCSSApp):
     def __init__(self, *rows: DetailValueRow) -> None:
         super().__init__()
         self._rows = rows
+        #: `DetailValueRow.Activated` rows received, in post order (PR-3
+        #: Task 1) -- Textual routes a message subclass to the handler
+        #: named after its dotted qualname (`DetailValueRow.Activated` ->
+        #: `on_detail_value_row_activated`), same convention as
+        #: `Button.Pressed` -> `on_button_pressed`.
+        self.activations: list[DetailValueRow] = []
 
     def compose(self) -> ComposeResult:
         yield from self._rows
+
+    def on_detail_value_row_activated(self, message: DetailValueRow.Activated) -> None:
+        self.activations.append(message.row)
 
 
 class _GroupHarness(ConsolidatedCSSApp):
@@ -276,3 +287,202 @@ async def test_row_carries_its_own_identity_and_focusability():
         assert keyed.can_focus is True
         keyed.focus()
         assert app.focused is keyed
+
+
+# ---------------------------------------------------------------------------
+# schedules-redesign PR-3, Task 1: activation + edit-swap API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_click_posts_activated_when_affordance_true_and_not_editing():
+    row = DetailValueRow("Repeat", "Weekly", affordance=True, id="row")
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 5)) as pilot:
+        await pilot.click(row)
+        await pilot.pause()
+        assert app.activations == [row]
+
+
+@pytest.mark.asyncio
+async def test_enter_posts_activated_when_row_focused():
+    row = DetailValueRow(
+        "Repeat", "Weekly", affordance=True, can_focus=True, id="row"
+    )
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 5)) as pilot:
+        row.focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.activations == [row]
+
+
+@pytest.mark.asyncio
+async def test_click_on_a_dormant_row_never_posts_activated():
+    """PR-1/PR-2 preservation: `affordance` left at its default `False`
+    (every current TaskDetail/DefinitionDetail row) must stay a complete
+    no-op, exactly as before this row had a click/key handler at all."""
+    row = DetailValueRow("Status", "Waiting", id="row")
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 5)) as pilot:
+        await pilot.click(row)
+        await pilot.pause()
+        assert app.activations == []
+
+
+@pytest.mark.asyncio
+async def test_enter_on_a_focusable_but_non_editable_row_never_posts_activated():
+    """`can_focus` and `affordance` are independent flags -- a row can be
+    keyboard-focusable (spec §12 traversal) without being editable; Enter
+    on it must not activate."""
+    row = DetailValueRow(
+        "Status", "Waiting", can_focus=True, id="row"
+    )
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 5)) as pilot:
+        row.focus()
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert app.activations == []
+
+
+@pytest.mark.asyncio
+async def test_click_while_an_editor_is_already_open_does_not_reactivate():
+    row = DetailValueRow("Repeat", "Weekly", affordance=True, id="row")
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 5)) as pilot:
+        row.begin_edit(Input(id="editor"))
+        await pilot.pause()
+
+        await pilot.click(row)
+        await pilot.pause()
+        assert app.activations == []
+
+
+@pytest.mark.asyncio
+async def test_begin_edit_hides_the_value_and_mounts_a_focused_editor():
+    row = DetailValueRow("Repeat", "Weekly", affordance=True, id="row")
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 5)) as pilot:
+        value = row.query_one(".detail-value-row-value")
+        assert value.display is True
+
+        editor = Input(id="editor")
+        row.begin_edit(editor)
+        await pilot.pause()
+
+        assert value.display is False
+        assert row.query_one("#editor") is editor
+        assert app.focused is editor
+
+
+@pytest.mark.asyncio
+async def test_end_edit_restores_the_value_and_refocuses_the_row_by_default():
+    row = DetailValueRow(
+        "Repeat", "Weekly", affordance=True, can_focus=True, id="row"
+    )
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 5)) as pilot:
+        value = row.query_one(".detail-value-row-value")
+        row.begin_edit(Input(id="editor"))
+        await pilot.pause()
+
+        row.end_edit()
+        await pilot.pause()
+
+        with pytest.raises(NoMatches):
+            row.query_one("#editor")
+        assert value.display is True
+        assert value.render_line(0).text.strip() == "Weekly"
+        assert app.focused is row
+
+
+@pytest.mark.asyncio
+async def test_end_edit_with_restore_focus_false_leaves_focus_alone():
+    row = DetailValueRow(
+        "Repeat", "Weekly", affordance=True, can_focus=True, id="row"
+    )
+    other = DetailValueRow("At", "9:00 AM", can_focus=True, id="other")
+    app = _RowHarness(row, other)
+    async with app.run_test(size=(40, 6)) as pilot:
+        row.begin_edit(Input(id="editor"))
+        await pilot.pause()
+        other.focus()
+        await pilot.pause()
+
+        row.end_edit(restore_focus=False)
+        await pilot.pause()
+
+        assert app.focused is other
+
+
+@pytest.mark.asyncio
+async def test_begin_edit_is_a_guarded_noop_while_already_editing():
+    """One editor at a time -- a second `begin_edit` while one is open must
+    not mount its editor at all."""
+    row = DetailValueRow("Repeat", "Weekly", affordance=True, id="row")
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 5)) as pilot:
+        first = Input(id="first-editor")
+        second = Input(id="second-editor")
+        row.begin_edit(first)
+        await pilot.pause()
+
+        row.begin_edit(second)
+        await pilot.pause()
+
+        assert row.query_one("#first-editor") is first
+        assert second.parent is None, "second editor must never be mounted"
+        assert app.focused is first
+
+
+@pytest.mark.asyncio
+async def test_error_line_coexists_with_an_open_editor():
+    row = DetailValueRow(
+        "Repeat", "Weekly", affordance=True, value_id="row-repeat", id="row"
+    )
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 6)) as pilot:
+        row.begin_edit(Input(id="editor"))
+        await pilot.pause()
+
+        row.show_error("Invalid cron expression")
+        await pilot.pause()
+
+        error = row.query_one("#row-repeat-error")
+        assert error.region.height > 0
+        assert "Invalid cron expression" in error.render_line(0).text
+        # The editor must still be there -- showing an error must not
+        # close it out from under the user.
+        assert row.query_one("#editor").display is True
+
+
+@pytest.mark.asyncio
+async def test_affordance_undims_to_the_value_color_when_the_row_has_focus():
+    """PR-3 Task 1's live-state CSS: PR-1's resting affordance is dimmer
+    than the value (pinned by
+    `test_affordance_glyph_is_painted_and_dimmer_than_the_value` above); a
+    focused row's affordance un-dims to (about) the value's own colour."""
+    row = DetailValueRow(
+        "Repeat", "Weekly", affordance=True, can_focus=True, id="row"
+    )
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 5)) as pilot:
+        # A focusable widget auto-focuses on app start -- blur it first so
+        # "resting" actually means unfocused, not just "before the test's
+        # own `.focus()` call".
+        row.blur()
+        await pilot.pause()
+
+        affordance = row.query_one(".detail-value-row-affordance")
+        value = row.query_one(".detail-value-row-value")
+        value_luminance = _relative_luminance(_painted_color(app, value))
+        resting_luminance = _relative_luminance(_painted_color(app, affordance))
+        assert resting_luminance < value_luminance
+
+        row.focus()
+        await pilot.pause()
+        focused_luminance = _relative_luminance(_painted_color(app, affordance))
+        assert focused_luminance == pytest.approx(value_luminance, abs=0.02)

--- a/Tests/UI/test_detail_value_row.py
+++ b/Tests/UI/test_detail_value_row.py
@@ -14,7 +14,7 @@ import pytest
 from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.css.query import NoMatches
-from textual.widgets import Input
+from textual.widgets import Input, Select
 from textual.widgets._collapsible import CollapsibleTitle
 
 from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
@@ -486,3 +486,36 @@ async def test_affordance_undims_to_the_value_color_when_the_row_has_focus():
         await pilot.pause()
         focused_luminance = _relative_luminance(_painted_color(app, affordance))
         assert focused_luminance == pytest.approx(value_luminance, abs=0.02)
+
+
+@pytest.mark.asyncio
+async def test_a_select_editor_mounted_via_begin_edit_still_opens_on_enter():
+    """Fix round 1, review finding 1 (task-1-review.md): an unconditional
+    `event.stop()`/`prevent_default()` in `_on_key`'s already-editing
+    branch silently ate a mounted `Select`'s own Enter-to-open binding
+    (`expanded` stayed `False`, verified against a bare `Select` which
+    does open). Textual only resolves a non-priority `BINDINGS` action
+    (`Select`'s `Binding("enter,down,space,up", "show_overlay")`) once the
+    raw `Key` event bubbles unstopped all the way up to `App` -- a
+    `DetailValueRow` ancestor stopping it broke the editor `begin_edit`'s
+    own docstring names as the typical case. This is the regression test
+    the review said would have caught it."""
+    row = DetailValueRow(
+        "Repeat", "Weekly", affordance=True, can_focus=True, id="row"
+    )
+    app = _RowHarness(row)
+    async with app.run_test(size=(40, 8)) as pilot:
+        select: Select[str] = Select(
+            [("Weekly", "weekly"), ("Daily", "daily")], id="editor"
+        )
+        row.begin_edit(select)
+        await pilot.pause()
+        assert app.focused is select
+        assert select.expanded is False
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert select.expanded is True, (
+            "Select's own Enter-to-open binding must still fire while it "
+            "is the row's open editor"
+        )

--- a/Tests/UI/test_schedules_terminology.py
+++ b/Tests/UI/test_schedules_terminology.py
@@ -226,3 +226,39 @@ def test_no_bare_reminder_noun_in_schedules_screen_copy():
     for module in (wb, td, form):
         offenders = _sentence_copy_offenders(module)
         assert not offenders, (module.__name__, offenders)
+
+
+def test_timezone_options_labels_the_stored_zone_with_the_calling_surface_noun():
+    """Final review F10: task 3's consolidation of the third
+    `_timezone_options` copy put the REMINDER wording ("stored on this
+    task") on the automations surface -- reachable from both the
+    definition modal and the definition pane's inline Timezone editor.
+    Same task-vs-automation slip PR-1's owner-row bug was about."""
+    from tldw_chatbook.UI.Screens.scheduling.forms.automation_definition_form import (
+        AutomationDefinitionForm,
+    )
+    from tldw_chatbook.UI.Screens.scheduling.forms.reminder_form import (
+        timezone_options,
+    )
+
+    unknown = "Mars/Olympus"
+    task_label = {value: label for label, value in timezone_options(unknown)}[unknown]
+    automation_label = {
+        value: label
+        for label, value in timezone_options(unknown, noun="automation")
+    }[unknown]
+
+    assert task_label == "Mars/Olympus — stored on this task, not recognized here"
+    assert (
+        automation_label
+        == "Mars/Olympus — stored on this automation, not recognized here"
+    )
+
+    # The definition modal's own delegating helper passes the noun too --
+    # not just the pane's inline editor.
+    form = AutomationDefinitionForm.__new__(AutomationDefinitionForm)
+    form._definition_row = {"schedule": {"timezone": unknown}}
+    assert (
+        {value: label for label, value in form._timezone_options()}[unknown]
+        == "Mars/Olympus — stored on this automation, not recognized here"
+    )

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -23,6 +23,7 @@ from textual.widgets._collapsible import CollapsibleTitle
 
 from tldw_chatbook.Scheduling.events import (
     DeleteTaskRequested,
+    ReminderFieldEditRequested,
     ReminderOwnerActionRequested,
     SyncCompleted,
     SyncFailed,
@@ -1142,6 +1143,24 @@ async def test_definition_timezone_row_editor_preselects_current_zone():
         await pilot.pause()
         editor = row.query_one(Select)
         assert editor.value == "America/New_York"
+
+
+@pytest.mark.asyncio
+async def test_definition_timezone_editor_says_automation_not_task(monkeypatch):
+    """Final review F10: this pane's inline Timezone editor is one of the
+    two surfaces that got the reminder wording from task 3's option-source
+    consolidation -- it passes `noun="automation"` now."""
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        definition = _editable_definition()
+        definition["schedule"]["timezone"] = "Mars/Olympus"
+        detail.set_definition(definition)
+        await pilot.pause()
+        row = detail._timezone_row
+        await pilot.click(row)
+        await pilot.pause()
+        labels = [str(prompt) for prompt, _value in row.query_one(Select)._options]
+        assert "Mars/Olympus — stored on this automation, not recognized here" in labels
 
 
 @pytest.mark.asyncio
@@ -3503,7 +3522,28 @@ async def test_runs_on_same_owner_selection_is_a_no_op():
     it preselects the row's OWN current owner (same trap Task 3's Repeat/
     Timezone commits already guard against, reused verbatim) must not
     close the editor or post a transfer request -- same as those rows,
-    the editor stays open for a real pick rather than self-closing."""
+    the editor stays open for a real pick rather than self-closing.
+
+    Final review F8/M8 ADJUDICATION. The controller's ruling was "the
+    CODE is wrong -- close the editor on a same-owner pick, and update
+    this test"; re-probed against Textual 8.2.8, that ruling is not
+    implementable and the shipped behavior stands:
+
+    * the synthetic mount `Changed` is real -- `Select.value` is
+      `var(NULL, init=False)`, so `_on_mount`'s `_init_selected_option`
+      assignment is a genuine change and posts `Changed`. Probed: the
+      commit handler fires with `"local"` before any user input, and an
+      `end_edit()` there leaves `editor still open: False` -- the
+      dropdown shuts the instant it opens and the owner picker becomes
+      unusable;
+    * a genuine re-pick of the SAME option posts nothing at all
+      (`Select._update_selection` assigns only `if value != self.value`),
+      so a "close on a same-owner pick" branch has no reachable caller to
+      hang off in the first place.
+
+    The docstring that claimed otherwise is what got fixed instead
+    (`TaskDetail._commit_runs_on_edit`). Escape is the cancel path.
+    """
     async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
         detail = pilot.app.query_one(TaskDetail)
         detail.set_task(
@@ -3512,13 +3552,25 @@ async def test_runs_on_same_owner_selection_is_a_no_op():
         )
         await pilot.pause()
 
-        with patch.object(
+        commits: list[str] = []
+        real_commit = TaskDetail._commit_runs_on_edit
+
+        def _spy(self, event):
+            commits.append(str(event.value))
+            return real_commit(self, event)
+
+        with patch.object(TaskDetail, "_commit_runs_on_edit", _spy), patch.object(
             detail, "post_message", wraps=detail.post_message
         ) as post_spy:
             row = detail._runs_on_row
             await pilot.click(row)
             await pilot.pause()
 
+            # The mount echo is real and DOES reach the commit path with
+            # the row's own current owner -- the whole reason that branch
+            # exists. Pinned, so a later "simplification" that closes on
+            # it fails here rather than in the user's hands.
+            assert commits == ["local"]
             assert row.query(Select)
             assert not any(
                 isinstance(call.args[0], ReminderOwnerActionRequested)
@@ -4574,5 +4626,251 @@ async def test_definition_runs_on_dropdown_and_automations_tab_keybindings_coexi
             # triggers (`_show_automations_inline_reason`'s own documented
             # behavior), racy to assert on here.
             assert service.cancel_refusal(fresh_row) is not None
+    finally:
+        db.close()
+
+
+# --- redesign PR-3, final review fix wave (I2/I3/I4, M5, M12) --------------
+
+
+@pytest.mark.asyncio
+async def test_repaint_with_another_task_closes_the_open_editor():
+    """Final review F2/I2. The reminder pane repaints on every tick and
+    `_update_detail_for_index` falls back to index 0 whenever the selected
+    row leaves the filter -- so an open editor could end up mounted over a
+    DIFFERENT reminder and commit its typed value onto that one.
+
+    Probe output against the branch before this fix:
+    `editor still open after repaint with another task: True` /
+    `edit posted for task id: ['task-B']`.
+    """
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        task_a = _frequency_reminder(id="task-A", title="A")
+        task_b = _frequency_reminder(id="task-B", title="B")
+        detail.set_task(task_a)
+        await pilot.pause()
+
+        row = detail._timezone_row
+        await pilot.click(row)
+        await pilot.pause()
+        assert row.query(Select)
+
+        detail.set_task(task_b)
+        await pilot.pause()
+
+        assert not row.query(Select), "editor survived a repaint with another task"
+
+        # Belt: a commit that crossed the repaint in flight is discarded,
+        # never written onto whichever task is painted now.
+        with patch.object(
+            detail, "post_message", wraps=detail.post_message
+        ) as post_spy:
+            detail._commit_timezone_edit(
+                Select.Changed(Select([("UTC", "UTC")], value="UTC"), "UTC")
+            )
+            assert not any(
+                isinstance(call.args[0], ReminderFieldEditRequested)
+                for call in post_spy.call_args_list
+            )
+
+
+@pytest.mark.asyncio
+async def test_same_row_repaint_preserves_an_open_editor_and_its_typed_text():
+    """The other half of I2: the reminder pane repaints on EVERY tick, so
+    closing the editor on a same-row repaint would make typing
+    impossible. The value region is skipped for the editing row instead
+    (`DetailValueRow.update_value`)."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        task = _frequency_reminder(
+            id="task-A",
+            schedule_kind=ScheduleKind.ONE_TIME,
+            cron=None,
+            timezone=None,
+            run_at=datetime(2099, 9, 9, 9, 0, tzinfo=timezone.utc),
+        )
+        detail.set_task(task)
+        await pilot.pause()
+
+        row = detail._at_row
+        await pilot.click(row)
+        await pilot.pause()
+        editor = row.query_one(Input)
+        editor.value = "2026-09-09 08:30"
+
+        # Five ticks' worth of same-row repaints.
+        for _ in range(5):
+            detail.set_task(task)
+            await pilot.pause()
+
+        assert row.query_one(Input) is editor
+        assert editor.value == "2026-09-09 08:30"
+
+
+@pytest.mark.asyncio
+async def test_repaint_with_another_task_clears_a_stale_row_error():
+    """Final review F3/I3: `show_error` was only ever cleared by
+    reactivating that row or by a successful commit, so B's Frequency
+    group kept accusing a value of A's that B never had. Probe output
+    before the fix: `stale error still displayed on the new task's row:
+    True | Unknown timezone: Mars/Olympus`."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(_frequency_reminder(id="task-A"))
+        await pilot.pause()
+
+        row = detail._timezone_row
+        row.show_error("Unknown timezone: Mars/Olympus")
+        await pilot.pause()
+        assert row.query_one(".detail-value-row-error", Static).display is True
+
+        detail.set_task(_frequency_reminder(id="task-B"))
+        await pilot.pause()
+
+        error = row.query_one(".detail-value-row-error", Static)
+        assert error.display is False
+        assert "Mars/Olympus" not in str(error.renderable)
+
+
+@pytest.mark.asyncio
+async def test_definition_pane_repaint_with_another_row_closes_editor_and_error():
+    """The definition pane's twin of I2/I3 -- same mechanism, same
+    row-identity trigger."""
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition(id="def-A"))
+        await pilot.pause()
+
+        row = detail._generation_row
+        await pilot.click(row)
+        await pilot.pause()
+        assert row.query(Select)
+        detail._sources_row.show_error("Choose at least one source.")
+
+        detail.set_definition(_editable_definition(id="def-B"))
+        await pilot.pause()
+
+        assert not row.query(Select)
+        assert (
+            detail._sources_row.query_one(
+                ".detail-value-row-error", Static
+            ).display
+            is False
+        )
+
+
+@pytest.mark.asyncio
+async def test_owner_actions_row_reserves_no_line_without_a_transfer():
+    """Final review F5/M5: `.detail-value-row-owner-actions` had a fixed
+    `height: 1` on an always-mounted container whose two buttons are
+    `.display`-toggled, so every reminder and every definition carried one
+    dead line inside its Details group. Probe before the fix:
+    `Region(x=3, y=12, width=75, height=1)`."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(_frequency_reminder(transfer_state=None))
+        await pilot.pause()
+
+        actions = detail.query_one(".detail-value-row-owner-actions")
+        assert actions.region.height == 0
+
+        detail.set_task(
+            _frequency_reminder(id="task-moving", transfer_state="to_server_pending")
+        )
+        await pilot.pause()
+        assert detail.query_one(".detail-value-row-owner-actions").region.height == 1
+
+
+@pytest.mark.asyncio
+async def test_editable_rows_carry_a_row_key_for_per_row_worker_groups():
+    """Final review F12/M12: both edit workers group per ROW now, so
+    committing a second row's editor cannot cancel the first commit
+    mid-write. The group name is built from `row.row_key`, so every
+    editable row needs a distinct one -- a `None` key would collapse them
+    all back into one group without failing anything visibly."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        keys = [row.row_key for row in pilot.app.query_one(TaskDetail)._editable_rows()]
+    assert keys and None not in keys and len(set(keys)) == len(keys)
+
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        keys = [
+            row.row_key
+            for row in pilot.app.query_one(DefinitionDetail)._editable_rows()
+        ]
+    assert keys and None not in keys and len(set(keys)) == len(keys)
+
+
+@pytest.mark.asyncio
+async def test_queue_definition_pane_repaints_after_a_successful_in_pane_edit(tmp_path):
+    """Final review F4/I4. `DefinitionDetail` is mounted TWICE and the
+    edit success path only refreshed the Automations one; the Queue tab's
+    instance is painted from `_update_detail_for_index`, which
+    early-returns for the same row on a tick. So a user editing from the
+    Queue tab saw the editor close, the OLD value come back, and no error
+    -- indefinitely, even though the edit had persisted."""
+    from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+    from tldw_chatbook.Scheduling.services.scheduling_service import SchedulingService
+    from tldw_chatbook.UI.Screens.scheduling.definition_detail import (
+        _definition_edit_payload,
+    )
+
+    db = ScheduledTasksDB(tmp_path / "scheduled_tasks.db")
+    try:
+        service = SchedulingService(db=db, server_client=None, runtime_source="local")
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Daily Q",
+            schedule={"kind": "interval", "every_seconds": 3600},
+            input={"question": "What shipped?"},
+            config={"generation_mode": "optional"},
+        )
+        definition = db.get_automation_definition(definition_id)
+
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            workbench = SchedulesWorkbench(app_instance=pilot.app)
+            await pilot.app.push_screen(workbench)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            queue_detail = pilot.app.screen.query_one(
+                "#scheduling-queue-definition-detail", DefinitionDetail
+            )
+            # The Queue tab has this definition's row selected and painted.
+            workbench._selected_row_id = f"definition:{definition_id}"
+            queue_detail.set_definition(definition)
+            await pilot.pause()
+            row = queue_detail._generation_row
+            assert "Only when something new is found" == str(
+                row.query_one(
+                    "#scheduling-automation-detail-generation", Static
+                ).renderable
+            )
+
+            payload = _definition_edit_payload(
+                definition, config={"generation_mode": "required"}
+            )
+            workbench._edit_definition_field(definition, payload, row)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert (
+                db.get_automation_definition(definition_id)["config"][
+                    "generation_mode"
+                ]
+                == "required"
+            )
+            painted = str(
+                row.query_one(
+                    "#scheduling-automation-detail-generation", Static
+                ).renderable
+            )
+            assert painted == "Always generate a draft", (
+                f"the Queue tab's definition pane still shows {painted!r}"
+            )
     finally:
         db.close()

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -1875,6 +1875,342 @@ async def test_committing_at_edit_persists_and_repaints_automations_pane(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_at_edit_on_a_daily_automation_edits_time_of_day_not_run_at(tmp_path):
+    """Qodo finding 8: the `At` row commits the field THIS schedule kind
+    owns and never converts the kind.
+
+    A `daily` schedule's `At` used to be editable (the row was gated on
+    "not cron") while the commit hard-coded `{"kind": "one_time",
+    "run_at": ...}` -- so setting the time on a daily automation turned it
+    into a one-shot and dropped `time_of_day`. The pin is the whole
+    schedule dict, `weekday` included: only the edited field moves."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Weekly digest",
+            schedule={
+                "kind": "weekly",
+                "time_of_day": "09:00",
+                "weekday": 2,
+                "timezone": "America/New_York",
+            },
+            input={"question": "What shipped?"},
+            config={},
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            row = detail._at_row
+            assert row.affordance is True, "a weekly schedule has a time target"
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            input_widget = row.query_one(Input)
+            # Seeded from the field the kind owns, not from `run_at`.
+            assert input_widget.value == "09:00"
+            input_widget.value = "7:30"
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            stored = db.get_automation_definition(definition_id)["schedule"]
+            assert stored["time_of_day"] == "07:30"  # normalized, zero-padded
+            assert stored["kind"] == "weekly"  # NEVER converted
+            assert stored["weekday"] == 2  # sibling fields preserved
+            assert stored["timezone"] == "America/New_York"
+            assert "run_at" not in stored
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_at_row_is_read_only_for_an_interval_automation(tmp_path):
+    """Qodo finding 8, the other half: an `interval` schedule has no
+    single time field for `At` to edit, so the row offers no affordance
+    rather than an editor that would rewrite the kind."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Every hour",
+            schedule={"kind": "interval", "every_seconds": 3600},
+            input={"question": "What shipped?"},
+            config={},
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            assert detail._at_row.affordance is False
+            assert detail._at_row.can_focus is False
+            detail._at_row.post_message(DetailValueRow.Activated(detail._at_row))
+            await pilot.pause()
+            assert not detail._at_row.query(Input)
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_two_fields_of_one_definition_both_land_without_a_lost_update(tmp_path):
+    """Qodo finding 7: the edit worker groups per DEFINITION, not per
+    field.
+
+    With a per-FIELD group the two commits below ran concurrently, and
+    `save_definition` merges each payload onto the row it read at entry
+    -- so whichever finished second wrote back a snapshot taken before
+    the first landed, silently reverting it. Serialized per definition,
+    both survive."""
+    from tldw_chatbook.UI.Screens.scheduling.definition_detail import (
+        _definition_edit_payload,
+    )
+
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Daily standup question",
+            schedule={"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+            input={"question": "What shipped?"},
+            config={"generation_mode": "optional"},
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            definition = dict(detail._definition)
+
+            # Two DIFFERENT fields of the SAME definition, dispatched
+            # back to back with nothing awaited in between -- the shape
+            # a fast typist produces.
+            workbench._edit_definition_field(
+                definition,
+                _definition_edit_payload(definition, input={"model": "gpt-5"}),
+                detail._model_row,
+            )
+            workbench._edit_definition_field(
+                definition,
+                _definition_edit_payload(
+                    definition, config={"generation_mode": "required"}
+                ),
+                detail._generation_row,
+            )
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            stored = db.get_automation_definition(definition_id)
+            assert stored["config"]["generation_mode"] == "required"
+            assert stored["input"]["model"] == "gpt-5"  # not reverted by the second
+            assert stored["input"]["question"] == "What shipped?"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_model_only_target_round_trips_through_an_unchanged_submit(tmp_path):
+    """Qodo finding 10: a stored `model` with no `provider` must survive
+    being opened and submitted unchanged.
+
+    The editor seeds `/model` for that shape -- the exact inverse of the
+    commit's parse, where bare text means "provider". Seeding the bare
+    model instead (what the row's display label shows) silently moved the
+    value into the provider slot on the next Enter."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Daily standup question",
+            schedule={"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+            input={"question": "What shipped?", "model": "gpt-5"},
+            config={},
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            # The row still READS as a bare model -- the display label is
+            # unchanged, only the editor's seed is the parse's inverse.
+            model_static = detail.query_one(
+                "#scheduling-automation-detail-model", Static
+            )
+            assert model_static.render_line(0).text.strip() == "gpt-5"
+
+            row = detail._model_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            assert row.query_one(Input).value == "/gpt-5"
+            await pilot.press("enter")  # submitted UNCHANGED
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            stored = db.get_automation_definition(definition_id)["input"]
+            assert stored["model"] == "gpt-5"
+            assert not stored.get("provider")
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_non_recurring_question_definition_exposes_no_editors(tmp_path):
+    """Qodo finding 11: the pane only authors `recurring_question`, and
+    every payload it builds declares that family -- so an `agent_task`
+    row renders every row read-only and says why, instead of offering
+    editors whose commit would push it through the wrong family's
+    normalizer."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        db.create_automation_definition(
+            "local",
+            "agent_task",
+            "Nightly agent run",
+            schedule={"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+            input={},
+            config={},
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            assert detail._definition["family"] == "agent_task"
+            assert [row.row_key for row in detail._editable_rows() if row.affordance] == []
+            for row in detail._editable_rows():
+                row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            assert not detail.query(Input)
+            assert not detail.query(Select)
+            why = detail.query_one("#scheduling-automation-detail-why", Static)
+            assert "isn't a recurring question" in why.render_line(0).text
+    finally:
+        db.close()
+
+
+def test_stale_definition_row_error_is_not_painted_on_another_row(tmp_path):
+    """Qodo finding 9: the edit worker holds a `DetailValueRow` across an
+    `await`, so a failure arriving after the pane moved on must not stamp
+    its message under a different automation's field. The commit path
+    already validates the captured identity (`_editing_definition`); this
+    is the same check on the error path."""
+    detail = DefinitionDetail()
+    detail._definition = {"id": "def-B"}
+    row = DetailValueRow("Model", "-", row_key="model")
+    # Not mounted under the pane: the helper reads the row's ancestors,
+    # so drive it through the pane it would really have found.
+    workbench = SchedulesWorkbench.__new__(SchedulesWorkbench)
+
+    painted: list[str] = []
+    row.show_error = painted.append  # type: ignore[method-assign]
+
+    with patch.object(
+        type(row), "ancestors", property(lambda _self: [detail])
+    ):
+        workbench._show_definition_row_error(row, {"def-A"}, "boom")
+        assert painted == [], "an error for def-A must not land while def-B shows"
+        workbench._show_definition_row_error(row, {"def-B"}, "boom")
+        assert painted == ["boom"]
+
+
+@pytest.mark.asyncio
 async def test_not_set_model_preserved_across_an_unrelated_edit(tmp_path):
     """The Model row's 'Not set'/blank honesty (task-4 brief AC) survives
     an edit to an UNRELATED row: `_definition_edit_payload`'s empty-dict
@@ -2154,8 +2490,12 @@ async def test_lifecycle_toggle_on_server_owned_row_survives_a_racing_pull(tmp_p
             button = detail.query_one("#scheduling-automation-pause-resume", Button)
             assert button.label.plain == "Resume"
 
+            # Qodo findings 5+6: the toggle queues under the LIFECYCLE
+            # primitive now, which is the same slot the pull guard reads.
+            # The optimistic path and the guard must stay keyed on the
+            # SAME primitive, or the racing pull below reverts the pause.
             mutation = db.get_pending_mutation_for_local_id(
-                definition_id, "automation_definition"
+                definition_id, "automation_lifecycle"
             )
             assert mutation is not None
             assert mutation["payload"]["action"] == "pause"

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -38,6 +38,9 @@ from tldw_chatbook.UI.Screens.scheduling.definition_detail import (
     DefinitionDetail,
     _definition_owner_label,
 )
+from tldw_chatbook.Scheduling.services import (
+    scheduling_service as scheduling_service_module,
+)
 from tldw_chatbook.UI.Screens.scheduling.forms.reminder_form import ReminderForm
 from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import SchedulesWorkbench
 from tldw_chatbook.UI.Screens.scheduling.sync_status_widget import SyncStatusWidget
@@ -3552,43 +3555,99 @@ async def test_runs_on_escape_cancels_dropdown_without_posting():
 
 @pytest.mark.asyncio
 async def test_runs_on_row_reflects_transfer_state():
-    """Three states (task-5 brief): normal (affordance on, both buttons
-    hidden), in flight (affordance off, Cancel only), `to_server_failed`
-    (affordance off, Cancel + Retry) -- mirroring the existing per-button
-    visibility rules `test_schedules_transfer_actions.py` already pins."""
+    """Cancel/Retry button visibility across all four `transfer_state`
+    values (task-5 brief), mirroring the existing per-button visibility
+    rules `test_schedules_transfer_actions.py` already pins. Affordance
+    stays ON unconditionally in EVERY state (fix round 1 finding 2:
+    ruling 3's "dropdown always renders" -- a locked/failed row's
+    activation still reaches `on_detail_value_row_activated`, which is
+    what decides dropdown-vs-show-why now, not a disabled affordance;
+    see the dedicated activation tests below)."""
     async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
         detail = pilot.app.query_one(TaskDetail)
 
-        detail.set_task(_frequency_reminder(transfer_state=None))
-        await pilot.pause()
-        assert detail._runs_on_row.affordance is True
-        assert detail._runs_on_cancel_button.display is False
-        assert detail._runs_on_retry_button.display is False
+        for transfer_state, cancel_visible, retry_visible in (
+            (None, False, False),
+            ("to_server_pending", True, False),
+            ("to_server_failed", True, True),
+            ("from_server_pending", True, False),
+            (None, False, False),  # back to normal
+        ):
+            detail.set_task(_frequency_reminder(transfer_state=transfer_state))
+            await pilot.pause()
+            assert detail._runs_on_row.affordance is True
+            assert detail._runs_on_cancel_button.display is cancel_visible
+            assert detail._runs_on_retry_button.display is retry_visible
 
+
+@pytest.mark.asyncio
+async def test_runs_on_activation_on_in_flight_row_shows_lock_reason_not_dropdown():
+    """Fix round 1 finding 2: an in-flight row's activation now shows
+    its `_lifecycle_lock_reason` -- the SAME reason
+    `transfer_lock_reason` computes and the Frequency rows already
+    surface on click -- instead of going silently inert or opening a
+    dropdown with nothing sensible to offer."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
         detail.set_task(_frequency_reminder(transfer_state="to_server_pending"))
+        detail.set_lifecycle_lock(
+            "This row is moving between this device and the server."
+        )
         await pilot.pause()
-        assert detail._runs_on_row.affordance is False
-        assert detail._runs_on_cancel_button.display is True
-        assert detail._runs_on_retry_button.display is False
 
+        row = detail._runs_on_row
+        await pilot.click(row)
+        await pilot.pause()
+
+        assert not row.query(Select)
+        error = row.query_one(".detail-value-row-error", Static)
+        assert error.display is True
+        assert (
+            "moving between this device and the server"
+            in error.render_line(0).text
+        )
+
+
+@pytest.mark.asyncio
+async def test_runs_on_activation_on_failed_row_shows_stored_transfer_error():
+    """Fix round 1 finding 2: the SAME "Last transfer error: …" copy the
+    legacy Retry button already renders (`set_transfer_reasons`), now on
+    the Runs-on row too -- fed via `set_runs_on_transfer_errors`."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(_frequency_reminder(transfer_state="to_server_failed"))
+        detail.set_runs_on_transfer_errors(["Connection refused"])
+        await pilot.pause()
+
+        row = detail._runs_on_row
+        await pilot.click(row)
+        await pilot.pause()
+
+        assert not row.query(Select)
+        error = row.query_one(".detail-value-row-error", Static)
+        assert error.display is True
+        assert (
+            error.render_line(0).text.strip()
+            == "Last transfer error: Connection refused"
+        )
+
+
+@pytest.mark.asyncio
+async def test_runs_on_activation_on_failed_row_without_stored_errors_falls_back():
+    """No stored `transfer_errors` (e.g. a pre-existing failed row) still
+    surfaces SOMETHING rather than going silent."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
         detail.set_task(_frequency_reminder(transfer_state="to_server_failed"))
         await pilot.pause()
-        assert detail._runs_on_row.affordance is False
-        assert detail._runs_on_cancel_button.display is True
-        assert detail._runs_on_retry_button.display is True
 
-        detail.set_task(_frequency_reminder(transfer_state="from_server_pending"))
+        row = detail._runs_on_row
+        await pilot.click(row)
         await pilot.pause()
-        assert detail._runs_on_row.affordance is False
-        assert detail._runs_on_cancel_button.display is True
-        assert detail._runs_on_retry_button.display is False
 
-        # Back to normal restores the dropdown and hides both buttons.
-        detail.set_task(_frequency_reminder(transfer_state=None))
-        await pilot.pause()
-        assert detail._runs_on_row.affordance is True
-        assert detail._runs_on_cancel_button.display is False
-        assert detail._runs_on_retry_button.display is False
+        error = row.query_one(".detail-value-row-error", Static)
+        assert error.display is True
+        assert "Transfer failed" in error.render_line(0).text
 
 
 @pytest.mark.asyncio
@@ -3606,15 +3665,60 @@ async def test_definition_runs_on_row_reflects_transfer_state():
             _editable_definition(transfer_state="from_server_pending")
         )
         await pilot.pause()
-        assert detail._runs_on_row.affordance is False
+        assert detail._runs_on_row.affordance is True
         assert detail._runs_on_cancel_button.display is True
         assert detail._runs_on_retry_button.display is False
 
         detail.set_definition(_editable_definition(transfer_state="to_server_failed"))
         await pilot.pause()
-        assert detail._runs_on_row.affordance is False
+        assert detail._runs_on_row.affordance is True
         assert detail._runs_on_cancel_button.display is True
         assert detail._runs_on_retry_button.display is True
+
+
+@pytest.mark.asyncio
+async def test_definition_runs_on_activation_on_in_flight_row_shows_lock_reason():
+    """Definition-pane counterpart of the reminder-pane lock-reason test
+    (fix round 1 finding 2)."""
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(
+            _editable_definition(transfer_state="from_server_pending")
+        )
+        detail.set_lifecycle_lock("Read-only mid-transfer.")
+        await pilot.pause()
+
+        row = detail._runs_on_row
+        await pilot.click(row)
+        await pilot.pause()
+
+        assert not row.query(Select)
+        error = row.query_one(".detail-value-row-error", Static)
+        assert error.display is True
+        assert error.render_line(0).text.strip() == "Read-only mid-transfer."
+
+
+@pytest.mark.asyncio
+async def test_definition_runs_on_activation_on_failed_row_shows_stored_transfer_error():
+    """Definition-pane counterpart of the reminder-pane stored-error test
+    (fix round 1 finding 2)."""
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition(transfer_state="to_server_failed"))
+        detail.set_runs_on_transfer_errors(["Server rejected the request"])
+        await pilot.pause()
+
+        row = detail._runs_on_row
+        await pilot.click(row)
+        await pilot.pause()
+
+        assert not row.query(Select)
+        error = row.query_one(".detail-value-row-error", Static)
+        assert error.display is True
+        assert (
+            error.render_line(0).text.strip()
+            == "Last transfer error: Server rejected the request"
+        )
 
 
 # -- integration: real DB + service + full workbench -------------------------
@@ -3972,7 +4076,9 @@ async def test_runs_on_dropdown_and_legacy_transfer_buttons_coexist(tmp_path):
             )
             assert not legacy_cancel.disabled
             assert detail._runs_on_cancel_button.display is True
-            assert detail._runs_on_row.affordance is False
+            # Affordance stays ON (fix round 1 finding 2) -- activation
+            # would show the lock reason instead of opening a dropdown.
+            assert detail._runs_on_row.affordance is True
 
             # NEW surface: cancel via the row's own affordance.
             detail._runs_on_cancel_button.press()
@@ -3988,5 +4094,485 @@ async def test_runs_on_dropdown_and_legacy_transfer_buttons_coexist(tmp_path):
             )
             assert legacy_cancel_after.disabled
             assert detail._runs_on_row.affordance is True
+    finally:
+        db.close()
+
+
+# -- definition-pane twins of the deep reminder-side tests above (fix
+# round 1, finding 3: coverage gap -- finding 1 lived exactly here) --------
+
+
+def _stub_ready_health(monkeypatch) -> None:
+    """A `recurring_question` `to_local` refusal also gates on local
+    health (spec §6.4/§7.4) -- irrelevant to what these tests exercise
+    (the transfer machine's own routing) -- stubbed ready, mirroring
+    `test_schedules_transfer_actions.py`'s own `_stub_ready_health`
+    exactly (duplicated locally per this file's own no-cross-file-test-
+    coupling precedent)."""
+    monkeypatch.setattr(
+        scheduling_service_module,
+        "compute_local_health",
+        lambda app, row: ("ready", ""),
+    )
+
+
+@pytest.mark.asyncio
+async def test_definition_owner_action_marks_stale_before_resolving(
+    tmp_path, monkeypatch
+):
+    """Fix round 1 finding 1, pinned via ORDERING, not a post-hoc flag
+    read: a real mounted workbench has its own background refreshes
+    (mount-time, `TabActivated` on the initial tab) that legitimately
+    consume/clear `_definitions_stale` too, so asserting the flag's
+    value some time AFTER the action is racy against those -- this pins
+    the actual claim instead: `self._definitions_stale` is ALREADY
+    `True` by the time `_resolve_local_definition_id` runs, proving the
+    write happens unconditionally BEFORE resolving (the exact ordering
+    `_begin_automation_transfer`/`_cancel_automation_transfer` already
+    use, schedules_workbench.py:2766-2778) rather than only in `_refresh`
+    on a later success path.
+
+    `_resolve_local_definition_id` can itself mirror a brand-new local
+    row (`upsert_automation_definitions_from_server`) the FIRST time a
+    pure server-fetch definition is touched -- no existing local shadow
+    for this definition id, forcing that mirror path (every OTHER test
+    in this file happens to hit the "already mirrored" fast path, which
+    is exactly why this gap went untested)."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            observed_stale_at_resolve: list[bool] = []
+            original_resolve = workbench._resolve_local_definition_id
+
+            async def _spy_resolve(service_arg, definition_arg):
+                observed_stale_at_resolve.append(workbench._definitions_stale)
+                return await original_resolve(service_arg, definition_arg)
+
+            monkeypatch.setattr(
+                workbench, "_resolve_local_definition_id", _spy_resolve
+            )
+
+            # A pure server-fetch dict (Task 4's own documented trap):
+            # `id` IS the server's own id, and NO local row exists for it
+            # yet anywhere in the DB.
+            server_item = {
+                "id": "srv-brand-new",
+                "owner_id": "server:1",
+                "server_id": "srv-brand-new",
+                "family": "recurring_question",
+                "name": "Brand new server automation",
+                "lifecycle": "configured",
+                "schedule": {"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+                "config": {"scope": {"mode": "all_searchable_library"}},
+            }
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            row = detail._runs_on_row
+
+            workbench._definition_owner_action(server_item, "to_local", row)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            # The spy saw `_definitions_stale` already True the moment
+            # `_resolve_local_definition_id` was entered -- proves the
+            # unconditional-before-resolving placement, not just "True
+            # at some point".
+            assert observed_stale_at_resolve == [True]
+
+            # Refused (no ready health wired in this bare app), and the
+            # mirror this call created is real.
+            error = row.query_one(".detail-value-row-error", Static)
+            assert error.display is True
+            mirrored = db.get_automation_definition_by_server_id(
+                "server:1", "srv-brand-new"
+            )
+            assert mirrored is not None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_definition_runs_on_dropdown_confirm_dialog_lists_warnings(tmp_path):
+    """Definition-pane twin of `test_runs_on_dropdown_confirm_dialog_
+    lists_warnings` -- `to_server` never triggers the family/health
+    check (only `to_local` does), so no health stub is needed here."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        imminent = (datetime.now(timezone.utc) + timedelta(minutes=2)).isoformat()
+        db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Almost due automation",
+            schedule={"kind": "one_time", "run_at": imminent},
+            input={"question": "What shipped?"},
+            config={"scope": {"mode": "all_searchable_library"}},
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            assert table.row_count == 1
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            row = detail._runs_on_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            select = row.query_one(Select)
+            select.value = "server:1"
+            await pilot.pause()
+
+            assert isinstance(pilot.app.screen, ConfirmationDialog)
+            message = pilot.app.screen.message
+            assert "Almost due automation" in message
+            assert "unverified" in message
+            pilot.app.screen.dismiss(False)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_definition_runs_on_dropdown_confirm_begins_to_local_transfer_with_dormant_copy_id(
+    tmp_path, monkeypatch
+):
+    """Definition-pane twin of the reminder-side dormant-copy-id test --
+    `to_local` on a `recurring_question` row needs `_stub_ready_health`
+    (irrelevant to what this test targets)."""
+    _stub_ready_health(monkeypatch)
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        mirror_id = db.create_automation_definition(
+            "server:1",
+            "recurring_question",
+            "Server automation",
+            server_id="srv-9",
+            schedule={"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+            input={"question": "What shipped?"},
+            config={"scope": {"mode": "all_searchable_library"}},
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+
+            mirror = db.get_automation_definition(mirror_id)
+            detail = pilot.app.screen.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            detail.set_definition(mirror, runs_on_options=[("This device", "local")])
+            await pilot.pause()
+
+            row = detail._runs_on_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            select = row.query_one(Select)
+            select.value = "local"
+            await pilot.pause()
+
+            assert isinstance(pilot.app.screen, ConfirmationDialog)
+            pilot.app.screen.dismiss(True)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            mirror_after = db.get_automation_definition(mirror_id)
+            assert mirror_after["transfer_state"] is None
+            assert mirror_after["owner_id"] == "server:1"
+
+            local_rows = [
+                row_dict
+                for row_dict in db.list_automation_definitions(owner_id="local")
+                if row_dict["id"] != mirror_id
+            ]
+            assert len(local_rows) == 1
+            copy = local_rows[0]
+            assert copy["id"] != mirror_id
+            assert copy["transfer_state"] == "from_server_pending"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_definition_runs_on_dropdown_confirm_begins_to_server_transfer(tmp_path):
+    """Definition-pane twin of the reminder-side `to_server` test."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Nightly digest automation",
+            schedule={"kind": "one_time", "run_at": "2030-01-01T00:00:00+00:00"},
+            input={"question": "What shipped?"},
+            config={"scope": {"mode": "all_searchable_library"}},
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            assert table.row_count == 1
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            row = detail._runs_on_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            select = row.query_one(Select)
+            select.value = "server:1"
+            await pilot.pause()
+
+            assert isinstance(pilot.app.screen, ConfirmationDialog)
+            pilot.app.screen.dismiss(True)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            row_after = db.get_automation_definition(definition_id)
+            assert row_after["transfer_state"] == "to_server_pending"
+            assert row_after["owner_id"] == "local"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_definition_runs_on_cancel_button_cancels_the_dormant_copy_using_its_own_id(
+    tmp_path, monkeypatch
+):
+    """Definition-pane twin of the reminder-side dormant-copy Cancel
+    test."""
+    _stub_ready_health(monkeypatch)
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        mirror_id = db.create_automation_definition(
+            "server:1",
+            "recurring_question",
+            "Server automation",
+            server_id="srv-9",
+            schedule={"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+            input={"question": "What shipped?"},
+            config={"scope": {"mode": "all_searchable_library"}},
+        )
+        outcome = await service.begin_transfer_to_local(
+            "automation_definition", mirror_id
+        )
+        assert outcome.status == "pending"
+        copy_id = outcome.row_id
+        assert copy_id is not None
+        assert copy_id != mirror_id
+
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # `_load_local_automations` only ever shows a `server_id`-less
+            # row (survey §3): the copy, not the mirror -- the mirror is
+            # the SERVER fetch half's row, and this harness's fake server
+            # client has no `list_automation_definitions` (out of this
+            # test's scope; the mirror-side assertion below reads the DB
+            # directly instead of depending on the table showing it).
+            assert table.row_count == 1
+            copy_index = next(
+                index
+                for index, definition in enumerate(workbench._automations)
+                if str(definition.get("id")) == copy_id
+            )
+            table.cursor_coordinate = (copy_index, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            assert detail._runs_on_cancel_button.display is True
+            detail._runs_on_cancel_button.press()
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert db.get_automation_definition(copy_id) is None
+            mirror = db.get_automation_definition(mirror_id)
+            assert mirror is not None
+            assert mirror["transfer_state"] is None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_definition_runs_on_retry_button_rebegins_a_failed_transfer(tmp_path):
+    """Definition-pane twin of the reminder-side Retry test."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Nightly digest automation",
+            schedule={"kind": "one_time", "run_at": "2030-01-01T00:00:00+00:00"},
+            input={"question": "What shipped?"},
+            config={"scope": {"mode": "all_searchable_library"}},
+        )
+        db.set_transfer_state(
+            "automation_definition", definition_id, "to_server_failed",
+            expected=(None,),
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            assert table.row_count == 1
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            assert detail._runs_on_retry_button.display is True
+            detail._runs_on_retry_button.press()
+            await pilot.pause()
+
+            assert isinstance(pilot.app.screen, ConfirmationDialog)
+            pilot.app.screen.dismiss(True)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            row_after = db.get_automation_definition(definition_id)
+            assert row_after["transfer_state"] == "to_server_pending"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_definition_runs_on_dropdown_and_automations_tab_keybindings_coexist(
+    tmp_path,
+):
+    """Definition-pane twin of the reminder-side coexistence test -- the
+    Automations tab has no per-row transfer BUTTONS (spec §6, PR-5 task
+    7's own design: `m`/`M`/`y`/`k` keybindings instead), so "coexistence"
+    here means the keybinding-driven legacy flow
+    (`action_move_automation_to_server`/`_cancel_automation_transfer`)
+    and the NEW Runs-on row read/write the SAME underlying state."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Nightly digest automation",
+            schedule={"kind": "one_time", "run_at": "2030-01-01T00:00:00+00:00"},
+            input={"question": "What shipped?"},
+            config={"scope": {"mode": "all_searchable_library"}},
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            assert table.row_count == 1
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            # Legacy surface: begin via the EXISTING keybinding, untouched.
+            workbench.action_move_automation_to_server()
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, ConfirmationDialog)
+            pilot.app.screen.dismiss(True)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert (
+                db.get_automation_definition(definition_id)["transfer_state"]
+                == "to_server_pending"
+            )
+            # NEW surface reflects the state the LEGACY keybinding wrote.
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            assert detail._runs_on_cancel_button.display is True
+            assert detail._runs_on_row.affordance is True
+
+            # NEW surface: cancel via the row's own affordance.
+            detail._runs_on_cancel_button.press()
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            fresh_row = db.get_automation_definition(definition_id)
+            assert fresh_row["transfer_state"] is None
+            # The LEGACY surface's own refusal check (`cancel_refusal`,
+            # what `_cancel_automation_transfer`'s keybinding path itself
+            # calls) sees the SAME state -- no drift between the two
+            # surfaces. Read directly rather than firing a second
+            # keybinding action: that action's own success/refusal notice
+            # is transient and gets overwritten by the very refresh it
+            # triggers (`_show_automations_inline_reason`'s own documented
+            # behavior), racy to assert on here.
+            assert service.cancel_refusal(fresh_row) is not None
     finally:
         db.close()

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -1509,6 +1509,349 @@ async def test_committing_timezone_edit_preserves_cron(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_committing_model_edit_persists_and_repaints_automations_pane(
+    tmp_path,
+):
+    """Model row commit persists `input.provider`/`model` and repaints the
+    pane (task-4 review Finding 2: this row type had no real-DB persist
+    test in the original diff)."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Daily standup question",
+            schedule={
+                "kind": "cron",
+                "cron": "0 9 * * 1",
+                "timezone": "America/New_York",
+            },
+            input={"question": "What shipped?"},
+            config={"generation_mode": "optional"},
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            row = detail._model_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            input_widget = row.query_one(Input)
+            input_widget.value = "openai/gpt-5"
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            stored = db.get_automation_definition(definition_id)
+            assert stored["input"]["provider"] == "openai"
+            assert stored["input"]["model"] == "gpt-5"
+            assert stored["input"]["question"] == "What shipped?"  # not dropped
+            model_static = detail.query_one(
+                "#scheduling-automation-detail-model", Static
+            )
+            assert model_static.render_line(0).text.strip() == "openai/gpt-5"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_committing_finding_policy_edit_persists_and_repaints_automations_pane(
+    tmp_path,
+):
+    """Finding-policy row commit writes `config.finding_policy.preset`
+    AND persists it back to the TOP-LEVEL `finding_policy` column this
+    row reads for display (task-4 review Finding 2)."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Daily standup question",
+            schedule={
+                "kind": "cron",
+                "cron": "0 9 * * 1",
+                "timezone": "America/New_York",
+            },
+            input={"question": "What shipped?"},
+            config={"finding_policy": {"preset": "balanced_findings"}},
+            finding_policy={"preset": "balanced_findings"},
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            row = detail._finding_policy_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            select = row.query_one(Select)
+            select.value = "high_confidence_only"
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            stored = db.get_automation_definition(definition_id)
+            assert (
+                stored["config"]["finding_policy"]["preset"]
+                == "high_confidence_only"
+            )
+            assert stored["finding_policy"]["preset"] == "high_confidence_only"
+            finding_static = detail.query_one(
+                "#scheduling-automation-detail-finding-policy", Static
+            )
+            assert (
+                finding_static.render_line(0).text.strip()
+                == "High confidence only"
+            )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_committing_sources_edit_persists_and_repaints_automations_pane(
+    tmp_path,
+):
+    """Sources editor Apply persists the explicit `{"mode": "sources", ...}`
+    shape and repaints the pane (task-4 review Finding 2)."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Daily standup question",
+            schedule={
+                "kind": "cron",
+                "cron": "0 9 * * 1",
+                "timezone": "America/New_York",
+            },
+            input={"question": "What shipped?"},
+            config={"scope": {"mode": "all_searchable_library"}},
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            row = detail._sources_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            for checkbox in row.query(Checkbox):
+                checkbox.value = (
+                    checkbox.id == "scheduling-automation-detail-sources-notes"
+                )
+            await pilot.pause()
+            apply_button = row.query_one(
+                "#scheduling-automation-detail-sources-apply", Button
+            )
+            # A real pixel click on a widget nested this deep inside the
+            # full 3-pane embedded workbench is exactly the layout quirk
+            # Task 3's own report documents (bare-harness clicks land
+            # fine, embedded ones do not reliably match `Widget.region`)
+            # -- post the Pressed message directly, same workaround this
+            # file already uses for row Activation.
+            apply_button.post_message(Button.Pressed(apply_button))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            stored = db.get_automation_definition(definition_id)
+            assert stored["config"]["scope"] == {
+                "mode": "sources",
+                "sources": ["notes"],
+            }
+            sources_static = detail.query_one(
+                "#scheduling-automation-detail-sources", Static
+            )
+            assert sources_static.render_line(0).text.strip() == "Notes"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_committing_notifications_edit_persists_and_repaints_automations_pane(
+    tmp_path,
+):
+    """Notifications row commit writes the boolean on/off shape for BOTH
+    outcomes and repaints the pane (task-4 review Finding 2)."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Daily standup question",
+            schedule={
+                "kind": "cron",
+                "cron": "0 9 * * 1",
+                "timezone": "America/New_York",
+            },
+            input={"question": "What shipped?"},
+            config={},
+            notification_policy={"on_success": False, "on_failure": False},
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            row = detail._notifications_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            select = row.query_one(Select)
+            select.value = "on"
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            stored = db.get_automation_definition(definition_id)
+            assert stored["notification_policy"] == {
+                "on_success": True,
+                "on_failure": True,
+            }
+            notif_static = detail.query_one(
+                "#scheduling-automation-detail-notifications", Static
+            )
+            assert notif_static.render_line(0).text.strip() == "On"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_committing_at_edit_persists_and_repaints_automations_pane(tmp_path):
+    """At row commit persists `run_at` on a one-time definition and
+    repaints the pane (task-4 review Finding 2)."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "One-off digest",
+            schedule={"kind": "one_time", "run_at": "2030-01-01T09:00:00+00:00"},
+            input={"question": "What shipped?"},
+            config={},
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            row = detail._at_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            new_run_at = datetime(2031, 6, 15, 9, 0, tzinfo=timezone.utc)
+            input_widget = row.query_one(Input)
+            input_widget.value = new_run_at.isoformat()
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            stored = db.get_automation_definition(definition_id)
+            assert stored["schedule"]["kind"] == "one_time"
+            assert stored["schedule"]["run_at"] == new_run_at.isoformat()
+            at_static = detail.query_one(
+                "#scheduling-automation-detail-at", Static
+            )
+            assert (
+                at_static.render_line(0).text.strip()
+                == "One-time at 2031-06-15 09:00 UTC"
+            )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
 async def test_not_set_model_preserved_across_an_unrelated_edit(tmp_path):
     """The Model row's 'Not set'/blank honesty (task-4 brief AC) survives
     an edit to an UNRELATED row: `_definition_edit_payload`'s empty-dict

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -1894,7 +1894,7 @@ async def test_at_edit_on_a_daily_automation_edits_time_of_day_not_run_at(tmp_pa
                 "kind": "weekly",
                 "time_of_day": "09:00",
                 "weekday": 2,
-                "timezone": "America/New_York",
+                "timezone": "UTC",
             },
             input={"question": "What shipped?"},
             config={},
@@ -1939,8 +1939,40 @@ async def test_at_edit_on_a_daily_automation_edits_time_of_day_not_run_at(tmp_pa
             assert stored["time_of_day"] == "07:30"  # normalized, zero-padded
             assert stored["kind"] == "weekly"  # NEVER converted
             assert stored["weekday"] == 2  # sibling fields preserved
-            assert stored["timezone"] == "America/New_York"
+            assert stored["timezone"] == "UTC"
             assert "run_at" not in stored
+
+            # Ruling 2: the row must repaint to the AUTHORITATIVE value.
+            # `_definition_at_label` used to answer "-" for every kind but
+            # cron/one_time, so this row went on reading "-" after a
+            # successful edit -- the dishonest-repaint class this program
+            # polices, on the row task 4 had just made editable.
+            at_static = detail.query_one(
+                "#scheduling-automation-detail-at", Static
+            )
+            assert (
+                at_static.render_line(0).text.strip()
+                == "Weekly on Wednesday at 07:30 UTC"
+            )
+
+            # SECOND surface: `_definition_at_label` also feeds the Queue
+            # tab's unified-row subtitle (`build_unified_rows`'s
+            # `schedule_summary` -> `_row_subtitle`). Painted, so the
+            # shared-helper change is verified where it actually lands
+            # rather than assumed.
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-queue-tab"
+            )
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            queue_table = workbench.query_one("#scheduling-task-table", DataTable)
+            painted = " ".join(
+                str(cell)
+                for index in range(queue_table.row_count)
+                for cell in queue_table.get_row_at(index)
+            )
+            assert "Weekly on Wednesday at 07:30 UTC" in painted
     finally:
         db.close()
 

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -39,6 +39,7 @@ from tldw_chatbook.UI.Screens.scheduling.task_detail import (
 )
 from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
 from tldw_chatbook.Widgets.delete_confirmation_dialog import DeleteConfirmationDialog
+from tldw_chatbook.Widgets.detail_value_row import DetailValueRow
 
 
 # Shared across the Schedules UI test files (task-23106 review round F15).
@@ -46,6 +47,7 @@ from Tests.UI.schedules_test_helpers import (
     MockSchedulingDB as _MockSchedulingDB,
     MockSchedulingServiceMixin as _MockSchedulingServiceMixin,
     MockServerClient as _MockServerClient,
+    rendered_row_cells,
 )
 
 
@@ -429,6 +431,435 @@ async def test_task_detail_shows_the_reminder_body_card():
         detail.set_task(_frequency_reminder(body=None))
         await pilot.pause()
         assert card.display is False
+
+
+# --- redesign PR-3, task 3: reminder-pane in-pane Frequency-row editing ----
+
+
+def _real_scheduling_service(tmp_path):
+    """A real (in-memory-file) `ScheduledTasksDB` + `SchedulingService`,
+    no server -- for tests that need genuine persistence/validation
+    (Task 2's bridge), not a hand-rolled stub of it."""
+    from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+    from tldw_chatbook.Scheduling.services.scheduling_service import SchedulingService
+
+    db = ScheduledTasksDB(tmp_path / "scheduled_tasks.db")
+    service = SchedulingService(db=db, runtime_source="local")
+    return db, service
+
+
+@pytest.mark.asyncio
+async def test_repeat_row_editor_opens_with_current_preset_preselected():
+    """Activating a recurring reminder's Repeat row mounts a Select
+    preloaded with the CURRENT cron's preset (task-3 brief AC)."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        # `_frequency_reminder`'s default cron "0 9 * * 1" == Monday 09:00.
+        detail.set_task(_frequency_reminder())
+        await pilot.pause()
+
+        repeat_row = detail._repeat_row
+        assert repeat_row.affordance is True
+        await pilot.click(repeat_row)
+        await pilot.pause()
+
+        editor = repeat_row.query_one(Select)
+        assert editor.value == "monday"
+
+
+@pytest.mark.asyncio
+async def test_at_row_editor_opens_with_current_run_at_preselected():
+    """A one-time reminder's At row opens an Input preloaded with the
+    task's own `run_at.isoformat()` -- the same prefill shape the
+    create/edit modal uses."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        run_at = datetime(2030, 1, 1, 9, 0, tzinfo=timezone.utc)
+        detail.set_task(
+            _frequency_reminder(
+                schedule_kind=ScheduleKind.ONE_TIME,
+                cron=None,
+                timezone=None,
+                run_at=run_at,
+            )
+        )
+        await pilot.pause()
+
+        at_row = detail._at_row
+        assert at_row.affordance is True
+        await pilot.click(at_row)
+        await pilot.pause()
+
+        editor = at_row.query_one(Input)
+        assert editor.value == run_at.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_timezone_row_editor_opens_with_current_zone_preselected():
+    """A recurring reminder's Timezone row opens a Select preloaded with
+    the task's OWN stored zone."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(_frequency_reminder())  # timezone="America/New_York"
+        await pilot.pause()
+
+        tz_row = detail._timezone_row
+        assert tz_row.affordance is True
+        await pilot.click(tz_row)
+        await pilot.pause()
+
+        editor = tz_row.query_one(Select)
+        assert editor.value == "America/New_York"
+
+
+@pytest.mark.asyncio
+async def test_frequency_row_affordance_matches_schedule_kind():
+    """Repeat/Timezone only apply to a recurring schedule, At only to a
+    one-time one (survey §2: the other combination is silently clobbered
+    by `update_reminder`'s own recompute step) -- the non-applicable row
+    stays read-only instead of offering a guaranteed-to-fail control."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(_frequency_reminder())  # recurring
+        await pilot.pause()
+        assert detail._repeat_row.affordance is True
+        assert detail._at_row.affordance is False
+        assert detail._timezone_row.affordance is True
+
+        detail.set_task(
+            _frequency_reminder(
+                schedule_kind=ScheduleKind.ONE_TIME,
+                cron=None,
+                timezone=None,
+                run_at=datetime(2030, 1, 1, 9, 0, tzinfo=timezone.utc),
+            )
+        )
+        await pilot.pause()
+        assert detail._repeat_row.affordance is False
+        assert detail._at_row.affordance is True
+        assert detail._timezone_row.affordance is False
+
+
+@pytest.mark.asyncio
+async def test_escape_cancels_open_editor_without_committing():
+    """Escape closes the open editor via `end_edit` -- no field-edit
+    request is posted, and the row's old value is still shown."""
+
+    class _CapturingApp(_BareTaskDetailApp):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.requests: list = []
+
+        def on_reminder_field_edit_requested(self, event) -> None:
+            self.requests.append(event)
+
+    async with _CapturingApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(_frequency_reminder())
+        await pilot.pause()
+
+        repeat_row = detail._repeat_row
+        await pilot.click(repeat_row)
+        await pilot.pause()
+        assert repeat_row.query(Select)
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert not repeat_row.query(Select)
+        assert pilot.app.requests == []
+        assert (
+            detail.query_one("#scheduling-detail-repeat", Static)
+            .render_line(0)
+            .text.strip()
+            == "Recurring"
+        )
+
+
+@pytest.mark.asyncio
+async def test_repeat_row_selecting_custom_target_refuses_without_a_bridge_call():
+    """Picking "Custom cron..." as a NEW Repeat target has no single-value
+    edit shape here (the raw cron field only exists in the full modal),
+    so it is refused client-side rather than sent to the bridge (ruling
+    2: never silent) -- distinct from "custom" merely being the row's
+    CURRENT (round-tripped) value, which never triggers a commit at all."""
+
+    class _CapturingApp(_BareTaskDetailApp):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.requests: list = []
+
+        def on_reminder_field_edit_requested(self, event) -> None:
+            self.requests.append(event)
+
+    async with _CapturingApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        # `_frequency_reminder`'s default cron "0 9 * * 1" == "monday".
+        detail.set_task(_frequency_reminder())
+        await pilot.pause()
+
+        repeat_row = detail._repeat_row
+        await pilot.click(repeat_row)
+        await pilot.pause()
+        editor = repeat_row.query_one(Select)
+        assert editor.value == "monday"
+
+        editor.value = "custom"  # a genuine change to an unsupported target
+        await pilot.pause()
+
+        assert not repeat_row.query(Select)  # editor closed
+        assert pilot.app.requests == []  # never reached the bridge
+        error = repeat_row.query_one(".detail-value-row-error", Static)
+        assert error.display is True
+        assert "full Edit form" in error.render_line(0).text
+        # The stored cron is untouched -- nothing was persisted.
+        assert (
+            detail.query_one("#scheduling-detail-at", Static)
+            .render_line(0)
+            .text.strip()
+            == "Weekly on Monday at 09:00 America/New_York"
+        )
+
+
+@pytest.mark.asyncio
+async def test_locked_row_activation_shows_lock_reason_and_opens_no_editor():
+    """Ruling 2 (never silent): a locked row's Frequency rows keep their
+    affordance ON so activation still responds -- with the lock reason
+    via `show_error`, never an editor."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(_frequency_reminder())
+        detail.set_lifecycle_lock(
+            "This row is moving between this device and the server -- it "
+            "is read-only until the move finishes. Cancel the transfer first."
+        )
+        await pilot.pause()
+
+        repeat_row = detail._repeat_row
+        assert repeat_row.affordance is True  # still responsive, not silently off
+        await pilot.click(repeat_row)
+        await pilot.pause()
+
+        assert not repeat_row.query(Select)
+        error = repeat_row.query_one(".detail-value-row-error", Static)
+        assert error.display is True
+        assert "moving between this device and the server" in error.render_line(0).text
+
+
+@pytest.mark.asyncio
+async def test_committing_repeat_edit_persists_and_repaints_pane_and_queue_list(
+    tmp_path,
+):
+    """Commit persists via Task 2's bridge; success repaints the pane from
+    a fresh read AND the unified Queue list's own row data (task-3 brief
+    AC: 'unified-list row updates after edit')."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        reminder = await service.create_reminder(
+            {
+                "title": "Weekly digest",
+                "schedule_kind": "recurring",
+                "run_at": None,
+                "cron": "0 9 * * 1",
+                "timezone": "America/New_York",
+            }
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+
+            table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
+            assert table.row_count == 1
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+
+            detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
+            at_before = detail.query_one("#scheduling-detail-at", Static)
+            assert (
+                at_before.render_line(0).text.strip()
+                == "Weekly on Monday at 09:00 America/New_York"
+            )
+
+            # `pilot.click` targets a screen coordinate computed from
+            # `Widget.region`, which the Frequency group's real position
+            # inside the full 3-pane workbench does not reliably match
+            # (Task 1's own click-mechanics tests are BARE-harness only,
+            # never embedded here) -- posting `Activated` directly drives
+            # the exact same handler a real click reaches, without
+            # depending on pixel-perfect layout in a pane this narrow.
+            detail._repeat_row.post_message(
+                DetailValueRow.Activated(detail._repeat_row)
+            )
+            await pilot.pause()
+            select = detail._repeat_row.query_one(Select)
+            select.value = "daily"
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert db.get_reminder_task(reminder.id)["cron"] == "0 9 * * *"
+
+            at_after = detail.query_one("#scheduling-detail-at", Static)
+            assert (
+                at_after.render_line(0).text.strip()
+                == "Daily at 09:00 America/New_York"
+            )
+
+            # The unified Queue list's own underlying row data, not just
+            # the detail pane, reflects the persisted edit -- proven via
+            # the workbench's own refreshed `_tasks` (deterministic; the
+            # rendered relative-time subtitle is wall-clock-dependent and
+            # not a safe assertion here).
+            workbench = pilot.app.screen
+            assert workbench._tasks[0].cron == "0 9 * * *"
+            assert rendered_row_cells(table, 0)[1] == "Weekly digest"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_committing_edit_on_a_server_owned_row_persists_under_its_own_owner(
+    tmp_path,
+):
+    """PR-2's Queue spans owners -- a server-owned row's edit must persist
+    (row-owner threading is the bridge's own job, Task 2) without ever
+    repointing the service's active ('local') owner (task-3 brief AC)."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        task_id = db.create_reminder_task(
+            owner_id="server:example.com",
+            title="Server reminder",
+            schedule_kind="recurring",
+            run_at=None,
+            cron="0 9 * * 1",
+            timezone="America/New_York",
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+
+            table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
+            assert table.row_count == 1
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+
+            detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
+            detail._timezone_row.post_message(
+                DetailValueRow.Activated(detail._timezone_row)
+            )
+            await pilot.pause()
+            select = detail._timezone_row.query_one(Select)
+            select.value = "UTC"
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            row = db.get_reminder_task(task_id)
+            assert row["timezone"] == "UTC"
+            assert row["owner_id"] == "server:example.com"
+        assert service.owner_id == "local"  # never repointed by the edit
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_junk_at_value_shows_inline_error_and_restores_old_display(tmp_path):
+    """A junk At submission surfaces the bridge's field error inline and
+    leaves the OLD display + DB value untouched (task-3 brief AC)."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        task_id = db.create_reminder_task(
+            owner_id="local",
+            title="One-off",
+            schedule_kind="one_time",
+            run_at="2030-01-01T09:00:00+00:00",
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+
+            table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
+            assert table.row_count == 1
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+
+            detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
+            at_row = detail._at_row
+            at_static = detail.query_one("#scheduling-detail-at", Static)
+            original_text = at_static.render_line(0).text.strip()
+
+            at_row.post_message(DetailValueRow.Activated(at_row))
+            await pilot.pause()
+            input_widget = at_row.query_one(Input)
+            input_widget.value = "not-a-date"
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            error = at_row.query_one(".detail-value-row-error", Static)
+            assert error.display is True
+            assert "Run At must be a date and time" in error.render_line(0).text
+
+            assert (
+                db.get_reminder_task(task_id)["run_at"]
+                == "2030-01-01T09:00:00+00:00"
+            )
+            assert at_static.render_line(0).text.strip() == original_text
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_locked_row_via_real_service_refuses_edit_and_leaves_row_unchanged(
+    tmp_path,
+):
+    """The lock guard holds end-to-end through the real bridge too: a
+    locked row's Repeat editor never opens, and the DB row is untouched."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        task_id = db.create_reminder_task(
+            owner_id="local",
+            title="Locked",
+            schedule_kind="recurring",
+            run_at=None,
+            cron="0 9 * * 1",
+            timezone="America/New_York",
+        )
+        db.set_transfer_state(
+            "reminder_task", task_id, "to_server_pending", expected=(None,)
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+
+            table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
+            assert table.row_count == 1
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+
+            detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
+            repeat_row = detail._repeat_row
+            assert repeat_row.affordance is True
+
+            repeat_row.post_message(DetailValueRow.Activated(repeat_row))
+            await pilot.pause()
+
+            assert not repeat_row.query(Select)
+            error = repeat_row.query_one(".detail-value-row-error", Static)
+            assert error.display is True
+            assert "moving between this device and the server" in error.render_line(0).text
+            assert db.get_reminder_task(task_id)["cron"] == "0 9 * * 1"
+    finally:
+        db.close()
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -1,7 +1,7 @@
 """Tests for the SchedulesWorkbench shell."""
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -23,6 +23,7 @@ from textual.widgets._collapsible import CollapsibleTitle
 
 from tldw_chatbook.Scheduling.events import (
     DeleteTaskRequested,
+    ReminderOwnerActionRequested,
     SyncCompleted,
     SyncFailed,
 )
@@ -3414,3 +3415,578 @@ async def test_status_strip_sync_widget_is_not_compact_at_wide_width():
             "#scheduling-sync-status", SyncStatusWidget
         )
         assert "compact" not in sync_status.classes
+
+
+# --- redesign PR-3, task 5: owner-row transfer dropdown ---------------------
+
+
+class _FakeConnectedServerClient:
+    """Reads as "a server is connected" (`notifications_service is not
+    None`) without making any real network call -- local duplicate of
+    `test_schedules_transfer_actions.py`'s own `_FakeServerClient`,
+    matching this file's own no-cross-file-test-coupling precedent."""
+
+    def __init__(self) -> None:
+        self.notifications_service = object()
+
+
+def _connected_service(tmp_path, app):
+    """A real `ScheduledTasksDB` + `SchedulingService`, wired to LOOK
+    connected to a server (`active_server_id="1"`, a fake `server_
+    client`) -- for tests where the owner-row dropdown must actually
+    OFFER a `Server (1)` option (`SchedulesWorkbench._server_available`/
+    `SchedulingService._active_server_owner_id` both gate on this)."""
+    from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+    from tldw_chatbook.Scheduling.services.scheduling_service import SchedulingService
+
+    db = ScheduledTasksDB(tmp_path / "scheduled_tasks.db")
+    app.active_server_id = "1"
+    app.runtime_policy = SimpleNamespace(
+        state=SimpleNamespace(active_server_id="1")
+    )
+    service = SchedulingService(
+        db=db,
+        server_client=_FakeConnectedServerClient(),
+        runtime_source="local",
+        app_getter=lambda: app,
+    )
+    app.scheduling_service = service
+    return db, service
+
+
+# -- bare-harness: widget mechanics, no service needed -----------------------
+
+
+@pytest.mark.asyncio
+async def test_runs_on_dropdown_opens_with_current_owner_preselected():
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(
+            _frequency_reminder(owner_id="local"),
+            runs_on_options=[("This device", "local"), ("Server (1)", "server:1")],
+        )
+        await pilot.pause()
+
+        row = detail._runs_on_row
+        await pilot.click(row)
+        await pilot.pause()
+        select = row.query_one(Select)
+        assert select.value == "local"
+
+
+@pytest.mark.asyncio
+async def test_definition_runs_on_dropdown_opens_with_current_owner_preselected():
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(
+            _editable_definition(owner_id="server:9"),
+            runs_on_options=[("This device", "local")],
+        )
+        await pilot.pause()
+
+        row = detail._runs_on_row
+        await pilot.click(row)
+        await pilot.pause()
+        select = row.query_one(Select)
+        # `server:9` isn't in the base options -- the row's own current
+        # owner is appended as a fallback (survey §7's "never a value
+        # outside a Select's own options" precedent) so it still preselects.
+        assert select.value == "server:9"
+
+
+@pytest.mark.asyncio
+async def test_runs_on_same_owner_selection_is_a_no_op():
+    """The mount-time synthetic `Changed` `begin_edit` posts the moment
+    it preselects the row's OWN current owner (same trap Task 3's Repeat/
+    Timezone commits already guard against, reused verbatim) must not
+    close the editor or post a transfer request -- same as those rows,
+    the editor stays open for a real pick rather than self-closing."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(
+            _frequency_reminder(owner_id="local"),
+            runs_on_options=[("This device", "local"), ("Server (1)", "server:1")],
+        )
+        await pilot.pause()
+
+        with patch.object(
+            detail, "post_message", wraps=detail.post_message
+        ) as post_spy:
+            row = detail._runs_on_row
+            await pilot.click(row)
+            await pilot.pause()
+
+            assert row.query(Select)
+            assert not any(
+                isinstance(call.args[0], ReminderOwnerActionRequested)
+                for call in post_spy.call_args_list
+            )
+
+
+@pytest.mark.asyncio
+async def test_runs_on_escape_cancels_dropdown_without_posting():
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(
+            _frequency_reminder(owner_id="local"),
+            runs_on_options=[("This device", "local"), ("Server (1)", "server:1")],
+        )
+        await pilot.pause()
+
+        with patch.object(
+            detail, "post_message", wraps=detail.post_message
+        ) as post_spy:
+            row = detail._runs_on_row
+            await pilot.click(row)
+            await pilot.pause()
+            assert row.query(Select)
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert not row.query(Select)
+            assert not any(
+                isinstance(call.args[0], ReminderOwnerActionRequested)
+                for call in post_spy.call_args_list
+            )
+
+
+@pytest.mark.asyncio
+async def test_runs_on_row_reflects_transfer_state():
+    """Three states (task-5 brief): normal (affordance on, both buttons
+    hidden), in flight (affordance off, Cancel only), `to_server_failed`
+    (affordance off, Cancel + Retry) -- mirroring the existing per-button
+    visibility rules `test_schedules_transfer_actions.py` already pins."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+
+        detail.set_task(_frequency_reminder(transfer_state=None))
+        await pilot.pause()
+        assert detail._runs_on_row.affordance is True
+        assert detail._runs_on_cancel_button.display is False
+        assert detail._runs_on_retry_button.display is False
+
+        detail.set_task(_frequency_reminder(transfer_state="to_server_pending"))
+        await pilot.pause()
+        assert detail._runs_on_row.affordance is False
+        assert detail._runs_on_cancel_button.display is True
+        assert detail._runs_on_retry_button.display is False
+
+        detail.set_task(_frequency_reminder(transfer_state="to_server_failed"))
+        await pilot.pause()
+        assert detail._runs_on_row.affordance is False
+        assert detail._runs_on_cancel_button.display is True
+        assert detail._runs_on_retry_button.display is True
+
+        detail.set_task(_frequency_reminder(transfer_state="from_server_pending"))
+        await pilot.pause()
+        assert detail._runs_on_row.affordance is False
+        assert detail._runs_on_cancel_button.display is True
+        assert detail._runs_on_retry_button.display is False
+
+        # Back to normal restores the dropdown and hides both buttons.
+        detail.set_task(_frequency_reminder(transfer_state=None))
+        await pilot.pause()
+        assert detail._runs_on_row.affordance is True
+        assert detail._runs_on_cancel_button.display is False
+        assert detail._runs_on_retry_button.display is False
+
+
+@pytest.mark.asyncio
+async def test_definition_runs_on_row_reflects_transfer_state():
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+
+        detail.set_definition(_editable_definition(transfer_state=None))
+        await pilot.pause()
+        assert detail._runs_on_row.affordance is True
+        assert detail._runs_on_cancel_button.display is False
+        assert detail._runs_on_retry_button.display is False
+
+        detail.set_definition(
+            _editable_definition(transfer_state="from_server_pending")
+        )
+        await pilot.pause()
+        assert detail._runs_on_row.affordance is False
+        assert detail._runs_on_cancel_button.display is True
+        assert detail._runs_on_retry_button.display is False
+
+        detail.set_definition(_editable_definition(transfer_state="to_server_failed"))
+        await pilot.pause()
+        assert detail._runs_on_row.affordance is False
+        assert detail._runs_on_cancel_button.display is True
+        assert detail._runs_on_retry_button.display is True
+
+
+# -- integration: real DB + service + full workbench -------------------------
+
+
+@pytest.mark.asyncio
+async def test_runs_on_dropdown_refusal_renders_inline_with_health_reason(tmp_path):
+    """A refused target renders via `row.show_error` (this row's OWN
+    surface, never the Automations tab's shared inline notice) -- health-
+    quoting preserved verbatim (spec §6.4/§7), and nothing is written.
+
+    `transfer_refusal`'s FIRST gate ("No server connection is
+    configured.") applies to EVERY direction, not only `to_server` --
+    `_connected_service` is required here too, purely to get PAST that
+    gate and reach the `to_local`/`recurring_question` health check this
+    test actually targets.
+    """
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        definition_id = db.create_automation_definition(
+            "server:1",
+            "recurring_question",
+            "Server automation",
+            server_id="srv-1",
+            schedule={"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+            input={"question": "What shipped?"},
+            config={
+                "generation_mode": "optional",
+                "scope": {"mode": "all_searchable_library"},
+            },
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+
+            # A server-fetch-shaped dict (Task 4's own documented trap,
+            # its report's "trap hit while writing the lifecycle/offline
+            # tests": `id` IS the server's own id) -- painted directly
+            # onto the Automations-tab `DefinitionDetail` instance rather
+            # than driving a real server-list fetch (out of this test's
+            # scope), matching what `_selected_automation()` would hand
+            # this pane for a pure server row.
+            server_item = dict(db.get_automation_definition(definition_id) or {})
+            server_item["id"] = "srv-1"
+            detail = pilot.app.screen.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            detail.set_definition(
+                server_item, runs_on_options=[("This device", "local")]
+            )
+            await pilot.pause()
+
+            row = detail._runs_on_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            select = row.query_one(Select)
+            # "This device" (`to_local`) is always offered, server or not.
+            select.value = "local"
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            error = row.query_one(".detail-value-row-error", Static)
+            assert error.display is True
+            assert (
+                "Library RAG search is not available"
+                in error.render_line(0).text
+            )
+            assert db.get_automation_definition(definition_id)["transfer_state"] is None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_runs_on_dropdown_confirm_dialog_lists_warnings(tmp_path):
+    """Allowed -> the SAME `ConfirmationDialog` + `transfer_warnings`
+    shape the legacy buttons already use (imminent run_at + the
+    non-transferring `timeout_seconds` field, spec §6.4)."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        imminent = (datetime.now(timezone.utc) + timedelta(minutes=2)).isoformat()
+        db.create_reminder_task(
+            owner_id="local",
+            title="Almost due",
+            schedule_kind="one_time",
+            run_at=imminent,
+            timeout_seconds=30,
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
+            assert table.row_count == 1
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+
+            detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
+            row = detail._runs_on_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            select = row.query_one(Select)
+            select.value = "server:1"
+            await pilot.pause()
+
+            assert isinstance(pilot.app.screen, ConfirmationDialog)
+            message = pilot.app.screen.message
+            assert "Almost due" in message
+            assert "unverified" in message
+            assert "timeout_seconds" in message
+            pilot.app.screen.dismiss(False)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_runs_on_dropdown_confirm_begins_to_local_transfer_with_dormant_copy_id(
+    tmp_path,
+):
+    """Task-5 brief pinned case: `begin_transfer_to_local`'s outcome
+    carries the NEW dormant copy's own id, DISTINCT from the mirror's --
+    the mirror itself stays untouched (survey §3's `create_local_copy_
+    from_mirror` precedent). `_connected_service` -- `transfer_refusal`'s
+    FIRST gate ("No server connection is configured.") applies to `to_
+    local` too, not only `to_server`."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        mirror_id = db.create_reminder_task(
+            owner_id="server:1",
+            server_id="srv-9",
+            title="Server task",
+            schedule_kind="one_time",
+            run_at="2030-01-01T00:00:00+00:00",
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
+            assert table.row_count == 1
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+
+            detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
+            row = detail._runs_on_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            select = row.query_one(Select)
+            select.value = "local"
+            await pilot.pause()
+
+            assert isinstance(pilot.app.screen, ConfirmationDialog)
+            pilot.app.screen.dismiss(True)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            mirror = db.get_reminder_task(mirror_id)
+            assert mirror["transfer_state"] is None
+            assert mirror["owner_id"] == "server:1"
+
+            local_rows = [
+                row_dict
+                for row_dict in db.list_reminder_tasks(owner_id="local")
+                if row_dict["id"] != mirror_id
+            ]
+            assert len(local_rows) == 1
+            copy = local_rows[0]
+            assert copy["id"] != mirror_id
+            assert copy["transfer_state"] == "from_server_pending"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_runs_on_dropdown_confirm_begins_to_server_transfer(tmp_path):
+    """The other direction: confirm fires `begin_transfer_to_server` with
+    the currently-displayed row's own local id (task-5 brief: 'the right
+    facade call with the right row id per direction')."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        task_id = db.create_reminder_task(
+            owner_id="local",
+            title="Nightly check",
+            schedule_kind="one_time",
+            run_at="2030-01-01T00:00:00+00:00",
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+
+            detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
+            row = detail._runs_on_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            select = row.query_one(Select)
+            select.value = "server:1"
+            await pilot.pause()
+
+            assert isinstance(pilot.app.screen, ConfirmationDialog)
+            pilot.app.screen.dismiss(True)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            row_after = db.get_reminder_task(task_id)
+            assert row_after["transfer_state"] == "to_server_pending"
+            assert row_after["owner_id"] == "local"  # still local while queued
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_runs_on_cancel_button_cancels_the_dormant_copy_using_its_own_id(
+    tmp_path,
+):
+    """Same pinned mechanism `test_cancel_on_dormant_copy_uses_the_copys_
+    own_id` (`test_schedules_transfer_actions.py`) proves for the legacy
+    Cancel button -- proven again here for the NEW row-level Cancel
+    affordance (task-5 brief: 'assert it'). `_connected_service` is only
+    needed for the SETUP call below (`begin_transfer_to_local` itself
+    checks `transfer_refusal`'s server-connection gate); the actual
+    cancel path (`cancel_transfer`) never checks it."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        mirror_id = db.create_reminder_task(
+            owner_id="server:1",
+            server_id="srv-9",
+            title="Server task",
+            schedule_kind="one_time",
+            run_at="2030-01-01T00:00:00+00:00",
+        )
+        outcome = await service.begin_transfer_to_local("reminder_task", mirror_id)
+        assert outcome.status == "pending"
+        copy_id = outcome.row_id
+        assert copy_id is not None
+        assert copy_id != mirror_id
+
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
+            assert table.row_count == 2
+            workbench = pilot.app.screen
+            copy_index = next(
+                index
+                for index, row in enumerate(workbench._visible_rows)
+                if row.kind == "reminder" and row.source_row.id == copy_id
+            )
+            table.cursor_coordinate = (copy_index, 0)
+            await pilot.pause()
+
+            detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
+            assert detail._runs_on_cancel_button.display is True
+            detail._runs_on_cancel_button.press()
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert db.get_reminder_task(copy_id) is None
+            mirror = db.get_reminder_task(mirror_id)
+            assert mirror is not None
+            assert mirror["transfer_state"] is None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_runs_on_retry_button_rebegins_a_failed_transfer(tmp_path):
+    """`to_server_failed`: Retry = re-begin (the PR-5 retry leg) -- same
+    facade call a first-time `to_server` begin makes."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        task_id = db.create_reminder_task(
+            owner_id="local",
+            title="Nightly check",
+            schedule_kind="one_time",
+            run_at="2030-01-01T00:00:00+00:00",
+        )
+        db.set_transfer_state(
+            "reminder_task", task_id, "to_server_failed", expected=(None,)
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+
+            detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
+            assert detail._runs_on_retry_button.display is True
+            detail._runs_on_retry_button.press()
+            await pilot.pause()
+
+            assert isinstance(pilot.app.screen, ConfirmationDialog)
+            pilot.app.screen.dismiss(True)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert db.get_reminder_task(task_id)["transfer_state"] == "to_server_pending"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_runs_on_dropdown_and_legacy_transfer_buttons_coexist(tmp_path):
+    """Coexistence (task-5 brief, pinned): the PR-5 buttons stay
+    untouched until PR-4 -- both surfaces read/write the SAME underlying
+    transfer state and stay in sync with each other, side by side."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        task_id = db.create_reminder_task(
+            owner_id="local",
+            title="Nightly check",
+            schedule_kind="one_time",
+            run_at="2030-01-01T00:00:00+00:00",
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+
+            detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
+
+            # Legacy surface: begin via the EXISTING button, untouched.
+            legacy_to_server = pilot.app.screen.query_one(
+                "#scheduling-transfer-to-server", Button
+            )
+            assert not legacy_to_server.disabled
+            legacy_to_server.press()
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, ConfirmationDialog)
+            pilot.app.screen.dismiss(True)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert db.get_reminder_task(task_id)["transfer_state"] == "to_server_pending"
+            # BOTH surfaces now reflect the in-flight state.
+            legacy_cancel = pilot.app.screen.query_one(
+                "#scheduling-cancel-transfer", Button
+            )
+            assert not legacy_cancel.disabled
+            assert detail._runs_on_cancel_button.display is True
+            assert detail._runs_on_row.affordance is False
+
+            # NEW surface: cancel via the row's own affordance.
+            detail._runs_on_cancel_button.press()
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert db.get_reminder_task(task_id)["transfer_state"] is None
+            # The LEGACY button reflects the SAME underlying state,
+            # refreshed via the SAME `_request_tasks_refresh` seam.
+            legacy_cancel_after = pilot.app.screen.query_one(
+                "#scheduling-cancel-transfer", Button
+            )
+            assert legacy_cancel_after.disabled
+            assert detail._runs_on_row.affordance is True
+    finally:
+        db.close()

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -10,7 +10,15 @@ import pytest
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
 from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
-from textual.widgets import Button, DataTable, Input, Select, Static, TabbedContent
+from textual.widgets import (
+    Button,
+    Checkbox,
+    DataTable,
+    Input,
+    Select,
+    Static,
+    TabbedContent,
+)
 from textual.widgets._collapsible import CollapsibleTitle
 
 from tldw_chatbook.Scheduling.events import (
@@ -26,6 +34,7 @@ from tldw_chatbook.Scheduling.models import (
 )
 from tldw_chatbook.UI.Screens.scheduling.conflicts_tab import ConflictsTab
 from tldw_chatbook.UI.Screens.scheduling.definition_detail import (
+    DefinitionDetail,
     _definition_owner_label,
 )
 from tldw_chatbook.UI.Screens.scheduling.forms.reminder_form import ReminderForm
@@ -858,6 +867,946 @@ async def test_locked_row_via_real_service_refuses_edit_and_leaves_row_unchanged
             assert error.display is True
             assert "moving between this device and the server" in error.render_line(0).text
             assert db.get_reminder_task(task_id)["cron"] == "0 9 * * 1"
+    finally:
+        db.close()
+
+
+# --- redesign PR-3, task 4: definition-pane in-pane editing + lifecycle ----
+
+
+class _BareDefinitionDetailApp(ConsolidatedCSSApp):
+    """Bare app mounting one `DefinitionDetail` (schedules-redesign PR-3,
+    task 4), matching `_BareTaskDetailApp`'s own pattern."""
+
+    CSS_PATH = str(BUNDLED_STYLESHEET)
+
+    def compose(self):
+        yield DefinitionDetail()
+
+
+def _editable_definition(**overrides) -> dict:
+    """A representative local `recurring_question` definition dict
+    covering every task-4 editable Details/Frequency row: a recurring
+    cron schedule, a pinned model, a non-default generation mode, an
+    explicit sources scope, and an on notification policy."""
+    base: dict = {
+        "id": "def-1",
+        "owner_id": "local",
+        "family": "recurring_question",
+        "name": "Daily standup question",
+        "lifecycle": "configured",
+        "schedule": {
+            "kind": "cron",
+            "cron": "0 9 * * 1",
+            "timezone": "America/New_York",
+        },
+        "input": {
+            "question": "What shipped?",
+            "provider": "openai",
+            "model": "gpt-5",
+        },
+        "config": {
+            "generation_mode": "required",
+            "scope": {"mode": "sources", "sources": ["media_db", "notes"]},
+            "finding_policy": {"preset": "high_confidence_only"},
+        },
+        "finding_policy": {"preset": "high_confidence_only"},
+        "notification_policy": {"on_success": True, "on_failure": True},
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_definition_details_rows_are_always_editable_regardless_of_schedule_kind():
+    """Model/Generation/Finding policy/Sources/Notifications don't depend
+    on schedule kind (unlike Repeat/At/Timezone) -- affordance stays on
+    for both kinds."""
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())
+        await pilot.pause()
+        for row in (
+            detail._model_row,
+            detail._generation_row,
+            detail._finding_policy_row,
+            detail._sources_row,
+            detail._notifications_row,
+        ):
+            assert row.affordance is True
+
+        detail.set_definition(
+            _editable_definition(
+                schedule={"kind": "one_time", "run_at": "2030-01-01T09:00:00+00:00"}
+            )
+        )
+        await pilot.pause()
+        for row in (
+            detail._model_row,
+            detail._generation_row,
+            detail._finding_policy_row,
+            detail._sources_row,
+            detail._notifications_row,
+        ):
+            assert row.affordance is True
+
+
+@pytest.mark.asyncio
+async def test_definition_frequency_row_affordance_gated_by_schedule_kind():
+    """Repeat/Timezone only apply to a cron schedule, At only to a
+    one_time one -- same reasoning `task_detail.py`'s reminder Frequency
+    rows already use."""
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())  # cron
+        await pilot.pause()
+        assert detail._repeat_row.affordance is True
+        assert detail._at_row.affordance is False
+        assert detail._timezone_row.affordance is True
+
+        detail.set_definition(
+            _editable_definition(
+                schedule={"kind": "one_time", "run_at": "2030-01-01T09:00:00+00:00"}
+            )
+        )
+        await pilot.pause()
+        assert detail._repeat_row.affordance is False
+        assert detail._at_row.affordance is True
+        assert detail._timezone_row.affordance is False
+
+
+@pytest.mark.asyncio
+async def test_model_row_editor_preselects_provider_slash_model_and_is_blank_when_not_set():
+    """Task-4 brief: 'blank = provider default, the "Not set" honesty
+    preserved' -- the Input opens blank, not literal 'auto'."""
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())
+        await pilot.pause()
+
+        model_row = detail._model_row
+        await pilot.click(model_row)
+        await pilot.pause()
+        editor = model_row.query_one(Input)
+        assert editor.value == "openai/gpt-5"
+        await pilot.press("escape")
+        await pilot.pause()
+
+        detail.set_definition(_editable_definition(input={"question": "What shipped?"}))
+        await pilot.pause()
+        model_row = detail._model_row
+        await pilot.click(model_row)
+        await pilot.pause()
+        editor = model_row.query_one(Input)
+        assert editor.value == ""
+
+
+@pytest.mark.asyncio
+async def test_generation_row_editor_preselects_current_value_defaulting_to_optional():
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())  # generation_mode="required"
+        await pilot.pause()
+        row = detail._generation_row
+        await pilot.click(row)
+        await pilot.pause()
+        editor = row.query_one(Select)
+        assert editor.value == "required"
+        await pilot.press("escape")
+        await pilot.pause()
+
+        detail.set_definition(
+            _editable_definition(config={"scope": {"mode": "all_searchable_library"}})
+        )
+        await pilot.pause()
+        row = detail._generation_row
+        await pilot.click(row)
+        await pilot.pause()
+        editor = row.query_one(Select)
+        assert editor.value == "optional"
+
+
+@pytest.mark.asyncio
+async def test_finding_policy_row_editor_preselects_current_value():
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())  # high_confidence_only
+        await pilot.pause()
+        row = detail._finding_policy_row
+        await pilot.click(row)
+        await pilot.pause()
+        editor = row.query_one(Select)
+        assert editor.value == "high_confidence_only"
+
+
+@pytest.mark.asyncio
+async def test_sources_row_editor_checks_stored_sources_and_all_when_library_wide():
+    """The 3-checkbox mini-editor (task-4 brief's own suggested Sources
+    shape) prechecks the stored subset, or every box when the scope is
+    library-wide/unset -- visually 'everything', matching the row's own
+    displayed value."""
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())  # sources: media_db, notes
+        await pilot.pause()
+        row = detail._sources_row
+        await pilot.click(row)
+        await pilot.pause()
+        checkboxes = {cb.id: cb.value for cb in row.query(Checkbox)}
+        assert checkboxes["scheduling-automation-detail-sources-media_db"] is True
+        assert checkboxes["scheduling-automation-detail-sources-notes"] is True
+        assert checkboxes["scheduling-automation-detail-sources-chats"] is False
+        await pilot.press("escape")
+        await pilot.pause()
+
+        detail.set_definition(
+            _editable_definition(config={"scope": {"mode": "all_searchable_library"}})
+        )
+        await pilot.pause()
+        row = detail._sources_row
+        await pilot.click(row)
+        await pilot.pause()
+        checkboxes = {cb.id: cb.value for cb in row.query(Checkbox)}
+        assert all(checkboxes.values())
+
+
+@pytest.mark.asyncio
+async def test_notifications_row_editor_preselects_on_off():
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())  # on
+        await pilot.pause()
+        row = detail._notifications_row
+        await pilot.click(row)
+        await pilot.pause()
+        editor = row.query_one(Select)
+        assert editor.value == "on"
+        await pilot.press("escape")
+        await pilot.pause()
+
+        detail.set_definition(
+            _editable_definition(
+                notification_policy={"on_success": False, "on_failure": False}
+            )
+        )
+        await pilot.pause()
+        row = detail._notifications_row
+        await pilot.click(row)
+        await pilot.pause()
+        editor = row.query_one(Select)
+        assert editor.value == "off"
+
+
+@pytest.mark.asyncio
+async def test_definition_repeat_row_editor_preselects_current_preset():
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())  # "0 9 * * 1" == monday
+        await pilot.pause()
+        row = detail._repeat_row
+        await pilot.click(row)
+        await pilot.pause()
+        editor = row.query_one(Select)
+        assert editor.value == "monday"
+
+
+@pytest.mark.asyncio
+async def test_definition_at_row_editor_preselects_current_run_at():
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(
+            _editable_definition(
+                schedule={"kind": "one_time", "run_at": "2030-01-01T09:00:00+00:00"}
+            )
+        )
+        await pilot.pause()
+        row = detail._at_row
+        await pilot.click(row)
+        await pilot.pause()
+        editor = row.query_one(Input)
+        assert editor.value == "2030-01-01T09:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_definition_timezone_row_editor_preselects_current_zone():
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())  # America/New_York
+        await pilot.pause()
+        row = detail._timezone_row
+        await pilot.click(row)
+        await pilot.pause()
+        editor = row.query_one(Select)
+        assert editor.value == "America/New_York"
+
+
+@pytest.mark.asyncio
+async def test_definition_escape_cancels_open_editor_without_committing():
+    class _CapturingApp(_BareDefinitionDetailApp):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.requests: list = []
+
+        def on_definition_field_edit_requested(self, event) -> None:
+            self.requests.append(event)
+
+    async with _CapturingApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())
+        await pilot.pause()
+
+        row = detail._generation_row
+        await pilot.click(row)
+        await pilot.pause()
+        assert row.query(Select)
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert not row.query(Select)
+        assert pilot.app.requests == []
+
+
+@pytest.mark.asyncio
+async def test_definition_repeat_row_custom_target_refuses_client_side_without_bridge_call():
+    class _CapturingApp(_BareDefinitionDetailApp):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.requests: list = []
+
+        def on_definition_field_edit_requested(self, event) -> None:
+            self.requests.append(event)
+
+    async with _CapturingApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())
+        await pilot.pause()
+
+        row = detail._repeat_row
+        await pilot.click(row)
+        await pilot.pause()
+        editor = row.query_one(Select)
+        editor.value = "custom"
+        await pilot.pause()
+
+        assert not row.query(Select)
+        assert pilot.app.requests == []
+        error = row.query_one(".detail-value-row-error", Static)
+        assert error.display is True
+        assert "full Edit form" in error.render_line(0).text
+
+
+@pytest.mark.asyncio
+async def test_sources_editor_apply_with_nothing_checked_refuses_client_side():
+    """Sources editor honesty (task-4 brief): unchecking every box and
+    applying is refused inline rather than sent to the bridge -- an
+    empty scope is a guaranteed `scope_empty` server refusal anyway."""
+
+    class _CapturingApp(_BareDefinitionDetailApp):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.requests: list = []
+
+        def on_definition_field_edit_requested(self, event) -> None:
+            self.requests.append(event)
+
+    async with _CapturingApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())
+        await pilot.pause()
+
+        row = detail._sources_row
+        await pilot.click(row)
+        await pilot.pause()
+        for checkbox in row.query(Checkbox):
+            checkbox.value = False
+        await pilot.pause()
+        apply_button = row.query_one(
+            "#scheduling-automation-detail-sources-apply", Button
+        )
+        await pilot.click(apply_button)
+        await pilot.pause()
+
+        assert not row.query(Checkbox)  # editor closed
+        assert pilot.app.requests == []
+        error = row.query_one(".detail-value-row-error", Static)
+        assert error.display is True
+        assert "at least one source" in error.render_line(0).text
+
+
+@pytest.mark.asyncio
+async def test_definition_locked_row_activation_shows_lock_reason_and_opens_no_editor():
+    """Survey point 10: `DefinitionDetail` gains the SAME transfer-lock
+    wiring `TaskDetail` has -- a locked row keeps its affordance ON so
+    activation still responds, with the lock reason, never an editor."""
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())
+        detail.set_lifecycle_lock(
+            "This row is moving between this device and the server -- it "
+            "is read-only until the move finishes. Cancel the transfer first."
+        )
+        await pilot.pause()
+
+        row = detail._generation_row
+        assert row.affordance is True  # still responsive, not silently off
+        await pilot.click(row)
+        await pilot.pause()
+
+        assert not row.query(Select)
+        error = row.query_one(".detail-value-row-error", Static)
+        assert error.display is True
+        assert "moving between this device and the server" in error.render_line(0).text
+
+
+class _LifecycleCapturingApp(_BareDefinitionDetailApp):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.requests: list = []
+
+    def on_definition_lifecycle_toggle_requested(self, event) -> None:
+        self.requests.append(event)
+
+
+@pytest.mark.asyncio
+async def test_pause_resume_button_shows_pause_and_posts_pause_when_configured():
+    async with _LifecycleCapturingApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition(lifecycle="configured"))
+        await pilot.pause()
+        button = detail.query_one("#scheduling-automation-pause-resume", Button)
+        assert button.label.plain == "Pause"
+        await pilot.click(button)
+        await pilot.pause()
+        assert len(pilot.app.requests) == 1
+        assert pilot.app.requests[0].action == "pause"
+
+
+@pytest.mark.asyncio
+async def test_pause_resume_button_shows_resume_and_posts_resume_when_paused():
+    async with _LifecycleCapturingApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition(lifecycle="paused"))
+        await pilot.pause()
+        button = detail.query_one("#scheduling-automation-pause-resume", Button)
+        assert button.label.plain == "Resume"
+        await pilot.click(button)
+        await pilot.pause()
+        assert len(pilot.app.requests) == 1
+        assert pilot.app.requests[0].action == "resume"
+
+
+@pytest.mark.asyncio
+async def test_pause_resume_button_disabled_and_reason_shown_when_locked():
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())
+        detail.set_lifecycle_lock("Read-only mid-transfer.")
+        await pilot.pause()
+        button = detail.query_one("#scheduling-automation-pause-resume", Button)
+        assert button.disabled is True
+        assert button.tooltip == "Read-only mid-transfer."
+        why = detail.query_one("#scheduling-automation-detail-why", Static)
+        assert why.render_line(0).text.strip() == "Read-only mid-transfer."
+
+        detail.set_lifecycle_lock(None)
+        await pilot.pause()
+        assert button.disabled is False
+
+
+# --- integration: real DB + service + full workbench -----------------------
+
+
+@pytest.mark.asyncio
+async def test_committing_generation_edit_persists_and_repaints_automations_pane(
+    tmp_path,
+):
+    """Commit persists via `save_definition`; success repaints the
+    Automations-tab pane from a fresh read AND arms the unified Queue
+    list's own (lazy, tab-activation-gated) refresh -- the same
+    `_definitions_stale` seam every other definition mutation in this
+    file uses (run-now, transfer begin/cancel)."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Daily standup question",
+            schedule={
+                "kind": "cron",
+                "cron": "0 9 * * 1",
+                "timezone": "America/New_York",
+            },
+            input={"question": "What shipped?"},
+            config={
+                "generation_mode": "optional",
+                "scope": {"mode": "all_searchable_library"},
+            },
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            assert table.row_count == 1
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            row = detail._generation_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            select = row.query_one(Select)
+            select.value = "required"
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert (
+                db.get_automation_definition(definition_id)["config"][
+                    "generation_mode"
+                ]
+                == "required"
+            )
+            generation_static = detail.query_one(
+                "#scheduling-automation-detail-generation", Static
+            )
+            assert (
+                generation_static.render_line(0).text.strip()
+                == "Always generate a draft"
+            )
+            # The unified Queue list's own next (lazy) refresh is armed.
+            assert workbench._definitions_stale is True
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_committing_repeat_edit_resends_whole_schedule_preserving_timezone(
+    tmp_path,
+):
+    """Pinned (task-4 brief): schedule edits RESEND THE WHOLE schedule
+    dict -- an edited Repeat (cron) must not drop the recurring
+    schedule's own timezone."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Weekly digest",
+            schedule={
+                "kind": "cron",
+                "cron": "0 9 * * 1",
+                "timezone": "America/New_York",
+            },
+            input={"question": "What shipped?"},
+            config={},
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            row = detail._repeat_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            select = row.query_one(Select)
+            select.value = "daily"
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            stored = db.get_automation_definition(definition_id)
+            assert stored["schedule"]["cron"] == "0 9 * * *"
+            assert stored["schedule"]["kind"] == "cron"
+            assert stored["schedule"]["timezone"] == "America/New_York"  # not dropped
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_committing_timezone_edit_preserves_cron(tmp_path):
+    """Companion pin: a Timezone edit must not drop the schedule's cron."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Weekly digest",
+            schedule={
+                "kind": "cron",
+                "cron": "0 9 * * 1",
+                "timezone": "America/New_York",
+            },
+            input={"question": "What shipped?"},
+            config={},
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            row = detail._timezone_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            select = row.query_one(Select)
+            select.value = "UTC"
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            stored = db.get_automation_definition(definition_id)
+            assert stored["schedule"]["timezone"] == "UTC"
+            assert stored["schedule"]["cron"] == "0 9 * * 1"  # not dropped
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_not_set_model_preserved_across_an_unrelated_edit(tmp_path):
+    """The Model row's 'Not set'/blank honesty (task-4 brief AC) survives
+    an edit to an UNRELATED row: `_definition_edit_payload`'s empty-dict
+    `input`/`notification_policy` groups round-trip through `save_
+    definition`'s one-level merge untouched.
+
+    Scoped to `input`/`notification_policy` deliberately, NOT `config`'s
+    own generation_mode/scope/finding_policy trio: traced (empirically,
+    via `preview_automation_definition` -> `validate_recurring_question_
+    config`) that those three are unconditionally NORMALIZED WITH
+    DEFAULTS on every local save regardless of which row was actually
+    edited -- a PRE-EXISTING behavior of the shared preview pipeline the
+    create/edit modal never exercises (it always sends explicit values),
+    now newly reachable because task 4 is the first caller that can send
+    a payload leaving them genuinely absent. Not a task-4 regression and
+    out of this task's scope to change; flagged in the report instead."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Bare-model digest",
+            schedule={"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+            input={"question": "What shipped?"},  # no provider/model
+            config={"generation_mode": "optional"},
+            notification_policy={"on_success": True, "on_failure": False},
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            model_static = detail.query_one(
+                "#scheduling-automation-detail-model", Static
+            )
+            assert model_static.render_line(0).text.strip() == "auto"
+
+            row = detail._generation_row
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            select = row.query_one(Select)
+            select.value = "required"
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            stored = db.get_automation_definition(definition_id)
+            assert stored["config"]["generation_mode"] == "required"
+            assert "provider" not in stored["input"]
+            assert "model" not in stored["input"]
+            assert stored["notification_policy"] == {
+                "on_success": True,
+                "on_failure": False,
+            }
+            assert model_static.render_line(0).text.strip() == "auto"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_edit_on_server_owned_row_with_unreachable_seam_queues_a_mutation(
+    tmp_path,
+):
+    """A server-owned row whose seam is unreachable still writes locally
+    and queues ONE pending mutation, under the ROW's OWN owner -- never
+    the service's active owner (mirrors Task 2's reminder-side row-owner
+    threading test) -- and `outcome.status == "queued"` is treated as UI
+    success (no inline error), same as `"saved"`."""
+    from tldw_chatbook.Scheduling.services.server_client import ServerUnavailableError
+    from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+    from tldw_chatbook.Scheduling.services.scheduling_service import (
+        SchedulingService,
+    )
+    from tldw_chatbook.UI.Screens.scheduling.definition_detail import (
+        _definition_edit_payload,
+    )
+
+    db = ScheduledTasksDB(tmp_path / "scheduled_tasks.db")
+    try:
+        server_client = AsyncMock()
+        server_client.preview_automation_definition.side_effect = (
+            ServerUnavailableError("offline")
+        )
+        service = SchedulingService(
+            db=db, server_client=server_client, runtime_source="local"
+        )
+        # Shaped like a genuine `_load_server_automations` item (`id` is
+        # the SERVER's own id) -- the shape `_resolve_local_definition_id`
+        # expects. A row read back via `db.get_automation_definition`
+        # instead (LOCAL id in `id`) is a DIFFERENT shape and trips
+        # `_resolve_local_definition_id`'s server/local branch into
+        # mirroring a SECOND, bogus row (its own "server_id" would be
+        # the already-local uuid) instead of resolving the real one.
+        server_item = {
+            "id": "srv-def-1",
+            "owner_id": "server:1",
+            "family": "recurring_question",
+            "name": "Server automation",
+            "lifecycle": "configured",
+            "schedule": {
+                "kind": "cron",
+                "cron": "0 9 * * 1",
+                "timezone": "UTC",
+            },
+            "input": {"question": "What shipped?"},
+            "config": {"generation_mode": "optional"},
+            "version": 3,
+        }
+        db.upsert_automation_definitions_from_server("server:1", [server_item])
+        definition_id = db.get_automation_definition_by_server_id(
+            "server:1", "srv-def-1"
+        )["id"]
+
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            workbench = SchedulesWorkbench(app_instance=pilot.app)
+            await pilot.app.push_screen(workbench)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = pilot.app.screen.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            detail.set_definition(server_item)
+            await pilot.pause()
+
+            row = detail._generation_row
+            payload = _definition_edit_payload(
+                server_item, config={"generation_mode": "required"}
+            )
+            workbench._edit_definition_field(server_item, payload, row)
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            stored = db.get_automation_definition(definition_id)
+            assert stored["config"]["generation_mode"] == "required"
+            # Final review C1 precedent: the mirror's `version` must not
+            # drift locally -- the server checks it for exact equality.
+            assert stored["version"] == 3
+            assert service.owner_id == "local"  # never repointed by the edit
+            mutation = db.get_pending_mutation_for_local_id(
+                definition_id, "automation_definition"
+            )
+            assert mutation is not None
+            assert mutation["payload"]["action"] == "update"
+            pending = db.get_pending_mutations(
+                "server:1", primitive="automation_definition"
+            )
+            assert len(pending) == 1  # queued under the ROW's own owner
+
+            error = row.query_one(".detail-value-row-error", Static)
+            assert error.display is False  # "queued" treated as success
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_toggle_pauses_a_local_automation_and_the_button_flips(
+    tmp_path,
+):
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Local automation",
+            schedule={"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+            input={"question": "What shipped?"},
+            config={},
+        )
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            workbench = pilot.app.screen
+            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
+                "scheduling-automations-tab"
+            )
+            await pilot.pause()
+            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            table.cursor_coordinate = (0, 0)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = workbench.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            button = detail.query_one("#scheduling-automation-pause-resume", Button)
+            assert button.label.plain == "Pause"
+            await pilot.click(button)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert db.get_automation_definition(definition_id)["lifecycle"] == "paused"
+            assert button.label.plain == "Resume"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_toggle_on_server_owned_row_survives_a_racing_pull(tmp_path):
+    """Pinned (task-4 brief): the pause/resume toggle's DB write races a
+    sync pull -- Task 2's own `upsert_automation_definitions_from_server`
+    lifecycle pull-guard must keep that pull from reverting the pause,
+    and that guarantee must be VISIBLE at the UI level (this pane's own
+    button) after the next paint, not merely true in the DB."""
+    db, service = _real_scheduling_service(tmp_path)
+    try:
+        # Shaped like a genuine `_load_server_automations` item (`id` is
+        # the SERVER's own id, `owner_id` stamped by that fetch) -- the
+        # shape `_resolve_local_definition_id` expects and the shape
+        # `DefinitionDetail._definition`/the toggle event actually carry
+        # in real usage. A row read back via `db.get_automation_
+        # definition` instead (LOCAL id in `id`) is a DIFFERENT shape and
+        # trips `_resolve_local_definition_id`'s own server/local branch.
+        server_item = {
+            "id": "srv-def-1",
+            "owner_id": "server:1",
+            "family": "recurring_question",
+            "name": "Server automation",
+            "lifecycle": "configured",
+            "schedule": {"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+            "input": {"question": "What shipped?"},
+            "config": {},
+            "version": 1,
+        }
+        db.upsert_automation_definitions_from_server("server:1", [server_item])
+        definition_id = db.get_automation_definition_by_server_id(
+            "server:1", "srv-def-1"
+        )["id"]
+
+        app = WorkbenchTestApp()
+        app.scheduling_service = service
+        async with app.run_test(size=(220, 60)) as pilot:
+            workbench = SchedulesWorkbench(app_instance=pilot.app)
+            await pilot.app.push_screen(workbench)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            detail = pilot.app.screen.query_one(
+                "#scheduling-automation-detail", DefinitionDetail
+            )
+            detail.set_definition(server_item)
+            await pilot.pause()
+
+            workbench._toggle_definition_lifecycle(server_item, "pause")
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert db.get_automation_definition(definition_id)["lifecycle"] == "paused"
+            # Optimistic repaint already applied, ahead of/independent of
+            # the background `_request_automations_refresh` reload.
+            button = detail.query_one("#scheduling-automation-pause-resume", Button)
+            assert button.label.plain == "Resume"
+
+            mutation = db.get_pending_mutation_for_local_id(
+                definition_id, "automation_definition"
+            )
+            assert mutation is not None
+            assert mutation["payload"]["action"] == "pause"
+
+            # A racing pull that still thinks the row is "configured" --
+            # nothing has replayed the pending mutation yet, so Task 2's
+            # guard is live for it.
+            db.upsert_automation_definitions_from_server("server:1", [server_item])
+            assert (
+                db.get_automation_definition(definition_id)["lifecycle"] == "paused"
+            )  # guarded, not reverted
+
+            # The UI-visible check: a fresh paint from this (guarded) DB
+            # state still shows Resume -- no flicker back to Pause.
+            detail.set_definition(db.get_automation_definition(definition_id))
+            await pilot.pause()
+            assert button.label.plain == "Resume"
     finally:
         db.close()
 

--- a/backlog/decisions/099-schedule-editor-shape.md
+++ b/backlog/decisions/099-schedule-editor-shape.md
@@ -72,14 +72,17 @@ better shape that needs a second shape as a safety net.
 
 The modal remains the durable shape for creation, for multi-field surgery
 ("Edit in full…" — question text, custom cron, scope rework), and as the
-narrow-width fallback where the detail pane is hidden; the width-cliff
-argument above still stands for all three, unchanged.
+way to reach every field at every width — including any width at which
+the redesign's PR-4 responsive floor later hides the detail pane (today's
+`schedules-workbench-compact` rule only narrows the panes, it never hides
+one). The width-cliff argument above still stands for all three,
+unchanged.
 
 A narrower carve-out ships alongside the redesign program's inspector-pane
-work: single-value rows in the detail pane (Repeat/At/Timezone/
-Notifications, and — recurring-question definitions only — Model/
-Generation/Finding policy/Sources, plus the header pause/resume affordance
-and the owner row's transfer dropdown) now edit in place via
+work: single-value rows in the detail pane (Repeat/At/Timezone, and —
+recurring-question definitions only — Notifications/Model/Generation/
+Finding policy/Sources, plus the header pause/resume affordance and the
+owner row's transfer dropdown) now edit in place via
 `DetailValueRow`'s activation/edit-swap API, committing or cancelling
 (Escape) without leaving the row. This does not reopen the three-shape
 comparison this ADR closed — a fixed-height row swap has none of the

--- a/backlog/decisions/099-schedule-editor-shape.md
+++ b/backlog/decisions/099-schedule-editor-shape.md
@@ -67,3 +67,23 @@ better shape that needs a second shape as a safety net.
 - The queue-as-forecast question from the same critique (lead with a
   next-24-hours timeline) is orthogonal to editor shape and remains open in
   the critique snapshot; this ADR neither adopts nor rejects it.
+
+## Amendment (2026-09-03)
+
+The modal remains the durable shape for creation, for multi-field surgery
+("Edit in full…" — question text, custom cron, scope rework), and as the
+narrow-width fallback where the detail pane is hidden; the width-cliff
+argument above still stands for all three, unchanged.
+
+A narrower carve-out ships alongside the redesign program's inspector-pane
+work: single-value rows in the detail pane (Repeat/At/Timezone/
+Notifications, and — recurring-question definitions only — Model/
+Generation/Finding policy/Sources, plus the header pause/resume affordance
+and the owner row's transfer dropdown) now edit in place via
+`DetailValueRow`'s activation/edit-swap API, committing or cancelling
+(Escape) without leaving the row. This does not reopen the three-shape
+comparison this ADR closed — a fixed-height row swap has none of the
+scrolling, discard-guard, or 80×24-floor costs that made the modal the only
+shape that worked everywhere for the *whole* form, so it was never inside
+the width-cliff argument to begin with. See
+`116-schedules-inspector-editing.md` for the full decision and rationale.

--- a/backlog/decisions/116-schedules-inspector-editing.md
+++ b/backlog/decisions/116-schedules-inspector-editing.md
@@ -50,15 +50,28 @@ every group already renders with:
    server` gained a two-layer guard scoped to the `lifecycle` column
    only, ported field-for-field from `upsert_automation_results_from_
    server`'s existing TOCTOU/same-cycle-echo design (schedules-handoff
-   program): (1) an in-transaction check for a pending local mutation
-   whose `payload["action"]` is `pause`/`resume`/`archive` withholds
-   `lifecycle` on that row for that pull; (2) a `skip_lifecycle_server_
-   ids` set, threaded from `SyncEngine`'s own lifecycle-replay phase,
-   withholds it for ids already pushed *this* sync cycle, whose pending
-   mutation is already gone by the time the pull runs. Every other field
-   keeps writing server-wins unconditionally; the guard is surgical to
-   one column because `automation_definition` also carries ordinary edit
-   and transfer mutations that must not freeze alongside a lifecycle one.
+   program): (1) an in-transaction check for a pending local mutation in
+   the `automation_lifecycle` slot withholds `lifecycle` on that row for
+   that pull; (2) a `skip_lifecycle_server_ids` set, threaded from
+   `SyncEngine`'s own lifecycle-replay phase, withholds it for ids
+   already pushed *this* sync cycle, whose pending mutation is already
+   gone by the time the pull runs. Every other field keeps writing
+   server-wins unconditionally; the guard is surgical to one column.
+4. **Lifecycle mutations get their own primitive, not a shared slot.**
+   `pending_mutations` is `UNIQUE(local_id, primitive, owner_id)`, so
+   filing pause/resume/archive under `automation_definition` alongside
+   edits and transfers gave each row exactly one queue slot: an offline
+   edit and an offline pause could not coexist, and whichever was queued
+   second destroyed the first without a trace. Recording them under
+   `automation_lifecycle` instead is a new slot **by construction, with
+   no schema migration** — both queue, both replay, both land. The
+   consequences: `SyncEngine`'s definition-push phase reads both slots
+   (definition first, so the edit's echo is adopted while the pause is
+   still queued and the pull guard above can withhold the stale
+   `lifecycle`); the guard becomes a plain slot-presence check instead of
+   a `payload["action"]` inspection; and the edit-vs-lifecycle
+   cross-action refusal is deleted. The edit-vs-**transfer** refusal
+   stays — those two do still share the definition slot.
 
 ## Context
 

--- a/backlog/decisions/116-schedules-inspector-editing.md
+++ b/backlog/decisions/116-schedules-inspector-editing.md
@@ -1,0 +1,111 @@
+# ADR-116: Schedules inspector-pane editing
+
+Status: Proposed
+Date: 2026-09-03
+Related Task: schedules-redesign PR-3 (`.superpowers/sdd/plan-2026-09-03-schedules-redesign-pr3/`)
+
+## Decision
+
+The Schedules workbench's inspector-style detail pane (spec
+`backlog/docs/spec-2026-09-02-schedules-screen-redesign.md`) edits
+single-value rows in place, through the same `DetailValueRow` grammar
+every group already renders with:
+
+1. **Hybrid editing, not a pane-only editor.** Each `Details`/`Frequency`
+   row that has a real single-field write target activates in place
+   (click/Enter opens a `Select`/`Input`/small mini-editor built from
+   `DetailValueRow.begin_edit`; the row's own commit closes it via
+   `end_edit`). Question text, custom cron, and full-scope surgery stay
+   in the create/edit modal (`ReminderForm`) behind "Edit in full…", and
+   the modal remains the fallback at narrow terminal widths where the
+   detail pane is hidden. This is the amendment to
+   `099-schedule-editor-shape.md` (see below): that ADR closed the
+   pane-vs-modal question in favor of the modal for the *whole* form;
+   this decision does not reopen that call. It carves out a narrower one
+   — single fields only, still backed by the modal everywhere the pane
+   itself is unavailable — so the width-cliff argument that made the
+   modal durable stays intact for every case that argument covers.
+2. **The owner row is the transfer surface.** "Runs on" renders like
+   every other row and its dropdown *is* the spec §7 transfer machine:
+   opening it lists `This device` / `Server (<id>)`; picking the current
+   owner is a no-op; picking the other runs `transfer_refusal` first
+   (a refusal renders inline via `DetailValueRow.show_error`, Textual
+   `Select` cannot disable one option); an allowed pick opens the PR-5
+   confirmation dialog with `transfer_warnings`; confirming drives
+   `begin_transfer_to_server`/`begin_transfer_to_local` exactly as the
+   existing Move/Retry/Cancel buttons do. Those buttons are a second,
+   independently wired surface onto the same facade and are left in
+   place through this PR (coexistence, not a refactor) — retiring them
+   is PR-4's job, alongside the responsive floor and the old tab bar.
+3. **Lifecycle writes need a pull guard, not a migration.** The
+   definition pane's header Pause/Resume button is
+   `SchedulingService.set_definition_lifecycle`'s first UI caller, and an
+   optimistic local toggle races the same server pull that already
+   overwrites every other field server-wins. Rather than add
+   conflict-resolution machinery, `upsert_automation_definitions_from_
+   server` gained a two-layer guard scoped to the `lifecycle` column
+   only, ported field-for-field from `upsert_automation_results_from_
+   server`'s existing TOCTOU/same-cycle-echo design (schedules-handoff
+   program): (1) an in-transaction check for a pending local mutation
+   whose `payload["action"]` is `pause`/`resume`/`archive` withholds
+   `lifecycle` on that row for that pull; (2) a `skip_lifecycle_server_
+   ids` set, threaded from `SyncEngine`'s own lifecycle-replay phase,
+   withholds it for ids already pushed *this* sync cycle, whose pending
+   mutation is already gone by the time the pull runs. Every other field
+   keeps writing server-wins unconditionally; the guard is surgical to
+   one column because `automation_definition` also carries ordinary edit
+   and transfer mutations that must not freeze alongside a lifecycle one.
+
+## Context
+
+The spec's unified workbench (§3) retired the old Queue/Automations/
+Conflicts/Results tab bar in favor of one filtered list (rail, ~40%) plus
+an inspector-style detail pane (~60%) whose grouped key-value rows —
+`DetailValueRow`, shipped read-only in PR-1 — were dormant placeholders
+until this PR. Three rows needed a decision beyond "wire the existing
+seam": the owner row, because it doubles as the PR-5 transfer machine
+rather than an ordinary field; the header lifecycle toggle, because it
+is the first caller of a facade method whose only existing write path
+(`SyncEngine`'s definitions pull) is unconditionally server-wins; and
+the editing model itself, because `099-schedule-editor-shape.md` had
+already closed "should Schedules edit in a pane" against the *whole*
+create/edit form, for reasons (the width cliff at narrow terminals, the
+need for a discard-guarded lifecycle) that do not disappear just because
+this PR only touches single fields.
+
+`099-schedule-editor-shape.md`'s own "Consequences" section anticipated
+this: "Reopen only if a future schedule editor must show live queue
+context while editing … reconsider all three shapes against the width
+floor rather than defaulting to the pane." This program does not reopen
+the three-shape comparison — it stays inside shape 1 (modal) for every
+case that comparison covers, and adds a narrower, additive carve-out for
+rows the modal was never uniquely necessary for in the first place: a
+`Select`/`Input` swapped into a fixed-height row commits or cancels
+(Escape) without ever needing to scroll, discard-guard across a queue
+selection change, or fit at the 80×24 floor — the modal's entire cost
+column in that ADR. Where the pane is unavailable (narrow width), Enter
+on a list row still opens the modal unchanged.
+
+## Consequences
+
+- `099-schedule-editor-shape.md` gets an "Amendment (2026-09-03)"
+  section (this PR, in place, no renumbering) rather than a superseding
+  ADR: the original decision and its width-cliff argument still hold for
+  the surface it actually decided (create/full-edit/narrow fallback).
+- The owner row's dropdown and the legacy Move/Retry/Cancel buttons are
+  two live surfaces onto one facade (`SchedulingService.transfer_
+  refusal`/`transfer_warnings`/`begin_transfer_to_server`/`begin_
+  transfer_to_local`/`cancel_transfer`) until PR-4 removes the legacy
+  one; a future change to transfer semantics must update both call
+  sites until then.
+- The lifecycle pull-guard is intentionally column-scoped, not a general
+  per-row conflict system — a future field that needs the same
+  optimistic-write protection (e.g. a second lifecycle-shaped write path)
+  should extend the existing `_DEFINITION_LIFECYCLE_ACTIONS`/`skip_
+  lifecycle_server_ids` mechanism or its `upsert_automation_results_
+  from_server` sibling, not invent a third pattern.
+- No schema migration: every write in this PR routes through seams that
+  already existed (`save_definition`, `update_reminder`, `set_
+  definition_lifecycle`, the PR-5 transfer facade); the only DB change is
+  the two-layer guard's extra `SELECT`/parameter, not a new column or
+  table.

--- a/backlog/decisions/116-schedules-inspector-editing.md
+++ b/backlog/decisions/116-schedules-inspector-editing.md
@@ -16,14 +16,18 @@ every group already renders with:
    (click/Enter opens a `Select`/`Input`/small mini-editor built from
    `DetailValueRow.begin_edit`; the row's own commit closes it via
    `end_edit`). Question text, custom cron, and full-scope surgery stay
-   in the create/edit modal (`ReminderForm`) behind "Edit in full…", and
-   the modal remains the fallback at narrow terminal widths where the
-   detail pane is hidden. This is the amendment to
+   in the create/edit modal (`ReminderForm`) behind "Edit in full…",
+   which stays reachable at every width. (The workbench's only
+   responsive rule today, `_sync_responsive_workbench`'s
+   `schedules-workbench-compact` class, NARROWS the panes; it never
+   hides one. A width at which the detail pane is hidden altogether is
+   PR-4's responsive floor to define, and the modal is the fallback
+   there when it does.) This is the amendment to
    `099-schedule-editor-shape.md` (see below): that ADR closed the
    pane-vs-modal question in favor of the modal for the *whole* form;
    this decision does not reopen that call. It carves out a narrower one
-   — single fields only, still backed by the modal everywhere the pane
-   itself is unavailable — so the width-cliff argument that made the
+   — single fields only, with the modal still the way to reach every
+   field, at every width — so the width-cliff argument that made the
    modal durable stays intact for every case that argument covers.
 2. **The owner row is the transfer surface.** "Runs on" renders like
    every other row and its dropdown *is* the spec §7 transfer machine:
@@ -83,8 +87,9 @@ rows the modal was never uniquely necessary for in the first place: a
 `Select`/`Input` swapped into a fixed-height row commits or cancels
 (Escape) without ever needing to scroll, discard-guard across a queue
 selection change, or fit at the 80×24 floor — the modal's entire cost
-column in that ADR. Where the pane is unavailable (narrow width), Enter
-on a list row still opens the modal unchanged.
+column in that ADR. Enter on a list row still opens the modal
+unchanged, at every width — including any width at which PR-4's
+responsive floor later decides to hide the detail pane.
 
 ## Consequences
 

--- a/backlog/docs/lessons-textual.md
+++ b/backlog/docs/lessons-textual.md
@@ -439,3 +439,26 @@ restores the opener (focus was inside the popup); outside-click and stranded-Esc
 paths skip it. The pinned test is
 `test_click_outside_closes_the_menu_without_dispatching`, which asserts focus is NOT
 the opener after the click.
+
+## `run_worker(exclusive=True)` CANCELS the group — it never queues behind it
+
+**schedules-redesign PR-3 Qodo round, 2026-09-03.** The Automations pane's in-place
+row editors dispatch one `save_definition` worker per commit, and `save_definition`
+merges the payload onto the row it reads at entry — a read-merge-write. A first review
+found that grouping every commit under one key made a second row's edit cancel the
+first mid-flight (fixed by keying the group per FIELD); the Qodo round then found the
+mirror bug: per-field groups let two fields of the SAME definition run concurrently, so
+the slower one wrote back a snapshot taken before the faster one landed. The pinned
+test (`test_two_fields_of_one_definition_both_land_without_a_lost_update`) fails on the
+per-field version with `KeyError: 'model'` — the first edit is simply gone.
+
+The obvious fix — key the group per definition and keep `exclusive=True` — does NOT
+serialize them. `WorkerManager._new_worker` cancels the group's running workers and
+then starts the new one; there is no queue. That version fails the same test from the
+other side, with `WorkerCancelled: Worker was cancelled, and did not complete.`
+raised out of `pilot.app.workers.wait_for_complete()`.
+
+`exclusive=True` means "only the newest matters" (a live filter, a repaint, a search).
+When every dispatch must actually land, that is the wrong primitive: hold an
+`asyncio.Lock` keyed by whatever must serialize, and leave the worker non-exclusive.
+The group name is then only a label for observability.

--- a/backlog/docs/plan-2026-09-03-schedules-redesign-pr3.md
+++ b/backlog/docs/plan-2026-09-03-schedules-redesign-pr3.md
@@ -1,0 +1,80 @@
+# Schedules Redesign — PR-3: In-pane editing + owner-row transfer + lifecycle pull-guard + ADRs
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The dormant PR-1 surfaces come alive: single-value rows on both detail panes edit in place through the existing facade seams with field-addressed errors inline; "Runs on" becomes the transfer dropdown (refusal → inline error; confirm → the PR-5 machine); lifecycle pause/resume gets its first UI caller with the pull-guard that keeps optimistic writes from flickering back; the program's ADR-116 (renumbered from 115 at commit-time sweep) and the ADR-099-schedule-editor-shape amendment land.
+
+**Architecture:** `DetailValueRow` gains an activation message and a value↔editor swap API (`begin_edit(widget)`/`end_edit()` — the MediaDetailsWidget edit-mode toggle scaled to one row); rows stay dumb, panes provide the editor (plain `Select`/`Input` reuse — no repo inline idiom exists, modal pickers are too heavy for closed enums) and commit through the seams: definitions via `save_definition(definition_id=...)` (merge-on-edit; **schedule dicts resend whole — one-level merge only**), reminders via a NEW service-side validation bridge (`update_reminder` today surfaces raw Pydantic errors — the bridge returns the same `{field,code,message}` shape definitions get). Lifecycle rows route through `set_definition_lifecycle` (its first UI caller); `upsert_automation_definitions_from_server` gains the two-layer pending-mutation guard ported from the results upsert, scoped to lifecycle-action mutations. The owner row's dropdown feeds from `_runs_on_options()` and drives `transfer_refusal` → `ConfirmationDialog` + `transfer_warnings` → `begin_transfer_*`, with refusals rendering through `show_error` (their first row-level surface). `DefinitionDetail` gains the transfer-lock UI wiring `TaskDetail` already has.
+
+**Tech Stack:** Python ≥3.11, Textual 8.x, SQLite, pytest.
+
+**Spec:** `backlog/docs/spec-2026-09-02-schedules-screen-redesign.md` §6/§7 (tracked on dev). Planning rulings (binding):
+1. **Editing scope**: exactly the spec-§5 single-value rows — reminder Frequency (Repeat preset/At/Timezone/Notifications); definition Details (Model, Generation, Finding policy, Sources) + Frequency (Repeat/At/Timezone, Notifications) + header pause/resume via lifecycle. Question text, custom cron, scope rework stay in the modals ("Edit in full…" unchanged). NO debounce machinery (per-record mutation coalescing already exists).
+2. **Commit semantics**: commit-on-close (Select change or Input submit → immediate seam call); success repaints the row from the authoritative re-read; failure renders the field-addressed error via `show_error` and restores the display value. Locked rows (transfer in-flight/dormant): the affordance disables and activation shows `transfer_lock_reason` via `show_error` — the same guard surface, never a silent no-op.
+3. **Owner row = the spec-§7 flow verbatim**: dropdown always renders; a refused target's selection → `transfer_refusal` reason inline under the row (Textual Selects cannot disable per-option — documented); allowed → `ConfirmationDialog` listing `transfer_warnings` → `begin_transfer_to_server/to_local`; in-flight → the existing badge + Cancel affordance (route release-leg cancels to the DORMANT COPY's row id — the PR-5 lesson).
+4. **Lifecycle pull-guard**: port the results-upsert two-layer guard (in-transaction pending-mutation check + same-cycle skip set) onto the definitions upsert, scoped to mutations whose payload `action ∈ {pause,resume,archive}` — lifecycle fields only; every other field stays server-wins. No migration.
+5. **ADRs by filename**: new `backlog/decisions/116-schedules-inspector-editing.md` (the unified-workbench IA + hybrid editing decision, spec §10); amend `099-schedule-editor-shape.md` in place (Status → Amended-by-115 note + the hybrid carve-out) — cite by FILENAME everywhere (the 099 number collision is renumbered elsewhere).
+6. **Reminder validation bridge**: a `ReminderEditOutcome`-shaped service wrapper (status + `{field,code,message}` errors) — NOT a raw exception surface; reuses the schedule validators the create form uses.
+
+## Global Constraints
+
+- Worktree `/Users/macbook-dev/Documents/GitHub/tldw_chatbook-redesign-pr3`, branch `feat/schedules-inline-editing` off current `origin/dev`. Never the main checkout; NEVER `git stash`; no pkill beyond own PIDs; `git --no-pager`; FOREGROUND pytest only; tmp_path DBs.
+- NO schema migration. Editing routes through EXISTING seams only — any new write path is a plan violation; escalate instead.
+- Survey with exact seams: `redesign-pr3-survey.md` in the SDD workspace.
+- Diagnostics pin is a SCRIPT (`--write` + commit JSON) on any logger change. Census merge bar = COUNT parity vs dev CI. CSS via build flow, `$ds-*` tokens, source+bundle together. Geometry/paint tests need `CSS_PATH = BUNDLED_STYLESHEET`. Painted assertions only. `DetailGroup(title=...)` keyword-only. Escape/Text discipline on all values.
+- Preservation: read-only behavior of non-edited rows, all existing actions/badges/tests — zero unrelated assertion changes.
+- UI change ⇒ `Docs/User_Guide/` schedules page.
+- Commit trailer on every commit:
+
+```
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01WocisXw6SEEG6nb1aKFHtv
+```
+
+---
+
+### Task 1: DetailValueRow activation + edit-swap API
+
+**Files:** Modify `tldw_chatbook/Widgets/detail_value_row.py` (+CSS via the features file). Test: `Tests/UI/test_detail_value_row.py`.
+
+**Interfaces (produced; Tasks 3-5 consume):**
+- Message `DetailValueRow.Activated(row)` posted on click/Enter WHEN `affordance` is truthy AND no editor is open (dormant rows stay inert — preservation).
+- `begin_edit(editor: Widget) -> None`: hides the value, mounts the editor in its place, focuses it; `end_edit(*, restore_focus: bool = True) -> None`: unmounts, re-shows the value. One editor at a time; `begin_edit` while editing is a guarded no-op. The error line (`show_error`) coexists with an open editor.
+- `affordance` gains a visual live state (the `▾` un-dims) — read the PR-1 dimmed styling and add the active variant.
+
+- [ ] TDD: activation fires only with affordance + not-editing (painted + message assertions); swap round-trip (value hidden, editor mounted/focused, end_edit restores); guarded double-begin; error line + editor coexistence; dormant rows inert. FAIL → implement → PASS → commit `feat(ui): DetailValueRow activation + edit swap`.
+
+### Task 2: Reminder validation bridge + lifecycle pull-guard (service/DB)
+
+**Files:** Modify `tldw_chatbook/Scheduling/services/scheduling_service.py` (+`ReminderEditOutcome` dataclass + `async edit_reminder_fields(task_id, payload) -> ReminderEditOutcome` wrapping `update_reminder` — validates via the SAME schedule validators the create form uses (survey: the forgiving-datetime/preset helpers), catches the Pydantic surface, returns `{field,code,message}` errors; respects `transfer_lock_reason` — a locked row returns the reason as a field error on `_row`), `tldw_chatbook/Scheduling/db/scheduled_tasks_db.py` (the lifecycle pull-guard per ruling 4 — port the results-upsert two-layer mechanism: in-transaction check for a pending `automation_definition` mutation with `action ∈ {pause,resume,archive}` → skip `lifecycle` field on that row; plus the same-cycle skip-set parameter threaded from the sync engine's push phase like `skip_review_server_ids`), `tldw_chatbook/Scheduling/services/sync_engine.py` (thread the pushed-lifecycle skip set — mirror the review-pushback precedent exactly). Tests: `test_scheduling_service.py`, `test_scheduled_tasks_db.py`, `test_sync_engine.py`.
+
+- [ ] TDD: bridge returns field errors for junk schedule/timezone (no raw exception escapes); locked-row refusal; valid edit persists + records the mutation under the ROW owner (the PR-2 threading); pull-guard both layers (pending lifecycle mutation → lifecycle field skipped, other fields still server-wins; same-cycle pushed set skips; no mutation → server-wins unchanged); fault-ordering pinned like the results precedent. FAIL → implement → PASS → commit `feat(scheduling): reminder edit bridge + lifecycle pull-guard`.
+
+### Task 3: Reminder pane in-pane editing
+
+**Files:** Modify `tldw_chatbook/UI/Screens/scheduling/task_detail.py` (Frequency rows editable: Repeat preset Select, At Input (forgiving datetime/time — reuse the create-form parsing), Timezone Select (the create form's option source incl. the stored-zone preservation lesson), Notifications Select; commits via Task 2's bridge; success repaints from the re-read, failure → `show_error` + restore; locked rows per ruling 2), workbench wiring for the re-read/refresh after a successful edit (the unified list's row must update — the existing refresh seam). Tests: task_detail/workbench files + unified-list file.
+
+- [ ] TDD: each row's editor opens with the CURRENT value preselected; commit persists (authoritative repaint pinned); a server-owned row's edit records the mutation (row-owner threading pinned); junk At value → inline error + display restored; locked row → reason shown, no editor; non-edited behaviors preserved (zero unrelated assertion changes). FAIL → implement → PASS → commit `feat(scheduling): reminder frequency rows edit in place`.
+
+### Task 4: Definition pane in-pane editing + lifecycle UI
+
+**Files:** Modify `tldw_chatbook/UI/Screens/scheduling/definition_detail.py` (Details rows: Model Input (blank = provider default — the PR-1 "Not set" honesty preserved), Generation Select, Finding-policy Select, Sources multi-toggle (the smallest honest editor — a Select of the 7 combinations is ugly; prefer a 3-checkbox mini-editor mounted via begin_edit, or sequential toggles — pick and document), Frequency rows (schedule edits RESEND THE WHOLE schedule dict — the one-level-merge constraint; build it from the row's current schedule + the edited field), Notifications Select; commits via `save_definition(definition_id=...)`, errors field-addressed; locked rows per ruling 2 + `DefinitionDetail` gains the transfer-lock wiring TaskDetail has (survey point 10)), header pause/resume affordance → `set_definition_lifecycle` (FIRST UI caller: optimistic repaint + the Task 2 pull-guard keeps it from flickering; server rows record the mutation, local rows write direct — read the producer). Tests: definition_detail/automations-tab files.
+
+- [ ] TDD: each row edits + persists (server echo mirrored for online server rows; offline queues); schedule-field edit resends the whole dict (pinned — an edited At must not drop the kind/timezone); lifecycle toggle round-trip with a pull racing it (guard pinned at the UI-visible level: no flicker-back); sources editor honest; locked + "Not set" states preserved. FAIL → implement → PASS → commit `feat(scheduling): definition rows edit in place + lifecycle toggle`.
+
+### Task 5: Owner-row transfer dropdown
+
+**Files:** Modify both panes (the "Runs on" row: affordance on; activation mounts a Select fed by `SchedulesWorkbench._runs_on_options()` — hoist/share if it's workbench-private; selection == current owner → close; other owner → `transfer_refusal` first (reason via `show_error`, editor closes, value restored), allowed → `ConfirmationDialog` with `transfer_warnings` list → confirmed → `begin_transfer_to_server`/`to_local` by direction; outcome drives the existing badge rendering; in-flight rows: affordance disabled + Cancel affordance (release-leg cancel targets the dormant copy's id — assert it); failed: Retry via re-begin), workbench routing. Tests: both pane files + transfer-actions file.
+
+- [ ] TDD: dropdown opens with current owner; same-owner close is a no-op; refused target → inline reason (health-quoting pinned); allowed → dialog lists warnings → confirm fires the right facade call with the right row id per direction (dormant-copy case pinned); cancel/retry affordances; existing transfer buttons/badges unchanged (they remain until PR-4 — coexistence pinned). FAIL → implement → PASS → commit `feat(scheduling): owner-row transfer dropdown`.
+
+### Task 6: ADRs + docs + gates
+
+**Files:** Create `backlog/decisions/116-schedules-inspector-editing.md` (Status Proposed; the unified-workbench IA recap + the hybrid editing decision + the owner-row-as-transfer-surface + the lifecycle pull-guard rationale; cites the spec + `099-schedule-editor-shape.md` BY FILENAME). Modify `backlog/decisions/099-schedule-editor-shape.md` (append an Amendment section: the modal remains for create/full-edit/narrow fallback; single-value rows edit in the pane per ADR-116 (renumbered from 115 at commit-time sweep) — do NOT renumber, do NOT touch the colliding 099 file). Update `Docs/User_Guide/` schedules page (editing, owner dropdown, pause/resume). Gates.
+
+- [ ] Full `Tests/Scheduling/ -q`; the assembled schedules UI set; census (count parity vs dev CI); pin script; ruff; bundle byte-identical. Verify ADR-116 (renumbered from 115 at commit-time sweep) is still unclaimed on origin/dev AND across remote branches at commit time (the collision lesson — sweep). Commit `docs(scheduling): ADR-116 (renumbered from 115 at commit-time sweep) + 099 amendment + editing docs`.
+
+---
+
+## After the tasks
+Final whole-branch review (opus; editing-correctness + guard-coherence + preservation lenses) → one fix wave → PR `feat(scheduling): in-pane editing + owner-row transfer (redesign PR-3)` → paged bot read → adjudicate → the full cycle (rebase→artifacts→gate→push→watch→merge-in-loop) as ONE background pipeline; coordinate a merge window with the peer session if the treadmill exceeds two laps.

--- a/backlog/docs/spec-2026-09-02-schedules-screen-redesign.md
+++ b/backlog/docs/spec-2026-09-02-schedules-screen-redesign.md
@@ -119,6 +119,13 @@ owns exclusively and we cannot push (none today — lifecycle, model,
 schedule, notifications all have push paths post-PR-5) would render
 read-only with a reason.
 
+> **Errata (PR-3, T6):** the "notifications … push paths post-PR-5" claim
+> above does not hold for reminders — a reminder's Notifications row has no
+> backing schema field at all (verified during PR-3 task 3; a dispatch
+> always writes the same fixed inbox+toast), so it stays read-only until a
+> field exists to push. `recurring_question` definitions do carry a real
+> notifications toggle and edit in place per §6.
+
 ## 6. Editing model (ADR-099 amendment)
 
 - In-pane quick edits cover single-value rows only. Each row commit goes

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -2662,6 +2662,22 @@ class ScheduledTasksDB(BaseDB):
     #: value -- see sync_engine.py's `_RESULT_REVIEW_PRIMITIVE`).
     _RESULT_REVIEW_PRIMITIVE = "automation_result_review"
 
+    #: Primitive name pending `automation_definition` mutations are
+    #: stored under -- matches `SchedulingService._DEFINITION_PRIMITIVE`/
+    #: `SyncEngine._DEFINITION_PRIMITIVE` (duplicated per-module, same
+    #: precedent as `_RESULT_REVIEW_PRIMITIVE` above). This ONE primitive
+    #: covers `save_definition`'s edit path, the transfer machine, AND
+    #: lifecycle mutations -- see `_DEFINITION_LIFECYCLE_ACTIONS` below
+    #: for how the lifecycle pull-guard tells them apart.
+    _DEFINITION_PRIMITIVE = "automation_definition"
+
+    #: `payload["action"]` values that identify a pending
+    #: `automation_definition` mutation as a LIFECYCLE change specifically
+    #: (as opposed to an edit or transfer mutation sharing the same
+    #: primitive) -- matches `SchedulingService._LIFECYCLE_ACTIONS`'s keys
+    #: and the verbs `SyncEngine._push_definition_lifecycle` replays.
+    _DEFINITION_LIFECYCLE_ACTIONS = frozenset({"pause", "resume", "archive"})
+
     #: Result columns that may be copied verbatim from a server item on
     #: insert, beyond id/server_id/owner_id (handled separately).
     _AUTOMATION_RESULT_INSERT_FIELDS = _AUTOMATION_RESULT_COLUMNS | {
@@ -2677,17 +2693,52 @@ class ScheduledTasksDB(BaseDB):
     }
 
     def upsert_automation_definitions_from_server(
-        self, owner_id: str, items: list[dict[str, Any]]
+        self,
+        owner_id: str,
+        items: list[dict[str, Any]],
+        *,
+        skip_lifecycle_server_ids: frozenset[str] = frozenset(),
     ) -> dict[str, int]:
         """Server-wins mirror of automation definitions pulled from the server.
 
         Matches local rows by ``(owner_id, server_id)``. Absent -> insert a
         new mirror row (server ``id`` becomes local ``server_id``; local
         ``id`` is a fresh UUID). Present -> every server-carried field is
-        written EXCEPT ``transfer_state``: a server payload must never
-        clear a local transfer marker (spec-2026-08-31-schedules-handoff-
-        parity.md §6 parked finding). Archived lifecycle mirrors like any
-        other field -- rows are never deleted here.
+        written EXCEPT ``transfer_state`` (unconditional -- spec-2026-08-
+        31-schedules-handoff-parity.md §6 parked finding: a server payload
+        must never clear a local transfer marker) and, conditionally,
+        ``lifecycle``. Rows are never deleted here (an archived lifecycle
+        mirrors like any other field, when not withheld below).
+
+        ``lifecycle`` pull-guard (redesign PR-3 ruling 4), two layers --
+        SURGICAL: only ``lifecycle`` is ever withheld, every other field
+        on the row still writes server-wins. Mirrors
+        `upsert_automation_results_from_server`'s two-layer TOCTOU/same-
+        cycle guard (see that method's docstring for the full rationale)
+        but scoped to one field instead of a fixed field allowlist,
+        because `automation_definition` is a much busier primitive: it
+        also carries `save_definition`'s edit-path mutations and the
+        transfer machine's, so a bare "any pending mutation for this row"
+        check would wrongly freeze `lifecycle` during an unrelated
+        pending edit or transfer. `_definition_lifecycle_guard_active`
+        (below) is what tells a lifecycle mutation apart from those --
+        it inspects `payload["action"]` against
+        `_DEFINITION_LIFECYCLE_ACTIONS`.
+
+        1. Pending-mutation guard: a per-row `pending_mutations` SELECT
+           run inside THIS write transaction, immediately before that
+           row's own UPDATE -- an unpushed local `pause`/`resume`/
+           `archive` outranks the mirror until `SyncEngine`'s lifecycle
+           replay (which runs before this pull in `sync_now`) has pushed
+           it.
+        2. Pushed-this-cycle guard: `server_id in
+           skip_lifecycle_server_ids`, a `frozenset[str]` threaded in
+           from `SyncEngine._replay_definition_mutations` with ids it
+           already pushed THIS sync cycle -- their pending mutation is
+           already gone by the time this pull runs, so guard 1 can't see
+           them; without this second layer a same-cycle definitions page
+           that still echoes the pre-transition lifecycle (server write/
+           read-path lag) would revert the change that was just pushed.
 
         Returns:
             ``{"inserted": n, "updated": n}``.
@@ -2743,6 +2794,17 @@ class ScheduledTasksDB(BaseDB):
                 else:
                     if not fields:
                         continue
+                    if "lifecycle" in fields and self._definition_lifecycle_guard_active(
+                        conn,
+                        owner_id,
+                        existing["id"],
+                        server_id,
+                        skip_lifecycle_server_ids,
+                    ):
+                        fields = dict(fields)
+                        del fields["lifecycle"]
+                        if not fields:
+                            continue
                     serialized = self._serialize_definition_fields(fields)
                     self._validate_sql_identifiers(list(serialized.keys()))
                     updates = ", ".join(f"{key} = ?" for key in serialized)
@@ -2752,6 +2814,42 @@ class ScheduledTasksDB(BaseDB):
                     )
                     updated += 1
         return {"inserted": inserted, "updated": updated}
+
+    def _definition_lifecycle_guard_active(
+        self,
+        conn: sqlite3.Connection,
+        owner_id: str,
+        existing_id: str,
+        server_id: str,
+        skip_lifecycle_server_ids: frozenset[str],
+    ) -> bool:
+        """True when this row's server-wins update must withhold ``lifecycle``.
+
+        See `upsert_automation_definitions_from_server`'s docstring for
+        the full two-layer design; this is guard 1 (pending-mutation) and
+        guard 2 (pushed-this-cycle) combined into the one per-row check
+        its caller needs.
+        """
+        if server_id in skip_lifecycle_server_ids:
+            return True
+        row = conn.execute(
+            """
+            SELECT payload FROM pending_mutations
+            WHERE local_id = ? AND primitive = ? AND owner_id = ?
+            LIMIT 1
+            """,
+            (existing_id, self._DEFINITION_PRIMITIVE, owner_id),
+        ).fetchone()
+        if row is None:
+            return False
+        try:
+            payload = json.loads(row["payload"])
+        except (TypeError, ValueError):
+            return False
+        return (
+            isinstance(payload, dict)
+            and payload.get("action") in self._DEFINITION_LIFECYCLE_ACTIONS
+        )
 
     def _serialize_definition_fields(self, fields: dict[str, Any]) -> dict[str, Any]:
         """Apply the same JSON/datetime conversion `update_automation_definition` uses.

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -2779,6 +2779,19 @@ class ScheduledTasksDB(BaseDB):
                     insert_fields.setdefault("lifecycle", "configured")
                     insert_fields.setdefault("health", "execution_unavailable")
                     insert_fields.setdefault("version", 1)
+                    # task-4 review Finding 1: a server item that omits
+                    # these keys entirely used to leave the column SQL
+                    # NULL (no schema-level DEFAULT for any of the three,
+                    # unlike finding_policy/retention_policy) -- distinct
+                    # from `{}`, which every local-authoring write path
+                    # already normalizes to. `_merge_definition_payload`'s
+                    # `isinstance(stored, dict)` check treated NULL as
+                    # "nothing to merge", not "empty", so a later row edit
+                    # dropped the untouched group entirely (e.g. `input`
+                    # losing `question`) instead of preserving it.
+                    insert_fields.setdefault("input", {})
+                    insert_fields.setdefault("config", {})
+                    insert_fields.setdefault("notification_policy", {})
                     insert_fields.setdefault("created_at", now_iso)
                     insert_fields.setdefault("updated_at", now_iso)
                     serialized = self._serialize_definition_fields(insert_fields)

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -2665,18 +2665,28 @@ class ScheduledTasksDB(BaseDB):
     #: Primitive name pending `automation_definition` mutations are
     #: stored under -- matches `SchedulingService._DEFINITION_PRIMITIVE`/
     #: `SyncEngine._DEFINITION_PRIMITIVE` (duplicated per-module, same
-    #: precedent as `_RESULT_REVIEW_PRIMITIVE` above). This ONE primitive
-    #: covers `save_definition`'s edit path, the transfer machine, AND
-    #: lifecycle mutations -- see `_DEFINITION_LIFECYCLE_ACTIONS` below
-    #: for how the lifecycle pull-guard tells them apart.
+    #: precedent as `_RESULT_REVIEW_PRIMITIVE` above). Covers
+    #: `save_definition`'s edit path and the transfer machine; lifecycle
+    #: changes live in their OWN primitive, below.
     _DEFINITION_PRIMITIVE = "automation_definition"
 
-    #: `payload["action"]` values that identify a pending
-    #: `automation_definition` mutation as a LIFECYCLE change specifically
-    #: (as opposed to an edit or transfer mutation sharing the same
-    #: primitive) -- matches `SchedulingService._LIFECYCLE_ACTIONS`'s keys
-    #: and the verbs `SyncEngine._push_definition_lifecycle` replays.
-    _DEFINITION_LIFECYCLE_ACTIONS = frozenset({"pause", "resume", "archive"})
+    #: Primitive name pending pause/resume/archive mutations are stored
+    #: under -- matches `SchedulingService._LIFECYCLE_PRIMITIVE`/
+    #: `SyncEngine._LIFECYCLE_PRIMITIVE` (same per-module duplication
+    #: precedent as the two constants above).
+    #:
+    #: A SEPARATE primitive, not a `payload["action"]` discriminator
+    #: inside `_DEFINITION_PRIMITIVE` (Qodo findings 5+6, which reversed
+    #: final review C1's cross-action refusal): `pending_mutations` is
+    #: `UNIQUE(local_id, primitive, owner_id)`, so one shared primitive
+    #: gave a row exactly ONE queue slot -- an edit and a pause could not
+    #: coexist, and whichever was queued second destroyed the first
+    #: (`record_pending_mutation`'s `INSERT OR REPLACE`). Its own
+    #: primitive IS its own slot, by construction and with no schema
+    #: change: both queue, both replay, both land. It also reduces the
+    #: lifecycle pull-guard below to a plain "is anything queued in the
+    #: lifecycle slot" check instead of a payload inspection.
+    _LIFECYCLE_PRIMITIVE = "automation_lifecycle"
 
     #: Result columns that may be copied verbatim from a server item on
     #: insert, beyond id/server_id/owner_id (handled separately).
@@ -2715,15 +2725,11 @@ class ScheduledTasksDB(BaseDB):
         on the row still writes server-wins. Mirrors
         `upsert_automation_results_from_server`'s two-layer TOCTOU/same-
         cycle guard (see that method's docstring for the full rationale)
-        but scoped to one field instead of a fixed field allowlist,
-        because `automation_definition` is a much busier primitive: it
-        also carries `save_definition`'s edit-path mutations and the
-        transfer machine's, so a bare "any pending mutation for this row"
-        check would wrongly freeze `lifecycle` during an unrelated
-        pending edit or transfer. `_definition_lifecycle_guard_active`
-        (below) is what tells a lifecycle mutation apart from those --
-        it inspects `payload["action"]` against
-        `_DEFINITION_LIFECYCLE_ACTIONS`.
+        but scoped to one field instead of a fixed field allowlist.
+        `_definition_lifecycle_guard_active` (below) keys off
+        `_LIFECYCLE_PRIMITIVE`, the lifecycle mutations' own queue slot,
+        so an unrelated pending edit or transfer (which live in
+        `_DEFINITION_PRIMITIVE`) never wrongly freezes ``lifecycle``.
 
         1. Pending-mutation guard: a per-row `pending_mutations` SELECT
            run inside THIS write transaction, immediately before that
@@ -2844,27 +2850,24 @@ class ScheduledTasksDB(BaseDB):
         its callers need. `adopt_server_definition_identity` is the second
         caller (final review C1's belt) and passes an empty skip-set:
         layer 2 is a PULL-side concept.
+
+        Keyed on `_LIFECYCLE_PRIMITIVE` -- lifecycle mutations have their
+        own queue slot (Qodo findings 5+6), so mere PRESENCE of a row
+        there is the whole test; the old shared-slot version had to parse
+        `payload["action"]` to tell a pause apart from an edit sharing
+        the definition primitive.
         """
         if server_id in skip_lifecycle_server_ids:
             return True
         row = conn.execute(
             """
-            SELECT payload FROM pending_mutations
+            SELECT 1 FROM pending_mutations
             WHERE local_id = ? AND primitive = ? AND owner_id = ?
             LIMIT 1
             """,
-            (existing_id, self._DEFINITION_PRIMITIVE, owner_id),
+            (existing_id, self._LIFECYCLE_PRIMITIVE, owner_id),
         ).fetchone()
-        if row is None:
-            return False
-        try:
-            payload = json.loads(row["payload"])
-        except (TypeError, ValueError):
-            return False
-        return (
-            isinstance(payload, dict)
-            and payload.get("action") in self._DEFINITION_LIFECYCLE_ACTIONS
-        )
+        return row is not None
 
     def _serialize_definition_fields(self, fields: dict[str, Any]) -> dict[str, Any]:
         """Apply the same JSON/datetime conversion `update_automation_definition` uses.

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -2841,7 +2841,9 @@ class ScheduledTasksDB(BaseDB):
         See `upsert_automation_definitions_from_server`'s docstring for
         the full two-layer design; this is guard 1 (pending-mutation) and
         guard 2 (pushed-this-cycle) combined into the one per-row check
-        its caller needs.
+        its callers need. `adopt_server_definition_identity` is the second
+        caller (final review C1's belt) and passes an empty skip-set:
+        layer 2 is a PULL-side concept.
         """
         if server_id in skip_lifecycle_server_ids:
             return True
@@ -2920,6 +2922,21 @@ class ScheduledTasksDB(BaseDB):
         local row this mutation came from, rather than matching by
         ``(owner_id, server_id)``.
 
+        Carries the SAME ``lifecycle`` pull-guard as that upsert (final
+        review C1's belt): an echo applied here is just as capable of
+        reverting an unpushed local `pause` as a pulled page is, and this
+        path had no guard at all. The window is real -- an online
+        `save_definition` reads the queue, goes to the network, and the
+        user presses Pause before the echo comes back -- and the guard's
+        pending-mutation SELECT runs INSIDE this same write transaction
+        for exactly that reason, the TOCTOU discipline
+        `upsert_automation_results_from_server`'s docstring sets out.
+        Only guard layer 1 applies: this is the PUSH side, so there is no
+        "already pushed this cycle" skip-set to thread. The guard is
+        surgical -- only ``lifecycle`` is ever withheld; ``server_id`` and
+        every other echoed field still write, so the adopt's own job
+        (linking the local row to its new server identity) always lands.
+
         Args:
             local_id: The local definition row that pushed the mutation.
             server_item: The definition row echoed back by the server's
@@ -2943,10 +2960,23 @@ class ScheduledTasksDB(BaseDB):
         fields.pop("transfer_state", None)
         fields["server_id"] = server_id
 
-        serialized = self._serialize_definition_fields(fields)
-        self._validate_sql_identifiers(list(serialized.keys()))
-        updates = ", ".join(f"{key} = ?" for key in serialized)
         with self.transaction() as conn:
+            if "lifecycle" in fields:
+                owner_row = conn.execute(
+                    "SELECT owner_id FROM automation_definitions WHERE id = ?",
+                    (local_id,),
+                ).fetchone()
+                if owner_row is not None and self._definition_lifecycle_guard_active(
+                    conn,
+                    str(owner_row["owner_id"]),
+                    local_id,
+                    str(server_id),
+                    frozenset(),
+                ):
+                    del fields["lifecycle"]
+            serialized = self._serialize_definition_fields(fields)
+            self._validate_sql_identifiers(list(serialized.keys()))
+            updates = ", ".join(f"{key} = ?" for key in serialized)
             cursor = conn.execute(
                 f"UPDATE automation_definitions SET {updates} WHERE id = ?",
                 [*serialized.values(), local_id],

--- a/tldw_chatbook/Scheduling/events.py
+++ b/tldw_chatbook/Scheduling/events.py
@@ -177,6 +177,47 @@ class DefinitionLifecycleToggleRequested(Message):
         self.action = action
 
 
+class ReminderOwnerActionRequested(Message):
+    """Posted by the reminder pane's 'Runs on' row (redesign PR-3, task 5):
+    a dropdown owner pick (``action`` is the transfer direction,
+    ``"to_server"``/``"to_local"``), or the row's own proactively-shown
+    Cancel/Retry affordance for an in-flight/failed transfer (``action``
+    is ``"cancel"``/``"retry"``).
+
+    ``row`` travels with it (same "carry the widget the handler needs"
+    idiom `DetailValueRow.Activated`/`ReminderFieldEditRequested` already
+    use) so the workbench can call `row.show_error(...)` directly on a
+    refusal -- this row's transfer refusals render inline (health-quoting
+    preserved), NOT through the legacy toast the existing Move/Cancel/
+    Retry buttons still use (`SchedulesWorkbench._begin_transfer`'s own
+    ``notify(reason, ...)``) -- the two surfaces are deliberately
+    independent (coexistence, task-5 brief). `TaskDetail` has already
+    called `row.end_edit()` (a dropdown commit) before posting this.
+    """
+
+    def __init__(self, task: ReminderTask, action: str, row: DetailValueRow) -> None:
+        super().__init__()
+        self.task = task
+        self.action = action
+        self.row = row
+
+
+class DefinitionOwnerActionRequested(Message):
+    """Definition-pane counterpart of `ReminderOwnerActionRequested`
+    (redesign PR-3, task 5). ``definition`` is the raw dict
+    `DefinitionDetail.set_definition` was last painted with, same
+    resolve-to-a-local-id handling as `DefinitionFieldEditRequested`.
+    """
+
+    def __init__(
+        self, definition: dict[str, Any], action: str, row: DetailValueRow
+    ) -> None:
+        super().__init__()
+        self.definition = definition
+        self.action = action
+        self.row = row
+
+
 class SyncCompleted(Message):
     """Posted when a non-failing sync attempt completes.
 

--- a/tldw_chatbook/Scheduling/events.py
+++ b/tldw_chatbook/Scheduling/events.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from textual.message import Message
 
+from ..Widgets.detail_value_row import DetailValueRow
 from .models import ReminderTask
 
 
@@ -100,6 +101,30 @@ class RetryTransferRequested(Message):
     def __init__(self, task: ReminderTask) -> None:
         super().__init__()
         self.task = task
+
+
+class ReminderFieldEditRequested(Message):
+    """Posted when a reminder-pane Frequency row's inline editor commits
+    an edit (redesign PR-3, task 3).
+
+    ``row`` travels with the message so the handler (the workbench, which
+    owns the `SchedulingService` `TaskDetail` does not reach into) can
+    render a field-specific failure directly on the row that started the
+    edit (`DetailValueRow.show_error`) without a second lookup -- the
+    same "carry the widget the caller will need" idiom
+    `DetailValueRow.Activated` already uses for its own ``row``.
+    `TaskDetail` has already called `row.end_edit()` before posting this
+    (closing the editor, restoring the OLD display) -- a failure needs no
+    separate "restore" step beyond that.
+    """
+
+    def __init__(
+        self, task: ReminderTask, payload: dict[str, Any], row: DetailValueRow
+    ) -> None:
+        super().__init__()
+        self.task = task
+        self.payload = payload
+        self.row = row
 
 
 class SyncCompleted(Message):

--- a/tldw_chatbook/Scheduling/events.py
+++ b/tldw_chatbook/Scheduling/events.py
@@ -127,6 +127,56 @@ class ReminderFieldEditRequested(Message):
         self.row = row
 
 
+class DefinitionFieldEditRequested(Message):
+    """Posted when a definition-pane Details/Frequency row's inline editor
+    commits an edit (redesign PR-3, task 4).
+
+    ``definition`` is the raw definition dict `DefinitionDetail.set_
+    definition` was last painted with (a local DB row or a raw server
+    list-response dict -- either shape). Its own ``id`` may be a LOCAL row
+    id or, for a row shown from a pure server fetch that has no local
+    shadow yet, the SERVER's id -- the handler resolves the actual local
+    id `SchedulingService.save_definition` needs the same way the
+    existing full-modal Edit action already does
+    (`SchedulesWorkbench._resolve_local_definition_id`), rather than
+    assuming ``id`` is always local.
+
+    ``payload`` is already shaped for `save_definition` (family/name/
+    schedule resent verbatim per `definition_detail._definition_edit_
+    payload`'s own docstring -- `_merge_definition_payload` does not
+    default those from storage the way its docstring implies). ``row``
+    travels with it (same "carry the widget the handler needs" idiom
+    `DetailValueRow.Activated`/`ReminderFieldEditRequested` already use)
+    so the workbench can call `row.show_error(...)` directly on failure.
+    `DefinitionDetail` has already called `row.end_edit()` before posting
+    this.
+    """
+
+    def __init__(
+        self, definition: dict[str, Any], payload: dict[str, Any], row: DetailValueRow
+    ) -> None:
+        super().__init__()
+        self.definition = definition
+        self.payload = payload
+        self.row = row
+
+
+class DefinitionLifecycleToggleRequested(Message):
+    """Posted when the definition pane's header Pause/Resume button is
+    pressed (redesign PR-3, task 4 -- `SchedulingService.set_definition_
+    lifecycle`'s first UI caller).
+
+    ``action`` is ``"pause"`` or ``"resume"`` (`DefinitionDetail` decides
+    which, from the definition's current ``lifecycle``) -- the same two
+    action strings `SchedulingService._LIFECYCLE_ACTIONS` accepts.
+    """
+
+    def __init__(self, definition: dict[str, Any], action: str) -> None:
+        super().__init__()
+        self.definition = definition
+        self.action = action
+
+
 class SyncCompleted(Message):
     """Posted when a non-failing sync attempt completes.
 

--- a/tldw_chatbook/Scheduling/schedule_input_parsing.py
+++ b/tldw_chatbook/Scheduling/schedule_input_parsing.py
@@ -1,0 +1,93 @@
+"""Forgiving reminder-schedule text parsing: datetime + IANA timezone.
+
+Pure module (no I/O, no imports of other Scheduling submodules, no
+Textual) -- same discipline as ``schedule_compute.py``. Hoisted out of
+``UI/Screens/scheduling/forms/reminder_form.py`` (redesign PR-3, task 3's
+folded-in refactor, closing task-2-review.md finding 1: `SchedulingService.
+edit_reminder_fields` was reaching UP into a UI-layer module for two
+functions that were always pure -- a leading-underscore, module-private
+name at that). ``reminder_form.py`` imports both back under their
+original call shape; ``is_valid_zone`` is the public spelling of what was
+``reminder_form.py``'s ``_is_valid_zone`` -- publicized because a
+service-layer caller reaching across modules for a private name was part
+of the smell.
+
+Why these parsers live here and not in ``Utils/input_validation.py``: that
+module is the *security* boundary ("Input validation utilities for
+secure user input handling") -- boolean gatekeepers for traversal,
+injection, SSRF and size-class risks. The helpers below are domain
+format parsers: they normalize text into schedule values (an aware
+datetime, a validated IANA zone name) and hand back presentation signals
+callers render as live hints, such as ``parse_forgiving_datetime``'s
+``assumed_local`` flag. Nothing here guards a trust boundary -- the parsed
+values reach SQLite only through parameterized queries -- so hoisting them
+into the security module would import zoneinfo into a module the
+security-critical paths depend on, for no safety gain.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+#: Forgiving local datetime formats (naive -> system local zone).
+_FORGIVING_DATETIME_FORMATS: tuple[str, ...] = (
+    "%Y-%m-%d %H:%M",
+    "%Y-%m-%dT%H:%M",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%dT%H:%M:%S",
+)
+
+
+def is_valid_zone(name: str) -> bool:
+    """Return True when ``name`` resolves to an IANA timezone.
+
+    Args:
+        name: Candidate IANA zone name, e.g. ``"Europe/Berlin"``.
+
+    Returns:
+        True when the local tzdata can resolve ``name``, False otherwise.
+    """
+    try:
+        ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError, TypeError):
+        return False
+    return True
+
+
+def parse_forgiving_datetime(raw: str) -> tuple[datetime | None, bool]:
+    """Parse a run-at datetime, accepting forgiving local forms.
+
+    Returns ``(parsed, assumed_local)``: full ISO-8601 keeps its offset
+    (``assumed_local`` False); a naive form such as ``2026-08-28 09:00``
+    is interpreted in the system's local timezone (``assumed_local``
+    True). ``(None, False)`` when nothing parses.
+
+    Args:
+        raw: The user-entered run-at text; surrounding whitespace is
+            ignored and an empty string is treated as "not a date".
+
+    Returns:
+        A ``(datetime | None, bool)`` pair. The datetime is always
+        timezone-aware when parsing succeeds. The bool is True only when
+        a naive input was assumed to be local time, so the caller can say
+        so in the UI.
+    """
+    text = raw.strip()
+    if not text:
+        return None, False
+    parsed: datetime | None = None
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        for fmt in _FORGIVING_DATETIME_FORMATS:
+            try:
+                parsed = datetime.strptime(text, fmt)
+            except ValueError:
+                continue
+            break
+    if parsed is None:
+        return None, False
+    if parsed.tzinfo is None:
+        return parsed.astimezone(), True
+    return parsed, False

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -1533,6 +1533,85 @@ class SchedulingService:
         "archive": "archived",
     }
 
+    #: The `automation_definition` payload actions `save_definition` OWNS
+    #: -- the only ones it may replace in the shared queue slot (final
+    #: review C1). Every other action in that slot belongs to a different
+    #: writer (lifecycle, transfer) and must not be silently overwritten.
+    _EDIT_ACTIONS = frozenset({"create", "update"})
+
+    #: User-facing names for the non-edit actions that can be holding the
+    #: slot, for `_cross_action_mutation_reason`'s refusal copy.
+    _PENDING_ACTION_LABELS = {
+        "pause": "a pause",
+        "resume": "a resume",
+        "archive": "an archive",
+        "transfer_to_server": "a move to the server",
+        "release_from_server": "a move to this device",
+    }
+
+    def _cross_action_mutation_reason(self, row_id: str) -> str | None:
+        """Why editing ``row_id`` must be refused right now, or ``None``.
+
+        `pending_mutations` holds exactly ONE row per `(local_id,
+        primitive, owner_id)`, and lifecycle, edit and transfer mutations
+        all share the `automation_definition` primitive -- so a
+        server-owned row can only ever have one of them queued. An edit
+        committed while a pause is waiting destroys that pause twice over
+        (final review C1, probe-proven both online and offline): offline,
+        `record_pending_mutation`'s `INSERT OR REPLACE` overwrites it;
+        online, the server echo reverts `lifecycle` and the mirror clears
+        the queued mutation outright. Neither leaves a trace.
+
+        So the edit is refused at the entry instead, naming the change
+        that is waiting -- the same shape as `transfer_lock_reason`'s
+        refusal, which both panes already render inline under the row.
+        Same-ACTION replacement (an update over a queued update) is
+        untouched: that coalescing is what `_save_definition_offline`
+        documents and wants.
+
+        Read via `get_pending_mutation_for_local_id` -- the mutation's
+        OWN `owner_id`, never "today's active server", the same lesson
+        `_delete_transfer_mutation` records.
+        """
+        mutation = self.db.get_pending_mutation_for_local_id(
+            row_id, _DEFINITION_PRIMITIVE
+        )
+        if mutation is None:
+            return None
+        action = str((mutation.get("payload") or {}).get("action") or "")
+        if action in self._EDIT_ACTIONS:
+            return None
+        label = self._PENDING_ACTION_LABELS.get(action, "a pending change")
+        return (
+            f"{label[0].upper()}{label[1:]} is waiting to sync — edit this "
+            "automation once it lands."
+        )
+
+    def _clear_stale_edit_mutation(self, row_id: str, owner_id: str) -> None:
+        """Drop the queued EDIT mutation an online save just superseded.
+
+        Scoped to `_EDIT_ACTIONS` rather than clearing whatever sits in
+        the slot: the only mutation this save supersedes is an earlier
+        offline save of its own (`_mirror_server_definition`'s docstring).
+        A lifecycle or transfer mutation in the slot was queued by another
+        writer DURING the online round-trip -- `_cross_action_mutation_
+        reason` refused the edit if one was already there -- so deleting
+        it would silently drop a pause the server has not heard about.
+        Same action-scoped-delete shape, for the same reason, as
+        `_delete_transfer_mutation`.
+        """
+        mutation = self.db.get_pending_mutation_for_local_id(
+            row_id, _DEFINITION_PRIMITIVE
+        )
+        if mutation is None:
+            return
+        action = str((mutation.get("payload") or {}).get("action") or "")
+        if action not in self._EDIT_ACTIONS:
+            return
+        self.db.delete_pending_mutation_for_record(
+            row_id, _DEFINITION_PRIMITIVE, owner_id
+        )
+
     async def set_definition_lifecycle(
         self, row_id: str, action: str
     ) -> SaveDefinitionOutcome:
@@ -1552,11 +1631,16 @@ class SchedulingService:
         the replay to push -- so a lifecycle change made offline survives
         and lands on the next sync, exactly like an offline edit.
 
-        **No UI is wired to this yet, deliberately**: the Automations
-        tab's pause/resume/archive affordances belong to the schedules
-        redesign program, not to PR-5, whose scope is the transfer
-        machine. This method exists so the replay leg below it is
-        reachable and tested rather than dead code.
+        The UI caller is the definition pane's header Pause/Resume
+        affordance (schedules-redesign PR-3 Task 4,
+        `DefinitionDetail._toggle_lifecycle` ->
+        `SchedulesWorkbench._toggle_definition_lifecycle`) -- this
+        method's FIRST, added by that task. It shipped ahead of that
+        caller (PR-5) so the replay leg below it was reachable and tested
+        rather than dead code; the paragraph claiming it still has no UI
+        caller outlived that, and final review F9 recorded the cost --
+        "no UI can reach this" is exactly what made the C1 slot collision
+        with `save_definition` easy to miss once a UI could.
 
         Args:
             row_id: The definition's LOCAL row id.
@@ -2214,6 +2298,24 @@ class SchedulingService:
                     definition_id=definition_id,
                 )
             payload = self._merge_definition_payload(payload, local_row)
+            # final review C1: only a SERVER-owned row queues mutations at
+            # all, so only it can collide in the shared slot. A local row
+            # -- including a `to_server_failed` one, which deliberately
+            # keeps its transfer mutation queued and stays editable
+            # (`transfer_lock_reason`) -- writes straight through below
+            # and never touches the queue.
+            if self._owner_uses_server(owner_id):
+                blocked = await asyncio.to_thread(
+                    self._cross_action_mutation_reason, definition_id
+                )
+                if blocked is not None:
+                    return SaveDefinitionOutcome(
+                        status="error",
+                        errors=[
+                            field_error("_pending", "pending_mutation", blocked)
+                        ],
+                        definition_id=definition_id,
+                    )
 
         if not self._owner_uses_server(owner_id):
             mode = "update" if local_row is not None else "create"
@@ -2425,9 +2527,12 @@ class SchedulingService:
         its new server id -- that upsert reports only insert/update
         counts, not the generated id.
 
-        Either way, any pending `automation_definition` mutation left over
-        from an earlier offline save on this row is cleared once this
-        online save actually lands -- same precedent as
+        Either way, a pending `automation_definition` EDIT mutation left
+        over from an earlier offline save on this row is cleared once this
+        online save actually lands (`_clear_stale_edit_mutation`; final
+        review C1 scoped it to the edit actions, so a lifecycle or
+        transfer mutation that took the shared slot mid-round-trip
+        survives) -- same precedent as
         `_persist_server_reminder_response`'s `delete_pending_mutation_
         for_record` call. Without this, a stale queued mutation survives a
         later successful online save and the next sync replays it: for a
@@ -2456,10 +2561,7 @@ class SchedulingService:
 
         if saved_id is not None:
             await asyncio.to_thread(
-                self.db.delete_pending_mutation_for_record,
-                saved_id,
-                _DEFINITION_PRIMITIVE,
-                owner_id,
+                self._clear_stale_edit_mutation, saved_id, owner_id
             )
         return saved_id
 

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -18,6 +18,7 @@ from zoneinfo import ZoneInfo
 
 from croniter import croniter
 from loguru import logger
+from pydantic import ValidationError
 
 # ADR-097 boot ratchet: automation_health loads on first use. A thin module-
 # level proxy (not a plain deferred import) keeps `compute_local_health`
@@ -198,6 +199,32 @@ class ResolveOutcome:
 
     status: str
     reason: str | None = None
+
+
+@dataclass(slots=True)
+class ReminderEditOutcome:
+    """Result of `SchedulingService.edit_reminder_fields` (PR-3 task 3's
+    reminder row editors).
+
+    Gives the reminder side the same ``{field, code, message}`` validation
+    surface `save_definition` already gives the definition side (survey
+    §2's asymmetry: `update_reminder` alone raises a bare, uncaught
+    `pydantic.ValidationError` on a bad schedule/timezone value and
+    returns `None` -- with no per-field detail -- on a locked row).
+
+    Attributes:
+        status: ``"saved"`` (persisted, via `update_reminder`) or
+            ``"error"`` (nothing written -- an unknown row, a locked
+            row, or a validation failure).
+        errors: Field-addressed validation errors (``{"field", "code",
+            "message"}``), populated for ``"error"``. A locked or unknown
+            row addresses the pseudo-field ``"_row"``.
+        task: The updated `ReminderTask`, populated only for ``"saved"``.
+    """
+
+    status: str
+    errors: list[dict[str, Any]] = _dataclass_field(default_factory=list)
+    task: ReminderTask | None = None
 
 
 def _seam_failure_warning(exc: Exception) -> dict[str, str]:
@@ -581,6 +608,144 @@ class SchedulingService:
         row = self.db.get_reminder_task(task_id)
         assert row is not None
         return self._row_to_reminder(row)
+
+    async def edit_reminder_fields(
+        self, task_id: str, payload: dict[str, Any]
+    ) -> ReminderEditOutcome:
+        """Validate and persist a single-row reminder edit (PR-3 task 3).
+
+        Wraps `update_reminder` with the create form's own schedule
+        validators (`ReminderForm`'s `parse_forgiving_datetime`/
+        `_is_valid_zone`, plus `croniter.is_valid` for cron) -- reused
+        rather than re-derived, so a Repeat/At/Timezone row editor gets
+        the same forgiving-local-datetime and known-zone behavior the
+        create form gives, and the same errors when it doesn't parse.
+        `update_reminder` alone does none of this: an invalid `cron`/
+        `timezone` would silently persist (the `ReminderTask` model
+        never validates their contents), and an invalid `run_at`/
+        `schedule_kind` combination raises a bare `pydantic.
+        ValidationError` with no field-addressed detail for a row editor
+        to render.
+
+        Args:
+            task_id: The local reminder row to update.
+            payload: The one or few fields the row editor is changing --
+                same partial shape `update_reminder` already accepts.
+
+        Returns:
+            A `ReminderEditOutcome`. ``status="error"`` covers: an
+            unknown ``task_id``, a locked (in-transfer) row (`errors`
+            addresses the pseudo-field ``"_row"``, per
+            `transfer_lock_reason`), or a bad schedule/timezone value
+            (`errors` addresses the offending field). ``status="saved"``
+            means `update_reminder` was called -- threading the ROW's
+            OWN owner, not `self.owner_id` (PR-2's Queue lists reminders
+            across owners, so the row under a cursor is not necessarily
+            the service's active owner -- same rationale as
+            `delete_reminder`'s) -- and returned the updated task.
+        """
+        from tldw_chatbook.Scheduling.automation_validation import field_error
+
+        row = self.db.get_reminder_task(task_id)
+        if row is None:
+            return ReminderEditOutcome(
+                status="error",
+                errors=[field_error("_row", "not_found", f"Reminder {task_id} was not found.")],
+            )
+
+        locked = self.transfer_lock_reason(row)
+        if locked is not None:
+            return ReminderEditOutcome(
+                status="error",
+                errors=[field_error("_row", "transfer_in_progress", locked)],
+            )
+
+        # Deferred (ADR-097 boot ratchet): `ReminderForm` pulls in the
+        # whole Textual widget stack at module import time. By the time a
+        # row edit reaches this method the UI is already running and
+        # Textual is already loaded, so this costs nothing here -- it
+        # would cost boot time if hoisted to module level, same reasoning
+        # as the `automation_validation`/`automation_preview` imports
+        # elsewhere in this file.
+        from tldw_chatbook.UI.Screens.scheduling.forms.reminder_form import (
+            _is_valid_zone,
+            parse_forgiving_datetime,
+        )
+
+        errors: list[dict[str, Any]] = []
+        cleaned = dict(payload)
+        if "run_at" in cleaned and isinstance(cleaned["run_at"], str):
+            parsed, _assumed_local = parse_forgiving_datetime(cleaned["run_at"])
+            if parsed is None:
+                errors.append(
+                    field_error(
+                        "run_at",
+                        "invalid_datetime",
+                        "Run At must be a date and time like 2026-08-28 09:00.",
+                    )
+                )
+            else:
+                cleaned["run_at"] = parsed
+        if "cron" in cleaned and cleaned["cron"] is not None:
+            if not croniter.is_valid(cleaned["cron"]):
+                errors.append(
+                    field_error("cron", "invalid_cron", "Cron expression is invalid.")
+                )
+        if "timezone" in cleaned and cleaned["timezone"] is not None:
+            new_zone = cleaned["timezone"]
+            # Same stored-zone round-trip carve-out as the create form
+            # (reminder_form.py's `_save`): a zone already on the row must
+            # keep validating even if this machine's tzdata can't resolve
+            # it -- only a genuinely NEW zone value is checked.
+            if new_zone != row.get("timezone") and not _is_valid_zone(new_zone):
+                errors.append(
+                    field_error(
+                        "timezone", "invalid_timezone", f"Unknown timezone: {new_zone}"
+                    )
+                )
+
+        if errors:
+            return ReminderEditOutcome(status="error", errors=errors)
+
+        try:
+            task = await self.update_reminder(
+                task_id, cleaned, owner_id=row.get("owner_id")
+            )
+        except ValidationError as exc:
+            # Belt-and-suspenders: a schedule_kind/run_at/cron combination
+            # the checks above don't cover (e.g. a one_time edit that
+            # leaves run_at unset) still routes through `ReminderTask`'s
+            # own model validation inside `update_reminder` -- catch that
+            # surface here too so it never escapes as a raw exception.
+            return ReminderEditOutcome(
+                status="error",
+                errors=[
+                    field_error(
+                        ".".join(str(part) for part in err["loc"]) or "_row",
+                        str(err["type"]),
+                        str(err["msg"]),
+                    )
+                    for err in exc.errors()
+                ],
+            )
+
+        if task is None:
+            # `update_reminder` refuses (returns None) if the row was
+            # deleted or newly locked between the check above and this
+            # call -- a narrow race, not a validation failure.
+            return ReminderEditOutcome(
+                status="error",
+                errors=[
+                    field_error(
+                        "_row",
+                        "update_refused",
+                        "This reminder could not be updated -- it may have "
+                        "just been deleted or locked by a transfer.",
+                    )
+                ],
+            )
+
+        return ReminderEditOutcome(status="saved", task=task)
 
     async def delete_reminder(
         self, task_id: str, *, owner_id: str | None = None

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -2485,6 +2485,14 @@ class SchedulingService:
         `notification_policy` merge one level deep for the same reason,
         which is why the form emits `provider`/`model` explicitly as
         `None` when blank rather than omitting them.
+
+        `stored` may be SQL NULL (Python `None`) rather than `{}` -- a
+        server-mirrored row whose server item omitted the key entirely
+        (`upsert_automation_definitions_from_server`'s INSERT path,
+        task-4 review Finding 1) leaves the column NULL. Treated as `{}`
+        here so the merge still runs instead of silently skipping (which
+        used to drop the whole group -- e.g. `input.question` -- on any
+        edit that didn't itself touch that group).
         """
         merged: dict[str, Any] = {}
         for key in ("description", "visibility_policy", "approval_policy"):
@@ -2494,8 +2502,11 @@ class SchedulingService:
         for key in ("config", "input", "notification_policy"):
             stored = local_row.get(key)
             incoming = payload.get(key)
-            if isinstance(stored, dict) and isinstance(incoming, dict):
-                merged[key] = {**stored, **incoming}
+            if isinstance(incoming, dict):
+                merged[key] = {
+                    **(stored if isinstance(stored, dict) else {}),
+                    **incoming,
+                }
         return merged
 
     @staticmethod

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -74,6 +74,14 @@ _RESULT_REVIEW_PRIMITIVE = "automation_result_review"
 #: mutations, SyncEngine the consumer/replayer).
 _DEFINITION_PRIMITIVE = "automation_definition"
 
+#: Matches ScheduledTasksDB._LIFECYCLE_PRIMITIVE / SyncEngine's constant of
+#: the same value. Pause/resume/archive get their OWN `pending_mutations`
+#: slot (Qodo findings 5+6) so a queued lifecycle change and a queued edit
+#: can coexist on one row instead of destroying each other in the shared
+#: `UNIQUE(local_id, primitive, owner_id)` slot -- see the DB constant's
+#: comment for the full rationale.
+_LIFECYCLE_PRIMITIVE = "automation_lifecycle"
+
 #: v1 scope guard (schedules-handoff PR-4, task 4): only this family can be
 #: authored through `preview_definition`/`save_definition`. `agent_task`
 #: authoring rides a follow-up program -- see `_reject_unsupported_family`.
@@ -1535,16 +1543,16 @@ class SchedulingService:
 
     #: The `automation_definition` payload actions `save_definition` OWNS
     #: -- the only ones it may replace in the shared queue slot (final
-    #: review C1). Every other action in that slot belongs to a different
-    #: writer (lifecycle, transfer) and must not be silently overwritten.
+    #: review C1). The transfer actions in that slot belong to a different
+    #: writer and must not be silently overwritten.
     _EDIT_ACTIONS = frozenset({"create", "update"})
 
     #: User-facing names for the non-edit actions that can be holding the
-    #: slot, for `_cross_action_mutation_reason`'s refusal copy.
+    #: `automation_definition` slot, for `_cross_action_mutation_reason`'s
+    #: refusal copy. Lifecycle actions are absent by design: they live in
+    #: `_LIFECYCLE_PRIMITIVE`'s own slot now (Qodo findings 5+6) and
+    #: coexist with an edit rather than being refused.
     _PENDING_ACTION_LABELS = {
-        "pause": "a pause",
-        "resume": "a resume",
-        "archive": "an archive",
         "transfer_to_server": "a move to the server",
         "release_from_server": "a move to this device",
     }
@@ -1553,18 +1561,21 @@ class SchedulingService:
         """Why editing ``row_id`` must be refused right now, or ``None``.
 
         `pending_mutations` holds exactly ONE row per `(local_id,
-        primitive, owner_id)`, and lifecycle, edit and transfer mutations
-        all share the `automation_definition` primitive -- so a
-        server-owned row can only ever have one of them queued. An edit
-        committed while a pause is waiting destroys that pause twice over
-        (final review C1, probe-proven both online and offline): offline,
-        `record_pending_mutation`'s `INSERT OR REPLACE` overwrites it;
-        online, the server echo reverts `lifecycle` and the mirror clears
-        the queued mutation outright. Neither leaves a trace.
+        primitive, owner_id)`, and edit and TRANSFER mutations still
+        share the `automation_definition` primitive -- so a server-owned
+        row can have only one of those two queued. An edit committed
+        while a transfer is waiting would destroy it silently
+        (`record_pending_mutation`'s `INSERT OR REPLACE`), so the edit is
+        refused at the entry instead, naming the change that is waiting
+        -- the same shape as `transfer_lock_reason`'s refusal, which both
+        panes already render inline under the row.
 
-        So the edit is refused at the entry instead, naming the change
-        that is waiting -- the same shape as `transfer_lock_reason`'s
-        refusal, which both panes already render inline under the row.
+        LIFECYCLE is no longer part of this refusal (Qodo findings 5+6,
+        reversing final review C1's lifecycle half): pause/resume/archive
+        moved to `_LIFECYCLE_PRIMITIVE`, a different slot, so an edit and
+        a lifecycle change now coexist -- both queue, both replay, both
+        land -- instead of one being refused to protect the other.
+
         Same-ACTION replacement (an update over a queued update) is
         untouched: that coalescing is what `_save_definition_offline`
         documents and wants.
@@ -1593,12 +1604,16 @@ class SchedulingService:
         Scoped to `_EDIT_ACTIONS` rather than clearing whatever sits in
         the slot: the only mutation this save supersedes is an earlier
         offline save of its own (`_mirror_server_definition`'s docstring).
-        A lifecycle or transfer mutation in the slot was queued by another
-        writer DURING the online round-trip -- `_cross_action_mutation_
-        reason` refused the edit if one was already there -- so deleting
-        it would silently drop a pause the server has not heard about.
-        Same action-scoped-delete shape, for the same reason, as
+        A TRANSFER mutation in the slot was queued by another writer
+        DURING the online round-trip -- `_cross_action_mutation_reason`
+        refused the edit if one was already there -- so deleting it would
+        silently drop a move the server has not heard about. Same
+        action-scoped-delete shape, for the same reason, as
         `_delete_transfer_mutation`.
+
+        Lifecycle needs no scoping here at all any more (Qodo findings
+        5+6): a queued pause lives in `_LIFECYCLE_PRIMITIVE`'s own slot,
+        which this `_DEFINITION_PRIMITIVE`-keyed lookup cannot even see.
         """
         mutation = self.db.get_pending_mutation_for_local_id(
             row_id, _DEFINITION_PRIMITIVE
@@ -1630,6 +1645,15 @@ class SchedulingService:
         (`update_automation_definition`'s `pending_mutation` kwarg), for
         the replay to push -- so a lifecycle change made offline survives
         and lands on the next sync, exactly like an offline edit.
+
+        That mutation is recorded under `_LIFECYCLE_PRIMITIVE`, NOT the
+        shared `_DEFINITION_PRIMITIVE` (Qodo findings 5+6). `pending_
+        mutations` is `UNIQUE(local_id, primitive, owner_id)`, so a
+        lifecycle change sharing the definition primitive occupied the
+        one slot an offline edit also needs: whichever was queued second
+        silently destroyed the first. Its own primitive is its own slot,
+        with no schema change -- an offline pause and an offline edit of
+        the same row now both queue, both replay, and both land.
 
         The UI caller is the definition pane's header Pause/Resume
         affordance (schedules-redesign PR-3 Task 4,
@@ -1694,7 +1718,7 @@ class SchedulingService:
         pending_mutation = None
         if self._owner_uses_server(owner_id):
             pending_mutation = {
-                "primitive": _DEFINITION_PRIMITIVE,
+                "primitive": _LIFECYCLE_PRIMITIVE,
                 "owner_id": owner_id,
                 "payload": {
                     "action": action,
@@ -2298,8 +2322,10 @@ class SchedulingService:
                     definition_id=definition_id,
                 )
             payload = self._merge_definition_payload(payload, local_row)
-            # final review C1: only a SERVER-owned row queues mutations at
-            # all, so only it can collide in the shared slot. A local row
+            # final review C1 (lifecycle half reversed by Qodo 5+6; the
+            # TRANSFER half stands): only a SERVER-owned row queues
+            # mutations at all, so only it can collide in the shared
+            # `automation_definition` slot with a transfer. A local row
             # -- including a `to_server_failed` one, which deliberately
             # keeps its transfer mutation queued and stays editable
             # (`transfer_lock_reason`) -- writes straight through below
@@ -2530,9 +2556,10 @@ class SchedulingService:
         Either way, a pending `automation_definition` EDIT mutation left
         over from an earlier offline save on this row is cleared once this
         online save actually lands (`_clear_stale_edit_mutation`; final
-        review C1 scoped it to the edit actions, so a lifecycle or
-        transfer mutation that took the shared slot mid-round-trip
-        survives) -- same precedent as
+        review C1 scoped it to the edit actions, so a transfer mutation
+        that took the shared slot mid-round-trip survives -- a lifecycle
+        mutation is in a different slot entirely and was never at risk
+        here) -- same precedent as
         `_persist_server_reminder_response`'s `delete_pending_mutation_
         for_record` call. Without this, a stale queued mutation survives a
         later successful online save and the next sync replays it: for a

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -615,8 +615,10 @@ class SchedulingService:
         """Validate and persist a single-row reminder edit (PR-3 task 3).
 
         Wraps `update_reminder` with the create form's own schedule
-        validators (`ReminderForm`'s `parse_forgiving_datetime`/
-        `_is_valid_zone`, plus `croniter.is_valid` for cron) -- reused
+        validators (`schedule_input_parsing.parse_forgiving_datetime`/
+        `is_valid_zone` -- the pure module `ReminderForm` itself also
+        imports these from, task 3's folded-in refactor -- plus
+        `croniter.is_valid` for cron) -- reused
         rather than re-derived, so a Repeat/At/Timezone row editor gets
         the same forgiving-local-datetime and known-zone behavior the
         create form gives, and the same errors when it doesn't parse.
@@ -660,15 +662,16 @@ class SchedulingService:
                 errors=[field_error("_row", "transfer_in_progress", locked)],
             )
 
-        # Deferred (ADR-097 boot ratchet): `ReminderForm` pulls in the
-        # whole Textual widget stack at module import time. By the time a
-        # row edit reaches this method the UI is already running and
-        # Textual is already loaded, so this costs nothing here -- it
-        # would cost boot time if hoisted to module level, same reasoning
-        # as the `automation_validation`/`automation_preview` imports
-        # elsewhere in this file.
-        from tldw_chatbook.UI.Screens.scheduling.forms.reminder_form import (
-            _is_valid_zone,
+        # redesign PR-3, task 3's folded-in refactor (task-2-review.md
+        # finding 1): these two used to live in `reminder_form.py`, a
+        # UI-layer module this service-layer file had no business
+        # importing from. Hoisted to a pure `Scheduling/`-side module --
+        # still function-local (ADR-097 boot ratchet), though this one no
+        # longer carries any Textual weight, so hoisting the IMPORT to
+        # module level would also be safe; left function-local anyway for
+        # a minimal diff against Task 2's shape.
+        from tldw_chatbook.Scheduling.schedule_input_parsing import (
+            is_valid_zone,
             parse_forgiving_datetime,
         )
 
@@ -697,7 +700,7 @@ class SchedulingService:
             # (reminder_form.py's `_save`): a zone already on the row must
             # keep validating even if this machine's tzdata can't resolve
             # it -- only a genuinely NEW zone value is checked.
-            if new_zone != row.get("timezone") and not _is_valid_zone(new_zone):
+            if new_zone != row.get("timezone") and not is_valid_zone(new_zone):
                 errors.append(
                     field_error(
                         "timezone", "invalid_timezone", f"Unknown timezone: {new_zone}"

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -30,11 +30,17 @@ _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 #: `_RESULT_REVIEW_PRIMITIVE`'s review-pushback shape.
 _DEFINITION_PRIMITIVE = "automation_definition"
 
-#: `payload["action"]` values that identify a pending `automation_
-#: definition` mutation as a lifecycle change specifically -- matches
-#: `ScheduledTasksDB._DEFINITION_LIFECYCLE_ACTIONS` and
-#: `SchedulingService._LIFECYCLE_ACTIONS`'s keys (redesign PR-3 ruling 4
-#: lifecycle pull-guard).
+#: Pending pause/resume/archive mutations, in their OWN queue slot --
+#: matches `ScheduledTasksDB._LIFECYCLE_PRIMITIVE`/`SchedulingService.
+#: _LIFECYCLE_PRIMITIVE` (Qodo findings 5+6; see the DB constant's comment
+#: for why a lifecycle change cannot share the definition primitive's
+#: `UNIQUE(local_id, primitive, owner_id)` slot with an edit).
+_LIFECYCLE_PRIMITIVE = "automation_lifecycle"
+
+#: The `payload["action"]` verbs `_push_definition_lifecycle` replays --
+#: matches `SchedulingService._LIFECYCLE_ACTIONS`'s keys. Still an action
+#: set (not just "everything in `_LIFECYCLE_PRIMITIVE`") because the push
+#: loop dispatches on `action` and reports per-action outcomes.
 _DEFINITION_LIFECYCLE_ACTIONS = frozenset({"pause", "resume", "archive"})
 
 #: Matches ScheduledTasksDB._RESULT_REVIEW_PRIMITIVE -- pending mutations
@@ -512,7 +518,27 @@ class SyncEngine:
     async def _replay_definition_mutations(
         self, owner_id: str
     ) -> tuple[dict[str, int], frozenset[str]]:
-        """Replay pending `automation_definition` mutations to the server.
+        """Replay pending automation-definition mutations to the server.
+
+        Reads BOTH definition queue slots -- `_DEFINITION_PRIMITIVE`
+        (create/update/transfer) and `_LIFECYCLE_PRIMITIVE`
+        (pause/resume/archive, its own slot since Qodo findings 5+6) --
+        and settles them in ONE phase rather than two. The dispatch is
+        `payload["action"]`-keyed either way, and one phase keeps the
+        existing containment discipline intact unchanged: one
+        `_run_phase` error entry, one abort-on-retryable-error boundary,
+        one `pushed_lifecycle_server_ids` set threaded into the pull
+        below it.
+
+        Definition mutations are replayed FIRST so that, for a row
+        carrying both, the edit's server echo is adopted while the
+        lifecycle mutation is still queued -- which is exactly when
+        `adopt_server_definition_identity`'s pull-guard withholds the
+        echoed (pre-transition) `lifecycle`. The reverse order converges
+        too: the lifecycle push lands server-side before the edit's
+        round-trip, so the echo already carries the new value. Both
+        orders are pinned (`test_sync_now_replays_a_queued_edit_and_
+        pause_together`).
 
         `create` -> preview(mode="create") -> a `"valid"` preview is
         consumed via `create_automation_definition`, and the response's
@@ -555,7 +581,7 @@ class SyncEngine:
         assert self.server_client is not None
         mutations = self.db.get_pending_mutations(
             owner_id, primitive=_DEFINITION_PRIMITIVE
-        )
+        ) + self.db.get_pending_mutations(owner_id, primitive=_LIFECYCLE_PRIMITIVE)
         counts: dict[str, int] = {}
         pushed_lifecycle_server_ids: set[str] = set()
         for mutation in mutations:
@@ -659,8 +685,8 @@ class SyncEngine:
             return "invalid"
 
         logger.warning(
-            f"Unknown pending automation_definition mutation action {action!r} "
-            f"for local {local_id}; dropping"
+            f"Unknown pending {mutation.get('primitive')} mutation action "
+            f"{action!r} for local {local_id}; dropping"
         )
         self.db.delete_pending_mutation(mutation_id)
         return "unknown"
@@ -832,8 +858,8 @@ class SyncEngine:
         response = response if isinstance(response, dict) else {}
         # Delete BEFORE mirroring the echo (Task 2 lifecycle pull-guard):
         # this mutation is what the guard's own pending-mutation check
-        # would key off (same local_id/primitive/owner_id, `action` in
-        # `_DEFINITION_LIFECYCLE_ACTIONS`) -- if it were still present
+        # would key off (same local_id/owner_id in `_LIFECYCLE_
+        # PRIMITIVE`'s slot) -- if it were still present
         # when `upsert_automation_definitions_from_server` runs, the guard
         # would (correctly, in general) withhold `lifecycle` from THIS
         # write too, and the just-confirmed transition would never reach

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -30,6 +30,13 @@ _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 #: `_RESULT_REVIEW_PRIMITIVE`'s review-pushback shape.
 _DEFINITION_PRIMITIVE = "automation_definition"
 
+#: `payload["action"]` values that identify a pending `automation_
+#: definition` mutation as a lifecycle change specifically -- matches
+#: `ScheduledTasksDB._DEFINITION_LIFECYCLE_ACTIONS` and
+#: `SchedulingService._LIFECYCLE_ACTIONS`'s keys (redesign PR-3 ruling 4
+#: lifecycle pull-guard).
+_DEFINITION_LIFECYCLE_ACTIONS = frozenset({"pause", "resume", "archive"})
+
 #: Matches ScheduledTasksDB._RESULT_REVIEW_PRIMITIVE -- pending mutations
 #: recorded when a local review is made on a server-mirrored result
 #: (Task 5) are replayed to the server here.
@@ -229,21 +236,33 @@ class SyncEngine:
         # inside this phase's own transaction, so the definitions pull
         # right after matches it by (owner_id, server_id) instead of
         # inserting a duplicate mirror row (Task 3 pull-ordering note).
-        error, definition_push_counts = await self._run_phase(
+        error, definition_push_result = await self._run_phase(
             target_owner,
             "Automation definition push",
             self._replay_definition_mutations,
         )
         if error:
             phase_errors.append(error)
+        definition_push_counts, pushed_lifecycle_server_ids = (
+            definition_push_result
+            if definition_push_result is not None
+            else ({}, frozenset())
+        )
         if definition_push_counts:
             logger.info(
                 f"Automation definition push for {target_owner}: "
                 f"{definition_push_counts}"
             )
-
+        # Task 2 same-cycle echo (mirrors `skip_review_server_ids` above):
+        # thread the server_definition_ids just pushed above into this SAME
+        # definitions pull so a stale same-cycle echo of the pre-transition
+        # lifecycle can't revert what was just pushed -- see the design
+        # comment on `ScheduledTasksDB.upsert_automation_definitions_from_server`.
         error, counts = await self._run_phase(
-            target_owner, "Automation definitions pull", self._pull_definitions
+            target_owner,
+            "Automation definitions pull",
+            self._pull_definitions,
+            skip_lifecycle_server_ids=pushed_lifecycle_server_ids,
         )
         if error:
             phase_errors.append(error)
@@ -419,11 +438,12 @@ class SyncEngine:
             A ``(error, result)`` tuple. ``error`` is ``None`` on success
             or a policy refusal (not an error); otherwise the message that
             was also recorded via `_record_sync_error`. ``result`` is the
-            phase's own return value (an upsert-count dict, or the
-            pushed-review-ids set for the pushback phase) on success, or
-            ``None`` when the phase raised or returned nothing -- callers
-            use it so a truncated/failed phase never silently discards
-            what did land (F2/F8).
+            phase's own return value (an upsert-count dict; the pushed-
+            review-ids set for the review pushback phase; or the
+            ``(counts, pushed_lifecycle_server_ids)`` tuple for the
+            definition push phase) on success, or ``None`` when the phase
+            raised or returned nothing -- callers use it so a truncated/
+            failed phase never silently discards what did land (F2/F8).
         """
         try:
             result = await phase(owner_id, **phase_kwargs)
@@ -489,7 +509,9 @@ class SyncEngine:
             pushed_server_ids.add(server_result_id)
         return frozenset(pushed_server_ids)
 
-    async def _replay_definition_mutations(self, owner_id: str) -> dict[str, int]:
+    async def _replay_definition_mutations(
+        self, owner_id: str
+    ) -> tuple[dict[str, int], frozenset[str]]:
         """Replay pending `automation_definition` mutations to the server.
 
         `create` -> preview(mode="create") -> a `"valid"` preview is
@@ -517,14 +539,25 @@ class SyncEngine:
         `_push_definition_mutation`).
 
         Returns:
-            Counts of what happened this cycle (``created``/``updated``/
-            ``invalid``/``orphaned``), for the caller's info log.
+            A ``(counts, pushed_lifecycle_server_ids)`` tuple. ``counts``
+            is what happened this cycle (``created``/``updated``/
+            ``invalid``/``orphaned``/...), for the caller's info log.
+            ``pushed_lifecycle_server_ids`` is the `server_definition_id`s
+            whose `pause`/`resume`/`archive` mutation settled successfully
+            THIS cycle -- `sync_now` feeds this into the definitions pull
+            as `skip_lifecycle_server_ids` (Task 2 same-cycle echo,
+            mirroring `_replay_review_mutations`'s
+            `skip_review_server_ids`) so a stale same-cycle echo of the
+            pre-transition lifecycle can't revert what was just pushed --
+            see the design comment on
+            `ScheduledTasksDB.upsert_automation_definitions_from_server`.
         """
         assert self.server_client is not None
         mutations = self.db.get_pending_mutations(
             owner_id, primitive=_DEFINITION_PRIMITIVE
         )
         counts: dict[str, int] = {}
+        pushed_lifecycle_server_ids: set[str] = set()
         for mutation in mutations:
             payload = mutation.get("payload") or {}
             if payload.get("transfer_errors"):
@@ -534,9 +567,17 @@ class SyncEngine:
                 # retry/cancel via Task 6's facade, not another sync cycle.
                 counts["transfer_skipped"] = counts.get("transfer_skipped", 0) + 1
                 continue
+            action = payload.get("action")
+            server_definition_id = payload.get("server_definition_id")
             outcome = await self._push_definition_mutation(mutation, owner_id)
             counts[outcome] = counts.get(outcome, 0) + 1
-        return counts
+            if (
+                action in _DEFINITION_LIFECYCLE_ACTIONS
+                and outcome == action
+                and server_definition_id
+            ):
+                pushed_lifecycle_server_ids.add(server_definition_id)
+        return counts, frozenset(pushed_lifecycle_server_ids)
 
     async def _push_definition_mutation(self, mutation: dict, owner_id: str) -> str:
         """Replay one pending `automation_definition` mutation. Returns what happened.
@@ -789,8 +830,18 @@ class SyncEngine:
             return f"{action}_not_found"
 
         response = response if isinstance(response, dict) else {}
-        self.db.upsert_automation_definitions_from_server(owner_id, [response])
+        # Delete BEFORE mirroring the echo (Task 2 lifecycle pull-guard):
+        # this mutation is what the guard's own pending-mutation check
+        # would key off (same local_id/primitive/owner_id, `action` in
+        # `_DEFINITION_LIFECYCLE_ACTIONS`) -- if it were still present
+        # when `upsert_automation_definitions_from_server` runs, the guard
+        # would (correctly, in general) withhold `lifecycle` from THIS
+        # write too, and the just-confirmed transition would never reach
+        # the local row. Clearing it first means the guard sees nothing
+        # pending for this row and the echo's `lifecycle` writes through
+        # normally, exactly as it did before the guard existed.
         self.db.delete_pending_mutation(mutation_id)
+        self.db.upsert_automation_definitions_from_server(owner_id, [response])
         return action
 
     async def _push_definition_release(
@@ -1066,7 +1117,11 @@ class SyncEngine:
         )
         self.db.delete_pending_mutation(mutation_id)
 
-    async def _pull_definitions(self, owner_id: str) -> dict[str, int]:
+    async def _pull_definitions(
+        self,
+        owner_id: str,
+        skip_lifecycle_server_ids: frozenset[str] = frozenset(),
+    ) -> dict[str, int]:
         """Page up to `_SYNC_MAX_PAGES` of the server's automation definitions.
 
         Upserted per page (not batched to the end) so a later page's
@@ -1075,6 +1130,11 @@ class SyncEngine:
         Stops early on an empty page or `has_more=False`; logs (info) when
         the cap was hit with more remaining, so a truncated pull is never
         silent (F4: this was an unbounded `while True` against the server).
+
+        ``skip_lifecycle_server_ids`` (Task 2 same-cycle echo) is
+        forwarded unchanged to every page's upsert call -- see the design
+        comment on
+        `ScheduledTasksDB.upsert_automation_definitions_from_server`.
         """
         assert self.server_client is not None
         totals: dict[str, int] = {}
@@ -1086,7 +1146,9 @@ class SyncEngine:
             if not isinstance(response, dict):
                 response = {}
             page = list(response.get("items") or [])
-            counts = self.db.upsert_automation_definitions_from_server(owner_id, page)
+            counts = self.db.upsert_automation_definitions_from_server(
+                owner_id, page, skip_lifecycle_server_ids=skip_lifecycle_server_ids
+            )
             for key, value in counts.items():
                 totals[key] = totals.get(key, 0) + value
             offset += len(page)

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -6,9 +6,14 @@ had no field-level rendering of a selected `automation_definition` at all
 history pane; see `redesign-pr1-survey.md` section 1's "no per-row detail
 widget" finding). `DefinitionDetail` fills that gap using the same
 `DetailValueRow`/`DetailGroup` row grammar Task 3 used to regrammar the
-Queue tab's `TaskDetail` -- Details/Frequency/History groups, read-only
-(plan ruling 1: every row's `affordance` stays at its `False` default, no
-new bindings/actions).
+Queue tab's `TaskDetail` -- Details/Frequency/History groups. PR-1 shipped
+every row read-only (`affordance` at its `False` default); schedules-
+redesign PR-3, task 4 wires in-pane editing onto the Details/Frequency
+rows (Model/Generation/Finding policy/Sources/Notifications always
+editable, Repeat/At/Timezone gated by schedule kind) plus a header
+Pause/Resume affordance -- see the `DefinitionDetail` class docstring
+below for the row-editing/lifecycle-toggle design. `Runs on`/History rows
+stay read-only.
 
 Like `task_detail.py` and `results_tab.py`, this is a leaf module:
 `schedules_workbench.py` imports FROM here (`DefinitionDetail`, plus
@@ -54,21 +59,34 @@ same reason.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 from textual.app import ComposeResult
-from textual.containers import Vertical
-from textual.widgets import Static
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Button, Checkbox, Input, Select, Static
 
+from ....Scheduling.schedule_input_parsing import parse_forgiving_datetime
+from ....Scheduling.events import (
+    DefinitionFieldEditRequested,
+    DefinitionLifecycleToggleRequested,
+)
 from ....Widgets.detail_value_row import DetailGroup, DetailValueRow
 from .forms.automation_definition_form import (
     _FINDING_POLICY_OPTIONS,
     _GENERATION_MODE_OPTIONS,
     _SCOPE_SOURCE_CHECKBOXES,
 )
+# PR-3 task 4: the Frequency row editors reuse the create/edit modal's own
+# preset<->cron mapping and timezone-option builder verbatim (never
+# re-derived) -- same precedent `task_detail.py`'s Task 3 reminder rows
+# already established; `reminder_form.py` is already part of this same
+# lazy-loaded Scheduling-screen import chain (ADR-097).
+from .forms.reminder_form import ReminderForm, cron_to_preset, preset_to_cron, timezone_options
 from .task_detail import (
     _TRANSFER_STATE_ROW_LABELS,
     _format_timezone,
+    definition_cron_expression,
     owner_display_label,
 )
 # `_definition_at_label`/`_definition_question_text`/`_parse_iso` moved to
@@ -76,6 +94,98 @@ from .task_detail import (
 # too and cannot import a Textual-heavy module without dragging Textual in
 # as a side effect); imported back here unchanged.
 from .unified_rows import _definition_at_label, _definition_question_text, _parse_iso
+
+#: v1 scope guard (`save_definition._reject_unsupported_family`): this pane
+#: only ever edits `recurring_question` definitions. A bare string literal
+#: here (matching `AutomationDefinitionForm._FAMILY`'s own value) rather
+#: than importing that name -- it is a private constant of a sibling UI
+#: module for a different surface (the full create/edit modal), and one
+#: literal is simpler than a cross-module import for it.
+_FAMILY = "recurring_question"
+
+#: Stable ids for the row editors (PR-3 task 4), routed on by
+#: `on_select_changed`/`on_input_submitted`/`on_button_pressed` -- same
+#: "filter on `.id`" idiom `task_detail.py`'s Task 3 Frequency rows use.
+_MODEL_EDITOR_ID = "scheduling-automation-detail-model-editor"
+_GENERATION_EDITOR_ID = "scheduling-automation-detail-generation-editor"
+_FINDING_POLICY_EDITOR_ID = "scheduling-automation-detail-finding-policy-editor"
+_NOTIFICATIONS_EDITOR_ID = "scheduling-automation-detail-notifications-editor"
+_REPEAT_EDITOR_ID = "scheduling-automation-detail-repeat-editor"
+_AT_EDITOR_ID = "scheduling-automation-detail-at-editor"
+_TIMEZONE_EDITOR_ID = "scheduling-automation-detail-timezone-editor"
+_SOURCES_EDITOR_ID = "scheduling-automation-detail-sources-editor"
+_SOURCES_APPLY_ID = "scheduling-automation-detail-sources-apply"
+_SOURCES_CHECKBOX_IDS: dict[str, str] = {
+    value: f"scheduling-automation-detail-sources-{value}"
+    for _label, value in _SCOPE_SOURCE_CHECKBOXES
+}
+
+#: Repeat's "custom" preset has no single-value edit target here (same
+#: rule task_detail.py's Task 3 Repeat row already documents) -- shown so
+#: the row's CURRENT value round-trips (`Select` requires the initial
+#: value be among its options), but selecting it as a NEW target is
+#: refused with this copy rather than silently doing nothing (ruling 2).
+_REPEAT_CUSTOM_REFUSAL = "Use the full Edit form to set a custom cron expression."
+
+#: The header Pause/Resume button's two reachable actions (this pane never
+#: offers Archive -- not named anywhere in the task-4 brief, and a
+#: destructive third state deserves its own considered affordance, not a
+#: bolt-on to a "toggle" button). Deliberately duplicates just these two
+#: entries of `SchedulingService._LIFECYCLE_ACTIONS` (a private constant
+#: of the service module) rather than importing it -- a two-entry mapping
+#: this stable is a low-risk, display-only duplication: if it ever drifted
+#: the worst case is a stale button label until the next background
+#: refresh repaints from a real DB read, never a wrong write (the actual
+#: persisted value always comes from the service's own mapping).
+_LIFECYCLE_TOGGLE_RESULTS: dict[str, str] = {"pause": "paused", "resume": "configured"}
+
+
+def _definition_edit_payload(
+    definition: dict[str, Any], **field_changes: Any
+) -> dict[str, Any]:
+    """Build a `SchedulingService.save_definition` payload for ONE row's edit.
+
+    `SchedulingService._merge_definition_payload` (verified empirically
+    against the real service -- no existing test exercises a single-field
+    definition edit, since the create/edit MODAL always sends a full
+    payload) does NOT behave the way its own docstring implies for a
+    payload this small:
+
+    - `description`/`visibility_policy`/`approval_policy` ARE seeded from
+      the stored row unconditionally.
+    - `config`/`input`/`notification_policy` are merged ONE LEVEL DEEP,
+      but ONLY when the payload's own top-level key is present as a dict
+      -- an ABSENT key is dropped from the merge entirely, not defaulted
+      from storage. A payload missing `notification_policy` altogether
+      silently WIPES a previously configured policy to `{}` on save (an
+      empty dict `{}` is safe -- `{**stored, **{}}` preserves everything
+      -- it is a MISSING key that is dangerous).
+    - `name`, `family`, and `schedule` get NO merge treatment at all. A
+      payload missing `family` is rejected outright by `_reject_
+      unsupported_family` (run on the RAW, pre-merge payload); missing
+      `name` fails the preview's own required-field check; a missing
+      `schedule` silently drops the definition's schedule.
+
+    So every row-edit payload here resends `family` + `name` verbatim,
+    the definition's CURRENT `schedule` dict (unless the edit IS a
+    Frequency row, which passes its own already-modified whole dict via
+    `field_changes["schedule"]` -- the task-4 brief's "whole-dict resend"
+    rule), and an empty-or-partial dict for each of `config`/`input`/
+    `notification_policy` so the one-level merge preserves whatever
+    subkey this particular edit does not touch.
+    """
+    schedule = definition.get("schedule")
+    payload: dict[str, Any] = {
+        "family": _FAMILY,
+        "name": definition.get("name"),
+        "schedule": dict(schedule) if isinstance(schedule, dict) else {},
+        "config": {},
+        "input": {},
+        "notification_policy": {},
+    }
+    payload.update(field_changes)
+    return payload
+
 
 #: Absent key -> honest placeholder (final review F2). A definition this
 #: client did not author carries none of the create-form's config keys,
@@ -350,13 +460,23 @@ def _definition_last_run_label(last_run: dict[str, Any] | None) -> str:
 
 
 class DefinitionDetail(Vertical):
-    """Automations tab per-definition detail pane.
+    """Automations tab (and Queue tab sibling) per-definition detail pane.
 
-    Read-only (plan ruling 1): every `DetailValueRow` here uses the
-    `affordance` default of `False`; no new bindings or actions.
-    `set_definition` is the single feed point -- called by
-    `SchedulesWorkbench` after a definitions-table row highlight, with
-    the DB-derived counts/last-run already fetched off the event loop.
+    schedules-redesign PR-3, task 4 wires in-pane editing onto the
+    Details/Frequency rows PR-1 left read-only, plus the header Pause/
+    Resume affordance (`SchedulingService.set_definition_lifecycle`'s
+    first UI caller). `set_definition` is still the single PAINT feed
+    point -- called by `SchedulesWorkbench` after a definitions-table row
+    highlight, with the DB-derived counts/last-run already fetched off
+    the event loop -- and remains pure (no I/O). A row's edit and the
+    lifecycle toggle instead POST a `Scheduling.events` message
+    (`DefinitionFieldEditRequested`/`DefinitionLifecycleToggleRequested`)
+    the workbench handles, mirroring `TaskDetail`'s own Task 3 Frequency
+    rows exactly -- this widget still performs no I/O of its own.
+
+    `Runs on`/`Last run`/`Run count`/`Unread results`/`Results` stay
+    permanently read-only (out of this task's row list; owner transfer is
+    a separate, not-yet-built feature per survey §7).
     """
 
     def __init__(self, *args, **kwargs: object) -> None:
@@ -374,6 +494,18 @@ class DefinitionDetail(Vertical):
         self._last_run_row: DetailValueRow | None = None
         self._run_count_row: DetailValueRow | None = None
         self._unread_row: DetailValueRow | None = None
+        # PR-3 task 4:
+        self._definition: dict[str, Any] | None = None
+        self._pause_resume_button: Button | None = None
+        self._why_static: Static | None = None
+        #: Cached from `set_lifecycle_lock` (never re-derived here) --
+        #: same one-source-of-truth rule survey §8 documents for
+        #: `TaskDetail`. `None` means unlocked.
+        self._lifecycle_lock_reason: str | None = None
+        #: Threaded in by the workbench's `set_definition` call site, same
+        #: as `TaskDetail.set_task`'s own `known_timezones` param -- empty
+        #: by default so every pre-task-4 caller/test keeps working.
+        self._known_timezones: Sequence[str] = ()
 
     def compose(self) -> ComposeResult:
         """Compose the empty pane skeleton (populated by `set_definition`).
@@ -391,6 +523,28 @@ class DefinitionDetail(Vertical):
             id="scheduling-automation-detail-empty-state",
         )
         with Vertical(id="scheduling-automation-detail-body"):
+            # PR-3 task 4: the header Pause/Resume affordance --
+            # `set_definition_lifecycle`'s first UI caller. Archive is
+            # deliberately not offered here (see `_LIFECYCLE_TOGGLE_
+            # RESULTS`'s comment); the label/tooltip are set by
+            # `_refresh_lifecycle_button`, called from `set_definition`.
+            with Horizontal(id="scheduling-automation-detail-lifecycle"):
+                self._pause_resume_button = Button(
+                    "Pause",
+                    id="scheduling-automation-pause-resume",
+                    variant="warning",
+                )
+                yield self._pause_resume_button
+            # Visible when the lifecycle button (or an editable row) is
+            # locked by an in-flight transfer: keyboard users can't see
+            # hover tooltips, so the reason must live in text too
+            # (UX-073) -- same idiom `TaskDetail`'s own `#scheduling-
+            # transfer-why` uses.
+            self._why_static = Static(
+                "", id="scheduling-automation-detail-why", classes="follow-why"
+            )
+            yield self._why_static
+
             self._question_static = Static(
                 "", id="scheduling-automation-detail-question", markup=False
             )
@@ -482,6 +636,7 @@ class DefinitionDetail(Vertical):
         last_run: dict[str, Any] | None = None,
         unread_count: int = 0,
         history_error: bool = False,
+        known_timezones: Sequence[str] = (),
     ) -> None:
         """Paint the pane for `definition` (or the empty state for `None`).
 
@@ -499,7 +654,14 @@ class DefinitionDetail(Vertical):
             unread_count: Pre-fetched unread-results count.
             history_error: True when the history fetch failed -- the rows
                 render "couldn't load" copy instead of unproven zeros.
+            known_timezones: PR-3 task 4 -- zones already used by other
+                tasks, passed through to the Timezone row editor's option
+                source (`timezone_options`), same param `TaskDetail.
+                set_task` already threads for its own Timezone row. Every
+                pre-task-4 caller/test omits this and is unaffected.
         """
+        self._definition = definition
+        self._known_timezones = known_timezones
         empty_state = self.query_one(
             "#scheduling-automation-detail-empty-state", Static
         )
@@ -507,6 +669,12 @@ class DefinitionDetail(Vertical):
         if definition is None:
             empty_state.display = True
             body.display = False
+            # PR-3 task 4: stale lock state from a PREVIOUS selection must
+            # not survive into a cleared pane -- same discipline `TaskDetail.
+            # set_task`'s `None` branch already documents.
+            self._lifecycle_lock_reason = None
+            if self._why_static is not None:
+                self._why_static.update("")
             return
         empty_state.display = False
         body.display = True
@@ -552,3 +720,521 @@ class DefinitionDetail(Vertical):
         self._unread_row.update_value(
             _HISTORY_READ_FAILED if history_error else str(unread_count)
         )
+
+        self._configure_row_editability(schedule)
+        self._refresh_lifecycle_button()
+
+    # -- In-pane row editing (PR-3 task 4) -----------------------------------
+
+    def _configure_row_editability(self, schedule: dict[str, Any]) -> None:
+        """Wire each editable row's affordance for the CURRENT definition.
+
+        Model/Generation/Finding policy/Sources/Notifications are always
+        editable -- none of them depend on schedule kind. Repeat/Timezone
+        only apply to a `"cron"` schedule and At only to a `"one_time"`
+        one (same reasoning `task_detail._configure_frequency_
+        editability` already documents for the reminder pane's own
+        Repeat/At/Timezone trio -- editing the "wrong" one for the
+        current kind has no sensible target here either, even though
+        THIS pane controls the whole outgoing `schedule` dict itself and
+        so has no service-side clobber risk to avoid).
+
+        Locked rows keep their affordance ON (not off): ruling 2 requires
+        activation to still respond with the lock reason via
+        `show_error`, and `on_detail_value_row_activated` checks `self.
+        _lifecycle_lock_reason` before ever opening an editor -- so the
+        affordance glyph staying lit is what makes that reachable at all
+        (`set_lifecycle_lock` never touches row affordance).
+        """
+        recurring = schedule.get("kind") == "cron"
+        for row, editable in (
+            (self._model_row, True),
+            (self._generation_row, True),
+            (self._finding_policy_row, True),
+            (self._sources_row, True),
+            (self._notifications_row, True),
+            (self._repeat_row, recurring),
+            (self._at_row, not recurring),
+            (self._timezone_row, recurring),
+        ):
+            assert row is not None
+            row.affordance = editable
+            row.can_focus = editable
+
+    def on_detail_value_row_activated(self, event: DetailValueRow.Activated) -> None:
+        """Open the activated row's editor, or -- locked -- show why
+        editing is refused instead of doing nothing (ruling 2)."""
+        row = event.row
+        editable_rows = (
+            self._model_row,
+            self._generation_row,
+            self._finding_policy_row,
+            self._sources_row,
+            self._notifications_row,
+            self._repeat_row,
+            self._at_row,
+            self._timezone_row,
+        )
+        if row not in editable_rows:
+            return
+        event.stop()
+        if self._lifecycle_lock_reason is not None:
+            row.show_error(self._lifecycle_lock_reason)
+            return
+        definition = self._definition
+        if definition is None:
+            return
+        row.clear_error()
+
+        if row is self._model_row:
+            input_fields = (
+                definition.get("input")
+                if isinstance(definition.get("input"), dict)
+                else {}
+            )
+            provider = str(input_fields.get("provider") or "").strip()
+            model = str(input_fields.get("model") or "").strip()
+            initial = (
+                f"{provider}/{model}" if provider and model else (provider or model)
+            )
+            row.begin_edit(
+                Input(
+                    value=initial,
+                    placeholder="provider/model — blank for auto",
+                    id=_MODEL_EDITOR_ID,
+                )
+            )
+        elif row is self._generation_row:
+            config = (
+                definition.get("config")
+                if isinstance(definition.get("config"), dict)
+                else {}
+            )
+            current = str(config.get("generation_mode") or "optional")
+            row.begin_edit(
+                Select(
+                    list(_GENERATION_MODE_OPTIONS),
+                    allow_blank=False,
+                    value=current,
+                    id=_GENERATION_EDITOR_ID,
+                )
+            )
+        elif row is self._finding_policy_row:
+            finding_policy = (
+                definition.get("finding_policy")
+                if isinstance(definition.get("finding_policy"), dict)
+                else {}
+            )
+            current = str(finding_policy.get("preset") or "balanced_findings")
+            row.begin_edit(
+                Select(
+                    list(_FINDING_POLICY_OPTIONS),
+                    allow_blank=False,
+                    value=current,
+                    id=_FINDING_POLICY_EDITOR_ID,
+                )
+            )
+        elif row is self._sources_row:
+            self._begin_sources_edit(definition, row)
+        elif row is self._notifications_row:
+            current = "on" if self._notifications_on(definition) else "off"
+            row.begin_edit(
+                Select(
+                    [("On", "on"), ("Off", "off")],
+                    allow_blank=False,
+                    value=current,
+                    id=_NOTIFICATIONS_EDITOR_ID,
+                )
+            )
+        elif row is self._repeat_row:
+            schedule = (
+                definition.get("schedule")
+                if isinstance(definition.get("schedule"), dict)
+                else {}
+            )
+            cron_value = definition_cron_expression(schedule) or ""
+            current_preset, _time_text = cron_to_preset(cron_value)
+            row.begin_edit(
+                Select(
+                    ReminderForm._preset_options(),
+                    allow_blank=False,
+                    value=current_preset,
+                    id=_REPEAT_EDITOR_ID,
+                )
+            )
+        elif row is self._at_row:
+            schedule = (
+                definition.get("schedule")
+                if isinstance(definition.get("schedule"), dict)
+                else {}
+            )
+            initial = str(schedule.get("run_at") or "")
+            row.begin_edit(Input(value=initial, id=_AT_EDITOR_ID))
+        elif row is self._timezone_row:
+            schedule = (
+                definition.get("schedule")
+                if isinstance(definition.get("schedule"), dict)
+                else {}
+            )
+            current_tz = str(schedule.get("timezone") or "UTC")
+            row.begin_edit(
+                Select(
+                    timezone_options(current_tz, self._known_timezones),
+                    allow_blank=False,
+                    value=current_tz,
+                    id=_TIMEZONE_EDITOR_ID,
+                )
+            )
+
+    @staticmethod
+    def _notifications_on(definition: dict[str, Any]) -> bool:
+        """The Notifications editor's current On/Off, from either policy
+        shape `_definition_notifications_label` already tolerates: this
+        client's bool shape, or the server's channel-string shape (e.g.
+        `{"on_success": "toast"}`, where any non-empty string is also
+        truthy) -- one `bool(...)` reads both correctly."""
+        policy = definition.get("notification_policy")
+        if not isinstance(policy, dict) or not policy:
+            return False
+        return bool(policy.get("on_success")) or bool(policy.get("on_failure"))
+
+    def _begin_sources_edit(
+        self, definition: dict[str, Any], row: DetailValueRow
+    ) -> None:
+        """Mount the Sources mini-editor: three checkboxes (Media/Notes/
+        Chats) + an Apply button, per the task-4 brief's own suggested
+        shape -- a `Select` of the 7 mode/subset combinations would be
+        uglier, and a checkbox has no single "commit" event of its own
+        (unlike `Select`/`Input`), so an explicit Apply button is the
+        smallest honest way to let several checkboxes settle before
+        posting one edit.
+
+        Documented simplification: this editor only ever WRITES the
+        explicit `{"mode": "sources", "sources": [...]}` shape, even when
+        every box ends up checked -- it never writes back `"mode":
+        "all_searchable_library"` (which re-resolves the readable-source
+        set live at every dispatch, rather than freezing today's three
+        names). Reaching the frozen-vs-live distinction needs the full
+        Edit form. All three boxes start CHECKED when the stored scope is
+        `all_searchable_library` (or unset) -- visually "everything",
+        matching what the row's own value currently reads -- and reflect
+        the stored subset when the mode is already `"sources"`.
+        """
+        config = (
+            definition.get("config") if isinstance(definition.get("config"), dict) else {}
+        )
+        scope = config.get("scope") if isinstance(config.get("scope"), dict) else {}
+        if scope.get("mode") == "sources":
+            selected = set(scope.get("sources") or [])
+        else:
+            selected = {value for _label, value in _SCOPE_SOURCE_CHECKBOXES}
+        checkboxes = [
+            Checkbox(
+                label,
+                value=(value in selected),
+                id=_SOURCES_CHECKBOX_IDS[value],
+            )
+            for label, value in _SCOPE_SOURCE_CHECKBOXES
+        ]
+        apply_button = Button("Apply", id=_SOURCES_APPLY_ID, variant="primary")
+        editor = Horizontal(*checkboxes, apply_button, id=_SOURCES_EDITOR_ID)
+        row.begin_edit(editor)
+        # `begin_edit`'s own `editor.focus()` is a no-op (a bare
+        # `Horizontal` isn't focusable) -- focus the first checkbox
+        # explicitly so Enter-to-open lands somewhere Tab/Space can drive,
+        # matching a `Select`/`Input` editor's own auto-focus-on-open feel.
+        self.call_after_refresh(checkboxes[0].focus)
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """Route a row Select editor's commit by its stable id."""
+        editor_id = event.select.id
+        if editor_id == _REPEAT_EDITOR_ID:
+            self._commit_repeat_edit(event)
+        elif editor_id == _TIMEZONE_EDITOR_ID:
+            self._commit_timezone_edit(event)
+        elif editor_id == _GENERATION_EDITOR_ID:
+            self._commit_generation_edit(event)
+        elif editor_id == _FINDING_POLICY_EDITOR_ID:
+            self._commit_finding_policy_edit(event)
+        elif editor_id == _NOTIFICATIONS_EDITOR_ID:
+            self._commit_notifications_edit(event)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Route a row Input editor's commit (Enter submits) by its id."""
+        if event.input.id == _AT_EDITOR_ID:
+            self._commit_at_edit(event)
+        elif event.input.id == _MODEL_EDITOR_ID:
+            self._commit_model_edit(event)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        button_id = event.button.id
+        if button_id == _SOURCES_APPLY_ID:
+            self._commit_sources_edit(event)
+        elif button_id == "scheduling-automation-pause-resume":
+            event.stop()
+            self._toggle_lifecycle()
+
+    def _commit_generation_edit(self, event: Select.Changed) -> None:
+        definition = self._definition
+        row = self._generation_row
+        if definition is None or row is None:
+            return
+        event.stop()
+        config = (
+            definition.get("config") if isinstance(definition.get("config"), dict) else {}
+        )
+        current = str(config.get("generation_mode") or "optional")
+        new_value = str(event.value)
+        if new_value == current:
+            # `Select` posts a synthetic `Changed` the moment `begin_edit`
+            # mounts it with its CURRENT value preselected (same trap
+            # task_detail.py's Task 3 Repeat/Timezone commits already
+            # guard against) -- correctly no-ops both that mount echo and
+            # a genuine reselect of the unchanged value.
+            return
+        row.end_edit()
+        payload = _definition_edit_payload(
+            definition, config={"generation_mode": new_value}
+        )
+        self.post_message(DefinitionFieldEditRequested(definition, payload, row))
+
+    def _commit_finding_policy_edit(self, event: Select.Changed) -> None:
+        definition = self._definition
+        row = self._finding_policy_row
+        if definition is None or row is None:
+            return
+        event.stop()
+        finding_policy = (
+            definition.get("finding_policy")
+            if isinstance(definition.get("finding_policy"), dict)
+            else {}
+        )
+        current = str(finding_policy.get("preset") or "balanced_findings")
+        new_value = str(event.value)
+        if new_value == current:
+            return
+        row.end_edit()
+        payload = _definition_edit_payload(
+            definition, config={"finding_policy": {"preset": new_value}}
+        )
+        self.post_message(DefinitionFieldEditRequested(definition, payload, row))
+
+    def _commit_notifications_edit(self, event: Select.Changed) -> None:
+        definition = self._definition
+        row = self._notifications_row
+        if definition is None or row is None:
+            return
+        event.stop()
+        current = "on" if self._notifications_on(definition) else "off"
+        new_value = str(event.value)
+        if new_value == current:
+            return
+        row.end_edit()
+        notify = new_value == "on"
+        payload = _definition_edit_payload(
+            definition,
+            notification_policy={"on_success": notify, "on_failure": notify},
+        )
+        self.post_message(DefinitionFieldEditRequested(definition, payload, row))
+
+    def _commit_model_edit(self, event: Input.Submitted) -> None:
+        definition = self._definition
+        row = self._model_row
+        if definition is None or row is None:
+            return
+        event.stop()
+        row.end_edit()
+        raw = event.value.strip()
+        if "/" in raw:
+            provider_text, _sep, model_text = raw.partition("/")
+            provider = provider_text.strip() or None
+            model = model_text.strip() or None
+        elif raw:
+            provider, model = raw, None
+        else:
+            provider, model = None, None
+        payload = _definition_edit_payload(
+            definition, input={"provider": provider, "model": model}
+        )
+        self.post_message(DefinitionFieldEditRequested(definition, payload, row))
+
+    def _commit_sources_edit(self, event: Button.Pressed) -> None:
+        definition = self._definition
+        row = self._sources_row
+        if definition is None or row is None:
+            return
+        event.stop()
+        checked = {cb.id: cb.value for cb in row.query(Checkbox)}
+        selected = [
+            value
+            for _label, value in _SCOPE_SOURCE_CHECKBOXES
+            if checked.get(_SOURCES_CHECKBOX_IDS[value])
+        ]
+        row.end_edit()
+        if not selected:
+            # Client-side, same rule as `AutomationDefinitionForm`'s own
+            # preflight checks -- the server-side equivalent
+            # (`config.scope`/`scope_empty`) would refuse the round trip
+            # identically, this just skips the trip (ruling 2: never
+            # silent, this DOES show why).
+            row.show_error("Choose at least one source.")
+            return
+        payload = _definition_edit_payload(
+            definition, config={"scope": {"mode": "sources", "sources": selected}}
+        )
+        self.post_message(DefinitionFieldEditRequested(definition, payload, row))
+
+    def _commit_repeat_edit(self, event: Select.Changed) -> None:
+        definition = self._definition
+        row = self._repeat_row
+        if definition is None or row is None:
+            return
+        event.stop()
+        schedule = (
+            definition.get("schedule")
+            if isinstance(definition.get("schedule"), dict)
+            else {}
+        )
+        cron_value = definition_cron_expression(schedule) or ""
+        current_preset, current_time_text = cron_to_preset(cron_value)
+        new_preset = str(event.value)
+        if new_preset == current_preset:
+            return
+        row.end_edit()
+        if new_preset == "custom":
+            row.show_error(_REPEAT_CUSTOM_REFUSAL)
+            return
+        new_cron = preset_to_cron(new_preset, current_time_text or "09:00")
+        assert new_cron is not None, (
+            "every _preset_options() value besides 'custom' always yields a cron"
+        )
+        # Whole-dict resend (task-4 brief, pinned): built from the row's
+        # CURRENT schedule + only the edited field, so an edited Repeat
+        # never drops `timezone` -- `_merge_definition_payload` does not
+        # deep-merge `schedule` at all (`_definition_edit_payload`'s own
+        # docstring). `expression` (the server's own cron key,
+        # `definition_cron_expression`'s OTHER read) is dropped rather
+        # than left stale beside the new `cron` -- this client always
+        # writes `cron`, and leaving both would be confusing, if inert
+        # (reads prefer `cron`).
+        new_schedule = {**schedule, "kind": "cron", "cron": new_cron}
+        new_schedule.pop("expression", None)
+        payload = _definition_edit_payload(definition, schedule=new_schedule)
+        self.post_message(DefinitionFieldEditRequested(definition, payload, row))
+
+    def _commit_timezone_edit(self, event: Select.Changed) -> None:
+        definition = self._definition
+        row = self._timezone_row
+        if definition is None or row is None:
+            return
+        event.stop()
+        schedule = (
+            definition.get("schedule")
+            if isinstance(definition.get("schedule"), dict)
+            else {}
+        )
+        current_tz = str(schedule.get("timezone") or "UTC")
+        new_zone = str(event.value)
+        if new_zone == current_tz:
+            return
+        row.end_edit()
+        new_schedule = {**schedule, "kind": "cron", "timezone": new_zone}
+        payload = _definition_edit_payload(definition, schedule=new_schedule)
+        self.post_message(DefinitionFieldEditRequested(definition, payload, row))
+
+    def _commit_at_edit(self, event: Input.Submitted) -> None:
+        definition = self._definition
+        row = self._at_row
+        if definition is None or row is None:
+            return
+        event.stop()
+        row.end_edit()
+        raw = event.value.strip()
+        if not raw:
+            row.show_error("Run at is required for one-time automations.")
+            return
+        # Reused, not re-derived: the exact parser the create/edit modal's
+        # own client-side preflight (`AutomationDefinitionForm._client_
+        # side_schedule_error`) already runs, since the ported server
+        # validator (`validate_schedule`) only checks `kind`, never
+        # `run_at`'s own parseability.
+        parsed, _assumed_local = parse_forgiving_datetime(raw)
+        if parsed is None:
+            row.show_error("Run at must be a date and time like 2026-08-28 09:00.")
+            return
+        schedule = (
+            definition.get("schedule")
+            if isinstance(definition.get("schedule"), dict)
+            else {}
+        )
+        new_schedule = {**schedule, "kind": "one_time", "run_at": parsed.isoformat()}
+        payload = _definition_edit_payload(definition, schedule=new_schedule)
+        self.post_message(DefinitionFieldEditRequested(definition, payload, row))
+
+    # -- Header lifecycle toggle (PR-3 task 4) -------------------------------
+
+    def _refresh_lifecycle_button(self) -> None:
+        """Repaint the Pause/Resume button's label/tooltip from `self.
+        _definition`'s CURRENT `lifecycle` -- called after every paint
+        (`set_definition`), after a lock-state change (`set_lifecycle_
+        lock`), and after a successful toggle's optimistic patch
+        (`apply_lifecycle`), so all three share one repaint path.
+        """
+        button = self._pause_resume_button
+        if button is None or self._definition is None:
+            return
+        lifecycle = str(self._definition.get("lifecycle") or "configured")
+        if lifecycle == "configured":
+            button.label = "Pause"
+            default_tooltip = "Pause this automation."
+        else:
+            button.label = "Resume"
+            default_tooltip = "Resume this automation."
+        button.disabled = self._lifecycle_lock_reason is not None
+        button.tooltip = self._lifecycle_lock_reason or default_tooltip
+
+    def _toggle_lifecycle(self) -> None:
+        definition = self._definition
+        if definition is None or self._lifecycle_lock_reason is not None:
+            return
+        lifecycle = str(definition.get("lifecycle") or "configured")
+        action = "resume" if lifecycle != "configured" else "pause"
+        self.post_message(DefinitionLifecycleToggleRequested(definition, action))
+
+    def apply_lifecycle(self, definition_id: str, lifecycle: str) -> None:
+        """Patch + repaint the lifecycle in place after a successful
+        toggle (the task-4 brief's "optimistic repaint") -- called by the
+        workbench on EVERY mounted `DefinitionDetail` instance right
+        after `set_definition_lifecycle` succeeds, ahead of the slower
+        background refresh (`_request_automations_refresh`), so this pane
+        never shows a stale Pause/Resume label while that worker is still
+        running. Task 2's own DB-level pull-guard is what then keeps a
+        RACING sync pull from reverting the value that background refresh
+        eventually reads back from the DB.
+
+        A no-op when this instance isn't currently showing
+        ``definition_id`` (a different row, or nothing selected) --
+        sibling `DefinitionDetail` instances never repaint each other for
+        the wrong row.
+        """
+        if self._definition is None or str(self._definition.get("id")) != definition_id:
+            return
+        self._definition["lifecycle"] = lifecycle
+        self._refresh_lifecycle_button()
+
+    def set_lifecycle_lock(self, reason: str | None) -> None:
+        """Freeze the Pause/Resume button while a transfer is in flight
+        (spec §6.3's "dormant and in-flight rows are read-only except
+        cancel"), mirroring `TaskDetail.set_lifecycle_lock` exactly:
+        ``reason`` comes from `SchedulingService.transfer_lock_reason`
+        (never re-derived here) and is both the button's tooltip and a
+        line in the always-visible `#scheduling-automation-detail-why`
+        Static (UX-073). Row affordance is untouched here -- editable
+        rows stay lit and surface the SAME cached reason at activation
+        time instead (`on_detail_value_row_activated`), the same split
+        `TaskDetail`'s own Frequency rows already use.
+        """
+        self._lifecycle_lock_reason = reason
+        self._refresh_lifecycle_button()
+        if self._why_static is not None:
+            self._why_static.update(reason or "")

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -527,6 +527,9 @@ class DefinitionDetail(Vertical):
         #: other small helper in this file's own Frequency-row editors).
         self._runs_on_cancel_button: Button | None = None
         self._runs_on_retry_button: Button | None = None
+        #: PR-3 task 5 fix round 1 (finding 2): see `task_detail.py`'s
+        #: own `_runs_on_transfer_errors`.
+        self._runs_on_transfer_errors: list[str] = []
 
     def compose(self) -> ComposeResult:
         """Compose the empty pane skeleton (populated by `set_definition`).
@@ -725,6 +728,7 @@ class DefinitionDetail(Vertical):
                 self._runs_on_cancel_button.display = False
             if self._runs_on_retry_button is not None:
                 self._runs_on_retry_button.display = False
+            self._runs_on_transfer_errors = []
             return
         empty_state.display = False
         body.display = True
@@ -814,23 +818,33 @@ class DefinitionDetail(Vertical):
 
     def _configure_runs_on_row(self, definition: dict[str, Any]) -> None:
         """Definition-pane counterpart of `task_detail.TaskDetail._
-        configure_runs_on_row` (PR-3 task 5) -- see that method's
-        docstring for the full three-state rationale (normal / in-flight
-        / `to_server_failed`) and for why the Cancel/Retry buttons are
-        plain `.display`-toggled siblings rather than `begin_edit`-
-        mounted into the row; only the state-read (dict key vs.
-        attribute) differs here."""
+        configure_runs_on_row` (PR-3 task 5, fix round 1 finding 2) --
+        see that method's docstring for the full rationale (affordance
+        stays ON unconditionally; `on_detail_value_row_activated` decides
+        dropdown-vs-show-why; Cancel/Retry are plain `.display`-toggled
+        siblings, never `begin_edit`-mounted into the row); only the
+        state-read (dict key vs. attribute) differs here."""
         row = self._runs_on_row
         assert row is not None
+        row.affordance = True
+        row.can_focus = True
         state = definition.get("transfer_state")
         failed = state == "to_server_failed"
         locked = failed or state in IN_FLIGHT_TRANSFER_STATES
-        row.affordance = not locked
-        row.can_focus = not locked
         assert self._runs_on_cancel_button is not None
         assert self._runs_on_retry_button is not None
         self._runs_on_cancel_button.display = locked
         self._runs_on_retry_button.display = failed
+
+    def _runs_on_failure_reason(self, definition: dict[str, Any]) -> str:
+        """Definition-pane counterpart of `task_detail.TaskDetail._
+        runs_on_failure_reason` (fix round 1 finding 2)."""
+        errors = self._runs_on_transfer_errors
+        if errors:
+            return "Last transfer error: " + "; ".join(errors)
+        return _TRANSFER_STATE_ROW_LABELS.get(
+            definition.get("transfer_state") or "", "This transfer failed."
+        )
 
     def on_detail_value_row_activated(self, event: DetailValueRow.Activated) -> None:
         """Open the activated row's editor, or -- locked -- show why
@@ -856,12 +870,21 @@ class DefinitionDetail(Vertical):
         definition = self._definition
         if definition is None:
             return
+        if (
+            row is self._runs_on_row
+            and definition.get("transfer_state") == "to_server_failed"
+        ):
+            # fix round 1 finding 2: same as the reminder pane -- not
+            # `_lifecycle_lock_reason`-covered, but the dropdown has
+            # nothing sensible to offer a failed row either.
+            row.show_error(self._runs_on_failure_reason(definition))
+            return
         row.clear_error()
 
         if row is self._runs_on_row:
-            # `_configure_runs_on_row` already refused this row's
-            # affordance for an in-flight/failed transfer -- reaching
-            # here means a normal, unlocked owner pick (spec §7 flow).
+            # A normal, unlocked owner pick (spec §7 flow) -- an
+            # in-flight row never reaches here: the top-of-function
+            # `_lifecycle_lock_reason` check above already intercepted it.
             current_owner = str(definition.get("owner_id") or "local")
             options = list(self._runs_on_options)
             if current_owner not in {value for _, value in options}:
@@ -1355,6 +1378,11 @@ class DefinitionDetail(Vertical):
             return
         self._definition["lifecycle"] = lifecycle
         self._refresh_lifecycle_button()
+
+    def set_runs_on_transfer_errors(self, errors: list[str]) -> None:
+        """Definition-pane counterpart of `task_detail.TaskDetail.set_
+        runs_on_transfer_errors` (fix round 1, finding 2)."""
+        self._runs_on_transfer_errors = list(errors)
 
     def set_lifecycle_lock(self, reason: str | None) -> None:
         """Freeze the Pause/Resume button while a transfer is in flight

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -70,7 +70,12 @@ from ....Scheduling.schedule_input_parsing import parse_forgiving_datetime
 from ....Scheduling.events import (
     DefinitionFieldEditRequested,
     DefinitionLifecycleToggleRequested,
+    DefinitionOwnerActionRequested,
 )
+# PR-3 task 5: same lock/failed-state gating `task_detail.py`'s own
+# Runs-on row uses (survey §3) -- see that module's import comment for
+# why this is a plain, no-new-boot-cost constant import.
+from ....Scheduling.db.scheduled_tasks_db import IN_FLIGHT_TRANSFER_STATES
 from ....Widgets.detail_value_row import DetailGroup, DetailValueRow
 from .forms.automation_definition_form import (
     _FINDING_POLICY_OPTIONS,
@@ -115,6 +120,12 @@ _AT_EDITOR_ID = "scheduling-automation-detail-at-editor"
 _TIMEZONE_EDITOR_ID = "scheduling-automation-detail-timezone-editor"
 _SOURCES_EDITOR_ID = "scheduling-automation-detail-sources-editor"
 _SOURCES_APPLY_ID = "scheduling-automation-detail-sources-apply"
+#: PR-3 task 5: the owner-row transfer dropdown and its proactively-shown
+#: Cancel/Retry mini-bar -- same stable-id routing idiom as the rest of
+#: this file's row editors.
+_RUNS_ON_EDITOR_ID = "scheduling-automation-detail-runs-on-editor"
+_RUNS_ON_CANCEL_ID = "scheduling-automation-detail-runs-on-cancel"
+_RUNS_ON_RETRY_ID = "scheduling-automation-detail-runs-on-retry"
 _SOURCES_CHECKBOX_IDS: dict[str, str] = {
     value: f"scheduling-automation-detail-sources-{value}"
     for _label, value in _SCOPE_SOURCE_CHECKBOXES
@@ -506,6 +517,16 @@ class DefinitionDetail(Vertical):
         #: as `TaskDetail.set_task`'s own `known_timezones` param -- empty
         #: by default so every pre-task-4 caller/test keeps working.
         self._known_timezones: Sequence[str] = ()
+        #: PR-3 task 5: same threaded-in-by-the-workbench shape as
+        #: `_known_timezones` above, for the Runs-on row's owner-picker.
+        self._runs_on_options: Sequence[tuple[str, str]] = ()
+        #: PR-3 task 5: the Runs-on row's proactive Cancel/Retry
+        #: affordances -- see `task_detail.py`'s own
+        #: `_runs_on_cancel_button`/`_runs_on_retry_button` for the full
+        #: rationale (shared design, duplicated per-pane like every
+        #: other small helper in this file's own Frequency-row editors).
+        self._runs_on_cancel_button: Button | None = None
+        self._runs_on_retry_button: Button | None = None
 
     def compose(self) -> ComposeResult:
         """Compose the empty pane skeleton (populated by `set_definition`).
@@ -567,8 +588,25 @@ class DefinitionDetail(Vertical):
             self._sources_row = DetailValueRow(
                 "Sources", "-", value_id="scheduling-automation-detail-sources"
             )
+            # PR-3 task 5: the Runs-on row's own proactive Cancel/Retry
+            # affordances -- see `task_detail.py`'s own compose()
+            # comment for why these are plain, always-mounted siblings
+            # (`.display`-toggled) rather than `begin_edit`-mounted into
+            # the row itself.
+            self._runs_on_cancel_button = Button(
+                "Cancel transfer", id=_RUNS_ON_CANCEL_ID, variant="warning"
+            )
+            self._runs_on_retry_button = Button(
+                "Retry transfer", id=_RUNS_ON_RETRY_ID, variant="warning"
+            )
+            runs_on_actions = Horizontal(
+                self._runs_on_cancel_button,
+                self._runs_on_retry_button,
+                classes="detail-value-row-owner-actions",
+            )
             yield DetailGroup(
                 self._runs_on_row,
+                runs_on_actions,
                 self._model_row,
                 self._generation_row,
                 self._finding_policy_row,
@@ -637,6 +675,7 @@ class DefinitionDetail(Vertical):
         unread_count: int = 0,
         history_error: bool = False,
         known_timezones: Sequence[str] = (),
+        runs_on_options: Sequence[tuple[str, str]] = (),
     ) -> None:
         """Paint the pane for `definition` (or the empty state for `None`).
 
@@ -659,9 +698,14 @@ class DefinitionDetail(Vertical):
                 source (`timezone_options`), same param `TaskDetail.
                 set_task` already threads for its own Timezone row. Every
                 pre-task-4 caller/test omits this and is unaffected.
+            runs_on_options: PR-3 task 5 -- the workbench's own
+                `_runs_on_options()[0]`, threaded in the same shape
+                `known_timezones` already is. Every pre-task-5
+                caller/test omits this and is unaffected.
         """
         self._definition = definition
         self._known_timezones = known_timezones
+        self._runs_on_options = runs_on_options
         empty_state = self.query_one(
             "#scheduling-automation-detail-empty-state", Static
         )
@@ -675,6 +719,12 @@ class DefinitionDetail(Vertical):
             self._lifecycle_lock_reason = None
             if self._why_static is not None:
                 self._why_static.update("")
+            # PR-3 task 5: the Runs-on row's Cancel/Retry buttons from a
+            # PREVIOUS selection must not stay visible in a cleared pane.
+            if self._runs_on_cancel_button is not None:
+                self._runs_on_cancel_button.display = False
+            if self._runs_on_retry_button is not None:
+                self._runs_on_retry_button.display = False
             return
         empty_state.display = False
         body.display = True
@@ -722,6 +772,7 @@ class DefinitionDetail(Vertical):
         )
 
         self._configure_row_editability(schedule)
+        self._configure_runs_on_row(definition)
         self._refresh_lifecycle_button()
 
     # -- In-pane row editing (PR-3 task 4) -----------------------------------
@@ -761,11 +812,32 @@ class DefinitionDetail(Vertical):
             row.affordance = editable
             row.can_focus = editable
 
+    def _configure_runs_on_row(self, definition: dict[str, Any]) -> None:
+        """Definition-pane counterpart of `task_detail.TaskDetail._
+        configure_runs_on_row` (PR-3 task 5) -- see that method's
+        docstring for the full three-state rationale (normal / in-flight
+        / `to_server_failed`) and for why the Cancel/Retry buttons are
+        plain `.display`-toggled siblings rather than `begin_edit`-
+        mounted into the row; only the state-read (dict key vs.
+        attribute) differs here."""
+        row = self._runs_on_row
+        assert row is not None
+        state = definition.get("transfer_state")
+        failed = state == "to_server_failed"
+        locked = failed or state in IN_FLIGHT_TRANSFER_STATES
+        row.affordance = not locked
+        row.can_focus = not locked
+        assert self._runs_on_cancel_button is not None
+        assert self._runs_on_retry_button is not None
+        self._runs_on_cancel_button.display = locked
+        self._runs_on_retry_button.display = failed
+
     def on_detail_value_row_activated(self, event: DetailValueRow.Activated) -> None:
         """Open the activated row's editor, or -- locked -- show why
         editing is refused instead of doing nothing (ruling 2)."""
         row = event.row
         editable_rows = (
+            self._runs_on_row,
             self._model_row,
             self._generation_row,
             self._finding_policy_row,
@@ -786,7 +858,23 @@ class DefinitionDetail(Vertical):
             return
         row.clear_error()
 
-        if row is self._model_row:
+        if row is self._runs_on_row:
+            # `_configure_runs_on_row` already refused this row's
+            # affordance for an in-flight/failed transfer -- reaching
+            # here means a normal, unlocked owner pick (spec §7 flow).
+            current_owner = str(definition.get("owner_id") or "local")
+            options = list(self._runs_on_options)
+            if current_owner not in {value for _, value in options}:
+                options = [*options, (owner_display_label(current_owner), current_owner)]
+            row.begin_edit(
+                Select(
+                    options,
+                    allow_blank=False,
+                    value=current_owner,
+                    id=_RUNS_ON_EDITOR_ID,
+                )
+            )
+        elif row is self._model_row:
             input_fields = (
                 definition.get("input")
                 if isinstance(definition.get("input"), dict)
@@ -958,6 +1046,8 @@ class DefinitionDetail(Vertical):
             self._commit_finding_policy_edit(event)
         elif editor_id == _NOTIFICATIONS_EDITOR_ID:
             self._commit_notifications_edit(event)
+        elif editor_id == _RUNS_ON_EDITOR_ID:
+            self._commit_runs_on_edit(event)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Route a row Input editor's commit (Enter submits) by its id."""
@@ -973,6 +1063,12 @@ class DefinitionDetail(Vertical):
         elif button_id == "scheduling-automation-pause-resume":
             event.stop()
             self._toggle_lifecycle()
+        elif button_id == _RUNS_ON_CANCEL_ID:
+            event.stop()
+            self._request_runs_on_cancel()
+        elif button_id == _RUNS_ON_RETRY_ID:
+            event.stop()
+            self._request_runs_on_retry()
 
     def _commit_generation_edit(self, event: Select.Changed) -> None:
         definition = self._definition
@@ -1170,6 +1266,44 @@ class DefinitionDetail(Vertical):
         new_schedule = {**schedule, "kind": "one_time", "run_at": parsed.isoformat()}
         payload = _definition_edit_payload(definition, schedule=new_schedule)
         self.post_message(DefinitionFieldEditRequested(definition, payload, row))
+
+    def _commit_runs_on_edit(self, event: Select.Changed) -> None:
+        """Commit the owner-picker Select (PR-3 task 5, spec §7 flow) --
+        definition-pane counterpart of `task_detail.TaskDetail._commit_
+        runs_on_edit`; see that method's docstring for the full
+        same-owner-no-op / direction rationale."""
+        definition = self._definition
+        row = self._runs_on_row
+        if definition is None or row is None:
+            return
+        event.stop()
+        current_owner = str(definition.get("owner_id") or "local")
+        new_owner = str(event.value)
+        if new_owner == current_owner:
+            return
+        row.end_edit()
+        direction = "to_server" if new_owner.startswith("server:") else "to_local"
+        self.post_message(DefinitionOwnerActionRequested(definition, direction, row))
+
+    def _request_runs_on_cancel(self) -> None:
+        """Post a cancel request from the Runs-on row's own mini-bar
+        (PR-3 task 5) -- a SEPARATE surface from the Automations tab's
+        `k`-key `_cancel_automation_transfer` (coexistence, task-5
+        brief): this one renders a refusal via `row.show_error`, not the
+        tab's shared inline-notice Static."""
+        definition = self._definition
+        row = self._runs_on_row
+        if definition is not None and row is not None:
+            self.post_message(DefinitionOwnerActionRequested(definition, "cancel", row))
+
+    def _request_runs_on_retry(self) -> None:
+        """Post a retry request from the Runs-on row's own mini-bar
+        (PR-3 task 5) -- the PR-5 retry leg (re-begin), same SEPARATE
+        row-scoped surface as `_request_runs_on_cancel` above."""
+        definition = self._definition
+        row = self._runs_on_row
+        if definition is not None and row is not None:
+            self.post_message(DefinitionOwnerActionRequested(definition, "retry", row))
 
     # -- Header lifecycle toggle (PR-3 task 4) -------------------------------
 

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -606,6 +606,7 @@ class DefinitionDetail(Vertical):
                     "Pause",
                     id="scheduling-automation-pause-resume",
                     variant="warning",
+                    classes="detail-lifecycle-button",
                 )
                 yield self._pause_resume_button
             # Visible when the lifecycle button (or an editable row) is
@@ -664,10 +665,10 @@ class DefinitionDetail(Vertical):
             # (`.display`-toggled) rather than `begin_edit`-mounted into
             # the row itself.
             self._runs_on_cancel_button = Button(
-                "Cancel transfer", id=_RUNS_ON_CANCEL_ID, variant="warning"
+                "Cancel transfer", id=_RUNS_ON_CANCEL_ID, variant="warning", classes="detail-owner-action-button"
             )
             self._runs_on_retry_button = Button(
-                "Retry transfer", id=_RUNS_ON_RETRY_ID, variant="warning"
+                "Retry transfer", id=_RUNS_ON_RETRY_ID, variant="warning", classes="detail-owner-action-button"
             )
             runs_on_actions = Horizontal(
                 self._runs_on_cancel_button,

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -62,6 +62,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
+from loguru import logger
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.widgets import Button, Checkbox, Input, Select, Static
@@ -530,6 +531,11 @@ class DefinitionDetail(Vertical):
         #: PR-3 task 5 fix round 1 (finding 2): see `task_detail.py`'s
         #: own `_runs_on_transfer_errors`.
         self._runs_on_transfer_errors: list[str] = []
+        #: Final review I2: see `TaskDetail._editing_task_id` -- the
+        #: definition id an open row editor was opened AGAINST, captured
+        #: at `begin_edit` time and validated at commit time by
+        #: `_editing_definition`. Never reset by a repaint.
+        self._editing_definition_id: str | None = None
 
     def compose(self) -> ComposeResult:
         """Compose the empty pane skeleton (populated by `set_definition`).
@@ -574,22 +580,40 @@ class DefinitionDetail(Vertical):
             )
             yield self._question_static
 
+            # `row_key` (final review M12): the per-row identity the
+            # workbench's edit worker groups its commit under, so two
+            # quick edits on DIFFERENT rows stop cancelling each other.
+            # Set on every editable row, nowhere else -- same as
+            # `task_detail.py`'s own Frequency/Runs-on rows.
             self._runs_on_row = DetailValueRow(
-                "Runs on", "-", value_id="scheduling-automation-detail-runs-on"
+                "Runs on",
+                "-",
+                value_id="scheduling-automation-detail-runs-on",
+                row_key="runs_on",
             )
             self._model_row = DetailValueRow(
-                "Model", "-", value_id="scheduling-automation-detail-model"
+                "Model",
+                "-",
+                value_id="scheduling-automation-detail-model",
+                row_key="model",
             )
             self._generation_row = DetailValueRow(
-                "Generation", "-", value_id="scheduling-automation-detail-generation"
+                "Generation",
+                "-",
+                value_id="scheduling-automation-detail-generation",
+                row_key="generation_mode",
             )
             self._finding_policy_row = DetailValueRow(
                 "Finding policy",
                 "-",
                 value_id="scheduling-automation-detail-finding-policy",
+                row_key="finding_policy",
             )
             self._sources_row = DetailValueRow(
-                "Sources", "-", value_id="scheduling-automation-detail-sources"
+                "Sources",
+                "-",
+                value_id="scheduling-automation-detail-sources",
+                row_key="sources",
             )
             # PR-3 task 5: the Runs-on row's own proactive Cancel/Retry
             # affordances -- see `task_detail.py`'s own compose()
@@ -619,13 +643,22 @@ class DefinitionDetail(Vertical):
             )
 
             self._repeat_row = DetailValueRow(
-                "Repeat", "-", value_id="scheduling-automation-detail-repeat"
+                "Repeat",
+                "-",
+                value_id="scheduling-automation-detail-repeat",
+                row_key="cron",
             )
             self._at_row = DetailValueRow(
-                "At", "-", value_id="scheduling-automation-detail-at"
+                "At",
+                "-",
+                value_id="scheduling-automation-detail-at",
+                row_key="run_at",
             )
             self._timezone_row = DetailValueRow(
-                "Timezone", "-", value_id="scheduling-automation-detail-timezone"
+                "Timezone",
+                "-",
+                value_id="scheduling-automation-detail-timezone",
+                row_key="timezone",
             )
             # Spec §5 gives BOTH columns a Frequency `Notifications` row;
             # the plan's Task 4 text quietly dropped it (final review F8).
@@ -633,6 +666,7 @@ class DefinitionDetail(Vertical):
                 "Notifications",
                 "-",
                 value_id="scheduling-automation-detail-notifications",
+                row_key="notification_policy",
             )
             yield DetailGroup(
                 self._repeat_row,
@@ -706,6 +740,12 @@ class DefinitionDetail(Vertical):
                 `known_timezones` already is. Every pre-task-5
                 caller/test omits this and is unaffected.
         """
+        # Final review I2/I3: a repaint that swaps in a DIFFERENT
+        # definition takes the open editor and the inline error with it --
+        # `TaskDetail.set_task`'s twin; see `_reset_row_editing`.
+        previous = self._definition
+        if (definition or {}).get("id") != (previous or {}).get("id"):
+            self._reset_row_editing()
         self._definition = definition
         self._known_timezones = known_timezones
         self._runs_on_options = runs_on_options
@@ -846,22 +886,61 @@ class DefinitionDetail(Vertical):
             definition.get("transfer_state") or "", "This transfer failed."
         )
 
+    def _editable_rows(self) -> tuple[DetailValueRow, ...]:
+        """Every row this pane can open an editor on (mounted ones only)
+        -- `task_detail.TaskDetail._editable_rows`' twin; see it for why
+        the `Activated` router and `_reset_row_editing` share one list."""
+        return tuple(
+            row
+            for row in (
+                self._runs_on_row,
+                self._model_row,
+                self._generation_row,
+                self._finding_policy_row,
+                self._sources_row,
+                self._notifications_row,
+                self._repeat_row,
+                self._at_row,
+                self._timezone_row,
+            )
+            if row is not None
+        )
+
+    def _reset_row_editing(self) -> None:
+        """Close every open row editor and clear every row error --
+        `task_detail.TaskDetail._reset_row_editing`'s twin (final review
+        I2/I3); see it for the full rationale. Called by `set_definition`
+        on a row-identity change only."""
+        for row in self._editable_rows():
+            row.end_edit(restore_focus=False)
+            row.clear_error()
+
+    def _editing_definition(self) -> dict[str, Any] | None:
+        """The definition an open editor was opened against, or ``None``
+        -- `task_detail.TaskDetail._editing_task`'s twin (final review
+        I2's belt); see it for the full rationale."""
+        definition = self._definition
+        if definition is None:
+            return None
+        current_id = str(definition.get("id") or "")
+        if (
+            self._editing_definition_id is not None
+            and self._editing_definition_id != current_id
+        ):
+            logger.debug(
+                "Discarding an automation row edit opened for {} while the "
+                "definition pane now shows {}",
+                self._editing_definition_id,
+                current_id,
+            )
+            return None
+        return definition
+
     def on_detail_value_row_activated(self, event: DetailValueRow.Activated) -> None:
         """Open the activated row's editor, or -- locked -- show why
         editing is refused instead of doing nothing (ruling 2)."""
         row = event.row
-        editable_rows = (
-            self._runs_on_row,
-            self._model_row,
-            self._generation_row,
-            self._finding_policy_row,
-            self._sources_row,
-            self._notifications_row,
-            self._repeat_row,
-            self._at_row,
-            self._timezone_row,
-        )
-        if row not in editable_rows:
+        if row not in self._editable_rows():
             return
         event.stop()
         if self._lifecycle_lock_reason is not None:
@@ -880,6 +959,9 @@ class DefinitionDetail(Vertical):
             row.show_error(self._runs_on_failure_reason(definition))
             return
         row.clear_error()
+        # Final review I2: capture the identity this editor is being
+        # opened against, for `_editing_definition` to validate at commit.
+        self._editing_definition_id = str(definition.get("id") or "")
 
         if row is self._runs_on_row:
             # A normal, unlocked owner pick (spec §7 flow) -- an
@@ -990,7 +1072,9 @@ class DefinitionDetail(Vertical):
             current_tz = str(schedule.get("timezone") or "UTC")
             row.begin_edit(
                 Select(
-                    timezone_options(current_tz, self._known_timezones),
+                    timezone_options(
+                        current_tz, self._known_timezones, noun="automation"
+                    ),
                     allow_blank=False,
                     value=current_tz,
                     id=_TIMEZONE_EDITOR_ID,
@@ -1094,7 +1178,7 @@ class DefinitionDetail(Vertical):
             self._request_runs_on_retry()
 
     def _commit_generation_edit(self, event: Select.Changed) -> None:
-        definition = self._definition
+        definition = self._editing_definition()
         row = self._generation_row
         if definition is None or row is None:
             return
@@ -1118,7 +1202,7 @@ class DefinitionDetail(Vertical):
         self.post_message(DefinitionFieldEditRequested(definition, payload, row))
 
     def _commit_finding_policy_edit(self, event: Select.Changed) -> None:
-        definition = self._definition
+        definition = self._editing_definition()
         row = self._finding_policy_row
         if definition is None or row is None:
             return
@@ -1139,7 +1223,7 @@ class DefinitionDetail(Vertical):
         self.post_message(DefinitionFieldEditRequested(definition, payload, row))
 
     def _commit_notifications_edit(self, event: Select.Changed) -> None:
-        definition = self._definition
+        definition = self._editing_definition()
         row = self._notifications_row
         if definition is None or row is None:
             return
@@ -1157,7 +1241,7 @@ class DefinitionDetail(Vertical):
         self.post_message(DefinitionFieldEditRequested(definition, payload, row))
 
     def _commit_model_edit(self, event: Input.Submitted) -> None:
-        definition = self._definition
+        definition = self._editing_definition()
         row = self._model_row
         if definition is None or row is None:
             return
@@ -1178,7 +1262,7 @@ class DefinitionDetail(Vertical):
         self.post_message(DefinitionFieldEditRequested(definition, payload, row))
 
     def _commit_sources_edit(self, event: Button.Pressed) -> None:
-        definition = self._definition
+        definition = self._editing_definition()
         row = self._sources_row
         if definition is None or row is None:
             return
@@ -1204,7 +1288,7 @@ class DefinitionDetail(Vertical):
         self.post_message(DefinitionFieldEditRequested(definition, payload, row))
 
     def _commit_repeat_edit(self, event: Select.Changed) -> None:
-        definition = self._definition
+        definition = self._editing_definition()
         row = self._repeat_row
         if definition is None or row is None:
             return
@@ -1242,7 +1326,7 @@ class DefinitionDetail(Vertical):
         self.post_message(DefinitionFieldEditRequested(definition, payload, row))
 
     def _commit_timezone_edit(self, event: Select.Changed) -> None:
-        definition = self._definition
+        definition = self._editing_definition()
         row = self._timezone_row
         if definition is None or row is None:
             return
@@ -1262,7 +1346,7 @@ class DefinitionDetail(Vertical):
         self.post_message(DefinitionFieldEditRequested(definition, payload, row))
 
     def _commit_at_edit(self, event: Input.Submitted) -> None:
-        definition = self._definition
+        definition = self._editing_definition()
         row = self._at_row
         if definition is None or row is None:
             return
@@ -1295,7 +1379,7 @@ class DefinitionDetail(Vertical):
         definition-pane counterpart of `task_detail.TaskDetail._commit_
         runs_on_edit`; see that method's docstring for the full
         same-owner-no-op / direction rationale."""
-        definition = self._definition
+        definition = self._editing_definition()
         row = self._runs_on_row
         if definition is None or row is None:
             return

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -9,8 +9,9 @@ widget" finding). `DefinitionDetail` fills that gap using the same
 Queue tab's `TaskDetail` -- Details/Frequency/History groups. PR-1 shipped
 every row read-only (`affordance` at its `False` default); schedules-
 redesign PR-3, task 4 wires in-pane editing onto the Details/Frequency
-rows (Model/Generation/Finding policy/Sources/Notifications always
-editable, Repeat/At/Timezone gated by schedule kind) plus a header
+rows (Model/Generation/Finding policy/Sources/Notifications editable,
+Repeat/At/Timezone gated by schedule kind, and all of them gated on the
+`recurring_question` family this pane can actually author) plus a header
 Pause/Resume affordance -- see the `DefinitionDetail` class docstring
 below for the row-editing/lifecycle-toggle design. `Runs on`/History rows
 stay read-only.
@@ -88,7 +89,14 @@ from .forms.automation_definition_form import (
 # re-derived) -- same precedent `task_detail.py`'s Task 3 reminder rows
 # already established; `reminder_form.py` is already part of this same
 # lazy-loaded Scheduling-screen import chain (ADR-097).
-from .forms.reminder_form import ReminderForm, cron_to_preset, preset_to_cron, timezone_options
+from .forms.reminder_form import (
+    DEFAULT_TIME_OF_DAY,
+    ReminderForm,
+    cron_to_preset,
+    parse_time_of_day,
+    preset_to_cron,
+    timezone_options,
+)
 from .task_detail import (
     _TRANSFER_STATE_ROW_LABELS,
     _format_timezone,
@@ -138,6 +146,36 @@ _SOURCES_CHECKBOX_IDS: dict[str, str] = {
 #: value be among its options), but selecting it as a NEW target is
 #: refused with this copy rather than silently doing nothing (ruling 2).
 _REPEAT_CUSTOM_REFUSAL = "Use the full Edit form to set a custom cron expression."
+
+#: Schedule kinds whose `At` row has a single-value edit target, and which
+#: payload field that target is (Qodo finding 8). A definition's schedule
+#: `kind` is one of `schedule_compute.py`'s five (`one_time`, `interval`,
+#: `daily`, `weekly`, `cron`) -- not the two the pane originally assumed.
+#: `At` used to be editable for every non-`cron` kind and always committed
+#: `{"kind": "one_time", "run_at": ...}`, so editing the time on a `daily`
+#: automation silently CONVERTED it to a one-shot and dropped its
+#: `time_of_day`/`weekday`. Kind is never converted by a row edit now:
+#: `one_time` edits its `run_at`, `daily`/`weekly` edit their shared
+#: `time_of_day`, and `interval`/`cron` (and any unknown kind) leave the
+#: row read-only, exactly as `task_detail._configure_frequency_
+#: editability` gates the reminder pane's own Repeat/At/Timezone trio.
+_AT_EDIT_FIELD_BY_KIND: dict[str, str] = {
+    "one_time": "run_at",
+    "daily": "time_of_day",
+    "weekly": "time_of_day",
+}
+
+#: Refusal copy for the Automations pane's family gate (Qodo finding 11).
+#: `save_definition` only authors `recurring_question` (`_reject_
+#: unsupported_family`), and every row-edit payload this module builds
+#: hard-codes that family -- so offering editors on, say, an `agent_task`
+#: row invited an edit that either bounced or, worse, re-normalized the
+#: row through the wrong family's rules. The create form already refuses
+#: the same way; this is that refusal, stated in the pane.
+_UNSUPPORTED_FAMILY_NOTE = (
+    "This automation isn't a recurring question — its fields are "
+    "read-only here."
+)
 
 #: The header Pause/Resume button's two reachable actions (this pane never
 #: offers Archive -- not named anywhere in the task-4 brief, and a
@@ -536,6 +574,11 @@ class DefinitionDetail(Vertical):
         #: at `begin_edit` time and validated at commit time by
         #: `_editing_definition`. Never reset by a repaint.
         self._editing_definition_id: str | None = None
+        #: Qodo finding 11: why every row is read-only right now, or
+        #: `None`. Set from the painted definition's `family` and shown
+        #: in the same `#scheduling-automation-detail-why` Static the
+        #: transfer lock uses (`_refresh_why_note`).
+        self._family_note: str | None = None
 
     def compose(self) -> ComposeResult:
         """Compose the empty pane skeleton (populated by `set_definition`).
@@ -760,8 +803,8 @@ class DefinitionDetail(Vertical):
             # not survive into a cleared pane -- same discipline `TaskDetail.
             # set_task`'s `None` branch already documents.
             self._lifecycle_lock_reason = None
-            if self._why_static is not None:
-                self._why_static.update("")
+            self._family_note = None
+            self._refresh_why_note()
             # PR-3 task 5: the Runs-on row's Cancel/Retry buttons from a
             # PREVIOUS selection must not stay visible in a cleared pane.
             if self._runs_on_cancel_button is not None:
@@ -815,32 +858,60 @@ class DefinitionDetail(Vertical):
             _HISTORY_READ_FAILED if history_error else str(unread_count)
         )
 
+        self._family_note = (
+            None if definition.get("family") == _FAMILY else _UNSUPPORTED_FAMILY_NOTE
+        )
         self._configure_row_editability(schedule)
         self._configure_runs_on_row(definition)
         self._refresh_lifecycle_button()
+        self._refresh_why_note()
 
     # -- In-pane row editing (PR-3 task 4) -----------------------------------
+
+    def _refresh_why_note(self) -> None:
+        """Repaint `#scheduling-automation-detail-why` from the two
+        reasons that can make this pane read-only.
+
+        The transfer lock wins when both apply -- it is the transient one
+        and the one with a user action attached (cancel the move); the
+        family note is a standing property of the row. Both are plain
+        text in an always-visible Static, never a hover tooltip (UX-073).
+        """
+        if self._why_static is not None:
+            self._why_static.update(self._lifecycle_lock_reason or self._family_note or "")
 
     def _configure_row_editability(self, schedule: dict[str, Any]) -> None:
         """Wire each editable row's affordance for the CURRENT definition.
 
-        Model/Generation/Finding policy/Sources/Notifications are always
-        editable -- none of them depend on schedule kind. Repeat/Timezone
-        only apply to a `"cron"` schedule and At only to a `"one_time"`
-        one (same reasoning `task_detail._configure_frequency_
-        editability` already documents for the reminder pane's own
-        Repeat/At/Timezone trio -- editing the "wrong" one for the
-        current kind has no sensible target here either, even though
-        THIS pane controls the whole outgoing `schedule` dict itself and
-        so has no service-side clobber risk to avoid).
+        Model/Generation/Finding policy/Sources/Notifications do not
+        depend on schedule kind and stay editable. Repeat/Timezone only apply
+        to a `"cron"` schedule; `At` applies to the kinds that have a
+        single-value time target (`_AT_EDIT_FIELD_BY_KIND` -- `one_time`'s
+        `run_at`, `daily`/`weekly`'s `time_of_day`) and stays read-only
+        for `interval` and `cron`. Same reasoning `task_detail._configure_
+        frequency_editability` documents for the reminder pane's own
+        Repeat/At/Timezone trio: editing the "wrong" one for the current
+        kind has no sensible target, and here it was worse than useless
+        -- the commit hard-coded `kind: "one_time"`, so an `At` edit on a
+        `daily` automation converted it to a one-shot (Qodo finding 8).
 
-        Locked rows keep their affordance ON (not off): ruling 2 requires
-        activation to still respond with the lock reason via
-        `show_error`, and `on_detail_value_row_activated` checks `self.
-        _lifecycle_lock_reason` before ever opening an editor -- so the
-        affordance glyph staying lit is what makes that reachable at all
-        (`set_lifecycle_lock` never touches row affordance).
+        A definition of any family but `recurring_question` turns EVERY
+        row read-only, Runs-on included (Qodo finding 11): this pane's
+        payloads all declare `family=recurring_question`, which the
+        service's own scope guard is the only thing standing between an
+        `agent_task` row and a re-normalization through the wrong
+        family's rules. `_family_note` says so under the header.
+
+        Locked rows (a transfer in flight) keep their affordance ON, in
+        contrast: ruling 2 requires activation to still respond with the
+        lock reason via `show_error`, and `on_detail_value_row_activated`
+        checks `self._lifecycle_lock_reason` before ever opening an
+        editor -- so the affordance glyph staying lit is what makes that
+        reachable at all (`set_lifecycle_lock` never touches row
+        affordance). A family refusal needs no such affordance: it is
+        permanent for this row and stated in the always-visible note.
         """
+        supported_family = self._family_note is None
         recurring = schedule.get("kind") == "cron"
         for row, editable in (
             (self._model_row, True),
@@ -849,12 +920,12 @@ class DefinitionDetail(Vertical):
             (self._sources_row, True),
             (self._notifications_row, True),
             (self._repeat_row, recurring),
-            (self._at_row, not recurring),
+            (self._at_row, schedule.get("kind") in _AT_EDIT_FIELD_BY_KIND),
             (self._timezone_row, recurring),
         ):
             assert row is not None
-            row.affordance = editable
-            row.can_focus = editable
+            row.affordance = editable and supported_family
+            row.can_focus = editable and supported_family
 
     def _configure_runs_on_row(self, definition: dict[str, Any]) -> None:
         """Definition-pane counterpart of `task_detail.TaskDetail._
@@ -863,11 +934,18 @@ class DefinitionDetail(Vertical):
         stays ON unconditionally; `on_detail_value_row_activated` decides
         dropdown-vs-show-why; Cancel/Retry are plain `.display`-toggled
         siblings, never `begin_edit`-mounted into the row); only the
-        state-read (dict key vs. attribute) differs here."""
+        state-read (dict key vs. attribute) differs here.
+
+        One definition-only departure: the owner dropdown is family-gated
+        like every other editor in this pane (Qodo finding 11).
+        `transfer_refusal` already refuses a non-`recurring_question`
+        transfer on family grounds, so the dropdown could only ever offer
+        a move that bounces. Cancel/Retry stay visible either way -- a
+        transfer already in flight still needs its exit."""
         row = self._runs_on_row
         assert row is not None
-        row.affordance = True
-        row.can_focus = True
+        row.affordance = self._family_note is None
+        row.can_focus = row.affordance
         state = definition.get("transfer_state")
         failed = state == "to_server_failed"
         locked = failed or state in IN_FLIGHT_TRANSFER_STATES
@@ -915,6 +993,19 @@ class DefinitionDetail(Vertical):
             row.end_edit(restore_focus=False)
             row.clear_error()
 
+    @property
+    def shown_definition_id(self) -> str:
+        """The id of the definition this pane is painting, `""` for none.
+
+        The read half of `_editing_definition`'s captured-identity belt,
+        exposed publicly for `SchedulesWorkbench._edit_definition_field`
+        (Qodo finding 9): its save worker holds a `DetailValueRow`
+        reference across an `await`, and a failure landing after the
+        selection moved on would otherwise paint the old row's error
+        under a different automation's field.
+        """
+        return str((self._definition or {}).get("id") or "")
+
     def _editing_definition(self) -> dict[str, Any] | None:
         """The definition an open editor was opened against, or ``None``
         -- `task_detail.TaskDetail._editing_task`'s twin (final review
@@ -945,6 +1036,15 @@ class DefinitionDetail(Vertical):
         event.stop()
         if self._lifecycle_lock_reason is not None:
             row.show_error(self._lifecycle_lock_reason)
+            return
+        if self._family_note is not None:
+            # Belt for the family gate (Qodo finding 11): a gated row's
+            # `affordance` is already off, so it does not normally post
+            # `Activated` at all -- but a row activated on the frame
+            # before a repaint swapped in an unsupported family would
+            # otherwise open an editor whose commit declares the wrong
+            # family. Same "say why, never go silent" shape as the lock.
+            row.show_error(self._family_note)
             return
         definition = self._definition
         if definition is None:
@@ -987,9 +1087,14 @@ class DefinitionDetail(Vertical):
             )
             provider = str(input_fields.get("provider") or "").strip()
             model = str(input_fields.get("model") or "").strip()
-            initial = (
-                f"{provider}/{model}" if provider and model else (provider or model)
-            )
+            # The exact inverse of `_commit_model_edit`'s parse (Qodo
+            # finding 10), NOT the row's display label: bare text has to
+            # mean "provider" there (the common case), so a stored
+            # model-with-no-provider must seed the editor as `/model` or
+            # submitting it back unchanged silently moved the value into
+            # the provider slot. `"".partition("/")` reads `/model` back
+            # as exactly `(None, model)`.
+            initial = f"{provider}/{model}" if model else provider
             row.begin_edit(
                 Input(
                     value=initial,
@@ -1061,8 +1166,20 @@ class DefinitionDetail(Vertical):
                 if isinstance(definition.get("schedule"), dict)
                 else {}
             )
-            initial = str(schedule.get("run_at") or "")
-            row.begin_edit(Input(value=initial, id=_AT_EDITOR_ID))
+            # Whichever field THIS kind's `At` actually owns (Qodo
+            # finding 8) -- `run_at` for `one_time`, `time_of_day` for
+            # `daily`/`weekly`. Unreachable for any other kind: the row
+            # is not editable there.
+            field = _AT_EDIT_FIELD_BY_KIND.get(str(schedule.get("kind") or ""))
+            if field is None:
+                return
+            initial = str(schedule.get(field) or "")
+            placeholder = (
+                "2026-08-28 09:00" if field == "run_at" else DEFAULT_TIME_OF_DAY
+            )
+            row.begin_edit(
+                Input(value=initial, placeholder=placeholder, id=_AT_EDITOR_ID)
+            )
         elif row is self._timezone_row:
             schedule = (
                 definition.get("schedule")
@@ -1241,6 +1358,14 @@ class DefinitionDetail(Vertical):
         self.post_message(DefinitionFieldEditRequested(definition, payload, row))
 
     def _commit_model_edit(self, event: Input.Submitted) -> None:
+        """Parse `provider/model` text back into the two `input` fields.
+
+        The inverse of the editor's own seed value (see the `_model_row`
+        branch of `on_detail_value_row_activated`, Qodo finding 10): a
+        leading `/` means "model only, no provider", bare text means
+        "provider only", and empty means neither (`auto`). Every stored
+        shape therefore round-trips through an unchanged submit.
+        """
         definition = self._editing_definition()
         row = self._model_row
         if definition is None or row is None:
@@ -1307,7 +1432,9 @@ class DefinitionDetail(Vertical):
         if new_preset == "custom":
             row.show_error(_REPEAT_CUSTOM_REFUSAL)
             return
-        new_cron = preset_to_cron(new_preset, current_time_text or "09:00")
+        new_cron = preset_to_cron(
+            new_preset, current_time_text or DEFAULT_TIME_OF_DAY
+        )
         assert new_cron is not None, (
             "every _preset_options() value besides 'custom' always yields a cron"
         )
@@ -1346,31 +1473,50 @@ class DefinitionDetail(Vertical):
         self.post_message(DefinitionFieldEditRequested(definition, payload, row))
 
     def _commit_at_edit(self, event: Input.Submitted) -> None:
+        """Commit the `At` row, writing THIS schedule kind's own field.
+
+        Never converts the kind (Qodo finding 8): the outgoing schedule
+        is the stored dict with one field replaced, so a `daily` row
+        keeps `kind`/`weekday`/`timezone` and only its `time_of_day`
+        moves. Each kind is validated by the parser that owns its format
+        -- `parse_forgiving_datetime` for a `one_time` `run_at` (the same
+        one `AutomationDefinitionForm._client_side_schedule_error` runs,
+        since the ported server validator only checks `kind`), and
+        `parse_time_of_day` for a `daily`/`weekly` `time_of_day` (the
+        same one `preset_to_cron` runs).
+        """
         definition = self._editing_definition()
         row = self._at_row
         if definition is None or row is None:
             return
         event.stop()
-        row.end_edit()
-        raw = event.value.strip()
-        if not raw:
-            row.show_error("Run at is required for one-time automations.")
-            return
-        # Reused, not re-derived: the exact parser the create/edit modal's
-        # own client-side preflight (`AutomationDefinitionForm._client_
-        # side_schedule_error`) already runs, since the ported server
-        # validator (`validate_schedule`) only checks `kind`, never
-        # `run_at`'s own parseability.
-        parsed, _assumed_local = parse_forgiving_datetime(raw)
-        if parsed is None:
-            row.show_error("Run at must be a date and time like 2026-08-28 09:00.")
-            return
         schedule = (
             definition.get("schedule")
             if isinstance(definition.get("schedule"), dict)
             else {}
         )
-        new_schedule = {**schedule, "kind": "one_time", "run_at": parsed.isoformat()}
+        field = _AT_EDIT_FIELD_BY_KIND.get(str(schedule.get("kind") or ""))
+        if field is None:
+            return
+        row.end_edit()
+        raw = event.value.strip()
+        if field == "run_at":
+            if not raw:
+                row.show_error("Run at is required for one-time automations.")
+                return
+            parsed, _assumed_local = parse_forgiving_datetime(raw)
+            if parsed is None:
+                row.show_error("Run at must be a date and time like 2026-08-28 09:00.")
+                return
+            new_value: Any = parsed.isoformat()
+        else:
+            parsed_time = parse_time_of_day(raw)
+            if parsed_time is None:
+                row.show_error("Time of day must be a 24-hour time like 09:00.")
+                return
+            hour, minute = parsed_time
+            new_value = f"{hour:02d}:{minute:02d}"
+        new_schedule = {**schedule, field: new_value}
         payload = _definition_edit_payload(definition, schedule=new_schedule)
         self.post_message(DefinitionFieldEditRequested(definition, payload, row))
 
@@ -1482,5 +1628,4 @@ class DefinitionDetail(Vertical):
         """
         self._lifecycle_lock_reason = reason
         self._refresh_lifecycle_button()
-        if self._why_static is not None:
-            self._why_static.update(reason or "")
+        self._refresh_why_note()

--- a/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
@@ -544,17 +544,18 @@ class AutomationDefinitionForm(ModalScreen):
         options` for a bare-function inline-row editor to reuse; task 4's
         review flagged this method as a third, still-independent copy --
         folded in here, no test pins either difference below). Two small
-        observable differences from the pre-consolidation body: the
-        unrecognized-zone label's wording (generic "stored on this task,
-        not recognized here" -> this method's own former "stored on this
-        automation..."), and an UNDETECTED machine zone (`detect_system_
-        timezone()` returning `None`) now gets an honest "machine zone
-        not detected" label on the fallback entry instead of silently
-        offering the bare default zone -- a strict improvement, not a
-        behavior this form deliberately avoided. Option VALUES/ordering
-        are unchanged.
+        observable difference from the pre-consolidation body: an
+        UNDETECTED machine zone (`detect_system_timezone()` returning
+        `None`) now gets an honest "machine zone not detected" label on
+        the fallback entry instead of silently offering the bare default
+        zone -- a strict improvement, not a behavior this form
+        deliberately avoided. The unrecognized-zone label keeps saying
+        "stored on this automation" via the `noun` argument: the
+        consolidation had briefly put the reminder wording on this
+        surface, which is the vocabulary slip final review F10 caught.
+        Option VALUES/ordering are unchanged.
         """
-        return timezone_options(self._stored_timezone())
+        return timezone_options(self._stored_timezone(), noun="automation")
 
     def _initial_timezone(self) -> str:
         return self._stored_timezone() or system_timezone_name()

--- a/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
@@ -4,9 +4,12 @@ Mirrors `ReminderForm`'s structure (ADR-099 idiom parity: the modal box is
 its own scroll container, a docked footer keeps the live preview/errors/
 actions visible, Escape triggers a discard guard). The recurring-cron
 schedule sub-form reuses `reminder_form.py`'s task-23102 pure helpers
-(`preset_to_cron`, `cron_to_preset`, `parse_forgiving_datetime`, timezone
-helpers) directly -- only the Textual wiring (widget ids, compose layout)
-is necessarily duplicated, since it is bound to this form's own field ids.
+(`preset_to_cron`, `cron_to_preset`) directly, plus `parse_forgiving_
+datetime`/`is_valid_zone` from `Scheduling/schedule_input_parsing.py`
+(redesign PR-3, task 3 hoisted these two out of `reminder_form.py` -- pure
+stdlib, no Textual, no layering reason left to route through the form
+module) -- only the Textual wiring (widget ids, compose layout) is
+necessarily duplicated, since it is bound to this form's own field ids.
 `cron_to_preset` is used for edit-mode prefill (mapping a stored cron
 expression back onto the preset/time-of-day fields); nothing here needs
 `parse_time_of_day` directly since `cron_to_preset` already returns the
@@ -35,6 +38,10 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Input, Label, Select, Static, TextArea
 
 from tldw_chatbook.Scheduling.models import PreviewStatus, ScheduleKind
+from tldw_chatbook.Scheduling.schedule_input_parsing import (
+    is_valid_zone,
+    parse_forgiving_datetime,
+)
 
 from ..task_detail import definition_cron_expression
 
@@ -42,10 +49,8 @@ from .reminder_form import (
     _CURATED_TIMEZONES,
     _DEFAULT_TIMEZONE,
     _TIME_OF_DAY_PRESETS,
-    _is_valid_zone,
     cron_to_preset,
     detect_system_timezone,
-    parse_forgiving_datetime,
     preset_to_cron,
     system_timezone_name,
 )
@@ -543,7 +548,7 @@ class AutomationDefinitionForm(ModalScreen):
         zones = [detected or _DEFAULT_TIMEZONE]
         stored = self._stored_timezone()
         for zone in list(_CURATED_TIMEZONES) + ([stored] if stored else []):
-            if zone not in zones and _is_valid_zone(zone):
+            if zone not in zones and is_valid_zone(zone):
                 zones.append(zone)
         options = [(zone, zone) for zone in zones]
         if stored and stored not in zones:

--- a/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
@@ -38,21 +38,16 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Input, Label, Select, Static, TextArea
 
 from tldw_chatbook.Scheduling.models import PreviewStatus, ScheduleKind
-from tldw_chatbook.Scheduling.schedule_input_parsing import (
-    is_valid_zone,
-    parse_forgiving_datetime,
-)
+from tldw_chatbook.Scheduling.schedule_input_parsing import parse_forgiving_datetime
 
 from ..task_detail import definition_cron_expression
 
 from .reminder_form import (
-    _CURATED_TIMEZONES,
-    _DEFAULT_TIMEZONE,
     _TIME_OF_DAY_PRESETS,
     cron_to_preset,
-    detect_system_timezone,
     preset_to_cron,
     system_timezone_name,
+    timezone_options,
 )
 
 if TYPE_CHECKING:
@@ -543,19 +538,23 @@ class AutomationDefinitionForm(ModalScreen):
         but non-curated zone (`Pacific/Apia`) assigned a value outside the
         Select's own options and raised `InvalidSelectValueError`, taking
         the whole edit modal down.
+
+        Delegates to the module-level `timezone_options()` (redesign PR-3
+        task 3 hoisted this same body out of `ReminderForm._timezone_
+        options` for a bare-function inline-row editor to reuse; task 4's
+        review flagged this method as a third, still-independent copy --
+        folded in here, no test pins either difference below). Two small
+        observable differences from the pre-consolidation body: the
+        unrecognized-zone label's wording (generic "stored on this task,
+        not recognized here" -> this method's own former "stored on this
+        automation..."), and an UNDETECTED machine zone (`detect_system_
+        timezone()` returning `None`) now gets an honest "machine zone
+        not detected" label on the fallback entry instead of silently
+        offering the bare default zone -- a strict improvement, not a
+        behavior this form deliberately avoided. Option VALUES/ordering
+        are unchanged.
         """
-        detected = detect_system_timezone()
-        zones = [detected or _DEFAULT_TIMEZONE]
-        stored = self._stored_timezone()
-        for zone in list(_CURATED_TIMEZONES) + ([stored] if stored else []):
-            if zone not in zones and is_valid_zone(zone):
-                zones.append(zone)
-        options = [(zone, zone) for zone in zones]
-        if stored and stored not in zones:
-            options.append(
-                (f"{stored} — stored on this automation, not recognized here", stored)
-            )
-        return options
+        return timezone_options(self._stored_timezone())
 
     def _initial_timezone(self) -> str:
         return self._stored_timezone() or system_timezone_name()

--- a/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/automation_definition_form.py
@@ -43,6 +43,7 @@ from tldw_chatbook.Scheduling.schedule_input_parsing import parse_forgiving_date
 from ..task_detail import definition_cron_expression
 
 from .reminder_form import (
+    DEFAULT_TIME_OF_DAY,
     _TIME_OF_DAY_PRESETS,
     cron_to_preset,
     preset_to_cron,
@@ -358,7 +359,10 @@ class AutomationDefinitionForm(ModalScreen):
                 )
                 with Vertical(id="automation-preset-time-group"):
                     yield Label("Time of day (24-hour):", classes="form-label")
-                    yield Input(placeholder="09:00", id="automation-preset-time")
+                    yield Input(
+                        placeholder=DEFAULT_TIME_OF_DAY,
+                        id="automation-preset-time",
+                    )
                 with Vertical(id="automation-cron-custom-group"):
                     yield Label("Cron Expression:", classes="form-label")
                     yield Input(placeholder="0 9 * * 1", id="automation-cron")
@@ -412,7 +416,7 @@ class AutomationDefinitionForm(ModalScreen):
                     yield Button("Cancel", id="automation-cancel")
 
     def on_mount(self) -> None:
-        self.query_one("#automation-preset-time", Input).value = "09:00"
+        self.query_one("#automation-preset-time", Input).value = DEFAULT_TIME_OF_DAY
         self.query_one("#automation-cron", Input).value = "0 9 * * *"
         self._update_schedule_field_visibility(ScheduleKind.ONE_TIME.value)
         self._update_preset_field_visibility("daily")

--- a/tldw_chatbook/UI/Screens/scheduling/forms/reminder_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/reminder_form.py
@@ -95,6 +95,14 @@ def system_timezone_name() -> str:
     return detect_system_timezone() or _DEFAULT_TIMEZONE
 
 
+#: The time of day every preset-driven surface falls back to when it has
+#: no stored one to reuse: the two forms' `HH:MM` placeholder and reset
+#: value, and both detail panes' Repeat-row `preset_to_cron` fallback
+#: (Qodo finding 4 -- five copies of the same literal, one of which
+#: silently decides when a rescheduled automation actually fires).
+DEFAULT_TIME_OF_DAY = "09:00"
+
+
 def parse_time_of_day(raw: str) -> tuple[int, int] | None:
     """Parse ``HH:MM`` (24-hour, single-digit hour allowed) to (hour, minute).
 
@@ -521,7 +529,7 @@ class ReminderForm(ModalScreen):
                 with Vertical(id="reminder-preset-time-group"):
                     yield Label("Time of day (24-hour):", classes="form-label")
                     yield Input(
-                        placeholder="09:00",
+                        placeholder=DEFAULT_TIME_OF_DAY,
                         id="reminder-preset-time",
                     )
                 with Vertical(id="reminder-cron-custom-group"):
@@ -561,7 +569,7 @@ class ReminderForm(ModalScreen):
         """Prefill the form when editing an existing reminder."""
         if self._reminder_task is None:
             # Create mode: start from the default preset (daily at 09:00).
-            self.query_one("#reminder-preset-time", Input).value = "09:00"
+            self.query_one("#reminder-preset-time", Input).value = DEFAULT_TIME_OF_DAY
             self.query_one("#reminder-cron", Input).value = "0 9 * * *"
             self._update_preset_field_visibility("daily")
             self._update_cron_preview()
@@ -586,7 +594,7 @@ class ReminderForm(ModalScreen):
             # Recurring reveals a coherent preset + time (not both
             # sub-groups at once with a preset that silently overrides a
             # typed cron on save).
-            self.query_one("#reminder-preset-time", Input).value = "09:00"
+            self.query_one("#reminder-preset-time", Input).value = DEFAULT_TIME_OF_DAY
             self.query_one("#reminder-cron", Input).value = "0 9 * * *"
             self._update_preset_field_visibility("daily")
             self._update_cron_preview()

--- a/tldw_chatbook/UI/Screens/scheduling/forms/reminder_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/reminder_form.py
@@ -194,7 +194,10 @@ def cron_to_preset(cron: str) -> tuple[str, str]:
 
 
 def timezone_options(
-    task_zone: str | None, known_timezones: Sequence[str] = ()
+    task_zone: str | None,
+    known_timezones: Sequence[str] = (),
+    *,
+    noun: str = "task",
 ) -> list[tuple[str, str]]:
     """(label, zone) options: system zone first, then curated zones, then
     task-used zones, then ``task_zone`` itself (redesign PR-3, task 3:
@@ -216,6 +219,15 @@ def timezone_options(
             no such inventory (a single-row editor, not the full form) may
             omit this -- the system zone, curated list, and ``task_zone``
             itself are still always offered.
+        noun: What the calling surface calls the row being edited, for
+            the unrecognized-zone label ("stored on this <noun>").
+            Consolidating the third copy of this builder (task 3) put the
+            reminder wording on the automations surface too, where the
+            row is an automation, not a task -- the same task-vs-
+            automation vocabulary slip PR-1's owner-row bug was about
+            (final review F10; `Tests/UI/test_schedules_terminology.py`
+            is the standing guard for that class). Defaults to the
+            reminder wording, so every existing caller is unchanged.
 
     Returns:
         ``(label, zone)`` options, safe to pass directly to a `Select`.
@@ -237,7 +249,7 @@ def timezone_options(
             options.append((zone, zone))
     if task_zone and task_zone not in zones:
         options.append(
-            (f"{task_zone} — stored on this task, not recognized here", task_zone)
+            (f"{task_zone} — stored on this {noun}, not recognized here", task_zone)
         )
     return options
 

--- a/tldw_chatbook/UI/Screens/scheduling/forms/reminder_form.py
+++ b/tldw_chatbook/UI/Screens/scheduling/forms/reminder_form.py
@@ -7,7 +7,6 @@ import re
 from collections.abc import Sequence
 from datetime import datetime
 from typing import Any
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from croniter import croniter
 from textual.app import ComposeResult
@@ -18,6 +17,10 @@ from textual.widgets import Button, Input, Label, Select, Static, TextArea
 
 from tldw_chatbook.Scheduling.events import ReminderFormSubmitted
 from tldw_chatbook.Scheduling.models import ReminderTask, ScheduleKind
+from tldw_chatbook.Scheduling.schedule_input_parsing import (
+    is_valid_zone,
+    parse_forgiving_datetime,
+)
 
 
 _DEFAULT_TIMEZONE = "UTC"
@@ -44,14 +47,6 @@ _CURATED_TIMEZONES: tuple[str, ...] = (
     "Australia/Sydney",
 )
 
-#: Forgiving local datetime formats (naive -> system local zone).
-_FORGIVING_DATETIME_FORMATS: tuple[str, ...] = (
-    "%Y-%m-%d %H:%M",
-    "%Y-%m-%dT%H:%M",
-    "%Y-%m-%d %H:%M:%S",
-    "%Y-%m-%dT%H:%M:%S",
-)
-
 _TIME_OF_DAY_RE = re.compile(r"^(\d{1,2}):(\d{2})$")
 
 #: Day-of-week field per time-of-day preset (task-23102).
@@ -62,36 +57,6 @@ _PRESET_DOW: dict[str, str] = {
 }
 
 _TIME_OF_DAY_PRESETS = frozenset(_PRESET_DOW)
-
-
-# Why these parsers live here and not in ``Utils/input_validation.py``:
-# that module is the *security* boundary ("Input validation utilities for
-# secure user input handling") -- boolean gatekeepers for traversal,
-# injection, SSRF and size-class risks. The helpers below are domain
-# format parsers: they normalize text into schedule values (an aware
-# datetime, an (hour, minute) pair, a cron expression) and hand back
-# presentation signals the form renders as live hints, such as
-# ``parse_forgiving_datetime``'s ``assumed_local`` flag. Nothing here
-# guards a trust boundary -- the parsed values reach SQLite only through
-# parameterized queries, and cron validity is enforced by ``croniter`` --
-# so hoisting them would import croniter, zoneinfo and this screen's
-# preset vocabulary into a module the security-critical paths depend on,
-# for no safety gain. Bounds checks that DO protect a boundary belong in
-# the shared module; these belong with the form whose messages they feed.
-def _is_valid_zone(name: str) -> bool:
-    """Return True when ``name`` resolves to an IANA timezone.
-
-    Args:
-        name: Candidate IANA zone name, e.g. ``"Europe/Berlin"``.
-
-    Returns:
-        True when the local tzdata can resolve ``name``, False otherwise.
-    """
-    try:
-        ZoneInfo(name)
-    except (ZoneInfoNotFoundError, ValueError, TypeError):
-        return False
-    return True
 
 
 def detect_system_timezone() -> str | None:
@@ -107,7 +72,7 @@ def detect_system_timezone() -> str | None:
         The detected IANA zone name, or None when detection fails.
     """
     tz_env = os.environ.get("TZ", "").strip()
-    if tz_env and _is_valid_zone(tz_env):
+    if tz_env and is_valid_zone(tz_env):
         return tz_env
     try:
         localtime = os.path.realpath("/etc/localtime")
@@ -115,7 +80,7 @@ def detect_system_timezone() -> str | None:
         localtime = ""
     if "/zoneinfo/" in localtime:
         name = localtime.split("/zoneinfo/", 1)[1]
-        if _is_valid_zone(name):
+        if is_valid_zone(name):
             return name
     return None
 
@@ -128,44 +93,6 @@ def system_timezone_name() -> str:
         back to ``"UTC"``.
     """
     return detect_system_timezone() or _DEFAULT_TIMEZONE
-
-
-def parse_forgiving_datetime(raw: str) -> tuple[datetime | None, bool]:
-    """Parse a run-at datetime, accepting forgiving local forms.
-
-    Returns ``(parsed, assumed_local)``: full ISO-8601 keeps its offset
-    (``assumed_local`` False); a naive form such as ``2026-08-28 09:00``
-    is interpreted in the system's local timezone (``assumed_local``
-    True). ``(None, False)`` when nothing parses.
-
-    Args:
-        raw: The user-entered run-at text; surrounding whitespace is
-            ignored and an empty string is treated as "not a date".
-
-    Returns:
-        A ``(datetime | None, bool)`` pair. The datetime is always
-        timezone-aware when parsing succeeds. The bool is True only when
-        a naive input was assumed to be local time, so the caller can say
-        so in the UI.
-    """
-    text = raw.strip()
-    if not text:
-        return None, False
-    parsed: datetime | None = None
-    try:
-        parsed = datetime.fromisoformat(text)
-    except ValueError:
-        for fmt in _FORGIVING_DATETIME_FORMATS:
-            try:
-                parsed = datetime.strptime(text, fmt)
-            except ValueError:
-                continue
-            break
-    if parsed is None:
-        return None, False
-    if parsed.tzinfo is None:
-        return parsed.astimezone(), True
-    return parsed, False
 
 
 def parse_time_of_day(raw: str) -> tuple[int, int] | None:
@@ -264,6 +191,55 @@ def cron_to_preset(cron: str) -> tuple[str, str]:
                 if dow == preset_dow:
                     return preset, time_text
     return "custom", ""
+
+
+def timezone_options(
+    task_zone: str | None, known_timezones: Sequence[str] = ()
+) -> list[tuple[str, str]]:
+    """(label, zone) options: system zone first, then curated zones, then
+    task-used zones, then ``task_zone`` itself (redesign PR-3, task 3:
+    module-level so `TaskDetail`'s inline Timezone row editor can reuse
+    the exact same option source `ReminderForm._timezone_options` builds,
+    without instantiating a modal screen just to call one method).
+
+    ``task_zone``'s stored value is always offered -- even when it does
+    not resolve in local tzdata -- labeled as unrecognized, so an
+    unrelated edit round-trips it instead of silently rewriting it to the
+    system zone (review F4). An undetected machine zone is labeled
+    honestly (review F7).
+
+    Args:
+        task_zone: The zone already stored on the row being edited, or
+            ``None`` for a fresh (create-mode) selector.
+        known_timezones: Zones already used by other existing tasks,
+            offered alongside the curated list (task-23102). Callers with
+            no such inventory (a single-row editor, not the full form) may
+            omit this -- the system zone, curated list, and ``task_zone``
+            itself are still always offered.
+
+    Returns:
+        ``(label, zone)`` options, safe to pass directly to a `Select`.
+    """
+    detected = detect_system_timezone()
+    zones = [detected or _DEFAULT_TIMEZONE]
+    candidates = list(_CURATED_TIMEZONES) + [zone for zone in known_timezones if zone]
+    if task_zone:
+        candidates.append(task_zone)
+    for zone in candidates:
+        if zone not in zones and is_valid_zone(zone):
+            zones.append(zone)
+
+    options: list[tuple[str, str]] = []
+    for zone in zones:
+        if detected is None and zone == _DEFAULT_TIMEZONE:
+            options.append((f"{zone} — machine zone not detected", zone))
+        else:
+            options.append((zone, zone))
+    if task_zone and task_zone not in zones:
+        options.append(
+            (f"{task_zone} — stored on this task, not recognized here", task_zone)
+        )
+    return options
 
 
 class ReminderForm(ModalScreen):
@@ -411,38 +387,16 @@ class ReminderForm(ModalScreen):
         return task_owner or self._default_owner
 
     def _timezone_options(self) -> list[tuple[str, str]]:
-        """(label, zone) options: system zone first, then curated zones,
-        then task-used zones, then this task's stored zone.
+        """(label, zone) options for this form's own edited task.
 
-        The edited task's OWN stored zone is always offered -- even when
-        it does not resolve in local tzdata -- labeled as unrecognized,
-        so an unrelated edit round-trips it instead of silently rewriting
-        the task's timezone to the system zone (review F4). An undetected
-        machine zone is labeled honestly (review F7).
+        Thin wrapper around the module-level `timezone_options` (redesign
+        PR-3, task 3): the create/edit modal's own known-zones/edited-task
+        inputs feed the same reusable option-builder `TaskDetail`'s inline
+        Timezone row editor now consumes too, so both surfaces stay
+        byte-identical without a second implementation to drift.
         """
-        detected = detect_system_timezone()
-        zones = [detected or _DEFAULT_TIMEZONE]
-        candidates = list(_CURATED_TIMEZONES) + [
-            zone for zone in self._known_timezones if zone
-        ]
         task_zone = getattr(self._reminder_task, "timezone", None)
-        if task_zone:
-            candidates.append(task_zone)
-        for zone in candidates:
-            if zone not in zones and _is_valid_zone(zone):
-                zones.append(zone)
-
-        options: list[tuple[str, str]] = []
-        for zone in zones:
-            if detected is None and zone == _DEFAULT_TIMEZONE:
-                options.append((f"{zone} — machine zone not detected", zone))
-            else:
-                options.append((zone, zone))
-        if task_zone and task_zone not in zones:
-            options.append(
-                (f"{task_zone} — stored on this task, not recognized here", task_zone)
-            )
-        return options
+        return timezone_options(task_zone, self._known_timezones)
 
     def _initial_timezone(self) -> str:
         """The zone preselected on open: the task's own, else the system's.
@@ -849,7 +803,7 @@ class ReminderForm(ModalScreen):
                 # The unknown-zone error stays as a defensive backstop for
                 # programmatic value assignment only.
                 stored_zone = getattr(self._reminder_task, "timezone", None)
-                if timezone != stored_zone and not _is_valid_zone(timezone):
+                if timezone != stored_zone and not is_valid_zone(timezone):
                     errors.append(f"Unknown timezone: {timezone}")
 
         if errors:

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -376,6 +376,10 @@ class SchedulesWorkbench(BaseAppScreen):
         # `_selected_task_id` above stays reminder-only for the existing
         # action code that reads it directly.
         self._selected_row_id: str | None = None
+        #: One `asyncio.Lock` per definition an in-pane row edit has
+        #: touched, serializing that definition's read-merge-write saves
+        #: (Qodo finding 7) -- see `_edit_definition_field`.
+        self._definition_edit_locks: dict[str, asyncio.Lock] = {}
         self._marked_ids: set[str] = set()
         #: The current hidden-panes notice from on_resize; combined with
         #: the marks/glyph legend in _update_pane_notice (task-23107).
@@ -2282,7 +2286,14 @@ class SchedulesWorkbench(BaseAppScreen):
             try:
                 outcome = await service.edit_reminder_fields(task.id, payload)
             except Exception:  # noqa: BLE001
-                logger.exception("Failed to edit reminder field")
+                logger.exception(
+                    # Qodo finding 2: an unattributed "it failed" line is
+                    # unusable in a log with many reminders. Ids only --
+                    # the VALUE is the user's own reminder text.
+                    "Failed to edit reminder {task_id} field {field}",
+                    task_id=task.id,
+                    field=row.row_key,
+                )
                 row.show_error("Failed to save this edit.")
                 return
             if outcome.status != "saved":
@@ -2341,55 +2352,128 @@ class SchedulesWorkbench(BaseAppScreen):
         -- PLUS `_repaint_queue_definition_detail`, because that lazy
         Queue refresh is not a repaint of the Queue tab's own SECOND
         `DefinitionDetail` instance (final review F4/I4).
+
+        Every failure path paints through `_show_definition_row_error`
+        rather than `row.show_error` directly (Qodo finding 9): this
+        worker holds `row` across an `await`, so a late failure could
+        otherwise stamp its message under whatever automation the pane
+        moved on to -- the same crossed-identity class the commit path's
+        `_editing_definition` belt closes on the way in.
         """
         service = self._scheduling_service
+        definition_id = str(definition.get("id") or "")
         if service is None:
             row.show_error(
                 "Scheduling service is unavailable; cannot save this edit."
             )
             return
 
+        # Per-DEFINITION serialization (Qodo finding 7, narrowing final
+        # review M12): a field-keyed worker group let two edits of the
+        # SAME automation run concurrently, and `save_definition` merges
+        # each payload onto the row it read at ENTRY -- so the slower one
+        # wrote back a snapshot taken before the faster one landed,
+        # silently reverting it. The gate is a per-definition lock rather
+        # than `exclusive=True` on a per-definition group, because
+        # Textual's exclusivity CANCELS the running worker instead of
+        # queueing behind it: that turns "two quick edits" into "the
+        # first one is discarded", which is the same lost update by
+        # another route (M12 hit exactly this across rows). Different
+        # automations hold different locks and still run in parallel.
+        # The map is never pruned: one `asyncio.Lock` per definition
+        # edited this session, which is bounded by what a human clicks.
+        lock = self._definition_edit_locks.setdefault(definition_id, asyncio.Lock())
+
         async def _edit_and_refresh() -> None:
-            local_id = await self._resolve_local_definition_id(service, definition)
-            if local_id is None:
-                row.show_error(
-                    "Could not prepare this automation for editing — see "
-                    "the log."
+            async with lock:
+                await self._save_definition_field(
+                    service, definition, definition_id, payload, row
                 )
-                return
-            owner_id = str(definition.get("owner_id") or "local")
-            try:
-                outcome = await service.save_definition(
-                    payload, owner_id, definition_id=local_id
-                )
-            except Exception:  # noqa: BLE001
-                logger.exception(
-                    "Failed to edit automation definition field for {}", local_id
-                )
-                row.show_error("Failed to save this edit.")
-                return
-            if outcome.status not in ("saved", "queued"):
-                message = "; ".join(
-                    str(err.get("message") or "")
-                    for err in outcome.errors
-                    if err.get("message")
-                ) or "This edit could not be saved."
-                row.show_error(message)
-                return
-            row.clear_error()
-            self._definitions_stale = True
-            self._request_automations_refresh()
-            await self._repaint_queue_definition_detail(
-                service, local_id, definition
-            )
 
         self.run_worker(
             _edit_and_refresh,
-            exclusive=True,
-            # Per-ROW group (final review M12) -- see `_edit_reminder_
-            # field`'s own group for why.
-            group=f"schedules-edit-definition-field-{row.row_key}",
+            group=f"schedules-edit-definition-{definition_id}",
         )  # type: ignore[arg-type]
+
+    async def _save_definition_field(
+        self,
+        service: "SchedulingService",
+        definition: dict[str, Any],
+        definition_id: str,
+        payload: dict[str, Any],
+        row: DetailValueRow,
+    ) -> None:
+        """`_edit_definition_field`'s worker body, under its row lock."""
+        local_id = await self._resolve_local_definition_id(service, definition)
+        if local_id is None:
+            self._show_definition_row_error(
+                row,
+                {definition_id},
+                "Could not prepare this automation for editing — see the log.",
+            )
+            return
+        owner_id = str(definition.get("owner_id") or "local")
+        painted = {definition_id, local_id}
+        try:
+            outcome = await service.save_definition(
+                payload, owner_id, definition_id=local_id
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                # Qodo finding 2: which automation, and which of its
+                # fields -- never the value, which is the user's own
+                # question/model text.
+                "Failed to edit automation definition {definition_id} field "
+                "{field}",
+                definition_id=local_id,
+                field=row.row_key,
+            )
+            self._show_definition_row_error(row, painted, "Failed to save this edit.")
+            return
+        if outcome.status not in ("saved", "queued"):
+            message = "; ".join(
+                str(err.get("message") or "")
+                for err in outcome.errors
+                if err.get("message")
+            ) or "This edit could not be saved."
+            self._show_definition_row_error(row, painted, message)
+            return
+        row.clear_error()
+        self._definitions_stale = True
+        self._request_automations_refresh()
+        await self._repaint_queue_definition_detail(service, local_id, definition)
+
+    def _show_definition_row_error(
+        self, row: DetailValueRow, definition_ids: set[str], message: str
+    ) -> None:
+        """`row.show_error(message)`, unless the row moved on (finding 9).
+
+        The pane that owns ``row`` is asked what it is currently
+        painting; if that is no longer one of ``definition_ids`` -- the
+        listing id the edit was dispatched for plus the local id it
+        resolved to, the same both-shapes pair `_repaint_queue_
+        definition_detail` matches on -- the message is dropped with a
+        debug line instead of being stamped onto another automation's
+        field. An unparented row (never mounted, or already removed)
+        paints as before: there is no pane to contradict it.
+        """
+        pane = next(
+            (
+                ancestor
+                for ancestor in row.ancestors
+                if isinstance(ancestor, DefinitionDetail)
+            ),
+            None,
+        )
+        if pane is not None and pane.shown_definition_id not in definition_ids:
+            logger.debug(
+                "Dropping a stale automation edit error for {expected}: the "
+                "pane now shows {actual}",
+                expected=sorted(definition_ids),
+                actual=pane.shown_definition_id,
+            )
+            return
+        row.show_error(message)
 
     async def _repaint_queue_definition_detail(
         self,

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -29,6 +29,8 @@ from ....runtime_policy.bootstrap import set_authoritative_runtime_source
 from ....Scheduling.automation_health import compute_local_health
 from ....Scheduling.events import (
     CancelTransferRequested,
+    DefinitionFieldEditRequested,
+    DefinitionLifecycleToggleRequested,
     DeleteTaskRequested,
     DisableTaskRequested,
     AcknowledgeIncidentRequested,
@@ -76,6 +78,7 @@ from ....Widgets.detail_value_row import DetailValueRow
 from .definition_detail import (
     DefinitionDetail,
     _definition_transfer_suffix,
+    _LIFECYCLE_TOGGLE_RESULTS,
     automation_execution_target_label,
     automation_name_cell,
 )
@@ -2264,6 +2267,164 @@ class SchedulesWorkbench(BaseAppScreen):
             group="schedules-edit-reminder-field",
         )  # type: ignore[arg-type]
 
+    @on(DefinitionFieldEditRequested)
+    def _on_definition_field_edit_requested(
+        self, event: DefinitionFieldEditRequested
+    ) -> None:
+        """A Details/Frequency row's inline editor committed a value
+        (PR-3 task 4)."""
+        event.stop()
+        self._edit_definition_field(event.definition, event.payload, event.row)
+
+    def _edit_definition_field(
+        self,
+        definition: dict[str, Any],
+        payload: dict[str, Any],
+        row: DetailValueRow,
+    ) -> None:
+        """Persist one Details/Frequency row's edit via `save_definition`.
+
+        `DefinitionDetail` has already closed the row's editor (`end_
+        edit`, restoring the OLD display) before posting the request --
+        a failure needs no separate "restore" step here, only `show_
+        error`. `definition["id"]` may be a LOCAL row id or, for a row
+        shown from a pure server fetch with no local shadow yet, the
+        SERVER's id -- resolved to a real local id the same way the
+        existing full-modal Edit action already does (`_resolve_local_
+        definition_id`, `_edit_selected_automation`'s own precedent).
+        Success repaints authoritatively via the SAME staleness-plus-
+        refresh seam every other definition mutation in this file uses
+        (run-now, transfer begin/cancel) -- `_definitions_stale = True`
+        + `_request_automations_refresh()`, which reloads the Automations
+        tab's own table+detail immediately and marks the Queue's unified
+        list stale for its own next (lazy, tab-activation-gated) refresh.
+        """
+        service = self._scheduling_service
+        if service is None:
+            row.show_error(
+                "Scheduling service is unavailable; cannot save this edit."
+            )
+            return
+
+        async def _edit_and_refresh() -> None:
+            local_id = await self._resolve_local_definition_id(service, definition)
+            if local_id is None:
+                row.show_error(
+                    "Could not prepare this automation for editing — see "
+                    "the log."
+                )
+                return
+            owner_id = str(definition.get("owner_id") or "local")
+            try:
+                outcome = await service.save_definition(
+                    payload, owner_id, definition_id=local_id
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Failed to edit automation definition field for {}", local_id
+                )
+                row.show_error("Failed to save this edit.")
+                return
+            if outcome.status not in ("saved", "queued"):
+                message = "; ".join(
+                    str(err.get("message") or "")
+                    for err in outcome.errors
+                    if err.get("message")
+                ) or "This edit could not be saved."
+                row.show_error(message)
+                return
+            row.clear_error()
+            self._definitions_stale = True
+            self._request_automations_refresh()
+
+        self.run_worker(
+            _edit_and_refresh,
+            exclusive=True,
+            group="schedules-edit-definition-field",
+        )  # type: ignore[arg-type]
+
+    @on(DefinitionLifecycleToggleRequested)
+    def _on_definition_lifecycle_toggle_requested(
+        self, event: DefinitionLifecycleToggleRequested
+    ) -> None:
+        """The header Pause/Resume button was pressed (PR-3 task 4 --
+        `set_definition_lifecycle`'s first UI caller)."""
+        event.stop()
+        self._toggle_definition_lifecycle(event.definition, event.action)
+
+    def _toggle_definition_lifecycle(
+        self, definition: dict[str, Any], action: str
+    ) -> None:
+        """Pause/resume one automation via `set_definition_lifecycle`.
+
+        Optimistic repaint (task-4 brief): on success, every mounted
+        `DefinitionDetail` instance currently showing this definition is
+        patched + repainted in place (`apply_lifecycle`) BEFORE the
+        slower background refresh below runs, so neither pane shows a
+        stale label while that worker is still fetching. Task 2's own
+        DB-level pull-guard (`ScheduledTasksDB.upsert_automation_
+        definitions_from_server`'s lifecycle skip) is what then keeps a
+        sync pull racing that background refresh from reverting the
+        value it eventually reads back -- this method does not need to
+        know about that guard, only rely on it already existing.
+        """
+        service = self._scheduling_service
+        if service is None:
+            self.app_instance.notify(
+                "Scheduling service is unavailable; cannot update the "
+                "automation.",
+                severity="warning",
+            )
+            return
+        name = str(definition.get("name") or definition.get("id") or "")
+        definition_id = str(definition.get("id") or "")
+
+        async def _toggle_and_refresh() -> None:
+            local_id = await self._resolve_local_definition_id(service, definition)
+            if local_id is None:
+                self.app_instance.notify(
+                    f"Could not prepare '{name}' — see the log.",
+                    severity="error",
+                )
+                return
+            try:
+                outcome = await service.set_definition_lifecycle(local_id, action)
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Failed to toggle lifecycle for automation {}", local_id
+                )
+                self.app_instance.notify(
+                    f"Failed to update '{name}'.", severity="error"
+                )
+                return
+            if outcome.status != "saved":
+                message = (
+                    outcome.errors[0]["message"]
+                    if outcome.errors
+                    else f"Could not update '{name}'."
+                )
+                self.app_instance.notify(message, severity="warning")
+                return
+            new_lifecycle = _LIFECYCLE_TOGGLE_RESULTS[action]
+            definition["lifecycle"] = new_lifecycle
+            for widget_id in (
+                "#scheduling-automation-detail",
+                "#scheduling-queue-definition-detail",
+            ):
+                try:
+                    detail = self.query_one(widget_id, DefinitionDetail)
+                except Exception:  # noqa: BLE001 - not mounted yet
+                    continue
+                detail.apply_lifecycle(definition_id, new_lifecycle)
+            self._definitions_stale = True
+            self._request_automations_refresh()
+
+        self.run_worker(
+            _toggle_and_refresh,
+            exclusive=True,
+            group="schedules-definition-lifecycle",
+        )  # type: ignore[arg-type]
+
     @on(RunReminderNowRequested)
     def _on_run_reminder_now_requested(self, event: RunReminderNowRequested) -> None:
         """Dispatch the requested reminder immediately."""
@@ -2783,6 +2944,9 @@ class SchedulesWorkbench(BaseAppScreen):
             detail.set_definition(
                 definition, run_count=0, last_run=None, unread_count=0
             )
+            # Same fallback `_update_transfer_actions` uses for `TaskDetail`
+            # when there is no service to derive a real reason from.
+            detail.set_lifecycle_lock(None)
             return
 
         run_count, last_run, unread_count, history_error = (
@@ -2798,7 +2962,15 @@ class SchedulesWorkbench(BaseAppScreen):
             last_run=last_run,
             unread_count=unread_count,
             history_error=history_error,
+            known_timezones=self._task_timezones(),
         )
+        # PR-3 task 4: `DefinitionDetail` gains the SAME transfer-lock
+        # wiring `TaskDetail` has (survey point 10) -- `reason` comes from
+        # `SchedulingService.transfer_lock_reason` (never re-derived in
+        # the widget), fed right after `set_definition` per that
+        # method's own docstring, same as `_update_transfer_actions` does
+        # for the reminder pane.
+        detail.set_lifecycle_lock(service.transfer_lock_reason(definition))
 
     async def _fetch_definition_detail_counts(
         self,
@@ -2876,6 +3048,7 @@ class SchedulesWorkbench(BaseAppScreen):
                 detail.set_definition(
                     definition, run_count=0, last_run=None, unread_count=0
                 )
+                detail.set_lifecycle_lock(None)
             return
         run_count, last_run, unread_count, history_error = (
             await self._fetch_definition_detail_counts(
@@ -2892,7 +3065,14 @@ class SchedulesWorkbench(BaseAppScreen):
             last_run=last_run,
             unread_count=unread_count,
             history_error=history_error,
+            known_timezones=self._task_timezones(),
         )
+        # PR-3 task 4: same transfer-lock wiring as `_load_automation_
+        # detail`'s Automations-tab pane -- this is the Queue tab's own
+        # sibling instance of the SAME widget class, so it needs the
+        # same call, independently (each `DefinitionDetail` instance
+        # locks itself; there's no shared state between them).
+        detail.set_lifecycle_lock(service.transfer_lock_reason(definition))
 
     @on(DataTable.RowHighlighted, "#scheduling-automations-table")
     def _on_automations_row_highlighted(

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -184,6 +184,37 @@ def _cancel_toast_text(name: str) -> str:
     )
 
 
+def _pending_transfer_errors(
+    service: "SchedulingService", table_kind: str, row_id: str
+) -> list[str]:
+    """The stored `transfer_errors` from `row_id`'s queued transfer
+    mutation, or `[]` when none exist -- shared by `_update_transfer_
+    actions`'s existing Retry-button computation (reminders) and both
+    panes' Runs-on row (fix round 1, finding 2: same source `set_
+    transfer_reasons`'s own "Last transfer error: …" line already reads,
+    fed here rather than re-derived, one lookup per row)."""
+    mutation = service.db.get_pending_mutation_for_local_id(row_id, table_kind)
+    if mutation is None:
+        return []
+    errors = (mutation.get("payload") or {}).get("transfer_errors")
+    return list(errors) if errors else []
+
+
+def _definition_transfer_errors(
+    service: "SchedulingService", definition: dict[str, Any]
+) -> list[str]:
+    """`_pending_transfer_errors` for a definition dict, only when it is
+    actually `to_server_failed` -- a `to_server_failed` row is always
+    local-owned (a failed to_server transfer never became server-owned),
+    so `definition["id"]` is already the local id, no `_resolve_local_
+    definition_id` round trip needed (fix round 1, finding 2)."""
+    if definition.get("transfer_state") != "to_server_failed":
+        return []
+    return _pending_transfer_errors(
+        service, "automation_definition", str(definition.get("id"))
+    )
+
+
 #: Delayed second fetch of the run-history pane after a Run-now dispatch:
 #: the terminal audit event lands only after the server finishes executing
 #: the run, so an immediate fetch alone would usually miss it.
@@ -1484,6 +1515,7 @@ class SchedulesWorkbench(BaseAppScreen):
                 retry_errors=[],
             )
             task_detail.set_lifecycle_lock(None)
+            task_detail.set_runs_on_transfer_errors([])
             return
 
         row = transfer_row_dict(task)
@@ -1515,14 +1547,7 @@ class SchedulesWorkbench(BaseAppScreen):
             # whatever server was active at the time of the failed
             # attempt, which silently stops matching after a server
             # switch if guessed instead of read.
-            mutation = service.db.get_pending_mutation_for_local_id(
-                task.id, "reminder_task"
-            )
-            if mutation is not None:
-                payload = mutation.get("payload") or {}
-                errors = payload.get("transfer_errors")
-                if errors:
-                    retry_errors = list(errors)
+            retry_errors = _pending_transfer_errors(service, "reminder_task", task.id)
 
         task_detail.set_transfer_reasons(
             to_server_reason=to_server_reason,
@@ -1534,6 +1559,10 @@ class SchedulesWorkbench(BaseAppScreen):
         # spec §6.3 read-only-except-cancel (final review I7). Applied
         # AFTER set_transfer_reasons, which owns the same reason Static.
         task_detail.set_lifecycle_lock(service.transfer_lock_reason(row))
+        # PR-3 task 5 fix round 1 (finding 2): the SAME `retry_errors`
+        # feeds the Runs-on row's own failure text -- one source, not a
+        # second derivation.
+        task_detail.set_runs_on_transfer_errors(retry_errors)
 
     def _refuse_if_transfer_locked(self, task: Any, verb: str) -> bool:
         """Notify and return True when ``task`` is read-only mid-transfer.
@@ -2610,10 +2639,19 @@ class SchedulesWorkbench(BaseAppScreen):
         name = str(definition.get("name") or definition.get("id") or "")
 
         def _refresh() -> None:
-            self._definitions_stale = True
             self._request_automations_refresh()
 
         async def _do() -> None:
+            # fix round 1 finding 1: unconditional, BEFORE resolving --
+            # same rule `_begin_automation_transfer`/`_cancel_automation_
+            # transfer` follow (schedules_workbench.py:2766-2778).
+            # `_resolve_local_definition_id` can itself mirror a brand
+            # new local row (`upsert_automation_definitions_from_server`)
+            # the first time a pure server-fetch definition is touched --
+            # regardless of which branch below this lands on (refused,
+            # failed, `local_id is None`, or a genuine success), the
+            # Automations tab's cached list may now be outdated.
+            self._definitions_stale = True
             local_id = await self._resolve_local_definition_id(service, definition)
             if local_id is None:
                 row.show_error(
@@ -3172,6 +3210,7 @@ class SchedulesWorkbench(BaseAppScreen):
             # Same fallback `_update_transfer_actions` uses for `TaskDetail`
             # when there is no service to derive a real reason from.
             detail.set_lifecycle_lock(None)
+            detail.set_runs_on_transfer_errors([])
             return
 
         run_count, last_run, unread_count, history_error = (
@@ -3199,6 +3238,11 @@ class SchedulesWorkbench(BaseAppScreen):
         # method's own docstring, same as `_update_transfer_actions` does
         # for the reminder pane.
         detail.set_lifecycle_lock(service.transfer_lock_reason(definition))
+        # PR-3 task 5 fix round 1 (finding 2): the Runs-on row's own
+        # failure text, same source the legacy Retry button would use.
+        detail.set_runs_on_transfer_errors(
+            _definition_transfer_errors(service, definition)
+        )
 
     async def _fetch_definition_detail_counts(
         self,
@@ -3277,6 +3321,7 @@ class SchedulesWorkbench(BaseAppScreen):
                     definition, run_count=0, last_run=None, unread_count=0
                 )
                 detail.set_lifecycle_lock(None)
+                detail.set_runs_on_transfer_errors([])
             return
         run_count, last_run, unread_count, history_error = (
             await self._fetch_definition_detail_counts(
@@ -3304,6 +3349,11 @@ class SchedulesWorkbench(BaseAppScreen):
         # same call, independently (each `DefinitionDetail` instance
         # locks itself; there's no shared state between them).
         detail.set_lifecycle_lock(service.transfer_lock_reason(definition))
+        # PR-3 task 5 fix round 1 (finding 2): same as the Automations-tab
+        # sibling instance above.
+        detail.set_runs_on_transfer_errors(
+            _definition_transfer_errors(service, definition)
+        )
 
     @on(DataTable.RowHighlighted, "#scheduling-automations-table")
     def _on_automations_row_highlighted(

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -31,12 +31,14 @@ from ....Scheduling.events import (
     CancelTransferRequested,
     DefinitionFieldEditRequested,
     DefinitionLifecycleToggleRequested,
+    DefinitionOwnerActionRequested,
     DeleteTaskRequested,
     DisableTaskRequested,
     AcknowledgeIncidentRequested,
     EditTaskRequested,
     EnableTaskRequested,
     ReminderFieldEditRequested,
+    ReminderOwnerActionRequested,
     RetryTransferRequested,
     RunReminderNowRequested,
     SyncCompleted,
@@ -1433,6 +1435,10 @@ class SchedulesWorkbench(BaseAppScreen):
                 # own Timezone selector reads (`_task_timezones`), so the
                 # pane's inline Timezone row editor offers the same zones.
                 known_timezones=self._task_timezones(),
+                # PR-3 task 5: same option source the create/edit forms'
+                # own owner selector reads, so the Runs-on row's dropdown
+                # offers the same choices.
+                runs_on_options=self._runs_on_options()[0],
             )
             self._update_transfer_actions(task_detail, task)
             self.query_one("#scheduling-task-inspector", TaskInspector).set_task(task)
@@ -2425,6 +2431,225 @@ class SchedulesWorkbench(BaseAppScreen):
             group="schedules-definition-lifecycle",
         )  # type: ignore[arg-type]
 
+    # -- Owner-row transfer dropdown (PR-3 task 5, spec §7 flow) -------------
+    #
+    # A SECOND, row-scoped surface onto the SAME PR-5 transfer facade the
+    # legacy Move/Retry/Cancel buttons (`_begin_transfer`/`_cancel_
+    # transfer`/`_begin_automation_transfer`/`_cancel_automation_transfer`
+    # above/below) already drive -- deliberately independent end to end
+    # (own events, own helpers), not a refactor of them: coexistence is a
+    # pinned requirement (task-5 brief), and the two surfaces differ in
+    # how a refusal renders (this one uses `DetailValueRow.show_error`,
+    # the legacy ones toast/write the tab's shared inline notice).
+
+    async def _run_owner_transfer(
+        self,
+        *,
+        table_kind: str,
+        row_id: str,
+        row_dict: dict[str, Any],
+        name: str,
+        direction: str,
+        row: DetailValueRow,
+        refresh,
+    ) -> None:
+        """Shared move/retry body for both panes' Runs-on row.
+
+        `transfer_refusal` runs FIRST (health-quoting preserved, since it
+        is the SAME call `_begin_transfer`/`_begin_automation_transfer`
+        make) -- a refusal renders inline via `row.show_error`, never the
+        legacy toast/notice. Allowed -> the SAME `ConfirmationDialog` +
+        `transfer_warnings` + honest-toast shape those flows already use;
+        confirmed -> `begin_transfer_to_server`/`to_local` by `direction`
+        with `row_id` (the CURRENTLY DISPLAYED row's own local id for
+        both directions -- a `to_local` release's returned dormant-copy
+        id is a DIFFERENT id, `outcome.row_id`, relevant to a later
+        Cancel on that new row, not to this call).
+        """
+        service = self._scheduling_service
+        if service is None:
+            row.show_error(
+                "Scheduling service is unavailable; cannot start a transfer."
+            )
+            return
+        reason = service.transfer_refusal(row_dict, direction)
+        if reason is not None:
+            row.show_error(reason)
+            return
+        warnings = service.transfer_warnings(row_dict, direction)
+        dialog = self._transfer_confirm_dialog(name, direction, warnings)
+        confirmed = await self.app.push_screen_wait(dialog)
+        if not confirmed:
+            return
+        try:
+            if direction == "to_server":
+                outcome = await service.begin_transfer_to_server(table_kind, row_id)
+            else:
+                outcome = await service.begin_transfer_to_local(table_kind, row_id)
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to begin owner-row transfer for {}", row_id)
+            row.show_error(f"Failed to start the transfer for '{name}'.")
+            return
+        if outcome.status == "refused":
+            row.show_error(outcome.reason or f"Could not move '{name}'.")
+            return
+        if outcome.status == "not_found":
+            row.show_error(f"'{name}' no longer exists.")
+            return
+        row.clear_error()
+        self.app_instance.notify(
+            self._transfer_pending_toast_text(name, direction),
+            severity="information",
+        )
+        refresh()
+
+    async def _run_owner_cancel(
+        self,
+        *,
+        table_kind: str,
+        row_id: str,
+        name: str,
+        row: DetailValueRow,
+        refresh,
+    ) -> None:
+        """Shared cancel body for both panes' Runs-on row mini-bar.
+
+        No confirm dialog (same rationale `_cancel_transfer`'s own
+        docstring gives: cancel is the escape hatch). `row_id` is
+        whichever row the pane is CURRENTLY DISPLAYING -- for a release
+        leg (`from_server_pending`) that is already the DORMANT COPY's
+        own id, never the mirror's: the mirror's own `transfer_state`
+        stays untouched by `create_local_copy_from_mirror` (survey §3),
+        so this row-level Cancel affordance is only ever proactively
+        shown (`_configure_runs_on_row`) on a row whose OWN state is
+        in-flight -- which, for a release, can only be the copy itself.
+        """
+        service = self._scheduling_service
+        if service is None:
+            row.show_error(
+                "Scheduling service is unavailable; cannot cancel the transfer."
+            )
+            return
+        try:
+            outcome = await service.cancel_transfer(table_kind, row_id)
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to cancel owner-row transfer for {}", row_id)
+            row.show_error(f"Failed to cancel the transfer for '{name}'.")
+            return
+        if outcome.status != "cancelled":
+            row.show_error(
+                outcome.reason or f"Could not cancel the transfer for '{name}'."
+            )
+            return
+        row.clear_error()
+        self.app_instance.notify(_cancel_toast_text(name), severity="information")
+        refresh()
+
+    @on(ReminderOwnerActionRequested)
+    def _on_reminder_owner_action_requested(
+        self, event: ReminderOwnerActionRequested
+    ) -> None:
+        """The reminder pane's Runs-on row dropdown/mini-bar fired
+        (PR-3 task 5)."""
+        event.stop()
+        self._reminder_owner_action(event.task, event.action, event.row)
+
+    def _reminder_owner_action(
+        self, task: ReminderTask, action: str, row: DetailValueRow
+    ) -> None:
+        def _refresh() -> None:
+            self._request_tasks_refresh(refresh_definitions=False)
+
+        if action == "cancel":
+            async def _do() -> None:
+                await self._run_owner_cancel(
+                    table_kind="reminder_task",
+                    row_id=task.id,
+                    name=task.title,
+                    row=row,
+                    refresh=_refresh,
+                )
+
+            self.run_worker(_do, exclusive=True, group="schedules-transfer")  # type: ignore[arg-type]
+            return
+
+        direction = "to_server" if action == "retry" else action
+        row_dict = transfer_row_dict(task)
+
+        async def _do() -> None:
+            await self._run_owner_transfer(
+                table_kind="reminder_task",
+                row_id=task.id,
+                row_dict=row_dict,
+                name=task.title,
+                direction=direction,
+                row=row,
+                refresh=_refresh,
+            )
+
+        self.run_worker(_do, exclusive=True, group="schedules-transfer")  # type: ignore[arg-type]
+
+    @on(DefinitionOwnerActionRequested)
+    def _on_definition_owner_action_requested(
+        self, event: DefinitionOwnerActionRequested
+    ) -> None:
+        """A definition pane's Runs-on row dropdown/mini-bar fired
+        (PR-3 task 5)."""
+        event.stop()
+        self._definition_owner_action(event.definition, event.action, event.row)
+
+    def _definition_owner_action(
+        self, definition: dict[str, Any], action: str, row: DetailValueRow
+    ) -> None:
+        service = self._scheduling_service
+        if service is None:
+            row.show_error(
+                "Scheduling service is unavailable; cannot start a transfer."
+            )
+            return
+        name = str(definition.get("name") or definition.get("id") or "")
+
+        def _refresh() -> None:
+            self._definitions_stale = True
+            self._request_automations_refresh()
+
+        async def _do() -> None:
+            local_id = await self._resolve_local_definition_id(service, definition)
+            if local_id is None:
+                row.show_error(
+                    "Could not prepare this automation for transfer — see "
+                    "the log."
+                )
+                return
+            if action == "cancel":
+                await self._run_owner_cancel(
+                    table_kind="automation_definition",
+                    row_id=local_id,
+                    name=name,
+                    row=row,
+                    refresh=_refresh,
+                )
+                return
+            direction = "to_server" if action == "retry" else action
+            # A fresh read, like `_begin_automation_transfer`'s own
+            # precedent -- `self._definition` may be a raw server-fetch
+            # dict without the local row's `transfer_state`/`lifecycle`.
+            db_row = await asyncio.to_thread(
+                service.db.get_automation_definition, local_id
+            )
+            row_dict = db_row if db_row is not None else definition
+            await self._run_owner_transfer(
+                table_kind="automation_definition",
+                row_id=local_id,
+                row_dict=row_dict,
+                name=name,
+                direction=direction,
+                row=row,
+                refresh=_refresh,
+            )
+
+        self.run_worker(_do, exclusive=True, group="schedules-automation-transfer")  # type: ignore[arg-type]
+
     @on(RunReminderNowRequested)
     def _on_run_reminder_now_requested(self, event: RunReminderNowRequested) -> None:
         """Dispatch the requested reminder immediately."""
@@ -2963,6 +3188,9 @@ class SchedulesWorkbench(BaseAppScreen):
             unread_count=unread_count,
             history_error=history_error,
             known_timezones=self._task_timezones(),
+            # PR-3 task 5: same option source the Queue reminder pane's
+            # own Runs-on row reads (`_update_detail_for_index`).
+            runs_on_options=self._runs_on_options()[0],
         )
         # PR-3 task 4: `DefinitionDetail` gains the SAME transfer-lock
         # wiring `TaskDetail` has (survey point 10) -- `reason` comes from
@@ -3066,6 +3294,9 @@ class SchedulesWorkbench(BaseAppScreen):
             unread_count=unread_count,
             history_error=history_error,
             known_timezones=self._task_timezones(),
+            # PR-3 task 5: same option source the Automations-tab sibling
+            # instance's own Runs-on row reads (`_load_automation_detail`).
+            runs_on_options=self._runs_on_options()[0],
         )
         # PR-3 task 4: same transfer-lock wiring as `_load_automation_
         # detail`'s Automations-tab pane -- this is the Queue tab's own

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -2299,7 +2299,12 @@ class SchedulesWorkbench(BaseAppScreen):
         self.run_worker(
             _edit_and_refresh,
             exclusive=True,
-            group="schedules-edit-reminder-field",
+            # Per-ROW group (final review M12): one group for the whole
+            # KIND meant committing a second row's editor cancelled the
+            # first commit mid-flight -- possibly after its write landed,
+            # so the success repaint never ran. `exclusive=True` still
+            # holds, now within one row.
+            group=f"schedules-edit-reminder-field-{row.row_key}",
         )  # type: ignore[arg-type]
 
     @on(DefinitionFieldEditRequested)
@@ -2332,7 +2337,10 @@ class SchedulesWorkbench(BaseAppScreen):
         (run-now, transfer begin/cancel) -- `_definitions_stale = True`
         + `_request_automations_refresh()`, which reloads the Automations
         tab's own table+detail immediately and marks the Queue's unified
-        list stale for its own next (lazy, tab-activation-gated) refresh.
+        list stale for its own next (lazy, tab-activation-gated) refresh
+        -- PLUS `_repaint_queue_definition_detail`, because that lazy
+        Queue refresh is not a repaint of the Queue tab's own SECOND
+        `DefinitionDetail` instance (final review F4/I4).
         """
         service = self._scheduling_service
         if service is None:
@@ -2371,12 +2379,58 @@ class SchedulesWorkbench(BaseAppScreen):
             row.clear_error()
             self._definitions_stale = True
             self._request_automations_refresh()
+            await self._repaint_queue_definition_detail(
+                service, local_id, definition
+            )
 
         self.run_worker(
             _edit_and_refresh,
             exclusive=True,
-            group="schedules-edit-definition-field",
+            # Per-ROW group (final review M12) -- see `_edit_reminder_
+            # field`'s own group for why.
+            group=f"schedules-edit-definition-field-{row.row_key}",
         )  # type: ignore[arg-type]
+
+    async def _repaint_queue_definition_detail(
+        self,
+        service: "SchedulingService",
+        local_id: str,
+        definition: dict[str, Any],
+    ) -> None:
+        """Repaint the QUEUE tab's `DefinitionDetail` for ``local_id``.
+
+        `DefinitionDetail` is mounted TWICE -- `#scheduling-automation-
+        detail` (Automations tab) and `#scheduling-queue-definition-
+        detail` (Queue tab) -- and `_request_automations_refresh` only
+        ever repaints the first. The Queue one is painted from
+        `_update_detail_for_index`, which early-returns for the same row
+        on a tick, so nothing repainted it after an in-pane edit: the
+        editor closed, the row restored the OLD value, and stayed that
+        way indefinitely even though the edit had persisted (final review
+        F4/I4). `_toggle_definition_lifecycle` got this right by looping
+        over both widget ids via `apply_lifecycle`; this is the same
+        both-homes discipline for a field edit, which needs the
+        authoritative re-read `apply_lifecycle`'s single known column
+        does not.
+
+        Only paints when the Queue's selected row IS this definition --
+        which is also what makes the widget guaranteed-mounted here. The
+        row id is matched against BOTH ids: `build_unified_rows` keys the
+        row on whatever id the merged listing carried (the SERVER id for
+        a pure server fetch with no local shadow yet), while the edit
+        itself went through `_resolve_local_definition_id`.
+        """
+        if self._selected_row_id not in {
+            f"definition:{local_id}",
+            f"definition:{definition.get('id') or ''}",
+        }:
+            return
+        fresh = await asyncio.to_thread(
+            service.db.get_automation_definition, local_id
+        )
+        if fresh is None:
+            return
+        await self._load_queue_definition_detail(self._selected_row_id, fresh)
 
     @on(DefinitionLifecycleToggleRequested)
     def _on_definition_lifecycle_toggle_requested(

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -34,6 +34,7 @@ from ....Scheduling.events import (
     AcknowledgeIncidentRequested,
     EditTaskRequested,
     EnableTaskRequested,
+    ReminderFieldEditRequested,
     RetryTransferRequested,
     RunReminderNowRequested,
     SyncCompleted,
@@ -64,6 +65,7 @@ from ....UI.Screens.scheduling.results_tab import (
 )
 from ....UI.Screens.scheduling.sync_status_widget import SyncStatusWidget
 from ....Widgets.confirmation_dialog import ConfirmationDialog
+from ....Widgets.detail_value_row import DetailValueRow
 # schedules-redesign PR-1, Task 4: `automation_execution_target_label`/
 # `automation_name_cell` moved to `definition_detail.py` (that leaf
 # module's own "Model"/"Runs on" row formatters need them and importing
@@ -1424,6 +1426,10 @@ class SchedulesWorkbench(BaseAppScreen):
                 task,
                 run_history=self._run_history_for(task.id),
                 incidents=self._incidents_for(task.id),
+                # PR-3 task 3: same option source the create/edit modal's
+                # own Timezone selector reads (`_task_timezones`), so the
+                # pane's inline Timezone row editor offers the same zones.
+                known_timezones=self._task_timezones(),
             )
             self._update_transfer_actions(task_detail, task)
             self.query_one("#scheduling-task-inspector", TaskInspector).set_task(task)
@@ -2201,6 +2207,62 @@ class SchedulesWorkbench(BaseAppScreen):
         """Disable the requested reminder and refresh the queue."""
         event.stop()
         self._set_reminder_enabled(event.task, False)
+
+    @on(ReminderFieldEditRequested)
+    def _on_reminder_field_edit_requested(
+        self, event: ReminderFieldEditRequested
+    ) -> None:
+        """A Frequency row's inline editor committed a value (PR-3 task 3)."""
+        event.stop()
+        self._edit_reminder_field(event.task, event.payload, event.row)
+
+    def _edit_reminder_field(
+        self,
+        task: ReminderTask,
+        payload: dict[str, Any],
+        row: DetailValueRow,
+    ) -> None:
+        """Persist one Frequency row's edit via Task 2's validation bridge.
+
+        `TaskDetail` has already closed the row's editor (`end_edit`,
+        restoring the OLD display) before posting the request -- a
+        failure needs no separate "restore" step here, only `show_error`.
+        Success repaints authoritatively from a fresh read: the SAME
+        reminder-only refresh (`refresh_definitions=False`) every other
+        reminder mutation in this file uses, which re-selects the row by
+        id and re-feeds `TaskDetail.set_task` -- so the row shows the
+        value the bridge actually persisted, not a locally-guessed one.
+        """
+        service = self._scheduling_service
+        if service is None:
+            row.show_error(
+                "Scheduling service is unavailable; cannot save this edit."
+            )
+            return
+
+        async def _edit_and_refresh() -> None:
+            try:
+                outcome = await service.edit_reminder_fields(task.id, payload)
+            except Exception:  # noqa: BLE001
+                logger.exception("Failed to edit reminder field")
+                row.show_error("Failed to save this edit.")
+                return
+            if outcome.status != "saved":
+                message = "; ".join(
+                    str(err.get("message") or "")
+                    for err in outcome.errors
+                    if err.get("message")
+                ) or "This edit could not be saved."
+                row.show_error(message)
+                return
+            row.clear_error()
+            self._request_tasks_refresh(refresh_definitions=False)
+
+        self.run_worker(
+            _edit_and_refresh,
+            exclusive=True,
+            group="schedules-edit-reminder-field",
+        )  # type: ignore[arg-type]
 
     @on(RunReminderNowRequested)
     def _on_run_reminder_now_requested(self, event: RunReminderNowRequested) -> None:

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -19,12 +19,20 @@ from ....Scheduling.events import (
     EditTaskRequested,
     EnableTaskRequested,
     ReminderFieldEditRequested,
+    ReminderOwnerActionRequested,
     RetryTransferRequested,
     RunReminderNowRequested,
     TransferToLocalRequested,
     TransferToServerRequested,
 )
 from ....Scheduling.models import ReminderTask, ScheduledTask, ScheduleKind, TaskStatus
+# PR-3 task 5: the owner-row dropdown's own lock/failed-state gating reads
+# the SAME state tuple `SchedulingService.transfer_lock_reason` keys off
+# (survey §3) -- a plain constant import, not a fresh boot-cost tier
+# (`scheduled_tasks_db` is already loaded via `scheduling_service.py`
+# by the time this lazy-loaded Scheduling screen is up, same reasoning
+# Task 3's own `reminder_form`/`schedule_input_parsing` imports rely on).
+from ....Scheduling.db.scheduled_tasks_db import IN_FLIGHT_TRANSFER_STATES
 from ....Widgets.delete_confirmation_dialog import DeleteConfirmationDialog
 from ....Widgets.detail_value_row import DetailGroup, DetailValueRow
 from ..destination_recovery import DestinationRecoveryState
@@ -60,6 +68,13 @@ _TIMEZONE_EDITOR_ID = "scheduling-detail-timezone-editor"
 #: options), but selecting it as a NEW target is refused with this copy
 #: rather than silently doing nothing (ruling 2: never silent).
 _REPEAT_CUSTOM_REFUSAL = "Use the full Edit form to set a custom cron expression."
+
+#: Stable ids for the owner-row transfer dropdown (PR-3 task 5) and its
+#: proactively-shown Cancel/Retry mini-bar -- same "filter on `.id`" idiom
+#: the Frequency editors above already use.
+_RUNS_ON_EDITOR_ID = "scheduling-detail-runs-on-editor"
+_RUNS_ON_CANCEL_ID = "scheduling-detail-runs-on-cancel"
+_RUNS_ON_RETRY_ID = "scheduling-detail-runs-on-retry"
 
 
 SCHEDULES_EMPTY_CONSOLE_RECOVERY = DestinationRecoveryState(
@@ -553,6 +568,20 @@ class TaskDetail(Vertical):
         #: by default: every other `set_task` caller (including every
         #: pre-task-3 test) keeps working unchanged.
         self._known_timezones: Sequence[str] = ()
+        #: PR-3 task 5: the workbench's own `_runs_on_options()` result
+        #: (hoisted the SAME way `known_timezones` already is -- the
+        #: workbench holds the service/server state needed to compute it,
+        #: this widget does not). Empty by default: every pre-task-5
+        #: `set_task` caller/test keeps working unchanged.
+        self._runs_on_options: Sequence[tuple[str, str]] = ()
+        #: PR-3 task 5: the Runs-on row's proactive Cancel/Retry
+        #: affordances -- plain always-mounted `Button`s toggled via
+        #: `.display` (never `begin_edit`-swapped INTO the row: that
+        #: would hide `#scheduling-detail-runs-on`'s own value Static,
+        #: which the existing transfer-badge rendering pins verbatim --
+        #: see `_configure_runs_on_row`). `None` until first `compose()`.
+        self._runs_on_cancel_button: Button | None = None
+        self._runs_on_retry_button: Button | None = None
 
     def compose(self) -> ComposeResult:
         yield Static(
@@ -636,8 +665,27 @@ class TaskDetail(Vertical):
                 self._runs_on_row = DetailValueRow(
                     "Runs on", "-", value_id="scheduling-detail-runs-on"
                 )
+                # PR-3 task 5: the Runs-on row's own proactive Cancel/
+                # Retry affordances for an in-flight/failed transfer --
+                # a plain sibling `Horizontal`, hidden by default
+                # (`_configure_runs_on_row` toggles `.display`), NOT
+                # `begin_edit`-mounted into the row itself (that would
+                # hide the row's own value Static, which the existing
+                # transfer-badge rendering pins verbatim).
+                self._runs_on_cancel_button = Button(
+                    "Cancel transfer", id=_RUNS_ON_CANCEL_ID, variant="warning"
+                )
+                self._runs_on_retry_button = Button(
+                    "Retry transfer", id=_RUNS_ON_RETRY_ID, variant="warning"
+                )
+                runs_on_actions = Horizontal(
+                    self._runs_on_cancel_button,
+                    self._runs_on_retry_button,
+                    classes="detail-value-row-owner-actions",
+                )
                 yield DetailGroup(
                     self._runs_on_row,
+                    runs_on_actions,
                     title="Details",
                     id="scheduling-detail-group-details",
                 )
@@ -810,6 +858,8 @@ class TaskDetail(Vertical):
             "scheduling-transfer-to-local",
             "scheduling-retry-transfer",
             "scheduling-cancel-transfer",
+            _RUNS_ON_CANCEL_ID,
+            _RUNS_ON_RETRY_ID,
         }:
             event.stop()
         if button_id == "scheduling-edit-task":
@@ -832,6 +882,10 @@ class TaskDetail(Vertical):
             self._request_cancel_transfer()
         elif button_id == "scheduling-ack-incident":
             self._request_acknowledge()
+        elif button_id == _RUNS_ON_CANCEL_ID:
+            self._request_runs_on_cancel()
+        elif button_id == _RUNS_ON_RETRY_ID:
+            self._request_runs_on_retry()
 
     def _sync_acknowledge_button(self) -> None:
         """Enable the acknowledge button only when an alerting incident exists."""
@@ -898,6 +952,25 @@ class TaskDetail(Vertical):
         if isinstance(self._current_task, ReminderTask):
             self.post_message(CancelTransferRequested(self._current_task))
 
+    def _request_runs_on_cancel(self) -> None:
+        """Post a cancel request from the Runs-on row's own mini-bar
+        (PR-3 task 5) -- a SEPARATE surface from `_request_cancel_
+        transfer` above (coexistence, task-5 brief): this one renders a
+        refusal via `row.show_error`, not the legacy toast."""
+        task = self._current_task
+        row = self._runs_on_row
+        if isinstance(task, ReminderTask) and row is not None:
+            self.post_message(ReminderOwnerActionRequested(task, "cancel", row))
+
+    def _request_runs_on_retry(self) -> None:
+        """Post a retry request from the Runs-on row's own mini-bar
+        (PR-3 task 5) -- the PR-5 retry leg (re-begin), same SEPARATE
+        row-scoped surface as `_request_runs_on_cancel` above."""
+        task = self._current_task
+        row = self._runs_on_row
+        if isinstance(task, ReminderTask) and row is not None:
+            self.post_message(ReminderOwnerActionRequested(task, "retry", row))
+
     def request_delete(self) -> None:
         """Open the delete confirmation modal for the current task."""
         if self._current_task is None:
@@ -952,11 +1025,50 @@ class TaskDetail(Vertical):
             row.affordance = editable
             row.can_focus = editable
 
+    def _configure_runs_on_row(self, task: ReminderTask) -> None:
+        """Wire the Runs-on row's dropdown-vs-Cancel/Retry state (PR-3
+        task 5).
+
+        Three states, keyed off `task.transfer_state`: normal (affordance
+        on, the owner-picker `Select` opens on activation, both buttons
+        hidden); in flight (`IN_FLIGHT_TRANSFER_STATES` -- affordance
+        off, Cancel shown); `to_server_failed` (affordance off, BOTH
+        Cancel and Retry shown -- `cancel_refusal`/the PR-5 retry leg
+        both allow this substate, mirroring the existing buttons' own
+        Retry-alongside-Cancel visibility rule).
+
+        The two buttons are plain always-mounted siblings of the row,
+        toggled via `.display` -- deliberately NOT `begin_edit`-mounted
+        INTO the row: `begin_edit` hides the row's own value `Static`
+        (`#scheduling-detail-runs-on`), and the existing transfer-badge
+        rendering (`_reminder_runs_on_label`'s suffix, painted into that
+        SAME Static by `set_task` above) is pinned verbatim by an
+        existing test -- this row's value must stay readable while the
+        actions show, not be replaced by them.
+        """
+        row = self._runs_on_row
+        assert row is not None
+        state = task.transfer_state
+        failed = state == "to_server_failed"
+        locked = failed or state in IN_FLIGHT_TRANSFER_STATES
+        row.affordance = not locked
+        row.can_focus = not locked
+        assert self._runs_on_cancel_button is not None
+        assert self._runs_on_retry_button is not None
+        self._runs_on_cancel_button.display = locked
+        self._runs_on_retry_button.display = failed
+
     def on_detail_value_row_activated(self, event: DetailValueRow.Activated) -> None:
-        """Open the activated Frequency row's editor, or -- locked -- show
-        why editing is refused instead of doing nothing (ruling 2)."""
+        """Open the activated Frequency/Runs-on row's editor, or -- locked
+        -- show why editing is refused instead of doing nothing (ruling 2).
+        """
         row = event.row
-        if row not in (self._repeat_row, self._at_row, self._timezone_row):
+        if row not in (
+            self._repeat_row,
+            self._at_row,
+            self._timezone_row,
+            self._runs_on_row,
+        ):
             return
         event.stop()
         if self._lifecycle_lock_reason is not None:
@@ -966,7 +1078,27 @@ class TaskDetail(Vertical):
         if not isinstance(task, ReminderTask):
             return
         row.clear_error()
-        if row is self._repeat_row:
+        if row is self._runs_on_row:
+            # `_configure_runs_on_row` already refused this row's
+            # affordance for an in-flight/failed transfer -- reaching
+            # here means a normal, unlocked owner pick (spec §7 flow).
+            current_owner = task.owner_id or "local"
+            options = list(self._runs_on_options)
+            if current_owner not in {value for _, value in options}:
+                # Same "the row's real owner always round-trips" fallback
+                # `_edit_selected_automation`'s own options-building
+                # already uses (survey §7) -- a `Select`'s initial value
+                # must be among its options.
+                options = [*options, (owner_display_label(current_owner), current_owner)]
+            row.begin_edit(
+                Select(
+                    options,
+                    allow_blank=False,
+                    value=current_owner,
+                    id=_RUNS_ON_EDITOR_ID,
+                )
+            )
+        elif row is self._repeat_row:
             current_preset, _time_text = cron_to_preset(task.cron or "")
             row.begin_edit(
                 Select(
@@ -994,11 +1126,13 @@ class TaskDetail(Vertical):
             )
 
     def on_select_changed(self, event: Select.Changed) -> None:
-        """Route a Frequency Select editor's commit by its stable id."""
+        """Route a Frequency/Runs-on Select editor's commit by its stable id."""
         if event.select.id == _REPEAT_EDITOR_ID:
             self._commit_repeat_edit(event)
         elif event.select.id == _TIMEZONE_EDITOR_ID:
             self._commit_timezone_edit(event)
+        elif event.select.id == _RUNS_ON_EDITOR_ID:
+            self._commit_runs_on_edit(event)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Route the At row's Input editor commit (Enter submits)."""
@@ -1064,6 +1198,31 @@ class TaskDetail(Vertical):
         # by the workbench's own outcome handler.
         self.post_message(ReminderFieldEditRequested(task, {"run_at": raw}, row))
 
+    def _commit_runs_on_edit(self, event: Select.Changed) -> None:
+        """Commit the owner-picker Select (PR-3 task 5, spec §7 flow).
+
+        Same-owner selection (including the mount-time synthetic
+        `Changed` `begin_edit` posts -- Task 3's own guard, reused
+        verbatim) is a no-op: `row.end_edit()` closes it right back to
+        the read-only display, no request posted. Otherwise the target
+        owner decides the transfer direction (a server-shaped value is
+        `to_server`, anything else is `to_local`) and the workbench (via
+        `ReminderOwnerActionRequested`) runs `transfer_refusal` FIRST --
+        refusal renders inline via `row.show_error`.
+        """
+        task = self._current_task
+        row = self._runs_on_row
+        if not isinstance(task, ReminderTask) or row is None:
+            return
+        event.stop()
+        current_owner = task.owner_id or "local"
+        new_owner = str(event.value)
+        if new_owner == current_owner:
+            return
+        row.end_edit()
+        direction = "to_server" if new_owner.startswith("server:") else "to_local"
+        self.post_message(ReminderOwnerActionRequested(task, direction, row))
+
     def set_task(
         self,
         task: ReminderTask | ScheduledTask | None,
@@ -1072,6 +1231,7 @@ class TaskDetail(Vertical):
         run_history=None,
         incidents=None,
         known_timezones: Sequence[str] = (),
+        runs_on_options: Sequence[tuple[str, str]] = (),
     ) -> None:
         """Update the detail view for the given task (or clear it).
 
@@ -1081,10 +1241,16 @@ class TaskDetail(Vertical):
                 source (`timezone_options`) so it offers the same choices
                 the create/edit modal does. Every pre-task-3 caller omits
                 this and is unaffected.
+            runs_on_options: PR-3 task 5 -- the workbench's own
+                `_runs_on_options()[0]`, passed through to the Runs-on
+                row's owner-picker `Select` (same threaded-in-by-the-
+                workbench shape `known_timezones` already uses). Every
+                pre-task-5 caller/test omits this and is unaffected.
         """
         self._current_task = task
         self._current_incidents = list(incidents or [])
         self._known_timezones = known_timezones
+        self._runs_on_options = runs_on_options
         metadata = self.query_one("#scheduling-task-detail-metadata", Vertical)
         lifecycle = self.query_one("#scheduling-task-detail-lifecycle", Horizontal)
         self.query_one("#schedules-follow-in-console", Button)
@@ -1119,6 +1285,12 @@ class TaskDetail(Vertical):
             # groups are hidden either way, but `on_detail_value_row_
             # activated` reads this directly -- keep it honest).
             self._lifecycle_lock_reason = None
+            # PR-3 task 5: the Runs-on row's Cancel/Retry buttons from a
+            # PREVIOUS selection must not stay visible in a cleared pane.
+            if self._runs_on_cancel_button is not None:
+                self._runs_on_cancel_button.display = False
+            if self._runs_on_retry_button is not None:
+                self._runs_on_retry_button.display = False
             return
 
         empty_state.display = False
@@ -1149,6 +1321,7 @@ class TaskDetail(Vertical):
             self._timezone_row.update_value(_reminder_timezone_label(task))
             self._last_fire_row.update_value(_reminder_last_fire_label(task))
             self._configure_frequency_editability(task)
+            self._configure_runs_on_row(task)
 
         if isinstance(task, ReminderTask):
             # Structural visibility only (spec §6, PR-5 task 7): Move to

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -42,7 +42,13 @@ from ..destination_recovery import DestinationRecoveryState
 # re-derived) -- `reminder_form.py` is already part of this same lazy-
 # loaded Scheduling-screen import chain (`schedules_workbench.py` imports
 # it at module level too), so this adds no new boot-cost tier (ADR-097).
-from .forms.reminder_form import ReminderForm, cron_to_preset, preset_to_cron, timezone_options
+from .forms.reminder_form import (
+    DEFAULT_TIME_OF_DAY,
+    ReminderForm,
+    cron_to_preset,
+    preset_to_cron,
+    timezone_options,
+)
 # Hoisted to `unified_rows.py` (redesign PR-2 Task 1) so that pure module can
 # reuse them without pulling Textual in as an import side effect; re-exported
 # here unchanged so every existing call site/test import keeps working.
@@ -1275,7 +1281,9 @@ class TaskDetail(Vertical):
         if new_preset == "custom":
             row.show_error(_REPEAT_CUSTOM_REFUSAL)
             return
-        new_cron = preset_to_cron(new_preset, current_time_text or "09:00")
+        new_cron = preset_to_cron(
+            new_preset, current_time_text or DEFAULT_TIME_OF_DAY
+        )
         assert new_cron is not None, (
             "every _preset_options() value besides 'custom' always yields a cron"
         )
@@ -1366,6 +1374,20 @@ class TaskDetail(Vertical):
         """Update the detail view for the given task (or clear it).
 
         Args:
+            task: The row to paint, or ``None`` for the empty state. A
+                `ReminderTask` fills every group; a bare `ScheduledTask`
+                (the legacy shape) paints only what it carries.
+            queue_empty: True when the queue has no rows at all, which
+                picks the "schedule your first task" empty copy over the
+                "select a task" one. Read only when ``task`` is ``None``.
+            run_history: Pre-fetched run rows for the History group,
+                already read off the event loop by the caller (this
+                method performs no I/O of its own). ``None``/empty
+                renders `format_run_history`'s own no-history copy.
+            incidents: Pre-fetched incident rows -- rendered by
+                `format_incidents` and retained for the acknowledge
+                action's own open-incident lookup. Same caller-fetched
+                contract as ``run_history``.
             known_timezones: PR-3 task 3 -- zones already used by other
                 tasks, passed through to the Timezone row editor's option
                 source (`timezone_options`) so it offers the same choices

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Any
 
+from loguru import logger
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
@@ -588,6 +589,13 @@ class TaskDetail(Vertical):
         #: the legacy Retry button's own reason line -- read by
         #: `_runs_on_failure_reason` when the row is activated.
         self._runs_on_transfer_errors: list[str] = []
+        #: Final review I2: the id of the reminder an open row editor was
+        #: opened AGAINST, captured at `begin_edit` time and validated at
+        #: commit time by `_editing_task`. Never reset by a repaint -- a
+        #: commit that crossed a repaint in flight has to still see the
+        #: id it was opened for, so it can be discarded instead of
+        #: writing one row's typed value onto another.
+        self._editing_task_id: str | None = None
 
     def compose(self) -> ComposeResult:
         yield Static(
@@ -668,8 +676,15 @@ class TaskDetail(Vertical):
                     "", id="scheduling-task-detail-body-card", markup=False
                 )
                 yield self._body_card
+                # `row_key` (final review M12): the per-row identity the
+                # workbench's edit worker groups its commit under, so two
+                # quick edits on DIFFERENT rows stop cancelling each
+                # other. Set on every editable row, nowhere else.
                 self._runs_on_row = DetailValueRow(
-                    "Runs on", "-", value_id="scheduling-detail-runs-on"
+                    "Runs on",
+                    "-",
+                    value_id="scheduling-detail-runs-on",
+                    row_key="runs_on",
                 )
                 # PR-3 task 5: the Runs-on row's own proactive Cancel/
                 # Retry affordances for an in-flight/failed transfer --
@@ -696,13 +711,19 @@ class TaskDetail(Vertical):
                     id="scheduling-detail-group-details",
                 )
                 self._repeat_row = DetailValueRow(
-                    "Repeat", "-", value_id="scheduling-detail-repeat"
+                    "Repeat",
+                    "-",
+                    value_id="scheduling-detail-repeat",
+                    row_key="cron",
                 )
                 self._at_row = DetailValueRow(
-                    "At", "-", value_id="scheduling-detail-at"
+                    "At", "-", value_id="scheduling-detail-at", row_key="run_at"
                 )
                 self._timezone_row = DetailValueRow(
-                    "Timezone", "-", value_id="scheduling-detail-timezone"
+                    "Timezone",
+                    "-",
+                    value_id="scheduling-detail-timezone",
+                    row_key="timezone",
                 )
                 notifications_row = DetailValueRow(
                     "Notifications",
@@ -1084,17 +1105,71 @@ class TaskDetail(Vertical):
             task.transfer_state or "", "This transfer failed."
         )
 
+    def _editable_rows(self) -> tuple[DetailValueRow, ...]:
+        """Every row this pane can open an editor on (mounted ones only).
+
+        One list, read by the `Activated` router below AND by
+        `_reset_row_editing` -- a row that can open an editor is exactly a
+        row whose editor a repaint has to be able to close again.
+        """
+        return tuple(
+            row
+            for row in (
+                self._repeat_row,
+                self._at_row,
+                self._timezone_row,
+                self._runs_on_row,
+            )
+            if row is not None
+        )
+
+    def _reset_row_editing(self) -> None:
+        """Close every open row editor and clear every row error.
+
+        Final review I2/I3: an open editor and an inline error both belong
+        to the ROW THEY WERE OPENED ON. Left standing across a repaint
+        that swaps in a DIFFERENT reminder, the editor commits its typed
+        value onto the new task and the error accuses a value that is
+        perfectly valid. `set_task` calls this on a row-identity change
+        only -- never on a same-row tick repaint, which this pane does
+        continuously and which would otherwise make typing impossible.
+
+        `_editing_task_id` is deliberately NOT cleared here: it is the
+        commit-time evidence `_editing_task` needs to discard an edit that
+        crossed this repaint in flight.
+        """
+        for row in self._editable_rows():
+            row.end_edit(restore_focus=False)
+            row.clear_error()
+
+    def _editing_task(self) -> ReminderTask | None:
+        """The reminder an open editor was opened against, or ``None``.
+
+        Final review I2's belt. `set_task` closes the editors on a
+        row-identity change, so a commit that still arrives for a row the
+        pane no longer shows means the `Changed`/`Submitted` message and
+        the repaint crossed in flight. Writing it would land the typed
+        value on WHATEVER reminder is painted now -- discard it instead.
+        """
+        task = self._current_task
+        if not isinstance(task, ReminderTask):
+            return None
+        if self._editing_task_id is not None and self._editing_task_id != task.id:
+            logger.debug(
+                "Discarding a reminder row edit opened for {} while the "
+                "detail pane now shows {}",
+                self._editing_task_id,
+                task.id,
+            )
+            return None
+        return task
+
     def on_detail_value_row_activated(self, event: DetailValueRow.Activated) -> None:
         """Open the activated Frequency/Runs-on row's editor, or -- locked
         -- show why editing is refused instead of doing nothing (ruling 2).
         """
         row = event.row
-        if row not in (
-            self._repeat_row,
-            self._at_row,
-            self._timezone_row,
-            self._runs_on_row,
-        ):
+        if row not in self._editable_rows():
             return
         event.stop()
         if self._lifecycle_lock_reason is not None:
@@ -1112,6 +1187,9 @@ class TaskDetail(Vertical):
             row.show_error(self._runs_on_failure_reason(task))
             return
         row.clear_error()
+        # Final review I2: capture the identity this editor is being
+        # opened against, for `_editing_task` to validate at commit time.
+        self._editing_task_id = task.id
         if row is self._runs_on_row:
             # A normal, unlocked owner pick (spec §7 flow) -- an
             # in-flight row never reaches here at all: the top-of-
@@ -1176,9 +1254,9 @@ class TaskDetail(Vertical):
             self._commit_at_edit(event)
 
     def _commit_repeat_edit(self, event: Select.Changed) -> None:
-        task = self._current_task
+        task = self._editing_task()
         row = self._repeat_row
-        if not isinstance(task, ReminderTask) or row is None:
+        if task is None or row is None:
             return
         event.stop()
         new_preset = str(event.value)
@@ -1204,9 +1282,9 @@ class TaskDetail(Vertical):
         self.post_message(ReminderFieldEditRequested(task, {"cron": new_cron}, row))
 
     def _commit_timezone_edit(self, event: Select.Changed) -> None:
-        task = self._current_task
+        task = self._editing_task()
         row = self._timezone_row
-        if not isinstance(task, ReminderTask) or row is None:
+        if task is None or row is None:
             return
         event.stop()
         new_zone = str(event.value)
@@ -1220,9 +1298,9 @@ class TaskDetail(Vertical):
         )
 
     def _commit_at_edit(self, event: Input.Submitted) -> None:
-        task = self._current_task
+        task = self._editing_task()
         row = self._at_row
-        if not isinstance(task, ReminderTask) or row is None:
+        if task is None or row is None:
             return
         event.stop()
         row.end_edit()
@@ -1237,18 +1315,34 @@ class TaskDetail(Vertical):
     def _commit_runs_on_edit(self, event: Select.Changed) -> None:
         """Commit the owner-picker Select (PR-3 task 5, spec §7 flow).
 
-        Same-owner selection (including the mount-time synthetic
-        `Changed` `begin_edit` posts -- Task 3's own guard, reused
-        verbatim) is a no-op: `row.end_edit()` closes it right back to
-        the read-only display, no request posted. Otherwise the target
+        Same-owner selection is a no-op that leaves the dropdown OPEN,
+        and it has to be (final review F8/M8 -- this docstring used to
+        claim `end_edit()` closed it "right back to the read-only
+        display", which is not what the code, its pinning test, or
+        Textual allow). Two facts, both re-probed during the final fix
+        wave against Textual 8.2.8:
+
+        1. `begin_edit` mounting a `Select` with the row's current owner
+           preselected posts a synthetic `Changed` immediately -- the
+           reactive `value` var starts at `NULL`, so `_on_mount`'s
+           `_init_selected_option` assignment is a real change. Probed:
+           this handler fires with the current owner before the user
+           touches anything, and closing on it leaves the dropdown shut
+           the instant it opens.
+        2. A genuine re-pick of the SAME option posts nothing at all:
+           `Select._update_selection` assigns only `if value !=
+           self.value`. So this branch is reachable ONLY from (1).
+
+        Cancelling without picking is Escape, which `DetailValueRow._on_
+        key` already handles. Otherwise the target
         owner decides the transfer direction (a server-shaped value is
         `to_server`, anything else is `to_local`) and the workbench (via
         `ReminderOwnerActionRequested`) runs `transfer_refusal` FIRST --
         refusal renders inline via `row.show_error`.
         """
-        task = self._current_task
+        task = self._editing_task()
         row = self._runs_on_row
-        if not isinstance(task, ReminderTask) or row is None:
+        if task is None or row is None:
             return
         event.stop()
         current_owner = task.owner_id or "local"
@@ -1283,6 +1377,13 @@ class TaskDetail(Vertical):
                 workbench shape `known_timezones` already uses). Every
                 pre-task-5 caller/test omits this and is unaffected.
         """
+        # Final review I2/I3: a repaint that swaps in a DIFFERENT reminder
+        # (a filter keystroke, a chip switch, a row aging out of the
+        # filter -- `_update_detail_for_index` falls back to index 0)
+        # takes the open editor and the inline error with it. A same-row
+        # tick repaint, which is what this pane mostly does, must not.
+        if getattr(task, "id", None) != getattr(self._current_task, "id", None):
+            self._reset_row_editing()
         self._current_task = task
         self._current_incidents = list(incidents or [])
         self._known_timezones = known_timezones

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Any
 
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
-from textual.widgets import Button, Static
+from textual.widgets import Button, Input, Select, Static
 
 from ....Scheduling.events import (
     CancelTransferRequested,
@@ -17,6 +18,7 @@ from ....Scheduling.events import (
     AcknowledgeIncidentRequested,
     EditTaskRequested,
     EnableTaskRequested,
+    ReminderFieldEditRequested,
     RetryTransferRequested,
     RunReminderNowRequested,
     TransferToLocalRequested,
@@ -26,6 +28,12 @@ from ....Scheduling.models import ReminderTask, ScheduledTask, ScheduleKind, Tas
 from ....Widgets.delete_confirmation_dialog import DeleteConfirmationDialog
 from ....Widgets.detail_value_row import DetailGroup, DetailValueRow
 from ..destination_recovery import DestinationRecoveryState
+# PR-3 task 3: the Frequency row editors reuse the create/edit modal's own
+# preset<->cron mapping and timezone-option builder verbatim (never
+# re-derived) -- `reminder_form.py` is already part of this same lazy-
+# loaded Scheduling-screen import chain (`schedules_workbench.py` imports
+# it at module level too), so this adds no new boot-cost tier (ADR-097).
+from .forms.reminder_form import ReminderForm, cron_to_preset, preset_to_cron, timezone_options
 # Hoisted to `unified_rows.py` (redesign PR-2 Task 1) so that pure module can
 # reuse them without pulling Textual in as an import side effect; re-exported
 # here unchanged so every existing call site/test import keeps working.
@@ -36,6 +44,22 @@ from .unified_rows import (
     definition_cron_expression,  # noqa: F401  (re-export: definition_detail.py imports this from here)
     owner_display_label,
 )
+
+
+#: Stable ids for the Frequency row editors (PR-3 task 3), so the
+#: `on_select_changed`/`on_input_submitted` handlers can route by id --
+#: same "filter on `.id`" idiom `on_button_pressed` already uses in this
+#: file for its own action buttons.
+_REPEAT_EDITOR_ID = "scheduling-detail-repeat-editor"
+_AT_EDITOR_ID = "scheduling-detail-at-editor"
+_TIMEZONE_EDITOR_ID = "scheduling-detail-timezone-editor"
+
+#: Repeat's "custom" preset has no single-value edit target here (the raw
+#: cron field only exists in the full modal) -- shown so the row's current
+#: value round-trips (Select requires the initial value be among its
+#: options), but selecting it as a NEW target is refused with this copy
+#: rather than silently doing nothing (ruling 2: never silent).
+_REPEAT_CUSTOM_REFUSAL = "Use the full Edit form to set a custom cron expression."
 
 
 SCHEDULES_EMPTY_CONSOLE_RECOVERY = DestinationRecoveryState(
@@ -517,6 +541,18 @@ class TaskDetail(Vertical):
         self._timezone_row: DetailValueRow | None = None
         self._last_fire_row: DetailValueRow | None = None
         self._body_card: Static | None = None
+        # PR-3 task 3: cached from `set_lifecycle_lock` (never re-derived
+        # here, same "one source of truth" rule survey §8 names) so the
+        # Frequency rows' `Activated` handler can tell a locked row apart
+        # from an editable one without a second `transfer_lock_reason`
+        # call -- the workbench already computed this once per selection.
+        self._lifecycle_lock_reason: str | None = None
+        #: Zones already used by other tasks (task-23102), threaded in by
+        #: the workbench's own `set_task` call so the Timezone row editor
+        #: offers the same option set the create/edit modal does. Empty
+        #: by default: every other `set_task` caller (including every
+        #: pre-task-3 test) keeps working unchanged.
+        self._known_timezones: Sequence[str] = ()
 
     def compose(self) -> ComposeResult:
         yield Static(
@@ -880,6 +916,154 @@ class TaskDetail(Vertical):
         if confirmed and isinstance(self._current_task, ReminderTask):
             self.post_message(DeleteTaskRequested(self._current_task))
 
+    # -- Frequency row in-pane editing (PR-3 task 3) -------------------------
+
+    def _configure_frequency_editability(self, task: ReminderTask) -> None:
+        """Wire each Frequency row's affordance to whether it has a real
+        single-field edit target for the task's CURRENT schedule kind.
+
+        Repeat (regenerates `cron`) and Timezone (`timezone`) only apply
+        to a recurring schedule; At (`run_at`) only applies to a one-time
+        one. Editing the "wrong" one for the current kind is not merely
+        unhelpful -- `update_reminder`'s own recompute step (survey §2)
+        silently clobbers it back (a `cron`/`timezone` write on a
+        one-time row is reset to `None`; a `run_at` write on a recurring
+        row is reset to `None` too), so offering the affordance there
+        would be a guaranteed-to-silently-fail control. Notifications has
+        no backing field at all (survey §2 -- a reminder dispatch always
+        writes the same fixed inbox+toast, nothing per-row to persist)
+        and stays permanently read-only; `Runs on` is out of this task's
+        row list entirely.
+
+        Locked rows keep their affordance ON (not off): ruling 2 requires
+        activation to still respond with the lock reason via `show_error`
+        rather than going silent, and `on_detail_value_row_activated`
+        checks `self._lifecycle_lock_reason` before ever opening an
+        editor -- so the affordance glyph staying lit is what makes that
+        reachable at all, not a bug.
+        """
+        recurring = task.schedule_kind == ScheduleKind.RECURRING
+        for row, editable in (
+            (self._repeat_row, recurring),
+            (self._at_row, not recurring),
+            (self._timezone_row, recurring),
+        ):
+            assert row is not None
+            row.affordance = editable
+            row.can_focus = editable
+
+    def on_detail_value_row_activated(self, event: DetailValueRow.Activated) -> None:
+        """Open the activated Frequency row's editor, or -- locked -- show
+        why editing is refused instead of doing nothing (ruling 2)."""
+        row = event.row
+        if row not in (self._repeat_row, self._at_row, self._timezone_row):
+            return
+        event.stop()
+        if self._lifecycle_lock_reason is not None:
+            row.show_error(self._lifecycle_lock_reason)
+            return
+        task = self._current_task
+        if not isinstance(task, ReminderTask):
+            return
+        row.clear_error()
+        if row is self._repeat_row:
+            current_preset, _time_text = cron_to_preset(task.cron or "")
+            row.begin_edit(
+                Select(
+                    ReminderForm._preset_options(),
+                    allow_blank=False,
+                    value=current_preset,
+                    id=_REPEAT_EDITOR_ID,
+                )
+            )
+        elif row is self._at_row:
+            initial = task.run_at.isoformat() if task.run_at is not None else ""
+            row.begin_edit(Input(value=initial, id=_AT_EDITOR_ID))
+        elif row is self._timezone_row:
+            # task.timezone is guaranteed set here: this row's affordance
+            # is only ever True while `task.schedule_kind` is RECURRING,
+            # and `ReminderTask`'s own model validator requires a
+            # timezone for every recurring row.
+            row.begin_edit(
+                Select(
+                    timezone_options(task.timezone, self._known_timezones),
+                    allow_blank=False,
+                    value=task.timezone,
+                    id=_TIMEZONE_EDITOR_ID,
+                )
+            )
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """Route a Frequency Select editor's commit by its stable id."""
+        if event.select.id == _REPEAT_EDITOR_ID:
+            self._commit_repeat_edit(event)
+        elif event.select.id == _TIMEZONE_EDITOR_ID:
+            self._commit_timezone_edit(event)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Route the At row's Input editor commit (Enter submits)."""
+        if event.input.id == _AT_EDITOR_ID:
+            self._commit_at_edit(event)
+
+    def _commit_repeat_edit(self, event: Select.Changed) -> None:
+        task = self._current_task
+        row = self._repeat_row
+        if not isinstance(task, ReminderTask) or row is None:
+            return
+        event.stop()
+        new_preset = str(event.value)
+        current_preset, current_time_text = cron_to_preset(task.cron or "")
+        if new_preset == current_preset:
+            # `Select` posts a synthetic `Changed` the moment `begin_edit`
+            # mounts it with its CURRENT value preselected (Textual's own
+            # `_init_selected_option` assigns `self.value` on `_on_mount`,
+            # which its `_watch_value` always turns into a `Changed` post)
+            # -- indistinguishable from a real commit except by comparing
+            # against the stored value. Also correctly no-ops a genuine
+            # reselect of the unchanged value: nothing to persist either
+            # way, so the editor stays open for a real pick.
+            return
+        row.end_edit()
+        if new_preset == "custom":
+            row.show_error(_REPEAT_CUSTOM_REFUSAL)
+            return
+        new_cron = preset_to_cron(new_preset, current_time_text or "09:00")
+        assert new_cron is not None, (
+            "every _preset_options() value besides 'custom' always yields a cron"
+        )
+        self.post_message(ReminderFieldEditRequested(task, {"cron": new_cron}, row))
+
+    def _commit_timezone_edit(self, event: Select.Changed) -> None:
+        task = self._current_task
+        row = self._timezone_row
+        if not isinstance(task, ReminderTask) or row is None:
+            return
+        event.stop()
+        new_zone = str(event.value)
+        if new_zone == (task.timezone or ""):
+            # Same mount-time-synthetic-`Changed` guard as the Repeat
+            # editor above.
+            return
+        row.end_edit()
+        self.post_message(
+            ReminderFieldEditRequested(task, {"timezone": new_zone}, row)
+        )
+
+    def _commit_at_edit(self, event: Input.Submitted) -> None:
+        task = self._current_task
+        row = self._at_row
+        if not isinstance(task, ReminderTask) or row is None:
+            return
+        event.stop()
+        row.end_edit()
+        raw = event.value.strip()
+        # Validated by the bridge (`SchedulingService.edit_reminder_fields`
+        # reuses the exact same `parse_forgiving_datetime` this pane's
+        # `At` display already implies) -- junk/empty text comes back as
+        # a `run_at`-addressed field error, rendered via `row.show_error`
+        # by the workbench's own outcome handler.
+        self.post_message(ReminderFieldEditRequested(task, {"run_at": raw}, row))
+
     def set_task(
         self,
         task: ReminderTask | ScheduledTask | None,
@@ -887,10 +1071,20 @@ class TaskDetail(Vertical):
         queue_empty: bool = False,
         run_history=None,
         incidents=None,
+        known_timezones: Sequence[str] = (),
     ) -> None:
-        """Update the detail view for the given task (or clear it)."""
+        """Update the detail view for the given task (or clear it).
+
+        Args:
+            known_timezones: PR-3 task 3 -- zones already used by other
+                tasks, passed through to the Timezone row editor's option
+                source (`timezone_options`) so it offers the same choices
+                the create/edit modal does. Every pre-task-3 caller omits
+                this and is unaffected.
+        """
         self._current_task = task
         self._current_incidents = list(incidents or [])
+        self._known_timezones = known_timezones
         metadata = self.query_one("#scheduling-task-detail-metadata", Vertical)
         lifecycle = self.query_one("#scheduling-task-detail-lifecycle", Horizontal)
         self.query_one("#schedules-follow-in-console", Button)
@@ -920,6 +1114,11 @@ class TaskDetail(Vertical):
             self.query_one("#schedules-follow-in-console", Button).label = (
                 "Follow in Console"
             )
+            # PR-3 task 3: stale lock state from a PREVIOUS selection must
+            # not survive into a cleared pane (harmless today since the
+            # groups are hidden either way, but `on_detail_value_row_
+            # activated` reads this directly -- keep it honest).
+            self._lifecycle_lock_reason = None
             return
 
         empty_state.display = False
@@ -949,6 +1148,7 @@ class TaskDetail(Vertical):
             self._at_row.update_value(_reminder_at_label(task))
             self._timezone_row.update_value(_reminder_timezone_label(task))
             self._last_fire_row.update_value(_reminder_last_fire_label(task))
+            self._configure_frequency_editability(task)
 
         if isinstance(task, ReminderTask):
             # Structural visibility only (spec §6, PR-5 task 7): Move to
@@ -1187,7 +1387,13 @@ class TaskDetail(Vertical):
         line in the always-visible Static, since keyboard users cannot
         see tooltips (UX-073). ``None`` restores the row's normal
         enabled/disabled logic, which `set_task` has already applied.
+
+        PR-3 task 3: also cached for the Frequency rows' `Activated`
+        handler (`self._lifecycle_lock_reason`) -- the SAME reason, not a
+        second `transfer_lock_reason` call, per survey §8's one-source-
+        of-truth rule.
         """
+        self._lifecycle_lock_reason = reason
         locked = reason is not None
         for button_id, tooltip in (
             ("scheduling-edit-task", "Edit this scheduled task."),

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -582,6 +582,12 @@ class TaskDetail(Vertical):
         #: see `_configure_runs_on_row`). `None` until first `compose()`.
         self._runs_on_cancel_button: Button | None = None
         self._runs_on_retry_button: Button | None = None
+        #: PR-3 task 5 fix round 1 (finding 2): a `to_server_failed`
+        #: row's stored `transfer_errors`, threaded in by the workbench
+        #: (`set_runs_on_transfer_errors`) the SAME way it already feeds
+        #: the legacy Retry button's own reason line -- read by
+        #: `_runs_on_failure_reason` when the row is activated.
+        self._runs_on_transfer_errors: list[str] = []
 
     def compose(self) -> ComposeResult:
         yield Static(
@@ -1026,37 +1032,57 @@ class TaskDetail(Vertical):
             row.can_focus = editable
 
     def _configure_runs_on_row(self, task: ReminderTask) -> None:
-        """Wire the Runs-on row's dropdown-vs-Cancel/Retry state (PR-3
+        """Wire the Runs-on row's Cancel/Retry button visibility (PR-3
         task 5).
 
-        Three states, keyed off `task.transfer_state`: normal (affordance
-        on, the owner-picker `Select` opens on activation, both buttons
-        hidden); in flight (`IN_FLIGHT_TRANSFER_STATES` -- affordance
-        off, Cancel shown); `to_server_failed` (affordance off, BOTH
-        Cancel and Retry shown -- `cancel_refusal`/the PR-5 retry leg
-        both allow this substate, mirroring the existing buttons' own
-        Retry-alongside-Cancel visibility rule).
+        `row.affordance`/`can_focus` stay ON unconditionally (ruling 3:
+        "dropdown always renders") -- unlike the Frequency rows' kind
+        gating, nothing about the owner row ever makes activation itself
+        unreachable; `on_detail_value_row_activated` is what decides
+        whether activating it opens the dropdown or shows why not (fix
+        round 1 finding 2: a locked/failed row must not go silently
+        inert, same idiom the Frequency rows already use for their own
+        lock reason).
 
-        The two buttons are plain always-mounted siblings of the row,
-        toggled via `.display` -- deliberately NOT `begin_edit`-mounted
-        INTO the row: `begin_edit` hides the row's own value `Static`
-        (`#scheduling-detail-runs-on`), and the existing transfer-badge
-        rendering (`_reminder_runs_on_label`'s suffix, painted into that
-        SAME Static by `set_task` above) is pinned verbatim by an
-        existing test -- this row's value must stay readable while the
-        actions show, not be replaced by them.
+        The Cancel[/Retry] buttons are plain always-mounted siblings of
+        the row, toggled via `.display` -- deliberately NOT `begin_edit`-
+        mounted INTO the row: `begin_edit` hides the row's own value
+        `Static` (`#scheduling-detail-runs-on`), and the existing
+        transfer-badge rendering (`_reminder_runs_on_label`'s suffix,
+        painted into that SAME Static by `set_task` above) is pinned
+        verbatim by an existing test -- this row's value must stay
+        readable while the actions show, not be replaced by them.
+        `to_server_failed` shows BOTH (`cancel_refusal`/the PR-5 retry
+        leg both allow this substate, mirroring the existing buttons'
+        own Retry-alongside-Cancel visibility rule); any other in-flight
+        state shows Cancel only.
         """
         row = self._runs_on_row
         assert row is not None
+        row.affordance = True
+        row.can_focus = True
         state = task.transfer_state
         failed = state == "to_server_failed"
         locked = failed or state in IN_FLIGHT_TRANSFER_STATES
-        row.affordance = not locked
-        row.can_focus = not locked
         assert self._runs_on_cancel_button is not None
         assert self._runs_on_retry_button is not None
         self._runs_on_cancel_button.display = locked
         self._runs_on_retry_button.display = failed
+
+    def _runs_on_failure_reason(self, task: ReminderTask) -> str:
+        """The Runs-on row's own `to_server_failed` explanation (fix
+        round 1 finding 2): the SAME "Last transfer error: …" copy
+        `set_transfer_reasons` already renders for the legacy Retry
+        button, reusing the SAME stored `transfer_errors` (threaded in
+        by `set_runs_on_transfer_errors`) -- falls back to the plain
+        state label when no stored errors exist (e.g. a row that failed
+        before this field existed)."""
+        errors = self._runs_on_transfer_errors
+        if errors:
+            return "Last transfer error: " + "; ".join(errors)
+        return _TRANSFER_STATE_ROW_LABELS.get(
+            task.transfer_state or "", "This transfer failed."
+        )
 
     def on_detail_value_row_activated(self, event: DetailValueRow.Activated) -> None:
         """Open the activated Frequency/Runs-on row's editor, or -- locked
@@ -1077,11 +1103,21 @@ class TaskDetail(Vertical):
         task = self._current_task
         if not isinstance(task, ReminderTask):
             return
+        if row is self._runs_on_row and task.transfer_state == "to_server_failed":
+            # fix round 1 finding 2: `_lifecycle_lock_reason` does not
+            # cover `to_server_failed` (it is not "locked" for the OTHER
+            # rows -- editing before a retry is meant to work there), but
+            # the Runs-on row's own dropdown has nothing sensible to
+            # offer a failed row either -- show why instead of opening it.
+            row.show_error(self._runs_on_failure_reason(task))
+            return
         row.clear_error()
         if row is self._runs_on_row:
-            # `_configure_runs_on_row` already refused this row's
-            # affordance for an in-flight/failed transfer -- reaching
-            # here means a normal, unlocked owner pick (spec §7 flow).
+            # A normal, unlocked owner pick (spec §7 flow) -- an
+            # in-flight row never reaches here at all: the top-of-
+            # function `_lifecycle_lock_reason` check above already
+            # intercepted it (that reason IS `transfer_lock_reason`,
+            # which covers every `IN_FLIGHT_TRANSFER_STATES` member).
             current_owner = task.owner_id or "local"
             options = list(self._runs_on_options)
             if current_owner not in {value for _, value in options}:
@@ -1291,6 +1327,7 @@ class TaskDetail(Vertical):
                 self._runs_on_cancel_button.display = False
             if self._runs_on_retry_button is not None:
                 self._runs_on_retry_button.display = False
+            self._runs_on_transfer_errors = []
             return
 
         empty_state.display = False
@@ -1546,6 +1583,15 @@ class TaskDetail(Vertical):
         self.query_one("#scheduling-transfer-why", Static).update(
             "\n".join(reason_lines)
         )
+
+    def set_runs_on_transfer_errors(self, errors: list[str]) -> None:
+        """Cache a `to_server_failed` row's stored `transfer_errors` (PR-3
+        task 5 fix round 1, finding 2) for `_runs_on_failure_reason` --
+        called by the workbench right alongside `set_transfer_reasons`,
+        fed from the SAME `retry_errors` list that already backs the
+        legacy Retry button's own reason line (one source, not a second
+        derivation)."""
+        self._runs_on_transfer_errors = list(errors)
 
     def set_lifecycle_lock(self, reason: str | None) -> None:
         """Freeze Edit/Enable/Disable/Delete while a transfer is in flight.

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -700,10 +700,10 @@ class TaskDetail(Vertical):
                 # hide the row's own value Static, which the existing
                 # transfer-badge rendering pins verbatim).
                 self._runs_on_cancel_button = Button(
-                    "Cancel transfer", id=_RUNS_ON_CANCEL_ID, variant="warning"
+                    "Cancel transfer", id=_RUNS_ON_CANCEL_ID, variant="warning", classes="detail-owner-action-button"
                 )
                 self._runs_on_retry_button = Button(
-                    "Retry transfer", id=_RUNS_ON_RETRY_ID, variant="warning"
+                    "Retry transfer", id=_RUNS_ON_RETRY_ID, variant="warning", classes="detail-owner-action-button"
                 )
                 runs_on_actions = Horizontal(
                     self._runs_on_cancel_button,

--- a/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
+++ b/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
@@ -29,6 +29,7 @@ existing call site, test import, and docstring cross-reference unchanged.
 
 from __future__ import annotations
 
+import calendar
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -36,6 +37,7 @@ from typing import Any, Literal
 
 from tldw_chatbook.Scheduling.db.scheduled_tasks_db import DORMANT_TRANSFER_STATES
 from tldw_chatbook.Scheduling.models import ReminderTask, ScheduleKind
+from tldw_chatbook.Scheduling.schedule_compute import _parse_time_of_day
 
 RowKind = Literal["reminder", "definition"]
 RowBucket = Literal["active", "paused", "completed"]
@@ -302,9 +304,27 @@ def _definition_at_label(schedule: dict[str, Any]) -> str:
     `_humanize_cron` for a cron-kind schedule rather than re-deriving
     cron-cadence prose.
 
+    ``daily``/``weekly`` render their own ``time_of_day`` (Qodo follow-up
+    to finding 8): those two used to fall through to ``"-"`` here, which
+    only became a contradiction once the `At` row was made genuinely
+    editable for them -- editing the time and repainting a dash is the
+    dishonest-repaint class ruling 2 exists to forbid. Deliberately NOT
+    routed through `_humanize_cron` by synthesizing a cron: that
+    function's ``_WEEKDAYS`` is Sunday-first (croniter's day-of-week),
+    while a definition ``schedule["weekday"]`` is Monday-first
+    (`schedule_compute._compute_weekly`, Python's own ``weekday()``), so
+    the round trip would confidently name the wrong day. The wording
+    still MATCHES `_humanize_cron`'s ("Daily at HH:MM TZ" / "Weekly on
+    <Day> at HH:MM TZ") so the same cadence reads identically whichever
+    kind expressed it.
+
+    ``interval`` keeps its ``"-"``: it has no single time to show, and
+    its `At` row is read-only, so no edit can repaint into it.
+
     Args:
-        schedule: A definition's ``schedule`` dict (``kind`` is
-            ``"cron"``/``"one_time"``).
+        schedule: A definition's ``schedule`` dict -- ``kind`` is one of
+            `schedule_compute.py`'s five (``one_time``/``interval``/
+            ``daily``/``weekly``/``cron``).
 
     Returns:
         A human-readable schedule summary, or ``"-"`` for an
@@ -323,6 +343,23 @@ def _definition_at_label(schedule: dict[str, Any]) -> str:
         if dt is None:
             return f"One-time at {run_at}" if run_at else "One-time"
         return f"One-time at {dt.strftime('%Y-%m-%d %H:%M')} {_format_timezone(dt)}"
+    if kind in ("daily", "weekly"):
+        # The SAME parser the scheduler itself applies to this field, so
+        # a value this label renders is exactly a value that will fire --
+        # and unparseable text says "-" rather than being echoed as if it
+        # were a schedule.
+        parsed = _parse_time_of_day(schedule.get("time_of_day"))
+        if parsed is None:
+            return "-"
+        at = f"{parsed.strftime('%H:%M')} {schedule.get('timezone') or 'UTC'}"
+        weekday = schedule.get("weekday")
+        if kind == "weekly":
+            if isinstance(weekday, bool) or not isinstance(weekday, int):
+                return f"Weekly at {at}"
+            if not 0 <= weekday <= 6:
+                return f"Weekly at {at}"
+            return f"Weekly on {calendar.day_name[weekday]} at {at}"
+        return f"Daily at {at}"
     return "-"
 
 

--- a/tldw_chatbook/Widgets/detail_value_row.py
+++ b/tldw_chatbook/Widgets/detail_value_row.py
@@ -187,8 +187,20 @@ class DetailValueRow(Vertical):
             )
 
     def update_value(self, value: str | Text) -> None:
-        """Refresh the painted value in place -- no recompose."""
+        """Refresh the painted value in place -- no recompose.
+
+        A no-op while an editor is open (PR-3 final review I2): the panes
+        that own these rows repaint on a timer, and the value region
+        belongs to the editor for as long as it is mounted. The write
+        would land on the hidden `Static` and only surface as a flash of
+        a value the user did not choose, the moment `end_edit` restores
+        it. A repaint that changes the ROW's identity closes the editor
+        first (`TaskDetail._reset_row_editing` and its `DefinitionDetail`
+        twin), so the next `update_value` after that lands normally.
+        """
         assert self._value_static is not None, "update_value called before mount"
+        if self._editor is not None:
+            return
         self._value_static.update(_literal(value))
 
     def show_error(self, msg: str) -> None:

--- a/tldw_chatbook/Widgets/detail_value_row.py
+++ b/tldw_chatbook/Widgets/detail_value_row.py
@@ -76,7 +76,15 @@ def _literal(value: str | Text) -> Text:
 
 
 class DetailValueRow(Vertical):
-    """One label/value detail-pane field, with an editable affordance and error slot."""
+    """One label/value detail-pane field, with an editable affordance and error slot.
+
+    ``affordance=True`` makes the row post ``Activated`` on click OR Enter,
+    but Enter only ever reaches a widget that has focus: a caller that wants
+    an editable row to be keyboard-reachable (not just clickable) must also
+    pass ``can_focus=True`` (review finding 2, task-1-review.md) -- the two
+    flags are independent by design, so ``affordance=True`` alone is a
+    click-only, keyboard-unreachable row.
+    """
 
     class Activated(Message):
         """Posted when the row's affordance is triggered by click or Enter.
@@ -194,24 +202,27 @@ class DetailValueRow(Vertical):
 
         A dormant row (``affordance`` False) never intercepts the click --
         it bubbles up untouched, same as before this row had a handler at
-        all. An editable row owns the click either way; it only posts
-        ``Activated`` while no editor is open yet (once one is, focus has
-        already moved to the editor and this handler will not fire).
+        all. Only the activation case (no editor open yet) stops the event
+        and posts ``Activated``. Once an editor is open the row must NOT
+        stop the event -- review finding 1 (task-1-review.md): Textual only
+        resolves a BINDINGS-driven editor's own key/click handling once the
+        raw event bubbles unstopped up to ``App``, so an unconditional stop
+        here silently ate a mounted ``Select``'s Enter-to-open even though
+        that is `begin_edit`'s own named typical case. While editing, the
+        event passes through untouched and the editor/App own it.
         """
-        if not self._affordance:
+        if not self._affordance or self._editor is not None:
             return
         event.stop()
-        if self._editor is None:
-            self.post_message(self.Activated(self))
+        self.post_message(self.Activated(self))
 
     def _on_key(self, event: events.Key) -> None:
         """Activate on Enter -- see ``_on_click``."""
-        if event.key != "enter" or not self._affordance:
+        if event.key != "enter" or not self._affordance or self._editor is not None:
             return
         event.stop()
         event.prevent_default()
-        if self._editor is None:
-            self.post_message(self.Activated(self))
+        self.post_message(self.Activated(self))
 
     def begin_edit(self, editor: Widget) -> None:
         """Swap the read-only value for ``editor``, in place, and focus it.

--- a/tldw_chatbook/Widgets/detail_value_row.py
+++ b/tldw_chatbook/Widgets/detail_value_row.py
@@ -4,20 +4,30 @@ schedules-redesign PR-1, Task 1 (`.superpowers/sdd/plan-2026-09-03-
 schedules-redesign-pr1/task-1-brief.md`, the approved spec's section 5 row
 grammar). A row renders one field as ``label`` (muted, left) and ``value``
 (right-aligned, ellipsized rather than wrapped when it overflows). An
-optional dimmed ``▾`` affordance glyph marks a row whose value will become
-interactive in a later PR -- it is purely decorative here, not clickable or
-focusable. A hidden error-line slot below the row is implemented and tested
+optional dimmed ``▾`` affordance glyph marks a row whose value is editable.
+A hidden error-line slot below the row is implemented and tested
 (``show_error``/``clear_error``) but unused by any PR-1 caller; PR-3 wires a
 caller to it.
 
-Three PR-3 seams are dormant in PR-1 (final review F13, fixed while the row
-had only two consumers): ``affordance`` is a settable property, not a
-construction-only flag (the glyph is always mounted and toggled with
-``display``, so flipping a row read-only<->editable never means a remount);
-``row_key`` gives the row an identity of its own to carry on whatever
-message PR-3 posts; and ``can_focus`` is a constructor flag (default
-``False``, as every PR-1 caller leaves it) so spec §12's Up/Down row
-traversal needs no subclass.
+schedules-redesign PR-3, Task 1 activates the three dormant PR-1 seams
+below: a row with ``affordance=True`` now posts ``DetailValueRow.Activated``
+on click or Enter, but only while no editor is open -- a dormant row
+(``affordance`` left at its ``False`` default, as every PR-1/PR-2 caller
+still does) stays a complete no-op, exactly as before. ``begin_edit``/
+``end_edit`` swap the read-only value ``Static`` for a caller-built editor
+widget in place (no recompose); ``begin_edit`` is a guarded no-op while an
+editor is already open, and the error slot coexists with an open editor.
+The affordance glyph also gains a live visual state -- it un-dims while the
+row (or its open editor) has focus, or on hover.
+
+Three PR-3 seams were left dormant in PR-1 (final review F13, fixed while
+the row had only two consumers) and are wired up starting with PR-3 Task 1
+above: ``affordance`` is a settable property, not a construction-only flag
+(the glyph is always mounted and toggled with ``display``, so flipping a row
+read-only<->editable never means a remount); ``row_key`` gives the row an
+identity of its own, carried on ``Activated``; and ``can_focus`` is a
+constructor flag (default ``False``, as every PR-1/PR-2 caller still leaves
+it) so spec §12's Up/Down row traversal needs no subclass.
 
 ``DetailGroup`` is a thin ``Collapsible`` subclass (the house idiom already
 used directly across this codebase -- see
@@ -52,8 +62,10 @@ after editing ``_scheduling.tcss`` and commit the regenerated
 from __future__ import annotations
 
 from rich.text import Text
+from textual import events
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
+from textual.message import Message
 from textual.widget import Widget
 from textual.widgets import Collapsible, Static
 
@@ -64,7 +76,25 @@ def _literal(value: str | Text) -> Text:
 
 
 class DetailValueRow(Vertical):
-    """One label/value detail-pane field, plus a dormant affordance and error slot."""
+    """One label/value detail-pane field, with an editable affordance and error slot."""
+
+    class Activated(Message):
+        """Posted when the row's affordance is triggered by click or Enter.
+
+        Only posted while ``affordance`` is true and no editor is
+        currently open (``begin_edit`` not yet called, or ``end_edit``
+        already closed it) -- a dormant row (``affordance`` left at its
+        ``False`` default) never posts this message, so every PR-1/PR-2
+        read-only consumer stays untouched.
+
+        Attributes:
+            row: The ``DetailValueRow`` that was activated. Carries its own
+                ``row_key`` for a handler to route on.
+        """
+
+        def __init__(self, row: "DetailValueRow") -> None:
+            self.row = row
+            super().__init__()
 
     def __init__(
         self,
@@ -86,6 +116,10 @@ class DetailValueRow(Vertical):
         self._value_static: Static | None = None
         self._error_static: Static | None = None
         self._affordance_static: Static | None = None
+        self._line: Horizontal | None = None
+        #: The open editor widget, if any (PR-3 Task 1's edit-swap API).
+        #: ``None`` means the row is showing its read-only value.
+        self._editor: Widget | None = None
         #: Stable field identity for the row itself (final-review F13.2).
         #: PR-3 addresses the ROW (open its editor, route its error) and
         #: must not reach through `static.parent.parent` to find it.
@@ -96,7 +130,9 @@ class DetailValueRow(Vertical):
         self.can_focus = can_focus
 
     def compose(self) -> ComposeResult:
-        with Horizontal(classes="detail-value-row-line"):
+        line = Horizontal(classes="detail-value-row-line")
+        self._line = line
+        with line:
             yield Static(self._label, classes="detail-value-row-label", markup=False)
             self._value_static = Static(
                 _literal(self._initial_value),
@@ -152,6 +188,70 @@ class DetailValueRow(Vertical):
         assert self._error_static is not None, "clear_error called before mount"
         self._error_static.styles.display = "none"
         self._error_static.update("")
+
+    def _on_click(self, event: events.Click) -> None:
+        """Activate on click, per PR-3 Task 1's edit-swap API (module docstring).
+
+        A dormant row (``affordance`` False) never intercepts the click --
+        it bubbles up untouched, same as before this row had a handler at
+        all. An editable row owns the click either way; it only posts
+        ``Activated`` while no editor is open yet (once one is, focus has
+        already moved to the editor and this handler will not fire).
+        """
+        if not self._affordance:
+            return
+        event.stop()
+        if self._editor is None:
+            self.post_message(self.Activated(self))
+
+    def _on_key(self, event: events.Key) -> None:
+        """Activate on Enter -- see ``_on_click``."""
+        if event.key != "enter" or not self._affordance:
+            return
+        event.stop()
+        event.prevent_default()
+        if self._editor is None:
+            self.post_message(self.Activated(self))
+
+    def begin_edit(self, editor: Widget) -> None:
+        """Swap the read-only value for ``editor``, in place, and focus it.
+
+        Hides the value ``Static`` and mounts ``editor`` where it sat, no
+        recompose. Guarded: a no-op while an editor is already open -- one
+        editor at a time. The error slot (`show_error`/`clear_error`) is
+        untouched and keeps working alongside an open editor.
+
+        Args:
+            editor: The widget to mount in the value's place -- typically a
+                ``Select`` or a small composite editor built by the caller.
+        """
+        if self._editor is not None:
+            return
+        assert self._value_static is not None and self._line is not None, (
+            "begin_edit called before mount"
+        )
+        self._editor = editor
+        self._value_static.styles.display = "none"
+        self._line.mount(editor, before=self._value_static)
+        self.call_after_refresh(editor.focus)
+
+    def end_edit(self, *, restore_focus: bool = True) -> None:
+        """Close the open editor and restore the read-only value display.
+
+        A no-op if no editor is currently open.
+
+        Args:
+            restore_focus: When ``True`` (default), give focus back to the
+                row itself once the editor is removed.
+        """
+        if self._editor is None:
+            return
+        editor, self._editor = self._editor, None
+        editor.remove()
+        assert self._value_static is not None, "end_edit called before mount"
+        self._value_static.styles.display = "block"
+        if restore_focus:
+            self.call_after_refresh(self.focus)
 
 
 class DetailGroup(Collapsible):

--- a/tldw_chatbook/Widgets/detail_value_row.py
+++ b/tldw_chatbook/Widgets/detail_value_row.py
@@ -20,6 +20,12 @@ editor is already open, and the error slot coexists with an open editor.
 The affordance glyph also gains a live visual state -- it un-dims while the
 row (or its open editor) has focus, or on hover.
 
+schedules-redesign PR-3, Task 3 adds one more general behavior: Escape
+while an editor is open closes it via ``end_edit()`` without notifying the
+caller (no ``Activated`` re-fire, no commit) -- a plain cancel, available
+to every `DetailValueRow` consumer, not just the reminder pane that first
+wires a caller through it.
+
 Three PR-3 seams were left dormant in PR-1 (final review F13, fixed while
 the row had only two consumers) and are wired up starting with PR-3 Task 1
 above: ``affordance`` is a settable property, not a construction-only flag
@@ -217,7 +223,26 @@ class DetailValueRow(Vertical):
         self.post_message(self.Activated(self))
 
     def _on_key(self, event: events.Key) -> None:
-        """Activate on Enter -- see ``_on_click``."""
+        """Activate on Enter, or cancel an open editor on Escape.
+
+        PR-3 Task 3: Escape while editing closes the editor without
+        committing (``end_edit()``, no caller notified) -- checked FIRST
+        and independently of ``self._affordance`` so it works the same
+        whether or not the row's glyph is currently shown. Neither
+        `Select` nor `Input` binds Escape for anything while collapsed/
+        idle (verified against Textual's own `Select`/`Input`/
+        `SelectOverlay` BINDINGS -- only `SelectOverlay` binds it, and
+        only to dismiss its own open dropdown), so the raw key event
+        bubbles here untouched exactly like Task 1's Enter fix relies on
+        for the OPEN case; stopping it here for the EDITING case is safe
+        and deliberate, unlike the open-Select-overlay's own Enter, which
+        must keep bubbling to resolve via `App`'s BINDINGS chain.
+        """
+        if event.key == "escape" and self._editor is not None:
+            event.stop()
+            event.prevent_default()
+            self.end_edit()
+            return
         if event.key != "enter" or not self._affordance or self._editor is not None:
             return
         event.stop()

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -291,6 +291,27 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     padding: 0 1;
 }
 
+/* schedules-redesign PR-3, Task 4: the definitions pane's header
+ * Pause/Resume row -- same one-Button lifecycle-row shape as
+ * `#scheduling-task-detail-lifecycle` above. `DefinitionDetail` mounts
+ * under two different ids (Automations tab + Queue tab sibling), so both
+ * selectors share this declaration rather than one id-scoped rule. */
+#scheduling-automation-detail-lifecycle {
+    height: auto;
+    padding: 0 0 1 0;
+}
+
+#scheduling-automation-detail-lifecycle Button {
+    margin: 0 1 0 0;
+}
+
+#scheduling-automation-detail .follow-why,
+#scheduling-queue-definition-detail .follow-why {
+    color: $text-muted;
+    height: auto;
+    padding: 0 1;
+}
+
 /* Status badge base (detail pane) */
 #scheduling-task-status-badge {
     width: auto;

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -477,6 +477,28 @@ DetailValueRow .detail-value-row-error {
     text-overflow: ellipsis;
 }
 
+/* schedules-redesign PR-3, Task 5: the Runs-on row's proactively-shown
+ * Cancel[/Retry] buttons -- a plain sibling `Horizontal` of the "Runs on"
+ * `DetailValueRow` inside its own `DetailGroup` (NOT nested inside the
+ * row itself: `begin_edit` would hide the row's own value `Static`,
+ * which the existing transfer-badge rendering pins verbatim -- see
+ * `task_detail.TaskDetail._configure_runs_on_row`'s docstring). Same
+ * compact single-row Button idiom `#scheduling-queue-chips .scheduling-
+ * queue-chip` already uses elsewhere in this file, so the row costs one
+ * line rather than a full 3-row Button box. Bare class selector (not
+ * scoped under `DetailValueRow`) since this widget lives outside it. */
+.detail-value-row-owner-actions {
+    height: 1;
+    align: right middle;
+}
+
+.detail-value-row-owner-actions Button {
+    height: 1;
+    min-width: 8;
+    border: none;
+    margin: 0 0 0 1;
+}
+
 DetailGroup {
     background: $ds-surface-panel;
     border-top: hkey $ds-grid-line;

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -301,7 +301,7 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     padding: 0 0 1 0;
 }
 
-#scheduling-automation-detail-lifecycle Button {
+#scheduling-automation-detail-lifecycle .detail-lifecycle-button {
     margin: 0 1 0 0;
 }
 
@@ -498,7 +498,7 @@ DetailValueRow .detail-value-row-error {
     align: right middle;
 }
 
-.detail-value-row-owner-actions Button {
+.detail-value-row-owner-actions .detail-owner-action-button {
     height: 1;
     min-width: 8;
     border: none;

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -488,7 +488,13 @@ DetailValueRow .detail-value-row-error {
  * line rather than a full 3-row Button box. Bare class selector (not
  * scoped under `DetailValueRow`) since this widget lives outside it. */
 .detail-value-row-owner-actions {
-    height: 1;
+    /* `auto`, not a fixed `1` (final review M5): both buttons are
+     * `.display`-toggled and hidden in the overwhelmingly common
+     * no-transfer-in-flight case, but a fixed height still reserved a
+     * blank line inside the Details group of every reminder and every
+     * definition. `auto` measures 0 when both are hidden, 1 when either
+     * shows. */
+    height: auto;
     align: right middle;
 }
 

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -436,6 +436,18 @@ DetailValueRow .detail-value-row-affordance {
     padding: 0 0 0 1;
 }
 
+/* schedules-redesign PR-3, Task 1: the affordance's live state. `:focus-
+ * within` covers both a row focused via spec §12's Up/Down traversal AND
+ * (once `begin_edit` mounts an editor into the row) the editor itself
+ * holding focus -- `has_focus_within` counts a widget's own focus as
+ * "within itself" too, so one selector covers both. `:hover` mirrors it
+ * for mouse users. Un-dimming to the same colour as the value tells a user
+ * "Enter/click acts on this row" without a new token. */
+DetailValueRow:focus-within .detail-value-row-affordance,
+DetailValueRow:hover .detail-value-row-affordance {
+    color: $ds-text-primary;
+}
+
 DetailValueRow .detail-value-row-error {
     color: $ds-status-error-readable;
     width: 1fr;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -14104,6 +14104,28 @@ DetailValueRow .detail-value-row-error {
     text-overflow: ellipsis;
 }
 
+/* schedules-redesign PR-3, Task 5: the Runs-on row's proactively-shown
+ * Cancel[/Retry] buttons -- a plain sibling `Horizontal` of the "Runs on"
+ * `DetailValueRow` inside its own `DetailGroup` (NOT nested inside the
+ * row itself: `begin_edit` would hide the row's own value `Static`,
+ * which the existing transfer-badge rendering pins verbatim -- see
+ * `task_detail.TaskDetail._configure_runs_on_row`'s docstring). Same
+ * compact single-row Button idiom `#scheduling-queue-chips .scheduling-
+ * queue-chip` already uses elsewhere in this file, so the row costs one
+ * line rather than a full 3-row Button box. Bare class selector (not
+ * scoped under `DetailValueRow`) since this widget lives outside it. */
+.detail-value-row-owner-actions {
+    height: 1;
+    align: right middle;
+}
+
+.detail-value-row-owner-actions Button {
+    height: 1;
+    min-width: 8;
+    border: none;
+    margin: 0 0 0 1;
+}
+
 DetailGroup {
     background: $ds-surface-panel;
     border-top: hkey $ds-grid-line;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -14115,7 +14115,13 @@ DetailValueRow .detail-value-row-error {
  * line rather than a full 3-row Button box. Bare class selector (not
  * scoped under `DetailValueRow`) since this widget lives outside it. */
 .detail-value-row-owner-actions {
-    height: 1;
+    /* `auto`, not a fixed `1` (final review M5): both buttons are
+     * `.display`-toggled and hidden in the overwhelmingly common
+     * no-transfer-in-flight case, but a fixed height still reserved a
+     * blank line inside the Details group of every reminder and every
+     * definition. `auto` measures 0 when both are hidden, 1 when either
+     * shows. */
+    height: auto;
     align: right middle;
 }
 

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -14063,6 +14063,18 @@ DetailValueRow .detail-value-row-affordance {
     padding: 0 0 0 1;
 }
 
+/* schedules-redesign PR-3, Task 1: the affordance's live state. `:focus-
+ * within` covers both a row focused via spec §12's Up/Down traversal AND
+ * (once `begin_edit` mounts an editor into the row) the editor itself
+ * holding focus -- `has_focus_within` counts a widget's own focus as
+ * "within itself" too, so one selector covers both. `:hover` mirrors it
+ * for mouse users. Un-dimming to the same colour as the value tells a user
+ * "Enter/click acts on this row" without a new token. */
+DetailValueRow:focus-within .detail-value-row-affordance,
+DetailValueRow:hover .detail-value-row-affordance {
+    color: $ds-text-primary;
+}
+
 DetailValueRow .detail-value-row-error {
     color: $ds-status-error-readable;
     width: 1fr;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13928,7 +13928,7 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     padding: 0 0 1 0;
 }
 
-#scheduling-automation-detail-lifecycle Button {
+#scheduling-automation-detail-lifecycle .detail-lifecycle-button {
     margin: 0 1 0 0;
 }
 
@@ -14125,7 +14125,7 @@ DetailValueRow .detail-value-row-error {
     align: right middle;
 }
 
-.detail-value-row-owner-actions Button {
+.detail-value-row-owner-actions .detail-owner-action-button {
     height: 1;
     min-width: 8;
     border: none;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13918,6 +13918,27 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     padding: 0 1;
 }
 
+/* schedules-redesign PR-3, Task 4: the definitions pane's header
+ * Pause/Resume row -- same one-Button lifecycle-row shape as
+ * `#scheduling-task-detail-lifecycle` above. `DefinitionDetail` mounts
+ * under two different ids (Automations tab + Queue tab sibling), so both
+ * selectors share this declaration rather than one id-scoped rule. */
+#scheduling-automation-detail-lifecycle {
+    height: auto;
+    padding: 0 0 1 0;
+}
+
+#scheduling-automation-detail-lifecycle Button {
+    margin: 0 1 0 0;
+}
+
+#scheduling-automation-detail .follow-why,
+#scheduling-queue-definition-detail .follow-why {
+    color: $text-muted;
+    height: auto;
+    padding: 0 1;
+}
+
 /* Status badge base (detail pane) */
 #scheduling-task-status-badge {
     width: auto;


### PR DESCRIPTION
Third slice of the approved schedules-screen redesign (spec §6/§7; plan tracked in this PR; ADR: backlog/decisions/116-schedules-inspector-editing.md — numbered 116 after the commit-time sweep caught 115 claimed mid-development, the programs' 8th collision).

## What ships
- **The dormant PR-1 surfaces come alive**: `DetailValueRow` gains activation + a value↔editor swap; single-value rows on both detail panes edit in place — reminder Frequency (Repeat preset / At / Timezone), definition Details (Model, Generation, Finding policy, Sources) + Frequency + Notifications — commit-on-close through the existing facade seams, field-addressed errors inline, Escape cancels, locked rows refuse with their reason. Question text, custom cron, and scope rework stay in the modals per the hybrid decision.
- **A reminder validation bridge**: `edit_reminder_fields` returns the same `{field,code,message}` shape definitions get (raw Pydantic errors never reach the panes), reusing the create form's forgiving parsers — now hoisted to a pure module both consume.
- **The lifecycle toggle's first UI wiring** (pause/resume on the definition pane header) with a two-layer pull-guard ported from the results-sync precedent, so an optimistic pause can't flicker back under a racing pull — pinned by a genuinely racing test.
- **"Runs on" is now the transfer dropdown** on both panes: refusal-first with health-quoting inline, confirm dialog listing the transfer warnings, the right facade call and row id per direction (release-leg cancels target the dormant copy — pinned), Cancel/Retry affordances with stored transfer errors surfaced; the legacy transfer buttons coexist until PR-4 retires them.
- **Review-caught along the way**: a Critical mutation-slot collision (an in-pane edit silently destroyed a queued Pause and let the server echo revert it — closed by cross-action refusal at the edit entry, a lifecycle guard on the identity-adoption path, and an edit-class-scoped queue clear); an open editor surviving pane repaints and committing onto the wrong row; stale errors crossing rows; the Queue-tab pane never repainting after edits; a NULL-JSON-column corner from server-inserted rows breaking all edits with a misleading message.
- One ruling was refuted by probe evidence and reversed: Textual's Select fires `Changed` on mount-preselect, so closing the owner dropdown on a same-owner pick would shut it the instant it opens — the pinning test now carries that evidence.

## Review trail
6 SDD tasks, each reviewed with fix rounds; final whole-branch review (opus): 1 Critical + 3 Important + 8 Minor, every top finding probe-proven — one wave fixed 12/13 as ruled (the 13th refuted with evidence), scoped re-review ALL RESOLVED with the deferral spot-probed honest. Gates: 1025 Scheduling + 588 schedules-UI green; census 969-970/972; diagnostics pin exact; CSS bundle byte-identical.

## Pre-existing, NOT this PR (verified byte-identical at the merge base / on dev HEAD)
The 11 `test_destination_visual_parity_correction.py` failures (dev baseline) and the boot-css byte-budget ratchet breach (dev itself red at 807,010/806,000 B; tracked by task-24459; not a required CI check).

## Deferred (ledgered)
The C1 mirror direction (a Pause over a queued edit drops the edit's push — the honest fix is a dedicated lifecycle mutation primitive; follow-up task at close-out); the shared-normalizer backfill (runtime-identical defaults, display-honesty only); legacy transfer-flow duplication + always-mounted Cancel/Retry consistency (PR-4's retirement sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WocisXw6SEEG6nb1aKFHtv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Third slice of the schedules-screen redesign. Single-value rows on both detail panes edit in place, "Runs on" becomes the owner-transfer dropdown, and the definition pane header gains a Pause/Resume toggle.

**What changed**

- Reminder Frequency rows (Repeat, At, Timezone) and definition Details/Frequency rows (Model, Generation, Finding policy, Sources, Notifications) edit in place; Escape cancels, and field errors render inline on the row.
- Reminder edits now return the same `{field, code, message}` validation shape definitions use, so raw Pydantic errors never reach the pane.
- "Runs on" opens an owner-transfer dropdown on both panes, with health-quoted refusals, a confirm dialog for warnings, and Cancel/Retry for in-flight transfers. The legacy transfer buttons stay until PR-4 retires them.
- The Pause/Resume toggle is the lifecycle mutation's first UI caller, guarded so an optimistic pause can't flicker back under a racing pull.
- The hybrid editing model (in-pane for single fields, modals for question text/custom cron/scope) is documented in ADR-116 and an amendment to ADR-099.

**Fixed along the way**

- Lifecycle mutations moved to their own `automation_lifecycle` queue slot so a queued Pause and a queued edit coexist instead of destroying each other.
- Open editors no longer survive row repaints or commit to the wrong row; stale errors no longer cross rows.
- Server-inserted rows with NULL JSON columns broke all edits; those columns now merge as empty dicts.
- The Queue-tab detail pane repaints after edits; edit workers serialize per definition so two fields of one row can't race, and daily/weekly At rows render their time instead of a dash.

<sup>Written for commit 34ecddfa1fa98a692a630870faacc599e80ae5d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

