### PR TITLE
feat(console): pin the agent's task list above the transcript (PRD M1)

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -110,6 +110,40 @@ contains private text; its expanded notice is
 `Proprietary thinking obfuscated - not available`. This distinction describes
 observable provider events and does not promise hidden chain-of-thought.
 
+### Task panel — the agent's task list stays in view
+
+When the agent keeps a task list (the `todo_create` / `todo_update` tools),
+a **Tasks** panel sits pinned above the transcript for as long as the list
+has entries:
+
+```
+▾ Tasks · 3 of 7 done · Writing the migration
+[x] Read the schema
+[x] Draft the migration plan
+[x] Add the version bump
+[~] Writing the migration
+[ ] Run the DB tests
+[ ] Update the docs
+[ ] Open the PR
+```
+
+- The header always shows how many tasks are done and what the agent is
+  working on right now. `[~]` marks the in-progress task, `[x]` a finished
+  one, `[ ]` one still waiting.
+- The panel updates the instant the agent changes the list. The transcript
+  still gets its `☰ Tasks` marker on every change, so the history stays
+  intact; the panel is the copy that does not scroll away.
+- Click the header to collapse the panel to its one-line summary, and click
+  again to expand it. Each tab remembers its own collapsed state.
+- Long lists scroll inside the panel rather than pushing the transcript
+  down.
+- The list belongs to the tab: switching tabs switches the panel, and a tab
+  with no tasks shows no panel at all. Like the rest of a run, the list
+  lives only while Console stays open.
+
+The panel is read-only — it shows the agent's plan; it is not a place to
+edit it.
+
 ### Approvals — tools ask before they run
 
 Nothing is ever auto-approved, and built-in tools always ask first. When the

--- a/Tests/UI/test_console_task_panel.py
+++ b/Tests/UI/test_console_task_panel.py
@@ -1,9 +1,9 @@
 """PRD Feature B (milestone M1): the pinned Console task panel.
 
 Covers the pure renderer, the widget's show/hide/collapse behaviour under
-the real consolidated CSS, and the controller wiring that feeds it (the
-``todo_*`` change callback on the worker thread and the session-activation
-re-derive on the UI thread).
+the real consolidated CSS, and the controller/runtime wiring that feeds it
+(the ``todo_*`` change callback on the worker thread, the session
+activation re-derives on the UI thread, and the re-derive at view attach).
 """
 
 from __future__ import annotations
@@ -13,6 +13,8 @@ from types import SimpleNamespace
 import pytest
 from textual.app import ComposeResult
 from textual.widgets import Static
+
+from Tests.Chat.test_console_runtime_lifetime import _runtime_with, _View
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
@@ -76,10 +78,7 @@ class _Harness(ConsolidatedCSSApp):
 
 
 def _rows(panel: ConsoleTaskPanel) -> list[str]:
-    return [
-        str(row.render())
-        for row in panel.query("#console-task-panel-body Static")
-    ]
+    return str(panel.query_one("#console-task-panel-rows", Static).render()).splitlines()
 
 
 @pytest.mark.asyncio
@@ -105,6 +104,22 @@ async def test_panel_hidden_until_tasks_arrive_then_hidden_again_when_cleared():
         panel.set_tasks("s1", [])
         await pilot.pause()
         assert panel.display is False
+
+
+@pytest.mark.asyncio
+async def test_back_to_back_snapshots_render_only_the_newest():
+    """Repaint is a synchronous ``update()``: no remove/mount cycle to race."""
+    app = _Harness()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        panel = app.query_one(ConsoleTaskPanel)
+        for n in range(1, 6):
+            panel.set_tasks(
+                "s1",
+                [{"content": f"task {i}", "status": "pending"} for i in range(n)],
+            )
+        await pilot.pause()
+        assert _rows(panel) == [f"[ ] task {i}" for i in range(5)]
 
 
 @pytest.mark.asyncio
@@ -139,7 +154,7 @@ async def test_collapse_is_remembered_per_session_and_survives_updates():
         assert body.display is False
 
 
-# --- controller wiring -------------------------------------------------------
+# --- controller and runtime wiring -------------------------------------------
 
 
 def _wired_controller() -> tuple[ConsoleChatController, list[tuple[str | None, list]]]:
@@ -186,3 +201,35 @@ def test_session_activation_re_derives_the_panel_from_the_todo_store():
 
     controller.set_task_panel = None
     controller._remount_task_panel(first.id)  # viewless: no-op, no raise
+
+
+def test_closing_the_last_session_clears_the_panel():
+    """No neighbour to activate still has to take the departed tasks down."""
+    controller, calls = _wired_controller()
+    only = controller.new_session(title="only")
+    only.todo_store.create(content="doomed")
+    controller._remount_task_panel(only.id)
+    assert calls[-1][1], "precondition: the panel shows the task"
+
+    controller.close_session(only.id)
+    assert controller.store.active_session_id is None
+    assert calls[-1] == (None, [])
+
+
+def test_attaching_a_new_view_pushes_the_active_sessions_tasks():
+    """The runtime outlives the screen; a fresh panel must not start empty."""
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=None)
+    session = controller.new_session(title="kept")
+    session.todo_store.create(content="survives navigation")
+
+    calls: list[tuple[str | None, list]] = []
+    view = _View(
+        {"set_task_panel": lambda sid, tasks: calls.append((sid, list(tasks)))}
+    )
+    _runtime_with(controller, view)
+
+    assert calls, "attach must re-derive the panel"
+    session_id, tasks = calls[-1]
+    assert session_id == session.id
+    assert [t["content"] for t in tasks] == ["survives navigation"]

--- a/Tests/UI/test_console_task_panel.py
+++ b/Tests/UI/test_console_task_panel.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 from textual.app import ComposeResult
+from textual.containers import Vertical
 from textual.widgets import Static
 
 from Tests.Chat.test_console_runtime_lifetime import _runtime_with, _View
@@ -21,6 +22,8 @@ from Tests.Chat.test_console_runtime_lifetime import _runtime_with, _View
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+from tldw_chatbook.Widgets.Chat_Widgets.chat_task_cards import ChatTaskCards
 from tldw_chatbook.Widgets.Console.console_task_panel import (
     ConsoleTaskPanel,
     render_task_lines,
@@ -104,6 +107,49 @@ async def test_panel_hidden_until_tasks_arrive_then_hidden_again_when_cleared():
         panel.set_tasks("s1", [])
         await pilot.pause()
         assert panel.display is False
+
+
+@pytest.mark.asyncio
+async def test_snapshot_given_before_mount_is_painted_on_mount():
+    """The screen mounts the panel lazily on the first non-empty snapshot and
+    hands it the tasks in the same breath, before its children exist."""
+    app = ConsolidatedCSSApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        panel = ConsoleTaskPanel(id="console-task-panel")
+        panel.set_tasks("s1", _tasks())
+        await app.mount(panel)
+        await pilot.pause()
+        assert panel.display is True
+        assert _rows(panel) == [
+            "[x] Read the schema",
+            "[~] Writing the migration",
+            "[ ] Run the DB tests",
+        ]
+
+
+class _SurfaceHarness(ConsolidatedCSSApp):
+    """A stand-in for the Console session surface's card slot."""
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="surface"):
+            yield Static("title", id="title")
+            yield ChatTaskCards(id="console-task-surface")
+            yield Static("transcript", id="transcript")
+
+
+@pytest.mark.asyncio
+async def test_screen_mounts_the_panel_lazily_right_after_the_task_cards():
+    """ADR-097: the panel module stays off the boot path until first use, so
+    the screen mounts it on demand -- and it must land in the card slot."""
+    app = _SurfaceHarness()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        panel = ChatScreen._mount_console_task_panel(app)
+        await pilot.pause()
+        assert panel is not None and panel.is_mounted
+        order = [child.id for child in app.query_one("#surface").children]
+        assert order == ["title", "console-task-surface", "console-task-panel", "transcript"]
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_task_panel.py
+++ b/Tests/UI/test_console_task_panel.py
@@ -1,0 +1,188 @@
+"""PRD Feature B (milestone M1): the pinned Console task panel.
+
+Covers the pure renderer, the widget's show/hide/collapse behaviour under
+the real consolidated CSS, and the controller wiring that feeds it (the
+``todo_*`` change callback on the worker thread and the session-activation
+re-derive on the UI thread).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from textual.app import ComposeResult
+from textual.widgets import Static
+
+# Harness apps load the consolidated widget CSS the real app loads
+# (TASK-15450); without it the widgets under test mount unstyled.
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Widgets.Console.console_task_panel import (
+    ConsoleTaskPanel,
+    render_task_lines,
+)
+
+
+def _tasks() -> list[dict[str, object]]:
+    return [
+        {"id": "1", "content": "Read the schema", "status": "completed"},
+        {
+            "id": "2",
+            "content": "Write the migration",
+            "status": "in_progress",
+            "activeForm": "Writing the migration",
+        },
+        {"id": "3", "content": "Run the DB tests", "status": "pending"},
+    ]
+
+
+# --- pure renderer ---------------------------------------------------------
+
+
+def test_render_header_counts_done_and_names_the_active_form():
+    header, rows = render_task_lines(_tasks())
+    assert header == "▾ Tasks · 1 of 3 done · Writing the migration"
+    assert rows == [
+        ("completed", "[x] Read the schema"),
+        ("in_progress", "[~] Writing the migration"),
+        ("pending", "[ ] Run the DB tests"),
+    ]
+
+
+def test_render_collapsed_flips_the_chevron_and_omits_active_when_none():
+    header, _ = render_task_lines(
+        [{"content": "a", "status": "pending"}], collapsed=True
+    )
+    assert header == "▸ Tasks · 0 of 1 done"
+
+
+def test_render_sanitises_labels_like_the_transcript_marker():
+    _, rows = render_task_lines(
+        [{"content": "line one\nline two\x07", "status": "pending"}]
+    )
+    (row,) = rows
+    assert "\n" not in row[1] and "\x07" not in row[1]
+    assert row[1].startswith("[ ] line one")
+
+
+# --- widget under the real CSS ---------------------------------------------
+
+
+class _Harness(ConsolidatedCSSApp):
+    def compose(self) -> ComposeResult:
+        yield ConsoleTaskPanel(id="console-task-panel")
+
+
+def _rows(panel: ConsoleTaskPanel) -> list[str]:
+    return [
+        str(row.render())
+        for row in panel.query("#console-task-panel-body Static")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_panel_hidden_until_tasks_arrive_then_hidden_again_when_cleared():
+    app = _Harness()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        panel = app.query_one(ConsoleTaskPanel)
+        assert panel.display is False, "AC-B1: no panel without tasks"
+
+        panel.set_tasks("s1", _tasks())
+        await pilot.pause()
+        assert panel.display is True
+        header = panel.query_one("#console-task-panel-header", Static)
+        assert "1 of 3 done" in str(header.render())
+        assert "Writing the migration" in str(header.render())
+        assert _rows(panel) == [
+            "[x] Read the schema",
+            "[~] Writing the migration",
+            "[ ] Run the DB tests",
+        ]
+
+        panel.set_tasks("s1", [])
+        await pilot.pause()
+        assert panel.display is False
+
+
+@pytest.mark.asyncio
+async def test_collapse_is_remembered_per_session_and_survives_updates():
+    app = _Harness()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        panel = app.query_one(ConsoleTaskPanel)
+        panel.set_tasks("s1", _tasks())
+        await pilot.pause()
+        body = panel.query_one("#console-task-panel-body")
+        assert body.display is True
+
+        await pilot.click("#console-task-panel-header")
+        await pilot.pause()
+        assert body.display is False, "click on the header collapses"
+        assert str(
+            panel.query_one("#console-task-panel-header", Static).render()
+        ).startswith("▸")
+
+        # A live update keeps the collapsed state (AC-B6).
+        panel.set_tasks("s1", _tasks()[:2])
+        await pilot.pause()
+        assert body.display is False
+
+        # Another session starts expanded; coming back restores collapsed.
+        panel.set_tasks("s2", _tasks()[:1])
+        await pilot.pause()
+        assert body.display is True
+        panel.set_tasks("s1", _tasks())
+        await pilot.pause()
+        assert body.display is False
+
+
+# --- controller wiring -------------------------------------------------------
+
+
+def _wired_controller() -> tuple[ConsoleChatController, list[tuple[str | None, list]]]:
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(store=store, provider_gateway=None)
+    calls: list[tuple[str | None, list]] = []
+    controller.app = SimpleNamespace(call_from_thread=lambda fn, *args: fn(*args))
+    controller.set_task_panel = lambda session_id, tasks: calls.append(
+        (session_id, list(tasks))
+    )
+    return controller, calls
+
+
+def test_todo_change_feeds_the_panel_alongside_the_transcript_marker():
+    controller, calls = _wired_controller()
+    session = controller.new_session(title="t")
+    calls.clear()
+    markers: list[tuple[str, list]] = []
+    controller._agent_bridge = SimpleNamespace(
+        append_todo_marker=lambda sid, tasks: markers.append((sid, tasks))
+    )
+
+    wiring = controller._todo_wiring(session.id)
+    snapshot = [{"id": "1", "content": "x", "status": "pending"}]
+    wiring["on_todo_change"](snapshot)
+
+    assert markers == [(session.id, snapshot)], "transcript marker still fires"
+    assert calls == [(session.id, snapshot)], "AC-B4: panel sink fires too"
+
+
+def test_session_activation_re_derives_the_panel_from_the_todo_store():
+    controller, calls = _wired_controller()
+    first = controller.new_session(title="first")
+    assert calls[-1] == (first.id, []), "a new session clears the panel"
+    first.todo_store.create(content="only in first")
+
+    second = controller.new_session(title="second")
+    assert calls[-1] == (second.id, [])
+
+    controller.switch_session(first.id)
+    session_id, tasks = calls[-1]
+    assert session_id == first.id
+    assert [t["content"] for t in tasks] == ["only in first"], "AC-B5"
+
+    controller.set_task_panel = None
+    controller._remount_task_panel(first.id)  # viewless: no-op, no raise

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -10744,7 +10744,11 @@ class ConsoleChatController:
             self._remount_parked_skill_install(new_active_id)
             self._remount_parked_skill_script(new_active_id)
             self._remount_parked_worktree_merge(new_active_id)
-            self._remount_task_panel(new_active_id)
+        # Unconditional: closing the LAST session leaves no neighbour to
+        # activate (`new_active_id` is None) and the screen's follow-up sync
+        # creates the blank replacement straight through the store, so this
+        # is the only place the departed session's tasks get cleared.
+        self._remount_task_panel(new_active_id)
         return closed
 
     def original_attempt_for_message(self, message_id: str) -> str | None:
@@ -13746,15 +13750,18 @@ class ConsoleChatController:
         if self.app is not None and self.set_task_panel is not None:
             self.app.call_from_thread(self.set_task_panel, session_id, tasks)
 
-    def _remount_task_panel(self, session_id: str) -> None:
+    def _remount_task_panel(self, session_id: str | None) -> None:
         """UI THREAD: re-derive the pinned task panel for ``session_id``.
 
         Called from `switch_session`/`new_session`/`close_session` next to
-        the card re-derives, so the panel always shows the VIEWED session's
-        tasks (AC-B5) and hides when that session has none.
+        the card re-derives, and from `ConsoleRuntime.attach_view` when a
+        new screen claims the surviving runtime, so the panel always shows
+        the VIEWED session's tasks (AC-B5) and hides when that session has
+        none -- or when there is no session at all.
 
         Args:
-            session_id: The session now being activated/viewed.
+            session_id: The session now being activated/viewed, or None
+                when none is (the last session was just closed).
         """
         if self.set_task_panel is None:
             return

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -3608,6 +3608,9 @@ class ConsoleChatController:
         #: request_skill_script_confirm. Mirrors set_pending_skill_install,
         #: but the round-trip decision carries a "remember" flag too.
         self.set_pending_skill_script: Callable[[dict | None], None] | None = None
+        #: PRD Feature B: UI-thread sink for the pinned task panel --
+        #: ``(session_id, tasks)``. Bound by `attach_view`; None = no view.
+        self.set_task_panel: Callable[[str | None, list[dict[str, object]]], None] | None = None
         #: Optional test override for the confirm timeout, mirroring
         #: `skill_install_confirm_timeout_seconds`.
         self.skill_script_confirm_timeout_seconds: Callable[[], float] | None = None
@@ -10180,6 +10183,7 @@ class ConsoleChatController:
         self._remount_parked_skill_install(session.id)
         self._remount_parked_skill_script(session.id)
         self._remount_parked_worktree_merge(session.id)
+        self._remount_task_panel(session.id)
         return session
 
     def _ensure_default_session(self) -> ConsoleChatSession:
@@ -10565,6 +10569,7 @@ class ConsoleChatController:
         self._remount_parked_skill_install(session_id)
         self._remount_parked_skill_script(session_id)
         self._remount_parked_worktree_merge(session_id)
+        self._remount_task_panel(session_id)
         return session
 
     def close_session(self, session_id: str) -> ConsoleChatSession | None:
@@ -10739,6 +10744,7 @@ class ConsoleChatController:
             self._remount_parked_skill_install(new_active_id)
             self._remount_parked_skill_script(new_active_id)
             self._remount_parked_worktree_merge(new_active_id)
+            self._remount_task_panel(new_active_id)
         return closed
 
     def original_attempt_for_message(self, message_id: str) -> str | None:
@@ -12746,6 +12752,7 @@ class ConsoleChatController:
 
         def _on_todo_change(tasks: list[dict[str, object]]) -> None:
             bridge.append_todo_marker(session_id, tasks)
+            self._marshal_task_panel(session_id, tasks)
 
         return {
             "todo_store": session.todo_store,
@@ -13722,6 +13729,38 @@ class ConsoleChatController:
         """
         if self.app is not None and self.set_pending_skill_script is not None:
             self.app.call_from_thread(self.set_pending_skill_script, payload)
+
+    def _marshal_task_panel(
+        self, session_id: str, tasks: list[dict[str, object]]
+    ) -> None:
+        """WORKER THREAD: hand a session's task snapshot to the pinned panel.
+
+        PRD Feature B (AC-B4): fires on every ``todo_*`` change alongside
+        the transcript marker. The screen-side setter ignores snapshots
+        for sessions that are not the viewed one.
+
+        Args:
+            session_id: The session whose todo store changed.
+            tasks: Its full task list after the change.
+        """
+        if self.app is not None and self.set_task_panel is not None:
+            self.app.call_from_thread(self.set_task_panel, session_id, tasks)
+
+    def _remount_task_panel(self, session_id: str) -> None:
+        """UI THREAD: re-derive the pinned task panel for ``session_id``.
+
+        Called from `switch_session`/`new_session`/`close_session` next to
+        the card re-derives, so the panel always shows the VIEWED session's
+        tasks (AC-B5) and hides when that session has none.
+
+        Args:
+            session_id: The session now being activated/viewed.
+        """
+        if self.set_task_panel is None:
+            return
+        session = next((s for s in self.store.sessions() if s.id == session_id), None)
+        tasks = session.todo_store.list_after(None) if session is not None else []
+        self.set_task_panel(session_id, tasks)
 
     def resolve_pending_skill_script(
         self, allow: bool, remember: bool, request_id: str | None = None

--- a/tldw_chatbook/Chat/console_runtime.py
+++ b/tldw_chatbook/Chat/console_runtime.py
@@ -1571,15 +1571,8 @@ class ConsoleRuntime:
         controller = self._chat_controller
         store = self._chat_store
         remount = getattr(controller, "_remount_task_panel", None)
-        if store is None or not callable(remount):
-            return
-        try:
+        if store is not None and callable(remount):
             remount(store.active_session_id)
-        except Exception as exc:  # noqa: BLE001 - a UI re-derive must not break attach
-            logger.warning(
-                "Task-panel remount raised at attach (exception_type={})",
-                type(exc).__name__,
-            )
 
     def detach_view(self, view: Any | None = None) -> bool:
         """Clear every screen-owned slot; the runtime itself survives.

--- a/tldw_chatbook/Chat/console_runtime.py
+++ b/tldw_chatbook/Chat/console_runtime.py
@@ -1558,6 +1558,28 @@ class ConsoleRuntime:
         self._rearm_delivery_ui_hook()
         if claimed:
             self.remount_pending_approval()
+            self._remount_task_panel()
+
+    def _remount_task_panel(self) -> None:
+        """Push the active session's tasks into a newly claimed view's panel.
+
+        PRD Feature B: the runtime and its todo stores outlive the screen,
+        but the panel widget is screen-owned and mounts empty. Without this
+        a return visit to Console shows no tasks until the next ``todo_*``
+        change or session switch.
+        """
+        controller = self._chat_controller
+        store = self._chat_store
+        remount = getattr(controller, "_remount_task_panel", None)
+        if store is None or not callable(remount):
+            return
+        try:
+            remount(store.active_session_id)
+        except Exception as exc:  # noqa: BLE001 - a UI re-derive must not break attach
+            logger.warning(
+                "Task-panel remount raised at attach (exception_type={})",
+                type(exc).__name__,
+            )
 
     def detach_view(self, view: Any | None = None) -> bool:
         """Clear every screen-owned slot; the runtime itself survives.

--- a/tldw_chatbook/Chat/console_runtime.py
+++ b/tldw_chatbook/Chat/console_runtime.py
@@ -634,6 +634,14 @@ CONSOLE_VIEW_HOOK_SLOTS: tuple[ConsoleViewHookSlot, ...] = (
         "`request_skill_script_confirm` (`allow=False, remember=False`).",
     ),
     ConsoleViewHookSlot(
+        "set_task_panel",
+        "controller",
+        why="Every read site is an `is not None` guard: the pinned task "
+        "panel is a mirror of the session's todo store, and with no view "
+        "there is nothing to mirror into. The store itself keeps the tasks, "
+        "so the next attach re-derives the panel from it.",
+    ),
+    ConsoleViewHookSlot(
         "wake_user_priority_probe",
         "controller",
         viewless_user_priority_probe,

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -20723,21 +20723,46 @@ class ChatScreen(BaseAppScreen):
         session's ``todo_*`` calls must not repaint the panel the user is
         looking at; ``switch_session`` re-derives it on arrival (AC-B5).
 
+        The panel is NOT part of the session surface's ``compose``: the
+        Console surface composes during boot, and ADR-097's module census
+        ratchet counts every module resident at UI-ready. The first
+        non-empty snapshot mounts it after the task cards, so nothing about
+        the panel loads until an agent actually keeps a list.
+
         Args:
             session_id: The session the snapshot belongs to.
             tasks: That session's full task list; empty hides the panel.
         """
-        # Local import: keeps the panel module off the boot path (ADR-097).
-        from ...Widgets.Console.console_task_panel import ConsoleTaskPanel
-
         controller = self._console_chat_controller
         if controller is None or controller.store.active_session_id != session_id:
             return
         try:
-            panel = self.query_one("#console-task-panel", ConsoleTaskPanel)
+            panel = self.query_one("#console-task-panel")
         except QueryError:
-            return
+            if not tasks:
+                return
+            panel = self._mount_console_task_panel()
+            if panel is None:
+                return
         panel.set_tasks(session_id, tasks)
+
+    def _mount_console_task_panel(self):
+        """Mount the task panel right after the Console task cards.
+
+        Returns:
+            The new ``ConsoleTaskPanel``, or None when the Console surface is
+            not composed (no ``#console-task-surface`` to anchor to).
+        """
+        # Local import by design -- see `_set_console_task_panel`.
+        from ...Widgets.Console.console_task_panel import ConsoleTaskPanel
+
+        try:
+            cards = self.query_one("#console-task-surface", ChatTaskCards)
+        except QueryError:
+            return None
+        panel = ConsoleTaskPanel(id="console-task-panel")
+        cards.parent.mount(panel, after=cards)
+        return panel
 
     def _park_console_approval(self, session_id: str) -> None:
         """PA-T9 (parked background approvals): badge a NON-viewed session's

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -491,7 +491,6 @@ from ...Widgets.Chat_Widgets.chat_approval_card import ChatApprovalCard
 from ...Widgets.Chat_Widgets.skill_install_confirm_card import SkillInstallConfirmCard
 from ...Widgets.Chat_Widgets.skill_script_confirm_card import SkillScriptConfirmCard
 from ...Widgets.Chat_Widgets.chat_task_cards import ChatTaskCards
-from ...Widgets.Console.console_task_panel import ConsoleTaskPanel
 from ...Widgets.Chat_Widgets.watchlists_operation_card import (
     WatchlistsOperationCard,
 )
@@ -20728,6 +20727,9 @@ class ChatScreen(BaseAppScreen):
             session_id: The session the snapshot belongs to.
             tasks: That session's full task list; empty hides the panel.
         """
+        # Local import: keeps the panel module off the boot path (ADR-097).
+        from ...Widgets.Console.console_task_panel import ConsoleTaskPanel
+
         controller = self._console_chat_controller
         if controller is None or controller.store.active_session_id != session_id:
             return

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -491,6 +491,7 @@ from ...Widgets.Chat_Widgets.chat_approval_card import ChatApprovalCard
 from ...Widgets.Chat_Widgets.skill_install_confirm_card import SkillInstallConfirmCard
 from ...Widgets.Chat_Widgets.skill_script_confirm_card import SkillScriptConfirmCard
 from ...Widgets.Chat_Widgets.chat_task_cards import ChatTaskCards
+from ...Widgets.Console.console_task_panel import ConsoleTaskPanel
 from ...Widgets.Chat_Widgets.watchlists_operation_card import (
     WatchlistsOperationCard,
 )
@@ -8415,6 +8416,8 @@ class ChatScreen(BaseAppScreen):
             "set_pending_skill_script": getattr(
                 skill, "_set_console_pending_skill_script", None
             ),
+            # PRD Feature B: the pinned task panel above the transcript.
+            "set_task_panel": self._set_console_task_panel,
             # PR3a-2 Task 5, user-wins-ties.
             "wake_user_priority_probe": self._fleet._console_wake_user_priority,
             # task-15971: the delivery COMMIT's visibility probe -- a wake
@@ -20710,6 +20713,29 @@ class ChatScreen(BaseAppScreen):
         except QueryError:
             return
         card.set_summary(round_id, text)
+
+    def _set_console_task_panel(
+        self, session_id: str | None, tasks: list[dict[str, object]]
+    ) -> None:
+        """PRD Feature B: mirror ``session_id``'s task list into the pinned panel.
+
+        UI-thread target of the controller's ``set_task_panel`` hook. Ignores
+        snapshots for any session other than the viewed one -- a background
+        session's ``todo_*`` calls must not repaint the panel the user is
+        looking at; ``switch_session`` re-derives it on arrival (AC-B5).
+
+        Args:
+            session_id: The session the snapshot belongs to.
+            tasks: That session's full task list; empty hides the panel.
+        """
+        controller = self._console_chat_controller
+        if controller is None or controller.store.active_session_id != session_id:
+            return
+        try:
+            panel = self.query_one("#console-task-panel", ConsoleTaskPanel)
+        except QueryError:
+            return
+        panel.set_tasks(session_id, tasks)
 
     def _park_console_approval(self, session_id: str) -> None:
         """PA-T9 (parked background approvals): badge a NON-viewed session's

--- a/tldw_chatbook/Widgets/Console/console_session_surface.py
+++ b/tldw_chatbook/Widgets/Console/console_session_surface.py
@@ -265,12 +265,6 @@ class ConsoleSessionSurface(Vertical):
         yield self._build_tab_strip_row()
         yield self._build_fleet_coachmark()
         yield ChatTaskCards(id="console-task-surface")
-        # Imported here, not at module level: this module is on the boot
-        # path (ADR-097 UI-ready module census) and the panel is only
-        # needed once a Console surface actually composes.
-        from tldw_chatbook.Widgets.Console.console_task_panel import ConsoleTaskPanel
-
-        yield ConsoleTaskPanel(id="console-task-panel")
         yield ConsoleActivityOutcomeNotice(id="console-activity-outcome-notice")
         yield ConsoleTranscriptSurface(
             self._transcript_background_effect_settings(

--- a/tldw_chatbook/Widgets/Console/console_session_surface.py
+++ b/tldw_chatbook/Widgets/Console/console_session_surface.py
@@ -35,7 +35,6 @@ from tldw_chatbook.Widgets.Chat_Widgets.chat_task_cards import ChatTaskCards
 from tldw_chatbook.Widgets.Console.console_background_effect import (
     ConsoleTranscriptSurface,
 )
-from tldw_chatbook.Widgets.Console.console_task_panel import ConsoleTaskPanel
 from tldw_chatbook.Widgets.Console.console_activity_outcome_notice import (
     ConsoleActivityOutcomeNotice,
 )
@@ -266,6 +265,11 @@ class ConsoleSessionSurface(Vertical):
         yield self._build_tab_strip_row()
         yield self._build_fleet_coachmark()
         yield ChatTaskCards(id="console-task-surface")
+        # Imported here, not at module level: this module is on the boot
+        # path (ADR-097 UI-ready module census) and the panel is only
+        # needed once a Console surface actually composes.
+        from tldw_chatbook.Widgets.Console.console_task_panel import ConsoleTaskPanel
+
         yield ConsoleTaskPanel(id="console-task-panel")
         yield ConsoleActivityOutcomeNotice(id="console-activity-outcome-notice")
         yield ConsoleTranscriptSurface(

--- a/tldw_chatbook/Widgets/Console/console_session_surface.py
+++ b/tldw_chatbook/Widgets/Console/console_session_surface.py
@@ -35,6 +35,7 @@ from tldw_chatbook.Widgets.Chat_Widgets.chat_task_cards import ChatTaskCards
 from tldw_chatbook.Widgets.Console.console_background_effect import (
     ConsoleTranscriptSurface,
 )
+from tldw_chatbook.Widgets.Console.console_task_panel import ConsoleTaskPanel
 from tldw_chatbook.Widgets.Console.console_activity_outcome_notice import (
     ConsoleActivityOutcomeNotice,
 )
@@ -265,6 +266,7 @@ class ConsoleSessionSurface(Vertical):
         yield self._build_tab_strip_row()
         yield self._build_fleet_coachmark()
         yield ChatTaskCards(id="console-task-surface")
+        yield ConsoleTaskPanel(id="console-task-panel")
         yield ConsoleActivityOutcomeNotice(id="console-activity-outcome-notice")
         yield ConsoleTranscriptSurface(
             self._transcript_background_effect_settings(

--- a/tldw_chatbook/Widgets/Console/console_task_panel.py
+++ b/tldw_chatbook/Widgets/Console/console_task_panel.py
@@ -1,0 +1,174 @@
+"""Pinned, read-only view of the agent's session task list (PRD Feature B).
+
+The ``todo_*`` tools have kept a per-session ``SessionTodoStore`` since
+TASK-13216, but the only UI was a transcript marker that scrolls away.
+This panel sits above the transcript, mirrors the store on every change,
+and stays put while the conversation moves.
+
+Rendering reuses the transcript marker's glyphs and label sanitiser so
+the two views can never disagree about what a task is called.
+"""
+
+from __future__ import annotations
+
+from rich.markup import escape as _escape_markup
+from textual import events
+from textual.app import ComposeResult
+from textual.containers import Vertical, VerticalScroll
+from textual.widgets import Static
+
+from tldw_chatbook.Chat.console_agent_bridge import _sanitize_task_marker_label
+
+_GLYPHS = {"completed": "[x]", "in_progress": "[~]", "pending": "[ ]"}
+_STATUS_CLASS = {
+    "completed": "console-task-panel-done",
+    "in_progress": "console-task-panel-active",
+    "pending": "console-task-panel-pending",
+}
+
+
+def render_task_lines(
+    tasks: list[dict[str, object]], *, collapsed: bool = False
+) -> tuple[str, list[tuple[str, str]]]:
+    """Derive the panel header and body rows from a task snapshot.
+
+    Args:
+        tasks: Task records as ``SessionTodoStore.list_after(None)`` returns
+            them (``content``, ``status``, optional ``activeForm``).
+        collapsed: Whether the body is hidden, which flips the header chevron.
+
+    Returns:
+        ``(header, rows)`` where ``header`` is the one-line summary
+        (``Tasks · 3 of 7 done · Writing the migration``) and each row is a
+        ``(status, text)`` pair -- ``text`` already carries the glyph.
+    """
+    done = sum(1 for task in tasks if task.get("status") == "completed")
+    active = next(
+        (task for task in tasks if task.get("status") == "in_progress"), None
+    )
+    parts = [f"Tasks · {done} of {len(tasks)} done"]
+    if active is not None:
+        parts.append(
+            _sanitize_task_marker_label(
+                str(active.get("activeForm") or active.get("content") or "")
+            )
+        )
+    chevron = "▸" if collapsed else "▾"
+    header = f"{chevron} " + " · ".join(parts)
+    rows: list[tuple[str, str]] = []
+    for task in tasks:
+        status = str(task.get("status") or "pending")
+        label = task.get("activeForm") if status == "in_progress" else None
+        label = _sanitize_task_marker_label(str(label or task.get("content") or ""))
+        rows.append((status, f"{_GLYPHS.get(status, '[ ]')} {label}"))
+    return header, rows
+
+
+class ConsoleTaskPanel(Vertical):
+    """Collapsible task list pinned above the Console transcript.
+
+    Hidden while the active session has no tasks (AC-B1). Collapse state is
+    remembered per session for the widget's lifetime (AC-B6).
+    """
+
+    BUNDLED_CSS = """
+    ConsoleTaskPanel {
+        height: auto;
+        max-height: 12;
+        width: 1fr;
+        border-top: solid $secondary;
+        border-bottom: solid $secondary;
+        padding: 0 1;
+    }
+    ConsoleTaskPanel > #console-task-panel-header {
+        height: 1;
+        text-style: bold;
+    }
+    ConsoleTaskPanel > #console-task-panel-header:hover {
+        background: $boost;
+    }
+    ConsoleTaskPanel > #console-task-panel-body {
+        height: auto;
+        max-height: 10;
+        overflow-y: auto;
+        scrollbar-gutter: stable;
+    }
+    ConsoleTaskPanel .console-task-panel-row {
+        height: auto;
+        width: 1fr;
+    }
+    ConsoleTaskPanel .console-task-panel-done {
+        color: $text-muted;
+    }
+    ConsoleTaskPanel .console-task-panel-active {
+        color: $accent;
+        text-style: bold;
+    }
+    """
+
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self.display = False
+        self._session_id: str | None = None
+        self._tasks: list[dict[str, object]] = []
+        self._collapsed_by_session: dict[str, bool] = {}
+
+    def compose(self) -> ComposeResult:
+        yield Static("", id="console-task-panel-header")
+        yield VerticalScroll(id="console-task-panel-body")
+
+    @property
+    def collapsed(self) -> bool:
+        """Whether the current session's body is hidden."""
+        return self._collapsed_by_session.get(self._session_id or "", False)
+
+    def set_tasks(
+        self, session_id: str | None, tasks: list[dict[str, object]]
+    ) -> None:
+        """Replace the rendered list with ``tasks`` for ``session_id``.
+
+        Args:
+            session_id: The session the snapshot belongs to; the panel
+                renders whatever it is last told about and does not itself
+                know which session is active.
+            tasks: The session's full task list; empty hides the panel.
+        """
+        self._session_id = session_id
+        self._tasks = list(tasks)
+        self.display = bool(tasks)
+        if not tasks:
+            return
+        self._repaint()
+
+    def toggle_collapsed(self) -> None:
+        """Flip the body's visibility for the current session."""
+        key = self._session_id or ""
+        self._collapsed_by_session[key] = not self._collapsed_by_session.get(key, False)
+        self._repaint()
+
+    def on_click(self, event: events.Click) -> None:
+        if event.widget is not None and event.widget.id == "console-task-panel-header":
+            event.stop()
+            self.toggle_collapsed()
+
+    def _repaint(self) -> None:
+        if not self.is_mounted:
+            return
+        header, rows = render_task_lines(self._tasks, collapsed=self.collapsed)
+        self.query_one("#console-task-panel-header", Static).update(
+            _escape_markup(header)
+        )
+        body = self.query_one("#console-task-panel-body", VerticalScroll)
+        body.display = not self.collapsed
+        body.remove_children()
+        body.mount_all(
+            Static(
+                _escape_markup(text),
+                classes=f"console-task-panel-row {_STATUS_CLASS.get(status, '')}".strip(),
+            )
+            for status, text in rows
+        )
+
+    def on_mount(self) -> None:
+        if self._tasks:
+            self._repaint()

--- a/tldw_chatbook/Widgets/Console/console_task_panel.py
+++ b/tldw_chatbook/Widgets/Console/console_task_panel.py
@@ -11,7 +11,7 @@ the two views can never disagree about what a task is called.
 
 from __future__ import annotations
 
-from rich.markup import escape as _escape_markup
+from rich.text import Text
 from textual import events
 from textual.app import ComposeResult
 from textual.containers import Vertical, VerticalScroll
@@ -20,11 +20,7 @@ from textual.widgets import Static
 from tldw_chatbook.Chat.console_agent_bridge import _sanitize_task_marker_label
 
 _GLYPHS = {"completed": "[x]", "in_progress": "[~]", "pending": "[ ]"}
-_STATUS_CLASS = {
-    "completed": "console-task-panel-done",
-    "in_progress": "console-task-panel-active",
-    "pending": "console-task-panel-pending",
-}
+_STATUS_STYLE = {"completed": "dim", "in_progress": "bold", "pending": ""}
 
 
 def render_task_lines(
@@ -69,6 +65,11 @@ class ConsoleTaskPanel(Vertical):
 
     Hidden while the active session has no tasks (AC-B1). Collapse state is
     remembered per session for the widget's lifetime (AC-B6).
+
+    The body is ONE ``Static`` holding every row, repainted with a
+    synchronous ``update()``: there is no remove/mount cycle, so two
+    snapshots arriving back to back cannot interleave -- the last one
+    written is the one shown.
     """
 
     BUNDLED_CSS = """
@@ -93,16 +94,9 @@ class ConsoleTaskPanel(Vertical):
         overflow-y: auto;
         scrollbar-gutter: stable;
     }
-    ConsoleTaskPanel .console-task-panel-row {
+    ConsoleTaskPanel #console-task-panel-rows {
         height: auto;
         width: 1fr;
-    }
-    ConsoleTaskPanel .console-task-panel-done {
-        color: $text-muted;
-    }
-    ConsoleTaskPanel .console-task-panel-active {
-        color: $accent;
-        text-style: bold;
     }
     """
 
@@ -114,8 +108,10 @@ class ConsoleTaskPanel(Vertical):
         self._collapsed_by_session: dict[str, bool] = {}
 
     def compose(self) -> ComposeResult:
+        """Yield the clickable header line and the scrollable rows body."""
         yield Static("", id="console-task-panel-header")
-        yield VerticalScroll(id="console-task-panel-body")
+        with VerticalScroll(id="console-task-panel-body"):
+            yield Static("", id="console-task-panel-rows")
 
     @property
     def collapsed(self) -> bool:
@@ -147,28 +143,30 @@ class ConsoleTaskPanel(Vertical):
         self._repaint()
 
     def on_click(self, event: events.Click) -> None:
+        """Collapse or expand the panel when its header line is clicked.
+
+        Args:
+            event: The click; only one landing on the header is consumed.
+        """
         if event.widget is not None and event.widget.id == "console-task-panel-header":
             event.stop()
             self.toggle_collapsed()
+
+    def on_mount(self) -> None:
+        """Paint a snapshot that arrived before the children existed."""
+        if self._tasks:
+            self._repaint()
 
     def _repaint(self) -> None:
         if not self.is_mounted:
             return
         header, rows = render_task_lines(self._tasks, collapsed=self.collapsed)
-        self.query_one("#console-task-panel-header", Static).update(
-            _escape_markup(header)
-        )
+        self.query_one("#console-task-panel-header", Static).update(Text(header))
         body = self.query_one("#console-task-panel-body", VerticalScroll)
         body.display = not self.collapsed
-        body.remove_children()
-        body.mount_all(
-            Static(
-                _escape_markup(text),
-                classes=f"console-task-panel-row {_STATUS_CLASS.get(status, '')}".strip(),
-            )
-            for status, text in rows
-        )
-
-    def on_mount(self) -> None:
-        if self._tasks:
-            self._repaint()
+        text = Text()
+        for index, (status, line) in enumerate(rows):
+            if index:
+                text.append("\n")
+            text.append(line, style=_STATUS_STYLE.get(status, ""))
+        self.query_one("#console-task-panel-rows", Static).update(text)

--- a/tldw_chatbook/Widgets/Console/console_task_panel.py
+++ b/tldw_chatbook/Widgets/Console/console_task_panel.py
@@ -15,6 +15,7 @@ from rich.text import Text
 from textual import events
 from textual.app import ComposeResult
 from textual.containers import Vertical, VerticalScroll
+from textual.css.query import QueryError
 from textual.widgets import Static
 
 from tldw_chatbook.Chat.console_agent_bridge import _sanitize_task_marker_label
@@ -158,15 +159,20 @@ class ConsoleTaskPanel(Vertical):
             self._repaint()
 
     def _repaint(self) -> None:
-        if not self.is_mounted:
+        try:
+            header_widget = self.query_one("#console-task-panel-header", Static)
+            body = self.query_one("#console-task-panel-body", VerticalScroll)
+            rows_widget = self.query_one("#console-task-panel-rows", Static)
+        except QueryError:
+            # Not composed yet (a snapshot handed over before mount); `on_mount`
+            # repaints from the retained `_tasks`.
             return
         header, rows = render_task_lines(self._tasks, collapsed=self.collapsed)
-        self.query_one("#console-task-panel-header", Static).update(Text(header))
-        body = self.query_one("#console-task-panel-body", VerticalScroll)
+        header_widget.update(Text(header))
         body.display = not self.collapsed
         text = Text()
         for index, (status, line) in enumerate(rows):
             if index:
                 text.append("\n")
             text.append(line, style=_STATUS_STYLE.get(status, ""))
-        self.query_one("#console-task-panel-rows", Static).update(text)
+        rows_widget.update(text)

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -2208,6 +2208,42 @@
 
 
 
+/* ===== WIDGET: ConsoleTaskPanel (Widgets/Console/console_task_panel.py) ===== */
+
+    ConsoleTaskPanel {
+        height: auto;
+        max-height: 12;
+        width: 1fr;
+        border-top: solid $secondary;
+        border-bottom: solid $secondary;
+        padding: 0 1;
+    }
+    ConsoleTaskPanel > #console-task-panel-header {
+        height: 1;
+        text-style: bold;
+    }
+    ConsoleTaskPanel > #console-task-panel-header:hover {
+        background: $boost;
+    }
+    ConsoleTaskPanel > #console-task-panel-body {
+        height: auto;
+        max-height: 10;
+        overflow-y: auto;
+        scrollbar-gutter: stable;
+    }
+    ConsoleTaskPanel .console-task-panel-row {
+        height: auto;
+        width: 1fr;
+    }
+    ConsoleTaskPanel .console-task-panel-done {
+        color: $text-muted;
+    }
+    ConsoleTaskPanel .console-task-panel-active {
+        color: $accent;
+        text-style: bold;
+    }
+
+
 /* ===== WIDGET: ConsoleMessageHeader (Widgets/Console/console_transcript.py) ===== */
 
     ConsoleMessageHeader {

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -2231,16 +2231,9 @@
         overflow-y: auto;
         scrollbar-gutter: stable;
     }
-    ConsoleTaskPanel .console-task-panel-row {
+    ConsoleTaskPanel #console-task-panel-rows {
         height: auto;
         width: 1fr;
-    }
-    ConsoleTaskPanel .console-task-panel-done {
-        color: $text-muted;
-    }
-    ConsoleTaskPanel .console-task-panel-active {
-        color: $accent;
-        text-style: bold;
     }
 
 


### PR DESCRIPTION
## Summary

First milestone of the [Console Agent Interaction PRD](Docs/Development/Chatbook/Chatbook-Console-Agent-Interaction-PRD.md) (Feature B, the persistent task list). The `todo_*` tools have kept a per-session `SessionTodoStore` since TASK-13216; the only UI was the transcript's `☰ Tasks` marker, which scrolls away. This mounts a read-only, collapsible **Tasks** panel in the card slot above the transcript.

```
▾ Tasks · 3 of 7 done · Writing the migration
[x] Read the schema
[~] Writing the migration
[ ] Run the DB tests
```

| AC | Behaviour |
|---|---|
| B1 | Not mounted (`display = False`) while the viewed session has no tasks |
| B2 | Header `Tasks · N of M done · <activeForm>`; `[x]`/`[~]`/`[ ]` rows; in-progress row shows `activeForm` |
| B3/B4 | Live update on every `todo_*` change via the existing change callback; transcript marker still fires |
| B5 | `new_session` / `switch_session` / `close_session` re-derive the panel from the arriving session's store; snapshots for non-viewed sessions are dropped screen-side |
| B6 | Click the header to collapse to one line; state remembered per session; body scrolls past 10 rows |
| B7 | Read-only; labels go through the same sanitiser as the transcript marker |

## How it's wired (no new abstractions)

- `ConsoleViewHookSlot("set_task_panel", "controller", …)` added to `CONSOLE_VIEW_HOOK_SLOTS`; every read site is an `is not None` guard, so the viewless default `None` is inert.
- `_todo_wiring`'s `_on_todo_change` gains one line: `self._marshal_task_panel(session_id, tasks)` (worker thread → `call_from_thread`).
- `_remount_task_panel(session_id)` sits next to the card re-derives and is called at the same three sites.
- `ChatScreen._set_console_task_panel` is the UI-thread target. The panel is **not** part of the session surface's `compose`: the Console surface composes during boot and ADR-097's UI-ready module census caught the module riding along (973 > 972). The first non-empty snapshot mounts it right after `ChatTaskCards`, so nothing about the panel loads until an agent actually keeps a list (ADR-097 response 1, defer). `ConsoleRuntime.attach_view` re-derives it on a new claim so a return visit to Console is not empty.
- Styles are `BUNDLED_CSS`; `widget_defaults_self.tcss` regenerated with `build_css.py`.

## Tests

New `Tests/UI/test_console_task_panel.py` (12 tests): pure renderer (counts, activeForm, chevron, sanitiser), widget under the consolidated CSS (hidden→shown→hidden, snapshot-before-mount painted on mount, back-to-back snapshots render only the newest, click-collapse remembered per session and across updates), lazy mount lands right after the task cards, controller/runtime wiring (change callback feeds both sinks; activation re-derives from the todo store; closing the last session clears; attach_view re-derives; viewless no-op). `Tests/Performance/test_ui_ready_module_census.py` passes locally.

Ran alongside: `test_widget_css_consolidation`, `test_console_runtime_ownership`, `test_chat_task_cards_sync`, `test_console_viewless_hooks`, `test_console_mcp_approval`, and every suite that mounts the session surface (`activity_outcome_notice`, `tab_strip_budget`, `native_chat_flow`, `rail_sections`, `parallel_runs`, `prompt_queue`, `sync_outlives_screen`): **531 passed, 22 failed**. All 22 failures reproduce on clean `origin/dev` (re-measured at `8defb396c6` in a detached worktree; that tip has 15 failures in `native_chat_flow`+`parallel_runs` alone, a superset of this branch's 12). `test_class_level_css_stays_within_the_allowlist` is also baseline-red: its six offenders are pre-existing `DEFAULT_CSS` declarations in files this PR does not touch.

`./scripts/preflight.sh`: all four derived-artifact checks pass.

## Docs

`Docs/User_Guide/console/agent-runs-and-tools.md` gains a "Task panel" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018q5PsHwn5kgHPmNwX9DKoo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the agent's task list in a read-only, collapsible Tasks panel above the Console transcript (PRD Feature B M1) so it no longer scrolls away with the conversation. Re-entering Console now repopulates the panel from the active session's tasks, and closing the last session clears it.

- Header shows `Tasks · N of M done · <activeForm>`; rows reuse the transcript marker's `[x]`/`[~]`/`[ ]` glyphs and label sanitiser.
- Hidden while the viewed session has no tasks; mounted on first use after the task cards, not during boot, so the module stays off the boot path (ADR-097 census).
- Clicking the header collapses to one line (remembered per session); long lists scroll inside the panel.
- Wired via a new `set_task_panel` controller hook: the todo change callback feeds both the transcript marker and the panel, and `new_session`/`switch_session`/`close_session` re-derive it from the arriving session's store.
- Snapshots for non-viewed sessions are dropped screen-side, and viewless runs no-op since every read site is `is not None` guarded.
- Panel repaints are synchronous `update()` calls, so back-to-back task snapshots cannot interleave.

<sup>Written for commit 5bb16a525c039457643b9fa4f027a3df4b9b395a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

