### PR TITLE
fix(themes): AA muted/error text + visible focus tints across all legacy themes (31283/31284)

### DIFF
--- a/Tests/UI/test_theme_contrast.py
+++ b/Tests/UI/test_theme_contrast.py
@@ -97,21 +97,64 @@ def test_core_variables_do_not_freeze_readable_tokens_to_literals():
         )
 
 
-@pytest.mark.parametrize(
-    "theme", [t for t in ALL_THEMES if t.name in ORB_THEMES], ids=lambda t: t.name
-)
-def test_generated_readable_tokens_clear_aa_on_orb_themes(theme):
-    """The values `$text-error` / `$text-muted` actually resolve to (Textual's
-    generated variables) must clear AA on the theme's surfaces — this is what
-    the ds readable tokens paint after task-31264's fix."""
-    generated = theme.to_color_system().generate()
-    surfaces = [Color.parse(generated[k]) for k in ("surface", "panel")]
+def _resolved_variables(theme) -> dict:
+    """Mirror runtime resolution: theme dict entries win over generated."""
+    return {**theme.to_color_system().generate(), **(theme.variables or {})}
+
+
+def _over(base: Color, color: Color) -> Color:
+    """Composite a possibly-translucent color over a base surface."""
+    return base.blend(Color(color.r, color.g, color.b), color.a)
+
+
+def _resolve_color(value: str, base: Color) -> Color:
+    """Parse a variable value ('#hex', '#hexAA', or 'auto NN%') over a base."""
+    if value.startswith("auto"):
+        percent = float(value.split()[1].rstrip("%")) / 100
+        pole = Color(0, 0, 0) if base.brightness > 0.5 else Color(255, 255, 255)
+        return base.blend(pole, percent)
+    return _over(base, Color.parse(value))
+
+
+@pytest.mark.parametrize("theme", ALL_THEMES, ids=lambda t: t.name)
+def test_resolved_readable_tokens_clear_aa_on_every_theme(theme):
+    """The values `$text-error` / `$text-muted` resolve to at runtime (theme
+    variables dict over Textual's generated set) must clear AA on the theme's
+    own surfaces — these feed the ds readable tokens since task-31264;
+    task-31283 extended the gate from the Orb 12 to every registered theme."""
+    resolved = _resolved_variables(theme)
+    surfaces = [Color.parse(resolved[k]) for k in ("surface", "panel")]
     for token in ("text-error", "text-muted"):
-        color = Color.parse(generated[token])
         for surface in surfaces:
-            blended = surface.blend(Color(color.r, color.g, color.b), color.a)
+            blended = _resolve_color(resolved[token], surface)
             ratio = _ratio(blended.hex, surface.hex)
             assert ratio >= AA, (
-                f"{theme.name}: generated {token} {color.hex} is {ratio:.2f}:1 "
+                f"{theme.name}: resolved {token} {blended.hex} is {ratio:.2f}:1 "
                 f"against {surface.hex} (needs {AA}:1)"
             )
+
+
+# task-31284: the non-obscuring focus contract needs a *visible* background
+# shift (TASK-345); primary-at-30% nullified it on themes whose primary sits
+# near their surface. Floor chosen at 1.25x — well clear of the measured
+# 1.02–1.08x failures, achievable with readable text on both polarities.
+FOCUS_SHIFT_FLOOR = 1.25
+
+
+@pytest.mark.parametrize("theme", ALL_THEMES, ids=lambda t: t.name)
+def test_resolved_focus_tint_is_visible_and_readable_on_every_theme(theme):
+    resolved = _resolved_variables(theme)
+    surface = Color.parse(resolved["surface"])
+    text = _resolve_color(resolved["text"], surface)
+    tint = Color.parse(resolved["block-cursor-blurred-background"])
+    composite = _over(surface, tint)
+    shift = _ratio(composite.hex, surface.hex)
+    assert shift >= FOCUS_SHIFT_FLOOR, (
+        f"{theme.name}: focus tint {tint.hex} shifts the surface only "
+        f"{shift:.2f}x (needs {FOCUS_SHIFT_FLOOR}x)"
+    )
+    readable = _ratio(text.hex, composite.hex)
+    assert readable >= AA, (
+        f"{theme.name}: text on the focus tint is {readable:.2f}:1 "
+        f"(needs {AA}:1)"
+    )

--- a/Tests/UI/test_theme_contrast.py
+++ b/Tests/UI/test_theme_contrast.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from textual.color import Color
+from textual.theme import Theme
 
 from tldw_chatbook.css.Themes.themes import ALL_THEMES
 
@@ -117,7 +118,7 @@ def _resolve_color(value: str, base: Color) -> Color:
 
 
 @pytest.mark.parametrize("theme", ALL_THEMES, ids=lambda t: t.name)
-def test_resolved_readable_tokens_clear_aa_on_every_theme(theme):
+def test_resolved_readable_tokens_clear_aa_on_every_theme(theme: Theme) -> None:
     """The values `$text-error` / `$text-muted` resolve to at runtime (theme
     variables dict over Textual's generated set) must clear AA on the theme's
     own surfaces — these feed the ds readable tokens since task-31264;
@@ -142,7 +143,11 @@ FOCUS_SHIFT_FLOOR = 1.25
 
 
 @pytest.mark.parametrize("theme", ALL_THEMES, ids=lambda t: t.name)
-def test_resolved_focus_tint_is_visible_and_readable_on_every_theme(theme):
+def test_resolved_focus_tint_is_visible_and_readable_on_every_theme(
+    theme: Theme,
+) -> None:
+    """The resolved focus tint must visibly shift the surface and keep text
+    readable on the composite (task-31284; floors documented above)."""
     resolved = _resolved_variables(theme)
     surface = Color.parse(resolved["surface"])
     text = _resolve_color(resolved["text"], surface)

--- a/backlog/tasks/task-31282 - Make-theme-ds-token-dict-entries-real-overrides-or-stop-implying-they-are.md
+++ b/backlog/tasks/task-31282 - Make-theme-ds-token-dict-entries-real-overrides-or-stop-implying-they-are.md
@@ -1,0 +1,24 @@
+---
+id: TASK-31282
+title: Make theme ds-token dict entries real overrides (or stop implying they are)
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:03'
+labels:
+  - themes
+  - tech-debt
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+task-31264 established that a theme's variables dict cannot override any ds-* token defined in a tcss source (per-source variable scope: file tokens win). The 13 themes carrying 'full ds-* token sets' are therefore documentation, not behavior — misleading for the next theme author. Two honest exits: (a) move ds token defaults out of tcss into TldwCli.get_css_variables() so theme dicts genuinely win — blocked on ~35 test harnesses that parse tldw_cli_modular.tcss standalone and would hit unresolved variables; or (b) keep formulas as the only mechanism and trim/annotate the inert dict entries. Decide, then do one.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A theme author can tell from the code whether a ds-* dict entry has runtime effect (either it does, or the inert entries are removed/marked)
+- [ ] #2 If (a): the ~35 bundle-parsing test harnesses still pass; if (b): themes.py documents the formula mechanism at the top
+<!-- AC:END -->

--- a/backlog/tasks/task-31283 - Legacy-themes-generated-text-error-text-muted-below-AA-on-their-own-surfaces.md
+++ b/backlog/tasks/task-31283 - Legacy-themes-generated-text-error-text-muted-below-AA-on-their-own-surfaces.md
@@ -1,0 +1,38 @@
+---
+id: TASK-31283
+title: 'Legacy themes: generated text-error/text-muted below AA on their own surfaces'
+status: Done
+assignee: []
+created_date: '2026-09-04 19:03'
+updated_date: '2026-09-04 19:09'
+labels:
+  - themes
+  - a11y
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Measured during task-31264 across all 70 registered themes: ~31 legacy themes' generated text-error and ~35's text-muted resolve below 4.5:1 against their own surface/panel (worst: earthy_nature text-error 1.7:1, modern_dark_dracula text-muted 1.94:1). These now feed $ds-status-error-readable/$ds-text-placeholder etc., so muted/error text in those themes is hard to read. The 12 Orb themes are gated by test_theme_contrast.py; legacy themes are not.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Every registered theme's resolved text-error and text-muted (theme variables dict over generated, mirroring runtime resolution) clear 4.5:1 against its surface and panel
+- [x] #2 The contrast gate in test_theme_contrast.py covers all registered themes, not just the Orb 12
+- [x] #3 Fixes preserve each theme's overall look (base palettes unchanged unless unavoidable)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Mirror runtime resolution ({**generated, **theme.variables}) in test_theme_contrast.py and extend the AA gate to all registered themes (red = worklist)\n2. Solver: hue-preserving lightness walk per failing theme for text-muted/text-error until 4.5:1 vs surface+panel\n3. Apply as per-theme variables dict entries (base palettes untouched); verify all-themes gate green
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+43 legacy themes fixed via per-theme variables dict entries for text-muted/text-error (hue-preserving lightness walks to >=4.55:1 vs surface+panel; base palettes untouched; existing entries' comments preserved). Mechanism: these generated-token names are defined in no tcss source, so dict entries genuinely win at runtime ({**generated, **theme.variables}) — unlike ds-* tokens (task-31264 lesson). Gate extended: test_resolved_readable_tokens_clear_aa_on_every_theme now parametrizes ALL registered themes and mirrors runtime resolution (incl. 'auto NN%' values). Solver kept at scratchpad-only; values are data in themes.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31284 - Pastel-themes-focus-tint-nearly-invisible-primary-too-close-to-surface.md
+++ b/backlog/tasks/task-31284 - Pastel-themes-focus-tint-nearly-invisible-primary-too-close-to-surface.md
@@ -1,0 +1,37 @@
+---
+id: TASK-31284
+title: 'Pastel themes: focus tint nearly invisible (primary too close to surface)'
+status: Done
+assignee: []
+created_date: '2026-09-04 19:03'
+updated_date: '2026-09-04 19:09'
+labels:
+  - themes
+  - a11y
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+task-31264 replaced the frozen slate $ds-focus-bg with the generated primary-at-30% tint. Measured fallout: 10 themes whose primary sits near their surface luminance (pastel_dreams 1.07x, sweet_sorbet 1.02x, kawaii_candy, bunny_fluff, neon_sunset_drive, spring_meadowburst, +4) get a focus background shift under 1.15x — the bold+underline cues in Button:focus carry them, but the non-obscuring focus contract's own mechanism (a visible bg shift, TASK-345) is effectively nullified there, the same failure mode that motivated the original literal.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Each affected theme's resolved focus tint shifts its composite at least 1.25x against the theme's surface while keeping text on the composite at 4.5:1 or better
+- [x] #2 A test pins the focus-tint floor for all registered themes
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add all-themes focus-tint test: resolved block-cursor-blurred-background composited over surface must shift >=1.25x with text >=4.5:1 on the composite (red = worklist)\n2. Solver: adjust tint base lightness (30% alpha kept) per failing theme; 8-digit-hex dict override block-cursor-blurred-background\n3. Verify gate green + live spot-check one pastel theme
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+10 weak-tint themes + 3 unreadable-text-on-tint themes fixed by overriding block-cursor-blurred-background per theme (8-digit hex, 30% alpha kept, tint base walked in lightness until composite shifts >=1.30x vs surface AND text >=4.55:1 on the composite). Side effect (intended): Textual's blurred block cursor in the same themes gains the same visibility. New gate test_resolved_focus_tint_is_visible_and_readable_on_every_theme pins a 1.25x shift floor + AA text for all registered themes. Live-verified pastel_dreams: focused button paints #fddacd vs white surface, matching the computed composite.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/css/Themes/themes.py
+++ b/tldw_chatbook/css/Themes/themes.py
@@ -164,7 +164,8 @@ modern_dark_dracula_theme = Theme(
     variables={
         "footer-key-foreground": "#8be9fd",  # Cyan
         "input-selection-background": "#bd93f9 40%",  # Purple with 40% alpha
-        "text-muted": "#6272a4",  # Lighter purple/gray for comments/dimmed text
+        "text-muted": "#afb8d1",  # Lighter purple/gray for comments/dimmed text
+        "text-error": "#ff9d9d",
     },
 )
 
@@ -185,7 +186,7 @@ paper_light_theme = Theme(
     variables={
         "footer-key-foreground": "#5B4636",  # Sepia
         "input-selection-background": "#AACCFF 50%",  # Soft blue with 50% alpha
-        "text-muted": "#777777",  # Lighter gray for subtle text
+        "text-muted": "#636363",  # Lighter gray for subtle text
     },
 )
 
@@ -206,6 +207,8 @@ high_contrast_yellow_black_theme = Theme(
     variables={
         "footer-key-foreground": "#FFFFFF",  # White
         "input-selection-background": "#FFFFFF 30%",  # White with 30% alpha
+        "text-error": "#ff6d6d",
+        "block-cursor-blurred-background": "#dedede4c",
     },
 )
 
@@ -229,6 +232,7 @@ ocean_depths_theme = Theme(
         "text-muted": "#ADD8E6",  # Light blue
         "statusbar-background": "#F0E68C",  # Sandy beige (for specific components like status bar)
         "statusbar-foreground": "#0A2342",  # Deep dark blue (text on status bar)
+        "text-error": "#ffa392",
     },
 )
 
@@ -249,7 +253,7 @@ solarized_dark_theme = Theme(
     variables={
         "footer-key-foreground": "#2aa198",  # cyan
         "input-selection-background": "#268bd2 40%",  # blue with 40% alpha
-        "text-muted": "#586e75",  # base01 (dimmed text)
+        "text-muted": "#879da5",  # base01 (dimmed text)
         "text-highlight": "#93a1a1",  # base1 (more important text)
     },
 )
@@ -271,7 +275,7 @@ solarized_light_theme = Theme(
     variables={
         "footer-key-foreground": "#2aa198",  # cyan
         "input-selection-background": "#268bd2 40%",  # blue with 40% alpha
-        "text-muted": "#93a1a1",  # base1 (dimmed text for light theme)
+        "text-muted": "#5c6a6a",  # base1 (dimmed text for light theme)
         "text-highlight": "#586e75",  # base01 (more important text for light theme)
     },
 )
@@ -293,9 +297,10 @@ monokai_pro_theme = Theme(
     variables={
         "footer-key-foreground": "#66D9EF",  # Blue
         "input-selection-background": "#AE81FF 40%",  # Purple with 40% alpha
-        "text-muted": "#75715E",  # Gray (comments)
+        "text-muted": "#b9b6a8",  # Gray (comments)
         "log-view-background": "#272822",  # Custom for specific widget example
         "log-view-foreground": "#E6DB74",  # Custom for specific widget example
+        "block-cursor-blurred-background": "#91cb1c4c",
     },
 )
 
@@ -316,7 +321,7 @@ gruvbox_dark_theme = Theme(
     variables={
         "footer-key-foreground": "#83a598",  # Bright Blue
         "input-selection-background": "#fabd2f 40%",  # Bright Yellow with 40% alpha
-        "text-muted": "#a89984",  # Gray
+        "text-muted": "#afa28e",  # Gray
     },
 )
 
@@ -337,7 +342,7 @@ gruvbox_light_theme = Theme(
     variables={
         "footer-key-foreground": "#458588",  # Dark Blue
         "input-selection-background": "#d65d0e 40%",  # Dark Orange with 40% alpha
-        "text-muted": "#7c6f64",  # Gray for light background
+        "text-muted": "#685d54",  # Gray for light background
     },
 )
 
@@ -379,8 +384,10 @@ earthy_nature_theme = Theme(
     variables={
         "footer-key-foreground": "#E2725B",  # Terracotta
         "input-selection-background": "#CD853F 40%",  # Peru with 40% alpha
-        "text-muted": "#BDB76B",  # Dark Khaki
+        "text-muted": "#e5e3c5",  # Dark Khaki
         "tree-control-background": "#3A322A",  # Darker Brown for tree view specific (example)
+        "text-error": "#f3dddd",
+        "block-cursor-blurred-background": "#3f27104c",
     },
 )
 
@@ -403,6 +410,9 @@ pastel_dreams_theme = Theme(
         "input-border-default": "#C9EBFB",  # Light Sky Blue for input border
         "button-default-foreground": "#BF8A7E",  # Muted Rose for default button text
         "button-confirm-foreground": "#7BAA8F",  # Muted Mint for confirm button text
+        "text-error": "#87575e",
+        "text-muted": "#636363",
+        "block-cursor-blurred-background": "#ff84564c",
     },
 )
 
@@ -426,6 +436,8 @@ sweet_sorbet_theme = Theme(
         "button-special-foreground": "#996570",  # Muted Dark Pink for special button text
         "progressbar-background": "#FFE0CC",  # Light peach track for progress bar
         "progressbar-color": "#FFB6C1",  # Raspberry fill for progress bar
+        "text-error": "#935f67",
+        "block-cursor-blurred-background": "#b6a4004c",
     },
 )
 
@@ -444,12 +456,14 @@ cloudy_day_theme = Theme(
     error="#DEB0B0",  # Soft Red
     dark=False,
     variables={
-        "text-muted": "#778899",  # Light Slate Gray for info text
+        "text-muted": "#607080",  # Light Slate Gray for info text
         "input-background": "#FFFFFF",  # White for input backgrounds
         "input-border-default": "#D0D8E0",  # Default input border
         "button-default-background": "#FAFAFA",  # Soft white for default buttons
         "button-default-foreground": "#5A6470",  # Cool dark gray for default button text
         "button-navigation-foreground": "#42505E",  # Text for navigation buttons
+        "text-error": "#836767",
+        "block-cursor-blurred-background": "#7c9dc84c",
     },
 )
 
@@ -473,6 +487,7 @@ kawaii_candy_theme = Theme(
         "markdown-h1-color": "#FF69B4",
         "markdown-h2-color": "#754C59",
         "markdown-link-color": "#7FFFD4",
+        "block-cursor-blurred-background": "#9595ea4c",
     },
 )
 
@@ -495,6 +510,8 @@ bunny_fluff_theme = Theme(
         "button-default-foreground": "#7A736E",  # Default button text color
         "footer-background": "#F0EBE8",
         "footer-foreground": "#8D8580",
+        "text-error": "#756666",
+        "block-cursor-blurred-background": "#a3a32f4c",
     },
 )
 
@@ -517,6 +534,7 @@ neon_sunset_drive_theme = Theme(
         "input-border-default": "#00FFFF",  # Cyan for input border
         "button-default-foreground": "#FFD700",  # Golden Yellow for default button text
         "button-action-foreground": "#FFFFFF",  # White for action button text
+        "block-cursor-blurred-background": "#00bdbd4c",
     },
 )
 
@@ -541,6 +559,7 @@ palm_mall_theme = Theme(
         "header-foreground": "#4B0082",
         "statusbar-background": "#4B0082",
         "statusbar-foreground": "#B0E0E6",  # Soft Cyan for status bar text
+        "text-error": "#9a4d60",
     },
 )
 
@@ -584,6 +603,8 @@ paradise_virtua_theme = Theme(
         "button-select-foreground": "#002030",  # Dark text for select buttons
         "titlebar-background": "#FF007F",  # Magenta Rose for title bar
         "titlebar-foreground": "#FFFFFF",  # White text for title bar
+        "text-error": "#ffe0e0",
+        "text-muted": "#dce9eb",
     },
 )
 
@@ -602,7 +623,7 @@ lost_artifacts_atari_theme = Theme(
     error="#B07070",  # Dusty Rose
     dark=True,
     variables={
-        "text-muted": "#70A0A0",  # Muted Cyan for descriptions
+        "text-muted": "#82acac",  # Muted Cyan for descriptions
         "button-critical-background": "#B07070",  # Dusty Rose for critical buttons
         "button-critical-foreground": "#FFFFFF",  # White text for critical buttons
     },
@@ -710,7 +731,7 @@ ghost_in_the_shell_theme = Theme(
     error="#907070",  # Very subtle desaturated red
     dark=True,
     variables={
-        "text-muted": "#888888",
+        "text-muted": "#9c9c9c",
         "input-border-default": "#555555",
         "statusbar-background": "#111111",
         "statusbar-foreground": "#A0A0A0",
@@ -736,10 +757,11 @@ retro_mint_chip_theme = Theme(
     error="#D2691E",  # Chocolate Brown/Sienna (error messages)
     dark=False,
     variables={
-        "text-muted": "#8C7853",  # Muted brown for less important text
+        "text-muted": "#716143",  # Muted brown for less important text
         "input-placeholder": "#BEB2A7",  # Lighter placeholder text
         "border-subtle": "#D1C7B7",  # Subtle border color
         "scrollbar-color": "#68B0AB",  # Primary color for scrollbar
+        "block-cursor-blurred-background": "#5098934c",
     },
 )
 
@@ -763,6 +785,7 @@ blueprint_tech_theme = Theme(
         "grid-line-major": "#3030A0",  # For schematic-like grids
         "grid-line-minor": "#181860",  # Fainter grid lines
         "code-background": "#000060",  # Background for code blocks
+        "text-muted": "#9f9fec",
     },
 )
 
@@ -805,10 +828,11 @@ twilight_lavender_fields_theme = Theme(
     error="#DB7093",  # PaleVioletRed (Dusky Rose/Muted Magenta)
     dark=True,
     variables={
-        "text-muted": "#B0A4C4",  # Muted light purple for less important text
+        "text-muted": "#bfb5cf",  # Muted light purple for less important text
         "focus-border": "#FFB6C1",  # Accent color for focus borders
         "progress-bar-color": "#9370DB",  # Primary color for progress bars
         "tooltip-background": "#483D8B",  # Surface color for tooltips
+        "text-error": "#e9a6bc",
     },
 )
 
@@ -828,7 +852,7 @@ golden_hour_desert_theme = Theme(
     error="#B22222",  # Rusty Red (Firebrick)
     dark=False,
     variables={
-        "text-muted": "#8B7D6B",  # Muted sandy brown
+        "text-muted": "#665b4e",  # Muted sandy brown
         "button-primary-hover-background": "#E06000",  # Darker orange for hover
         "link-color": "#007BA7",  # Cerulean blue for links
         "border-strong": "#A0522D",  # Sienna for stronger borders
@@ -855,6 +879,7 @@ industrial_gearworks_theme = Theme(
         "border-heavy": "#A9A9A9",  # DarkGray for heavier borders
         "widget-border": "#505050",  # Standard widget border
         "tooltip-background": "#4A4A4A",  # Tooltip background
+        "text-error": "#e49292",
     },
 )
 
@@ -874,7 +899,7 @@ coral_bloom_theme = Theme(
     error="#FF4081",  # Bright Pink (Material Pink A200)
     dark=False,
     variables={
-        "text-muted": "#778899",  # LightSlateGray
+        "text-muted": "#637484",  # LightSlateGray
         "list-item-active-background": "#FFEBCD",  # BlanchedAlmond (warm highlight)
         "highlight-primary": "#FF7F50 30%",  # Primary color with alpha for selections
         "badge-background": "#40E0D0",  # Secondary for badges
@@ -902,6 +927,7 @@ autumn_embers_theme = Theme(
         "log-date-foreground": "#F1C40F",  # Golden yellow for dates in logs
         "code-comment-color": "#A0522D",  # Sienna for code comments
         "button-hover-text": "#FFFFFF",
+        "text-error": "#d8a6a6",
     },
 )
 
@@ -921,10 +947,11 @@ zen_garden_theme = Theme(
     error="#CD5C5C",  # Terracotta/Muted Red (IndianRed)
     dark=False,
     variables={
-        "text-muted": "#707070",  # Medium gray for muted text
+        "text-muted": "#686868",  # Medium gray for muted text
         "border-zen": "#C0C0C0",  # Silver for subtle borders
         "input-focus-border": "#8FBC8F",  # Primary color for input focus border
         "container-background-alt": "#ECECEC",  # Alternative background for containers
+        "block-cursor-blurred-background": "#5f9f5f4c",
     },
 )
 
@@ -969,7 +996,7 @@ volcanic_ash_lava_theme = Theme(
     variables={
         "tooltip-background": "#3D3D3D",  # Darker tooltip background
         "border-accent": "#FF5A00",  # Use primary for prominent borders
-        "text-muted": "#777777",  # Muted grey for less important text
+        "text-muted": "#949494",  # Muted grey for less important text
         "scrollbar-color-hover": "#FF8C00",  # DarkOrange for scrollbar hover
     },
 )
@@ -994,6 +1021,7 @@ spring_meadowburst_theme = Theme(
         "text-highlight-bg": "#FFFFB3",  # Pale yellow for text selection background
         "input-border-active": "#7FFF00",  # Primary color for active input border
         "footer-background": "#D0E0D0",  # Light, earthy green for footer
+        "block-cursor-blurred-background": "#59b2004c",
     },
 )
 
@@ -1038,7 +1066,7 @@ ancient_papyrus_theme = Theme(
     variables={
         "blockquote-text": "#4A2E20",  # Darker brown for blockquote text
         "header-underline-color": "#0047AB",  # Primary color for header underlines
-        "text-muted": "#A08C78",  # Muted beige/brown for less important text
+        "text-muted": "#7a6856",  # Muted beige/brown for less important text
         "border-subtle": "#D2B48C",  # Tan for subtle borders
     },
 )
@@ -1063,6 +1091,8 @@ urban_stealth_camo_theme = Theme(
         "button-outline-focus": "#787269",  # Accent for button focus outline
         "panel-border": "#404552",  # Border for panels
         "placeholder-text": "#525860",  # Darker placeholder text
+        "text-error": "#cca1a1",
+        "block-cursor-blurred-background": "#677d8e4c",
     },
 )
 
@@ -1086,6 +1116,7 @@ confectionery_bliss_theme = Theme(
         "text-flavor-berry": "#800080",  # Purple for special flavor text
         "highlight-secondary": "#AFEEEE 40%",  # Secondary color with alpha for selection
         "button-text-primary": "#483263",  # Darker purple for text on primary buttons
+        "block-cursor-blurred-background": "#ff6f844c",
     },
 )
 
@@ -1109,6 +1140,7 @@ mystic_redwood_grove_theme = Theme(
         "log-level-debug": "#3AAFA9",  # Primary color for debug logs
         "code-background": "#243137",  # Background for code blocks
         "text-ephemeral": "#88B0A4",  # Muted teal for less important text
+        "text-error": "#da906f",
     },
 )
 
@@ -1132,6 +1164,7 @@ art_deco_metropolis_theme = Theme(
         "text-title": "#CAA472",  # Primary color for titles
         "widget-highlight-border": "#006A4E",  # Accent color for special widget borders
         "input-selection": "#455A64 50%",  # BlueGrey with alpha for input selection
+        "text-error": "#c47d7a",
     },
 )
 
@@ -1153,7 +1186,7 @@ desert_oasis_mirage_theme = Theme(
     variables={
         "water-text": "#00A2CA",  # Primary color for water-themed text
         "sand-dune-highlight": "#FAF0C8",  # Very light sand for highlights
-        "text-muted": "#8B7965",  # Muted sandy brown
+        "text-muted": "#786857",  # Muted sandy brown
         "border-strong": "#A0522D",  # Sienna for stronger borders
     },
 )
@@ -1178,6 +1211,8 @@ starlight_cinema_noir_theme = Theme(
         "text-subtle-contrast": "#CCCCCC",  # Lighter grey for subtitles or less critical text
         "button-critical-background": "#990000",  # Darker red for critical action buttons
         "dialog-border": "#444444",  # Border for dialogs
+        "text-error": "#e35f5f",
+        "block-cursor-blurred-background": "#f617224c",
     },
 )
 
@@ -1247,6 +1282,8 @@ magical_girl_transform_theme = Theme(
         "friendship-aura-bg": "#FFB6C1 30%",  # Primary pink with alpha for highlights
         "compact-mirror-border": "#C0C0C0",  # Silver for item borders
         "mascot-guide-text": "#4682B4",  # Steel blue for helper text
+        "text-error": "#86445a",
+        "block-cursor-blurred-background": "#ff3b9d4c",
     },
 )
 
@@ -1270,6 +1307,7 @@ jujutsu_sorcery_night_theme = Theme(
         "cursed-tool-sheen": "#A9A9A9",  # Dark grey for metallic tools
         "shikigami-outline": "#708090",  # Slate grey for summoned outlines
         "sukuna-tattoo-red": "#800000",  # Darker red for specific accents
+        "text-error": "#bb6969",
     },
 )
 
@@ -1293,6 +1331,8 @@ akira_neo_tokyo_grit_theme = Theme(
         "espers-power-glow": "#8A2BE2 40%",  # BlueViolet with alpha
         "government-data-blue": "#3366CC",  # Official blue for specific text
         "city-lights-yellow": "#FFFF66",  # Pale yellow for distant lights
+        "text-error": "#da8585",
+        "block-cursor-blurred-background": "#ff31314c",
     },
 )
 
@@ -1316,6 +1356,8 @@ scouting_legionnaire_theme = Theme(
         "uniform-strap-color": "#704214",  # Darker brown for details
         "titan-steam-white": "#F5F5F5 30%",  # Off-white with alpha for steam
         "flare-gun-green": "#2E8B57",  # SeaGreen for signals
+        "text-error": "#ce9c9c",
+        "block-cursor-blurred-background": "#6782394c",
     },
 )
 
@@ -1339,6 +1381,8 @@ saiyan_power_orange_theme = Theme(
         "scouter-display-green": "#00FF00",  # Bright green for scouter text
         "kame-house-roof": "#B22222",  # Firebrick for Namekian details
         "training-ground-earth": "#DEB887",  # BurlyWood for environment colors
+        "text-error": "#960000",
+        "block-cursor-blurred-background": "#a65b004c",
     },
 )
 
@@ -1385,6 +1429,7 @@ sakura_viewing_picnic_theme = Theme(
         "tatami-mat-beige": "#EEE8AA",  # PaleGoldenrod for surfaces
         "koi-pond-blue": "#87CEFA",  # LightSkyBlue for decorative elements
         "falling-petal-accent": "#FFC0CB 60%",  # Pink with alpha for subtle effects
+        "block-cursor-blurred-background": "#ff677e4c",
     },
 )
 


### PR DESCRIPTION
Files the three task-31264 residuals and fixes two of them:

- **task-31282** (filed, To Do): decide whether theme-dict ds-* entries become real overrides or stop implying they are.
- **task-31283** (fixed, Done): 43 legacy themes' resolved `text-muted`/`text-error` fell below 4.5:1 on their own surface/panel (worst: earthy_nature error text at 1.7:1). Fixed with per-theme `variables` dict entries computed by hue-preserving lightness walks — base palettes untouched, existing entries' comments preserved.
- **task-31284** (fixed, Done): 13 themes had an invisible focus tint (primary ≈ surface, 1.02–1.08× shift) or unreadable text on it. Fixed by per-theme `block-cursor-blurred-background` overrides (30% alpha kept, tint base walked until ≥1.30× shift and ≥4.5:1 text). Intended side effect: Textual's blurred block cursor gains the same visibility in those themes.

**Why dict entries work here** when they were inert for ds-* tokens (task-31264): `text-muted`, `text-error`, and `block-cursor-blurred-background` are defined in **no tcss source**, so `{**generated, **theme.variables}` is the final word — the same mechanism agentic_terminal's existing `text-muted` entry uses.

**Gates**: `test_theme_contrast.py` now parametrizes **all** registered themes (was: Orb 12) with runtime-mirror resolution (handles `auto NN%`), plus a new focus-tint floor test (≥1.25× composite shift + AA text). 154 pass / 0 fail; theme-adjacent suite green except the pre-existing task-31263 failure. Live-verified pastel_dreams: focused button paints `#fddacd` on white, matching the computed composite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CkkgHUvd9y2aGtE6mm3bs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TASK-31283 and TASK-31284: legacy themes' muted/error text now clears 4.5:1 on their own surfaces, and focus tints are visibly distinct and readable. Previously 43 themes failed the text contrast and 13 had near-invisible or unreadable focus tints; per-theme overrides fix both without changing base palettes, and affected themes' blurred block cursor picks up the same visibility.

**Validation**

- Extends `test_theme_contrast.py` to mirror runtime variable resolution and check every registered theme.
- Adds focus-tint checks requiring at least a 1.25× surface shift and 4.5:1 text contrast.
- Files TASK-31282 for the remaining ambiguity around inert `ds-*` theme dictionary entries.

<sup>Written for commit e8a7c4248a7df2f1014af924a7bf81ae7cac5f96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

