### PR TITLE
test(perf): sample the UI-ready module census at the flag, not on the next tick

### DIFF
--- a/Tests/Performance/test_ui_ready_module_census.py
+++ b/Tests/Performance/test_ui_ready_module_census.py
@@ -202,24 +202,48 @@ import json
 import sys
 
 
+FLAG_TIME_MODULES: list = []
+
+
+def _install_flag_time_snapshot(app_class) -> None:
+    # Copy sys.modules AT THE INSTANT `_ui_ready` flips, synchronously
+    # inside the assignment, not on the census's next poll tick. The app
+    # sets the flag and keeps running its mount path, which arms 0.1s
+    # timers (collections-capture wiring, audio service, workspace
+    # provisioning) that are deferred past `_ui_ready` on purpose; when the
+    # loop is starved after the flag on a slow runner the 5ms poll woke
+    # AFTER those timers and counted their imports (task-31281: PR #2373
+    # measured 973, 973, 977 on the same tree -- the 977 run carried five
+    # Library.collections_capture_* modules that dev's own run did not).
+    # A data descriptor on the class intercepts the instance assignment, so
+    # the count is exactly what ADR-097 pins: resident at `_ui_ready`.
+    def _get(self):
+        return self.__dict__.get("_ui_ready_flag", False)
+
+    def _set(self, value):
+        self.__dict__["_ui_ready_flag"] = value
+        if value and not FLAG_TIME_MODULES:
+            FLAG_TIME_MODULES.extend(sys.modules)
+
+    app_class._ui_ready = property(_get, _set)
+
+
 async def main() -> None:
     import tldw_chatbook.app
 
+    _install_flag_time_snapshot(tldw_chatbook.app.TldwCli)
     app = tldw_chatbook.app.TldwCli()
     async with app.run_test(size=(120, 40)):
         while not getattr(app, "_ui_ready", False):
             await asyncio.sleep(0.005)
-        # Snapshot BEFORE iterating: background threads (tick syncs, catalog
-        # refresh) keep importing after _ui_ready, and iterating the live
-        # dict raised "dictionary changed size during iteration" -- an
-        # intermittent guardrails failure on PR #2255 and a sibling branch,
-        # 2026-08-31. A point-in-time copy is also the honest census: every
-        # module in it existed at the same instant.
-        modules_now = list(sys.modules)
+        # The copy taken by the setter is also the honest census: every
+        # module in it existed at the same instant, and iterating the live
+        # dict raised "dictionary changed size during iteration" (PR #2255,
+        # 2026-08-31).
         mods = sorted(
             m
-            for m in modules_now
-            if m.startswith("tldw_chatbook") and sys.modules[m] is not None
+            for m in FLAG_TIME_MODULES
+            if m.startswith("tldw_chatbook") and sys.modules.get(m) is not None
         )
         for m in mods:
             print("MOD:" + m, flush=True)

--- a/Tests/Performance/test_ui_ready_module_census.py
+++ b/Tests/Performance/test_ui_ready_module_census.py
@@ -84,10 +84,13 @@ Documented blind spots (be honest about what a census cannot see):
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 import subprocess
 import sys
+import types
+import uuid
 from pathlib import Path
 
 import pytest
@@ -196,7 +199,42 @@ enabled = false
 api_key = "sk-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKL"
 """
 
-_CENSUS_SCRIPT = """
+def install_flag_time_snapshot(app_class: type, sink: list) -> None:
+    """Make ``app_class._ui_ready = True`` copy ``sys.modules`` into ``sink``.
+
+    Copies AT THE INSTANT the flag flips, synchronously inside the
+    assignment, not on the census's next poll tick. The app sets the flag
+    and keeps running its mount path, which arms 0.1s timers
+    (collections-capture wiring, audio service, workspace provisioning)
+    that are deferred past ``_ui_ready`` on purpose; when the loop is
+    starved after the flag on a slow runner the 5ms poll woke AFTER those
+    timers and counted their imports (task-31281: PR #2373 measured 973,
+    973, 977 on the same tree -- the 977 run carried five
+    ``Library.collections_capture_*`` modules that dev's own run did not).
+    A data descriptor on the class intercepts the instance assignment, so
+    the count is exactly what ADR-097 pins: resident at ``_ui_ready``.
+
+    Defined at module level so it has unit tests of its own; the census
+    subprocess embeds its source via ``inspect.getsource``.
+
+    Args:
+        app_class: The class whose ``_ui_ready`` attribute to intercept.
+        sink: Receives the module names once, on the first truthy set.
+    """
+
+    def _get(self):
+        return self.__dict__.get("_ui_ready_flag", False)
+
+    def _set(self, value):
+        self.__dict__["_ui_ready_flag"] = value
+        if value and not sink:
+            sink.extend(sys.modules)
+
+    app_class._ui_ready = property(_get, _set)
+
+
+_CENSUS_SCRIPT = (
+    """
 import asyncio
 import json
 import sys
@@ -205,33 +243,14 @@ import sys
 FLAG_TIME_MODULES: list = []
 
 
-def _install_flag_time_snapshot(app_class) -> None:
-    # Copy sys.modules AT THE INSTANT `_ui_ready` flips, synchronously
-    # inside the assignment, not on the census's next poll tick. The app
-    # sets the flag and keeps running its mount path, which arms 0.1s
-    # timers (collections-capture wiring, audio service, workspace
-    # provisioning) that are deferred past `_ui_ready` on purpose; when the
-    # loop is starved after the flag on a slow runner the 5ms poll woke
-    # AFTER those timers and counted their imports (task-31281: PR #2373
-    # measured 973, 973, 977 on the same tree -- the 977 run carried five
-    # Library.collections_capture_* modules that dev's own run did not).
-    # A data descriptor on the class intercepts the instance assignment, so
-    # the count is exactly what ADR-097 pins: resident at `_ui_ready`.
-    def _get(self):
-        return self.__dict__.get("_ui_ready_flag", False)
-
-    def _set(self, value):
-        self.__dict__["_ui_ready_flag"] = value
-        if value and not FLAG_TIME_MODULES:
-            FLAG_TIME_MODULES.extend(sys.modules)
-
-    app_class._ui_ready = property(_get, _set)
-
+"""
+    + inspect.getsource(install_flag_time_snapshot)
+    + """
 
 async def main() -> None:
     import tldw_chatbook.app
 
-    _install_flag_time_snapshot(tldw_chatbook.app.TldwCli)
+    install_flag_time_snapshot(tldw_chatbook.app.TldwCli, FLAG_TIME_MODULES)
     app = tldw_chatbook.app.TldwCli()
     async with app.run_test(size=(120, 40)):
         while not getattr(app, "_ui_ready", False):
@@ -252,6 +271,7 @@ async def main() -> None:
 
 asyncio.run(main())
 """
+)
 
 
 def _boot_and_census(tmp_path: Path) -> list[str]:
@@ -370,3 +390,66 @@ def test_ui_ready_module_census_stays_at_the_pinned_size(
         f"{on_leg}. Something re-eagered them on the import OR mount leg -- "
         "the closure guards in Tests/Packaging name the intended seams."
     )
+
+
+# -- unit coverage for the flag-time snapshot (task-31281) --------------------
+
+
+def test_flag_time_snapshot_copies_modules_inside_the_assignment_and_only_once():
+    """The copy happens synchronously when the flag flips True, not while
+    it is False, and never again -- a later import or a second assignment
+    cannot grow it (the race the census used to lose on slow runners)."""
+
+    class _Dummy:
+        def __init__(self) -> None:
+            self._ui_ready = False
+
+    sink: list[str] = []
+    install_flag_time_snapshot(_Dummy, sink)
+    app = _Dummy()
+    assert app._ui_ready is False
+    assert sink == [], "constructing with False must not snapshot"
+
+    before = f"tldw_census_probe_before_{uuid.uuid4().hex}"
+    after = f"tldw_census_probe_after_{uuid.uuid4().hex}"
+    sys.modules[before] = types.ModuleType(before)
+    try:
+        app._ui_ready = True
+        assert app._ui_ready is True
+        assert before in sink, "snapshot taken inside the assignment"
+        sys.modules[after] = types.ModuleType(after)
+        app._ui_ready = True
+        assert after not in sink, "a second True never re-snapshots"
+        app._ui_ready = False
+        app._ui_ready = True
+        assert after not in sink, "nor does flipping back and forth"
+    finally:
+        sys.modules.pop(before, None)
+        sys.modules.pop(after, None)
+
+
+def test_flag_time_snapshot_is_per_instance_state_on_the_class():
+    """Two instances keep their own flag; the sink is filled by whichever
+    flips first (the census boots exactly one app, but the descriptor must
+    not leak one instance's readiness into another)."""
+
+    class _Dummy:
+        pass
+
+    sink: list[str] = []
+    install_flag_time_snapshot(_Dummy, sink)
+    first, second = _Dummy(), _Dummy()
+    first._ui_ready = True
+    assert first._ui_ready is True and second._ui_ready is False
+    assert sink, "first instance's flip filled the sink"
+
+
+def test_census_script_embeds_the_unit_tested_helper():
+    """The subprocess runs the SAME function the unit tests cover, not a
+    hand-copied variant that could drift."""
+    assert "def install_flag_time_snapshot(" in _CENSUS_SCRIPT
+    assert (
+        "install_flag_time_snapshot(tldw_chatbook.app.TldwCli, FLAG_TIME_MODULES)"
+        in _CENSUS_SCRIPT
+    )
+    compile(_CENSUS_SCRIPT, "<census>", "exec")

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -158,6 +158,31 @@ instead of landing exactly at the local cap.
 
 ---
 
+## A census taken on the next tick is not a census taken at the flag
+
+**PR #2373 / task-31281, 2026-09-04.** The UI-ready module census failed on
+three consecutive CI runs of what was, after the second, the same tree: 973,
+973, then 977 modules against the 972 cap. The first two carried exactly the
+one new module the PR added (fixed by lazy-mounting the widget, ADR-097
+response 1). The third did not contain that module at all -- it carried five
+`Library.collections_capture_*` modules that neither sibling run nor `dev`'s
+own run of the merged tree had. The app sets `_ui_ready` and then keeps
+running its mount path, which arms 0.1s timers that are deferred past
+readiness *by design*; the census polled the flag every 5ms and copied
+`sys.modules` when it woke, and on a starved runner those timers won. `dev`
+sits exactly at the cap, so the "+/-1 wobble headroom" the constant's own
+comment promises does not exist, and a one-run race flips the check red.
+
+**What to do.** When a guard's contract is "resident at instant X", sample at
+instant X -- here, a class-level property whose setter copies `sys.modules`
+synchronously inside the `self._ui_ready = True` assignment -- never on the
+next scheduler turn after observing X. And when a non-required check fails on
+your PR, read its `+` list before believing it: if your module is not in it,
+compare against the base branch's own run of the same tree before spending a
+round on a fix.
+
+---
+
 ## Shipped migration and ADR numbers are allocation records, not merge labels
 
 **TASK-24613, 2026-08-30.** The Agent Lessons worktree and a newer `dev`

--- a/backlog/tasks/task-31281 - UI-ready-module-census-samples-after-the-flag-and-races-the-0.1s-deferred-startup-timers.md
+++ b/backlog/tasks/task-31281 - UI-ready-module-census-samples-after-the-flag-and-races-the-0.1s-deferred-startup-timers.md
@@ -1,0 +1,45 @@
+---
+id: TASK-31281
+title: >-
+  UI-ready module census samples after the flag and races the 0.1s
+  deferred-startup timers
+status: Done
+assignee:
+  - '@Robert'
+created_date: '2026-09-04 14:54'
+updated_date: '2026-09-04 14:55'
+labels:
+  - testing
+  - performance
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The perf-guard census (Tests/Performance/test_ui_ready_module_census.py) polls _ui_ready every 5ms and then copies sys.modules. TldwCli sets the flag and keeps running the rest of its mount path, which arms 0.1s timers (collections-capture wiring, audio service, workspace provisioning) that are deferred past _ui_ready by design. On a slow runner the loop is starved long enough after the flag that those timers fire before the census wakes, and their imports are counted. Observed on PR #2373 (2026-09-04): three runs of the same tree measured 973, 973 and 977 -- the 977 run carried +5 Library.collections_capture_* modules that neither sibling run nor dev's own run at the merge commit had. Dev sits exactly at the 972 ratchet, so the documented +/-1 wobble headroom is gone and this race flips the check red.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The census records sys.modules at the instant _ui_ready is set, not on the next poll tick
+- [x] #2 Three consecutive local census runs are green and report the same count
+- [x] #3 The evidence (the three PR #2373 run ids and their +/- module lists) is in the task notes
+- [x] #4 A lesson entry with the incident is added to backlog/docs/lessons-testing-evidence.md
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Intercept the flag with a class-level property in _CENSUS_SCRIPT whose setter copies sys.modules synchronously.
+2. Use that copy for the census; keep the poll only to wait for readiness.
+3. Run the census test three times locally; confirm the count is no higher than before.
+4. Lesson entry; PR; Qodo; merge.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: the census polled _ui_ready every 5ms and copied sys.modules when it woke, while TldwCli sets the flag mid-mount and then arms 0.1s deferred-startup timers (_schedule_deferred_startup_work: collections-capture wiring, audio service, workspace provisioning) later in the same path. On a starved runner those timers won the race. Fix: _CENSUS_SCRIPT installs a class-level property for _ui_ready whose setter copies sys.modules synchronously inside the assignment; the poll only waits for readiness and the census iterates that copy. Evidence, PR #2373 (same tree after the 2nd run): run 33844095943 = 973 (+18/-13, incl. the PR's own module), run 33882174928 = 973 (+19/-14, incl. that module), run 33884089897 = 977 (+23/-14, that module ABSENT, +5 Library.collections_capture_{models,repository,service}, collections_legacy_recovery, collections_offline_store); dev's own perf-guard run 33885569458 at the merge commit 50c9918935 = success. Local after the fix: three consecutive runs 966/972 (was 969 on this platform per the constant's comment), drift +16/-18 identical each time. Files: Tests/Performance/test_ui_ready_module_census.py, backlog/docs/lessons-testing-evidence.md (new entry).
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary

Fixes a race in the ADR-097 UI-ready module census (`Tests/Performance/test_ui_ready_module_census.py`), the check behind the non-required "UI latency guardrails" job. Closes task-31281.

**What happened.** On PR #2373 the census failed three times on what was, after the second run, the same tree: 973, 973, then **977** against the 972 cap. The first two carried exactly the one module that PR added (fixed there by lazy-mounting the widget). The third did not contain that module at all. It carried five `Library.collections_capture_*` modules that neither sibling run nor dev's own perf-guard run of the merged tree (`50c9918935`, success) had.

**Why.** `TldwCli` sets `_ui_ready` mid-mount and then, later in the same path, calls `_schedule_deferred_startup_work()`, which arms 0.1 s timers (collections-capture wiring, audio service, workspace provisioning) that are deferred past readiness *on purpose*. The census polled the flag every 5 ms and copied `sys.modules` when it woke. On a starved runner the timers fired first. Dev sits exactly at the cap, so the "+/-1 wobble headroom" the constant's comment promises no longer exists and a one-run race turns the check red.

**Fix.** The subprocess script installs a class-level property for `_ui_ready` whose setter copies `sys.modules` synchronously inside the `self._ui_ready = True` assignment. The poll only waits for readiness; the census iterates that copy. The count is now exactly what ADR-097 pins: resident at `_ui_ready`.

## Evidence

| run | head | count | diff vs snapshot | note |
|---|---|---|---|---|
| 33844095943 | 9127335e60 | 973 | +18 / −13 | includes the PR's own module |
| 33882174928 | 1684d9e388 | 973 | +19 / −14 | includes the PR's own module |
| 33884089897 | 5bb16a525c | 977 | +23 / −14 | that module **absent**; +5 `collections_capture_*` |
| 33885569458 (dev) | 50c9918935 | pass | | same tree as the row above |

Local after the fix, three consecutive runs: `966/972 modules (headroom 6); snapshot drift +16/-18`, identical each time. The constant's own comment recorded 969 for this platform under the old sampling, so the old method was counting post-flag imports.

## Also in this PR

- `backlog/docs/lessons-testing-evidence.md`: new entry "A census taken on the next tick is not a census taken at the flag", with the incident.
- task-31281 filed with the run ids and closed.

No production code changes. `./scripts/preflight.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018q5PsHwn5kgHPmNwX9DKoo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the UI-ready module census (`test_ui_ready_module_census.py`) that caused spurious perf-guard failures: the census polled `_ui_ready` every 5ms and copied `sys.modules` when it woke, but `TldwCli` arms 0.1s deferred-startup timers after setting the flag, so on a starved runner those timers' imports got counted (PR #2373 measured 973/973/977 on the same tree against the 972 cap).

The census now samples `sys.modules` at the flag via a class-level property, so the count is exactly what the flag-time snapshot pins. The snapshot logic lives in a module-level `install_flag_time_snapshot(app_class, sink)` helper with unit tests, and the subprocess embeds that same source via `inspect.getsource`. Adds a lesson entry to `backlog/docs/lessons-testing-evidence.md` and closes task-31281. No production code changes.

<sup>Written for commit 6a05b0ef0be0e30afb4722a6e952c4d63e10e153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

