### PR TITLE
Console: retry failed replies instead of continuing

### DIFF
--- a/Tests/Chat/test_console_message_actions.py
+++ b/Tests/Chat/test_console_message_actions.py
@@ -257,7 +257,7 @@ def test_variant_action_labels_fit_compact_terminal_width_budget():
     assert len(" ".join(labels)) <= 52
 
 
-def test_failed_action_labels_include_retry_inside_terminal_width_budget():
+def test_failed_action_labels_offer_retry_instead_of_continue():
     service = ConsoleMessageActionService()
     message = ConsoleChatMessage(
         role=ConsoleMessageRole.ASSISTANT,
@@ -265,9 +265,13 @@ def test_failed_action_labels_include_retry_inside_terminal_width_budget():
         status="failed",
     )
 
-    labels = service.plain_action_labels(message)
+    actions = service.available_actions(message)
+    action_ids = [action.action_id for action in actions]
+    labels = service.expand_plain_action_labels(actions)
 
-    assert " ".join(labels) == "Copy Edit Fork Retry ---> More…"
+    assert "retry" in action_ids
+    assert "continue" not in action_ids
+    assert " ".join(labels) == "Copy Edit Save as... Fork Retry 👍 👎 🗑"
     assert len(" ".join(labels)) <= 52
 
 
@@ -580,6 +584,49 @@ def test_continue_action_targets_selected_variant_content():
     assert result.status == "continue_requested"
     assert result.target_message_id == "m1"
     assert result.target_content == "second"
+
+
+def test_continue_action_is_blocked_for_failed_response():
+    service = ConsoleMessageActionService()
+    message = ConsoleChatMessage(
+        role=ConsoleMessageRole.ASSISTANT,
+        content="partial response",
+        status="failed",
+        id="m1",
+    )
+
+    result = service.dispatch("continue", message)
+
+    assert result.status == "blocked"
+    assert result.visible_copy == "Retry the failed response instead."
+
+
+def test_continue_action_remains_available_for_stopped_response():
+    service = ConsoleMessageActionService()
+    message = ConsoleChatMessage(
+        role=ConsoleMessageRole.ASSISTANT,
+        content="partial response",
+        status="stopped",
+        id="m1",
+    )
+
+    result = service.dispatch("continue", message)
+
+    assert result.status == "continue_requested"
+
+
+def test_continue_action_remains_available_for_failed_user_message():
+    service = ConsoleMessageActionService()
+    message = ConsoleChatMessage(
+        role=ConsoleMessageRole.USER,
+        content="partial request",
+        status="failed",
+        id="m1",
+    )
+
+    result = service.dispatch("continue", message)
+
+    assert result.status == "continue_requested"
 
 
 # --- TASK-1: speak (TTS) action ------------------------------------------

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -9246,7 +9246,7 @@ async def test_console_save_as_media_failure_notifies_without_crashing():
 
 
 @pytest.mark.asyncio
-async def test_console_failed_stream_renders_inline_retry_and_recovers():
+async def test_console_failed_stream_renders_retry_without_continue_and_recovers():
     gateway = FailThenRecoverGateway()
     app = _build_console_send_test_app()
     app.chat_api_provider_value = "llama_cpp"
@@ -9284,8 +9284,9 @@ async def test_console_failed_stream_renders_inline_retry_and_recovers():
         )
         assert str(retry_button.label) == "Retry"
         assert retry_button.tooltip == "Retry the failed response."
+        assert not console.query(f"#console-message-action-continue-{failed.id}")
 
-        await pilot.click(f"#console-message-action-retry-{failed.id}")
+        retry_button.press()
         await _wait_for_text(console, pilot, "recovered")
 
     assert store.get_message(failed.id).status == "complete"

--- a/backlog/tasks/task-31383 - Make-failed-Console-replies-offer-Retry-instead-of-Continue.md
+++ b/backlog/tasks/task-31383 - Make-failed-Console-replies-offer-Retry-instead-of-Continue.md
@@ -1,0 +1,55 @@
+---
+id: TASK-31383
+title: Make failed Console replies offer Retry instead of Continue
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-04 19:29'
+updated_date: '2026-09-04 19:44'
+labels:
+  - console
+  - messages
+  - bug
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prevent failed provider responses from presenting Continue as the recovery action, so users can retry the original turn without the empty composer guidance implying that new message content is required.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Failed assistant messages expose Retry and do not expose Continue
+- [x] #2 Completed assistant messages retain Continue
+- [x] #3 Retry still reuses the failed response path and no composer content is required
+- [x] #4 Focused action-service and mounted Console regressions pass
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: backlog/decisions/092-console-chat-fork-copy-and-authority-boundary.md
+Reason: This narrows when an existing message action is applicable and preserves the established Continue, Retry, storage, and provider/runtime contracts.
+
+1. Add a focused action-service regression asserting failed assistant rows expose Retry without Continue while completed rows retain Continue.
+2. Run the regression before production edits and confirm it fails on the unexpected Continue action.
+3. Remove Continue from the failed-assistant action list at the shared action-catalog seam.
+4. Run the focused action-service and mounted Console retry/continue regressions.
+5. Run targeted Ruff and diff checks, self-review the change, and complete TASK-31383 with evidence.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Updated the Console message-action catalog so failed assistant replies expose Retry without Continue, while completed, stopped, and failed user-authored messages retain their existing Continue behavior. Added a dispatch-boundary guard so stale Continue events cannot start a new assistant turn from a failed reply. Expanded service and mounted Console coverage, including retry recovery without composer content. Verification: focused action-service and mounted retry tests passed; the mounted completed-Continue regression passed separately; targeted Ruff and git diff checks passed. Independent review found and verified the dispatch guard and assistant-only scope corrections. ADR check: no new ADR required; this preserves the contracts in backlog/decisions/092-console-chat-fork-copy-and-authority-boundary.md. No new general lesson was needed because the mounted-button interaction follows the existing live-verification lesson.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Failed assistant replies now offer Retry instead of Continue, and the action service rejects stale Continue requests for failed assistant messages without changing stopped or user-message behavior.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_chatbook/Chat/console_message_actions.py
+++ b/tldw_chatbook/Chat/console_message_actions.py
@@ -438,13 +438,13 @@ class ConsoleMessageActionService:
             # Retry regenerates a failed ASSISTANT response. A failed USER row —
             # e.g. the TASK-457(a) optimistic echo rejected before any provider
             # send — has nothing to regenerate, so it must not offer retry (the
-            # user re-sends from the composer instead). Speak is also absent
-            # here (spec §1a) -- a failed row's content is not a completed
-            # response worth reading aloud.
+            # user re-sends from the composer instead). Speak and Continue are
+            # also absent: a failed response is retried in place rather than
+            # read aloud or extended as a new assistant turn.
             completed_actions = [
                 ("retry", "Retry") if action_id == "regenerate" else (action_id, label)
                 for action_id, label in completed_actions
-                if action_id != "speak"
+                if action_id not in {"speak", "continue"}
             ]
         return [
             ConsoleMessageAction(
@@ -828,6 +828,16 @@ class ConsoleMessageActionService:
                 action_id=action_id,
                 status="blocked",
                 visible_copy="Only assistant messages can be regenerated.",
+            )
+        if (
+            action_id == "continue"
+            and message.status == "failed"
+            and ConsoleMessageActionService._is_assistant_message(message)
+        ):
+            return ConsoleActionResult(
+                action_id=action_id,
+                status="blocked",
+                visible_copy="Retry the failed response instead.",
             )
         if action_id == "continue":
             target_content = (


### PR DESCRIPTION
## Summary

- replace Continue with Retry on failed assistant response rows
- reject stale Continue dispatches for failed assistant replies while preserving completed, stopped, and user-message behavior
- cover the action contract and mounted timeout recovery flow under TASK-31383

## Test plan

- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q --tb=short Tests/Chat/test_console_message_actions.py Tests/UI/test_console_native_chat_flow.py::test_console_failed_stream_renders_retry_without_continue_and_recovers Tests/UI/test_console_native_chat_flow.py::test_console_continue_action_streams_new_message_from_selected_turn` (108 passed)
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/ruff check tldw_chatbook/Chat/console_message_actions.py Tests/Chat/test_console_message_actions.py Tests/UI/test_console_native_chat_flow.py`
- `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m py_compile tldw_chatbook/Chat/console_message_actions.py Tests/Chat/test_console_message_actions.py Tests/UI/test_console_native_chat_flow.py`
- `git diff --check origin/dev...HEAD`

A full suite was not run, per repository guidance to use targeted verification unless explicitly requested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Failed assistant replies in the Console now offer Retry instead of Continue, so users can recover the original turn without being misled into starting a new message.

- Blocks Continue for failed assistant messages and shows "Retry the failed response instead."
- Leaves Continue available for stopped, completed, and failed user messages.
- Rejects stale Continue dispatches for failed assistant messages to prevent starting a new turn.
- Adds regression tests for the action catalog and mounted retry flow.

<sup>Written for commit 62621cffc3e96bb7d00973de9835bbdf7a75b932. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

