### PR TITLE
fix(console): close Conversation Settings UAT gaps

### DIFF
--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -1329,7 +1329,7 @@ async def test_conversation_settings_return_missing_environment_credential_stays
         return_copy = str(
             modal.query_one("#console-settings-return-status", Static).renderable
         )
-        assert "OpenAI missing API key" in readiness_copy
+        assert "API key missing for OpenAI" in readiness_copy
         assert f"Export {missing_name}, then relaunch Chatbook" in return_copy
 
 
@@ -1824,13 +1824,19 @@ async def test_conversation_settings_return_status_fault_blocks_replacement_unti
         )
 
         console.apply_navigation_context(first_target.to_context())
-        for _ in range(80):
+        deadline = time.monotonic() + _ASYNC_SETTLE_TIMEOUT
+        while time.monotonic() < deadline:
             if (
                 reopened_tokens
                 and not console._conversation_settings_return_restore_in_progress
             ):
                 break
             await pilot.pause(0.05)
+        else:
+            raise AssertionError(
+                "Timed out waiting for the first Conversation settings return "
+                "to finish restoring."
+            )
 
         assert reopened_tokens == [161]
         assert replacement_target is not None
@@ -1845,13 +1851,19 @@ async def test_conversation_settings_return_status_fault_blocks_replacement_unti
         )
 
         console._consume_pending_conversation_settings_return()
-        for _ in range(80):
+        deadline = time.monotonic() + _ASYNC_SETTLE_TIMEOUT
+        while time.monotonic() < deadline:
             if (
                 reopened_tokens == [161, 162]
                 and not console._conversation_settings_return_restore_in_progress
             ):
                 break
             await pilot.pause(0.05)
+        else:
+            raise AssertionError(
+                "Timed out waiting for the replacement Conversation settings "
+                "return to finish restoring."
+            )
 
         assert reopened_tokens == [161, 162]
         assert console._pending_conversation_settings_return_target is None
@@ -13059,7 +13071,7 @@ def test_console_readiness_copy_uses_typed_blocker_and_recovery_across_surfaces(
     )
 
     assert screen._console_provider_blocker_copy() == (
-        "Provider setup needed: OpenAI missing API key"
+        "Provider setup needed: API key missing for OpenAI"
     )
     assert screen._console_provider_recovery_action() == (
         CONSOLE_PROVIDER_CONFIGURE_API_KEY_LABEL,

--- a/Tests/UI/test_console_resize_reflow.py
+++ b/Tests/UI/test_console_resize_reflow.py
@@ -362,7 +362,7 @@ async def test_full_settings_actions_remain_mouse_reachable_at_narrow_width(
             "Cancel",
             "Save as provider defaults",
             "Default for new chats",
-            "Use in this conversation",
+            "Use for this conversation",
         ]
         assert panel.region.x >= 0
         assert panel.region.right <= width

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -32,6 +32,7 @@ from textual.widgets import (
 
 import tldw_chatbook.UI.Console_Modules.session as session_module
 import tldw_chatbook.UI.Screens.chat_screen as chat_screen_module
+import tldw_chatbook.UI.Screens.settings_endpoint_probe as settings_endpoint_probe_module
 import tldw_chatbook.Widgets.Console.console_settings_modal as settings_modal_module
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
@@ -4603,7 +4604,7 @@ async def test_summary_builder_mounted_rail_uses_typed_copy_and_provider_name() 
         )
 
         assert "Provider: OpenAI" in painted
-        assert "Not ready — OpenAI missing API key" in painted
+        assert "Not ready — API key missing for OpenAI" in painted
         assert "READY legacy poison" not in painted
         assert "Provider: openai" not in painted
 
@@ -9843,7 +9844,7 @@ def test_console_missing_key_recovery_action_is_provider_specific() -> None:
 
     assert (
         screen._console_provider_blocker_copy()
-        == "Provider setup needed: OpenAI missing API key"
+        == "Provider setup needed: API key missing for OpenAI"
     )
     assert label == CONSOLE_PROVIDER_CONFIGURE_API_KEY_LABEL
     assert target == "settings"
@@ -9954,7 +9955,7 @@ def test_console_missing_key_no_model_recovery_action_is_provider_action() -> No
     assert readiness.native_send_supported is False
     assert (
         screen._console_provider_blocker_copy()
-        == "Provider setup needed: OpenAI missing API key"
+        == "Provider setup needed: API key missing for OpenAI"
     )
     assert label == CONSOLE_PROVIDER_CONFIGURE_API_KEY_LABEL
     assert target == "settings"
@@ -11710,7 +11711,11 @@ async def test_console_connection_tester_uses_chat_catalog_and_returns_typed_res
             model_ids=("served-model",),
         )
 
-    monkeypatch.setattr(chat_screen_module, "probe_settings_endpoint", probe, raising=False)
+    monkeypatch.setattr(
+        settings_endpoint_probe_module,
+        "probe_settings_endpoint",
+        probe,
+    )
     identity = ProviderDraftIdentity(
         provider_key="llama_cpp",
         connection_identity=("llama_cpp", "http://127.0.0.1:9099"),
@@ -13738,12 +13743,7 @@ async def test_console_settings_task4_geometry_keeps_connection_and_footer_usabl
         assert actions.region.right <= frame.content_region.right
         assert str(cancel.label) == "Cancel"
         assert str(defaults.label) == "Save as provider defaults"
-        expected_use_label = (
-            "Use in this conversation"
-            if modal.has_class("-conversation-settings-compact")
-            else "Use for this conversation"
-        )
-        assert str(use.label) == expected_use_label
+        assert str(use.label) == "Use for this conversation"
         assert defaults.region.width >= len(str(defaults.label))
         assert use.region.width >= len(str(use.label))
 

--- a/Tests/UI/test_console_settings_geometry.py
+++ b/Tests/UI/test_console_settings_geometry.py
@@ -111,6 +111,11 @@ async def test_conversation_settings_size_matrix_has_bounded_fluid_geometry(
         assert str(connection.label) == MODEL_DISCOVER_BUTTON_LABEL
         assert str(save_default.label) == "Save as provider defaults"
         assert str(save.label) == "Use for this conversation"
+        painted = "\n".join(
+            strip.text for strip in app.screen._compositor.render_strips()
+        )
+        assert "Use for this conversation" in painted
+        assert "Use in this conversation" not in painted
         for action in (connection, cancel, save_default, save):
             assert action.region.width >= len(str(action.label))
 
@@ -216,6 +221,7 @@ async def test_compact_tab_traversal_reveals_every_body_focus_target(
         targets = modal._settings_focus_targets()
         assert targets
         targets[0].focus()
+        await pilot.pause(0.12)
         await pilot.pause()
 
         for index, expected in enumerate(targets):

--- a/Tests/UI/test_console_workbench_contract.py
+++ b/Tests/UI/test_console_workbench_contract.py
@@ -1177,7 +1177,7 @@ async def test_console_transcript_empty_state_renders_ready_activation_copy():
             "Choose a provider for this Console session",
         ),
         (
-            "Provider setup needed: OpenAI missing API key",
+            "Provider setup needed: API key missing for OpenAI",
             CONSOLE_PROVIDER_CONFIGURE_API_KEY_LABEL,
             "Configure API and API key before sending",
         ),
@@ -1231,7 +1231,7 @@ async def test_console_empty_transcript_provider_recovery_label_matches_setup_bl
 
 def test_console_empty_recovery_action_keeps_provider_label_with_empty_tooltip():
     assert ChatScreen._console_empty_recovery_action_copy(
-        "Provider setup needed: OpenAI missing API key",
+        "Provider setup needed: API key missing for OpenAI",
         provider_action_label="Localized recovery label",
         provider_action_tooltip="",
     ) == ("Localized recovery label", "")
@@ -1353,7 +1353,7 @@ def test_console_disabled_reason_copy_prefers_setup_blocker():
             "Send blocked — choose a provider to continue",
         ),
         (
-            "Provider setup needed: OpenAI missing API key",
+            "Provider setup needed: API key missing for OpenAI",
             "Send blocked — add an API key to continue",
         ),
         (

--- a/Tests/UI/test_product_maturity_phase1_empty_setup_states.py
+++ b/Tests/UI/test_product_maturity_phase1_empty_setup_states.py
@@ -178,7 +178,7 @@ async def test_clean_run_setup_and_runtime_blockers_expose_recovery_copy(
             )
             assert (
                 app.screen._console_provider_blocker_copy()
-                == "Provider setup needed: OpenAI missing API key"
+                == "Provider setup needed: API key missing for OpenAI"
             )
             # The shared Workbench recovery banner stays hidden — the setup
             # card's action button is the recovery/control surface now

--- a/Tests/UI/test_product_maturity_phase6_recovery_docs.py
+++ b/Tests/UI/test_product_maturity_phase6_recovery_docs.py
@@ -185,7 +185,7 @@ async def test_phase6_recovery_copy_is_visible_in_running_app(
             assert "Set up provider" in console_text
             assert (
                 app.screen._console_provider_blocker_copy()
-                == "Provider setup needed: OpenAI missing API key"
+                == "Provider setup needed: API key missing for OpenAI"
             )
 
             await app.handle_screen_navigation(NavigateToScreen("acp"))

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -43,6 +43,7 @@ from Tests.UI.test_console_session_settings import (
     _bare_console_state_screen,
 )
 import tldw_chatbook.UI.Screens.settings_screen as settings_screen_module
+import tldw_chatbook.UI.Screens.settings_endpoint_probe as settings_endpoint_probe_module
 import tldw_chatbook.config as config_module
 from tldw_chatbook.Chat import provider_setup_persistence as provider_persistence_module
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
@@ -4425,7 +4426,11 @@ async def test_settings_provider_test_toast_folds_in_reachable_endpoint_probe(
             model_count=3,
         )
 
-    monkeypatch.setattr(settings_screen_module, "probe_settings_endpoint", fake_probe)
+    monkeypatch.setattr(
+        settings_endpoint_probe_module,
+        "probe_settings_endpoint",
+        fake_probe,
+    )
     host = DestinationHarness(app, "settings")
 
     async with host.run_test(size=(180, 50)) as pilot:
@@ -4473,7 +4478,11 @@ async def test_settings_provider_test_toast_reports_unreachable_endpoint(monkeyp
             category="connection_refused",
         )
 
-    monkeypatch.setattr(settings_screen_module, "probe_settings_endpoint", fake_probe)
+    monkeypatch.setattr(
+        settings_endpoint_probe_module,
+        "probe_settings_endpoint",
+        fake_probe,
+    )
     host = DestinationHarness(app, "settings")
 
     async with host.run_test(size=(180, 50)) as pilot:
@@ -4516,7 +4525,11 @@ async def test_settings_provider_test_does_not_treat_missing_models_route_as_cha
             summary="Model listing unavailable; chat endpoint not tested",
         )
 
-    monkeypatch.setattr(settings_screen_module, "probe_settings_endpoint", fake_probe)
+    monkeypatch.setattr(
+        settings_endpoint_probe_module,
+        "probe_settings_endpoint",
+        fake_probe,
+    )
     host = DestinationHarness(app, "settings")
 
     async with host.run_test(size=(180, 50)) as pilot:
@@ -4553,7 +4566,11 @@ async def test_settings_provider_test_skips_probe_for_cloud_providers(monkeypatc
         probe_calls.append(base_url)
         return SettingsEndpointProbeOutcome(reachable=True, summary="reachable")
 
-    monkeypatch.setattr(settings_screen_module, "probe_settings_endpoint", fake_probe)
+    monkeypatch.setattr(
+        settings_endpoint_probe_module,
+        "probe_settings_endpoint",
+        fake_probe,
+    )
     host = DestinationHarness(app, "settings")
 
     async with host.run_test(size=(180, 50)) as pilot:
@@ -4586,7 +4603,11 @@ async def test_settings_provider_test_failure_skips_endpoint_probe(monkeypatch):
         probe_calls.append(base_url)
         return SettingsEndpointProbeOutcome(reachable=True, summary="reachable")
 
-    monkeypatch.setattr(settings_screen_module, "probe_settings_endpoint", fake_probe)
+    monkeypatch.setattr(
+        settings_endpoint_probe_module,
+        "probe_settings_endpoint",
+        fake_probe,
+    )
     host = DestinationHarness(app, "settings")
 
     async with host.run_test(size=(180, 50)) as pilot:
@@ -10304,7 +10325,11 @@ async def test_settings_provider_test_does_not_depend_on_console_sampling_defaul
             model_count=3,
         )
 
-    monkeypatch.setattr(settings_screen_module, "probe_settings_endpoint", fake_probe)
+    monkeypatch.setattr(
+        settings_endpoint_probe_module,
+        "probe_settings_endpoint",
+        fake_probe,
+    )
     host = StyledSettingsDestinationHarness(app, "settings")
 
     async with host.run_test(size=(180, 50)) as pilot:

--- a/Tests/UI/test_settings_endpoint_probe.py
+++ b/Tests/UI/test_settings_endpoint_probe.py
@@ -690,6 +690,69 @@ async def test_openai_probe_defaults_to_chat_catalog_contract() -> None:
     ]
 
 
+@pytest.mark.loopback_network
+@pytest.mark.asyncio
+async def test_console_connection_seam_reaches_real_models_endpoint() -> None:
+    """The lazy Console seam reaches /v1/models and preserves returned IDs."""
+    import http.server
+    import json
+    import threading
+
+    from tldw_chatbook.Chat.provider_endpoint_contract import (
+        canonical_connection_identity,
+    )
+    from tldw_chatbook.Chat.provider_test_evidence import (
+        ProviderDraftIdentity,
+        ProviderProbeResult,
+    )
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    requested_paths: list[str] = []
+    payload = json.dumps(
+        {"data": [{"id": "served-alpha"}, {"id": "served-beta"}]}
+    ).encode("utf-8")
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            requested_paths.append(self.path)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args) -> None:
+            return
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        endpoint = f"http://127.0.0.1:{server.server_port}/v1"
+        identity = ProviderDraftIdentity(
+            provider_key="llama_cpp",
+            connection_identity=canonical_connection_identity(
+                "llama_cpp",
+                endpoint,
+            ),
+            credential_source="none",
+            credential_revision=3,
+            draft_generation=7,
+        )
+
+        result = await ChatScreen._test_console_connection(identity)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert result == ProviderProbeResult(
+        "reachable",
+        ("served-alpha", "served-beta"),
+    )
+    assert requested_paths == ["/v1/models"]
+
+
 @pytest.mark.asyncio
 async def test_openai_probe_uses_tts_contract_only_when_explicit() -> None:
     requests: list[httpx.Request] = []

--- a/Tests/UI/test_settings_provider_switch_atomic.py
+++ b/Tests/UI/test_settings_provider_switch_atomic.py
@@ -20,7 +20,9 @@ from Tests.UI.test_settings_configuration_hub import (
 from tldw_chatbook.Chat import provider_setup_persistence as provider_persistence_module
 from tldw_chatbook.Chat.provider_test_evidence import ProviderProbeResult
 from tldw_chatbook.config import ConfigMutationResult
-from tldw_chatbook.UI.Screens import settings_screen as settings_screen_module
+from tldw_chatbook.UI.Screens import (
+    settings_endpoint_probe as settings_endpoint_probe_module,
+)
 from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
 from tldw_chatbook.UI.Screens.settings_endpoint_probe import (
     SettingsEndpointProbeOutcome,
@@ -282,7 +284,11 @@ async def test_exact_probe_evidence_survives_returned_model_selection_and_save(
             model_ids=("model-a", "model-b"),
         )
 
-    monkeypatch.setattr(settings_screen_module, "probe_settings_endpoint", fake_probe)
+    monkeypatch.setattr(
+        settings_endpoint_probe_module,
+        "probe_settings_endpoint",
+        fake_probe,
+    )
     monkeypatch.setattr(
         provider_persistence_module,
         "apply_settings_mutation_to_cli_config",
@@ -349,7 +355,11 @@ async def test_exact_draft_key_probe_evidence_survives_successful_commit(
             model_ids=("model-a",),
         )
 
-    monkeypatch.setattr(settings_screen_module, "probe_settings_endpoint", fake_probe)
+    monkeypatch.setattr(
+        settings_endpoint_probe_module,
+        "probe_settings_endpoint",
+        fake_probe,
+    )
     monkeypatch.setattr(
         provider_persistence_module,
         "apply_settings_mutation_to_cli_config",

--- a/Tests/UI/test_settings_provider_test_draft.py
+++ b/Tests/UI/test_settings_provider_test_draft.py
@@ -1028,7 +1028,7 @@ async def test_probe_worker_cancellation_clears_exact_testing_state(monkeypatch)
         raise asyncio.CancelledError("secret-cancel-detail")
 
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.settings_screen.probe_settings_endpoint",
+        "tldw_chatbook.UI.Screens.settings_endpoint_probe.probe_settings_endpoint",
         cancelled_probe,
     )
 
@@ -1068,7 +1068,7 @@ async def test_chat_settings_probe_worker_passes_explicit_chat_catalog_purpose(
         )
 
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.settings_screen.probe_settings_endpoint",
+        "tldw_chatbook.UI.Screens.settings_endpoint_probe.probe_settings_endpoint",
         capture_probe,
     )
 
@@ -1109,7 +1109,7 @@ async def test_stale_probe_cancellation_does_not_clear_newer_testing_token(monke
         raise asyncio.CancelledError
 
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.settings_screen.probe_settings_endpoint",
+        "tldw_chatbook.UI.Screens.settings_endpoint_probe.probe_settings_endpoint",
         cancelled_probe,
     )
 
@@ -1288,7 +1288,7 @@ async def test_test_provider_button_click_runs_the_check():
         assert _provider_test_result_text(screen) == "Configuration check has not run."
 
         with patch(
-            "tldw_chatbook.UI.Screens.settings_screen.probe_settings_endpoint",
+            "tldw_chatbook.UI.Screens.settings_endpoint_probe.probe_settings_endpoint",
             _reachable_endpoint_probe,
         ):
             await _click_scrolled_settings_button(
@@ -1334,7 +1334,7 @@ async def test_test_provider_button_runs_with_provider_input_focused():
         assert screen._settings_text_entry_has_focus() is True
 
         with patch(
-            "tldw_chatbook.UI.Screens.settings_screen.probe_settings_endpoint",
+            "tldw_chatbook.UI.Screens.settings_endpoint_probe.probe_settings_endpoint",
             _reachable_endpoint_probe,
         ):
             await _click_scrolled_settings_button(
@@ -1422,7 +1422,7 @@ async def test_model_edit_during_probe_rejects_late_old_model_result(monkeypatch
         )
 
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.settings_screen.probe_settings_endpoint",
+        "tldw_chatbook.UI.Screens.settings_endpoint_probe.probe_settings_endpoint",
         delayed_probe,
     )
     host = StyledSettingsDestinationHarness(app, "settings")
@@ -1460,7 +1460,7 @@ async def test_probe_worker_unexpected_exception_settles_bounded_failure(monkeyp
         raise RuntimeError("secret-probe-detail")
 
     monkeypatch.setattr(
-        "tldw_chatbook.UI.Screens.settings_screen.probe_settings_endpoint",
+        "tldw_chatbook.UI.Screens.settings_endpoint_probe.probe_settings_endpoint",
         failing_probe,
     )
     host = StyledSettingsDestinationHarness(app, "settings")

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -11103,3 +11103,20 @@ hex literal. And never verify a color fix by arithmetic on configuration
 values — check the resolved paint (rule-match probe or live capture); the
 dict-value contrast test in PR #2374 passed while the app painted the
 opposite.
+
+## Patch the owner of a lazy dependency, not a stale consumer alias (TASK-31301, 2026-09-04)
+
+**What happened.** Conversation Settings endpoint tests patched
+`settings_screen.probe_settings_endpoint` and
+`chat_screen.probe_settings_endpoint` after the production call sites had moved
+those imports inside their methods for the boot-budget boundary. One patch used
+`raising=False`, which silently installed an attribute the production code never
+read. The test then reached a real localhost endpoint instead of its fake; only
+the network guard exposed that the apparently isolated test no longer controlled
+its dependency.
+
+**What to do.** When production lazily imports a dependency inside a method,
+patch the symbol on the module that owns it. Do not use `raising=False` to make a
+missing consumer alias patchable. Pair the fake-driven test with one explicit,
+owned-loopback integration test so both isolation and the real call path remain
+observable.

--- a/backlog/tasks/task-31301 - Close-Conversation-Settings-post-merge-UAT-gaps.md
+++ b/backlog/tasks/task-31301 - Close-Conversation-Settings-post-merge-UAT-gaps.md
@@ -1,0 +1,56 @@
+---
+id: TASK-31301
+title: Close Conversation Settings post-merge UAT gaps
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-04 18:56'
+updated_date: '2026-09-04 19:59'
+labels:
+  - console
+  - ux
+  - testing
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Resolve the four defects found during post-merge UAT so first-time and experienced users receive consistent setup guidance, deterministic credential return behavior, and trustworthy provider verification without test-network leakage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Conversation Settings uses the full Use for this conversation action label at compact, normal, and wide terminal sizes.
+- [x] #2 Missing-credential guidance uses a consistent API key missing for Provider phrase in readiness and setup actions.
+- [x] #3 Endpoint-probe tests preserve production lazy imports and intercept the real dependency seam without unintended network access.
+- [x] #4 The credential return status-fault flow waits for its semantic completion condition under suite load, without retries, skips, flaky markers, or weakened assertions.
+- [x] #5 Focused automated regressions, static checks, localhost endpoint verification, and mounted 80x24, 100x30, and 160x40 UAT pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR paths: backlog/decisions/006-provider-aware-generation-settings.md; backlog/decisions/011-chatbook-workbench-ui-system.md; backlog/decisions/012-provider-credential-settings-boundary.md; backlog/decisions/033-application-session-state-ownership.md; backlog/decisions/097-boot-budget-ratchets.md
+Reason: This is copy and test-remediation within existing Conversation Settings, navigation, probe, and lazy-import boundaries.
+
+1. Capture RED evidence for each reported defect, including suite-order reproduction of the return fault.
+2. Apply the smallest production and test-seam fixes that satisfy the approved UX copy and isolation contracts.
+3. Run focused regressions, static checks, localhost probe validation, and mounted multi-size UAT.
+4. Self-review the diff and document verification evidence.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Kept the full primary action label at every supported width and changed compact footer groups to vertical, full-width, auto-height controls so the copy remains readable and pointer/keyboard reachable.
+- Standardized missing-credential readiness text as `API key missing for {Provider}` while preserving rejected-credential wording.
+- Repaired endpoint tests to patch the source module used by production lazy imports and added an owned-loopback `/v1/models` integration test that verifies returned model IDs.
+- Pre-PR review found seven additional stale consumer-alias patches in the provider-draft suite; all now patch the owning endpoint-probe module, and a repository sweep confirms none remain.
+- Replaced fixed four-second polling in the status-fault return test with a bounded semantic wait that retains the original exact assertions.
+- Stabilized the compact focus-traversal harness by observing the production reveal-settle timer for the first manually focused control, matching every subsequent Tab step without weakening geometry assertions.
+- Added a testing-evidence lesson for lazy-import dependency patching. No new ADR was required; the work stays within ADRs 006, 011, 012, 033, and 097.
+- Verification after rebasing onto current `origin/dev`: 69 focused workflow tests passed; all 76 provider-draft tests passed; 11 mounted geometry/keyboard tests passed across 80x24, 100x30, and 160x40, followed by three repeated compact-focus passes; the real localhost probe and lazy-import boot closure passed. Compileall, `git diff --check`, stale-seam search, and scoped Ruff checks passed. Independent re-review reported no remaining actionable findings.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/Console/console_settings_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_modal.py
@@ -3096,20 +3096,23 @@ class ConsoleSettingsModal(
         self._reveal_focused_control(focused, self._focus_reveal_generation)
 
     def _sync_action_copy(self, compact: bool) -> None:
-        """Use concise footer copy when the terminal cannot fit full labels."""
+        """Synchronize footer copy and widths for the responsive layout."""
 
         make_default = self.query_one("#console-settings-make-default", Button)
         apply_button = self.query_one("#console-settings-save", Button)
         make_default.label = (
             "Default for new chats" if compact else "Make default for new chats"
         )
-        apply_button.label = (
-            "Use in this conversation" if compact else "Use for this conversation"
-        )
-        for button in (make_default, apply_button):
-            width = len(str(button.label)) + 2
-            button.styles.width = width
-            button.styles.min_width = width
+        apply_button.label = "Use for this conversation"
+        actions = self.query_one("#console-settings-actions", Vertical)
+        for button in actions.query(Button):
+            if compact:
+                button.styles.width = "100%"
+                button.styles.min_width = 0
+            else:
+                width = max(12, len(str(button.label)) + 2)
+                button.styles.width = width
+                button.styles.min_width = width
 
     def _sync_action_layout(self, viewport_width: int) -> None:
         """Keep every footer action reachable at supported terminal widths."""
@@ -3142,13 +3145,13 @@ class ConsoleSettingsModal(
             button.styles.min_height = 1 if compact else MODAL_CONTROL_HEIGHT
         actions = self.query_one("#console-settings-actions", Vertical)
         actions.styles.layout = "vertical" if compact else "horizontal"
-        action_height = 1 if recovery_active or not compact else 2
-        actions.styles.height = action_height
-        actions.styles.min_height = action_height
+        actions.styles.height = "auto" if compact else 1
+        actions.styles.min_height = 1
         action_groups = list(actions.query(".console-settings-action-group"))
         for group in action_groups:
+            group.styles.layout = "vertical" if compact else "horizontal"
             group.styles.width = "100%" if compact else "auto"
-            group.styles.height = 1
+            group.styles.height = "auto" if compact else 1
             group.styles.min_height = 1
             group.styles.align_horizontal = "right"
         if len(action_groups) > 1:

--- a/tldw_chatbook/Widgets/Console/console_settings_summary.py
+++ b/tldw_chatbook/Widgets/Console/console_settings_summary.py
@@ -154,7 +154,9 @@ def build_console_readiness_presentation(
         action = ("Configure", "hidden", "Configure Console settings")
     else:
         blocker_copy = _BLOCKER_COPY.get(readiness.blocker, "review provider settings")
-        if readiness.blocker in {"credential_missing", "credential_rejected"}:
+        if readiness.blocker == "credential_missing":
+            blocker_copy = f"API key missing for {provider}"
+        elif readiness.blocker == "credential_rejected":
             blocker_copy = f"{provider} {blocker_copy}"
         primary = f"Not ready — {blocker_copy}"
         detail = f"Provider setup needed: {blocker_copy}"


### PR DESCRIPTION
## Summary

- keep the full **Use for this conversation** action label at compact, normal, and wide terminal sizes, with compact footer actions stacked and fully reachable
- standardize missing-credential guidance as **API key missing for Provider** across Console readiness and recovery surfaces
- repair endpoint-probe tests to patch the owning lazy-import module, add a real owned-loopback `/v1/models` test, and remove every stale consumer-alias patch
- make Conversation Settings return/focus tests wait for their semantic production settle boundaries instead of fixed or incomplete timing assumptions

## Verification

- [x] 69 focused Conversation Settings workflow, deep-link, return, provider, and recovery tests
- [x] 76/76 provider-draft tests
- [x] 11 mounted geometry and keyboard tests at 80x24, 100x30, and 160x40
- [x] compact focus traversal repeated three additional times
- [x] real localhost `/v1/models` integration test
- [x] lazy-import boot-closure test
- [x] compileall, `git diff --check`, stale-seam search, and scoped Ruff checks
- [x] independent pre-PR review and follow-up review: no remaining actionable findings

## Notes

- Rebased onto current `origin/dev` (`ab539077a9`) before final verification.
- No new ADR is required; this stays within ADRs 006, 011, 012, 033, and 097.
- Backlog task: TASK-31301.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the Conversation Settings post-merge UAT gaps: the full "Use for this conversation" action label now shows at compact, normal, and wide terminal sizes (compact footer actions stack vertically), and missing-credential guidance is standardized as "API key missing for Provider" across readiness and recovery surfaces.

- Endpoint-probe tests now patch the owning lazy-import module, add a real owned-loopback `/v1/models` test, and drop all stale consumer-alias patches.
- Return and focus tests wait on semantic production settle boundaries instead of fixed timing.

<sup>Written for commit 01a17624857cd92b4f4faba903d81bfac440e65c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

