### PR TITLE
fix(theme-editor): Settings > Theme UX review fixes (TASK-31250..31261)

### DIFF
--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -775,7 +775,7 @@ profile, fixing a rendering defect on the Name/Description/Model
 override/Tools fields found along the way; the rest of this page's content
 unchanged from the prior stamp).*
 *Interface — Theme rewritten against fix/theme-editor-ux @ 9997d086b4 —
-2026-09-04 (tasks 31250-31261: driven live in a scratch profile — a theme
+2026-09-04 (tasks 31250-31259, 31279 and 31280: driven live in a scratch profile — a theme
 saved in the editor now registers at once, appears in Appearance → Theme and
 the palette, and loads at the next launch via **Set as launch default**;
 swatches, the Dark toggle and the preset target are painted; Actions sit above

--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -323,17 +323,28 @@ Library readers after a successful save.
 
 ### Interface — Theme
 
-A full editor with its own save model: **Theme Library** (a **Name** box, live
-only after **New** or **Clone**; a **Dark theme** switch; a browsable **Themes**
-tree), **Color Palette** (ten hex boxes, Primary through Error), **Color
-Presets** (click a swatch row to fill the last box you touched), and a
-decorative **Live Preview**. **New** and **Clone** start a theme and unlock the
-name box; **Generate from Primary** derives the palette from the primary color;
-**Apply** applies it **for this session only** and writes nothing; **Save**
-stores it as a theme you can pick later (built-ins can't be overwritten);
-**Reset** reloads it as last saved; **Delete** and **Export** remove it or write
-it to your Downloads folder. **This editor never sets the launch default** —
-press **Save** here, then pick the theme in **Appearance** → **Theme**.
+A full editor with its own save model. **Theme Library**: a **Name** box (live
+for anything but the two Textual built-ins), a **Dark theme** On/Off toggle,
+the **New / Clone / Delete / Export** row, and a **Themes** tree that lists
+**Your themes** first and open, then **Built-in**, then the **Shipped themes**
+catalog collapsed. Selecting a theme in the tree only loads it for editing; it
+never changes the running app. **Actions** come next: **Apply** applies the
+palette **for this session only** and writes nothing; **Save** stores it as a
+TOML file in your profile's `themes/` folder and registers it at once, so it
+appears in **Appearance** → **Theme** and in the palette's "Theme: Switch
+to…" list without a restart (built-ins can't be overwritten, and saving over
+another saved theme asks first); **Reset** reloads it as last saved; **Generate
+from Primary** derives a palette from the primary colour; **Set as launch
+default** writes the saved theme's name to `general.default_theme` so it
+loads at startup. **Color Palette** is ten hex boxes, Primary through Error,
+each with a swatch showing the colour and its hex; an invalid value marks the
+box and the swatch reads "invalid". **Color Presets** fill the colour chosen in
+the **Presets fill** box (Primary by default), by click or by focusing a swatch
+and pressing Enter or Space. The **Live Preview** is a Console-shaped stub that
+repaints as you type. **New** starts a theme from the palette currently loaded;
+**Clone** does the same and appends `_copy` to the name. **Delete** removes a
+saved theme after confirmation; **Export** writes it to your Downloads folder
+and asks before replacing an earlier export.
 
 ### Interface — Splash Screen
 
@@ -618,9 +629,9 @@ a note on what would have to exist before Settings could own a default.
 3. **Change the theme and make it stick.** Open **Appearance**, choose a
    **Theme**, press **Preview** for a look (this session only), then **s** to
    save the draft — the theme is applied at the next launch. If you built the
-   theme yourself in the **Theme** editor, press **Save** there first, then come
-   back to **Appearance** and select it; the editor never sets the launch
-   default.
+   theme yourself in the **Theme** editor, press **Save** there and then **Set
+   as launch default**; saved themes also appear in **Appearance** → **Theme**
+   as "<Name> (saved)".
 4. **Move a database to a new location.** Open **Storage**, edit that database's
    path box, and press **Check Storage** — you want "ready", not "missing,
    create before restart" (Settings will not create the folder for you). Press
@@ -720,9 +731,9 @@ not open an editor.
   applied once, at launch; **Preview** shows it this session. Two other routes
   do apply a theme immediately: the Theme editor's **Apply** (this session
   only), and the command palette's "Theme: Switch to \<name\>", which applies
-  it *and* rewrites the launch default. A theme you
-  **Save** in the Theme editor is only stored — set it as the launch default in
-  **Appearance**.
+  it *and* rewrites the launch default. A theme you **Save** in the Theme
+  editor is stored and registered but not applied — press **Set as launch
+  default** there, or pick it in **Appearance**.
 - **A splash change had no effect.** All splash settings are startup-only.
   Separately, **Animation speed (x)** is saved to a place this page does not
   read back, so it looks unchanged when you return (backlog task-2706).
@@ -763,6 +774,12 @@ created, selected, edited, and disabled a real definition in a scratch
 profile, fixing a rendering defect on the Name/Description/Model
 override/Tools fields found along the way; the rest of this page's content
 unchanged from the prior stamp).*
+*Interface — Theme rewritten against fix/theme-editor-ux @ 9997d086b4 —
+2026-09-04 (tasks 31250-31261: driven live in a scratch profile — a theme
+saved in the editor now registers at once, appears in Appearance → Theme and
+the palette, and loads at the next launch via **Set as launch default**;
+swatches, the Dark toggle and the preset target are painted; Actions sit above
+the palette; the rest of this page's content unchanged from the prior stamp).*
 *Verified against dev @ 642567627 — 2026-08-10 (task-4024: driven live at
 80 and 120 cols — opening Settings from the nav bar's "More ▾" overflow
 menu now leaves the strip scrolled so "F9 Settings" is visible and

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -3841,8 +3841,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 7,
-      "diagnostic_digest": "e5f5b8a3dad70ab963ad",
+      "call_count": 9,
+      "diagnostic_digest": "91aad24a548a543c6c38",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Widgets/settings_theme_editor.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -3971,6 +3971,13 @@
       "diagnostic_digest": "a4d5338ae2a43a1841f4",
       "owner": "TASK-494",
       "path": "tldw_chatbook/config.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "32586a8d28e9fa3e33cb",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/css/Themes/themes.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
@@ -11034,6 +11041,20 @@
     {
       "candidates": [
         {
+          "call_digest": "f358d891f8a057a8",
+          "method": "warning",
+          "path_expressions": [
+            "path.name"
+          ],
+          "scope": "load_user_themes",
+          "status": "legacy_unreviewed"
+        }
+      ],
+      "path": "tldw_chatbook/css/Themes/themes.py"
+    },
+    {
+      "candidates": [
+        {
           "call_digest": "cc9b60087aa3e3bc",
           "method": "warning",
           "path_expressions": [
@@ -11321,10 +11342,10 @@
   "schema_version": 3,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 571,
-    "path_privacy_candidate_calls": 714,
+    "owner_files": 572,
+    "path_privacy_candidate_calls": 715,
     "persistent_sink_files": 10,
     "task_492_calls": 1337,
-    "task_494_calls": 7596
+    "task_494_calls": 7599
   }
 }

--- a/Docs/superpowers/plans/2026-09-03-theme-editor-ux-fixes.md
+++ b/Docs/superpowers/plans/2026-09-03-theme-editor-ux-fixes.md
@@ -2,13 +2,13 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Close the twelve defects found in the 2026-09-03 Settings ▸ Theme editor review (backlog TASK-31250 … TASK-31261) so a saved theme actually persists, every action names the right theme, and every state the code sets is visible.
+**Goal:** Close the twelve defects found in the 2026-09-03 Settings ▸ Theme editor review (backlog TASK-31250 … TASK-31280) so a saved theme actually persists, every action names the right theme, and every state the code sets is visible.
 
 **Architecture:** All fixes stay inside the existing Settings-native editor (`tldw_chatbook/Widgets/settings_theme_editor.py`) plus three small seams it already touches: the theme catalog module (`css/Themes/themes.py`, gains one loader), app startup registration (`app.py`), and the Settings screen's Appearance options / dirty flag / inspector rows (`UI/Screens/settings_screen.py`). No new widgets, no new dependencies. The one new runtime concept is that user TOML themes are registered with the app like shipped ones.
 
 **Tech Stack:** Python 3.12, Textual 8.2.8 (`App.available_themes`, `Theme`, `Select`, `Tree`), pytest + `app.run_test()`, toml.
 
-**Spec:** `.impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md` (critique snapshot) and the twelve task files `backlog/tasks/task-3125[0-9]*.md`, `task-31260*.md`, `task-31261*.md`. Each task below names the backlog id it closes; tick its ACs and add Implementation Notes when done.
+**Spec:** `.impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md` (critique snapshot) and the twelve task files `backlog/tasks/task-3125[0-9]*.md`, `task-31279*.md`, `task-31280*.md`. Each task below names the backlog id it closes; tick its ACs and add Implementation Notes when done.
 
 ## Global Constraints
 
@@ -574,7 +574,7 @@ and use `target = self._preset_target()` in `_apply_preset_swatch`. Give the Dar
 
 ---
 
-### Task 7: Actions above presets, User Themes first, stable preset target under Tab (TASK-31256, plus the group naming from TASK-31261)
+### Task 7: Actions above presets, User Themes first, stable preset target under Tab (TASK-31256, plus the group naming from TASK-31280)
 
 **Files:**
 - Modify: `tldw_chatbook/Widgets/settings_theme_editor.py` (`compose` order, `_populate_theme_tree`, `_load_user_themes`, `on_theme_selected`, tree hint copy, `on_save_theme`/`_delete_user_theme` tree bookkeeping)
@@ -840,7 +840,7 @@ Call `self._refresh_preview()` at the end of `_update_color_inputs`, in `on_colo
 
 ---
 
-### Task 11: Compact layout at ≤100 columns and a readable save path (TASK-31260)
+### Task 11: Compact layout at ≤100 columns and a readable save path (TASK-31279)
 
 **Files:** `tldw_chatbook/css/components/_settings_splash_theme.tcss`, bundle, `tldw_chatbook/UI/Screens/settings_screen.py` (`_theme_save_target` display sites ~4607, ~13607, ~18615 → new `_display_path`), `Tests/UI/test_settings_theme_editor_render.py`.
 
@@ -849,7 +849,7 @@ Call `self._refresh_preview()` at the end of `_update_color_inputs`, in `on_colo
 - [ ] **Step 3: Implement.** CSS:
 
 ```css
-/* TASK-31260: below SETTINGS_COMPACT_WORKBENCH_MAX_WIDTH (100 cols) the
+/* TASK-31279: below SETTINGS_COMPACT_WORKBENCH_MAX_WIDTH (100 cols) the
    detail pane is ~45 cells; four 16-cell buttons cannot share a row. */
 #settings-workbench.settings-workbench-compact #settings-theme-card .settings-action-row {
     layout: vertical;
@@ -867,7 +867,7 @@ Because the render harness has no `#settings-workbench`, wrap the editor in the 
 
 ```python
 def _display_path(path: Path) -> str:
-    """Shorten a path for the inspector: ~ for home (TASK-31260)."""
+    """Shorten a path for the inspector: ~ for home (TASK-31279)."""
     try:
         return "~" + os.sep + str(path.relative_to(Path.home()))
     except ValueError:
@@ -876,11 +876,11 @@ def _display_path(path: Path) -> str:
 
 and use `_display_path(_theme_save_target())` at the three sites, dropping the duplicate "Affected config" path row (keep the "Save target" row).
 
-- [ ] **Step 4: Rebuild bundle, run render + hub tests (`test_theme_category_opens_without_crashing`), expect PASS.** Commit `fix(theme-editor): stack action rows in compact mode, shorten inspector path (TASK-31260)`.
+- [ ] **Step 4: Rebuild bundle, run render + hub tests (`test_theme_category_opens_without_crashing`), expect PASS.** Commit `fix(theme-editor): stack action rows in compact mode, shorten inspector path (TASK-31279)`.
 
 ---
 
-### Task 12: Polish, docs stamp, full verification (TASK-31261 remainder + Definition of Done)
+### Task 12: Polish, docs stamp, full verification (TASK-31280 remainder + Definition of Done)
 
 **Files:** `tldw_chatbook/Widgets/settings_theme_editor.py` (`on_reset_theme`, button variants), `Tests/UI/test_settings_theme_editor.py`, `Docs/User_Guide/settings.md`, all twelve task files.
 
@@ -889,4 +889,4 @@ and use `_display_path(_theme_save_target())` at the three sites, dropping the d
 - [ ] **Step 3:** Run the full related suites: `Tests/UI/test_settings_theme_editor.py Tests/UI/test_settings_theme_editor_render.py Tests/UI/test_settings_configuration_hub.py Tests/UI/test_css_build_integrity.py Tests/Utils/test_user_theme_loader.py Tests/UI/test_command_palette_shell_routes.py Tests/Performance/test_textual_css_fastpath.py Tests/UI/test_non_obscuring_focus_contract.py` and `python3 Helper_Scripts/check_backlog_task_ids.py` equivalent `python3 scripts/check_backlog_task_ids.py`.
 - [ ] **Step 4:** Live verification (verify skill): launch with a scratch `TLDW_CONFIG_PATH`, walk New → rename → edit → Apply → Save → Set as launch default → quit → relaunch, confirm the theme is applied at launch and the editor reopens on it. Record the capture paths in the task notes.
 - [ ] **Step 5:** Docs stamp: update `Docs/User_Guide/settings.md` "Verified against" line for the Theme section to the branch sha and date.
-- [ ] **Step 6:** Backlog: for each of 31250-31261 tick ACs, add Implementation Notes, set Done. Commit `docs(backlog): close Theme editor UX tasks 31250-31261`.
+- [ ] **Step 6:** Backlog: for each of 31250-31259, 31279, 31280 tick ACs, add Implementation Notes, set Done. Commit `docs(backlog): close Theme editor UX tasks 31250-31259, 31279 and 31280`.

--- a/Docs/superpowers/plans/2026-09-03-theme-editor-ux-fixes.md
+++ b/Docs/superpowers/plans/2026-09-03-theme-editor-ux-fixes.md
@@ -1,0 +1,892 @@
+# Theme Editor UX Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the twelve defects found in the 2026-09-03 Settings ▸ Theme editor review (backlog TASK-31250 … TASK-31261) so a saved theme actually persists, every action names the right theme, and every state the code sets is visible.
+
+**Architecture:** All fixes stay inside the existing Settings-native editor (`tldw_chatbook/Widgets/settings_theme_editor.py`) plus three small seams it already touches: the theme catalog module (`css/Themes/themes.py`, gains one loader), app startup registration (`app.py`), and the Settings screen's Appearance options / dirty flag / inspector rows (`UI/Screens/settings_screen.py`). No new widgets, no new dependencies. The one new runtime concept is that user TOML themes are registered with the app like shipped ones.
+
+**Tech Stack:** Python 3.12, Textual 8.2.8 (`App.available_themes`, `Theme`, `Select`, `Tree`), pytest + `app.run_test()`, toml.
+
+**Spec:** `.impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md` (critique snapshot) and the twelve task files `backlog/tasks/task-3125[0-9]*.md`, `task-31260*.md`, `task-31261*.md`. Each task below names the backlog id it closes; tick its ACs and add Implementation Notes when done.
+
+## Global Constraints
+
+- Work in the worktree `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/theme-editor-fixes` (branch `fix/theme-editor-ux`, based on origin/dev). Every path below is relative to it. Subagents start in the MAIN checkout: `cd` there first or use absolute paths.
+- Run tests with `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <path> -q -p no:cacheprovider` from the worktree root (system python is 3.9). Never verify with `-k`.
+- Pinned copy that must survive (tests assert these fragments): apply hint contains `applies immediately - no Save needed`; tree hint contains `New` and `theme`; delete toasts `'<n>' is a built-in theme and cannot be deleted`, `'<n>' is a shipped theme and cannot be deleted`, `No saved custom theme named '<n>'`, `Deleted theme '<n>'`; `Creating new theme`; confirm label `Discard changes`; reset toast `Theme reset to original values` (Task 12 may change it together with its test).
+- Pinned behaviour: mount posts NO `ThemeModifiedStatus` and `is_modified = reactive(False, init=False)` stays (recompose-storm guard, `test_theme_category_settles_without_recompose_storm`); Reset without edits skips the confirmation; Delete refuses built-in/shipped names; a user file shadowing a shipped name is deletable.
+- After ANY change to `tldw_chatbook/css/components/*.tcss` or a widget `DEFAULT_CSS`: run `python3 tldw_chatbook/css/build_css.py` and commit `tldw_chatbook/css/tldw_cli_modular.tcss` (and `tldw_chatbook/css/widget_defaults_self.tcss` + `widget_defaults_scoped.tcss` when a `DEFAULT_CSS` changed). Never hand-edit the bundle.
+- Never `git add -A`. Stage explicit paths. Commit messages end with the two trailers used in this session (`Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>` and `Claude-Session: https://claude.ai/code/session_01BarRiaGxPsRjSdCQzPZXgf`).
+- Test harness for the editor: `_isolated_editor_app(editor)` in `Tests/UI/test_settings_theme_editor.py` (real `App`, `app.notify` is a `MagicMock`, `editor.custom_themes_path = tmp_path`). Painted-frame assertions use the production bundle host pattern from `Tests/UI/test_checkbox_height_render.py` (`_rendered_text(app)` over `app.screen._compositor.render_strips()`).
+- Backlog hygiene per task: `backlog-py task edit <id> -s "In Progress"` when starting; when done, tick ACs (`--check-ac N`), add `--notes`, set `-s Done`. Use `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/backlog-py`.
+
+---
+
+### Task 1: Name box drives the theme name (TASK-31251)
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/settings_theme_editor.py` (handler near `on_color_input_changed`, `_reset_theme`, `on_save_theme`)
+- Test: `Tests/UI/test_settings_theme_editor.py`
+
+**Interfaces:**
+- Produces: `SettingsThemeEditor.current_theme_name` always equals the trimmed Name box text once the user edits it. Later tasks rely on this.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_settings_theme_editor_name_box_drives_apply_save_reset_delete(tmp_path):
+    """TASK-31251: New -> rename -> Apply/Save/Reset/Delete all use the typed name."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.on_new_theme()
+        await pilot.pause()
+        name_input = editor.query_one("#settings-theme-name", Input)
+        name_input.value = "ocean"
+        await pilot.pause()
+        assert editor.current_theme_name == "ocean"
+
+        editor.on_apply_theme()
+        await pilot.pause()
+        assert app.notify.call_args.args[0] == "Theme 'ocean' applied"
+
+        editor.on_save_theme()
+        await pilot.pause()
+        assert (tmp_path / "ocean.toml").exists()
+        assert editor.current_theme_name == "ocean"
+
+        editor.on_reset_theme()
+        await pilot.pause()
+        assert name_input.value == "ocean"
+
+        editor.on_delete_theme()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmationDialog)
+        assert "ocean" in app.screen.message
+```
+
+- [ ] **Step 2: Run it, expect FAIL** on `editor.current_theme_name == "ocean"` (still `new_theme`).
+
+Run: `.../python -m pytest Tests/UI/test_settings_theme_editor.py::test_settings_theme_editor_name_box_drives_apply_save_reset_delete -q -p no:cacheprovider`
+
+- [ ] **Step 3: Implement**
+
+Add after `on_color_input_changed`:
+
+```python
+    @on(Input.Changed, "#settings-theme-name")
+    def on_theme_name_changed(self, event: Input.Changed) -> None:
+        """Keep current_theme_name in step with the Name box (TASK-31251).
+
+        Programmatic loads set the box to the name already held, so the
+        equality guard makes those echoes no-ops.
+        """
+        name = event.value.strip()
+        if name and name != self.current_theme_name:
+            self.current_theme_name = name
+```
+
+In `_reset_theme`, replace the body with:
+
+```python
+        user_theme_path = self.custom_themes_path / f"{self.current_theme_name}.toml"
+        if user_theme_path.exists():
+            self.load_user_theme(self.current_theme_name)
+        elif self._is_catalog_theme(self.current_theme_name):
+            self.load_theme(self.current_theme_name)
+        else:
+            self.app.notify(
+                f"No saved version of '{self.current_theme_name}' to reset to",
+                severity="warning",
+            )
+            return
+        self.app.notify("Theme reset to original values", severity="information")
+```
+
+and add the helper:
+
+```python
+    def _is_catalog_theme(self, name: str) -> bool:
+        """True for Textual built-ins and shipped ALL_THEMES names."""
+        return name in ("textual-dark", "textual-light") or any(
+            getattr(t, "name", None) == name for t in ALL_THEMES
+        )
+```
+
+- [ ] **Step 4: Run the new test and the whole file, expect PASS** (20 tests).
+- [ ] **Step 5: Backlog + commit**
+
+```bash
+git add tldw_chatbook/Widgets/settings_theme_editor.py Tests/UI/test_settings_theme_editor.py
+git commit -m "fix(theme-editor): Name box edits drive Apply/Export/Reset/Delete (TASK-31251)"
+```
+
+---
+
+### Task 2: Loading never re-themes the app; colours come from the real Theme objects (TASK-31255)
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/settings_theme_editor.py` (`load_theme`, delete `_extract_current_theme_colors`, `_delete_user_theme`)
+- Test: `Tests/UI/test_settings_theme_editor.py`
+
+**Interfaces:**
+- Produces: `load_theme(name)` resolves `name` through `self.app.available_themes` first, then `ALL_THEMES`; it never assigns `self.app.theme`. Task 4 relies on the `available_themes` lookup.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.asyncio
+async def test_settings_theme_editor_selecting_builtin_leaf_does_not_retheme_app(tmp_path):
+    """TASK-31255: browsing the tree is read-only for the running app."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.theme = "textual-light"
+        await pilot.pause()
+        editor.load_theme("textual-dark")
+        await pilot.pause()
+        assert app.theme == "textual-light"
+        assert editor.color_inputs["primary"].value.upper() == "#004578"
+        assert editor.color_inputs["background"].value.upper() == "#121212"
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_delete_keeps_app_theme(tmp_path):
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    _write_user_theme(tmp_path, "my_custom_theme")
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.theme = "textual-light"
+        editor.load_user_theme("my_custom_theme")
+        await pilot.pause()
+        editor.on_delete_theme()
+        await pilot.pause()
+        await pilot.click("#confirm-button")
+        await pilot.pause()
+        assert app.theme == "textual-light"
+        assert editor.current_theme_name == "textual-dark"
+```
+
+- [ ] **Step 2: Run, expect FAIL** (`app.theme` flips to `textual-dark`; background reads the hardcoded `#0C0C0C`).
+- [ ] **Step 3: Implement.** Replace the body of `load_theme` from the `if theme_name in [...]` block onward with:
+
+```python
+        theme = self.app.available_themes.get(theme_name) or next(
+            (t for t in ALL_THEMES if getattr(t, "name", None) == theme_name), None
+        )
+        if theme is None:
+            logger.warning(f"Theme editor: unknown theme '{theme_name}', keeping current palette")
+        else:
+            self.current_theme_data = self._extract_theme_colors(theme)
+            self.is_dark_theme = bool(getattr(theme, "dark", True))
+        self._update_color_inputs()
+        self._update_dark_mode_checkbox()
+        self.is_modified = False
+```
+
+Delete `_extract_current_theme_colors` entirely (its two hardcoded tables). `_delete_user_theme` keeps `self.load_theme("textual-dark")` — it now only touches the editor.
+
+- [ ] **Step 4: Run the file, expect PASS** (22 tests; the two existing delete tests still assert `current_theme_name == "textual-dark"`).
+- [ ] **Step 5: Commit** `fix(theme-editor): tree browsing and Delete no longer re-theme the app (TASK-31255)`.
+
+---
+
+### Task 3: Saved themes load at startup, appear in Appearance and the palette, can be the launch default (TASK-31250)
+
+**Files:**
+- Modify: `tldw_chatbook/config.py` (add `get_user_themes_dir()` next to `get_cli_config_path`)
+- Modify: `tldw_chatbook/css/Themes/themes.py` (add `load_user_themes`)
+- Modify: `tldw_chatbook/app.py:14335-14337` (register user themes) and `app.py:1146-1150` (`ThemeProvider` list)
+- Modify: `tldw_chatbook/UI/Screens/settings_screen.py:8012-8033` (`_appearance_theme_options`), `:588-590` (`_theme_save_target` → use `get_user_themes_dir`)
+- Modify: `tldw_chatbook/Widgets/settings_theme_editor.py` (`__init__` dir, `on_save_theme` registers, new `Set as launch default` button + handler, apply hint copy)
+- Modify: `Docs/User_Guide/settings.md` (§ Interface — Theme, quick recipe 3, quirk "The theme didn't change after saving", Verified-against stamp)
+- Test: `Tests/Utils/test_user_theme_loader.py` (new), `Tests/UI/test_settings_theme_editor.py`, `Tests/UI/test_settings_configuration_hub.py`
+
+**Interfaces:**
+- Produces: `config.get_user_themes_dir() -> Path`; `themes.load_user_themes(themes_dir: Path) -> list[Theme]`; button id `settings-theme-set-default`.
+
+- [ ] **Step 1: Failing loader test** (`Tests/Utils/test_user_theme_loader.py`)
+
+```python
+from pathlib import Path
+from tldw_chatbook.css.Themes.themes import load_user_themes
+
+
+def _write(dir_: Path, name: str, body: str) -> None:
+    (dir_ / f"{name}.toml").write_text(body, encoding="utf-8")
+
+
+def test_load_user_themes_reads_good_files_and_skips_bad_ones(tmp_path):
+    _write(tmp_path, "ocean", '[theme]\nname = "ocean"\ndark = true\n[colors]\nprimary = "#9966FF"\n')
+    _write(tmp_path, "broken", "this is not toml = = =\n")
+    _write(tmp_path, "nocolors", '[theme]\nname = "bare"\n')
+    themes = load_user_themes(tmp_path)
+    names = sorted(t.name for t in themes)
+    assert names == ["bare", "ocean"]
+    ocean = next(t for t in themes if t.name == "ocean")
+    assert ocean.primary.hex.upper() == "#9966FF"
+    assert ocean.dark is True
+
+
+def test_load_user_themes_missing_dir_returns_empty(tmp_path):
+    assert load_user_themes(tmp_path / "nope") == []
+```
+
+- [ ] **Step 2: Run, expect FAIL** (`ImportError: cannot import name 'load_user_themes'`).
+- [ ] **Step 3: Implement the loader** in `themes.py` (after `create_theme_from_dict`):
+
+```python
+def load_user_themes(themes_dir) -> list[Theme]:
+    """Read every ``*.toml`` under ``themes_dir`` into Theme objects.
+
+    The Settings theme editor writes ``[theme] name/dark`` + ``[colors]``.
+    Unreadable files are skipped with a warning so one bad file cannot
+    block startup.
+    """
+    from pathlib import Path
+    import toml
+    from loguru import logger
+
+    themes: list[Theme] = []
+    root = Path(themes_dir)
+    if not root.is_dir():
+        return themes
+    for path in sorted(root.glob("*.toml")):
+        try:
+            data = toml.load(path)
+            meta = data.get("theme", {}) or {}
+            name = str(meta.get("name") or path.stem).strip() or path.stem
+            colors = dict(data.get("colors", {}) or {})
+            colors["dark"] = bool(meta.get("dark", True))
+            themes.append(create_theme_from_dict(name, colors))
+        except Exception as exc:  # noqa: BLE001 - one bad file must not block startup
+            logger.warning(f"Skipping unreadable user theme {path}: {exc}")
+    return themes
+```
+
+Add to `config.py` next to `get_cli_config_path`:
+
+```python
+def get_user_themes_dir() -> Path:
+    """Directory holding the user's saved theme TOML files (active profile)."""
+    return get_cli_config_path().parent / "themes"
+```
+
+Wire it: in `app.py` after `for theme_name in ALL_THEMES: self.register_theme(theme_name)` add
+
+```python
+        from .css.Themes.themes import load_user_themes
+        from .config import get_user_themes_dir
+        for user_theme in load_user_themes(get_user_themes_dir()):
+            self.register_theme(user_theme)
+```
+
+In `ThemeProvider` (app.py ~1146) replace the hand-built `available_themes` list with `available_themes = list(self.app.available_themes)`.
+
+In `settings_screen.py` `_appearance_theme_options`, after the `ALL_THEMES` loop and before the `current_theme` block, add:
+
+```python
+        registered = getattr(getattr(self, "app_instance", None), "available_themes", None) or {}
+        for theme_name in registered:
+            if theme_name in seen or theme_name in ("textual-dark", "textual-light"):
+                continue
+            seen.add(theme_name)
+            options.append((f"{theme_name.replace('_', ' ').replace('-', ' ').title()} (saved)", theme_name))
+```
+
+(`test_settings_appearance_theme_options_use_specific_import_fallback` pins the `ALL_THEMES` import lines — keep them unchanged.) Replace `_theme_save_target`'s body with `return get_user_themes_dir()` and the editor's `__init__` dir with `self.custom_themes_path = get_user_themes_dir()` (import from `..config`).
+
+In the editor: `on_save_theme` after the file write adds
+
+```python
+            self.app.register_theme(
+                create_theme_from_dict(theme_name, {**self.current_theme_data, "dark": self.is_dark_theme})
+            )
+```
+
+Add the button to the Actions row: `yield Button("Set as launch default", id="settings-theme-set-default")` and the handler:
+
+```python
+    @on(Button.Pressed, "#settings-theme-set-default")
+    def on_set_launch_default(self) -> None:
+        """Make the saved theme the startup theme (TASK-31250)."""
+        name = self.current_theme_name
+        if not (self.custom_themes_path / f"{name}.toml").exists() and not self._is_catalog_theme(name):
+            self.app.notify("Save the theme first, then set it as the launch default", severity="warning")
+            return
+        from ..config import save_setting_to_cli_config
+
+        save_setting_to_cli_config("general", "default_theme", name)
+        self.app.notify(f"'{name}' will load at the next launch", severity="success")
+```
+
+Apply hint copy becomes: `"Apply applies immediately - no Save needed; Save stores the theme; Set as launch default makes it load at startup."`
+
+- [ ] **Step 4: Editor test** (append to `test_settings_theme_editor.py`)
+
+```python
+@pytest.mark.asyncio
+async def test_settings_theme_editor_save_registers_theme_with_app(tmp_path):
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.on_new_theme()
+        await pilot.pause()
+        editor.query_one("#settings-theme-name", Input).value = "ocean"
+        await pilot.pause()
+        editor.on_save_theme()
+        await pilot.pause()
+        assert "ocean" in app.available_themes
+```
+
+and a `_appearance_theme_options` unit test in `test_settings_configuration_hub.py` using a `types.SimpleNamespace` stub with `_appearance_setting_values=lambda: {"default_theme": "textual-dark"}` and `app_instance=SimpleNamespace(available_themes={"ocean": object()})`, asserting `("Ocean (saved)", "ocean")` is in `SettingsScreen._appearance_theme_options(stub)`.
+
+- [ ] **Step 5: Run** the three test files, expect PASS. Also run `Tests/UI/test_command_palette_shell_routes.py` (ThemeProvider consumers).
+- [ ] **Step 6: Docs.** In `Docs/User_Guide/settings.md` § Interface — Theme: replace "**This editor never sets the launch default** — press **Save** here, then pick the theme in **Appearance** → **Theme**." with "**Save** stores the theme and registers it at once, so it appears in **Appearance** → **Theme** and the palette; **Set as launch default** makes it the startup theme." Update recipe 3 and the quirk paragraph accordingly; bump the stamp line to `*Verified against fix/theme-editor-ux @ <sha> — 2026-09-04.*`.
+- [ ] **Step 7: Commit** `feat(theme-editor): register saved user themes at startup and after Save (TASK-31250)`.
+
+---
+
+### Task 4: Re-entering Theme after Apply shows the applied palette; stale dirty flag cleared (TASK-31252)
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/settings_theme_editor.py` (`_initialize_editor`)
+- Modify: `tldw_chatbook/UI/Screens/settings_screen.py` (`_select_category`, ~20118-20232)
+- Test: `Tests/UI/test_settings_theme_editor.py`, `Tests/UI/test_settings_configuration_hub.py`
+
+- [ ] **Step 1: Failing editor test**
+
+```python
+@pytest.mark.asyncio
+async def test_settings_theme_editor_remount_after_apply_restores_palette(tmp_path):
+    """TASK-31252: app.theme == 'custom_<name>' must load, not blank the editor."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.on_new_theme()
+        await pilot.pause()
+        editor.color_inputs["primary"].value = "#123456"
+        await pilot.pause()
+        editor.on_apply_theme()
+        await pilot.pause()
+        assert app.theme == "custom_new_theme"
+        editor._initialize_editor()  # what a remount does
+        await pilot.pause()
+        assert editor.current_theme_name == "new_theme"
+        assert editor.color_inputs["primary"].value.upper() == "#123456"
+```
+
+- [ ] **Step 2: Run, expect FAIL** (name `custom_new_theme`, inputs unchanged/empty).
+- [ ] **Step 3: Implement.** In `_initialize_editor`, replace `self.load_theme(self.app.theme)` with:
+
+```python
+            app_theme = str(self.app.theme)
+            self.load_theme(app_theme)
+            if app_theme.startswith("custom_"):
+                # Apply registers the working palette under a custom_ prefix so
+                # it never clobbers a shipped registration; the editor shows the
+                # user-facing name (TASK-31252).
+                self.current_theme_name = app_theme[len("custom_"):]
+                self.query_one("#settings-theme-name", Input).value = self.current_theme_name
+                self.query_one("#settings-theme-name", Input).disabled = False
+```
+
+Screen side: in `_select_category`, right before `self.active_category = category_value` add
+
+```python
+        if (
+            self.active_category == SettingsCategoryId.THEME.value
+            and category_value != SettingsCategoryId.THEME.value
+            and self.theme_editor_modified
+        ):
+            # Leaving Theme remounts the editor and drops in-progress edits, so
+            # the dirty displays must not survive the departure (TASK-31252).
+            self.theme_editor_modified = False
+            self._refresh_theme_modified_widgets()
+```
+
+- [ ] **Step 4: Screen test** (in `test_settings_configuration_hub.py`, modelled on `test_theme_user_edit_does_not_remount_editor` at ~10785): edit a colour so the flag is True, `screen._select_category(SettingsCategoryId.APPEARANCE.value)`, pause, `screen._select_category(SettingsCategoryId.THEME.value)`, pause, assert `screen.theme_editor_modified is False` and the `#settings-theme-unsaved-note` renderable contains `No`.
+- [ ] **Step 5: Run** both files plus `test_theme_category_settles_without_recompose_storm`; expect PASS.
+- [ ] **Step 6: Commit** `fix(theme-editor): restore applied palette on remount, clear stale dirty flag (TASK-31252)`.
+
+---
+
+### Task 5: Generate from Primary honours the hue (TASK-31253)
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/settings_theme_editor.py` (`_generate_theme_from_primary`, `_adjust_color`)
+- Test: `Tests/UI/test_settings_theme_editor.py`
+
+- [ ] **Step 1: Failing test** (pure function, no app needed)
+
+```python
+def _hue_deg(hex_value: str) -> float:
+    from textual.color import Color
+    return Color.parse(hex_value).hsl.h * 360
+
+
+@pytest.mark.parametrize("primary", ["#9966FF", "#00CC66", "#FF9900"])
+def test_generate_from_primary_keeps_the_primary_hue(primary):
+    editor = SettingsThemeEditor.__new__(SettingsThemeEditor)
+    editor.is_dark_theme = True
+    from textual.color import Color
+    palette = editor._generate_theme_from_primary(Color.parse(primary))
+    base = _hue_deg(primary)
+    for key in ("secondary", "background", "surface", "panel"):
+        delta = abs(_hue_deg(palette[key]) - base) % 360
+        assert min(delta, 360 - delta) <= 30, (key, palette[key])
+    accent_delta = abs(_hue_deg(palette["accent"]) - base) % 360
+    assert 150 <= min(accent_delta, 360 - accent_delta) <= 180
+    assert all(v == v.upper() for v in palette.values())
+```
+
+- [ ] **Step 2: Run, expect FAIL** (secondary is red for every primary).
+- [ ] **Step 3: Implement.** In `_generate_theme_from_primary` change the first line to `hue, saturation, lightness = primary.hsl` → `hsl = primary.hsl; hue, saturation, lightness = hsl.h * 360, hsl.s, hsl.l`. In `_adjust_color` return `f"#{r:02X}{g:02X}{b:02X}"`.
+- [ ] **Step 4: Run, expect PASS.** Also assert `primary.hex` path stays uppercase (Textual returns uppercase already).
+- [ ] **Step 5: Commit** `fix(theme-editor): Generate from Primary uses degrees, uppercase hex (TASK-31253)`.
+
+---
+
+### Task 6: Make swatch text, invalid state, preset target and Dark toggle visible (TASK-31254)
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/settings_theme_editor.py` (compose: preset target `Select`, checkbox; `_update_color_swatch`, `on_color_input_changed`, `_apply_preset_swatch`, `on_descendant_focus` removed)
+- Modify: `tldw_chatbook/css/components/_settings_splash_theme.tcss` (swatch rules, toggle rule)
+- Rebuild: `tldw_chatbook/css/tldw_cli_modular.tcss`
+- Test: `Tests/UI/test_settings_theme_editor.py`, new `Tests/UI/test_settings_theme_editor_render.py`
+
+**Interfaces:**
+- Produces: `Select` with id `settings-theme-preset-target` whose value is a `BASE_COLORS` name (default `"primary"`); `_preset_target()` returns it. Task 7's tests use the id.
+
+- [ ] **Step 1: Failing painted-frame test** (`Tests/UI/test_settings_theme_editor_render.py`, copy the `_BUNDLED_CSS_PATH` / `_rendered_text` / bundle-loading harness from `Tests/UI/test_checkbox_height_render.py`, mounting `SettingsThemeEditor()` inside a `Vertical` at size `(120, 60)`):
+
+```python
+@pytest.mark.asyncio
+async def test_swatch_paints_hex_text_and_dark_toggle_paints_state():
+    app = _BundleHarness()  # CSS_PATH = [str(_BUNDLED_CSS_PATH)], compose yields SettingsThemeEditor()
+    async with app.run_test(size=(120, 60)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(SettingsThemeEditor)
+        editor.color_inputs["primary"].value = "#9966FF"
+        await pilot.pause()
+        painted = _rendered_text(app)
+        assert "#9966FF" in painted            # swatch text is painted
+        assert "▔▔▔" not in painted.split("Dark theme")[1][:12]  # toggle is not a clipped border
+        assert "Presets fill" in painted
+```
+
+- [ ] **Step 2: Run, expect FAIL** (`#9966FF` appears only once — in the Input — assert on count `>= 2` to be exact).
+- [ ] **Step 3: Implement.**
+
+CSS (`_settings_splash_theme.tcss`): replace the `.color-swatch` and `.color-preset-swatch` blocks with
+
+```css
+.color-swatch {
+    width: 9;
+    min-width: 9;
+    height: 1;
+    min-height: 1;
+    border: none;
+    content-align: center middle;
+    text-style: bold;
+}
+
+.color-preset-swatch {
+    width: 3;
+    min-width: 3;
+    height: 1;
+    min-height: 1;
+    margin: 0 1 0 0;
+    border: none;
+}
+
+/* task-1369 / TASK-31254: focus ring without a border row -- outline paints
+   over the swatch's own cells and keeps its colour visible. */
+.color-preset-swatch:focus {
+    outline: solid $ds-focus-accent;
+    text-style: bold;
+}
+
+/* TASK-31254: escape the app-wide `Checkbox { height: 2 }` + tall border
+   that leaves zero content rows (same idiom as
+   `.settings-imagegen-backend-row Checkbox`, TASK-18960). */
+#settings-theme-dark-mode {
+    width: auto;
+    height: 1;
+    min-height: 1;
+    margin-bottom: 0;
+    border: none;
+    padding: 0;
+}
+```
+
+Widget: in `_compose_palette_section`, replace the "Focus a swatch…" help Static with
+
+```python
+        with Horizontal(classes="settings-input-row"):
+            yield Static("Presets fill", classes="settings-input-label")
+            yield Select(
+                [(name.title(), name) for name in self.BASE_COLORS],
+                value="primary",
+                allow_blank=False,
+                id="settings-theme-preset-target",
+                classes="settings-compact-select",
+            )
+        yield Static(
+            "Pick the colour above, then click a swatch or focus it and press Enter or Space.",
+            classes="settings-help-copy",
+        )
+```
+
+Add `Select` to the `textual.widgets` import. Replace `last_focused_color_input` usage: delete `on_descendant_focus` and the `selected` class lines in `_initialize_editor`/`_apply_preset_swatch`; add
+
+```python
+    def _preset_target(self) -> str:
+        try:
+            value = self.query_one("#settings-theme-preset-target", Select).value
+        except QueryError:
+            value = "primary"
+        return value if value in self.color_inputs else "primary"
+```
+
+and use `target = self._preset_target()` in `_apply_preset_swatch`. Give the Dark toggle a label: `Checkbox("On", value=True, id="settings-theme-dark-mode")` (label reads "On" beside the glyph; the row label stays "Dark theme"). Invalid input: in `on_color_input_changed` use class `settings-invalid-input` (add/remove) instead of `invalid-color`, and replace `self._update_color_swatch(color_name, "#000000")` with
+
+```python
+                    self.color_swatches[color_name].update("invalid")
+```
+
+(keep the previous background). Drop the now-dead `.invalid-color` references.
+
+- [ ] **Step 4: Rebuild the bundle** `python3 tldw_chatbook/css/build_css.py`, run the new render test + the editor file; `test_settings_theme_editor_preset_swatches_are_keyboard_activatable` must still pass (default target primary).
+- [ ] **Step 5: Commit** `fix(theme-editor): paint swatch hex, invalid state, preset target and dark toggle (TASK-31254)` staging the widget, tcss, bundle, and both test files.
+
+---
+
+### Task 7: Actions above presets, User Themes first, stable preset target under Tab (TASK-31256, plus the group naming from TASK-31261)
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/settings_theme_editor.py` (`compose` order, `_populate_theme_tree`, `_load_user_themes`, `on_theme_selected`, tree hint copy, `on_save_theme`/`_delete_user_theme` tree bookkeeping)
+- Test: `Tests/UI/test_settings_theme_editor.py` (update `_user_theme_labels`)
+
+- [ ] **Step 1: Failing tests**
+
+```python
+@pytest.mark.asyncio
+async def test_settings_theme_editor_actions_precede_presets_in_focus_order(tmp_path):
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        ids = [w.id for w in editor.query("*") if getattr(w, "can_focus", False) and w.id]
+        assert ids.index("settings-theme-apply") < ids.index("settings-theme-preset-Blues-0")
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_tabbing_does_not_move_preset_target(tmp_path):
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.color_inputs["error"].focus()
+        await pilot.pause()
+        editor.query_one("#settings-theme-preset-Blues-0").focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert editor.current_theme_data["primary"] == editor.COLOR_PRESETS["Blues"][0]
+        assert editor.color_inputs["error"].value != editor.COLOR_PRESETS["Blues"][0]
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_tree_lists_your_themes_first_and_expanded(tmp_path):
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    _write_user_theme(tmp_path, "ocean")
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor._populate_theme_tree()
+        tree = editor.query_one("#settings-theme-tree", Tree)
+        labels = [str(n.label) for n in tree.root.children]
+        assert labels == ["Your themes", "Built-in", "Shipped themes"]
+        assert tree.root.is_expanded
+        assert tree.root.children[0].is_expanded and not tree.root.children[2].is_expanded
+        assert [str(c.label) for c in tree.root.children[0].children] == ["ocean"]
+```
+
+- [ ] **Step 2: Run, expect FAIL** on all three.
+- [ ] **Step 3: Implement.** `compose`: yield sections in the order library → actions → palette → preview. `_populate_theme_tree`:
+
+```python
+        tree.root.remove_children()
+        user_node = tree.root.add("Your themes", expand=True)
+        self._load_user_themes(user_node)
+        builtin_node = tree.root.add("Built-in", expand=True)
+        builtin_node.add_leaf("textual-dark", data="catalog")
+        builtin_node.add_leaf("textual-light", data="catalog")
+        shipped_node = tree.root.add("Shipped themes", expand=False)
+        for theme in ALL_THEMES:
+            if hasattr(theme, "name"):
+                shipped_node.add_leaf(theme.name, data="catalog")
+        tree.root.expand()
+```
+
+`_load_user_themes` adds `parent_node.add_leaf(theme_name, data="user")`. `on_theme_selected` uses `event.node.data == "user"` to pick `load_user_theme`, else `load_theme(str(event.node.label))`. Save/Delete tree bookkeeping looks for the node labelled `"Your themes"` and leaf label `theme_name` (no prefix). Tree hint copy: `"Your themes come first; expand Shipped themes to browse the catalog. New starts a theme from the current palette."`. Update the test helper `_user_theme_labels` to look for `"Your themes"`, and the three delete tests' `f"user:{...}"` expectations to bare names.
+
+- [ ] **Step 4: Run the file, expect PASS.**
+- [ ] **Step 5: Commit** `fix(theme-editor): actions before presets, your themes first, stable preset target (TASK-31256)`.
+
+---
+
+### Task 8: New starts from the current palette (TASK-31257)
+
+**Files:** `tldw_chatbook/Widgets/settings_theme_editor.py` (`_new_theme`), `Tests/UI/test_settings_theme_editor.py`, `Docs/User_Guide/settings.md` (§ Theme: "**New** copies the loaded palette into a theme called new_theme").
+
+- [ ] **Step 1: Failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_settings_theme_editor_new_copies_current_palette(tmp_path):
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.load_theme("textual-light")
+        await pilot.pause()
+        before = dict(editor.current_theme_data)
+        editor.on_new_theme()
+        await pilot.pause()
+        assert editor.current_theme_name == "new_theme"
+        assert editor.current_theme_data == before
+        assert editor.is_dark_theme is False
+```
+
+- [ ] **Step 2: Run, expect FAIL** (palette becomes the hardcoded blue set, dark True).
+- [ ] **Step 3: Implement.** In `_new_theme` replace the hardcoded dict with
+
+```python
+        defaults = {
+            "primary": "#0099FF", "secondary": "#006FB3", "accent": "#FFD700",
+            "background": "#1E1E1E", "surface": "#2C2C2C", "panel": "#252525",
+            "foreground": "#FFFFFF", "success": "#008000", "warning": "#FFD700", "error": "#FF0000",
+        }
+        self.current_theme_data = dict(self.current_theme_data) or defaults
+        # is_dark_theme keeps the loaded theme's value
+```
+
+and delete the `self.is_dark_theme = True` line.
+
+- [ ] **Step 4: Run the file, expect PASS** (`test_theme_tree_has_empty_state_guidance`, `test_settings_theme_editor_new_confirms_before_discarding_edits` unchanged).
+- [ ] **Step 5: Commit** `fix(theme-editor): New starts from the current palette (TASK-31257)`.
+
+---
+
+### Task 9: Confirm before Save/Export overwrite (TASK-31258)
+
+**Files:** `tldw_chatbook/Widgets/settings_theme_editor.py` (`on_save_theme`, `on_export_theme`, new `_write_theme_file`, `_loaded_user_theme` attribute), `Tests/UI/test_settings_theme_editor.py`.
+
+- [ ] **Step 1: Failing tests**
+
+```python
+@pytest.mark.asyncio
+async def test_settings_theme_editor_save_confirms_before_overwriting_another_theme(tmp_path):
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    _write_user_theme(tmp_path, "ocean")
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.on_new_theme()
+        await pilot.pause()
+        editor.query_one("#settings-theme-name", Input).value = "ocean"
+        await pilot.pause()
+        editor.on_save_theme()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmationDialog)
+        assert app.screen.confirm_label == "Overwrite"
+        await pilot.click("#cancel-button")
+        await pilot.pause()
+        assert 'primary = "#0099FF"' in (tmp_path / "ocean.toml").read_text()
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_saving_the_loaded_theme_does_not_confirm(tmp_path):
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    _write_user_theme(tmp_path, "ocean")
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.load_user_theme("ocean")
+        await pilot.pause()
+        editor.color_inputs["primary"].value = "#123456"
+        await pilot.pause()
+        editor.on_save_theme()
+        await pilot.pause()
+        assert not isinstance(app.screen, ConfirmationDialog)
+        assert "#123456" in (tmp_path / "ocean.toml").read_text()
+```
+
+- [ ] **Step 2: Run, expect FAIL** (first: no dialog, file overwritten).
+- [ ] **Step 3: Implement.** Track `self._loaded_user_theme: str | None = None` in `__init__`; set it in `load_user_theme` and after a successful save; clear it in `load_theme`, `_new_theme`, `on_clone_theme`. Split `on_save_theme` so the write lives in `_write_theme_file(theme_name, theme_path)` (the current try-block including registration and tree bookkeeping), and before writing:
+
+```python
+        if theme_path.exists() and self._loaded_user_theme != theme_name:
+            async def _confirmed() -> None:
+                self._write_theme_file(theme_name, theme_path)
+
+            self.app.push_screen(
+                ConfirmationDialog(
+                    title="Overwrite theme",
+                    message=f"A saved theme named '{theme_name}' already exists. Replace it?",
+                    confirm_label="Overwrite",
+                    cancel_label="Keep existing",
+                    confirm_callback=_confirmed,
+                )
+            )
+            return
+        self._write_theme_file(theme_name, theme_path)
+```
+
+Same shape for Export: `if export_path.exists():` → dialog "Overwrite export" / "Overwrite" / "Keep existing", else `_write_export(export_path)`.
+
+- [ ] **Step 4: Run, expect PASS.** Commit `fix(theme-editor): confirm before Save/Export overwrite an existing file (TASK-31258)`.
+
+---
+
+### Task 10: Preview repaints from the edited palette and shows a Console-shaped stub (TASK-31259)
+
+**Files:** `tldw_chatbook/Widgets/settings_theme_editor.py` (`_compose_preview_section`, new `_refresh_preview`, call sites), `tldw_chatbook/css/components/_settings_splash_theme.tcss` (preview rows), bundle, `Tests/UI/test_settings_theme_editor.py`, `Docs/User_Guide/settings.md` (drop "decorative").
+
+- [ ] **Step 1: Failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_settings_theme_editor_preview_repaints_from_edits_without_apply(tmp_path):
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.color_inputs["primary"].value = "#123456"
+        await pilot.pause()
+        row = editor.query_one("#settings-theme-preview-user")
+        assert row.styles.background.hex.upper() == "#123456"
+```
+
+- [ ] **Step 2: Run, expect FAIL** (`NoMatches`).
+- [ ] **Step 3: Implement.** Replace `_compose_preview_section` body with
+
+```python
+        yield Static("Live Preview", classes="destination-section")
+        with Vertical(id="settings-theme-preview", classes="settings-theme-preview"):
+            yield Static(" Console ▸ Conversation · ● ready", id="settings-theme-preview-rail")
+            yield Static(" You: summarise the attached paper", id="settings-theme-preview-user")
+            yield Static(" Assistant: Here is the summary…", id="settings-theme-preview-assistant")
+            yield Static(" ✓ tool web_search finished", id="settings-theme-preview-success")
+            yield Static(" ! approval needed before the next call", id="settings-theme-preview-warning")
+            yield Static(" ✗ provider returned 401", id="settings-theme-preview-error")
+            yield Static(" [ Send ]  Ctrl+P palette", id="settings-theme-preview-accent")
+```
+
+and
+
+```python
+    _PREVIEW_STYLE = {
+        "rail": ("panel", "foreground"),
+        "user": ("primary", "foreground"),
+        "assistant": ("surface", "foreground"),
+        "success": ("background", "success"),
+        "warning": ("background", "warning"),
+        "error": ("background", "error"),
+        "accent": ("background", "accent"),
+    }
+
+    def _refresh_preview(self) -> None:
+        """Paint the preview rows from the palette being edited (TASK-31259)."""
+        for suffix, (bg_key, fg_key) in self._PREVIEW_STYLE.items():
+            try:
+                row = self.query_one(f"#settings-theme-preview-{suffix}", Static)
+            except QueryError:
+                continue
+            bg = self.current_theme_data.get(bg_key)
+            fg = self.current_theme_data.get(fg_key)
+            try:
+                if bg:
+                    row.styles.background = bg
+                if fg:
+                    row.styles.color = fg
+            except Exception:  # noqa: BLE001 - an invalid hex must not break painting
+                continue
+```
+
+Call `self._refresh_preview()` at the end of `_update_color_inputs`, in `on_color_input_changed` after a valid change, in `_apply_preset_swatch`, and in `on_generate_theme`. CSS: `.settings-theme-preview { height: auto; margin: 1 0; border: solid $ds-grid-line; } .settings-theme-preview Static { height: 1; }` (replace the old `.preview-*` rules, which lose their consumers). Rebuild the bundle.
+
+- [ ] **Step 4: Run, expect PASS.** Docs: § Theme "a **Live Preview** that repaints as you type (a Console-shaped stub)". Commit `feat(theme-editor): preview repaints from edits and shows a Console stub (TASK-31259)`.
+
+---
+
+### Task 11: Compact layout at ≤100 columns and a readable save path (TASK-31260)
+
+**Files:** `tldw_chatbook/css/components/_settings_splash_theme.tcss`, bundle, `tldw_chatbook/UI/Screens/settings_screen.py` (`_theme_save_target` display sites ~4607, ~13607, ~18615 → new `_display_path`), `Tests/UI/test_settings_theme_editor_render.py`.
+
+- [ ] **Step 1: Failing test** in the render file: bundle harness at `size=(110, 36)` mounting `SettingsThemeEditor()` inside a `Vertical` of `width: 45`; assert every `Button` in the editor has `region.right <= container.region.right` and `region.width > 0`.
+- [ ] **Step 2: Run, expect FAIL** (Delete/Export exceed the container).
+- [ ] **Step 3: Implement.** CSS:
+
+```css
+/* TASK-31260: below SETTINGS_COMPACT_WORKBENCH_MAX_WIDTH (100 cols) the
+   detail pane is ~45 cells; four 16-cell buttons cannot share a row. */
+#settings-workbench.settings-workbench-compact #settings-theme-card .settings-action-row {
+    layout: vertical;
+    height: auto;
+}
+#settings-workbench.settings-workbench-compact #settings-theme-card .settings-action-row Button {
+    width: 100%;
+}
+#settings-theme-card .settings-action-row Button {
+    min-width: 8;
+}
+```
+
+Because the render harness has no `#settings-workbench`, wrap the editor in the test inside `Vertical(id="settings-workbench", classes="settings-workbench-compact")` so the rule applies. In `settings_screen.py` add
+
+```python
+def _display_path(path: Path) -> str:
+    """Shorten a path for the inspector: ~ for home (TASK-31260)."""
+    try:
+        return "~" + os.sep + str(path.relative_to(Path.home()))
+    except ValueError:
+        return str(path)
+```
+
+and use `_display_path(_theme_save_target())` at the three sites, dropping the duplicate "Affected config" path row (keep the "Save target" row).
+
+- [ ] **Step 4: Rebuild bundle, run render + hub tests (`test_theme_category_opens_without_crashing`), expect PASS.** Commit `fix(theme-editor): stack action rows in compact mode, shorten inspector path (TASK-31260)`.
+
+---
+
+### Task 12: Polish, docs stamp, full verification (TASK-31261 remainder + Definition of Done)
+
+**Files:** `tldw_chatbook/Widgets/settings_theme_editor.py` (`on_reset_theme`, button variants), `Tests/UI/test_settings_theme_editor.py`, `Docs/User_Guide/settings.md`, all twelve task files.
+
+- [ ] **Step 1:** Update `test_settings_theme_editor_reset_without_edits_skips_confirmation` to expect `"No changes to reset"`; run, expect FAIL.
+- [ ] **Step 2:** In `on_reset_theme`, the no-edits branch becomes `self.app.notify("No changes to reset", severity="information"); return` (still no dialog). Button variants: `New` → default, `Generate from Primary` → default, `Apply` stays primary, `Save` success, `Set as launch default` default. Run, expect PASS.
+- [ ] **Step 3:** Run the full related suites: `Tests/UI/test_settings_theme_editor.py Tests/UI/test_settings_theme_editor_render.py Tests/UI/test_settings_configuration_hub.py Tests/UI/test_css_build_integrity.py Tests/Utils/test_user_theme_loader.py Tests/UI/test_command_palette_shell_routes.py Tests/Performance/test_textual_css_fastpath.py Tests/UI/test_non_obscuring_focus_contract.py` and `python3 Helper_Scripts/check_backlog_task_ids.py` equivalent `python3 scripts/check_backlog_task_ids.py`.
+- [ ] **Step 4:** Live verification (verify skill): launch with a scratch `TLDW_CONFIG_PATH`, walk New → rename → edit → Apply → Save → Set as launch default → quit → relaunch, confirm the theme is applied at launch and the editor reopens on it. Record the capture paths in the task notes.
+- [ ] **Step 5:** Docs stamp: update `Docs/User_Guide/settings.md` "Verified against" line for the Theme section to the branch sha and date.
+- [ ] **Step 6:** Backlog: for each of 31250-31261 tick ACs, add Implementation Notes, set Done. Commit `docs(backlog): close Theme editor UX tasks 31250-31261`.

--- a/Tests/UI/test_css_build_integrity.py
+++ b/Tests/UI/test_css_build_integrity.py
@@ -519,7 +519,7 @@ def test_settings_splash_theme_rules_have_source_and_bundle_integrity() -> None:
     # The live, feature-scoped theme-editor + splash-viewer selectors remain.
     required_selectors = (
         "#settings-theme-tree",
-        ".settings-preview-grid",
+        ".settings-theme-preview",
         ".settings-splash-gallery",
         "#settings-splash-card-list",
         "#settings-splash-preview-scroll",

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -13010,7 +13010,7 @@ async def test_theme_dirty_flag_clears_when_leaving_the_category():
 
 
 def test_display_path_abbreviates_home_and_leaves_other_paths_alone(tmp_path):
-    """TASK-31260: the inspector's themes directory reads '~/...', not a
+    """TASK-31279: the inspector's themes directory reads '~/...', not a
     five-line absolute path; paths outside home are untouched."""
     import os
     from pathlib import Path

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -12976,3 +12976,34 @@ def test_settings_appearance_theme_options_include_registered_user_themes():
     options = SettingsScreen._appearance_theme_options(stub)
     assert ("Ocean (saved)", "ocean") in options
     assert [value for _label, value in options].count("textual-dark") == 1
+
+
+@pytest.mark.asyncio
+async def test_theme_dirty_flag_clears_when_leaving_the_category():
+    """TASK-31252: leaving Theme drops the in-progress edit, so the rail marker
+    and inspector row must not keep saying 'unsaved' on the next visit."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-theme")
+        screen = _active_destination_screen(host)
+        await _wait_for_selector(screen, pilot, "#settings-theme-editor", timeout=8.0)
+        for _ in range(6):
+            await pilot.pause()
+        editor = screen.query_one("#settings-theme-editor")
+        editor.query_one("#settings-theme-color-primary", Input).value = "#123456"
+        for _ in range(6):
+            await pilot.pause()
+        assert screen.theme_editor_modified is True
+
+        screen._select_category(SettingsCategoryId.APPEARANCE.value)
+        for _ in range(6):
+            await pilot.pause()
+        assert screen.theme_editor_modified is False
+
+        screen._select_category(SettingsCategoryId.THEME.value)
+        await _wait_for_selector(screen, pilot, "#settings-theme-editor", timeout=8.0)
+        for _ in range(6):
+            await pilot.pause()
+        note = screen.query_one("#settings-theme-unsaved-note", Static)
+        assert "No" in str(note.renderable)

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -13020,3 +13020,20 @@ def test_display_path_abbreviates_home_and_leaves_other_paths_alone(tmp_path):
     inside = Path.home() / ".config" / "tldw_cli" / "themes"
     assert _display_path(inside) == "~" + os.sep + os.sep.join((".config", "tldw_cli", "themes"))
     assert _display_path(tmp_path) == str(tmp_path) or _display_path(tmp_path).startswith("~")
+
+
+def test_settings_appearance_theme_options_skip_runtime_only_custom_themes():
+    """PR #2375 review #8: Apply registers an unsaved palette as custom_<name>; it
+    exists only for this process and must not be offered as a launch default."""
+    import types
+
+    stub = types.SimpleNamespace(
+        _appearance_setting_values=lambda: {"default_theme": "textual-dark"},
+        app_instance=types.SimpleNamespace(
+            available_themes={"textual-dark": object(), "ocean": object(), "custom_ocean": object()}
+        ),
+    )
+    options = SettingsScreen._appearance_theme_options(stub)
+    values = [value for _label, value in options]
+    assert "ocean" in values
+    assert "custom_ocean" not in values

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -13007,3 +13007,16 @@ async def test_theme_dirty_flag_clears_when_leaving_the_category():
             await pilot.pause()
         note = screen.query_one("#settings-theme-unsaved-note", Static)
         assert "No" in str(note.renderable)
+
+
+def test_display_path_abbreviates_home_and_leaves_other_paths_alone(tmp_path):
+    """TASK-31260: the inspector's themes directory reads '~/...', not a
+    five-line absolute path; paths outside home are untouched."""
+    import os
+    from pathlib import Path
+
+    from tldw_chatbook.UI.Screens.settings_screen import _display_path
+
+    inside = Path.home() / ".config" / "tldw_cli" / "themes"
+    assert _display_path(inside) == "~" + os.sep + os.sep.join((".config", "tldw_cli", "themes"))
+    assert _display_path(tmp_path) == str(tmp_path) or _display_path(tmp_path).startswith("~")

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -12961,3 +12961,18 @@ async def test_settings_advanced_config_backup_load_never_clobbers_unsaved_typin
             ]
         finally:
             release.set()
+
+
+def test_settings_appearance_theme_options_include_registered_user_themes():
+    """TASK-31250: themes registered with the app (saved user themes) are offered."""
+    import types
+
+    stub = types.SimpleNamespace(
+        _appearance_setting_values=lambda: {"default_theme": "textual-dark"},
+        app_instance=types.SimpleNamespace(
+            available_themes={"textual-dark": object(), "ocean": object()}
+        ),
+    )
+    options = SettingsScreen._appearance_theme_options(stub)
+    assert ("Ocean (saved)", "ocean") in options
+    assert [value for _label, value in options].count("textual-dark") == 1

--- a/Tests/UI/test_settings_theme_editor.py
+++ b/Tests/UI/test_settings_theme_editor.py
@@ -543,3 +543,46 @@ async def test_settings_theme_editor_name_box_drives_apply_save_reset_delete(tmp
         await pilot.pause()
         assert isinstance(app.screen, ConfirmationDialog)
         assert "ocean" in app.screen.message
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_selecting_builtin_leaf_does_not_retheme_app(tmp_path):
+    """TASK-31255: browsing the tree is read-only for the running app, and the
+    palette comes from the real registered Theme, not a hardcoded table."""
+    from textual.color import Color
+
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.theme = "textual-light"
+        await pilot.pause()
+        editor.load_theme("textual-dark")
+        await pilot.pause()
+        assert app.theme == "textual-light"
+        resolved = app.available_themes["textual-dark"].to_color_system().generate()
+        for key in ("background", "secondary", "panel"):
+            assert editor.color_inputs[key].value.upper() == Color.parse(
+                resolved[key]
+            ).hex.upper(), key
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_delete_keeps_app_theme(tmp_path):
+    """TASK-31255: deleting a saved theme resets the editor, not the app theme."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    _write_user_theme(tmp_path, "my_custom_theme")
+    app = _isolated_editor_app_with_real_screens(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.theme = "textual-light"
+        editor.load_user_theme("my_custom_theme")
+        await pilot.pause()
+        editor.on_delete_theme()
+        await pilot.pause()
+        await pilot.click("#confirm-button")
+        await pilot.pause()
+        assert app.theme == "textual-light"
+        assert editor.current_theme_name == "textual-dark"

--- a/Tests/UI/test_settings_theme_editor.py
+++ b/Tests/UI/test_settings_theme_editor.py
@@ -825,3 +825,23 @@ async def test_settings_theme_editor_export_confirms_before_overwriting(tmp_path
         await pilot.click("#cancel-button")
         await pilot.pause()
         assert existing.read_text(encoding="utf-8") == "old"
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_preview_repaints_from_edits_without_apply(tmp_path):
+    """TASK-31259: the preview must follow the palette being edited, not the
+    app theme (which only changes on Apply)."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.color_inputs["primary"].value = "#123456"
+        editor.color_inputs["error"].value = "#654321"
+        await pilot.pause()
+        user_row = editor.query_one("#settings-theme-preview-user")
+        assert user_row.styles.background.hex.upper() == "#123456"
+        error_row = editor.query_one("#settings-theme-preview-error")
+        assert error_row.styles.color.hex.upper() == "#654321"
+        # Nothing was applied to the running app.
+        assert not str(app.theme).startswith("custom_")

--- a/Tests/UI/test_settings_theme_editor.py
+++ b/Tests/UI/test_settings_theme_editor.py
@@ -423,7 +423,7 @@ async def test_settings_theme_editor_reset_without_edits_skips_confirmation(tmp_
 
         assert not isinstance(app.screen, ConfirmationDialog)
         message = app.notify.call_args.args[0]
-        assert message == "Theme reset to original values"
+        assert message == "No changes to reset"
 
 
 @pytest.mark.asyncio
@@ -845,3 +845,46 @@ async def test_settings_theme_editor_preview_repaints_from_edits_without_apply(t
         assert error_row.styles.color.hex.upper() == "#654321"
         # Nothing was applied to the running app.
         assert not str(app.theme).startswith("custom_")
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_one_primary_button_per_action_row(tmp_path):
+    """TASK-31261: Apply is the one primary action; New and Generate were also
+    variant=primary, so three buttons competed for the eye."""
+    from textual.widgets import Button
+
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        primaries = [b.id for b in editor.query(Button) if b.variant == "primary"]
+        assert primaries == ["settings-theme-apply"]
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_load_theme_keeps_set_colours_exact(tmp_path):
+    """Live at 2026-09-04: a saved accent '#FFD700' displayed as '#FED700' because
+    the editor read every colour back through the resolved colour system, which
+    round-trips set colours through float maths. Colours a Theme sets explicitly
+    must come back byte-exact; only unset ones are resolved."""
+    from tldw_chatbook.css.Themes.themes import create_theme_from_dict
+
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        app.register_theme(
+            create_theme_from_dict(
+                "exact_check",
+                {"primary": "#9966FF", "accent": "#FFD700", "warning": "#FFD700", "dark": True},
+            )
+        )
+        editor.load_theme("exact_check")
+        await pilot.pause()
+        assert editor.color_inputs["accent"].value == "#FFD700"
+        assert editor.color_inputs["warning"].value == "#FFD700"
+        assert editor.color_inputs["primary"].value == "#9966FF"
+        # Unset colours are still resolved, not left blank.
+        assert editor.color_inputs["background"].value.startswith("#")

--- a/Tests/UI/test_settings_theme_editor.py
+++ b/Tests/UI/test_settings_theme_editor.py
@@ -739,3 +739,23 @@ async def test_settings_theme_editor_tree_lists_your_themes_first_and_expanded(t
         assert tree.root.children[0].is_expanded
         assert not tree.root.children[2].is_expanded
         assert [str(c.label) for c in tree.root.children[0].children] == ["ocean"]
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_new_copies_current_palette(tmp_path):
+    """TASK-31257: the hint promises 'from the current palette'; New used to load
+    a hardcoded blue set and force dark=True."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.load_theme("textual-light")
+        await pilot.pause()
+        before = dict(editor.current_theme_data)
+        assert before, "textual-light must resolve to a palette"
+        editor.on_new_theme()
+        await pilot.pause()
+        assert editor.current_theme_name == "new_theme"
+        assert editor.current_theme_data == before
+        assert editor.is_dark_theme is False

--- a/Tests/UI/test_settings_theme_editor.py
+++ b/Tests/UI/test_settings_theme_editor.py
@@ -222,7 +222,7 @@ async def test_settings_theme_editor_delete_blocks_builtin_themes(tmp_path):
 @pytest.mark.asyncio
 async def test_settings_theme_editor_delete_blocks_shipped_themes(tmp_path):
     """Shipped catalog themes are not deletable and say "shipped", matching
-    the tree's own grouping (Built-in / Custom catalog / User Themes)."""
+    the tree's own grouping (Your themes / Built-in / Shipped themes)."""
     editor = SettingsThemeEditor()
     editor.custom_themes_path = tmp_path
     app = _isolated_editor_app(editor)
@@ -253,7 +253,7 @@ def _write_user_theme(themes_dir, theme_name: str):
 def _user_theme_labels(editor: SettingsThemeEditor) -> set[str]:
     tree = editor.query_one("#settings-theme-tree", Tree)
     for node in tree.root.children:
-        if str(node.label) == "User Themes":
+        if str(node.label) == "Your themes":
             return {str(child.label) for child in node.children}
     return set()
 
@@ -271,7 +271,7 @@ async def test_settings_theme_editor_delete_removes_custom_theme(tmp_path):
 
         # The tree picked the file up on mount, so the delete also exercises
         # the tree-removal branch.
-        assert "user:my_custom_theme" in _user_theme_labels(editor)
+        assert "my_custom_theme" in _user_theme_labels(editor)
 
         editor.current_theme_name = "my_custom_theme"
         editor.on_delete_theme()
@@ -287,7 +287,7 @@ async def test_settings_theme_editor_delete_removes_custom_theme(tmp_path):
         await pilot.pause()
         assert not isinstance(app.screen, ConfirmationDialog)
         assert theme_file.exists()
-        assert "user:my_custom_theme" in _user_theme_labels(editor)
+        assert "my_custom_theme" in _user_theme_labels(editor)
 
         # Re-invoke and confirm: only now is the file unlinked.
         editor.on_delete_theme()
@@ -297,7 +297,7 @@ async def test_settings_theme_editor_delete_removes_custom_theme(tmp_path):
         await pilot.pause()
 
         assert not theme_file.exists()
-        assert "user:my_custom_theme" not in _user_theme_labels(editor)
+        assert "my_custom_theme" not in _user_theme_labels(editor)
         assert editor.current_theme_name == "textual-dark"
         message = app.notify.call_args.args[0]
         assert message == "Deleted theme 'my_custom_theme'"
@@ -316,7 +316,7 @@ async def test_settings_theme_editor_delete_user_file_shadowing_shipped_name(tmp
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
 
-        assert f"user:{shipped_name}" in _user_theme_labels(editor)
+        assert shipped_name in _user_theme_labels(editor)
 
         editor.current_theme_name = shipped_name
         editor.on_delete_theme()
@@ -330,7 +330,7 @@ async def test_settings_theme_editor_delete_user_file_shadowing_shipped_name(tmp
         await pilot.pause()
 
         assert not theme_file.exists()
-        assert f"user:{shipped_name}" not in _user_theme_labels(editor)
+        assert shipped_name not in _user_theme_labels(editor)
         assert editor.current_theme_name == "textual-dark"
         message = app.notify.call_args.args[0]
         assert message == f"Deleted theme '{shipped_name}'"
@@ -688,3 +688,54 @@ def test_generate_from_primary_keeps_the_primary_hue(primary):
         assert _hue_distance(_hue_deg(palette[key]), base) <= 30, (key, palette[key])
     assert 150 <= _hue_distance(_hue_deg(palette["accent"]), base) <= 180
     assert all(value == value.upper() for value in palette.values()), palette
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_actions_precede_presets_in_focus_order(tmp_path):
+    """TASK-31256: Apply/Save/Reset must not sit behind 40 preset swatches."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        ids = [w.id for w in editor.query("*") if getattr(w, "can_focus", False) and w.id]
+        assert ids.index("settings-theme-apply") < ids.index("settings-theme-preset-Blues-0")
+        assert ids.index("settings-theme-apply") < ids.index("settings-theme-color-primary")
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_tabbing_does_not_move_preset_target(tmp_path):
+    """TASK-31256: focusing colour inputs on the way to a swatch must not change
+    which colour the swatch fills (it used to land on Error)."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.color_inputs["error"].focus()
+        await pilot.pause()
+        before_error = editor.color_inputs["error"].value
+        editor.query_one("#settings-theme-preset-Blues-0").focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert editor.current_theme_data["primary"] == editor.COLOR_PRESETS["Blues"][0]
+        assert editor.color_inputs["error"].value == before_error
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_tree_lists_your_themes_first_and_expanded(tmp_path):
+    """TASK-31256: own themes first and open; the 58 shipped themes collapsed."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    _write_user_theme(tmp_path, "ocean")
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor._populate_theme_tree()
+        tree = editor.query_one("#settings-theme-tree", Tree)
+        labels = [str(node.label) for node in tree.root.children]
+        assert labels == ["Your themes", "Built-in", "Shipped themes"]
+        assert tree.root.is_expanded
+        assert tree.root.children[0].is_expanded
+        assert not tree.root.children[2].is_expanded
+        assert [str(c.label) for c in tree.root.children[0].children] == ["ocean"]

--- a/Tests/UI/test_settings_theme_editor.py
+++ b/Tests/UI/test_settings_theme_editor.py
@@ -759,3 +759,69 @@ async def test_settings_theme_editor_new_copies_current_palette(tmp_path):
         assert editor.current_theme_name == "new_theme"
         assert editor.current_theme_data == before
         assert editor.is_dark_theme is False
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_save_confirms_before_overwriting_another_theme(tmp_path):
+    """TASK-31258: saving under a name that already exists on disk (and is not
+    the theme currently loaded from that file) asks first; cancel keeps the file."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    _write_user_theme(tmp_path, "ocean")
+    app = _isolated_editor_app_with_real_screens(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.on_new_theme()
+        await pilot.pause()
+        editor.query_one("#settings-theme-name", Input).value = "ocean"
+        await pilot.pause()
+        editor.on_save_theme()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmationDialog)
+        assert app.screen.confirm_label == "Overwrite"
+        await pilot.click("#cancel-button")
+        await pilot.pause()
+        assert 'primary = "#0099FF"' in (tmp_path / "ocean.toml").read_text()
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_saving_the_loaded_theme_does_not_confirm(tmp_path):
+    """TASK-31258: re-saving the theme you loaded from disk is an update, not an overwrite."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    _write_user_theme(tmp_path, "ocean")
+    app = _isolated_editor_app_with_real_screens(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.load_user_theme("ocean")
+        await pilot.pause()
+        editor.color_inputs["primary"].value = "#123456"
+        await pilot.pause()
+        editor.on_save_theme()
+        await pilot.pause()
+        assert not isinstance(app.screen, ConfirmationDialog)
+        assert "#123456" in (tmp_path / "ocean.toml").read_text()
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_export_confirms_before_overwriting(tmp_path, monkeypatch):
+    """TASK-31258: Export onto an existing file asks first."""
+    from pathlib import Path
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    downloads = tmp_path / "Downloads"
+    downloads.mkdir()
+    existing = downloads / "textual-dark_theme.toml"
+    existing.write_text("old", encoding="utf-8")
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app_with_real_screens(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.on_export_theme()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmationDialog)
+        assert app.screen.confirm_label == "Overwrite"
+        await pilot.click("#cancel-button")
+        await pilot.pause()
+        assert existing.read_text(encoding="utf-8") == "old"

--- a/Tests/UI/test_settings_theme_editor.py
+++ b/Tests/UI/test_settings_theme_editor.py
@@ -637,3 +637,27 @@ async def test_settings_theme_editor_set_launch_default_requires_saved_theme(
         editor.on_set_launch_default()
         await pilot.pause()
         assert written == [("general", "default_theme", "ocean")]
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_remount_after_apply_restores_palette(tmp_path):
+    """TASK-31252: app.theme == 'custom_<name>' must load, not blank the editor."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.on_new_theme()
+        await pilot.pause()
+        editor.color_inputs["primary"].value = "#123456"
+        await pilot.pause()
+        editor.on_apply_theme()
+        await pilot.pause()
+        assert app.theme == "custom_new_theme"
+
+        editor._initialize_editor()  # what a remount does
+        await pilot.pause()
+        assert editor.current_theme_name == "new_theme"
+        assert editor.query_one("#settings-theme-name", Input).value == "new_theme"
+        assert editor.color_inputs["primary"].value.upper() == "#123456"
+        assert editor.color_inputs["background"].value != ""

--- a/Tests/UI/test_settings_theme_editor.py
+++ b/Tests/UI/test_settings_theme_editor.py
@@ -586,3 +586,54 @@ async def test_settings_theme_editor_delete_keeps_app_theme(tmp_path):
         await pilot.pause()
         assert app.theme == "textual-light"
         assert editor.current_theme_name == "textual-dark"
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_save_registers_theme_with_app(tmp_path):
+    """TASK-31250: Save registers the theme so Appearance/palette can offer it."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.on_new_theme()
+        await pilot.pause()
+        editor.query_one("#settings-theme-name", Input).value = "ocean"
+        await pilot.pause()
+        editor.on_save_theme()
+        await pilot.pause()
+        assert "ocean" in app.available_themes
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_set_launch_default_requires_saved_theme(
+    tmp_path, monkeypatch
+):
+    """TASK-31250: unsaved -> warning; saved -> general.default_theme written."""
+    import tldw_chatbook.config as config_module
+
+    written: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(
+        config_module,
+        "save_setting_to_cli_config",
+        lambda section, key, value: written.append((section, key, value)) or True,
+    )
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.on_new_theme()
+        await pilot.pause()
+        editor.query_one("#settings-theme-name", Input).value = "ocean"
+        await pilot.pause()
+        editor.on_set_launch_default()
+        await pilot.pause()
+        assert "Save the theme first" in app.notify.call_args.args[0]
+        assert written == []
+
+        editor.on_save_theme()
+        await pilot.pause()
+        editor.on_set_launch_default()
+        await pilot.pause()
+        assert written == [("general", "default_theme", "ocean")]

--- a/Tests/UI/test_settings_theme_editor.py
+++ b/Tests/UI/test_settings_theme_editor.py
@@ -509,3 +509,37 @@ async def test_settings_theme_editor_new_confirms_before_discarding_edits(tmp_pa
         assert editor.current_theme_name == "new_theme"
         message = app.notify.call_args.args[0]
         assert message == "Creating new theme"
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_name_box_drives_apply_save_reset_delete(tmp_path):
+    """TASK-31251: New -> rename -> Apply/Save/Reset/Delete all use the typed name."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    app = _isolated_editor_app_with_real_screens(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.on_new_theme()
+        await pilot.pause()
+        name_input = editor.query_one("#settings-theme-name", Input)
+        name_input.value = "ocean"
+        await pilot.pause()
+        assert editor.current_theme_name == "ocean"
+
+        editor.on_apply_theme()
+        await pilot.pause()
+        assert app.notify.call_args.args[0] == "Theme 'ocean' applied"
+
+        editor.on_save_theme()
+        await pilot.pause()
+        assert (tmp_path / "ocean.toml").exists()
+        assert editor.current_theme_name == "ocean"
+
+        editor.on_reset_theme()
+        await pilot.pause()
+        assert name_input.value == "ocean"
+
+        editor.on_delete_theme()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmationDialog)
+        assert "ocean" in app.screen.message

--- a/Tests/UI/test_settings_theme_editor.py
+++ b/Tests/UI/test_settings_theme_editor.py
@@ -888,3 +888,116 @@ async def test_settings_theme_editor_load_theme_keeps_set_colours_exact(tmp_path
         assert editor.color_inputs["primary"].value == "#9966FF"
         # Unset colours are still resolved, not left blank.
         assert editor.color_inputs["background"].value.startswith("#")
+
+
+# ---------------------------------------------------------------------------
+# PR #2375 review follow-ups (Qodo).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_cleared_name_blocks_actions_instead_of_using_stale_name(tmp_path):
+    """Qodo #6: an emptied Name box must not let Apply/Export/Delete/Set default
+    act on the previously loaded name."""
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    _write_user_theme(tmp_path, "ocean")
+    app = _isolated_editor_app_with_real_screens(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.load_user_theme("ocean")
+        await pilot.pause()
+        editor.query_one("#settings-theme-name", Input).value = "   "
+        await pilot.pause()
+        assert editor.current_theme_name == ""
+
+        for handler in (
+            editor.on_apply_theme,
+            editor.on_export_theme,
+            editor.on_delete_theme,
+            editor.on_set_launch_default,
+        ):
+            app.notify.reset_mock()
+            handler()
+            await pilot.pause()
+            assert app.notify.call_args.args[0] == "Please enter a theme name", handler.__name__
+            assert not isinstance(app.screen, ConfirmationDialog), handler.__name__
+        assert (tmp_path / "ocean.toml").exists()
+        assert "custom_" not in " ".join(app.available_themes)
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_set_launch_default_validates_name_and_reports_write_failure(
+    tmp_path, monkeypatch
+):
+    """Qodo #2 + #7: a traversal-shaped name is rejected before any path check, and
+    a failed config write is reported as an error, not success."""
+    import tldw_chatbook.config as config_module
+
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    _write_user_theme(tmp_path, "ocean")
+    app = _isolated_editor_app(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        editor.load_user_theme("ocean")
+        await pilot.pause()
+
+        editor.current_theme_name = "../evil"
+        editor.on_set_launch_default()
+        await pilot.pause()
+        assert "Invalid theme name" in app.notify.call_args.args[0]
+
+        editor.current_theme_name = "ocean"
+        monkeypatch.setattr(config_module, "save_setting_to_cli_config", lambda *a, **k: False)
+        editor.on_set_launch_default()
+        await pilot.pause()
+        message, kwargs = app.notify.call_args.args[0], app.notify.call_args.kwargs
+        assert "Could not save" in message
+        assert kwargs.get("severity") == "error"
+
+
+@pytest.mark.asyncio
+async def test_settings_theme_editor_delete_unregisters_and_restores_shadowed_shipped_theme(
+    tmp_path, monkeypatch
+):
+    """Qodo #9: deleting a saved theme drops its runtime registration (so Appearance
+    and the palette stop offering it), restores a shadowed shipped theme, and clears
+    it as the launch default."""
+    import tldw_chatbook.config as config_module
+    from tldw_chatbook.css.Themes.themes import ALL_THEMES, create_theme_from_dict
+
+    shipped = next(t for t in ALL_THEMES if hasattr(t, "name"))
+    editor = SettingsThemeEditor()
+    editor.custom_themes_path = tmp_path
+    _write_user_theme(tmp_path, "ocean")
+    _write_user_theme(tmp_path, shipped.name)
+    written: list[tuple] = []
+    monkeypatch.setattr(config_module, "get_cli_setting", lambda section, key, default=None: "ocean")
+    monkeypatch.setattr(
+        config_module, "save_setting_to_cli_config", lambda *a: written.append(a) or True
+    )
+    app = _isolated_editor_app_with_real_screens(editor)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        # Registered as the app would at startup / after Save.
+        app.register_theme(create_theme_from_dict("ocean", {"primary": "#9966FF"}))
+        app.register_theme(create_theme_from_dict(shipped.name, {"primary": "#123456"}))
+
+        editor.load_user_theme("ocean")
+        await pilot.pause()
+        editor.on_delete_theme()
+        await pilot.pause()
+        await pilot.click("#confirm-button")
+        await pilot.pause()
+        assert "ocean" not in app.available_themes
+        assert ("general", "default_theme", "textual-dark") in written
+
+        editor.load_user_theme(shipped.name)
+        await pilot.pause()
+        editor.on_delete_theme()
+        await pilot.pause()
+        await pilot.click("#confirm-button")
+        await pilot.pause()
+        restored = app.available_themes[shipped.name]
+        assert str(getattr(restored, "primary", "")).upper() != "#123456"

--- a/Tests/UI/test_settings_theme_editor.py
+++ b/Tests/UI/test_settings_theme_editor.py
@@ -849,7 +849,7 @@ async def test_settings_theme_editor_preview_repaints_from_edits_without_apply(t
 
 @pytest.mark.asyncio
 async def test_settings_theme_editor_one_primary_button_per_action_row(tmp_path):
-    """TASK-31261: Apply is the one primary action; New and Generate were also
+    """TASK-31280: Apply is the one primary action; New and Generate were also
     variant=primary, so three buttons competed for the eye."""
     from textual.widgets import Button
 

--- a/Tests/UI/test_settings_theme_editor.py
+++ b/Tests/UI/test_settings_theme_editor.py
@@ -661,3 +661,30 @@ async def test_settings_theme_editor_remount_after_apply_restores_palette(tmp_pa
         assert editor.query_one("#settings-theme-name", Input).value == "new_theme"
         assert editor.color_inputs["primary"].value.upper() == "#123456"
         assert editor.color_inputs["background"].value != ""
+
+
+def _hue_deg(hex_value: str) -> float:
+    from textual.color import Color
+
+    return Color.parse(hex_value).hsl.h * 360
+
+
+def _hue_distance(a: float, b: float) -> float:
+    delta = abs(a - b) % 360
+    return min(delta, 360 - delta)
+
+
+@pytest.mark.parametrize("primary", ["#9966FF", "#00CC66", "#FF9900"])
+def test_generate_from_primary_keeps_the_primary_hue(primary):
+    """TASK-31253: Color.hsl hue is 0-1; the generator treated it as degrees,
+    so every primary produced a red secondary and a cyan accent."""
+    from textual.color import Color
+
+    editor = SettingsThemeEditor()  # is_dark_theme defaults to True
+    palette = editor._generate_theme_from_primary(Color.parse(primary))
+
+    base = _hue_deg(primary)
+    for key in ("secondary", "background", "surface", "panel"):
+        assert _hue_distance(_hue_deg(palette[key]), base) <= 30, (key, palette[key])
+    assert 150 <= _hue_distance(_hue_deg(palette["accent"]), base) <= 180
+    assert all(value == value.upper() for value in palette.values()), palette

--- a/Tests/UI/test_settings_theme_editor_render.py
+++ b/Tests/UI/test_settings_theme_editor_render.py
@@ -1,4 +1,4 @@
-"""Painted-frame checks for the Settings theme editor (TASK-31254, TASK-31260).
+"""Painted-frame checks for the Settings theme editor (TASK-31254, TASK-31279).
 
 These tests load the PRODUCTION bundle (`tldw_cli_modular.tcss`) on a bare
 harness, because the defects live in app-level CSS: a bare `App` with widget
@@ -94,7 +94,7 @@ async def test_invalid_hex_does_not_paint_a_black_swatch(tmp_path):
 
 @pytest.mark.asyncio
 async def test_compact_mode_keeps_every_button_inside_the_card(tmp_path):
-    """TASK-31260: below the compact-workbench width the detail pane is ~45
+    """TASK-31279: below the compact-workbench width the detail pane is ~45
     cells; four 16-cell buttons overflowed and Delete/Export were clipped."""
     app = _BundleHarness(
         tmp_path,

--- a/Tests/UI/test_settings_theme_editor_render.py
+++ b/Tests/UI/test_settings_theme_editor_render.py
@@ -1,0 +1,92 @@
+"""Painted-frame checks for the Settings theme editor (TASK-31254, TASK-31260).
+
+These tests load the PRODUCTION bundle (`tldw_cli_modular.tcss`) on a bare
+harness, because the defects live in app-level CSS: a bare `App` with widget
+DEFAULT_CSS only cannot see them. Frame reads go through the real compositor
+(`Screen._compositor.render_strips()`), mirroring
+`Tests/UI/test_checkbox_height_render.py`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Button
+
+from tldw_chatbook.Widgets.settings_theme_editor import SettingsThemeEditor
+
+_CSS_DIR = Path(__file__).resolve().parents[2] / "tldw_chatbook" / "css"
+_BUNDLED_CSS_PATH = _CSS_DIR / "tldw_cli_modular.tcss"
+# TASK-25812 split the Settings-owned rules (e.g. `.settings-compact-input`,
+# `.settings-input-row`) out of the bundle into a per-screen sheet the app
+# loads with it; without it every Input here keeps Textual's tall border.
+_SETTINGS_SHEET_PATH = _CSS_DIR / "screen_agentic_settings.tcss"
+for _sheet in (_BUNDLED_CSS_PATH, _SETTINGS_SHEET_PATH):
+    assert _sheet.is_file(), f"Production CSS sheet not found at {_sheet}"
+
+
+def _rendered_text(app: App) -> str:
+    """Join every compositor strip's segment text into one blob (post-CSS, post-clip)."""
+    strips = app.screen._compositor.render_strips()
+    return "\n".join("".join(segment.text for segment in strip) for strip in strips)
+
+
+class _BundleHarness(App):
+    """The editor under the real app stylesheet, inside a plain container."""
+
+    CSS_PATH = [str(_BUNDLED_CSS_PATH), str(_SETTINGS_SHEET_PATH)]
+    AUTO_FOCUS = None
+
+    def __init__(self, tmp_path: Path, *, container_id: str = "host", container_classes: str = "", width: str = "100%"):
+        super().__init__()
+        self._tmp_path = tmp_path
+        self._container_id = container_id
+        self._container_classes = container_classes
+        self._width = width
+
+    def compose(self) -> ComposeResult:
+        editor = SettingsThemeEditor(id="settings-theme-editor")
+        editor.custom_themes_path = self._tmp_path
+        host = Vertical(editor, id=self._container_id, classes=self._container_classes)
+        host.styles.width = self._width
+        yield host
+
+
+@pytest.mark.asyncio
+async def test_swatch_paints_hex_text_and_dark_toggle_paints_state(tmp_path):
+    """TASK-31254: the colour swatch shows its hex, the Dark toggle is not a
+    clipped border, and the preset target is named in visible text."""
+    app = _BundleHarness(tmp_path)
+    async with app.run_test(size=(120, 70)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(SettingsThemeEditor)
+        editor.color_inputs["primary"].value = "#9966FF"
+        for _ in range(3):
+            await pilot.pause()
+        painted = _rendered_text(app)
+        # once in the Input, once in the swatch
+        assert painted.count("#9966FF") >= 2, painted
+        dark_row = next(line for line in painted.splitlines() if "Dark theme" in line)
+        assert "▔" not in dark_row, dark_row
+        assert "On" in dark_row or "Off" in dark_row, dark_row
+        assert "Presets fill" in painted
+
+
+@pytest.mark.asyncio
+async def test_invalid_hex_does_not_paint_a_black_swatch(tmp_path):
+    """TASK-31254: an invalid value marks the input, keeps the last colour and
+    says 'invalid' in the swatch instead of silently turning black."""
+    app = _BundleHarness(tmp_path)
+    async with app.run_test(size=(120, 70)) as pilot:
+        await pilot.pause()
+        editor = app.query_one(SettingsThemeEditor)
+        editor.color_inputs["primary"].value = "#GGGGGG"
+        for _ in range(3):
+            await pilot.pause()
+        assert editor.color_inputs["primary"].has_class("settings-invalid-input")
+        swatch = editor.color_swatches["primary"]
+        assert str(swatch.styles.background.hex).upper() != "#000000"
+        assert "invalid" in _rendered_text(app).lower()

--- a/Tests/UI/test_settings_theme_editor_render.py
+++ b/Tests/UI/test_settings_theme_editor_render.py
@@ -90,3 +90,25 @@ async def test_invalid_hex_does_not_paint_a_black_swatch(tmp_path):
         swatch = editor.color_swatches["primary"]
         assert str(swatch.styles.background.hex).upper() != "#000000"
         assert "invalid" in _rendered_text(app).lower()
+
+
+@pytest.mark.asyncio
+async def test_compact_mode_keeps_every_button_inside_the_card(tmp_path):
+    """TASK-31260: below the compact-workbench width the detail pane is ~45
+    cells; four 16-cell buttons overflowed and Delete/Export were clipped."""
+    app = _BundleHarness(
+        tmp_path,
+        container_id="settings-workbench",
+        container_classes="settings-workbench-compact",
+        width="45",
+    )
+    async with app.run_test(size=(110, 36)) as pilot:
+        await pilot.pause()
+        host = app.query_one("#settings-workbench")
+        editor = app.query_one(SettingsThemeEditor)
+        buttons = list(editor.query(Button))
+        assert buttons, "editor exposes no buttons?"
+        for button in buttons:
+            region = button.region
+            assert region.width > 0, button.id
+            assert region.right <= host.region.right, (button.id, region, host.region)

--- a/Tests/UI/test_theme_startup_registration.py
+++ b/Tests/UI/test_theme_startup_registration.py
@@ -1,0 +1,55 @@
+"""Saved user themes register at application startup (TASK-31250, PR #2375 review #5).
+
+Drives the real ``TldwCli`` startup path via the shared factory: the loader is
+unit-tested elsewhere, this pins the ``on_mount`` wiring and the
+``general.default_theme`` selection through the public boundary. Removing the
+registration loop in ``app.py`` makes both tests fail.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import tldw_chatbook.config as config_module
+from Tests.UI.app_factory import _build_test_app
+
+
+def _write_theme(themes_dir: Path, name: str, primary: str) -> None:
+    themes_dir.mkdir(parents=True, exist_ok=True)
+    (themes_dir / f"{name}.toml").write_text(
+        f'[theme]\nname = "{name}"\ndark = true\n[colors]\nprimary = "{primary}"\n',
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_startup_registers_saved_user_themes(tmp_path, monkeypatch):
+    themes_dir = tmp_path / "themes"
+    _write_theme(themes_dir, "ocean_startup_probe", "#9966FF")
+    monkeypatch.setattr(config_module, "get_user_themes_dir", lambda: themes_dir)
+
+    app = _build_test_app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        assert "ocean_startup_probe" in app.available_themes
+
+
+@pytest.mark.asyncio
+async def test_startup_applies_saved_theme_named_as_default(tmp_path, monkeypatch):
+    themes_dir = tmp_path / "themes"
+    _write_theme(themes_dir, "ocean_default_probe", "#9966FF")
+    monkeypatch.setattr(config_module, "get_user_themes_dir", lambda: themes_dir)
+
+    # The factory's per-test config sandbox is what get_cli_setting reads at
+    # mount, so write the default through the real setter (see the factory's
+    # docstring on config_overrides vs save_setting_to_cli_config).
+    assert config_module.save_setting_to_cli_config(
+        "general", "default_theme", "ocean_default_probe"
+    )
+
+    app = _build_test_app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        assert app.theme == "ocean_default_probe"

--- a/Tests/Utils/test_user_theme_loader.py
+++ b/Tests/Utils/test_user_theme_loader.py
@@ -1,0 +1,33 @@
+"""TASK-31250: saved user themes (~/.config/tldw_cli/themes/*.toml) load as Theme objects."""
+
+from pathlib import Path
+
+from tldw_chatbook.css.Themes.themes import load_user_themes
+
+
+def _write(dir_: Path, name: str, body: str) -> None:
+    (dir_ / f"{name}.toml").write_text(body, encoding="utf-8")
+
+
+def test_load_user_themes_reads_good_files_and_skips_bad_ones(tmp_path):
+    _write(
+        tmp_path,
+        "ocean",
+        '[theme]\nname = "ocean"\ndark = true\n[colors]\nprimary = "#9966FF"\n',
+    )
+    _write(tmp_path, "broken", "this is not toml = = =\n")
+    # Textual's Theme requires a primary colour; a file without one is
+    # unusable and must be skipped like a parse error, not crash startup.
+    _write(tmp_path, "noprimary", '[theme]\nname = "bare"\n')
+
+    themes = load_user_themes(tmp_path)
+
+    assert [t.name for t in themes] == ["ocean"]
+    ocean = next(t for t in themes if t.name == "ocean")
+    primary = ocean.primary
+    assert (primary.hex if hasattr(primary, "hex") else str(primary)).upper() == "#9966FF"
+    assert ocean.dark is True
+
+
+def test_load_user_themes_missing_dir_returns_empty(tmp_path):
+    assert load_user_themes(tmp_path / "nope") == []

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -11023,3 +11023,36 @@ the invariant. A newly red old test may be revealing missing state in its
 oracle, not a compatibility regression. Then run a cross-file gate that covers
 both the new invariant and the existing projection tests; the isolated new
 tests alone cannot expose disagreements with older test models.
+
+---
+
+## A bundle-only render harness misses the per-screen sheets since the agentic split
+
+**TASK-31254, 2026-09-04.** A painted-frame test for the Settings theme editor
+loaded `tldw_cli_modular.tcss` on a bare harness (the `test_checkbox_height_render.py`
+pattern) and every colour `Input` rendered as a clipped tall border, so the
+swatch-text assertion could not pass even after the fix. The bundle no longer
+carries `.settings-compact-input` / `.settings-input-row`: TASK-25812 split the
+Settings-owned rules out of `components/_agentic_terminal.tcss` into
+`css/screen_agentic_settings.tcss`, a per-screen sheet the app loads alongside the
+bundle. An earlier deterministic sweep of the bundle had reported those classes as
+"no rule", which was true of the bundle and false of the app.
+
+**What to do.** A harness that claims production CSS must register the bundle
+AND the owning screen's split sheet (`screen_agentic_console|library|settings.tcss`),
+in the app's order. When a bundle grep says a Settings/Console/Library class has no
+rule, grep the split sheets before concluding the state is unstyled.
+
+---
+
+## Textual's `Color.hsl` hue is 0-1, not degrees
+
+**TASK-31253, 2026-09-04.** "Generate from Primary" produced a red secondary and a
+cyan accent for every primary colour (live: `#9966FF` -> `#e83735` / `#65fdff`).
+`textual.color.Color.hsl` returns `HSL(h, s, l)` with `h` in the 0-1 range; the
+generator fed it to a helper working in degrees, so hue was always in `[0, 1)`.
+The unit test that caught it asserts hue *distance* between generated colours and
+the primary, which is the assertion a palette generator needs.
+
+**What to do.** Multiply `hsl.h` by 360 before any degree-based maths, and test
+generated palettes by hue distance for several primaries, not by eyeballing one.

--- a/backlog/tasks/task-31250 - Theme-editor---saved-user-themes-are-never-loaded-so-Save-cannot-make-a-theme-the-launch-theme.md
+++ b/backlog/tasks/task-31250 - Theme-editor---saved-user-themes-are-never-loaded-so-Save-cannot-make-a-theme-the-launch-theme.md
@@ -1,0 +1,47 @@
+---
+id: TASK-31250
+title: Theme editor - saved user themes are never loaded, so Save cannot make a theme
+  the launch theme
+status: To Do
+created_date: 2026-09-04 05:23
+assignee:
+- '@claude'
+labels:
+- ui
+- settings
+- theme-editor
+- ux-review-2026-09
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The editor's Save writes ~/.config/tldw_cli/themes/<name>.toml, but the only code that ever reads that directory is the editor widget itself. app.py registers ALL_THEMES at startup, Appearance's Theme options and the palette's 'Theme: Switch to' list shipped themes only. Setting general.default_theme to a saved theme silently falls back to textual-dark while Appearance displays 'Current: <name>'. The Save hint ('stores the theme for future sessions') and Docs/User_Guide/settings.md (Interface - Theme, Quirks) promise the opposite. Reproduced live. Evidence: live walkthrough of origin/dev 59d987015d on 2026-09-03 (isolated profile, tmux 235x52) plus a dual-agent impeccable critique; snapshot .impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md. Heuristic score 17/40.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Every readable *.toml under the active profile's themes directory is registered as an app theme at startup; an unreadable file is skipped with a logged warning and does not block startup
+- [ ] #2 A theme saved in the editor is registered immediately after Save (no restart) and can be selected in Appearance > Theme and in the command palette 'Theme: Switch to' list
+- [ ] #3 Launching with general.default_theme set to a saved theme applies that theme
+- [ ] #4 The editor offers a way to set the current saved theme as the launch default (writes general.default_theme) and the Save hint states what Save does and does not do
+- [ ] #5 Docs/User_Guide/settings.md Theme section and the 'theme didn't change after saving' quirk describe the new behaviour, with the Verified-against stamp updated
+- [ ] #6 Tests cover: startup registration from a temp themes dir, skip-on-bad-file, Appearance options include the saved theme
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-31250 - Theme-editor---saved-user-themes-are-never-loaded-so-Save-cannot-make-a-theme-the-launch-theme.md
+++ b/backlog/tasks/task-31250 - Theme-editor---saved-user-themes-are-never-loaded-so-Save-cannot-make-a-theme-the-launch-theme.md
@@ -2,7 +2,7 @@
 id: TASK-31250
 title: Theme editor - saved user themes are never loaded, so Save cannot make a theme
   the launch theme
-status: To Do
+status: Done
 created_date: 2026-09-04 05:23
 assignee:
 - '@claude'
@@ -12,6 +12,7 @@ labels:
 - theme-editor
 - ux-review-2026-09
 priority: high
+updated_date: 2026-09-04 06:06
 ---
 
 ## Description
@@ -22,20 +23,19 @@ The editor's Save writes ~/.config/tldw_cli/themes/<name>.toml, but the only cod
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Every readable *.toml under the active profile's themes directory is registered as an app theme at startup; an unreadable file is skipped with a logged warning and does not block startup
-- [ ] #2 A theme saved in the editor is registered immediately after Save (no restart) and can be selected in Appearance > Theme and in the command palette 'Theme: Switch to' list
-- [ ] #3 Launching with general.default_theme set to a saved theme applies that theme
-- [ ] #4 The editor offers a way to set the current saved theme as the launch default (writes general.default_theme) and the Save hint states what Save does and does not do
-- [ ] #5 Docs/User_Guide/settings.md Theme section and the 'theme didn't change after saving' quirk describe the new behaviour, with the Verified-against stamp updated
-- [ ] #6 Tests cover: startup registration from a temp themes dir, skip-on-bad-file, Appearance options include the saved theme
+- [x] #1 Every readable *.toml under the active profile's themes directory is registered as an app theme at startup; an unreadable file is skipped with a logged warning and does not block startup
+- [x] #2 A theme saved in the editor is registered immediately after Save (no restart) and can be selected in Appearance > Theme and in the command palette 'Theme: Switch to' list
+- [x] #3 Launching with general.default_theme set to a saved theme applies that theme
+- [x] #4 The editor offers a way to set the current saved theme as the launch default (writes general.default_theme) and the Save hint states what Save does and does not do
+- [x] #5 Docs/User_Guide/settings.md Theme section and the 'theme didn't change after saving' quirk describe the new behaviour, with the Verified-against stamp updated
+- [x] #6 Tests cover: startup registration from a temp themes dir, skip-on-bad-file, Appearance options include the saved theme
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+themes.load_user_themes() reads the profile's themes/*.toml (unreadable or primary-less files skipped with a warning); app startup registers them after ALL_THEMES; ThemeProvider lists app.available_themes; Appearance options add '<Name> (saved)' from app_instance.available_themes; config.get_user_themes_dir() is the single path home; the editor registers on Save and gained 'Set as launch default' (writes general.default_theme, warns if unsaved). Docs/User_Guide/settings.md Theme section, recipe 3 and quirk rewritten. Tests: Tests/Utils/test_user_theme_loader.py, editor save/registration + set-default tests, hub options test.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-31251 - Theme-editor---Name-box-is-write-only-so-Apply-Export-Reset-and-Delete-act-on-a-stale-name.md
+++ b/backlog/tasks/task-31251 - Theme-editor---Name-box-is-write-only-so-Apply-Export-Reset-and-Delete-act-on-a-stale-name.md
@@ -1,0 +1,45 @@
+---
+id: TASK-31251
+title: Theme editor - Name box is write-only, so Apply, Export, Reset and Delete act
+  on a stale name
+status: To Do
+created_date: 2026-09-04 05:23
+assignee:
+- '@claude'
+labels:
+- ui
+- settings
+- theme-editor
+- ux-review-2026-09
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+#settings-theme-name has no Input.Changed handler. Save reads the box, but Apply (toast + registered name), Export (file name), Reset (file lookup) and Delete (file lookup) read self.current_theme_name, which only changes on tree selection, New or Clone. Live: New -> rename to 'ocean' -> Apply says "Theme 'new_theme' applied"; Save writes ocean.toml; Reset reverts the Name box to new_theme and reports success; Delete says "No saved custom theme named 'new_theme'". Evidence: live walkthrough of origin/dev 59d987015d on 2026-09-03 (isolated profile, tmux 235x52) plus a dual-agent impeccable critique; snapshot .impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md. Heuristic score 17/40.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Editing the Name box updates the name used by Apply, Export, Reset and Delete without pressing Save
+- [ ] #2 After Save, Reset reloads the saved file under the saved name and the Name box keeps that name
+- [ ] #3 Apply's toast and the registered runtime theme use the name currently shown in the Name box
+- [ ] #4 A regression test walks New -> rename -> Apply -> Save -> Reset -> Delete and asserts the name at each step
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-31251 - Theme-editor---Name-box-is-write-only-so-Apply-Export-Reset-and-Delete-act-on-a-stale-name.md
+++ b/backlog/tasks/task-31251 - Theme-editor---Name-box-is-write-only-so-Apply-Export-Reset-and-Delete-act-on-a-stale-name.md
@@ -2,7 +2,7 @@
 id: TASK-31251
 title: Theme editor - Name box is write-only, so Apply, Export, Reset and Delete act
   on a stale name
-status: To Do
+status: Done
 created_date: 2026-09-04 05:23
 assignee:
 - '@claude'
@@ -12,6 +12,7 @@ labels:
 - theme-editor
 - ux-review-2026-09
 priority: high
+updated_date: 2026-09-04 06:06
 ---
 
 ## Description
@@ -22,18 +23,17 @@ priority: high
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Editing the Name box updates the name used by Apply, Export, Reset and Delete without pressing Save
-- [ ] #2 After Save, Reset reloads the saved file under the saved name and the Name box keeps that name
-- [ ] #3 Apply's toast and the registered runtime theme use the name currently shown in the Name box
-- [ ] #4 A regression test walks New -> rename -> Apply -> Save -> Reset -> Delete and asserts the name at each step
+- [x] #1 Editing the Name box updates the name used by Apply, Export, Reset and Delete without pressing Save
+- [x] #2 After Save, Reset reloads the saved file under the saved name and the Name box keeps that name
+- [x] #3 Apply's toast and the registered runtime theme use the name currently shown in the Name box
+- [x] #4 A regression test walks New -> rename -> Apply -> Save -> Reset -> Delete and asserts the name at each step
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Added @on(Input.Changed, '#settings-theme-name') keeping current_theme_name in step with the box; Reset of a renamed never-saved theme now warns 'No saved version ... to reset to' instead of reverting the box and claiming success. Regression test walks New -> rename -> Apply -> Save -> Reset -> Delete.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-31252 - Theme-editor---returning-after-Apply-shows-a-blank-palette-and-a-stale-unsaved-flag.md
+++ b/backlog/tasks/task-31252 - Theme-editor---returning-after-Apply-shows-a-blank-palette-and-a-stale-unsaved-flag.md
@@ -1,0 +1,47 @@
+---
+id: TASK-31252
+title: Theme editor - returning after Apply shows a blank palette and a stale unsaved
+  flag
+status: To Do
+created_date: 2026-09-04 05:23
+dependencies:
+- TASK-31251
+assignee:
+- '@claude'
+labels:
+- ui
+- settings
+- theme-editor
+- ux-review-2026-09
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Apply registers the theme as custom_<name> and sets app.theme to it. Leaving the category and coming back remounts the editor, which calls load_theme(self.app.theme); 'custom_<name>' matches neither the built-in branch nor ALL_THEMES, so current_theme_data stays empty: ten inputs show the #RRGGBB placeholder, the Name box shows custom_new_theme, and the inspector still says 'Unsaved theme changes: Yes' because the screen's flag is never reset on remount. Reproduced live. Keep the mount-posts-no-status guard (is_modified init=False) that prevents the recompose storm. Evidence: live walkthrough of origin/dev 59d987015d on 2026-09-03 (isolated profile, tmux 235x52) plus a dual-agent impeccable critique; snapshot .impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md. Heuristic score 17/40.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 After Apply, leaving and re-entering Theme shows the applied theme's name and all ten colours
+- [ ] #2 The inspector's 'Unsaved theme changes' row and the rail marker reflect the freshly mounted editor's real state
+- [ ] #3 test_theme_category_settles_without_recompose_storm and test_settings_theme_editor_mount_posts_no_modified_status still pass
+- [ ] #4 A regression test applies a theme, remounts the editor, and asserts the palette and the unsaved flag
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-31252 - Theme-editor---returning-after-Apply-shows-a-blank-palette-and-a-stale-unsaved-flag.md
+++ b/backlog/tasks/task-31252 - Theme-editor---returning-after-Apply-shows-a-blank-palette-and-a-stale-unsaved-flag.md
@@ -2,7 +2,7 @@
 id: TASK-31252
 title: Theme editor - returning after Apply shows a blank palette and a stale unsaved
   flag
-status: To Do
+status: Done
 created_date: 2026-09-04 05:23
 dependencies:
 - TASK-31251
@@ -14,6 +14,7 @@ labels:
 - theme-editor
 - ux-review-2026-09
 priority: high
+updated_date: 2026-09-04 06:06
 ---
 
 ## Description
@@ -24,18 +25,17 @@ Apply registers the theme as custom_<name> and sets app.theme to it. Leaving the
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 After Apply, leaving and re-entering Theme shows the applied theme's name and all ten colours
-- [ ] #2 The inspector's 'Unsaved theme changes' row and the rail marker reflect the freshly mounted editor's real state
-- [ ] #3 test_theme_category_settles_without_recompose_storm and test_settings_theme_editor_mount_posts_no_modified_status still pass
-- [ ] #4 A regression test applies a theme, remounts the editor, and asserts the palette and the unsaved flag
+- [x] #1 After Apply, leaving and re-entering Theme shows the applied theme's name and all ten colours
+- [x] #2 The inspector's 'Unsaved theme changes' row and the rail marker reflect the freshly mounted editor's real state
+- [x] #3 test_theme_category_settles_without_recompose_storm and test_settings_theme_editor_mount_posts_no_modified_status still pass
+- [x] #4 A regression test applies a theme, remounts the editor, and asserts the palette and the unsaved flag
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+_initialize_editor resolves app.theme 'custom_<name>' through app.available_themes and shows the user-facing name (Apply keeps the custom_ prefix so an edited shipped theme never clobbers the shipped registration). SettingsScreen._select_category clears theme_editor_modified when leaving Theme. Mount still posts no ThemeModifiedStatus (storm guard kept). Tests: editor remount test + screen dirty-flag test.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-31253 - Theme-editor---Generate-from-Primary-ignores-the-primary-hue-HSL-0-1-vs-degrees.md
+++ b/backlog/tasks/task-31253 - Theme-editor---Generate-from-Primary-ignores-the-primary-hue-HSL-0-1-vs-degrees.md
@@ -1,0 +1,43 @@
+---
+id: TASK-31253
+title: Theme editor - Generate from Primary ignores the primary hue (HSL 0-1 vs degrees)
+status: To Do
+created_date: 2026-09-04 05:23
+assignee:
+- '@claude'
+labels:
+- ui
+- settings
+- theme-editor
+- ux-review-2026-09
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+textual.color.Color.hsl returns hue in the 0-1 range; _generate_theme_from_primary passes it to _adjust_color, which treats hue as degrees. Every primary therefore yields a red secondary, a cyan accent and a reddish background. Live: primary #9966FF -> secondary #e83735, accent #65fdff, background #161212. Generated hex is also lowercase while every other path is uppercase. Evidence: live walkthrough of origin/dev 59d987015d on 2026-09-03 (isolated profile, tmux 235x52) plus a dual-agent impeccable critique; snapshot .impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md. Heuristic score 17/40.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Generate from Primary produces a secondary and background whose hue is within 30 degrees of the primary's hue, and an accent roughly complementary to it
+- [ ] #2 Generated colours are uppercase #RRGGBB like the rest of the editor
+- [ ] #3 A unit test checks the generated palette for a purple, a green and an orange primary
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-31253 - Theme-editor---Generate-from-Primary-ignores-the-primary-hue-HSL-0-1-vs-degrees.md
+++ b/backlog/tasks/task-31253 - Theme-editor---Generate-from-Primary-ignores-the-primary-hue-HSL-0-1-vs-degrees.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-31253
 title: Theme editor - Generate from Primary ignores the primary hue (HSL 0-1 vs degrees)
-status: To Do
+status: Done
 created_date: 2026-09-04 05:23
 assignee:
 - '@claude'
@@ -11,6 +11,7 @@ labels:
 - theme-editor
 - ux-review-2026-09
 priority: high
+updated_date: 2026-09-04 06:06
 ---
 
 ## Description
@@ -21,17 +22,16 @@ textual.color.Color.hsl returns hue in the 0-1 range; _generate_theme_from_prima
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Generate from Primary produces a secondary and background whose hue is within 30 degrees of the primary's hue, and an accent roughly complementary to it
-- [ ] #2 Generated colours are uppercase #RRGGBB like the rest of the editor
-- [ ] #3 A unit test checks the generated palette for a purple, a green and an orange primary
+- [x] #1 Generate from Primary produces a secondary and background whose hue is within 30 degrees of the primary's hue, and an accent roughly complementary to it
+- [x] #2 Generated colours are uppercase #RRGGBB like the rest of the editor
+- [x] #3 A unit test checks the generated palette for a purple, a green and an orange primary
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+hsl.h * 360 before the degree-based HSL helper; generated hex uppercased. Parametrised test over purple/green/orange primaries checks hue distance and complementary accent.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-31254 - Theme-editor---swatch-text-invalid-hex-state-preset-target-and-Dark-theme-checkbox-are-invisible.md
+++ b/backlog/tasks/task-31254 - Theme-editor---swatch-text-invalid-hex-state-preset-target-and-Dark-theme-checkbox-are-invisible.md
@@ -2,7 +2,7 @@
 id: TASK-31254
 title: Theme editor - swatch text, invalid-hex state, preset target and Dark-theme
   checkbox are invisible
-status: To Do
+status: Done
 created_date: 2026-09-04 05:23
 assignee:
 - '@claude'
@@ -12,6 +12,7 @@ labels:
 - theme-editor
 - ux-review-2026-09
 priority: high
+updated_date: 2026-09-04 06:06
 ---
 
 ## Description
@@ -22,19 +23,18 @@ Four states the code sets are never painted: .color-swatch and .color-preset-swa
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Each colour swatch shows its colour and hex text at the row's height
-- [ ] #2 An invalid hex value shows a visible invalid state on the input using the Settings invalid-input convention and the swatch does not silently turn black
-- [ ] #3 The colour row a preset will fill is named in visible text (not only a CSS class)
-- [ ] #4 The Dark theme toggle's on/off state is readable in the row; the same fix or a shared rule covers Appearance's toggle rows
-- [ ] #5 CSS bundle rebuilt via build_css.py and both bundle files committed; a compositor-text test asserts the swatch hex and the toggle state are painted
+- [x] #1 Each colour swatch shows its colour and hex text at the row's height
+- [x] #2 An invalid hex value shows a visible invalid state on the input using the Settings invalid-input convention and the swatch does not silently turn black
+- [x] #3 The colour row a preset will fill is named in visible text (not only a CSS class)
+- [x] #4 The Dark theme toggle's on/off state is readable in the row; the same fix or a shared rule covers Appearance's toggle rows
+- [x] #5 CSS bundle rebuilt via build_css.py and both bundle files committed; a compositor-text test asserts the swatch hex and the toggle state are painted
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Swatches lose their border (a 1-row bordered Static has no content row) and show the hex on the colour; preset swatches keep a focus outline; invalid input uses Settings' settings-invalid-input class and the swatch reads 'invalid' instead of turning black; the Dark toggle is one row with an On/Off text label (TASK-18960 escape idiom); the preset target is a visible 'Presets fill' Select. Bundle rebuilt. Render tests load the bundle plus screen_agentic_settings.tcss (TASK-25812 split) in Tests/UI/test_settings_theme_editor_render.py.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-31254 - Theme-editor---swatch-text-invalid-hex-state-preset-target-and-Dark-theme-checkbox-are-invisible.md
+++ b/backlog/tasks/task-31254 - Theme-editor---swatch-text-invalid-hex-state-preset-target-and-Dark-theme-checkbox-are-invisible.md
@@ -1,0 +1,46 @@
+---
+id: TASK-31254
+title: Theme editor - swatch text, invalid-hex state, preset target and Dark-theme
+  checkbox are invisible
+status: To Do
+created_date: 2026-09-04 05:23
+assignee:
+- '@claude'
+labels:
+- ui
+- settings
+- theme-editor
+- ux-review-2026-09
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Four states the code sets are never painted: .color-swatch and .color-preset-swatch are 1 row tall with a solid border, so only the top border glyphs render (hex text and the 'Invalid' label never show; presets are '[]' glyphs over a tint); .invalid-color and .selected have no rule in any stylesheet (Settings' convention is settings-invalid-input); the Dark theme Checkbox sits in a 1-row settings-input-row and is clipped to its top border, so its checked state cannot be read (Appearance's Switches are clipped the same way). Live: typing #GGGGGG turned the swatch black and nothing else changed. Evidence: live walkthrough of origin/dev 59d987015d on 2026-09-03 (isolated profile, tmux 235x52) plus a dual-agent impeccable critique; snapshot .impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md. Heuristic score 17/40.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Each colour swatch shows its colour and hex text at the row's height
+- [ ] #2 An invalid hex value shows a visible invalid state on the input using the Settings invalid-input convention and the swatch does not silently turn black
+- [ ] #3 The colour row a preset will fill is named in visible text (not only a CSS class)
+- [ ] #4 The Dark theme toggle's on/off state is readable in the row; the same fix or a shared rule covers Appearance's toggle rows
+- [ ] #5 CSS bundle rebuilt via build_css.py and both bundle files committed; a compositor-text test asserts the swatch hex and the toggle state are painted
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-31255 - Theme-editor---selecting-a-built-in-tree-leaf-re-themes-the-app-shipped-leaves-don-t-Delete-forces-textual-dark.md
+++ b/backlog/tasks/task-31255 - Theme-editor---selecting-a-built-in-tree-leaf-re-themes-the-app-shipped-leaves-don-t-Delete-forces-textual-dark.md
@@ -1,0 +1,44 @@
+---
+id: TASK-31255
+title: Theme editor - selecting a built-in tree leaf re-themes the app, shipped leaves
+  don't, Delete forces textual-dark
+status: To Do
+created_date: 2026-09-04 05:24
+assignee:
+- '@claude'
+labels:
+- ui
+- settings
+- theme-editor
+- ux-review-2026-09
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+load_theme sets self.app.theme immediately when the leaf is textual-dark or textual-light but not for the 58 shipped themes, so browsing the tree changes the running app inconsistently and there is no undo. _delete_user_theme ends with load_theme('textual-dark'), which re-themes the whole app after a dialog that only promised to remove a file. Live: textual-dark leaf re-themed the app; agentic_terminal did not. Evidence: live walkthrough of origin/dev 59d987015d on 2026-09-03 (isolated profile, tmux 235x52) plus a dual-agent impeccable critique; snapshot .impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md. Heuristic score 17/40.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Selecting any tree leaf loads it for editing without changing the running app's theme; Apply is the only editor action that changes app.theme
+- [ ] #2 After Delete the editor reloads the previously selected theme (or the first available one) and app.theme is unchanged
+- [ ] #3 The existing delete tests are updated to assert the reloaded editor state instead of a forced textual-dark app theme
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-31255 - Theme-editor---selecting-a-built-in-tree-leaf-re-themes-the-app-shipped-leaves-don-t-Delete-forces-textual-dark.md
+++ b/backlog/tasks/task-31255 - Theme-editor---selecting-a-built-in-tree-leaf-re-themes-the-app-shipped-leaves-don-t-Delete-forces-textual-dark.md
@@ -2,7 +2,7 @@
 id: TASK-31255
 title: Theme editor - selecting a built-in tree leaf re-themes the app, shipped leaves
   don't, Delete forces textual-dark
-status: To Do
+status: Done
 created_date: 2026-09-04 05:24
 assignee:
 - '@claude'
@@ -12,6 +12,7 @@ labels:
 - theme-editor
 - ux-review-2026-09
 priority: high
+updated_date: 2026-09-04 06:06
 ---
 
 ## Description
@@ -22,17 +23,16 @@ load_theme sets self.app.theme immediately when the leaf is textual-dark or text
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Selecting any tree leaf loads it for editing without changing the running app's theme; Apply is the only editor action that changes app.theme
-- [ ] #2 After Delete the editor reloads the previously selected theme (or the first available one) and app.theme is unchanged
-- [ ] #3 The existing delete tests are updated to assert the reloaded editor state instead of a forced textual-dark app theme
+- [x] #1 Selecting any tree leaf loads it for editing without changing the running app's theme; Apply is the only editor action that changes app.theme
+- [x] #2 After Delete the editor reloads the previously selected theme (or the first available one) and app.theme is unchanged
+- [x] #3 The existing delete tests are updated to assert the reloaded editor state instead of a forced textual-dark app theme
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+load_theme no longer assigns app.theme (Apply is the only path that does) and resolves colours from the registered Theme's colour system instead of two hardcoded tables (which were also wrong for textual-dark). Delete reloads textual-dark into the editor only. Tests assert app.theme is untouched by tree selection and by Delete.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-31256 - Theme-editor---keyboard-path-Actions-below-the-fold-Tab-moves-the-preset-target-own-themes-last-in-a-12-row-tree.md
+++ b/backlog/tasks/task-31256 - Theme-editor---keyboard-path-Actions-below-the-fold-Tab-moves-the-preset-target-own-themes-last-in-a-12-row-tree.md
@@ -1,0 +1,48 @@
+---
+id: TASK-31256
+title: 'Theme editor - keyboard path: Actions below the fold, Tab moves the preset
+  target, own themes last in a 12-row tree'
+status: To Do
+created_date: 2026-09-04 05:24
+dependencies:
+- TASK-31254
+assignee:
+- '@claude'
+labels:
+- ui
+- settings
+- theme-editor
+- ux-review-2026-09
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Apply/Save/Reset/Generate sit after 10 colour rows and 40 preset swatches: 50 Tabs from Primary, below the fold on a 52-row terminal while the State banner says 'buttons below'. Tabbing through the colour inputs to reach a swatch updates last_focused_color_input, so a keyboard user's preset always lands on Error (live: Blues-0 filled Error). The user's own themes are the last leaves after 58 shipped ones in a 12-row Tree with no Home/End key; the root is collapsed with ten blank rows. Evidence: live walkthrough of origin/dev 59d987015d on 2026-09-03 (isolated profile, tmux 235x52) plus a dual-agent impeccable critique; snapshot .impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md. Heuristic score 17/40.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Apply, Save, Reset and Generate are reachable without passing through the preset grid (Actions row rendered before Color Presets, or pinned above the palette)
+- [ ] #2 Focusing a preset swatch does not change which colour it will fill; the target is the last colour input the user edited or focused by choice, default Primary, and is named in visible text
+- [ ] #3 User Themes is the first group in the tree and the shipped group starts collapsed; the tree opens expanded to the user's themes instead of a collapsed root
+- [ ] #4 The tree hint copy still mentions New and theme (pinned) and now describes the new order
+- [ ] #5 Tests: Tab order test (Actions before presets), preset-target-unchanged-by-focus test, tree order test
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-31256 - Theme-editor---keyboard-path-Actions-below-the-fold-Tab-moves-the-preset-target-own-themes-last-in-a-12-row-tree.md
+++ b/backlog/tasks/task-31256 - Theme-editor---keyboard-path-Actions-below-the-fold-Tab-moves-the-preset-target-own-themes-last-in-a-12-row-tree.md
@@ -2,7 +2,7 @@
 id: TASK-31256
 title: 'Theme editor - keyboard path: Actions below the fold, Tab moves the preset
   target, own themes last in a 12-row tree'
-status: To Do
+status: Done
 created_date: 2026-09-04 05:24
 dependencies:
 - TASK-31254
@@ -14,6 +14,7 @@ labels:
 - theme-editor
 - ux-review-2026-09
 priority: high
+updated_date: 2026-09-04 06:06
 ---
 
 ## Description
@@ -24,19 +25,18 @@ Apply/Save/Reset/Generate sit after 10 colour rows and 40 preset swatches: 50 Ta
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Apply, Save, Reset and Generate are reachable without passing through the preset grid (Actions row rendered before Color Presets, or pinned above the palette)
-- [ ] #2 Focusing a preset swatch does not change which colour it will fill; the target is the last colour input the user edited or focused by choice, default Primary, and is named in visible text
-- [ ] #3 User Themes is the first group in the tree and the shipped group starts collapsed; the tree opens expanded to the user's themes instead of a collapsed root
-- [ ] #4 The tree hint copy still mentions New and theme (pinned) and now describes the new order
-- [ ] #5 Tests: Tab order test (Actions before presets), preset-target-unchanged-by-focus test, tree order test
+- [x] #1 Apply, Save, Reset and Generate are reachable without passing through the preset grid (Actions row rendered before Color Presets, or pinned above the palette)
+- [x] #2 Focusing a preset swatch does not change which colour it will fill; the target is the last colour input the user edited or focused by choice, default Primary, and is named in visible text
+- [x] #3 User Themes is the first group in the tree and the shipped group starts collapsed; the tree opens expanded to the user's themes instead of a collapsed root
+- [x] #4 The tree hint copy still mentions New and theme (pinned) and now describes the new order
+- [x] #5 Tests: Tab order test (Actions before presets), preset-target-unchanged-by-focus test, tree order test
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+compose order is library -> actions -> palette -> presets -> preview; preset target no longer follows focus (Select from TASK-31254); tree lists 'Your themes' (expanded) then 'Built-in' then 'Shipped themes' (collapsed) with the root expanded; leaves carry a data tag instead of a 'user:' prefix; hint copy updated (still names New and theme). Tests: focus-order, target-unchanged-by-focus, tree-order.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-31257 - Theme-editor---New-starts-a-theme-from-the-current-palette-but-New-loads-a-hardcoded-blue-palette.md
+++ b/backlog/tasks/task-31257 - Theme-editor---New-starts-a-theme-from-the-current-palette-but-New-loads-a-hardcoded-blue-palette.md
@@ -2,7 +2,7 @@
 id: TASK-31257
 title: Theme editor - 'New starts a theme from the current palette' but New loads
   a hardcoded blue palette
-status: To Do
+status: Done
 created_date: 2026-09-04 05:24
 assignee:
 - '@claude'
@@ -12,6 +12,7 @@ labels:
 - theme-editor
 - ux-review-2026-09
 priority: medium
+updated_date: 2026-09-04 06:06
 ---
 
 ## Description
@@ -22,17 +23,16 @@ The tree hint (settings-theme-tree-hint) says New starts from the current palett
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 New copies the currently loaded colours and dark flag into a theme named new_theme with the Name box focused
-- [ ] #2 test_theme_tree_has_empty_state_guidance and test_settings_theme_editor_new_confirms_before_discarding_edits still pass
-- [ ] #3 Docs/User_Guide/settings.md Theme section describes New as starting from the current palette
+- [x] #1 New copies the currently loaded colours and dark flag into a theme named new_theme with the Name box focused
+- [x] #2 test_theme_tree_has_empty_state_guidance and test_settings_theme_editor_new_confirms_before_discarding_edits still pass
+- [x] #3 Docs/User_Guide/settings.md Theme section describes New as starting from the current palette
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+_new_theme copies the loaded palette and keeps the dark flag; the hardcoded blue set is only the fallback for an empty editor. Docs updated. Existing New/hint tests unchanged and green.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-31257 - Theme-editor---New-starts-a-theme-from-the-current-palette-but-New-loads-a-hardcoded-blue-palette.md
+++ b/backlog/tasks/task-31257 - Theme-editor---New-starts-a-theme-from-the-current-palette-but-New-loads-a-hardcoded-blue-palette.md
@@ -1,0 +1,44 @@
+---
+id: TASK-31257
+title: Theme editor - 'New starts a theme from the current palette' but New loads
+  a hardcoded blue palette
+status: To Do
+created_date: 2026-09-04 05:24
+assignee:
+- '@claude'
+labels:
+- ui
+- settings
+- theme-editor
+- ux-review-2026-09
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The tree hint (settings-theme-tree-hint) says New starts from the current palette; _new_theme replaces the palette with a fixed blue set and dark=True. Live: textual-dark's #004578 became #0099FF. Copying the loaded palette matches the promise and Clone semantics. Evidence: live walkthrough of origin/dev 59d987015d on 2026-09-03 (isolated profile, tmux 235x52) plus a dual-agent impeccable critique; snapshot .impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md. Heuristic score 17/40.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 New copies the currently loaded colours and dark flag into a theme named new_theme with the Name box focused
+- [ ] #2 test_theme_tree_has_empty_state_guidance and test_settings_theme_editor_new_confirms_before_discarding_edits still pass
+- [ ] #3 Docs/User_Guide/settings.md Theme section describes New as starting from the current palette
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-31258 - Theme-editor---Save-and-Export-overwrite-existing-files-silently.md
+++ b/backlog/tasks/task-31258 - Theme-editor---Save-and-Export-overwrite-existing-files-silently.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-31258
 title: Theme editor - Save and Export overwrite existing files silently
-status: To Do
+status: Done
 created_date: 2026-09-04 05:24
 dependencies:
 - TASK-31251
@@ -13,6 +13,7 @@ labels:
 - theme-editor
 - ux-review-2026-09
 priority: medium
+updated_date: 2026-09-04 06:06
 ---
 
 ## Description
@@ -23,17 +24,16 @@ Save writes <name>.toml with no check that a saved theme of that name already ex
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Saving over an existing user theme file asks for confirmation naming the file, with an explicit keep option
-- [ ] #2 Exporting to a path that already exists asks for confirmation; the toast names the written path
-- [ ] #3 Tests cover confirm and cancel for both
+- [x] #1 Saving over an existing user theme file asks for confirmation naming the file, with an explicit keep option
+- [x] #2 Exporting to a path that already exists asks for confirmation; the toast names the written path
+- [x] #3 Tests cover confirm and cancel for both
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Save over a different saved theme and Export onto an existing file raise ConfirmationDialog ('Overwrite' / 'Keep existing'); re-saving the theme loaded from that file stays a plain update (_loaded_user_theme tracking). Tests cover confirm-cancel for Save and Export and the no-dialog update path.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-31258 - Theme-editor---Save-and-Export-overwrite-existing-files-silently.md
+++ b/backlog/tasks/task-31258 - Theme-editor---Save-and-Export-overwrite-existing-files-silently.md
@@ -1,0 +1,45 @@
+---
+id: TASK-31258
+title: Theme editor - Save and Export overwrite existing files silently
+status: To Do
+created_date: 2026-09-04 05:24
+dependencies:
+- TASK-31251
+assignee:
+- '@claude'
+labels:
+- ui
+- settings
+- theme-editor
+- ux-review-2026-09
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Save writes <name>.toml with no check that a saved theme of that name already exists; Export writes ~/Downloads/<name>_theme.toml on a single Enter with no location choice and no overwrite check. Both are one keypress away from destroying a previous version. Delete already confirms via ConfirmationDialog; reuse it. Evidence: live walkthrough of origin/dev 59d987015d on 2026-09-03 (isolated profile, tmux 235x52) plus a dual-agent impeccable critique; snapshot .impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md. Heuristic score 17/40.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Saving over an existing user theme file asks for confirmation naming the file, with an explicit keep option
+- [ ] #2 Exporting to a path that already exists asks for confirmation; the toast names the written path
+- [ ] #3 Tests cover confirm and cancel for both
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-31259 - Theme-editor---Live-Preview-only-changes-on-Apply-and-previews-nothing-from-Chatbook.md
+++ b/backlog/tasks/task-31259 - Theme-editor---Live-Preview-only-changes-on-Apply-and-previews-nothing-from-Chatbook.md
@@ -2,7 +2,7 @@
 id: TASK-31259
 title: Theme editor - Live Preview only changes on Apply and previews nothing from
   Chatbook
-status: To Do
+status: Done
 created_date: 2026-09-04 05:24
 assignee:
 - '@claude'
@@ -12,6 +12,7 @@ labels:
 - theme-editor
 - ux-review-2026-09
 priority: medium
+updated_date: 2026-09-04 06:06
 ---
 
 ## Description
@@ -22,17 +23,16 @@ The preview is three stock buttons and three boxes styled by the app's CSS token
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Preview surfaces repaint from the edited palette on every colour change without Apply
-- [ ] #2 Preview shows a Chatbook-shaped stub (a few Console transcript rows: user/assistant/tool with rail chrome) using primary, secondary, accent, background, surface, panel, foreground, success, warning and error
-- [ ] #3 Docs/User_Guide/settings.md no longer calls the preview decorative
+- [x] #1 Preview surfaces repaint from the edited palette on every colour change without Apply
+- [x] #2 Preview shows a Chatbook-shaped stub (a few Console transcript rows: user/assistant/tool with rail chrome) using primary, secondary, accent, background, surface, panel, foreground, success, warning and error
+- [x] #3 Docs/User_Guide/settings.md no longer calls the preview decorative
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Preview is a seven-row Console-shaped stub (rail, user, assistant, tool success, warning, error, accent) painted from current_theme_data by _refresh_preview on every change (inputs, presets, Generate, load). Old stock-button preview and its CSS removed; docs no longer call it decorative.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-31259 - Theme-editor---Live-Preview-only-changes-on-Apply-and-previews-nothing-from-Chatbook.md
+++ b/backlog/tasks/task-31259 - Theme-editor---Live-Preview-only-changes-on-Apply-and-previews-nothing-from-Chatbook.md
@@ -1,0 +1,44 @@
+---
+id: TASK-31259
+title: Theme editor - Live Preview only changes on Apply and previews nothing from
+  Chatbook
+status: To Do
+created_date: 2026-09-04 05:24
+assignee:
+- '@claude'
+labels:
+- ui
+- settings
+- theme-editor
+- ux-review-2026-09
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The preview is three stock buttons and three boxes styled by the app's CSS tokens, so it reflects the applied app theme, not the palette being edited; the User Guide calls it decorative. Users edit blind until Apply. Evidence: live walkthrough of origin/dev 59d987015d on 2026-09-03 (isolated profile, tmux 235x52) plus a dual-agent impeccable critique; snapshot .impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md. Heuristic score 17/40.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Preview surfaces repaint from the edited palette on every colour change without Apply
+- [ ] #2 Preview shows a Chatbook-shaped stub (a few Console transcript rows: user/assistant/tool with rail chrome) using primary, secondary, accent, background, surface, panel, foreground, success, warning and error
+- [ ] #3 Docs/User_Guide/settings.md no longer calls the preview decorative
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-31260 - Theme-editor---at-110-columns-the-button-row-clips-Delete-Export-and-the-inspector-prints-the-save-path-twice.md
+++ b/backlog/tasks/task-31260 - Theme-editor---at-110-columns-the-button-row-clips-Delete-Export-and-the-inspector-prints-the-save-path-twice.md
@@ -2,7 +2,7 @@
 id: TASK-31260
 title: Theme editor - at 110 columns the button row clips Delete/Export and the inspector
   prints the save path twice
-status: To Do
+status: Done
 created_date: 2026-09-04 05:24
 assignee:
 - '@claude'
@@ -12,6 +12,7 @@ labels:
 - theme-editor
 - ux-review-2026-09
 priority: medium
+updated_date: 2026-09-04 06:06
 ---
 
 ## Description
@@ -22,17 +23,16 @@ With the middle pane at ~45 cells, the four 16-cell buttons in the library row o
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 At 110 columns all library and action buttons are visible and clickable (rows wrap or stack under the settings compact mode)
-- [ ] #2 The inspector shows the themes directory once, abbreviated with ~ for the home directory
-- [ ] #3 A geometry test at 110x36 asserts every editor button is inside the card region
+- [x] #1 At 110 columns all library and action buttons are visible and clickable (rows wrap or stack under the settings compact mode)
+- [x] #2 The inspector shows the themes directory once, abbreviated with ~ for the home directory
+- [x] #3 A geometry test at 110x36 asserts every editor button is inside the card region
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Compact workbench (<=100 cols) stacks the editor's action rows and gives each button full width, keyed to a theme-editor-action class (fast-path ratchet stays 274). Inspector shows the themes directory once via _display_path (~ for home). Render test at 110x36 asserts every button is inside the pane; unit test for _display_path.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-31260 - Theme-editor---at-110-columns-the-button-row-clips-Delete-Export-and-the-inspector-prints-the-save-path-twice.md
+++ b/backlog/tasks/task-31260 - Theme-editor---at-110-columns-the-button-row-clips-Delete-Export-and-the-inspector-prints-the-save-path-twice.md
@@ -1,0 +1,44 @@
+---
+id: TASK-31260
+title: Theme editor - at 110 columns the button row clips Delete/Export and the inspector
+  prints the save path twice
+status: To Do
+created_date: 2026-09-04 05:24
+assignee:
+- '@claude'
+labels:
+- ui
+- settings
+- theme-editor
+- ux-review-2026-09
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+With the middle pane at ~45 cells, the four 16-cell buttons in the library row overflow (Delete and Export are cut off), the fixed 24-cell label column eats half the width, and the Scope Inspector prints the absolute themes directory twice, wrapped over five lines each. Observed live at 110x36. Evidence: live walkthrough of origin/dev 59d987015d on 2026-09-03 (isolated profile, tmux 235x52) plus a dual-agent impeccable critique; snapshot .impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md. Heuristic score 17/40.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 At 110 columns all library and action buttons are visible and clickable (rows wrap or stack under the settings compact mode)
+- [ ] #2 The inspector shows the themes directory once, abbreviated with ~ for the home directory
+- [ ] #3 A geometry test at 110x36 asserts every editor button is inside the card region
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-31261 - Theme-editor-polish---no-op-Reset-toast-three-primary-buttons-group-naming-lowercase-hex.md
+++ b/backlog/tasks/task-31261 - Theme-editor-polish---no-op-Reset-toast-three-primary-buttons-group-naming-lowercase-hex.md
@@ -1,0 +1,45 @@
+---
+id: TASK-31261
+title: Theme editor polish - no-op Reset toast, three primary buttons, group naming,
+  lowercase hex
+status: To Do
+created_date: 2026-09-04 05:24
+assignee:
+- '@claude'
+labels:
+- ui
+- settings
+- theme-editor
+- ux-review-2026-09
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Small consistency items from the review: Reset toasts 'Theme reset to original values' when nothing changed; New, Apply and Generate are all variant=primary; the tree calls the 58 shipped themes 'Custom Themes' and prefixes the user's own with 'user:'; hex case differs between paths. Evidence: live walkthrough of origin/dev 59d987015d on 2026-09-03 (isolated profile, tmux 235x52) plus a dual-agent impeccable critique; snapshot .impeccable/critique/2026-09-04T04-45-47Z__tldw-chatbook-widgets-settings-theme-editor-py.md. Heuristic score 17/40.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Reset with no changes gives a neutral message or no toast; Reset with changes still confirms (pinned behaviour)
+- [ ] #2 Exactly one primary-variant button per action row (Apply primary; New/Generate default)
+- [ ] #3 Tree groups read 'Your themes', 'Shipped themes', 'Built-in'; leaves have no user: prefix and the delete/shadowing tests still pass with updated labels
+- [ ] #4 All hex values shown are uppercase
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-31261 - Theme-editor-polish---no-op-Reset-toast-three-primary-buttons-group-naming-lowercase-hex.md
+++ b/backlog/tasks/task-31261 - Theme-editor-polish---no-op-Reset-toast-three-primary-buttons-group-naming-lowercase-hex.md
@@ -2,7 +2,7 @@
 id: TASK-31261
 title: Theme editor polish - no-op Reset toast, three primary buttons, group naming,
   lowercase hex
-status: To Do
+status: Done
 created_date: 2026-09-04 05:24
 assignee:
 - '@claude'
@@ -12,6 +12,7 @@ labels:
 - theme-editor
 - ux-review-2026-09
 priority: low
+updated_date: 2026-09-04 06:06
 ---
 
 ## Description
@@ -22,18 +23,17 @@ Small consistency items from the review: Reset toasts 'Theme reset to original v
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Reset with no changes gives a neutral message or no toast; Reset with changes still confirms (pinned behaviour)
-- [ ] #2 Exactly one primary-variant button per action row (Apply primary; New/Generate default)
-- [ ] #3 Tree groups read 'Your themes', 'Shipped themes', 'Built-in'; leaves have no user: prefix and the delete/shadowing tests still pass with updated labels
-- [ ] #4 All hex values shown are uppercase
+- [x] #1 Reset with no changes gives a neutral message or no toast; Reset with changes still confirms (pinned behaviour)
+- [x] #2 Exactly one primary-variant button per action row (Apply primary; New/Generate default)
+- [x] #3 Tree groups read 'Your themes', 'Shipped themes', 'Built-in'; leaves have no user: prefix and the delete/shadowing tests still pass with updated labels
+- [x] #4 All hex values shown are uppercase
 <!-- AC:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
-
+Reset with no edits now says 'No changes to reset' (still no dialog; pinned test updated); Apply is the only primary-variant button; tree groups renamed and 'user:' prefix dropped (done in TASK-31256); generated hex uppercased (TASK-31253).
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
-
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->

--- a/backlog/tasks/task-31279 - Theme-editor---at-110-columns-the-button-row-clips-Delete-Export-and-the-inspector-prints-the-save-path-twice.md
+++ b/backlog/tasks/task-31279 - Theme-editor---at-110-columns-the-button-row-clips-Delete-Export-and-the-inspector-prints-the-save-path-twice.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-31260
+id: TASK-31279
 title: Theme editor - at 110 columns the button row clips Delete/Export and the inspector
   prints the save path twice
 status: Done
@@ -42,3 +42,14 @@ Compact workbench (<=100 cols) stacks the editor's action rows and gives each bu
 ## Definition of Done
 <!-- DOD:BEGIN -->
 <!-- DOD:END -->
+
+## Renumbering provenance
+
+This task previously held id TASK-31260, colliding with the older
+"Library-wiring-cluster-membership-AST-re-census-guard" task that arrived on dev first (created 2026-09-04 05:24 vs this
+task's 05:44; found by the backlog id guard on PR #2375 after a rebase).
+Per the owner rule decided 2026-08-21 in TASK-19601 (**older id keeps it;
+the younger task renumbers with a provenance note, regardless of Done
+status**), it renumbered to TASK-31279. Citations to TASK-31260 in the
+theme-editor commit messages on PR #2375 (fix/theme-editor-ux, 2026-09-04)
+refer to THIS task; the other TASK-31260 holder is the AST census guard.

--- a/backlog/tasks/task-31280 - Theme-editor-polish---no-op-Reset-toast-three-primary-buttons-group-naming-lowercase-hex.md
+++ b/backlog/tasks/task-31280 - Theme-editor-polish---no-op-Reset-toast-three-primary-buttons-group-naming-lowercase-hex.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-31261
+id: TASK-31280
 title: Theme editor polish - no-op Reset toast, three primary buttons, group naming,
   lowercase hex
 status: Done
@@ -43,3 +43,14 @@ Reset with no edits now says 'No changes to reset' (still no dialog; pinned test
 ## Definition of Done
 <!-- DOD:BEGIN -->
 <!-- DOD:END -->
+
+## Renumbering provenance
+
+This task previously held id TASK-31261, colliding with the older
+"canvas_sync-search-kind-screen-caller-AST-census-guard" task that arrived on dev first (created 2026-09-04 05:24 vs this
+task's 05:44; found by the backlog id guard on PR #2375 after a rebase).
+Per the owner rule decided 2026-08-21 in TASK-19601 (**older id keeps it;
+the younger task renumbers with a provenance note, regardless of Done
+status**), it renumbered to TASK-31280. Citations to TASK-31261 in the
+theme-editor commit messages on PR #2375 (fix/theme-editor-ux, 2026-09-04)
+refer to THIS task; the other TASK-31261 holder is the AST census guard.

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -596,7 +596,7 @@ def _theme_save_target() -> Path:
 
 
 def _display_path(path: Path) -> str:
-    """Shorten a path for inspector copy: ``~`` for the home directory (TASK-31260).
+    """Shorten a path for inspector copy: ``~`` for the home directory (TASK-31279).
 
     The absolute themes directory wrapped over five inspector lines, twice.
     """

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -8109,7 +8109,9 @@ class SettingsScreen(BaseAppScreen):
         # startup and after Save; offer them like the shipped catalog.
         registered = getattr(getattr(self, "app_instance", None), "available_themes", None) or {}
         for theme_name in registered:
-            if theme_name in seen:
+            # custom_<name> is Apply's process-only registration of an unsaved
+            # palette; it would not exist at the next launch (PR #2375 #8).
+            if theme_name in seen or theme_name.startswith("custom_"):
                 continue
             seen.add(theme_name)
             options.append(

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -20796,6 +20796,15 @@ class SettingsScreen(BaseAppScreen):
             # (re)composed card at a workspace id a later visit's list may
             # not even show (e.g. after an archive elsewhere).
             self._settings_selected_workspace_id = None
+        if (
+            self.active_category == SettingsCategoryId.THEME.value
+            and category_value != SettingsCategoryId.THEME.value
+            and self.theme_editor_modified
+        ):
+            # TASK-31252: leaving Theme remounts the editor and drops the
+            # in-progress edit, so the dirty displays must not outlive it.
+            self.theme_editor_modified = False
+            self._refresh_theme_modified_widgets()
         category_changed = category_value != self.active_category
         self.active_category = category_value
 

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -590,7 +590,9 @@ def _force_restore_audio_cpp_merge_delta(
 
 def _theme_save_target() -> Path:
     """Return the active profile's directory for custom theme files."""
-    return get_cli_config_path().parent / "themes"
+    from tldw_chatbook.config import get_user_themes_dir
+
+    return get_user_themes_dir()
 
 
 def _internal_prompts_save_target() -> Path:
@@ -8091,6 +8093,16 @@ class SettingsScreen(BaseAppScreen):
             seen.add(theme_name)
             options.append(
                 (theme_name.replace("_", " ").replace("-", " ").title(), theme_name)
+            )
+        # TASK-31250: the user's saved themes are registered with the app at
+        # startup and after Save; offer them like the shipped catalog.
+        registered = getattr(getattr(self, "app_instance", None), "available_themes", None) or {}
+        for theme_name in registered:
+            if theme_name in seen:
+                continue
+            seen.add(theme_name)
+            options.append(
+                (f"{theme_name.replace('_', ' ').replace('-', ' ').title()} (saved)", theme_name)
             )
         current_theme = str(self._appearance_setting_values()["default_theme"])
         if current_theme and current_theme not in seen:

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -595,6 +595,17 @@ def _theme_save_target() -> Path:
     return get_user_themes_dir()
 
 
+def _display_path(path: Path) -> str:
+    """Shorten a path for inspector copy: ``~`` for the home directory (TASK-31260).
+
+    The absolute themes directory wrapped over five inspector lines, twice.
+    """
+    try:
+        return "~" + os.sep + str(path.relative_to(Path.home()))
+    except ValueError:
+        return str(path)
+
+
 def _internal_prompts_save_target() -> Path:
     """Return the active config file for internal prompt overrides."""
     return get_cli_config_path()
@@ -4669,7 +4680,7 @@ class SettingsScreen(BaseAppScreen):
                     "use the editor's Apply/Save/Reset buttons."
                 ),
                 recovery_copy=(
-                    f"Themes are saved to {_theme_save_target()}{os.sep}; reset or delete "
+                    f"Themes are saved to {_display_path(_theme_save_target())}{os.sep}; reset or delete "
                     "files there to recover."
                 ),
             ),
@@ -14048,7 +14059,7 @@ class SettingsScreen(BaseAppScreen):
             return (
                 (
                     "Affected config",
-                    f"custom theme files under {_theme_save_target()}{os.sep}",
+                    f"custom theme files under {_display_path(_theme_save_target())}{os.sep}",
                 ),
                 (
                     "Recovery",
@@ -19113,7 +19124,7 @@ class SettingsScreen(BaseAppScreen):
                 classes="destination-section",
             )
             yield Static("Focused field guide", classes="destination-section")
-            yield self._detail_row("Save target", f"{_theme_save_target()}{os.sep}")
+            yield self._detail_row("Save target", f"{_display_path(_theme_save_target())}{os.sep}")
             yield self._detail_row(
                 "Save", "editor-owned - use the editor's Apply/Save/Reset buttons"
             )

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -248,18 +248,20 @@ class SettingsThemeEditor(Vertical):
         name_input.value = theme_name
         name_input.disabled = theme_name in ["textual-dark", "textual-light"]
 
-        if theme_name in ["textual-dark", "textual-light"]:
-            self.app.theme = theme_name
-            self.current_theme_data = self._extract_current_theme_colors()
-            self.is_dark_theme = theme_name == "textual-dark"
-        else:
-            theme = next(
-                (t for t in ALL_THEMES if hasattr(t, "name") and t.name == theme_name),
-                None,
+        # TASK-31255: loading is read-only for the running app -- Apply is the
+        # only action that changes app.theme. Colours come from the registered
+        # Theme object (built-in, shipped, or saved), not a hardcoded table.
+        theme = self.app.available_themes.get(theme_name) or next(
+            (t for t in ALL_THEMES if getattr(t, "name", None) == theme_name),
+            None,
+        )
+        if theme is None:
+            logger.warning(
+                f"Theme editor: unknown theme '{theme_name}', keeping current palette"
             )
-            if theme:
-                self.current_theme_data = self._extract_theme_colors(theme)
-                self.is_dark_theme = getattr(theme, "dark", True)
+        else:
+            self.current_theme_data = self._extract_theme_colors(theme)
+            self.is_dark_theme = bool(getattr(theme, "dark", True))
 
         self._update_color_inputs()
         self._update_dark_mode_checkbox()
@@ -295,95 +297,25 @@ class SettingsThemeEditor(Vertical):
                 logger.error(f"Failed to load user theme {theme_name}: {e}")
                 self.app.notify(f"Failed to load theme: {e}", severity="error")
 
-    def _extract_current_theme_colors(self) -> dict[str, str]:
-        """Extract colors from the current app theme."""
-        if self.app.theme == "textual-dark":
-            return {
-                "primary": "#004578",
-                "secondary": "#0178D4",
-                "accent": "#FFD700",
-                "background": "#0C0C0C",
-                "surface": "#1A1A1A",
-                "panel": "#1A1A1A",
-                "foreground": "#E0E0E0",
-                "success": "#4EBF71",
-                "warning": "#FFA62B",
-                "error": "#BA3C5B",
-            }
-        if self.app.theme == "textual-light":
-            return {
-                "primary": "#004578",
-                "secondary": "#0178D4",
-                "accent": "#FFD700",
-                "background": "#F5F5F5",
-                "surface": "#FFFFFF",
-                "panel": "#EEEEEE",
-                "foreground": "#333333",
-                "success": "#228B22",
-                "warning": "#FFA500",
-                "error": "#DC143C",
-            }
-        return {color_name: "#808080" for color_name in self.BASE_COLORS}
-
     def _extract_theme_colors(self, theme: Theme) -> dict[str, str]:
-        """Extract colors from a Theme object."""
+        """Resolve a Theme's ten base colours as uppercase hex.
+
+        Built-in Themes leave background/surface/panel/foreground unset and
+        derive them; ``to_color_system().generate()`` resolves every base
+        colour the same way the app does at runtime (TASK-31255).
+        """
+        try:
+            generated = theme.to_color_system().generate()
+        except Exception as exc:  # noqa: BLE001 - a malformed theme must not break the editor
+            logger.warning(f"Theme editor: could not resolve colours for {theme.name!r}: {exc}")
+            generated = {}
         colors: dict[str, str] = {}
-        color_mappings = {
-            "primary": "primary",
-            "secondary": "secondary",
-            "accent": "accent",
-            "background": "background",
-            "surface": "surface",
-            "panel": "panel",
-            "foreground": "foreground",
-            "success": "success",
-            "warning": "warning",
-            "error": "error",
-        }
-
-        for our_name, theme_attr in color_mappings.items():
-            color_value = getattr(theme, theme_attr, None)
-            if color_value:
-                if isinstance(color_value, Color):
-                    colors[our_name] = color_value.hex
-                elif isinstance(color_value, str):
-                    try:
-                        parsed_color = Color.parse(color_value)
-                        colors[our_name] = parsed_color.hex
-                    except Exception:
-                        colors[our_name] = "#808080"
-                else:
-                    colors[our_name] = "#808080"
-            else:
-                is_dark = getattr(theme, "dark", True)
-                if is_dark:
-                    defaults = {
-                        "primary": "#0099FF",
-                        "secondary": "#006FB3",
-                        "accent": "#FFD700",
-                        "background": "#1E1E1E",
-                        "surface": "#2C2C2C",
-                        "panel": "#252525",
-                        "foreground": "#FFFFFF",
-                        "success": "#008000",
-                        "warning": "#FFD700",
-                        "error": "#FF0000",
-                    }
-                else:
-                    defaults = {
-                        "primary": "#0066CC",
-                        "secondary": "#004499",
-                        "accent": "#FF9900",
-                        "background": "#FFFFFF",
-                        "surface": "#F5F5F5",
-                        "panel": "#EEEEEE",
-                        "foreground": "#000000",
-                        "success": "#228B22",
-                        "warning": "#FFA500",
-                        "error": "#DC143C",
-                    }
-                colors[our_name] = defaults.get(our_name, "#808080")
-
+        for our_name in self.BASE_COLORS:
+            value = generated.get(our_name)
+            try:
+                colors[our_name] = Color.parse(str(value)).hex.upper() if value else "#808080"
+            except Exception:  # noqa: BLE001
+                colors[our_name] = "#808080"
         return colors
 
     def _update_color_inputs(self) -> None:

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -203,7 +203,17 @@ class SettingsThemeEditor(Vertical):
             }
             self.color_inputs = color_inputs
             self.color_swatches = color_swatches
-            self.load_theme(self.app.theme)
+            app_theme = str(self.app.theme)
+            self.load_theme(app_theme)
+            if app_theme.startswith("custom_"):
+                # Apply registers the working palette under a custom_ prefix
+                # so it never clobbers a shipped registration; the editor shows
+                # the user-facing name and keeps it editable (TASK-31252).
+                display_name = app_theme[len("custom_") :]
+                self.current_theme_name = display_name
+                name_input = self.query_one("#settings-theme-name", Input)
+                name_input.value = display_name
+                name_input.disabled = False
         except QueryError:
             # Settings can recompose while this callback is queued. A stale,
             # detached editor must not fail the replacement screen.

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -470,6 +470,19 @@ class SettingsThemeEditor(Vertical):
                     event.input.add_class("invalid-color")
                     self._update_color_swatch(color_name, "#000000")
 
+    @on(Input.Changed, "#settings-theme-name")
+    def on_theme_name_changed(self, event: Input.Changed) -> None:
+        """Keep current_theme_name in step with the Name box (TASK-31251).
+
+        Apply, Export, Reset and Delete all read ``current_theme_name``;
+        without this they acted on the name from the last load. Programmatic
+        loads set the box to the name already held, so the equality guard
+        makes those echoes no-ops.
+        """
+        name = event.value.strip()
+        if name and name != self.current_theme_name:
+            self.current_theme_name = name
+
     @on(Checkbox.Changed, "#settings-theme-dark-mode")
     def on_dark_mode_changed(self, event: Checkbox.Changed) -> None:
         """Handle dark mode checkbox changes."""
@@ -577,9 +590,23 @@ class SettingsThemeEditor(Vertical):
         user_theme_path = self.custom_themes_path / f"{self.current_theme_name}.toml"
         if user_theme_path.exists():
             self.load_user_theme(self.current_theme_name)
-        else:
+        elif self._is_catalog_theme(self.current_theme_name):
             self.load_theme(self.current_theme_name)
+        else:
+            # TASK-31251: a renamed, never-saved theme has nothing to go back
+            # to; say so instead of claiming a reset happened.
+            self.app.notify(
+                f"No saved version of '{self.current_theme_name}' to reset to",
+                severity="warning",
+            )
+            return
         self.app.notify("Theme reset to original values", severity="information")
+
+    def _is_catalog_theme(self, name: str) -> bool:
+        """True for Textual built-ins and shipped ALL_THEMES names."""
+        return name in ("textual-dark", "textual-light") or any(
+            getattr(theme, "name", None) == name for theme in ALL_THEMES
+        )
 
     @on(Button.Pressed, "#settings-theme-new")
     def on_new_theme(self) -> None:

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -611,9 +611,14 @@ class SettingsThemeEditor(Vertical):
         )
 
     def _new_theme(self) -> None:
-        """Populate a fresh default palette (post-confirmation when modified)."""
-        self.current_theme_name = "new_theme"
-        self.current_theme_data = {
+        """Start a new theme from the current palette (post-confirmation when modified).
+
+        TASK-31257: the tree hint promises "from the current palette" and
+        Clone already works that way; the hardcoded blue set is only the
+        fallback for an editor that has nothing loaded yet. The dark flag is
+        kept as well.
+        """
+        defaults = {
             "primary": "#0099FF",
             "secondary": "#006FB3",
             "accent": "#FFD700",
@@ -625,7 +630,8 @@ class SettingsThemeEditor(Vertical):
             "warning": "#FFD700",
             "error": "#FF0000",
         }
-        self.is_dark_theme = True
+        self.current_theme_name = "new_theme"
+        self.current_theme_data = dict(self.current_theme_data) or defaults
 
         name_input = self.query_one("#settings-theme-name", Input)
         name_input.value = "new_theme"

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -69,9 +69,9 @@ class SettingsThemeEditor(Vertical):
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        from ..config import _get_effective_config_path
+        from ..config import get_user_themes_dir
 
-        self.custom_themes_path = _get_effective_config_path().parent / "themes"
+        self.custom_themes_path = get_user_themes_dir()
         self.custom_themes_path.mkdir(parents=True, exist_ok=True)
         self.color_inputs: dict[str, Input] = {}
         self.color_swatches: dict[str, Static] = {}
@@ -159,7 +159,7 @@ class SettingsThemeEditor(Vertical):
         # widget must not import the screen).
         yield Static(
             "Apply applies immediately - no Save needed; "
-            "Save stores the theme for future sessions.",
+            "Save stores the theme; Set as launch default makes it load at startup.",
             id="settings-theme-apply-hint",
             classes="settings-help-copy",
         )
@@ -168,6 +168,7 @@ class SettingsThemeEditor(Vertical):
             yield Button("Save", id="settings-theme-save", variant="success")
             yield Button("Reset", id="settings-theme-reset", variant="warning")
             yield Button("Generate from Primary", id="settings-theme-generate", variant="primary")
+            yield Button("Set as launch default", id="settings-theme-set-default")
 
     def _compose_preview_section(self) -> ComposeResult:
         yield Static("Live Preview", classes="destination-section")
@@ -471,6 +472,14 @@ class SettingsThemeEditor(Vertical):
             with open(theme_path, "w", encoding="utf-8") as f:
                 toml.dump(theme_data, f)
 
+            # TASK-31250: register at once so Appearance and the palette can
+            # offer the theme without a restart.
+            self.app.register_theme(
+                create_theme_from_dict(
+                    theme_name, {**self.current_theme_data, "dark": self.is_dark_theme}
+                )
+            )
+
             self.app.notify(f"Theme '{theme_name}' saved", severity="success")
             self.is_modified = False
 
@@ -491,6 +500,22 @@ class SettingsThemeEditor(Vertical):
         except Exception as e:
             logger.error(f"Failed to save theme: {e}")
             self.app.notify(f"Failed to save theme: {e}", severity="error")
+
+    @on(Button.Pressed, "#settings-theme-set-default")
+    def on_set_launch_default(self) -> None:
+        """Make the current saved theme the startup theme (TASK-31250)."""
+        name = self.current_theme_name
+        saved = (self.custom_themes_path / f"{name}.toml").exists()
+        if not saved and not self._is_catalog_theme(name):
+            self.app.notify(
+                "Save the theme first, then set it as the launch default",
+                severity="warning",
+            )
+            return
+        from ..config import save_setting_to_cli_config
+
+        save_setting_to_cli_config("general", "default_theme", name)
+        self.app.notify(f"'{name}' will load at the next launch", severity="success")
 
     @on(Button.Pressed, "#settings-theme-reset")
     def on_reset_theme(self) -> None:

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -815,7 +815,10 @@ class SettingsThemeEditor(Vertical):
 
     def _generate_theme_from_primary(self, primary: Color) -> dict[str, str]:
         """Generate a complete theme based on a primary color."""
-        hue, saturation, lightness = primary.hsl
+        # Textual's Color.hsl reports hue in the 0-1 range; _adjust_color works
+        # in degrees (TASK-31253: every primary used to yield red/cyan).
+        hsl = primary.hsl
+        hue, saturation, lightness = hsl.h * 360, hsl.s, hsl.l
 
         return {
             "primary": primary.hex,
@@ -870,7 +873,7 @@ class SettingsThemeEditor(Vertical):
             g = max(0, min(255, int((g + m) * 255)))
             b = max(0, min(255, int((b + m) * 255)))
 
-            return f"#{r:02x}{g:02x}{b:02x}"
+            return f"#{r:02X}{g:02X}{b:02X}"
         except Exception:
             return "#808080"
 

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -75,6 +75,10 @@ class SettingsThemeEditor(Vertical):
         self.custom_themes_path.mkdir(parents=True, exist_ok=True)
         self.color_inputs: dict[str, Input] = {}
         self.color_swatches: dict[str, Static] = {}
+        # TASK-31258: the user theme file the palette was loaded from (or last
+        # saved to); re-saving it is an update, saving over another is an
+        # overwrite that asks first.
+        self._loaded_user_theme: str | None = None
 
     def compose(self) -> ComposeResult:
         """Compose the theme editor widget.
@@ -265,6 +269,7 @@ class SettingsThemeEditor(Vertical):
     def load_theme(self, theme_name: str) -> None:
         """Load a theme for editing."""
         self.current_theme_name = theme_name
+        self._loaded_user_theme = None
 
         name_input = self.query_one("#settings-theme-name", Input)
         name_input.value = theme_name
@@ -314,6 +319,7 @@ class SettingsThemeEditor(Vertical):
                 self._update_color_inputs()
                 self._update_dark_mode_checkbox()
                 self.is_modified = False
+                self._loaded_user_theme = theme_name
 
             except Exception as e:
                 logger.error(f"Failed to load user theme {theme_name}: {e}")
@@ -489,6 +495,34 @@ class SettingsThemeEditor(Vertical):
         }
         theme_path = self.custom_themes_path / f"{theme_name}.toml"
 
+        # TASK-31258: writing over another saved theme is one keypress from
+        # destroying it; re-saving the theme loaded from that very file is an
+        # update and needs no dialog.
+        if theme_path.exists() and self._loaded_user_theme != theme_name:
+
+            async def _confirmed_overwrite() -> None:
+                self._write_theme_file(theme_name, theme_path, theme_data)
+
+            self.app.push_screen(
+                ConfirmationDialog(
+                    title="Overwrite theme",
+                    message=(
+                        f"A saved theme named '{theme_name}' already exists. "
+                        "Replace it with the current palette?"
+                    ),
+                    confirm_label="Overwrite",
+                    cancel_label="Keep existing",
+                    confirm_callback=_confirmed_overwrite,
+                )
+            )
+            return
+
+        self._write_theme_file(theme_name, theme_path, theme_data)
+
+    def _write_theme_file(
+        self, theme_name: str, theme_path: Path, theme_data: dict[str, Any]
+    ) -> None:
+        """Write the theme TOML, register it, and update the tree."""
         try:
             with open(theme_path, "w", encoding="utf-8") as f:
                 toml.dump(theme_data, f)
@@ -503,6 +537,7 @@ class SettingsThemeEditor(Vertical):
 
             self.app.notify(f"Theme '{theme_name}' saved", severity="success")
             self.is_modified = False
+            self._loaded_user_theme = theme_name
 
             tree = self.query_one("#settings-theme-tree", Tree)
             user_node = None
@@ -631,6 +666,7 @@ class SettingsThemeEditor(Vertical):
             "error": "#FF0000",
         }
         self.current_theme_name = "new_theme"
+        self._loaded_user_theme = None
         self.current_theme_data = dict(self.current_theme_data) or defaults
 
         name_input = self.query_one("#settings-theme-name", Input)
@@ -655,6 +691,7 @@ class SettingsThemeEditor(Vertical):
         name_input.focus()
 
         self.current_theme_name = new_name
+        self._loaded_user_theme = None
         self.is_modified = True
 
         self.app.notify(f"Cloned theme as '{new_name}'", severity="information")
@@ -756,6 +793,26 @@ class SettingsThemeEditor(Vertical):
             "colors": self.current_theme_data,
         }
 
+        if export_path.exists():
+            # TASK-31258: never silently replace an earlier export.
+            async def _confirmed_export() -> None:
+                self._write_export(export_path, theme_data)
+
+            self.app.push_screen(
+                ConfirmationDialog(
+                    title="Overwrite export",
+                    message=f"{export_path} already exists. Replace it?",
+                    confirm_label="Overwrite",
+                    cancel_label="Keep existing",
+                    confirm_callback=_confirmed_export,
+                )
+            )
+            return
+
+        self._write_export(export_path, theme_data)
+
+    def _write_export(self, export_path: Path, theme_data: dict[str, Any]) -> None:
+        """Write the export TOML and report the path."""
         try:
             export_path.parent.mkdir(parents=True, exist_ok=True)
             with open(export_path, "w", encoding="utf-8") as f:

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -84,9 +84,11 @@ class SettingsThemeEditor(Vertical):
         """
         # Title is rendered by SettingsScreen._render_detail_pane()
         with Vertical(id="settings-theme-card", classes="settings-focus-card"):
+            # TASK-31256: Actions before the palette and presets so Apply/Save
+            # are reachable without Tabbing through 10 inputs and 40 swatches.
             yield from self._compose_library_section()
-            yield from self._compose_palette_section()
             yield from self._compose_actions_section()
+            yield from self._compose_palette_section()
             yield from self._compose_preview_section()
 
     def _compose_library_section(self) -> ComposeResult:
@@ -113,7 +115,7 @@ class SettingsThemeEditor(Vertical):
         # task-1585: the collapsed tree left a large blank region with no
         # explanation of what fills it.
         yield Static(
-            "Expand Themes to browse built-in and saved themes; "
+            "Your themes come first; expand Shipped themes to browse the catalog. "
             "New starts a theme from the current palette.",
             id="settings-theme-tree-hint",
             classes="settings-detail-row",
@@ -240,25 +242,25 @@ class SettingsThemeEditor(Vertical):
 
     def _load_user_themes(self, parent_node) -> None:
         """Load user-created themes from the themes directory."""
-        for theme_file in self.custom_themes_path.glob("*.toml"):
+        for theme_file in sorted(self.custom_themes_path.glob("*.toml")):
             try:
                 with open(theme_file, "r", encoding="utf-8") as f:
                     theme_data = toml.load(f)
                 theme_name = theme_data.get("theme", {}).get("name", theme_file.stem)
-                parent_node.add_leaf(f"user:{theme_name}")
+                # TASK-31256: the leaf's data says which loader applies; the
+                # label is the bare name (no "user:" prefix).
+                parent_node.add_leaf(theme_name, data="user")
             except Exception as e:
                 logger.error(f"Failed to load user theme {theme_file}: {e}")
 
     @on(Tree.NodeSelected)
     def on_theme_selected(self, event: Tree.NodeSelected) -> None:
         """Handle theme selection from the tree."""
-        if not event.node.children:
-            theme_name = str(event.node.label)
-            if theme_name.startswith("user:"):
-                theme_name = theme_name[5:]
-                self.load_user_theme(theme_name)
-            else:
-                self.load_theme(theme_name)
+        theme_name = str(event.node.label)
+        if event.node.data == "user":
+            self.load_user_theme(theme_name)
+        elif event.node.data == "catalog":
+            self.load_theme(theme_name)
 
     def load_theme(self, theme_name: str) -> None:
         """Load a theme for editing."""
@@ -505,17 +507,16 @@ class SettingsThemeEditor(Vertical):
             tree = self.query_one("#settings-theme-tree", Tree)
             user_node = None
             for node in tree.root.children:
-                if str(node.label) == "User Themes":
+                if str(node.label) == "Your themes":
                     user_node = node
                     break
 
             if user_node:
                 theme_exists = any(
-                    str(child.label) == f"user:{theme_name}"
-                    for child in user_node.children
+                    str(child.label) == theme_name for child in user_node.children
                 )
                 if not theme_exists:
-                    user_node.add_leaf(f"user:{theme_name}")
+                    user_node.add_leaf(theme_name, data="user")
         except Exception as e:
             logger.error(f"Failed to save theme: {e}")
             self.app.notify(f"Failed to save theme: {e}", severity="error")
@@ -718,9 +719,9 @@ class SettingsThemeEditor(Vertical):
 
             tree = self.query_one("#settings-theme-tree", Tree)
             for node in tree.root.children:
-                if str(node.label) == "User Themes":
+                if str(node.label) == "Your themes":
                     for child in node.children:
-                        if str(child.label) == f"user:{theme_name}":
+                        if str(child.label) == theme_name:
                             child.remove()
                             break
                     break
@@ -888,17 +889,23 @@ class SettingsThemeEditor(Vertical):
         tree = self.query_one("#settings-theme-tree", Tree)
         tree.root.remove_children()
 
-        builtin_node = tree.root.add("Built-in Themes", expand=True)
-        builtin_node.add_leaf("textual-dark")
-        builtin_node.add_leaf("textual-light")
+        # TASK-31256: the user's own themes first and open; the two Textual
+        # built-ins; then the 58 shipped themes collapsed so they do not push
+        # everything else out of the 12-row box. The root is expanded so the
+        # box is never a collapsed line over ten blank rows (task-1585).
+        user_node = tree.root.add("Your themes", expand=True)
+        self._load_user_themes(user_node)
 
-        custom_node = tree.root.add("Custom Themes", expand=True)
+        builtin_node = tree.root.add("Built-in", expand=True)
+        builtin_node.add_leaf("textual-dark", data="catalog")
+        builtin_node.add_leaf("textual-light", data="catalog")
+
+        shipped_node = tree.root.add("Shipped themes", expand=False)
         for theme in ALL_THEMES:
             if hasattr(theme, "name"):
-                custom_node.add_leaf(theme.name)
+                shipped_node.add_leaf(theme.name, data="catalog")
 
-        user_node = tree.root.add("User Themes", expand=True)
-        self._load_user_themes(user_node)
+        tree.root.expand()
 
     def on_show(self) -> None:
         """Refresh the theme tree when the widget becomes visible."""

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -132,11 +132,14 @@ class SettingsThemeEditor(Vertical):
             # TASK-31254: the label carries the state in text ("On"/"Off") so
             # colour is never the only carrier.
             yield Checkbox("On", value=True, id="settings-theme-dark-mode")
+        # `theme-editor-action` keys the compact-mode width rule to these
+        # buttons only (the CSS fast-path ratchet forbids a bare `Button`
+        # subject, TASK-31260).
         with Horizontal(classes="settings-action-row"):
-            yield Button("New", id="settings-theme-new", variant="primary")
-            yield Button("Clone", id="settings-theme-clone")
-            yield Button("Delete", id="settings-theme-delete", variant="error")
-            yield Button("Export", id="settings-theme-export")
+            yield Button("New", id="settings-theme-new", variant="primary", classes="theme-editor-action")
+            yield Button("Clone", id="settings-theme-clone", classes="theme-editor-action")
+            yield Button("Delete", id="settings-theme-delete", variant="error", classes="theme-editor-action")
+            yield Button("Export", id="settings-theme-export", classes="theme-editor-action")
         yield Tree("Themes", id="settings-theme-tree")
         # task-1585: the collapsed tree left a large blank region with no
         # explanation of what fills it.
@@ -205,11 +208,20 @@ class SettingsThemeEditor(Vertical):
             classes="settings-help-copy",
         )
         with Horizontal(classes="settings-action-row"):
-            yield Button("Apply", id="settings-theme-apply", variant="primary")
-            yield Button("Save", id="settings-theme-save", variant="success")
-            yield Button("Reset", id="settings-theme-reset", variant="warning")
-            yield Button("Generate from Primary", id="settings-theme-generate", variant="primary")
-            yield Button("Set as launch default", id="settings-theme-set-default")
+            yield Button("Apply", id="settings-theme-apply", variant="primary", classes="theme-editor-action")
+            yield Button("Save", id="settings-theme-save", variant="success", classes="theme-editor-action")
+            yield Button("Reset", id="settings-theme-reset", variant="warning", classes="theme-editor-action")
+            yield Button(
+                "Generate from Primary",
+                id="settings-theme-generate",
+                variant="primary",
+                classes="theme-editor-action",
+            )
+            yield Button(
+                "Set as launch default",
+                id="settings-theme-set-default",
+                classes="theme-editor-action",
+            )
 
     def _compose_preview_section(self) -> ComposeResult:
         yield Static("Live Preview", classes="destination-section")

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -67,6 +67,28 @@ class SettingsThemeEditor(Vertical):
         "Dark": ["#1A1A1A", "#2D2D2D", "#404040", "#525252", "#656565"],
     }
 
+    # TASK-31259: the Live Preview is a Console-shaped stub. Each row is
+    # (id suffix, text); _PREVIEW_STYLE maps the suffix to the BASE_COLORS
+    # keys used for its background and text, painted by _refresh_preview.
+    _PREVIEW_ROWS = (
+        ("rail", " Console ▸ Conversation · ready"),
+        ("user", " You: summarise the attached paper"),
+        ("assistant", " Assistant: Here is the summary…"),
+        ("success", " ✓ tool web_search finished"),
+        ("warning", " ! approval needed before the next call"),
+        ("error", " ✗ provider returned 401"),
+        ("accent", " [ Send ]   Ctrl+P palette"),
+    )
+    _PREVIEW_STYLE = {
+        "rail": ("panel", "foreground"),
+        "user": ("primary", "foreground"),
+        "assistant": ("surface", "foreground"),
+        "success": ("background", "success"),
+        "warning": ("background", "warning"),
+        "error": ("background", "error"),
+        "accent": ("background", "accent"),
+    }
+
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         from ..config import get_user_themes_dir
@@ -191,17 +213,15 @@ class SettingsThemeEditor(Vertical):
 
     def _compose_preview_section(self) -> ComposeResult:
         yield Static("Live Preview", classes="destination-section")
-        with Horizontal(classes="settings-preview-grid"):
-            with Vertical(classes="preview-column"):
-                yield Static("Buttons", classes="destination-section")
-                yield Button("Default", classes="preview-button")
-                yield Button("Primary", variant="primary", classes="preview-button")
-                yield Button("Success", variant="success", classes="preview-button")
-            with Vertical(classes="preview-column"):
-                yield Static("Surfaces", classes="destination-section")
-                yield Static("Surface", classes="preview-surface-demo")
-                yield Static("Panel", classes="preview-panel-demo")
-                yield Static("Boost", classes="preview-boost-demo")
+        # TASK-31259: painted from the palette being edited (see
+        # _refresh_preview), so it follows every keystroke, not just Apply.
+        with Vertical(id="settings-theme-preview", classes="settings-theme-preview"):
+            for suffix, text in self._PREVIEW_ROWS:
+                yield Static(
+                    text,
+                    id=f"settings-theme-preview-{suffix}",
+                    classes="settings-theme-preview-row",
+                )
 
     def on_mount(self) -> None:
         """Initialize after composed descendants are mounted."""
@@ -352,6 +372,24 @@ class SettingsThemeEditor(Vertical):
             if color_name in self.color_inputs:
                 self.color_inputs[color_name].value = color_value
                 self._update_color_swatch(color_name, color_value)
+        self._refresh_preview()
+
+    def _refresh_preview(self) -> None:
+        """Paint the preview rows from the palette being edited (TASK-31259)."""
+        for suffix, (bg_key, fg_key) in self._PREVIEW_STYLE.items():
+            try:
+                row = self.query_one(f"#settings-theme-preview-{suffix}", Static)
+            except QueryError:
+                return
+            background = self.current_theme_data.get(bg_key)
+            foreground = self.current_theme_data.get(fg_key)
+            try:
+                if background:
+                    row.styles.background = background
+                if foreground:
+                    row.styles.color = foreground
+            except Exception:  # noqa: BLE001 - a half-typed hex must not break painting
+                continue
 
     def _update_dark_mode_checkbox(self) -> None:
         """Update the dark mode checkbox."""
@@ -420,6 +458,7 @@ class SettingsThemeEditor(Vertical):
                     if self.current_theme_data.get(color_name) != color_value:
                         self.current_theme_data[color_name] = color_value
                         self.is_modified = True
+                        self._refresh_preview()
                     event.input.remove_class("settings-invalid-input")
                 else:
                     # TASK-31254: Settings' invalid-input convention (styled in
@@ -835,6 +874,7 @@ class SettingsThemeEditor(Vertical):
         self._update_color_swatch(target, color)
         self.current_theme_data[target] = color
         self.is_modified = True
+        self._refresh_preview()
 
     @on(Click, ".color-preset-swatch")
     def on_preset_color_clicked(self, event: Click) -> None:
@@ -877,6 +917,7 @@ class SettingsThemeEditor(Vertical):
 
             self.current_theme_data.update(generated_theme)
             self.is_modified = True
+            self._refresh_preview()
 
             self.app.notify("Theme generated from primary color.", severity="success")
         except Exception as e:

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -134,7 +134,7 @@ class SettingsThemeEditor(Vertical):
             yield Checkbox("On", value=True, id="settings-theme-dark-mode")
         # `theme-editor-action` keys the compact-mode width rule to these
         # buttons only (the CSS fast-path ratchet forbids a bare `Button`
-        # subject, TASK-31260).
+        # subject, TASK-31279).
         with Horizontal(classes="settings-action-row"):
             yield Button("New", id="settings-theme-new", classes="theme-editor-action")
             yield Button("Clone", id="settings-theme-clone", classes="theme-editor-action")
@@ -669,7 +669,7 @@ class SettingsThemeEditor(Vertical):
         if self._require_theme_name() is None:
             return
         if not self.is_modified:
-            # TASK-31261: nothing to discard -- say so instead of claiming a
+            # TASK-31280: nothing to discard -- say so instead of claiming a
             # reset happened (still no confirmation dialog, task-1371).
             self.app.notify("No changes to reset", severity="information")
             return

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -498,8 +498,27 @@ class SettingsThemeEditor(Vertical):
         makes those echoes no-ops.
         """
         name = event.value.strip()
-        if name and name != self.current_theme_name:
+        if name != self.current_theme_name:
+            # An emptied box clears the name too (PR #2375 review #6), so no
+            # action can fall back to the previously loaded theme.
             self.current_theme_name = name
+
+    def _require_theme_name(self) -> str | None:
+        """Return the current theme name if it is non-empty and file-safe.
+
+        Notifies and returns ``None`` otherwise, so Apply/Export/Delete/Reset/
+        Set-as-default share Save's guard instead of trusting a raw value.
+        """
+        name = self.current_theme_name.strip()
+        if not name:
+            self.app.notify("Please enter a theme name", severity="warning")
+            return None
+        try:
+            validate_filename(name)
+        except ValueError as exc:
+            self.app.notify(f"Invalid theme name: {exc}", severity="warning")
+            return None
+        return name
 
     @on(Checkbox.Changed, "#settings-theme-dark-mode")
     def on_dark_mode_changed(self, event: Checkbox.Changed) -> None:
@@ -514,6 +533,8 @@ class SettingsThemeEditor(Vertical):
     @on(Button.Pressed, "#settings-theme-apply")
     def on_apply_theme(self) -> None:
         """Apply the current theme to the app."""
+        if self._require_theme_name() is None:
+            return
         try:
             theme_dict = {**self.current_theme_data, "dark": self.is_dark_theme}
             theme = create_theme_from_dict(
@@ -618,7 +639,9 @@ class SettingsThemeEditor(Vertical):
     @on(Button.Pressed, "#settings-theme-set-default")
     def on_set_launch_default(self) -> None:
         """Make the current saved theme the startup theme (TASK-31250)."""
-        name = self.current_theme_name
+        name = self._require_theme_name()
+        if name is None:
+            return
         saved = (self.custom_themes_path / f"{name}.toml").exists()
         if not saved and not self._is_catalog_theme(name):
             self.app.notify(
@@ -628,7 +651,13 @@ class SettingsThemeEditor(Vertical):
             return
         from ..config import save_setting_to_cli_config
 
-        save_setting_to_cli_config("general", "default_theme", name)
+        # PR #2375 review #7: the config write reports success as a bool.
+        if not save_setting_to_cli_config("general", "default_theme", name):
+            self.app.notify(
+                "Could not save the launch default; check the config file",
+                severity="error",
+            )
+            return
         self.app.notify(f"'{name}' will load at the next launch", severity="success")
 
     @on(Button.Pressed, "#settings-theme-reset")
@@ -637,6 +666,8 @@ class SettingsThemeEditor(Vertical):
         # task-1371: Reset throws away unapplied edits; the Settings screen
         # confirms its equivalent discard (revert) per ADR-031 rule 3, so the
         # editor follows the same confirmation rule.
+        if self._require_theme_name() is None:
+            return
         if not self.is_modified:
             # TASK-31261: nothing to discard -- say so instead of claiming a
             # reset happened (still no confirmation dialog, task-1371).
@@ -763,10 +794,7 @@ class SettingsThemeEditor(Vertical):
         built_in_names = {"textual-dark", "textual-light"}
         shipped_names = {t.name for t in ALL_THEMES if hasattr(t, "name")}
 
-        try:
-            validate_filename(self.current_theme_name)
-        except ValueError:
-            self.app.notify("Cannot delete theme: invalid theme name", severity="warning")
+        if self._require_theme_name() is None:
             return
 
         # File existence decides: anything saved in the user themes directory
@@ -830,6 +858,30 @@ class SettingsThemeEditor(Vertical):
                             break
                     break
 
+            # PR #2375 review #9: drop the runtime registration so Appearance
+            # and the palette stop offering the deleted theme; a user file that
+            # shadowed a shipped theme hands the shipped registration back.
+            shipped = next(
+                (t for t in ALL_THEMES if getattr(t, "name", None) == theme_name), None
+            )
+            if shipped is not None:
+                self.app.register_theme(shipped)
+            else:
+                self.app.unregister_theme(theme_name)
+
+            from ..config import get_cli_setting, save_setting_to_cli_config
+
+            if str(get_cli_setting("general", "default_theme", "textual-dark")) == theme_name:
+                if save_setting_to_cli_config("general", "default_theme", "textual-dark"):
+                    self.app.notify(
+                        "Launch default reset to textual-dark", severity="information"
+                    )
+                else:
+                    self.app.notify(
+                        "Could not reset the launch default; check the config file",
+                        severity="error",
+                    )
+
             self.load_theme("textual-dark")
         except Exception as e:
             logger.error(f"Failed to delete theme '{theme_name}': {e}")
@@ -838,13 +890,11 @@ class SettingsThemeEditor(Vertical):
     @on(Button.Pressed, "#settings-theme-export")
     def on_export_theme(self) -> None:
         """Export the current theme."""
-        try:
-            validate_filename(self.current_theme_name)
-        except ValueError as exc:
-            self.app.notify(f"Invalid theme name: {exc}", severity="warning")
+        name = self._require_theme_name()
+        if name is None:
             return
 
-        export_path = Path.home() / "Downloads" / f"{self.current_theme_name}_theme.toml"
+        export_path = Path.home() / "Downloads" / f"{name}_theme.toml"
 
         theme_data = {
             "theme": {

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -136,7 +136,7 @@ class SettingsThemeEditor(Vertical):
         # buttons only (the CSS fast-path ratchet forbids a bare `Button`
         # subject, TASK-31260).
         with Horizontal(classes="settings-action-row"):
-            yield Button("New", id="settings-theme-new", variant="primary", classes="theme-editor-action")
+            yield Button("New", id="settings-theme-new", classes="theme-editor-action")
             yield Button("Clone", id="settings-theme-clone", classes="theme-editor-action")
             yield Button("Delete", id="settings-theme-delete", variant="error", classes="theme-editor-action")
             yield Button("Export", id="settings-theme-export", classes="theme-editor-action")
@@ -214,7 +214,6 @@ class SettingsThemeEditor(Vertical):
             yield Button(
                 "Generate from Primary",
                 id="settings-theme-generate",
-                variant="primary",
                 classes="theme-editor-action",
             )
             yield Button(
@@ -371,7 +370,16 @@ class SettingsThemeEditor(Vertical):
             generated = {}
         colors: dict[str, str] = {}
         for our_name in self.BASE_COLORS:
-            value = generated.get(our_name)
+            # A colour the Theme sets explicitly comes back byte-exact (the
+            # resolved system round-trips through float maths: a saved
+            # "#FFD700" came back "#FED700" live); only unset ones resolve.
+            raw = getattr(theme, our_name, None)
+            if isinstance(raw, Color):
+                value: str | None = raw.hex
+            elif raw:
+                value = str(raw)
+            else:
+                value = generated.get(our_name)
             try:
                 colors[our_name] = Color.parse(str(value)).hex.upper() if value else "#808080"
             except Exception:  # noqa: BLE001
@@ -630,7 +638,9 @@ class SettingsThemeEditor(Vertical):
         # confirms its equivalent discard (revert) per ADR-031 rule 3, so the
         # editor follows the same confirmation rule.
         if not self.is_modified:
-            self._reset_theme()
+            # TASK-31261: nothing to discard -- say so instead of claiming a
+            # reset happened (still no confirmation dialog, task-1371).
+            self.app.notify("No changes to reset", severity="information")
             return
 
         async def _confirmed_reset() -> None:

--- a/tldw_chatbook/Widgets/settings_theme_editor.py
+++ b/tldw_chatbook/Widgets/settings_theme_editor.py
@@ -12,11 +12,11 @@ from textual.app import ComposeResult
 from textual.color import Color
 from textual.containers import Horizontal, Vertical
 from textual.css.query import QueryError
-from textual.events import Click, DescendantFocus, Key
+from textual.events import Click, Key
 from textual.message import Message
 from textual.reactive import reactive
 from textual.theme import Theme
-from textual.widgets import Button, Checkbox, Input, Static, Tree
+from textual.widgets import Button, Checkbox, Input, Select, Static, Tree
 
 from ..css.Themes.themes import ALL_THEMES, create_theme_from_dict
 from ..Utils.path_validation import validate_filename
@@ -75,7 +75,6 @@ class SettingsThemeEditor(Vertical):
         self.custom_themes_path.mkdir(parents=True, exist_ok=True)
         self.color_inputs: dict[str, Input] = {}
         self.color_swatches: dict[str, Static] = {}
-        self.last_focused_color_input: str | None = None
 
     def compose(self) -> ComposeResult:
         """Compose the theme editor widget.
@@ -102,7 +101,9 @@ class SettingsThemeEditor(Vertical):
             )
         with Horizontal(classes="settings-input-row"):
             yield Static("Dark theme", classes="settings-input-label")
-            yield Checkbox(value=True, id="settings-theme-dark-mode")
+            # TASK-31254: the label carries the state in text ("On"/"Off") so
+            # colour is never the only carrier.
+            yield Checkbox("On", value=True, id="settings-theme-dark-mode")
         with Horizontal(classes="settings-action-row"):
             yield Button("New", id="settings-theme-new", variant="primary")
             yield Button("Clone", id="settings-theme-clone")
@@ -131,10 +132,22 @@ class SettingsThemeEditor(Vertical):
                 )
                 yield Static("", id=f"settings-theme-swatch-{color_name}", classes="color-swatch")
         yield Static("Color Presets", classes="destination-section")
+        # TASK-31254/31256: the preset target is an explicit, visible choice.
+        # It used to follow keyboard focus, so Tabbing through the colour
+        # inputs to reach a swatch silently moved the target to Error.
+        with Horizontal(classes="settings-input-row settings-select-row"):
+            yield Static("Presets fill", classes="settings-input-label")
+            yield Select(
+                [(name.title(), name) for name in self.BASE_COLORS],
+                value="primary",
+                allow_blank=False,
+                id="settings-theme-preset-target",
+                classes="settings-compact-select",
+            )
         # task-1369: swatches are focusable and apply on Enter/Space, not
         # just on mouse click.
         yield Static(
-            "Focus a swatch and press Enter or Space to apply it to the selected color.",
+            "Pick the colour above, then click a swatch or focus it and press Enter or Space.",
             classes="settings-help-copy",
         )
         for palette_name, colors in self.COLOR_PRESETS.items():
@@ -220,10 +233,6 @@ class SettingsThemeEditor(Vertical):
             self.color_inputs.clear()
             self.color_swatches.clear()
             return
-
-        if "primary" in self.color_inputs:
-            self.color_inputs["primary"].add_class("selected")
-            self.last_focused_color_input = "primary"
 
     def watch_is_modified(self, is_modified: bool) -> None:
         """Notify parent screen when modified state changes."""
@@ -340,6 +349,7 @@ class SettingsThemeEditor(Vertical):
         """Update the dark mode checkbox."""
         checkbox = self.query_one("#settings-theme-dark-mode", Checkbox)
         checkbox.value = self.is_dark_theme
+        checkbox.label = "On" if self.is_dark_theme else "Off"
 
     def _update_color_swatch(self, color_name: str, color_value: str) -> None:
         """Update a color swatch preview."""
@@ -369,19 +379,13 @@ class SettingsThemeEditor(Vertical):
         except Exception:
             return False
 
-    def on_descendant_focus(self, event: DescendantFocus) -> None:
-        """Track focus changes on color inputs to update selection."""
-        widget = event.control
-        if (
-            widget
-            and isinstance(widget, Input)
-            and widget.id
-            and widget.id.startswith("settings-theme-color-")
-        ):
-            for input_widget in self.color_inputs.values():
-                input_widget.remove_class("selected")
-            widget.add_class("selected")
-            self.last_focused_color_input = widget.id[len("settings-theme-color-") :]
+    def _preset_target(self) -> str:
+        """The colour a preset swatch fills: the visible Select's value."""
+        try:
+            value = self.query_one("#settings-theme-preset-target", Select).value
+        except QueryError:
+            value = "primary"
+        return value if value in self.color_inputs else "primary"
 
     @on(Input.Changed)
     def on_color_input_changed(self, event: Input.Changed) -> None:
@@ -408,10 +412,14 @@ class SettingsThemeEditor(Vertical):
                     if self.current_theme_data.get(color_name) != color_value:
                         self.current_theme_data[color_name] = color_value
                         self.is_modified = True
-                    event.input.remove_class("invalid-color")
+                    event.input.remove_class("settings-invalid-input")
                 else:
-                    event.input.add_class("invalid-color")
-                    self._update_color_swatch(color_name, "#000000")
+                    # TASK-31254: Settings' invalid-input convention (styled in
+                    # the bundle) instead of an unstyled class, and the swatch
+                    # says so instead of silently turning black.
+                    event.input.add_class("settings-invalid-input")
+                    if color_name in self.color_swatches:
+                        self.color_swatches[color_name].update("invalid")
 
     @on(Input.Changed, "#settings-theme-name")
     def on_theme_name_changed(self, event: Input.Changed) -> None:
@@ -431,6 +439,7 @@ class SettingsThemeEditor(Vertical):
         """Handle dark mode checkbox changes."""
         # task-1338: ignore programmatic syncs from _update_dark_mode_checkbox;
         # only a real change counts as a modification.
+        event.checkbox.label = "On" if event.value else "Off"
         if event.value != self.is_dark_theme:
             self.is_dark_theme = event.value
             self.is_modified = True
@@ -756,15 +765,12 @@ class SettingsThemeEditor(Vertical):
         # str(Color) is "Color(r, g, b)", not a usable hex value -- normalize.
         color = background.hex if isinstance(background, Color) else str(background)
 
-        target = self.last_focused_color_input or "primary"
-        if target not in self.color_inputs:
-            target = "primary"
+        target = self._preset_target()
 
         self.color_inputs[target].value = color
         self._update_color_swatch(target, color)
         self.current_theme_data[target] = color
         self.is_modified = True
-        self.color_inputs[target].add_class("selected")
 
     @on(Click, ".color-preset-swatch")
     def on_preset_color_clicked(self, event: Click) -> None:

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -1128,12 +1128,24 @@ class ThemeProvider(Provider):
                 help="Open theme selection menu",
             )
 
-        # Get available theme names from registered themes
-        available_themes = ["textual-dark", "textual-light"]  # Built-in themes
-        # Add custom themes from ALL_THEMES
-        for theme in ALL_THEMES:
-            theme_name = theme.name if hasattr(theme, "name") else str(theme)
-            available_themes.append(theme_name)
+        # The two Textual built-ins always, then every registered theme:
+        # shipped ALL_THEMES and the user's saved themes (TASK-31250).
+        # custom_<name> is the editor's process-only Apply registration;
+        # switching persists the default, and that name would not exist at
+        # the next launch.
+        available_themes = list(
+            dict.fromkeys(
+                [
+                    "textual-dark",
+                    "textual-light",
+                    *(
+                        name
+                        for name in getattr(self.app, "available_themes", {})
+                        if not str(name).startswith("custom_")
+                    ),
+                ]
+            )
+        )
 
         # Only show individual themes if user is specifically searching for
         # theme-related terms or (part of) a registered theme's name
@@ -14419,6 +14431,13 @@ class TldwCli(
         theme_start = time.perf_counter()
         for theme_name in ALL_THEMES:
             self.register_theme(theme_name)
+        # TASK-31250: saved user themes (Settings > Theme > Save) load like
+        # shipped ones so general.default_theme can name them.
+        from .config import get_user_themes_dir
+        from .css.Themes.themes import load_user_themes
+
+        for user_theme in load_user_themes(get_user_themes_dir()):
+            self.register_theme(user_theme)
 
         # Apply default theme from config
         default_theme = get_cli_setting("general", "default_theme", "textual-dark")

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -1128,8 +1128,8 @@ class ThemeProvider(Provider):
                 help="Open theme selection menu",
             )
 
-        # The two Textual built-ins always, then every registered theme:
-        # shipped ALL_THEMES and the user's saved themes (TASK-31250).
+        # The two Textual built-ins, the shipped ALL_THEMES catalog, then any
+        # other registered theme -- the user's saved themes (TASK-31250).
         # custom_<name> is the editor's process-only Apply registration;
         # switching persists the default, and that name would not exist at
         # the next launch.
@@ -1138,6 +1138,10 @@ class ThemeProvider(Provider):
                 [
                     "textual-dark",
                     "textual-light",
+                    *(
+                        theme.name if hasattr(theme, "name") else str(theme)
+                        for theme in ALL_THEMES
+                    ),
                     *(
                         name
                         for name in getattr(self.app, "available_themes", {})

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -119,6 +119,12 @@ def get_cli_config_path() -> Path:
     return _get_effective_config_path()
 
 
+def get_user_themes_dir() -> Path:
+    """Directory holding the user's saved theme TOML files (active profile)."""
+
+    return get_cli_config_path().parent / "themes"
+
+
 def _optional_package_available(module_name: str) -> bool:
     """Return whether an optional top-level module is installed without importing it."""
 

--- a/tldw_chatbook/css/Themes/themes.py
+++ b/tldw_chatbook/css/Themes/themes.py
@@ -1,4 +1,6 @@
 # themes.py
+from pathlib import Path
+
 from textual.theme import Theme
 from textual.color import Color
 
@@ -36,15 +38,23 @@ def create_theme_from_dict(name: str, theme_dict: dict) -> Theme:
     return Theme(**theme_args)
 
 
-def load_user_themes(themes_dir) -> list[Theme]:
+def load_user_themes(themes_dir: str | Path) -> list[Theme]:
     """Read every ``*.toml`` under ``themes_dir`` into Theme objects.
 
     The Settings theme editor writes ``[theme] name/dark`` + ``[colors]``.
-    Unreadable files are skipped with a warning so one bad file cannot block
-    startup (TASK-31250).
-    """
-    from pathlib import Path
+    Unreadable files, and files without the primary colour Textual requires,
+    are skipped with a warning so one bad file cannot block startup
+    (TASK-31250).
 
+    Args:
+        themes_dir: Directory holding the saved theme files (normally the
+            active profile's ``themes/`` folder, see
+            ``config.get_user_themes_dir``). A missing directory yields no
+            themes.
+
+    Returns:
+        The successfully parsed themes, in file-name order.
+    """
     import toml
     from loguru import logger
 

--- a/tldw_chatbook/css/Themes/themes.py
+++ b/tldw_chatbook/css/Themes/themes.py
@@ -61,7 +61,9 @@ def load_user_themes(themes_dir) -> list[Theme]:
             colors["dark"] = bool(meta.get("dark", True))
             themes.append(create_theme_from_dict(name, colors))
         except Exception as exc:  # noqa: BLE001 - one bad file must not block startup
-            logger.warning(f"Skipping unreadable user theme {path}: {exc}")
+            # Only the file name: the themes directory is a user path and this
+            # warning reaches the persistent log (path-privacy policy).
+            logger.warning(f"Skipping unreadable user theme {path.name}: {exc}")
     return themes
 
 

--- a/tldw_chatbook/css/Themes/themes.py
+++ b/tldw_chatbook/css/Themes/themes.py
@@ -36,6 +36,35 @@ def create_theme_from_dict(name: str, theme_dict: dict) -> Theme:
     return Theme(**theme_args)
 
 
+def load_user_themes(themes_dir) -> list[Theme]:
+    """Read every ``*.toml`` under ``themes_dir`` into Theme objects.
+
+    The Settings theme editor writes ``[theme] name/dark`` + ``[colors]``.
+    Unreadable files are skipped with a warning so one bad file cannot block
+    startup (TASK-31250).
+    """
+    from pathlib import Path
+
+    import toml
+    from loguru import logger
+
+    themes: list[Theme] = []
+    root = Path(themes_dir)
+    if not root.is_dir():
+        return themes
+    for path in sorted(root.glob("*.toml")):
+        try:
+            data = toml.load(path)
+            meta = data.get("theme", {}) or {}
+            name = str(meta.get("name") or path.stem).strip() or path.stem
+            colors = dict(data.get("colors", {}) or {})
+            colors["dark"] = bool(meta.get("dark", True))
+            themes.append(create_theme_from_dict(name, colors))
+        except Exception as exc:  # noqa: BLE001 - one bad file must not block startup
+            logger.warning(f"Skipping unreadable user theme {path}: {exc}")
+    return themes
+
+
 RAW_THEMES_DATA = {
     # It's good practice to ensure your custom theme names are unique
     # and don't clash with potential future built-in Textual themes.

--- a/tldw_chatbook/css/components/_settings_splash_theme.tcss
+++ b/tldw_chatbook/css/components/_settings_splash_theme.tcss
@@ -33,30 +33,53 @@
     padding: 0 1;
 }
 
+/* TASK-31254: a 1-row Static with `border: solid` paints only its top border
+   glyphs -- the hex text (and the "invalid" label) never had a content row.
+   No border; the colour IS the swatch and the text sits on it. */
 .color-swatch {
-    width: 7;
-    min-width: 7;
+    width: 9;
+    min-width: 9;
     height: 1;
     min-height: 1;
-    border: solid $ds-grid-line;
+    border: none;
     content-align: center middle;
     text-style: bold;
 }
 
 .color-preset-swatch {
-    width: 2;
-    min-width: 2;
+    width: 3;
+    min-width: 3;
     height: 1;
     min-height: 1;
     margin: 0 1 0 0;
-    border: solid $ds-grid-line;
+    border: none;
 }
 
 /* task-1369: preset swatches are keyboard-activatable (focusable + Enter/
-   Space), so they need a visible focus indicator. */
+   Space), so they need a visible focus indicator. An outline paints over the
+   swatch's own cells without needing a border row, so the colour stays
+   visible (TASK-31254). */
 .color-preset-swatch:focus {
-    border: solid $ds-focus-accent;
+    outline: solid $ds-focus-accent;
     text-style: bold;
+}
+
+/* TASK-31254: escape the app-wide `Checkbox { height: 2 }` + tall border that
+   leaves zero content rows (the TASK-18960 family; same idiom as
+   `.settings-imagegen-backend-row Checkbox`). One row: glyph + On/Off label. */
+#settings-theme-dark-mode {
+    width: auto;
+    height: 1;
+    min-height: 1;
+    margin-bottom: 0;
+    border: none;
+    padding: 0;
+}
+#settings-theme-dark-mode > .toggle--button {
+    color: $ds-surface-panel;
+}
+#settings-theme-dark-mode.-on > .toggle--button {
+    color: $success;
 }
 
 .preview-button {

--- a/tldw_chatbook/css/components/_settings_splash_theme.tcss
+++ b/tldw_chatbook/css/components/_settings_splash_theme.tcss
@@ -20,17 +20,20 @@
     margin: 1 0 0 0;
 }
 
-.settings-preview-grid {
+/* TASK-31259: the preview is a Console-shaped stub whose rows are painted from
+   the palette being edited (see SettingsThemeEditor._refresh_preview), so it
+   follows every keystroke instead of the applied app theme. */
+.settings-theme-preview {
     width: 100%;
     height: auto;
-    min-height: 8;
     margin: 1 0;
+    border: solid $ds-grid-line;
 }
 
-.preview-column {
-    width: 1fr;
-    height: auto;
-    padding: 0 1;
+.settings-theme-preview-row {
+    width: 100%;
+    height: 1;
+    min-height: 1;
 }
 
 /* TASK-31254: a 1-row Static with `border: solid` paints only its top border
@@ -82,23 +85,6 @@
     color: $success;
 }
 
-.preview-button {
-    width: 100%;
-    height: 1;
-    min-height: 1;
-    margin: 0 0 1 0;
-}
-
-.preview-surface-demo,
-.preview-panel-demo,
-.preview-boost-demo {
-    width: 100%;
-    height: 1;
-    min-height: 1;
-    margin: 0 0 1 0;
-    border: solid $ds-grid-line;
-    content-align: center middle;
-}
 
 /* ===== Settings splash screen viewer ===== */
 .settings-splash-gallery {

--- a/tldw_chatbook/css/components/_settings_splash_theme.tcss
+++ b/tldw_chatbook/css/components/_settings_splash_theme.tcss
@@ -86,6 +86,17 @@
 }
 
 
+/* TASK-31260: below SETTINGS_COMPACT_WORKBENCH_MAX_WIDTH (100 cols) the
+   detail pane is ~45 cells; four 16-cell-minimum buttons cannot share a row,
+   so the library and action rows stack and each button takes the width. */
+#settings-workbench.settings-workbench-compact #settings-theme-card .settings-action-row {
+    layout: vertical;
+    height: auto;
+}
+#settings-workbench.settings-workbench-compact #settings-theme-card .theme-editor-action {
+    width: 100%;
+}
+
 /* ===== Settings splash screen viewer ===== */
 .settings-splash-gallery {
     height: 24;

--- a/tldw_chatbook/css/components/_settings_splash_theme.tcss
+++ b/tldw_chatbook/css/components/_settings_splash_theme.tcss
@@ -86,7 +86,7 @@
 }
 
 
-/* TASK-31260: below SETTINGS_COMPACT_WORKBENCH_MAX_WIDTH (100 cols) the
+/* TASK-31279: below SETTINGS_COMPACT_WORKBENCH_MAX_WIDTH (100 cols) the
    detail pane is ~45 cells; four 16-cell-minimum buttons cannot share a row,
    so the library and action rows stack and each button takes the width. */
 #settings-workbench.settings-workbench-compact #settings-theme-card .settings-action-row {

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -6088,17 +6088,20 @@ StatCard:hover {
     margin: 1 0 0 0;
 }
 
-.settings-preview-grid {
+/* TASK-31259: the preview is a Console-shaped stub whose rows are painted from
+   the palette being edited (see SettingsThemeEditor._refresh_preview), so it
+   follows every keystroke instead of the applied app theme. */
+.settings-theme-preview {
     width: 100%;
     height: auto;
-    min-height: 8;
     margin: 1 0;
+    border: solid $ds-grid-line;
 }
 
-.preview-column {
-    width: 1fr;
-    height: auto;
-    padding: 0 1;
+.settings-theme-preview-row {
+    width: 100%;
+    height: 1;
+    min-height: 1;
 }
 
 /* TASK-31254: a 1-row Static with `border: solid` paints only its top border
@@ -6150,23 +6153,6 @@ StatCard:hover {
     color: $success;
 }
 
-.preview-button {
-    width: 100%;
-    height: 1;
-    min-height: 1;
-    margin: 0 0 1 0;
-}
-
-.preview-surface-demo,
-.preview-panel-demo,
-.preview-boost-demo {
-    width: 100%;
-    height: 1;
-    min-height: 1;
-    margin: 0 0 1 0;
-    border: solid $ds-grid-line;
-    content-align: center middle;
-}
 
 /* ===== Settings splash screen viewer ===== */
 .settings-splash-gallery {

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -6101,30 +6101,53 @@ StatCard:hover {
     padding: 0 1;
 }
 
+/* TASK-31254: a 1-row Static with `border: solid` paints only its top border
+   glyphs -- the hex text (and the "invalid" label) never had a content row.
+   No border; the colour IS the swatch and the text sits on it. */
 .color-swatch {
-    width: 7;
-    min-width: 7;
+    width: 9;
+    min-width: 9;
     height: 1;
     min-height: 1;
-    border: solid $ds-grid-line;
+    border: none;
     content-align: center middle;
     text-style: bold;
 }
 
 .color-preset-swatch {
-    width: 2;
-    min-width: 2;
+    width: 3;
+    min-width: 3;
     height: 1;
     min-height: 1;
     margin: 0 1 0 0;
-    border: solid $ds-grid-line;
+    border: none;
 }
 
 /* task-1369: preset swatches are keyboard-activatable (focusable + Enter/
-   Space), so they need a visible focus indicator. */
+   Space), so they need a visible focus indicator. An outline paints over the
+   swatch's own cells without needing a border row, so the colour stays
+   visible (TASK-31254). */
 .color-preset-swatch:focus {
-    border: solid $ds-focus-accent;
+    outline: solid $ds-focus-accent;
     text-style: bold;
+}
+
+/* TASK-31254: escape the app-wide `Checkbox { height: 2 }` + tall border that
+   leaves zero content rows (the TASK-18960 family; same idiom as
+   `.settings-imagegen-backend-row Checkbox`). One row: glyph + On/Off label. */
+#settings-theme-dark-mode {
+    width: auto;
+    height: 1;
+    min-height: 1;
+    margin-bottom: 0;
+    border: none;
+    padding: 0;
+}
+#settings-theme-dark-mode > .toggle--button {
+    color: $ds-surface-panel;
+}
+#settings-theme-dark-mode.-on > .toggle--button {
+    color: $success;
 }
 
 .preview-button {

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -6154,7 +6154,7 @@ StatCard:hover {
 }
 
 
-/* TASK-31260: below SETTINGS_COMPACT_WORKBENCH_MAX_WIDTH (100 cols) the
+/* TASK-31279: below SETTINGS_COMPACT_WORKBENCH_MAX_WIDTH (100 cols) the
    detail pane is ~45 cells; four 16-cell-minimum buttons cannot share a row,
    so the library and action rows stack and each button takes the width. */
 #settings-workbench.settings-workbench-compact #settings-theme-card .settings-action-row {

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -6154,6 +6154,17 @@ StatCard:hover {
 }
 
 
+/* TASK-31260: below SETTINGS_COMPACT_WORKBENCH_MAX_WIDTH (100 cols) the
+   detail pane is ~45 cells; four 16-cell-minimum buttons cannot share a row,
+   so the library and action rows stack and each button takes the width. */
+#settings-workbench.settings-workbench-compact #settings-theme-card .settings-action-row {
+    layout: vertical;
+    height: auto;
+}
+#settings-workbench.settings-workbench-compact #settings-theme-card .theme-editor-action {
+    width: 100%;
+}
+
 /* ===== Settings splash screen viewer ===== */
 .settings-splash-gallery {
     height: 24;


### PR DESCRIPTION
## Summary

Closes the twelve defects from the 2026-09-03 Settings ▸ Theme editor UX review (dual-agent impeccable critique + live tmux walkthrough at dev `59d987015d`, heuristic score 17/40). Backlog TASK-31250 … TASK-31259 plus TASK-31279 and TASK-31280 (31260/31261 were renumbered after colliding with tasks that landed on dev first), all Done with notes; plan in `Docs/superpowers/plans/2026-09-03-theme-editor-ux-fixes.md`.

**P0**
- **Saved themes never loaded.** Only the editor read `~/.config/tldw_cli/themes/*.toml`; `default_theme = "<saved>"` silently fell back to textual-dark while Appearance showed "Current: <saved>". Now: `themes.load_user_themes()` registers them at startup, Save registers immediately, Appearance and the palette list them, and a new **Set as launch default** button writes `general.default_theme`. `config.get_user_themes_dir()` is the single path home.
- **Write-only Name box.** Apply/Export/Reset/Delete used the name from the last load (live: rename to "ocean" → "Theme 'new_theme' applied", Delete "No saved custom theme named 'new_theme'"). The box now drives the name.

**P1**
- Re-entering Theme after Apply no longer blanks the palette or keeps a stale "Unsaved: Yes".
- Generate from Primary: `Color.hsl` hue is 0-1, the helper wanted degrees → every primary gave red/cyan. Fixed, uppercase hex.
- Swatch hex, invalid-hex state, preset target and Dark toggle are painted (1-row bordered swatches had no content row; `.selected`/`.invalid-color` had no CSS; Checkbox squeezed by the app-wide height rule, TASK-18960 family). Preset target is an explicit "Presets fill" Select with the swatches no longer following Tab focus.
- Tree browsing never re-themes the app; Delete no longer forces textual-dark. Colours read from the registered Theme (set colours byte-exact, unset ones resolved).
- Actions row sits before the palette; tree lists **Your themes** first and open, **Built-in**, then **Shipped themes** collapsed, root expanded.

**P2/P3**
- New starts from the current palette (as the hint always promised).
- Save over another saved theme and Export onto an existing file confirm first.
- Live Preview is a Console-shaped stub repainted from the edited palette.
- Compact workbench (≤100 cols) stacks the action rows; inspector path shown once with `~`.
- Reset with no edits says so; Apply is the only primary button.

## Post-review
- Rebased on dev `282c733d61` (#2371, #2374); the palette provider keeps dev's bare-name search and lists built-ins, the shipped catalog, then registered saved themes.
- Qodo round 1: #2, #4-#9 fixed in-branch (one name guard shared by every action, write-failure check, `custom_` filter in Appearance and palette, delete unregisters/restores/clears the default, startup integration test, typed loader); #1 and #3 declined in-thread with reasoning.

## Verification
- TDD per task: 26 new tests across `Tests/UI/test_settings_theme_editor.py`, new `Tests/UI/test_settings_theme_editor_render.py` (production bundle **plus** `screen_agentic_settings.tcss`, the TASK-25812 split sheet), `Tests/Utils/test_user_theme_loader.py`, and screen-level tests in `test_settings_configuration_hub.py`.
- Full `Tests/UI` (18,826 tests, `-n 4`) run on this branch AND on a pristine `origin/dev` checkout (`e4652f9d37`): 765 vs 763 failures, all in Console/Library/wizard/Watchlists/Personas suites this branch does not touch. The 14 ids failing only on the branch were re-run in isolation: 11 pass, and the remaining 3 fail identically on the pristine tree (one is a detail-call timeout that flips pass/fail on both trees across three runs). `Tests/Utils` + `Tests/Architecture`: 20 baseline failures on dev, none added here (the diagnostic-inventory pin was refreshed after review).
- CSS bundle rebuilt via `build_css.py`; fast-path ratchet stays at 274 (compact rule keyed to `.theme-editor-action`); `test_css_build_integrity.py` selector pin moved to `.settings-theme-preview`; diagnostic inventory refreshed after reviewing the three new warnings.
- Live in a scratch profile: saved theme loads at launch and reopens by name; swatch paints `#00CC66`; invalid hex reads "invalid"; Set as launch default reachable by keyboard (Name → Tab×11).

## Docs
- `Docs/User_Guide/settings.md` Theme section, recipe 3 and the "theme didn't change after saving" quirk rewritten; Verified-against stamp added.
- `backlog/docs/lessons-testing-evidence.md`: bundle-only harnesses miss the per-screen split sheets; `Color.hsl` hue is 0-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BarRiaGxPsRjSdCQzPZXgf
