### PR TITLE
docs(backlog): file the Console interaction program's follow-ups (tasks 31382, 31384-31386, 31420)

### DIFF
--- a/backlog/tasks/task-31382 - Name-the-asking-sub-agent-on-the-ask_user-card-and-its-transcript-marker.md
+++ b/backlog/tasks/task-31382 - Name-the-asking-sub-agent-on-the-ask_user-card-and-its-transcript-marker.md
@@ -1,0 +1,26 @@
+---
+id: TASK-31382
+title: Name the asking sub-agent on the ask_user card and its transcript marker
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:28'
+labels:
+  - console
+  - agents
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+PRD A11 says the question card names the asking agent. M2 (PR #2379) ships the attribution as a kind only -- the card title says 'A sub-agent has N questions for you' and the marker says 'Questions from a sub-agent' -- because a run carries no display label on dev: CurrentRunActor exposes kind, run_id and parent_run_id, and the transcript's own sub-agent markers are generic ('A sub-agent edited 3 files'). A user running a fleet cannot tell WHICH child is asking, which matters exactly when two children are working in parallel. Needs a run-id to display-label mapping (the fleet coordinator or AgentRuns_DB is the natural owner), threaded into the question payload's asked_by and read by the card title and the marker header.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The question card title names the asking sub-agent by its display label when one exists, falling back to the current generic copy
+- [ ] #2 The A14 transcript marker header carries the same label
+- [ ] #3 A primary-agent question is unchanged
+- [ ] #4 The label lookup never blocks the worker thread or raises into the round
+<!-- AC:END -->

--- a/backlog/tasks/task-31383 - Register-the-ask_user-restraint-description-in-the-internal-prompts-registry.md
+++ b/backlog/tasks/task-31383 - Register-the-ask_user-restraint-description-in-the-internal-prompts-registry.md
@@ -1,0 +1,26 @@
+---
+id: TASK-31383
+title: Register the ask_user restraint description in the internal-prompts registry
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:28'
+labels:
+  - console
+  - agents
+  - prompts
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The design spec (2026-08-19-console-user-interaction-design.md, section 5.1) asked for the ask_user tool description -- most of whose words say when NOT to ask -- to be registered in the internal-prompts registry alongside the other agent prompts rather than hardcoded at the call site, so it is inspectable and (once the registry's Settings surface lands) editable like every other prompt the app puts in front of a model. M2 (PR #2379) shipped it as the ASK_USER_DESCRIPTION constant in Agents/ask_user_questions.py because the PRD's acceptance criteria did not require the registration. With the gate defaulting ON, every user gets whatever this text says, so it deserves the same treatment as the registry's other 29 prompts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The ask_user tool description is served from the internal-prompts registry with a stable key and the constant becomes its default
+- [ ] #2 The LocalToolSpec built by _default_specs reads the registry copy at spec-build time
+- [ ] #3 Existing ask_user tests pass unchanged and one test pins that a registry override reaches the spec
+<!-- AC:END -->

--- a/backlog/tasks/task-31384 - Console-unified-interrupt-surface-one-round-helper-and-one-card-host-for-the-five-blocking-prompt-kinds.md
+++ b/backlog/tasks/task-31384 - Console-unified-interrupt-surface-one-round-helper-and-one-card-host-for-the-five-blocking-prompt-kinds.md
@@ -1,0 +1,28 @@
+---
+id: TASK-31384
+title: >-
+  Console unified interrupt surface: one round helper and one card host for the
+  five blocking prompt kinds
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:29'
+labels:
+  - console
+  - refactor
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The Console controller now carries FIVE hand-cloned copies of the same blocking round loop -- MCP approvals, skill install, skill script, worktree merge, and (since PR #2379) ask_user questions -- each with its own registry, lock, retained-payload map, marshal, remount-at-activation trio, and revocation leg, and ChatTaskCards routes each kind to its own bespoke card. Every new kind is a fourth or fifth copy of ~150 lines and three activation-site edits, and every bug fix (PR #1836's round-keying, M2's atomic busy check) has to be applied per copy. Sub-project C of the design spec (2026-08-19-console-user-interaction-design.md section 4) is the extraction: one _run_pending_round helper the kinds parameterise, and one card host routing by kind. A first spine (C1) was designed and implemented on PR #1903 and closed unmerged on 2026-09-04 after dev's approvals-verdict rewrite outran it; its design doc (2026-08-20-console-interrupt-host-design.md) and plan are recoverable from that branch's history and remain valid. The extraction is a refactor with a parity oracle: the existing interrupt battery must pass unchanged.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 One shared round helper backs all five kinds; the per-kind request_* methods keep their names and return shapes
+- [ ] #2 One host in the task-card slot routes payloads to cards by kind, including lazy mounting for kinds that stay off the boot path
+- [ ] #3 The interrupt battery (approval, skill-install, skill-script, worktree-merge, ask_user suites and the concurrency suites) passes with the same failure set as clean dev
+- [ ] #4 Per-kind behaviour differences (FIFO queueing for approvals vs busy for questions; verdict keying; revocation) are expressed as parameters, not copies
+<!-- AC:END -->

--- a/backlog/tasks/task-31385 - Console-attention-when-away-notify-the-user-when-a-run-blocks-on-them-off-screen.md
+++ b/backlog/tasks/task-31385 - Console-attention-when-away-notify-the-user-when-a-run-blocks-on-them-off-screen.md
@@ -1,0 +1,28 @@
+---
+id: TASK-31385
+title: >-
+  Console attention when away: notify the user when a run blocks on them
+  off-screen
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:29'
+labels:
+  - console
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+When an agent run blocks on the user -- an approval, a skill or worktree confirm, or an ask_user question -- the only attention affordances are inside Console: the rail badge, the parked-round toast, and the wake badge. A user on another screen (Library, Settings) or in another terminal window learns nothing until they come back, while the run sits paused for as long as ADR-067's indefinite default allows. Sub-project D of the design spec (2026-08-19-console-user-interaction-design.md section 4): a terminal bell and/or OSC notification, and a cross-screen badge on the Console nav item, raised when a round mounts or parks while Console is not the visible screen, and cleared when it resolves. Both reference implementations (Claude Code, Codex) ring or notify on a blocking prompt.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A blocking round raised while Console is not the visible screen produces a terminal notification (bell or OSC 9/777) governed by a [console] setting that defaults on
+- [ ] #2 The Console entry in the app navigation shows a pending-interrupt badge until the round resolves
+- [ ] #3 A round raised while Console is visible produces no bell
+- [ ] #4 Headless and test runs never emit terminal control sequences
+<!-- AC:END -->

--- a/backlog/tasks/task-31386 - Console-live-progress-sub-agent-activity-and-an-adjacent-cancel-during-long-tool-calls.md
+++ b/backlog/tasks/task-31386 - Console-live-progress-sub-agent-activity-and-an-adjacent-cancel-during-long-tool-calls.md
@@ -1,0 +1,27 @@
+---
+id: TASK-31386
+title: >-
+  Console live progress: sub-agent activity and an adjacent cancel during long
+  tool calls
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:29'
+labels:
+  - console
+  - ux
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Sub-project E of the design spec (2026-08-19-console-user-interaction-design.md section 4) asked for 'what the agent is doing now, elapsed time, visible cancel during long tool calls'. Part of it has since shipped: the unfinished Assistant row shows a live activity line during a turn (tool name and elapsed seconds, then Thinking and Generating states; see Docs/User_Guide/console/agent-runs-and-tools.md 'In the reply row itself'), and the composer's Stop button cancels the run. What remains from E: a sub-agent's work never appears in that line, so a fleet turn reads as idle while children run; and the Stop button is the run-wide stop, with no per-tool-call cancel next to the activity line for a single long tool call the user wants abandoned without ending the turn. This task is the residual, re-scoped against what exists rather than the spec's original ground truth.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 During a fleet turn the activity line reflects the running child agents (count and the longest-running tool) rather than reading idle
+- [ ] #2 A long-running tool call exposes a cancel adjacent to the activity line that abandons that call and lets the turn continue, using the existing per-call abandon path
+- [ ] #3 Single-agent turns are unchanged
+<!-- AC:END -->

--- a/backlog/tasks/task-31420 - Register-the-ask_user-restraint-description-in-the-internal-prompts-registry.md
+++ b/backlog/tasks/task-31420 - Register-the-ask_user-restraint-description-in-the-internal-prompts-registry.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-31383
+id: TASK-31420
 title: Register the ask_user restraint description in the internal-prompts registry
 status: To Do
 assignee: []
@@ -24,3 +24,13 @@ The design spec (2026-08-19-console-user-interaction-design.md, section 5.1) ask
 - [ ] #2 The LocalToolSpec built by _default_specs reads the registry copy at spec-build time
 - [ ] #3 Existing ask_user tests pass unchanged and one test pins that a registry override reaches the spec
 <!-- AC:END -->
+
+## Renumbering provenance
+
+Filed as task-31383 on 2026-09-04 (PR #2383, branch
+chore/console-interaction-follow-up-tasks). Renumbered to task-31420 the
+same day: while the PR waited, dev landed its own task-31383 ("Make failed
+Console replies offer Retry instead of Continue"), and under the 2026-08-21
+owner rule (TASK-19601) the older arrival keeps the id. 31420 is the first
+id above the highest task id on any remote branch or local worktree at the
+time (31419). No dependency, doc, or code referenced the old id.


### PR DESCRIPTION
## Summary

Backlog-only. Files the five follow-ups left by the Console Agent Interaction PRD's three milestones (#2373 task panel, #2379 `ask_user`, #2380 typed answers), each written against what is on dev today rather than the design spec's August ground truth.

| Task | Title | Why it exists |
|---|---|---|
| 31382 | Name the asking sub-agent on the `ask_user` card and its transcript marker | PRD A11 wants the asker named; runs carry no display label, so M2 ships "A sub-agent" |
| 31420 (was 31383) | Register the `ask_user` restraint description in the internal-prompts registry | The design spec asked for it; the PRD's ACs did not, so M2 ships a constant |
| 31384 | Unified interrupt surface: one round helper and one card host for the five blocking prompt kinds | Five hand-cloned round loops now; sub-project C, with the closed #1903 spine recoverable |
| 31385 | Attention when away: notify the user when a run blocks on them off-screen | Sub-project D; only in-Console badge and toast exist |
| 31386 | Live progress residual: sub-agent activity and an adjacent per-call cancel | Sub-project E, re-scoped: the reply-row activity line and Stop already shipped |

## Ids

Assigned above the highest task id on any remote branch or local worktree (31381) after three collisions with in-flight work at 31282–31287 (a theme branch and a vLLM worktree) and 31301 (a conversation-settings worktree). A fourth landed on dev while this PR waited (its own 31383), so that task is renumbered to 31420 with a provenance section per the TASK-19601 owner rule. `./scripts/preflight.sh` green on the rebased tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018q5PsHwn5kgHPmNwX9DKoo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backlog-only: files five follow-up tasks left by the Console Agent Interaction PRD's three milestones, each written against what currently exists on dev rather than the original design spec.

**Tasks**
- 31382: name the asking sub-agent on the `ask_user` card and transcript marker
- 31420 (was 31383): register the `ask_user` restraint description in the internal-prompts registry
- 31384: unify the five hand-cloned blocking prompt round loops into one helper and one card host
- 31385: notify the user when a run blocks on them off-screen
- 31386: surface sub-agent activity and a per-call cancel during long tool calls

Task 31383 was renumbered to 31420 because dev landed its own 31383 while this PR waited; the older arrival keeps the id per the TASK-19601 owner rule, and a provenance section records the change.

<sup>Written for commit 26676fd260bb80ffcf4ebdf6d042ab918263f8ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

