### PR TITLE
Console: clear focused composer with Ctrl+C

### DIFF
--- a/Docs/User_Guide/console/chat-basics.md
+++ b/Docs/User_Guide/console/chat-basics.md
@@ -152,8 +152,9 @@ tool, code, and link styling keeps priority over immersive coloring.
   move the caret between wrapped lines. While you type, a dim ghost
   completion of the most recent matching past prompt may appear after the
   caret — press **Right** at the end of the draft to accept it.
-- **Ctrl+A** selects the whole draft; with that full selection active,
-  **Ctrl+C** copies it to the clipboard. **Ctrl+U** clears the draft;
+- **Ctrl+C** clears the draft while the composer owns the cursor. If you first
+  use **Ctrl+A** to select the whole draft, **Ctrl+C** copies it instead.
+  **Ctrl+U** also clears the draft; **Ctrl+Z** restores an accidental clear;
   **Ctrl+W** deletes the word left of the caret.
 - **PageUp / PageDown** scroll the transcript — the composer never uses
   paging keys.
@@ -421,8 +422,9 @@ Composer:
 | Ctrl+J | Insert a newline (works in any terminal) |
 | Shift+Enter | Insert a newline (where the terminal delivers it) |
 | Ctrl+A | Select the whole draft |
-| Ctrl+C | Copy the draft (with the full selection active) |
+| Ctrl+C | Clear the draft; copy it instead when the full selection is active |
 | Ctrl+U | Clear the draft |
+| Ctrl+Z | Undo the last edit, including a cleared draft |
 | Ctrl+W | Delete the word left of the caret |
 | Home / End | Move the caret to the start / end of the draft |
 | Up / Down | Recall past prompts on the draft's first/last row; move the caret between wrapped rows otherwise |

--- a/Tests/UI/test_console_composer_keymap.py
+++ b/Tests/UI/test_console_composer_keymap.py
@@ -26,6 +26,7 @@ thing itself.
 from __future__ import annotations
 
 import pytest
+from textual.events import Key
 
 from Tests.UI.test_console_dictation import _mounted_console, _ready_host
 from tldw_chatbook.Widgets.Console import ConsoleComposerBar
@@ -122,6 +123,27 @@ async def test_ctrl_c_clears_an_unselected_focused_draft_and_is_undoable():
 
         assert composer.draft_text() == "throw me away"
         assert composer.cursor_index == len("throw me away")
+
+
+@pytest.mark.unit
+def test_ctrl_c_handler_records_history_and_posts_draft_changed(monkeypatch):
+    composer = ConsoleComposerBar()
+    composer.load_draft("throw me away")
+    composer.has_focus = True
+    posted: list[object] = []
+    monkeypatch.setattr(composer, "post_message", posted.append)
+
+    assert composer.handle_console_key(Key("ctrl+c", None)) is True
+
+    assert composer.draft_text() == ""
+    assert composer.cursor_index == 0
+    assert len(posted) == 1
+    message = posted[0]
+    assert isinstance(message, ConsoleComposerBar.DraftChanged)
+    assert message.composer is composer
+    assert message.is_insertion is False
+    assert composer.undo() is True
+    assert composer.draft_text() == "throw me away"
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/UI/test_console_composer_keymap.py
+++ b/Tests/UI/test_console_composer_keymap.py
@@ -105,6 +105,25 @@ async def test_ctrl_u_clears_the_whole_draft():
         assert composer.cursor_index == 0
 
 
+@pytest.mark.asyncio
+async def test_ctrl_c_clears_an_unselected_focused_draft_and_is_undoable():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        composer = await _focused_composer(host, pilot, "throw me away")
+
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+        assert composer.draft_text() == ""
+        assert composer.cursor_index == 0
+
+        await pilot.press("ctrl+z")
+        await pilot.pause()
+
+        assert composer.draft_text() == "throw me away"
+        assert composer.cursor_index == len("throw me away")
+
+
 # ---------------------------------------------------------------------------
 # Caret movement
 # ---------------------------------------------------------------------------
@@ -284,3 +303,20 @@ async def test_an_edit_key_reaches_the_composer_while_nothing_is_focused():
 
         assert composer.draft_text() == "ac"
         assert composer.cursor_index == 1
+
+
+@pytest.mark.asyncio
+async def test_ctrl_c_does_not_clear_the_draft_while_nothing_is_focused():
+    _, host = _ready_host()
+    async with host.run_test(size=APP_SIZE) as pilot:
+        console = await _mounted_console(host, pilot)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("keep me")
+        host.set_focus(None)
+        await pilot.pause()
+        assert host.focused is None
+
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+        assert composer.draft_text() == "keep me"

--- a/backlog/tasks/task-31381 - Console-Ctrl-C-clears-an-unselected-focused-composer-draft.md
+++ b/backlog/tasks/task-31381 - Console-Ctrl-C-clears-an-unselected-focused-composer-draft.md
@@ -1,0 +1,52 @@
+---
+id: TASK-31381
+title: Console Ctrl+C clears an unselected focused composer draft
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-04 00:00'
+updated_date: '2026-09-04 00:00'
+labels:
+  - console
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Let a user discard the complete prompt currently being composed with Ctrl+C while the Console composer owns the cursor, without requiring repeated Backspace presses or losing the existing selected-draft copy behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 Ctrl+C clears the complete unselected Console draft when the composer owns focus and resets the caret to the start.
+- [x] #2 The Ctrl+C clear is undoable with Ctrl+Z.
+- [x] #3 Ctrl+C continues to copy a fully selected draft instead of clearing it.
+- [x] #4 Ctrl+C does not clear a draft when the composer does not own focus.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add mounted Console key-path regressions for focused clear, undo, selected copy, and the unfocused boundary; confirm the new clear behavior fails before production changes.
+2. Route focused, unselected Ctrl+C through the composer's existing undoable full-clear operation, preserving the later selected-copy path.
+3. Update the Console user guide to describe the contextual Ctrl+C behavior.
+4. Run the targeted composer keymap/draft-change tests, focused static checks, and diff hygiene checks.
+
+ADR required: no
+ADR path: backlog/decisions/031-tui-keybinding-and-footer-hint-conventions.md
+Reason: This is a focused text-editing behavior implemented through the existing composer key router, not a new screen/widget `BINDINGS` app action; ADR-031 remains the governing keybinding decision.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added one contextual Ctrl+C branch to the existing Console composer key router. When the composer itself owns focus and no full-draft selection is active, the branch reuses the established history-recording clear operation and posts the normal draft-change notification; the screen's later selected-copy path remains unchanged. Added mounted keypress coverage for clear/undo and the unfocused boundary, retained the existing selected-copy regression, and documented the contextual shortcut in the Console guide.
+
+ADR required: no. Existing ADR-031 remains applicable because this is composer text editing routed outside `BINDINGS`, not a new application action.
+
+Verification: the new focused-clear test failed RED against the prior implementation while the other 14 composer-keymap cases passed. After implementation, the three focused clear/undo, unfocused, and selected-copy cases passed. Ruff check, Ruff format check, `py_compile`, and scoped `git diff --check` passed. Pytest reported pre-existing dependency and temporary-directory cleanup warnings after the passing cases; no task-specific test failed.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31381 - Console-Ctrl-C-clears-an-unselected-focused-composer-draft.md
+++ b/backlog/tasks/task-31381 - Console-Ctrl-C-clears-an-unselected-focused-composer-draft.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-04 00:00'
-updated_date: '2026-09-04 00:00'
+updated_date: '2026-09-04 19:24'
 labels:
   - console
   - ux
@@ -35,6 +35,7 @@ Let a user discard the complete prompt currently being composed with Ctrl+C whil
 2. Route focused, unselected Ctrl+C through the composer's existing undoable full-clear operation, preserving the later selected-copy path.
 3. Update the Console user guide to describe the contextual Ctrl+C behavior.
 4. Run the targeted composer keymap/draft-change tests, focused static checks, and diff hygiene checks.
+5. Add direct handler-level unit coverage for key consumption, history, clearing, and the `DraftChanged` notification in response to PR review.
 
 ADR required: no
 ADR path: backlog/decisions/031-tui-keybinding-and-footer-hint-conventions.md
@@ -46,7 +47,9 @@ Reason: This is a focused text-editing behavior implemented through the existing
 <!-- SECTION:NOTES:BEGIN -->
 Added one contextual Ctrl+C branch to the existing Console composer key router. When the composer itself owns focus and no full-draft selection is active, the branch reuses the established history-recording clear operation and posts the normal draft-change notification; the screen's later selected-copy path remains unchanged. Added mounted keypress coverage for clear/undo and the unfocused boundary, retained the existing selected-copy regression, and documented the contextual shortcut in the Console guide.
 
+PR review follow-up added a direct `@pytest.mark.unit` handler test covering key consumption, the undo snapshot, the cleared draft and caret, and the non-insertion `DraftChanged` message while retaining the mounted integration cases.
+
 ADR required: no. Existing ADR-031 remains applicable because this is composer text editing routed outside `BINDINGS`, not a new application action.
 
-Verification: the new focused-clear test failed RED against the prior implementation while the other 14 composer-keymap cases passed. After implementation, the three focused clear/undo, unfocused, and selected-copy cases passed. Ruff check, Ruff format check, `py_compile`, and scoped `git diff --check` passed. Pytest reported pre-existing dependency and temporary-directory cleanup warnings after the passing cases; no task-specific test failed.
+Verification: the new focused-clear test failed RED against the prior implementation while the other 14 composer-keymap cases passed. After implementation and the review follow-up, the complete composer-keymap file plus the selected-copy regression passed (17 tests). Ruff check, Ruff format check, `py_compile`, and scoped `git diff --check` passed. Pytest reported pre-existing dependency and temporary-directory cleanup warnings after the passing cases; no task-specific test failed.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -424,7 +424,8 @@ class ConsoleComposerBar(Horizontal):
             composer: The composer whose draft changed.
             is_insertion: True when the edit ADDED text (a printable
                 character, or Shift+Enter/Ctrl+J's newline), False when it
-                removed text (Backspace/Ctrl+H, Delete, Ctrl+W, Ctrl+U).
+                removed text (Backspace/Ctrl+H, Delete, Ctrl+W, Ctrl+U,
+                focused Ctrl+C).
                 The screen dismisses first-run guidance on insertions only
                 -- "the user has started composing" is not something a
                 Backspace says -- which is exactly the baseline split, and
@@ -3821,10 +3822,9 @@ class ConsoleComposerBar(Horizontal):
                 undoable (TASK-1281). Defaults to False -- most callers use
                 this to swap draft scope programmatically (session switches,
                 the post-send clear, restore-then-replace flows), and none
-                of those should be revertable with Ctrl+Z. The one caller
-                that must pass ``True`` is the Ctrl+U "clear draft" key
-                handler in `ChatScreen.on_key` -- an accidental full clear is
-                exactly what undo exists for.
+                of those should be revertable with Ctrl+Z. The Ctrl+U and
+                focused, unselected Ctrl+C key handlers pass ``True`` because
+                an accidental full clear is exactly what undo exists for.
         """
         if record_history and self._has_any_draft_content():
             self._record_undo_snapshot(coalesce=False)
@@ -4142,7 +4142,7 @@ class ConsoleComposerBar(Horizontal):
         reaches past the composer -- the clipboard, undo/redo's store
         persistence, send, transcript paging.
 
-        TASK-3749 added the six draft-EDITING keys (Backspace/Ctrl+H,
+        TASK-3749 added the draft-EDITING keys (Backspace/Ctrl+H,
         Delete, Ctrl+W, Shift+Enter/Ctrl+J, Ctrl+U and the printable
         fallthrough). Wave 5 had to leave those on the screen because each
         one called a screen method AFTER the edit; they now post
@@ -4232,9 +4232,10 @@ class ConsoleComposerBar(Horizontal):
         # edit with `DraftChanged` and the screen does the Workbench resync
         # (and, for insertions, the guidance dismissal) in its subscriber.
         # Ordering note: as a group these ran LATER in `on_key` than they do
-        # here -- but every key they match is disjoint from the branches that
-        # used to precede them (Ctrl+C's copy, Enter's send, PageUp/PageDown's
-        # paging, the undo/redo chords), so precedence is unchanged. The
+        # here. Focused, unselected Ctrl+C is intentionally handled before the
+        # screen's selected-draft copy branch; every other edit key remains
+        # disjoint from Enter's send, PageUp/PageDown's paging, and the
+        # undo/redo chords, so their precedence is unchanged. The
         # printable fallthrough in particular can never shadow those: their
         # characters are C0 control bytes or CR, none of which are
         # `is_printable`, and all of them are modifier chords besides.
@@ -4266,8 +4267,18 @@ class ConsoleComposerBar(Horizontal):
             event.prevent_default()
             return True
         if event.key == "ctrl+u":
-            # TASK-1281: this is the one call site that opts into undo --
+            # TASK-1281: user-requested full clears opt into undo --
             # an accidental full clear is exactly what undo exists for.
+            self.clear_draft(record_history=True)
+            self._post_draft_changed(is_insertion=False)
+            event.stop()
+            event.prevent_default()
+            return True
+        if (
+            event.key == "ctrl+c"
+            and self.has_focus
+            and not self.has_full_draft_selection()
+        ):
             self.clear_draft(record_history=True)
             self._post_draft_changed(is_insertion=False)
             event.stop()


### PR DESCRIPTION
## Summary

- clear an unselected Console composer draft when Ctrl+C is pressed while the composer owns focus
- keep Ctrl+A then Ctrl+C as the selected-draft copy path
- make the clear undoable with Ctrl+Z and leave unfocused drafts untouched
- document the contextual shortcut and track it in TASK-31381

## Test plan

- `pytest -q --disable-warnings Tests/UI/test_console_composer_keymap.py::test_ctrl_c_clears_an_unselected_focused_draft_and_is_undoable Tests/UI/test_console_composer_keymap.py::test_ctrl_c_does_not_clear_the_draft_while_nothing_is_focused Tests/UI/test_console_internals_decomposition.py::test_console_native_composer_select_all_shortcut_preserves_draft_and_copies` (3 passed)
- `ruff check` on the changed Python files
- `ruff format --check` on the changed Python files
- `py_compile` on the changed Python files
- `git diff --check origin/dev...HEAD`

A full suite was not run, per repository guidance to use targeted verification unless explicitly requested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements TASK-31381 so Ctrl+C clears an unselected Console composer draft when the composer owns focus, giving users a quick way to discard a draft instead of doing nothing. The clear is undoable with Ctrl+Z; Ctrl+A then Ctrl+C still copies, and unfocused drafts are left alone.

<sup>Written for commit a28e772c2752977e33b55081d15ec2a1f2a28b45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

