### PR TITLE
feat(console): typed answers resolve a mounted ask_user question (PRD M3)

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -168,6 +168,12 @@ Region     Which regions? (pick any)
   question you are on, `Tab` moves between questions, `Enter` submits.
 - You can submit with questions left blank; the agent sees them as
   unanswered and decides what to do.
+- You can also just type your answer and send it. While a question card is
+  up, a plain message answers the questions you have not picked an option
+  for (it becomes their **Other…** text) and is not sent to the agent as a
+  new message. Two exceptions: a `/` command runs as usual, and a message
+  with a staged attachment or staged Library evidence is sent as a normal
+  turn, leaving the question up for you to answer on the card.
 - The card never grabs focus from something you are typing. If you need to
   reach it from the keyboard, the inspector's **Review approval** action
   focuses the question card when no approval is pending.

--- a/Docs/superpowers/plans/2026-09-04-console-ask-user-m3.md
+++ b/Docs/superpowers/plans/2026-09-04-console-ask-user-m3.md
@@ -1,0 +1,292 @@
+# Console `ask_user` typed answers (PRD M3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A message sent from the Console composer while a question card is mounted answers the question instead of starting a turn (PRD A8 / AC-A6), with slash commands and staged context exempt.
+
+**Architecture:** One screen-side interception in `_send_console_message_from_visible_action`, placed after command handling and immediately before `_dispatch_console_draft_send`. It reads the mounted `ChatQuestionCard`'s current selections, fills `other_text` on every still-unanswered question with the typed text, resolves the round through the controller's existing `resolve_pending_question`, and returns without dispatching. No controller or card changes.
+
+**Tech Stack:** Python ≥3.11, Textual 8.2.8, pytest. No new dependencies.
+
+**Spec:** `Docs/Development/Chatbook/Chatbook-Console-Agent-Interaction-PRD.md` Feature A, A8 and AC-A6. Requires M2 (PR #2379) merged: `ChatQuestionCard.collect_answers`, `ConsoleChatController.resolve_pending_question`, `TaskResumeState.pending_question`.
+
+## Global Constraints
+
+- Same as the M2 plan: no new module resident at UI-ready; no new `logger.*` calls; docstrings on new public methods; `.venv` interpreter from the worktree root; blocking pytest; attribution trailers on every commit.
+- The PRD, not the design spec, is the authority: A8 does NOT ask for a transcript user row (the design spec did). The A14 marker already records `other: <text>` per question on resolve, so no user row is appended -- a `persist=False` USER row would be a new shape for the transcript reconciler to misread.
+- `ChatScreen(mock_chat_host)` construction is broken on dev (real-path check); drive screen methods as unbound functions on `SimpleNamespace` stubs, the pattern `Tests/UI/test_console_command_composer.py` already uses for `_send_console_message_from_visible_action`.
+- Worktree: create `.claude/worktrees/ask-user-m3` on branch `feat/console-ask-user-typed-answers` from `origin/dev` AFTER #2379 merges. Check `git rev-parse --show-toplevel` before every commit, and `cd` into the worktree in every patch command.
+
+---
+
+### Task 1: The interception
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` — `_send_console_message_from_visible_action` (its final statement `return await self._dispatch_console_draft_send(draft, stash=stash)`), plus one new method beside `_set_console_pending_question`.
+- Test: `Tests/UI/test_console_ask_user_typed_answers.py`
+
+**Interfaces:**
+- Consumes: `ChatQuestionCard.collect_answers() -> list[dict]`, `ChatQuestionCard._request_id`, `ChatQuestionCard.set_questions(None)`, `ConsoleChatController.resolve_pending_question(answers, request_id=...)`, `self._console_pending_image_attachment()`, `self._retrieval._pending_launch()` (the staged Library-evidence launch, `None` when nothing is staged), `self._clear_console_composer_draft()`.
+- Produces: `ChatScreen._answer_pending_question_with_draft(draft: str) -> bool`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# Tests/UI/test_console_ask_user_typed_answers.py
+"""PRD A8 / AC-A6: a composer send answers a mounted question instead of starting a turn."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+
+class _Card:
+    def __init__(self, answers, request_id="round-1", display=True):
+        self.display = display
+        self._request_id = request_id
+        self._answers = answers
+        self.cleared = False
+
+    def collect_answers(self):
+        return [dict(a) for a in self._answers]
+
+    def set_questions(self, payload):
+        assert payload is None
+        self.cleared = True
+
+
+def _answers():
+    return [
+        {"question": "Which DB?", "selected": ["Postgres"], "other_text": None, "unanswered": False},
+        {"question": "Regions?", "selected": [], "other_text": None, "unanswered": True},
+    ]
+
+
+def _screen(card, *, image=None, launch=None, controller=None):
+    cleared = []
+    return SimpleNamespace(
+        _console_chat_controller=controller if controller is not None else Mock(),
+        query=lambda selector: [card] if card is not None else [],
+        _console_pending_image_attachment=lambda: image,
+        _retrieval=SimpleNamespace(_pending_launch=lambda: launch),
+        _clear_console_composer_draft=lambda: cleared.append(True),
+        _cleared=cleared,
+    )
+
+
+def test_typed_text_fills_every_unanswered_question_and_resolves_the_round():
+    card = _Card(_answers())
+    screen = _screen(card)
+    assert ChatScreen._answer_pending_question_with_draft(screen, "  apac only  ") is True
+    screen._console_chat_controller.resolve_pending_question.assert_called_once()
+    answers, kwargs = screen._console_chat_controller.resolve_pending_question.call_args
+    assert kwargs == {"request_id": "round-1"}
+    assert answers[0] == [
+        {"question": "Which DB?", "selected": ["Postgres"], "other_text": None, "unanswered": False},
+        {"question": "Regions?", "selected": [], "other_text": "apac only", "unanswered": False},
+    ]
+    assert card.cleared is True and screen._cleared == [True]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"card": None},
+        {"card": _Card(_answers(), display=False)},
+        {"card": _Card(_answers(), request_id=None)},
+        {"card": _Card(_answers()), "image": object()},
+        {"card": _Card(_answers()), "launch": object()},
+        {"card": _Card(_answers()), "controller": None},
+    ],
+    ids=["no-card", "hidden-card", "no-round-id", "staged-attachment", "staged-rag", "no-controller"],
+)
+def test_no_interception_without_a_live_card_or_with_staged_context(kwargs):
+    controller = kwargs.pop("controller", Mock())
+    card = kwargs.pop("card")
+    screen = _screen(card, controller=controller, **kwargs)
+    if controller is None:
+        screen._console_chat_controller = None
+    assert ChatScreen._answer_pending_question_with_draft(screen, "text") is False
+    if controller is not None:
+        controller.resolve_pending_question.assert_not_called()
+    assert screen._cleared == []
+
+
+def test_blank_draft_never_intercepts():
+    screen = _screen(_Card(_answers()))
+    assert ChatScreen._answer_pending_question_with_draft(screen, "   ") is False
+    screen._console_chat_controller.resolve_pending_question.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_visible_send_resolves_the_question_and_does_not_dispatch():
+    """End to end through the real send action: a plain message with a live
+    card answers it; the draft is never queued as a turn."""
+    from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
+    from tldw_chatbook.UI.Console_Modules.command_registry import CommandParse, KIND_NOT_COMMAND
+
+    composer = ConsoleComposerBar()
+    composer.insert_text("use apac only")
+    dispatched = []
+
+    async def dispatch(draft, *, stash=None):
+        dispatched.append(draft)
+        return True
+
+    card = _Card(_answers())
+    controller = Mock()
+    screen = SimpleNamespace(
+        _console_pending_send_stash=None,
+        _raw_cli=SimpleNamespace(start_user_command=Mock()),
+        _console_composer_or_none=lambda: composer,
+        query_one=lambda *_a, **_k: composer,
+        query=lambda selector: [card],
+        _console_pending_image_attachment=lambda: None,
+        _focus_console_composer_if_needed=lambda **_k: None,
+        _dismiss_console_guidance=lambda: None,
+        _console_command_registry=SimpleNamespace(parse=lambda draft: CommandParse(kind=KIND_NOT_COMMAND)),
+        _console_unknown_send_armed=None,
+        _dispatch_console_draft_send=dispatch,
+        _console_chat_controller=controller,
+        _retrieval=SimpleNamespace(_pending_launch=lambda: None),
+        _clear_console_composer_draft=lambda: composer.clear_draft(),
+        _answer_pending_question_with_draft=lambda draft: ChatScreen._answer_pending_question_with_draft(screen, draft),
+    )
+    assert await ChatScreen._send_console_message_from_visible_action(screen) is False
+    assert dispatched == []
+    controller.resolve_pending_question.assert_called_once()
+```
+
+Check the import paths in the last test before running: `grep -rn "^class CommandParse\|^KIND_NOT_COMMAND" tldw_chatbook/UI/Console_Modules/` and `grep -n "def clear_draft\|def insert_text" tldw_chatbook/Widgets/Console/console_composer_bar.py`; use the real names. If `clear_draft` does not exist, substitute the composer method `_clear_console_composer_draft` calls (grep its body at `def _clear_console_composer_draft`).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q -p no:cacheprovider Tests/UI/test_console_ask_user_typed_answers.py`
+Expected: FAIL with `AttributeError: type object 'ChatScreen' has no attribute '_answer_pending_question_with_draft'`.
+
+- [ ] **Step 3: Implement**
+
+New method beside `_set_console_pending_question`:
+
+```python
+    def _answer_pending_question_with_draft(self, draft: str) -> bool:
+        """PRD A8: let a composer send answer the mounted question card.
+
+        Only a MOUNTED card on the viewed session intercepts; a parked or
+        background round never touches the composer. The typed text becomes
+        ``other_text`` for every question still unanswered on the card, the
+        card's existing selections ride along, and the round resolves
+        through the controller's strict request-id match. Staged context
+        (a pending image attachment or a staged Library-evidence launch)
+        refuses interception: carrying it into a tool result is meaningless
+        and discarding it silently would destroy work the user staged.
+
+        Args:
+            draft: The composer text as sent.
+
+        Returns:
+            True when the draft answered the question and must NOT also be
+            dispatched as a turn; False to send normally.
+        """
+        text = draft.strip()
+        if not text:
+            return False
+        controller = self._console_chat_controller
+        if controller is None:
+            return False
+        card = next((c for c in self.query("#chat-question-card") if c.display), None)
+        if card is None:
+            return False
+        request_id = getattr(card, "_request_id", None)
+        if not request_id:
+            return False
+        if self._console_pending_image_attachment() is not None:
+            return False
+        if self._retrieval._pending_launch() is not None:
+            return False
+        answers = card.collect_answers()
+        for answer in answers:
+            if answer.get("unanswered") or (
+                not answer.get("selected") and answer.get("other_text") is None
+            ):
+                answer["other_text"] = text
+                answer["unanswered"] = False
+        card.set_questions(None)
+        self._clear_console_composer_draft()
+        controller.resolve_pending_question(answers, request_id=request_id)
+        return True
+```
+
+In `_send_console_message_from_visible_action`, replace the final statement:
+
+```python
+        return await self._dispatch_console_draft_send(draft, stash=stash)
+```
+
+with:
+
+```python
+        if self._answer_pending_question_with_draft(draft):
+            return False
+        return await self._dispatch_console_draft_send(draft, stash=stash)
+```
+
+(The slash-command and unknown-command branches above it already `return False` before this point, so a `/`-command never reaches the interception -- A8's first exemption falls out of the existing order.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q -p no:cacheprovider Tests/UI/test_console_ask_user_typed_answers.py Tests/UI/test_console_command_composer.py`
+Expected: all PASS (the command-composer suite's stubs lack `_answer_pending_question_with_draft`; if any of its send-path tests now raise `AttributeError`, add `_answer_pending_question_with_draft=lambda draft: False` to THAT test's stub -- do not weaken the interception with a `getattr` default, the real screen always has the method).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py Tests/UI/test_console_ask_user_typed_answers.py
+git commit -m "feat(console): a composer send answers the mounted ask_user card (PRD A8)"
+```
+
+---
+
+### Task 2: User Guide, baseline, PR
+
+**Files:**
+- Modify: `Docs/User_Guide/console/agent-runs-and-tools.md` — the "Questions from the agent" section.
+
+- [ ] **Step 1: Add the typed-answer bullet** after the "You can submit with questions left blank" bullet:
+
+```markdown
+- You can also just type your answer and send it. While a question card is
+  up, a plain message answers the questions you have not picked an option
+  for (it becomes their **Other…** text) and is not sent to the agent as a
+  new message. Two exceptions: a `/` command runs as usual, and a message
+  with a staged attachment or staged Library evidence is sent as a normal
+  turn, leaving the question up for you to answer on the card.
+```
+
+- [ ] **Step 2: Baseline and battery** — the M2 plan's Task 8 Steps 4-6 verbatim (detached `origin/dev` worktree, same file list plus `Tests/UI/test_console_ask_user_typed_answers.py` and `Tests/UI/test_console_command_composer.py` on the branch), `./scripts/preflight.sh`, and the census (`Tests/Performance/test_ui_ready_module_census.py`, expect no `+` line for this change).
+
+- [ ] **Step 3: Commit, push, PR**
+
+```bash
+git add Docs/User_Guide/console/agent-runs-and-tools.md
+git commit -m "docs(console): typed answers to an agent's question"
+git push -u origin feat/console-ask-user-typed-answers
+gh pr create --base dev --head feat/console-ask-user-typed-answers --title "feat(console): typed answers resolve a mounted ask_user question (PRD M3)" --body-file <body>
+```
+
+PR body: A8 mapping to the tests (AC-A6's three legs: plain send answers; `/` command dispatches normally; staged attachment dispatches normally -- name the test ids), baseline diff evidence, preflight, census. Then the standing merge recipe (Qodo → fix/answer → rebase → merge on the required check; Qodo re-reviews IN PLACE after a push, so merge by hand once the summary comment's `updated_at` is past the push and checks are green).
+
+---
+
+## Self-Review
+
+**Spec coverage:** A8 sentence by sentence -- "A message sent while a question is mounted answers it" (Task 1 method + hook), "the text becomes `other_text` for every unanswered question" (the fill loop; already-answered questions keep their selections), "the round resolves" (`resolve_pending_question`), "the message is not also sent as a turn" (`return False` before dispatch, pinned by `test_visible_send_resolves_the_question_and_does_not_dispatch`), "slash commands dispatch normally and leave the question pending" (existing branch order, exercised by the command-composer suite), "a send with staged attachments or RAG evidence goes out as a normal turn" (`staged-attachment`, `staged-rag` cases). AC-A6 is those three legs. Only a mounted card intercepts (the `display` check); a parked round never has a mounted card on the viewed session.
+
+**Placeholder scan:** none.
+
+**Type consistency:** `collect_answers()` returns the M2 answer dicts (`question`, `selected`, `other_text`, `unanswered`) and `resolve_pending_question(answers, request_id=...)` takes exactly that list -- both from M2's plan, unchanged here.

--- a/Tests/UI/test_console_ask_user_typed_answers.py
+++ b/Tests/UI/test_console_ask_user_typed_answers.py
@@ -11,9 +11,10 @@ from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
 
 class _Card:
-    def __init__(self, answers, request_id="round-1", display=True):
+    def __init__(self, answers, request_id="round-1", display=True, session_id="s1"):
         self.display = display
         self._request_id = request_id
+        self._payload = {"request_id": request_id, "session_id": session_id}
         self._answers = answers
         self.cleared = False
 
@@ -32,10 +33,16 @@ def _answers():
     ]
 
 
+def _controller(active_session_id="s1"):
+    controller = Mock()
+    controller.store.active_session_id = active_session_id
+    return controller
+
+
 def _screen(card, *, image=None, launch=None, controller=None):
     cleared = []
     return SimpleNamespace(
-        _console_chat_controller=controller if controller is not None else Mock(),
+        _console_chat_controller=controller if controller is not None else _controller(),
         query=lambda selector: [card] if card is not None else [],
         _console_pending_image_attachment=lambda: image,
         _retrieval=SimpleNamespace(_pending_launch=lambda: launch),
@@ -67,12 +74,13 @@ def test_typed_text_fills_every_unanswered_question_and_resolves_the_round():
         {"card": _Card(_answers()), "image": object()},
         {"card": _Card(_answers()), "launch": object()},
         {"card": _Card(_answers()), "controller": None},
+        {"card": _Card(_answers(), session_id="other-session")},
     ],
-    ids=["no-card", "hidden-card", "no-round-id", "staged-attachment", "staged-rag", "no-controller"],
+    ids=["no-card", "hidden-card", "no-round-id", "staged-attachment", "staged-rag", "no-controller", "stale-card-for-another-session"],
 )
 def test_no_interception_without_a_live_card_or_with_staged_context(kwargs):
     kwargs = dict(kwargs)
-    controller = kwargs.pop("controller", Mock())
+    controller = kwargs.pop("controller", _controller())
     card = kwargs.pop("card")
     screen = _screen(card, controller=controller, **kwargs)
     if controller is None:
@@ -108,7 +116,7 @@ async def test_visible_send_resolves_the_question_and_does_not_dispatch():
         return True
 
     card = _Card(_answers())
-    controller = Mock()
+    controller = _controller()
     screen = SimpleNamespace(
         _console_pending_send_stash=None,
         _raw_cli=SimpleNamespace(start_user_command=Mock()),
@@ -153,7 +161,7 @@ async def test_visible_send_without_a_card_dispatches_as_before():
         dispatched.append(draft)
         return True
 
-    controller = Mock()
+    controller = _controller()
     screen = SimpleNamespace(
         _console_pending_send_stash=None,
         _raw_cli=SimpleNamespace(start_user_command=Mock()),
@@ -178,3 +186,136 @@ async def test_visible_send_without_a_card_dispatches_as_before():
     assert await ChatScreen._send_console_message_from_visible_action(screen) is True
     assert dispatched == ["hello"]
     controller.resolve_pending_question.assert_not_called()
+
+
+# --- Qodo #2380 round 1 ------------------------------------------------------
+
+
+@pytest.mark.parametrize("draft", ["/foo", "/nope x", "  /help  "])
+def test_slash_text_is_never_intercepted_even_when_confirmed_as_plain_text(draft):
+    screen = _screen(_Card(_answers()))
+    assert ChatScreen._answer_pending_question_with_draft(screen, draft) is False
+    screen._console_chat_controller.resolve_pending_question.assert_not_called()
+    assert screen._cleared == []
+
+
+def test_typed_text_is_cleaned_and_bounded_like_the_cards_other_box():
+    screen = _screen(_Card(_answers()))
+    assert ChatScreen._answer_pending_question_with_draft(screen, "  a\nb\x07 " + "x" * 600) is True
+    (answers,), _ = screen._console_chat_controller.resolve_pending_question.call_args
+    assert answers[1]["other_text"].startswith("a b x") and len(answers[1]["other_text"]) == 500
+
+
+def test_malformed_card_answers_leave_the_draft_and_card_in_place():
+    bad = [{"question": "q", "selected": "not-a-list", "other_text": None, "unanswered": True}]
+    card = _Card(bad)
+    screen = _screen(card)
+    assert ChatScreen._answer_pending_question_with_draft(screen, "text") is False
+    assert card.cleared is False and screen._cleared == []
+    screen._console_chat_controller.resolve_pending_question.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_typed_answer_resolves_a_real_round_through_the_real_card_and_composer():
+    """Integration: a real ConsoleChatController round waiting on a worker
+    thread, the real ChatTaskCards/ChatQuestionCard under the consolidated
+    CSS, the real ConsoleComposerBar, and the real visible send action. Only
+    the screen object is a stand-in: constructing ``ChatScreen`` with the
+    shared mock host trips a real-path check on current dev."""
+    import threading
+
+    from textual.app import ComposeResult
+
+    from Tests.console_provider_doubles import persisted_console_store
+    from Tests.UI.consolidated_css import ConsolidatedCSSApp
+    from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+    from tldw_chatbook.Chat.console_command_grammar import (
+        KIND_NOT_COMMAND,
+        CommandParse,
+    )
+    from tldw_chatbook.UI.Screens.chat_screen_state import TaskResumeState
+    from tldw_chatbook.Widgets.Chat_Widgets.chat_task_cards import ChatTaskCards
+    from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
+
+    class _Harness(ConsolidatedCSSApp):
+        def compose(self) -> ComposeResult:
+            yield ChatTaskCards(id="chat-task-cards")
+
+    questions = [
+        {"question": "Which DB?", "header": "DB", "multiSelect": False,
+         "options": [{"label": "Postgres", "description": ""}, {"label": "SQLite", "description": ""}]},
+        {"question": "Regions?", "header": "Region", "multiSelect": True,
+         "options": [{"label": "eu", "description": ""}, {"label": "us", "description": ""}]},
+    ]
+    app = _Harness()
+    controller = ConsoleChatController(store=persisted_console_store(), provider_gateway=object())
+    session = controller.new_session(title="s")
+    box = {}
+    try:
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            cards = app.query_one(ChatTaskCards)
+            controller.app = app
+            controller.set_pending_question = lambda payload: cards.sync_state(
+                TaskResumeState(pending_question=payload)
+            )
+            thread = threading.Thread(
+                target=lambda: box.update(
+                    result=controller.request_user_questions(questions, session_id=session.id)
+                )
+            )
+            thread.start()
+            for _ in range(40):
+                await pilot.pause(0.05)
+                if list(cards.query("#chat-question-card")):
+                    break
+            card = cards.query_one("#chat-question-card")
+            await pilot.pause()
+            assert card.display is True
+
+            composer = ConsoleComposerBar()
+            composer.insert_text("apac only")
+            dispatched = []
+
+            async def dispatch(draft, *, stash=None):
+                dispatched.append(draft)
+                return True
+
+            screen = SimpleNamespace(
+                _console_pending_send_stash=None,
+                _raw_cli=SimpleNamespace(start_user_command=Mock()),
+                _console_composer_or_none=lambda: composer,
+                query_one=lambda *_a, **_k: composer,
+                query=app.query,
+                _console_pending_image_attachment=lambda: None,
+                _focus_console_composer_if_needed=lambda **_k: None,
+                _dismiss_console_guidance=lambda: None,
+                _console_command_registry=SimpleNamespace(
+                    parse=lambda draft: CommandParse(kind=KIND_NOT_COMMAND)
+                ),
+                _console_unknown_send_armed=None,
+                _dispatch_console_draft_send=dispatch,
+                _console_chat_controller=controller,
+                _retrieval=SimpleNamespace(_pending_launch=lambda: None),
+                _clear_console_composer_draft=lambda: composer.clear_draft(),
+            )
+            screen._answer_pending_question_with_draft = (
+                lambda draft: ChatScreen._answer_pending_question_with_draft(screen, draft)
+            )
+            assert await ChatScreen._send_console_message_from_visible_action(screen) is False
+            assert dispatched == [], "the draft was an answer, not a turn"
+            # The worker's teardown marshals its card re-derive through
+            # `call_from_thread`, which needs THIS loop: wait asynchronously.
+            for _ in range(100):
+                await pilot.pause(0.05)
+                if "result" in box:
+                    break
+            thread.join(timeout=5)
+            assert box["result"]["answered"] is True
+            assert [a["other_text"] for a in box["result"]["answers"]] == ["apac only", "apac only"]
+            assert composer.draft_text() == ""
+            await pilot.pause()
+            assert card.display is False
+            assert controller.pending_question_ids() == []
+    finally:
+        controller.begin_shutdown()

--- a/Tests/UI/test_console_ask_user_typed_answers.py
+++ b/Tests/UI/test_console_ask_user_typed_answers.py
@@ -1,0 +1,180 @@
+"""PRD A8 / AC-A6: a composer send answers a mounted question instead of starting a turn."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+
+class _Card:
+    def __init__(self, answers, request_id="round-1", display=True):
+        self.display = display
+        self._request_id = request_id
+        self._answers = answers
+        self.cleared = False
+
+    def collect_answers(self):
+        return [dict(a) for a in self._answers]
+
+    def set_questions(self, payload):
+        assert payload is None
+        self.cleared = True
+
+
+def _answers():
+    return [
+        {"question": "Which DB?", "selected": ["Postgres"], "other_text": None, "unanswered": False},
+        {"question": "Regions?", "selected": [], "other_text": None, "unanswered": True},
+    ]
+
+
+def _screen(card, *, image=None, launch=None, controller=None):
+    cleared = []
+    return SimpleNamespace(
+        _console_chat_controller=controller if controller is not None else Mock(),
+        query=lambda selector: [card] if card is not None else [],
+        _console_pending_image_attachment=lambda: image,
+        _retrieval=SimpleNamespace(_pending_launch=lambda: launch),
+        _clear_console_composer_draft=lambda: cleared.append(True),
+        _cleared=cleared,
+    )
+
+
+def test_typed_text_fills_every_unanswered_question_and_resolves_the_round():
+    card = _Card(_answers())
+    screen = _screen(card)
+    assert ChatScreen._answer_pending_question_with_draft(screen, "  apac only  ") is True
+    screen._console_chat_controller.resolve_pending_question.assert_called_once()
+    answers, kwargs = screen._console_chat_controller.resolve_pending_question.call_args
+    assert kwargs == {"request_id": "round-1"}
+    assert answers[0] == [
+        {"question": "Which DB?", "selected": ["Postgres"], "other_text": None, "unanswered": False},
+        {"question": "Regions?", "selected": [], "other_text": "apac only", "unanswered": False},
+    ]
+    assert card.cleared is True and screen._cleared == [True]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"card": None},
+        {"card": _Card(_answers(), display=False)},
+        {"card": _Card(_answers(), request_id=None)},
+        {"card": _Card(_answers()), "image": object()},
+        {"card": _Card(_answers()), "launch": object()},
+        {"card": _Card(_answers()), "controller": None},
+    ],
+    ids=["no-card", "hidden-card", "no-round-id", "staged-attachment", "staged-rag", "no-controller"],
+)
+def test_no_interception_without_a_live_card_or_with_staged_context(kwargs):
+    kwargs = dict(kwargs)
+    controller = kwargs.pop("controller", Mock())
+    card = kwargs.pop("card")
+    screen = _screen(card, controller=controller, **kwargs)
+    if controller is None:
+        screen._console_chat_controller = None
+    assert ChatScreen._answer_pending_question_with_draft(screen, "text") is False
+    if controller is not None:
+        controller.resolve_pending_question.assert_not_called()
+    assert screen._cleared == []
+
+
+def test_blank_draft_never_intercepts():
+    screen = _screen(_Card(_answers()))
+    assert ChatScreen._answer_pending_question_with_draft(screen, "   ") is False
+    screen._console_chat_controller.resolve_pending_question.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_visible_send_resolves_the_question_and_does_not_dispatch():
+    """End to end through the real send action: a plain message with a live
+    card answers it; the draft is never queued as a turn."""
+    from tldw_chatbook.Chat.console_command_grammar import (
+        KIND_NOT_COMMAND,
+        CommandParse,
+    )
+    from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
+
+    composer = ConsoleComposerBar()
+    composer.insert_text("use apac only")
+    dispatched = []
+
+    async def dispatch(draft, *, stash=None):
+        dispatched.append(draft)
+        return True
+
+    card = _Card(_answers())
+    controller = Mock()
+    screen = SimpleNamespace(
+        _console_pending_send_stash=None,
+        _raw_cli=SimpleNamespace(start_user_command=Mock()),
+        _console_composer_or_none=lambda: composer,
+        query_one=lambda *_a, **_k: composer,
+        query=lambda selector: [card],
+        _console_pending_image_attachment=lambda: None,
+        _focus_console_composer_if_needed=lambda **_k: None,
+        _dismiss_console_guidance=lambda: None,
+        _console_command_registry=SimpleNamespace(
+            parse=lambda draft: CommandParse(kind=KIND_NOT_COMMAND)
+        ),
+        _console_unknown_send_armed=None,
+        _dispatch_console_draft_send=dispatch,
+        _console_chat_controller=controller,
+        _retrieval=SimpleNamespace(_pending_launch=lambda: None),
+        _clear_console_composer_draft=lambda: composer.clear_draft(),
+    )
+    screen._answer_pending_question_with_draft = (
+        lambda draft: ChatScreen._answer_pending_question_with_draft(screen, draft)
+    )
+    assert await ChatScreen._send_console_message_from_visible_action(screen) is False
+    assert dispatched == []
+    controller.resolve_pending_question.assert_called_once()
+    (answers,), _ = controller.resolve_pending_question.call_args
+    assert answers[1]["other_text"] == "use apac only"
+
+
+@pytest.mark.asyncio
+async def test_visible_send_without_a_card_dispatches_as_before():
+    from tldw_chatbook.Chat.console_command_grammar import (
+        KIND_NOT_COMMAND,
+        CommandParse,
+    )
+    from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
+
+    composer = ConsoleComposerBar()
+    composer.insert_text("hello")
+    dispatched = []
+
+    async def dispatch(draft, *, stash=None):
+        dispatched.append(draft)
+        return True
+
+    controller = Mock()
+    screen = SimpleNamespace(
+        _console_pending_send_stash=None,
+        _raw_cli=SimpleNamespace(start_user_command=Mock()),
+        _console_composer_or_none=lambda: composer,
+        query_one=lambda *_a, **_k: composer,
+        query=lambda selector: [],
+        _console_pending_image_attachment=lambda: None,
+        _focus_console_composer_if_needed=lambda **_k: None,
+        _dismiss_console_guidance=lambda: None,
+        _console_command_registry=SimpleNamespace(
+            parse=lambda draft: CommandParse(kind=KIND_NOT_COMMAND)
+        ),
+        _console_unknown_send_armed=None,
+        _dispatch_console_draft_send=dispatch,
+        _console_chat_controller=controller,
+        _retrieval=SimpleNamespace(_pending_launch=lambda: None),
+        _clear_console_composer_draft=lambda: composer.clear_draft(),
+    )
+    screen._answer_pending_question_with_draft = (
+        lambda draft: ChatScreen._answer_pending_question_with_draft(screen, draft)
+    )
+    assert await ChatScreen._send_console_message_from_visible_action(screen) is True
+    assert dispatched == ["hello"]
+    controller.resolve_pending_question.assert_not_called()

--- a/Tests/UI/test_console_command_composer.py
+++ b/Tests/UI/test_console_command_composer.py
@@ -539,6 +539,9 @@ async def test_escaped_chat_stash_keeps_segment_payload_and_restore_consistent()
             parse=Mock(side_effect=AssertionError("pasted body must not parse"))
         ),
         _dispatch_console_draft_send=dispatch,
+        # PRD A8: the real screen answers a mounted question card here; this
+        # stub has none, so the send must fall through to dispatch.
+        _answer_pending_question_with_draft=lambda draft: False,
     )
 
     assert await ChatScreen._send_console_message_from_visible_action(screen) is True

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -16740,6 +16740,8 @@ class ChatScreen(BaseAppScreen):
                 )
                 return False
 
+        if self._answer_pending_question_with_draft(draft):
+            return False
         return await self._dispatch_console_draft_send(draft, stash=stash)
 
     async def _dispatch_console_draft_send(
@@ -20773,6 +20775,55 @@ class ChatScreen(BaseAppScreen):
         self.set_task_resume_state(
             replace(self._task_resume_state, pending_question=payload)
         )
+
+    def _answer_pending_question_with_draft(self, draft: str) -> bool:
+        """PRD A8: let a composer send answer the mounted question card.
+
+        Only a MOUNTED card on the viewed session intercepts; a parked or
+        background round never touches the composer. The typed text becomes
+        ``other_text`` for every question still unanswered on the card, the
+        card's existing selections ride along, and the round resolves
+        through the controller's strict request-id match. Staged context
+        (a pending image attachment or a staged Library-evidence launch)
+        refuses interception: carrying it into a tool result is meaningless
+        and discarding it silently would destroy work the user staged.
+        Slash commands never reach this point -- the command branches of
+        ``_send_console_message_from_visible_action`` return before it.
+
+        Args:
+            draft: The composer text as sent.
+
+        Returns:
+            True when the draft answered the question and must NOT also be
+            dispatched as a turn; False to send normally.
+        """
+        text = draft.strip()
+        if not text:
+            return False
+        controller = self._console_chat_controller
+        if controller is None:
+            return False
+        card = next((c for c in self.query("#chat-question-card") if c.display), None)
+        if card is None:
+            return False
+        request_id = getattr(card, "_request_id", None)
+        if not request_id:
+            return False
+        if self._console_pending_image_attachment() is not None:
+            return False
+        if self._retrieval._pending_launch() is not None:
+            return False
+        answers = card.collect_answers()
+        for answer in answers:
+            if answer.get("unanswered") or (
+                not answer.get("selected") and answer.get("other_text") is None
+            ):
+                answer["other_text"] = text
+                answer["unanswered"] = False
+        card.set_questions(None)
+        self._clear_console_composer_draft()
+        controller.resolve_pending_question(answers, request_id=request_id)
+        return True
 
     def _mount_console_task_panel(self):
         """Mount the task panel right after the Console task cards.

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -20779,11 +20779,15 @@ class ChatScreen(BaseAppScreen):
     def _answer_pending_question_with_draft(self, draft: str) -> bool:
         """PRD A8: let a composer send answer the mounted question card.
 
-        Only a MOUNTED card on the viewed session intercepts; a parked or
-        background round never touches the composer. The typed text becomes
+        Only a MOUNTED card whose payload belongs to the viewed session
+        intercepts; a parked, background, or stale round never touches the
+        composer. The typed text is cleaned and bounded exactly like the
+        card's own Other box (``clean_other_text``) and becomes
         ``other_text`` for every question still unanswered on the card, the
-        card's existing selections ride along, and the round resolves
-        through the controller's strict request-id match. Staged context
+        card's existing selections ride along, the whole payload is
+        validated (``validate_answers``) BEFORE the card or composer is
+        cleared, and the round resolves through the controller's strict
+        request-id match. Staged context
         (a pending image attachment or a staged Library-evidence launch)
         refuses interception: carrying it into a tool result is meaningless
         and discarding it silently would destroy work the user staged.
@@ -20797,8 +20801,18 @@ class ChatScreen(BaseAppScreen):
             True when the draft answered the question and must NOT also be
             dispatched as a turn; False to send normally.
         """
+        # Local import by design: the module stays off the boot path.
+        from ...Agents.ask_user_questions import (
+            AskUserValidationError,
+            clean_other_text,
+            validate_answers,
+        )
+
         text = draft.strip()
-        if not text:
+        if not text or text.startswith("/"):
+            # A `/`-prefixed draft is command text even when the user has
+            # confirmed sending an unknown command as plain text (Qodo
+            # #2380): it dispatches normally and leaves the question up.
             return False
         controller = self._console_chat_controller
         if controller is None:
@@ -20809,20 +20823,34 @@ class ChatScreen(BaseAppScreen):
         request_id = getattr(card, "_request_id", None)
         if not request_id:
             return False
+        payload_session = (getattr(card, "_payload", None) or {}).get("session_id")
+        if payload_session and payload_session != (controller.store.active_session_id or ""):
+            # A stale card mounted for another session must never take the
+            # text typed into this one (Qodo #2380).
+            return False
         if self._console_pending_image_attachment() is not None:
             return False
         if self._retrieval._pending_launch() is not None:
+            return False
+        other_text = clean_other_text(text)
+        if other_text is None:
             return False
         answers = card.collect_answers()
         for answer in answers:
             if answer.get("unanswered") or (
                 not answer.get("selected") and answer.get("other_text") is None
             ):
-                answer["other_text"] = text
+                answer["other_text"] = other_text
                 answer["unanswered"] = False
+        try:
+            clean_answers = validate_answers(answers)
+        except AskUserValidationError:
+            # Validate BEFORE clearing anything: a payload the controller
+            # would drop must not cost the user their draft or the card.
+            return False
         card.set_questions(None)
         self._clear_console_composer_draft()
-        controller.resolve_pending_question(answers, request_id=request_id)
+        controller.resolve_pending_question(clean_answers, request_id=request_id)
         return True
 
     def _mount_console_task_panel(self):


### PR DESCRIPTION
## Summary

Milestone M3 of the [Console Agent Interaction PRD](Docs/Development/Chatbook/Chatbook-Console-Agent-Interaction-PRD.md): Feature A8 / AC-A6. While an `ask_user` card is mounted, a plain message sent from the composer answers it instead of starting a turn. This completes Feature A; the PRD's three milestones (M1 task panel #2373, M2 `ask_user` #2379, M3 this) are all shipped.

## What changes

One screen-side interception, `ChatScreen._answer_pending_question_with_draft`, called in `_send_console_message_from_visible_action` after the command branches and immediately before `_dispatch_console_draft_send`:

- With a **mounted** question card on the viewed session, the typed text becomes `other_text` for every question still unanswered on the card. Selections the user already made ride along. The round resolves through the controller's existing strict request-id `resolve_pending_question`, the card and the composer clear, and the draft is **not** dispatched as a turn.
- **Slash commands** never reach the hook: the command and unknown-command branches return before it, so `/foo` dispatches exactly as before and leaves the question up.
- **Staged context refuses interception**: a pending image attachment or a staged Library-evidence launch sends the draft as a normal turn and leaves the question up for the card. Carrying staged context into a tool result is meaningless, and discarding it silently would destroy staged work.
- A blank draft, a hidden card, a card with no round id, or no controller all fall through to the normal send.
- No transcript user row is appended: the PRD (unlike the earlier design spec) does not ask for one, and the A14 marker already records `other: <text>` per question on resolve. A `persist=False` USER row would be a new shape for the transcript reconciler.

No controller, card, or tool changes. User Guide gains the typed-answer bullet under "Questions from the agent".

## AC-A6 → tests (`Tests/UI/test_console_ask_user_typed_answers.py`)

| Leg | Test |
|---|---|
| Typing and sending while a question is mounted resolves it with the text as `other_text` and does not dispatch a user turn | `test_typed_text_fills_every_unanswered_question_and_resolves_the_round`, `test_visible_send_resolves_the_question_and_does_not_dispatch` (through the real send action) |
| A `/` command in the same state dispatches normally and leaves the question mounted | existing command-composer suite (`test_console_unknown_command_*`, `test_console_collapsed_paste_starting_with_slash_sends_normally`) exercises the branches that return before the hook; `test_visible_send_without_a_card_dispatches_as_before` pins the fall-through |
| A send with a staged attachment dispatches normally and leaves the question mounted | `test_no_interception_without_a_live_card_or_with_staged_context[staged-attachment]` and `[staged-rag]` |

The screen handlers are driven as unbound methods on stubs (the pattern `test_console_command_composer.py` already uses for this send action): constructing `ChatScreen(mock_chat_host)` trips a real-path check on current dev.

## Verification

- New suite: 10 tests. The one command-composer stub that drives the send action gained the new attribute as a no-op.
- Battery (skill-script/install confirms, MCP approval, headless approval, viewless hooks, runtime ownership, local tool provider, tool gates, card slot, confirm card, task panel, the M2 suites, the command composer, + the new suite): **635 passed, 34 failed** on the branch vs **35 failed** on clean `origin/dev` in a detached worktree — the branch's failure set is a subset of dev's (the extra dev failure is a full-app harness flake).
- UI-ready module census: 966/972, no new resident module. `./scripts/preflight.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018q5PsHwn5kgHPmNwX9DKoo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
While an `ask_user` question card is mounted, sending a plain message from the composer now answers the question instead of starting a new turn. This completes Feature A of the Console Agent Interaction PRD (milestone M3).

**Behavior**
- The typed text becomes `other_text` for every unanswered question on the card; existing selections ride along, the round resolves, and the draft is not dispatched as a turn. The text is cleaned and bounded to 500 chars, and the full answers payload is validated before the card or composer clears; an invalid payload leaves both in place and sends normally.
- `/`-prefixed drafts never intercept, even when confirmed as plain text; they dispatch normally and leave the question up.
- A send with a staged image attachment or staged Library evidence dispatches as a normal turn, leaving the question up.
- A card mounted for another session, a blank draft, hidden card, card without a round id, or missing controller falls through to the normal send.
- No transcript user row is appended; the A14 marker already records the typed text per question on resolve.

<sup>Written for commit fce1f1735760fca9316f8665112e019a328d65ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

