### PR TITLE
fix(library): wave 4 A — Find focus token, two-row receipts, explicit-open bypass (tasks 31269/31270/31273/31278)

### DIFF
--- a/.impeccable/critique/2026-09-04T13-50-05Z__tldw-chatbook-ui-screens-library-screen-py.md
+++ b/.impeccable/critique/2026-09-04T13-50-05Z__tldw-chatbook-ui-screens-library-screen-py.md
@@ -1,0 +1,88 @@
+---
+target: Library ▸ Media (post fix wave 3)
+total_score: 25
+max_score: 40
+na_heuristics: 
+p0_count: 1
+p1_count: 4
+timestamp: 2026-09-04T13-50-05Z
+slug: tldw-chatbook-ui-screens-library-screen-py
+---
+Method: dual-agent (A: design-review sub-agent · B: detector/evidence sub-agent, isolated; parent traced A's P0 and P1 mechanics in source before scoring)
+
+Target: Library ▸ Browse ▸ Media (Operate mode) at dev tip 8b6e7501d6, after fix wave 3 (#2366, #2367, #2369). Live at 235×52 and 100×30 against six seeded CRIT4 items (removed after the run).
+
+## Design Health Score — 25/40 (Acceptable, upper edge)
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Banner, footer progress, "Loaded ·" prefix and receipts are exemplary; but after Escape closes Find the footer keeps saying `esc close find` (A cap 08/23, B cap_21), and both undo receipts clip their Undo button to `Un`/`Und` in the Items pane (B cap_83, cap_99) |
+| 2 | Match System / Real World | 3 | "Page boundary is unknown.", "workspace workspace-local-1", "Local Media item" above every title, More ▸ "Open manager" that routes back to this screen (library_screen.py:41720-41740) |
+| 3 | User Control and Freedom | 2 | Walk keys typed into a search field (P0); three Escapes to leave the Reader with the second landing inside the rail's Search input (A cap 20); Escape does not close the More menu (B cap_106); "‹ Back" changes the key map without changing the screen |
+| 4 | Consistency and Standards | 2 | Read collapses Find until asked, Analysis mounts it permanently (viewer.py:626-631); receipts never got the multi-row grammar the toolbars got; eight distinct `esc …` labels; `]`/`[`/`m`/`R` advertised, `l`/`c`/`t` hidden (`show=False`, :1016-1018); doc says "Open in Library ▸ Media" and "no permanent delete", UI ships "Open manager" and "Delete permanently" |
+| 5 | Error Prevention | 3 | Destructive choreography is textbook (armed confirm naming both recovery paths, receipt, durable Trash); but `t` arms delete from the Reader unadvertised (B cap_97), Space with the footer's blessing collapsed the Library pane (A cap 31→32), picker Dismiss sits one cell from the open button |
+| 6 | Recognition Rather Than Recall | 2 | Rows show `type · age` and nothing else: no analysis marker, no reviewed marker mid-walk (B cap_02); "Analyze after import" off by default inside a collapsed "▶ Import behavior" group with no state on its header (ingest_capabilities.py:1013-1020); keyword `day2` on four rows filters to "No media matched" (B cap_15) |
+| 7 | Flexibility and Efficiency | 2 | The `]` walk is dead in Analysis mode (P0); no bulk Analyze; no key for "Review these" or "Sets"; Delete key unbound; F6's content stop is invisible (B cap_57) |
+| 8 | Aesthetic and Minimalist Design | 2 | Reader now fills its pane (held), but eight rows of chrome precede content (A cap 03), the Find bar jumps above the header on Enter (B cap_20), a `┐─────` join artifact appears after Find closes (14 captures), Trash shows ~36 blank rows above a pinned Restore (B cap_102), prose runs ~150 cells against DESIGN.md's 65–75 |
+| 9 | Error Recovery | 3 | Undo now covers delete, bulk delete and Dismiss; Retry, honest empty states; minus Generate learns the provider is unready only after the click (library_screen.py:41613-41618), and the Undo control is unreadable where it renders |
+| 10 | Help and Documentation | 3 | Footer teaching and F1 are strong; the guide drifts from the UI in two places; the completion gesture (final `]` on the last item) is not labelled anywhere on screen (B cap_50) |
+| **Total** | | **25/40** | **Acceptable (upper edge) — down from 28; a fix-wave regression of my own owns the drop** |
+
+## Design Specificity Verdict
+
+**LLM assessment (A, unanchored):** authored in its vocabulary, generic in its layout. The state language is unmistakably Chatbook's: the footer that relabels the same key by context (`] next item` → `] next in set … 3 of 6 · 2 reviewed`), `○` disabled markers with reasons, "Loaded ·" row prefixes, the receipt grammar naming Trash, the banner "Reviewing: All media — 1 of 6 · 0 reviewed · not yet reviewed". The shell those words sit in (rail | filter + choosers + list | identity line / Back / title / toolbar / tabs / section header / bordered box) is interchangeable list-detail scaffolding, and the one product-specific interaction, the `]` walk over a pinned set, is exactly where the seams now show.
+
+**Deterministic scan (B):** `detect.mjs --json` over the five media files returned `[]`, exit 0. No-signal: the engine scans web extensions only, `.py`/`.tcss` are skipped silently, and even an HTML probe ran degraded without parser modules. Mechanical greps: 0 hex colors in the five files and in the library-media TCSS section; buttons vs tooltips are canvas 24/5, viewer 25/0, content 2/0, picker 4/1; every Unicode marker sits next to words (none glyph-only); the one message sent at two severities is documented as deliberate ambient-vs-gesture; `#library-media-viewer-content` is `height: 1fr` with no `max-height` (the 75vh cap is gone).
+
+**Visual overlays:** not applicable, terminal UI.
+
+**Where A and B agree:** all six wave-3 fixes held under an independent live probe. Review-selected exits select mode and opens the Reader with `1 of 2` (B cap_73); auto-resume lands on the cursor item and the first `]` advances (cap_77/78); the sort chooser shows all four options with ✓ and works by keyboard (cap_03-08); Dismiss leaves an undo receipt (cap_83); the Reader box reaches row 49 of 52 with no Find bar on a fresh open and no dead pager (cap_17); the "Paused '2 selected items' at 1 of 2 · 0 reviewed. Resume from Sets." notice fires and picker rows carry dates (cap_74, cap_79). B's `]]]]]` in the search field (cap_32b) and A's `▊ ]` (cap 22) are the same defect seen from two sides.
+
+## Overall Impression
+
+The instrument-panel discipline is intact and the review-set model is right. But the wave-3 Find fix (#2367, mine) shipped with a focus hook that fires on every item load, and the Analysis tab (task-28026, mine) mounts that bar unconditionally. So the product's core sequential-review gesture now silently types into a text box. That regression, plus undo receipts that clip their own Undo button, is the whole story of the three-point drop. Fix those two and this surface is back above 28 with the rest as polish.
+
+## What's Working
+
+1. **The footer is a status contract, not decoration.** It drops `[` on the first item and `]` on the last, swaps to `enter choose sort | esc cancel` while a chooser is open, and carries set progress as a chip (`_review_footer_entries`, `_library_footer_shortcuts_for_current_state`). Verified in nine distinct states.
+2. **One undo grammar for every destructive act.** Single delete, bulk delete and set Dismiss all leave "✓ … · Undo / Dismiss" in place, name the durable path, and never open a modal (canvas.py:857-940; viewer.py:238-256).
+3. **The review-set model survives its chrome.** Pinned snapshot with tombstones, progress over live items only, forward-marks / back-never-marks, one-active with a displacement notice, resume on entry (review_set_state.py:198-280; library_screen.py:38804-38877). B's walk matched the model exactly.
+
+## Priority Issues
+
+1. **[P0] Walking with any search bar mounted types your keys into it.** Two faces of one mechanism. In Analysis mode the search bar is composed whenever an analysis exists (viewer.py:626-631) and its `on_mount` focuses the input whenever the query is empty (content.py:351-362), which is every fresh item load: `]` loads the next item, focus jumps into the box, the next `]` is text (A cap 22/24/36). In Read mode the same happens whenever Find is open across a walk: B's field read `]]]]]` (cap_32b) and, inside a review, `]`, `m`, `m`, `[` were swallowed with the banner frozen at `2 of 6 · 1 reviewed` (cap_41-44). The Find button does not toggle the bar off (cap_38); Escape from inside the input only blurs on the first press. **Why:** workflow 3, "review every analysis of a set", is precisely Analysis mode plus `]`; it now costs Escape + `]` per item and fails silently. **Origin:** my #2367 focus-on-mount hook meeting my task-28026 always-rendered Analysis bar. **Fix:** pass an explicit focus flag only from the Find gesture (`handle_library_media_reader_find`, library_screen.py:41064-41083) instead of inferring it from an empty query; gate the Analysis bar behind `find_open` exactly as Read does (viewer.py:311-322); on a `]`/`[` walk keep the query but never re-take focus; pin with a test that walks two items in Analysis mode and asserts `focused` is not the Input. **Command:** /impeccable harden.
+
+2. **[P1] Undo receipts clip their Undo button in the Items pane.** "✓ dismissed · 2 selected items  Un" and "✓ deleted · 1 item · in Trash  Und" (B cap_83, cap_99). Undo is unfindable by label, the trailing Dismiss button is off-pane, and B could only recover by a raw click on the `U` cell. Receipts are single-line content-width rows in the ~38-col pane; the toolbars were converted to multi-row grammar in #2350 but the receipts were not. **Why:** the receipt is the product's signature safety net; an unreadable Undo is a hidden recovery state, the product's own anti-reference. **Fix:** two-row receipt (message line, then `Undo   Dismiss` on its own row) with `width: 100%` and the toolbar min-width lift; shorten the message; pin with a painted-text test at 38 cols. **Command:** /impeccable adapt.
+
+3. **[P1] The footer lies at four seams.** (a) After Escape closes Find the footer still says `esc close find` because `_library_media_escape_label` (39761-39797) reads the DOM before the recompose lands. (b) Right after `s` the footer promises `space toggle selection` while Space is a no-op unless a row is focused (B cap_69; gate at 27812-27827) and, with focus on the pane grip, collapses the Library pane instead (A cap 31→32), since `_toggle_library_media_select_mode` never moves focus to a row. (c) At `6 of 6` the footer still reads `] next in set` although the next `]` is the completion gesture (B cap_50; 3685). (d) `l`/`c`/`t` are real Reader keys (:1016-1018, `show=False`) and `t` arms delete, yet nothing advertises them. **Fix:** recompute footer shortcuts after `_close_library_media_find` settles; focus the first row on `s` and compute the Space chip from `self.focused`; label the last-item key `] finish review`; add `l`/`c`/`t` (at least `t`) to the Reader footer set. **Command:** /impeccable audit.
+
+4. **[P1] Leaving and moving focus are three-key rituals that end in text fields.** "‹ Back" sets `_library_media_view = "list"` (38493-38522) but the Reader keeps showing the document (A cap 25/31/39), `]`/`[` go dead, and the footer switches to `s select` on identical pixels. Escape from the Reader goes focus Items → focus Library, and the second Escape lands inside `#library-search-input` (A cap 20); B's `s` at the F6 rail stop typed into "Search Library…" (cap_79). F6 cycles reader → rail search → filter and B could not see it land on the content box (cap_57) although the code lists content first (`_MEDIA_WORKBENCH_FOCUS_TARGETS`): the stop is real but invisible after the 31221 outline suppression. Escape does not close the More menu (B cap_106) though the label promises `close more`. Eight distinct `esc …` labels seen live. **Fix:** Escape from the Reader focuses the loaded list row, never an Input; give the content stop a visible focus treatment that does not paint over text (border tint); make Escape close More; in the three-pane shell either retire "‹ Back" or render list mode visibly. **Command:** /impeccable clarify.
+
+5. **[P1] Workflow 1 still has no set-level analysis path, and rows carry no state.** (carried from critique #1; both halves are work I filed and deferred: 28007 batch analyze, 28008/28009 row markers behind the 5-key summary contract.) Rows show `type · 5m` and nothing about analysis or reviewed state (B cap_02); "Analyze after import" is off by default inside a collapsed group with no state on its header; Select mode's bulk row is Export / Review / Delete (canvas.py:359-374); Generate learns "no provider" after the click via toast. **Fix:** "Analyze" in the bulk row reusing `_generate_library_media_analysis` per id in one worker group with an in-list receipt; a state summary on the collapsed header; disable Generate with the resolver's reason in the label; bump the summary contract so rows carry an analysis glyph and a reviewed glyph. **Command:** /impeccable shape.
+
+**P2 batch:** the filter matches titles only, so keyword `day2` on four rows yields "No media matched 'day2'" (B cap_15; cause suspected, not traced), undercutting "Review these" over a tag scope; returning from Trash after Restore leaves the list stale ("Media changed; retry to load a current page.", every row and action `○`, "Page boundary is unknown.") until a manual Retry (B cap_104-110) although the app itself made the change; the Find bar relocates above the header on Enter, pushing the header down six rows (B cap_20), and a `┐─────Local Media item` join artifact appears after Find closes (14 captures); eight rows of Reader chrome before content, an empty byline row, a section header repeating the tab, and `##` headings rendered literally for video transcripts (library_media_viewer_state.py:201-208); Trash header clipped to "Local Trash · 1 i" with ~36 blank rows above a pinned Restore (28015, deferred).
+
+## Persona Red Flags
+
+**Alex (impatient power user):** Analysis mode plus `]` is two keys per item with a silent miss when he forgets. Coming to Media to open a different file while a set is active pulls him to the cursor item on every entry (39683-39692) — user ruling at this close: an explicit open must bypass auto-resume. No key for "Review these" or "Sets"; nine controls above the rows to Tab through. No "next unreviewed" after un-marking with `m`. Delete key does nothing; `t` does, unlabelled. Generate tells him the provider is unready only after the click.
+
+**Sam (keyboard-only, text over color):** Space collapsed the rail while the footer said `space toggle selection`. The F6 content stop exists but shows nothing. The dead-key state is a two-word chip; the field that now owns `]` says nothing. At 100×30 the `esc` hint drops out of the footer entirely (`F1 · Ctrl+P · Ctrl+Q`, B cap_108). Pane grips are bare `--->` / `<---` with words only in a mouse tooltip. Works for Sam: `☑/☐/○` always beside words, `(selected)` on tabs, "✓ reviewed / not yet reviewed" spelled out.
+
+**Conference researcher (40 talks, must miss none):** the Items list never shows which rows are reviewed; the only ✓ is the banner for the loaded item, so finding the one she skipped means re-walking (my set-local design; row markers deferred). The gesture that completes the set (a final `]` on the last item) is labelled `] next in set`. A talk deleted mid-walk silently drops the total. Completion is a five-second toast and a footer chip, no landing state. "Review these" pins the current filter and names the set after it ("pdf items") without warning her the filter is on. Her tag filter says no media matched.
+
+## Minor Observations
+
+- After picking a sort the button clips to `sort: Title A` (B cap_04).
+- In the picker `✓` marks the active set and moves as you open sets; one line below, ✓ means completed (B cap_82).
+- "Loaded · " eats nine cells of the row that matters most; the ✓ glyph in a title is ellipsized away.
+- Viewer has 25 buttons and 0 tooltips (B).
+- "Restored outside the current filter." and "Selection discarded (N items)" exist; "1 item in this set was deleted" does not.
+- Sets cannot be named; auto-names plus dates are the only handle.
+- Doc/UI drift: "Open in Library ▸ Media" vs "Open manager"; "no permanent delete" vs "Delete permanently".
+- The Sets picker's empty state points at "Review these", which is behind the modal you are in.
+
+## Decisions I own (corrected at the close; originally mis-framed as questions to the user)
+
+1. Reviewed marks live only on the loaded item because I designed review sets with set-local done marks and twice parked the row-marker work (28008/28009). Proposal: bump the 5-key media summary contract so rows carry a reviewed glyph and an analysis glyph, as its own PR.
+2. Batch analysis is missing because I filed it (28007) and never shipped it. Proposal: an Analyze action on the select-mode bulk row, reusing the per-item generator in one worker group with an in-list receipt.
+3. I recommended resume-on-every-entry and the user approved it; it now overrides explicit opens. User ruling at this close: an explicit open (deep link, open-by-id, Enter on a row) bypasses auto-resume.

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -204,7 +204,7 @@ item-specific empty state; it does not silently switch modes.
 
 | Button | What it does |
 |---|---|
-| "Find" | Opens the in-item search bar (collapsed until then) focused and ready to type; this never filters Items. Escape closes the bar again. |
+| "Find" | Opens the search bar for the tab you are reading — the transcript on Read, the analysis on Analysis — focused and ready to type; a second press or Escape closes it. Walking with `]`/`[` keeps an active query but never moves your cursor into the field. This never filters Items. |
 | "Use in Console" | Stages this item as context for your next Console message. |
 | "Read later" ↔ "Remove later" | Toggles the loaded item's persisted reading-list state. |
 | "More" | Keeps secondary actions reachable: Edit metadata, Open original when available, Open manager, and Move to trash. Narrow layouts retain these actions here rather than hiding them. |
@@ -247,8 +247,9 @@ them one by one, with your place and progress saved between visits.
   that still exist, and a set whose items were all removed reports "No items
   to review" instead of completing.
 
-*Verified against fix/media-review-continuity — 2026-09-04 (task-31233/34/36/38:
-live create-from-selection → every-entry resume → dismiss-undo pass in tmux).*
+*Verified against fix/media-wave4-a — 2026-09-04 (task-31269: Analysis-mode [ ] walk over
+three items, Find on the Analysis tab, Escape, Find toggle, all live in tmux 235x52; the earlier
+task-31233/34/36/38 create-from-selection → every-entry resume → dismiss-undo pass still holds).*
 
 ### Conversations
 

--- a/Docs/superpowers/plans/2026-09-04-media-ux-wave4-pr-a.md
+++ b/Docs/superpowers/plans/2026-09-04-media-ux-wave4-pr-a.md
@@ -1,0 +1,694 @@
+# Media UX fix wave 4 — PR A (regressions + ruling) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the two regressions critique #4 traced to fix wave 3 (walk keys typed into the search field; undo receipts clipping their Undo button), the user's auto-resume-bypass ruling, and the row-marker design note, as one PR against `dev`.
+
+**Architecture:** The Reader's content search bar gains an explicit one-shot `focus_on_mount` token that only the Find gesture sets, so an item change can never move focus into the Input; the Analysis tab gates its bar behind `find_open` exactly as Read does. Receipts adopt the two-row grammar the toolbars got in #2350 (copy row + action row, width 100%). Explicit opens cancel a pending auto-resume worker and the banner names an off-set item honestly. Everything is pinned by tests on the production-CSS harness; painted-text assertions where paint-over or clipping is the bug.
+
+**Tech Stack:** Python 3.12, Textual 8.x, pytest + pytest-asyncio (`app.run_test`), the `LibraryProductionCSSHarness` from `Tests/UI/test_library_shell.py`, `ControlledDetailMediaService` from `Tests/UI/test_library_media_reader_flow.py`.
+
+**Spec:** `.impeccable/critique/2026-09-04T13-50-05Z__tldw-chatbook-ui-screens-library-screen-py.md` (critique #4) — priority issues 1 and 2, the "Decisions I own" section (ruling 3), and tasks `backlog/tasks/task-31269`, `task-31270`, `task-31273`, `task-31278`.
+
+## Global Constraints
+
+- Worktree: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/media-ux-p3`, branch `fix/media-wave4-a` off dev `282c733d61`. Every command: `cd <worktree> && PYTHONPATH=<worktree> /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest … -p no:cacheprovider` (the venv's editable install points at the MAIN checkout; PYTHONPATH pins the worktree). Use absolute paths; the shell cwd can be reset between calls.
+- Run UI test files in SEPARATE processes (never several heavy app-test files in one pytest invocation).
+- No new `logger.*` calls (each one forces `python scripts/check_persistent_diagnostic_inventory.py --write` and a committed inventory JSON). If you must add one, run the writer and commit `Docs/security/production-diagnostic-inventory.json`.
+- After editing any `BUNDLED_CSS` or `tldw_chatbook/css/components/*.tcss`: run `python -m tldw_chatbook.css.build_css` then `python tldw_chatbook/css/check_bundle_sync.py` (no pipe; read the real exit code) and commit every regenerated file (`tldw_chatbook/css/tldw_cli_modular.tcss`, `screen_*.tcss`, `widget_defaults_*`).
+- Any new id queried by a seam must be gated on the active Reader mode when the same id is reused across tabs (`#library-media-content-search-controls` and `#library-media-viewer-content` are reused by Read and Analysis).
+- Textual key names in `pilot.press`: `]` is `right_square_bracket`, `[` is `left_square_bracket`, Escape is `escape`.
+- Commit after every task with the trailer:
+  ```
+  Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_011LebG4HPfSniVohbuXkU4n
+  ```
+- Backlog task files: mark ACs `- [x]`, add `## Implementation Plan` and `## Implementation Notes`, flip `status: Done` via `backlog task edit <id> -s Done --check-ac N … --plan "…" --notes "…" --plain` run with cwd = the worktree. Never renumber ids.
+
+---
+
+### Task 1: The Find gesture, not the mount, decides focus (task-31269, P0)
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Library/library_media_content.py:330-366` (`LibraryMediaContentSearchControls.__init__` / `on_mount`)
+- Modify: `tldw_chatbook/Widgets/Library/library_media_viewer.py:84-122` (constructor), `:338-348` (Read-mode bar), `:626-641` (Analysis-mode bar)
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py:2662` (state init), `:40481` (viewer construction), `:40649-40790` (`_sync_library_media_viewer_state` compare/assign), `:41063-41083` (`handle_library_media_reader_find`)
+- Modify: `Tests/UI/test_library_media_reader_flow.py:1452-1490` (contract change for Find on the Analysis tab)
+- Test: `Tests/UI/test_library_media_render_fixes.py` (new tests appended)
+- Modify: `Docs/User_Guide/library/media-and-conversations.md` (Find paragraph + "Verified against" stamp)
+
+**Interfaces:**
+- Produces: `LibraryMediaContentSearchControls(…, focus_on_mount: bool = False)`; `LibraryMediaViewer(…, find_focus_pending: bool = False)` attribute `find_focus_pending` consumed (set `False`) by the viewer's own compose right after it yields the bar; screen attribute `_library_media_find_focus_pending: bool` set by the Find handler and consumed by whichever seam next builds or syncs the viewer.
+- Consumes: `screen._library_media_find_open`, `_close_library_media_find()`, `_sync_library_media_viewer_or_recompose()`, `_reset_library_media_search_on_mode_change(new_mode)`.
+
+- [ ] **Step 1: Write the failing tests** (append to `Tests/UI/test_library_media_render_fixes.py`; add these imports at the top of the file next to the existing ones)
+
+```python
+from textual.widgets import Input
+
+from Tests.UI.test_library_media_reader_flow import (
+    ControlledDetailMediaService,
+    _load_row_0,
+    _row_identity,
+    _wait_for_detail_call,
+)
+from Tests.UI.test_library_shell import _many_media_items
+from tldw_chatbook.Library.library_media_reader_session import set_mode
+
+
+def _analysis_flow_host(count: int = 3):
+    """Three local items, each with a current analysis version.
+
+    Local media detail never carries ``analysis_content`` at the top level;
+    the viewer reads the newest ``versions`` entry
+    (``library_media_viewer_state._latest_version_analysis_text``).
+    """
+    app = _build_media_test_app()
+    items = _many_media_items(count)
+    for index, item in enumerate(items, 1):
+        item["versions"] = [
+            {"version_number": 1, "analysis_content": f"Analysis of item {index}"}
+        ]
+    _seed_conversations(app, _two_conversations(), media=items)
+    service = ControlledDetailMediaService(items)
+    app.media_reading_scope_service = service
+    return LibraryProductionCSSHarness(app), service
+
+
+async def _walk_next(screen, service, pilot, expected_row: int) -> str:
+    """Press ] and settle the Reader on ``expected_row``; return its id."""
+    row = screen.query_one(f"#library-media-row-{expected_row}", Button)
+    row_id, backing_id, _ = _row_identity(row)
+    await pilot.press("right_square_bracket")
+    await _wait_for_detail_call(service, backing_id)
+    service.release(backing_id)
+    await _wait_for_condition(
+        pilot,
+        lambda: screen._library_media_reader_session.loaded_id == row_id,
+        message=f"] never loaded row {expected_row}.",
+    )
+    await pilot.pause()
+    return row_id
+
+
+@pytest.mark.asyncio
+async def test_analysis_mode_walk_never_moves_focus_into_the_search_field():
+    """task-31269 (critique #4 P0): ] in Analysis mode walks, it never types.
+
+    #2367's focus-on-mount hook fired on EVERY mount with an empty query,
+    and the Analysis tab (task-28026) mounted the bar unconditionally, so
+    each item load in Analysis mode parked focus in the Input and the next
+    ] became text (live: `▊ ]`, `]]]]]`).
+    """
+    host, service = _analysis_flow_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row_0(screen, service, pilot)
+        screen._library_media_reader_session = set_mode(
+            screen._library_media_reader_session, "analysis"
+        )
+        screen._sync_library_media_viewer_or_recompose()
+        await _wait_for_condition(
+            pilot,
+            lambda: "Analysis of item 1" in "".join(
+                str(w.render()) for w in screen.query("#library-media-viewer-content")
+            ) or bool(screen.query("#library-media-viewer-content")),
+            message="Analysis body never rendered.",
+        )
+        # The bar is collapsed until Find asks for it, exactly like Read.
+        assert not screen.query("#library-media-content-search-controls")
+
+        await _walk_next(screen, service, pilot, expected_row=1)
+        assert screen._library_media_reader_session.mode == "analysis"
+        assert not isinstance(screen.focused, Input), screen.focused
+        assert not screen.query("#library-media-content-search-controls")
+
+        # A second ] must still be a walk (the P0 symptom was it being typed).
+        await _walk_next(screen, service, pilot, expected_row=2)
+        assert not isinstance(screen.focused, Input), screen.focused
+
+
+@pytest.mark.asyncio
+async def test_find_on_the_analysis_tab_opens_the_bar_there_and_escape_closes_it():
+    """Find searches what you are reading: on Analysis it opens the analysis
+    bar (task-28026's Analysis->Read jump is retired), focuses its Input, and
+    one Escape collapses it (live: the first Escape only blurred)."""
+    host, service = _analysis_flow_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row_0(screen, service, pilot)
+        screen._library_media_reader_session = set_mode(
+            screen._library_media_reader_session, "analysis"
+        )
+        screen._sync_library_media_viewer_or_recompose()
+        await pilot.pause()
+        screen.query_one("#library-media-reader-find", Button).press()
+        search_input = await _wait_for_selector(
+            screen, pilot, "#library-media-content-search"
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: search_input.has_focus,
+            message="Find never focused the analysis search input.",
+        )
+        assert screen._library_media_reader_session.mode == "analysis"
+
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.pause()
+        assert not screen.query("#library-media-content-search-controls")
+        assert screen._library_media_find_open is False
+
+
+@pytest.mark.asyncio
+async def test_read_mode_walk_with_find_open_keeps_the_query_and_the_keys():
+    """task-31269 AC2: an open bar survives an item change with its query,
+    but focus stays where the user left it, so ] keeps walking."""
+    host, service = _analysis_flow_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row_0(screen, service, pilot)
+        screen.query_one("#library-media-reader-find", Button).press()
+        search_input = await _wait_for_selector(
+            screen, pilot, "#library-media-content-search"
+        )
+        await _wait_for_condition(
+            pilot, lambda: search_input.has_focus, message="Find never focused."
+        )
+        await pilot.press("i", "t", "e", "m")
+        await pilot.pause()
+        # Leave the field the way a reader does (F6 target = content body).
+        screen.query_one("#library-media-viewer-content").focus()
+        await pilot.pause()
+
+        await _walk_next(screen, service, pilot, expected_row=1)
+        assert screen._library_media_content_query == "item"
+        assert screen.query("#library-media-content-search-controls")
+        assert not isinstance(screen.focused, Input), screen.focused
+
+        await _walk_next(screen, service, pilot, expected_row=2)
+        assert screen._library_media_content_query == "item"
+
+
+@pytest.mark.asyncio
+async def test_find_toggles_the_bar_closed_when_it_is_open():
+    """task-31269 AC4: a second Find press closes the bar (live: it did nothing)."""
+    host, service = _analysis_flow_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row_0(screen, service, pilot)
+        find = screen.query_one("#library-media-reader-find", Button)
+        find.press()
+        await _wait_for_selector(screen, pilot, "#library-media-content-search-controls")
+        screen.query_one("#library-media-reader-find", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+        assert not screen.query("#library-media-content-search-controls")
+        assert screen._library_media_find_open is False
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `cd <worktree> && PYTHONPATH=<worktree> .venv-python -m pytest Tests/UI/test_library_media_render_fixes.py -p no:cacheprovider -q -k "analysis_mode_walk or find_on_the_analysis_tab or read_mode_walk_with_find_open or find_toggles" --no-header`
+Expected: `test_analysis_mode_walk…` FAILS on `assert not screen.query("#library-media-content-search-controls")` (the Analysis bar is unconditional today); `test_find_on_the_analysis_tab…` FAILS on `mode == "analysis"` (today Find jumps to read); `test_read_mode_walk…` FAILS on `not isinstance(screen.focused, Input)` after the first walk (empty-query remount is impossible here because the query is "item" — if this one passes today, keep it as a regression guard); `test_find_toggles…` FAILS on the bar still present.
+
+- [ ] **Step 3: Give the search controls an explicit focus token** (`library_media_content.py`)
+
+Replace the constructor tail and `on_mount`:
+
+```python
+    def __init__(
+        self,
+        *,
+        is_markdown: bool,
+        query: str,
+        matches: tuple[int, ...],
+        match_index: int,
+        focus_on_mount: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.is_markdown = is_markdown
+        self.query = query
+        self.matches = matches
+        self.match_index = match_index
+        self.focus_on_mount = focus_on_mount
+        self.set_class(bool(self.query), self.ACTIVE_SEARCH_CLASS)
+
+    def on_mount(self) -> None:
+        """Take focus into the input only on the Find-gesture mount.
+
+        task-31269 (critique #4 P0): inferring the gesture from an empty
+        query made EVERY mount with no query steal focus -- each ]/[ item
+        load in Analysis mode, and any walk with the bar open, parked the
+        caret in this Input and the next key was typed. The gesture is now
+        an explicit token the screen sets in the Find handler and the
+        viewer consumes on the one compose that follows; every other mount
+        (item change, mode flip, match navigation) leaves focus alone. The
+        focus still runs from THIS widget's post-refresh hook because no
+        screen-level defer can order itself after a nested recompose-mount
+        (task-31237).
+        """
+        if self.focus_on_mount:
+            self.call_after_refresh(self._focus_search_input)
+```
+
+- [ ] **Step 4: Thread the token through the viewer and gate the Analysis bar** (`library_media_viewer.py`)
+
+Constructor: add the parameter after `find_open: bool = False,` and store it:
+
+```python
+        find_open: bool = False,
+        find_focus_pending: bool = False,
+```
+```python
+        self.find_open = find_open
+        self.find_focus_pending = find_focus_pending
+```
+Docstring line under `find_open:` — add:
+```python
+            find_focus_pending: One-shot token from the Find gesture; the
+                bar it mounts takes focus, then the token is consumed here
+                so later syncs never re-take focus (task-31269).
+```
+
+Read-mode bar (the `if self.find_open or self.content_query:` block at ~338): pass and consume the token:
+
+```python
+            if self.find_open or self.content_query:
+                matches = find_content_matches(
+                    self.viewer.content, self.content_query
+                )
+                yield LibraryMediaContentSearchControls(
+                    is_markdown=self.viewer.is_markdown,
+                    query=self.content_query,
+                    matches=matches,
+                    match_index=self.content_match_index,
+                    focus_on_mount=self.find_focus_pending,
+                    id="library-media-content-search-controls",
+                )
+                # task-31269: the gesture token is spent on this mount.
+                self.find_focus_pending = False
+```
+
+Analysis-mode bar (~626): gate it like Read and pass the token; the body keeps rendering regardless:
+
+```python
+        if self.viewer.analysis:
+            # task-28026: the analysis is searchable through the SAME
+            # controls/body the Read tab uses. task-31269: like Read, the
+            # bar is collapsed until Find opens it -- an always-mounted bar
+            # stole focus on every item load and swallowed the walk keys.
+            matches = find_content_matches(self.viewer.analysis, self.content_query)
+            if self.find_open or self.content_query:
+                yield LibraryMediaContentSearchControls(
+                    is_markdown=False,
+                    query=self.content_query,
+                    matches=matches,
+                    match_index=self.content_match_index,
+                    focus_on_mount=self.find_focus_pending,
+                    id="library-media-content-search-controls",
+                )
+                self.find_focus_pending = False
+            yield LibraryMediaContentBody(
+                content=self.viewer.analysis,
+                is_markdown=False,
+                mode="raw",
+                query=self.content_query,
+                match_index=self.content_match_index,
+                id="library-media-viewer-content",
+            )
+```
+
+- [ ] **Step 5: Screen side — state, construction, sync, handler** (`library_screen.py`)
+
+State init (next to line 2662):
+```python
+        self._library_media_find_open: bool = False
+        # task-31269: one-shot Find-gesture token; consumed by the next
+        # viewer build/sync so an item change can never move focus into
+        # the search Input.
+        self._library_media_find_focus_pending: bool = False
+```
+
+Add a helper right above `handle_library_media_reader_find`:
+```python
+    def _consume_library_media_find_focus(self) -> bool:
+        """Return and clear the one-shot Find-gesture focus token (task-31269)."""
+        pending = self._library_media_find_focus_pending
+        self._library_media_find_focus_pending = False
+        return pending
+```
+
+Viewer construction (line ~40481): after `find_open=self._library_media_find_open,` add
+```python
+            find_focus_pending=self._consume_library_media_find_focus(),
+```
+
+`_sync_library_media_viewer_state`: in the "nothing changed → return False" compare (the block that contains `and viewer.find_open == self._library_media_find_open`), add one more conjunct so a pending gesture always takes the recompose path:
+```python
+            and not self._library_media_find_focus_pending
+```
+and in the assign block right after `viewer.find_open = self._library_media_find_open` add:
+```python
+            viewer.find_focus_pending = self._consume_library_media_find_focus()
+```
+
+Handler — replace the body of `handle_library_media_reader_find`:
+```python
+        event.stop()
+        if self._library_media_find_open:
+            # task-31269 AC4: Find is a toggle -- a second press closes the
+            # bar (live: it did nothing while the bar was open).
+            self._close_library_media_find()
+            self._sync_library_media_viewer_or_recompose()
+            return
+        # task-31269: Find searches the tab you are reading. The Analysis
+        # tab's bar is gated exactly like Read's now, so Find no longer
+        # jumps Analysis -> Read (task-28026's transition predates the
+        # collapsed bar). A same-mode reset is a no-op by design.
+        self._reset_library_media_search_on_mode_change(
+            self._library_media_reader_session.mode
+        )
+        self._library_media_find_open = True
+        self._library_media_find_focus_pending = True
+        self._sync_library_media_viewer_or_recompose()
+        self.call_after_refresh(self._focus_library_media_content_search_input)
+```
+Also update the handler docstring's first line to `"""Open (or close) the Find bar for the tab being read."""`.
+
+- [ ] **Step 6: Update the retired contract test** (`Tests/UI/test_library_media_reader_flow.py:1452`)
+
+Rename and rewrite the test so it pins the new semantics (keep the fake, add `_library_media_find_open=False` and `_library_media_find_focus_pending=False` to the `SimpleNamespace`):
+```python
+def test_find_from_analysis_opens_the_bar_on_the_analysis_tab():
+    """task-31269: Find searches the tab you are reading. On the Analysis
+    tab it opens the analysis bar in place (task-28026's Analysis->Read
+    jump is retired) and hands the viewer a one-shot focus token; the
+    query is untouched because the mode did not change."""
+    ...  # same session/fake construction as before, plus the two attrs above
+    LibraryScreen.handle_library_media_reader_find(
+        fake, SimpleNamespace(stop=lambda: None)
+    )
+    assert fake._library_media_reader_session.mode == "analysis"
+    assert fake._library_media_find_open is True
+    assert fake._library_media_find_focus_pending is True
+    assert fake._library_media_content_query == "needle"
+```
+
+- [ ] **Step 7: Run the four new tests plus the two existing Find tests; then the whole file, then reader_flow, each in its own process**
+
+Run: `… -m pytest Tests/UI/test_library_media_render_fixes.py -p no:cacheprovider -q --no-header` → Expected: all pass (including `test_find_bar_collapsed_until_find_and_escape_recollapses`).
+Run: `… -m pytest Tests/UI/test_library_media_reader_flow.py -p no:cacheprovider -q --no-header` → Expected: 49 passed (the renamed test included).
+Run: `… -m pytest Tests/UI/test_library_media_reader_match_nav_t22209.py -p no:cacheprovider -q --no-header` → Expected: 7 passed (`test_a_new_document_rescans_for_the_same_query` proves the query survives the walk).
+Run: `… -m pytest Tests/UI/test_library_shell.py -p no:cacheprovider -q --no-header -k "find or search or analysis"` → Expected: no new failures (the deep-link failure listed in task-31249 is pre-existing).
+
+- [ ] **Step 8: User guide** — in `Docs/User_Guide/library/media-and-conversations.md` find the sentence describing Find on the Analysis tab (grep `Find`); make it read: "Find opens a search bar for the tab you are reading — the transcript on Read, the analysis on Analysis — and a second press or Escape closes it. Walking with `]`/`[` keeps the query and never moves your cursor into the field." Update the "Verified against" stamp to today's dev tip.
+
+- [ ] **Step 9: Live verify (tmux, 235x52)** — seed via `python - <<EOF` with `MediaDatabase.add_media_with_keywords(..., analysis_content=...)` for three items (prefix `W4A`), launch `tmux -L w4a new-session -d -x 235 -y 52 "PYTHONPATH=<worktree> <python> -m tldw_chatbook.app"; sleep 14` (sleep in the same call), palette → library, click the Media rail, open item 1, click Analysis, press `]` three times → the banner/list must advance three times and the footer must never read `typing in field`. Capture to `Docs/…`-free scratch; soft-delete the seeds afterwards; `tmux -L w4a kill-server`.
+
+- [ ] **Step 10: Commit**
+```bash
+git add tldw_chatbook/Widgets/Library/library_media_content.py tldw_chatbook/Widgets/Library/library_media_viewer.py tldw_chatbook/UI/Screens/library_screen.py Tests/UI/test_library_media_render_fixes.py Tests/UI/test_library_media_reader_flow.py Docs/User_Guide/library/media-and-conversations.md
+git commit -m "fix(library): the Find gesture, not the mount, decides focus (task-31269)"
+```
+
+---
+
+### Task 2: Receipts adopt the two-row grammar (task-31270, P1)
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/Library/library_media_canvas.py:147-170` (`BUNDLED_CSS`), `:815-848` (bulk-delete receipt), `:850-881` (review-dismiss receipt)
+- Modify: `tldw_chatbook/css/components/_agentic_terminal.tcss` (library-media section, near the `#library-media-canvas > .ds-toolbar` rule from task-28025)
+- Regenerate: `tldw_chatbook/css/tldw_cli_modular.tcss`, `tldw_chatbook/css/screen_agentic_library.tcss`, `tldw_chatbook/css/widget_defaults_*` (whatever `python -m tldw_chatbook.css.build_css` rewrites)
+- Test: `Tests/UI/test_library_media_render_fixes.py` (painted-text tests appended)
+
+**Interfaces:**
+- Produces: containers `#library-media-bulk-delete-receipt` and `#library-media-review-dismiss-receipt` become `Vertical` (class `library-media-receipt`) holding a copy `Static` (class `library-media-receipt-copy`) and a `Horizontal(classes="ds-toolbar library-media-receipt-actions")` with the unchanged buttons `#library-media-bulk-delete-undo`, `#library-media-bulk-delete-receipt-dismiss`, `#library-media-review-dismiss-undo`, `#library-media-review-dismiss-receipt-close`.
+- Consumes: `self.canvas.delete_receipt_count`, `self.canvas.review_dismiss_receipt_name`, `_gate_stale_action`, `_gate_mutation_action` (unchanged).
+
+- [ ] **Step 1: Write the failing painted-text tests** (append to `Tests/UI/test_library_media_render_fixes.py`; add `from tldw_chatbook.UI.Screens.library_screen import _sync_library_canvas` to the imports)
+
+```python
+def _items_pane_width(screen) -> int:
+    return screen.query_one("#library-media-canvas").region.width
+
+
+@pytest.mark.asyncio
+async def test_delete_receipt_paints_undo_and_dismiss_at_the_items_pane_width():
+    """task-31270 (critique #4 P1): the receipt's Undo was clipped to `Und`
+    in the ~38-col Items pane (live cap_99). Painted text on purpose: a
+    region assertion cannot see a label cut by its parent's width."""
+    host = _host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        screen._library_media_delete_receipt_ids = ("local:media:1",)
+        _sync_library_canvas(screen, "media")
+        receipt = await _wait_for_selector(
+            screen, pilot, "#library-media-bulk-delete-receipt"
+        )
+        await pilot.pause()
+        await pilot.pause()
+        assert receipt.region.width <= _items_pane_width(screen)
+        painted = _painted(host, receipt.region)
+        assert "✓ deleted · 1 item · in Trash" in painted, painted
+        assert "Undo" in painted, painted
+        assert "Dismiss" in painted, painted
+
+
+@pytest.mark.asyncio
+async def test_dismiss_receipt_paints_undo_at_the_items_pane_width():
+    """task-31270: the set-dismiss receipt clipped to `… Un` (live cap_83)."""
+    host = _host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        screen._review_dismiss_receipt_name = lambda: "2 selected items"
+        _sync_library_canvas(screen, "media")
+        receipt = await _wait_for_selector(
+            screen, pilot, "#library-media-review-dismiss-receipt"
+        )
+        await pilot.pause()
+        await pilot.pause()
+        assert receipt.region.width <= _items_pane_width(screen)
+        painted = _painted(host, receipt.region)
+        assert "✓ dismissed · 2 selected items" in painted, painted
+        assert "Undo" in painted, painted
+        assert "Dismiss" in painted, painted
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `… -m pytest Tests/UI/test_library_media_render_fixes.py -p no:cacheprovider -q --no-header -k receipt_paints`
+Expected: both FAIL with `"Undo" in painted` (or `"Dismiss"`) — the painted text ends in `Und`/`Un`.
+
+- [ ] **Step 3: Restructure both receipts** (`library_media_canvas.py`)
+
+Bulk-delete receipt (replace the `receipt_row = Horizontal(...)` block):
+```python
+        receipt_count = getattr(self.canvas, "delete_receipt_count", 0)
+        if receipt_count:
+            receipt_word = "item" if receipt_count == 1 else "items"
+            # task-31270: two rows (copy, then actions), width 100% -- a
+            # single content-width Horizontal clipped Undo to "Und" at the
+            # Items pane's real width (critique #4). Same grammar as the
+            # multi-row toolbars (task-30043).
+            receipt = Vertical(
+                id="library-media-bulk-delete-receipt",
+                classes="library-media-receipt",
+            )
+            receipt.styles.height = "auto"
+            with receipt:
+                yield Static(
+                    f"✓ deleted · {receipt_count} {receipt_word} · in Trash",
+                    id="library-media-bulk-delete-receipt-copy",
+                    classes="library-toolbar-count library-media-receipt-copy",
+                    markup=False,
+                )
+                actions = Horizontal(classes="ds-toolbar library-media-receipt-actions")
+                actions.styles.height = "auto"
+                with actions:
+                    undo = Button(
+                        "Undo",
+                        id="library-media-bulk-delete-undo",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                    yield self._gate_stale_action(undo, "Undo")
+                    dismiss = Button(
+                        "Dismiss",
+                        id="library-media-bulk-delete-receipt-dismiss",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                    yield self._gate_mutation_action(dismiss, "Dismiss")
+```
+Keep every existing comment about ADR-055 / task-4025 above the copy. Apply the identical shape to the review-dismiss receipt (`id="library-media-review-dismiss-receipt"`, copy `f"✓ dismissed · {dismissed_set_name}"` with id `library-media-review-dismiss-receipt-copy`, buttons `library-media-review-dismiss-undo` / `library-media-review-dismiss-receipt-close`).
+
+- [ ] **Step 4: CSS at both tiers**
+
+`BUNDLED_CSS` (append inside the string):
+```css
+    /* task-31270: receipts are two rows, full width; the copy wraps and the
+     * action row keeps content-width buttons so Undo/Dismiss always paint. */
+    .library-media-receipt {
+        width: 100%;
+        height: auto;
+    }
+    .library-media-receipt > .library-media-receipt-copy {
+        width: 100%;
+        height: auto;
+    }
+    .library-media-receipt > .library-media-receipt-actions {
+        width: 100%;
+        height: auto;
+    }
+```
+`_agentic_terminal.tcss`: add the same three rules in the library-media section directly under the `#library-media-canvas > .ds-toolbar` block (task-28025), then run `python -m tldw_chatbook.css.build_css` and `python tldw_chatbook/css/check_bundle_sync.py` (exit 0 required).
+
+- [ ] **Step 5: Run the two painted tests, then the files that exercise receipts, each in its own process**
+
+Run: `… -m pytest Tests/UI/test_library_media_render_fixes.py -p no:cacheprovider -q --no-header` → Expected: all pass.
+Run: `… -m pytest Tests/UI/test_library_media_side_by_side.py -p no:cacheprovider -q --no-header` → Expected: 32 passed (line ~1270 waits for `#library-media-bulk-delete-receipt`, id unchanged).
+Run: `… -m pytest Tests/UI/test_library_multiselect_media.py -p no:cacheprovider -q --no-header` → Expected: 66 passed.
+Run: `… -m pytest Tests/UI/test_review_set_picker.py -p no:cacheprovider -q --no-header` (if it exists; grep `review-dismiss-receipt` under Tests/ and run every file that matches) → Expected: pass.
+Run: `… -m pytest Tests/CI/test_generated_stylesheet*.py -p no:cacheprovider -q --no-header` → Expected: pass (bundle regenerated and committed).
+
+- [ ] **Step 6: Live verify (tmux 235x52)** — seed one `W4A` item, arm delete with `t`, confirm; the receipt must show `✓ deleted · 1 item · in Trash` on one row and `Undo  Dismiss` fully painted on the next; click `Undo` by label with `click.py`; capture. Repeat with a set: `Review these` → `Sets` → `Dismiss` → the `✓ dismissed …` receipt with a readable `Undo`. Clean up.
+
+- [ ] **Step 7: Commit**
+```bash
+git add tldw_chatbook/Widgets/Library/library_media_canvas.py tldw_chatbook/css Tests/UI/test_library_media_render_fixes.py
+git commit -m "fix(library): receipts take the two-row grammar so Undo always paints (task-31270)"
+```
+
+---
+
+### Task 3: An explicit open bypasses auto-resume (task-31273, ruling)
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/library_screen.py:24082` (`handle_library_media_row`), `:42286-42340` (media branch of `_open_library_item_by_id`), `:38912-38966` (`_active_review_set_banner`)
+- Test: `Tests/UI/test_review_set_banner.py` (append), `Tests/UI/test_review_set_walker.py` (append)
+
+**Interfaces:**
+- Produces: `LibraryScreen._cancel_pending_review_set_resume()` — cancels worker group `library_review_set_resume`; banner suffix `" · this item is not in the set"` when the loaded item is off-set.
+- Consumes: `self.workers.cancel_group(self, group)`, `_maybe_auto_resume_review_set` (unchanged; still fires only from the rail-select seam).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/UI/test_review_set_banner.py`:
+```python
+def test_banner_names_an_off_set_item_honestly(tmp_path):
+    """task-31273 (user ruling): an explicit open of an item outside the
+    active set keeps the set's banner but says the item is not in it, so
+    the status line never claims a state the walk cannot honour."""
+    service = _service(tmp_path)
+    service.create_review_set(
+        "All media", origin="browse", items=[(10, "A"), (11, "B")]
+    )
+    banner = LibraryScreen._active_review_set_banner(
+        _banner_fake(service, loaded=99)
+    )
+    assert banner == "Reviewing: All media — 1 of 2 · 0 reviewed · this item is not in the set"
+```
+
+Append to `Tests/UI/test_review_set_walker.py`:
+```python
+def test_cancel_pending_resume_targets_the_resume_worker_group():
+    """task-31273: explicit opens cancel an in-flight auto-resume so the
+    landing worker cannot yank the Reader away from what the user chose."""
+    calls = []
+    fake = SimpleNamespace(workers=SimpleNamespace(cancel_group=lambda owner, group: calls.append(group)))
+    LibraryScreen._cancel_pending_review_set_resume(fake)
+    assert calls == ["library_review_set_resume"]
+
+
+def test_row_press_and_open_by_id_cancel_a_pending_resume():
+    """The two explicit-open seams both route through the cancel helper —
+    pinned at the source level because the handlers need a live screen."""
+    import inspect
+    row_src = inspect.getsource(LibraryScreen.handle_library_media_row)
+    open_src = inspect.getsource(LibraryScreen._open_library_item_by_id)
+    assert "_cancel_pending_review_set_resume()" in row_src
+    assert "_cancel_pending_review_set_resume()" in open_src
+```
+(`SimpleNamespace` and `LibraryScreen` are already imported in that file; add `from types import SimpleNamespace` if not.)
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `… -m pytest Tests/UI/test_review_set_banner.py Tests/UI/test_review_set_walker.py -p no:cacheprovider -q --no-header -k "off_set or cancel_pending or row_press_and_open"`
+Expected: banner test FAILS (no suffix today); the two walker tests FAIL with `AttributeError: _cancel_pending_review_set_resume`.
+
+- [ ] **Step 3: Implement**
+
+Helper, placed directly above `_maybe_auto_resume_review_set` (line ~39629):
+```python
+    def _cancel_pending_review_set_resume(self) -> None:
+        """Drop an in-flight auto-resume when the user opens something explicitly.
+
+        task-31273 (user ruling at the critique #4 close): an explicit open --
+        a row press, a deep link, open-by-id -- wins over the entry-time
+        auto-resume; plain rail entry with no target still resumes.
+        """
+        self.workers.cancel_group(self, "library_review_set_resume")
+```
+
+`handle_library_media_row`: in the non-select-mode branch, immediately before the call that opens the viewer for the pressed row, add `self._cancel_pending_review_set_resume()`.
+
+`_open_library_item_by_id`, media branch (the block starting `if source_type == "media":`): right after `self._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA` add `self._cancel_pending_review_set_resume()`.
+
+`_active_review_set_banner`: replace the `item_state` computation so an off-set loaded item is named:
+```python
+            item_state = ""
+            current = next(
+                (item for item in review_set.items if item.backing_media_id == loaded),
+                None,
+            )
+            if current is not None and current.backing_media_id in live_ids:
+                item_state = (
+                    " · ✓ reviewed" if current.done else " · not yet reviewed"
+                )
+            elif loaded is not None and current is None:
+                # task-31273: an explicit open outside the set keeps the
+                # set's banner but never claims a state for this item.
+                item_state = " · this item is not in the set"
+```
+Update the docstring's format line to mention the third suffix.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `… -m pytest Tests/UI/test_review_set_banner.py -p no:cacheprovider -q --no-header` → Expected: all pass.
+Run: `… -m pytest Tests/UI/test_review_set_walker.py -p no:cacheprovider -q --no-header` → Expected: 58 passed.
+Run: `… -m pytest Tests/UI/test_library_review_sets_entry.py -p no:cacheprovider -q --no-header` (grep `library_review_set_resume` under Tests/ and run each matching file) → Expected: pass.
+
+- [ ] **Step 5: Live verify** — with a `W4A` set mid-walk (2 of 3), Escape to the list, Enter on an item that is not in the set → banner ends with `· this item is not in the set`; `]` lands on the cursor item. Leave Media and return via the rail → still lands on the cursor item (plain entry resumes).
+
+- [ ] **Step 6: Commit**
+```bash
+git add tldw_chatbook/UI/Screens/library_screen.py Tests/UI/test_review_set_banner.py Tests/UI/test_review_set_walker.py
+git commit -m "fix(library): explicit opens bypass review-set auto-resume; off-set banner is honest (task-31273)"
+```
+
+---
+
+### Task 4: Row-marker design note (task-31278)
+
+**Files:**
+- Create: `backlog/docs/design-library-row-state-markers.md` — already drafted alongside this plan (same commit); review it against `tldw_chatbook/Library/library_media_state.py:65-66,150-190` (`_MEDIA_SUMMARY_KEYS`, `validate_media_browse_items`), `tldw_chatbook/DB/Client_Media_DB_v2.py:2475-3040` (`library_summary=True` projection), `tldw_chatbook/Media/media_reading_scope_service.py:501,717-776`, `tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py:148`, and the six test files that build the shape (`grep -rlE 'library_summary|_MEDIA_SUMMARY_KEYS' Tests`).
+
+- [ ] **Step 1: Verify every file:line the note cites still matches** (`sed -n` each range; fix the note if a line moved).
+- [ ] **Step 2: Commit**
+```bash
+git add backlog/docs/design-library-row-state-markers.md
+git commit -m "docs(library): design note for row state markers via the summary-contract bump (task-31278)"
+```
+The note's approval gate (AC#2) is the user's; do not start 28008/28009 in this PR.
+
+---
+
+### Task 5: Task hygiene, PR, landing
+
+- [ ] **Step 1: Flip tasks** (cwd = worktree): `backlog task edit 31269 -s Done --check-ac 1 --check-ac 2 --check-ac 3 --check-ac 4 --check-ac 5 --plan "<Task 1 steps>" --notes "<what shipped, the token design, the retired Analysis->Read jump>" --plain`; same for 31270 (ACs 1-4) and 31273 (ACs 1-4). For 31278: check AC#1 and AC#4 only, leave status `In Progress` with a note "awaiting user approval (AC#2)".
+- [ ] **Step 2: Derived-artifact checks** (no pipes): `python tldw_chatbook/css/check_bundle_sync.py`, `python scripts/check_persistent_diagnostic_inventory.py`, `python scripts/check_backlog_task_ids.py`, `python -m pytest Tests/CI/test_backlog_task_id_uniqueness.py -p no:cacheprovider -q`. All exit 0.
+- [ ] **Step 3: Merged-head test pass** — `git fetch origin dev && git merge origin/dev` (or rebase), then re-run every test file touched or whose production method changed: `grep -rln '_close_library_media_find\|handle_library_media_reader_find\|_active_review_set_banner\|bulk-delete-receipt\|review-dismiss-receipt' Tests/` and run each file in its own process.
+- [ ] **Step 4: Push and open the PR** against `dev`, title `fix(library): wave 4 A — Find focus token, two-row receipts, explicit-open bypass (tasks 31269/31270/31273/31278)`; body = the three fixes with their critique evidence, the retired 28026 Find transition called out, live-verification captures, and the standard footer.
+- [ ] **Step 5: Land** — address Qodo with evidence; the required job `Derived artifacts reproduce from their sources` spawns only after `PR Fast Lane` completes (`needs: [pr-fast-lane]`), so an absent check-run for the first 10-20 minutes is normal; update-branch when BEHIND; `gh pr merge --admin --merge` once both are green.

--- a/Tests/UI/test_library_media_reader_flow.py
+++ b/Tests/UI/test_library_media_reader_flow.py
@@ -1449,11 +1449,11 @@ async def test_capture_outside_read_never_persists_the_analysis_body_offset():
     assert fake._library_media_read_scroll_by_id == {}
 
 
-def test_find_from_analysis_clears_the_search_before_reading_the_transcript():
-    """task-28026: the always-visible Find action switches Analysis->Read, so
-    it must drop the analysis query/index/memo the same way the mode buttons
-    do -- otherwise a stale, possibly out-of-range match index scans the
-    transcript."""
+def test_find_from_analysis_opens_the_bar_on_the_analysis_tab():
+    """task-31269: Find searches the tab you are reading. On the Analysis
+    tab it opens the analysis bar in place (task-28026's Analysis->Read
+    jump is retired) and hands the viewer a one-shot focus token; the
+    query is untouched because the mode did not change."""
     session = set_mode(
         LibraryMediaReaderSessionState(
             selected_id="local:media:1",
@@ -1470,6 +1470,8 @@ def test_find_from_analysis_clears_the_search_before_reading_the_transcript():
         _library_media_content_query="needle",
         _library_media_content_match_index=5,
         _library_media_content_match_memo=(object(), "needle", (1, 2, 3), "analysis"),
+        _library_media_find_open=False,
+        _library_media_find_focus_pending=False,
         _sync_library_media_viewer_or_recompose=lambda: None,
         call_after_refresh=lambda *a, **k: None,
         _focus_library_media_content_search_input=lambda: None,
@@ -1477,19 +1479,16 @@ def test_find_from_analysis_clears_the_search_before_reading_the_transcript():
     fake._reset_library_media_search_on_mode_change = MethodType(
         LibraryScreen._reset_library_media_search_on_mode_change, fake
     )
-    # task-31237: the reset seam routes through the shared find-close helper.
     fake._close_library_media_find = MethodType(
         LibraryScreen._close_library_media_find, fake
     )
-
     LibraryScreen.handle_library_media_reader_find(
         fake, SimpleNamespace(stop=lambda: None)
     )
-
-    assert fake._library_media_reader_session.mode == "read"
-    assert fake._library_media_content_query == ""
-    assert fake._library_media_content_match_index == 0
-    assert fake._library_media_content_match_memo is None
+    assert fake._library_media_reader_session.mode == "analysis"
+    assert fake._library_media_find_open is True
+    assert fake._library_media_find_focus_pending is True
+    assert fake._library_media_content_query == "needle"
 
 
 def test_media_content_matches_scopes_corpus_to_the_active_reader_mode():

--- a/Tests/UI/test_library_media_reader_flow.py
+++ b/Tests/UI/test_library_media_reader_flow.py
@@ -1472,6 +1472,11 @@ def test_find_from_analysis_opens_the_bar_on_the_analysis_tab():
         _library_media_content_match_memo=(object(), "needle", (1, 2, 3), "analysis"),
         _library_media_find_open=False,
         _library_media_find_focus_pending=False,
+        _library_media_generating_analysis=False,
+        _library_media_editing_analysis=False,
+        _library_media_detail={
+            "versions": [{"version_number": 1, "analysis_content": "needle text"}]
+        },
         _sync_library_media_viewer_or_recompose=lambda: None,
         call_after_refresh=lambda *a, **k: None,
         _focus_library_media_content_search_input=lambda: None,
@@ -1481,6 +1486,10 @@ def test_find_from_analysis_opens_the_bar_on_the_analysis_tab():
     )
     fake._close_library_media_find = MethodType(
         LibraryScreen._close_library_media_find, fake
+    )
+    # Qodo on #2378: the handler refuses when the tab has nothing to search.
+    fake._library_media_find_unavailable_reason = MethodType(
+        LibraryScreen._library_media_find_unavailable_reason, fake
     )
     LibraryScreen.handle_library_media_reader_find(
         fake, SimpleNamespace(stop=lambda: None)

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -19,6 +19,7 @@ the chooser bug needs the screen's focus-on-open):
 from __future__ import annotations
 
 import pytest
+from types import SimpleNamespace
 from textual.widgets import Button, Input, OptionList
 
 from tldw_chatbook.Library.library_media_reader_state import set_mode
@@ -401,3 +402,25 @@ async def test_dismiss_receipt_paints_undo_at_the_items_pane_width():
         assert "✓ dismissed · 2 selected items" in painted, painted
         assert "Undo" in painted, painted
         assert "Dismiss" in painted, painted
+
+
+@pytest.mark.asyncio
+async def test_find_is_disabled_with_a_reason_when_the_analysis_tab_has_nothing_to_search():
+    """Qodo on #2378: with Find now opening the bar for the tab being read,
+    an Analysis tab with no analysis (or one still generating) has no bar
+    to mount -- pressing Find must not become a silent state toggle. The
+    button says why it is off, and the handler refuses to arm find_open."""
+    host = _host()  # _two_media_items carry no analysis
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _open_first_reader_row(screen, pilot)
+        await _switch_to_analysis(screen, pilot)
+        find = screen.query_one("#library-media-reader-find", Button)
+        assert find.disabled is True
+        assert "No analysis" in str(find.tooltip)
+        # Belt and braces: the handler itself refuses.
+        screen.handle_library_media_reader_find(SimpleNamespace(stop=lambda: None))
+        await pilot.pause()
+        await pilot.pause()
+        assert screen._library_media_find_open is False
+        assert not screen.query("#library-media-content-search-controls")

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -22,6 +22,7 @@ import pytest
 from textual.widgets import Button, Input, OptionList
 
 from tldw_chatbook.Library.library_media_reader_state import set_mode
+from tldw_chatbook.UI.Screens.library_screen import _sync_library_canvas
 
 from Tests.UI.test_library_media_side_by_side import (
     _build_media_test_app,
@@ -349,3 +350,54 @@ async def test_find_toggles_the_bar_closed_when_it_is_open():
         await pilot.pause()
         assert not screen.query("#library-media-content-search-controls")
         assert screen._library_media_find_open is False
+
+
+# ---------------------------------------------------------------------------
+# task-31270 (critique #4 P1): receipts paint Undo and Dismiss at pane width.
+# ---------------------------------------------------------------------------
+
+
+def _items_pane_width(screen) -> int:
+    return screen.query_one("#library-media-canvas").region.width
+
+
+@pytest.mark.asyncio
+async def test_delete_receipt_paints_undo_and_dismiss_at_the_items_pane_width():
+    """task-31270 (critique #4 P1): the receipt's Undo was clipped to `Und`
+    in the ~38-col Items pane (live cap_99). Painted text on purpose: a
+    region assertion cannot see a label cut by its parent's width."""
+    host = _host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        screen._library_media_delete_receipt_ids = ("local:media:1",)
+        _sync_library_canvas(screen, "media")
+        receipt = await _wait_for_selector(
+            screen, pilot, "#library-media-bulk-delete-receipt"
+        )
+        await pilot.pause()
+        await pilot.pause()
+        assert receipt.region.width <= _items_pane_width(screen)
+        painted = _painted(host, receipt.region)
+        assert "✓ deleted · 1 item · in Trash" in painted, painted
+        assert "Undo" in painted, painted
+        assert "Dismiss" in painted, painted
+
+
+@pytest.mark.asyncio
+async def test_dismiss_receipt_paints_undo_at_the_items_pane_width():
+    """task-31270: the set-dismiss receipt clipped to `… Un` (live cap_83)."""
+    host = _host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        screen._review_dismiss_receipt_name = lambda: "2 selected items"
+        _sync_library_canvas(screen, "media")
+        receipt = await _wait_for_selector(
+            screen, pilot, "#library-media-review-dismiss-receipt"
+        )
+        await pilot.pause()
+        await pilot.pause()
+        assert receipt.region.width <= _items_pane_width(screen)
+        painted = _painted(host, receipt.region)
+        assert "✓ dismissed · 2 selected items" in painted, painted
+        assert "Undo" in painted, painted
+        assert "Dismiss" in painted, painted

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -19,12 +19,21 @@ the chooser bug needs the screen's focus-on-open):
 from __future__ import annotations
 
 import pytest
-from textual.widgets import Button, OptionList
+from textual.widgets import Button, Input, OptionList
+
+from tldw_chatbook.Library.library_media_reader_state import set_mode
 
 from Tests.UI.test_library_media_side_by_side import (
     _build_media_test_app,
     _open_media_list,
     _two_media_items,
+)
+from Tests.UI.test_library_media_reader_flow import (
+    ControlledDetailMediaService,
+    _load_row_0,
+    _many_media_items,
+    _row_identity,
+    _wait_for_detail_call,
 )
 from Tests.UI.test_library_shell import (
     LibraryProductionCSSHarness,
@@ -184,3 +193,159 @@ async def test_find_bar_collapsed_until_find_and_escape_recollapses():
         await pilot.pause()
         await pilot.pause()
         assert not screen.query("#library-media-content-search-controls")
+
+
+# ---------------------------------------------------------------------------
+# task-31269 (critique #4 P0): the Find gesture, not the mount, decides focus.
+# ---------------------------------------------------------------------------
+
+
+def _analysis_flow_host(count: int = 3):
+    """Three local items, each with a current analysis version.
+
+    Local media detail never carries ``analysis_content`` at the top level;
+    the viewer reads the newest ``versions`` entry
+    (``library_media_viewer_state._latest_version_analysis_text``).
+    """
+    app = _build_media_test_app()
+    items = _many_media_items(count)
+    for index, item in enumerate(items, 1):
+        item["versions"] = [
+            {"version_number": 1, "analysis_content": f"Analysis of item {index}"}
+        ]
+    _seed_conversations(app, _two_conversations(), media=items)
+    service = ControlledDetailMediaService(items)
+    app.media_reading_scope_service = service
+    return LibraryProductionCSSHarness(app), service
+
+
+async def _walk_next(screen, service, pilot, expected_row: int) -> str:
+    """Press ] and settle the Reader on ``expected_row``; return its id."""
+    row = screen.query_one(f"#library-media-row-{expected_row}", Button)
+    row_id, backing_id, _ = _row_identity(row)
+    await pilot.press("right_square_bracket")
+    await _wait_for_detail_call(service, backing_id)
+    service.release(backing_id)
+    await _wait_for_condition(
+        pilot,
+        lambda: screen._library_media_reader_session.loaded_id == row_id,
+        message=f"] never loaded row {expected_row}.",
+    )
+    await pilot.pause()
+    return row_id
+
+
+async def _switch_to_analysis(screen, pilot) -> None:
+    screen._library_media_reader_session = set_mode(
+        screen._library_media_reader_session, "analysis"
+    )
+    screen._sync_library_media_viewer_or_recompose()
+    await _wait_for_selector(screen, pilot, "#library-media-viewer-analysis-title")
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_analysis_mode_walk_never_moves_focus_into_the_search_field():
+    """task-31269 (critique #4 P0): ] in Analysis mode walks, it never types.
+
+    #2367's focus-on-mount hook fired on EVERY mount with an empty query,
+    and the Analysis tab (task-28026) mounted the bar unconditionally, so
+    each item load in Analysis mode parked focus in the Input and the next
+    ] became text (live: `▊ ]`, `]]]]]`).
+    """
+    host, service = _analysis_flow_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row_0(screen, service, pilot)
+        await _switch_to_analysis(screen, pilot)
+        # The bar is collapsed until Find asks for it, exactly like Read.
+        assert not screen.query("#library-media-content-search-controls")
+
+        await _walk_next(screen, service, pilot, expected_row=1)
+        assert screen._library_media_reader_session.mode == "analysis"
+        assert not isinstance(screen.focused, Input), screen.focused
+        assert not screen.query("#library-media-content-search-controls")
+
+        # A second ] must still be a walk (the P0 symptom was it being typed).
+        await _walk_next(screen, service, pilot, expected_row=2)
+        assert not isinstance(screen.focused, Input), screen.focused
+
+
+@pytest.mark.asyncio
+async def test_find_on_the_analysis_tab_opens_the_bar_there_and_escape_closes_it():
+    """Find searches what you are reading: on Analysis it opens the analysis
+    bar (task-28026's Analysis->Read jump is retired), focuses its Input, and
+    one Escape collapses it (live: the first Escape only blurred)."""
+    host, service = _analysis_flow_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row_0(screen, service, pilot)
+        await _switch_to_analysis(screen, pilot)
+        screen.query_one("#library-media-reader-find", Button).press()
+        search_input = await _wait_for_selector(
+            screen, pilot, "#library-media-content-search"
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: search_input.has_focus,
+            message="Find never focused the analysis search input.",
+        )
+        assert screen._library_media_reader_session.mode == "analysis"
+
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.pause()
+        assert not screen.query("#library-media-content-search-controls")
+        assert screen._library_media_find_open is False
+
+
+@pytest.mark.asyncio
+async def test_read_mode_walk_with_an_empty_find_bar_never_steals_focus():
+    """task-31269 AC2: an open, still-empty bar survives an item change, but
+    focus stays where the reader left it, so ] keeps walking.
+
+    The empty-query remount was the Read-mode face of the P0: Find opened,
+    nothing typed yet, focus moved to the content body, then ] -- the
+    remounted bar took the caret and the next ] was typed. A submitted
+    query surviving traversal is pinned separately by
+    test_a_new_document_rescans_for_the_same_query.
+    """
+    host, service = _analysis_flow_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row_0(screen, service, pilot)
+        screen.query_one("#library-media-reader-find", Button).press()
+        search_input = await _wait_for_selector(
+            screen, pilot, "#library-media-content-search"
+        )
+        await _wait_for_condition(
+            pilot, lambda: search_input.has_focus, message="Find never focused."
+        )
+        # Leave the field the way a reader does (F6 target = content body).
+        screen.query_one("#library-media-viewer-content").focus()
+        await pilot.pause()
+        assert not isinstance(screen.focused, Input)
+
+        await _walk_next(screen, service, pilot, expected_row=1)
+        assert screen._library_media_find_open is True
+        assert screen.query("#library-media-content-search-controls")
+        assert not isinstance(screen.focused, Input), screen.focused
+
+        await _walk_next(screen, service, pilot, expected_row=2)
+        assert not isinstance(screen.focused, Input), screen.focused
+
+
+@pytest.mark.asyncio
+async def test_find_toggles_the_bar_closed_when_it_is_open():
+    """task-31269 AC4: a second Find press closes the bar (live: it did nothing)."""
+    host, service = _analysis_flow_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row_0(screen, service, pilot)
+        screen.query_one("#library-media-reader-find", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-content-search-controls")
+        screen.query_one("#library-media-reader-find", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+        assert not screen.query("#library-media-content-search-controls")
+        assert screen._library_media_find_open is False

--- a/Tests/UI/test_library_multiselect_media.py
+++ b/Tests/UI/test_library_multiselect_media.py
@@ -86,6 +86,8 @@ def _media_fake(
 ):
     notified = []
     fake = SimpleNamespace(
+        # task-31273: an explicit row open cancels a pending auto-resume.
+        _cancel_pending_review_set_resume=lambda: None,
         _library_media_select_mode=select_mode,
         _library_media_row_selection=RowSelection("media"),
         _library_media_confirming_bulk_delete=confirming_bulk_delete,

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -10647,6 +10647,18 @@ async def _open_media_viewer(screen, pilot):
     await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
 
 
+async def _open_media_find(screen, pilot):
+    """Press Find and return the mounted content search Input.
+
+    task-31237 collapsed the bar until the Find action opens it; task-31269
+    made Find open the bar for whichever tab is being read, so this works
+    on Read and on Analysis alike. A no-op when the bar is already open.
+    """
+    if not screen.query("#library-media-content-search"):
+        screen.query_one("#library-media-reader-find", Button).press()
+    return await _wait_for_selector(screen, pilot, "#library-media-content-search")
+
+
 @pytest.mark.asyncio
 async def test_library_media_sort_chooser_applies_the_selected_order():
     """task-28013: the media sort chooser re-fetches page one under the new order."""
@@ -11049,7 +11061,7 @@ async def test_library_shell_media_viewer_inplace_search_applies_only_on_enter()
         screen = _active_library_screen(host)
         await _wait_for_library_shell(screen, pilot)
         await _open_media_viewer(screen, pilot)
-        search_input = screen.query_one("#library-media-content-search", Input)
+        search_input = await _open_media_find(screen, pilot)
 
         search_input.value = "setup"
         await pilot.pause()
@@ -11584,6 +11596,7 @@ async def test_library_shell_media_viewer_search_chrome_undocks_when_inactive():
         screen = _active_library_screen(host)
         await _wait_for_library_shell(screen, pilot)
         await _open_media_viewer(screen, pilot)
+        await _open_media_find(screen, pilot)
         controls = screen.query_one(
             "#library-media-content-search-controls",
             LibraryMediaContentSearchControls,
@@ -11705,8 +11718,8 @@ async def test_library_shell_media_viewer_inplace_search_chrome_paints_above_con
         assert heading_row >= body.region.y
         assert body.styles.min_height is not None
         assert body.styles.min_height.value == 3
-        assert body.styles.max_height is not None
-        assert body.styles.max_height.value == 18
+        # task-31237: the 18-row cap is gone -- the box fills the pane (1fr).
+        assert body.styles.max_height is None
 
         parse_count_before_navigation = len(markdown_updates)
         next_button.focus()
@@ -33806,7 +33819,9 @@ async def test_library_media_analysis_tab_is_searchable():
         # Wait for the analysis tab to settle (its Edit action is the stable
         # signal the existing analysis tests use) before searching.
         await _wait_for_selector(screen, pilot, "#library-media-analysis-edit")
-        search = screen.query_one("#library-media-content-search", Input)
+        # task-31269: the Analysis bar is collapsed until Find opens it, in place.
+        search = await _open_media_find(screen, pilot)
+        assert screen._library_media_reader_session.mode == "analysis"
 
         search.value = "budget"
         search.focus()
@@ -33846,9 +33861,8 @@ async def test_library_media_switching_tabs_clears_the_search():
         await _wait_for_selector(screen, pilot, "#library-media-row-1")
         screen.query_one("#library-media-row-1").press()
         # Read tab: search the transcript.
-        search = await _wait_for_selector(
-            screen, pilot, "#library-media-content-search"
-        )
+        await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
+        search = await _open_media_find(screen, pilot)
         search.value = "roadmap"
         search.focus()
         await pilot.pause()

--- a/Tests/UI/test_review_set_banner.py
+++ b/Tests/UI/test_review_set_banner.py
@@ -151,3 +151,19 @@ def test_banner_omits_item_state_for_a_tombstoned_loaded_item(tmp_path):
 
     assert banner is not None and "All media" in banner
     assert "✓ reviewed" not in banner and "not yet" not in banner
+
+
+def test_banner_names_an_off_set_item_honestly(tmp_path):
+    """task-31273 (user ruling): an explicit open of an item outside the
+    active set keeps the set's banner but says the item is not in it, so
+    the status line never claims a state the walk cannot honour."""
+    service = _service(tmp_path)
+    service.create_review_set(
+        "All media", origin="browse", items=[(10, "A"), (11, "B")]
+    )
+    banner = LibraryScreen._active_review_set_banner(
+        _banner_fake(service, loaded=99)
+    )
+    assert banner == (
+        "Reviewing: All media — 1 of 2 · 0 reviewed · this item is not in the set"
+    )

--- a/Tests/UI/test_review_set_walker.py
+++ b/Tests/UI/test_review_set_walker.py
@@ -1274,3 +1274,25 @@ def test_review_set_active_reflects_the_service(tmp_path):
     assert LibraryScreen._review_set_active(fake) is False
     service.create_review_set("X", origin="browse", items=[(1, "a")])
     assert LibraryScreen._review_set_active(fake) is True
+
+
+def test_cancel_pending_resume_targets_the_resume_worker_group():
+    """task-31273: explicit opens cancel an in-flight auto-resume so the
+    landing worker cannot yank the Reader away from what the user chose."""
+    calls = []
+    fake = SimpleNamespace(
+        workers=SimpleNamespace(cancel_group=lambda owner, group: calls.append(group))
+    )
+    LibraryScreen._cancel_pending_review_set_resume(fake)
+    assert calls == ["library_review_set_resume"]
+
+
+def test_row_press_and_open_by_id_cancel_a_pending_resume():
+    """The two explicit-open seams both route through the cancel helper --
+    pinned at the source level because the handlers need a live screen."""
+    import inspect
+
+    row_src = inspect.getsource(LibraryScreen.handle_library_media_row)
+    open_src = inspect.getsource(LibraryScreen._open_library_item_by_id)
+    assert "_cancel_pending_review_set_resume()" in row_src
+    assert "_cancel_pending_review_set_resume()" in open_src

--- a/backlog/docs/design-library-row-state-markers.md
+++ b/backlog/docs/design-library-row-state-markers.md
@@ -1,0 +1,65 @@
+# Design note: row state markers for Library ▸ Media (task-31278)
+
+Status: DRAFT — awaiting user approval (task-31278 AC#2). No implementation until approved.
+Implements: task-28008 (analysis presence on rows), task-28009 (read/reviewed markers).
+Author's note: the absence of these markers is my own earlier decision (review sets shipped with set-local done marks; the summary-contract bump was parked twice as "invasive, own PR"). This note is the proposal I owe for it.
+
+## 1. The problem
+
+The Items list renders each row as `title` + `type · age` and nothing else (critique #4, B cap_02). Two facts the reading loop depends on are invisible until the item is open:
+
+- **Has this item been analysed?** Decides whether "review every analysis" will find anything, whether a batch Analyze is needed, and which rows Generate should target.
+- **Have I reviewed this item?** The only ✓ today is the banner for the loaded item; finding the one skipped item means re-walking the set.
+
+Both are blocked by the media summary contract.
+
+## 2. The contract today
+
+`tldw_chatbook/Library/library_media_state.py:65-66`:
+```python
+_MEDIA_SUMMARY_KEYS = frozenset({"id", "backing_media_id", "title", "media_type", "updated_at"})
+```
+`validate_media_browse_items` (`:150-190`) rejects any item whose key set is not exactly these five (`"Media browse items must contain exactly five summary keys."`), then checks the canonical id, positive backing id and page-uniqueness, and freezes the mapping.
+
+Producers of the five-key shape:
+- `tldw_chatbook/DB/Client_Media_DB_v2.py:2475-3040` — `search_media(library_summary=True)` selects only the summary columns (`:2638`, `:3040`).
+- `tldw_chatbook/Media/media_reading_scope_service.py:501` (`_normalize_local_library_summary`) and `:717-776` (the `library_summary` branch of the scope search).
+- `tldw_chatbook/Media/local_media_reading_service.py` (local backend passthrough).
+- `tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py:148` (the browse request sets `library_summary=True`).
+- `tldw_chatbook/UI/Screens/library_screen.py` (Review-these / Review-selected page the whole result through the same projection).
+
+Tests that build or assert the shape (six files): `Tests/UI/test_library_media_browse_controller.py`, `Tests/UI/test_console_rag_settings_modal.py`, `Tests/DB/test_client_media_debug_logging.py`, `Tests/DB/test_client_media_pagination.py`, `Tests/Media/test_local_media_reading_service.py`, `Tests/Media/test_media_reading_scope_service.py` — plus every UI test whose fake service returns browse rows (`_two_media_items`, `_many_media_items` in `Tests/UI/test_library_shell.py`, and the `StaticLibraryMediaScopeService` family), which is why the bump was called invasive.
+
+## 3. Options
+
+### Option A — Bump the contract to seven keys (recommended)
+
+Add two keys to `_MEDIA_SUMMARY_KEYS`: `has_analysis: bool` and `reviewed: bool | None`.
+
+- `has_analysis` is projected in SQL: `EXISTS (SELECT 1 FROM DocumentVersions v WHERE v.media_id = Media.id AND v.version_number = (SELECT MAX(version_number) …) AND TRIM(COALESCE(v.analysis_content,'')) <> '')` — the same "newest version's analysis" rule the viewer uses (`library_media_viewer_state._latest_version_analysis_text`), so list and Reader can never disagree.
+- `reviewed` is **not** a media-DB fact. It is the active review set's done mark for that backing id (set-local by design, `Library/review_set_state.py`). The projection leaves it `None`; the screen decorates rows from the active set (`ReviewSet.items` is already in memory for the banner) before handing rows to the canvas. `None` means "no active set"; `False`/`True` mean the item is in the active set and not-yet/reviewed.
+- Validation: the validator checks the exact seven-key set, `has_analysis is bool`, `reviewed in (None, False, True)`.
+- Rendering: rows get a one-cell state slot before the type: `☐`/`☑` is taken by select mode, so use `✓` for reviewed, `·` for in-set-not-reviewed, nothing when no set; and `A` (or `¶`) for has-analysis in the secondary line: `article · 5m · analysed`. Text, not colour, carries the meaning (PRODUCT.md accessibility). At the 38-col Items pane the secondary line has room: `document · 5m · analysed` is 24 cells.
+
+Cost: one SQL projection, one validator change, `_normalize_local_library_summary`, the local reading service passthrough, and every fake that returns browse rows must add the two keys (mechanical: a helper `_summary_row(**overrides)` in `Tests/UI/test_library_shell.py` that all fakes use, so future keys are one-line changes). Estimated 6 production files, ~8 test files.
+
+### Option B — Keep five keys, add a side lookup
+
+Leave the contract alone; the screen asks the media DB `analysis_present_for(ids)` per page and the review set for done marks, then the canvas takes an extra `row_flags: Mapping[str, RowFlags]` argument.
+
+Pro: no contract bump, no fake churn. Con: a second query per page (20 ids, cheap) and a second source of row truth that the reconciler must keep in step across pager/sort/filter, exactly the drift the five-key freeze exists to prevent. Not recommended.
+
+### Option C — Per-item read marker in the media DB (task-28009 as originally filed)
+
+A `MediaReadState` row per item (read/unread independent of sets). Solves "have I read this ever" but not "have I reviewed this in this set"; the review-set done mark already exists and is the honest source for the walk. Defer; if wanted later it is a third key, not a redesign.
+
+## 4. Decisions needed from the user
+
+1. **Contract bump (Option A) vs side lookup (Option B).** Recommendation: A.
+2. **Source of `reviewed`: active review set only (recommended), or a per-item read marker (Option C) as well?** Recommendation: set only, in v1.
+3. **Glyphs and placement.** Recommendation: `✓`/`·` in the row's leading state slot (select mode's `☑/☐` replaces it while active), `analysed` as a word on the secondary line rather than a glyph.
+4. **Scope of the migration PR.** Recommendation: one PR — contract + projection + validator + fakes helper + row rendering + painted-text tests at 38 cols; no batch Analyze in it (that is task-28007's PR).
+
+## 5. Approval
+
+- [ ] User approved Option ___ with decisions 2-4 as: ___ (record date and any changes here).

--- a/backlog/tasks/task-28007 - Library-import-queue-batch-re-analyze-a-runs-analysis-skipped-items.md
+++ b/backlog/tasks/task-28007 - Library-import-queue-batch-re-analyze-a-runs-analysis-skipped-items.md
@@ -4,6 +4,7 @@ title: Library import queue - batch re-analyze a run's analysis-skipped items
 status: To Do
 assignee: []
 created_date: '2026-09-02 04:10'
+updated_date: '2026-09-04 13:54'
 labels:
   - library
   - media-ux
@@ -25,4 +26,7 @@ When Analyze-after-import is on but the provider is unready, every imported row 
 - [ ] #1 A completed import run with analysis-skipped items offers a single action that generates analyses for all of them
 - [ ] #2 Per-item success and failure are reported in the same receipt style as import rows
 - [ ] #3 Items that already have an analysis are not overwritten without an explicit choice
+- [ ] #4 Select mode offers a bulk Analyze action that runs the per-item generator over the selection in one worker group with an in-list receipt (Analyzing N of M · K failed · Retry) — critique #4 P1
+- [ ] #5 Generate in the Reader is disabled with the resolver's reason in its label when no provider is configured, instead of a post-click toast
+- [ ] #6 The collapsed Import behavior header summarises its analysis state (e.g. Import behavior · analysis off)
 <!-- AC:END -->

--- a/backlog/tasks/task-28015 - Library-media-Trash-Restore-action-renders-detached-far-below-the-item-row.md
+++ b/backlog/tasks/task-28015 - Library-media-Trash-Restore-action-renders-detached-far-below-the-item-row.md
@@ -4,7 +4,7 @@ title: Library media Trash - Restore action renders detached far below the item 
 status: To Do
 assignee: []
 created_date: '2026-09-02 04:11'
-updated_date: '2026-09-02 21:08'
+updated_date: '2026-09-04 13:54'
 labels:
   - library
   - bug
@@ -25,6 +25,7 @@ Re-verified 2026-09-02 live on dev tip (worktree media-ux-fixes @ b7e89b6de, tmu
 <!-- AC:BEGIN -->
 - [ ] #1 Restore is visually associated with the trashed item list (no dead gap)
 - [ ] #2 A keyboard path from a trash row to Restore exists
+- [ ] #3 The Trash header no longer clips (Local Trash · 1 i) at the shell's pane width — critique #4 B cap_102
 <!-- AC:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-31249 - Library-UI-test-debt-on-dev---six-pre-existing-failures-nobody-owns.md
+++ b/backlog/tasks/task-31249 - Library-UI-test-debt-on-dev---six-pre-existing-failures-nobody-owns.md
@@ -15,7 +15,7 @@ priority: medium
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Six Library UI tests fail identically on clean dev (verified at 59d987015d and e4652f9d37, each file run in its own process) and no open task owns them. PR #2367's body noted them as pre-existing and the wave-3 landing hit them again; every media PR touching these files now has to re-verify them by hand to tell its own breakage from the baseline, which is how a real break (fixed in PR #2369) nearly hid among them. Suspected origins, unconfirmed: #2364 (Personas demand-mount, task-31215) for the `#library-media-edit` group; an unbound `MediaReadingScopeService` fake (`active_authority`) for the deep-link test.
+Eight Library UI tests fail identically on clean dev (verified at 59d987015d and e4652f9d37, each file run in its own process) and no open task owns them. PR #2367's body noted them as pre-existing and the wave-3 landing hit them again; every media PR touching these files now has to re-verify them by hand to tell its own breakage from the baseline, which is how a real break (fixed in PR #2369) nearly hid among them. Suspected origins, unconfirmed: #2364 (Personas demand-mount, task-31215) for the `#library-media-edit` group; an unbound `MediaReadingScopeService` fake (`active_authority`) for the deep-link test.
 
 Failures (`pytest --tb=line`, Tests/UI):
 - test_library_per_click_recompose_t21116.py::test_media_viewer_substate_escape_is_viewer_scoped -- `#library-media-edit never mounted within 30.0s` (test_library_shell.py:3686 helper)
@@ -24,6 +24,8 @@ Failures (`pytest --tb=line`, Tests/UI):
 - test_library_review_round_t21116.py::test_viewer_substate_escape_refreshes_the_footer_shortcut_set -- `#library-media-edit never mounted within 30.0s`
 - test_library_shell.py::test_library_starter_deep_link_opens_hidden_collection_or_note_route -- worker `AttributeError: 'SimpleNamespace' object has no attribute 'active_authority'` in library_collections_capture_controller.adopt_active_authority
 - test_library_choice_strips.py::test_media_type_strip_works_in_both_layouts -- `compact class never reached True at (100, 30)`
+- test_library_shell.py::test_library_shell_media_viewer_inplace_search_preserves_identity_focus_and_parse_count -- after a submitted search and a Next press in Rendered mode the `#library-media-viewer-content-markdown` widget is a new instance (in-place match navigation rebuilt the body); plain `LibraryHarness`
+- test_library_shell.py::test_library_shell_media_viewer_inplace_search_chrome_paints_above_content -- the content body lays out at `Region(x=83, y=53, height=3)` below the 48-row viewport after a rendered-mode search, so the document heading never paints; plain `LibraryHarness` (no production stylesheet). Its retired 18-row-cap assertion was updated in wave-4 PR A; the layout failure remains
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria

--- a/backlog/tasks/task-31269 - Reader-walk-keys-are-typed-into-the-content-search-field.md
+++ b/backlog/tasks/task-31269 - Reader-walk-keys-are-typed-into-the-content-search-field.md
@@ -1,0 +1,28 @@
+---
+id: TASK-31269
+title: Reader walk keys are typed into the content search field
+status: To Do
+assignee: []
+created_date: '2026-09-04 13:54'
+labels:
+  - library
+  - media-ux
+  - regression
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #4 P0 (my #2367 regression): the content search bar's on_mount focuses its Input whenever the query is empty, and the Analysis tab (task-28026) mounts that bar whenever an analysis exists. So in Analysis mode every ]/[ item load moves focus into the box and the next key is typed as text (A cap 22/24/36: `▊ ]`); in Read mode the same happens whenever Find is open across a walk (B cap_32b `]]]]]`, cap_41-44 with the review banner frozen). The Find button does not toggle the bar off and Escape from inside the input only blurs on the first press. Workflow 3 (review every analysis with ]) is exactly this path and fails silently.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 In Analysis mode, walking two items with ] never leaves focus in the search Input (test asserts `screen.focused` is not the Input after each load)
+- [ ] #2 With Find open in Read mode, ] [ m R still act as keys across item changes — the bar keeps its query but never re-takes focus on an item change
+- [ ] #3 The Analysis-tab search bar is collapsed until Find is invoked, matching the Read tab
+- [ ] #4 Pressing Find while the bar is open closes it; Escape from inside the Find input closes the bar in one press on every tab
+- [ ] #5 Live-verified in tmux: an Analysis-mode walk over three items using only ]
+<!-- AC:END -->

--- a/backlog/tasks/task-31269 - Reader-walk-keys-are-typed-into-the-content-search-field.md
+++ b/backlog/tasks/task-31269 - Reader-walk-keys-are-typed-into-the-content-search-field.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-31269
 title: Reader walk keys are typed into the content search field
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-04 13:54'
+updated_date: '2026-09-04 15:09'
 labels:
   - library
   - media-ux
@@ -20,9 +21,24 @@ Critique #4 P0 (my #2367 regression): the content search bar's on_mount focuses 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 In Analysis mode, walking two items with ] never leaves focus in the search Input (test asserts `screen.focused` is not the Input after each load)
-- [ ] #2 With Find open in Read mode, ] [ m R still act as keys across item changes — the bar keeps its query but never re-takes focus on an item change
-- [ ] #3 The Analysis-tab search bar is collapsed until Find is invoked, matching the Read tab
-- [ ] #4 Pressing Find while the bar is open closes it; Escape from inside the Find input closes the bar in one press on every tab
-- [ ] #5 Live-verified in tmux: an Analysis-mode walk over three items using only ]
+- [x] #1 In Analysis mode, walking two items with ] never leaves focus in the search Input (test asserts `screen.focused` is not the Input after each load)
+- [x] #2 With Find open in Read mode, ] [ m R still act as keys across item changes — the bar keeps its query but never re-takes focus on an item change
+- [x] #3 The Analysis-tab search bar is collapsed until Find is invoked, matching the Read tab
+- [x] #4 Pressing Find while the bar is open closes it; Escape from inside the Find input closes the bar in one press on every tab
+- [x] #5 Live-verified in tmux: an Analysis-mode walk over three items using only ]
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: Analysis-mode walk keeps focus out of the Input; Find on Analysis opens in place and one Escape closes; empty-bar Read walk never steals focus; Find toggles closed
+2. GREEN: LibraryMediaContentSearchControls(focus_on_mount) explicit token; viewer find_focus_pending spent on the one compose after the gesture; screen sets it only in handle_library_media_reader_find; Analysis bar gated behind find_open like Read; Find toggles
+3. Retire task-28026's Find Analysis->Read jump (reader-flow contract test rewritten); convert six shell tests that queried the bar before any Find press
+4. Live tmux 235x52: Analysis-mode [ ] walk over three items, Find on Analysis, Escape, Find toggle
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause was two of my own changes meeting: #2367's on_mount focused the search Input whenever the query was empty (inferring the Find gesture from an empty query), and task-28026 mounted the Analysis bar unconditionally, so every item load in Analysis mode (and any walk with an empty bar open) moved the caret into the field and the next ]/[/m was typed. Fix: the gesture is an explicit one-shot token. handle_library_media_reader_find sets _library_media_find_focus_pending; the viewer construction site and the in-place sync both consume it (a pending token forces the recompose path so it is never lost), the viewer passes focus_on_mount to the controls and spends the token right after yielding them, and on_mount focuses only when the token is set. The Analysis tab now gates its bar behind find_open exactly like Read, so Find opens the bar for the tab being read and one Escape collapses it on either tab; task-28026's Analysis->Read jump on Find is retired (same-mode reset is a no-op). Find is a toggle. Also converted six test_library_shell.py tests that queried the search input before any Find press (broken on dev since #2367 collapsed the bar) via a shared _open_media_find helper, and retired the 18-row-cap assertion. Two plain-harness search tests still fail on clean dev for layout/identity reasons and are recorded in task-31249. Live-verified in tmux 235x52 (Analysis-mode walk over three items with [ and ], Find on Analysis, Escape, Find toggle).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31270 - Undo-receipts-clip-their-Undo-and-Dismiss-controls-in-the-Items-pane.md
+++ b/backlog/tasks/task-31270 - Undo-receipts-clip-their-Undo-and-Dismiss-controls-in-the-Items-pane.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-31270
 title: Undo receipts clip their Undo and Dismiss controls in the Items pane
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-04 13:54'
+updated_date: '2026-09-04 15:09'
 labels:
   - library
   - media-ux
@@ -19,8 +20,22 @@ Critique #4 P1: the delete and dismiss receipts render as a single content-width
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Delete, bulk-delete and set-dismiss receipts paint Undo and Dismiss fully at the shell's Items-pane width (painted-text test at 38 cols)
-- [ ] #2 Receipts use the multi-row grammar: message row plus an action row, width 100%
-- [ ] #3 The message wraps or shortens without hiding either action
-- [ ] #4 Live-verified at 235x52 and 100x30
+- [x] #1 Delete, bulk-delete and set-dismiss receipts paint Undo and Dismiss fully at the shell's Items-pane width (painted-text test at 38 cols)
+- [x] #2 Receipts use the multi-row grammar: message row plus an action row, width 100%
+- [x] #3 The message wraps or shortens without hiding either action
+- [x] #4 Live-verified at 235x52 and 100x30
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: painted-text tests for both receipts at the real Items-pane width (235x52)
+2. GREEN: both receipts become a Vertical (copy row + ds-toolbar action row) with unchanged button ids; width 100% rules in BUNDLED_CSS and the component sheet; bundle regenerated
+3. Run render-fixes, side-by-side, multiselect, trash; live tmux 235x52 and 100x30
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The delete and set-dismiss receipts were single content-width Horizontals, so at the ~38-col Items pane they painted as '✓ deleted · 1 item · in Trash  Und' and '✓ dismissed · … Un' — Undo unfindable by label. Both are now a Vertical with a full-width copy Static (library-media-receipt-copy) and a ds-toolbar action row (library-media-receipt-actions) holding the same Undo/Dismiss buttons and ids, mirroring task-30043's multi-row toolbar grammar. CSS at both tiers (BUNDLED_CSS for the plain harnesses, _agentic_terminal.tcss for the app); bundle rebuilt and check_bundle_sync green. Painted-text tests pin both receipts at pane width. Live: 'Undo     Dismiss' on its own row under each receipt, Undo clickable by label, item and set restored; also at 100x30.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31270 - Undo-receipts-clip-their-Undo-and-Dismiss-controls-in-the-Items-pane.md
+++ b/backlog/tasks/task-31270 - Undo-receipts-clip-their-Undo-and-Dismiss-controls-in-the-Items-pane.md
@@ -1,0 +1,26 @@
+---
+id: TASK-31270
+title: Undo receipts clip their Undo and Dismiss controls in the Items pane
+status: To Do
+assignee: []
+created_date: '2026-09-04 13:54'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #4 P1: the delete and dismiss receipts render as a single content-width row, so in the shell's ~38-col Items pane they read `✓ deleted · 1 item · in Trash  Und` and `✓ dismissed · 2 selected items  Un` (B cap_99, cap_83). Undo is unfindable by label and the trailing Dismiss button is off-pane; recovery only worked by clicking the visible `U` cell. The toolbars were converted to the multi-row grammar in #2350; the receipts were not. An unreadable Undo is a hidden recovery state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Delete, bulk-delete and set-dismiss receipts paint Undo and Dismiss fully at the shell's Items-pane width (painted-text test at 38 cols)
+- [ ] #2 Receipts use the multi-row grammar: message row plus an action row, width 100%
+- [ ] #3 The message wraps or shortens without hiding either action
+- [ ] #4 Live-verified at 235x52 and 100x30
+<!-- AC:END -->

--- a/backlog/tasks/task-31271 - Media-footer-promises-the-wrong-key-at-four-seams.md
+++ b/backlog/tasks/task-31271 - Media-footer-promises-the-wrong-key-at-four-seams.md
@@ -1,0 +1,27 @@
+---
+id: TASK-31271
+title: Media footer promises the wrong key at four seams
+status: To Do
+assignee: []
+created_date: '2026-09-04 13:54'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #4 P1: (a) after Escape closes Find the footer still says `esc close find` because `_library_media_escape_label` reads the DOM before the recompose lands (A cap 08/23, B cap_21); (b) right after `s` the footer promises `space toggle selection` while Space is a no-op unless a row is focused and, with focus on the pane grip, collapses the Library pane (A cap 31→32, B cap_69) — `_toggle_library_media_select_mode` never moves focus to a row; (c) on the last item of a set the chip still reads `] next in set` although that ] is the completion gesture (B cap_50); (d) l/c/t are real Reader keys with show=False and `t` arms delete unadvertised (B cap_97). The footer is the surface's main trust instrument.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 After Escape closes Find, the footer no longer shows `esc close find`
+- [ ] #2 Pressing s focuses the first media row so the Space chip is true immediately; Space never falls through to the pane grip
+- [ ] #3 On the last item of a review set the ] chip names the completion gesture (e.g. `] finish review`) instead of `next in set`
+- [ ] #4 l, c and t are advertised in the Reader footer set (t at minimum, since it arms delete)
+- [ ] #5 Each seam has a pinning test
+<!-- AC:END -->

--- a/backlog/tasks/task-31272 - Reader-Escape,-F6-and-Back-never-strand-focus-in-a-text-input.md
+++ b/backlog/tasks/task-31272 - Reader-Escape,-F6-and-Back-never-strand-focus-in-a-text-input.md
@@ -1,0 +1,29 @@
+---
+id: TASK-31272
+title: Reader Escape, F6 and Back never strand focus in a text input
+status: To Do
+assignee: []
+created_date: '2026-09-04 13:54'
+labels:
+  - library
+  - media-ux
+  - a11y
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #4 P1: leaving the Reader takes three Escapes and the second lands inside the rail's Search input (A cap 20); `s` typed at the F6 rail stop lands in `Search Library…` (B cap_79); F6's content stop is real (first candidate in `_MEDIA_WORKBENCH_FOCUS_TARGETS`) but invisible after the task-31221 outline suppression, so a keyboard user cannot tell it landed (B cap_57); Escape does not close the More menu though the label promises `close more` (B cap_106); `‹ Back` flips `_library_media_view` to list without changing the visible Reader, so ]/[ die on identical pixels (A cap 25/31/39). Eight distinct `esc …` labels were seen live.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Escape from the Reader focuses the loaded list row, never an Input
+- [ ] #2 The F6 content stop has a visible focus treatment that does not paint over content (painted-text test proves content still paints; a focus test proves the treatment)
+- [ ] #3 Escape closes the More menu
+- [ ] #4 In the three-pane shell, Back either is removed or makes list mode visible (dimmed Reader or a parked label) so the key-map change is explained on screen
+- [ ] #5 Distinct `esc …` labels reduced to four or fewer, table recorded in the notes
+- [ ] #6 Live-verified
+<!-- AC:END -->

--- a/backlog/tasks/task-31273 - An-explicit-open-bypasses-review-set-auto-resume.md
+++ b/backlog/tasks/task-31273 - An-explicit-open-bypasses-review-set-auto-resume.md
@@ -1,0 +1,27 @@
+---
+id: TASK-31273
+title: An explicit open bypasses review-set auto-resume
+status: To Do
+assignee: []
+created_date: '2026-09-04 13:54'
+labels:
+  - library
+  - media-ux
+  - review-sets
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+User ruling at the critique #4 close. Task-31234 made auto-resume open the set's cursor item on every Media entry; that now overrides explicit opens — a deep link, open-by-id from another surface, or Enter on a different row while a set is active pulls the user back to the cursor item (library_screen.py:39683-39692). The ruling: an explicit open wins; plain rail entry with no target still resumes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A deep link, open-by-id, or Enter on a row that is not the cursor item opens that item even while a set is active
+- [ ] #2 The review banner states the off-set state honestly (e.g. `Reviewing paused: <name> — X of M · this item is not in the set`) and ] resumes the walk from the cursor
+- [ ] #3 Plain rail entry with no explicit target still auto-resumes to the cursor item
+- [ ] #4 Tests pin all three paths; live-verified
+<!-- AC:END -->

--- a/backlog/tasks/task-31273 - An-explicit-open-bypasses-review-set-auto-resume.md
+++ b/backlog/tasks/task-31273 - An-explicit-open-bypasses-review-set-auto-resume.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-31273
 title: An explicit open bypasses review-set auto-resume
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-04 13:54'
+updated_date: '2026-09-04 15:09'
 labels:
   - library
   - media-ux
@@ -20,8 +21,22 @@ User ruling at the critique #4 close. Task-31234 made auto-resume open the set's
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A deep link, open-by-id, or Enter on a row that is not the cursor item opens that item even while a set is active
-- [ ] #2 The review banner states the off-set state honestly (e.g. `Reviewing paused: <name> — X of M · this item is not in the set`) and ] resumes the walk from the cursor
-- [ ] #3 Plain rail entry with no explicit target still auto-resumes to the cursor item
-- [ ] #4 Tests pin all three paths; live-verified
+- [x] #1 A deep link, open-by-id, or Enter on a row that is not the cursor item opens that item even while a set is active
+- [x] #2 The review banner states the off-set state honestly (e.g. `Reviewing paused: <name> — X of M · this item is not in the set`) and ] resumes the walk from the cursor
+- [x] #3 Plain rail entry with no explicit target still auto-resumes to the cursor item
+- [x] #4 Tests pin all three paths; live-verified
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: banner unit test for an off-set loaded item; walker tests for a cancel helper and a source-level pin that both explicit-open seams call it
+2. GREEN: _cancel_pending_review_set_resume() cancels the library_review_set_resume worker group; called from handle_library_media_row (normal mode) and the media branch of _open_library_item_by_id; _active_review_set_banner adds ' · this item is not in the set'
+3. Live tmux: set mid-walk, Escape, open an off-set item, ], leave and return via the rail
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Explicit opens (row press, open-by-id / deep link) now cancel any in-flight auto-resume worker before opening, so the entry-time landing can never override what the user chose; the worker's own still-on-the-list gate remains as the second guard. Plain rail entry with no target still auto-resumes (task-31234 ruling). When the loaded item is not in the active set the banner reads 'Reviewing: <name> — X of M · N reviewed · this item is not in the set' and ] resumes from the cursor without marking (existing walker behaviour). Tests: banner suffix, cancel helper, source-level pin of both seams, multiselect row-press fake gains the seam. Live-verified in tmux 235x52.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31274 - Media-filter-matches-titles-only-so-keyword-tagged-items-are-missed.md
+++ b/backlog/tasks/task-31274 - Media-filter-matches-titles-only-so-keyword-tagged-items-are-missed.md
@@ -1,0 +1,26 @@
+---
+id: TASK-31274
+title: Media filter matches titles only so keyword-tagged items are missed
+status: To Do
+assignee: []
+created_date: '2026-09-04 13:54'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #4 P2: filtering the list by `day2` — a keyword on four seeded rows — produced `Media (0)` and `No media matched ‘day2’.` (B cap_15). The filter appears to match titles only (cause suspected, not traced). The user's stated sequential-review scenario is a tag/keyword-filtered browse, so a keyword miss undercuts `Review these` over a tag scope, and the empty state does not say what was searched.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The fields the filter searches are documented in the task notes after a code trace
+- [ ] #2 Keyword matches are included in the filter, or an explicit `keyword:` syntax exists and the input placeholder says so
+- [ ] #3 The empty state names what was searched (e.g. `No media matched “day2” in titles or keywords`)
+- [ ] #4 Tests pin keyword matching and the copy
+<!-- AC:END -->

--- a/backlog/tasks/task-31275 - List-returns-stale-after-Restore-from-Trash-and-demands-a-manual-Retry.md
+++ b/backlog/tasks/task-31275 - List-returns-stale-after-Restore-from-Trash-and-demands-a-manual-Retry.md
@@ -1,0 +1,25 @@
+---
+id: TASK-31275
+title: List returns stale after Restore from Trash and demands a manual Retry
+status: To Do
+assignee: []
+created_date: '2026-09-04 13:54'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #4 P2: after restoring an item in Trash and pressing `‹ Media`, the list comes back with `Media changed; retry to load a current page.`, every row and action rendered `○`, and `Page boundary is unknown.` until the user presses Retry (B cap_104-110). The app itself made the change, so it knows the page is stale; the honest-stale gate exists for external changes, not for the app's own mutations.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 After Restore or permanent delete in Trash, returning to Media shows a fresh list without pressing Retry
+- [ ] #2 The stale-list gate still fires for changes the app did not make itself
+- [ ] #3 Test plus live verification
+<!-- AC:END -->

--- a/backlog/tasks/task-31276 - Find-bar-relocates-above-the-Reader-header-on-Enter-and-leaves-a-join-artifact-when-closed.md
+++ b/backlog/tasks/task-31276 - Find-bar-relocates-above-the-Reader-header-on-Enter-and-leaves-a-join-artifact-when-closed.md
@@ -1,0 +1,25 @@
+---
+id: TASK-31276
+title: Find bar relocates above the Reader header on Enter and leaves a join artifact when closed
+status: To Do
+assignee: []
+created_date: '2026-09-04 13:54'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #4 P2: pressing Enter in the Find bar moved the whole bar from under the `Read` label to the top of the pane above `Local Media item`, pushing the header down six rows (B cap_20). After Escape closes Find, a five-cell `┐─────Local Media item` artifact appears at the pane join and persists across later interactions (14 captures; absent on a fresh open).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The Find bar stays in one place (under the mode row) through open, typing, Enter and match navigation
+- [ ] #2 No `┐─────` artifact at the pane join after Find close, tab clicks or the More menu
+- [ ] #3 Live-verified at 235x52 and 100x30 with captures in the notes
+<!-- AC:END -->

--- a/backlog/tasks/task-31277 - Reader-chrome-overhead-and-reading-measure.md
+++ b/backlog/tasks/task-31277 - Reader-chrome-overhead-and-reading-measure.md
@@ -1,0 +1,28 @@
+---
+id: TASK-31277
+title: Reader chrome overhead and reading measure
+status: To Do
+assignee: []
+created_date: '2026-09-04 13:54'
+labels:
+  - library
+  - media-ux
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #4 P2: eight rows of chrome precede the first content line at 235 cols (identity line `Local Media item`, `‹ Back`, title, an empty byline row when there is no author or URL, spacer, toolbar, mode row, a section header that repeats the selected tab — A cap 03); prose runs about 150 cells against DESIGN.md's 65-75; video transcripts render `## Section 1` literally because markdown detection is limited to plaintext/markdown/obsidian_note (library_media_viewer_state.py:201-208).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The identity line renders only for server or external items
+- [ ] #2 The empty byline row is collapsed when there is no author or URL
+- [ ] #3 The section header no longer repeats the selected tab
+- [ ] #4 Text bodies are capped at a readable measure (about 90 cells) without breaking raw or rendered modes
+- [ ] #5 Transcript bodies that contain markdown headings render them (or the sniff covers those media types); no literal `##`
+- [ ] #6 Before and after captures in the notes
+<!-- AC:END -->

--- a/backlog/tasks/task-31278 - Design-note-for-row-state-markers-via-the-media-summary-contract-bump.md
+++ b/backlog/tasks/task-31278 - Design-note-for-row-state-markers-via-the-media-summary-contract-bump.md
@@ -1,0 +1,27 @@
+---
+id: TASK-31278
+title: Design note for row state markers via the media summary-contract bump
+status: To Do
+assignee: []
+created_date: '2026-09-04 13:54'
+labels:
+  - library
+  - media-ux
+  - design
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #4 close, user ruling: reviewed and analysis markers on list rows need the 5-key media summary contract bumped (task-28008 analysis presence, task-28009 read markers), which was deferred twice as invasive. The user wants the proposal as a design note first, then its own implementation PR. The note must cover the contract change, the projection for has_analysis and reviewed state, the source of truth for reviewed (set-local done marks vs a per-item marker), rendering inside a 38-col row, and the migration plan for every producer and test fake of the summary shape.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A design note exists at backlog/docs/design-library-row-state-markers.md covering contract, projection, reviewed source-of-truth, 38-col rendering and the producer/fake migration plan
+- [ ] #2 The note lists the decisions that need the user's ruling with a recommendation for each
+- [ ] #3 User approval is recorded in the note before any implementation task is started
+- [ ] #4 Implementation tasks reference 28008 and 28009 rather than duplicating them
+<!-- AC:END -->

--- a/backlog/tasks/task-31278 - Design-note-for-row-state-markers-via-the-media-summary-contract-bump.md
+++ b/backlog/tasks/task-31278 - Design-note-for-row-state-markers-via-the-media-summary-contract-bump.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-31278
 title: Design note for row state markers via the media summary-contract bump
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-09-04 13:54'
+updated_date: '2026-09-04 15:09'
 labels:
   - library
   - media-ux
@@ -20,8 +21,14 @@ Critique #4 close, user ruling: reviewed and analysis markers on list rows need 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A design note exists at backlog/docs/design-library-row-state-markers.md covering contract, projection, reviewed source-of-truth, 38-col rendering and the producer/fake migration plan
+- [x] #1 A design note exists at backlog/docs/design-library-row-state-markers.md covering contract, projection, reviewed source-of-truth, 38-col rendering and the producer/fake migration plan
 - [ ] #2 The note lists the decisions that need the user's ruling with a recommendation for each
 - [ ] #3 User approval is recorded in the note before any implementation task is started
-- [ ] #4 Implementation tasks reference 28008 and 28009 rather than duplicating them
+- [x] #4 Implementation tasks reference 28008 and 28009 rather than duplicating them
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Design note drafted at backlog/docs/design-library-row-state-markers.md (options A/B/C, recommendation A: seven-key contract with has_analysis projected in SQL and reviewed decorated from the active set; four decisions listed for the user). Awaiting user approval (AC#2) before any implementation of 28008/28009.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/library_media_viewer_state.py
+++ b/tldw_chatbook/Library/library_media_viewer_state.py
@@ -450,3 +450,39 @@ def build_library_media_highlight_rows(
             )
         )
     return tuple(rows)
+
+
+def detail_analysis_text(detail: Mapping[str, Any]) -> str:
+    """Public read of the newest version's analysis text (see the private helper)."""
+    return _latest_version_analysis_text(detail)
+
+
+def analysis_find_unavailable_reason(
+    *, mode: str, analysis: str, generating: bool, editing: bool
+) -> str:
+    """Why Find cannot open on the Analysis tab right now, or "" when it can.
+
+    Qodo on #2378: Find opens the bar for the tab being read, and the
+    Analysis tab composes its bar only around analysis text. With no text
+    (or while generating / editing) there is nothing to mount, so the
+    gesture must be disabled with a reason instead of silently arming
+    ``find_open``. The Read tab always has a body to search.
+
+    Args:
+        mode: The Reader mode (``"read"``, ``"analysis"``, ...).
+        analysis: The current analysis text, or "".
+        generating: Whether an analysis is being generated.
+        editing: Whether the analysis edit form is open.
+
+    Returns:
+        The user-facing reason, or "" when Find is available.
+    """
+    if mode != "analysis":
+        return ""
+    if generating:
+        return "Analysis is still generating."
+    if editing:
+        return "Finish editing the analysis first."
+    if not analysis.strip():
+        return "No analysis to search yet."
+    return ""

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -164,6 +164,10 @@ from ...Library.library_ingest_state import (
     library_ingest_retry_label,
     parse_keywords,
 )
+from ...Library.library_media_viewer_state import (
+    analysis_find_unavailable_reason,
+    detail_analysis_text,
+)
 from ...Library.library_media_state import (
     LibraryMediaCanvasState,
     LibraryMediaTrashState,
@@ -721,6 +725,9 @@ def _library_ingest_options_for(owner: Any) -> dict[str, Any]:
 # than moved: it is new screen code, not part of the extracted support layer.)
 _MEDIA_SELECT_MODE_KEY = "s"
 _MEDIA_ROW_SELECT_KEY = "space"
+#: Qodo on #2378: one name for the review-set auto-resume worker group, shared
+#: by registration (_maybe_auto_resume_review_set) and cancellation.
+_REVIEW_SET_RESUME_WORKER_GROUP = "library_review_set_resume"
 #
 # _INGEST_OPTIONS_CACHE_ATTR, _read_library_ingest_options_from_config, and
 # _library_ingest_options_for (just above) STAY here rather than moving to
@@ -39643,7 +39650,7 @@ class LibraryScreen(BaseAppScreen):
         a row press, a deep link, open-by-id -- wins over the entry-time
         auto-resume; plain rail entry with no target still resumes.
         """
-        self.workers.cancel_group(self, "library_review_set_resume")
+        self.workers.cancel_group(self, _REVIEW_SET_RESUME_WORKER_GROUP)
 
     def _maybe_auto_resume_review_set(self) -> None:
         """Kick the once-per-set auto-resume of an active review set.
@@ -39660,7 +39667,7 @@ class LibraryScreen(BaseAppScreen):
         """
         self.run_worker(
             self._auto_resume_review_set_worker(),
-            group="library_review_set_resume",
+            group=_REVIEW_SET_RESUME_WORKER_GROUP,
             exclusive=True,
             exit_on_error=False,
         )
@@ -41082,6 +41089,17 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_content_query = ""
         self._library_media_content_match_index = 0
 
+    def _library_media_find_unavailable_reason(self) -> str:
+        """Why Find cannot open on the current Reader tab, or "" (Qodo on #2378)."""
+        detail = self._library_media_detail
+        analysis = detail_analysis_text(detail) if isinstance(detail, Mapping) else ""
+        return analysis_find_unavailable_reason(
+            mode=self._library_media_reader_session.mode,
+            analysis=analysis,
+            generating=self._library_media_generating_analysis,
+            editing=self._library_media_editing_analysis,
+        )
+
     def _consume_library_media_find_focus(self) -> bool:
         """Return and clear the one-shot Find-gesture focus token (task-31269)."""
         pending = self._library_media_find_focus_pending
@@ -41101,6 +41119,13 @@ class LibraryScreen(BaseAppScreen):
             # bar (live: it did nothing while the bar was open).
             self._close_library_media_find()
             self._sync_library_media_viewer_or_recompose()
+            return
+        reason = self._library_media_find_unavailable_reason()
+        if reason:
+            # Qodo on #2378: nothing to mount on this tab -- never arm
+            # find_open silently (the button is already disabled with the
+            # same reason; this guards the action path).
+            self.notify(reason, severity="warning")
             return
         # task-31269: Find searches the tab you are reading. The Analysis
         # tab's bar is gated exactly like Read's now, so Find no longer

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -24117,6 +24117,8 @@ class LibraryScreen(BaseAppScreen):
             self._library_media_row_selection.toggle(media_id)
             _apply_library_row_toggle(self, "media", event.button, media_id)
             return
+        # task-31273: an explicit row open wins over a pending auto-resume.
+        self._cancel_pending_review_set_resume()
         self._open_library_media_viewer(media_id)
 
     @on(Button.Pressed, "#library-media-select-toggle")
@@ -38965,6 +38967,10 @@ class LibraryScreen(BaseAppScreen):
                 item_state = (
                     " · ✓ reviewed" if current.done else " · not yet reviewed"
                 )
+            elif loaded is not None and current is None:
+                # task-31273: an explicit open outside the set keeps the
+                # set's banner but never claims a state for this item.
+                item_state = " · this item is not in the set"
             return f"Reviewing: {review_set.name} — {progress}{item_state}"
         except Exception:
             logger.opt(exception=True).warning(
@@ -39629,6 +39635,15 @@ class LibraryScreen(BaseAppScreen):
         return landing.backing_media_id
 
     # -- auto-resume on media entry (task-28245) ------------------------------
+
+    def _cancel_pending_review_set_resume(self) -> None:
+        """Drop an in-flight auto-resume when the user opens something explicitly.
+
+        task-31273 (user ruling at the critique #4 close): an explicit open --
+        a row press, a deep link, open-by-id -- wins over the entry-time
+        auto-resume; plain rail entry with no target still resumes.
+        """
+        self.workers.cancel_group(self, "library_review_set_resume")
 
     def _maybe_auto_resume_review_set(self) -> None:
         """Kick the once-per-set auto-resume of an active review set.
@@ -42320,6 +42335,7 @@ class LibraryScreen(BaseAppScreen):
                 )
             self._selected_media_id = record_id
             self._library_selected_row_id = LIBRARY_ROW_BROWSE_MEDIA
+            self._cancel_pending_review_set_resume()
             self._library_media_view = "viewer"
             reader_identity = self._library_media_reader_identity(record_id)
             if reader_identity is not None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -2660,6 +2660,10 @@ class LibraryScreen(BaseAppScreen):
         # action opens it -- a permanently open "Search content…" input
         # duplicated the Find button and spent 3 rows on every fresh item.
         self._library_media_find_open: bool = False
+        # task-31269: one-shot Find-gesture token; spent by the next viewer
+        # build/sync so an item change can never move focus into the
+        # search Input.
+        self._library_media_find_focus_pending: bool = False
         # task-22209: in-content match list for the open item, memoized on
         # (detail object identity, query). Both the query submit and every
         # Prev/Next click need it, and deriving it costs a full content
@@ -40479,6 +40483,7 @@ class LibraryScreen(BaseAppScreen):
             content_match_index=self._library_media_content_match_index,
             content_mode=self._library_media_content_mode,
             find_open=self._library_media_find_open,
+            find_focus_pending=self._consume_library_media_find_focus(),
             loading=(
                 self._library_media_reader_session.pending_request is not None
                 and self._library_media_reader_session.error is None
@@ -40723,6 +40728,7 @@ class LibraryScreen(BaseAppScreen):
             and viewer.content_match_index == self._library_media_content_match_index
             and viewer.content_mode == self._library_media_content_mode
             and viewer.find_open == self._library_media_find_open
+            and not self._library_media_find_focus_pending
             and viewer.error_message == (self._library_media_reader_session.error or "")
             and viewer.reader_mode == self._library_media_reader_session.mode
             and viewer.more_open == self._library_media_reader_session.more_open
@@ -40768,6 +40774,7 @@ class LibraryScreen(BaseAppScreen):
             viewer.content_match_index = self._library_media_content_match_index
             viewer.content_mode = self._library_media_content_mode
             viewer.find_open = self._library_media_find_open
+            viewer.find_focus_pending = self._consume_library_media_find_focus()
             viewer.loading = loading
             viewer.loading_message = loading_message
             viewer.error_message = self._library_media_reader_session.error or ""
@@ -41060,24 +41067,37 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_content_query = ""
         self._library_media_content_match_index = 0
 
+    def _consume_library_media_find_focus(self) -> bool:
+        """Return and clear the one-shot Find-gesture focus token (task-31269)."""
+        pending = self._library_media_find_focus_pending
+        self._library_media_find_focus_pending = False
+        return pending
+
     @on(Button.Pressed, "#library-media-reader-find")
     def handle_library_media_reader_find(self, event: Button.Pressed) -> None:
-        """Take Find to the loaded item's content body.
+        """Open (or close) the Find bar for the tab being read.
 
         Args:
             event: The Find button press.
         """
         event.stop()
-        # task-28026: Find is a real Analysis->Read transition too, so it
-        # clears any active analysis search before focusing the transcript
-        # find bar -- the same reset the Reader mode buttons apply.
-        self._reset_library_media_search_on_mode_change("read")
-        # task-31237: the bar is collapsed until this gesture opens it
-        # (AFTER the reset above, which closes it as part of the mode seam).
-        self._library_media_find_open = True
-        self._library_media_reader_session = set_mode(
-            self._library_media_reader_session, "read"
+        if self._library_media_find_open:
+            # task-31269 AC4: Find is a toggle -- a second press closes the
+            # bar (live: it did nothing while the bar was open).
+            self._close_library_media_find()
+            self._sync_library_media_viewer_or_recompose()
+            return
+        # task-31269: Find searches the tab you are reading. The Analysis
+        # tab's bar is gated exactly like Read's now, so Find no longer
+        # jumps Analysis -> Read (task-28026's transition predates the
+        # collapsed bar). A same-mode reset is a no-op by design.
+        self._reset_library_media_search_on_mode_change(
+            self._library_media_reader_session.mode
         )
+        # task-31237: the bar is collapsed until this gesture opens it; the
+        # token below is what lets its mount take focus -- once.
+        self._library_media_find_open = True
+        self._library_media_find_focus_pending = True
         self._sync_library_media_viewer_or_recompose()
         self.call_after_refresh(self._focus_library_media_content_search_input)
 

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -166,6 +166,20 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         width: auto;
         min-width: 0;
     }
+    /* task-31270: receipts are two rows, full width; the copy wraps and the
+     * action row keeps content-width buttons so Undo/Dismiss always paint. */
+    .library-media-receipt {
+        width: 100%;
+        height: auto;
+    }
+    .library-media-receipt > .library-media-receipt-copy {
+        width: 100%;
+        height: auto;
+    }
+    .library-media-receipt > .library-media-receipt-actions {
+        width: 100%;
+        height: auto;
+    }
     """
 
     def __init__(
@@ -815,34 +829,44 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         receipt_count = getattr(self.canvas, "delete_receipt_count", 0)
         if receipt_count:
             receipt_word = "item" if receipt_count == 1 else "items"
-            receipt_row = Horizontal(
-                classes="ds-toolbar", id="library-media-bulk-delete-receipt"
+            # task-31270 (critique #4 P1): two rows -- copy, then actions --
+            # at full width. A single content-width Horizontal clipped Undo
+            # to "Und" at the Items pane's real width; same multi-row
+            # grammar as the toolbars (task-30043).
+            receipt = Vertical(
+                id="library-media-bulk-delete-receipt",
+                classes="library-media-receipt",
             )
-            receipt_row.styles.height = "auto"
-            with receipt_row:
+            receipt.styles.height = "auto"
+            with receipt:
                 yield Static(
                     # task-4025 (ADR-055 Pattern A): the receipt names the
                     # durable path too -- "· in Trash" points at the Trash
                     # view that outlives this receipt's Undo/Dismiss.
                     f"✓ deleted · {receipt_count} {receipt_word} · in Trash",
                     id="library-media-bulk-delete-receipt-copy",
-                    classes="library-toolbar-count",
+                    classes="library-toolbar-count library-media-receipt-copy",
                     markup=False,
                 )
-                undo = Button(
-                    "Undo",
-                    id="library-media-bulk-delete-undo",
-                    classes="library-canvas-action",
-                    compact=True,
+                actions = Horizontal(
+                    classes="ds-toolbar library-media-receipt-actions"
                 )
-                yield self._gate_stale_action(undo, "Undo")
-                dismiss = Button(
-                    "Dismiss",
-                    id="library-media-bulk-delete-receipt-dismiss",
-                    classes="library-canvas-action",
-                    compact=True,
-                )
-                yield self._gate_mutation_action(dismiss, "Dismiss")
+                actions.styles.height = "auto"
+                with actions:
+                    undo = Button(
+                        "Undo",
+                        id="library-media-bulk-delete-undo",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                    yield self._gate_stale_action(undo, "Undo")
+                    dismiss = Button(
+                        "Dismiss",
+                        id="library-media-bulk-delete-receipt-dismiss",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                    yield self._gate_mutation_action(dismiss, "Dismiss")
 
         # task-31236: a dismissed review set's undo receipt -- the same
         # grammar as the bulk-delete receipt above, because a one-click
@@ -852,31 +876,37 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             self.canvas, "review_dismiss_receipt_name", ""
         )
         if dismissed_set_name:
-            dismiss_receipt_row = Horizontal(
-                classes="ds-toolbar", id="library-media-review-dismiss-receipt"
+            dismiss_receipt = Vertical(
+                id="library-media-review-dismiss-receipt",
+                classes="library-media-receipt",
             )
-            dismiss_receipt_row.styles.height = "auto"
-            with dismiss_receipt_row:
+            dismiss_receipt.styles.height = "auto"
+            with dismiss_receipt:
                 yield Static(
                     f"✓ dismissed · {dismissed_set_name}",
                     id="library-media-review-dismiss-receipt-copy",
-                    classes="library-toolbar-count",
+                    classes="library-toolbar-count library-media-receipt-copy",
                     markup=False,
                 )
-                undo_set = Button(
-                    "Undo",
-                    id="library-media-review-dismiss-undo",
-                    classes="library-canvas-action",
-                    compact=True,
+                set_actions = Horizontal(
+                    classes="ds-toolbar library-media-receipt-actions"
                 )
-                yield self._gate_stale_action(undo_set, "Undo")
-                close_receipt = Button(
-                    "Dismiss",
-                    id="library-media-review-dismiss-receipt-close",
-                    classes="library-canvas-action",
-                    compact=True,
-                )
-                yield self._gate_mutation_action(close_receipt, "Dismiss")
+                set_actions.styles.height = "auto"
+                with set_actions:
+                    undo_set = Button(
+                        "Undo",
+                        id="library-media-review-dismiss-undo",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                    yield self._gate_stale_action(undo_set, "Undo")
+                    close_receipt = Button(
+                        "Dismiss",
+                        id="library-media-review-dismiss-receipt-close",
+                        classes="library-canvas-action",
+                        compact=True,
+                    )
+                    yield self._gate_mutation_action(close_receipt, "Dismiss")
 
         status_text = (
             self.pager.status_copy

--- a/tldw_chatbook/Widgets/Library/library_media_content.py
+++ b/tldw_chatbook/Widgets/Library/library_media_content.py
@@ -339,6 +339,7 @@ class LibraryMediaContentSearchControls(Vertical):
         query: str,
         matches: tuple[int, ...],
         match_index: int,
+        focus_on_mount: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -346,19 +347,24 @@ class LibraryMediaContentSearchControls(Vertical):
         self.query = query
         self.matches = matches
         self.match_index = match_index
+        self.focus_on_mount = focus_on_mount
         self.set_class(bool(self.query), self.ACTIVE_SEARCH_CLASS)
 
     def on_mount(self) -> None:
-        """Take focus into the input on the Find-gesture mount (task-31237).
+        """Take focus into the input only on the Find-gesture mount.
 
-        The bar now mounts only when the Find action opens it (or a query
-        is already applied). On the gesture mount -- empty query -- the
-        input takes focus from THIS widget's own post-refresh hook (its
-        children exist by then), because no screen-level defer can order
-        itself after a nested recompose-mount; an active-query remount
-        (match navigation, mode flips) never steals focus.
+        task-31269 (critique #4 P0): inferring the gesture from an empty
+        query made EVERY mount with no query steal focus -- each ]/[ item
+        load in Analysis mode, and any walk with the bar still empty,
+        parked the caret in this Input and the next key was typed. The
+        gesture is now an explicit token the screen sets in the Find
+        handler and the viewer spends on the one compose that follows;
+        every other mount (item change, mode flip, match navigation)
+        leaves focus alone. The focus still runs from THIS widget's
+        post-refresh hook because no screen-level defer can order itself
+        after a nested recompose-mount (task-31237).
         """
-        if not self.query:
+        if self.focus_on_mount:
             self.call_after_refresh(self._focus_search_input)
 
     def _focus_search_input(self) -> None:

--- a/tldw_chatbook/Widgets/Library/library_media_content.py
+++ b/tldw_chatbook/Widgets/Library/library_media_content.py
@@ -342,6 +342,19 @@ class LibraryMediaContentSearchControls(Vertical):
         focus_on_mount: bool = False,
         **kwargs: Any,
     ) -> None:
+        """Build the in-item search bar.
+
+        Args:
+            is_markdown: Whether the searched body renders as Markdown (the
+                placeholder says search matches raw text).
+            query: The active query, or "" when the bar is empty.
+            matches: Line indexes that match ``query``.
+            match_index: Index into ``matches`` of the current match.
+            focus_on_mount: One-shot Find-gesture token (task-31269): take
+                focus into the Input after this mount; never set for an
+                item change, mode flip, or match navigation remount.
+            **kwargs: Passed to ``Vertical``.
+        """
         super().__init__(**kwargs)
         self.is_markdown = is_markdown
         self.query = query

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -82,6 +82,7 @@ class LibraryMediaViewer(Vertical):
         content_match_index: int = 0,
         content_mode: str = "raw",
         find_open: bool = False,
+        find_focus_pending: bool = False,
         loading: bool = False,
         loading_message: str = "Loading media…",
         error_message: str = "",
@@ -101,6 +102,9 @@ class LibraryMediaViewer(Vertical):
 
         Args:
             viewer: Pure display state for the loaded item.
+            find_focus_pending: One-shot token from the Find gesture; the
+                bar it mounts takes focus, then the token is spent here so
+                later syncs never re-take focus (task-31269).
             find_open: Whether the content Find bar renders (task-31237:
                 collapsed until the Find action opens it -- a permanently
                 open input duplicated Find and spent 3 rows per item).
@@ -120,6 +124,7 @@ class LibraryMediaViewer(Vertical):
         self.content_match_index = content_match_index
         self.content_mode = content_mode
         self.find_open = find_open
+        self.find_focus_pending = find_focus_pending
         self.loading = loading
         self.loading_message = loading_message
         self.error_message = error_message
@@ -346,8 +351,11 @@ class LibraryMediaViewer(Vertical):
                     query=self.content_query,
                     matches=matches,
                     match_index=self.content_match_index,
+                    focus_on_mount=self.find_focus_pending,
                     id="library-media-content-search-controls",
                 )
+                # task-31269: the gesture token is spent on this mount.
+                self.find_focus_pending = False
             yield LibraryMediaContentBody(
                 content=self.viewer.content,
                 is_markdown=self.viewer.is_markdown,
@@ -625,13 +633,19 @@ class LibraryMediaViewer(Vertical):
             # match count, Prev/Next, and Enter-advance all follow the
             # active tab. Analysis is plain text -> raw mode, not Markdown.
             matches = find_content_matches(self.viewer.analysis, self.content_query)
-            yield LibraryMediaContentSearchControls(
-                is_markdown=False,
-                query=self.content_query,
-                matches=matches,
-                match_index=self.content_match_index,
-                id="library-media-content-search-controls",
-            )
+            # task-31269: like Read, the bar is collapsed until Find opens
+            # it -- an always-mounted bar stole focus on every item load and
+            # swallowed the walk keys (critique #4 P0).
+            if self.find_open or self.content_query:
+                yield LibraryMediaContentSearchControls(
+                    is_markdown=False,
+                    query=self.content_query,
+                    matches=matches,
+                    match_index=self.content_match_index,
+                    focus_on_mount=self.find_focus_pending,
+                    id="library-media-content-search-controls",
+                )
+                self.find_focus_pending = False
             yield LibraryMediaContentBody(
                 content=self.viewer.analysis,
                 is_markdown=False,

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -12,7 +12,9 @@ from textual.css.query import NoMatches, QueryError
 from textual.widget import Widget
 from textual.widgets import Button, Collapsible, Input, Static, TextArea
 
+from tldw_chatbook.Library.library_shell_state import library_disabled_action_label
 from tldw_chatbook.Library.library_media_viewer_state import (
+    analysis_find_unavailable_reason,
     LibraryMediaHighlightRow,
     LibraryMediaViewerState,
     find_content_matches,
@@ -269,7 +271,23 @@ class LibraryMediaViewer(Vertical):
     def _compose_primary_toolbar(self) -> ComposeResult:
         """Render the always-reachable Reader actions."""
         with Horizontal(classes="ds-toolbar", id="library-media-reader-primary-toolbar"):
-            yield Button("Find", id="library-media-reader-find", compact=True)
+            # Qodo on #2378: an Analysis tab with nothing to search has no
+            # bar to mount -- say why Find is off instead of toggling silently.
+            find_reason = analysis_find_unavailable_reason(
+                mode=self.reader_mode,
+                analysis=self.viewer.analysis,
+                generating=self.generating_analysis,
+                editing=self.editing_analysis,
+            )
+            find = Button(
+                library_disabled_action_label("Find", bool(find_reason)),
+                id="library-media-reader-find",
+                compact=True,
+            )
+            if find_reason:
+                find.disabled = True
+                find.tooltip = find_reason
+            yield find
             if not self.external_detail:
                 yield Button(
                     "Remove later" if self.viewer.read_later else "Read later",

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -3333,6 +3333,24 @@ with stray left-edge border fragments), and padding 0 1 so the full
     max-width: 100%;
 }
 
+/* task-31270 (critique #4 P1): the delete / dismiss receipts are two rows
+   (copy, then Undo · Dismiss) at full width. A single content-width
+   Horizontal clipped Undo to "Und" at the Items pane's real width (live
+   2026-09-04) -- the one recovery control was unreadable exactly where it
+   renders. Same multi-row grammar as the toolbars (task-30043). */
+#library-media-canvas .library-media-receipt {
+    width: 100%;
+    height: auto;
+}
+#library-media-canvas .library-media-receipt > .library-media-receipt-copy {
+    width: 100%;
+    height: auto;
+}
+#library-media-canvas .library-media-receipt > .library-media-receipt-actions {
+    width: 100%;
+    height: auto;
+}
+
 /* task-30043 (critique 2026-09-03 P1) supersedes task-28025's 1fr squeeze:
    sharing the row width chopped every label to fragments (``t so E Tr R
    Se``) and collapsed disabled bulk actions to bare "○" markers at the

--- a/tldw_chatbook/css/screen_agentic_library.tcss
+++ b/tldw_chatbook/css/screen_agentic_library.tcss
@@ -2148,6 +2148,24 @@ with stray left-edge border fragments), and padding 0 1 so the full
     margin: 0 0 1 0;
 }
 
+/* task-31270 (critique #4 P1): the delete / dismiss receipts are two rows
+   (copy, then Undo · Dismiss) at full width. A single content-width
+   Horizontal clipped Undo to "Und" at the Items pane's real width (live
+   2026-09-04) -- the one recovery control was unreadable exactly where it
+   renders. Same multi-row grammar as the toolbars (task-30043). */
+#library-media-canvas .library-media-receipt {
+    width: 100%;
+    height: auto;
+}
+#library-media-canvas .library-media-receipt > .library-media-receipt-copy {
+    width: 100%;
+    height: auto;
+}
+#library-media-canvas .library-media-receipt > .library-media-receipt-actions {
+    width: 100%;
+    height: auto;
+}
+
 /* task-14900: Media list|preview side by side above the screen's one
    measured width regime. The workbench Horizontal (Collections'
    `#library-collections-workbench` grammar) splits its panes 1fr|1fr by

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -2852,6 +2852,20 @@
         width: auto;
         min-width: 0;
     }
+    /* task-31270: receipts are two rows, full width; the copy wraps and the
+     * action row keeps content-width buttons so Undo/Dismiss always paint. */
+    LibraryMediaCanvas .library-media-receipt {
+        width: 100%;
+        height: auto;
+    }
+    LibraryMediaCanvas .library-media-receipt > .library-media-receipt-copy {
+        width: 100%;
+        height: auto;
+    }
+    LibraryMediaCanvas .library-media-receipt > .library-media-receipt-actions {
+        width: 100%;
+        height: auto;
+    }
 
 
 /* ===== WIDGET: LibraryNoteFolderNameDialog (Widgets/Library/library_note_folder_dialog.py) ===== */

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -2344,6 +2344,11 @@
      * rendered at any width). Share the row instead. */
 
 
+    /* task-31270: receipts are two rows, full width; the copy wraps and the
+     * action row keeps content-width buttons so Undo/Dismiss always paint. */
+
+
+
 
 
 /* ===== WIDGET: LibraryNoteFolderNameDialog (Widgets/Library/library_note_folder_dialog.py) ===== */


### PR DESCRIPTION
First PR of fix wave 4 from critique #4 of Library ▸ Media (25/40, snapshot `.impeccable/critique/2026-09-04T13-50-05Z…`). It lands the two regressions that critique traced to my own fix wave 3, the user's auto-resume ruling, and the row-marker design note. Also files the wave-4 tasks 31269-31278 and extends 28007/28015.

## task-31269 — the Find gesture, not the mount, decides focus (P0)

#2367's `on_mount` focused the content search Input whenever the query was empty, and the Analysis tab (task-28026) mounted that bar unconditionally, so every `]`/`[` item load in Analysis mode — and any walk with an empty bar open — parked the caret in the field and the next key was typed (live: `▊ ]`, `]]]]]`). Workflow 3, "review every analysis", was exactly that path.

- `LibraryMediaContentSearchControls(focus_on_mount=…)` is an explicit one-shot token. The screen sets `_library_media_find_focus_pending` only in the Find handler; the viewer construction site and the in-place sync both consume it (a pending token forces the recompose path so it is never lost), and the viewer spends it right after yielding the bar.
- The Analysis tab gates its bar behind `find_open` exactly like Read, so Find opens the bar for the tab being read and one Escape collapses it on either tab. **Contract change:** task-28026's "Find is an Analysis→Read transition" is retired (its reader-flow test is rewritten to pin the in-place Analysis Find). Find is now a toggle.
- Six `test_library_shell.py` tests queried the search input before any Find press and have failed on dev since #2367 collapsed the bar; they now go through a shared `_open_media_find` helper, and the retired 18-row-cap assertion is gone. Two plain-harness search tests still fail on clean dev for layout/identity reasons and are recorded in task-31249.

## task-31270 — receipts take the two-row grammar (P1)

The delete and set-dismiss receipts were single content-width rows: at the ~38-col Items pane they painted as `✓ deleted · 1 item · in Trash  Und` and `✓ dismissed · … Un`. Both are now a Vertical (full-width copy row + `ds-toolbar` action row), same grammar as the task-30043 toolbars, button ids unchanged; CSS at both tiers, bundle regenerated. Painted-text tests at the real pane width.

## task-31273 — an explicit open bypasses auto-resume (user ruling)

Row presses and the open-by-id/deep-link seam cancel the `library_review_set_resume` worker group before opening; plain rail entry with no target still resumes to the cursor item. An item opened outside the active set gets an honest banner: `Reviewing: <name> — X of M · N reviewed · this item is not in the set`; `]` resumes from the cursor without marking.

## task-31278 — design note (awaiting approval)

`backlog/docs/design-library-row-state-markers.md`: options for reviewed/analysis markers on rows via the 5-key summary-contract bump (28008/28009), recommendation A, four decisions for the user. No implementation in this PR.

## Verification

Tests (each file its own process, on the merged head 50c9918935): render-fixes 10, reader-flow 49, match-nav 7, multiselect 66, banner 8, walker 58, side-by-side 32, trash 75; shell subset (`find|search|analysis|reader`) has one fewer failure than clean dev and no new ones. Derived-artifact checks all exit 0; no new `logger.*` calls.

Live in tmux 235x52 (seeded, cleaned up): Analysis-mode `[`/`]` walk over three items with the tab kept and the footer never reading `typing in field`; Find on the Analysis tab opens in place, Escape closes, Find toggles; both receipts render `Undo     Dismiss` on their own row and Undo restores by label (also at 100x30); 2-item set → off-set open shows the honest banner, `]` resumes at the cursor, leaving and returning via the rail still lands on the cursor item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LebG4HPfSniVohbuXkU4n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two regressions from fix wave 3, applies the explicit-open auto-resume ruling, and adds the row-state-marker design note (tasks 31269, 31270, 31273, 31278).

**Bug Fixes**
- Find now opens the search bar on the tab being read and toggles closed; only the Find gesture focuses the field, so `]`/`[` walks no longer type into it. The Analysis→Read jump is retired.
- Find is disabled with a reason when the Analysis tab has no searchable analysis text (missing, generating, or editing), instead of silently arming the bar.
- Delete and dismiss receipts render as two full-width rows, so Undo and Dismiss no longer clip at the Items pane width; button ids are unchanged.
- Row presses, open-by-id, and deep links now cancel the review-set auto-resume; plain rail entry still resumes. Off-set items show a banner noting the item is not in the set.

**Docs**
- Adds the row-state-marker design note (task-31278) for user approval; no implementation included.
- Files the remaining wave-4 tasks and adds this round's acceptance criteria to tasks 28007 and 28015.

<sup>Written for commit 5bd667aaf5c77d65a926e0a5d5cdd8edaed9ed01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

